### PR TITLE
WPF Integration: D3D11Image Implementation

### DIFF
--- a/build/Microsoft.Wpf.Interop.DirectX.props
+++ b/build/Microsoft.Wpf.Interop.DirectX.props
@@ -1,0 +1,5 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Wpf.Interop.DirectX-x86" Version="0.9.0-beta-22856" />
+  </ItemGroup>
+</Project>

--- a/build/readme.md
+++ b/build/readme.md
@@ -7,6 +7,7 @@
 <Import Project="..\..\build\Markup.props" />
 <Import Project="..\..\build\Microsoft.CSharp.props" />
 <Import Project="..\..\build\Microsoft.Reactive.Testing.props" />
+<Import Project="..\..\build\Microsoft.Wpf.Interop.DirectX.props" />
 <Import Project="..\..\build\Moq.props" />
 <Import Project="..\..\build\NetCore.props" />
 <Import Project="..\..\build\Rx.props" />

--- a/samples/interop/WindowsInteropTest/Program.cs
+++ b/samples/interop/WindowsInteropTest/Program.cs
@@ -15,7 +15,7 @@ namespace WindowsInteropTest
         {
             System.Windows.Forms.Application.EnableVisualStyles();
             System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
-            AppBuilder.Configure<App>().UseWin32().UseSkia().SetupWithoutStarting();
+            AppBuilder.Configure<App>().UseWin32().UseDirect2D1().SetupWithoutStarting();
             System.Windows.Forms.Application.Run(new SelectorForm());
         }
     }

--- a/src/Avalonia.Visuals/Platform/IPlatformRenderInterface.cs
+++ b/src/Avalonia.Visuals/Platform/IPlatformRenderInterface.cs
@@ -47,6 +47,13 @@ namespace Avalonia.Platform
         IRenderTarget CreateRenderTarget(IEnumerable<object> surfaces);
 
         /// <summary>
+        /// Checks if rendering platform can render to particular native surface
+        /// </summary>
+        /// <param name="surface"></param>
+        /// <returns></returns>
+        bool SupportsSurface(object surface);
+
+        /// <summary>
         /// Creates a render target bitmap implementation.
         /// </summary>
         /// <param name="width">The width of the bitmap.</param>

--- a/src/Gtk/Avalonia.Cairo/CairoPlatform.cs
+++ b/src/Gtk/Avalonia.Cairo/CairoPlatform.cs
@@ -68,6 +68,8 @@ namespace Avalonia.Cairo
                 "Don't know how to create a Cairo renderer from any of the provided surfaces."));
         }
 
+        public bool SupportsSurface(object surface) => surface is Func<Gdk.Drawable>;
+
         public IRenderTargetBitmapImpl CreateRenderTargetBitmap(int width, int height, double dpiX, double dpiY)
         {
             return new RenderTargetBitmapImpl(new ImageSurface(Format.Argb32, width, height));

--- a/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
+++ b/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
@@ -66,6 +66,8 @@ namespace Avalonia.Skia
             }
         }
 
+        public bool SupportsSurface(object surface) => (surface is IFramebufferPlatformSurface);
+
         public IRenderTargetBitmapImpl CreateRenderTargetBitmap(
             int width,
             int height,

--- a/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
+++ b/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
@@ -150,6 +150,10 @@ namespace Avalonia.Direct2D1
             throw new NotSupportedException("Don't know how to create a Direct2D1 renderer from any of provided surfaces");
         }
 
