### PR TITLE
 Fixed crash when redo is called on a TextBox with no redoable change #666

### DIFF
--- a/src/Avalonia.Controls/Utils/UndoRedoHelper.cs
+++ b/src/Avalonia.Controls/Utils/UndoRedoHelper.cs
@@ -68,7 +68,7 @@ namespace Avalonia.Controls.Utils
 
         public void Redo()
         {            
-			if (_currentNode != null) {
+			if (_currentNode?.Next != null) {
 				_currentNode = _currentNode.Next;
 			}
 


### PR DESCRIPTION
Same issue for redo.
