### PR TITLE
[WIP]: Fix binding to TabControl.Items.

### DIFF
--- a/samples/ControlCatalog/ControlCatalog.csproj
+++ b/samples/ControlCatalog/ControlCatalog.csproj
@@ -223,6 +223,15 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Splat.1.6.2\lib\Portable-net45+win+wpa81+wp80\Splat.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/samples/ControlCatalog/ControlCatalog.csproj
+++ b/samples/ControlCatalog/ControlCatalog.csproj
@@ -127,6 +127,9 @@
     <Compile Include="Pages\SliderPage.xaml.cs">
       <DependentUpon>SliderPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Pages\TabControlPage.xaml.cs">
+      <DependentUpon>TabControlPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Pages\TreeViewPage.xaml.cs">
       <DependentUpon>TreeViewPage.xaml</DependentUpon>
     </Compile>
@@ -212,6 +215,11 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Pages\TreeViewPage.xaml">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Pages\TabControlPage.xaml">
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>

--- a/samples/ControlCatalog/MainWindow.xaml
+++ b/samples/ControlCatalog/MainWindow.xaml
@@ -19,6 +19,7 @@
     <TabItem Header="Menu"><pages:MenuPage/></TabItem>
     <TabItem Header="RadioButton"><pages:RadioButtonPage/></TabItem>
     <TabItem Header="Slider"><pages:SliderPage/></TabItem>
+    <TabItem Header="TabControl"><pages:TabControlPage/></TabItem>
     <TabItem Header="TextBox"><pages:TextBoxPage/></TabItem>
     <TabItem Header="ToolTip"><pages:ToolTipPage/></TabItem>
     <TabItem Header="TreeView"><pages:TreeViewPage/></TabItem>

--- a/samples/ControlCatalog/Pages/TabControlPage.xaml
+++ b/samples/ControlCatalog/Pages/TabControlPage.xaml
@@ -1,0 +1,29 @@
+<UserControl xmlns="https://github.com/avaloniaui">
+  <StackPanel Orientation="Vertical" Gap="4">
+    <TextBlock Classes="h1">TabControl</TextBlock>
+    <TextBlock Classes="h2">A tab control that displays a tab strip along with the content of the selected tab</TextBlock>
+
+    <StackPanel Orientation="Horizontal"
+              Margin="0,16,0,0"
+              HorizontalAlignment="Center"
+              Gap="16">
+      <TabControl>
+        <TabItem Header="Arch" Padding="8">
+          <StackPanel Orientation="Vertical" Gap="8">
+            <TextBlock>This is the first page in the TabControl.</TextBlock>
+            <Image Source="resm:ControlCatalog.Assets.delicate-arch-896885_640.jpg"/>
+          </StackPanel>
+        </TabItem>
+        <TabItem Header="Leaf" Padding="8">
+          <StackPanel Orientation="Vertical" Gap="8">
+            <TextBlock>This is the second page in the TabControl.</TextBlock>
+            <Image Source="resm:ControlCatalog.Assets.maple-leaf-888807_640.jpg"/>
+          </StackPanel>
+        </TabItem>
+        <TabItem Header="Disabled" IsEnabled="False">
+          <TextBlock>You should not see this.</TextBlock>
+        </TabItem>
+      </TabControl>
+    </StackPanel>
+  </StackPanel>
+</UserControl>

--- a/samples/ControlCatalog/Pages/TabControlPage.xaml
+++ b/samples/ControlCatalog/Pages/TabControlPage.xaml
@@ -47,6 +47,11 @@
               </StackPanel>
             </DataTemplate>
           </TabControl.ContentTemplate>
+          <TabControl.Styles>
+            <Style Selector="TabItem">
+              <Setter Property="IsEnabled" Value="{Binding IsEnabled}"/>
+            </Style>
+          </TabControl.Styles>
         </TabControl>
       </StackPanel>
 

--- a/samples/ControlCatalog/Pages/TabControlPage.xaml
+++ b/samples/ControlCatalog/Pages/TabControlPage.xaml
@@ -4,14 +4,14 @@
     <TextBlock Classes="h2">A tab control that displays a tab strip along with the content of the selected tab</TextBlock>
 
     <StackPanel Orientation="Horizontal"
-              Margin="0,16,0,0"
-              HorizontalAlignment="Center"
-              Gap="8">
+                Margin="0,16,0,0"
+                HorizontalAlignment="Center"
+                Gap="8">
 
       <StackPanel>
         <TextBlock Classes="h1">From Inline TabItems</TextBlock>
 
-        <TabControl Margin="0 16">
+        <TabControl Margin="0 16" TabStripPlacement="{Binding TabPlacement}">
           <TabItem Header="Arch" Padding="8">
             <StackPanel Orientation="Vertical" Gap="8">
               <TextBlock>This is the first page in the TabControl.</TextBlock>
@@ -33,7 +33,7 @@
       <StackPanel>
         <TextBlock Classes="h1">From DataTemplate</TextBlock>
 
-        <TabControl Items="{Binding}" Margin="0 16">
+        <TabControl Items="{Binding Tabs}" Margin="0 16" TabStripPlacement="{Binding TabPlacement}">
           <TabControl.ItemTemplate>
             <DataTemplate>
               <TextBlock Text="{Binding Header}"/>
@@ -55,6 +55,16 @@
         </TabControl>
       </StackPanel>
 
+    </StackPanel>
+
+    <StackPanel Orientation="Horizontal" Gap="8" HorizontalAlignment="Center">
+      <TextBlock VerticalAlignment="Center">Tab Placement:</TextBlock>
+      <DropDown SelectedIndex="{Binding TabPlacement, Mode=TwoWay}">
+        <DropDownItem>Left</DropDownItem>
+        <DropDownItem>Top</DropDownItem>
+        <DropDownItem>Right</DropDownItem>
+        <DropDownItem>Bottom</DropDownItem>
+      </DropDown>
     </StackPanel>
   </StackPanel>
 </UserControl>

--- a/samples/ControlCatalog/Pages/TabControlPage.xaml
+++ b/samples/ControlCatalog/Pages/TabControlPage.xaml
@@ -3,10 +3,11 @@
     <TextBlock Classes="h1">TabControl</TextBlock>
     <TextBlock Classes="h2">A tab control that displays a tab strip along with the content of the selected tab</TextBlock>
 
-    <StackPanel Orientation="Horizontal"
+    <StackPanel Orientation="Vertical"
               Margin="0,16,0,0"
               HorizontalAlignment="Center"
               Gap="16">
+      
       <TabControl>
         <TabItem Header="Arch" Padding="8">
           <StackPanel Orientation="Vertical" Gap="8">
@@ -24,6 +25,15 @@
           <TextBlock>You should not see this.</TextBlock>
         </TabItem>
       </TabControl>
+
+      <TabControl Items="{Binding}">
+        <TabControl.ItemTemplate>
+          <DataTemplate>
+            <TextBlock Text="{Binding Header}"/>
+          </DataTemplate>
+        </TabControl.ItemTemplate>
+      </TabControl>
+      
     </StackPanel>
   </StackPanel>
 </UserControl>

--- a/samples/ControlCatalog/Pages/TabControlPage.xaml
+++ b/samples/ControlCatalog/Pages/TabControlPage.xaml
@@ -11,7 +11,7 @@
       <StackPanel>
         <TextBlock Classes="h1">From Inline TabItems</TextBlock>
 
-        <TabControl>
+        <TabControl Margin="0 16">
           <TabItem Header="Arch" Padding="8">
             <StackPanel Orientation="Vertical" Gap="8">
               <TextBlock>This is the first page in the TabControl.</TextBlock>
@@ -33,7 +33,7 @@
       <StackPanel>
         <TextBlock Classes="h1">From DataTemplate</TextBlock>
 
-        <TabControl Items="{Binding}">
+        <TabControl Items="{Binding}" Margin="0 16">
           <TabControl.ItemTemplate>
             <DataTemplate>
               <TextBlock Text="{Binding Header}"/>

--- a/samples/ControlCatalog/Pages/TabControlPage.xaml
+++ b/samples/ControlCatalog/Pages/TabControlPage.xaml
@@ -11,13 +11,13 @@
         <TabItem Header="Arch" Padding="8">
           <StackPanel Orientation="Vertical" Gap="8">
             <TextBlock>This is the first page in the TabControl.</TextBlock>
-            <Image Source="resm:ControlCatalog.Assets.delicate-arch-896885_640.jpg"/>
+            <Image Source="resm:ControlCatalog.Assets.delicate-arch-896885_640.jpg" Width="300"/>
           </StackPanel>
         </TabItem>
         <TabItem Header="Leaf" Padding="8">
           <StackPanel Orientation="Vertical" Gap="8">
             <TextBlock>This is the second page in the TabControl.</TextBlock>
-            <Image Source="resm:ControlCatalog.Assets.maple-leaf-888807_640.jpg"/>
+            <Image Source="resm:ControlCatalog.Assets.maple-leaf-888807_640.jpg" Width="300"/>
           </StackPanel>
         </TabItem>
         <TabItem Header="Disabled" IsEnabled="False">