+        public bool SupportsSurface(object surface) =>
+            surface is IExternalDirect2DRenderTargetSurface ||
+            (surface is IPlatformHandle handle && handle.HandleDescriptor == "HWND");
+
         public IRenderTargetBitmapImpl CreateRenderTargetBitmap(
             int width,
             int height,

--- a/src/Windows/Avalonia.Direct2D1/ExternalRenderTarget.cs
+++ b/src/Windows/Avalonia.Direct2D1/ExternalRenderTarget.cs
@@ -15,7 +15,6 @@ namespace Avalonia.Direct2D1
     {
         private readonly IExternalDirect2DRenderTargetSurface _externalRenderTargetProvider;
         private readonly DirectWriteFactory _dwFactory;
-        private SharpDX.Direct2D1.RenderTarget _target;
         public ExternalRenderTarget(IExternalDirect2DRenderTargetSurface externalRenderTargetProvider,
             DirectWriteFactory dwFactory)
         {
@@ -23,17 +22,13 @@ namespace Avalonia.Direct2D1
             _dwFactory = dwFactory;
         }
 
-        public void Dispose()
-        {
-            _target?.Dispose();
-            _target = null;
-        }
+        public void Dispose() => _externalRenderTargetProvider.DestroyRenderTarget();
 
         public IDrawingContextImpl CreateDrawingContext(IVisualBrushRenderer visualBrushRenderer)
         {
-            _target = _target ?? _externalRenderTargetProvider.CreateRenderTarget();
+            var target = _externalRenderTargetProvider.GetOrCreateRenderTarget();
             _externalRenderTargetProvider.BeforeDrawing();
-            return new DrawingContextImpl(visualBrushRenderer, _target, _dwFactory, null, () =>
+            return new DrawingContextImpl(visualBrushRenderer, target, _dwFactory, null, () =>
             {
                 try
                 {
@@ -41,8 +36,7 @@ namespace Avalonia.Direct2D1
                 }
                 catch (SharpDXException ex) when ((uint) ex.HResult == 0x8899000C) // D2DERR_RECREATE_TARGET
                 {
-                    _target?.Dispose();
-                    _target = null;
+                    _externalRenderTargetProvider.DestroyRenderTarget();
                 }
             });
         }

--- a/src/Windows/Avalonia.Direct2D1/IExternalDirect2DRenderTargetSurface.cs
+++ b/src/Windows/Avalonia.Direct2D1/IExternalDirect2DRenderTargetSurface.cs
@@ -8,7 +8,8 @@ namespace Avalonia.Direct2D1
 {
     public interface IExternalDirect2DRenderTargetSurface
     {
-        SharpDX.Direct2D1.RenderTarget CreateRenderTarget();
+        SharpDX.Direct2D1.RenderTarget GetOrCreateRenderTarget();
+        void DestroyRenderTarget();
         void BeforeDrawing();
         void AfterDrawing();
     }

--- a/src/Windows/Avalonia.Direct2D1/Media/Imaging/RenderTargetBitmapImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Imaging/RenderTargetBitmapImpl.cs
@@ -14,6 +14,7 @@ namespace Avalonia.Direct2D1.Media
     {
         private readonly DirectWriteFactory _dwriteFactory;
         private readonly WicRenderTarget _target;
+        public WicRenderTarget RenderTarget => _target;
 
         public RenderTargetBitmapImpl(
             ImagingFactory imagingFactory,

--- a/src/Windows/Avalonia.Win32.Interop/Avalonia.Win32.Interop.csproj
+++ b/src/Windows/Avalonia.Win32.Interop/Avalonia.Win32.Interop.csproj
@@ -34,6 +34,7 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Windows/Avalonia.Win32.Interop/Avalonia.Win32.Interop.csproj
+++ b/src/Windows/Avalonia.Win32.Interop/Avalonia.Win32.Interop.csproj
@@ -49,6 +49,7 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Wpf\CursorShim.cs" />
+    <Compile Include="Wpf\D3D11ImageSurface.cs" />
     <Compile Include="Wpf\WpfInteropExtensions.cs" />
     <Compile Include="Wpf\WpfAvaloniaHost.cs" />
     <Compile Include="Wpf\WpfMouseDevice.cs" />
@@ -104,10 +105,17 @@
       <Project>{6417e941-21bc-467b-a771-0de389353ce6}</Project>
       <Name>Avalonia.Markup</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Avalonia.Direct2D1\Avalonia.Direct2D1.csproj">
+      <Project>{3E908F67-5543-4879-A1DC-08EACE79B3CD}</Project>
+      <Name>Avalonia.Direct2D1</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Avalonia.Win32\Avalonia.Win32.csproj">
       <Project>{811a76cf-1cf6-440f-963b-bbe31bd72a82}</Project>
       <Name>Avalonia.Win32</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\..\src\Shared\nuget.workaround.targets" />
+  <Import Project="..\..\..\build\SharpDX.props" />
+  <Import Project="..\..\..\build\Microsoft.Wpf.Interop.DirectX.props" />
 </Project>

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/D3D11ImageSurface.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/D3D11ImageSurface.cs
@@ -35,7 +35,6 @@ namespace Avalonia.Win32.Interop.Wpf
 
         public void DestroyRenderTarget()
         {
-           
         }
 
         public void BeforeDrawing()
@@ -100,13 +99,15 @@ namespace Avalonia.Win32.Interop.Wpf
                     _renderTarget = new RenderTarget(AvaloniaLocator.Current.GetService<Factory>(), surface, properties);
                 }
             }
-                _root.ControlRoot.PlatformImpl?.Paint?.Invoke(new Rect(0, 0, _root.ActualWidth,
-                    _root.ActualHeight));
+            _root.ControlRoot.PlatformImpl?.Paint?.Invoke(new Rect(0, 0, _root.ActualWidth,
+                _root.ActualHeight));
             _isDirty = false;
         }
 
         private void OnCompositionTargetRendering(object sender, EventArgs e)
         {
+            if (_root.Parent == null)
+                return;
             UpdateImageSize();
             if (_isDirty)
             {
@@ -117,15 +118,13 @@ namespace Avalonia.Win32.Interop.Wpf
 
         public void Dispose()
         {
-            DestroyRenderTarget();
+            _renderTarget?.Dispose();
+            _renderTarget = null;
             _image?.Dispose();
             _image = null;
             CompositionTarget.Rendering -= OnCompositionTargetRendering;
         }
 
-        public void MakeDirty()
-        {
-            _isDirty = true;
-        }
+        public void MakeDirty() => _isDirty = true;
     }
 }

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/D3D11ImageSurface.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/D3D11ImageSurface.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Media;
+using Avalonia.Direct2D1;
+using Microsoft.Wpf.Interop.DirectX;
+using SharpDX;
+using SharpDX.Direct2D1;
+using RenderTarget = SharpDX.Direct2D1.RenderTarget;
+
+namespace Avalonia.Win32.Interop.Wpf
+{
+    class D3D11ImageSurface : IExternalDirect2DRenderTargetSurface
+    {
+        private readonly D3D11Image _image = new D3D11Image();
+        private readonly WpfTopLevelImpl _root;
+
+        private RenderTarget _renderTarget;
+        private Size _imageSize = Size.Empty;
+        private TimeSpan _lastRenderTime;
+
+        public D3D11ImageSurface(WpfTopLevelImpl root)
+        {
+            _root = root;
+        }
+
+        public RenderTarget CreateRenderTarget()
+        {
+            InitializeRenderTarget();
+            Debug.Assert(_renderTarget != null);
+            return _renderTarget;
+        }
+
+        public void BeforeDrawing()
+        {
+            UpdateImageSize();
+        }
+
+        public void AfterDrawing()
+        {
+        }
+
+        private void InitializeRenderTarget()
+        {
+            var window = Window.GetWindow(_root.Parent);
+            if (window == null)
+            {
+                return;
+            }
+
+            UpdateImageSize();
+            _root.ImageSource = _image;
+
+            _image.WindowOwner = new System.Windows.Interop.WindowInteropHelper(window).Handle;
+            _image.OnRender = OnImageRender;
+            CompositionTarget.Rendering += OnCompositionTargetRendering; // TODO[F]: Remove handler on dispose?
+            _image.RequestRender();
+        }
+
+        private void UpdateImageSize()
+        {
+            var currentSize = new Size(_root.ActualWidth, _root.ActualHeight);
+            if (currentSize != _imageSize && currentSize.Width > 0.0 && currentSize.Height > 0.0)
+            {
+                _image.SetPixelSize((int)currentSize.Width, (int)currentSize.Height);
+                _imageSize = currentSize;
+            }
+        }
+
+        private void OnImageRender(IntPtr handle, bool isNewSurface)
+        {
+            if (isNewSurface)
+            {
+                if (_renderTarget != null)
+                {
+                    _renderTarget.Dispose();
+                    _renderTarget = null;
+                }
+
+                var comObject = new ComObject(handle);
+                var resource = comObject.QueryInterface<SharpDX.DXGI.Resource>();
+                var texture = resource.QueryInterface<SharpDX.Direct3D11.Texture2D>();
+                using (var surface = texture.QueryInterface<SharpDX.DXGI.Surface>())
+                {
+                    var source = PresentationSource.FromVisual(_root);
+                    Debug.Assert(source != null);
+                    Debug.Assert(source.CompositionTarget != null);
+
+                    var dpiX = 96.0f * (float)source.CompositionTarget.TransformToDevice.M11;
+                    var dpiY = 96.0f * (float)source.CompositionTarget.TransformToDevice.M22;
+                    var properties = new RenderTargetProperties
+                    {
+                        DpiX = dpiX,
+                        DpiY = dpiY,
+                        MinLevel = FeatureLevel.Level_DEFAULT,
+                        PixelFormat = new SharpDX.Direct2D1.PixelFormat(SharpDX.DXGI.Format.Unknown, AlphaMode.Premultiplied),
+                        Type = RenderTargetType.Default,
+                        Usage = RenderTargetUsage.None
+                    };
+
+                    var factory = AvaloniaLocator.Current.GetService<Factory>();
+                    _renderTarget = new RenderTarget(factory, surface, properties);
+                }
+            }
+        }
+
+        private void OnCompositionTargetRendering(object sender, EventArgs e)
+        {
+            var args = (RenderingEventArgs)e;
+
+            // It's possible for Rendering to call back twice in the same frame
+            // so only render when we haven't already rendered in this frame.
+            if (_lastRenderTime != args.RenderingTime)
+            {
+                _image.RequestRender();
+                _lastRenderTime = args.RenderingTime;
+            }
+        }
+    }
+}

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/D3D11ImageSurface.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/D3D11ImageSurface.cs
@@ -22,7 +22,6 @@ namespace Avalonia.Win32.Interop.Wpf
 
         private RenderTarget _renderTarget;
         private Size _imageSize = Size.Empty;
-        private bool _isDirty = false;
 
         public D3D11ImageSurface(WpfTopLevelImpl root)
         {
@@ -54,7 +53,6 @@ namespace Avalonia.Win32.Interop.Wpf
             _root.ImageSource = _image;
             _image.WindowOwner = s_dummy.Handle;
             _image.OnRender = OnImageRender;
-            CompositionTarget.Rendering += OnCompositionTargetRendering; // TODO[F]: Remove handler on dispose?
         }
 
         Size GetSize() => new Size(_root.ActualWidth, _root.ActualHeight);
@@ -101,30 +99,21 @@ namespace Avalonia.Win32.Interop.Wpf
             }
             _root.ControlRoot.PlatformImpl?.Paint?.Invoke(new Rect(0, 0, _root.ActualWidth,
                 _root.ActualHeight));
-            _isDirty = false;
         }
-
-        private void OnCompositionTargetRendering(object sender, EventArgs e)
-        {
-            if (_root.Parent == null)
-                return;
-            UpdateImageSize();
-            if (_isDirty)
-            {
-                _image.RequestRender();
-                _root.InvalidateVisual();
-            }
-        }
-
+        
         public void Dispose()
         {
             _renderTarget?.Dispose();
             _renderTarget = null;
             _image?.Dispose();
             _image = null;
-            CompositionTarget.Rendering -= OnCompositionTargetRendering;
         }
+        
 
-        public void MakeDirty() => _isDirty = true;
+        public void Render()
+        {
+            UpdateImageSize();
+            _image.RequestRender();
+        }
     }
 }

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/D3D11ImageSurface.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/D3D11ImageSurface.cs
@@ -3,9 +3,17 @@ using System.Diagnostics;
 using System.Windows;
 using System.Windows.Media;
 using Avalonia.Direct2D1;
