### PR TITLE
Fixes memory leak in hit testing

### DIFF
--- a/src/Avalonia.Input/InputExtensions.cs
+++ b/src/Avalonia.Input/InputExtensions.cs
@@ -25,7 +25,6 @@ namespace Avalonia.Input
         {
             Contract.Requires<ArgumentNullException>(element != null);
             var transformedBounds = BoundsTracker.GetTransformedBounds((Visual)element);
-            var geometry = transformedBounds.GetTransformedBoundsGeometry();
 
             if (element.IsVisible &&
                 element.IsHitTestVisible &&
@@ -42,7 +41,7 @@ namespace Avalonia.Input
                     }
                 }
 
-                if (geometry.FillContains(p))
+                if (transformedBounds.Contains(p))
                 {
                     yield return element;
                 }
@@ -71,7 +70,6 @@ namespace Avalonia.Input
                 })
                 .OrderBy(x => x, null)
                 .Select(x => x.Element);
-                
         }
 
         private class ZOrderElement : IComparable<ZOrderElement>

--- a/src/Avalonia.SceneGraph/Rect.cs
+++ b/src/Avalonia.SceneGraph/Rect.cs
@@ -230,8 +230,8 @@ namespace Avalonia
         /// <returns>true if the point is in the bounds of the rectangle; otherwise false.</returns>
         public bool Contains(Point p)
         {
-            return p.X >= _x && p.X < _x + _width &&
-                   p.Y >= _y && p.Y < _y + _height;
+            return p.X >= _x && p.X <= _x + _width &&
+                   p.Y >= _y && p.Y <= _y + _height;
         }
 
         /// <summary>

--- a/src/Avalonia.SceneGraph/VisualTree/TransformedBounds.cs
+++ b/src/Avalonia.SceneGraph/VisualTree/TransformedBounds.cs
@@ -38,20 +38,18 @@ namespace Avalonia.VisualTree
         /// </summary>
         public Matrix Transform { get; }
 
-        public Geometry GetTransformedBoundsGeometry()
+        public bool Contains(Point point)
         {
-            StreamGeometry geometry = new StreamGeometry();
-            using (var context = geometry.Open())
+            if (Transform.HasInverse)
             {
-                context.SetFillRule(FillRule.EvenOdd);
-                context.BeginFigure(Bounds.TopLeft * Transform, true);
-                context.LineTo(Bounds.TopRight * Transform);
-                context.LineTo(Bounds.BottomRight * Transform);
-                context.LineTo(Bounds.BottomLeft * Transform);
-                context.LineTo(Bounds.TopLeft * Transform);
-                context.EndFigure(true);
+                Point trPoint = point * Transform.Invert();
+
+                return Bounds.Contains(trPoint);
             }
-            return geometry;
+            else
+            {
+                return Bounds.Contains(point);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes memory leak in hit testing
simplifies hit testing not to use geometry, but simple transforms
@grokys @jkoritzinsky it should also improve the performance of hit testing as geometry is not used
