### PR TITLE
Only create render layers when Opacity is animating.

### DIFF
--- a/.ncrunch/Avalonia.Direct2D1.RenderTests.v3.ncrunchproject
+++ b/.ncrunch/Avalonia.Direct2D1.RenderTests.v3.ncrunchproject
@@ -1,7 +1,6 @@
 ﻿<ProjectConfiguration>
   <Settings>
-    <DefaultTestTimeout>1000</DefaultTestTimeout>
-    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+    <DefaultTestTimeout>3000</DefaultTestTimeout>
     <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
   </Settings>
 </ProjectConfiguration>

--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -226,6 +226,19 @@ namespace Avalonia
         }
 
         /// <summary>
+        /// Checks whether a <see cref="AvaloniaProperty"/> is animating.
+        /// </summary>
+        /// <param name="property">The property.</param>
+        /// <returns>True if the property is animating, otherwise false.</returns>
+        public bool IsAnimating(AvaloniaProperty property)
+        {
+            Contract.Requires<ArgumentNullException>(property != null);
+            VerifyAccess();
+
+            return _values.TryGetValue(property, out PriorityValue value) ? value.IsAnimating : false;
+        }
+
+        /// <summary>
         /// Checks whether a <see cref="AvaloniaProperty"/> is set on this object.
         /// </summary>
         /// <param name="property">The property.</param>

--- a/src/Avalonia.Base/IAvaloniaObject.cs
+++ b/src/Avalonia.Base/IAvaloniaObject.cs
@@ -32,6 +32,13 @@ namespace Avalonia
         T GetValue<T>(AvaloniaProperty<T> property);
 
         /// <summary>
+        /// Checks whether a <see cref="AvaloniaProperty"/> is animating.
+        /// </summary>
+        /// <param name="property">The property.</param>
+        /// <returns>True if the property is animating, otherwise false.</returns>
+        bool IsAnimating(AvaloniaProperty property);
+
+        /// <summary>
         /// Checks whether a <see cref="AvaloniaProperty"/> is set on this object.
         /// </summary>
         /// <param name="property">The property.</param>

--- a/src/Avalonia.Base/PriorityValue.cs
+++ b/src/Avalonia.Base/PriorityValue.cs
@@ -52,7 +52,17 @@ namespace Avalonia
             _validate = validate;
         }
 
-        public bool IsAnimating => ValuePriority < 0 && GetLevel(ValuePriority).ActiveBindingIndex != -1;
+        /// <summary>
+        /// Gets a value indicating whether the property is animating.
+        /// </summary>
+        public bool IsAnimating
+        {
+            get
+            {
+                return ValuePriority <= (int)BindingPriority.Animation && 
+                    GetLevel(ValuePriority).ActiveBindingIndex != -1;
+            }
+        }
 
         /// <summary>
         /// Gets the owner of the value.

--- a/src/Avalonia.Base/PriorityValue.cs
+++ b/src/Avalonia.Base/PriorityValue.cs
@@ -52,6 +52,8 @@ namespace Avalonia
             _validate = validate;
         }
 
+        public bool IsAnimating => ValuePriority < 0 && GetLevel(ValuePriority).ActiveBindingIndex != -1;
+
         /// <summary>
         /// Gets the owner of the value.
         /// </summary>

--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -235,7 +235,7 @@ namespace Avalonia.Rendering
             {
                 clipBounds = node.ClipBounds.Intersect(clipBounds);
 
-                if (!clipBounds.IsEmpty)
+                if (!clipBounds.IsEmpty && node.Opacity > 0)
                 {
                     node.BeginRender(context);
 
@@ -353,7 +353,6 @@ namespace Avalonia.Rendering
 
             if (DrawFps)
             {
-                RenderFps(context, clientRect, true);
                 RenderFps(context, clientRect, scene.Layers.Count);
             }
         }

--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -354,6 +354,7 @@ namespace Avalonia.Rendering
             if (DrawFps)
             {
                 RenderFps(context, clientRect, true);
+                RenderFps(context, clientRect, scene.Layers.Count);
             }
         }
 

--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -25,7 +25,6 @@ namespace Avalonia.Rendering
         private readonly IRenderLoop _renderLoop;
         private readonly IVisual _root;
         private readonly ISceneBuilder _sceneBuilder;