--- a/samples/ControlCatalog/Pages/TabControlPage.xaml
+++ b/samples/ControlCatalog/Pages/TabControlPage.xaml
@@ -3,37 +3,53 @@
     <TextBlock Classes="h1">TabControl</TextBlock>
     <TextBlock Classes="h2">A tab control that displays a tab strip along with the content of the selected tab</TextBlock>
 
-    <StackPanel Orientation="Vertical"
+    <StackPanel Orientation="Horizontal"
               Margin="0,16,0,0"
               HorizontalAlignment="Center"
-              Gap="16">
-      
-      <TabControl>
-        <TabItem Header="Arch" Padding="8">
-          <StackPanel Orientation="Vertical" Gap="8">
-            <TextBlock>This is the first page in the TabControl.</TextBlock>
-            <Image Source="resm:ControlCatalog.Assets.delicate-arch-896885_640.jpg" Width="300"/>
-          </StackPanel>
-        </TabItem>
-        <TabItem Header="Leaf" Padding="8">
-          <StackPanel Orientation="Vertical" Gap="8">
-            <TextBlock>This is the second page in the TabControl.</TextBlock>
-            <Image Source="resm:ControlCatalog.Assets.maple-leaf-888807_640.jpg" Width="300"/>
-          </StackPanel>
-        </TabItem>
-        <TabItem Header="Disabled" IsEnabled="False">
-          <TextBlock>You should not see this.</TextBlock>
-        </TabItem>
-      </TabControl>
+              Gap="8">
 
-      <TabControl Items="{Binding}">
-        <TabControl.ItemTemplate>
-          <DataTemplate>
-            <TextBlock Text="{Binding Header}"/>
-          </DataTemplate>
-        </TabControl.ItemTemplate>
-      </TabControl>
-      
+      <StackPanel>
+        <TextBlock Classes="h1">From Inline TabItems</TextBlock>
+
+        <TabControl>
+          <TabItem Header="Arch" Padding="8">
+            <StackPanel Orientation="Vertical" Gap="8">
+              <TextBlock>This is the first page in the TabControl.</TextBlock>
+              <Image Source="resm:ControlCatalog.Assets.delicate-arch-896885_640.jpg" Width="300"/>
+            </StackPanel>
+          </TabItem>
+          <TabItem Header="Leaf" Padding="8">
+            <StackPanel Orientation="Vertical" Gap="8">
+              <TextBlock>This is the second page in the TabControl.</TextBlock>
+              <Image Source="resm:ControlCatalog.Assets.maple-leaf-888807_640.jpg" Width="300"/>
+            </StackPanel>
+          </TabItem>
+          <TabItem Header="Disabled" IsEnabled="False">
+            <TextBlock>You should not see this.</TextBlock>
+          </TabItem>
+        </TabControl>
+      </StackPanel>
+
+      <StackPanel>
+        <TextBlock Classes="h1">From DataTemplate</TextBlock>
+
+        <TabControl Items="{Binding}">
+          <TabControl.ItemTemplate>
+            <DataTemplate>
+              <TextBlock Text="{Binding Header}"/>
+            </DataTemplate>
+          </TabControl.ItemTemplate>
+          <TabControl.ContentTemplate>
+            <DataTemplate>
+              <StackPanel Orientation="Vertical" Gap="8">
+                <TextBlock Text="{Binding Text}"/>
+                <Image Source="{Binding Image}" Width="300"/>
+              </StackPanel>
+            </DataTemplate>
+          </TabControl.ContentTemplate>
+        </TabControl>
+      </StackPanel>
+
     </StackPanel>
   </StackPanel>
 </UserControl>

--- a/samples/ControlCatalog/Pages/TabControlPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/TabControlPage.xaml.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace ControlCatalog.Pages
+{
+    public class TabControlPage : UserControl
+    {
+        public TabControlPage()
+        {
+            this.InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/samples/ControlCatalog/Pages/TabControlPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/TabControlPage.xaml.cs
@@ -1,5 +1,9 @@
+using System;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using Avalonia.Media.Imaging;
+using Avalonia;
+using Avalonia.Platform;
 
 namespace ControlCatalog.Pages
 {
@@ -15,13 +19,13 @@ namespace ControlCatalog.Pages
                 {
                     Header = "Arch",
                     Text = "This is the first templated tab page.",
-                    ImageUrl = "resm:ControlCatalog.Assets.delicate-arch-896885_640.jpg",
+                    Image = LoadBitmap("resm:ControlCatalog.Assets.delicate-arch-896885_640.jpg?assembly=ControlCatalog"),
                 },
                 new TabItemViewModel
                 {
                     Header = "Leaf",
                     Text = "This is the second templated tab page.",
-                    ImageUrl = "resm:ControlCatalog.Assets.maple-leaf-888807_640.jpg",
+                    Image = LoadBitmap("resm:ControlCatalog.Assets.maple-leaf-888807_640.jpg?assembly=ControlCatalog"),
                 },
                 new TabItemViewModel
                 {
@@ -36,11 +40,17 @@ namespace ControlCatalog.Pages
             AvaloniaXamlLoader.Load(this);
         }
 
+        private IBitmap LoadBitmap(string uri)
+        {
+            var assets = AvaloniaLocator.Current.GetService<IAssetLoader>();
+            return new Bitmap(assets.Open(new Uri(uri)));
+        }
+
         private class TabItemViewModel
         {
             public string Header { get; set; }
             public string Text { get; set; }
-            public string ImageUrl { get; set; }
+            public IBitmap Image { get; set; }
             public bool IsEnabled { get; set; }
         }
     }

--- a/samples/ControlCatalog/Pages/TabControlPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/TabControlPage.xaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Media.Imaging;
 using Avalonia;
 using Avalonia.Platform;
+using ReactiveUI;
 
 namespace ControlCatalog.Pages
 {
@@ -13,26 +14,30 @@ namespace ControlCatalog.Pages
         {
             this.InitializeComponent();
 
-            DataContext = new[]
+            DataContext = new PageViewModel
             {
-                new TabItemViewModel
+                Tabs = new[]
                 {
-                    Header = "Arch",
-                    Text = "This is the first templated tab page.",
-                    Image = LoadBitmap("resm:ControlCatalog.Assets.delicate-arch-896885_640.jpg?assembly=ControlCatalog"),
+                    new TabItemViewModel
+                    {
+                        Header = "Arch",
+                        Text = "This is the first templated tab page.",
+                        Image = LoadBitmap("resm:ControlCatalog.Assets.delicate-arch-896885_640.jpg?assembly=ControlCatalog"),
+                    },
+                    new TabItemViewModel
+                    {
+                        Header = "Leaf",
+                        Text = "This is the second templated tab page.",
+                        Image = LoadBitmap("resm:ControlCatalog.Assets.maple-leaf-888807_640.jpg?assembly=ControlCatalog"),
+                    },
+                    new TabItemViewModel
+                    {
+                        Header = "Disabled",
+                        Text = "You should not see this.",
+                        IsEnabled = false,
+                    },
                 },
-                new TabItemViewModel
-                {
-                    Header = "Leaf",
-                    Text = "This is the second templated tab page.",
-                    Image = LoadBitmap("resm:ControlCatalog.Assets.maple-leaf-888807_640.jpg?assembly=ControlCatalog"),
-                },
-                new TabItemViewModel
-                {
-                    Header = "Disabled",
-                    Text = "You should not see this.",
-                    IsEnabled = false,
-                },
+                TabPlacement = Dock.Top,
             };
         }
 
@@ -45,6 +50,19 @@ namespace ControlCatalog.Pages
         {
             var assets = AvaloniaLocator.Current.GetService<IAssetLoader>();
             return new Bitmap(assets.Open(new Uri(uri)));
+        }
+
+        private class PageViewModel : ReactiveObject
+        {
+            Dock _tabPlacement;
+
+            public TabItemViewModel[] Tabs { get; set; }
+
+            public Dock TabPlacement
+            {
+                get { return _tabPlacement; }
+                set { this.RaiseAndSetIfChanged(ref _tabPlacement, value); }
+            }
         }
 
         private class TabItemViewModel

--- a/samples/ControlCatalog/Pages/TabControlPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/TabControlPage.xaml.cs
@@ -31,6 +31,7 @@ namespace ControlCatalog.Pages
                 {
                     Header = "Disabled",
                     Text = "You should not see this.",
+                    IsEnabled = false,
                 },
             };
         }
@@ -51,7 +52,7 @@ namespace ControlCatalog.Pages
             public string Header { get; set; }
             public string Text { get; set; }
             public IBitmap Image { get; set; }
-            public bool IsEnabled { get; set; }
+            public bool IsEnabled { get; set; } = true;
         }
     }
 }

--- a/samples/ControlCatalog/Pages/TabControlPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/TabControlPage.xaml.cs
@@ -8,11 +8,40 @@ namespace ControlCatalog.Pages
         public TabControlPage()
         {
             this.InitializeComponent();
+
+            DataContext = new[]
+            {
+                new TabItemViewModel
+                {
+                    Header = "Arch",
+                    Text = "This is the first templated tab page.",
+                    ImageUrl = "resm:ControlCatalog.Assets.delicate-arch-896885_640.jpg",
+                },
+                new TabItemViewModel
+                {
+                    Header = "Leaf",
+                    Text = "This is the second templated tab page.",
+                    ImageUrl = "resm:ControlCatalog.Assets.maple-leaf-888807_640.jpg",
+                },
+                new TabItemViewModel
+                {
+                    Header = "Disabled",
+                    Text = "You should not see this.",
+                },
+            };
         }
 
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
+        }
+
+        private class TabItemViewModel
+        {
+            public string Header { get; set; }
+            public string Text { get; set; }
+            public string ImageUrl { get; set; }
+            public bool IsEnabled { get; set; }
         }
     }
 }

