### PR TITLE
canvas attached properties arrange improvement

### DIFF
--- a/src/Perspex.Controls/Canvas.cs
+++ b/src/Perspex.Controls/Canvas.cs
@@ -226,7 +226,7 @@ namespace Perspex.Controls
         private static void AffectsCanvasArrangeInvalidate(PerspexPropertyChangedEventArgs e)
         {
             var control = e.Sender as IControl;
-            var canvas = control?.Parent as Canvas;
+            var canvas = control?.VisualParent as Canvas;
             canvas?.InvalidateArrange();
         }
     }


### PR DESCRIPTION
PR solves a problem with rearrange Canvas children in case the Canvas is not the logical parent. 
The sitation can happend in a Listbox with Canvas used as a PanelTemplate
