### PR TITLE
Environment.CurrentDirectory is modified after showing a Dialog

### DIFF
--- a/src/Windows/Avalonia.Win32/SystemDialogImpl.cs
+++ b/src/Windows/Avalonia.Win32/SystemDialogImpl.cs
@@ -88,9 +88,16 @@ namespace Avalonia.Win32
 
                     var pofn = &ofn;
 
+                    // We should save the current directory to restore it later.
+                    var currentDirectory = Environment.CurrentDirectory;
+
                     var res = dialog is OpenFileDialog
                         ? UnmanagedMethods.GetOpenFileName(new IntPtr(pofn))
                         : UnmanagedMethods.GetSaveFileName(new IntPtr(pofn));
+
+                    // Restore the old current directory, since GetOpenFileName and GetSaveFileName change it after they're called
+                    Environment.CurrentDirectory = currentDirectory;
+
                     if (!res)
                         return null;
                     if (dialog?.Filters.Count > 0)


### PR DESCRIPTION
Environment.CurrentDirectory is modified after the call to GetOpenFileName / GetSaveFileName. This should happen implicitly.

**MORE INFO:** Some libraries, like DotImaging (https://github.com/dajuric/dot-imaging), use native libraries that are dynamically loaded using the current directory. After a call to **Save Dialog** or **Open Dialog** the current directory is modified, so subsequent calls to those native libraries fail.

In my case, DotImaging uses OpenCV (http://opencv.org/), that is a pretty popular library to work of image/video manipulation and detection, and it seems it uses the PInvokes looking at the `PATH` environment variable.
