### PR TITLE
#46 Added remove-tests for TabStrip and TabControl.

### DIFF
--- a/Tests/Perspex.Controls.UnitTests/Primitives/TabStripTests.cs
+++ b/Tests/Perspex.Controls.UnitTests/Primitives/TabStripTests.cs
@@ -6,6 +6,7 @@
 
 namespace Perspex.Controls.UnitTests.Primitives
 {
+    using System.Collections.ObjectModel;
     using System.Linq;
     using Perspex.Controls.Presenters;
     using Perspex.Controls.Primitives;
@@ -87,6 +88,41 @@ namespace Perspex.Controls.UnitTests.Primitives
             target.SelectedTab = target.Items.Cast<TabItem>().ElementAt(1);
 
             Assert.Same(target.SelectedItem, target.SelectedTab);
+        }
+
+        [Fact]
+        public void Removing_Selected_Should_Select_Next()
+        {
+            var list = new ObservableCollection<TabItem>()
+                {
+                    new TabItem
+                    {
+                        Name = "first"
+                    },
+                    new TabItem
+                    {
+                        Name = "second"
+                    },
+                    new TabItem
+                    {
+                        Name = "3rd"
+                    },
+                };
+
+            var target = new TabStrip
+            {
+                Template = new ControlTemplate<TabStrip>(this.CreateTabStripTemplate),
+                Items = list
+            };
+
+            target.ApplyTemplate();
+            target.SelectedTab = list[1];
+            Assert.Same(list[1], target.SelectedTab);
+            list.RemoveAt(1);
+
+            // Assert for former element [2] now [1] == "3rd"
+            Assert.Same(list[1], target.SelectedTab);
+            Assert.Same("3rd", target.SelectedTab.Name);
         }
 
         private Control CreateTabStripTemplate(TabStrip parent)

--- a/Tests/Perspex.Controls.UnitTests/TabControlTests.cs
+++ b/Tests/Perspex.Controls.UnitTests/TabControlTests.cs
@@ -12,6 +12,7 @@ namespace Perspex.Controls.UnitTests
     using Perspex.Controls.Templates;
     using Perspex.LogicalTree;
     using Xunit;
+    using System.Collections.ObjectModel;
 
     public class TabControlTests
     {
@@ -121,6 +122,44 @@ namespace Perspex.Controls.UnitTests
 
             Assert.Equal(1, target.GetLogicalChildren().Count());
             Assert.Equal("foo", ((TextBlock)target.GetLogicalChildren().First()).Text);
+        }
+
+        [Fact]
+        public void Removal_Should_Set_Next_Tab()
+        {
+            var collection = new ObservableCollection<TabItem>()
+                {
+                    new TabItem
+                    {
+                        Name = "first",
+                        Content = "foo",
+                    },
+                    new TabItem
+                    {
+                        Name = "second",
+                        Content = "bar",
+                    },
+                    new TabItem
+                    {
+                        Name = "3rd",
+                        Content = "barf",
+                    },
+                };
+
+            var target = new TabControl
+            {
+                Template = new ControlTemplate<TabControl>(this.CreateTabControlTemplate),
+                Items = collection,
+            };
+
+            target.ApplyTemplate();
+            target.SelectedItem = collection[1];
+            collection.RemoveAt(1);
+
+            // compare with former [2] now [1] == "3rd"
+            Assert.Same(collection[1], target.SelectedItem);
+            Assert.Same(target.SelectedTab, target.SelectedItem);
+            Assert.Equal("barf", target.SelectedContent);
         }
 
         private Control CreateTabControlTemplate(TabControl parent)


### PR DESCRIPTION
TabControl's SelectedContent fails.
