### PR TITLE
Add SkiaSharp dependency to WindowsInteropTest

### DIFF
--- a/samples/interop/WindowsInteropTest/WindowsInteropTest.csproj
+++ b/samples/interop/WindowsInteropTest/WindowsInteropTest.csproj
@@ -181,5 +181,6 @@
   </ItemGroup>
   <Import Project="..\..\..\build\Rx.props" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\..\build\SkiaSharp.props" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\src\Shared\nuget.workaround.targets" />
 </Project>


### PR DESCRIPTION
Otherwise it fails with "System.DllNotFoundException: Cannot find libSkiaSharp.dll" on my machine.