-        private readonly RenderLayers _layers;
 
         private bool _running;
         private Scene _scene;
@@ -56,7 +55,7 @@ namespace Avalonia.Rendering
             _dispatcher = dispatcher ?? Dispatcher.UIThread;
             _root = root;
             _sceneBuilder = sceneBuilder ?? new SceneBuilder();
-            _layers = new RenderLayers();
+            Layers = new RenderLayers();
             _renderLoop = renderLoop;
         }
 
@@ -80,7 +79,7 @@ namespace Avalonia.Rendering
             _root = root;
             _renderTarget = renderTarget;
             _sceneBuilder = sceneBuilder ?? new SceneBuilder();
-            _layers = new RenderLayers();
+            Layers = new RenderLayers();
         }
 
         /// <inheritdoc/>
@@ -93,6 +92,11 @@ namespace Avalonia.Rendering
         /// Gets or sets a path to which rendered frame should be rendered for debugging.
         /// </summary>
         public string DebugFramesPath { get; set; }
+
+        /// <summary>
+        /// Gets the render layers.
+        /// </summary>
+        internal RenderLayers Layers { get; }
 
         /// <inheritdoc/>
         public void AddDirty(IVisual visual)
@@ -192,7 +196,7 @@ namespace Avalonia.Rendering
                     if (scene.Generation != _lastSceneId)
                     {
                         context = _renderTarget.CreateDrawingContext(this);
-                        _layers.Update(scene, context);
+                        Layers.Update(scene, context);
 
                         RenderToLayers(scene);
 
@@ -262,7 +266,7 @@ namespace Avalonia.Rendering
             {
                 foreach (var layer in scene.Layers)
                 {
-                    var renderTarget = _layers[layer.LayerRoot].Bitmap;
+                    var renderTarget = Layers[layer.LayerRoot].Bitmap;
                     var node = (VisualNode)scene.FindNode(layer.LayerRoot);
 
                     if (node != null)
@@ -322,7 +326,7 @@ namespace Avalonia.Rendering
 
             foreach (var layer in scene.Layers)
             {
-                var bitmap = _layers[layer.LayerRoot].Bitmap;
+                var bitmap = Layers[layer.LayerRoot].Bitmap;
                 var sourceRect = new Rect(0, 0, bitmap.PixelWidth, bitmap.PixelHeight);
 
                 if (layer.GeometryClip != null)
@@ -442,7 +446,7 @@ namespace Avalonia.Rendering
         {
             var index = 0;
 
-            foreach (var layer in _layers)
+            foreach (var layer in Layers)
             {
                 var fileName = Path.Combine(DebugFramesPath, $"frame-{id}-layer-{index++}.png");
                 layer.Bitmap.Save(fileName);

--- a/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
@@ -69,7 +69,7 @@ namespace Avalonia.Rendering
 
                     if (DrawFps)
                     {
-                        RenderFps(context.PlatformImpl, _root.Bounds, true);
+                        RenderFps(context.PlatformImpl, _root.Bounds, null);
                     }
                 }
             }

--- a/src/Avalonia.Visuals/Rendering/RendererBase.cs
+++ b/src/Avalonia.Visuals/Rendering/RendererBase.cs
@@ -22,15 +22,12 @@ namespace Avalonia.Rendering
             };
         }
 
-        protected void RenderFps(IDrawingContextImpl context, Rect clientRect, bool incrementFrameCount)
+        protected void RenderFps(IDrawingContextImpl context, Rect clientRect, int? layerCount)
         {
             var now = _stopwatch.Elapsed;
             var elapsed = now - _lastFpsUpdate;
 
-            if (incrementFrameCount)
-            {
-                ++_framesThisSecond;
-            }
+            ++_framesThisSecond;
 
             if (elapsed.TotalSeconds > 1)
             {
@@ -39,7 +36,15 @@ namespace Avalonia.Rendering
                 _lastFpsUpdate = now;
             }
 
-            _fpsText.Text = string.Format("FPS: {0:000}", _fps);
+            if (layerCount.HasValue)
+            {
+                _fpsText.Text = string.Format("Layers: {0} FPS: {1:000}", layerCount, _fps);
+            }
+            else
+            {
+                _fpsText.Text = string.Format("FPS: {0:000}", _fps);
+            }
+
             var size = _fpsText.Measure();
             var rect = new Rect(clientRect.Right - size.Width, 0, size.Width, size.Height);
 

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/IVisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/IVisualNode.cs
@@ -72,13 +72,15 @@ namespace Avalonia.Rendering.SceneGraph
         /// Sets up the drawing context for rendering the node's geometry.
         /// </summary>
         /// <param name="context">The drawing context.</param>
-        void BeginRender(IDrawingContextImpl context);
+        /// <param name="skipOpacity">Whether to skip pushing the control's opacity.</param>
+        void BeginRender(IDrawingContextImpl context, bool skipOpacity);
 
         /// <summary>
         /// Resets the drawing context after rendering the node's geometry.
         /// </summary>
         /// <param name="context">The drawing context.</param>
-        void EndRender(IDrawingContextImpl context);
+        /// <param name="skipOpacity">Whether to skip popping the control's opacity.</param>
+        void EndRender(IDrawingContextImpl context, bool skipOpacity);
 
         /// <summary>
         /// Hit test the geometry in this node.

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -167,7 +167,6 @@ namespace Avalonia.Rendering.SceneGraph
                 using (context.PushPostTransform(m))
                 using (context.PushTransformContainer())
                 {
-                    var startLayer = (visual as IAvaloniaObject)?.IsAnimating(Visual.OpacityProperty) ?? false;
                     var clipBounds = bounds.TransformToAABB(contextImpl.Transform).Intersect(clip);
 
                     forceRecurse = forceRecurse ||
@@ -181,7 +180,7 @@ namespace Avalonia.Rendering.SceneGraph
                     node.Opacity = opacity;
                     node.OpacityMask = visual.OpacityMask;
 
-                    if (startLayer)
+                    if (ShouldStartLayer(visual))
                     {
                         if (node.LayerRoot != visual)
                         {
@@ -364,6 +363,14 @@ namespace Avalonia.Rendering.SceneGraph
                     PropagateLayer(child, layer, oldLayer);
                 }
             }
+        }
+
+        private static bool ShouldStartLayer(IVisual visual)
+        {
+            var o = visual as IAvaloniaObject;
+            return visual.VisualChildren.Count > 0 &&
+                o != null &&
+                o.IsAnimating(Visual.OpacityProperty);
         }
 
         private static IGeometryImpl CreateLayerGeometryClip(VisualNode node)

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -167,7 +167,7 @@ namespace Avalonia.Rendering.SceneGraph
                 using (context.PushPostTransform(m))
                 using (context.PushTransformContainer())
                 {
-                    var startLayer = opacity < 1 || visual.OpacityMask != null;
+                    var startLayer = (visual as IAvaloniaObject)?.IsAnimating(Visual.OpacityProperty) ?? false;
                     var clipBounds = bounds.TransformToAABB(contextImpl.Transform).Intersect(clip);
 
                     forceRecurse = forceRecurse ||

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -178,7 +178,9 @@ namespace Avalonia.Rendering.SceneGraph
                     node.ClipToBounds = clipToBounds;
                     node.GeometryClip = visual.Clip?.PlatformImpl;
                     node.Opacity = opacity;
-                    node.OpacityMask = visual.OpacityMask;
+
+                    // TODO: Check equality between node.OpacityMask and visual.OpacityMask before assigning.
+                    node.OpacityMask = visual.OpacityMask?.ToImmutable();
 
                     if (ShouldStartLayer(visual))
                     {

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
@@ -226,6 +226,11 @@ namespace Avalonia.Rendering.SceneGraph
                 context.PushClip(ClipBounds);
             }
 
+            if (Opacity != 1)
+            {
+                context.PushOpacity(Opacity);
+            }
+
             context.Transform = Transform;
 
             if (GeometryClip != null)
@@ -240,6 +245,11 @@ namespace Avalonia.Rendering.SceneGraph
             if (GeometryClip != null)
             {
                 context.PopGeometryClip();
+            }
+
+            if (Opacity != 1)
+            {
+                context.PopOpacity();
             }
 
             if (ClipToBounds)

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
@@ -218,15 +218,15 @@ namespace Avalonia.Rendering.SceneGraph
         }
 
         /// <inheritdoc/>
-        public void BeginRender(IDrawingContextImpl context)
+        public void BeginRender(IDrawingContextImpl context, bool skipOpacity)
         {
             if (ClipToBounds)
             {
                 context.Transform = Matrix.Identity;
                 context.PushClip(ClipBounds);
             }
-
-            if (Opacity != 1)
+            
+            if (Opacity != 1 && !skipOpacity)
             {
                 context.PushOpacity(Opacity);
             }
@@ -240,14 +240,14 @@ namespace Avalonia.Rendering.SceneGraph
         }
 
         /// <inheritdoc/>
-        public void EndRender(IDrawingContextImpl context)
+        public void EndRender(IDrawingContextImpl context, bool skipOpacity)
         {
             if (GeometryClip != null)
             {
                 context.PopGeometryClip();
             }
 
-            if (Opacity != 1)
+            if (Opacity != 1 && !skipOpacity)
             {
                 context.PopOpacity();
             }

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
@@ -231,6 +231,11 @@ namespace Avalonia.Rendering.SceneGraph
                 context.PushOpacity(Opacity);
             }
 
+            if (OpacityMask != null)
+            {
+                context.PushOpacityMask(OpacityMask, ClipBounds);
+            }
+
             context.Transform = Transform;
 
             if (GeometryClip != null)
@@ -245,6 +250,11 @@ namespace Avalonia.Rendering.SceneGraph
             if (GeometryClip != null)
             {
                 context.PopGeometryClip();
+            }
+
+            if (OpacityMask != null)
+            {
+                context.PopOpacityMask();
             }
 
             if (Opacity != 1 && !skipOpacity)

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Binding.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Binding.cs
@@ -387,6 +387,46 @@ namespace Avalonia.Base.UnitTests
             }
         }
 
+        [Fact]
+        public void IsAnimating_On_Property_With_No_Value_Returns_False()
+        {
+            var target = new Class1();
+
+            Assert.False(target.IsAnimating(Class1.FooProperty));
+        }
+
+        [Fact]
+        public void IsAnimating_On_Property_With_Animation_Value_Returns_False()
+        {
+            var target = new Class1();
+
+            target.SetValue(Class1.FooProperty, "foo", BindingPriority.Animation);
+
+            Assert.False(target.IsAnimating(Class1.FooProperty));
+        }
+
+        [Fact]
+        public void IsAnimating_On_Property_With_Non_Animation_Binding_Returns_False()
+        {
+            var target = new Class1();
+            var source = new Subject<string>();
+
+            target.Bind(Class1.FooProperty, source, BindingPriority.LocalValue);
+
+            Assert.False(target.IsAnimating(Class1.FooProperty));
+        }
+
+        [Fact]
+        public void IsAnimating_On_Property_With_Animation_Binding_Returns_True()
+        {
+            var target = new Class1();
+            var source = new BehaviorSubject<string>("foo");
+
+            target.Bind(Class1.FooProperty, source, BindingPriority.Animation);
+
+            Assert.True(target.IsAnimating(Class1.FooProperty));
+        }
+
         /// <summary>
         /// Returns an observable that returns a single value but does not complete.
         /// </summary>

--- a/tests/Avalonia.Base.UnitTests/DirectPropertyTests.cs
+++ b/tests/Avalonia.Base.UnitTests/DirectPropertyTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using System.Reactive.Subjects;
 using Avalonia.Data;
 using Xunit;
 
@@ -68,6 +69,17 @@ namespace Avalonia.Base.UnitTests
 
             Assert.Same(p1.Changed, p2.Changed);
             Assert.Same(p1.Initialized, p2.Initialized);
+        }
+
+        [Fact]
+        public void IsAnimating_On_DirectProperty_With_Binding_Returns_False()
+        {
+            var target = new Class1();
+            var source = new BehaviorSubject<string>("foo");
+
+            target.Bind(Class1.FooProperty, source, BindingPriority.Animation);
+
+            Assert.False(target.IsAnimating(Class1.FooProperty));
         }
 
         private class Class1 : AvaloniaObject

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_Child.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_Child.cs
@@ -135,6 +135,11 @@ namespace Avalonia.Styling.UnitTests
                 throw new NotImplementedException();
             }
 
