### PR TITLE
Implemented extensibility system for Avalonia

### DIFF
--- a/src/Avalonia.Controls/AppBuilderBase.cs
+++ b/src/Avalonia.Controls/AppBuilderBase.cs
@@ -17,7 +17,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets or sets the <see cref="IRuntimePlatform"/> instance.
         /// </summary>
-        public IRuntimePlatform RuntimePlatform { get; private set; }
+        public IRuntimePlatform RuntimePlatform { get; set; }
 
         /// <summary>
         /// Gets or sets a method to call the initialize the runtime platform services (e. g. AssetLoader)
@@ -105,7 +105,7 @@ namespace Avalonia.Controls
             return Self;
         }
 
-        public AppBuilder AfterSetup(Action<TAppBuilder> callback)
+        public TAppBuilder AfterSetup(Action<TAppBuilder> callback)
         {
             AfterSetupCallback = (Action<TAppBuilder>)Delegate.Combine(AfterSetupCallback, callback);
             return Self;

--- a/src/Avalonia.Controls/Avalonia.Controls.csproj
+++ b/src/Avalonia.Controls/Avalonia.Controls.csproj
@@ -58,6 +58,7 @@
     <Compile Include="IScrollable.cs" />
     <Compile Include="Embedding\EmbeddableControlRoot.cs" />
     <Compile Include="Platform\IEmbeddableWindowImpl.cs" />
+    <Compile Include="Platform\ExportAvaloniaModuleAttribute.cs" />
     <Compile Include="WindowIcon.cs" />
     <Compile Include="IPseudoClasses.cs" />
     <Compile Include="DropDownItem.cs" />

--- a/src/Avalonia.Controls/Avalonia.Controls.csproj
+++ b/src/Avalonia.Controls/Avalonia.Controls.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Embedding\EmbeddableControlRoot.cs" />
     <Compile Include="Platform\IEmbeddableWindowImpl.cs" />
     <Compile Include="Platform\ExportAvaloniaModuleAttribute.cs" />
+    <Compile Include="Platform\ExportWindowingSubsystemAttribute.cs" />
     <Compile Include="WindowIcon.cs" />
     <Compile Include="IPseudoClasses.cs" />
     <Compile Include="DropDownItem.cs" />

--- a/src/Avalonia.Controls/Platform/ExportAvaloniaModuleAttribute.cs
+++ b/src/Avalonia.Controls/Platform/ExportAvaloniaModuleAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Avalonia.Platform
+{
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    public class ExportAvaloniaModuleAttribute : Attribute
+    {
+        public ExportAvaloniaModuleAttribute(string name, Type moduleType)
+        {
+            Name = name;
+            ModuleType = moduleType;
+        }
+
+        public string Name { get; private set; }
+        public Type ModuleType { get; private set; }
+
+        public string RequiredWindowingSubsystem { get; set; } = "";
+        public string RequiredRenderingSubsystem { get; set; } = "";
+    }
+}

--- a/src/Avalonia.Controls/Platform/ExportAvaloniaModuleAttribute.cs
+++ b/src/Avalonia.Controls/Platform/ExportAvaloniaModuleAttribute.cs
@@ -2,6 +2,44 @@
 
 namespace Avalonia.Platform
 {
+    /// <summary>
+    /// Defines an "Avalonia Module", a 3rd party extension to Avalonia that can be automatically initialized by an AppBuilder instance.
+    /// </summary>
+    /// <remarks>
+    /// Avalonia Modules can either be platform independent (ex default control styles provider) or dependent on a
+    /// specific windowing or rendering subsystem being used (ex native rendering speedup, subsystem-specific interop backends).
+    /// In the case of a subsystem-specific module, you can specify multiple module implementations, and also a fallback
+    /// platform-independent module if you so choose. Additionally, these different implementations can be in different assemblies.
+    /// They just need to all share the same module name.
+    /// 
+    /// For example, if I had a module Foo that has a special back-end for Skia and a less performant/less user friendly back-end for
+    /// any other rendering subsystem, I would do the following:
+    /// <code>
+    /// // In assembly FooModuleSkia.dll
+    /// [assembly:ExportAvaloniaModule("Foo", typeof(FooModuleSkia), ForRenderingSubsystem="Skia")]
+    /// 
+    /// class FooModuleSkia
+    /// {
+    ///     public FooModuleSkia()
+    ///     {
+    ///         InitializeModule();
+    ///     }
+    /// }
+    /// 
+    /// // In assembly FooModuleFallback.dll
+    /// [assembly:ExportAvaloniaModule("Foo", typeof(FooModuleFallback))]
+    /// 
+    /// class FooModuleFallback
+    /// {
+    ///     public FooModuleFallback()
+    ///     {
+    ///         InitializeModule();
+    ///     }
+    /// }
+    /// 
+    /// </code>
+    /// The fallback module will only be initialized if the Skia-specific module is not applicable.
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
     public class ExportAvaloniaModuleAttribute : Attribute
     {
@@ -14,7 +52,7 @@ namespace Avalonia.Platform
         public string Name { get; private set; }
         public Type ModuleType { get; private set; }
 
-        public string RequiredWindowingSubsystem { get; set; } = "";
-        public string RequiredRenderingSubsystem { get; set; } = "";
+        public string ForWindowingSubsystem { get; set; } = "";
+        public string ForRenderingSubsystem { get; set; } = "";
     }
 }

--- a/src/Avalonia.Controls/Platform/ExportWindowingSubsystemAttribute.cs
+++ b/src/Avalonia.Controls/Platform/ExportWindowingSubsystemAttribute.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Avalonia.Platform
+{
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    public class ExportWindowingSubsystemAttribute : Attribute
+    {
+        public ExportWindowingSubsystemAttribute(OperatingSystemType requiredRuntimePlatform, int priority, string name, Type initializationType, string initializationMethod)
+        {
+            Name = name;
+            InitializationType = initializationType;
+            InitializationMethod = initializationMethod;
+            RequiredOS = requiredRuntimePlatform;
+            Priority = priority;
+        }
+
+        public string InitializationMethod { get; private set; }
+        public Type InitializationType { get; private set; }
+        public string Name { get; private set; }
+        public int Priority { get; private set; }
+        public OperatingSystemType RequiredOS { get; private set; }
+    }
+}

--- a/src/Avalonia.DotNetFrameworkRuntime/AppBuilder.cs
+++ b/src/Avalonia.DotNetFrameworkRuntime/AppBuilder.cs
@@ -43,12 +43,12 @@ namespace Avalonia
                                                select attribute).First();
 
             UseWindowingSubsystem(() => windowingSubsystemAttribute.InitializationType
-                .GetRuntimeMethod(windowingSubsystemAttribute.InitializationMethod, Type.EmptyTypes).Invoke(null, null));
-            WindowingSubsystemName = windowingSubsystemAttribute.Name;
+                .GetRuntimeMethod(windowingSubsystemAttribute.InitializationMethod, Type.EmptyTypes).Invoke(null, null),
+                windowingSubsystemAttribute.Name);
 
             UseRenderingSubsystem(() => renderingSubsystemAttribute.InitializationType
-                .GetRuntimeMethod(renderingSubsystemAttribute.InitializationMethod, Type.EmptyTypes).Invoke(null, null));
-            RenderingSubsystemName = renderingSubsystemAttribute.Name;
+                .GetRuntimeMethod(renderingSubsystemAttribute.InitializationMethod, Type.EmptyTypes).Invoke(null, null),
+                renderingSubsystemAttribute.Name);
             
             return this;
         }

