### PR TITLE
Lazily initialize some things

### DIFF
--- a/src/Avalonia.Controls/Application.cs
+++ b/src/Avalonia.Controls/Application.cs
@@ -39,6 +39,7 @@ namespace Avalonia
         private readonly Lazy<IClipboard> _clipboard =
             new Lazy<IClipboard>(() => (IClipboard)AvaloniaLocator.Current.GetService(typeof(IClipboard)));
         private readonly Styler _styler = new Styler();
+        private Styles _styles;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Application"/> class.
@@ -109,12 +110,15 @@ namespace Avalonia
         /// <remarks>
         /// Global styles apply to all windows in the application.
         /// </remarks>
-        public Styles Styles { get; } = new Styles();
+        public Styles Styles => _styles ?? (_styles = new Styles());
 
         /// <summary>
         /// Gets the styling parent of the application, which is null.
         /// </summary>
         IStyleHost IStyleHost.StylingParent => null;
+
+        /// <inheritdoc/>
+        bool IStyleHost.IsStylesInitialized => _styles != null;
 
         /// <summary>
         /// Initializes the application by loading XAML etc.

--- a/src/Avalonia.Controls/Application.cs
+++ b/src/Avalonia.Controls/Application.cs
@@ -66,11 +66,7 @@ namespace Avalonia
         /// <value>
         /// The application's global data templates.
         /// </value>
-        public DataTemplates DataTemplates
-        {
-            get { return _dataTemplates ?? (_dataTemplates = new DataTemplates()); }
-            set { _dataTemplates = value; }
-        }
+        public DataTemplates DataTemplates => _dataTemplates ?? (_dataTemplates = new DataTemplates());
 
         /// <summary>
         /// Gets the application's focus manager.
@@ -111,6 +107,9 @@ namespace Avalonia
         /// Global styles apply to all windows in the application.
         /// </remarks>
         public Styles Styles => _styles ?? (_styles = new Styles());
+
+        /// <inheritdoc/>
+        bool IDataTemplateHost.IsDataTemplatesInitialized => _dataTemplates != null;
 
         /// <summary>
         /// Gets the styling parent of the application, which is null.

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -97,8 +97,8 @@ namespace Avalonia.Controls
         private bool _isAttachedToLogicalTree;
         private IAvaloniaList<ILogical> _logicalChildren;
         private INameScope _nameScope;
-        private Styles _styles;
         private bool _styled;
+        private Styles _styles;
         private Subject<IStyleable> _styleDetach = new Subject<IStyleable>();
 
         /// <summary>
@@ -259,18 +259,14 @@ namespace Avalonia.Controls
         public bool IsInitialized { get; private set; }
 
         /// <summary>
-        /// Gets or sets the styles for the control.
+        /// Gets the styles for the control.
         /// </summary>
         /// <remarks>
         /// Styles for the entire application are added to the Application.Styles collection, but
         /// each control may in addition define its own styles which are applied to the control
         /// itself and its children.
         /// </remarks>
-        public Styles Styles
-        {
-            get { return _styles ?? (_styles = new Styles()); }
-            set { _styles = value; }
-        }
+        public Styles Styles => _styles ?? (_styles = new Styles());
 
         /// <summary>
         /// Gets the control's logical parent.
@@ -335,6 +331,9 @@ namespace Avalonia.Controls
 
         /// <inheritdoc/>
         IObservable<IStyleable> IStyleable.StyleDetach => _styleDetach;
+
+        /// <inheritdoc/>
+        bool IStyleHost.IsStylesInitialized => _styles != null;
 
         /// <inheritdoc/>
         IStyleHost IStyleHost.StylingParent => (IStyleHost)InheritanceParent;

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -243,11 +243,7 @@ namespace Avalonia.Controls
         /// Each control may define data templates which are applied to the control itself and its
         /// children.
         /// </remarks>
-        public DataTemplates DataTemplates
-        {
-            get { return _dataTemplates ?? (_dataTemplates = new DataTemplates()); }
-            set { _dataTemplates = value; }
-        }
+        public DataTemplates DataTemplates => _dataTemplates ?? (_dataTemplates = new DataTemplates());
 
         /// <summary>
         /// Gets a value that indicates whether the element has finished initialization.
