### PR TITLE
Update moq to 4.7.99.

### DIFF
--- a/build/Moq.props
+++ b/build/Moq.props
@@ -1,5 +1,5 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.7.25" />
+    <PackageReference Include="Moq" Version="4.7.99" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This fixes a bunch of build warnings of the form:

```
Warning	NU1603	Castle.Core 4.0.0 depends on System.ComponentModel.TypeConverter (>= 4.0.1) but System.ComponentModel.TypeConverter 4.0.1 was not found. An approximate best match of System.ComponentModel.TypeConverter 4.1.0 was resolved.	Avalonia.Visuals.UnitTests	D:\projects\Avalonia\tests\Avalonia.Visuals.UnitTests\Avalonia.Visuals.UnitTests.csproj	1	
```