### PR TITLE
Update to latest SkiaSharp and fix some Perspex-Skia functionality that was waiting on this.

### DIFF
--- a/src/Skia/Perspex.Skia.Android/Perspex.Skia.Android.csproj
+++ b/src/Skia/Perspex.Skia.Android/Perspex.Skia.Android.csproj
@@ -40,7 +40,7 @@
     <Reference Include="Mono.Android" />
     <Reference Include="mscorlib" />
     <Reference Include="SkiaSharp, Version=1.49.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\SkiaSharp.1.49.2.0-beta\lib\MonoAndroid\SkiaSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\SkiaSharp.1.49.2.1-beta\lib\MonoAndroid\SkiaSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Skia/Perspex.Skia.Android/packages.config
+++ b/src/Skia/Perspex.Skia.Android/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SkiaSharp" version="1.49.2.0-beta" targetFramework="monoandroid60" />
+  <package id="SkiaSharp" version="1.49.2.1-beta" targetFramework="monoandroid50" />
 </packages>

--- a/src/Skia/Perspex.Skia.Desktop/Perspex.Skia.Desktop.csproj
+++ b/src/Skia/Perspex.Skia.Desktop/Perspex.Skia.Desktop.csproj
@@ -57,7 +57,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="SkiaSharp, Version=1.49.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\SkiaSharp.1.49.2.0-beta\lib\net45\SkiaSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\SkiaSharp.1.49.2.1-beta\lib\net45\SkiaSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -116,12 +116,12 @@
   <Import Project="..\Perspex.Skia\Perspex.Skia.projitems" Label="Shared" />
   <Import Project="..\..\Shared\RenderHelpers\RenderHelpers.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\..\packages\SkiaSharp.1.49.2.0-beta\build\net45\SkiaSharp.targets" Condition="Exists('..\..\..\packages\SkiaSharp.1.49.2.0-beta\build\net45\SkiaSharp.targets')" />
+  <Import Project="..\..\..\packages\SkiaSharp.1.49.2.1-beta\build\net45\SkiaSharp.targets" Condition="Exists('..\..\..\packages\SkiaSharp.1.49.2.1-beta\build\net45\SkiaSharp.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\SkiaSharp.1.49.2.0-beta\build\net45\SkiaSharp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\SkiaSharp.1.49.2.0-beta\build\net45\SkiaSharp.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\SkiaSharp.1.49.2.1-beta\build\net45\SkiaSharp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\SkiaSharp.1.49.2.1-beta\build\net45\SkiaSharp.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Skia/Perspex.Skia.Desktop/packages.config
+++ b/src/Skia/Perspex.Skia.Desktop/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SkiaSharp" version="1.49.2.0-beta" targetFramework="net45" />
+  <package id="SkiaSharp" version="1.49.2.1-beta" targetFramework="net45" />
 </packages>

--- a/src/Skia/Perspex.Skia.iOS/Perspex.Skia.iOS.csproj
+++ b/src/Skia/Perspex.Skia.iOS/Perspex.Skia.iOS.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="SkiaSharp, Version=1.49.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\SkiaSharp.1.49.2.0-beta\lib\XamariniOS\SkiaSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\SkiaSharp.1.49.2.1-beta\lib\XamariniOS\SkiaSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Skia/Perspex.Skia.iOS/packages.config
+++ b/src/Skia/Perspex.Skia.iOS/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SkiaSharp" version="1.49.2.0-beta" targetFramework="xamarinios10" />
+  <package id="SkiaSharp" version="1.49.2.1-beta" targetFramework="xamarinios10" />
 </packages>

--- a/src/Skia/Perspex.Skia/DrawingContextImpl.cs
+++ b/src/Skia/Perspex.Skia/DrawingContextImpl.cs
@@ -229,10 +229,7 @@ namespace Perspex.Skia
                 }
                 else
                 {
-                    // TODO: DrawRRect (ore DrawRoundedRect) is not accesible in SkiaSharp yet. We should add that
-                    // to SkiaSharp and initiate a PR....
-                    Canvas.DrawRect(rc, paint.Paint);
-                    //Canvas.DrawRoundedRect(rc, cornerRadius, cornerRadius, paint);
+                    Canvas.DrawRoundRect(rc, cornerRadius, cornerRadius, paint.Paint);
                 }
             }
         }