--- a/src/Avalonia.DotNetFrameworkRuntime/AppBuilder.cs
+++ b/src/Avalonia.DotNetFrameworkRuntime/AppBuilder.cs
@@ -28,11 +28,15 @@ namespace Avalonia
             {
                 UseRenderingSubsystem("Avalonia.Cairo");
                 UseWindowingSubsystem("Avalonia.Gtk");
+                WindowingSubsystemName = "Gtk";
+                RenderingSubsystemName = "Cairo";
             }
             else
             {
                 UseRenderingSubsystem("Avalonia.Direct2D1");
                 UseWindowingSubsystem("Avalonia.Win32");
+                WindowingSubsystemName = "Win32";
+                RenderingSubsystemName = "Direct2D1";
             }
             return this;
         }

--- a/src/Avalonia.DotNetFrameworkRuntime/Avalonia.DotNetFrameworkRuntime.csproj
+++ b/src/Avalonia.DotNetFrameworkRuntime/Avalonia.DotNetFrameworkRuntime.csproj
@@ -64,6 +64,10 @@
       <Project>{D2221C82-4A25-4583-9B43-D791E3F6820C}</Project>
       <Name>Avalonia.Controls</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Avalonia.SceneGraph\Avalonia.SceneGraph.csproj">
+      <Project>{eb582467-6abb-43a1-b052-e981ba910e3a}</Project>
+      <Name>Avalonia.SceneGraph</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Avalonia.Styling\Avalonia.Styling.csproj">
       <Project>{f1baa01a-f176-4c6a-b39d-5b40bb1b148f}</Project>
       <Name>Avalonia.Styling</Name>

--- a/src/Avalonia.SceneGraph/Avalonia.SceneGraph.csproj
+++ b/src/Avalonia.SceneGraph/Avalonia.SceneGraph.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Media\FormattedText.cs" />
     <Compile Include="Media\Geometry.cs" />
     <Compile Include="Media\IDrawingContext.cs" />
+    <Compile Include="Platform\ExportRenderingSubsystemAttribute.cs" />
     <Compile Include="RenderTargetCorruptedException.cs" />
     <Compile Include="VisualTree\IVisual.cs" />
     <Compile Include="Media\Imaging\Bitmap.cs" />