+using Avalonia.Direct2D1.Media;
+using Avalonia.Platform;
 using Microsoft.Wpf.Interop.DirectX;
 using SharpDX;
 using SharpDX.Direct2D1;
+using SharpDX.Direct3D11;
+using SharpDX.DXGI;
+using SharpDX.Mathematics.Interop;
+using AlphaMode = SharpDX.Direct2D1.AlphaMode;
+using Device = SharpDX.Direct3D11.Device;
+using Factory = SharpDX.Direct2D1.Factory;
 using RenderTarget = SharpDX.Direct2D1.RenderTarget;
 
 namespace Avalonia.Win32.Interop.Wpf
@@ -13,22 +21,31 @@ namespace Avalonia.Win32.Interop.Wpf
     class D3D11ImageSurface : IExternalDirect2DRenderTargetSurface
     {
         private readonly D3D11Image _image = new D3D11Image();
+        private Direct2D1Platform _platform;
+        private Factory _factory;
         private readonly WpfTopLevelImpl _root;
+        private bool _initialized = false;
 
-        private RenderTarget _renderTarget;
+        private RenderTarget _frontRenderTarget;
+        private RenderTargetBitmapImpl _backBuffer;
         private Size _imageSize = Size.Empty;
-        private TimeSpan _lastRenderTime;
+        private bool _isDirty = false;
 
         public D3D11ImageSurface(WpfTopLevelImpl root)
         {
             _root = root;
         }
 
-        public RenderTarget CreateRenderTarget()
+        public RenderTarget GetOrCreateRenderTarget()
         {
             InitializeRenderTarget();
-            Debug.Assert(_renderTarget != null);
-            return _renderTarget;
+            Debug.Assert(_backBuffer != null);
+            return _backBuffer.RenderTarget;
+        }
+
+        public void DestroyRenderTarget()
+        {
+            //TODO
         }
 
         public void BeforeDrawing()
@@ -38,83 +55,91 @@ namespace Avalonia.Win32.Interop.Wpf
 
         public void AfterDrawing()
         {
+            _isDirty = true;
         }
 
         private void InitializeRenderTarget()
         {
+            if (_platform == null)
+            {
+                _platform = (Direct2D1Platform) AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+                _factory = AvaloniaLocator.Current.GetService<Factory>();
+            }
             var window = Window.GetWindow(_root.Parent);
             if (window == null)
-            {
                 return;
-            }
-
+            
             UpdateImageSize();
+            if (_initialized)
+                return;
             _root.ImageSource = _image;
 
             _image.WindowOwner = new System.Windows.Interop.WindowInteropHelper(window).Handle;
             _image.OnRender = OnImageRender;
             CompositionTarget.Rendering += OnCompositionTargetRendering; // TODO[F]: Remove handler on dispose?
-            _image.RequestRender();
+            _initialized = true;
         }
 
+        Size GetSize() => new Size(_root.ActualWidth, _root.ActualHeight);
+        
         private void UpdateImageSize()
         {
-            var currentSize = new Size(_root.ActualWidth, _root.ActualHeight);
+            
+            var virtualSize = GetSize();
+            var scaling = _root.GetScaling();
+            var currentSize = virtualSize * scaling;
             if (currentSize != _imageSize && currentSize.Width > 0.0 && currentSize.Height > 0.0)
             {
                 _image.SetPixelSize((int)currentSize.Width, (int)currentSize.Height);
                 _imageSize = currentSize;
+                _backBuffer?.Dispose();
+                _backBuffer = null;
+                _backBuffer = (RenderTargetBitmapImpl) _platform.CreateRenderTargetBitmap((int) virtualSize.Width,
+                    (int) virtualSize.Height,
+                    scaling.X * 96, scaling.Y * 96);
             }
         }
+        
 
         private void OnImageRender(IntPtr handle, bool isNewSurface)
         {
             if (isNewSurface)
             {
-                if (_renderTarget != null)
-                {
-                    _renderTarget.Dispose();
-                    _renderTarget = null;
-                }
+                _frontRenderTarget?.Dispose();
+                _frontRenderTarget = null;
 
-                var comObject = new ComObject(handle);
-                var resource = comObject.QueryInterface<SharpDX.DXGI.Resource>();
-                var texture = resource.QueryInterface<SharpDX.Direct3D11.Texture2D>();
-                using (var surface = texture.QueryInterface<SharpDX.DXGI.Surface>())
+                using (var comObject = new ComObject(handle))
+                using (var surface = comObject.QueryInterface<SharpDX.DXGI.Surface>())
                 {
-                    var source = PresentationSource.FromVisual(_root);
-                    Debug.Assert(source != null);
-                    Debug.Assert(source.CompositionTarget != null);
-
-                    var dpiX = 96.0f * (float)source.CompositionTarget.TransformToDevice.M11;
-                    var dpiY = 96.0f * (float)source.CompositionTarget.TransformToDevice.M22;
+                    var scale = _root.GetScaling();
+                    var dpiX = 96.0f * (float) scale.X;
+                    var dpiY = 96.0f * (float) scale.Y;
                     var properties = new RenderTargetProperties
                     {
                         DpiX = dpiX,
                         DpiY = dpiY,
                         MinLevel = FeatureLevel.Level_DEFAULT,
-                        PixelFormat = new SharpDX.Direct2D1.PixelFormat(SharpDX.DXGI.Format.Unknown, AlphaMode.Premultiplied),
+                        PixelFormat =
+                            new SharpDX.Direct2D1.PixelFormat(SharpDX.DXGI.Format.Unknown, AlphaMode.Premultiplied),
                         Type = RenderTargetType.Default,
                         Usage = RenderTargetUsage.None
                     };
-
-                    var factory = AvaloniaLocator.Current.GetService<Factory>();
-                    _renderTarget = new RenderTarget(factory, surface, properties);
+                    _frontRenderTarget = new RenderTarget(_factory, surface, properties);
                 }
             }
+            _frontRenderTarget.BeginDraw();
+            using (var bitmap = _backBuffer.GetDirect2DBitmap(_frontRenderTarget))
+                _frontRenderTarget.DrawBitmap(bitmap,
+                    new RawRectangleF(0, 0, bitmap.Size.Width, bitmap.Size.Height),
+                    1, BitmapInterpolationMode.Linear);
+            _frontRenderTarget.EndDraw();
+            _isDirty = false;
         }
 
         private void OnCompositionTargetRendering(object sender, EventArgs e)
         {
-            var args = (RenderingEventArgs)e;
-
-            // It's possible for Rendering to call back twice in the same frame
-            // so only render when we haven't already rendered in this frame.
-            if (_lastRenderTime != args.RenderingTime)
-            {
+            if (_isDirty)
                 _image.RequestRender();
-                _lastRenderTime = args.RenderingTime;
-            }
         }
     }
 }

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/WpfAvaloniaHost.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/WpfAvaloniaHost.cs
@@ -21,15 +21,31 @@ namespace Avalonia.Win32.Interop.Wpf
     {
         private WpfTopLevelImpl _impl;
         private readonly SynchronizationContext _sync;
+        private bool _hasChildren;
         public WpfAvaloniaHost()
         {
             _sync = SynchronizationContext.Current;
             _impl = new WpfTopLevelImpl();
             _impl.ControlRoot.Prepare();
             _impl.Visibility = Visibility.Visible;
-            AddLogicalChild(_impl);
-            AddVisualChild(_impl);
             SnapsToDevicePixels = true;
+        }
+
+        protected override void OnVisualParentChanged(DependencyObject oldParent)
+        {
+            if (Parent != null && !_hasChildren)
+            {
+                AddLogicalChild(_impl);
+                AddVisualChild(_impl);
+                _hasChildren = true;
+            }
+            else
+            {
+                RemoveVisualChild(_impl);
+                RemoveLogicalChild(_impl);
+                _hasChildren = false;
+            }
+            base.OnVisualParentChanged(oldParent);
         }
 
         public object Content

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
@@ -142,17 +142,13 @@ namespace Avalonia.Win32.Interop.Wpf
                 return;
             if (_wbImage != null)
                 _ttl.Paint?.Invoke(new Rect(0, 0, ActualWidth, ActualHeight));
+            else
+                _dxImage.Render();
             if (ImageSource != null)
                 drawingContext.DrawImage(ImageSource, new System.Windows.Rect(0, 0, ActualWidth, ActualHeight));
         }
 
