### PR TITLE
Improve rendering when resizing

### DIFF
--- a/src/Perspex.Application/Application.cs
+++ b/src/Perspex.Application/Application.cs
@@ -167,7 +167,7 @@ namespace Perspex
                 .Bind<IInputManager>().ToConstant(InputManager)
                 .Bind<IKeyboardNavigationHandler>().ToTransient<KeyboardNavigationHandler>()
                 .Bind<IStyler>().ToConstant(_styler)
-                .Bind<ILayoutManager>().ToTransient<LayoutManager>()
+                .Bind<ILayoutManager>().ToSingleton<LayoutManager>()
                 .Bind<IRenderQueueManager>().ToTransient<RenderQueueManager>();
         }
 

--- a/src/Perspex.Layout/LayoutManager.cs
+++ b/src/Perspex.Layout/LayoutManager.cs
@@ -99,6 +99,8 @@ namespace Perspex.Layout
                 stopwatch.Stop();
                 _log.Information("Layout pass finised in {Time}", stopwatch.Elapsed);
             }
+
+            _queued = false;
         }
 
         /// <inheritdoc/>

--- a/src/Windows/Perspex.Win32/WindowImpl.cs
+++ b/src/Windows/Perspex.Win32/WindowImpl.cs
@@ -585,7 +585,7 @@ namespace Perspex.Win32
                 lpfnWndProc = _wndProcDelegate,
                 hInstance = Marshal.GetHINSTANCE(GetType().Module),
                 hCursor = DefaultCursor,
-                hbrBackground = (IntPtr)5,
+                hbrBackground = IntPtr.Zero,
                 lpszClassName = _className,
             };
 


### PR DESCRIPTION
Improved two things:
- Use one layout manager so we are executing a layout pass on resize with the same layout manager that had received layout invalidations.
- Use NULL for the window background so the window is not cleared with a colour before we render. This caused the screen to flicker if the render took a while.
