### PR TITLE
Added Rect.Union

### DIFF
--- a/src/Avalonia.Controls/Image.cs
+++ b/src/Avalonia.Controls/Image.cs
@@ -63,10 +63,10 @@ namespace Avalonia.Controls
                 Vector scale = Stretch.CalculateScaling(Bounds.Size, sourceSize);
                 Size scaledSize = sourceSize * scale;
                 Rect destRect = viewPort
-                    .CenterIn(new Rect(scaledSize))
+                    .CenterRect(new Rect(scaledSize))
                     .Intersect(viewPort);
                 Rect sourceRect = new Rect(sourceSize)
-                    .CenterIn(new Rect(destRect.Size / scale));
+                    .CenterRect(new Rect(destRect.Size / scale));
 
                 context.DrawImage(source, 1, sourceRect, destRect);
             }

--- a/src/Avalonia.Visuals/Rect.cs
+++ b/src/Avalonia.Visuals/Rect.cs
@@ -238,7 +238,7 @@ namespace Avalonia
         /// </summary>
         /// <param name="rect">The rectangle to center.</param>
         /// <returns>The centered rectangle.</returns>
-        public Rect CenterIn(Rect rect)
+        public Rect CenterRect(Rect rect)
         {
             return new Rect(
                 _x + ((_width - rect._width) / 2),

--- a/src/Avalonia.Visuals/Rect.cs
+++ b/src/Avalonia.Visuals/Rect.cs
@@ -402,6 +402,32 @@ namespace Avalonia
         }
 
         /// <summary>
+        /// Gets the union of two rectangles.
+        /// </summary>
+        /// <param name="rect">The other rectangle.</param>
+        /// <returns>The union.</returns>
+        public Rect Union(Rect rect)
+        {
+            if (IsEmpty)
+            {
+                return rect;
+            }
+            else if (rect.IsEmpty)
+            {
+                return this;
+            }
+            else
+            {
+                var x1 = Math.Min(this.X, rect.X);
+                var x2 = Math.Max(this.Right, rect.Right);
+                var y1 = Math.Min(this.Y, rect.Y);
+                var y2 = Math.Max(this.Bottom, rect.Bottom);
+
+                return new Rect(new Point(x1, y1), new Point(x2, y2));
+            }
+        }
+
+        /// <summary>
         /// Returns a new <see cref="Rect"/> with the specified X position.
         /// </summary>
         /// <param name="x">The x position.</param>

--- a/tests/Avalonia.Visuals.UnitTests/Avalonia.Visuals.UnitTests.csproj
+++ b/tests/Avalonia.Visuals.UnitTests/Avalonia.Visuals.UnitTests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Media\FormattedTextTests.cs" />
     <Compile Include="Media\PathMarkupParserTests.cs" />
     <Compile Include="RelativeRectComparer.cs" />
+    <Compile Include="RectTests.cs" />
     <Compile Include="RelativeRectTests.cs" />
     <Compile Include="ThicknessTests.cs" />
     <Compile Include="Media\BrushTests.cs" />

--- a/tests/Avalonia.Visuals.UnitTests/RectTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/RectTests.cs
@@ -1,0 +1,26 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using Xunit;
+
+namespace Avalonia.Visuals.UnitTests
+{
+    public class RectTests
+    {
+        [Fact]
+        public void Union_Should_Return_Correct_Value_For_Intersecting_Rects()
+        {
+            var result = new Rect(0, 0, 100, 100).Union(new Rect(50, 50, 100, 100));
+
+            Assert.Equal(new Rect(0, 0, 150, 150), result);
+        }
+
+        [Fact]
+        public void Union_Should_Return_Correct_Value_For_NonIntersecting_Rects()
+        {
+            var result = new Rect(0, 0, 100, 100).Union(new Rect(150, 150, 100, 100));
+
+            Assert.Equal(new Rect(0, 0, 250, 250), result);
+        }
+    }
+}

--- a/tests/Avalonia.Visuals.UnitTests/RectTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/RectTests.cs
@@ -22,5 +22,21 @@ namespace Avalonia.Visuals.UnitTests
 
             Assert.Equal(new Rect(0, 0, 250, 250), result);
         }
+
+        [Fact]
+        public void Union_Should_Ignore_Empty_This_rect()
+        {
+            var result = new Rect(0, 0, 0, 0).Union(new Rect(150, 150, 100, 100));
+
+            Assert.Equal(new Rect(150, 150, 100, 100), result);
+        }
+
+        [Fact]
+        public void Union_Should_Ignore_Empty_Other_rect()
+        {
+            var result = new Rect(0, 0, 100, 100).Union(new Rect(150, 150, 0, 0));
+
+            Assert.Equal(new Rect(0, 0, 100, 100), result);
+        }
     }
 }


### PR DESCRIPTION
And renamed `Rect.CenterIn` -> `CenterRect`: the previous naming suggested that the `Rect` that the method was being called on was the one being centered.