-        void ITopLevelImpl.Invalidate(Rect rect)
-        {
-            if (_dxImage != null)
-                _dxImage.MakeDirty();
-            else
-                InvalidateVisual();
-        }
+        void ITopLevelImpl.Invalidate(Rect rect) => InvalidateVisual();
 
         void ITopLevelImpl.SetInputRoot(IInputRoot inputRoot) => _inputRoot = inputRoot;
 

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
@@ -96,7 +96,12 @@ namespace Avalonia.Win32.Interop.Wpf
             _ttl.ScalingChanged?.Invoke(_ttl.Scaling);
         }
 
-        public void Dispose() => _ttl.Closed?.Invoke();
+        public void Dispose()
+        {
+            _ttl.Closed?.Invoke();
+            foreach (var d in _surfaces.OfType<IDisposable>())
+                d.Dispose();
+        }
 
         Size ITopLevelImpl.ClientSize => _finalSize;
         IMouseDevice ITopLevelImpl.MouseDevice => _mouse;

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
@@ -73,6 +73,14 @@ namespace Avalonia.Win32.Interop.Wpf
             };
         }
 
+        internal Vector GetScaling()
+        {
+            var src = PresentationSource.FromVisual(this)?.CompositionTarget;
+            if (src == null)
+                return new Vector(1, 1);
+            return new Vector(src.TransformToDevice.M11, src.TransformToDevice.M22);
+        }
+
         private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wparam, IntPtr lparam, ref bool handled)
         {
             if (msg == (int)UnmanagedMethods.WindowsMessage.WM_DPICHANGED)

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
@@ -60,7 +60,7 @@ namespace Avalonia.Win32.Interop.Wpf
             PresentationSource.AddSourceChangedHandler(this, OnSourceChanged);
             _hook = WndProc;
             _ttl = this;
-            _surfaces = new object[] {new WritableBitmapSurface(this)};
+            _surfaces = new object[] { new D3D11ImageSurface(this), new WritableBitmapSurface(this) };
             _mouse = new WpfMouseDevice(this);
             _keyboard = AvaloniaLocator.Current.GetService<IKeyboardDevice>();
 

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
@@ -32,6 +32,8 @@ namespace Avalonia.Win32.Interop.Wpf
 
         public EmbeddableControlRoot ControlRoot { get; }
         internal ImageSource ImageSource { get; set; }
+        internal bool TriggerPaintOnRender { get; set; } = true;
+        internal Action InvalidateVisualImpl { get; set; }
 
         public class CustomControlRoot : EmbeddableControlRoot, IEmbeddedLayoutRoot
         {
@@ -131,12 +133,19 @@ namespace Avalonia.Win32.Interop.Wpf
         {
             if(ActualHeight == 0 || ActualWidth == 0)
                 return;
-            _ttl.Paint?.Invoke(new Rect(0, 0, ActualWidth, ActualHeight));
+            if (TriggerPaintOnRender)
+                _ttl.Paint?.Invoke(new Rect(0, 0, ActualWidth, ActualHeight));
             if (ImageSource != null)
                 drawingContext.DrawImage(ImageSource, new System.Windows.Rect(0, 0, ActualWidth, ActualHeight));
         }
 
-        void ITopLevelImpl.Invalidate(Rect rect) => InvalidateVisual();
+        void ITopLevelImpl.Invalidate(Rect rect)
+        {
+            if (InvalidateVisualImpl != null)
+                InvalidateVisualImpl();
+            else
+                InvalidateVisual();
+        }
 
         void ITopLevelImpl.SetInputRoot(IInputRoot inputRoot) => _inputRoot = inputRoot;
 

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/WritableBitmapSurface.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/WritableBitmapSurface.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Win32.Interop.Wpf
 
         public ILockedFramebuffer Lock()
         {
-            var scale = GetScaling();
+            var scale = _impl.GetScaling();
             var size = new Size(_impl.ActualWidth * scale.X, _impl.ActualHeight * scale.Y);
             var dpi = scale * 96;
             if (_bitmap == null || _bitmap.PixelWidth != (int) size.Width || _bitmap.PixelHeight != (int) size.Height)
@@ -68,14 +68,6 @@ namespace Avalonia.Win32.Interop.Wpf
             public int RowBytes => _bitmap.BackBufferStride;
             public Vector Dpi { get; }
             public PixelFormat Format => PixelFormat.Bgra8888;
-        }
-
-        Vector GetScaling()
-        {
-            var src = PresentationSource.FromVisual(_impl)?.CompositionTarget;
-            if (src == null)
-                return new Vector(1, 1);
-            return new Vector(src.TransformToDevice.M11, src.TransformToDevice.M22);
         }
     }
 }