@@ -248,10 +245,7 @@ namespace Perspex.Skia
                 }
                 else
                 {
-                    // TODO: this does not exist in SkiaSharp yet
-                    //throw new NotImplementedException();
-                    //Canvas.DrawRoundedRect(rc, cornerRadius, cornerRadius, paint);
-                    Canvas.DrawRect(rc, paint.Paint);
+                    Canvas.DrawRoundRect(rc, cornerRadius, cornerRadius, paint.Paint);
                 }
             }
         }

--- a/src/Skia/Perspex.Skia/SkiaSharpExtensions.cs
+++ b/src/Skia/Perspex.Skia/SkiaSharpExtensions.cs
@@ -65,5 +65,10 @@ namespace Perspex.Skia
                 case TextAlignment.Right: return SKTextAlign.Right;
             }
         }
+
+        public static SKPath Clone(this SKPath src)
+        {
+            return src != null ? new SKPath(src) : null;
+        }
     }
 }

--- a/src/Skia/Perspex.Skia/StreamGeometryImpl.cs
+++ b/src/Skia/Perspex.Skia/StreamGeometryImpl.cs
@@ -50,28 +50,23 @@ namespace Perspex.Skia
                 _transformedPath.Dispose();
                 _transformedPath = null;
             }
-            
-            // TODO: SkiaSharp does not expose Transform yet!!!
-            //if (!Transform.IsIdentity)
-            //{
-            //	_transformedPath = new SKPath();
-            //	_path.Transform(Transform.ToSKMatrix(), _transformedPath);
-            //}
+
+            if (!Transform.IsIdentity)
+            {
+                _transformedPath = new SKPath(_path);
+                _transformedPath.Transform(Transform.ToSKMatrix());
+            }
         }
 
         public IStreamGeometryImpl Clone()
         {
-            // TODO: there is no SKPath.Clone yet!!!!!!!!!!!!!
-            //
-            //return new StreamGeometryImpl
-            //{
-            //	_path = _path?.Clone(),
-            //	_transformedPath = _transformedPath?.Clone(),
-            //	_transform = Transform,
-            //	Bounds = Bounds
-            //};
-
-            return this;        // this will probably end bad!!
+            return new StreamGeometryImpl
+            {
+                _path = _path?.Clone(),
+                _transformedPath = _transformedPath?.Clone(),
+                _transform = Transform,
+                Bounds = Bounds
+            };
         }
 
         public IStreamGeometryContextImpl Open()
@@ -94,15 +89,6 @@ namespace Perspex.Skia
 
             public void Dispose()
             {
-                // TODO: Not sure what we need to do here. This code left here for reference.
-                //
-                //	var arr = _elements.ToArray();
-                //             SkRect rc;
-                //             _path?.Dispose();
-                //             _path = new SKPath(new SkPath(MethodTable.Instance.CreatePath(arr, arr.Length, out rc)));
-                //             _geometryImpl.ApplyTransform();
-                //             _geometryImpl.Bounds = rc.ToRect();
-
                 SKRect rc;
                 _path.GetBounds(out rc);
                 _geometryImpl.ApplyTransform();

--- a/src/Skia/Perspex.Skia/readme.md
+++ b/src/Skia/Perspex.Skia/readme.md
@@ -17,12 +17,6 @@ RenderTarget
 - Figure out a cleaner implementation across all platforms
 - HW acceleration
 
-StreamGeometry
-- Paths within Paths may not work right
-- Paths cannot be Cloned (lack of SkiaSupport)
-- Paths cannot be transformed (lack of SkiaSupport)
-- ArcTo
-
 App Bootstrapping
 - Cleanup the testapplications across all platforms
 - Add a cleaner Fluent API for the subsystems

--- a/src/Skia/Perspex.Skia/readme.md
+++ b/src/Skia/Perspex.Skia/readme.md
@@ -5,7 +5,6 @@ BitmapImpl
 - Save
 
 DrawingContextImpl
-- DrawRoundRect is not properly implemented due to lack of support in SkiaSharp
 - Alpha support missing as SkiaSharp does not expose this
 - Gradient Shader caching?
 - TileBrushes


### PR DESCRIPTION
SKPath Clone/Transform can now be used and DrawRoundRect.
