### PR TITLE
Correctly trim whitespace in XAML elements.

### DIFF
--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
@@ -868,6 +868,25 @@ do we need it?")]
             }
         }
 
+        [Fact]
+        public void Element_Whitespace_Should_Be_Trimmed()
+        {
+            using (UnitTestApplication.Start(TestServices.MockWindowingPlatform))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'>
+    <TextBlock>
+        Hello World!
+    </TextBlock>
+</Window>";
+
+                var window = AvaloniaXamlLoader.Parse<Window>(xaml);
+                var textBlock = (TextBlock)window.Content;
+
+                Assert.Equal("Hello World!", textBlock.Text);
+            }
+        }
+
         private class SelectedItemsViewModel : INotifyPropertyChanged
         {
             public string[] Items { get; set; }


### PR DESCRIPTION
Fixes whitespace trimming in Portable.Xaml: previously the whitespace in XAML like:

```xml
<TextBlock>
    Hello World!
</TextBlock>
```

Would end up in `TextBlock.Text` instead of being trimmed to `"Hello World!"`.

This PR merges `fixes/76-trim-whitespace` (https://github.com/cwensley/Portable.Xaml/pull/77) into `avalonia` branch of [AvaloniaUI/Portable.Xaml](https://github.com/AvaloniaUI/Portable.Xaml) and adds a unit test.