### PR TITLE
Update to SharpDX 3.0.2 and cleanup references.

### DIFF
--- a/src/Perspex.Controls/Canvas.cs
+++ b/src/Perspex.Controls/Canvas.cs
@@ -21,25 +21,25 @@ namespace Perspex.Controls
         /// Defines the Left attached property.
         /// </summary>
         public static readonly AttachedProperty<double> LeftProperty =
-            PerspexProperty.RegisterAttached<StackPanel, Control, double>("Left");
+            PerspexProperty.RegisterAttached<Canvas, Control, double>("Left");
 
         /// <summary>
         /// Defines the Top attached property.
         /// </summary>
         public static readonly AttachedProperty<double> TopProperty =
-            PerspexProperty.RegisterAttached<StackPanel, Control, double>("Top");
+            PerspexProperty.RegisterAttached<Canvas, Control, double>("Top");
 
         /// <summary>
         /// Defines the Right attached property.
         /// </summary>
         public static readonly AttachedProperty<double> RightProperty =
-            PerspexProperty.RegisterAttached<StackPanel, Control, double>("Right");
+            PerspexProperty.RegisterAttached<Canvas, Control, double>("Right");
 
         /// <summary>
         /// Defines the Bottom attached property.
         /// </summary>
         public static readonly AttachedProperty<double> BottomProperty =
-            PerspexProperty.RegisterAttached<StackPanel, Control, double>("Bottom");
+            PerspexProperty.RegisterAttached<Canvas, Control, double>("Bottom");
 
         /// <summary>
         /// Initializes static members of the <see cref="Canvas"/> class.

--- a/src/Windows/Perspex.Direct2D1/Perspex.Direct2D1.csproj
+++ b/src/Windows/Perspex.Direct2D1/Perspex.Direct2D1.csproj
@@ -36,27 +36,19 @@
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="SharpDX, Version=3.0.1.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\SharpDX.3.0.1\lib\net45\SharpDX.dll</HintPath>
+    <Reference Include="SharpDX, Version=3.0.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\SharpDX.3.0.2\lib\net45\SharpDX.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SharpDX.Direct2D1, Version=3.0.1.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\SharpDX.Direct2D1.3.0.1\lib\net45\SharpDX.Direct2D1.dll</HintPath>
+    <Reference Include="SharpDX.Direct2D1">
+      <HintPath>..\..\..\packages\SharpDX.Direct2D1.3.0.2\lib\net45\SharpDX.Direct2D1.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SharpDX.DXGI, Version=3.0.1.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\SharpDX.DXGI.3.0.1\lib\net45\SharpDX.DXGI.dll</HintPath>
+    <Reference Include="SharpDX.DXGI, Version=3.0.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\SharpDX.DXGI.3.0.2\lib\net45\SharpDX.DXGI.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
     <Reference Include="System.Reactive.Core">
       <HintPath>..\..\..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
     </Reference>

--- a/src/Windows/Perspex.Direct2D1/packages.config
+++ b/src/Windows/Perspex.Direct2D1/packages.config
@@ -3,7 +3,7 @@
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
-  <package id="SharpDX" version="3.0.1" targetFramework="net45" />
-  <package id="SharpDX.Direct2D1" version="3.0.1" targetFramework="net45" />
-  <package id="SharpDX.DXGI" version="3.0.1" targetFramework="net45" />
+  <package id="SharpDX" version="3.0.2" targetFramework="net45" />
+  <package id="SharpDX.Direct2D1" version="3.0.2" targetFramework="net45" />
+  <package id="SharpDX.DXGI" version="3.0.2" targetFramework="net45" />
 </packages>

--- a/src/Windows/Perspex.Win32/Perspex.Win32.csproj
+++ b/src/Windows/Perspex.Win32/Perspex.Win32.csproj
@@ -39,15 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
     <Reference Include="System.Reactive.Core">
       <HintPath>..\..\..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
     </Reference>
@@ -60,6 +52,7 @@
     <Reference Include="System.Reactive.PlatformServices">
       <HintPath>..\..\..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
+    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\SharedAssemblyInfo.cs">


### PR DESCRIPTION
Update to SharpDX 3.0.2 and cleanup references for Win32 and Direct2D1.