--- a/samples/ControlCatalog/SideBar.xaml
+++ b/samples/ControlCatalog/SideBar.xaml
@@ -27,14 +27,14 @@
     </Setter>
   </Style>
 
-  <Style Selector="TabControl.sidebar TabStripItem">
+  <Style Selector="TabControl.sidebar /template/ TabStripItem">
     <Setter Property="Foreground" Value="White"/>
     <Setter Property="FontSize" Value="14"/>
     <Setter Property="Margin" Value="0"/>
     <Setter Property="Padding" Value="16"/>
   </Style>
 
-  <Style Selector="TabControl.sidebar TabStripItem:selected">
+  <Style Selector="TabControl.sidebar /template/ TabStripItem:selected">
     <Setter Property="Background" Value="{StyleResource ThemeAccentBrush2}"/>
   </Style>
 </Styles>

--- a/samples/ControlCatalog/SideBar.xaml
+++ b/samples/ControlCatalog/SideBar.xaml
@@ -4,16 +4,17 @@
       <ControlTemplate>
         <DockPanel>
           <ScrollViewer MinWidth="190" Background="{StyleResource ThemeAccentBrush}" DockPanel.Dock="Left">
-            <TabStrip Name="PART_TabStrip"
-                      MemberSelector="{Static TabControl.HeaderSelector}"
-                      Items="{TemplateBinding Items}"
-                      SelectedIndex="{TemplateBinding Path=SelectedIndex, Mode=TwoWay}">
-              <TabStrip.ItemsPanel>
+            <ItemsPresenter Name="PART_ItemsPresenter"
+                            Items="{TemplateBinding Items}"
+                            ItemTemplate="{TemplateBinding ItemTemplate}"
+                            Margin="{TemplateBinding Padding}"
+                            VirtualizationMode="{TemplateBinding VirtualizationMode}">
+              <ItemsPresenter.ItemsPanel>
                 <ItemsPanelTemplate>
                   <StackPanel Orientation="Vertical"/>
                 </ItemsPanelTemplate>
-              </TabStrip.ItemsPanel>
-            </TabStrip>
+              </ItemsPresenter.ItemsPanel>
+            </ItemsPresenter>
           </ScrollViewer>
           <Carousel Name="PART_Content"
                     Margin="8 0 0 0"
@@ -27,14 +28,17 @@
     </Setter>
   </Style>
 
-  <Style Selector="TabControl.sidebar /template/ TabStripItem">
-    <Setter Property="Foreground" Value="White"/>
-    <Setter Property="FontSize" Value="14"/>
+  <Style Selector="TabControl.sidebar > TabItem">
     <Setter Property="Margin" Value="0"/>
+  </Style>
+
+  <Style Selector="TabControl.sidebar > TabItem /template/ ContentPresenter">
+    <Setter Property="TextBlock.Foreground" Value="White"/>
+    <Setter Property="TextBlock.FontSize" Value="14"/>
     <Setter Property="Padding" Value="16"/>
   </Style>
 
-  <Style Selector="TabControl.sidebar /template/ TabStripItem:selected">
+  <Style Selector="TabControl.sidebar > TabItem:selected /template/ ContentPresenter">
     <Setter Property="Background" Value="{StyleResource ThemeAccentBrush2}"/>
   </Style>
 </Styles>

--- a/samples/ControlCatalog/packages.config
+++ b/samples/ControlCatalog/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Serilog" version="1.5.14" targetFramework="net46" />
+  <package id="Splat" version="1.6.2" targetFramework="portable45-net45+win8" />
 </packages>

--- a/samples/TestApplicationShared/GalleryStyle.cs
+++ b/samples/TestApplicationShared/GalleryStyle.cs
@@ -99,7 +99,6 @@ namespace TestApplication
                                 Name = "PART_TabStrip",
                                 ItemsPanel = new FuncTemplate<IPanel>(() => new StackPanel { Orientation = Orientation.Vertical, Gap = 4 }),
                                 Margin = new Thickness(0, 10, 0, 0),
-                                MemberSelector = TabControl.HeaderSelector,
                                 [!ItemsControl.ItemsProperty] = control[!ItemsControl.ItemsProperty],
                                 [!!SelectingItemsControl.SelectedItemProperty] = control[!!SelectingItemsControl.SelectedItemProperty],
                             }

--- a/src/Avalonia.Controls/Avalonia.Controls.csproj
+++ b/src/Avalonia.Controls/Avalonia.Controls.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Design.cs" />
     <Compile Include="DockPanel.cs" />
     <Compile Include="Expander.cs" />
+    <Compile Include="Generators\HeaderedItemContainerGenerator`1.cs" />
     <Compile Include="Generators\ItemContainerInfo.cs" />
     <Compile Include="Generators\MenuItemContainerGenerator.cs" />
     <Compile Include="Generators\TreeContainerIndex.cs" />

--- a/src/Avalonia.Controls/Canvas.cs
+++ b/src/Avalonia.Controls/Canvas.cs
@@ -47,7 +47,7 @@ namespace Avalonia.Controls
         /// </summary>
         static Canvas()
         {
-            AffectsCanvasArrange(LeftProperty, TopProperty, RightProperty, BottomProperty);
+            AffectsPanelArrange<Canvas>(LeftProperty, TopProperty, RightProperty, BottomProperty);
         }
 
         /// <summary>
@@ -204,30 +204,6 @@ namespace Avalonia.Controls
             }
 
             return finalSize;
-        }
-
-        /// <summary>
-        /// Marks a property on a child as affecting the canvas' arrangement.
-        /// </summary>
-        /// <param name="properties">The properties.</param>
-        private static void AffectsCanvasArrange(params AvaloniaProperty[] properties)
-        {
-            foreach (var property in properties)
-            {
-                property.Changed.Subscribe(AffectsCanvasArrangeInvalidate);
-            }
-        }
-
-        /// <summary>
-        /// Calls <see cref="Layoutable.InvalidateArrange"/> on the parent of the control whose
-        /// property changed, if that parent is a canvas.
-        /// </summary>
-        /// <param name="e">The event args.</param>
-        private static void AffectsCanvasArrangeInvalidate(AvaloniaPropertyChangedEventArgs e)
-        {
-            var control = e.Sender as IControl;
-            var canvas = control?.VisualParent as Canvas;
-            canvas?.InvalidateArrange();
         }
     }
 }

