### PR TITLE
Changed default value returned by GetWindowDpi

### DIFF
--- a/src/Windows/Perspex.Direct2D1/RenderTarget.cs
+++ b/src/Windows/Perspex.Direct2D1/RenderTarget.cs
@@ -128,7 +128,7 @@ namespace Perspex.Direct2D1
                 }
             }
 
-            return new Size2F(1, 1);
+            return new Size2F(96, 96);
         }
 
         private Size2 GetWindowSize()


### PR DESCRIPTION
This fixes issue when `ShCoreAvailable` is not available the black window is displayed.

![win10_96dpi](https://cloud.githubusercontent.com/assets/2297442/14065580/289d65d2-f430-11e5-9ca7-89f872dd5d9b.PNG)

![win10_1dpi](https://cloud.githubusercontent.com/assets/2297442/14065579/289d4552-f430-11e5-9a0a-551c214d43bd.PNG)
