### PR TITLE
Fix xunit warnings.

### DIFF
--- a/tests/Avalonia.Base.UnitTests/AvaloniaPropertyTests.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaPropertyTests.cs
@@ -113,8 +113,8 @@ namespace Avalonia.Base.UnitTests
         {
             var p1 = new TestProperty<string>("p1", typeof(Class1));
 
-            Assert.NotEqual(p1, null);
-            Assert.NotEqual(null, p1);
+            Assert.NotNull(p1);
+            Assert.NotNull(p1);
             Assert.False(p1 == null);
             Assert.False(null == p1);
             Assert.False(p1.Equals(null));

--- a/tests/Avalonia.Base.UnitTests/PriorityValueTests.cs
+++ b/tests/Avalonia.Base.UnitTests/PriorityValueTests.cs
@@ -206,7 +206,7 @@ namespace Avalonia.Base.UnitTests
 
             Assert.Equal(2, target.GetBindings().Count());
             disposable.Dispose();
-            Assert.Equal(1, target.GetBindings().Count());
+            Assert.Single(target.GetBindings());
         }
 
         [Fact]
@@ -248,7 +248,7 @@ namespace Avalonia.Base.UnitTests
 
             Assert.Equal(2, target.GetBindings().Count());
             subject.OnCompleted();
-            Assert.Equal(1, target.GetBindings().Count());
+            Assert.Single(target.GetBindings());
         }
 
         [Fact]

--- a/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
@@ -47,7 +47,7 @@ namespace Avalonia.Controls.UnitTests
             target.ApplyTemplate();
             target.Presenter.ApplyTemplate();
 
-            Assert.Equal(1, target.GetLogicalChildren().Count());
+            Assert.Single(target.GetLogicalChildren());
 
             var child = target.GetLogicalChildren().Single();
             
@@ -69,9 +69,9 @@ namespace Avalonia.Controls.UnitTests
             target.ApplyTemplate();
             target.Presenter.ApplyTemplate();
 
-            Assert.Equal(1, target.ItemContainerGenerator.Containers.Count());
+            Assert.Single(target.ItemContainerGenerator.Containers);
             target.SelectedIndex = 1;
-            Assert.Equal(1, target.ItemContainerGenerator.Containers.Count());
+            Assert.Single(target.ItemContainerGenerator.Containers);
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace Avalonia.Controls.UnitTests
             target.ApplyTemplate();
             target.Presenter.ApplyTemplate();
 
-            Assert.Equal(1, target.ItemContainerGenerator.Containers.Count());
+            Assert.Single(target.ItemContainerGenerator.Containers);
             target.SelectedIndex = 1;
             Assert.Equal(2, target.ItemContainerGenerator.Containers.Count());
         }

--- a/tests/Avalonia.Controls.UnitTests/ControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ControlTests.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Controls.UnitTests
         {
             var target = new Control();
 
-            Assert.Equal(0, target.Classes.Count);
+            Assert.Empty(target.Classes);
         }
 
         [Fact]

--- a/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
@@ -323,7 +323,7 @@ namespace Avalonia.Controls.UnitTests
                 Template = GetTemplate(),
             };
 
-            Assert.True(target.Classes.Contains(":empty"));
+            Assert.Contains(":empty", target.Classes);
         }
 
         [Fact]
@@ -335,7 +335,7 @@ namespace Avalonia.Controls.UnitTests
                 Items = new[] { 1, 2, 3 },
             };
 
-            Assert.False(target.Classes.Contains(":empty"));
+            Assert.DoesNotContain(":empty", target.Classes);
         }
 
         [Fact]
@@ -349,7 +349,7 @@ namespace Avalonia.Controls.UnitTests
 
             target.Items = new int[0];
 
-            Assert.True(target.Classes.Contains(":empty"));
+            Assert.Contains(":empty", target.Classes);
         }
 
         [Fact]

--- a/tests/Avalonia.Controls.UnitTests/Presenters/CarouselPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/CarouselPresenterTests.cs
@@ -91,9 +91,9 @@ namespace Avalonia.Controls.UnitTests.Presenters
             };
 
             target.ApplyTemplate();