--- a/src/Avalonia.Controls/DockPanel.cs
+++ b/src/Avalonia.Controls/DockPanel.cs
@@ -1,5 +1,6 @@
 namespace Avalonia.Controls
 {
+    using Layout;
     using System;
 
     /// <summary>
@@ -7,10 +8,10 @@ namespace Avalonia.Controls
     /// </summary>
     public enum Dock
     {
-        Left = 0,
-        Bottom,
+        Left,
+        Top,
         Right,
-        Top
+        Bottom,
     }
 
     /// <summary>
@@ -37,7 +38,7 @@ namespace Avalonia.Controls
         /// </summary>
         static DockPanel()
         {
-            AffectsArrange(DockProperty);
+            AffectsPanelMeasure<DockPanel>(DockProperty);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Generators/HeaderedItemContainerGenerator`1.cs
+++ b/src/Avalonia.Controls/Generators/HeaderedItemContainerGenerator`1.cs
@@ -22,30 +22,22 @@ namespace Avalonia.Controls.Generators
         /// <param name="contentProperty">The container's Content property.</param>
         /// <param name="contentTemplateProperty">The container's ContentTemplate property.</param>
         /// <param name="headerProperty">The container's Header property.</param>
-        /// <param name="headerTemplateProperty">The container's HeaderTemplate property.</param>
         public HeaderedItemContainerGenerator(
             IControl owner, 
             AvaloniaProperty contentProperty,
             AvaloniaProperty contentTemplateProperty,
-            AvaloniaProperty headerProperty,
-            AvaloniaProperty headerTemplateProperty)
+            AvaloniaProperty headerProperty)
             : base(owner, contentProperty, contentTemplateProperty)
         {
             Contract.Requires<ArgumentNullException>(headerProperty != null);
 
             HeaderProperty = headerProperty;
-            HeaderTemplateProperty = headerTemplateProperty;
         }
 
         /// <summary>
         /// Gets the container's Content property.
         /// </summary>
         protected AvaloniaProperty HeaderProperty { get; }
-
-        /// <summary>
-        /// Gets the container's HeaderTemplate property.
-        /// </summary>
-        protected AvaloniaProperty HeaderTemplateProperty { get; }
 
         /// <inheritdoc/>
         protected override IControl CreateContainer(object item)
@@ -66,11 +58,6 @@ namespace Avalonia.Controls.Generators
 
                 if (!(item is IControl))
                 {
-                    if (HeaderTemplateProperty != null)
-                    {
-                        result.SetValue(HeaderTemplateProperty, ItemTemplate, BindingPriority.Style);
-                    }
-
                     result.SetValue(HeaderProperty, item, BindingPriority.Style);
                 }
 

--- a/src/Avalonia.Controls/Generators/HeaderedItemContainerGenerator`1.cs
+++ b/src/Avalonia.Controls/Generators/HeaderedItemContainerGenerator`1.cs
@@ -1,0 +1,78 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+
+namespace Avalonia.Controls.Generators
+{
+    /// <summary>
+    /// Creates containers for headered items and maintains a list of created containers.
+    /// </summary>
+    /// <typeparam name="T">The type of the container.</typeparam>
+    public class HeaderedItemContainerGenerator<T> : ItemContainerGenerator<T> where T : class, IControl, new()
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ItemContainerGenerator{T}"/> class.
+        /// </summary>
+        /// <param name="owner">The owner control.</param>
+        /// <param name="contentProperty">The container's Content property.</param>
+        /// <param name="contentTemplateProperty">The container's ContentTemplate property.</param>
+        /// <param name="headerProperty">The container's Header property.</param>
+        /// <param name="headerTemplateProperty">The container's HeaderTemplate property.</param>
+        public HeaderedItemContainerGenerator(
+            IControl owner, 
+            AvaloniaProperty contentProperty,
+            AvaloniaProperty contentTemplateProperty,
+            AvaloniaProperty headerProperty,
+            AvaloniaProperty headerTemplateProperty)
+            : base(owner, contentProperty, contentTemplateProperty)
+        {
+            Contract.Requires<ArgumentNullException>(headerProperty != null);
+
+            HeaderProperty = headerProperty;
+            HeaderTemplateProperty = headerTemplateProperty;
+        }
+
+        /// <summary>
+        /// Gets the container's Content property.
+        /// </summary>
+        protected AvaloniaProperty HeaderProperty { get; }
+
+        /// <summary>
+        /// Gets the container's HeaderTemplate property.
+        /// </summary>
+        protected AvaloniaProperty HeaderTemplateProperty { get; }
+
+        /// <inheritdoc/>
+        protected override IControl CreateContainer(object item)
+        {
+            var container = item as T;
+
+            if (item == null)
+            {
+                return null;
+            }
+            else if (container != null)
+            {
+                return container;
+            }
+            else
+            {
+                var result = base.CreateContainer(item);
+
+                if (HeaderTemplateProperty != null)
+                {
+                    result.SetValue(HeaderTemplateProperty, ItemTemplate, BindingPriority.Style);
+                }
+
+                result.SetValue(HeaderProperty, item, BindingPriority.Style);
+
+                return result;
+            }
+        }
+    }
+}

--- a/src/Avalonia.Controls/Generators/HeaderedItemContainerGenerator`1.cs
+++ b/src/Avalonia.Controls/Generators/HeaderedItemContainerGenerator`1.cs
@@ -64,12 +64,15 @@ namespace Avalonia.Controls.Generators
             {
                 var result = base.CreateContainer(item);
 
-                if (HeaderTemplateProperty != null)
+                if (!(item is IControl))
                 {
-                    result.SetValue(HeaderTemplateProperty, ItemTemplate, BindingPriority.Style);
-                }
+                    if (HeaderTemplateProperty != null)
+                    {
+                        result.SetValue(HeaderTemplateProperty, ItemTemplate, BindingPriority.Style);
+                    }
 
-                result.SetValue(HeaderProperty, item, BindingPriority.Style);
+                    result.SetValue(HeaderProperty, item, BindingPriority.Style);
+                }
 
                 return result;
             }

--- a/src/Avalonia.Controls/Image.cs
+++ b/src/Avalonia.Controls/Image.cs
@@ -85,7 +85,7 @@ namespace Avalonia.Controls
             {
                 Size sourceSize = new Size(source.PixelWidth, source.PixelHeight);
 
-                if (double.IsInfinity(availableSize.Width) || double.IsInfinity(availableSize.Height))
+                if (double.IsInfinity(availableSize.Width) && double.IsInfinity(availableSize.Height))
                 {
                     return sourceSize;
                 }

--- a/src/Avalonia.Controls/Panel.cs
+++ b/src/Avalonia.Controls/Panel.cs
@@ -7,6 +7,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using Avalonia.Media;
 using Avalonia.Metadata;
+using Avalonia.Layout;
 
 namespace Avalonia.Controls
 {
@@ -96,6 +97,34 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
+        /// Marks a property on a child as affecting the parent panel's measure if the parent
+        /// is a <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the parent panel.</typeparam>
+        /// <param name="properties">The properties.</param>
+        protected static void AffectsPanelMeasure<T>(params AvaloniaProperty[] properties) where T : Panel
+        {
+            foreach (var property in properties)
+            {
+                property.Changed.Subscribe(AffectsPanelMeasureInvalidate<T>);
+            }
+        }
+
+        /// <summary>
+        /// Marks a property on a child as affecting the parent panel's measure if the parent
+        /// is a <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the parent panel.</typeparam>
+        /// <param name="properties">The properties.</param>
+        protected static void AffectsPanelArrange<T>(params AvaloniaProperty[] properties) where T : Panel
+        {
+            foreach (var property in properties)
+            {
+                property.Changed.Subscribe(AffectsPanelArrangeInvalidate<T>);
+            }
+        }
+
+        /// <summary>
         /// Called when the <see cref="Children"/> collection changes.
         /// </summary>
         /// <param name="sender">The event sender.</param>
@@ -137,6 +166,32 @@ namespace Avalonia.Controls
             }
 
             InvalidateMeasure();
+        }
+
+        /// <summary>
+        /// Calls <see cref="Layoutable.InvalidateMeasure"/> on the parent of the control whose
+        /// property changed, if that parent is of the correct type.
+        /// </summary>
+        /// <param name="e">The event args.</param>
+        private static void AffectsPanelMeasureInvalidate<T>(AvaloniaPropertyChangedEventArgs e)
+            where T : Panel
+        {
+            var control = e.Sender as IControl;
+            var canvas = control?.VisualParent as T;
+            canvas?.InvalidateMeasure();
+        }
+
+        /// <summary>
+        /// Calls <see cref="Layoutable.InvalidateArrange"/> on the parent of the control whose
+        /// property changed, if that parent is of the correct type.
+        /// </summary>
+        /// <param name="e">The event args.</param>
+        private static void AffectsPanelArrangeInvalidate<T>(AvaloniaPropertyChangedEventArgs e)
+            where T : Panel
+        {
+            var control = e.Sender as IControl;
+            var canvas = control?.VisualParent as T;
+            canvas?.InvalidateArrange();
         }
     }
 }

--- a/src/Avalonia.Controls/Presenters/ItemVirtualizer.cs
+++ b/src/Avalonia.Controls/Presenters/ItemVirtualizer.cs
@@ -188,9 +188,9 @@ namespace Avalonia.Controls.Presenters
             if (VirtualizingPanel != null)
             {
                 VirtualizingPanel.Controller = null;
-                VirtualizingPanel.Children.Clear();
             }
 
+            Owner.Panel?.Children.Clear();
             Owner.ItemContainerGenerator.Clear();
         }
 

--- a/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
@@ -134,6 +134,13 @@ namespace Avalonia.Controls.Presenters
             _virtualizer?.ItemsChanged(Items, e);
         }
 
+        protected override void ItemsPanelChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            base.ItemsPanelChanged(e);
+            _virtualizer?.Dispose();
+            _virtualizer = null;
+        }
+
         private Vector CoerceOffset(Vector value)
         {
             var scrollable = (ILogicalScrollable)this;

--- a/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
@@ -48,6 +48,7 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         static ItemsPresenterBase()
         {
+            ItemsPanelProperty.Changed.AddClassHandler<ItemsPresenterBase>(x => x.ItemsPanelChanged);
             TemplatedParentProperty.Changed.AddClassHandler<ItemsPresenterBase>(x => x.TemplatedParentChanged);
         }
 
@@ -216,6 +217,16 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         /// <param name="e">A description of the change.</param>
         protected abstract void ItemsChanged(NotifyCollectionChangedEventArgs e);
+
+        /// <summary>
+        /// Called when the <see cref="ItemsPanel"/> property changes.
+        /// </summary>
+        /// <param name="e">The event args.</param>
+        protected virtual void ItemsPanelChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            _createdPanel = false;
+            InvalidateMeasure();
+        }
 
         /// <summary>
         /// Creates the <see cref="Panel"/> when <see cref="ApplyTemplate"/> is called for the first

