### PR TITLE
Don't focus Win32 window in design mode.

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -709,7 +709,10 @@ namespace Avalonia.Win32
                 MaximizeWithoutCoveringTaskbar();
             }
 
-            SetFocus(_hwnd);
+            if (!Design.IsDesignMode)
+            {
+                SetFocus(_hwnd);
+            }
         }
 
         private void MaximizeWithoutCoveringTaskbar()


### PR DESCRIPTION
Fixes #837.