### PR TITLE
Small changes to text selection for the TextBox

### DIFF
--- a/Perspex.Controls/TextBox.cs
+++ b/Perspex.Controls/TextBox.cs
@@ -256,7 +256,6 @@ namespace Perspex.Controls
                 return false;
             }
         }
-
         private void OnKeyDown(object sender, KeyEventArgs e)
         {
             string text = this.Text ?? string.Empty;
@@ -267,6 +266,14 @@ namespace Perspex.Controls
 
             switch (e.Key)
             {
+                case Key.A:
+                    if (modifiers == ModifierKeys.Control)
+                    {
+                        this.SelectionStart = 0;
+                        this.SelectionEnd = this.Text.Length;
+                    }
+
+                    break;
                 case Key.Left:
                     this.MoveHorizontal(-1, modifiers);
                     movement = true;

--- a/Perspex.Controls/TextBoxView.cs
+++ b/Perspex.Controls/TextBoxView.cs
@@ -55,6 +55,9 @@ namespace Perspex.Controls
 
         public new void LostFocus()
         {
+            this.parent.SelectionStart = 0;
+            this.parent.SelectionEnd = 0;
+
             this.caretTimer.Stop();
             this.InvalidateVisual();
         }


### PR DESCRIPTION
- Made the TextBox lose its selection when focus is lost.
- Added Ctrl+A to select all text in the TextBox
