### PR TITLE
Letter A bug and SelectAll method

### DIFF
--- a/Perspex.Controls/Presenters/TextPresenter.cs
+++ b/Perspex.Controls/Presenters/TextPresenter.cs
@@ -179,8 +179,13 @@ namespace Perspex.Controls
                 case Key.A:
                     if (modifiers == ModifierKeys.Control)
                     {
-                        this.SelectionStart = 0;
-                        this.SelectionEnd = this.Text.Length;
+                        SelectAll();
+                        
+                    }
+                    else
+                    {
+                        textEntered = true;
+                        goto default;
                     }
 
                     break;
@@ -271,6 +276,12 @@ namespace Perspex.Controls
             }
 
             e.Handled = true;
+        }
+
+        private void SelectAll()
+        {
+            this.SelectionStart = 0;
+            this.SelectionEnd = this.Text.Length;
         }
 
         protected override void OnPointerPressed(PointerPressEventArgs e)


### PR DESCRIPTION
- Fixed: the letter A cannot be entered.
- The SelectAll method is added for legibility and (maybe) reusability
