### PR TITLE
Clear mouse capture when control removed.

### DIFF
--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -656,7 +656,6 @@ namespace Avalonia.Controls
         /// <param name="e">The event args.</param>
         protected virtual void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
         {
-            AttachedToLogicalTree?.Invoke(this, e);
         }
 
         /// <summary>
@@ -665,7 +664,6 @@ namespace Avalonia.Controls
         /// <param name="e">The event args.</param>
         protected virtual void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)
         {
-            DetachedFromLogicalTree?.Invoke(this, e);
         }
 
         /// <inheritdoc/>
@@ -844,6 +842,7 @@ namespace Avalonia.Controls
                 InitializeStylesIfNeeded(true);
 
                 OnAttachedToLogicalTree(e);
+                AttachedToLogicalTree?.Invoke(this, e);
             }
 
             foreach (var child in LogicalChildren.OfType<Control>())
@@ -864,6 +863,7 @@ namespace Avalonia.Controls
                 _isAttachedToLogicalTree = false;
                 _styleDetach.OnNext(this);
                 OnDetachedFromLogicalTree(e);
+                DetachedFromLogicalTree?.Invoke(this, e);
 
                 foreach (var child in LogicalChildren.OfType<Control>())
                 {

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/Scene.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/Scene.cs
@@ -173,7 +173,7 @@ namespace Avalonia.Rendering.SceneGraph
                         }
                     }
 
-                    if (node.HitTest(p))
+                    if (node.HitTest(p) && node.Visual.IsAttachedToVisualTree)
                     {
                         yield return node.Visual;
                     }

--- a/src/Avalonia.Visuals/Visual.cs
+++ b/src/Avalonia.Visuals/Visual.cs
@@ -329,6 +329,7 @@ namespace Avalonia
             }
 
             OnAttachedToVisualTree(e);
+            AttachedToVisualTree?.Invoke(this, e);
             InvalidateVisual();
 
             if (VisualChildren != null)
@@ -357,6 +358,7 @@ namespace Avalonia
             }
 
             OnDetachedFromVisualTree(e);
+            DetachedFromVisualTree?.Invoke(this, e);
             e.Root?.Renderer?.AddDirty(this);
 
             if (VisualChildren != null)
@@ -374,7 +376,6 @@ namespace Avalonia
         /// <param name="e">The event args.</param>
         protected virtual void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
-            AttachedToVisualTree?.Invoke(this, e);
         }
 
         /// <summary>
@@ -383,7 +384,6 @@ namespace Avalonia
         /// <param name="e">The event args.</param>
         protected virtual void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
-            DetachedFromVisualTree?.Invoke(this, e);
         }
 
         /// <summary>

--- a/tests/Avalonia.Input.UnitTests/MouseDeviceTests.cs
+++ b/tests/Avalonia.Input.UnitTests/MouseDeviceTests.cs
@@ -1,6 +1,5 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Input.Raw;
-using Avalonia.Layout;
 using Avalonia.Rendering;
 using Avalonia.UnitTests;
 using Avalonia.VisualTree;
@@ -12,6 +11,24 @@ namespace Avalonia.Input.UnitTests
 {
     public class MouseDeviceTests
     {
+        [Fact]
+        public void Capture_Is_Cleared_When_Control_Removed()
+        {
+            Canvas control;
+            var root = new TestRoot
+            {
+                Child = control = new Canvas(),
+            };
+            var target = new MouseDevice();
+
+            target.Capture(control);
+            Assert.Same(control, target.Captured);
+
+            root.Child = null;
+
+            Assert.Null(target.Captured);
+        }
+
         [Fact]
         public void MouseMove_Should_Update_PointerOver()
         {


### PR DESCRIPTION
When a captured control is removed from the visual tree, clear the mouse capture.

Note that our capture logic needs to be improved - it shouldn't be possible to capture a non-visible or non-enabled control. This doesn't address that but it does fix the crash in #1203.

Also, if a control has been detached from the visual tree but the scene hasn't yet been updated, don't return the control as part of a hit-test.

(Doesn't) Fix #1203