### PR TITLE
Enable SharpDX EnableReleaseOnFinalizer.

### DIFF
--- a/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
+++ b/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
@@ -72,14 +72,18 @@ namespace Avalonia.Direct2D1
             }
         }
 
-        public static void Initialize() => AvaloniaLocator.CurrentMutable
-            .Bind<IPlatformRenderInterface>().ToConstant(s_instance)
-            .Bind<IRendererFactory>().ToConstant(s_instance)
-            .BindToSelf(s_d2D1Factory)
-            .BindToSelf(s_dwfactory)
-            .BindToSelf(s_imagingFactory)
-            .BindToSelf(s_dxgiDevice)
-            .BindToSelf(s_d2D1Device);
+        public static void Initialize()
+        {
+            AvaloniaLocator.CurrentMutable
+                        .Bind<IPlatformRenderInterface>().ToConstant(s_instance)
+                        .Bind<IRendererFactory>().ToConstant(s_instance)
+                        .BindToSelf(s_d2D1Factory)
+                        .BindToSelf(s_dwfactory)
+                        .BindToSelf(s_imagingFactory)
+                        .BindToSelf(s_dxgiDevice)
+                        .BindToSelf(s_d2D1Device);
+            SharpDX.Configuration.EnableReleaseOnFinalizer = true;
+        }
 
         public IBitmapImpl CreateBitmap(int width, int height)
         {


### PR DESCRIPTION
We need to enable to avoid memory leaks this as we're not doing cleanup of SharpDX objects ourselves.