### PR TITLE
fixed misuse of OrderBy

### DIFF
--- a/src/Perspex.Diagnostics/ViewModels/ControlDetailsViewModel.cs
+++ b/src/Perspex.Diagnostics/ViewModels/ControlDetailsViewModel.cs
@@ -16,8 +16,8 @@ namespace Perspex.Diagnostics.ViewModels
             {
                 Properties = control.GetRegisteredProperties()
                     .Select(x => new PropertyDetails(control, x))
-                    .OrderBy(x => x.Name)
-                    .OrderBy(x => x.IsAttached);
+                    .OrderBy(x => x.IsAttached)
+                    .ThenBy(x => x.Name);
             }
         }
 


### PR DESCRIPTION
To order further inside equivalent groups, one should use ThenBy, as subsequent OrderBy calls are not guaranteed to preserve the original elements order.
