### PR TITLE
Implemented TextAlignment property for TextBox.

### DIFF
--- a/samples/XamlTestApplicationPcl/Views/MainWindow.paml
+++ b/samples/XamlTestApplicationPcl/Views/MainWindow.paml
@@ -63,6 +63,9 @@
                       <TextBox Width="200" Watermark="Floating Watermark" UseFloatingWatermark="True" />
                       <TextBox AcceptsReturn="True" TextWrapping="Wrap" Width="200" Height="150"
                                 Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus magna. Cras in mi at felis aliquet congue. Ut a est eget ligula molestie gravida. Curabitur massa. Donec eleifend, libero at sagittis mollis, tellus est malesuada tellus, at luctus turpis elit sit amet quam. Vivamus pretium ornare est." />
+                      <TextBox Width="200" Text="Left aligned text" TextAlignment="Left" />
+                      <TextBox Width="200" Text="Center aligned text" TextAlignment="Center" />
+                      <TextBox Width="200" Text="Right aligned text" TextAlignment="Right" />
                       <TextBlock Margin="0, 40, 0, 0" Text="CheckBox" FontWeight="Medium" FontSize="20"
                                   Foreground="#212121" />
                       <TextBlock Text="A check box control" FontSize="13" Foreground="#727272" Margin="0, 0, 0, 10" />

--- a/src/Perspex.Controls/Presenters/TextPresenter.cs
+++ b/src/Perspex.Controls/Presenters/TextPresenter.cs
@@ -180,7 +180,7 @@ namespace Perspex.Controls.Presenters
                     FontFamily,
                     FontSize,
                     FontStyle,
-                    TextAlignment.Left,
+                    TextAlignment,
                     FontWeight))
                 {
                     return formattedText.Measure();

--- a/src/Perspex.Controls/TextBox.cs
+++ b/src/Perspex.Controls/TextBox.cs
@@ -37,6 +37,9 @@ namespace Perspex.Controls
         public static readonly PerspexProperty<string> TextProperty =
             TextBlock.TextProperty.AddOwner<TextBox>();
 
+        public static readonly PerspexProperty<TextAlignment> TextAlignmentProperty =
+            TextBlock.TextAlignmentProperty.AddOwner<TextBox>();
+
         public static readonly PerspexProperty<TextWrapping> TextWrappingProperty =
             TextBlock.TextWrappingProperty.AddOwner<TextBox>();
 
@@ -107,6 +110,12 @@ namespace Perspex.Controls
         {
             get { return GetValue(TextProperty); }
             set { SetValue(TextProperty, value); }
+        }
+
+        public TextAlignment TextAlignment
+        {
+            get { return GetValue(TextAlignmentProperty); }
+            set { SetValue(TextAlignmentProperty, value); }
         }
 
         public string Watermark

--- a/src/Perspex.Themes.Default/TextBox.paml
+++ b/src/Perspex.Themes.Default/TextBox.paml
@@ -39,6 +39,7 @@
                                SelectionStart="{TemplateBinding SelectionStart}"
                                SelectionEnd="{TemplateBinding SelectionEnd}"
                                Text="{TemplateBinding Text}"
+                               TextAlignment="{TemplateBinding TextAlignment}"
                                TextWrapping="{TemplateBinding TextWrapping}"/>
               </Panel>
             </StackPanel>


### PR DESCRIPTION
Assigned for issue #247: https://github.com/Perspex/Perspex/issues/247.

Test look available in XamlTestApplication on "Input" tab.

Unsure about switching TextAlignment.Left to TextAlignment property value at 'src/Perspex.Controls/Presenters/TextPresenter.cs'.
Seems work well for me.
