### PR TITLE
Move CaretIndex to SelectionStart/End when SelectionStart equals SelectionEnd

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -178,6 +178,10 @@ namespace Avalonia.Controls
             {
                 value = CoerceCaretIndex(value);
                 SetAndRaise(SelectionStartProperty, ref _selectionStart, value);
+                if (SelectionStart == SelectionEnd)
+                {
+                    CaretIndex = SelectionStart;
+                }
             }
         }
 
@@ -192,6 +196,10 @@ namespace Avalonia.Controls
             {
                 value = CoerceCaretIndex(value);
                 SetAndRaise(SelectionEndProperty, ref _selectionEnd, value);
+                if (SelectionStart == SelectionEnd)
+                {
+                    CaretIndex = SelectionEnd;
+                }
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -203,6 +203,22 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Setting_SelectionStart_To_SelectionEnd_Sets_CaretPosition_To_SelectionStart()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var textBox = new TextBox
+                {
+                    Text = "0123456789"
+                };
+
+                textBox.SelectionStart = 2;
+                textBox.SelectionEnd = 2;
+                Assert.Equal(2, textBox.CaretIndex);
+            }
+        }
+
+        [Fact]
         public void Setting_Text_Updates_CaretPosition()
         {
             using (UnitTestApplication.Start(Services))


### PR DESCRIPTION
Fix #424.