### PR TITLE
Correctly clone binding in Style.

### DIFF
--- a/src/Avalonia.Styling/Styling/Setter.cs
+++ b/src/Avalonia.Styling/Styling/Setter.cs
@@ -141,20 +141,20 @@ namespace Avalonia.Styling
             {
                 var description = style?.ToString();
 
-                if (sourceInstance.Subject != null)
+                if (sourceInstance.Mode == BindingMode.TwoWay || sourceInstance.Mode == BindingMode.OneWayToSource)
                 {
                     var activated = new ActivatedSubject(activator, sourceInstance.Subject, description);
                     cloned = new InstancedBinding(activated, sourceInstance.Mode, BindingPriority.StyleTrigger);
                 }
-                else if (sourceInstance.Observable != null)
-                {
-                    var activated = new ActivatedObservable(activator, sourceInstance.Observable, description);
-                    cloned = new InstancedBinding(activated, sourceInstance.Mode, BindingPriority.StyleTrigger);
-                }
-                else
+                else if (sourceInstance.Mode == BindingMode.OneTime)
                 {
                     var activated = new ActivatedValue(activator, sourceInstance.Value, description);
                     cloned = new InstancedBinding(activated, BindingMode.OneWay, BindingPriority.StyleTrigger);
+                }
+                else
+                {
+                    var activated = new ActivatedObservable(activator, sourceInstance.Observable ?? sourceInstance.Subject, description);
+                    cloned = new InstancedBinding(activated, sourceInstance.Mode, BindingPriority.StyleTrigger);
                 }
             }
             else


### PR DESCRIPTION
Previously, `Converter.ConvertBack` was being called from a `Binding` set as a `Style.Value` because `Style.Clone` was assuming that if the binding source was a subject then it was a two-way binding. Correctly check the `Mode` of the binding when cloning.

The API for `InstancedBinding` is not at all clear which led to this bug. Will follow up with a PR which attempts to provide a better API.

Fixes #1218 