### PR TITLE
Drawing (vector icons)

### DIFF
--- a/samples/RenderTest/MainWindow.xaml
+++ b/samples/RenderTest/MainWindow.xaml
@@ -27,6 +27,7 @@
       </TabControl.Transition>
       <TabItem Header="Animations"><pages:AnimationsPage/></TabItem>
       <TabItem Header="Clipping"><pages:ClippingPage/></TabItem>
+      <TabItem Header="Drawing"><pages:DrawingPage/></TabItem>
     </TabControl>
   </DockPanel>
 </Window>

--- a/samples/RenderTest/Pages/DrawingPage.xaml
+++ b/samples/RenderTest/Pages/DrawingPage.xaml
@@ -1,0 +1,132 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <UserControl.Styles>
+        <Style>
+            <Style.Resources>
+                <DrawingGroup x:Key="Bulb">
+                    <DrawingGroup.Transform>
+                        <MatrixTransform Matrix="1,0,0,1,0,-1028.4" />
+                    </DrawingGroup.Transform>
+                    <DrawingGroup>
+                        <DrawingGroup.Transform>
+                            <MatrixTransform Matrix="1,0,0,1.25,-10,1031.4" />
+                        </DrawingGroup.Transform>
+                        <GeometryDrawing Brush="#FF7F8C8D"
+                                         Geometry="F1 M24,14 A2,2,0,1,1,20,14 A2,2,0,1,1,24,14 z" />
+                    </DrawingGroup>
+                    <GeometryDrawing Brush="#FFF39C12"
+                                     Geometry="F1 M12,1030.4 C8.134,1030.4 5,1033.6 5,1037.6 5,1040.7 8.125,1043.5 9,1045.4 9.875,1047.2 9,1050.4 9,1050.4 L12,1049.9 15,1050.4 C15,1050.4 14.125,1047.2 15,1045.4 15.875,1043.5 19,1040.7 19,1037.6 19,1033.6 15.866,1030.4 12,1030.4 z" />
+                    <GeometryDrawing Brush="#FFF1C40F"
+                                     Geometry="F1 M12,1030.4 C15.866,1030.4 19,1033.6 19,1037.6 19,1040.7 15.875,1043.5 15,1045.4 14.125,1047.2 15,1050.4 15,1050.4 L12,1049.9 12,1030.4 z" />
+                    <GeometryDrawing Brush="#FFE67E22"
+                                     Geometry="F1 M9,1036.4 L8,1037.4 12,1049.4 16,1037.4 15,1036.4 14,1037.4 13,1036.4 12,1037.4 11,1036.4 10,1037.4 9,1036.4 z M9,1037.4 L10,1038.4 10.5,1037.9 11,1037.4 11.5,1037.9 12,1038.4 12.5,1037.9 13,1037.4 13.5,1037.9 14,1038.4 15,1037.4 15.438,1037.8 12,1048.1 8.5625,1037.8 9,1037.4 z" />
+                    <DrawingGroup>
+                        <DrawingGroup.Transform>
+                            <MatrixTransform Matrix="1,0,0,1,9,1045.4" />
+                        </DrawingGroup.Transform>
+                        <GeometryDrawing Brush="#FFBDC3C7">
+                            <GeometryDrawing.Geometry>
+                                <RectangleGeometry Rect="0,0,6,5" />
+                            </GeometryDrawing.Geometry>
+                        </GeometryDrawing>
+                    </DrawingGroup>
+                    <GeometryDrawing Brush="#FF95A5A6"
+                                     Geometry="F1 M9,1045.4 L9,1050.4 12,1050.4 12,1049.4 15,1049.4 15,1048.4 12,1048.4 12,1047.4 15,1047.4 15,1046.4 12,1046.4 12,1045.4 9,1045.4 z" />
+                    <GeometryDrawing Brush="#FF7F8C8D"
+                                     Geometry="F1 M9,1046.4 L9,1047.4 12,1047.4 12,1046.4 9,1046.4 z M9,1048.4 L9,1049.4 12,1049.4 12,1048.4 9,1048.4 z" />
+                </DrawingGroup>
+            </Style.Resources>
+        </Style>
+    </UserControl.Styles>
+    <Grid RowDefinitions="Auto,Auto,Auto"
+          ColumnDefinitions="Auto,Auto,Auto,Auto">
+        <TextBlock Text="None"
+                   Margin="3" />
+        <Border Grid.Column="0"
+                Grid.Row="1"
+                VerticalAlignment="Top"
+                HorizontalAlignment="Left"
+                BorderThickness="1"
+                BorderBrush="Gray"
+                Margin="5">
+            <DrawingPresenter Drawing="{StyleResource Bulb}" />
+        </Border>
+        <TextBlock Text="Fill"
+                   Margin="3"
+                   Grid.Column="1" />
+        <Border Grid.Column="1"
+                Grid.Row="1"
+                VerticalAlignment="Top"
+                HorizontalAlignment="Left"
+                BorderThickness="1"
+                BorderBrush="Gray"
+                Margin="5">
+            <DrawingPresenter Drawing="{StyleResource Bulb}"
+                              Width="100"
+                              Height="50"
+                              Strech="Fill" />
+        </Border>
+        <TextBlock Text="Uniform"
+                   Margin="3"
+                   Grid.Column="2" />
+        <Border Grid.Column="2"
+                Grid.Row="1"
+                VerticalAlignment="Top"
+                HorizontalAlignment="Left"
+                BorderThickness="1"
+                BorderBrush="Gray"
+                Margin="5">
+            <DrawingPresenter Drawing="{StyleResource Bulb}"
+                              Width="100"
+                              Height="50"
+                              Strech="Uniform" />
+        </Border>
+        <TextBlock Text="UniformToFill"
+                   Margin="3"
+                   Grid.Column="3" />
+        <Border Grid.Column="3"
+                Grid.Row="1"
+                VerticalAlignment="Top"
+                HorizontalAlignment="Left"
+                BorderThickness="1"
+                BorderBrush="Gray"
+                Margin="5">
+            <DrawingPresenter Drawing="{StyleResource Bulb}"
+                              Width="100"
+                              Height="50"
+                              Strech="UniformToFill" />
+        </Border>
+
+        <!-- For comparison -->
+        
+        <Ellipse Grid.Row="2"
+                 Grid.Column="0"
+                 Width="100"
+                 Height="50"
+                 Stretch="None"
+                 Fill="Blue"
+                 Margin="5"/>
+        <Ellipse Grid.Row="2"
+                 Grid.Column="1"
+                 Width="100"
+                 Height="50"
+                 Stretch="Fill"
+                 Fill="Blue"
+                 Margin="5" />
+        <Ellipse Grid.Row="2"
+                 Grid.Column="2"
+                 Width="100"
+                 Height="50"
+                 Stretch="Uniform"
+                 Fill="Blue"
+                 Margin="5" />
+        <Ellipse Grid.Row="2"
+                 Grid.Column="3"
+                 Width="100"
+                 Height="50"
+                 Stretch="UniformToFill"
+                 Fill="Blue"
+                 Margin="5" />
+        
+    </Grid>
+</UserControl>

