### PR TITLE
Update binding chain on null root.

### DIFF
--- a/src/Markup/Avalonia.Markup/Data/ExpressionNode.cs
+++ b/src/Markup/Avalonia.Markup/Data/ExpressionNode.cs
@@ -131,20 +131,14 @@ namespace Avalonia.Markup.Data
             }
             else
             {
-                if (notification.Error != null)
+                if (Next != null)
                 {
-                    _observer.OnNext(notification);
+                    Next.Target = new WeakReference(notification.Value);
                 }
-                else if (notification.HasValue)
+                
+                if (Next == null || notification.Error != null)
                 {
-                    if (Next != null)
-                    {
-                        Next.Target = new WeakReference(notification.Value);
-                    }
-                    else
-                    {
-                        _observer.OnNext(value);
-                    }
+                    _observer.OnNext(value);
                 }
             }
         }

--- a/tests/Avalonia.Markup.UnitTests/Data/ExpressionObserverTests_SetValue.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/ExpressionObserverTests_SetValue.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using Avalonia.Markup.Data;
 using Avalonia.UnitTests;
 using Xunit;
@@ -52,6 +52,28 @@ namespace Avalonia.Markup.UnitTests.Data
             data.Foo = null;
 
             Assert.False(target.SetValue("foo"));
+        }
+
+        /// <summary>
+        /// Test for #831 - Bound properties are incorrectly updated when changing tab items.
+        /// </summary>
+        /// <remarks>
+        /// There was a bug whereby pushing a null as the ExpressionObserver root didn't update
+        /// the leaf node, cauing a subsequent SetValue to update an object that should have become
+        /// unbound.
+        /// </remarks>
+        [Fact]
+        public void Pushing_Null_To_RootObservable_Updates_Leaf_Node()
+        {
+            var data = new Class1 { Foo = new Class2 { Bar = "bar" } };
+            var rootObservable = new BehaviorSubject<Class1>(data);
+            var target = new ExpressionObserver(rootObservable, "Foo.Bar");
+
+            target.Subscribe(_ => { });
+            rootObservable.OnNext(null);
+            target.SetValue("baz");
+
+            Assert.Equal("bar", data.Foo.Bar);
         }
 
         private class Class1 : NotifyingBase


### PR DESCRIPTION
Pushing a null as the ExpressionObserver root wasn't updating the leaf node, cauing a subsequent SetValue to update an object that should have become unbound.

cc @wieslawsoltes 

Fixes #831.