### PR TITLE
Recreate render target when SharpDX throws an exception

### DIFF
--- a/src/Avalonia.Controls/Platform/ITopLevelRenderer.cs
+++ b/src/Avalonia.Controls/Platform/ITopLevelRenderer.cs
@@ -38,7 +38,17 @@ namespace Avalonia.Controls.Platform
 
             topLevel.PlatformImpl.Paint = rect =>
             {
-                viewport.Render(topLevel);
+                try
+                {
+                    viewport.Render(topLevel);
+                }
+                catch (RenderTargetCorruptedException ex)
+                {
+                    Logging.Logger.Error("Renderer", this, "Render target was corrupted. Exception: {0}", ex);
+                    viewport.Dispose();
+                    viewport = PlatformManager.CreateRenderTarget(topLevel.PlatformImpl);
+                    topLevel.PlatformImpl.Paint(rect); // Retry painting
+                }
                 queueManager.RenderFinished();
             };
 

--- a/src/Avalonia.Controls/Platform/ITopLevelRenderer.cs
+++ b/src/Avalonia.Controls/Platform/ITopLevelRenderer.cs
@@ -46,7 +46,9 @@ namespace Avalonia.Controls.Platform
                 {
                     Logging.Logger.Error("Renderer", this, "Render target was corrupted. Exception: {0}", ex);
                     viewport.Dispose();
+                    resources.Remove(viewport);
                     viewport = PlatformManager.CreateRenderTarget(topLevel.PlatformImpl);
+                    resources.Add(viewport);
                     topLevel.PlatformImpl.Paint(rect); // Retry painting
                 }
                 queueManager.RenderFinished();

--- a/src/Avalonia.SceneGraph/Avalonia.SceneGraph.csproj
+++ b/src/Avalonia.SceneGraph/Avalonia.SceneGraph.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Media\FormattedText.cs" />
     <Compile Include="Media\Geometry.cs" />
     <Compile Include="Media\IDrawingContext.cs" />
+    <Compile Include="RenderTargetCorruptedException.cs" />
     <Compile Include="VisualTree\IVisual.cs" />
     <Compile Include="Media\Imaging\Bitmap.cs" />
     <Compile Include="Media\Imaging\IBitmap.cs" />

--- a/src/Avalonia.SceneGraph/RenderTargetCorruptedException.cs
+++ b/src/Avalonia.SceneGraph/RenderTargetCorruptedException.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Avalonia
+{
+    public class RenderTargetCorruptedException : Exception
+    {
+        public RenderTargetCorruptedException()
+        {
+        }
+
+        public RenderTargetCorruptedException(string message)
+            : base(message)
+        {
+        }
+
+        public RenderTargetCorruptedException(Exception innerException)
+            : base(null, innerException)
+        {
+        }
+
+        public RenderTargetCorruptedException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
+++ b/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
@@ -26,8 +26,12 @@ namespace Avalonia.Direct2D1
     {
         private static readonly Direct2D1Platform s_instance = new Direct2D1Platform();
 
-        private static readonly SharpDX.Direct2D1.Factory s_d2D1Factory = new SharpDX.Direct2D1.Factory();
-
+        private static readonly SharpDX.Direct2D1.Factory s_d2D1Factory =
+#if DEBUG
+            new SharpDX.Direct2D1.Factory(SharpDX.Direct2D1.FactoryType.SingleThreaded, SharpDX.Direct2D1.DebugLevel.Error);
+#else
+            new SharpDX.Direct2D1.Factory(SharpDX.Direct2D1.FactoryType.SingleThreaded, SharpDX.Direct2D1.DebugLevel.None);
+#endif
         private static readonly SharpDX.DirectWrite.Factory s_dwfactory = new SharpDX.DirectWrite.Factory();
 
         private static readonly SharpDX.WIC.ImagingFactory s_imagingFactory = new SharpDX.WIC.ImagingFactory();

--- a/src/Windows/Avalonia.Direct2D1/Media/DrawingContext.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/DrawingContext.cs
@@ -57,7 +57,14 @@ namespace Avalonia.Direct2D1.Media
         {
             foreach (var layer in _layerPool)
                 layer.Dispose();
-            _renderTarget.EndDraw();
+            try
+            {
+                _renderTarget.EndDraw();
+            }
+            catch (SharpDXException ex) when((uint)ex.HResult == 0x8899000C) // D2DERR_RECREATE_TARGET
+            {
+                throw new RenderTargetCorruptedException(ex);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #521 