--- a/src/Avalonia.SceneGraph/Platform/ExportRenderingSubsystemAttribute.cs
+++ b/src/Avalonia.SceneGraph/Platform/ExportRenderingSubsystemAttribute.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Avalonia.Platform
+{
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    public class ExportRenderingSubsystemAttribute : Attribute
+    {
+        public ExportRenderingSubsystemAttribute(OperatingSystemType requiredOS, int priority, string name, Type initializationType, string initializationMethod)
+        {
+            Name = name;
+            InitializationType = initializationType;
+            InitializationMethod = initializationMethod;
+            RequiredOS = requiredOS;
+            Priority = priority;
+        }
+
+        public string InitializationMethod { get; private set; }
+        public Type InitializationType { get; private set; }
+        public string Name { get; private set; }
+        public int Priority { get; private set; }
+        public OperatingSystemType RequiredOS { get; private set; }
+        public string RequiresWindowingSubsystem { get; set; }
+    }
+}

--- a/src/Gtk/Avalonia.Cairo/CairoPlatform.cs
+++ b/src/Gtk/Avalonia.Cairo/CairoPlatform.cs
@@ -14,8 +14,7 @@ namespace Avalonia
     {
         public static T UseCairo<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.UseRenderingSubsystem(Cairo.CairoPlatform.Initialize);
-            builder.RenderingSubsystemName = "Cairo";
+            builder.UseRenderingSubsystem(Cairo.CairoPlatform.Initialize, "Cairo");
             return builder;
         }
     }

--- a/src/Gtk/Avalonia.Cairo/CairoPlatform.cs
+++ b/src/Gtk/Avalonia.Cairo/CairoPlatform.cs
@@ -14,7 +14,8 @@ namespace Avalonia
     {
         public static T UseCairo<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.RenderingSubsystem = Avalonia.Cairo.CairoPlatform.Initialize;
+            builder.RenderingSubsystemInitializer = Cairo.CairoPlatform.Initialize;
+            builder.RenderingSubsystemName = "Cairo";
             return builder;
         }
     }

--- a/src/Gtk/Avalonia.Cairo/CairoPlatform.cs
+++ b/src/Gtk/Avalonia.Cairo/CairoPlatform.cs
@@ -14,7 +14,7 @@ namespace Avalonia
     {
         public static T UseCairo<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.RenderingSubsystemInitializer = Cairo.CairoPlatform.Initialize;
+            builder.UseRenderingSubsystem(Cairo.CairoPlatform.Initialize);
             builder.RenderingSubsystemName = "Cairo";
             return builder;
         }

--- a/src/Gtk/Avalonia.Cairo/Properties/AssemblyInfo.cs
+++ b/src/Gtk/Avalonia.Cairo/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using Avalonia.Cairo;
+using Avalonia.Platform;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -37,3 +39,7 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: ExportRenderingSubsystem(OperatingSystemType.WinNT, 2, "Cairo", typeof(CairoPlatform), nameof(CairoPlatform.Initialize), RequiresWindowingSubsystem = "GTK")]
+[assembly: ExportRenderingSubsystem(OperatingSystemType.Linux, 1, "Cairo", typeof(CairoPlatform), nameof(CairoPlatform.Initialize), RequiresWindowingSubsystem = "GTK")]
+[assembly: ExportRenderingSubsystem(OperatingSystemType.OSX, 2, "Cairo", typeof(CairoPlatform), nameof(CairoPlatform.Initialize), RequiresWindowingSubsystem = "GTK")]

--- a/src/Gtk/Avalonia.Gtk/GtkPlatform.cs
+++ b/src/Gtk/Avalonia.Gtk/GtkPlatform.cs
@@ -16,8 +16,7 @@ namespace Avalonia
     {
         public static T UseGtk<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.UseWindowingSubsystem(Gtk.GtkPlatform.Initialize);
-            builder.WindowingSubsystemName = "Gtk";
+            builder.UseWindowingSubsystem(Gtk.GtkPlatform.Initialize, "Gtk");
             return builder;
         }
     }

--- a/src/Gtk/Avalonia.Gtk/GtkPlatform.cs
+++ b/src/Gtk/Avalonia.Gtk/GtkPlatform.cs
@@ -16,7 +16,7 @@ namespace Avalonia
     {
         public static T UseGtk<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.WindowingSubsystemInitializer = Gtk.GtkPlatform.Initialize;
+            builder.UseWindowingSubsystem(Gtk.GtkPlatform.Initialize);
             builder.WindowingSubsystemName = "Gtk";
             return builder;
         }

--- a/src/Gtk/Avalonia.Gtk/GtkPlatform.cs
+++ b/src/Gtk/Avalonia.Gtk/GtkPlatform.cs
@@ -16,7 +16,8 @@ namespace Avalonia
     {
         public static T UseGtk<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.WindowingSubsystem = Avalonia.Gtk.GtkPlatform.Initialize;
+            builder.WindowingSubsystemInitializer = Gtk.GtkPlatform.Initialize;
+            builder.WindowingSubsystemName = "Gtk";
             return builder;
         }
     }

