### PR TITLE
Fix for #834 ListBox displays unnecessary horizontal scrollbar

### DIFF
--- a/src/Avalonia.Controls/Presenters/ItemVirtualizer.cs
+++ b/src/Avalonia.Controls/Presenters/ItemVirtualizer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Specialized;
+using System.Reactive.Linq;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Utils;
 using Avalonia.Input;
@@ -17,6 +18,7 @@ namespace Avalonia.Controls.Presenters
     internal abstract class ItemVirtualizer : IVirtualizingController, IDisposable
     {
         private double _crossAxisOffset;
+        private IDisposable _subscriptions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ItemVirtualizer"/> class.
@@ -27,6 +29,15 @@ namespace Avalonia.Controls.Presenters
             Owner = owner;
             Items = owner.Items;
             ItemCount = owner.Items.Count();
+
+            var panel = VirtualizingPanel;
+
+            if (panel != null)
+            {
+                _subscriptions = panel.GetObservable(Panel.BoundsProperty)
+                    .Skip(1)
+                    .Subscribe(_ => InvalidateScroll());
+            }
         }
 
         /// <summary>
@@ -240,6 +251,9 @@ namespace Avalonia.Controls.Presenters
         /// <inheritdoc/>
         public virtual void Dispose()
         {
+            _subscriptions?.Dispose();
+            _subscriptions = null;
+
             if (VirtualizingPanel != null)
             {
                 VirtualizingPanel.Controller = null;

--- a/src/Avalonia.Controls/ScrollViewer.cs
+++ b/src/Avalonia.Controls/ScrollViewer.cs
@@ -157,10 +157,6 @@ namespace Avalonia.Controls
         /// </summary>
         public ScrollViewer()
         {
-            Observable.CombineLatest(
-                this.GetObservable(ExtentProperty),
-                this.GetObservable(ViewportProperty))
-                .Select(x => new { Extent = x[0], Viewport = x[1] });
         }
 
         /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
@@ -153,6 +153,23 @@ namespace Avalonia.Controls.UnitTests
             Assert.False(((ListBoxItem)target.Presenter.Panel.Children[0]).IsSelected);
         }
 
+        [Fact]
+        public void ScrollViewer_Should_Have_Correct_Extent_And_Viewport()
+        {
+            var target = new ListBox
+            {
+                Template = ListBoxTemplate(),
+                Items = Enumerable.Range(0, 20).Select(x => $"Item {x}").ToList(),
+                ItemTemplate = new FuncDataTemplate<string>(x => new TextBlock { Width = 20, Height = 10 }),
+                SelectedIndex = 0,
+            };
+
+            Prepare(target);
+
+            Assert.Equal(new Size(20, 20), target.Scroll.Extent);
+            Assert.Equal(new Size(100, 10), target.Scroll.Viewport);
+        }
+
         private FuncControlTemplate ListBoxTemplate()
         {
             return new FuncControlTemplate<ListBox>(parent => 
@@ -233,6 +250,7 @@ namespace Avalonia.Controls.UnitTests
                 i.InvalidateMeasure();
             }
 
+            target.Measure(new Size(100, 100));
             target.Arrange(new Rect(0, 0, 100, 100));
         }
 

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests_Virtualization.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests_Virtualization.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Avalonia.Collections;
 using Avalonia.Controls.Generators;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
@@ -113,7 +112,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
 
             var scroll = (ScrollContentPresenter)target.Parent;
             Assert.Equal(new Size(10, 20), scroll.Extent);
-            Assert.Equal(new Size(0, 10), scroll.Viewport);
+            Assert.Equal(new Size(100, 10), scroll.Viewport);
         }
 
         [Fact]
@@ -255,7 +254,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
 
             Assert.Equal(10, target.Panel.Children.Count);
             Assert.Equal(new Size(10, 20), scroll.Extent);
-            Assert.Equal(new Size(0, 10), scroll.Viewport);
+            Assert.Equal(new Size(100, 10), scroll.Viewport);
 
             target.VirtualizationMode = ItemVirtualizationMode.None;
             target.Measure(new Size(100, 100));


### PR DESCRIPTION
`ILogicalScrollable.InvalidateScroll` is called from the measure/arrange pass but before the control's bounds have been updated. It needs to listen for changes to the panel's bounds to correctly update the Extent/Viewport properties.