### PR TITLE
Treat warnings as errors.

### DIFF
--- a/samples/ControlCatalog.Android/ControlCatalog.Android.v2.ncrunchproject
+++ b/samples/ControlCatalog.Android/ControlCatalog.Android.v2.ncrunchproject
@@ -1,0 +1,26 @@
+﻿<ProjectConfiguration>
+  <AutoDetectNugetBuildDependencies>true</AutoDetectNugetBuildDependencies>
+  <BuildPriority>1000</BuildPriority>
+  <CopyReferencedAssembliesToWorkspace>false</CopyReferencedAssembliesToWorkspace>
+  <ConsiderInconclusiveTestsAsPassing>false</ConsiderInconclusiveTestsAsPassing>
+  <PreloadReferencedAssemblies>false</PreloadReferencedAssemblies>
+  <AllowDynamicCodeContractChecking>true</AllowDynamicCodeContractChecking>
+  <AllowStaticCodeContractChecking>false</AllowStaticCodeContractChecking>
+  <AllowCodeAnalysis>false</AllowCodeAnalysis>
+  <IgnoreThisComponentCompletely>true</IgnoreThisComponentCompletely>
+  <RunPreBuildEvents>false</RunPreBuildEvents>
+  <RunPostBuildEvents>false</RunPostBuildEvents>
+  <PreviouslyBuiltSuccessfully>false</PreviouslyBuiltSuccessfully>
+  <InstrumentAssembly>true</InstrumentAssembly>
+  <PreventSigningOfAssembly>false</PreventSigningOfAssembly>
+  <AnalyseExecutionTimes>true</AnalyseExecutionTimes>
+  <DetectStackOverflow>true</DetectStackOverflow>
+  <IncludeStaticReferencesInWorkspace>true</IncludeStaticReferencesInWorkspace>
+  <DefaultTestTimeout>60000</DefaultTestTimeout>
+  <UseBuildConfiguration />
+  <UseBuildPlatform />
+  <ProxyProcessPath />
+  <UseCPUArchitecture>AutoDetect</UseCPUArchitecture>
+  <MSTestThreadApartmentState>STA</MSTestThreadApartmentState>
+  <BuildProcessArchitecture>x86</BuildProcessArchitecture>
+</ProjectConfiguration>

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/MainWindowImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/MainWindowImpl.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         {
         }
 
-        public WindowState WindowState
+        public new WindowState WindowState
         {
             get { return WindowState.Normal; }
             set { }

--- a/src/Avalonia.Animation/Avalonia.Animation.csproj
+++ b/src/Avalonia.Animation/Avalonia.Animation.csproj
@@ -25,6 +25,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Avalonia.Animation.XML</DocumentationFile>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -35,6 +36,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Avalonia.Animation.XML</DocumentationFile>
     <NoWarn>CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->

--- a/src/Avalonia.Base/Avalonia.Base.csproj
+++ b/src/Avalonia.Base/Avalonia.Base.csproj
@@ -38,6 +38,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Avalonia.Base.XML</DocumentationFile>
     <NoWarn>CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Shared\SharedAssemblyInfo.cs">

--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -164,9 +164,7 @@ namespace Avalonia
 
             set
             {
-                var metadata = binding.Property.GetMetadata(GetType());
                 var sourceBinding = value as IBinding;
-
                 this.Bind(binding.Property, sourceBinding);
             }
         }