+            public bool IsAnimating(AvaloniaProperty property)
+            {
+                throw new NotImplementedException();
+            }
+
             public bool IsSet(AvaloniaProperty property)
             {
                 throw new NotImplementedException();

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_Descendent.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_Descendent.cs
@@ -165,6 +165,11 @@ namespace Avalonia.Styling.UnitTests
                 throw new NotImplementedException();
             }
 
+            public bool IsAnimating(AvaloniaProperty property)
+            {
+                throw new NotImplementedException();
+            }
+
             public bool IsSet(AvaloniaProperty property)
             {
                 throw new NotImplementedException();

--- a/tests/Avalonia.Styling.UnitTests/TestControlBase.cs
+++ b/tests/Avalonia.Styling.UnitTests/TestControlBase.cs
@@ -59,6 +59,11 @@ namespace Avalonia.Styling.UnitTests
             throw new NotImplementedException();
         }
 
+        public bool IsAnimating(AvaloniaProperty property)
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsSet(AvaloniaProperty property)
         {
             throw new NotImplementedException();

--- a/tests/Avalonia.Styling.UnitTests/TestTemplatedControl.cs
+++ b/tests/Avalonia.Styling.UnitTests/TestTemplatedControl.cs
@@ -67,6 +67,11 @@ namespace Avalonia.Styling.UnitTests
             throw new NotImplementedException();
         }
 
