### PR TITLE
VirtualizingStackPanel reports Full when there are no Children

### DIFF
--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -24,9 +24,10 @@ namespace Avalonia.Controls
         {
             get
             {
-                return Orientation == Orientation.Horizontal ?
+                return Children.Count > 0 &&
+                    (Orientation == Orientation.Horizontal ?
                     _takenSpace >= _availableSpace.Width :
-                    _takenSpace >= _availableSpace.Height;
+                    _takenSpace >= _availableSpace.Height);
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
@@ -165,6 +165,19 @@ namespace Avalonia.Controls.UnitTests
 
                 scrollable.Verify(x => x.GetControlInDirection(NavigationDirection.Next, from));
             }
+
+            [Fact]
+            public void Reports_IsFull_False_When_Children_Empty()
+            {
+                var target = (IVirtualizingPanel)new VirtualizingStackPanel();
+
+                target.Measure(new Size(100, 0));
+
+                Assert.Equal(new Size(0, 0), target.DesiredSize);
+                Assert.Equal(new Size(0, 0), target.Bounds.Size);
+
+                Assert.False(target.IsFull);
+            }
         }
     }
 }


### PR DESCRIPTION
VirtualizingStackPanel reports Full when there are no Children. This was causing issues when some invisible listboxes had items add/remove. Now  the items are generated properly after this commit
https://github.com/AvaloniaUI/Avalonia/commit/1ca2e80991cf1a97b4816e8acc9696055bad140c 
