### PR TITLE
Fixed dark background in Expander Header #502

### DIFF
--- a/src/Avalonia.Themes.Default/Expander.xaml
+++ b/src/Avalonia.Themes.Default/Expander.xaml
@@ -90,7 +90,11 @@
                       VerticalAlignment="Center"
                       Data="M 0 2 L 4 6 L 0 10 Z" />
             </Border>
-            <ContentPresenter Grid.Column="1" Content="{TemplateBinding Content}" VerticalAlignment="Center" />
+            <ContentPresenter Name="PART_ContentPresenter"
+                              Grid.Column="1" 
+                              Background="Transparent" 
+                              Content="{TemplateBinding Content}" 
+                              VerticalAlignment="Center" />
           </Grid>
         </Border>
       </ControlTemplate>


### PR DESCRIPTION
Fixes #502

![controlcatalog desktop vshost_2016-08-06_19-34-56](https://cloud.githubusercontent.com/assets/2297442/17458279/e477e428-5c0c-11e6-99a4-5d943bc9fcbb.png)
