### PR TITLE
Memory leak fixes

### DIFF
--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -268,8 +268,13 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnDetachedFromLogicalTree(e);
             _topLevel = null;
-            _popupRoot?.Dispose();
-            _popupRoot = null;
+            
+            if (_popupRoot != null)
+            {
+                ((ISetLogicalParent)_popupRoot).SetParent(null);
+                _popupRoot.Dispose();
+                _popupRoot = null;
+            }
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -182,6 +182,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         IVisual IVisualTreeHost.Root => _popupRoot;
 
+        bool _ignoreIsOpenChanged = false;
+
         /// <summary>
         /// Opens the popup.
         /// </summary>
@@ -220,7 +222,11 @@ namespace Avalonia.Controls.Primitives
             PopupRootCreated?.Invoke(this, EventArgs.Empty);
 
             _popupRoot.Show();
+
+            _ignoreIsOpenChanged = true;
             IsOpen = true;
+            _ignoreIsOpenChanged = false;
+
             Opened?.Invoke(this, EventArgs.Empty);
         }
 
@@ -283,13 +289,16 @@ namespace Avalonia.Controls.Primitives
         /// <param name="e">The event args.</param>
         private void IsOpenChanged(AvaloniaPropertyChangedEventArgs e)
         {
-            if ((bool)e.NewValue)
+            if (!_ignoreIsOpenChanged)
             {
-                Open();
-            }
-            else
-            {
-                Close();
+                if ((bool)e.NewValue)
+                {
+                    Open();
+                }
+                else
+                {
+                    Close();
+                }
             }
         }
 

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -68,6 +68,7 @@ namespace Avalonia.Controls.Primitives
         private PopupRoot _popupRoot;
         private TopLevel _topLevel;
         private IDisposable _nonClientListener;
+        bool _ignoreIsOpenChanged = false;
 
         /// <summary>
         /// Initializes static members of the <see cref="Popup"/> class.
@@ -181,8 +182,6 @@ namespace Avalonia.Controls.Primitives
         /// Gets the root of the popup window.
         /// </summary>
         IVisual IVisualTreeHost.Root => _popupRoot;
-
-        bool _ignoreIsOpenChanged = false;
 
         /// <summary>
         /// Opens the popup.

--- a/src/Avalonia.Themes.Default/DropDown.xaml
+++ b/src/Avalonia.Themes.Default/DropDown.xaml
@@ -10,10 +10,10 @@
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}">
           <Grid ColumnDefinitions="*,Auto">
-            <ContentPresenter Content="{TemplateBinding SelectionBoxItem}"
-                              Margin="{TemplateBinding Padding}"
-                              HorizontalAlignment="Left"
-                              VerticalAlignment="Center"/>
+            <ContentControl Content="{TemplateBinding SelectionBoxItem}"
+                            Margin="{TemplateBinding Padding}"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"/>
             <ToggleButton Name="toggle"
                           BorderThickness="0"
                           Background="Transparent"

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -167,6 +167,24 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
+        public void PopupRoot_Should_Be_Detached_From_Logical_Tree_When_Popup_Is_Detached()
+        {
+            using (CreateServices())
+            {
+                var target = new Popup();
+                var root = new TestRoot { Child = target };
+
+                target.Open();
+
+                var popupRoot = (ILogical)target.PopupRoot;
+
+                Assert.True(popupRoot.IsAttachedToLogicalTree);
+                root.Child = null;
+                Assert.False(((ILogical)target).IsAttachedToLogicalTree);
+            }
+        }
+
+        [Fact]
         public void PopupRoot_Should_Have_Template_Applied()
         {
             using (CreateServices())


### PR DESCRIPTION
- Use ContentControl in DropDown template instead of `ContentPresenter`. This fixes a memory leak whereby `DropDown` wasn't correctly parenting the `Rectangle` created for `SelectionBoxItem` when the selected item is a control. 
- Remove `PopupRoot` from logical tree when parent `Popup` is removed.

Fixes #706.
