### PR TITLE
reference projects based on conditional compilation symbols provided

### DIFF
--- a/samples/ControlCatalog/ControlCatalog.csproj
+++ b/samples/ControlCatalog/ControlCatalog.csproj
@@ -104,11 +104,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Gtk\Perspex.Cairo\Perspex.Cairo.csproj">
+    <ProjectReference Include="..\..\src\Gtk\Perspex.Cairo\Perspex.Cairo.csproj" Condition="$(DefineConstants.Contains('PERSPEX_CAIRO'))">
       <Project>{fb05ac90-89ba-4f2f-a924-f37875fb547c}</Project>
       <Name>Perspex.Cairo</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\Gtk\Perspex.Gtk\Perspex.Gtk.csproj">
+    <ProjectReference Include="..\..\src\Gtk\Perspex.Gtk\Perspex.Gtk.csproj" Condition="$(DefineConstants.Contains('PERSPEX_GTK'))">
       <Project>{54f237d5-a70a-4752-9656-0c70b1a7b047}</Project>
       <Name>Perspex.Gtk</Name>
     </ProjectReference>

--- a/samples/TestApplication/TestApplication.csproj
+++ b/samples/TestApplication/TestApplication.csproj
@@ -76,11 +76,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Gtk\Perspex.Cairo\Perspex.Cairo.csproj">
+    <ProjectReference Include="..\..\src\Gtk\Perspex.Cairo\Perspex.Cairo.csproj" Condition="$(DefineConstants.Contains('PERSPEX_CAIRO'))">
       <Project>{FB05AC90-89BA-4F2F-A924-F37875FB547C}</Project>
       <Name>Perspex.Cairo</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\Gtk\Perspex.Gtk\Perspex.Gtk.csproj">
+    <ProjectReference Include="..\..\src\Gtk\Perspex.Gtk\Perspex.Gtk.csproj" Condition="$(DefineConstants.Contains('PERSPEX_GTK'))">
       <Project>{54f237d5-a70a-4752-9656-0c70b1a7b047}</Project>
       <Name>Perspex.Gtk</Name>
     </ProjectReference>


### PR DESCRIPTION
This change, along with the updated docs in https://github.com/shiftkey/Perspex/commit/954fe6da11ba57bbcc085727801c16fb8efbdab3 - let's me build the project in VS2015 without touching csproj files.

And of course, to make it crystal clear:

![](http://i.imgur.com/xVyoSl.jpg)
