### PR TITLE
Moved hiddenPostTransform inside Skia backend

### DIFF
--- a/src/Avalonia.Visuals/Media/DrawingContext.cs
+++ b/src/Avalonia.Visuals/Media/DrawingContext.cs
@@ -12,10 +12,6 @@ namespace Avalonia.Media
     {
         private readonly IDrawingContextImpl _impl;
         private int _currentLevel;
-        //Internal tranformation that is applied but not exposed anywhere
-        //To be used for DPI scaling, etc
-        private Matrix? _hiddenPostTransform = Matrix.Identity;
-
         
 
         static readonly Stack<Stack<PushedState>> StateStackPool = new Stack<Stack<PushedState>>();
@@ -39,10 +35,9 @@ namespace Avalonia.Media
             }
         }
 
-        public DrawingContext(IDrawingContextImpl impl, Matrix? hiddenPostTransform = null)
+        public DrawingContext(IDrawingContextImpl impl)
         {
             _impl = impl;
-            _hiddenPostTransform = hiddenPostTransform;
         }
 
 
@@ -60,8 +55,6 @@ namespace Avalonia.Media
             {
                 _currentTransform = value;
                 var transform = _currentTransform*_currentContainerTransform;
-                if (_hiddenPostTransform.HasValue)
-                    transform = transform*_hiddenPostTransform.Value;
                 _impl.Transform = transform;
             }
         }

--- a/src/Skia/Avalonia.Skia.iOS/RenderTarget.cs
+++ b/src/Skia/Avalonia.Skia.iOS/RenderTarget.cs
@@ -103,9 +103,7 @@ namespace Avalonia.Skia
             canvas.Clear(SKColors.Red);
             canvas.ResetMatrix();
 
-            return
-                new DrawingContext(
-                    new WindowDrawingContextImpl(this));
+            return new DrawingContext(new WindowDrawingContextImpl(this));
         }
 
         public void Present()

--- a/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
+++ b/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
@@ -10,13 +10,16 @@ namespace Avalonia.Skia
 {
     internal class DrawingContextImpl : IDrawingContextImpl
     {
+        private readonly Matrix? _postTransform;
         private readonly IDisposable[] _disposables;
         private Stack<PaintWrapper> maskStack = new Stack<PaintWrapper>();
         
         public SKCanvas Canvas { get; private set; }
 
-        public DrawingContextImpl(SKCanvas canvas, params IDisposable[] disposables)
+        public DrawingContextImpl(SKCanvas canvas, Matrix? postTransform = null, params IDisposable[] disposables)
         {
+            if (_postTransform.HasValue && !_postTransform.Value.IsIdentity)
+                _postTransform = postTransform;
             _disposables = disposables;
             Canvas = canvas;
             Canvas.Clear();
@@ -360,7 +363,10 @@ namespace Avalonia.Skia
                     return;
 
                 _currentTransform = value;
-                Canvas.SetMatrix(value.ToSKMatrix());
+                var transform = value;
+                if (_postTransform.HasValue)
+                    transform *= _postTransform.Value;
+                Canvas.SetMatrix(transform.ToSKMatrix());
             }
         }
     }

--- a/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs
@@ -89,9 +89,8 @@ namespace Avalonia.Skia
             canvas.Save();
             canvas.Clear(SKColors.Red);
             canvas.ResetMatrix();
-            
-            return new DrawingContext(new DrawingContextImpl(canvas, canvas, surface, shim, fb),
-                Matrix.CreateScale(fb.Dpi.Width / 96, fb.Dpi.Height / 96));
+            var scale = Matrix.CreateScale(fb.Dpi.Width / 96, fb.Dpi.Height / 96);
+            return new DrawingContext(new DrawingContextImpl(canvas, scale, canvas, surface, shim, fb));
         }
     }
 }


### PR DESCRIPTION
Needed for `scenegraph`, since `DrawingContext` there doesn't have support for that.