--- a/src/Avalonia.Base/AvaloniaPropertyRegistry.cs
+++ b/src/Avalonia.Base/AvaloniaPropertyRegistry.cs
@@ -64,8 +64,6 @@ namespace Avalonia
         {
             Contract.Requires<ArgumentNullException>(type != null);
 
-            var i = type.GetTypeInfo();
-
             while (type != null)
             {
                 // Ensure the type's static ctor has been run.
@@ -265,7 +263,8 @@ namespace Avalonia
         /// <param name="property">The property.</param>
         /// <remarks>
         /// You won't usually want to call this method directly, instead use the
-        /// <see cref="AvaloniaProperty.Register"/> method.
+        /// <see cref="AvaloniaProperty.Register{TOwner, TValue}(string, TValue, bool, Data.BindingMode, Func{TOwner, TValue, TValue}, Action{IAvaloniaObject, bool})"/>
+        /// method.
         /// </remarks>
         public void Register(Type type, AvaloniaProperty property)
         {

--- a/src/Avalonia.Base/Collections/AvaloniaDictionary.cs
+++ b/src/Avalonia.Base/Collections/AvaloniaDictionary.cs
@@ -207,7 +207,6 @@ namespace Avalonia.Collections
 
             if (CollectionChanged != null)
             {
-                var val = new KeyValuePair<TKey, TValue>(key, value);
                 var e = new NotifyCollectionChangedEventArgs(
                     NotifyCollectionChangedAction.Add,
                     new[] { new KeyValuePair<TKey, TValue>(key, value) },

--- a/src/Avalonia.Base/Collections/AvaloniaList.cs
+++ b/src/Avalonia.Base/Collections/AvaloniaList.cs
@@ -397,8 +397,6 @@ namespace Avalonia.Collections
         {
             Contract.Requires<ArgumentNullException>(items != null);
 
-            var list = (items as IList) ?? items.ToList();
-
             foreach (var i in items)
             {
                 // TODO: Optimize to only send as many notifications as necessary.

--- a/src/Avalonia.Base/Data/InstancedBinding.cs
+++ b/src/Avalonia.Base/Data/InstancedBinding.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Data
     /// <remarks>
     /// Whereas an <see cref="IBinding"/> holds a description of a binding such as "Bind to the X
     /// property on a control's DataContext"; this class represents a binding that has been 
-    /// *instanced* by calling <see cref="IBinding.Initiate(IAvaloniaObject, AvaloniaProperty, object)"/>
+    /// *instanced* by calling <see cref="IBinding.Initiate(IAvaloniaObject, AvaloniaProperty, object, bool)"/>
     /// on a target object.
     /// 
     /// When a binding is initiated, it can return one of 3 possible sources for the binding:

--- a/src/Avalonia.Base/Platform/IPlatformThreadingInterface.cs
+++ b/src/Avalonia.Base/Platform/IPlatformThreadingInterface.cs
@@ -21,9 +21,6 @@ namespace Avalonia.Platform
         /// <returns>An <see cref="IDisposable"/> used to stop the timer.</returns>
         IDisposable StartTimer(TimeSpan interval, Action tick);
 
-        /// <summary>
-        /// Sends a message that causes <see cref="ProcessMessage"/> to exit.
-        /// </summary>
         void Signal();
 
         bool CurrentThreadIsLoopThread { get; }

--- a/src/Avalonia.Base/PriorityBindingEntry.cs
+++ b/src/Avalonia.Base/PriorityBindingEntry.cs
@@ -21,7 +21,6 @@ namespace Avalonia
         /// <param name="index">
         /// The binding index. Later bindings should have higher indexes.
         /// </param>
-        /// <param name="validation">The validation settings for the binding.</param>
         public PriorityBindingEntry(PriorityLevel owner, int index)
         {
             _owner = owner;

--- a/src/Avalonia.Controls/AppBuilderBase.cs
+++ b/src/Avalonia.Controls/AppBuilderBase.cs
@@ -9,9 +9,9 @@ using Avalonia.Platform;
 namespace Avalonia.Controls
 {
     /// <summary>
-    /// Initializes up platform-specific services for an <see cref="Application"/>.
+    /// Base class for initializing platform-specific services for an <see cref="Application"/>.
     /// </summary>
-    /// <typeparam name="TAppBuilder"></typeparam>
+    /// <typeparam name="TAppBuilder">The type of the AppBuilder class itself.</typeparam>
     public abstract class AppBuilderBase<TAppBuilder> where TAppBuilder : AppBuilderBase<TAppBuilder>, new()
     {
         /// <summary>
@@ -140,6 +140,7 @@ namespace Avalonia.Controls
         /// Specifies a windowing subsystem to use.
         /// </summary>
         /// <param name="initializer">The method to call to initialize the windowing subsystem.</param>
+        /// <param name="name">The name of the windowing subsystem.</param>
         /// <returns>An <typeparamref name="TAppBuilder"/> instance.</returns>
         public TAppBuilder UseWindowingSubsystem(Action initializer, string name = "")
         {
@@ -159,6 +160,7 @@ namespace Avalonia.Controls
         /// Specifies a rendering subsystem to use.
         /// </summary>
         /// <param name="initializer">The method to call to initialize the rendering subsystem.</param>
+        /// <param name="name">The name of the rendering subsystem.</param>
         /// <returns>An <typeparamref name="TAppBuilder"/> instance.</returns>
         public TAppBuilder UseRenderingSubsystem(Action initializer, string name = "")
         {

--- a/src/Avalonia.Controls/Avalonia.Controls.csproj
+++ b/src/Avalonia.Controls/Avalonia.Controls.csproj
@@ -38,6 +38,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Avalonia.Controls.XML</DocumentationFile>
     <NoWarn>CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Shared\SharedAssemblyInfo.cs">

--- a/src/Avalonia.Controls/Classes.cs
+++ b/src/Avalonia.Controls/Classes.cs
@@ -197,7 +197,6 @@ namespace Avalonia.Controls
         /// <param name="count">The number of items to remove.</param>
         public override void RemoveRange(int index, int count)
         {
-            var names = GetRange(index, count);
             base.RemoveRange(index, count);
         }
 

--- a/src/Avalonia.Controls/Generators/TreeItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/TreeItemContainerGenerator.cs
@@ -124,11 +124,6 @@ namespace Avalonia.Controls.Generators
             return false;
         }
 
-        /// <summary>
-        /// Gets the data template for the specified item.
-        /// </summary>
-        /// <param name="item">The item.</param>
-        /// <returns>The template.</returns>
         private ITreeDataTemplate GetTreeDataTemplate(object item, IDataTemplate primary)
         {
             var template = Owner.FindDataTemplate(item, primary) ?? FuncDataTemplate.Default;

--- a/src/Avalonia.Controls/HotkeyManager.cs
+++ b/src/Avalonia.Controls/HotkeyManager.cs
@@ -30,9 +30,9 @@ namespace Avalonia.Controls
 
             public void Execute(object parameter) => GetCommand()?.Execute(parameter);
 
-#pragma warning disable CS0067 // Event not used
+#pragma warning disable 67 // Event not used
             public event EventHandler CanExecuteChanged;
-#pragma warning restore CS0067
+#pragma warning restore 67
         }
 
 

--- a/src/Avalonia.Controls/HotkeyManager.cs
+++ b/src/Avalonia.Controls/HotkeyManager.cs
@@ -30,8 +30,9 @@ namespace Avalonia.Controls
 
             public void Execute(object parameter) => GetCommand()?.Execute(parameter);
 
-            //Implementation isn't needed in this case
+#pragma warning disable CS0067 // Event not used
             public event EventHandler CanExecuteChanged;
+#pragma warning restore CS0067
         }
 
 

--- a/src/Avalonia.Controls/Platform/PlatformManager.cs
+++ b/src/Avalonia.Controls/Platform/PlatformManager.cs
@@ -11,7 +11,6 @@ namespace Avalonia.Controls.Platform
             => AvaloniaLocator.Current.GetService<IPlatformSettings>();
 
         static bool s_designerMode;
-        private static double _designerScalingFactor = 1;
 
         public static IRenderTarget CreateRenderTarget(ITopLevelImpl window)
         {
@@ -28,7 +27,6 @@ namespace Avalonia.Controls.Platform
 
         public static void SetDesignerScalingFactor(double factor)
         {
-            _designerScalingFactor = factor;
         }
 
         public static IWindowImpl CreateWindow()

--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -97,7 +97,9 @@ namespace Avalonia.Controls.Presenters
         /// <inheritdoc/>
         protected override void PanelCreated(IPanel panel)
         {
-            var task = MoveToPage(-1, SelectedIndex);
+#pragma warning disable 4014
+            MoveToPage(-1, SelectedIndex);
+#pragma warning restore 4014
         }
 
         /// <inheritdoc/>
@@ -139,7 +141,6 @@ namespace Avalonia.Controls.Presenters
 
                 if (toIndex != -1)
                 {
-                    var item = Items.Cast<object>().ElementAt(toIndex);
                     to = GetOrCreateContainer(toIndex);
                 }
 

--- a/src/Avalonia.Controls/Presenters/ItemVirtualizer.cs
+++ b/src/Avalonia.Controls/Presenters/ItemVirtualizer.cs
@@ -16,8 +16,6 @@ namespace Avalonia.Controls.Presenters
     /// </summary>
     internal abstract class ItemVirtualizer : IVirtualizingController, IDisposable
     {
-        private bool disposedValue;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ItemVirtualizer"/> class.
         /// </summary>

--- a/src/Avalonia.Controls/Presenters/ItemVirtualizerSimple.cs
+++ b/src/Avalonia.Controls/Presenters/ItemVirtualizerSimple.cs
@@ -359,7 +359,6 @@ namespace Avalonia.Controls.Presenters
             var count = Math.Min(Math.Abs(delta), panel.Children.Count);
             var move = count < panel.Children.Count;
             var first = delta < 0 && move ? panel.Children.Count + delta : 0;
-            var containers = panel.Children.GetRange(first, count).ToList();
 
             for (var i = 0; i < count; ++i)
             {

--- a/src/Avalonia.Controls/ScrollViewer.cs
+++ b/src/Avalonia.Controls/ScrollViewer.cs
@@ -157,7 +157,7 @@ namespace Avalonia.Controls
         /// </summary>
         public ScrollViewer()
         {
-            var extentAndViewport = Observable.CombineLatest(
+            Observable.CombineLatest(
                 this.GetObservable(ExtentProperty),
                 this.GetObservable(ViewportProperty))
                 .Select(x => new { Extent = x[0], Viewport = x[1] });

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -105,7 +105,7 @@ namespace Avalonia.Controls
 
         public TextBox()
         {
-            var canScrollHorizontally = this.GetObservable(TextWrappingProperty)
+            this.GetObservable(TextWrappingProperty)
                 .Select(x => x == TextWrapping.NoWrap)
                 .Subscribe(x => CanScrollHorizontally = x);
 

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -88,7 +88,6 @@ namespace Avalonia.Controls
             PlatformImpl = impl;
 
             dependencyResolver = dependencyResolver ?? AvaloniaLocator.Current;
-            var renderInterface = TryGetService<IPlatformRenderInterface>(dependencyResolver);
             var styler = TryGetService<IStyler>(dependencyResolver);
             _accessKeyHandler = TryGetService<IAccessKeyHandler>(dependencyResolver);
             _inputManager = TryGetService<IInputManager>(dependencyResolver);

--- a/src/Avalonia.Diagnostics/Avalonia.Diagnostics.csproj
+++ b/src/Avalonia.Diagnostics/Avalonia.Diagnostics.csproj
@@ -38,6 +38,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Avalonia.Diagnostics.XML</DocumentationFile>
     <NoWarn>CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->

--- a/src/Avalonia.Diagnostics/ViewModels/DevToolsViewModel.cs
+++ b/src/Avalonia.Diagnostics/ViewModels/DevToolsViewModel.cs
@@ -11,8 +11,6 @@ namespace Avalonia.Diagnostics.ViewModels
 {
     internal class DevToolsViewModel : ReactiveObject
     {
-        private IControl _root;
-
         private ReactiveObject _content;
 
         private int _selectedTab;
@@ -27,7 +25,6 @@ namespace Avalonia.Diagnostics.ViewModels
 
         public DevToolsViewModel(IControl root)
         {
-            _root = root;
             _logicalTree = new TreePageViewModel(LogicalTreeNode.Create(root));
             _visualTree = new TreePageViewModel(VisualTreeNode.Create(root));
 

--- a/src/Avalonia.DotNetFrameworkRuntime/AppBuilder.cs
+++ b/src/Avalonia.DotNetFrameworkRuntime/AppBuilder.cs
@@ -1,27 +1,39 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Platform;
 using Avalonia.Shared.PlatformSupport;
-using System.IO;
 
 namespace Avalonia
 {
+    /// <summary>
+    /// Initializes platform-specific services for an <see cref="Application"/>.
+    /// </summary>
     public sealed class AppBuilder : AppBuilderBase<AppBuilder>
     {
-        public AppBuilder() : base(new StandardRuntimePlatform(), () => StandardRuntimePlatformServices.Register())
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AppBuilder"/> class.
+        /// </summary>
+        public AppBuilder()
+            : base(new StandardRuntimePlatform(), () => StandardRuntimePlatformServices.Register())
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AppBuilder"/> class.
+        /// </summary>
+        /// <param name="app">The <see cref="Application"/> instance.</param>
         public AppBuilder(Application app) : this()
         {
             Instance = app;
         }
 
+        /// <summary>
+        /// Instructs the <see cref="AppBuilder"/> to use the best settings for the platform.
+        /// </summary>
+        /// <returns>An <see cref="AppBuilder"/> instance.</returns>
         public AppBuilder UsePlatformDetect()
         {
             var os = RuntimePlatform.GetRuntimeInfo().OperatingSystem;

--- a/src/Avalonia.DotNetFrameworkRuntime/Avalonia.DotNetFrameworkRuntime.csproj
+++ b/src/Avalonia.DotNetFrameworkRuntime/Avalonia.DotNetFrameworkRuntime.csproj
@@ -31,6 +31,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Avalonia.DotNetFrameworkRuntime.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/Avalonia.Input/Avalonia.Input.csproj
+++ b/src/Avalonia.Input/Avalonia.Input.csproj
@@ -38,6 +38,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Avalonia.Input.XML</DocumentationFile>
     <NoWarn>CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->

--- a/src/Avalonia.Input/Navigation/DirectionalNavigation.cs
+++ b/src/Avalonia.Input/Navigation/DirectionalNavigation.cs
@@ -90,7 +90,6 @@ namespace Avalonia.Input.Navigation
         /// <returns>The element's focusable descendents.</returns>
         private static IEnumerable<IInputElement> GetFocusableDescendents(IInputElement element)
         {
-            var mode = KeyboardNavigation.GetDirectionalNavigation((InputElement)element);
             var children = element.GetVisualChildren().OfType<IInputElement>();
 
             foreach (var child in children)

--- a/src/Avalonia.Interactivity/Avalonia.Interactivity.csproj
+++ b/src/Avalonia.Interactivity/Avalonia.Interactivity.csproj
@@ -38,6 +38,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Avalonia.Interactivity.XML</DocumentationFile>
     <NoWarn>CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->

--- a/src/Avalonia.Layout/Avalonia.Layout.csproj
+++ b/src/Avalonia.Layout/Avalonia.Layout.csproj
@@ -38,6 +38,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Avalonia.Layout.XML</DocumentationFile>
     <NoWarn>CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->

--- a/src/Avalonia.Logging.Serilog/Avalonia.Logging.Serilog.csproj
+++ b/src/Avalonia.Logging.Serilog/Avalonia.Logging.Serilog.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -34,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Avalonia.Logging.Serilog.XML</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="SerilogLogger.cs" />

--- a/src/Avalonia.Logging.Serilog/SerilogLogger.cs
+++ b/src/Avalonia.Logging.Serilog/SerilogLogger.cs
@@ -8,21 +8,33 @@ using SerilogLogEventLevel = Serilog.Events.LogEventLevel;
 
 namespace Avalonia.Logging.Serilog
 {
+    /// <summary>
+    /// Sends log output to serilog.
+    /// </summary>
     public class SerilogLogger : ILogSink
     {
         private readonly ILogger _output;
         private readonly Dictionary<string, ILogger> _areas = new Dictionary<string, ILogger>();
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SerilogLogger"/> class.
+        /// </summary>
+        /// <param name="output">The serilog logger to use.</param>
         public SerilogLogger(ILogger output)
         {
             _output = output;
         }
 
+        /// <summary>
+        /// Initializes the Avalonia logging with a new instance of a <see cref="SerilogLogger"/>.
+        /// </summary>
+        /// <param name="output">The serilog logger to use.</param>
         public static void Initialize(ILogger output)
         {
             Logger.Sink = new SerilogLogger(output);
         }
 
+        /// <inheritdoc/>
         public void Log(
             AvaloniaLogEventLevel level, 
             string area, 

--- a/src/Avalonia.SceneGraph/Avalonia.SceneGraph.csproj
+++ b/src/Avalonia.SceneGraph/Avalonia.SceneGraph.csproj
@@ -38,6 +38,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Avalonia.SceneGraph.XML</DocumentationFile>
     <NoWarn>CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->

--- a/src/Avalonia.SceneGraph/Media/DrawingContext.cs
+++ b/src/Avalonia.SceneGraph/Media/DrawingContext.cs
@@ -208,6 +208,9 @@ namespace Avalonia.Media
         /// Pushes an opacity mask.
         /// </summary>
         /// <param name="mask">The opacity mask.</param>
+        /// <param name="bounds">
+        /// The size of the brush's target area. TODO: Are we sure this is needed?
+        /// </param>
         /// <returns>A disposable to undo the opacity mask.</returns>
         public PushedState PushOpacityMask(IBrush mask, Rect bounds)
         {
@@ -216,15 +219,24 @@ namespace Avalonia.Media
         }
 
         /// <summary>
-        /// Pushes a matrix transformation.
+        /// Pushes a matrix post-transformation.
         /// </summary>
         /// <param name="matrix">The matrix</param>
         /// <returns>A disposable used to undo the transformation.</returns>
         public PushedState PushPostTransform(Matrix matrix) => PushSetTransform(CurrentTransform*matrix);
 
+        /// <summary>
+        /// Pushes a matrix pre-transformation.
+        /// </summary>
+        /// <param name="matrix">The matrix</param>
+        /// <returns>A disposable used to undo the transformation.</returns>
         public PushedState PushPreTransform(Matrix matrix) => PushSetTransform(matrix*CurrentTransform);
-        
 
+        /// <summary>
+        /// Sets the current matrix transformation.
+        /// </summary>
+        /// <param name="matrix">The matrix</param>
+        /// <returns>A disposable used to undo the transformation.</returns>
         PushedState PushSetTransform(Matrix matrix)
         {
             var oldMatrix = CurrentTransform;
@@ -233,7 +245,10 @@ namespace Avalonia.Media
             return new PushedState(this, PushedState.PushedStateType.Matrix, oldMatrix);
         }
 
-
+        /// <summary>
+        /// Pushes a new transform context.
+        /// </summary>
+        /// <returns>A disposable used to undo the transformation.</returns>
         public PushedState PushTransformContainer()
         {
             _transformContainers.Push(new TransformContainer(CurrentTransform, _currentContainerTransform));
@@ -242,6 +257,9 @@ namespace Avalonia.Media
             return new PushedState(this, PushedState.PushedStateType.MatrixContainer);
         }
 
+        /// <summary>
+        /// Disposes of any resources held by the <see cref="DrawingContext"/>.
+        /// </summary>
         public void Dispose()
         {
             while (_states.Count != 0)

--- a/src/Avalonia.SceneGraph/Media/Imaging/RenderTargetBitmap.cs
+++ b/src/Avalonia.SceneGraph/Media/Imaging/RenderTargetBitmap.cs
@@ -4,6 +4,7 @@
 using System;
 using Avalonia.Platform;
 using Avalonia.Rendering;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Media.Imaging
 {

--- a/src/Avalonia.SceneGraph/Media/MatrixTransform.cs
+++ b/src/Avalonia.SceneGraph/Media/MatrixTransform.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Media
 {

--- a/src/Avalonia.SceneGraph/Media/PathMarkupParser.cs
+++ b/src/Avalonia.SceneGraph/Media/PathMarkupParser.cs
@@ -32,18 +32,14 @@ namespace Avalonia.Media
             {'1', FillRule.NonZero }
         };
 
-        private StreamGeometry _geometry;
-
         private readonly StreamGeometryContext _context;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PathMarkupParser"/> class.
         /// </summary>
-        /// <param name="geometry">The geometry in which the path should be stored.</param>
-        /// <param name="context">The context for <paramref name="geometry"/>.</param>
-        public PathMarkupParser(StreamGeometry geometry, StreamGeometryContext context)
+        /// <param name="context">The context for the geometry.</param>
+        public PathMarkupParser(StreamGeometryContext context)
         {
-            _geometry = geometry;
             _context = context;
         }
 

--- a/src/Avalonia.SceneGraph/Media/RotateTransform.cs
+++ b/src/Avalonia.SceneGraph/Media/RotateTransform.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Media
 {

--- a/src/Avalonia.SceneGraph/Media/ScaleTransform.cs
+++ b/src/Avalonia.SceneGraph/Media/ScaleTransform.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Media
 {

--- a/src/Avalonia.SceneGraph/Media/StreamGeometry.cs
+++ b/src/Avalonia.SceneGraph/Media/StreamGeometry.cs
@@ -39,7 +39,7 @@ namespace Avalonia.Media
 
             using (StreamGeometryContext ctx = result.Open())
             {
-                PathMarkupParser parser = new PathMarkupParser(result, ctx);
+                PathMarkupParser parser = new PathMarkupParser(ctx);
                 parser.Parse(s);
                 return result;
             }

--- a/src/Avalonia.SceneGraph/Media/Transform.cs
+++ b/src/Avalonia.SceneGraph/Media/Transform.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Avalonia.Animation;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Media
 {

--- a/src/Avalonia.SceneGraph/Media/TranslateTransform.cs
+++ b/src/Avalonia.SceneGraph/Media/TranslateTransform.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Media
 {

--- a/src/Avalonia.Styling/Avalonia.Styling.csproj
+++ b/src/Avalonia.Styling/Avalonia.Styling.csproj
@@ -38,6 +38,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Avalonia.Styling.XML</DocumentationFile>
     <NoWarn>CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Shared\SharedAssemblyInfo.cs">

--- a/src/Avalonia.Styling/Styling/SelectorMatch.cs
+++ b/src/Avalonia.Styling/Styling/SelectorMatch.cs
@@ -6,12 +6,12 @@ using System;
 namespace Avalonia.Styling
 {
     /// <summary>
-    /// Holds the result of a <see cref="FuncSelector"/> match.
+    /// Holds the result of a <see cref="Selector"/> match.
     /// </summary>
     /// <remarks>
     /// There are two types of selectors - ones whose match can never change for a particular
-    /// control (such as <see cref="Selectors.OfType{T}(FuncSelector)"/>) and ones whose result can
-    /// change over time (such as <see cref="Selectors.Class(FuncSelector, string)"/>. For the first
+    /// control (such as <see cref="Selectors.OfType(Selector, Type)"/>) and ones whose result can
+    /// change over time (such as <see cref="Selectors.Class(Selector, string)"/>. For the first
     /// category of selectors, the value of <see cref="ImmediateResult"/> will be set but for the
     /// second, <see cref="ImmediateResult"/> will be null and <see cref="ObservableResult"/> will
     /// hold an observable which tracks the match.

--- a/src/Avalonia.Styling/Styling/Style.cs
+++ b/src/Avalonia.Styling/Styling/Style.cs
@@ -82,7 +82,6 @@ namespace Avalonia.Styling
         {
             if (Selector != null)
             {
-                var description = "Style " + Selector.ToString();
                 var match = Selector.Match(control);
 
                 if (match.ImmediateResult != false)

--- a/src/Avalonia.Themes.Default/Avalonia.Themes.Default.csproj
+++ b/src/Avalonia.Themes.Default/Avalonia.Themes.Default.csproj
@@ -36,6 +36,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Avalonia.Themes.Default.XML</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->

--- a/src/Gtk/Avalonia.Gtk/EmbeddableImpl.cs
+++ b/src/Gtk/Avalonia.Gtk/EmbeddableImpl.cs
@@ -14,7 +14,9 @@ namespace Avalonia.Gtk
 {
     class EmbeddableImpl : WindowImplBase, IEmbeddableWindowImpl
     {
+#pragma warning disable CS0067 // Method not used
         public event Action LostFocus;
+#pragma warning restore CS0067
 
         public EmbeddableImpl(DrawingArea area) : base(area)
         {

--- a/src/Markup/Avalonia.Markup.Xaml/AvaloniaXamlLoader.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/AvaloniaXamlLoader.cs
@@ -8,14 +8,14 @@ using System.Reflection;
 using System.Text;
 using OmniXaml;
 using Avalonia.Platform;
+using Avalonia.Markup.Xaml.Context;
+using Avalonia.Markup.Xaml.Styling;
+using OmniXaml.ObjectAssembler;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml.Data;
 
 namespace Avalonia.Markup.Xaml
 {
-    using Context;
-    using Controls;
-    using Data;
-    using OmniXaml.ObjectAssembler;
-    using System.Linq;
     /// <summary>
     /// Loads XAML for a avalonia application.
     /// </summary>
@@ -47,7 +47,7 @@ namespace Avalonia.Markup.Xaml
         /// </summary>
         /// <remarks>
         /// TODO: Making this internal for now as I'm not sure that this is the correct
-        /// thing to do, but its needd by <see cref="StyleInclude"/> to get the URL of
+        /// thing to do, but its needed by <see cref="StyleInclude"/> to get the URL of
         /// the currently loading XAML file, as we can't use the OmniXAML parsing context
         /// there. Maybe we need a way to inject OmniXAML context into the objects its
         /// constructing?

--- a/src/Markup/Avalonia.Markup/Avalonia.Markup.csproj
+++ b/src/Markup/Avalonia.Markup/Avalonia.Markup.csproj
@@ -36,6 +36,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Avalonia.Markup.XML</DocumentationFile>
     <NoWarn>CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\SharedAssemblyInfo.cs">

--- a/src/Shared/PlatformSupport/AssetLoader.cs
+++ b/src/Shared/PlatformSupport/AssetLoader.cs
@@ -20,6 +20,12 @@ namespace Avalonia.Shared.PlatformSupport
 
         private AssemblyDescriptor _defaultAssembly;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssetLoader"/> class.
+        /// </summary>
+        /// <param name="assembly">
+        /// The default assembly from which to load assets for which no assembly is specified.
+        /// </param>
         public AssetLoader(Assembly assembly = null)
         {
             if (assembly == null)
@@ -28,6 +34,10 @@ namespace Avalonia.Shared.PlatformSupport
                 _defaultAssembly = new AssemblyDescriptor(assembly);
         }
 
+        /// <summary>
+        /// Sets the default assembly from which to load assets for which no assembly is specified.
+        /// </summary>
+        /// <param name="assembly">The default assembly.</param>
         public void SetDefaultAssembly(Assembly assembly)
         {
             _defaultAssembly = new AssemblyDescriptor(assembly);

--- a/src/Shared/PlatformSupport/AssetLoader.cs
+++ b/src/Shared/PlatformSupport/AssetLoader.cs
@@ -83,8 +83,6 @@ namespace Avalonia.Shared.PlatformSupport
         {
             if (!uri.IsAbsoluteUri || uri.Scheme == "resm")
             {
-                var uriQueryParams = ParseQueryString(uri);
-                var baseUriQueryParams = uri != null ? ParseQueryString(uri) : null;
                 var asm = GetAssembly(uri) ?? GetAssembly(baseUri) ?? _defaultAssembly;
 
                 if (asm == null && _defaultAssembly == null)

--- a/src/Windows/Avalonia.Direct2D1/Avalonia.Direct2D1.csproj
+++ b/src/Windows/Avalonia.Direct2D1/Avalonia.Direct2D1.csproj
@@ -34,6 +34,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Avalonia.Direct2D1.XML</DocumentationFile>
     <NoWarn>CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="SharpDX, Version=3.0.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">

--- a/src/Windows/Avalonia.Direct2D1/Media/StreamGeometryImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/StreamGeometryImpl.cs
@@ -8,7 +8,7 @@ using D2DGeometry = SharpDX.Direct2D1.Geometry;
 namespace Avalonia.Direct2D1.Media
 {
     /// <summary>
-    /// A Direct2D implementation of a <see cref="StreamGeometry"/>.
+    /// A Direct2D implementation of a <see cref="Avalonia.Media.StreamGeometry"/>.
     /// </summary>
     public class StreamGeometryImpl : GeometryImpl, IStreamGeometryImpl
     {
@@ -56,7 +56,7 @@ namespace Avalonia.Direct2D1.Media
         /// Opens the geometry to start defining it.
         /// </summary>
         /// <returns>
-        /// A <see cref="StreamGeometryContext"/> which can be used to define the geometry.
+        /// An <see cref="Avalonia.Platform.IStreamGeometryContextImpl"/> which can be used to define the geometry.
         /// </returns>
         public IStreamGeometryContextImpl Open()
         {

--- a/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
+++ b/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
@@ -36,6 +36,7 @@
     <DocumentationFile>bin\Release\Avalonia.Win32.XML</DocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Direct.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Direct.cs
@@ -337,7 +337,6 @@ namespace Avalonia.Base.UnitTests
         [Fact]
         public void Property_Notifies_Initialized()
         {
-            Class1 target;
             bool raised = false;
 
             Class1.FooProperty.Initialized.Subscribe(e =>
@@ -346,7 +345,7 @@ namespace Avalonia.Base.UnitTests
                          (string)e.NewValue == "initial" &&
                          e.Priority == BindingPriority.Unset);
 
-            target = new Class1();
+            var target = new Class1();
 
             Assert.True(raised);
         }

--- a/tests/Avalonia.Controls.UnitTests/Primitives/TabStripTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/TabStripTests.cs
@@ -19,8 +19,10 @@ namespace Avalonia.Controls.UnitTests.Primitives
         {
             var items = new[]
             {
+#pragma warning disable CS0252 // Possible unintended reference comparison; left hand side needs cast
                 Mock.Of<IHeadered>(x => x.Header == "foo"),
                 Mock.Of<IHeadered>(x => x.Header == "bar"),
+#pragma warning restore CS0252 // Possible unintended reference comparison; left hand side needs cast
             };
 
             var target = new TabStrip

--- a/tests/Avalonia.Input.UnitTests/KeyboardNavigationTests_Arrows.cs
+++ b/tests/Avalonia.Input.UnitTests/KeyboardNavigationTests_Arrows.cs
@@ -13,7 +13,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Down_Continue_Returns_Down_Control_In_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -21,7 +20,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Continue,
                         Children = new Controls
@@ -30,7 +29,7 @@ namespace Avalonia.Input.UnitTests
                             (current = new Button { Name = "Button2" }),
                             (next = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Continue,
@@ -52,7 +51,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Down_Continue_Returns_First_Control_In_Down_Sibling_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -60,7 +58,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Continue,
                         Children = new Controls
@@ -69,7 +67,7 @@ namespace Avalonia.Input.UnitTests
                             new Button { Name = "Button2" },
                             (current = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Continue,
@@ -91,7 +89,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Down_Continue_Returns_Down_Sibling()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -99,7 +96,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Continue,
                         Children = new Controls
@@ -108,7 +105,7 @@ namespace Avalonia.Input.UnitTests
                             new Button { Name = "Button2" },
                             (current = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     (next = new Button { Name = "Button4" }),
                 }
             };
@@ -121,7 +118,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Down_Continue_Returns_First_Control_In_Down_Uncle_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -133,7 +129,7 @@ namespace Avalonia.Input.UnitTests
                     {
                         Children = new Controls
                         {
-                            (container = new StackPanel
+                            new StackPanel
                             {
                                 [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Continue,
                                 Children = new Controls
@@ -142,7 +138,7 @@ namespace Avalonia.Input.UnitTests
                                     new Button { Name = "Button2" },
                                     (current = new Button { Name = "Button3" }),
                                 }
-                            }),
+                            },
                         },
                     },
                     new StackPanel
@@ -185,7 +181,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Down_Continue_Wraps()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -199,7 +194,7 @@ namespace Avalonia.Input.UnitTests
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Continue,
                         Children = new Controls
                         {
-                            (container = new StackPanel
+                            new StackPanel
                             {
                                 [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Continue,
                                 Children = new Controls
@@ -208,7 +203,7 @@ namespace Avalonia.Input.UnitTests
                                     new Button { Name = "Button2" },
                                     new Button { Name = "Button3" },
                                 }
-                            }),
+                            },
                         },
                     },
                     new StackPanel
@@ -232,7 +227,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Down_Cycle_Returns_Down_Control_In_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -240,7 +234,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Cycle,
                         Children = new Controls
@@ -249,7 +243,7 @@ namespace Avalonia.Input.UnitTests
                             (current = new Button { Name = "Button2" }),
                             (next = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls
@@ -270,7 +264,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Down_Cycle_Wraps_To_First()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -278,7 +271,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Cycle,
                         Children = new Controls
@@ -287,7 +280,7 @@ namespace Avalonia.Input.UnitTests
                             new Button { Name = "Button2" },
                             (current = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls
@@ -308,7 +301,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Down_Contained_Returns_Down_Control_In_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -316,7 +308,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Contained,
                         Children = new Controls
@@ -325,7 +317,7 @@ namespace Avalonia.Input.UnitTests
                             (current = new Button { Name = "Button2" }),
                             (next = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Contained,
@@ -347,24 +339,22 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Down_Contained_Stops_At_End()
         {
-            StackPanel container;
             Button current;
-            Button next;
 
             var top = new StackPanel
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Contained,
                         Children = new Controls
                         {
-                            (next = new Button { Name = "Button1" }),
+                            new Button { Name = "Button1" },
                             new Button { Name = "Button2" },
                             (current = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Contained,
@@ -386,14 +376,13 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Down_None_Does_Nothing()
         {
-            StackPanel container;
             Button current;
 
             var top = new StackPanel
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.None,
                         Children = new Controls
@@ -402,7 +391,7 @@ namespace Avalonia.Input.UnitTests
                             (current = new Button { Name = "Button2" }),
                             new Button { Name = "Button3" },
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Contained,
@@ -424,7 +413,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Up_Continue_Returns_Up_Control_In_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -432,7 +420,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Continue,
                         Children = new Controls
@@ -441,7 +429,7 @@ namespace Avalonia.Input.UnitTests
                             (next = new Button { Name = "Button2" }),
                             (current = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Contained,
@@ -463,7 +451,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Up_Continue_Returns_Last_Control_In_Up_Sibling_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -471,7 +458,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Continue,
                         Children = new Controls
@@ -480,7 +467,7 @@ namespace Avalonia.Input.UnitTests
                             new Button { Name = "Button2" },
                             (next = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Continue,
@@ -502,7 +489,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Up_Continue_Returns_Last_Child_Of_Sibling()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -511,7 +497,7 @@ namespace Avalonia.Input.UnitTests
                 [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Continue,
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Continue,
                         Children = new Controls
@@ -520,7 +506,7 @@ namespace Avalonia.Input.UnitTests
                             new Button { Name = "Button2" },
                             (next = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     (current = new Button { Name = "Button4" }),
                 }
             };
@@ -533,7 +519,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Up_Continue_Returns_Last_Control_In_Up_Nephew_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -545,7 +530,7 @@ namespace Avalonia.Input.UnitTests
                     {
                         Children = new Controls
                         {
-                            (container = new StackPanel
+                            new StackPanel
                             {
                                 [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Continue,
                                 Children = new Controls
@@ -554,7 +539,7 @@ namespace Avalonia.Input.UnitTests
                                     new Button { Name = "Button2" },
                                     (next = new Button { Name = "Button3" }),
                                 }
-                            }),
+                            },
                         },
                     },
                     new StackPanel
@@ -578,7 +563,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Up_Continue_Wraps()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -590,7 +574,7 @@ namespace Avalonia.Input.UnitTests
                     {
                         Children = new Controls
                         {
-                            (container = new StackPanel
+                            new StackPanel
                             {
                                 [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Continue,
                                 Children = new Controls
@@ -599,7 +583,7 @@ namespace Avalonia.Input.UnitTests
                                     new Button { Name = "Button2" },
                                     new Button { Name = "Button3" },
                                 }
-                            }),
+                            },
                         },
                     },
                     new StackPanel
@@ -643,7 +627,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Up_Cycle_Returns_Up_Control_In_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -651,7 +634,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Cycle,
                         Children = new Controls
@@ -660,7 +643,7 @@ namespace Avalonia.Input.UnitTests
                             (current = new Button { Name = "Button2" }),
                             new Button { Name = "Button3" },
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Cycle,
@@ -682,7 +665,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Up_Cycle_Wraps_To_Last()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -690,7 +672,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Cycle,
                         Children = new Controls
@@ -699,7 +681,7 @@ namespace Avalonia.Input.UnitTests
                             new Button { Name = "Button2" },
                             (next = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Cycle,
@@ -721,7 +703,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Up_Contained_Returns_Up_Control_In_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -729,7 +710,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Contained,
                         Children = new Controls
@@ -738,7 +719,7 @@ namespace Avalonia.Input.UnitTests
                             (current = new Button { Name = "Button2" }),
                             new Button { Name = "Button3" },
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Contained,
@@ -760,14 +741,13 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Up_Contained_Stops_At_Beginning()
         {
-            StackPanel container;
             Button current;
 
             var top = new StackPanel
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Contained,
                         Children = new Controls
@@ -776,7 +756,7 @@ namespace Avalonia.Input.UnitTests
                             new Button { Name = "Button2" },
                             new Button { Name = "Button3" },
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         [KeyboardNavigation.DirectionalNavigationProperty] = KeyboardNavigationMode.Contained,

--- a/tests/Avalonia.Input.UnitTests/KeyboardNavigationTests_Tab.cs
+++ b/tests/Avalonia.Input.UnitTests/KeyboardNavigationTests_Tab.cs
@@ -13,7 +13,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Next_Continue_Returns_Next_Control_In_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -21,7 +20,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         Children = new Controls
                         {
@@ -29,7 +28,7 @@ namespace Avalonia.Input.UnitTests
                             (current = new Button { Name = "Button2" }),
                             (next = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls
@@ -50,7 +49,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Next_Continue_Returns_First_Control_In_Next_Sibling_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -58,7 +56,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         Children = new Controls
                         {
@@ -66,7 +64,7 @@ namespace Avalonia.Input.UnitTests
                             new Button { Name = "Button2" },
                             (current = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls
@@ -87,7 +85,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Next_Continue_Doesnt_Enter_Panel_With_TabNavigation_None()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -95,7 +92,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         Children = new Controls
                         {
@@ -103,7 +100,7 @@ namespace Avalonia.Input.UnitTests
                             new Button { Name = "Button2" },
                             (current = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.None,
@@ -131,7 +128,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Next_Continue_Returns_Next_Sibling()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -139,7 +135,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         Children = new Controls
                         {
@@ -147,7 +143,7 @@ namespace Avalonia.Input.UnitTests
                             new Button { Name = "Button2" },
                             (current = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     (next = new Button { Name = "Button4" }),
                 }
             };
@@ -160,7 +156,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Next_Continue_Returns_First_Control_In_Next_Uncle_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -172,7 +167,7 @@ namespace Avalonia.Input.UnitTests
                     {
                         Children = new Controls
                         {
-                            (container = new StackPanel
+                            new StackPanel
                             {
                                 Children = new Controls
                                 {
@@ -180,7 +175,7 @@ namespace Avalonia.Input.UnitTests
                                     new Button { Name = "Button2" },
                                     (current = new Button { Name = "Button3" }),
                                 }
-                            }),
+                            },
                         },
                     },
                     new StackPanel
@@ -221,7 +216,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Next_Continue_Wraps()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -233,7 +227,7 @@ namespace Avalonia.Input.UnitTests
                     {
                         Children = new Controls
                         {
-                            (container = new StackPanel
+                            new StackPanel
                             {
                                 Children = new Controls
                                 {
@@ -241,7 +235,7 @@ namespace Avalonia.Input.UnitTests
                                     new Button { Name = "Button2" },
                                     new Button { Name = "Button3" },
                                 }
-                            }),
+                            },
                         },
                     },
                     new StackPanel
@@ -264,7 +258,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Next_Cycle_Returns_Next_Control_In_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -272,7 +265,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Cycle,
                         Children = new Controls
@@ -281,7 +274,7 @@ namespace Avalonia.Input.UnitTests
                             (current = new Button { Name = "Button2" }),
                             (next = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls
@@ -302,7 +295,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Next_Cycle_Wraps_To_First()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -310,7 +302,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Cycle,
                         Children = new Controls
@@ -319,7 +311,7 @@ namespace Avalonia.Input.UnitTests
                             new Button { Name = "Button2" },
                             (current = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls
@@ -340,7 +332,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Next_Contained_Returns_Next_Control_In_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -348,7 +339,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Contained,
                         Children = new Controls
@@ -357,7 +348,7 @@ namespace Avalonia.Input.UnitTests
                             (current = new Button { Name = "Button2" }),
                             (next = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls
@@ -378,24 +369,22 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Next_Contained_Stops_At_End()
         {
-            StackPanel container;
             Button current;
-            Button next;
 
             var top = new StackPanel
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Contained,
                         Children = new Controls
                         {
-                            (next = new Button { Name = "Button1" }),
+                            new Button { Name = "Button1" },
                             new Button { Name = "Button2" },
                             (current = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls
@@ -416,7 +405,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Next_Once_Moves_To_Next_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -424,7 +412,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Once,
                         Children = new Controls
@@ -433,7 +421,7 @@ namespace Avalonia.Input.UnitTests
                             (current = new Button { Name = "Button2" }),
                             new Button { Name = "Button3" },
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls
@@ -494,7 +482,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Next_None_Moves_To_Next_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -502,7 +489,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.None,
                         Children = new Controls
@@ -511,7 +498,7 @@ namespace Avalonia.Input.UnitTests
                             (current = new Button { Name = "Button2" }),
                             new Button { Name = "Button3" },
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls
@@ -572,7 +559,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Previous_Continue_Returns_Previous_Control_In_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -580,7 +566,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         Children = new Controls
                         {
@@ -588,7 +574,7 @@ namespace Avalonia.Input.UnitTests
                             (next = new Button { Name = "Button2" }),
                             (current = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls
@@ -609,7 +595,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Previous_Continue_Returns_Last_Control_In_Previous_Sibling_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -617,7 +602,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         Children = new Controls
                         {
@@ -625,7 +610,7 @@ namespace Avalonia.Input.UnitTests
                             new Button { Name = "Button2" },
                             (next = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls
@@ -646,7 +631,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Previous_Continue_Returns_Last_Child_Of_Sibling()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -654,7 +638,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         Children = new Controls
                         {
@@ -662,7 +646,7 @@ namespace Avalonia.Input.UnitTests
                             new Button { Name = "Button2" },
                             (next = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     (current = new Button { Name = "Button4" }),
                 }
             };
@@ -675,7 +659,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Previous_Continue_Returns_Last_Control_In_Previous_Nephew_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -687,7 +670,7 @@ namespace Avalonia.Input.UnitTests
                     {
                         Children = new Controls
                         {
-                            (container = new StackPanel
+                            new StackPanel
                             {
                                 Children = new Controls
                                 {
@@ -695,7 +678,7 @@ namespace Avalonia.Input.UnitTests
                                     new Button { Name = "Button2" },
                                     (next = new Button { Name = "Button3" }),
                                 }
-                            }),
+                            },
                         },
                     },
                     new StackPanel
@@ -718,7 +701,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Previous_Continue_Wraps()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -730,7 +712,7 @@ namespace Avalonia.Input.UnitTests
                     {
                         Children = new Controls
                         {
-                            (container = new StackPanel
+                            new StackPanel
                             {
                                 Children = new Controls
                                 {
@@ -738,7 +720,7 @@ namespace Avalonia.Input.UnitTests
                                     new Button { Name = "Button2" },
                                     new Button { Name = "Button3" },
                                 }
-                            }),
+                            },
                         },
                     },
                     new StackPanel
@@ -780,7 +762,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Previous_Cycle_Returns_Previous_Control_In_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -788,7 +769,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Cycle,
                         Children = new Controls
@@ -797,7 +778,7 @@ namespace Avalonia.Input.UnitTests
                             (current = new Button { Name = "Button2" }),
                             new Button { Name = "Button3" },
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls
@@ -818,7 +799,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Previous_Cycle_Wraps_To_Last()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -826,7 +806,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Cycle,
                         Children = new Controls
@@ -835,7 +815,7 @@ namespace Avalonia.Input.UnitTests
                             new Button { Name = "Button2" },
                             (next = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls
@@ -856,7 +836,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Previous_Contained_Returns_Previous_Control_In_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -864,7 +843,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Contained,
                         Children = new Controls
@@ -873,7 +852,7 @@ namespace Avalonia.Input.UnitTests
                             (current = new Button { Name = "Button2" }),
                             new Button { Name = "Button3" },
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls
@@ -894,24 +873,22 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Previous_Contained_Stops_At_Beginning()
         {
-            StackPanel container;
             Button current;
-            Button next;
 
             var top = new StackPanel
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Contained,
                         Children = new Controls
                         {
                             (current = new Button { Name = "Button1" }),
                             new Button { Name = "Button2" },
-                            (next = new Button { Name = "Button3" }),
+                            new Button { Name = "Button3" },
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls
@@ -932,7 +909,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Previous_Once_Moves_To_Previous_Container()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -940,7 +916,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         Children = new Controls
                         {
@@ -948,7 +924,7 @@ namespace Avalonia.Input.UnitTests
                             new Button { Name = "Button2" },
                             (next = new Button { Name = "Button3" }),
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Once,
@@ -1010,7 +986,6 @@ namespace Avalonia.Input.UnitTests
         [Fact]
         public void Previous_Once_Moves_To_First_Element()
         {
-            StackPanel container;
             Button current;
             Button next;
 
@@ -1018,7 +993,7 @@ namespace Avalonia.Input.UnitTests
             {
                 Children = new Controls
                 {
-                    (container = new StackPanel
+                    new StackPanel
                     {
                         [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Once,
                         Children = new Controls
@@ -1027,7 +1002,7 @@ namespace Avalonia.Input.UnitTests
                             new Button { Name = "Button2" },
                             new Button { Name = "Button3" },
                         }
-                    }),
+                    },
                     new StackPanel
                     {
                         Children = new Controls

--- a/tests/Avalonia.SceneGraph.UnitTests/Media/PathMarkupParserTests.cs
+++ b/tests/Avalonia.SceneGraph.UnitTests/Media/PathMarkupParserTests.cs
@@ -92,7 +92,6 @@ namespace Avalonia.SceneGraph.UnitTests.Media
                     .ToConstant(Mock.Of<IPlatformRenderInterface>());
 
             return new PathMarkupParser(
-                new StreamGeometry(),
                 new StreamGeometryContext(implMock != null ? implMock.Object : Mock.Of<IStreamGeometryContextImpl>()));
         }
     }

--- a/tests/Avalonia.Styling.UnitTests/TestControlBase.cs
+++ b/tests/Avalonia.Styling.UnitTests/TestControlBase.cs
@@ -17,7 +17,9 @@ namespace Avalonia.Styling.UnitTests
             SubscribeCheckObservable = new TestObservable();
         }
 
+#pragma warning disable CS0067 // Event not used
         public event EventHandler<AvaloniaPropertyChangedEventArgs> PropertyChanged;
+#pragma warning restore CS0067
 
         public string Name { get; set; }
 


### PR DESCRIPTION
In Release build in main Avalonia assemblies (couldn't do it in Avalonia.Markup.Xaml due to warnings in OmniXaml). To do this, fixed a number of warnings.
