### PR TITLE
Fix for 870 whitepsace keys not accepted in gtk

### DIFF
--- a/src/Gtk/Avalonia.Gtk/WindowImplBase.cs
+++ b/src/Gtk/Avalonia.Gtk/WindowImplBase.cs
@@ -9,6 +9,7 @@ using Avalonia.Platform;
 using Gdk;
 using Action = System.Action;
 using WindowEdge = Avalonia.Controls.WindowEdge;
+using GLib;
 
 namespace Avalonia.Gtk
 {
@@ -49,6 +50,7 @@ namespace Avalonia.Gtk
             _window.KeyReleaseEvent += OnKeyReleaseEvent;
             _window.ExposeEvent += OnExposeEvent;
             _window.MotionNotifyEvent += OnMotionNotifyEvent;
+
             
         }
 
@@ -269,6 +271,7 @@ namespace Avalonia.Gtk
             Input(e);
         }
 
+		[ConnectBefore]
         void OnKeyPressEvent(object o, Gtk.KeyPressEventArgs args)
         {
             args.RetVal = true;


### PR DESCRIPTION
@kekekeks not sure if this is the correct fix, http://stackoverflow.com/questions/1698437/why-does-pressing-the-return-key-not-trigger-a-keypressevent-in-my-gtk-entry

seems to work. Can you have a look at the issue.