### PR TITLE
Updated SkiaSharp nuget package version

### DIFF
--- a/nuget/template/Avalonia.Skia.Desktop.nuspec
+++ b/nuget/template/Avalonia.Skia.Desktop.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright 2015</copyright>
     <tags>Avalonia</tags>
     <dependencies>
-      <dependency id="SkiaSharp" version="1.49.2.0-beta"/>
+      <dependency id="SkiaSharp" version="1.49.2.1-beta"/>
       <dependency id="Avalonia" version="#VERSION#" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
Updated SkiaSharp nuget package version, current avalonia NuGet for Skia causes exception.

```
System.MissingMethodException was unhandled
  HResult=-2146233069
  Message=Nie odnaleziono metody: 'Void SkiaSharp.SKCanvas.DrawRoundRect(SkiaSharp.SKRect, Single, Single, SkiaSharp.SKPaint)'.
  Source=Avalonia.Skia.Desktop
  StackTrace:
       w Avalonia.Skia.DrawingContextImpl.FillRectangle(IBrush brush, Rect rect, Single cornerRadius)
       w Avalonia.Controls.Border.Render(DrawingContext context)
       w Avalonia.Rendering.RendererMixin.Render(DrawingContext context, IVisual visual, Rect clipRect)
       w Avalonia.Rendering.RendererMixin.Render(DrawingContext context, IVisual visual, Rect clipRect)
       w Avalonia.Rendering.RendererMixin.Render(IRenderTarget renderTarget, IVisual visual)
       w Avalonia.Controls.Platform.DefaultTopLevelRenderer.<>c__DisplayClass0_0.<Attach>b__2(Rect rect)
       w Avalonia.Win32.WindowImpl.WndProc(IntPtr hWnd, UInt32 msg, IntPtr wParam, IntPtr lParam)
  InnerException: 
```
