### PR TITLE
Switch TravisCI to use mono latest instead of nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono:
-  - nightly
+  - latest
 solution: Avalonia.mono.sln
 before_install:
   - mkdir -p .nuget


### PR DESCRIPTION
This is related to this issue https://github.com/travis-ci/travis-ci/issues/6319, which is causing CI to fail installing mono runtime.
