### PR TITLE
Add ContentTemplate and ItemTemplate

### DIFF
--- a/samples/XamlTestApplicationPcl/Views/MainWindow.xaml
+++ b/samples/XamlTestApplicationPcl/Views/MainWindow.xaml
@@ -143,14 +143,14 @@
       <TabItem Header="Lists">
         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
           <ListBox Items="{Binding Items}" SelectionMode="Multiple">
-            <ListBox.DataTemplates>
+            <ListBox.ItemTemplate>
               <DataTemplate DataType="vm:TestItem">
                 <StackPanel>
                   <TextBlock Text="{Binding Header}" FontSize="24" />
                   <TextBlock Text="{Binding SubHeader}" />
                 </StackPanel>
               </DataTemplate>
-            </ListBox.DataTemplates>
+            </ListBox.ItemTemplate>
           </ListBox>
           <DropDown VerticalAlignment="Center" SelectedIndex="0">
             <StackPanel>
@@ -168,14 +168,14 @@
                 <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
               </Style>
             </TreeView.Styles>
-            <TreeView.DataTemplates>
+            <TreeView.ItemTemplate>
               <TreeDataTemplate DataType="vm:TestNode" ItemsSource="{Binding Children}">
                 <StackPanel>
                   <TextBlock Text="{Binding Header}" FontSize="24" />
                   <TextBlock Text="{Binding SubHeader}" />
                 </StackPanel>
               </TreeDataTemplate>
-            </TreeView.DataTemplates>
+            </TreeView.ItemTemplate>
           </TreeView>
           <StackPanel Orientation="Vertical" Gap="4">
             <Button Command="{Binding CollapseNodesCommand}">Collapse Nodes</Button>

--- a/src/Avalonia.Controls/ContentControl.cs
+++ b/src/Avalonia.Controls/ContentControl.cs
@@ -22,6 +22,12 @@ namespace Avalonia.Controls
             AvaloniaProperty.Register<ContentControl, object>(nameof(Content));
 
         /// <summary>
+        /// Defines the <see cref="ContentTemplate"/> property.
+        /// </summary>
+        public static readonly StyledProperty<IDataTemplate> ContentTemplateProperty =
+            AvaloniaProperty.Register<ContentControl, IDataTemplate>(nameof(ContentTemplate));
+
+        /// <summary>
         /// Defines the <see cref="HorizontalContentAlignment"/> property.
         /// </summary>
         public static readonly StyledProperty<HorizontalAlignment> HorizontalContentAlignmentProperty =