--- a/samples/RenderTest/Pages/DrawingPage.xaml
+++ b/samples/RenderTest/Pages/DrawingPage.xaml
@@ -64,7 +64,7 @@
             <DrawingPresenter Drawing="{StyleResource Bulb}"
                               Width="100"
                               Height="50"
-                              Strech="Fill" />
+                              Stretch="Fill" />
         </Border>
         <TextBlock Text="Uniform"
                    Margin="3"
@@ -79,7 +79,7 @@
             <DrawingPresenter Drawing="{StyleResource Bulb}"
                               Width="100"
                               Height="50"
-                              Strech="Uniform" />
+                              Stretch="Uniform" />
         </Border>
         <TextBlock Text="UniformToFill"
                    Margin="3"
@@ -94,7 +94,7 @@
             <DrawingPresenter Drawing="{StyleResource Bulb}"
                               Width="100"
                               Height="50"
-                              Strech="UniformToFill" />
+                              Stretch="UniformToFill" />
         </Border>
 
         <!-- For comparison -->

--- a/samples/RenderTest/Pages/DrawingPage.xaml.cs
+++ b/samples/RenderTest/Pages/DrawingPage.xaml.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace RenderTest.Pages
+{
+    public class DrawingPage : UserControl
+    {
+        public DrawingPage()
+        {
+            InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/samples/RenderTest/RenderTest.csproj
+++ b/samples/RenderTest/RenderTest.csproj
@@ -51,6 +51,9 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Pages\DrawingPage.xaml.cs">
+      <DependentUpon>DrawingPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Pages\ClippingPage.xaml.cs">
       <DependentUpon>ClippingPage.xaml</DependentUpon>
     </Compile>
@@ -175,6 +178,11 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Pages\ClippingPage.xaml">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Pages\DrawingPage.xaml">
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>

--- a/src/Avalonia.Controls/DrawingPresenter.cs
+++ b/src/Avalonia.Controls/DrawingPresenter.cs
@@ -1,0 +1,58 @@
+﻿using Avalonia.Controls.Shapes;
+using Avalonia.Media;
+using Avalonia.Metadata;
+
+namespace Avalonia.Controls
+{
+    public class DrawingPresenter : Control
+    {
+        public static readonly StyledProperty<Drawing> DrawingProperty =
+            AvaloniaProperty.Register<DrawingPresenter, Drawing>(nameof(Drawing));
+
+        [Content]
+        public Drawing Drawing
+        {
+            get => GetValue(DrawingProperty);
+            set => SetValue(DrawingProperty, value);
+        }
+
+        public static readonly StyledProperty<Stretch> StretchProperty =
+            AvaloniaProperty.Register<DrawingPresenter, Stretch>(nameof(Stretch), Stretch.Uniform);
+
+        public Stretch Stretch
+        {
+            get => GetValue(StretchProperty);
+            set => SetValue(StretchProperty, value);
+        }
+
+        static DrawingPresenter()
+        {
+            AffectsMeasure(DrawingProperty);
+            AffectsRender(DrawingProperty);
+        }
+
+        private Matrix _transform = Matrix.Identity;
+
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            if (Drawing == null) return new Size();
+
+            var (size, transform) = Shape.CalculateSizeAndTransform(availableSize, Drawing.GetBounds(), Stretch);
+
+            _transform = transform;
+
+            return size;
+        }
+
+        public override void Render(DrawingContext context)
+        {
+            if (Drawing != null)
+            {
+                using (context.PushPreTransform(_transform))
+                {
+                    Drawing.Draw(context);
+                }
+            }
+        }
+    }
+}

--- a/src/Avalonia.Controls/DrawingPresenter.cs
+++ b/src/Avalonia.Controls/DrawingPresenter.cs
@@ -6,8 +6,17 @@ namespace Avalonia.Controls
 {
     public class DrawingPresenter : Control
     {
+        static DrawingPresenter()
+        {
+            AffectsMeasure(DrawingProperty);
+            AffectsRender(DrawingProperty);
+        }
+
         public static readonly StyledProperty<Drawing> DrawingProperty =
             AvaloniaProperty.Register<DrawingPresenter, Drawing>(nameof(Drawing));
+
+        public static readonly StyledProperty<Stretch> StretchProperty =
+            AvaloniaProperty.Register<DrawingPresenter, Stretch>(nameof(Stretch), Stretch.Uniform);
 
         [Content]
         public Drawing Drawing
@@ -16,19 +25,10 @@ namespace Avalonia.Controls
             set => SetValue(DrawingProperty, value);
         }
 
-        public static readonly StyledProperty<Stretch> StretchProperty =
-            AvaloniaProperty.Register<DrawingPresenter, Stretch>(nameof(Stretch), Stretch.Uniform);
-
         public Stretch Stretch
         {
             get => GetValue(StretchProperty);
             set => SetValue(StretchProperty, value);
-        }
-
-        static DrawingPresenter()
-        {
-            AffectsMeasure(DrawingProperty);
-            AffectsRender(DrawingProperty);
         }
 
         private Matrix _transform = Matrix.Identity;

--- a/src/Avalonia.Controls/DrawingPresenter.cs
+++ b/src/Avalonia.Controls/DrawingPresenter.cs
@@ -49,6 +49,7 @@ namespace Avalonia.Controls
             if (Drawing != null)
             {
                 using (context.PushPreTransform(_transform))
+                using (context.PushClip(Bounds))
                 {
                     Drawing.Draw(context);
                 }

--- a/src/Avalonia.Controls/Shapes/Shape.cs
+++ b/src/Avalonia.Controls/Shapes/Shape.cs
@@ -155,11 +155,21 @@ namespace Avalonia.Controls.Shapes
         {
             // This should probably use GetRenderBounds(strokeThickness) but then the calculations
             // will multiply the stroke thickness as well, which isn't correct.
-            Rect shapeBounds = DefiningGeometry.Bounds;
+            var (size, transform) = CalculateSizeAndTransform(availableSize, DefiningGeometry.Bounds, Stretch);
+            
+            if (_transform != transform)
+            {
+                _transform = transform;
+                _renderedGeometry = null;
+            }
+
+            return size;
+        }
+
+        internal static (Size, Matrix) CalculateSizeAndTransform(Size availableSize, Rect shapeBounds, Stretch Stretch)
+        {
             Size shapeSize = new Size(shapeBounds.Right, shapeBounds.Bottom);
             Matrix translate = Matrix.Identity;
-            double width = Width;
-            double height = Height;
             double desiredX = availableSize.Width;
             double desiredY = availableSize.Height;
             double sx = 0.0;
@@ -226,15 +236,9 @@ namespace Avalonia.Controls.Shapes
                     break;
             }
 
-            var t = translate * Matrix.CreateScale(sx, sy);
-
-            if (_transform != t)
-            {
-                _transform = t;
-                _renderedGeometry = null;
-            }
-
-            return new Size(shapeSize.Width * sx, shapeSize.Height * sy);
+            var transform = translate * Matrix.CreateScale(sx, sy);
+            var size = new Size(shapeSize.Width * sx, shapeSize.Height * sy);
+            return (size, transform);
         }
 
         private static void AffectsGeometryInvalidate(AvaloniaPropertyChangedEventArgs e)

--- a/src/Avalonia.Visuals/Matrix.cs
+++ b/src/Avalonia.Visuals/Matrix.cs
@@ -302,7 +302,7 @@ namespace Avalonia
         /// </summary>
         /// <param name="s">The string.</param>
         /// <param name="culture">The current culture.</param>
-        /// <returns>The <see cref="Thickness"/>.</returns>
+        /// <returns>The <see cref="Matrix"/>.</returns>
         public static Matrix Parse(string s, CultureInfo culture)
         {
             var parts = s.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries)

--- a/src/Avalonia.Visuals/Matrix.cs
+++ b/src/Avalonia.Visuals/Matrix.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Linq;
 
 namespace Avalonia
 {
@@ -294,6 +295,34 @@ namespace Avalonia
                 _m11 / d,
                 ((_m21 * _m32) - (_m22 * _m31)) / d,
                 ((_m12 * _m31) - (_m11 * _m32)) / d);
+        }
+
+        /// <summary>
+        /// Parses a <see cref="Matrix"/> string.
+        /// </summary>
+        /// <param name="s">The string.</param>
+        /// <param name="culture">The current culture.</param>
+        /// <returns>The <see cref="Thickness"/>.</returns>
+        public static Matrix Parse(string s, CultureInfo culture)
+        {
+            var parts = s.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => x.Trim())
+                .ToArray();
+
+            if (parts.Length == 6)
+            {
+                return new Matrix(
+                    double.Parse(parts[0], culture), 
+                    double.Parse(parts[1], culture), 
+                    double.Parse(parts[2], culture), 
+                    double.Parse(parts[3], culture), 
+                    double.Parse(parts[4], culture), 
+                    double.Parse(parts[5], culture));
+            }
+            else
+            {
+                throw new FormatException("Invalid Matrix.");
+            }
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/Drawing.cs
+++ b/src/Avalonia.Visuals/Media/Drawing.cs
@@ -1,0 +1,9 @@
+﻿namespace Avalonia.Media
+{
+    public abstract class Drawing : AvaloniaObject
+    {
+        public abstract void Draw(DrawingContext context);
+
+        public abstract Rect GetBounds();
+    }
+}

--- a/src/Avalonia.Visuals/Media/DrawingGroup.cs
+++ b/src/Avalonia.Visuals/Media/DrawingGroup.cs
@@ -5,11 +5,11 @@ namespace Avalonia.Media
 {
     public class DrawingGroup : Drawing
     {
-        [Content]
-        public AvaloniaList<Drawing> Children { get; } = new AvaloniaList<Drawing>();
-
         public static readonly StyledProperty<double> OpacityProperty =
             AvaloniaProperty.Register<DrawingGroup, double>(nameof(Opacity), 1);
+
+        public static readonly StyledProperty<Transform> TransformProperty =
+            AvaloniaProperty.Register<DrawingGroup, Transform>(nameof(Transform));
 
         public double Opacity
         {
@@ -17,14 +17,14 @@ namespace Avalonia.Media
             set => SetValue(OpacityProperty, value);
         }
 
-        public static readonly StyledProperty<Transform> TransformProperty =
-            AvaloniaProperty.Register<DrawingGroup, Transform>(nameof(Transform));
-
         public Transform Transform
         {
             get => GetValue(TransformProperty);
             set => SetValue(TransformProperty, value);
         }
+
+        [Content]
+        public AvaloniaList<Drawing> Children { get; } = new AvaloniaList<Drawing>();
 
         public override void Draw(DrawingContext context)
         {

--- a/src/Avalonia.Visuals/Media/DrawingGroup.cs
+++ b/src/Avalonia.Visuals/Media/DrawingGroup.cs
@@ -1,0 +1,58 @@
+﻿using Avalonia.Collections;
+using Avalonia.Metadata;
+
+namespace Avalonia.Media
+{
+    public class DrawingGroup : Drawing
+    {
+        [Content]
+        public AvaloniaList<Drawing> Children { get; } = new AvaloniaList<Drawing>();
+
+        public static readonly StyledProperty<double> OpacityProperty =
+            AvaloniaProperty.Register<DrawingGroup, double>(nameof(Opacity), 1);
+
+        public double Opacity
+        {
+            get => GetValue(OpacityProperty);
+            set => SetValue(OpacityProperty, value);
+        }
+
+        public static readonly StyledProperty<Transform> TransformProperty =
+            AvaloniaProperty.Register<DrawingGroup, Transform>(nameof(Transform));
+
+        public Transform Transform
+        {
+            get => GetValue(TransformProperty);
+            set => SetValue(TransformProperty, value);
+        }
+
+        public override void Draw(DrawingContext context)
+        {
+            using (context.PushPreTransform(Transform?.Value ?? Matrix.Identity))
+            using (context.PushOpacity(Opacity))
+            {
+                foreach (var drawing in Children)
+                {
+                    drawing.Draw(context);
+                }
+            }
+        }
+
+        public override Rect GetBounds()
+        {
+            var rect = new Rect();
+
+            foreach (var drawing in Children)
+            {
+                rect = rect.Union(drawing.GetBounds());
+            }
+
+            if (Transform != null)
+            {
+                rect = rect.TransformToAABB(Transform.Value);
+            }
+
+            return rect;
+        }
+    }
+}

--- a/src/Avalonia.Visuals/Media/EllipseGeometry.cs
+++ b/src/Avalonia.Visuals/Media/EllipseGeometry.cs
@@ -12,15 +12,50 @@ namespace Avalonia.Media
     public class EllipseGeometry : Geometry
     {
         /// <summary>
+        /// Defines the <see cref="Rect"/> property.
+        /// </summary>
+        public static readonly StyledProperty<Rect> RectProperty =
+            AvaloniaProperty.Register<EllipseGeometry, Rect>(nameof(Rect));
+
+        public Rect Rect
+        {
+            get => GetValue(RectProperty);
+            set => SetValue(RectProperty, value);
+        }
+
+        static EllipseGeometry()
+        {
+            RectProperty.Changed.AddClassHandler<EllipseGeometry>(x => x.RectChanged);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EllipseGeometry"/> class.
+        /// </summary>
+        public EllipseGeometry()
+        {
+            IPlatformRenderInterface factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+            PlatformImpl = factory.CreateStreamGeometry();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="EllipseGeometry"/> class.
         /// </summary>
         /// <param name="rect">The rectangle that the ellipse should fill.</param>
-        public EllipseGeometry(Rect rect)
+        public EllipseGeometry(Rect rect) : this()
         {
-            IPlatformRenderInterface factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
-            IStreamGeometryImpl impl = factory.CreateStreamGeometry();
+            Rect = rect;
+        }
 
-            using (IStreamGeometryContextImpl ctx = impl.Open())
+        /// <inheritdoc/>
+        public override Geometry Clone()
+        {
+            return new EllipseGeometry(Rect);
+        }
+
+        private void RectChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            var rect = (Rect)e.NewValue;
+            using (var ctx = ((IStreamGeometryImpl)PlatformImpl).Open())
             {
                 double controlPointRatio = (Math.Sqrt(2) - 1) * 4 / 3;
                 var center = rect.Center;
@@ -45,14 +80,6 @@ namespace Avalonia.Media
                 ctx.CubicBezierTo(new Point(x0, y1), new Point(x1, y0), new Point(x2, y0));
                 ctx.EndFigure(true);
             }
-
-            PlatformImpl = impl;
-        }
-
-        /// <inheritdoc/>
-        public override Geometry Clone()
-        {
-            return new EllipseGeometry(Bounds);
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/GeometryDrawing.cs
+++ b/src/Avalonia.Visuals/Media/GeometryDrawing.cs
@@ -1,0 +1,43 @@
+﻿namespace Avalonia.Media
+{
+    public class GeometryDrawing : Drawing
+    {
+        public static readonly StyledProperty<Geometry> GeometryProperty =
+            AvaloniaProperty.Register<GeometryDrawing, Geometry>(nameof(Geometry));
+
+        public Geometry Geometry
+        {
+            get => GetValue(GeometryProperty);
+            set => SetValue(GeometryProperty, value);
+        }
+
+        public static readonly StyledProperty<IBrush> BrushProperty =
+            AvaloniaProperty.Register<GeometryDrawing, IBrush>(nameof(Brush), Brushes.Transparent);
+
+        public IBrush Brush
+        {
+            get => GetValue(BrushProperty);
+            set => SetValue(BrushProperty, value);
+        }
+
+        public static readonly StyledProperty<Pen> PenProperty =
+            AvaloniaProperty.Register<GeometryDrawing, Pen>(nameof(Pen));
+
+        public Pen Pen
+        {
+            get => GetValue(PenProperty);
+            set => SetValue(PenProperty, value);
+        }
+
+        public override void Draw(DrawingContext context)
+        {
+            context.DrawGeometry(Brush, Pen, Geometry);
+        }
+
+        public override Rect GetBounds()
+        {
+            // adding the Pen's stroke thickness here could yield wrong results due to transforms
+            return Geometry?.GetRenderBounds(0) ?? new Rect();
+        }
+    }
+}

--- a/src/Avalonia.Visuals/Media/PathMarkupParser.cs
+++ b/src/Avalonia.Visuals/Media/PathMarkupParser.cs
@@ -141,6 +141,7 @@ namespace Avalonia.Media
                                 bool isLargeArc = ReadBool(reader);
                                 ReadSeparator(reader);
                                 SweepDirection sweepDirection = ReadBool(reader) ? SweepDirection.Clockwise : SweepDirection.CounterClockwise;
+                                ReadSeparator(reader);
                                 point = ReadPoint(reader, point, relative);
 
                                 _context.ArcTo(point, size, rotationAngle, isLargeArc, sweepDirection);

--- a/src/Avalonia.Visuals/Media/PolylineGeometry.cs
+++ b/src/Avalonia.Visuals/Media/PolylineGeometry.cs
@@ -26,13 +26,15 @@ namespace Avalonia.Media
         public static readonly AvaloniaProperty<bool> IsFilledProperty =
             AvaloniaProperty.Register<PolylineGeometry, bool>(nameof(IsFilled));
 
+        private Points _points;
+        private bool _isDirty;
+        private IDisposable _pointsObserver;
+
         static PolylineGeometry()
         {
-            PointsProperty.Changed.Subscribe(onNext: v =>
-            {
-                (v.Sender as PolylineGeometry)?.OnPointsChanged(v.OldValue as Points, v.NewValue as Points);
-            });
-            IsFilledProperty.Changed.AddClassHandler<PolylineGeometry>(x => a => x.NotifyChanged());
+            PointsProperty.Changed.AddClassHandler<PolylineGeometry>((s, e) =>
+                s.OnPointsChanged(e.OldValue as Points, e.NewValue as Points));
+            IsFilledProperty.Changed.AddClassHandler<PolylineGeometry>((s, _) => s.NotifyChanged());
         }
 
         /// <summary>
@@ -53,8 +55,6 @@ namespace Avalonia.Media
         {
             Points.AddRange(points);
             IsFilled = isFilled;
-
-            PrepareIfNeeded();
         }
 
         public void PrepareIfNeeded()
@@ -108,10 +108,6 @@ namespace Avalonia.Media
             }
             protected set => base.PlatformImpl = value;
         }
-
-        private Points _points;
-        private bool _isDirty;
-        private IDisposable _pointsObserver;
 
         /// <inheritdoc/>
         public override Geometry Clone()

--- a/src/Avalonia.Visuals/Media/PolylineGeometry.cs
+++ b/src/Avalonia.Visuals/Media/PolylineGeometry.cs
@@ -3,10 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Avalonia.Platform;
+using Avalonia.Metadata;
+using Avalonia.Collections;
 
 namespace Avalonia.Media
 {
@@ -15,36 +14,122 @@ namespace Avalonia.Media
     /// </summary>
     public class PolylineGeometry : Geometry
     {
-        private IList<Point> _points;
-        private bool _isFilled;
+        /// <summary>
+        /// Defines the <see cref="Points"/> property.
+        /// </summary>
+        public static readonly DirectProperty<PolylineGeometry, Points> PointsProperty =
+            AvaloniaProperty.RegisterDirect<PolylineGeometry, Points>(nameof(Points), g => g.Points, (g, f) => g.Points = f);
 
-        public PolylineGeometry(IList<Point> points, bool isFilled)
+        /// <summary>
+        /// Defines the <see cref="IsFilled"/> property.
+        /// </summary>
+        public static readonly AvaloniaProperty<bool> IsFilledProperty =
+            AvaloniaProperty.Register<PolylineGeometry, bool>(nameof(IsFilled));
+
+        static PolylineGeometry()
         {
-            _points = points;
-            _isFilled = isFilled;
-            IPlatformRenderInterface factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
-            IStreamGeometryImpl impl = factory.CreateStreamGeometry();
-
-            using (IStreamGeometryContextImpl context = impl.Open())
+            PointsProperty.Changed.Subscribe(onNext: v =>
             {
-                if (points.Count > 0)
+                (v.Sender as PolylineGeometry)?.OnPointsChanged(v.OldValue as Points, v.NewValue as Points);
+            });
+            IsFilledProperty.Changed.AddClassHandler<PolylineGeometry>(x => a => x.NotifyChanged());
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PolylineGeometry"/> class.
+        /// </summary>
+        public PolylineGeometry()
+        {
+            IPlatformRenderInterface factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+            PlatformImpl = factory.CreateStreamGeometry();
+
+            Points = new Points();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PolylineGeometry"/> class.
+        /// </summary>
+        public PolylineGeometry(IEnumerable<Point> points, bool isFilled) : this()
+        {
+            Points.AddRange(points);
+            IsFilled = isFilled;
+
+            PrepareIfNeeded();
+        }
+
+        public void PrepareIfNeeded()
+        {
+            if (_isDirty)
+            {
+                _isDirty = false;
+
+                using (var context = ((IStreamGeometryImpl)PlatformImpl).Open())
                 {
-                    context.BeginFigure(points[0], isFilled);
-                    for (int i = 1; i < points.Count; i++)
+                    var points = Points;
+                    var isFilled = IsFilled;
+                    if (points.Count > 0)
                     {
-                        context.LineTo(points[i]);
+                        context.BeginFigure(points[0], isFilled);
+                        for (int i = 1; i < points.Count; i++)
+                        {
+                            context.LineTo(points[i]);
+                        }
+                        context.EndFigure(isFilled);
                     }
-                    context.EndFigure(isFilled);
                 }
             }
-
-            PlatformImpl = impl;
         }
+
+        /// <summary>
+        /// Gets or sets the figures.
+        /// </summary>
+        /// <value>
+        /// The points.
+        /// </value>
+        [Content]
+        public Points Points
+        {
+            get => _points;
+            set => SetAndRaise(PointsProperty, ref _points, value);
+        }
+
+        public bool IsFilled
+        {
+            get => GetValue(IsFilledProperty);
+            set => SetValue(IsFilledProperty, value);
+        }
+
+        public override IGeometryImpl PlatformImpl
+        {
+            get
+            {
+                PrepareIfNeeded();
+                return base.PlatformImpl;
+            }
+            protected set => base.PlatformImpl = value;
+        }
+
+        private Points _points;
+        private bool _isDirty;
+        private IDisposable _pointsObserver;
 
         /// <inheritdoc/>
         public override Geometry Clone()
         {
-            return new PolylineGeometry(new List<Point>(_points), _isFilled);
+            PrepareIfNeeded();
+            return new PolylineGeometry(Points, IsFilled);
+        }
+
+        private void OnPointsChanged(Points oldValue, Points newValue)
+        {
+            _pointsObserver?.Dispose();
+
+            _pointsObserver = newValue?.ForEachItem(f => NotifyChanged(), f => NotifyChanged(), () => NotifyChanged());
+        }
+
+        internal void NotifyChanged()
+        {
+            _isDirty = true;
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/RectangleGeometry.cs
+++ b/src/Avalonia.Visuals/Media/RectangleGeometry.cs
@@ -11,15 +11,50 @@ namespace Avalonia.Media
     public class RectangleGeometry : Geometry
     {
         /// <summary>
+        /// Defines the <see cref="Rect"/> property.
+        /// </summary>
+        public static readonly StyledProperty<Rect> RectProperty =
+            AvaloniaProperty.Register<RectangleGeometry, Rect>(nameof(Rect));
+
+        public Rect Rect
+        {
+            get => GetValue(RectProperty);
+            set => SetValue(RectProperty, value);
+        }
+
+        static RectangleGeometry()
+        {
+            RectProperty.Changed.AddClassHandler<RectangleGeometry>(x => x.RectChanged);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RectangleGeometry"/> class.
+        /// </summary>
+        public RectangleGeometry()
+        {
+            IPlatformRenderInterface factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+            PlatformImpl = factory.CreateStreamGeometry();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RectangleGeometry"/> class.
         /// </summary>
         /// <param name="rect">The rectangle bounds.</param>
-        public RectangleGeometry(Rect rect)
+        public RectangleGeometry(Rect rect) : this()
         {
-            IPlatformRenderInterface factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
-            IStreamGeometryImpl impl = factory.CreateStreamGeometry();
+            Rect = rect;
+        }
 
-            using (IStreamGeometryContextImpl context = impl.Open())
+        /// <inheritdoc/>
+        public override Geometry Clone()
+        {
+            return new RectangleGeometry(Rect);
+        }
+
+        private void RectChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            var rect = (Rect)e.NewValue;
+            using (var context = ((IStreamGeometryImpl)PlatformImpl).Open())
             {
                 context.BeginFigure(rect.TopLeft, true);
                 context.LineTo(rect.TopRight);
@@ -27,14 +62,6 @@ namespace Avalonia.Media
                 context.LineTo(rect.BottomLeft);
                 context.EndFigure(true);
             }
-
-            PlatformImpl = impl;
-        }
-
-        /// <inheritdoc/>
-        public override Geometry Clone()
-        {
-            return new RectangleGeometry(Bounds);
         }
     }
 }

--- a/src/Avalonia.Visuals/Point.cs
+++ b/src/Avalonia.Visuals/Point.cs
@@ -183,7 +183,7 @@ namespace Avalonia
             }
             else
             {
-                throw new FormatException("Invalid Thickness.");
+                throw new FormatException("Invalid Point.");
             }
         }
 

--- a/src/Avalonia.Visuals/Points.cs
+++ b/src/Avalonia.Visuals/Points.cs
@@ -1,0 +1,9 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using Avalonia.Collections;
+
+namespace Avalonia
+{
+    public sealed class Points : AvaloniaList<Point> { }
+}

--- a/src/Avalonia.Visuals/Rect.cs
+++ b/src/Avalonia.Visuals/Rect.cs
@@ -481,5 +481,31 @@ namespace Avalonia
                 _width,
                 _height);
         }
+
+        /// <summary>
+        /// Parses a <see cref="Rect"/> string.
+        /// </summary>
+        /// <param name="s">The string.</param>
+        /// <param name="culture">The current culture.</param>
+        /// <returns>The parsed <see cref="Rect"/>.</returns>
+        public static Rect Parse(string s, CultureInfo culture)
+        {
+            var parts = s.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => x.Trim())
+                .ToList();
+
+            if (parts.Count == 4)
+            {
+                return new Rect(
+                    double.Parse(parts[0], culture),
+                    double.Parse(parts[1], culture),
+                    double.Parse(parts[2], culture),
+                    double.Parse(parts[3], culture));
+            }
+            else
+            {
+                throw new FormatException("Invalid Rect.");
+            }
+        }
     }
 }

--- a/src/Avalonia.Visuals/RelativeRect.cs
+++ b/src/Avalonia.Visuals/RelativeRect.cs
@@ -203,7 +203,7 @@ namespace Avalonia
             }
             else
             {
-                throw new FormatException("Invalid Rect.");
+                throw new FormatException("Invalid RelativeRect.");
             }
         }
     }

--- a/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
+++ b/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
@@ -31,6 +31,7 @@
         </Compile>
         <Compile Include="AvaloniaXamlLoaderPortableXaml.cs" />
         <Compile Include="AvaloniaXamlLoader.cs" />
+        <Compile Include="Converters\MatrixTypeConverter.cs" />
         <Compile Include="Converters\SetterValueTypeConverter.cs" />
         <Compile Include="MarkupExtensions\StyleIncludeExtension.cs" />
         <Compile Include="PortableXaml\AvaloniaXamlContext.cs" />

--- a/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
+++ b/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
@@ -32,6 +32,7 @@
         <Compile Include="AvaloniaXamlLoaderPortableXaml.cs" />
         <Compile Include="AvaloniaXamlLoader.cs" />
         <Compile Include="Converters\MatrixTypeConverter.cs" />
+        <Compile Include="Converters\RectTypeConverter.cs" />
         <Compile Include="Converters\SetterValueTypeConverter.cs" />
         <Compile Include="MarkupExtensions\StyleIncludeExtension.cs" />
         <Compile Include="PortableXaml\AvaloniaXamlContext.cs" />

--- a/src/Markup/Avalonia.Markup.Xaml/Converters/MatrixTypeConverter.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Converters/MatrixTypeConverter.cs
@@ -1,0 +1,23 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using System.Globalization;
+
+namespace Avalonia.Markup.Xaml.Converters
+{
+	using System.ComponentModel;
+
+    public class MatrixTypeConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            return Matrix.Parse((string)value, culture);
+        }
+    }
+}

