### PR TITLE
Fixes #596

### DIFF
--- a/src/Avalonia.Styling/Styling/Setter.cs
+++ b/src/Avalonia.Styling/Styling/Setter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reactive.Disposables;
 using System.Reactive.Subjects;
+using System.Reflection;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Metadata;
@@ -98,8 +99,10 @@ namespace Avalonia.Styling
             if (binding == null)
             {
                 var template = value as ITemplate;
+                bool isPropertyOfTypeITemplate = typeof(ITemplate).GetTypeInfo()
+                    .IsAssignableFrom(Property.PropertyType.GetTypeInfo());
 
-                if (template != null)
+                if (template != null && !isPropertyOfTypeITemplate)
                 {
                     var materialized = template.Build();
                     NameScope.SetNameScope((Visual)materialized, new NameScope());

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
@@ -254,5 +254,36 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
                 Assert.Equal("Hello World!", ((TextBlock)target.Content).Text);
             }
         }
+
+        [Fact]
+        public void Setter_Value_Is_Bound_Directly_If_The_Target_Type_Derives_From_ITemplate()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <Window.Styles>
+        <Style Selector=':is(Control)'>
+		  <Setter Property='FocusAdorner'>
+			<FocusAdornerTemplate>
+			  <Rectangle Stroke='Black'
+						 StrokeThickness='1'
+						 StrokeDashArray='1,2'/>
+			</FocusAdornerTemplate>
+		  </Setter>
+		</Style>
+	</Window.Styles>
+
+    <TextBlock Name='target'/>    
+</Window>";
+
+                var loader = new AvaloniaXamlLoader();
+                var window = (Window)loader.Load(xaml);
+                var target = window.Find<TextBlock>("target");
+
+                Assert.NotNull(target.FocusAdorner);
+            }
+        }
     }
 }


### PR DESCRIPTION
In `Setter.Apply(...)` method if the value is a template, its `Build()` method is called and the resulting control is used for the binding. This prevents binding if the target property derives from `ITemplate`.