--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -15,6 +15,18 @@ namespace Avalonia.Controls
     public class TabControl : SelectingItemsControl
     {
         /// <summary>
+        /// Defines the <see cref="ContentTemplate"/> property.
+        /// </summary>
+        public static readonly StyledProperty<IDataTemplate> ContentTemplateProperty =
+            ContentControl.ContentTemplateProperty.AddOwner<TabControl>();
+
+        /// <summary>
+        /// Defines the <see cref="TabStripPlacement"/> property.
+        /// </summary>
+        public static readonly StyledProperty<Dock> TabStripPlacementProperty =
+            AvaloniaProperty.Register<TabControl, Dock>(nameof(TabStripPlacement), defaultValue: Dock.Top);
+
+        /// <summary>
         /// Defines the <see cref="Transition"/> property.
         /// </summary>
         public static readonly StyledProperty<IPageTransition> TransitionProperty =
@@ -27,12 +39,6 @@ namespace Avalonia.Controls
             new FuncMemberSelector<object, object>(SelectContent);
 
         /// <summary>
-        /// Defines the <see cref="TabStripPlacement"/> property.
-        /// </summary>
-        public static readonly StyledProperty<Dock> TabStripPlacementProperty =
-            AvaloniaProperty.Register<TabControl, Dock>(nameof(TabStripPlacement), defaultValue: Dock.Top);
-
-        /// <summary>
         /// Initializes static members of the <see cref="TabControl"/> class.
         /// </summary>
         static TabControl()
@@ -40,6 +46,24 @@ namespace Avalonia.Controls
             SelectionModeProperty.OverrideDefaultValue<TabControl>(SelectionMode.AlwaysSelected);
             FocusableProperty.OverrideDefaultValue<TabControl>(false);
             AffectsMeasure(TabStripPlacementProperty);
+        }
+
+        /// <summary>
+        /// Gets or sets the data template used to display the content of a tab.
+        /// </summary>
+        public IDataTemplate ContentTemplate
+        {
+            get { return GetValue(ContentTemplateProperty); }
+            set { SetValue(ContentTemplateProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the tabstrip placement of the tabcontrol.
+        /// </summary>
+        public Dock TabStripPlacement
+        {
+            get { return GetValue(TabStripPlacementProperty); }
+            set { SetValue(TabStripPlacementProperty, value); }
         }
 
         /// <summary>
@@ -60,15 +84,6 @@ namespace Avalonia.Controls
             set { SetValue(TransitionProperty, value); }
         }
 
-        /// <summary>
-        /// Gets or sets the tabstrip placement of the tabcontrol.
-        /// </summary>
-        public Dock TabStripPlacement
-        {
-            get { return GetValue(TabStripPlacementProperty); }
-            set { SetValue(TabStripPlacementProperty, value); }
-        }
-
         /// <inheritdoc/>
         protected override IItemContainerGenerator CreateItemContainerGenerator()
         {
@@ -76,8 +91,7 @@ namespace Avalonia.Controls
                 this,
                 TabItem.ContentProperty,
                 TabItem.ContentTemplateProperty,
-                TabItem.HeaderProperty,
-                null);
+                TabItem.HeaderProperty);
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -72,10 +72,12 @@ namespace Avalonia.Controls
         /// <inheritdoc/>
         protected override IItemContainerGenerator CreateItemContainerGenerator()
         {
-            return new ItemContainerGenerator<TabItem>(
+            return new HeaderedItemContainerGenerator<TabItem>(
                 this,
                 TabItem.ContentProperty,
-                TabItem.ContentTemplateProperty);
+                TabItem.ContentTemplateProperty,
+                TabItem.HeaderProperty,
+                null);
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Themes.Default/Avalonia.Themes.Default.csproj
+++ b/src/Avalonia.Themes.Default/Avalonia.Themes.Default.csproj
@@ -208,6 +208,11 @@
       <Private>True</Private>
     </Reference>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="TabItem.xaml">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Avalonia.Themes.Default/DefaultTheme.xaml
+++ b/src/Avalonia.Themes.Default/DefaultTheme.xaml
@@ -25,6 +25,7 @@
   <StyleInclude Source="resm:Avalonia.Themes.Default.TabStripItem.xaml?assembly=Avalonia.Themes.Default"/>
   <!-- TabControl needs to come after TabStrip as it redefines the inner TabStrip.ItemsPanel-->
   <StyleInclude Source="resm:Avalonia.Themes.Default.TabControl.xaml?assembly=Avalonia.Themes.Default"/>
+  <StyleInclude Source="resm:Avalonia.Themes.Default.TabItem.xaml?assembly=Avalonia.Themes.Default"/>
   <StyleInclude Source="resm:Avalonia.Themes.Default.TextBox.xaml?assembly=Avalonia.Themes.Default"/>
   <StyleInclude Source="resm:Avalonia.Themes.Default.ToggleButton.xaml?assembly=Avalonia.Themes.Default"/>
   <StyleInclude Source="resm:Avalonia.Themes.Default.Expander.xaml?assembly=Avalonia.Themes.Default"/>

--- a/src/Avalonia.Themes.Default/TabControl.xaml
+++ b/src/Avalonia.Themes.Default/TabControl.xaml
@@ -22,11 +22,6 @@
                       SelectedIndex="{TemplateBinding Path=SelectedIndex}"
                       Transition="{TemplateBinding Transition}"
                       Grid.Row="1">
-              <Carousel.ItemTemplate>
-                <DataTemplate>
-                  <ContentControl Content="{Binding Content}"/>
-                </DataTemplate>
-              </Carousel.ItemTemplate>
             </Carousel>
           </DockPanel>
         </Border>

--- a/src/Avalonia.Themes.Default/TabControl.xaml
+++ b/src/Avalonia.Themes.Default/TabControl.xaml
@@ -9,10 +9,10 @@
             <ItemsPresenter Name="PART_ItemsPresenter"
                             Items="{TemplateBinding Items}"
                             ItemTemplate="{TemplateBinding ItemTemplate}"
-                            Margin="{TemplateBinding Padding}">
+                            Margin="0 16">
               <ItemsPresenter.ItemsPanel>
                 <ItemsPanelTemplate>
-                  <WrapPanel Orientation="Horizontal"/>
+                  <WrapPanel Orientation="Horizontal" Gap="16"/>
                 </ItemsPanelTemplate>
               </ItemsPresenter.ItemsPanel>
             </ItemsPresenter>

--- a/src/Avalonia.Themes.Default/TabControl.xaml
+++ b/src/Avalonia.Themes.Default/TabControl.xaml
@@ -40,7 +40,7 @@
     <Setter Property="ItemsPanel">
       <Setter.Value>
         <ItemsPanelTemplate>
-          <StackPanel Orientation="Vertical"/>
+          <WrapPanel Orientation="Vertical" Gap="16"/>
         </ItemsPanelTemplate>
       </Setter.Value>
     </Setter>
@@ -50,7 +50,7 @@
     <Setter Property="ItemsPanel">
       <Setter.Value>
         <ItemsPanelTemplate>
-          <StackPanel Orientation="Vertical"/>
+          <WrapPanel Orientation="Vertical" Gap="16"/>
         </ItemsPanelTemplate>
       </Setter.Value>
     </Setter>

--- a/src/Avalonia.Themes.Default/TabControl.xaml
+++ b/src/Avalonia.Themes.Default/TabControl.xaml
@@ -6,28 +6,40 @@
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}">
           <DockPanel>
-            <TabStrip Name="PART_TabStrip"
-                      MemberSelector="{Static TabControl.HeaderSelector}"
-                      Items="{TemplateBinding Items}"
-                      SelectedIndex="{TemplateBinding Path=SelectedIndex, Mode=TwoWay}"/>
+            <ItemsPresenter Name="PART_ItemsPresenter"
+                            Items="{TemplateBinding Items}"
+                            ItemTemplate="{TemplateBinding ItemTemplate}"
+                            Margin="{TemplateBinding Padding}">
+              <ItemsPresenter.ItemsPanel>
+                <ItemsPanelTemplate>
+                  <WrapPanel Orientation="Horizontal"/>
+                </ItemsPanelTemplate>
+              </ItemsPresenter.ItemsPanel>
+            </ItemsPresenter>
             <Carousel Name="PART_Content"
-                      MemberSelector="{Static TabControl.ContentSelector}"
                       Items="{TemplateBinding Items}"
+                      MemberSelector="{Static TabControl.ContentSelector}"
                       SelectedIndex="{TemplateBinding Path=SelectedIndex}"
                       Transition="{TemplateBinding Transition}"
-                      Grid.Row="1"/>
+                      Grid.Row="1">
+              <Carousel.ItemTemplate>
+                <DataTemplate>
+                  <ContentControl Content="{Binding Content}"/>
+                </DataTemplate>
+              </Carousel.ItemTemplate>
+            </Carousel>
           </DockPanel>
         </Border>
       </ControlTemplate>
     </Setter>
   </Style>
-  <Style Selector="TabControl[TabStripPlacement=Top] /template/ TabStrip">
+  <Style Selector="TabControl[TabStripPlacement=Top] /template/ ItemsPresenter">
     <Setter Property="DockPanel.Dock" Value="Top"/>
   </Style>
-  <Style Selector="TabControl[TabStripPlacement=Bottom] /template/ TabStrip">
+  <Style Selector="TabControl[TabStripPlacement=Bottom] /template/ ItemsPresenter">
     <Setter Property="DockPanel.Dock" Value="Bottom"/>
   </Style>
-  <Style Selector="TabControl[TabStripPlacement=Left] /template/ TabStrip">
+  <Style Selector="TabControl[TabStripPlacement=Left] /template/ ItemsPresenter">
     <Setter Property="DockPanel.Dock" Value="Left"/>
     <Setter Property="ItemsPanel">
       <Setter.Value>
@@ -37,7 +49,7 @@
       </Setter.Value>
     </Setter>
   </Style>
-  <Style Selector="TabControl[TabStripPlacement=Right] /template/ TabStrip">
+  <Style Selector="TabControl[TabStripPlacement=Right] /template/ ItemsPresenter">
     <Setter Property="DockPanel.Dock" Value="Right"/>
     <Setter Property="ItemsPanel">
       <Setter.Value>

--- a/src/Avalonia.Themes.Default/TabControl.xaml
+++ b/src/Avalonia.Themes.Default/TabControl.xaml
@@ -18,6 +18,7 @@
             </ItemsPresenter>
             <Carousel Name="PART_Content"
                       Items="{TemplateBinding Items}"
+                      ItemTemplate="{TemplateBinding ContentTemplate}"
                       MemberSelector="{Static TabControl.ContentSelector}"
                       SelectedIndex="{TemplateBinding Path=SelectedIndex}"
                       Transition="{TemplateBinding Transition}"

--- a/src/Avalonia.Themes.Default/TabControl.xaml
+++ b/src/Avalonia.Themes.Default/TabControl.xaml
@@ -8,14 +8,7 @@
           <DockPanel>
             <ItemsPresenter Name="PART_ItemsPresenter"
                             Items="{TemplateBinding Items}"
-                            ItemTemplate="{TemplateBinding ItemTemplate}"
-                            Margin="0 16">
-              <ItemsPresenter.ItemsPanel>
-                <ItemsPanelTemplate>
-                  <WrapPanel Orientation="Horizontal" Gap="16"/>
-                </ItemsPanelTemplate>
-              </ItemsPresenter.ItemsPanel>
-            </ItemsPresenter>
+                            ItemTemplate="{TemplateBinding ItemTemplate}"/>
             <Carousel Name="PART_Content"
                       Items="{TemplateBinding Items}"
                       ItemTemplate="{TemplateBinding ContentTemplate}"
@@ -31,9 +24,25 @@
   </Style>
   <Style Selector="TabControl[TabStripPlacement=Top] /template/ ItemsPresenter">
     <Setter Property="DockPanel.Dock" Value="Top"/>
+    <Setter Property="ItemsPanel">
+      <Setter.Value>
+        <ItemsPanelTemplate>
+          <WrapPanel Orientation="Horizontal" Gap="16"/>
+        </ItemsPanelTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Margin" Value="0,16"/>
   </Style>
   <Style Selector="TabControl[TabStripPlacement=Bottom] /template/ ItemsPresenter">
     <Setter Property="DockPanel.Dock" Value="Bottom"/>
+    <Setter Property="ItemsPanel">
+      <Setter.Value>
+        <ItemsPanelTemplate>
+          <WrapPanel Orientation="Horizontal" Gap="16"/>
+        </ItemsPanelTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Margin" Value="0,16"/>
   </Style>
   <Style Selector="TabControl[TabStripPlacement=Left] /template/ ItemsPresenter">
     <Setter Property="DockPanel.Dock" Value="Left"/>
@@ -44,6 +53,7 @@
         </ItemsPanelTemplate>
       </Setter.Value>
     </Setter>
+    <Setter Property="Margin" Value="16,0"/>
   </Style>
   <Style Selector="TabControl[TabStripPlacement=Right] /template/ ItemsPresenter">
     <Setter Property="DockPanel.Dock" Value="Right"/>
@@ -54,5 +64,6 @@
         </ItemsPanelTemplate>
       </Setter.Value>
     </Setter>
+    <Setter Property="Margin" Value="16,0"/>
   </Style>
 </Styles>

--- a/src/Avalonia.Themes.Default/TabItem.xaml
+++ b/src/Avalonia.Themes.Default/TabItem.xaml
@@ -1,7 +1,6 @@
 <Styles xmlns="https://github.com/avaloniaui">
   <Style Selector="TabItem">
     <Setter Property="Foreground" Value="{StyleResource ThemeForegroundLightBrush}"/>
-    <Setter Property="Margin" Value="16"/>
     <Setter Property="Template">
       <ControlTemplate>
         <ContentPresenter Name="PART_ContentPresenter"

--- a/src/Avalonia.Themes.Default/TabItem.xaml
+++ b/src/Avalonia.Themes.Default/TabItem.xaml
@@ -1,0 +1,21 @@
+<Styles xmlns="https://github.com/avaloniaui">
+  <Style Selector="TabItem">
+    <Setter Property="Foreground" Value="{StyleResource ThemeForegroundLightBrush}"/>
+    <Setter Property="Margin" Value="16"/>
+    <Setter Property="Template">
+      <ControlTemplate>
+        <ContentPresenter Name="PART_ContentPresenter"
+                          Content="{TemplateBinding Header}"
+                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                          Margin="{TemplateBinding Margin}"
+                          TextBlock.FontSize="{StyleResource FontSizeLarge}"/>
+      </ControlTemplate>
+    </Setter>
+  </Style>
+  <Style Selector="TabItem:selected">
+    <Setter Property="Foreground" Value="{StyleResource ThemeForegroundBrush}"/>
+  </Style>
+  <Style Selector="TabItem:disabled">
+    <Setter Property="Opacity" Value="{StyleResource ThemeDisabledOpacity}"/>
+  </Style>
+</Styles>

--- a/src/Avalonia.Themes.Default/TabStripItem.xaml
+++ b/src/Avalonia.Themes.Default/TabStripItem.xaml
@@ -17,4 +17,7 @@
   <Style Selector="TabStripItem:selected">
     <Setter Property="Foreground" Value="{StyleResource ThemeForegroundBrush}"/>
   </Style>
+  <Style Selector="TabStripItem:disabled">
+    <Setter Property="Opacity" Value="{StyleResource ThemeDisabledOpacity}"/>
+  </Style>
 </Styles>

--- a/tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj
+++ b/tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="LayoutTransformControlTests.cs" />
     <Compile Include="Presenters\ItemsPresenterTests_Virtualization_Simple.cs" />
     <Compile Include="Presenters\ItemsPresenterTests_Virtualization.cs" />
+    <Compile Include="TabItemTests.cs" />
     <Compile Include="TextBoxTests_ValidationState.cs" />
     <Compile Include="UserControlTests.cs" />
     <Compile Include="DockPanelTests.cs" />

--- a/tests/Avalonia.Controls.UnitTests/DockPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DockPanelTests.cs
@@ -58,5 +58,28 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Rect(50, 350, 500, 50), target.Children[3].Bounds);
             Assert.Equal(new Rect(50, 50, 500, 300), target.Children[4].Bounds);
         }
