### PR TITLE
Make AttachDevTools conditional for Debug builds.

### DIFF
--- a/src/Avalonia.Diagnostics/DevTools.xaml.cs
+++ b/src/Avalonia.Diagnostics/DevTools.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Linq;
 using Avalonia.Controls;
@@ -16,11 +17,12 @@ namespace Avalonia
 {
 	public static class DevToolsExtensions
 	{
-		public static void AttachDevTools(this TopLevel control)
+        [Conditional("DEBUG")]
+        public static void AttachDevTools(this TopLevel control)
 		{
 			Avalonia.Diagnostics.DevTools.Attach(control);
 		}
-	}
+    }
 }
 
 namespace Avalonia.Diagnostics

--- a/src/Avalonia.Diagnostics/DevTools.xaml.cs
+++ b/src/Avalonia.Diagnostics/DevTools.xaml.cs
@@ -19,9 +19,9 @@ namespace Avalonia
 	{
         [Conditional("DEBUG")]
         public static void AttachDevTools(this TopLevel control)
-		{
-			Avalonia.Diagnostics.DevTools.Attach(control);
-		}
+        {
+            Avalonia.Diagnostics.DevTools.Attach(control);
+        }
     }
 }
 


### PR DESCRIPTION
In our [templates](https://github.com/AvaloniaUI/AvaloniaVS/blob/677d0e0b137c8952142520557028c29549ee4bb8/src/Templates/AvaloniaApplicationTemplate/App.xaml.cs#L29) we define an `App.AttachDevTools` method which conditionally enables dev tools in debug mode. This PR adds a `[Conditional("DEBUG")]` attribute to the `TopLevel.AttachDevTools` extension method to automatically only enable dev tools in debug builds.

If the user wants to enable dev tools in all builds, they can simply call what `AttachDevTools` calls, i.e. `Avalonia.Diagnostics.DevTools.Attach(control);`.

The aim of this is to make our templates simpler while still providing the most useful behavior.