### PR TITLE
Use GDK to scale images instead of cairo

### DIFF
--- a/src/Gtk/Avalonia.Cairo/Media/DrawingContext.cs
+++ b/src/Gtk/Avalonia.Cairo/Media/DrawingContext.cs
@@ -77,40 +77,25 @@ namespace Avalonia.Cairo.Media
         /// <param name="destRect">The rect in the output to draw to.</param>
         public void DrawImage(IBitmap bitmap, double opacity, Rect sourceRect, Rect destRect)
         {
-            var impl = bitmap.PlatformImpl as BitmapImpl;
-            var size = new Size(impl.PixelWidth, impl.PixelHeight);
-            var scale = new Vector(destRect.Width / sourceRect.Width, destRect.Height / sourceRect.Height);
+			var impl = bitmap.PlatformImpl as BitmapImpl;
+			var size = new Size(impl.PixelWidth, impl.PixelHeight);
+			var scale = new Vector(destRect.Width / sourceRect.Width, destRect.Height / sourceRect.Height);
 
-            _context.Save();
-            _context.Scale(scale.X, scale.Y);
-            destRect /= scale;
+			_context.Save();
 
-			if (opacityOverride < 1.0f) {
-				_context.PushGroup ();
-				Gdk.CairoHelper.SetSourcePixbuf (
-					_context, 
-					impl, 
-					-sourceRect.X + destRect.X, 
-					-sourceRect.Y + destRect.Y);
+			Gdk.CairoHelper.SetSourcePixbuf (
+				_context, 
+				impl, 
+				-sourceRect.X + destRect.X, 
+				-sourceRect.Y + destRect.Y);
+			impl.Scale (impl, 0, 0, (int)destRect.Width, (int)destRect.Height, 0, 0, scale.X, scale.Y, Gdk.InterpType.Bilinear);
 
-				_context.Rectangle (destRect.ToCairo ());
-				_context.Fill ();
-				_context.PopGroupToSource ();
-				_context.PaintWithAlpha (opacityOverride);
-			} else {
-				_context.PushGroup ();
-				Gdk.CairoHelper.SetSourcePixbuf (
-					_context, 
-					impl, 
-					-sourceRect.X + destRect.X, 
-					-sourceRect.Y + destRect.Y);
-
-                _context.Rectangle (destRect.ToCairo ());
-                _context.Fill ();
-                _context.PopGroupToSource ();
-                _context.PaintWithAlpha (opacityOverride);			
-            }
-            _context.Restore();
+			_context.PushGroup ();
+			_context.Rectangle (destRect.ToCairo ());
+			_context.Fill ();
+			_context.PopGroupToSource ();
+			_context.PaintWithAlpha (opacityOverride);		
+			_context.Restore();
         }
 
         /// <summary>

--- a/src/Gtk/Avalonia.Cairo/Media/DrawingContext.cs
+++ b/src/Gtk/Avalonia.Cairo/Media/DrawingContext.cs
@@ -88,7 +88,7 @@ namespace Avalonia.Cairo.Media
 				impl, 
 				-sourceRect.X + destRect.X, 
 				-sourceRect.Y + destRect.Y);
-			impl.Scale (impl, 0, 0, (int)destRect.Width, (int)destRect.Height, 0, 0, scale.X, scale.Y, Gdk.InterpType.Bilinear);
+			impl.Scale (impl, (int)destRect.X, (int)destRect.Y, (int)destRect.Width, (int)destRect.Height, 0, 0, scale.X, scale.Y, Gdk.InterpType.Bilinear);
 
 			_context.PushGroup ();
 			_context.Rectangle (destRect.ToCairo ());


### PR DESCRIPTION
This helps the case where an image is scaled down in Cairo. Currently it looks pretty bad. Switching to GDK we can take advantage of filtering options to give something comparable to Direct2D.

Before: 
![before](https://cloud.githubusercontent.com/assets/17953668/17464151/82a2366a-5ca5-11e6-833e-0413f10ee9b3.png)
After: 
![after](https://cloud.githubusercontent.com/assets/17953668/17464152/840d7e7e-5ca5-11e6-8baa-f6532b99d070.png)
