### PR TITLE
[need feedback] Create ToggleGroup control

### DIFF
--- a/src/Avalonia.Controls/Primitives/ToggleButton.cs
+++ b/src/Avalonia.Controls/Primitives/ToggleButton.cs
@@ -9,9 +9,11 @@ namespace Avalonia.Controls.Primitives
 {
     public class ToggleButton : Button
     {
+        public const string IsCheckedPropertyName = "IsChecked";
+
         public static readonly DirectProperty<ToggleButton, bool> IsCheckedProperty =
             AvaloniaProperty.RegisterDirect<ToggleButton, bool>(
-                "IsChecked",
+                IsCheckedPropertyName,
                 o => o.IsChecked,
                 (o,v) => o.IsChecked = v,
                 defaultBindingMode: BindingMode.TwoWay);

--- a/src/Avalonia.Controls/ToggleGroup.cs
+++ b/src/Avalonia.Controls/ToggleGroup.cs
@@ -1,0 +1,61 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using System.Linq;
+using Avalonia.Controls.Primitives;
+using Avalonia.VisualTree;
+using Avalonia.Collections;
+using System.ComponentModel;
+using Avalonia.Data;
+
+namespace Avalonia.Controls
+{
+    public class ToggleGroup : TemplatedControl
+    {
+        public const string SelectedItemPropertyName = "SelectedItem";
+
+        public static readonly DirectProperty<ToggleGroup, ToggleButton> SelectedItemProperty =
+            AvaloniaProperty.RegisterDirect<ToggleGroup, ToggleButton>(
+                SelectedItemPropertyName,
+                o => o.SelectedItem,
+                (o, v) => o.SelectedItem = v,
+                defaultBindingMode: BindingMode.TwoWay);
+
+        private ToggleButton _selectedItem;
+
+        public ToggleGroup()
+        {
+            this.VisualChildren.TrackItemPropertyChanged(OnItemPropertyChanged);
+        }
+
+        public ToggleButton SelectedItem
+        {
+            get => _selectedItem;
+            set => SetAndRaise(SelectedItemProperty, ref _selectedItem, value);
+        }
+
+        private void OnItemPropertyChanged(Tuple<object, PropertyChangedEventArgs> args)
+        {
+            if (args.Item1 is ToggleButton && args.Item2.PropertyName == ToggleButton.IsCheckedPropertyName)
+            {
+                OnItemToggled((ToggleButton)args.Item1);
+            }
+        }
+
+        private void OnItemToggled(ToggleButton button)
+        {
+            // if the selected item is still checked, then a different button was 
+            // toggled (and is now the selected item). Otherwise, the selectedItem was
+            // toggled off (and there is now no selected item).
+            ToggleButton newlySelectedItem = SelectedItem.IsChecked ? button : null;
+
+            if (SelectedItem != null && SelectedItem.IsChecked)
+            {
+                SelectedItem.IsChecked = false;
+            }
+
+            SelectedItem = newlySelectedItem;
+        }
+    }
+}


### PR DESCRIPTION
This is an early PR for help on next steps -- I saw discussion on #224 that asked for a way to scope groupnames, and it seems like this is what a Control is for. 

I'm not extremely familiar with Avalonia/WPF, so could use some feedback on whether this is a good start, and what I need to do to actually have a usable Control (and how to use it).

Ideally, I believe a ToggleGroup should:

* be able to contain arbitrary other Controls
* only allow at-most one ToggleButton within it to be selected at a time, by unselecting all other ToggleButtons whenever one is selected