### PR TITLE
Fixes/cleanups to the Gtk/Cairo platforms

### DIFF
--- a/Cairo/Perspex.Cairo/CairoExtensions.cs
+++ b/Cairo/Perspex.Cairo/CairoExtensions.cs
@@ -76,7 +76,7 @@ namespace Perspex.Cairo
                 return Pango.Alignment.Left;
             }
 
-            if (alignment == Perspex.Media.TextAlignment.Centered)
+            if (alignment == Perspex.Media.TextAlignment.Center)
             {
                 return Pango.Alignment.Center;
             }

--- a/Gtk/Perspex.Gtk/GtkPlatform.cs
+++ b/Gtk/Perspex.Gtk/GtkPlatform.cs
@@ -40,6 +40,7 @@ namespace Perspex.Gtk
         {
             var locator = Locator.CurrentMutable;
             locator.Register(() => new WindowImpl(), typeof(IWindowImpl));
+            locator.Register(() => new PopupImpl(), typeof(IPopupImpl));
             locator.Register(() => GtkKeyboardDevice.Instance, typeof(IKeyboardDevice));
             locator.Register(() => instance, typeof(IPlatformSettings));
             locator.Register(() => instance, typeof(IPlatformThreadingInterface));

--- a/Gtk/Perspex.Gtk/Perspex.Gtk.csproj
+++ b/Gtk/Perspex.Gtk/Perspex.Gtk.csproj
@@ -59,6 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GtkExtensions.cs" />
+    <Compile Include="PopupImpl.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="GtkPlatform.cs" />
     <Compile Include="WindowImpl.cs" />

--- a/Gtk/Perspex.Gtk/PopupImpl.cs
+++ b/Gtk/Perspex.Gtk/PopupImpl.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Perspex.Gtk
+{
+    using System;
+    using Perspex.Platform;
+    using global::Gtk;
+
+    public class PopupImpl : WindowImpl, IPopupImpl
+    {
+        public PopupImpl()
+            : base(WindowType.Popup)
+        {
+            this.DefaultSize = new Gdk.Size(640, 480);
+            this.Events = Gdk.EventMask.PointerMotionMask |
+                          Gdk.EventMask.ButtonPressMask |
+                          Gdk.EventMask.ButtonReleaseMask;
+        }
+
+        public void SetPosition(Point p)
+        {
+            this.Move((int)p.X, (int)p.Y);
+        }
+    }
+}

--- a/TestApplication/Program.cs
+++ b/TestApplication/Program.cs
@@ -17,9 +17,6 @@ using Perspex.Gtk;
 #endif
 using ReactiveUI;
 using Splat;
-using Serilog;
-using Serilog.Filters;
-using Serilog.Events;
 
 namespace TestApplication
 {


### PR DESCRIPTION
- Added PopupImpl support in Perspex.Gtk
- Added ShowDialog support to WindowImpl in Perspex.Gtk
- Fixed resize issues in Perspex.Gtk
- Renamed Centered to Center to match WPF in Cairo
- Removed old Serilog references breaking compile
