### PR TITLE
Implement property aliases (primarily for XAML Standard support).

### DIFF
--- a/src/Avalonia.Base/AliasedProperty.cs
+++ b/src/Avalonia.Base/AliasedProperty.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Avalonia
+{
+    public class AliasedProperty<TValue> : AvaloniaProperty<TValue>, IAliasedPropertyAccessor
+    {
+        public AliasedProperty(AvaloniaProperty<TValue> property, string alias)
+            : base(property, alias) => Property = property;
+
+        public AvaloniaProperty<TValue> Property { get; }
+
+        AvaloniaProperty IAliasedPropertyAccessor.ResolveAlias()
+        {
+            if (Property is IAliasedPropertyAccessor accessor)
+            {
+                return accessor.ResolveAlias();
+            }
+
+            return Property;
+        }
+    }
+}

--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -57,7 +57,8 @@ namespace Avalonia
         public AvaloniaObject()
         {
             VerifyAccess();
-            foreach (var property in AvaloniaPropertyRegistry.Instance.GetRegistered(this))
+            foreach (var property in AvaloniaPropertyRegistry.Instance.GetRegistered(this)
+                .Where(prop => !(prop is IAliasedPropertyAccessor)))
             {
                 object value = property.IsDirect ?
                     ((IDirectPropertyAccessor)property).GetValue(this) :
@@ -197,6 +198,8 @@ namespace Avalonia
             Contract.Requires<ArgumentNullException>(property != null);
             VerifyAccess();
 
+            property = AvaloniaProperty.ResolveAliases(property);
+
             if (property.IsDirect)
             {
                 return ((IDirectPropertyAccessor)GetRegistered(property)).GetValue(this);
@@ -239,9 +242,10 @@ namespace Avalonia
             Contract.Requires<ArgumentNullException>(property != null);
             VerifyAccess();
 
-            PriorityValue value;
+            property = AvaloniaProperty.ResolveAliases(property);
 
-            if (_values.TryGetValue(property, out value))
+
+            if (_values.TryGetValue(property, out PriorityValue value))
             {
                 return value.Value != AvaloniaProperty.UnsetValue;
             }
@@ -262,6 +266,8 @@ namespace Avalonia
         {
             Contract.Requires<ArgumentNullException>(property != null);
             VerifyAccess();
+
+            property = AvaloniaProperty.ResolveAliases(property);
 
             if (property.IsDirect)
             {
@@ -312,7 +318,12 @@ namespace Avalonia
             var description = GetDescription(source);
 
             var scheduler = AvaloniaLocator.Current.GetService<IScheduler>() ?? ImmediateScheduler.Instance;
-            source = source.ObserveOn(scheduler); 
+            source = source.ObserveOn(scheduler);
+
+            if (property is IAliasedPropertyAccessor accessor)
+            {
+                property = accessor.ResolveAlias();
+            }
 
             if (property.IsDirect)
             {
@@ -350,14 +361,13 @@ namespace Avalonia
             }
             else
             {
-                PriorityValue v;
 
                 if (!AvaloniaPropertyRegistry.Instance.IsRegistered(this, property))
                 {
                     ThrowNotRegistered(property);
                 }
 
-                if (!_values.TryGetValue(property, out v))
+                if (!_values.TryGetValue(property, out PriorityValue v))
                 {
                     v = CreatePriorityValue(property);
                     _values.Add(property, v);
@@ -402,9 +412,10 @@ namespace Avalonia
         public void Revalidate(AvaloniaProperty property)
         {
             VerifyAccess();
-            PriorityValue value;
 
-            if (_values.TryGetValue(property, out value))
+            property = AvaloniaProperty.ResolveAliases(property);
+
+            if (_values.TryGetValue(property, out PriorityValue value))
             {
                 value.Revalidate();
             }
@@ -553,6 +564,9 @@ namespace Avalonia
         protected bool SetAndRaise<T>(AvaloniaProperty<T> property, ref T field, T value)
         {
             VerifyAccess();
+
+            property = AvaloniaProperty.ResolveAliases(property);
+
             if (!object.Equals(field, value))
             {
                 var old = field;

--- a/src/Avalonia.Base/AvaloniaProperty.cs
+++ b/src/Avalonia.Base/AvaloniaProperty.cs
@@ -98,6 +98,25 @@ namespace Avalonia
             }
         }
 
+        protected AvaloniaProperty(
+            AvaloniaProperty source,
+            string alias)
+        {
+            Contract.Requires<ArgumentNullException>(source != null);
+            Contract.Requires<ArgumentNullException>(alias != null);
+
+            _initialized = source._initialized;
+            _changed = source._changed;
+            _metadata = new Dictionary<Type, PropertyMetadata>();
+
+            Name = alias;
+            PropertyType = source.PropertyType;
+            OwnerType = source.OwnerType;
+            Notifying = source.Notifying;
+            Id = source.Id;
+            _defaultMetadata = source._defaultMetadata;
+        }
+
         /// <summary>
         /// Gets the name of the property.
         /// </summary>
@@ -385,6 +404,15 @@ namespace Avalonia
             return result;
         }
 
+        public static AliasedProperty<TValue> RegisterAlias<TOwner, TValue>(
+            AvaloniaProperty<TValue> property,
+            string name)
+        {
+            var result = new AliasedProperty<TValue>(property, name);
+            AvaloniaPropertyRegistry.Instance.Register(typeof(TOwner), result);
+            return result;
+        }
+
         /// <summary>
         /// Returns a binding accessor that can be passed to <see cref="AvaloniaObject"/>'s []
         /// operator to initiate a binding.
@@ -540,6 +568,21 @@ namespace Avalonia
             {
                 return null;
             }
+        }
+
+        internal static AvaloniaProperty ResolveAliases(AvaloniaProperty property)
+        {
+            if (property is IAliasedPropertyAccessor accessor)
+            {
+                property = accessor.ResolveAlias();
+            }
+
+            return property;
+        }
+
+        internal static AvaloniaProperty<T> ResolveAliases<T>(AvaloniaProperty<T> property)
+        {
+            return (AvaloniaProperty<T>)ResolveAliases((AvaloniaProperty)property);
         }
 
         /// <summary>

--- a/src/Avalonia.Base/AvaloniaProperty`1.cs
+++ b/src/Avalonia.Base/AvaloniaProperty`1.cs
@@ -40,5 +40,13 @@ namespace Avalonia
             : base(source, ownerType, metadata)
         {
         }
+
+        protected AvaloniaProperty(
+            AvaloniaProperty<TValue> source,
+            string alias)
+            : base(source, alias)
+        {
+
+        }
     }
 }

--- a/src/Avalonia.Base/IAliasedPropertyAccessor.cs
+++ b/src/Avalonia.Base/IAliasedPropertyAccessor.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Avalonia
+{
+    interface IAliasedPropertyAccessor
+    {
+        AvaloniaProperty ResolveAlias();
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Aliases.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Aliases.cs
@@ -13,9 +13,9 @@ namespace Avalonia.Base.UnitTests
         [Fact]
         public void Setting_Aliased_Property_Sets_Property()
         {
-            var target = new Class1();
+            var target = new Direct();
 
-            target.SetValue(Class1.AliasProperty, "Test");
+            target.SetValue(Direct.AliasProperty, "Test");
 
             Assert.Equal("Test", target.Foo);
         }
@@ -23,21 +23,21 @@ namespace Avalonia.Base.UnitTests
         [Fact]
         public void Setting_Property_Sets_Aliased_Property()
         {
-            var target = new Class1
+            var target = new Direct
             {
                 Foo = "Test"
             };
 
-            Assert.Equal("Test", target.GetValue(Class1.AliasProperty));
+            Assert.Equal("Test", target.GetValue(Direct.AliasProperty));
         }
 
         [Fact]
         public void Binding_Aliased_Property_Binds_Property()
         {
             var subject = new Subject<string>();
-            var target = new Class1();
+            var target = new Direct();
 
-            target.Bind(Class1.AliasProperty, subject);
+            target.Bind(Direct.AliasProperty, subject);
 
             subject.OnNext("Test");
 
@@ -47,27 +47,42 @@ namespace Avalonia.Base.UnitTests
         [Fact]
         public void Checking_If_Property_Is_Set_Propagates_Through_Aliases()
         {
-            var target = new Class1
+            var target = new Styled
             {
                 Foo = "Test"
             };
 
-            Assert.True(target.IsSet(Class1.AliasProperty));
+            Assert.True(target.IsSet(Direct.AliasProperty));
         }
 
-        private class Class1 : AvaloniaObject
+        private class Direct : AvaloniaObject
         {
-            public static readonly DirectProperty<Class1, string> FooProperty =
-                AvaloniaProperty.RegisterDirect<Class1, string>(nameof(Foo), o => o.Foo, (o, v) => o.Foo = v);
+            public static readonly DirectProperty<Direct, string> FooProperty =
+                AvaloniaProperty.RegisterDirect<Direct, string>(nameof(Foo), o => o.Foo, (o, v) => o.Foo = v);
 
             public static readonly AliasedProperty<string> AliasProperty =
-                AvaloniaProperty.RegisterAlias<Class1, string>(FooProperty, "Alias");
+                AvaloniaProperty.RegisterAlias<Direct, string>(FooProperty, "Alias");
 
             private string _foo;
             public string Foo
             {
                 get { return _foo; }
                 set { SetAndRaise(FooProperty, ref _foo, value); }
+            }
+        }
+
+        private class Styled : AvaloniaObject
+        {
+            public static readonly StyledProperty<string> FooProperty =
+                AvaloniaProperty.Register<Direct, string>(nameof(Foo));
+
+            public static readonly AliasedProperty<string> AliasProperty =
+                AvaloniaProperty.RegisterAlias<Direct, string>(FooProperty, "Alias");
+
+            public string Foo
+            {
+                get { return GetValue(FooProperty); }
+                set { SetValue(FooProperty, value); }
             }
         }
     }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Aliases.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Aliases.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Subjects;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests
+{
+    public class AvaloniaObjectTests_Aliases
+    {
+        [Fact]
+        public void Setting_Aliased_Property_Sets_Property()
+        {
+            var target = new Class1();
+
+            target.SetValue(Class1.AliasProperty, "Test");
+
+            Assert.Equal("Test", target.Foo);
+        }
+
+        [Fact]
+        public void Setting_Property_Sets_Aliased_Property()
+        {
+            var target = new Class1
+            {
+                Foo = "Test"
+            };
+
+            Assert.Equal("Test", target.GetValue(Class1.AliasProperty));
+        }
+
+        [Fact]
+        public void Binding_Aliased_Property_Binds_Property()
+        {
+            var subject = new Subject<string>();
+            var target = new Class1();
+
+            target.Bind(Class1.AliasProperty, subject);
+
+            subject.OnNext("Test");
+
+            Assert.Equal("Test", target.Foo);
+        }
+
+        [Fact]
+        public void Checking_If_Property_Is_Set_Propagates_Through_Aliases()
+        {
+            var target = new Class1
+            {
+                Foo = "Test"
+            };
+
+            Assert.True(target.IsSet(Class1.AliasProperty));
+        }
+
+        private class Class1 : AvaloniaObject
+        {
+            public static readonly DirectProperty<Class1, string> FooProperty =
+                AvaloniaProperty.RegisterDirect<Class1, string>(nameof(Foo), o => o.Foo, (o, v) => o.Foo = v);
+
+            public static readonly AliasedProperty<string> AliasProperty =
+                AvaloniaProperty.RegisterAlias<Class1, string>(FooProperty, "Alias");
+
+            private string _foo;
+            public string Foo
+            {
+                get { return _foo; }
+                set { SetAndRaise(FooProperty, ref _foo, value); }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Property Aliases will allow us to create aliased property names. These properties will allow us to add properties that have different names required by XAML Standard but still allow users to use either name without us changing our property names.