--- a/tests/Avalonia.UnitTests/MockPlatformRenderInterface.cs
+++ b/tests/Avalonia.UnitTests/MockPlatformRenderInterface.cs
@@ -25,6 +25,11 @@ namespace Avalonia.UnitTests
             return Mock.Of<IRenderTarget>();
         }
 
+        public bool SupportsSurface(object surface)
+        {
+            return true;
+        }
+
         public IRenderTargetBitmapImpl CreateRenderTargetBitmap(
             int width,
             int height,

--- a/tests/Avalonia.Visuals.UnitTests/VisualTree/MockRenderInterface.cs
+++ b/tests/Avalonia.Visuals.UnitTests/VisualTree/MockRenderInterface.cs
@@ -24,6 +24,11 @@ namespace Avalonia.Visuals.UnitTests.VisualTree
             throw new NotImplementedException();
         }
 
+        public bool SupportsSurface(object surface)
+        {
+            return true;
+        }
+
         public IRenderTargetBitmapImpl CreateRenderTargetBitmap(int width, int height, double dpiX, double dpiY)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
This is an integration with WPF through Direct2D / Direct3D11Image using [WPFDXInterop](https://github.com/Microsoft/WPFDXInterop) library from Microsoft.

@kekekeks said he will review this and help me with the remaining issues.

### How to build

Build the project as usual, run `WindowsInteropTest`, click "Embed to WPF" button.

### Remaining issues

1. There's notable flickering when switching the tabs in the sample. We still don't know the reason for flickering, but we want to fix it before the merge.
2. The WPFDXInterop library is written in C++/CLI, and @kekekeks says he'd like to avoid the maintenance burden of having to produce both x86 and x64 artifacts. We're still not sure how to solve that; probably I'll port the relevant parts of C++/CLI code to C# later (and it won't be an easy task).