+
+        [Fact]
+        public void Changing_Child_Dock_Property_Should_Invalidate_Measure()
+        {
+            var target = new DockPanel
+            {
+                Children = new Controls
+                {
+                    new Border { Width = 50, Height = 50 }
+                }
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(target.DesiredSize));
+
+            Assert.True(target.IsMeasureValid);
+            Assert.True(target.IsArrangeValid);
+
+            DockPanel.SetDock((Control)target.Children[0], Dock.Bottom);
+
+            Assert.False(target.IsMeasureValid);
+            Assert.False(target.IsArrangeValid);
+        }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests.cs
@@ -311,6 +311,27 @@ namespace Avalonia.Controls.UnitTests.Presenters
         }
 
         [Fact]
+        public void Panel_Can_Be_Changed()
+        {
+            var target = new ItemsPresenter
+            {
+                Items = new[] { "foo", "bar" }
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(target.DesiredSize));
+            Assert.True(target.IsMeasureValid);
+
+            var panel = new Canvas();
+            target.ItemsPanel = new FuncTemplate<IPanel>(() => panel);
+            Assert.False(target.IsMeasureValid);
+
+            target.ApplyTemplate();
+            Assert.Same(panel, target.Panel);
+            Assert.Same(target, target.Panel.Parent);
+        }
+
+        [Fact]
         public void MemberSelector_Should_Select_Member()
         {
             var target = new ItemsPresenter

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -237,7 +237,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Content_And_Header_Should_Be_Set_For_DataTemplate_Generated_Items()
         {
-            var data = new[]
+            var items = new[]
             {
                 new TabViewModel("Foo", "foocontent"),
                 new TabViewModel("Bar", "barcontent"),
@@ -247,17 +247,42 @@ namespace Avalonia.Controls.UnitTests
             TabControl target = new TabControl
             {
                 Template = TabControlTemplate(),
-                Items = data,
+                Items = items,
             };
 
             ApplyTemplate(target);
 
-            var items = target.GetLogicalChildren().OfType<TabItem>().ToList();
-            var content = items.Select(x => x.Content).ToList();
-            var headers = items.Select(x => x.Header).ToList();
+            var tabItems = target.GetLogicalChildren().OfType<TabItem>().ToList();
+            var content = tabItems.Select(x => x.Content).ToList();
+            var headers = tabItems.Select(x => x.Header).ToList();
 
-            Assert.Equal(data, content);
-            Assert.Equal(data, headers);
+            Assert.Equal(items, content);
+            Assert.Equal(items, headers);
+        }
+
+        [Fact]
+        public void Control_In_Items_Should_Set_TabItem_Content_Not_Header()
+        {
+            var items = new object[]
+            {
+                new TabViewModel("Foo", "foocontent"),
+                new TextBlock { Text = "Bar" },
+            };
+
+            var target = new TabControl
+            {
+                Template = TabControlTemplate(),
+                Items = items,
+            };
+
+            ApplyTemplate(target);
+
+            var tabItems = target.GetLogicalChildren().OfType<TabItem>().ToList();
+            var content = tabItems.Select(x => x.Content).ToList();
+            var headers = tabItems.Select(x => x.Header).ToList();
+
+            Assert.Equal(items, content);
+            Assert.Equal(new[] { items[0], null }, headers);
         }
 
         private IControlTemplate TabControlTemplate()
@@ -291,7 +316,7 @@ namespace Avalonia.Controls.UnitTests
                 new ContentPresenter
                 {
                     Name = "PART_ContentPresenter",
-                    [!ContentPresenter.ContentProperty] = parent[!TabItem.ContentProperty],
+                    [!ContentPresenter.ContentProperty] = parent[!TabItem.HeaderProperty],
                     [!ContentPresenter.ContentTemplateProperty] = parent[!TabItem.ContentTemplateProperty],
                 });
         }
