### PR TITLE
Fix RenderTest default orientation.

### DIFF
--- a/samples/VirtualizationTest/ViewModels/MainWindowViewModel.cs
+++ b/samples/VirtualizationTest/ViewModels/MainWindowViewModel.cs
@@ -17,7 +17,7 @@ namespace VirtualizationTest.ViewModels
         private int _newItemIndex;
         private IReactiveList<ItemViewModel> _items;
         private string _prefix = "Item";
-        private Orientation _orientation;
+        private Orientation _orientation = Orientation.Vertical;
         private ItemVirtualizationMode _virtualizationMode = ItemVirtualizationMode.Simple;
 
         public MainWindowViewModel()


### PR DESCRIPTION
7cb4485d changed the order of the `Orientation` enum members to match WPF but didn't change the default in `RenderTest`  which caused it to display horizontal by default. Fix this.