### PR TITLE
Changed Skia text rendering to subpixel text

### DIFF
--- a/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
+++ b/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
@@ -207,6 +207,10 @@ namespace Avalonia.Skia
                 try
                 {
                     ApplyWrapperTo(ref currentPaint, foreground, ref currd, paint);
+
+                    paint.SubpixelText = true;
+                    paint.LcdRenderText = false;
+
                     bool hasCusomFGBrushes = _foregroundBrushes.Any();
 
                     for (int c = 0; c < _skiaLines.Count; c++)

--- a/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
+++ b/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
@@ -37,7 +37,7 @@ namespace Avalonia.Skia
             _paint.TextEncoding = SKTextEncoding.Utf16;
             _paint.IsStroke = false;
             _paint.IsAntialias = true;            
-            _paint.LcdRenderText = true;            
+            _paint.LcdRenderText = false;            
             _paint.SubpixelText = true;
             _paint.Typeface = skiaTypeface;
             _paint.TextSize = (float)(typeface?.FontSize ?? 12);
@@ -207,9 +207,6 @@ namespace Avalonia.Skia
                 try
                 {
                     ApplyWrapperTo(ref currentPaint, foreground, ref currd, paint);
-
-                    paint.SubpixelText = true;
-                    paint.LcdRenderText = false;
 
                     bool hasCusomFGBrushes = _foregroundBrushes.Any();
 


### PR DESCRIPTION
This should fix #1092 and other artifacts caused by transparent surfaces and text.

Skia does not support LCD text rendering and transparent surfaces therefore Subpixel text rendering has to be used.