--- a/src/Markup/Avalonia.Markup.Xaml/Converters/RectTypeConverter.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Converters/RectTypeConverter.cs
@@ -1,0 +1,23 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using System.Globalization;
+
+namespace Avalonia.Markup.Xaml.Converters
+{
+	using System.ComponentModel;
+
+    public class RectTypeConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            return Rect.Parse((string)value, culture);
+        }
+    }
+}

--- a/src/Markup/Avalonia.Markup.Xaml/PortableXaml/AvaloniaDefaultTypeConverters.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/PortableXaml/AvaloniaDefaultTypeConverters.cs
@@ -39,6 +39,7 @@ namespace Avalonia.Markup.Xaml.PortableXaml
             { typeof(RelativeRect), typeof(RelativeRectTypeConverter) },
             { typeof(RowDefinitions), typeof(RowDefinitionsTypeConverter) },
             { typeof(Size), typeof(SizeTypeConverter) },
+            { typeof(Rect), typeof(RectTypeConverter) },
             { typeof(Selector), typeof(SelectorTypeConverter)},
             { typeof(SolidColorBrush), typeof(BrushTypeConverter) },
             { typeof(Thickness), typeof(ThicknessTypeConverter) },

--- a/src/Markup/Avalonia.Markup.Xaml/PortableXaml/AvaloniaDefaultTypeConverters.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/PortableXaml/AvaloniaDefaultTypeConverters.cs
@@ -32,6 +32,7 @@ namespace Avalonia.Markup.Xaml.PortableXaml
             { typeof(AvaloniaList<double>), typeof(AvaloniaListTypeConverter<double>) },
             { typeof(IMemberSelector), typeof(MemberSelectorTypeConverter) },
             { typeof(Point), typeof(PointTypeConverter) },
