### PR TITLE
Clear ContentPresenter data context.

### DIFF
--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -232,6 +232,10 @@ namespace Avalonia.Controls.Presenters
             {
                 DataContext = content;
             }
+            else
+            {
+                ClearValue(DataContextProperty);
+            }
 
             // Update the Child.
             if (newChild == null)

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests.cs
@@ -172,6 +172,22 @@ namespace Avalonia.Controls.UnitTests.Presenters
         }
 
         [Fact]
+        public void Assigning_Control_To_Content_After_NonControl_Should_Clear_DataContext()
+        {
+            var target = new ContentPresenter();
+
+            target.Content = "foo";
+            target.UpdateChild();
+
+            Assert.True(target.IsSet(Control.DataContextProperty));
+
+            target.Content = new Border();
+            target.UpdateChild();
+
+            Assert.False(target.IsSet(Control.DataContextProperty));
+        }
+
+        [Fact]
         public void Tries_To_Recycle_DataTemplate()
         {
             var target = new ContentPresenter


### PR DESCRIPTION
When assigning a control to `ContentPresenter.Content` after a non-control the data context should get cleared. Fixes another problem in #831.