### PR TITLE
Register an IRendererFactory on GTK.

### DIFF
--- a/src/Gtk/Avalonia.Gtk/GtkPlatform.cs
+++ b/src/Gtk/Avalonia.Gtk/GtkPlatform.cs
@@ -28,7 +28,7 @@ namespace Avalonia.Gtk
     using Rendering;
     using Gtk = global::Gtk;
 
-    public class GtkPlatform : IPlatformThreadingInterface, IPlatformSettings, IWindowingPlatform, IPlatformIconLoader
+    public class GtkPlatform : IPlatformThreadingInterface, IPlatformSettings, IWindowingPlatform, IPlatformIconLoader, IRendererFactory
     {
         private static readonly GtkPlatform s_instance = new GtkPlatform();
         private static Thread _uiThread;
@@ -54,6 +54,7 @@ namespace Avalonia.Gtk
                 .Bind<IMouseDevice>().ToConstant(GtkMouseDevice.Instance)
                 .Bind<IPlatformSettings>().ToConstant(s_instance)
                 .Bind<IPlatformThreadingInterface>().ToConstant(s_instance)
+                .Bind<IRendererFactory>().ToConstant(s_instance)
                 .Bind<IRenderLoop>().ToConstant(new DefaultRenderLoop(60))
                 .Bind<ISystemDialogImpl>().ToSingleton<SystemDialogImpl>()
                 .Bind<IPlatformIconLoader>().ToConstant(s_instance);
@@ -110,6 +111,11 @@ namespace Avalonia.Gtk
         public IPopupImpl CreatePopup()
         {
             return new PopupImpl();
+        }
+
+        public IRenderer CreateRenderer(IRenderRoot root, IRenderLoop renderLoop)
+        {
+            return new Renderer(root, renderLoop);
         }
 
         public IWindowIconImpl LoadIcon(string fileName)


### PR DESCRIPTION
Fixes GTK backed apps not starting. cc @wieslawsoltes 
