### PR TITLE
Make sure old adorner is removed.

### DIFF
--- a/src/Avalonia.Diagnostics/Views/TreePage.xaml.cs
+++ b/src/Avalonia.Diagnostics/Views/TreePage.xaml.cs
@@ -27,6 +27,12 @@ namespace Avalonia.Diagnostics.Views
 
             if (layer != null)
             {
+                if (_adorner != null)
+                {
+                    ((Panel)_adorner.Parent).Children.Remove(_adorner);
+                    _adorner = null;
+                }
+
                 _adorner = new Rectangle
                 {
                     Fill = new SolidColorBrush(0x80a0c5e8),


### PR DESCRIPTION
Control enter/leave events seem to sometimes get raised in the wrong order, this needs investigation. However in the meantime, make sure that if there's an existing adorner it's removed before adding a new one.

Fixes #1299