--- a/src/Gtk/Avalonia.Gtk/Properties/AssemblyInfo.cs
+++ b/src/Gtk/Avalonia.Gtk/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using Avalonia.Gtk;
+using Avalonia.Platform;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -19,3 +21,8 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 [assembly: AssemblyVersion("1.0.*")]
+
+[assembly: ExportWindowingSubsystem(OperatingSystemType.WinNT, 2, "GTK", typeof(GtkPlatform), nameof(GtkPlatform.Initialize))]
+[assembly: ExportWindowingSubsystem(OperatingSystemType.Linux, 1, "GTK", typeof(GtkPlatform), nameof(GtkPlatform.Initialize))]
+[assembly: ExportWindowingSubsystem(OperatingSystemType.OSX, 2, "GTK", typeof(GtkPlatform), nameof(GtkPlatform.Initialize))]
+

--- a/src/Skia/Avalonia.Skia.Desktop/Properties/AssemblyInfo.cs
+++ b/src/Skia/Avalonia.Skia.Desktop/Properties/AssemblyInfo.cs
@@ -1,3 +1,5 @@
+using Avalonia.Platform;
+using Avalonia.Skia;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -34,3 +36,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: ExportRenderingSubsystem(OperatingSystemType.WinNT, 3, "Skia", typeof(SkiaPlatform), nameof(SkiaPlatform.Initialize))]

--- a/src/Skia/Avalonia.Skia/SkiaPlatform.cs
+++ b/src/Skia/Avalonia.Skia/SkiaPlatform.cs
@@ -10,7 +10,8 @@ namespace Avalonia
     {
         public static T UseSkia<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.RenderingSubsystem = Avalonia.Skia.SkiaPlatform.Initialize;
+            builder.RenderingSubsystemInitializer = Avalonia.Skia.SkiaPlatform.Initialize;
+            builder.RenderingSubsystemName = "Skia";
             return builder;
         }
     }

--- a/src/Skia/Avalonia.Skia/SkiaPlatform.cs
+++ b/src/Skia/Avalonia.Skia/SkiaPlatform.cs
@@ -10,7 +10,7 @@ namespace Avalonia
     {
         public static T UseSkia<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.RenderingSubsystemInitializer = Avalonia.Skia.SkiaPlatform.Initialize;
+            builder.UseRenderingSubsystem(Skia.SkiaPlatform.Initialize);
             builder.RenderingSubsystemName = "Skia";
             return builder;
         }

--- a/src/Skia/Avalonia.Skia/SkiaPlatform.cs
+++ b/src/Skia/Avalonia.Skia/SkiaPlatform.cs
@@ -10,8 +10,7 @@ namespace Avalonia
     {
         public static T UseSkia<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.UseRenderingSubsystem(Skia.SkiaPlatform.Initialize);
-            builder.RenderingSubsystemName = "Skia";
+            builder.UseRenderingSubsystem(Skia.SkiaPlatform.Initialize, "Skia");
             return builder;
         }
     }

--- a/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
+++ b/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
@@ -14,8 +14,7 @@ namespace Avalonia
     {
         public static T UseDirect2D1<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.UseRenderingSubsystem(Direct2D1.Direct2D1Platform.Initialize);
-            builder.RenderingSubsystemName = "Direct2D1";
+            builder.UseRenderingSubsystem(Direct2D1.Direct2D1Platform.Initialize, "Direct2D1");
             return builder;
         }
     }

--- a/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
+++ b/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
@@ -14,7 +14,7 @@ namespace Avalonia
     {
         public static T UseDirect2D1<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.RenderingSubsystemInitializer = Avalonia.Direct2D1.Direct2D1Platform.Initialize;
+            builder.UseRenderingSubsystem(Direct2D1.Direct2D1Platform.Initialize);
             builder.RenderingSubsystemName = "Direct2D1";
             return builder;
         }

--- a/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
+++ b/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
@@ -14,7 +14,8 @@ namespace Avalonia
     {
         public static T UseDirect2D1<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.RenderingSubsystem = Avalonia.Direct2D1.Direct2D1Platform.Initialize;
+            builder.RenderingSubsystemInitializer = Avalonia.Direct2D1.Direct2D1Platform.Initialize;
+            builder.RenderingSubsystemName = "Direct2D1";
             return builder;
         }
     }

--- a/src/Windows/Avalonia.Direct2D1/Properties/AssemblyInfo.cs
+++ b/src/Windows/Avalonia.Direct2D1/Properties/AssemblyInfo.cs
@@ -2,5 +2,9 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System.Reflection;
+using Avalonia.Platform;
+using Avalonia.Direct2D1;
 
 [assembly: AssemblyTitle("Avalonia.Direct2D1")]
+[assembly: ExportRenderingSubsystem(OperatingSystemType.WinNT, 1, "Direct2D1", typeof(Direct2D1Platform), nameof(Direct2D1Platform.Initialize))]
+

--- a/src/Windows/Avalonia.Win32/Properties/AssemblyInfo.cs
+++ b/src/Windows/Avalonia.Win32/Properties/AssemblyInfo.cs
@@ -1,6 +1,9 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using Avalonia.Platform;
+using Avalonia.Win32;
 using System.Reflection;
 
 [assembly: AssemblyTitle("Avalonia.Win32")]
