### PR TITLE
Fixed Test running in CI

### DIFF
--- a/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
+++ b/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
@@ -585,7 +585,7 @@ namespace Avalonia.Skia
             if (_skiaLines.Count == 0)
             {
                 _lines.Add(new FormattedTextLine(0, _lineHeight));
-                _size = new Size(0, _lineHeight + lastLineDescent);
+                _size = new Size(0, _lineHeight);
             }
             else
             {

--- a/tests/Avalonia.DesignerSupport.TestApp/Avalonia.DesignerSupport.TestApp.csproj
+++ b/tests/Avalonia.DesignerSupport.TestApp/Avalonia.DesignerSupport.TestApp.csproj
@@ -18,7 +18,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\artifacts\tests\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -27,7 +27,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\..\artifacts\tests\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/tests/Avalonia.DesignerSupport.Tests/Avalonia.DesignerSupport.Tests.csproj
+++ b/tests/Avalonia.DesignerSupport.Tests/Avalonia.DesignerSupport.Tests.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\artifacts\tests\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -24,7 +24,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\..\artifacts\tests\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -68,6 +68,12 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Avalonia.DesignerSupport.TestApp\Avalonia.DesignerSupport.TestApp.csproj">
+      <Project>{f1381f98-4d24-409a-a6c5-1c5b1e08bb08}</Project>
+      <Name>Avalonia.DesignerSupport.TestApp</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/tests/Avalonia.DesignerSupport.Tests/DesignerSupportTests.cs
+++ b/tests/Avalonia.DesignerSupport.Tests/DesignerSupportTests.cs
@@ -12,8 +12,8 @@ namespace Avalonia.DesignerSupport.Tests
     public class DesignerSupportTests
     {
         [Theory,
-         InlineData(@"..\..\..\Avalonia.DesignerSupport.TestApp\bin\$BUILD\Avalonia.DesignerSupport.TestApp.exe", @"..\..\..\Avalonia.DesignerSupport.TestApp\MainWindow.xaml"),
-         InlineData(@"..\..\..\..\samples\ControlCatalog.Desktop\bin\$BUILD\ControlCatalog.dll", @"..\..\..\..\samples\ControlCatalog\MainWindow.xaml")]
+         InlineData(@"Avalonia.DesignerSupport.TestApp.exe", @"..\..\tests\Avalonia.DesignerSupport.TestApp\MainWindow.xaml"),
+         InlineData(@"..\..\samples\ControlCatalog.Desktop\bin\$BUILD\ControlCatalog.dll", @"..\..\samples\ControlCatalog\MainWindow.xaml")]
         public void DesgignerApiShoudBeOperational(string outputDir, string xamlFile)
         {
             var xaml = File.ReadAllText(xamlFile);

--- a/tests/Avalonia.RenderTests/Avalonia.Cairo.RenderTests.csproj
+++ b/tests/Avalonia.RenderTests/Avalonia.Cairo.RenderTests.csproj
@@ -23,7 +23,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\artifacts\tests\</OutputPath>
     <DefineConstants>TRACE;DEBUG;AVALONIA_CAIRO</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -31,7 +31,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\..\artifacts\tests\</OutputPath>
     <DefineConstants>TRACE;AVALONIA_CAIRO</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/tests/Avalonia.RenderTests/Avalonia.Direct2D1.RenderTests.csproj
+++ b/tests/Avalonia.RenderTests/Avalonia.Direct2D1.RenderTests.csproj
@@ -22,20 +22,22 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\artifacts\tests\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\Avalonia.Direct2D1.RenderTests.XML</DocumentationFile>
+    <DocumentationFile>..\..\artifacts\tests\Avalonia.Direct2D1.RenderTests.XML</DocumentationFile>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\..\artifacts\tests\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>
+    </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Magick.NET-Q16-AnyCPU, Version=7.0.0.0, Culture=neutral, PublicKeyToken=2004825badfa91ec, processorArchitecture=MSIL">

--- a/tests/Avalonia.RenderTests/Avalonia.Skia.RenderTests.csproj
+++ b/tests/Avalonia.RenderTests/Avalonia.Skia.RenderTests.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
+    <OutputPath>..\..\artifacts\tests\</OutputPath>
     <DefineConstants>TRACE;DEBUG;AVALONIA_SKIA;AVALONIA_SKIA_SKIP_FAIL</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -42,8 +42,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE;AVALONIA_SKIA;AVALONIA_SKIA_SKIP_FAIL</DefineConstants>
+    <OutputPath>..\..\artifacts\tests\</OutputPath>
+    <DefineConstants>TRACE;AVALONIA_SKIA;AVALONIA_SKIA_SKIP_FAIL;</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>

--- a/tests/Avalonia.RenderTests/Media/FormattedTextImplTests.cs
+++ b/tests/Avalonia.RenderTests/Media/FormattedTextImplTests.cs
@@ -101,20 +101,12 @@ namespace Avalonia.Direct2D1.RenderTests.Media
         [InlineData(stringmiddlenewlines, FontSize, 72.01, 4 * FontSizeHeight)]
         public void Should_Measure_String_Correctly(string input, double fontSize, double expWidth, double expHeight)
         {
-#if !AVALONIA_SKIA
-            double heightCorr = 0;
-#else
-            //In skia there is a small descent added to last line,
-            //otherwise some letters are clipped at bottom
-            //4.55273438 for font 12 size
-            double heightCorr = 0.3793945*fontSize;
-#endif
             using (var fmt = Create(input, fontSize))
             {
                 var size = fmt.Measure();
 
                 Assert.Equal(expWidth, size.Width, 2);
-                Assert.Equal(expHeight + heightCorr, size.Height, 2);
+                Assert.Equal(expHeight, size.Height, 2);
 
                 var linesHeight = fmt.GetLines().Sum(l => l.Height);
 

--- a/tests/Avalonia.RenderTests/TestBase.cs
+++ b/tests/Avalonia.RenderTests/TestBase.cs
@@ -42,11 +42,11 @@ namespace Avalonia.Direct2D1.RenderTests
         public TestBase(string outputPath)
         {
 #if AVALONIA_CAIRO
-            string testFiles = Path.GetFullPath(@"..\..\..\TestFiles\Cairo");
+            string testFiles = Path.GetFullPath(@"..\..\tests\TestFiles\Cairo");
 #elif AVALONIA_SKIA
-            string testFiles = Path.GetFullPath(@"..\..\..\TestFiles\Skia");
+            string testFiles = Path.GetFullPath(@"..\..\tests\TestFiles\Skia");
 #else
-            string testFiles = Path.GetFullPath(@"..\..\..\TestFiles\Direct2D1");
+            string testFiles = Path.GetFullPath(@"..\..\tests\TestFiles\Direct2D1");
 #endif
             OutputPath = Path.Combine(testFiles, outputPath);
         }


### PR DESCRIPTION
Changed render tests and designer support test to always output to the artifacts/tests folder and modify the relative paths within so they don't fail on CI. Fixed CI to fail if tests fail (got turned off when OpenCover was added accidentally).

@donandren @danwalmsley Can you guys try to fix the text measure render tests for Skia in here?