### PR TITLE
Added Orientation and IsIndeterminate properties to ProgressBar

### DIFF
--- a/samples/ControlCatalog/ControlCatalog.csproj
+++ b/samples/ControlCatalog/ControlCatalog.csproj
@@ -69,6 +69,9 @@
     <EmbeddedResource Include="Pages\MenuPage.xaml">
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="Pages\ProgressBarPage.xaml">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="Pages\RadioButtonPage.xaml">
       <SubType>Designer</SubType>
     </EmbeddedResource>
@@ -130,6 +133,9 @@
     </Compile>
     <Compile Include="Pages\MenuPage.xaml.cs">
       <DependentUpon>MenuPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Pages\ProgressBarPage.xaml.cs">
+      <DependentUpon>ProgressBarPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="Pages\RadioButtonPage.xaml.cs">
       <DependentUpon>RadioButtonPage.xaml</DependentUpon>

--- a/samples/ControlCatalog/MainView.xaml
+++ b/samples/ControlCatalog/MainView.xaml
@@ -16,6 +16,7 @@
     <TabItem Header="Image"><pages:ImagePage/></TabItem>
     <TabItem Header="LayoutTransformControl"><pages:LayoutTransformControlPage/></TabItem>
     <TabItem Header="Menu"><pages:MenuPage/></TabItem>
+    <TabItem Header="ProgressBar"><pages:ProgressBarPage/></TabItem>
     <TabItem Header="RadioButton"><pages:RadioButtonPage/></TabItem>
     <TabItem Header="Slider"><pages:SliderPage/></TabItem>
     <TabItem Header="TextBox"><pages:TextBoxPage/></TabItem>

--- a/samples/ControlCatalog/Pages/ProgressBarPage.xaml
+++ b/samples/ControlCatalog/Pages/ProgressBarPage.xaml
@@ -1,0 +1,24 @@
+<UserControl xmlns="https://github.com/avaloniaui">
+  <StackPanel Orientation="Vertical" Gap="4">
+    <TextBlock Classes="h1">ProgressBar</TextBlock>
+    <TextBlock Classes="h2">A progress bar control</TextBlock>
+
+    <StackPanel>
+      <StackPanel Orientation="Horizontal"
+                  Margin="0,16,0,0"
+                  HorizontalAlignment="Center"
+                  Gap="16">
+        <StackPanel Gap="16">
+          <ProgressBar Value="{Binding #hprogress.Value}" />
+          <ProgressBar IsIndeterminate="True"/>
+        </StackPanel>
+        <ProgressBar Value="{Binding #vprogress.Value}" Orientation="Vertical" />
+        <ProgressBar Orientation="Vertical" IsIndeterminate="True" />
+      </StackPanel>
+      <StackPanel Margin="16">
+        <Slider Name="hprogress" Maximum="100" Value="40"/>
+        <Slider Name="vprogress" Maximum="100" Value="60"/>
+      </StackPanel>
+    </StackPanel>
+  </StackPanel>
+</UserControl>

