### PR TITLE
Don't pass a null Path to Binding in TemplateBindingExtension.

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/TemplateBindingExtension.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/TemplateBindingExtension.cs
@@ -29,7 +29,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
                 ElementName = ElementName,
                 Mode = Mode,
                 RelativeSource = new RelativeSource(RelativeSourceMode.TemplatedParent),
-                Path = Path,
+                Path = Path ?? string.Empty,
                 Priority = Priority,
             };
         }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests.cs
@@ -13,6 +13,7 @@ using Moq;
 using Xunit;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using Avalonia.UnitTests;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Data
 {
@@ -335,6 +336,28 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
             target[!ContentControl.ContentProperty] = new Binding("Foo");
 
             Assert.Equal("foo", target.Content);
+        }
+
+        [Fact]
+        public void Binding_With_Null_Path_Works()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <TextBlock Name='textBlock' Text='{Binding}'/>
+</Window>";
+                var loader = new AvaloniaXamlLoader();
+                var window = (Window)loader.Load(xaml);
+                var textBlock = window.FindControl<TextBlock>("textBlock");
+
+                window.DataContext = "foo";
+                window.ApplyTemplate();
+
+                Assert.Equal("foo", textBlock.Text);
+            }
         }
 
         private class TwoWayBindingTest : Control

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests_TemplatedParent.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests_TemplatedParent.cs
@@ -11,6 +11,9 @@ using Avalonia.Markup.Xaml.Data;
 using Avalonia.Styling;
 using Xunit;
 using System.Reactive.Disposables;
+using Avalonia.UnitTests;
+using Avalonia.VisualTree;
+using System.Linq;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Data
 {
@@ -54,6 +57,35 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
                 TextBox.TextProperty,
                 It.IsAny<ISubject<object>>(),
                 BindingPriority.TemplatedParent));
+        }
+
+        [Fact]
+        public void TemplateBinding_With_Null_Path_Works()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <Button Name='button'>
+       <Button.Template>
+         <ControlTemplate>
+           <TextBlock Text='{TemplateBinding}'/>
+         </ControlTemplate>
+       </Button.Template>
+    </Button>
+</Window>";
+                var loader = new AvaloniaXamlLoader();
+                var window = (Window)loader.Load(xaml);
+                var button = window.FindControl<Button>("button");
+
+                window.ApplyTemplate();
+                button.ApplyTemplate();
+
+                var textBlock = (TextBlock)button.GetVisualChildren().Single();
+                Assert.Equal("Avalonia.Controls.Button", textBlock.Text);
+            }
         }
 
         private Mock<IControl> CreateTarget(


### PR DESCRIPTION
#1209 broke `{TemplateBinding}` without a path.

Fixes #1303 
