### PR TITLE
[GTK3] Special resize handling for popups

### DIFF
--- a/src/Gtk/Avalonia.Gtk3/Interop/Native.cs
+++ b/src/Gtk/Avalonia.Gtk3/Interop/Native.cs
@@ -102,6 +102,9 @@ namespace Avalonia.Gtk3.Interop
             
             [UnmanagedFunctionPointer(CallingConvention.Cdecl), GtkImport(GtkDll.Gdk)]
             public delegate void gdk_window_resize(IntPtr gtkWindow, int width, int height);
+            
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl), GtkImport(GtkDll.Gdk)]
+            public delegate void gdk_window_set_override_redirect(IntPtr gdkWindow, bool value);
 
             [UnmanagedFunctionPointer(CallingConvention.Cdecl), GtkImport(GtkDll.Gtk)]
             public delegate void gtk_widget_realize(GtkWidget gtkWidget);
@@ -402,6 +405,7 @@ namespace Avalonia.Gtk3.Interop
         public static D.gtk_window_get_size GtkWindowGetSize;
         public static D.gtk_window_resize GtkWindowResize;
         public static D.gdk_window_resize GdkWindowResize;
+        public static D.gdk_window_set_override_redirect GdkWindowSetOverrideRedirect;
         public static D.gtk_widget_set_size_request GtkWindowSetSizeRequest;
         public static D.gtk_window_set_default_size GtkWindowSetDefaultSize;
         public static D.gtk_window_get_position GtkWindowGetPosition;

--- a/src/Gtk/Avalonia.Gtk3/PopupImpl.cs
+++ b/src/Gtk/Avalonia.Gtk3/PopupImpl.cs
@@ -19,6 +19,7 @@ namespace Avalonia.Gtk3
 
         public PopupImpl() : base(CreateWindow())
         {
+            OverrideRedirect = true;
         }
     }
 }

--- a/src/Gtk/Avalonia.Gtk3/WindowBaseImpl.cs
+++ b/src/Gtk/Avalonia.Gtk3/WindowBaseImpl.cs
@@ -32,6 +32,7 @@ namespace Avalonia.Gtk3
         private IDeferredRenderOperation _nextRenderOperation;
         private readonly AutoResetEvent _canSetNextOperation = new AutoResetEvent(true);
         internal IntPtr? GdkWindowHandle;
+        private bool _overrideRedirect;
         public WindowBaseImpl(GtkWindow gtkWidget)
         {
             
@@ -406,6 +407,28 @@ namespace Avalonia.Gtk3
             if (GtkWidget.IsClosed)
                 return;
             Native.GtkWindowResize(GtkWidget, (int)value.Width, (int)value.Height);
+            if (OverrideRedirect)
+            {
+                var size = ClientSize = value;
+                if (_lastSize != size)
+                {
+                    Resized?.Invoke(size);
+                    _lastSize = size;
+                }
+            }
+        }
+
+        public bool OverrideRedirect
+        {
+            get => _overrideRedirect;
+            set
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    Native.GdkWindowSetOverrideRedirect(Native.GtkWidgetGetWindow(GtkWidget), value);
+                    _overrideRedirect = value;
+                }
+            }
         }
         
         public IScreenImpl Screen

--- a/src/Gtk/Avalonia.Gtk3/WindowBaseImpl.cs
+++ b/src/Gtk/Avalonia.Gtk3/WindowBaseImpl.cs
@@ -70,12 +70,15 @@ namespace Avalonia.Gtk3
         private bool OnConfigured(IntPtr gtkwidget, IntPtr ev, IntPtr userdata)
         {
             int w, h;
-            Native.GtkWindowGetSize(GtkWidget, out w, out h);
-            var size = ClientSize = new Size(w, h);
-            if (_lastSize != size)
+            if (!OverrideRedirect)
             {
-                Resized?.Invoke(size);
-                _lastSize = size;
+                Native.GtkWindowGetSize(GtkWidget, out w, out h);
+                var size = ClientSize = new Size(w, h);
+                if (_lastSize != size)
+                {
+                    Resized?.Invoke(size);
+                    _lastSize = size;
+                }
             }
             var pos = Position;
             if (_lastPosition != pos)


### PR DESCRIPTION
In case of popups with override-redirect flag set we can safely assume that X server will resize the window to specified size, so we can trigger `Resized` event immediately.