### PR TITLE
[StackPanel] Gap value is not added to the measured width or height a…

### DIFF
--- a/src/Avalonia.Controls/StackPanel.cs
+++ b/src/Avalonia.Controls/StackPanel.cs
@@ -170,6 +170,15 @@ namespace Avalonia.Controls
                 }
             }
 
+            if (Orientation == Orientation.Vertical)
+            {
+                measuredHeight -= gap;
+            }
+            else
+            {
+                measuredWidth -= gap;
+            }
+
             return new Size(measuredWidth, measuredHeight);
         }
 

--- a/tests/Avalonia.Controls.UnitTests/StackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/StackPanelTests.cs
@@ -70,7 +70,7 @@ namespace Avalonia.Controls.UnitTests
             target.Measure(Size.Infinity);
             target.Arrange(new Rect(target.DesiredSize));
 
-            Assert.Equal(new Size(120, 130), target.Bounds.Size);
+            Assert.Equal(new Size(120, 120), target.Bounds.Size);
             Assert.Equal(new Rect(0, 0, 120, 20), target.Children[0].Bounds);
             Assert.Equal(new Rect(0, 30, 120, 30), target.Children[1].Bounds);
             Assert.Equal(new Rect(0, 70, 120, 50), target.Children[2].Bounds);
@@ -94,7 +94,7 @@ namespace Avalonia.Controls.UnitTests
             target.Measure(Size.Infinity);
             target.Arrange(new Rect(target.DesiredSize));
 
-            Assert.Equal(new Size(130, 120), target.Bounds.Size);
+            Assert.Equal(new Size(120, 120), target.Bounds.Size);
             Assert.Equal(new Rect(0, 0, 20, 120), target.Children[0].Bounds);
             Assert.Equal(new Rect(30, 0, 30, 120), target.Children[1].Bounds);
             Assert.Equal(new Rect(70, 0, 50, 120), target.Children[2].Bounds);


### PR DESCRIPTION
…fter the last child.

Fixes #1185 

Following code:

```
<Border BorderBrush="{DynamicResource ThemeAccentBrush}" BorderThickness="2" Padding="16">
        <StackPanel Gap="40">
          <TextBlock>Border</TextBlock>
          <TextBlock>Border</TextBlock>
        </StackPanel>
      </Border>
```

Before fix:
![image](https://user-images.githubusercontent.com/4672627/31175317-cce12368-a906-11e7-8fb5-d6a1439ba512.png)

After fix:
![image](https://user-images.githubusercontent.com/4672627/31175376-091f93c8-a907-11e7-9f5a-f292b9c962f2.png)