+[assembly: ExportWindowingSubsystem(OperatingSystemType.WinNT, 1, "Win32", typeof(Win32Platform), nameof(Win32Platform.Initialize))]

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -23,7 +23,8 @@ namespace Avalonia
     {
         public static T UseWin32<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.WindowingSubsystem = Avalonia.Win32.Win32Platform.Initialize;
+            builder.WindowingSubsystemInitializer = Win32.Win32Platform.Initialize;
+            builder.WindowingSubsystemName = "Win32";
             return builder;
         }
     }

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -23,8 +23,7 @@ namespace Avalonia
     {
         public static T UseWin32<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.UseWindowingSubsystem(Win32.Win32Platform.Initialize);
-            builder.WindowingSubsystemName = "Win32";
+            builder.UseWindowingSubsystem(Win32.Win32Platform.Initialize, "Win32");
             return builder;
         }
     }

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -23,7 +23,7 @@ namespace Avalonia
     {
         public static T UseWin32<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.WindowingSubsystemInitializer = Win32.Win32Platform.Initialize;
+            builder.UseWindowingSubsystem(Win32.Win32Platform.Initialize);
             builder.WindowingSubsystemName = "Win32";
             return builder;
         }

--- a/src/iOS/Avalonia.iOS/iOSPlatform.cs
+++ b/src/iOS/Avalonia.iOS/iOSPlatform.cs
@@ -15,7 +15,7 @@ namespace Avalonia
     {
         public static T UseiOS<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.WindowingSubsystemInitializer = iOSPlatform.Initialize;
+            builder.UseWindowingSubsystem(iOSPlatform.Initialize);
             builder.WindowingSubsystemName = "iOS";
             return builder;
         }

--- a/src/iOS/Avalonia.iOS/iOSPlatform.cs
+++ b/src/iOS/Avalonia.iOS/iOSPlatform.cs
@@ -15,8 +15,7 @@ namespace Avalonia
     {
         public static T UseiOS<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.UseWindowingSubsystem(iOSPlatform.Initialize);
-            builder.WindowingSubsystemName = "iOS";
+            builder.UseWindowingSubsystem(iOSPlatform.Initialize, "iOS");
             return builder;
         }
 

