### PR TITLE
Bind TextPresenter.Text before CaretIndex.

### DIFF
--- a/src/Avalonia.Themes.Default/TextBox.xaml
+++ b/src/Avalonia.Themes.Default/TextBox.xaml
@@ -46,10 +46,10 @@
                            Text="{TemplateBinding Watermark}"
                            IsVisible="{TemplateBinding Path=Text, Converter={Static StringConverters.NullOrEmpty}}"/>
                 <TextPresenter Name="PART_TextPresenter"
+                               Text="{TemplateBinding Text, Mode=TwoWay}"
                                CaretIndex="{TemplateBinding CaretIndex}"
                                SelectionStart="{TemplateBinding SelectionStart}"
                                SelectionEnd="{TemplateBinding SelectionEnd}"
-                               Text="{TemplateBinding Text, Mode=TwoWay}"
                                TextAlignment="{TemplateBinding TextAlignment}"
                                TextWrapping="{TemplateBinding TextWrapping}"/>
               </Panel>


### PR DESCRIPTION
Otherwise if `TextBox.CaretIndex` is set before the `TextBox`'s template is applied then it will be coerced to null on the `TextPresenter` when created as `Text` will still be null at this point.