### PR TITLE
Use size enforced by Width/Height for content measurements

### DIFF
--- a/src/Avalonia.Layout/Layoutable.cs
+++ b/src/Avalonia.Layout/Layoutable.cs
@@ -460,6 +460,11 @@ namespace Avalonia.Layout
                     .ApplyLayoutConstraints(this, availableSize)
                     .Deflate(margin);
 
+                if (!double.IsNaN(Width))
+                    constrained = constrained.WithWidth(Width);
+                if (!double.IsNaN(Height))
+                    constrained = constrained.WithHeight(Height);
+
                 var measured = MeasureOverride(constrained);
 
                 var width = measured.Width;


### PR DESCRIPTION
If Size is being enforced by Width/Height, contents are still measured with `availableSize`. 


Minimal code to reproduce the issue:
```xaml
<Window xmlns="https://github.com/avaloniaui" Title="Test app" WindowState="Maximized" MinWidth="500" MinHeight="300">
    <Button Content="Button text" Margin="40,65,0,0" Width="201" Height="65">
        <TextBlock>Button Text</TextBlock>
    </Button>
</Window>
```

I'm not sure that we should fix it this way, so no unit test for now