### PR TITLE
Listbox failing unit tests for issues  #637

### DIFF
--- a/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
@@ -86,13 +86,14 @@ namespace Avalonia.Controls.Generators
         {
             if (count > 0)
             {
-                var toMove = _containers.Where(x => x.Key >= index).ToList();
+                var toMove = _containers.Where(x => x.Key >= index)
+                                .OrderByDescending(x => x.Key).ToList();
 
                 foreach (var i in toMove)
                 {
                     _containers.Remove(i.Key);
                     i.Value.Index += count;
-                    _containers[i.Value.Index] = i.Value;
+                    _containers.Add(i.Value.Index, i.Value);
                 }
             }
         }
@@ -116,7 +117,8 @@ namespace Avalonia.Controls.Generators
                     _containers.Remove(i);
                 }
 
-                var toMove = _containers.Where(x => x.Key >= startingIndex).ToList();
+                var toMove = _containers.Where(x => x.Key >= startingIndex)
+                                        .OrderBy(x => x.Key).ToList();
 
                 foreach (var i in toMove)
                 {

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
@@ -187,6 +187,38 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(items.Count, target.Presenter.Panel.Children.Count);
         }
 
+        [Fact]
+        public void ListBox_Virt_None_Should_Sync_Items_When_Inserted_AtSameIndex_Or_Removed()
+        {
+            var items = new AvaloniaList<string>(Enumerable.Range(0, 5).Select(x => $"Item {x}"));
+            var toAdd = Enumerable.Range(0, 3).Select(x => $"Added Item {x}").ToArray();
+            var target = new ListBox
+            {
+                Template = ListBoxTemplate(),
+                VirtualizationMode = ItemVirtualizationMode.None,
+                Items = items,
+                ItemTemplate = new FuncDataTemplate<string>(x => new TextBlock { Height = 10 }),
+                SelectedIndex = 0,
+            };
+
+            Prepare(target);
+
+            Assert.Equal(items.Count, target.Presenter.Panel.Children.Count);
+
+            foreach (var item in toAdd)
+            {
+                items.Insert(1, item);
+            }
+
+            Assert.Equal(items.Count, target.Presenter.Panel.Children.Count);
+
+            foreach (var item in toAdd)
+            {
+                items.Remove(item);
+            }
+
+            Assert.Equal(items.Count, target.Presenter.Panel.Children.Count);
+        }
         private FuncControlTemplate ListBoxTemplate()
         {
             return new FuncControlTemplate<ListBox>(parent => 

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
@@ -10,6 +10,7 @@ using Avalonia.Styling;
 using Avalonia.UnitTests;
 using Avalonia.VisualTree;
 using Xunit;
+using Avalonia.Collections;
 
 namespace Avalonia.Controls.UnitTests
 {
@@ -150,6 +151,40 @@ namespace Avalonia.Controls.UnitTests
 
             // Make sure recycled item isn't now selected.
             Assert.False(((ListBoxItem)target.Presenter.Panel.Children[0]).IsSelected);
+        }
+
+        [Fact]
+        public void ListBox_Virt_None_Should_Sync_Items_When_Inserted_Or_Removed()
+        {
+            var items = new AvaloniaList<string>(Enumerable.Range(0, 5).Select(x => $"Item {x}"));
+            var toAdd = Enumerable.Range(0, 3).Select(x => $"Added Item {x}").ToArray();
+            var target = new ListBox
+            {
+                Template = ListBoxTemplate(),
+                VirtualizationMode = ItemVirtualizationMode.None,
+                Items = items,
+                ItemTemplate = new FuncDataTemplate<string>(x => new TextBlock { Height = 10 }),
+                SelectedIndex = 0,
+            };
+
+            Prepare(target);
+
+            Assert.Equal(items.Count, target.Presenter.Panel.Children.Count);
+
+            int addIndex = 1;
+            foreach(var item in toAdd)
+            {
+                items.Insert(addIndex++, item);
+            }
+
+            Assert.Equal(items.Count, target.Presenter.Panel.Children.Count);
+
+            foreach (var item in toAdd)
+            {
+                items.Remove(item);
+            }
+
+            Assert.Equal(items.Count, target.Presenter.Panel.Children.Count);
         }
 
         private FuncControlTemplate ListBoxTemplate()


### PR DESCRIPTION
Probably not syncing properly items of list box (with virtualization none) with the bound collectionis is the first cause for the strange behavior of issues #636, #635