-            Assert.Equal(1, target.ItemContainerGenerator.Containers.Count());
+            Assert.Single(target.ItemContainerGenerator.Containers);
             target.SelectedIndex = 1;
-            Assert.Equal(1, target.ItemContainerGenerator.Containers.Count());
+            Assert.Single(target.ItemContainerGenerator.Containers);
         }
 
         [Fact]
@@ -107,8 +107,8 @@ namespace Avalonia.Controls.UnitTests.Presenters
             };
 
             target.ApplyTemplate();
-            Assert.Equal(1, target.ItemContainerGenerator.Containers.Count());
-            Assert.Equal(1, target.Panel.Children.Count);
+            Assert.Single(target.ItemContainerGenerator.Containers);
+            Assert.Single(target.Panel.Children);
             target.SelectedIndex = 1;
             Assert.Equal(2, target.ItemContainerGenerator.Containers.Count());
             Assert.Equal(2, target.Panel.Children.Count);
@@ -134,24 +134,24 @@ namespace Avalonia.Controls.UnitTests.Presenters
             items.Add("foo");
             target.SelectedIndex = 0;
 
-            Assert.Equal(1, target.ItemContainerGenerator.Containers.Count());
-            Assert.Equal(1, target.Panel.Children.Count);
+            Assert.Single(target.ItemContainerGenerator.Containers);
+            Assert.Single(target.Panel.Children);
 
             items.Add("bar");
-            Assert.Equal(1, target.ItemContainerGenerator.Containers.Count());
-            Assert.Equal(1, target.Panel.Children.Count);
+            Assert.Single(target.ItemContainerGenerator.Containers);
+            Assert.Single(target.Panel.Children);
 
             target.SelectedIndex = 1;
             Assert.Equal(2, target.ItemContainerGenerator.Containers.Count());
             Assert.Equal(2, target.Panel.Children.Count);            
 
             items.Remove(items[0]);
-            Assert.Equal(1, target.ItemContainerGenerator.Containers.Count());
-            Assert.Equal(1, target.Panel.Children.Count);            
+            Assert.Single(target.ItemContainerGenerator.Containers);
+            Assert.Single(target.Panel.Children);            
 
             items.Remove(items[0]);
-            Assert.Equal(0, target.ItemContainerGenerator.Containers.Count());
-            Assert.Equal(0, target.Panel.Children.Count);            
+            Assert.Empty(target.ItemContainerGenerator.Containers);
+            Assert.Empty(target.Panel.Children);            
         }
 
         [Fact]
@@ -171,12 +171,12 @@ namespace Avalonia.Controls.UnitTests.Presenters
             items.Add("foo");
             target.SelectedIndex = 0;
 
-            Assert.Equal(1, target.ItemContainerGenerator.Containers.Count());
-            Assert.Equal(1, target.Panel.Children.Count);
+            Assert.Single(target.ItemContainerGenerator.Containers);
+            Assert.Single(target.Panel.Children);
 
             items.Add("bar");
-            Assert.Equal(1, target.ItemContainerGenerator.Containers.Count());
-            Assert.Equal(1, target.Panel.Children.Count);
+            Assert.Single(target.ItemContainerGenerator.Containers);
+            Assert.Single(target.Panel.Children);
 
             target.SelectedIndex = 1;
             Assert.Equal(2, target.ItemContainerGenerator.Containers.Count());
@@ -184,13 +184,13 @@ namespace Avalonia.Controls.UnitTests.Presenters
             Assert.Equal(0, target.ItemContainerGenerator.Containers.First().Index);
 
             items.Remove(items[0]);
-            Assert.Equal(1, target.ItemContainerGenerator.Containers.Count());
-            Assert.Equal(1, target.Panel.Children.Count);
+            Assert.Single(target.ItemContainerGenerator.Containers);
+            Assert.Single(target.Panel.Children);
             Assert.Equal(0, target.ItemContainerGenerator.Containers.First().Index);
 
             items.Remove(items[0]);
