### PR TITLE
Change ILockedFrameBuffer.Dpi to Vector.

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/AndroidFramebuffer.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/AndroidFramebuffer.cs
@@ -44,7 +44,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         public int Width { get; }
         public int Height { get; }
         public int RowBytes { get; }
-        public Size Dpi { get; } = new Size(96, 96);
+        public Vector Dpi { get; } = new Vector(96, 96);
         public PixelFormat Format { get; }
 
         [DllImport("android")]

--- a/src/Avalonia.Visuals/Platform/ILockedFramebuffer.cs
+++ b/src/Avalonia.Visuals/Platform/ILockedFramebuffer.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Platform
         /// <summary>
         /// DPI of underling screen
         /// </summary>
-        Size Dpi { get; }
+        Vector Dpi { get; }
         
         /// <summary>
         /// Pixel format

--- a/src/Avalonia.Visuals/Vector.cs
+++ b/src/Avalonia.Visuals/Vector.cs
@@ -52,8 +52,6 @@ namespace Avalonia
             return new Point(a._x, a._y);
         }
 
-        
-
         /// <summary>
         /// Calculates the dot product of two vectors
         /// </summary>
@@ -63,6 +61,17 @@ namespace Avalonia
         public static double operator *(Vector a, Vector b)
         {
             return a.X*b.X + a.Y*b.Y;
+        }
+
+        /// <summary>
+        /// Scales a vector.
+        /// </summary>
+        /// <param name="vector">The vector</param>
+        /// <param name="scale">The scaling factor.</param>
+        /// <returns>The scaled vector.</returns>
+        public static Vector operator *(Vector vector, double scale)
+        {
+            return new Vector(vector._x * scale, vector._y * scale);
         }
 
         /// <summary>

--- a/src/Gtk/Avalonia.Gtk/SurfaceFramebuffer.cs
+++ b/src/Gtk/Avalonia.Gtk/SurfaceFramebuffer.cs
@@ -48,7 +48,7 @@ namespace Avalonia.Gtk
         public int Height => _surface.Height;
         public int RowBytes => _surface.Stride;
         //TODO: Proper DPI detect
-        public Size Dpi => new Size(96, 96);
+        public Vector Dpi => new Vector(96, 96);
         public PixelFormat Format => PixelFormat.Bgra8888;
     }
 }

--- a/src/Gtk/Avalonia.Gtk3/ImageSurfaceFramebuffer.cs
+++ b/src/Gtk/Avalonia.Gtk3/ImageSurfaceFramebuffer.cs
@@ -52,12 +52,11 @@ namespace Avalonia.Gtk3
         public int RowBytes { get; }
 
         
-        public Size Dpi
+        public Vector Dpi
         {
             get
             {
-                
-                return new Size(96, 96) * _factor;
+                return new Vector(96, 96) * _factor;
             }
         }
 

--- a/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebuffer.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebuffer.cs
@@ -13,16 +13,16 @@ namespace Avalonia.LinuxFramebuffer
 {
     public sealed unsafe class LinuxFramebuffer : IFramebufferPlatformSurface, IDisposable
     {
-        private readonly Size _dpi;
+        private readonly Vector _dpi;
         private int _fd;
         private fb_fix_screeninfo _fixedInfo;
         private fb_var_screeninfo _varInfo;
         private IntPtr _mappedLength;
         private IntPtr _mappedAddress;
 
-        public LinuxFramebuffer(string fileName = null, Size? dpi = null)
+        public LinuxFramebuffer(string fileName = null, Vector? dpi = null)
         {
-            _dpi = dpi ?? new Size(96, 96);
+            _dpi = dpi ?? new Vector(96, 96);
             fileName = fileName ?? Environment.GetEnvironmentVariable("FRAMEBUFFER") ?? "/dev/fb0";
             _fd = NativeUnsafeMethods.open(fileName, 2, 0);
             if (_fd <= 0)

--- a/src/Linux/Avalonia.LinuxFramebuffer/LockedFramebuffer.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/LockedFramebuffer.cs
@@ -11,7 +11,7 @@ namespace Avalonia.LinuxFramebuffer
         private fb_var_screeninfo _varInfo;
         private readonly IntPtr _address;
 
-        public LockedFramebuffer(int fb, fb_fix_screeninfo fixedInfo, fb_var_screeninfo varInfo, IntPtr address, Size dpi)
+        public LockedFramebuffer(int fb, fb_fix_screeninfo fixedInfo, fb_var_screeninfo varInfo, IntPtr address, Vector dpi)
         {
             _fb = fb;
             _fixedInfo = fixedInfo;
@@ -41,7 +41,7 @@ namespace Avalonia.LinuxFramebuffer
         public int Width => (int)_varInfo.xres;
         public int Height => (int) _varInfo.yres;
         public int RowBytes => (int) _fixedInfo.line_length;
-        public Size Dpi { get; }
+        public Vector Dpi { get; }
         public PixelFormat Format => _varInfo.blue.offset == 16 ? PixelFormat.Rgba8888 : PixelFormat.Bgra8888;
     }
 }

--- a/src/Skia/Avalonia.Skia/BitmapImpl.cs
+++ b/src/Skia/Avalonia.Skia/BitmapImpl.cs
@@ -131,7 +131,7 @@ namespace Avalonia.Skia
             public int Width => _bmp.Width;
             public int Height => _bmp.Height;
             public int RowBytes => _bmp.RowBytes;
-            public Size Dpi { get; } = new Size(96, 96);
+            public Vector Dpi { get; } = new Vector(96, 96);
             public PixelFormat Format => _bmp.ColorType.ToPixelFormat();
         }
 

--- a/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs
@@ -76,7 +76,7 @@ namespace Avalonia.Skia
             canvas.RestoreToCount(0);
             canvas.Save();
             canvas.ResetMatrix();
-            var scale = Matrix.CreateScale(fb.Dpi.Width / 96, fb.Dpi.Height / 96);
+            var scale = Matrix.CreateScale(fb.Dpi.X / 96, fb.Dpi.Y / 96);
             return new DrawingContextImpl(canvas, visualBrushRenderer, scale, canvas, surface, shim, fb);
         }
     }

