### PR TITLE
Added missing SkiaSharp dependency for Avalonia.Android NuGet package

### DIFF
--- a/nuget/template/Avalonia.Android.nuspec
+++ b/nuget/template/Avalonia.Android.nuspec
@@ -21,6 +21,7 @@
       <dependency id="System.Reactive.Interfaces" version="3.0.0" />
       <dependency id="System.Reactive.Linq" version="3.0.0" />
       <dependency id="System.Reactive.PlatformServices" version="3.0.0" />
+      <dependency id="SkiaSharp" version="1.53.0"/>
       <dependency id="Avalonia" version="#VERSION#" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
The `Avalonia.Android` is missing SkiaSharp NuGet package dependency. Currently you have to install it manually otherwise you get build error.