--- a/samples/ControlCatalog/Pages/ProgressBarPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/ProgressBarPage.xaml.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace ControlCatalog.Pages
+{
+    public class ProgressBarPage : UserControl
+    {
+        public ProgressBarPage()
+        {
+            this.InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/src/Avalonia.Controls/Orientation.cs
+++ b/src/Avalonia.Controls/Orientation.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+namespace Avalonia.Controls
+{
+    /// <summary>
+    /// Defines vertical or horizontal orientation.
+    /// </summary>
+    public enum Orientation
+    {
+        /// <summary>
+        /// Horizontal orientation.
+        /// </summary>
+        Horizontal,
+
+        /// <summary>
+        /// Vertical orientation.
+        /// </summary>
+        Vertical,
+    }
+}

--- a/src/Avalonia.Controls/Primitives/ScrollBar.cs
+++ b/src/Avalonia.Controls/Primitives/ScrollBar.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Controls.Primitives
         /// Defines the <see cref="Orientation"/> property.
         /// </summary>
         public static readonly StyledProperty<Orientation> OrientationProperty =
-            AvaloniaProperty.Register<ScrollBar, Orientation>(nameof(Orientation));
+            AvaloniaProperty.Register<ScrollBar, Orientation>(nameof(Orientation), Orientation.Vertical);
 
         private Button _lineUpButton;
         private Button _lineDownButton;

--- a/src/Avalonia.Controls/ProgressBar.cs
+++ b/src/Avalonia.Controls/ProgressBar.cs
@@ -1,8 +1,12 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using System;
+using System.Reactive.Linq;
+
+using Avalonia.Animation;
 using Avalonia.Controls.Primitives;
-using Avalonia.Controls.Templates;
+using Avalonia.Layout;
 
 namespace Avalonia.Controls
 {
@@ -11,11 +15,41 @@ namespace Avalonia.Controls
     /// </summary>
     public class ProgressBar : RangeBase
     {
+        public static readonly StyledProperty<bool> IsIndeterminateProperty =
+            AvaloniaProperty.Register<ProgressBar, bool>(nameof(IsIndeterminate));
+
+        public static readonly StyledProperty<Orientation> OrientationProperty =
+            AvaloniaProperty.Register<ProgressBar, Orientation>(nameof(Orientation), Orientation.Horizontal);
+
         private Border _indicator;
+        private IDisposable _indeterminateBindSubscription;
 
         static ProgressBar()
         {
             ValueProperty.Changed.AddClassHandler<ProgressBar>(x => x.ValueChanged);
+
+            HorizontalAlignmentProperty.OverrideDefaultValue<ProgressBar>(HorizontalAlignment.Left);
+            VerticalAlignmentProperty.OverrideDefaultValue<ProgressBar>(VerticalAlignment.Top);
+        }
+
+        public bool IsIndeterminate
+        {
+            get => GetValue(IsIndeterminateProperty);
+            set
+            {
+                SetValue(IsIndeterminateProperty, value);
+                UpdateIsIndeterminate(value);
+            }
+        }
+
+        public Orientation Orientation
+        {
+            get => GetValue(OrientationProperty);
+            set
+            {
+                SetValue(OrientationProperty, value);
+                UpdateOrientation(value);
+            }
         }
 
         /// <inheritdoc/>
@@ -29,16 +63,80 @@ namespace Avalonia.Controls
         protected override void OnTemplateApplied(TemplateAppliedEventArgs e)
         {
             _indicator = e.NameScope.Get<Border>("PART_Indicator");
+
             UpdateIndicator(Bounds.Size);
+            UpdateOrientation(Orientation);
+            UpdateIsIndeterminate(IsIndeterminate);
         }
 
         private void UpdateIndicator(Size bounds)
         {
             if (_indicator != null)
             {
-                double percent = Maximum == Minimum ? 1.0 : (Value - Minimum) / (Maximum - Minimum);
-                _indicator.Width = bounds.Width * percent;
+                if (IsIndeterminate)
+                {
+                    if (Orientation == Orientation.Horizontal)
+                        _indicator.Width = bounds.Width / 5.0;
+                    else
+                        _indicator.Height = bounds.Height / 5.0;
+                }
+                else
+                {
+                    double percent = Maximum == Minimum ? 1.0 : (Value - Minimum) / (Maximum - Minimum);
+
+                    if (Orientation == Orientation.Horizontal)
+                        _indicator.Width = bounds.Width * percent;
+                    else
+                        _indicator.Height = bounds.Height * percent;
+                }
             }
+        }
+
+        private void UpdateOrientation(Orientation orientation)
+        {
+            if (orientation == Orientation.Horizontal)
+            {
+                MinHeight = 14;
+                MinWidth = 200;
+
+                _indicator.HorizontalAlignment = HorizontalAlignment.Left;
+                _indicator.VerticalAlignment = VerticalAlignment.Stretch;
+            }
+            else
+            {
+                MinHeight = 200;
+                MinWidth = 14;
+
+                _indicator.HorizontalAlignment = HorizontalAlignment.Stretch;
+                _indicator.VerticalAlignment = VerticalAlignment.Bottom;
+            }
+        }
+
+        private void UpdateIsIndeterminate(bool isIndeterminate)
+        {
+            if (isIndeterminate)
+            {
+                var start = Animate.Stopwatch.Elapsed;
+
+                if (Orientation == Orientation.Horizontal)
+                {
+                    _indeterminateBindSubscription = Animate.Timer.TakeWhile(x => (x - start).TotalSeconds <= 4.0)
+                                                                  .Select(x => new Rect(-_indicator.Width - 5 + (x - start).TotalSeconds / 4.0 * (Bounds.Width + _indicator.Width + 10), 0, _indicator.Bounds.Width, _indicator.Bounds.Height))
+                                                                  .Finally(() => start = Animate.Stopwatch.Elapsed)
+                                                                  .Repeat()
+                                                                  .Subscribe(x => _indicator.Arrange(x));
+                }
+                else
+                {
+                    _indeterminateBindSubscription = Animate.Timer.TakeWhile(x => (x - start).TotalSeconds <= 4.0)
+                                                                  .Select(x => new Rect(0, Bounds.Height + 5 - (x - start).TotalSeconds / 4.0 * (Bounds.Height + _indicator.Height + 10), _indicator.Bounds.Width, _indicator.Bounds.Height))
+                                                                  .Finally(() => start = Animate.Stopwatch.Elapsed)
+                                                                  .Repeat()
+                                                                  .Subscribe(x => _indicator.Arrange(x));
+                }
+            }
+            else
+                _indeterminateBindSubscription?.Dispose();
         }
 
         private void ValueChanged(AvaloniaPropertyChangedEventArgs e)

--- a/src/Avalonia.Controls/ProgressBar.cs
+++ b/src/Avalonia.Controls/ProgressBar.cs
@@ -112,7 +112,8 @@ namespace Avalonia.Controls
         private void UpdateIsIndeterminate(bool isIndeterminate)
         {
             if (isIndeterminate)
-                _indeterminateAnimation = IndeterminateAnimation.StartAnimation(this);
+                if (_indeterminateAnimation == null || _indeterminateAnimation.Disposed)
+                    _indeterminateAnimation = IndeterminateAnimation.StartAnimation(this);
             else
                 _indeterminateAnimation?.Dispose();
         }
@@ -127,6 +128,9 @@ namespace Avalonia.Controls
             private WeakReference<ProgressBar> _progressBar;
             private IDisposable _indeterminateBindSubscription;
             private TimeSpan _startTime;
+            private bool _disposed;
+
+            public bool Disposed => _disposed;
 
             private IndeterminateAnimation(ProgressBar progressBar)
             {
@@ -171,6 +175,7 @@ namespace Avalonia.Controls
             public void Dispose()
             {
                 _indeterminateBindSubscription?.Dispose();
+                _disposed = true;
             }
         }
     }

--- a/src/Avalonia.Controls/StackPanel.cs
+++ b/src/Avalonia.Controls/StackPanel.cs
@@ -7,22 +7,6 @@ using Avalonia.Input;
 namespace Avalonia.Controls
 {
     /// <summary>
-    /// Defines vertical or horizontal orientation.
-    /// </summary>
-    public enum Orientation
-    {
-        /// <summary>
-        /// Vertical orientation.
-        /// </summary>
-        Vertical,
-
-        /// <summary>
-        /// Horizontal orientation.
-        /// </summary>
-        Horizontal,
-    }
-
-    /// <summary>
     /// A panel which lays out its children horizontally or vertically.
     /// </summary>
     public class StackPanel : Panel, INavigableContainer
@@ -37,7 +21,7 @@ namespace Avalonia.Controls
         /// Defines the <see cref="Orientation"/> property.
         /// </summary>
         public static readonly StyledProperty<Orientation> OrientationProperty =
-            AvaloniaProperty.Register<StackPanel, Orientation>(nameof(Orientation));
+            AvaloniaProperty.Register<StackPanel, Orientation>(nameof(Orientation), Orientation.Vertical);
 
         /// <summary>
         /// Initializes static members of the <see cref="StackPanel"/> class.

--- a/src/Avalonia.Themes.Default/ProgressBar.xaml
+++ b/src/Avalonia.Themes.Default/ProgressBar.xaml
@@ -1,8 +1,6 @@
 <Style xmlns="https://github.com/avaloniaui" Selector="ProgressBar">
   <Setter Property="Background" Value="{DynamicResource ThemeAccentBrush4}"/>
   <Setter Property="Foreground" Value="{DynamicResource ThemeAccentBrush}"/>
-  <Setter Property="MinHeight" Value="14"/>
-  <Setter Property="MinWidth" Value="200"/>
   <Setter Property="Template">
     <ControlTemplate>
       <Border Background="{TemplateBinding Background}"
@@ -14,8 +12,7 @@
                   BorderBrush="{TemplateBinding Background}"/>
           <Border Name="PART_Indicator"
                   BorderThickness="1"
-                  Background="{TemplateBinding Foreground}"
-                  HorizontalAlignment="Left"/>
+                  Background="{TemplateBinding Foreground}"/>
         </Grid>
       </Border>
     </ControlTemplate>


### PR DESCRIPTION
## Changes
- Added `Orientation` and `IsIndeterminate` properties to `ProgressBar`.
- Added a `ProgressBar` page to the ControlCatalog sample.
- Moved the `Orientation` enum to a separate file.

## Issues
- When `IsIndeterminate` is set to `true`, the animation (which uses `Arrange(Rect)`) produces rendering artifacts.