--- a/src/Windows/Avalonia.Direct2D1/Media/Imaging/WritableWicBitmapImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Imaging/WritableWicBitmapImpl.cs
@@ -37,7 +37,7 @@ namespace Avalonia.Direct2D1.Media.Imaging
             public int Width => _lock.Size.Width;
             public int Height => _lock.Size.Height;
             public int RowBytes => _lock.Stride;
-            public Size Dpi { get; } = new Size(96, 96);
+            public Vector Dpi { get; } = new Vector(96, 96);
             public PixelFormat Format => _format;
 
         }

--- a/src/Windows/Avalonia.Win32/WindowFramebuffer.cs
+++ b/src/Windows/Avalonia.Win32/WindowFramebuffer.cs
@@ -39,7 +39,7 @@ namespace Avalonia.Win32
         public int RowBytes => Width * 4;
         public PixelFormat Format => PixelFormat.Bgra8888;
 
-        public Size Dpi
+        public Vector Dpi
         {
             get
             {
@@ -56,10 +56,10 @@ namespace Avalonia.Win32
                             out dpix,
                             out dpiy) == 0)
                     {
-                        return new Size(dpix, dpiy);
+                        return new Vector(dpix, dpiy);
                     }
                 }
-                return new Size(96, 96);
+                return new Vector(96, 96);
             }
         }
 

--- a/src/iOS/Avalonia.iOS/EmulatedFramebuffer.cs
+++ b/src/iOS/Avalonia.iOS/EmulatedFramebuffer.cs
@@ -24,7 +24,7 @@ namespace Avalonia.iOS
             Width = (int) frame.Width * factor;
             Height = (int) frame.Height * factor;
             RowBytes = Width * 4;
-            Dpi = new Size(96, 96) * factor;
+            Dpi = new Vector(96, 96) * factor;
             Format = PixelFormat.Rgba8888;
             Address = Marshal.AllocHGlobal(Height * RowBytes);
         }
@@ -53,7 +53,7 @@ namespace Avalonia.iOS
         public int Width { get; }
         public int Height { get; }
         public int RowBytes { get; }
-        public Size Dpi { get; }
+        public Vector Dpi { get; }
         public PixelFormat Format { get; }
     }
 }

--- a/tests/Avalonia.RenderTests/Media/BitmapTests.cs
+++ b/tests/Avalonia.RenderTests/Media/BitmapTests.cs
@@ -43,7 +43,7 @@ namespace Avalonia.Direct2D1.RenderTests.Media
 
             public IntPtr Address { get; }
 
-            public Size Dpi { get; } = new Size(96, 96);
+            public Vector Dpi { get; } = new Vector(96, 96);
 
             public PixelFormat Format { get; }
 


### PR DESCRIPTION
`ILockedFrameBuffer.Dpi` was a `Size` but it would make more sense as a `Vector` because `Size * Vector` produces a `Size` whereas a `Size * Size` would produce a `Size3D` if that type existed.

Fixes #997.