-            Assert.Equal(0, target.ItemContainerGenerator.Containers.Count());
-            Assert.Equal(0, target.Panel.Children.Count);            
+            Assert.Empty(target.ItemContainerGenerator.Containers);
+            Assert.Empty(target.Panel.Children);            
         }
 
         private class TestItem : ContentControl

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_Standalone.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_Standalone.cs
@@ -42,7 +42,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
 
             var logicalChildren = target.GetLogicalChildren();
 
-            Assert.Equal(1, logicalChildren.Count());
+            Assert.Single(logicalChildren);
             Assert.Equal(content, logicalChildren.First());
         }
 
@@ -190,7 +190,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
 
             var logicalChildren = target.GetLogicalChildren();
 
-            Assert.Equal(1, logicalChildren.Count());
+            Assert.Single(logicalChildren);
 
             target.Content = "bar";
             target.UpdateChild();
@@ -199,7 +199,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
 
             logicalChildren = target.GetLogicalChildren();
 
-            Assert.Equal(1, logicalChildren.Count());
+            Assert.Single(logicalChildren);
             Assert.NotEqual(foo, logicalChildren.First());
         }
 

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests.cs
@@ -87,7 +87,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
             target.ApplyTemplate();
             items.RemoveAt(0);
 
-            Assert.Equal(1, target.Panel.Children.Count);
+            Assert.Single(target.Panel.Children);
             Assert.Equal("bar", ((ContentPresenter)target.Panel.Children[0]).Content);
             Assert.Equal("bar", ((ContentPresenter)target.ItemContainerGenerator.ContainerFromIndex(0)).Content);
         }

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests_Virtualization_Simple.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests_Virtualization_Simple.cs
@@ -704,7 +704,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
             target.Measure(new Size(100, 100));
             target.Arrange(new Rect(target.DesiredSize));
 
-            Assert.Equal(0, target.Panel.Children.Count);
+            Assert.Empty(target.Panel.Children);
 
             items.AddRange(defaultItems.Select(s => s + " new"));
 

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -194,7 +194,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
                 target.Open();
 
-                Assert.Equal(1, target.PopupRoot.GetVisualChildren().Count());
+                Assert.Single(target.PopupRoot.GetVisualChildren());
 
                 var templatedChild = target.PopupRoot.GetVisualChildren().Single();
                 Assert.IsType<ContentPresenter>(templatedChild);

--- a/tests/Avalonia.Controls.UnitTests/Primitives/ScrollBarTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/ScrollBarTests.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             var track = (Track)target.GetTemplateChildren().First(x => x.Name == "track");
             target.Value = 50;
 
-            Assert.Equal(track.Value, 50);
+            Assert.Equal(50, track.Value);
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             var track = (Track)target.GetTemplateChildren().First(x => x.Name == "track");
             track.Value = 50;
 
-            Assert.Equal(target.Value, 50);
+            Assert.Equal(50, target.Value);
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             target.Value = 25;
             track.Value = 50;
 
-            Assert.Equal(target.Value, 50);
+            Assert.Equal(50, target.Value);
         }
 
         [Fact]

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests_DataValidation.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests_DataValidation.cs
@@ -33,11 +33,11 @@ namespace Avalonia.Controls.UnitTests
 
                 target.ApplyTemplate();
 
-                Assert.False(target.Classes.Contains(":error"));
+                Assert.DoesNotContain(":error", target.Classes);
                 target.Text = "20";
-                Assert.True(target.Classes.Contains(":error"));
+                Assert.Contains(":error", target.Classes);
                 target.Text = "1";
-                Assert.False(target.Classes.Contains(":error"));
+                Assert.DoesNotContain(":error", target.Classes);
             }
         }
 
@@ -57,7 +57,7 @@ namespace Avalonia.Controls.UnitTests
 
                 Assert.Null(target.DataValidationErrors);
                 target.Text = "20";
-                Assert.Equal(1, target.DataValidationErrors.Count());
+                Assert.Single(target.DataValidationErrors);
                 Assert.IsType<InvalidOperationException>(target.DataValidationErrors.Single());
                 target.Text = "1";
                 Assert.Null(target.DataValidationErrors);

