### PR TITLE
Contentpresenter bug

### DIFF
--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -277,6 +277,11 @@ namespace Avalonia.Controls.Presenters
 
                 Child = newChild;
 
+                if (oldChild?.LogicalParent == this)
+                {
+                    ((ISetLogicalParent)oldChild).SetParent(null);
+                }
+
                 if (newChild.Parent == null)
                 {
                     ((ISetLogicalParent)newChild).SetParent((ILogical)this.TemplatedParent ?? this);

--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -279,12 +279,21 @@ namespace Avalonia.Controls.Presenters
 
                 if (oldChild?.LogicalParent == this)
                 {
-                    ((ISetLogicalParent)oldChild).SetParent(null);
+                    LogicalChildren.Remove(oldChild);
                 }
 
                 if (newChild.Parent == null)
                 {
-                    ((ISetLogicalParent)newChild).SetParent((ILogical)this.TemplatedParent ?? this);
+                    var templatedLogicalParent = TemplatedParent as ILogical;
+
+                    if (templatedLogicalParent != null)
+                    {
+                        ((ISetLogicalParent)newChild).SetParent(templatedLogicalParent);
+                    }
+                    else
+                    {
+                        LogicalChildren.Add(newChild);
+                    }
                 }
 
                 VisualChildren.Add(newChild);


### PR DESCRIPTION
probably related to #539 
Actually ContentPresenter if not used in ContentControl was not detaching it's child from logical tree.