@@ -299,6 +295,9 @@ namespace Avalonia.Controls
             get { return GetValue(TemplatedParentProperty); }
             internal set { SetValue(TemplatedParentProperty, value); }
         }
+
+        /// <inheritdoc/>
+        bool IDataTemplateHost.IsDataTemplatesInitialized => _dataTemplates != null;
 
         /// <summary>
         /// Gets a value indicating whether the element is attached to a rooted logical tree.

--- a/src/Avalonia.Controls/IControl.cs
+++ b/src/Avalonia.Controls/IControl.cs
@@ -14,7 +14,14 @@ namespace Avalonia.Controls
     /// <summary>
     /// Interface for Avalonia controls.
     /// </summary>
-    public interface IControl : IVisual, ILogical, ILayoutable, IInputElement, INamed, IStyleable, IStyleHost
+    public interface IControl : IVisual,
+        IDataTemplateHost,
+        ILogical,
+        ILayoutable,
+        IInputElement,
+        INamed,
+        IStyleable,
+        IStyleHost
     {
         /// <summary>
         /// Occurs when the control has finished initialization.
@@ -30,11 +37,6 @@ namespace Avalonia.Controls
         /// Gets or sets the control's data context.
         /// </summary>
         object DataContext { get; set; }
-
-        /// <summary>
-        /// Gets the data templates for the control.
-        /// </summary>
-        DataTemplates DataTemplates { get; }
 
         /// <summary>
         /// Gets a value that indicates whether the element has finished initialization.

--- a/src/Avalonia.Controls/IGlobalDataTemplates.cs
+++ b/src/Avalonia.Controls/IGlobalDataTemplates.cs
@@ -8,11 +8,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// Defines the application-global data templates.
     /// </summary>
-    public interface IGlobalDataTemplates
+    public interface IGlobalDataTemplates : IDataTemplateHost
     {
-        /// <summary>
-        /// Gets the application-global data templates.
-        /// </summary>
-        DataTemplates DataTemplates { get; }
     }
 }

--- a/src/Avalonia.Controls/Templates/DataTemplateExtensions.cs
+++ b/src/Avalonia.Controls/Templates/DataTemplateExtensions.cs
@@ -17,8 +17,8 @@ namespace Avalonia.Controls.Templates
         /// <param name="control">The control searching for the data template.</param>
         /// <param name="data">The data.</param>
         /// <param name="primary">
-        /// An optional primary template that can will be tried before the
-        /// <see cref="IControl.DataTemplates"/> in the tree are searched.
+        /// An optional primary template that can will be tried before the DataTemplates in the
+        /// tree are searched.
         /// </param>
         /// <returns>The data template or null if no matching data template was found.</returns>
         public static IDataTemplate FindDataTemplate(
@@ -31,13 +31,16 @@ namespace Avalonia.Controls.Templates
                 return primary;
             }
 
-            foreach (var i in control.GetSelfAndLogicalAncestors().OfType<IControl>())
+            foreach (var i in control.GetSelfAndLogicalAncestors().OfType<IDataTemplateHost>())
             {
-                foreach (IDataTemplate dt in i.DataTemplates)
+                if (i.IsDataTemplatesInitialized)
                 {
-                    if (dt.Match(data))
+                    foreach (IDataTemplate dt in i.DataTemplates)
                     {
-                        return dt;
+                        if (dt.Match(data))
+                        {
+                            return dt;
+                        }
                     }
                 }
             }
@@ -46,11 +49,14 @@ namespace Avalonia.Controls.Templates
 
             if (global != null)
             {
-                foreach (IDataTemplate dt in global.DataTemplates)
+                if (global.IsDataTemplatesInitialized)
                 {
-                    if (dt.Match(data))
+                    foreach (IDataTemplate dt in global.DataTemplates)
                     {
-                        return dt;
+                        if (dt.Match(data))
+                        {
+                            return dt;
+                        }
                     }
                 }
             }

