### PR TITLE
Fixed issue #226

### DIFF
--- a/samples/XamlTestApplicationPcl/Views/MainWindow.paml
+++ b/samples/XamlTestApplicationPcl/Views/MainWindow.paml
@@ -16,6 +16,25 @@
           <Separator/>
           <MenuItem Header="_World"/>
         </MenuItem>
+        <MenuItem Header="_Edit">
+          <MenuItem Header="_Command">
+            <MenuItem Header="_And">
+              <MenuItem Header="C_onquer"/>
+            </MenuItem>
+          </MenuItem>
+          <MenuItem Header="Beware">
+            <MenuItem Header="the alien">
+               <MenuItem Header="_Sectoid"/>
+               <MenuItem Header="_Muton"/>
+               <MenuItem Header="_Xenomorph"/>
+            </MenuItem>  
+            <MenuItem Header="the mutant"/>
+            <MenuItem Header="the heretic"/>
+          </MenuItem>       
+          <MenuItem Header="Cut"/>
+          <Separator/>
+          <MenuItem Header="Paste"/>
+        </MenuItem>
       </Menu>
       <TabControl Grid.Row="1" Grid.ColumnSpan="2" Padding="5">
           <TabControl.Transition>

--- a/src/Perspex.Controls/MenuItem.cs
+++ b/src/Perspex.Controls/MenuItem.cs
@@ -303,11 +303,30 @@ namespace Perspex.Controls
                     IsSubMenuOpen = true;
                 }
             }
-            else if (HasSubMenu && !IsSubMenuOpen)
+            else
             {
-                _submenuTimer = DispatcherTimer.Run(
-                    () => IsSubMenuOpen = true,
-                    TimeSpan.FromMilliseconds(400));
+                var parentItem = Parent as MenuItem;
+                if (parentItem != null)
+                {
+                    foreach (var child in Parent.LogicalChildren.OfType<MenuItem>())
+                    {
+                        if (child != this && child.IsSubMenuOpen)
+                        {
+                            child.IsSubMenuOpen = false;
+                            child.IsSelected = child.AlwaysSelected;
+                        }
+                    }
+                }
+
+                if (HasSubMenu)
+                {
+                    if (!IsSubMenuOpen)
+                    {
+                        _submenuTimer = DispatcherTimer.Run(
+                            () => IsSubMenuOpen = true,
+                            TimeSpan.FromMilliseconds(400));
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Assigned for issue #226 

Now opened submenus close properly when pointer leave.

Due to incorrect or not implemented keyboard navigation for menus it is only partically fix.
