### PR TITLE
Register an IRendererFactory on Skia

### DIFF
--- a/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
+++ b/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
@@ -2,11 +2,12 @@ using System;
 using System.IO;
 using Avalonia.Media;
 using Avalonia.Platform;
+using Avalonia.Rendering;
 using SkiaSharp;
 
 namespace Avalonia.Skia
 {
-    public class PlatformRenderInterface : IPlatformRenderInterface
+    public class PlatformRenderInterface : IPlatformRenderInterface, IRendererFactory
     {
         public IBitmapImpl CreateBitmap(int width, int height)
         {
@@ -46,6 +47,11 @@ namespace Avalonia.Skia
             {
                 return LoadBitmap(stream);
             }
+        }
+
+        public IRenderer CreateRenderer(IRenderRoot root, IRenderLoop renderLoop)
+        {
+            return new Renderer(root, renderLoop);
         }
 
         public IRenderTargetBitmapImpl CreateRenderTargetBitmap(int width, int height)

--- a/src/Skia/Avalonia.Skia/SkiaPlatform.cs
+++ b/src/Skia/Avalonia.Skia/SkiaPlatform.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Avalonia.Controls;
 using Avalonia.Platform;
+using Avalonia.Rendering;
 
 namespace Avalonia
 {
@@ -23,7 +24,12 @@ namespace Avalonia.Skia
         private static bool s_forceSoftwareRendering;
 
         public static void Initialize()
-            => AvaloniaLocator.CurrentMutable.Bind<IPlatformRenderInterface>().ToConstant(new PlatformRenderInterface());
+        {
+            var renderInterface = new PlatformRenderInterface();
+            AvaloniaLocator.CurrentMutable
+                .Bind<IPlatformRenderInterface>().ToConstant(renderInterface)
+                .Bind<IRendererFactory>().ToConstant(renderInterface);
+        }
 
         public static bool ForceSoftwareRendering
         {


### PR DESCRIPTION
This fixes Win32/Skia not working. GTK/Skia is flickering however, and I'm not sure why - it seems that by the time the GTK Expose event is called, the window contents have been cleared. This doesn't appear to happen with GTK/Cairo so I assume it's something in the Skia backend?

Any idea @kekekeks @jazzay @danwalmsley?