--- a/src/Avalonia.Controls/Templates/IDataTemplateHost.cs
+++ b/src/Avalonia.Controls/Templates/IDataTemplateHost.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+
+namespace Avalonia.Controls.Templates
+{
+    /// <summary>
+    /// Defines an element that has a <see cref="DataTemplates"/> collection.
+    /// </summary>
+    public interface IDataTemplateHost
+    {
+        /// <summary>
+        /// Gets the data templates for the element.
+        /// </summary>
+        DataTemplates DataTemplates { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether <see cref="DataTemplates"/> is initialized.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="DataTemplates"/> property may be lazily initialized, if so this property
+        /// indicates whether it has been initialized.
+        /// </remarks>
+        bool IsDataTemplatesInitialized { get; }
+    }
+}

--- a/src/Avalonia.Diagnostics/DevTools.xaml.cs
+++ b/src/Avalonia.Diagnostics/DevTools.xaml.cs
@@ -71,7 +71,7 @@ namespace Avalonia.Diagnostics
                         Width = 1024,
                         Height = 512,
                         Content = devTools,
-                        DataTemplates = new DataTemplates
+                        DataTemplates =
                         {
                             new ViewLocator<ViewModelBase>(),
                         }

--- a/src/Avalonia.Diagnostics/Views/ControlDetailsView.cs
+++ b/src/Avalonia.Diagnostics/Views/ControlDetailsView.cs
@@ -42,7 +42,7 @@ namespace Avalonia.Diagnostics.Views
             {
                 Content = _grid = new SimpleGrid
                 {
-                    Styles = new Styles
+                    Styles =
                     {
                         new Style(x => x.Is<Control>())
                         {

--- a/src/Avalonia.Interactivity/Interactive.cs
+++ b/src/Avalonia.Interactivity/Interactive.cs
@@ -16,13 +16,17 @@ namespace Avalonia.Interactivity
     /// </summary>
     public class Interactive : Layoutable, IInteractive
     {
-        private readonly Dictionary<RoutedEvent, List<EventSubscription>> _eventHandlers =
-            new Dictionary<RoutedEvent, List<EventSubscription>>();
+        private Dictionary<RoutedEvent, List<EventSubscription>> _eventHandlers;
 
         /// <summary>
         /// Gets the interactive parent of the object for bubbling and tunnelling events.
         /// </summary>
         IInteractive IInteractive.InteractiveParent => ((IVisual)this).VisualParent as IInteractive;
+
+        private Dictionary<RoutedEvent, List<EventSubscription>> EventHandlers
+        {
+            get { return _eventHandlers ?? (_eventHandlers = new Dictionary<RoutedEvent, List<EventSubscription>>()); }
+        }
 
         /// <summary>
         /// Adds a handler for the specified routed event.
@@ -43,10 +47,10 @@ namespace Avalonia.Interactivity
 
             List<EventSubscription> subscriptions;
 
-            if (!_eventHandlers.TryGetValue(routedEvent, out subscriptions))
+            if (!EventHandlers.TryGetValue(routedEvent, out subscriptions))
             {
                 subscriptions = new List<EventSubscription>();
-                _eventHandlers.Add(routedEvent, subscriptions);
+                EventHandlers.Add(routedEvent, subscriptions);
             }
 
             var sub = new EventSubscription
@@ -89,9 +93,9 @@ namespace Avalonia.Interactivity
             Contract.Requires<ArgumentNullException>(routedEvent != null);
             Contract.Requires<ArgumentNullException>(handler != null);
 
-            List<EventSubscription> subscriptions;
+            List<EventSubscription> subscriptions = null;
 
-            if (_eventHandlers.TryGetValue(routedEvent, out subscriptions))
+            if (_eventHandlers?.TryGetValue(routedEvent, out subscriptions) == true)
             {
                 subscriptions.RemoveAll(x => x.Handler == handler);
             }
@@ -181,9 +185,9 @@ namespace Avalonia.Interactivity
 
             e.RoutedEvent.InvokeRaised(this, e);
 
-            List<EventSubscription> subscriptions;
+            List<EventSubscription> subscriptions = null;
 
-            if (_eventHandlers.TryGetValue(e.RoutedEvent, out subscriptions))
+            if (_eventHandlers?.TryGetValue(e.RoutedEvent, out subscriptions) == true)
             {
                 foreach (var sub in subscriptions.ToList())
                 {

--- a/src/Avalonia.Styling/Styling/IStyleHost.cs
+++ b/src/Avalonia.Styling/Styling/IStyleHost.cs
@@ -1,6 +1,8 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using System;
+
 namespace Avalonia.Styling
 {
     /// <summary>
@@ -8,6 +10,15 @@ namespace Avalonia.Styling
     /// </summary>
     public interface IStyleHost
     {
+        /// <summary>
+        /// Gets a value indicating whether <see cref="Styles"/> is initialized.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Styles"/> property may be lazily initialized, if so this property
+        /// indicates whether it has been initialized.
+        /// </remarks>
+        bool IsStylesInitialized { get; }
+
         /// <summary>
         /// Gets the styles for the element.
         /// </summary>
@@ -17,6 +28,5 @@ namespace Avalonia.Styling
         /// Gets the parent style host element.
         /// </summary>
         IStyleHost StylingParent { get; }
-
     }
 }

--- a/src/Avalonia.Styling/Styling/StyleExtensions.cs
+++ b/src/Avalonia.Styling/Styling/StyleExtensions.cs
@@ -23,11 +23,14 @@ namespace Avalonia.Styling
 
             while (control != null)
             {
-                var result = control.Styles.FindResource(name);
-
-                if (result != AvaloniaProperty.UnsetValue)
+                if (control.IsStylesInitialized)
                 {
-                    return result;
+                    var result = control.Styles.FindResource(name);
+
+                    if (result != AvaloniaProperty.UnsetValue)
+                    {
+                        return result;
+                    }
                 }
 
                 control = control.StylingParent;

--- a/src/Avalonia.Styling/Styling/Styler.cs
+++ b/src/Avalonia.Styling/Styling/Styler.cs
@@ -29,7 +29,10 @@ namespace Avalonia.Styling
                 ApplyStyles(control, parentContainer);
             }
 
-            styleHost.Styles.Attach(control, styleHost);
+            if (styleHost.IsStylesInitialized)
+            {
+                styleHost.Styles.Attach(control, styleHost);
+            }
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
@@ -388,7 +388,7 @@ namespace Avalonia.Controls.UnitTests
             {
                 Template = GetTemplate(),
                 DataContext = "Base",
-                DataTemplates = new DataTemplates
+                DataTemplates =
                 {
                     new FuncDataTemplate<Item>(x => new Button { Content = x })
                 },

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
@@ -109,10 +109,10 @@ namespace Avalonia.Controls.UnitTests
                 {
                     Template = ListBoxTemplate(),
                     DataContext = "Base",
-                    DataTemplates = new DataTemplates
-                {
-                    new FuncDataTemplate<Item>(x => new Button { Content = x })
-                },
+                    DataTemplates =
+                    {
+                        new FuncDataTemplate<Item>(x => new Button { Content = x })
+                    },
                     Items = items,
                 };
 

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_Unrooted.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_Unrooted.cs
@@ -88,7 +88,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
             root.Child = null;
             root = new TestRoot
             {
-                DataTemplates = new DataTemplates
+                DataTemplates =
                 {
                     new FuncDataTemplate<string>(x => new Decorator()),
                 },

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -265,6 +265,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             };
 
             var globalStyles = new Mock<IGlobalStyles>();
+            globalStyles.Setup(x => x.IsStylesInitialized).Returns(true);
             globalStyles.Setup(x => x.Styles).Returns(styles);
 
             var renderInterface = new Mock<IPlatformRenderInterface>();

--- a/tests/Avalonia.Controls.UnitTests/Primitives/TemplatedControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/TemplatedControlTests.cs
@@ -399,7 +399,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                 TestTemplatedControl target;
                 var root = new TestRoot
                 {
-                    Styles = new Styles
+                    Styles =
                     {
                         new Style(x => x.OfType<TestTemplatedControl>())
                         {
@@ -435,7 +435,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                 TestTemplatedControl target;
                 var root = new TestRoot
                 {
-                    Styles = new Styles
+                    Styles =
                     {
                         new Style(x => x.OfType<TestTemplatedControl>())
                         {
@@ -474,7 +474,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
                 var root = new TestRoot
                 {
-                    Styles = new Styles
+                    Styles =
                     {
                         new Style(x => x.OfType<TestTemplatedControl>())
                         {
@@ -494,7 +494,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
                 var root2 = new TestRoot
                 {
-                    Styles = new Styles
+                    Styles =
                     {
                         new Style(x => x.OfType<TestTemplatedControl>())
                         {

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -135,7 +135,7 @@ namespace Avalonia.Controls.UnitTests
             {
                 var root = new TestRoot
                 {
-                    Styles = new Styles
+                    Styles =
                     {
                         new Style(x => x.OfType<TabItem>())
                         {

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -174,7 +174,7 @@ namespace Avalonia.Controls.UnitTests
             {
                 Template = new FuncControlTemplate<TabControl>(CreateTabControlTemplate),
                 DataContext = "Base",
-                DataTemplates = new DataTemplates
+                DataTemplates =
                 {
                     new FuncDataTemplate<Item>(x => new Button { Content = x })
                 },

--- a/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
@@ -25,9 +25,9 @@ namespace Avalonia.Controls.UnitTests
             {
                 Template = CreateTreeViewTemplate(),
                 Items = CreateTestTreeData(),
-                DataTemplates = CreateNodeDataTemplate(),
             };
 
+            CreateNodeDataTemplate(target);
             ApplyTemplates(target);
 
             Assert.Equal(new[] { "Root" }, ExtractItemHeader(target, 0));
@@ -69,9 +69,9 @@ namespace Avalonia.Controls.UnitTests
             {
                 Template = CreateTreeViewTemplate(),
                 Items = CreateTestTreeData(),
-                DataTemplates = CreateNodeDataTemplate(),
             };
 
+            CreateNodeDataTemplate(target);
             ApplyTemplates(target);
 
             var container = (TreeViewItem)target.ItemContainerGenerator.Containers.Single().ContainerControl;
@@ -87,7 +87,6 @@ namespace Avalonia.Controls.UnitTests
             {
                 Template = CreateTreeViewTemplate(),
                 Items = tree,
-                DataTemplates = CreateNodeDataTemplate(),
             };
 
             // For TreeViewItem to find its parent TreeView, OnAttachedToLogicalTree needs
@@ -95,6 +94,7 @@ namespace Avalonia.Controls.UnitTests
             var root = new TestRoot();
             root.Child = target;
 
+            CreateNodeDataTemplate(target);
             ApplyTemplates(target);
 
             var container = target.ItemContainerGenerator.Index.ContainerFromItem(
@@ -116,11 +116,12 @@ namespace Avalonia.Controls.UnitTests
             {
                 Template = CreateTreeViewTemplate(),
                 Items = tree,
-                DataTemplates = CreateNodeDataTemplate(),
             };
 
             var visualRoot = new TestRoot();
             visualRoot.Child = target;
+
+            CreateNodeDataTemplate(target);
             ApplyTemplates(target);
 
             var item = tree[0].Children[1].Children[0];
@@ -146,11 +147,12 @@ namespace Avalonia.Controls.UnitTests
             {
                 Template = CreateTreeViewTemplate(),
                 Items = tree,
-                DataTemplates = CreateNodeDataTemplate(),
             };
 
             var visualRoot = new TestRoot();
             visualRoot.Child = target;
+
+            CreateNodeDataTemplate(target);
             ApplyTemplates(target);
 
             var item = tree[0].Children[1].Children[0];
@@ -191,12 +193,13 @@ namespace Avalonia.Controls.UnitTests
             var target = new TreeView
             {
                 Template = CreateTreeViewTemplate(),
-                DataTemplates = CreateNodeDataTemplate(),
                 Items = tree,
             };
 
             var root = new TestRoot();
             root.Child = target;
+
+            CreateNodeDataTemplate(target);
             ApplyTemplates(target);
 
             Assert.Equal(5, target.ItemContainerGenerator.Index.Items.Count());
@@ -221,7 +224,7 @@ namespace Avalonia.Controls.UnitTests
             {
                 Template = CreateTreeViewTemplate(),
                 DataContext = "Base",
-                DataTemplates = new DataTemplates
+                DataTemplates =
                 {
                     new FuncDataTemplate<Node>(x => new Button { Content = x })
                 },
@@ -291,9 +294,9 @@ namespace Avalonia.Controls.UnitTests
             {
                 Template = CreateTreeViewTemplate(),
                 Items = data,
-                DataTemplates = CreateNodeDataTemplate(),
             };
 
+            CreateNodeDataTemplate(target);
             ApplyTemplates(target);
 
             Assert.Equal(new[] { "Root" }, ExtractItemHeader(target, 0));
@@ -328,7 +331,6 @@ namespace Avalonia.Controls.UnitTests
                 {
                     Template = CreateTreeViewTemplate(),
                     Items = data,
-                    DataTemplates = CreateNodeDataTemplate(),
                 };
 
                 var button = new Button();
@@ -341,6 +343,7 @@ namespace Avalonia.Controls.UnitTests
                     }
                 };
 
+                CreateNodeDataTemplate(target);
                 ApplyTemplates(target);
 
                 var item = data[0].Children[0];
@@ -411,12 +414,9 @@ namespace Avalonia.Controls.UnitTests
             };
         }
 
-        private DataTemplates CreateNodeDataTemplate()
+        private void CreateNodeDataTemplate(IControl control)
         {
-            return new DataTemplates
-            {
-                new TestTreeDataTemplate()
-            };
+            control.DataTemplates.Add(new TestTreeDataTemplate());
         }
 
         private IControlTemplate CreateTreeViewTemplate()

--- a/tests/Avalonia.Controls.UnitTests/UserControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/UserControlTests.cs
@@ -21,7 +21,7 @@ namespace Avalonia.Controls.UnitTests
                 var target = new UserControl();
                 var root = new TestRoot
                 {
-                    Styles = new Styles
+                    Styles =
                     {
                         new Style(x => x.OfType<ContentControl>())
                         {

--- a/tests/Avalonia.Layout.UnitTests/FullLayoutTests.cs
+++ b/tests/Avalonia.Layout.UnitTests/FullLayoutTests.cs
@@ -193,6 +193,7 @@ namespace Avalonia.Layout.UnitTests
                 .Bind<IWindowingPlatform>().ToConstant(new Avalonia.Controls.UnitTests.WindowingPlatformMock(() => windowImpl.Object));
 
             var theme = new DefaultTheme();
+            globalStyles.Setup(x => x.IsStylesInitialized).Returns(true);
             globalStyles.Setup(x => x.Styles).Returns(theme);
         }
     }

--- a/tests/Avalonia.LeakTests/ControlTests.cs
+++ b/tests/Avalonia.LeakTests/ControlTests.cs
@@ -276,7 +276,7 @@ namespace Avalonia.LeakTests
                     {
                         Content = target = new TreeView
                         {
-                            DataTemplates = new DataTemplates
+                            DataTemplates =
                             {
                                 new FuncTreeDataTemplate<Node>(
                                     x => new TextBlock { Text = x.Name },

--- a/tests/Avalonia.Styling.UnitTests/ResourceTests.cs
+++ b/tests/Avalonia.Styling.UnitTests/ResourceTests.cs
@@ -16,7 +16,7 @@ namespace Avalonia.Styling.UnitTests
 
             var tree = new Decorator
             {
-                Styles = new Styles
+                Styles =
                 {
                     new Style
                     {
@@ -29,7 +29,7 @@ namespace Avalonia.Styling.UnitTests
                 },
                 Child = target = new Border
                 {
-                    Styles = new Styles
+                    Styles =
                     {
                         new Style
                         {
@@ -60,16 +60,16 @@ namespace Avalonia.Styling.UnitTests
 
             var tree = target = new Border
             {
-                Styles = new Styles
+                Styles =
+                {
+                    new Style
                     {
-                        new Style
+                        Resources = new StyleResources
                         {
-                            Resources = new StyleResources
-                            {
-                                { "Foo", "foo" },
-                            }
-                        },
-                    }
+                            { "Foo", "foo" },
+                        }
+                    },
+                }
             };
 
             Assert.Equal(AvaloniaProperty.UnsetValue, target.FindStyleResource("Baz"));


### PR DESCRIPTION
This PR makes the following properties/fields lazily initialized:

- `Application.Styles`
- `Control.DataTemplates`
- `Control.Styles`
- `Interactive.EventHandlers`

It does this by adding an `Is{Property}Initialized` field to the relevant interfaces so that the property will need not be read if it's not used. This is used instead of `Lazy<>` as that requires an allocation, which more-or-less adds up to the same as an empty collection.

## Benchmarks

The following benchmarks were measured in `Release` mode using the VS diagnostics tools by running ControlCatalog and opening each page:

`master`: 456,957 objects / 13,025kb
`lazy-initialize`: 454,202 objects / 12,929kb

The savings aren't amazing, but we cut down 100kb essentially for free.

## Cleanups

I've also made the `DataTemplates` and `Styles` properties read-only. They were only writable because I wasn't aware of the C# list initialization syntax.