+            { typeof(Matrix), typeof(MatrixTypeConverter) },
             { typeof(IList<Point>), typeof(PointsListTypeConverter) },
             { typeof(AvaloniaProperty), typeof(AvaloniaPropertyTypeConverter) },
             { typeof(RelativePoint), typeof(RelativePointTypeConverter) },

--- a/tests/Avalonia.Visuals.UnitTests/Media/MatrixTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/MatrixTests.cs
@@ -1,0 +1,16 @@
+﻿using System.Globalization;
+using Xunit;
+
+namespace Avalonia.Visuals.UnitTests.Media
+{
+    public class MatrixTests
+    {
+        [Fact]
+        public void Parse_Parses()
+        {
+            var matrix = Matrix.Parse("1,2,3,-4,5 6", CultureInfo.CurrentCulture);
+            var expected = new Matrix(1, 2, 3, -4, 5, 6);
+            Assert.Equal(expected, matrix);
+        }
+    }
+}

--- a/tests/Avalonia.Visuals.UnitTests/Media/PathMarkupParserTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/PathMarkupParserTests.cs
@@ -56,6 +56,7 @@ namespace Avalonia.Visuals.UnitTests.Media
         }
 
         [Theory]
+        [InlineData("F1 M24,14 A2,2,0,1,1,20,14 A2,2,0,1,1,24,14 z")] // issue #1107
         [InlineData("M0 0L10 10z")]
         [InlineData("M50 50 L100 100 L150 50")]
         [InlineData("M50 50L100 100L150 50")]

