### PR TITLE
Fix type conversions.

### DIFF
--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -578,13 +578,13 @@ namespace Avalonia
 
             if (notification == null)
             {
-                return TypeUtilities.CastOrDefault(value, type);
+                return TypeUtilities.ConvertImplicitOrDefault(value, type);
             }
             else
             {
                 if (notification.HasValue)
                 {
-                    notification.SetValue(TypeUtilities.CastOrDefault(notification.Value, type));
+                    notification.SetValue(TypeUtilities.ConvertImplicitOrDefault(notification.Value, type));
                 }
 
                 return notification;
@@ -735,7 +735,7 @@ namespace Avalonia
                 ThrowNotRegistered(property);
             }
 
-            if (!TypeUtilities.TryCast(property.PropertyType, value, out value))
+            if (!TypeUtilities.TryConvertImplicit(property.PropertyType, value, out value))
             {
                 throw new ArgumentException(string.Format(
                     "Invalid value for Property '{0}': '{1}' ({2})",

--- a/src/Avalonia.Base/AvaloniaProperty.cs
+++ b/src/Avalonia.Base/AvaloniaProperty.cs
@@ -476,7 +476,7 @@ namespace Avalonia
         /// <returns>True if the value is valid, otherwise false.</returns>
         public bool IsValidValue(object value)
         {
-            return TypeUtilities.TryCast(PropertyType, value, out value);
+            return TypeUtilities.TryConvertImplicit(PropertyType, value, out value);
         }
 
         /// <summary>

--- a/src/Avalonia.Base/PriorityValue.cs
+++ b/src/Avalonia.Base/PriorityValue.cs
@@ -249,7 +249,7 @@ namespace Avalonia
                 value = (notification.HasValue) ? notification.Value : null;
             }
 
-            if (TypeUtilities.TryCast(_valueType, value, out castValue))
+            if (TypeUtilities.TryConvertImplicit(_valueType, value, out castValue))
             {
                 var old = _value;
 

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Parsers/SelectorParserTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Parsers/SelectorParserTests.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml.Parsers;
+using Xunit;
+
+namespace Avalonia.Markup.Xaml.UnitTests.Parsers
+{
+    public class SelectorParserTests
+    {
+        [Fact]
+        public void Parses_Boolean_Property_Selector()
+        {
+            var target = new SelectorParser((type, ns) => typeof(TextBlock));
+            var result = target.Parse("TextBlock[IsPointerOver=True]");
+        }
+    }
+}


### PR DESCRIPTION
They were not correct before. Also clarified the two types of conversions:

- `TryConvertImplicit` implements the implicit conversions allowed by the C# language
- `TryConvert` tries every means at its disposal to convert a value to a type

`AvaloniaObject` uses only implicit conversions. This allows one to write:

```
var control = new TextBlock
{
    [Canvas.TopProperty] = 10
}
```

Without implicit conversions, this would fail because `Canvas.Top` is a `double` whereas `10` is an `int`, however only implicit conversions should be used here, otherwise the following would pass, which is probably not what would be wanted:

```
var control = new TextBlock
{
    [TextBlock.TextProperty] = observable, // Text is now the type name of `observable`
}
```

`DefaultValueConverter` uses `TryConvert`, i.e. every conversion possible.

Fixes #972.