--- a/src/iOS/Avalonia.iOS/iOSPlatform.cs
+++ b/src/iOS/Avalonia.iOS/iOSPlatform.cs
@@ -15,7 +15,8 @@ namespace Avalonia
     {
         public static T UseiOS<T>(this T builder) where T : AppBuilderBase<T>, new()
         {
-            builder.WindowingSubsystem = Avalonia.iOS.iOSPlatform.Initialize;
+            builder.WindowingSubsystemInitializer = iOSPlatform.Initialize;
+            builder.WindowingSubsystemName = "iOS";
             return builder;
         }
 

--- a/tests/Avalonia.Controls.UnitTests/AppBuilderTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/AppBuilderTests.cs
@@ -61,52 +61,61 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void LoadsDefaultModule()
         {
-            ResetModuleLoadStates();
-            AppBuilder.Configure<App>()
-                .UseWindowingSubsystem(() => { })
-                .UseRenderingSubsystem(() => { })
-                .UseAvaloniaModules()
-                .SetupWithoutStarting();
+            using (AvaloniaLocator.EnterScope())
+            {
+                ResetModuleLoadStates();
+                AppBuilder.Configure<App>()
+                    .UseWindowingSubsystem(() => { })
+                    .UseRenderingSubsystem(() => { })
+                    .UseAvaloniaModules()
+                    .SetupWithoutStarting();
 
-            Assert.True(DefaultModule.IsLoaded);
+                Assert.True(DefaultModule.IsLoaded); 
+            }
         }
 
         [Fact]
         public void LoadsRenderingModuleWithMatchingRenderingSubsystem()
         {
-            ResetModuleLoadStates();
-            var builder = AppBuilder.Configure<App>()
-                .UseWindowingSubsystem(() => { })
-                .UseRenderingSubsystem(() => { });
-            builder.RenderingSubsystemName = "Direct2D1";
-            builder.UseAvaloniaModules().SetupWithoutStarting();
-            Assert.False(DefaultRenderingModule.IsLoaded);
-            Assert.True(Direct2DModule.IsLoaded);
-            Assert.False(SkiaModule.IsLoaded);
+            using (AvaloniaLocator.EnterScope())
+            {
+                ResetModuleLoadStates();
+                var builder = AppBuilder.Configure<App>()
+                    .UseWindowingSubsystem(() => { })
+                    .UseRenderingSubsystem(() => { });
+                builder.RenderingSubsystemName = "Direct2D1";
+                builder.UseAvaloniaModules().SetupWithoutStarting();
+                Assert.False(DefaultRenderingModule.IsLoaded);
+                Assert.True(Direct2DModule.IsLoaded);
+                Assert.False(SkiaModule.IsLoaded);
 
-            ResetModuleLoadStates();
-            builder = AppBuilder.Configure<App>()
-                .UseWindowingSubsystem(() => { })
-                .UseRenderingSubsystem(() => { });
-            builder.RenderingSubsystemName = "Skia";
-            builder.UseAvaloniaModules().SetupWithoutStarting();
-            Assert.False(DefaultRenderingModule.IsLoaded);
-            Assert.False(Direct2DModule.IsLoaded);
-            Assert.True(SkiaModule.IsLoaded);
+                ResetModuleLoadStates();
+                builder = AppBuilder.Configure<App>()
+                    .UseWindowingSubsystem(() => { })
+                    .UseRenderingSubsystem(() => { });
+                builder.RenderingSubsystemName = "Skia";
+                builder.UseAvaloniaModules().SetupWithoutStarting();
+                Assert.False(DefaultRenderingModule.IsLoaded);
+                Assert.False(Direct2DModule.IsLoaded);
+                Assert.True(SkiaModule.IsLoaded); 
+            }
         }
 
         [Fact]
         public void LoadsRenderingModuleWithoutDependenciesWhenNoModuleMatches()
         {
-            ResetModuleLoadStates();
-            var builder = AppBuilder.Configure<App>()
-                .UseWindowingSubsystem(() => { })
-                .UseRenderingSubsystem(() => { });
-            builder.RenderingSubsystemName = "Cairo";
-            builder.UseAvaloniaModules().SetupWithoutStarting();
-            Assert.True(DefaultRenderingModule.IsLoaded);
-            Assert.False(Direct2DModule.IsLoaded);
-            Assert.False(SkiaModule.IsLoaded);
+            using (AvaloniaLocator.EnterScope())
+            {
+                ResetModuleLoadStates();
+                var builder = AppBuilder.Configure<App>()
+                    .UseWindowingSubsystem(() => { })
+                    .UseRenderingSubsystem(() => { });
+                builder.RenderingSubsystemName = "Cairo";
+                builder.UseAvaloniaModules().SetupWithoutStarting();
+                Assert.True(DefaultRenderingModule.IsLoaded);
+                Assert.False(Direct2DModule.IsLoaded);
+                Assert.False(SkiaModule.IsLoaded); 
+            }
         }
 
         private static void ResetModuleLoadStates()

--- a/tests/Avalonia.Controls.UnitTests/AppBuilderTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/AppBuilderTests.cs
@@ -8,8 +8,8 @@ using Avalonia.Controls.UnitTests;
 using Avalonia.Platform;
 
 [assembly: ExportAvaloniaModule("DefaultModule", typeof(AppBuilderTests.DefaultModule))]
-[assembly: ExportAvaloniaModule("RenderingModule", typeof(AppBuilderTests.Direct2DModule), RequiredRenderingSubsystem = "Direct2D1")]
-[assembly: ExportAvaloniaModule("RenderingModule", typeof(AppBuilderTests.SkiaModule), RequiredRenderingSubsystem = "Skia")]
+[assembly: ExportAvaloniaModule("RenderingModule", typeof(AppBuilderTests.Direct2DModule), ForRenderingSubsystem = "Direct2D1")]
+[assembly: ExportAvaloniaModule("RenderingModule", typeof(AppBuilderTests.SkiaModule), ForRenderingSubsystem = "Skia")]
 [assembly: ExportAvaloniaModule("RenderingModule", typeof(AppBuilderTests.DefaultRenderingModule))]
 
 
@@ -82,8 +82,7 @@ namespace Avalonia.Controls.UnitTests
                 ResetModuleLoadStates();
                 var builder = AppBuilder.Configure<App>()
                     .UseWindowingSubsystem(() => { })
-                    .UseRenderingSubsystem(() => { });
-                builder.RenderingSubsystemName = "Direct2D1";
+                    .UseRenderingSubsystem(() => { }, "Direct2D1");
                 builder.UseAvaloniaModules().SetupWithoutStarting();
                 Assert.False(DefaultRenderingModule.IsLoaded);
                 Assert.True(Direct2DModule.IsLoaded);
@@ -92,8 +91,7 @@ namespace Avalonia.Controls.UnitTests
                 ResetModuleLoadStates();
                 builder = AppBuilder.Configure<App>()
                     .UseWindowingSubsystem(() => { })
-                    .UseRenderingSubsystem(() => { });
-                builder.RenderingSubsystemName = "Skia";
+                    .UseRenderingSubsystem(() => { }, "Skia");
                 builder.UseAvaloniaModules().SetupWithoutStarting();
                 Assert.False(DefaultRenderingModule.IsLoaded);
                 Assert.False(Direct2DModule.IsLoaded);
@@ -109,8 +107,7 @@ namespace Avalonia.Controls.UnitTests
                 ResetModuleLoadStates();
                 var builder = AppBuilder.Configure<App>()
                     .UseWindowingSubsystem(() => { })
-                    .UseRenderingSubsystem(() => { });
-                builder.RenderingSubsystemName = "Cairo";
+                    .UseRenderingSubsystem(() => { }, "Cairo");
                 builder.UseAvaloniaModules().SetupWithoutStarting();
                 Assert.True(DefaultRenderingModule.IsLoaded);
                 Assert.False(Direct2DModule.IsLoaded);

--- a/tests/Avalonia.Controls.UnitTests/AppBuilderTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/AppBuilderTests.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Avalonia.Controls.UnitTests;
+using Avalonia.Platform;
+
+[assembly: ExportAvaloniaModule("DefaultModule", typeof(AppBuilderTests.DefaultModule))]
+[assembly: ExportAvaloniaModule("RenderingModule", typeof(AppBuilderTests.Direct2DModule), RequiredRenderingSubsystem = "Direct2D1")]
+[assembly: ExportAvaloniaModule("RenderingModule", typeof(AppBuilderTests.SkiaModule), RequiredRenderingSubsystem = "Skia")]
+[assembly: ExportAvaloniaModule("RenderingModule", typeof(AppBuilderTests.DefaultRenderingModule))]
+
+
+namespace Avalonia.Controls.UnitTests
+{
+
+    public class AppBuilderTests
+    {
+        class App : Application
+        {
+        }
+
+        public class DefaultModule
+        {
+            public static bool IsLoaded = false;
+            public DefaultModule()
+            {
+                IsLoaded = true;
+            }
+        }
+
+        public class DefaultRenderingModule
+        {
+            public static bool IsLoaded = false;
+            public DefaultRenderingModule()
+            {
+                IsLoaded = true;
+            }
+        }
+
+        public class Direct2DModule
+        {
+            public static bool IsLoaded = false;
+            public Direct2DModule()
+            {
+                IsLoaded = true;
+            }
+        }
+
+        public class SkiaModule
+        {
+            public static bool IsLoaded = false;
+            public SkiaModule()
+            {
+                IsLoaded = true;
+            }
+        }
+        
+        [Fact]
+        public void LoadsDefaultModule()
+        {
+            ResetModuleLoadStates();
+            AppBuilder.Configure<App>()
+                .UseWindowingSubsystem(() => { })
+                .UseRenderingSubsystem(() => { })
+                .UseAvaloniaModules()
+                .SetupWithoutStarting();
+
+            Assert.True(DefaultModule.IsLoaded);
+        }
+
+        [Fact]
+        public void LoadsRenderingModuleWithMatchingRenderingSubsystem()
+        {
+            ResetModuleLoadStates();
+            var builder = AppBuilder.Configure<App>()
+                .UseWindowingSubsystem(() => { })
+                .UseRenderingSubsystem(() => { });
+            builder.RenderingSubsystemName = "Direct2D1";
+            builder.UseAvaloniaModules().SetupWithoutStarting();
+            Assert.False(DefaultRenderingModule.IsLoaded);
+            Assert.True(Direct2DModule.IsLoaded);
+            Assert.False(SkiaModule.IsLoaded);
+
+            ResetModuleLoadStates();
+            builder = AppBuilder.Configure<App>()
+                .UseWindowingSubsystem(() => { })
+                .UseRenderingSubsystem(() => { });
+            builder.RenderingSubsystemName = "Skia";
+            builder.UseAvaloniaModules().SetupWithoutStarting();
+            Assert.False(DefaultRenderingModule.IsLoaded);
+            Assert.False(Direct2DModule.IsLoaded);
+            Assert.True(SkiaModule.IsLoaded);
+        }
+
+        [Fact]
+        public void LoadsRenderingModuleWithoutDependenciesWhenNoModuleMatches()
+        {
+            ResetModuleLoadStates();
+            var builder = AppBuilder.Configure<App>()
+                .UseWindowingSubsystem(() => { })
+                .UseRenderingSubsystem(() => { });
+            builder.RenderingSubsystemName = "Cairo";
+            builder.UseAvaloniaModules().SetupWithoutStarting();
+            Assert.True(DefaultRenderingModule.IsLoaded);
+            Assert.False(Direct2DModule.IsLoaded);
+            Assert.False(SkiaModule.IsLoaded);
+        }
+
+        private static void ResetModuleLoadStates()
+        {
+            DefaultModule.IsLoaded = false;
+            DefaultRenderingModule.IsLoaded = false;
+            Direct2DModule.IsLoaded = false;
+            SkiaModule.IsLoaded = false;
+        }
+    }
+}

--- a/tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj
+++ b/tests/Avalonia.Controls.UnitTests/Avalonia.Controls.UnitTests.csproj
@@ -94,6 +94,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="AppBuilderTests.cs" />
     <Compile Include="ClassesTests.cs" />
     <Compile Include="LayoutTransformControlTests.cs" />
     <Compile Include="Presenters\ItemsPresenterTests_Virtualization_Simple.cs" />
@@ -152,6 +153,10 @@
     <Compile Include="WrapPanelTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Avalonia.DotNetFrameworkRuntime\Avalonia.DotNetFrameworkRuntime.csproj">
+      <Project>{4a1abb09-9047-4bd5-a4ad-a055e52c5ee0}</Project>
+      <Name>Avalonia.DotNetFrameworkRuntime</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Markup\Avalonia.Markup.Xaml\Avalonia.Markup.Xaml.csproj">
       <Project>{3e53a01a-b331-47f3-b828-4a5717e77a24}</Project>
       <Name>Avalonia.Markup.Xaml</Name>

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -249,12 +249,16 @@ namespace Avalonia.Controls.UnitTests.Primitives
             var globalStyles = new Mock<IGlobalStyles>();
             globalStyles.Setup(x => x.Styles).Returns(styles);
 
+            var renderInterface = new Mock<IPlatformRenderInterface>();
+            renderInterface.Setup(x => x.CreateRenderer(It.IsAny<IPlatformHandle>())).Returns(() => new Mock<IRenderTarget>().Object);
+
             AvaloniaLocator.CurrentMutable
                 .Bind<ILayoutManager>().ToTransient<LayoutManager>()
                 .Bind<IGlobalStyles>().ToFunc(() => globalStyles.Object)
                 .Bind<IWindowingPlatform>().ToConstant(new WindowingPlatformMock())
-                .Bind<IStyler>().ToTransient<Styler>();
-
+                .Bind<IStyler>().ToTransient<Styler>()
+                .Bind<IPlatformRenderInterface>().ToFunc(() => renderInterface.Object);
+            
             return result;
         }
 