@@ -313,6 +338,13 @@ namespace Avalonia.Controls.UnitTests
         {
             target.ApplyTemplate();
             target.Presenter.ApplyTemplate();
+
+            foreach (var tabItem in target.GetLogicalChildren().OfType<TabItem>())
+            {
+                tabItem.Template = TabItemTemplate();
+                tabItem.ApplyTemplate();
+                ((ContentPresenter)tabItem.Presenter).UpdateChild();
+            }
 
             var carousel = (Carousel)target.Pages;
             carousel.ApplyTemplate();

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -211,111 +211,6 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
-        public void TabStripItems_Should_Be_Created_For_TabItem_Headers()
-        {
-            TabControl target = new TabControl
-            {
-                Template = TabControlTemplate(),
-                Items = new[]
-                {
-                    new TabItem { Header = "Foo" },
-                    new TabItem { Header = new Canvas() },
-                    new TabItem { Header = "Baz", IsEnabled = false },
-                },
-            };
-
-            ApplyTemplate(target);
-
-            var tabStrips = target.TabStrip.GetLogicalChildren()
-                .OfType<TabStripItem>();
-
-            var result = tabStrips
-                .Select(x => x.Content)
-                .ToList();
-
-            var enabled = tabStrips
-                .Select(x => x.IsEnabled)
-                .ToList();
-
-            Assert.Equal(3, result.Count);
-            Assert.Equal("Foo", result[0]);
-            Assert.IsType<Canvas>(result[1]);
-            Assert.Equal("Baz", result[2]);
-
-
-            Assert.Equal(new[] { true, true, false }, enabled);
-        }
-
-        [Fact]
-        public void TabStripItems_Should_Be_Created_From_ItemTemplate()
-        {
-            var items = new[]
-            {
-                new TabViewModel("Foo", "FooContent"),
-                new TabViewModel("Bar", "BarContent"),
-                new TabViewModel("Baz", "BazContent"),
-            };
-
-            TabControl target = new TabControl
-            {
-                Template = TabControlTemplate(),
-                ItemTemplate = new FuncDataTemplate<TabViewModel>(x => new TextBlock { Text = x.Header }),
-                Items = items,
-            };
-
-            ApplyTemplate(target);
-
-            var result = target.TabStrip.GetLogicalChildren()
-                .OfType<TabStripItem>()
-                .Do(x =>
-                {
-                    x.Template = TabStripItemTemplate();
-                    x.ApplyTemplate();
-                    ((ContentPresenter)x.Presenter).UpdateChild();
-                })
-                .Select(x => x.Presenter.Child)
-                .OfType<TextBlock>()
-                .Select(x => x.Text)
-                .ToList();
-
-            Assert.Equal(new[] { "Foo", "Bar", "Baz" }, result);
-        }
-
-        /// <summary>
-        /// Non-headered control items should result in TabStripItems with empty content.
-        /// </summary>
-        /// <remarks>
-        /// If a TabStrip is created with non IHeadered controls as its items, don't try to
-        /// display the control in the TabStripItem: if the TabStrip is part of a TabControl
-        /// then *that* will also try to display the control, resulting in dual-parentage 
-        /// breakage.
-        /// </remarks>
-        [Fact]
-        public void Non_IHeadered_Control_Items_Should_Be_Ignored()
-        {
-            var items = new[]
-            {
-                new TextBlock { Text = "foo" },
-                new TextBlock { Text = "bar" },
-            };
-
-            var target = new TabControl
-            {
-                Template = TabControlTemplate(),
-                Items = items,
-            };
-
-            ApplyTemplate(target);
-
-            var result = target.TabStrip.GetLogicalChildren()
-                .OfType<TabStripItem>()
-                .Select(x => x.Content)
-                .ToList();
-
-            Assert.Equal(new object[] { string.Empty, string.Empty }, result);
-        }
-
-        [Fact]
         public void Should_Handle_Changing_To_TabItem_With_Null_Content()
         {
             TabControl target = new TabControl
@@ -346,14 +241,11 @@ namespace Avalonia.Controls.UnitTests
                 {
                     Children = new Controls
                     {
-                        new TabStrip
+                        new ItemsPresenter
                         {
-                            Name = "PART_TabStrip",
-                            Template = TabStripTemplate(),
-                            MemberSelector = TabControl.HeaderSelector,
+                            Name = "PART_ItemsPresenter",
                             [!TabStrip.ItemsProperty] = parent[!TabControl.ItemsProperty],
                             [!TabStrip.ItemTemplateProperty] = parent[!TabControl.ItemTemplateProperty],
-                            [!!TabStrip.SelectedIndexProperty] = parent[!!TabControl.SelectedIndexProperty]
                         },
                         new Carousel
                         {
@@ -361,32 +253,20 @@ namespace Avalonia.Controls.UnitTests
                             Template = new FuncControlTemplate<Carousel>(CreateCarouselTemplate),
                             MemberSelector = TabControl.ContentSelector,
                             [!Carousel.ItemsProperty] = parent[!TabControl.ItemsProperty],
-                            [!Carousel.SelectedItemProperty] = parent[!TabControl.SelectedItemProperty],
+                            [!Carousel.SelectedIndexProperty] = parent[!TabControl.SelectedIndexProperty],
                         }
                     }
                 });
         }
 
-        private IControlTemplate TabStripTemplate()
+        private IControlTemplate TabItemTemplate()
         {
-            return new FuncControlTemplate<TabStrip>(parent =>
-                new ItemsPresenter
-                {
-                    Name = "PART_ItemsPresenter",
-                    [!ItemsPresenter.ItemsProperty] = parent[!ItemsControl.ItemsProperty],
-                    [!ItemsPresenter.ItemTemplateProperty] = parent[!ItemsControl.ItemTemplateProperty],
-                    [!CarouselPresenter.MemberSelectorProperty] = parent[!ItemsControl.MemberSelectorProperty],
-                });
-        }
-
-        private IControlTemplate TabStripItemTemplate()
-        {
-            return new FuncControlTemplate<TabStripItem>(parent =>
+            return new FuncControlTemplate<TabItem>(parent =>
                 new ContentPresenter
                 {
                     Name = "PART_ContentPresenter",
-                    [!ContentPresenter.ContentProperty] = parent[!TabStripItem.ContentProperty],
-                    [!ContentPresenter.ContentTemplateProperty] = parent[!TabStripItem.ContentTemplateProperty],
+                    [!ContentPresenter.ContentProperty] = parent[!TabItem.ContentProperty],
+                    [!ContentPresenter.ContentTemplateProperty] = parent[!TabItem.ContentTemplateProperty],
                 });
         }
 
@@ -409,9 +289,6 @@ namespace Avalonia.Controls.UnitTests
             var carousel = (Carousel)target.Pages;
             carousel.ApplyTemplate();
             carousel.Presenter.ApplyTemplate();
-            var tabStrip = (TabStrip)target.TabStrip;
-            tabStrip.ApplyTemplate();
-            tabStrip.Presenter.ApplyTemplate();
         }
 
         private class Item

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -234,6 +234,32 @@ namespace Avalonia.Controls.UnitTests
             Assert.Null(page.Content);
         }
 