--- a/tests/Avalonia.Layout.UnitTests/FullLayoutTests.cs
+++ b/tests/Avalonia.Layout.UnitTests/FullLayoutTests.cs
@@ -109,7 +109,7 @@ namespace Avalonia.Layout.UnitTests
                 var presenters = scrollViewer.GetTemplateChildren().OfType<ScrollContentPresenter>().ToList();
 
                 Assert.Equal(2, scrollBars.Count);
-                Assert.Equal(1, presenters.Count);
+                Assert.Single(presenters);
 
                 var presenter = presenters[0];
                 Assert.Equal(new Size(190, 190), presenter.Bounds.Size);

--- a/tests/Avalonia.LeakTests/ControlTests.cs
+++ b/tests/Avalonia.LeakTests/ControlTests.cs
@@ -155,7 +155,7 @@ namespace Avalonia.LeakTests
                     // template applied.
                     LayoutManager.Instance.ExecuteInitialLayoutPass(window);
                     Assert.IsType<TextBox>(window.Presenter.Child);
-                    Assert.NotEqual(0, window.Presenter.Child.GetVisualChildren().Count());
+                    Assert.NotEmpty(window.Presenter.Child.GetVisualChildren());
 
                     // Clear the content and ensure the TextBox is removed.
                     window.Content = null;
@@ -290,7 +290,7 @@ namespace Avalonia.LeakTests
 
                     // Do a layout and make sure that TreeViewItems get realized.
                     LayoutManager.Instance.ExecuteInitialLayoutPass(window);
-                    Assert.Equal(1, target.ItemContainerGenerator.Containers.Count());
+                    Assert.Single(target.ItemContainerGenerator.Containers);
 
                     // Clear the content and ensure the TreeView is removed.
                     window.Content = null;

--- a/tests/Avalonia.Markup.UnitTests/Data/ExpressionObserverTests_Negation.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/ExpressionObserverTests_Negation.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Markup.UnitTests.Data
             var target = new ExpressionObserver(data, "!Foo");
             var result = await target.Take(1);
 
-            Assert.Equal(false, result);
+            Assert.False((bool)result);
 
             GC.KeepAlive(data);
         }
@@ -31,7 +31,7 @@ namespace Avalonia.Markup.UnitTests.Data
             var target = new ExpressionObserver(data, "!Foo");
             var result = await target.Take(1);
 
-            Assert.Equal(true, result);
+            Assert.True((bool)result);
 
             GC.KeepAlive(data);
         }
@@ -43,7 +43,7 @@ namespace Avalonia.Markup.UnitTests.Data
             var target = new ExpressionObserver(data, "!Foo");
             var result = await target.Take(1);
 
-            Assert.Equal(false, result);
+            Assert.False((bool)result);
 
             GC.KeepAlive(data);
         }
@@ -55,7 +55,7 @@ namespace Avalonia.Markup.UnitTests.Data
             var target = new ExpressionObserver(data, "!Foo");
             var result = await target.Take(1);
 
-            Assert.Equal(true, result);
+            Assert.True((bool)result);
 
             GC.KeepAlive(data);
         }
@@ -67,7 +67,7 @@ namespace Avalonia.Markup.UnitTests.Data
             var target = new ExpressionObserver(data, "!Foo");
             var result = await target.Take(1);
 
-            Assert.Equal(false, result);
+            Assert.False((bool)result);
 
             GC.KeepAlive(data);
         }

--- a/tests/Avalonia.Markup.UnitTests/Data/ExpressionObserverTests_Task.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/ExpressionObserverTests_Task.cs
@@ -28,7 +28,7 @@ namespace Avalonia.Markup.UnitTests.Data
                 tcs.SetResult("foo");
                 sync.ExecutePostedCallbacks();
 
-                Assert.Equal(1, result.Count);
+                Assert.Single(result);
                 Assert.IsType<Task<string>>(result[0]);
 
                 GC.KeepAlive(data);

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests_Source.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests_Source.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
 
             target.Bind(TextBlock.TextProperty, binding);
 
-            Assert.Equal(target.Text, "foo");
+            Assert.Equal("foo", target.Text);
         }
         
         public class Source : INotifyPropertyChanged

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
@@ -119,7 +119,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             var target = AvaloniaXamlLoader.Parse<Panel>(xaml);
 
