### PR TITLE
Reduce TabStripItem Margin value

### DIFF
--- a/src/Perspex.Themes.Default/TabStrip.paml
+++ b/src/Perspex.Themes.Default/TabStrip.paml
@@ -15,6 +15,6 @@
     </Setter>
   </Style>
   <Style Selector="TabStrip > TabStripItem">
-    <Setter Property="Margin" Value="16"/>
+    <Setter Property="Margin" Value="4"/>
   </Style>
 </Styles>


### PR DESCRIPTION
The `TabStripItem` margin value is a bit too much I think, reduced to 4.