+        [Fact]
+        public void Content_And_Header_Should_Be_Set_For_DataTemplate_Generated_Items()
+        {
+            var data = new[]
+            {
+                new TabViewModel("Foo", "foocontent"),
+                new TabViewModel("Bar", "barcontent"),
+                new TabViewModel("Baz", "bazcontent"),
+            };
+
+            TabControl target = new TabControl
+            {
+                Template = TabControlTemplate(),
+                Items = data,
+            };
+
+            ApplyTemplate(target);
+
+            var items = target.GetLogicalChildren().OfType<TabItem>().ToList();
+            var content = items.Select(x => x.Content).ToList();
+            var headers = items.Select(x => x.Header).ToList();
+
+            Assert.Equal(data, content);
+            Assert.Equal(data, headers);
+        }
+
         private IControlTemplate TabControlTemplate()
         {
             return new FuncControlTemplate<TabControl>(parent => 
@@ -286,6 +312,8 @@ namespace Avalonia.Controls.UnitTests
         private void ApplyTemplate(TabControl target)
         {
             target.ApplyTemplate();
+            target.Presenter.ApplyTemplate();
+
             var carousel = (Carousel)target.Pages;
             carousel.ApplyTemplate();
             carousel.Presenter.ApplyTemplate();

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -285,9 +285,60 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new[] { items[0], null }, headers);
         }
 
+        [Fact]
+        public void ItemTemplate_Should_Be_Used_For_DataTemplate_Generated_Items()
+        {
+            var items = new object[]
+            {
+                new TabViewModel("Foo", "foocontent"),
+                new TabViewModel("Bar", "barcontent"),
+                new TextBlock { Text = "Baz" },
+            };
+
+            TabControl target = new TabControl
+            {
+                Template = TabControlTemplate(),
+                Items = items,
+                ItemTemplate = new FuncDataTemplate<TabViewModel>(x => new Canvas { Tag = x.Header }),
+            };
+
+            ApplyTemplate(target);
+
+            var tabItems = target.GetLogicalChildren().OfType<TabItem>().ToList();
+            Assert.IsType<Canvas>(tabItems[0].Presenter.Child);
+            Assert.IsType<Canvas>(tabItems[1].Presenter.Child);
+            Assert.Null(tabItems[2].Presenter.Child);
+        }
+
+        [Fact]
+        public void ContentTemplate_Should_Be_Used_For_DataTemplate_Generated_Content()
+        {
+            var items = new object[]
+            {
+                new TabViewModel("Foo", "foocontent"),
+                new TabViewModel("Bar", "barcontent"),
+                new TextBlock { Text = "Baz" },
+            };
+
+            TabControl target = new TabControl
+            {
+                Template = TabControlTemplate(),
+                Items = items,
+                ContentTemplate = new FuncDataTemplate<TabViewModel>(x => new Canvas { Tag = x.Header }),
+            };
+
+            ApplyTemplate(target);
+
+            var carousel = (Carousel)target.Pages;
+            var container = (ContentPresenter)carousel.Presenter.Panel.Children.Single();
+            container.UpdateChild();
+
+            Assert.IsType<Canvas>(container.Child);
+        }
+
         private IControlTemplate TabControlTemplate()
         {
-            return new FuncControlTemplate<TabControl>(parent => 
+            return new FuncControlTemplate<TabControl>(parent =>
                 new StackPanel
                 {
                     Children = new Controls
@@ -304,6 +355,7 @@ namespace Avalonia.Controls.UnitTests
                             Template = new FuncControlTemplate<Carousel>(CreateCarouselTemplate),
                             MemberSelector = TabControl.ContentSelector,
                             [!Carousel.ItemsProperty] = parent[!TabControl.ItemsProperty],
+                            [!Carousel.ItemTemplateProperty] = parent[!TabControl.ContentTemplateProperty],
                             [!Carousel.SelectedIndexProperty] = parent[!TabControl.SelectedIndexProperty],
                         }
                     }

--- a/tests/Avalonia.Controls.UnitTests/TabItemTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabItemTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using System.Linq;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Templates;
+using Avalonia.LogicalTree;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests
+{
+    public class TabItemTests
+    {
+        [Fact]
+        public void Logical_Child_Should_Be_Content_Control()
+        {
+            var target = new TabItem
+            {
+                Header = new Canvas(),
+                Content = new Border(),
+                Template = Template(),
+            };
+
+            target.ApplyTemplate();
+            ((ContentPresenter)target.Presenter).UpdateChild();
+
+            var logicalChildren = ((ILogical)target).LogicalChildren;
+
+            Assert.Equal(1, logicalChildren.Count);
+            Assert.IsType<Border>(logicalChildren[0]);
+        }
+
+        [Fact]
+        public void Logical_Child_Should_Be_DataTemplated_Content()
+        {
+            var target = new TabItem
+            {
+                Header = "header",
+                Content = "content",
+                Template = Template(),
+            };
+
+            target.ApplyTemplate();
+            ((ContentPresenter)target.Presenter).UpdateChild();
+
+            var logicalChildren = ((ILogical)target).LogicalChildren;
+
+            Assert.Equal(1, logicalChildren.Count);
+            Assert.IsType<TextBlock>(logicalChildren[0]);
+            Assert.Equal("content", ((TextBlock)logicalChildren[0]).Text);
+        }
+
+        private static IControlTemplate Template()
+        {
+            return new FuncControlTemplate<TabItem>(parent =>
+                new ContentPresenter
+                {
+                    Name = "PART_ContentPresenter",
+                    [!ContentPresenter.ContentProperty] = parent[!TabItem.HeaderProperty],
+                });
+        }
+    }
+}

--- a/tests/Avalonia.Controls.UnitTests/WrapPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WrapPanelTests.cs
@@ -11,14 +11,14 @@ namespace Avalonia.Controls.UnitTests
         public void Lays_Out_Horizontally_On_Separate_Lines()
         {
             var target = new WrapPanel()
-                         {
-                             Width = 100,
-                             Children = new Controls
-                                        {
-                                            new Border { Height = 50, Width = 100 },
-                                            new Border { Height = 50, Width = 100 },
-                                        }
-                         };
+            {
+                Width = 100,
+                Children = new Controls
+                {
+                    new Border { Height = 50, Width = 100 },
+                    new Border { Height = 50, Width = 100 },
+                }
+            };
 
             target.Measure(Size.Infinity);
             target.Arrange(new Rect(target.DesiredSize));
@@ -32,14 +32,14 @@ namespace Avalonia.Controls.UnitTests
         public void Lays_Out_Horizontally_On_A_Single_Line()
         {
             var target = new WrapPanel()
-                         {
-                             Width = 200,
-                             Children = new Controls
-                                        {
-                                            new Border { Height = 50, Width = 100 },
-                                            new Border { Height = 50, Width = 100 },
-                                        }
-                         };
+            {
+                Width = 200,
+                Children = new Controls
+                {
+                    new Border { Height = 50, Width = 100 },
+                    new Border { Height = 50, Width = 100 },
+                }
+            };
 
             target.Measure(Size.Infinity);
             target.Arrange(new Rect(target.DesiredSize));
@@ -53,15 +53,15 @@ namespace Avalonia.Controls.UnitTests
         public void Lays_Out_Vertically_Children_On_A_Single_Line()
         {
             var target = new WrapPanel()
-                         {
-                             Orientation = Orientation.Vertical,
-                             Height = 120,
-                             Children = new Controls
-                                        {
-                                            new Border { Height = 50, Width = 100 },
-                                            new Border { Height = 50, Width = 100 },
-                                        }
-                         };
+            {
+                Orientation = Orientation.Vertical,
+                Height = 120,
+                Children = new Controls
+                {
+                    new Border { Height = 50, Width = 100 },
+                    new Border { Height = 50, Width = 100 },
+                }
+            };
 
             target.Measure(Size.Infinity);
             target.Arrange(new Rect(target.DesiredSize));
@@ -75,15 +75,15 @@ namespace Avalonia.Controls.UnitTests
         public void Lays_Out_Vertically_On_Separate_Lines()
         {
             var target = new WrapPanel()
-                         {
-                             Orientation = Orientation.Vertical,
-                             Height = 60,
-                             Children = new Controls
-                                        {
-                                            new Border { Height = 50, Width = 100 },
-                                            new Border { Height = 50, Width = 100 },
-                                        }
-                         };
+            {
+                Orientation = Orientation.Vertical,
+                Height = 60,
+                Children = new Controls
+                {
+                    new Border { Height = 50, Width = 100 },
+                    new Border { Height = 50, Width = 100 },
+                }
+            };
 
             target.Measure(Size.Infinity);
             target.Arrange(new Rect(target.DesiredSize));
@@ -91,6 +91,33 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Size(200, 60), target.Bounds.Size);
             Assert.Equal(new Rect(0, 0, 100, 50), target.Children[0].Bounds);
             Assert.Equal(new Rect(100, 0, 100, 50), target.Children[1].Bounds);
+        }
+
+        [Fact]
+        public void Lays_Out_Horizontally_With_Gap()
+        {
+            var target = new WrapPanel()
+            {
+                Gap = 10,
+                CrossAxisGap = 20,
+                Width = 200,
+                Children = new Controls
+                {
+                    new Border { Height = 50, Width = 50 },
+                    new Border { Height = 50, Width = 50 },
+                    new Border { Height = 50, Width = 50 },
+                    new Border { Height = 50, Width = 50 },
+                }
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(target.DesiredSize));
+
+            Assert.Equal(new Size(200, 120), target.Bounds.Size);
+            Assert.Equal(new Rect(0, 0, 50, 50), target.Children[0].Bounds);
+            Assert.Equal(new Rect(60, 0, 50, 50), target.Children[1].Bounds);
+            Assert.Equal(new Rect(120, 0, 50, 50), target.Children[2].Bounds);
+            Assert.Equal(new Rect(0, 70, 50, 50), target.Children[3].Bounds);
         }
     }
 }


### PR DESCRIPTION
Fixes #536 .

This PR allows you to create `TabItems` in a `TabControl` using `DataTemplates`. It works in the same way that WPF works: http://stackoverflow.com/a/5651542/6448 You should also be able to use styles to bind the `IsEnabled` property.

An Avalonia example can be found in the ControlCatalog: https://github.com/AvaloniaUI/Avalonia/blob/tabcontrol-data-templates/samples/ControlCatalog/Pages/TabControlPage.xaml#L36

Please let me know of any problems!