--- a/tests/Avalonia.UnitTests/TestServices.cs
+++ b/tests/Avalonia.UnitTests/TestServices.cs
@@ -152,7 +152,8 @@ namespace Avalonia.UnitTests
                     It.IsAny<FontWeight>(),
                     It.IsAny<TextWrapping>()) == Mock.Of<IFormattedTextImpl>() &&
                 x.CreateStreamGeometry() == Mock.Of<IStreamGeometryImpl>(
-                    y => y.Open() == Mock.Of<IStreamGeometryContextImpl>()));
+                    y => y.Open() == Mock.Of<IStreamGeometryContextImpl>()) &&
+                x.CreateRenderer(It.IsAny<IPlatformHandle>()) == Mock.Of<IRenderTarget>());
         }
     }
 }


### PR DESCRIPTION
This PR adds a way for automatically initializing 3rd party libraries and for automatically loading the best windowing and rendering subsystems available for the current OS platform.
## 3rd Party -- AvaloniaModules

An AvalonaModule is a class that sets up any services or styles needed at startup. For example, if a library provides a templated control with default styles, an AvaloniaModule can load those modules into the `IGlobalStyles` collection. For some more examples, registering services for controls that have custom backends (like a SharpDX native one and a Skia native one) or adding new property accessors or validation plugins.

