### PR TITLE
Fix multiple figure cairo path

### DIFF
--- a/src/Gtk/Avalonia.Cairo/Media/StreamGeometryContextImpl.cs
+++ b/src/Gtk/Avalonia.Cairo/Media/StreamGeometryContextImpl.cs
@@ -91,9 +91,6 @@ namespace Avalonia.Cairo.Media
 			{
 				if (isClosed)
 					_context.ClosePath ();
-
-				Path = _context.CopyPath ();
-				Bounds = _context.FillExtents ().ToAvalonia ();
 			}
         }
 
@@ -105,7 +102,13 @@ namespace Avalonia.Cairo.Media
 
         public void Dispose()
         {
-			_context.Dispose ();
+            if (this.Path == null)
+            {
+                Path = _context.CopyPath();
+                Bounds = _context.FillExtents().ToAvalonia();
+            }
+
+            _context.Dispose ();
 			_surf.Dispose ();
         }
     }


### PR DESCRIPTION
``` XAML
<Path Fill="Orange" Data="M0,0L90,0L90,60L0,60z M15,15L15,45L30,45L30,15z" Canvas.Left="30" Canvas.Top="250"/>
```

This path would render incorrectly when using Cairo. This is multi-figure path, previously it was only possible to create one figure paths.