@@ -49,6 +55,15 @@ namespace Avalonia.Controls
         {
             get { return GetValue(ContentProperty); }
             set { SetValue(ContentProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the data template used to display the content of the control.
+        /// </summary>
+        public IDataTemplate ContentTemplate
+        {
+            get { return GetValue(ContentTemplateProperty); }
+            set { SetValue(ContentTemplateProperty, value); }
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/DropDown.cs
+++ b/src/Avalonia.Controls/DropDown.cs
@@ -68,7 +68,10 @@ namespace Avalonia.Controls
         /// <inheritdoc/>
         protected override IItemContainerGenerator CreateItemContainerGenerator()
         {
-            return new ItemContainerGenerator<DropDownItem>(this, DropDownItem.ContentProperty);
+            return new ItemContainerGenerator<DropDownItem>(
+                this,
+                DropDownItem.ContentProperty,
+                DropDownItem.ContentTemplateProperty);
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/Generators/IItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/IItemContainerGenerator.cs
@@ -19,6 +19,11 @@ namespace Avalonia.Controls.Generators
         IEnumerable<ItemContainer> Containers { get; }
 
         /// <summary>
+        /// Gets or sets the data template used to display the items in the control.
+        /// </summary>
+        IDataTemplate ItemTemplate { get; set; }
+
+        /// <summary>
         /// Signalled whenever new containers are materialized.
         /// </summary>
         event EventHandler<ItemContainerEventArgs> Materialized;

--- a/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
@@ -38,6 +38,11 @@ namespace Avalonia.Controls.Generators
         public event EventHandler<ItemContainerEventArgs> Dematerialized;
 
         /// <summary>
+        /// Gets or sets the data template used to display the items in the control.
+        /// </summary>
+        public IDataTemplate ItemTemplate { get; set; }
+
+        /// <summary>
         /// Gets the owner control.
         /// </summary>
         public IControl Owner { get; }
@@ -156,7 +161,7 @@ namespace Avalonia.Controls.Generators
         /// <returns>The created container control.</returns>
         protected virtual IControl CreateContainer(object item)
         {
-            var result = Owner.MaterializeDataTemplate(item);
+            var result = Owner.MaterializeDataTemplate(item, ItemTemplate);
 
             if (result != null && !(item is IControl))
             {

--- a/src/Avalonia.Controls/Generators/ItemContainerGenerator`1.cs
+++ b/src/Avalonia.Controls/Generators/ItemContainerGenerator`1.cs
@@ -19,21 +19,29 @@ namespace Avalonia.Controls.Generators
         /// </summary>
         /// <param name="owner">The owner control.</param>
         /// <param name="contentProperty">The container's Content property.</param>
+        /// <param name="contentTemplateProperty">The container's ContentTemplate property.</param>
         public ItemContainerGenerator(
             IControl owner, 
-            AvaloniaProperty contentProperty)
+            AvaloniaProperty contentProperty,
+            AvaloniaProperty contentTemplateProperty)
             : base(owner)
         {
             Contract.Requires<ArgumentNullException>(owner != null);
             Contract.Requires<ArgumentNullException>(contentProperty != null);
 
             ContentProperty = contentProperty;
+            ContentTemplateProperty = contentTemplateProperty;
         }
 
         /// <summary>
         /// Gets the container's Content property.
         /// </summary>
         protected AvaloniaProperty ContentProperty { get; }
+
+        /// <summary>
+        /// Gets the container's ContentTemplate property.
+        /// </summary>
+        protected AvaloniaProperty ContentTemplateProperty { get; }
 
         /// <inheritdoc/>
         protected override IControl CreateContainer(object item)
@@ -51,6 +59,12 @@ namespace Avalonia.Controls.Generators
             else
             {
                 var result = new T();
+
+                if (ContentTemplateProperty != null)
+                {
+                    result.SetValue(ContentTemplateProperty, ItemTemplate);
+                }
+
                 result.SetValue(ContentProperty, item);
 
                 if (!(item is IControl))

--- a/src/Avalonia.Controls/Generators/TreeItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/TreeItemContainerGenerator.cs
@@ -20,16 +20,18 @@ namespace Avalonia.Controls.Generators
         /// </summary>
         /// <param name="owner">The owner control.</param>
         /// <param name="contentProperty">The container's Content property.</param>
+        /// <param name="contentTemplateProperty">The container's ContentTemplate property.</param>
         /// <param name="itemsProperty">The container's Items property.</param>
         /// <param name="isExpandedProperty">The container's IsExpanded property.</param>
         /// <param name="index">The container index for the tree</param>
         public TreeItemContainerGenerator(
             IControl owner,
             AvaloniaProperty contentProperty,
+            AvaloniaProperty contentTemplateProperty,
             AvaloniaProperty itemsProperty,
             AvaloniaProperty isExpandedProperty,
             TreeContainerIndex index)
-            : base(owner, contentProperty)
+            : base(owner, contentProperty, contentTemplateProperty)
         {
             Contract.Requires<ArgumentNullException>(owner != null);
             Contract.Requires<ArgumentNullException>(contentProperty != null);

--- a/src/Avalonia.Controls/Generators/TreeItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/TreeItemContainerGenerator.cs
@@ -75,7 +75,7 @@ namespace Avalonia.Controls.Generators
             }
             else
             {
-                var template = GetTreeDataTemplate(item);
+                var template = GetTreeDataTemplate(item, ItemTemplate);
                 var result = new T();
 
                 result.SetValue(ContentProperty, template.Build(item));
@@ -123,9 +123,9 @@ namespace Avalonia.Controls.Generators
         /// </summary>
         /// <param name="item">The item.</param>
         /// <returns>The template.</returns>
-        private ITreeDataTemplate GetTreeDataTemplate(object item)
+        private ITreeDataTemplate GetTreeDataTemplate(object item, IDataTemplate primary)
         {
-            var template = Owner.FindDataTemplate(item) ?? FuncDataTemplate.Default;
+            var template = Owner.FindDataTemplate(item, primary) ?? FuncDataTemplate.Default;
             var treeTemplate = template as ITreeDataTemplate ??
                 new FuncTreeDataTemplate(typeof(object), template.Build, x => null);
             return treeTemplate;

--- a/src/Avalonia.Controls/IContentControl.cs
+++ b/src/Avalonia.Controls/IContentControl.cs
@@ -1,6 +1,7 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using Avalonia.Controls.Templates;
 using Avalonia.Layout;
 
 namespace Avalonia.Controls
@@ -15,6 +16,11 @@ namespace Avalonia.Controls
         /// Gets or sets the content to display.
         /// </summary>
         object Content { get; set; }
+
+        /// <summary>
+        /// Gets or sets the data template used to display the content of the control.
+        /// </summary>
+        IDataTemplate ContentTemplate { get; set; }
 
         /// <summary>
         /// Gets or sets the horizontal alignment of the content within the control.

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -42,6 +42,12 @@ namespace Avalonia.Controls
             AvaloniaProperty.Register<ItemsControl, ITemplate<IPanel>>(nameof(ItemsPanel), DefaultPanel);
 
         /// <summary>
+        /// Defines the <see cref="ItemTemplate"/> property.
+        /// </summary>
+        public static readonly StyledProperty<IDataTemplate> ItemTemplateProperty =
+            AvaloniaProperty.Register<ItemsControl, IDataTemplate>(nameof(ItemTemplate));
+
+        /// <summary>
         /// Defines the <see cref="MemberSelector"/> property.
         /// </summary>
         public static readonly StyledProperty<IMemberSelector> MemberSelectorProperty =
@@ -65,6 +71,7 @@ namespace Avalonia.Controls
         {
             PseudoClasses.Add(":empty");
             SubscribeToItems(_items);
+            ItemTemplateProperty.Changed.AddClassHandler<ItemsControl>(x => x.ItemTemplateChanged);
         }
 
         /// <summary>
@@ -80,6 +87,7 @@ namespace Avalonia.Controls
 
                     if (_itemContainerGenerator != null)
                     {
+                        _itemContainerGenerator.ItemTemplate = ItemTemplate;
                         _itemContainerGenerator.Materialized += (_, e) => OnContainersMaterialized(e);
                         _itemContainerGenerator.Dematerialized += (_, e) => OnContainersDematerialized(e);
                     }
@@ -106,6 +114,15 @@ namespace Avalonia.Controls
         {
             get { return GetValue(ItemsPanelProperty); }
             set { SetValue(ItemsPanelProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the data template used to display the items in the control.
+        /// </summary>
+        public IDataTemplate ItemTemplate
+        {
+            get { return GetValue(ItemTemplateProperty); }
+            set { SetValue(ItemTemplateProperty, value); }
         }
 
         /// <summary>
@@ -354,7 +371,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Subscribes to an <see cref="Items"/> collection.
         /// </summary>
-        /// <param name="items"></param>
+        /// <param name="items">The items collection.</param>
         private void SubscribeToItems(IEnumerable items)
         {
             PseudoClasses.Set(":empty", items == null || items.Count() == 0);
@@ -364,6 +381,19 @@ namespace Avalonia.Controls
             if (incc != null)
             {
                 incc.CollectionChanged += ItemsCollectionChanged;
+            }
+        }
+
+        /// <summary>
+        /// Called when the <see cref="ItemTemplate"/> changes.
+        /// </summary>
+        /// <param name="e">The event args.</param>
+        private void ItemTemplateChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            if (_itemContainerGenerator != null)
+            {
+                _itemContainerGenerator.ItemTemplate = (IDataTemplate)e.NewValue;
+                // TODO: Rebuild the item containers.
             }
         }
     }

--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -41,7 +41,10 @@ namespace Avalonia.Controls
         /// <inheritdoc/>
         protected override IItemContainerGenerator CreateItemContainerGenerator()
         {
-            return new ItemContainerGenerator<ListBoxItem>(this, ListBoxItem.ContentProperty);
+            return new ItemContainerGenerator<ListBoxItem>(
+                this, 
+                ListBoxItem.ContentProperty,
+                ListBoxItem.ContentTemplateProperty);
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -49,6 +49,12 @@ namespace Avalonia.Controls.Presenters
             ContentControl.ContentProperty.AddOwner<ContentPresenter>();
 
         /// <summary>
+        /// Defines the <see cref="ContentTemplate"/> property.
+        /// </summary>
+        public static readonly StyledProperty<IDataTemplate> ContentTemplateProperty =
+            ContentControl.ContentTemplateProperty.AddOwner<ContentPresenter>();
+
+        /// <summary>
         /// Defines the <see cref="CornerRadius"/> property.
         /// </summary>
         public static readonly StyledProperty<float> CornerRadiusProperty =
@@ -141,6 +147,15 @@ namespace Avalonia.Controls.Presenters
         }
 
         /// <summary>
+        /// Gets or sets the data template used to display the content of the control.
+        /// </summary>
+        public IDataTemplate ContentTemplate
+        {
+            get { return GetValue(ContentTemplateProperty); }
+            set { SetValue(ContentTemplateProperty, value); }
+        }
+
+        /// <summary>
         /// Gets or sets the radius of the border rounded corners.
         /// </summary>
         public float CornerRadius
@@ -200,7 +215,7 @@ namespace Avalonia.Controls.Presenters
         {
             var old = Child;
             var content = Content;
-            var result = this.MaterializeDataTemplate(content);
+            var result = this.MaterializeDataTemplate(content, ContentTemplate);
 
             if (old != null)
             {

--- a/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
@@ -28,6 +28,12 @@ namespace Avalonia.Controls.Presenters
             ItemsControl.ItemsPanelProperty.AddOwner<ItemsPresenterBase>();
 
         /// <summary>
+        /// Defines the <see cref="ItemTemplate"/> property.
+        /// </summary>
+        public static readonly StyledProperty<IDataTemplate> ItemTemplateProperty =
+            ItemsControl.ItemTemplateProperty.AddOwner<ItemsPresenterBase>();
+
+        /// <summary>
         /// Defines the <see cref="MemberSelector"/> property.
         /// </summary>
         public static readonly StyledProperty<IMemberSelector> MemberSelectorProperty =
@@ -120,6 +126,15 @@ namespace Avalonia.Controls.Presenters
         {
             get { return GetValue(ItemsPanelProperty); }
             set { SetValue(ItemsPanelProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the data template used to display the items in the control.
+        /// </summary>
+        public IDataTemplate ItemTemplate
+        {
+            get { return GetValue(ItemTemplateProperty); }
+            set { SetValue(ItemTemplateProperty, value); }
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/TabStrip.cs
+++ b/src/Avalonia.Controls/Primitives/TabStrip.cs
@@ -20,7 +20,10 @@ namespace Avalonia.Controls.Primitives
 
         protected override IItemContainerGenerator CreateItemContainerGenerator()
         {
-            return new ItemContainerGenerator<TabStripItem>(this, ContentControl.ContentProperty);
+            return new ItemContainerGenerator<TabStripItem>(
+                this,
+                ContentControl.ContentProperty,
+                ContentControl.ContentTemplateProperty);
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/Templates/DataTemplateExtensions.cs
+++ b/src/Avalonia.Controls/Templates/DataTemplateExtensions.cs
@@ -16,8 +16,15 @@ namespace Avalonia.Controls.Templates
         /// </summary>
         /// <param name="control">The control materializing the data template.</param>
         /// <param name="data">The data.</param>
+        /// <param name="primary">
+        /// An optional primary template that can will be tried before the
+        /// <see cref="IControl.DataTemplates"/> in the tree are searched.
+        /// </param>
         /// <returns>The data materialized as a control.</returns>
-        public static IControl MaterializeDataTemplate(this IControl control, object data)
+        public static IControl MaterializeDataTemplate(
+            this IControl control,
+            object data,
+            IDataTemplate primary = null)
         {
             if (data == null)
             {
@@ -33,7 +40,7 @@ namespace Avalonia.Controls.Templates
                 }
                 else
                 {
-                    IDataTemplate template = control.FindDataTemplate(data);
+                    IDataTemplate template = control.FindDataTemplate(data, primary);
                     IControl result;
 
                     if (template != null)
@@ -57,9 +64,21 @@ namespace Avalonia.Controls.Templates
         /// </summary>
         /// <param name="control">The control searching for the data template.</param>
         /// <param name="data">The data.</param>
+        /// <param name="primary">
+        /// An optional primary template that can will be tried before the
+        /// <see cref="IControl.DataTemplates"/> in the tree are searched.
+        /// </param>
         /// <returns>The data template or null if no matching data template was found.</returns>
-        public static IDataTemplate FindDataTemplate(this IControl control, object data)
+        public static IDataTemplate FindDataTemplate(
+            this IControl control,
+            object data,
+            IDataTemplate primary = null)
         {
+            if (primary?.Match(data) == true)
+            {
+                return primary;
+            }
+
             foreach (var i in control.GetSelfAndLogicalAncestors().OfType<IControl>())
             {
                 foreach (IDataTemplate dt in i.DataTemplates)

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -96,6 +96,7 @@ namespace Avalonia.Controls
             var result = new TreeItemContainerGenerator<TreeViewItem>(
                 this,
                 TreeViewItem.HeaderProperty,
+                null,
                 TreeViewItem.ItemsProperty,
                 TreeViewItem.IsExpandedProperty,
                 new TreeContainerIndex());

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -96,7 +96,7 @@ namespace Avalonia.Controls
             var result = new TreeItemContainerGenerator<TreeViewItem>(
                 this,
                 TreeViewItem.HeaderProperty,
-                null,
+                TreeViewItem.ItemTemplateProperty,
                 TreeViewItem.ItemsProperty,
                 TreeViewItem.IsExpandedProperty,
                 new TreeContainerIndex());

--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -80,7 +80,7 @@ namespace Avalonia.Controls
             return new TreeItemContainerGenerator<TreeViewItem>(
                 this,
                 TreeViewItem.HeaderProperty,
-                null,
+                TreeViewItem.ItemTemplateProperty,
                 TreeViewItem.ItemsProperty,
                 TreeViewItem.IsExpandedProperty,
                 _treeView?.ItemContainerGenerator.Index ?? new TreeContainerIndex());
@@ -91,6 +91,11 @@ namespace Avalonia.Controls
         {
             base.OnAttachedToLogicalTree(e);
             _treeView = this.GetLogicalAncestors().OfType<TreeView>().FirstOrDefault();
+
+            if (ItemTemplate == null && _treeView?.ItemTemplate != null)
+            {
+                ItemTemplate = _treeView.ItemTemplate;
+            }
         }
 
         protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)

--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -80,6 +80,7 @@ namespace Avalonia.Controls
             return new TreeItemContainerGenerator<TreeViewItem>(
                 this,
                 TreeViewItem.HeaderProperty,
+                null,
                 TreeViewItem.ItemsProperty,
                 TreeViewItem.IsExpandedProperty,
                 _treeView?.ItemContainerGenerator.Index ?? new TreeContainerIndex());

--- a/src/Avalonia.Themes.Default/Button.xaml
+++ b/src/Avalonia.Themes.Default/Button.xaml
@@ -14,6 +14,7 @@
                           BorderBrush="{TemplateBinding BorderBrush}"
                           BorderThickness="{TemplateBinding BorderThickness}"
                           Content="{TemplateBinding Content}"
+                          ContentTemplate="{TemplateBinding ContentTemplate}"
                           Padding="{TemplateBinding Padding}"
                           TextBlock.Foreground="{TemplateBinding Foreground}"
                           HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/src/Avalonia.Themes.Default/CheckBox.xaml
+++ b/src/Avalonia.Themes.Default/CheckBox.xaml
@@ -22,6 +22,7 @@
           </Border>
           <ContentPresenter Name="PART_ContentPresenter"
                             Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
                             Margin="4,0,0,0"
                             VerticalAlignment="Center"
                             Grid.Column="1"/>

--- a/src/Avalonia.Themes.Default/ContentControl.xaml
+++ b/src/Avalonia.Themes.Default/ContentControl.xaml
@@ -5,7 +5,8 @@
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
-                        Content="{TemplateBinding Content}" 
+                        Content="{TemplateBinding Content}"
+                        ContentTemplate="{TemplateBinding ContentTemplate}"
                         Padding="{TemplateBinding Padding}"/>
     </ControlTemplate>
   </Setter>

--- a/src/Avalonia.Themes.Default/ContextMenu.xaml
+++ b/src/Avalonia.Themes.Default/ContextMenu.xaml
@@ -13,6 +13,7 @@
         <ItemsPresenter Name="PART_ItemsPresenter"
                         Items="{TemplateBinding Items}"
                         ItemsPanel="{TemplateBinding ItemsPanel}"
+                        ItemTemplate="{TemplateBinding ItemTemplate}"
                         KeyboardNavigation.TabNavigation="Continue"/>
       </Border>
     </ControlTemplate>

--- a/src/Avalonia.Themes.Default/DropDown.xaml
+++ b/src/Avalonia.Themes.Default/DropDown.xaml
@@ -38,6 +38,7 @@
                       BorderThickness="1">
                 <ItemsPresenter Name="PART_ItemsPresenter"
                                 Items="{TemplateBinding Items}" 
+                                ItemTemplate="{TemplateBinding ItemTemplate}"
                                 MemberSelector="{TemplateBinding MemberSelector}"/>
               </Border>
             </Popup>

--- a/src/Avalonia.Themes.Default/DropDown.xaml
+++ b/src/Avalonia.Themes.Default/DropDown.xaml
@@ -11,6 +11,7 @@
                 BorderThickness="{TemplateBinding BorderThickness}">
           <Grid ColumnDefinitions="*,Auto">
             <ContentPresenter Content="{TemplateBinding SelectionBoxItem}"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
                               Margin="{TemplateBinding Padding}"
                               HorizontalAlignment="Center"
                               VerticalAlignment="Center"/>

--- a/src/Avalonia.Themes.Default/DropDownItem.xaml
+++ b/src/Avalonia.Themes.Default/DropDownItem.xaml
@@ -10,6 +10,7 @@
                           BorderBrush="{TemplateBinding BorderBrush}"
                           BorderThickness="{TemplateBinding BorderThickness}"
                           Content="{TemplateBinding Content}"
+                          ContentTemplate="{TemplateBinding ContentTemplate}"
                           HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                           VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                           Padding="{TemplateBinding Padding}"/>

--- a/src/Avalonia.Themes.Default/Expander.xaml
+++ b/src/Avalonia.Themes.Default/Expander.xaml
@@ -17,6 +17,7 @@
                               Grid.Row="1"
                               IsVisible="{TemplateBinding IsExpanded}"
                               Content="{TemplateBinding Content}"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
                               HorizontalAlignment="Stretch"
                               VerticalAlignment="Stretch" />
           </Grid>
@@ -34,6 +35,7 @@
                               Grid.Row="0"
                               IsVisible="{TemplateBinding IsExpanded}"
                               Content="{TemplateBinding Content}"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
                               HorizontalAlignment="Stretch"
                               VerticalAlignment="Stretch" />
           </Grid>
@@ -51,6 +53,7 @@
                               Grid.Column="1"
                               IsVisible="{TemplateBinding IsExpanded}"
                               Content="{TemplateBinding Content}"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
                               HorizontalAlignment="Stretch"
                               VerticalAlignment="Stretch" />
           </Grid>
@@ -68,6 +71,7 @@
                               Grid.Column="0"
                               IsVisible="{TemplateBinding IsExpanded}"
                               Content="{TemplateBinding Content}"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
                               HorizontalAlignment="Stretch"
                               VerticalAlignment="Stretch" />
           </Grid>

--- a/src/Avalonia.Themes.Default/ItemsControl.xaml
+++ b/src/Avalonia.Themes.Default/ItemsControl.xaml
@@ -4,6 +4,7 @@
       <ItemsPresenter Name="PART_ItemsPresenter"
                       Items="{TemplateBinding Items}"
                       ItemsPanel="{TemplateBinding ItemsPanel}"
+                      ItemTemplate="{TemplateBinding ItemTemplate}"
                       MemberSelector="{TemplateBinding MemberSelector}"/>
     </ControlTemplate>
   </Setter>

--- a/src/Avalonia.Themes.Default/LayoutTransformControl.xaml
+++ b/src/Avalonia.Themes.Default/LayoutTransformControl.xaml
@@ -6,6 +6,7 @@
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         Content="{TemplateBinding Content}" 
+                        ContentTemplate="{TemplateBinding ContentTemplate}"
                         Padding="{TemplateBinding Padding}"/>
     </ControlTemplate>
   </Setter>

--- a/src/Avalonia.Themes.Default/ListBox.xaml
+++ b/src/Avalonia.Themes.Default/ListBox.xaml
@@ -11,6 +11,7 @@
           <ItemsPresenter Name="PART_ItemsPresenter"
                           Items="{TemplateBinding Items}"
                           ItemsPanel="{TemplateBinding ItemsPanel}"
+                          ItemTemplate="{TemplateBinding ItemTemplate}"
                           Margin="{TemplateBinding Padding}"
                           MemberSelector="{TemplateBinding MemberSelector}"/>
         </ScrollViewer>

--- a/src/Avalonia.Themes.Default/ListBoxItem.xaml
+++ b/src/Avalonia.Themes.Default/ListBoxItem.xaml
@@ -7,6 +7,7 @@
                           BorderBrush="{TemplateBinding BorderBrush}"
                           BorderThickness="{TemplateBinding BorderThickness}"
                           Content="{TemplateBinding Content}"
+                          ContentTemplate="{TemplateBinding ContentTemplate}"
                           Padding="{TemplateBinding Padding}"/>
       </ControlTemplate>
     </Setter>

--- a/src/Avalonia.Themes.Default/Menu.xaml
+++ b/src/Avalonia.Themes.Default/Menu.xaml
@@ -8,6 +8,7 @@
         <ItemsPresenter Name="PART_ItemsPresenter" 
                         Items="{TemplateBinding Items}" 
                         ItemsPanel="{TemplateBinding ItemsPanel}"
+                        ItemTemplate="{TemplateBinding ItemTemplate}"
                         KeyboardNavigation.TabNavigation="Continue"/>
       </Border>
     </ControlTemplate>

--- a/src/Avalonia.Themes.Default/MenuItem.xaml
+++ b/src/Avalonia.Themes.Default/MenuItem.xaml
@@ -53,6 +53,7 @@
                     <ItemsPresenter Name="PART_ItemsPresenter"
                                     Items="{TemplateBinding Items}"
                                     ItemsPanel="{TemplateBinding ItemsPanel}"
+                                    ItemTemplate="{TemplateBinding ItemTemplate}"
                                     Margin="2"
                                     MemberSelector="{TemplateBinding MemberSelector}"/>
                     <Rectangle Name="iconSeparator"
@@ -99,6 +100,7 @@
                     <ItemsPresenter Name="PART_ItemsPresenter"
                                     Items="{TemplateBinding Items}"
                                     ItemsPanel="{TemplateBinding ItemsPanel}"
+                                    ItemTemplate="{TemplateBinding ItemTemplate}"
                                     Margin="2"
                                     MemberSelector="{TemplateBinding MemberSelector}"/>
                     <Rectangle Name="iconSeparator"

--- a/src/Avalonia.Themes.Default/MenuItem.xaml
+++ b/src/Avalonia.Themes.Default/MenuItem.xaml
@@ -13,6 +13,7 @@
           <Grid ColumnDefinitions="22,13,*,20">
             <ContentPresenter Name="icon"
                               Content="{TemplateBinding Icon}"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
                               Width="16"
                               Height="16"
                               Margin="3"
@@ -26,6 +27,7 @@
                   VerticalAlignment="Center"/>
             <ContentPresenter Name="PART_HeaderPresenter"
                               Content="{TemplateBinding Header}"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
                               Margin="{TemplateBinding Padding}"
                               VerticalAlignment="Center"
                               Grid.Column="2">
@@ -82,6 +84,7 @@
           <Panel>
             <ContentPresenter Name="PART_HeaderPresenter"
                               Content="{TemplateBinding Header}"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
                               Margin="{TemplateBinding Padding}">
               <ContentPresenter.DataTemplates>
                 <DataTemplate DataType="sys:String">

--- a/src/Avalonia.Themes.Default/PopupRoot.xaml
+++ b/src/Avalonia.Themes.Default/PopupRoot.xaml
@@ -5,6 +5,7 @@
       <ContentPresenter Name="PART_ContentPresenter"
                         Background="{TemplateBinding Background}"
                         Content="{TemplateBinding Content}" 
+                        ContentTemplate="{TemplateBinding ContentTemplate}"
                         Padding="{TemplateBinding Padding}"/>
     </ControlTemplate>
   </Setter>

--- a/src/Avalonia.Themes.Default/RadioButton.xaml
+++ b/src/Avalonia.Themes.Default/RadioButton.xaml
@@ -21,6 +21,7 @@
                    VerticalAlignment="Center"/>
           <ContentPresenter Name="PART_ContentPresenter"
                             Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
                             Margin="4,0,0,0"
                             VerticalAlignment="Center"
                             Grid.Column="1"/>

--- a/src/Avalonia.Themes.Default/TabStrip.xaml
+++ b/src/Avalonia.Themes.Default/TabStrip.xaml
@@ -5,7 +5,8 @@
         <ItemsPresenter Name="PART_ItemsPresenter"
                         MemberSelector="{TemplateBinding MemberSelector}"
                         Items="{TemplateBinding Items}"
-                        ItemsPanel="{TemplateBinding ItemsPanel}"/>
+                        ItemsPanel="{TemplateBinding ItemsPanel}"
+                        ItemTemplate="{TemplateBinding ItemTemplate}"/>
       </ControlTemplate>
     </Setter>
     <Setter Property="ItemsPanel">

--- a/src/Avalonia.Themes.Default/TabStripItem.xaml
+++ b/src/Avalonia.Themes.Default/TabStripItem.xaml
@@ -9,6 +9,7 @@
                           BorderBrush="{TemplateBinding BorderBrush}"
                           BorderThickness="{TemplateBinding BorderThickness}"
                           Content="{TemplateBinding Content}"
+                          ContentTemplate="{TemplateBinding ContentTemplate}"
                           Padding="{TemplateBinding Padding}"/>
       </ControlTemplate>
     </Setter>

--- a/src/Avalonia.Themes.Default/ToggleButton.xaml
+++ b/src/Avalonia.Themes.Default/ToggleButton.xaml
@@ -14,6 +14,7 @@
                           BorderBrush="{TemplateBinding BorderBrush}"
                           BorderThickness="{TemplateBinding BorderThickness}"
                           Content="{TemplateBinding Content}"
+                          ContentTemplate="{TemplateBinding ContentTemplate}"
                           Padding="{TemplateBinding Padding}"
                           TextBlock.Foreground="{TemplateBinding Foreground}"
                           HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/src/Avalonia.Themes.Default/ToolTip.xaml
+++ b/src/Avalonia.Themes.Default/ToolTip.xaml
@@ -10,6 +10,7 @@
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         Content="{TemplateBinding Content}" 
+                        ContentTemplate="{TemplateBinding ContentTemplate}"
                         Padding="{TemplateBinding Padding}"/>
     </ControlTemplate>
   </Setter>

--- a/src/Avalonia.Themes.Default/Window.xaml
+++ b/src/Avalonia.Themes.Default/Window.xaml
@@ -6,7 +6,10 @@
     <ControlTemplate>
       <Border Background="{TemplateBinding Background}">
         <AdornerDecorator>
-          <ContentPresenter Name="PART_ContentPresenter" Content="{TemplateBinding Content}" Margin="{TemplateBinding Padding}"/>
+          <ContentPresenter Name="PART_ContentPresenter" 
+                            Content="{TemplateBinding Content}" 
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            Margin="{TemplateBinding Padding}"/>
         </AdornerDecorator>
       </Border>
     </ControlTemplate>

--- a/tests/Avalonia.Controls.UnitTests/ContentControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ContentControlTests.cs
@@ -117,6 +117,24 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Should_Use_ContentTemplate_To_Create_Control()
+        {
+            var target = new ContentControl
+            {
+                Template = GetTemplate(),
+                ContentTemplate = new FuncDataTemplate<string>(_ => new Canvas()),
+            };
+
+            target.Content = "Foo";
+            target.ApplyTemplate();
+            ((ContentPresenter)target.Presenter).UpdateChild();
+
+            var child = target.Presenter.Child;
+
+            Assert.IsType<Canvas>(child);
+        }
+
+        [Fact]
         public void DataTemplate_Created_Control_Should_Be_Logical_Child_After_ApplyTemplate()
         {
             var target = new ContentControl
@@ -266,6 +284,7 @@ namespace Avalonia.Controls.UnitTests
                     {
                         Name = "PART_ContentPresenter",
                         [~ContentPresenter.ContentProperty] = parent[~ContentControl.ContentProperty],
+                        [~ContentPresenter.ContentTemplateProperty] = parent[~ContentControl.ContentTemplateProperty],
                     }
                 };
             });

--- a/tests/Avalonia.Controls.UnitTests/Generators/ItemContainerGeneratorTypedTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Generators/ItemContainerGeneratorTypedTests.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Controls.UnitTests.Generators
         {
             var items = new[] { "foo", "bar", "baz" };
             var owner = new Decorator();
-            var target = new ItemContainerGenerator<ListBoxItem>(owner, ListBoxItem.ContentProperty);
+            var target = new ItemContainerGenerator<ListBoxItem>(owner, ListBoxItem.ContentProperty, null);
             var containers = target.Materialize(0, items, null);
             var result = containers
                 .Select(x => x.ContainerControl)

--- a/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
@@ -15,6 +15,22 @@ namespace Avalonia.Controls.UnitTests
     public class ItemsControlTests
     {
         [Fact]
+        public void Should_Use_ItemTemplate_To_Create_Control()
+        {
+            var target = new ItemsControl
+            {
+                Template = GetTemplate(),
+                ItemTemplate = new FuncDataTemplate<string>(_ => new Canvas()),
+            };
+
+            target.Items = new[] { "Foo" };
+            target.ApplyTemplate();
+            target.Presenter.ApplyTemplate();
+
+            Assert.IsType<Canvas>(target.Presenter.Panel.Children[0]);
+        }
+
+        [Fact]
         public void Panel_Should_Have_TemplatedParent_Set_To_ItemsControl()
         {
             var target = new ItemsControl();

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
@@ -15,6 +15,27 @@ namespace Avalonia.Controls.UnitTests
     public class ListBoxTests
     {
         [Fact]
+        public void Should_Use_ItemTemplate_To_Create_Item_Content()
+        {
+            var target = new ListBox
+            {
+                Template = new FuncControlTemplate(CreateListBoxTemplate),
+                ItemTemplate = new FuncDataTemplate<string>(_ => new Canvas()),
+            };
+
+            target.Items = new[] { "Foo" };
+            target.ApplyTemplate();
+            target.Presenter.ApplyTemplate();
+
+            var container = (ListBoxItem)target.Presenter.Panel.Children[0];
+            container.Template = ListBoxItemTemplate();
+            container.ApplyTemplate();
+            ((ContentPresenter)container.Presenter).UpdateChild();
+
+            Assert.IsType<Canvas>(container.Presenter.Child);
+        }
+
+        [Fact]
         public void ListBox_Should_Find_ItemsPresenter_In_ScrollViewer()
         {
             var target = new ListBox
@@ -123,6 +144,7 @@ namespace Avalonia.Controls.UnitTests
             {
                 Name = "PART_ContentPresenter",
                 [!ContentPresenter.ContentProperty] = parent[!ListBoxItem.ContentProperty],
+                [!ContentPresenter.ContentTemplateProperty] = parent[!ListBoxItem.ContentTemplateProperty],
             });
         }
 

--- a/tests/Avalonia.Controls.UnitTests/Presenters/CarouselPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/CarouselPresenterTests.cs
@@ -201,7 +201,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
         {
             protected override IItemContainerGenerator CreateItemContainerGenerator()
             {
-                return new ItemContainerGenerator<TestItem>(this, TestItem.ContentProperty);
+                return new ItemContainerGenerator<TestItem>(this, TestItem.ContentProperty, null);
             }
         }
     }

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests.cs
@@ -54,7 +54,8 @@ namespace Avalonia.Controls.UnitTests.Presenters
 
             target.ItemContainerGenerator = new ItemContainerGenerator<ListBoxItem>(
                 target, 
-                ListBoxItem.ContentProperty);
+                ListBoxItem.ContentProperty,
+                null);
             target.ApplyTemplate();
 
             Assert.Equal(2, target.Panel.Children.Count);
@@ -332,7 +333,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
         {
             protected override IItemContainerGenerator CreateItemContainerGenerator()
             {
-                return new ItemContainerGenerator<TestItem>(this, TestItem.ContentProperty);
+                return new ItemContainerGenerator<TestItem>(this, TestItem.ContentProperty, null);
             }
         }
     }


### PR DESCRIPTION
In response to issue #524 the idea was to have `ContentControl.ContentTemplate` and `ItemsControl.ItemTemplate` as in WPF etc and only allow templates without a `DataType` in these properties, not in a `Control.DataTemplates` collection.

However this proved unfeasable as the XAML adds the `DataTemplate` to the `DataTemplates` collection before any properties have been set, meaning that all DataTemplates fail. If we were to use Portable.Xaml or OmniXaml adds support for immutable types. that might be an option.

Another option might be to throw when trying to materialize a data template if one is found in a `DataTemplates` collection without a `DataType`.

In the meantime this PR just adds the ContentTemplate and ItemTemplate properties.
