### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # Perspex
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/grokys/Perspex?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/Perspex/Perspex?utm_campaign=pr-badge&utm_content=badge&utm_medium=badge&utm_source=badge)
 
 [![Build status](https://ci.appveyor.com/api/projects/status/hubk3k0w9idyibfg/branch/master?svg=true)](https://ci.appveyor.com/project/Perspex/Perspex/branch/master)
 
@@ -39,7 +39,7 @@ framework.
 As mentioned above, Perspex is still in alpha and as such there's not much documentation yet. You can
 take a look at the [getting started page](docs/gettingstarted.md) for an
 overview of how to get started but probably the best thing to do for now is to already know a little bit
-about WPF/Silverlight/UWP/XAML and ask questions in our [Gitter room](https://gitter.im/grokys/Perspex).
+about WPF/Silverlight/UWP/XAML and ask questions in our [Gitter room](https://gitter.im/Perspex/Perspex).
 
 There's also a high-level [architecture document](docs/architecture.md) that is currently a little bit
 out of date, and I've also started writing blog posts on Perspex at http://grokys.github.io/.


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein
### Corrected URLs

| Was | Now |
| --- | --- |
| https://gitter.im/grokys/Perspex | https://gitter.im/Perspex/Perspex |
| https://gitter.im/grokys/Perspex?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge | https://gitter.im/Perspex/Perspex?utm_campaign=pr-badge&utm_content=badge&utm_medium=badge&utm_source=badge |