Add an attribute to an assembly as follows:

``` csharp
[assembly: ExportAvaloniaModuleAttribute("ModuleName", typeof(ModuleType))]
```

Additionally, you can have a module depend on a specific windowing or rendering subsystem. You can have multiple modules with the same name with varying requirements on windowing and rendering subsystems. The one with the most dependencies fulfilled will be loaded. Like the following:

``` csharp
[assembly: ExportAvaloniaModule("RenderingModule", typeof(Direct2DModule), RequiredRenderingSubsystem = "Direct2D1")]
[assembly: ExportAvaloniaModule("RenderingModule", typeof(SkiaModule), RequiredRenderingSubsystem = "Skia")]
[assembly: ExportAvaloniaModule("RenderingModule", typeof(DefaultRenderingModule))]
```
## Windowing and Rendering Subsystems

These function very similar (registered via assembly attributes). And a rendering subsystem can depend on a windowing subsystem (like how Cairo depends on GTK). Windowing and Rendering subsystems depend on operating systems. For example, Win32, Cairo and GTK are registered as follows:

``` csharp
[assembly: ExportWindowingSubsystem(OperatingSystemType.WinNT, 1, "Win32", typeof(Win32Platform), nameof(Win32Platform.Initialize))]

[assembly: ExportRenderingSubsystem(OperatingSystemType.WinNT, 2, "Cairo", typeof(CairoPlatform), nameof(CairoPlatform.Initialize), RequiresWindowingSubsystem = "GTK")]
[assembly: ExportRenderingSubsystem(OperatingSystemType.Linux, 1, "Cairo", typeof(CairoPlatform), nameof(CairoPlatform.Initialize), RequiresWindowingSubsystem = "GTK")]
[assembly: ExportRenderingSubsystem(OperatingSystemType.OSX, 2, "Cairo", typeof(CairoPlatform), nameof(CairoPlatform.Initialize), RequiresWindowingSubsystem = "GTK")]

[assembly: ExportWindowingSubsystem(OperatingSystemType.WinNT, 2, "GTK", typeof(GtkPlatform), nameof(GtkPlatform.Initialize))]
[assembly: ExportWindowingSubsystem(OperatingSystemType.Linux, 1, "GTK", typeof(GtkPlatform), nameof(GtkPlatform.Initialize))]
[assembly: ExportWindowingSubsystem(OperatingSystemType.OSX, 2, "GTK", typeof(GtkPlatform), nameof(GtkPlatform.Initialize))]

```
