### PR TITLE
 Propagate ClipBounds to child nodes

### DIFF
--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -168,11 +168,14 @@ namespace Avalonia.Rendering.SceneGraph
                 using (context.PushTransformContainer())
                 {
                     var startLayer = opacity < 1 || visual.OpacityMask != null;
+                    var clipBounds = bounds.TransformToAABB(contextImpl.Transform).Intersect(clip);
 
-                    forceRecurse = forceRecurse || node.Transform != contextImpl.Transform;
+                    forceRecurse = forceRecurse ||
+                        node.Transform != contextImpl.Transform ||
+                        node.ClipBounds != clipBounds;
 
                     node.Transform = contextImpl.Transform;
-                    node.ClipBounds = bounds.TransformToAABB(node.Transform).Intersect(clip);
+                    node.ClipBounds = clipBounds;
                     node.ClipToBounds = clipToBounds;
                     node.GeometryClip = visual.Clip?.PlatformImpl;
                     node.Opacity = opacity;

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests.cs
@@ -143,13 +143,61 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
 
                 var borderNode = scene.FindNode(border);
                 Assert.Equal(new Rect(50, 50, 50, 50), borderNode.ClipBounds);
+            }
+        }
 
-                // Initial ClipBounds are correct, make sure they're still correct after updating border.
+        [Fact]
+        public void Should_Update_Descendent_ClipBounds_When_Margin_Changed()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                Border border;
+                Canvas canvas;
+                var tree = new TestRoot
+                {
+                    Width = 200,
+                    Height = 300,
+                    Child = canvas = new Canvas
+                    {
+                        ClipToBounds = true,
+                        Width = 100,
+                        Height = 100,
+                        HorizontalAlignment = HorizontalAlignment.Left,
+                        VerticalAlignment = VerticalAlignment.Top,
+                        Children =
+                        {
+                            (border = new Border
+                            {
+                                Background = Brushes.AliceBlue,
+                                Width = 100,
+                                Height = 100,
+                                [Canvas.LeftProperty] = 50,
+                                [Canvas.TopProperty] = 50,
+                            })
+                        }
+                    }
+                };
+
+                tree.Measure(Size.Infinity);
+                tree.Arrange(new Rect(tree.DesiredSize));
+
+                var scene = new Scene(tree);
+                var sceneBuilder = new SceneBuilder();
+                sceneBuilder.UpdateAll(scene);
+
+                var borderNode = scene.FindNode(border);
+                Assert.Equal(new Rect(50, 50, 50, 50), borderNode.ClipBounds);
+
+                canvas.Width = canvas.Height = 125;
+                canvas.Measure(Size.Infinity);
+                canvas.Arrange(new Rect(tree.DesiredSize));
+
+                // Initial ClipBounds are correct, make sure they're still correct after updating canvas.
                 scene = scene.Clone();
-                Assert.True(sceneBuilder.Update(scene, border));
+                Assert.True(sceneBuilder.Update(scene, canvas));
 
                 borderNode = scene.FindNode(border);
-                Assert.Equal(new Rect(50, 50, 50, 50), borderNode.ClipBounds);
+                Assert.Equal(new Rect(50, 50, 75, 75), borderNode.ClipBounds);
             }
         }
 


### PR DESCRIPTION
When a scenegraph node's ClipBounds changes, ensure that that change is propagated to child nodes.

Fixes #1171 
Fixes #1194 