### PR TITLE
Disable xunit appdomains on non-Windows.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -660,10 +660,7 @@ Task("Run-Unit-Tests")
         Parallelism = ParallelismOption.None 
     };
 
-    if (!isRunningOnWindows)
-    {
-        settings.NoAppDomain = true;
-    }
+    settings.NoAppDomain = !isRunningOnWindows;
 
     foreach (var file in unitTests)
     {

--- a/build.cake
+++ b/build.cake
@@ -660,9 +660,9 @@ Task("Run-Unit-Tests")
         Parallelism = ParallelismOption.None 
     };
 
-    if (isRunningOnWindows)
+    if (!isRunningOnWindows)
     {
-        settings.NoAppDomain = false;
+        settings.NoAppDomain = true;
     }
 
     foreach (var file in unitTests)


### PR DESCRIPTION
(Apparently) fixes #741

@wieslawsoltes does this look right to you? From what I can see the default value for `settings.NoAppDomain` is `false` so previously the changed line wasn't doing anything anyway.
