### PR TITLE
Fixes/allow alt modifier for text input

### DIFF
--- a/src/Avalonia.Input/AccessKeyHandler.cs
+++ b/src/Avalonia.Input/AccessKeyHandler.cs
@@ -44,6 +44,11 @@ namespace Avalonia.Input
         private bool _ignoreAltUp;
 
         /// <summary>
+        /// Whether the AltKey is down.
+        /// </summary>
+        private bool _altIsDown;
+
+        /// <summary>
         /// Gets or sets the window's main menu.
         /// </summary>
         public IMainMenu MainMenu { get; set; }
@@ -110,6 +115,8 @@ namespace Avalonia.Input
         {
             if (e.Key == Key.LeftAlt)
             {
+                _altIsDown = true;
+
                 if (MainMenu == null || !MainMenu.IsOpen)
                 {
                     // When Alt is pressed without a main menu, or with a closed main menu, show
@@ -125,6 +132,10 @@ namespace Avalonia.Input
 
                 // We always handle the Alt key.
                 e.Handled = true;
+            }
+            else if(_altIsDown)
+            {
+                _ignoreAltUp = true;
             }
         }
 
@@ -179,6 +190,8 @@ namespace Avalonia.Input
             switch (e.Key)
             {
                 case Key.LeftAlt:
+                    _altIsDown = false;
+
                     if (_ignoreAltUp)
                     {
                         _ignoreAltUp = false;

--- a/src/Avalonia.Input/AccessKeyHandler.cs
+++ b/src/Avalonia.Input/AccessKeyHandler.cs
@@ -124,8 +124,9 @@ namespace Avalonia.Input
 
                 if (MainMenu == null || !MainMenu.IsOpen)
                 {
+                    // TODO: Use FocusScopes to store the current element and restore it when context menu is closed.
                     // Save currently focused input element.
-                    _restoreFocusElement = FocusManager.Instance.Current;
+                    _restoreFocusElement = FocusManager.Instance.Current;                    
 
                     // When Alt is pressed without a main menu, or with a closed main menu, show
                     // access key markers in the window (i.e. "_File").

--- a/src/Avalonia.Input/AccessKeyHandler.cs
+++ b/src/Avalonia.Input/AccessKeyHandler.cs
@@ -129,14 +129,14 @@ namespace Avalonia.Input
 
                     // When Alt is pressed without a main menu, or with a closed main menu, show
                     // access key markers in the window (i.e. "_File").
-                    _owner.ShowAccessKeys = _showingAccessKeys = true;                    
+                    _owner.ShowAccessKeys = _showingAccessKeys = true;
                 }
                 else
                 {
                     // If the Alt key is pressed and the main menu is open, close the main menu.
                     CloseMenu();
                     _ignoreAltUp = true;
-                    
+
                     _restoreFocusElement?.Focus();
                     _restoreFocusElement = null;
                 }
@@ -144,7 +144,7 @@ namespace Avalonia.Input
                 // We always handle the Alt key.
                 e.Handled = true;
             }
-            else if(_altIsDown)
+            else if (_altIsDown)
             {
                 _ignoreAltUp = true;
             }

--- a/src/Avalonia.Input/AccessKeyHandler.cs
+++ b/src/Avalonia.Input/AccessKeyHandler.cs
@@ -49,6 +49,11 @@ namespace Avalonia.Input
         private bool _altIsDown;
 
         /// <summary>
+        /// Element to restore folowing AltKey taking focus.
+        /// </summary>
+        private IInputElement _restoreFocusElement;
+
+        /// <summary>
         /// Gets or sets the window's main menu.
         /// </summary>
         public IMainMenu MainMenu { get; set; }
@@ -119,15 +124,21 @@ namespace Avalonia.Input
 
                 if (MainMenu == null || !MainMenu.IsOpen)
                 {
+                    // Save currently focused input element.
+                    _restoreFocusElement = FocusManager.Instance.Current;
+
                     // When Alt is pressed without a main menu, or with a closed main menu, show
                     // access key markers in the window (i.e. "_File").
-                    _owner.ShowAccessKeys = _showingAccessKeys = true;
+                    _owner.ShowAccessKeys = _showingAccessKeys = true;                    
                 }
                 else
                 {
                     // If the Alt key is pressed and the main menu is open, close the main menu.
                     CloseMenu();
                     _ignoreAltUp = true;
+                    
+                    _restoreFocusElement?.Focus();
+                    _restoreFocusElement = null;
                 }
 
                 // We always handle the Alt key.


### PR DESCRIPTION
This allows non-English keyboards to type special chars which require ALT modifier keys.

Also restores focus to the input element that alt steals focus from.

Behaviour now matches WPF.
