### PR TITLE
Call SetFocus in ShowWindow.

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -682,6 +682,7 @@ namespace Avalonia.Win32
             }
 
             UnmanagedMethods.ShowWindow(_hwnd, command);
+            UnmanagedMethods.SetFocus(_hwnd);
         }
 
         public void SetIcon(IWindowIconImpl icon)


### PR DESCRIPTION
Dialogs weren't receiving text input (WM_CHAR) after being shown (though
they were receiving key down/up messages). Fixes #785.
