### PR TITLE
Use the dirty rect from BeginPaint on WM_PAINT.

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -572,9 +572,8 @@ namespace Avalonia.Win32
 
                     if (UnmanagedMethods.BeginPaint(_hwnd, out ps) != IntPtr.Zero)
                     {
-                        UnmanagedMethods.RECT r;
-                        UnmanagedMethods.GetUpdateRect(_hwnd, out r, false);
                         var f = Scaling;
+                        var r = ps.rcPaint;
                         Paint?.Invoke(new Rect(r.left / f, r.top / f, (r.right - r.left) / f, (r.bottom - r.top) / f));
                         UnmanagedMethods.EndPaint(_hwnd, ref ps);
                     }


### PR DESCRIPTION
The one returned by `GetUpdateRect` at this point will be empty; from the win32 docs:

> BeginPaint automatically validates the update region, so any call to
GetUpdateRect made immediately after the call to BeginPaint retrieves an
empty update region.