-            Assert.Equal(0, target.Children.Count);
+            Assert.Empty(target.Children);
 
             Assert.Equal("Foo", ToolTip.GetTip(target));
         }
@@ -377,7 +377,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             var styles = AvaloniaXamlLoader.Parse<Styles>(xaml);
 
-            Assert.Equal(1, styles.Count);
+            Assert.Single(styles);
 
             var style = (Style)styles[0];
 
@@ -405,13 +405,13 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             var styles = AvaloniaXamlLoader.Parse<Styles>(xaml);
 
-            Assert.Equal(1, styles.Count);
+            Assert.Single(styles);
 
             var style = (Style)styles[0];
 
             var setters = style.Setters.Cast<Setter>().ToArray();
 
-            Assert.Equal(1, setters.Length);
+            Assert.Single(setters);
 
             Assert.Equal(TextBlock.FontSizeProperty, setters[0].Property);
             Assert.Equal(21.0, setters[0].Value);
@@ -459,7 +459,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 ";
                 var styles = AvaloniaXamlLoader.Parse<Styles>(xaml);
 
-                Assert.Equal(1, styles.Count);
+                Assert.Single(styles);
 
                 var style = (Style)styles[0];
 
@@ -688,7 +688,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             var style = AvaloniaXamlLoader.Parse<Style>(xaml);
 
-            Assert.Equal(1, style.Setters.Count());
+            Assert.Single(style.Setters);
 
             var setter = (Setter)style.Setters.First();
 

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
@@ -76,7 +76,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
                 var window = AvaloniaXamlLoader.Parse<ContentControl>(xaml);
 
-                Assert.Equal(1, window.Styles.Count);
+                Assert.Single(window.Styles);
 
                 var styleInclude = window.Styles[0] as StyleInclude;
 

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_Template.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_Template.cs
@@ -133,7 +133,7 @@ namespace Avalonia.Styling.UnitTests
 
             using (activator.Subscribe(_ => { }))
             {
-                Assert.Equal(1, inccDebug.GetCollectionChangedSubscribers().Length);
+                Assert.Single(inccDebug.GetCollectionChangedSubscribers());
             }
 
             Assert.Null(inccDebug.GetCollectionChangedSubscribers());

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests_Layers.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests_Layers.cs
@@ -70,11 +70,11 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
                 Assert.Same(tree, rootNode.LayerRoot);
                 Assert.Same(tree, borderNode.LayerRoot);
                 Assert.Same(tree, canvasNode.LayerRoot);
-                Assert.Equal(1, scene.Layers.Count());
+                Assert.Single(scene.Layers);
 
                 var rootDirty = scene.Layers[tree].Dirty;
 
-                Assert.Equal(1, rootDirty.Count());
+                Assert.Single(rootDirty);
                 Assert.Equal(new Rect(21, 21, 58, 78), rootDirty.Single());
             }
         }
@@ -136,11 +136,11 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
                 Assert.Same(tree, rootNode.LayerRoot);
                 Assert.Same(tree, borderNode.LayerRoot);
                 Assert.Same(tree, canvasNode.LayerRoot);
-                Assert.Equal(1, scene.Layers.Count());
+                Assert.Single(scene.Layers);
 
                 var rootDirty = scene.Layers[tree].Dirty;
 
-                Assert.Equal(1, rootDirty.Count());
+                Assert.Single(rootDirty);
                 Assert.Equal(new Rect(21, 21, 58, 78), rootDirty.Single());
             }
         }

--- a/tests/Avalonia.Visuals.UnitTests/VisualTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/VisualTests.cs
@@ -190,7 +190,7 @@ namespace Avalonia.Visuals.UnitTests
             root1.Child = child;
 
             Assert.Throws<InvalidOperationException>(() => root2.Child = child);
-            Assert.Equal(0, root2.GetVisualChildren().Count());
+            Assert.Empty(root2.GetVisualChildren());
         }
     }
 }


### PR DESCRIPTION
xunit was giving us a load of warnings that we were using its `Assert`s incorrectly. Ran the code fixes that the analyzer provides to fix them.