### PR TITLE
Added AppBuilder methods for logging.

### DIFF
--- a/Avalonia.sln
+++ b/Avalonia.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.10
+VisualStudioVersion = 15.0.27004.2008
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Base", "src\Avalonia.Base\Avalonia.Base.csproj", "{B09B78D8-9B26-48B0-9149-D64A2F120F3F}"
 EndProject
@@ -155,7 +155,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Props", "Props", "{F3AC8BC1
 		build\ReactiveUI.props = build\ReactiveUI.props
 		build\Rx.props = build\Rx.props
 		build\Serilog.props = build\Serilog.props
-		build\Serilog.Sinks.Trace.props = build\Serilog.Sinks.Trace.props
 		build\SharpDX.props = build\SharpDX.props
 		build\SkiaSharp.Desktop.props = build\SkiaSharp.Desktop.props
 		build\SkiaSharp.props = build\SkiaSharp.props

--- a/build/Serilog.Sinks.Trace.props
+++ b/build/Serilog.Sinks.Trace.props
@@ -1,5 +1,0 @@
-﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-     <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
-  </ItemGroup>
-</Project>

--- a/build/Serilog.props
+++ b/build/Serilog.props
@@ -1,5 +1,7 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-     <PackageReference Include="Serilog" Version="2.4.0" />
+    <PackageReference Include="Serilog" Version="2.5.0" />
+    <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/packages.cake
+++ b/packages.cake
@@ -243,6 +243,8 @@ public class Packages
                 Dependencies = new DependencyBuilder(this)
                 {
                     new NuSpecDependency() { Id = "Serilog", Version = SerilogVersion },
+                    new NuSpecDependency() { Id = "Serilog.Sinks.Debug", Version = "1.0.0" },
+                    new NuSpecDependency() { Id = "Serilog.Sinks.Trace", Version = "2.1.0" },
                     new NuSpecDependency() { Id = "Sprache", Version = SpracheVersion },
                     new NuSpecDependency() { Id = "System.Reactive", Version = SystemReactiveVersion },
                     new NuSpecDependency() { Id = "Avalonia.Remote.Protocol", Version = parameters.Version },
@@ -251,6 +253,8 @@ public class Packages
                     new NuSpecDependency() { Id = "Microsoft.Extensions.DependencyModel", TargetFramework = "netcoreapp2.0", Version = "1.1.0" },
                     new NuSpecDependency() { Id = "NETStandard.Library", TargetFramework = "netcoreapp2.0", Version = "1.6.0" },
                     new NuSpecDependency() { Id = "Serilog", TargetFramework = "netcoreapp2.0", Version = SerilogVersion },
+                    new NuSpecDependency() { Id = "Serilog.Sinks.Debug", TargetFramework = "netcoreapp2.0", VersionVersion = "1.0.0" },
+                    new NuSpecDependency() { Id = "Serilog.Sinks.Trace", TargetFramework = "netcoreapp2.0", VersionVersion = "2.1.0" },
                     new NuSpecDependency() { Id = "Sprache", TargetFramework = "netcoreapp2.0", Version = SpracheVersion },
                     new NuSpecDependency() { Id = "System.Reactive", TargetFramework = "netcoreapp2.0", Version = SystemReactiveVersion },
                     new NuSpecDependency() { Id = "Avalonia.Remote.Protocol", TargetFramework = "netcoreapp2.0", Version = parameters.Version },

--- a/packages.cake
+++ b/packages.cake
@@ -107,6 +107,8 @@ public class Packages
         context.Information("Setting NuGet package dependencies versions:");
 
         var SerilogVersion = packageVersions["Serilog"].FirstOrDefault().Item1;
+        var SerilogSinksDebugVersion = packageVersions["Serilog.Sinks.Debug"].FirstOrDefault().Item1;
+        var SerilogSinksTraceVersion = packageVersions["Serilog.Sinks.Trace"].FirstOrDefault().Item1;
         var SpracheVersion = packageVersions["Sprache"].FirstOrDefault().Item1;
         var SystemReactiveVersion = packageVersions["System.Reactive"].FirstOrDefault().Item1;
         var ReactiveUIVersion = packageVersions["reactiveui"].FirstOrDefault().Item1;
@@ -243,8 +245,8 @@ public class Packages
                 Dependencies = new DependencyBuilder(this)
                 {
                     new NuSpecDependency() { Id = "Serilog", Version = SerilogVersion },
-                    new NuSpecDependency() { Id = "Serilog.Sinks.Debug", Version = "1.0.0" },
-                    new NuSpecDependency() { Id = "Serilog.Sinks.Trace", Version = "2.1.0" },
+                    new NuSpecDependency() { Id = "Serilog.Sinks.Debug", Version = SerilogSinksDebugVersion },
+                    new NuSpecDependency() { Id = "Serilog.Sinks.Trace", Version = SerilogSinksTraceVersion },
                     new NuSpecDependency() { Id = "Sprache", Version = SpracheVersion },
                     new NuSpecDependency() { Id = "System.Reactive", Version = SystemReactiveVersion },
                     new NuSpecDependency() { Id = "Avalonia.Remote.Protocol", Version = parameters.Version },
@@ -253,8 +255,8 @@ public class Packages
                     new NuSpecDependency() { Id = "Microsoft.Extensions.DependencyModel", TargetFramework = "netcoreapp2.0", Version = "1.1.0" },
                     new NuSpecDependency() { Id = "NETStandard.Library", TargetFramework = "netcoreapp2.0", Version = "1.6.0" },
                     new NuSpecDependency() { Id = "Serilog", TargetFramework = "netcoreapp2.0", Version = SerilogVersion },
-                    new NuSpecDependency() { Id = "Serilog.Sinks.Debug", TargetFramework = "netcoreapp2.0", VersionVersion = "1.0.0" },
-                    new NuSpecDependency() { Id = "Serilog.Sinks.Trace", TargetFramework = "netcoreapp2.0", VersionVersion = "2.1.0" },
+                    new NuSpecDependency() { Id = "Serilog.Sinks.Debug", TargetFramework = "netcoreapp2.0", Version = SerilogSinksDebugVersion },
+                    new NuSpecDependency() { Id = "Serilog.Sinks.Trace", TargetFramework = "netcoreapp2.0", Version = SerilogSinksTraceVersion },
                     new NuSpecDependency() { Id = "Sprache", TargetFramework = "netcoreapp2.0", Version = SpracheVersion },
                     new NuSpecDependency() { Id = "System.Reactive", TargetFramework = "netcoreapp2.0", Version = SystemReactiveVersion },
                     new NuSpecDependency() { Id = "Avalonia.Remote.Protocol", TargetFramework = "netcoreapp2.0", Version = parameters.Version },

--- a/samples/BindingTest/App.xaml.cs
+++ b/samples/BindingTest/App.xaml.cs
@@ -16,22 +16,11 @@ namespace BindingTest
 
         private static void Main()
         {
-            InitializeLogging();
-
             AppBuilder.Configure<App>()
                 .UsePlatformDetect()
                 .UseReactiveUI()
+                .LogToDebug()
                 .Start<MainWindow>();
-        }
-
-        private static void InitializeLogging()
-        {
-#if DEBUG
-            SerilogLogger.Initialize(new LoggerConfiguration()
-                .MinimumLevel.Warning()
-                .WriteTo.Trace(outputTemplate: "{Area}: {Message}")
-                .CreateLogger());
-#endif
         }
     }
 }

--- a/samples/BindingTest/BindingTest.csproj
+++ b/samples/BindingTest/BindingTest.csproj
@@ -151,7 +151,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\build\Serilog.props" />
-  <Import Project="..\..\build\Serilog.Sinks.Trace.props" />
   <Import Project="..\..\build\Rx.props" />
   <Import Project="..\..\build\ReactiveUI.props" />
 </Project>

--- a/samples/ControlCatalog.Desktop/ControlCatalog.Desktop.csproj
+++ b/samples/ControlCatalog.Desktop/ControlCatalog.Desktop.csproj
@@ -135,5 +135,4 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\build\Serilog.props" />
   <Import Project="..\..\build\SkiaSharp.props" />
-  <Import Project="..\..\build\Serilog.Sinks.Trace.props" />
 </Project>

--- a/samples/ControlCatalog.Desktop/Program.cs
+++ b/samples/ControlCatalog.Desktop/Program.cs
@@ -12,8 +12,6 @@ namespace ControlCatalog
     {
         static void Main(string[] args)
         {
-            InitializeLogging();
-
             // TODO: Make this work with GTK/Skia/Cairo depending on command-line args
             // again.
             BuildAvaloniaApp().Start<MainWindow>();
@@ -23,18 +21,7 @@ namespace ControlCatalog
         /// This method is needed for IDE previewer infrastructure
         /// </summary>
         public static AppBuilder BuildAvaloniaApp()
-            => AppBuilder.Configure<App>().UsePlatformDetect();
-
-        // This will be made into a runtime configuration extension soon!
-        private static void InitializeLogging()
-        {
-#if DEBUG
-            SerilogLogger.Initialize(new LoggerConfiguration()
-                .MinimumLevel.Warning()
-                .WriteTo.Trace(outputTemplate: "{Area}: {Message}")
-                .CreateLogger());
-#endif
-        }
+            => AppBuilder.Configure<App>().LogToDebug().UsePlatformDetect();
 
         private static void ConfigureAssetAssembly(AppBuilder builder)
         {

--- a/samples/RenderTest/Program.cs
+++ b/samples/RenderTest/Program.cs
@@ -12,25 +12,13 @@ namespace RenderTest
     {
         static void Main(string[] args)
         {
-            InitializeLogging();
-
             // TODO: Make this work with GTK/Skia/Cairo depending on command-line args
             // again.
             AppBuilder.Configure<App>()
                 .UsePlatformDetect()
                 .UseReactiveUI()
+                .LogToDebug()
                 .Start<MainWindow>();
-        }
-
-        // This will be made into a runtime configuration extension soon!
-        private static void InitializeLogging()
-        {
-#if DEBUG
-            SerilogLogger.Initialize(new LoggerConfiguration()
-                .MinimumLevel.Warning()
-                .WriteTo.Trace(outputTemplate: "{Area}: {Message}")
-                .CreateLogger());
-#endif
         }
     }
 }

--- a/samples/RenderTest/RenderTest.csproj
+++ b/samples/RenderTest/RenderTest.csproj
@@ -180,7 +180,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\build\Serilog.props" />
-  <Import Project="..\..\build\Serilog.Sinks.Trace.props" />
   <Import Project="..\..\build\Rx.props" />
   <Import Project="..\..\build\ReactiveUI.props" />
 </Project>

--- a/samples/VirtualizationTest/Program.cs
+++ b/samples/VirtualizationTest/Program.cs
@@ -13,22 +13,11 @@ namespace VirtualizationTest
     {
         static void Main(string[] args)
         {
-            InitializeLogging();
-
             AppBuilder.Configure<App>()
                .UsePlatformDetect()
                .UseReactiveUI()
+               .LogToDebug()
                .Start<MainWindow>();
-        }
-
-        private static void InitializeLogging()
-        {
-#if DEBUG
-            SerilogLogger.Initialize(new LoggerConfiguration()
-                .MinimumLevel.Warning()
-                .WriteTo.Trace(outputTemplate: "{Area}: {Message}")
-                .CreateLogger());
-#endif
         }
     }
 }

--- a/samples/VirtualizationTest/VirtualizationTest.csproj
+++ b/samples/VirtualizationTest/VirtualizationTest.csproj
@@ -147,7 +147,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\build\Serilog.props" />
-  <Import Project="..\..\build\Serilog.Sinks.Trace.props" />
   <Import Project="..\..\build\Rx.props" />
   <Import Project="..\..\build\ReactiveUI.props" />
 </Project>

--- a/samples/interop/Direct3DInteropSample/Direct3DInteropSample.csproj
+++ b/samples/interop/Direct3DInteropSample/Direct3DInteropSample.csproj
@@ -28,6 +28,5 @@
         <ProjectReference Include="..\..\..\src\Windows\Avalonia.Win32\Avalonia.Win32.csproj" />
     </ItemGroup>
     <Import Project="..\..\..\build\Serilog.props" />
-    <Import Project="..\..\..\build\Serilog.Sinks.Trace.props" />
     <Import Project="..\..\..\build\Rx.props" />
 </Project>

--- a/src/Avalonia.Logging.Serilog/Avalonia.Logging.Serilog.csproj
+++ b/src/Avalonia.Logging.Serilog/Avalonia.Logging.Serilog.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Avalonia.Base\Avalonia.Base.csproj" />
+    <ProjectReference Include="..\Avalonia.Controls\Avalonia.Controls.csproj" />
   </ItemGroup>
   <Import Project="..\..\build\Serilog.props" />
 </Project>

--- a/src/Avalonia.Logging.Serilog/SerilogExtensions.cs
+++ b/src/Avalonia.Logging.Serilog/SerilogExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Avalonia.Controls;
+using Serilog;
+using SerilogLevel = Serilog.Events.LogEventLevel;
+
+namespace Avalonia.Logging.Serilog
+{
+    /// <summary>
+    /// Extension methods for Serilog logging.
+    /// </summary>
+    public static class SerilogExtensions
+    {
+        /// <summary>
+        /// Logs Avalonia events to the <see cref="System.Diagnostics.Debug"/> sink.
+        /// </summary>
+        /// <typeparam name="T">The application class type.</typeparam>
+        /// <param name="builder">The app builder instance.</param>
+        /// <param name="level">The minimum level to log.</param>
+        /// <returns>The app builder instance.</returns>
+        public static T LogToDebug<T>(
+            this T builder,
+            LogEventLevel level = LogEventLevel.Warning)
+                where T : AppBuilderBase<T>, new()
+        {
+            SerilogLogger.Initialize(new LoggerConfiguration()
+                .MinimumLevel.Is((SerilogLevel)level)
+                .WriteTo.Debug(outputTemplate: "{Area}: {Message}")
+                .CreateLogger());
+            return builder;
+        }
+
+        /// <summary>
+        /// Logs Avalonia events to the <see cref="System.Diagnostics.Trace"/> sink.
+        /// </summary>
+        /// <typeparam name="T">The application class type.</typeparam>
+        /// <param name="builder">The app builder instance.</param>
+        /// <param name="level">The minimum level to log.</param>
+        /// <returns>The app builder instance.</returns>
+        public static T LogToTrace<T>(
+            this T builder,
+            LogEventLevel level = LogEventLevel.Warning)
+                where T : AppBuilderBase<T>, new()
+        {
+            SerilogLogger.Initialize(new LoggerConfiguration()
+                .MinimumLevel.Is((SerilogLevel)level)
+                .WriteTo.Trace(outputTemplate: "{Area}: {Message}")
+                .CreateLogger());
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
You can now set up serilog logging to `Debug` or `Trace` by calling e.g.:

```
AppBuilder.Configure<App()
    .LogToDebug()
    .UsePlatformDetect();
```

The methods accept an optional `level` parameter to control the minimum log level.