--- a/tests/Avalonia.Visuals.UnitTests/Media/RectTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/RectTests.cs
@@ -1,0 +1,16 @@
+﻿using System.Globalization;
+using Xunit;
+
+namespace Avalonia.Visuals.UnitTests.Media
+{
+    public class RectTests
+    {
+        [Fact]
+        public void Parse_Parses()
+        {
+            var rect = Rect.Parse("1,2 3,-4", CultureInfo.CurrentCulture);
+            var expected = new Rect(1, 2, 3, -4);
+            Assert.Equal(expected, rect);
+        }
+    }
+}


### PR DESCRIPTION
`Drawing` is a convenient way to create vector icons, used by WPF. The [Visual Studio Image Library](http://vsicons-msdn.azurewebsites.net/) provides many icons as Drawings, and there are other tools that can produce them. They are much more lightweight compared to `Shape` controls since they are not part of the visual tree.

Here's a sample **Avalonia** rendering:
![image](https://user-images.githubusercontent.com/496737/29495267-9440c000-85c4-11e7-8220-0cbac131ece5.png)

The bottom are `Ellipse` controls I thought to use for `Stretch` reference, but it looks like there's a bug there. It's weird since I'm using the exact same transform from `Shape`. 

Sample **WPF** rendering:

![image](https://user-images.githubusercontent.com/496737/29495277-c32110b4-85c4-11e7-90ad-e86ff14ba1c6.png)

There's also an issue of required clipping in `UniformToFill`. Any idea how to do that?

Note that I created a control called `DrawingPresenter` since Avalonia doesn't have an `ImageSource` base class that supports both vector and bitmaps. Perhaps it's worth considering something like this so that vector images could be rendered anywhere bitmaps can (e.g. `ImageBrush`, `Image`).