### PR TITLE
Fixed ToggleButton OnClick behavior

### DIFF
--- a/samples/BindingTest/MainWindow.xaml
+++ b/samples/BindingTest/MainWindow.xaml
@@ -71,9 +71,9 @@
     <TabItem Header="Commands">
       <StackPanel Margin="18" Gap="4" Width="200">
         <Button Content="Button" Command="{Binding StringValueCommand}" CommandParameter="Button"/>
-        <ToggleButton Content="ToggleButton" Command="{Binding StringValueCommand}" CommandParameter="ToggleButton"/>
-        <CheckBox Content="CheckBox" Command="{Binding StringValueCommand}" CommandParameter="CheckBox"/>
-        <RadioButton Content="RadionButton" Command="{Binding StringValueCommand}" CommandParameter="RadioButton"/>
+        <ToggleButton Content="ToggleButton" IsChecked="{Binding BooleanFlag, Mode=OneWay}" Command="{Binding StringValueCommand}" CommandParameter="ToggleButton"/>
+        <CheckBox Content="CheckBox" IsChecked="{Binding !BooleanFlag, Mode=OneWay}" Command="{Binding StringValueCommand}" CommandParameter="CheckBox"/>
+        <RadioButton Content="RadionButton" IsChecked="{Binding !!BooleanFlag, Mode=OneWay}" Command="{Binding StringValueCommand}" CommandParameter="RadioButton"/>
         <TextBox Text="{Binding Path=StringValue}"/>
       </StackPanel>
     </TabItem>

--- a/samples/BindingTest/ViewModels/MainWindowViewModel.cs
+++ b/samples/BindingTest/ViewModels/MainWindowViewModel.cs
@@ -11,6 +11,7 @@ namespace BindingTest.ViewModels
         private string _booleanString = "True";
         private double _doubleValue = 5.0;
         private string _stringValue = "Simple Binding";
+        private bool _booleanFlag = false;
 
         public MainWindowViewModel()
         {
@@ -31,7 +32,11 @@ namespace BindingTest.ViewModels
             });
 
             StringValueCommand = ReactiveCommand.Create();
-            StringValueCommand.Subscribe(param => StringValue = param.ToString());
+            StringValueCommand.Subscribe(param =>
+            {
+                BooleanFlag = !BooleanFlag;
+                StringValue = param.ToString();
+            });
         }
 
         public ObservableCollection<TestItem> Items { get; }
@@ -54,6 +59,12 @@ namespace BindingTest.ViewModels
         {
             get { return _stringValue; }
             set { this.RaiseAndSetIfChanged(ref _stringValue, value); }
+        }
+
+        public bool BooleanFlag
+        {
+            get { return _booleanFlag; }
+            set { this.RaiseAndSetIfChanged(ref _booleanFlag, value); }
         }
 
         public ReactiveCommand<object> StringValueCommand { get; }

--- a/src/Perspex.Controls/Primitives/ToggleButton.cs
+++ b/src/Perspex.Controls/Primitives/ToggleButton.cs
@@ -31,8 +31,8 @@ namespace Perspex.Controls.Primitives
 
         protected override void OnClick(RoutedEventArgs e)
         {
-            base.OnClick(e);
             Toggle();
+            base.OnClick(e);
         }
 
         protected virtual void Toggle()


### PR DESCRIPTION
``` XAML
<CheckBox IsChecked="{Binding IsFilled, Mode=OneWay}" Command="{Binding IsFilledCommand}"/>
```

When `IsFilledCommand` command is invoked after user click and the command changes value of `IsFilled` property than `IsChecked` behavior is incorrect. This PR fixes this issue.
