### PR TITLE
Deafult ItemsPresenter virtualization to None

### DIFF
--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -42,7 +42,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="VirtualizationMode"/> property.
         /// </summary>
-        public static readonly AvaloniaProperty<ItemVirtualizationMode> VirtualizationModeProperty =
+        public static readonly StyledProperty<ItemVirtualizationMode> VirtualizationModeProperty =
             ItemsPresenter.VirtualizationModeProperty.AddOwner<ListBox>();
 
         private IScrollable _scroll;
@@ -53,6 +53,7 @@ namespace Avalonia.Controls
         static ListBox()
         {
             ItemsPanelProperty.OverrideDefaultValue<ListBox>(DefaultPanel);
+            VirtualizationModeProperty.OverrideDefaultValue<ListBox>(ItemVirtualizationMode.Simple);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
@@ -20,7 +20,7 @@ namespace Avalonia.Controls.Presenters
         public static readonly StyledProperty<ItemVirtualizationMode> VirtualizationModeProperty =
             AvaloniaProperty.Register<ItemsPresenter, ItemVirtualizationMode>(
                 nameof(VirtualizationMode),
-                defaultValue: ItemVirtualizationMode.Simple);
+                defaultValue: ItemVirtualizationMode.None);
 
         private ItemVirtualizer _virtualizer;
 

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
@@ -164,6 +164,7 @@ namespace Avalonia.Controls.UnitTests
                         Name = "PART_ItemsPresenter",
                         [~ItemsPresenter.ItemsProperty] = parent.GetObservable(ItemsControl.ItemsProperty).AsBinding(),
                         [~ItemsPresenter.ItemsPanelProperty] = parent.GetObservable(ItemsControl.ItemsPanelProperty).AsBinding(),
+                        [~ItemsPresenter.VirtualizationModeProperty] = parent.GetObservable(ListBox.VirtualizationModeProperty).AsBinding(),
                     }
                 });
         }


### PR DESCRIPTION
And override it in ListBox. This prevents ItemsPresenter thinking it's virtualized in a TreeView. Fixes #610.