+        public bool IsAnimating(AvaloniaProperty property)
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsSet(AvaloniaProperty property)
         {
             throw new NotImplementedException();

--- a/tests/Avalonia.UnitTests/TestRoot.cs
+++ b/tests/Avalonia.UnitTests/TestRoot.cs
@@ -16,8 +16,6 @@ namespace Avalonia.UnitTests
     public class TestRoot : Decorator, IFocusScope, ILayoutRoot, IInputRoot, INameScope, IRenderRoot, IStyleRoot
     {
         private readonly NameScope _nameScope = new NameScope();
-        private readonly IRenderTarget _renderTarget = Mock.Of<IRenderTarget>(
-            x => x.CreateDrawingContext(It.IsAny<IVisualBrushRenderer>()) == Mock.Of<IDrawingContextImpl>());
 
         public TestRoot()
         {
@@ -65,7 +63,21 @@ namespace Avalonia.UnitTests
 
         IStyleHost IStyleHost.StylingParent => StylingParent;
 
-        public IRenderTarget CreateRenderTarget() => _renderTarget;
+        public IRenderTarget CreateRenderTarget()
+        {
+            var dc = new Mock<IDrawingContextImpl>();
+            dc.Setup(x => x.CreateLayer(It.IsAny<Size>())).Returns(() =>
+            {
+                var layerDc = new Mock<IDrawingContextImpl>();
+                var layer = new Mock<IRenderTargetBitmapImpl>();
+                layer.Setup(x => x.CreateDrawingContext(It.IsAny<IVisualBrushRenderer>())).Returns(layerDc.Object);
+                return layer.Object;
+            });
+
+            var result = new Mock<IRenderTarget>();
+            result.Setup(x => x.CreateDrawingContext(It.IsAny<IVisualBrushRenderer>())).Returns(dc.Object);
+            return result.Object;
+        }
 
         public void Invalidate(Rect rect)
         {

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/DeferredRendererTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/DeferredRendererTests.cs
@@ -261,6 +261,7 @@ namespace Avalonia.Visuals.UnitTests.Rendering
                     Child = border = new Border
                     {
                         Background = Brushes.Green,
+                        Child = new Canvas(),
                     }
                 }
             };

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/DeferredRendererTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/DeferredRendererTests.cs
@@ -166,6 +166,32 @@ namespace Avalonia.Visuals.UnitTests.Rendering
         }
 
         [Fact]
+        public void Should_Push_Opacity_Mask()
+        {
+            var root = new TestRoot
+            {
+                Width = 100,
+                Height = 100,
+                Child = new Border
+                {
+                    Background = Brushes.Red,
+                    OpacityMask = Brushes.Green,
+                }
+            };
+
+            root.Measure(Size.Infinity);
+            root.Arrange(new Rect(root.DesiredSize));
+
+            var target = CreateTargetAndRunFrame(root);
+            var context = GetLayerContext(target, root);
+            var animation = new BehaviorSubject<double>(0.5);
+
+            context.Verify(x => x.PushOpacityMask(Brushes.Green, new Rect(0, 0, 100, 100)), Times.Once);
+            context.Verify(x => x.FillRectangle(Brushes.Red, new Rect(0, 0, 100, 100), 0), Times.Once);
+            context.Verify(x => x.PopOpacityMask(), Times.Once);
+        }
+
+        [Fact]
         public void Should_Create_Layer_For_Root()
         {
             var loop = new Mock<IRenderLoop>();

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests.cs
@@ -9,6 +9,8 @@ using Xunit;
 using Avalonia.Layout;
 using Moq;
 using Avalonia.Platform;
+using System.Reactive.Subjects;
+using Avalonia.Data;
 
 namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
 {
@@ -620,12 +622,14 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
                         Margin = new Thickness(0, 10, 0, 0),
                         Child = border = new Border
                         {
-                            Opacity = 0.5,
                             Background = Brushes.Red,
                             Child = canvas = new Canvas(),
                         }
                     }
                 };
+
+                var animation = new BehaviorSubject<double>(0.5);
+                border.Bind(Border.OpacityProperty, animation, BindingPriority.Animation);
 
                 var scene = new Scene(tree);
                 var sceneBuilder = new SceneBuilder();

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests_Layers.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests_Layers.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
     public partial class SceneBuilderTests
     {
         [Fact]
-        public void Control_With_Animated_Opacity_Should_Start_New_Layer()
+        public void Control_With_Animated_Opacity_And_Children_Should_Start_New_Layer()
         {
             using (TestApplication())
             {
@@ -34,7 +34,7 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
                         {
                             Background = Brushes.Red,
                             Padding = new Thickness(12),
-                            Child = canvas = new Canvas(),
+                            Child = canvas = new Canvas()
                         }
                     }
                 };
@@ -83,6 +83,42 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
         }
 
         [Fact]
+        public void Control_With_Animated_Opacity_And_No_Children_Should_Not_Start_New_Layer()
+        {
+            using (TestApplication())
+            {
+                Decorator decorator;
+                Border border;
+                var tree = new TestRoot
+                {
+                    Padding = new Thickness(10),
+                    Width = 100,
+                    Height = 120,
+                    Child = decorator = new Decorator
+                    {
+                        Padding = new Thickness(11),
+                        Child = border = new Border
+                        {
+                            Background = Brushes.Red,
+                        }
+                    }
+                };
+
+                var layout = AvaloniaLocator.Current.GetService<ILayoutManager>();
+                layout.ExecuteInitialLayoutPass(tree);
+
+                var animation = new BehaviorSubject<double>(0.5);
+                border.Bind(Border.OpacityProperty, animation, BindingPriority.Animation);
+
+                var scene = new Scene(tree);
+                var sceneBuilder = new SceneBuilder();
+                sceneBuilder.UpdateAll(scene);
+
+                Assert.Single(scene.Layers);
+            }
+        }
+
+        [Fact]
         public void Removing_Control_With_Animated_Opacity_Should_Remove_Layers()
         {
             using (TestApplication())
@@ -102,7 +138,10 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
                         {
                             Background = Brushes.Red,
                             Padding = new Thickness(12),
-                            Child = canvas = new Canvas()
+                            Child = canvas = new Canvas
+                            {
+                                Children = { new TextBlock() },
+                            }
                         }
                     }
                 };
@@ -149,7 +188,10 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
                         {
                             Background = Brushes.Red,
                             Padding = new Thickness(12),
-                            Child = canvas = new Canvas(),
+                            Child = canvas = new Canvas
+                            {
+                                Children = { new TextBlock() },
+                            }
                         }
                     }
                 };
@@ -193,6 +235,7 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
                         Child = border = new Border
                         {
                             Opacity = 0.5,
+                            Child = new Canvas(),
                         }
                     }
                 };


### PR DESCRIPTION
- Add `AvaloniaObject.IsAnimating(property)` to allow us to check if a property has an active animation on a property
- Only create a render layer when a property:
  1. Has an animating `Opacity` property _and_
  2. Has child controls
- Don't render controls with 0 opacity

We should also create a new render layer when a control has an animating `RenderTransform` but that would be best to put in a separate PR I think.