### PR TITLE
Fix Slider.TickFrequency OmniXaml.ParseException

### DIFF
--- a/src/Perspex.Controls/Slider.cs
+++ b/src/Perspex.Controls/Slider.cs
@@ -30,7 +30,7 @@ namespace Perspex.Controls
         /// Defines the <see cref="TickFrequency"/> property.
         /// </summary>
         public static readonly StyledProperty<double> TickFrequencyProperty =
-            PerspexProperty.Register<Slider, double>(nameof(TickFrequencyProperty), 0.0);
+            PerspexProperty.Register<Slider, double>(nameof(TickFrequency), 0.0);
 
         // Slider required parts
         private Track _track;


### PR DESCRIPTION
Fixed exception:

```
OmniXaml.LoadException was unhandled
  HResult=-2146233088
  LineNumber=213
  LinePosition=11
  Message=Error loading XAML: OmniXaml.ParseException: Could not find PerspexProperty 'Slider.TickFrequency'.
   w Perspex.Markup.Xaml.Converters.PerspexPropertyTypeConverter.ConvertFrom(IValueContext context, CultureInfo culture, Object value)
   w OmniXaml.Typing.CommonValueConversion.ConverterStep.TryConvert(Object value, XamlType targetType, IValueContext valueContext, Object& result)
   w OmniXaml.Typing.CommonValueConversion.TryConvert(Object value, XamlType targetType, IValueContext valueContext, Object& result)
   w OmniXaml.ObjectAssembler.StateCommuter.AssignChildToParentProperty()
   w OmniXaml.ObjectAssembler.StateCommuter.AssociateCurrentInstanceToParent()
   w OmniXaml.ObjectAssembler.Commands.ValueCommand.Execute()
   w OmniXaml.ObjectAssembler.ObjectAssembler.Process(Instruction instruction)
   w OmniXaml.TemplateHostingObjectAssembler.Process(Instruction instruction)
   w Perspex.Markup.Xaml.Context.PerspexObjectAssembler.Process(Instruction node)
   w OmniXaml.XmlParser.Parse(IEnumerable`1 xamlNodes)
   w OmniXaml.XmlParser.Parse(IXmlReader stream)
   w OmniXaml.XmlLoader.Load(Stream stream, IParser parser)
  Source=Perspex.Markup.Xaml
  StackTrace:
       w OmniXaml.XmlLoader.Load(Stream stream, IParser parser)
       w Perspex.Markup.Xaml.PerspexXamlLoader.Load(Type type, Object rootInstance)
       w Perspex.Markup.Xaml.PerspexXamlLoader.Load(Object obj)
       w Core2D.Perspex.App.InitializeComponent() w C:\DOWNLOADS\GitHub-Core2D\Core2D\src\Core2D.Perspex\App.xaml.cs:wiersz 91
       w Core2D.Perspex.App..ctor() w C:\DOWNLOADS\GitHub-Core2D\Core2D\src\Core2D.Perspex\App.xaml.cs:wiersz 83
       w Core2D.Perspex.App.Main(String[] args) w C:\DOWNLOADS\GitHub-Core2D\Core2D\src\Core2D.Perspex\App.xaml.cs:wiersz 111
       w System.AppDomain._nExecuteAssembly(RuntimeAssembly assembly, String[] args)
       w System.AppDomain.ExecuteAssembly(String assemblyFile, Evidence assemblySecurity, String[] args)
       w Microsoft.VisualStudio.HostingProcess.HostProc.RunUsersAssembly()
       w System.Threading.ThreadHelper.ThreadStart_Context(Object state)
       w System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
       w System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
       w System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
       w System.Threading.ThreadHelper.ThreadStart()
  InnerException: 
       HResult=-2146233088
       Message=Could not find PerspexProperty 'Slider.TickFrequency'.
       Source=Perspex.Markup.Xaml
       StackTrace:
            w Perspex.Markup.Xaml.Converters.PerspexPropertyTypeConverter.ConvertFrom(IValueContext context, CultureInfo culture, Object value)
            w OmniXaml.Typing.CommonValueConversion.ConverterStep.TryConvert(Object value, XamlType targetType, IValueContext valueContext, Object& result)
            w OmniXaml.Typing.CommonValueConversion.TryConvert(Object value, XamlType targetType, IValueContext valueContext, Object& result)
            w OmniXaml.ObjectAssembler.StateCommuter.AssignChildToParentProperty()
            w OmniXaml.ObjectAssembler.StateCommuter.AssociateCurrentInstanceToParent()
            w OmniXaml.ObjectAssembler.Commands.ValueCommand.Execute()
            w OmniXaml.ObjectAssembler.ObjectAssembler.Process(Instruction instruction)
            w OmniXaml.TemplateHostingObjectAssembler.Process(Instruction instruction)
            w Perspex.Markup.Xaml.Context.PerspexObjectAssembler.Process(Instruction node)
            w OmniXaml.XmlParser.Parse(IEnumerable`1 xamlNodes)
            w OmniXaml.XmlParser.Parse(IXmlReader stream)
            w OmniXaml.XmlLoader.Load(Stream stream, IParser parser)
       InnerException: 
```
