### PR TITLE
Add the uri to the error message of the xaml loader

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
+++ b/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
@@ -91,6 +91,7 @@
         <Compile Include="Templates\TemplateContent.cs" />
         <Compile Include="Templates\TemplateLoader.cs" />
         <Compile Include="Templates\TreeDataTemplate.cs" />
+        <Compile Include="XamlLoadException.cs" />
         <Compile Include="PortableXaml\portable.xaml.github\src\Portable.Xaml\**\*.cs" Exclude="PortableXaml\portable.xaml.github\src\Portable.Xaml\Assembly\**\*.cs" />
         <Compile Remove="**\UriTypeConverter.cs" />
     </ItemGroup>

--- a/src/Markup/Avalonia.Markup.Xaml/AvaloniaXamlLoaderPortableXaml.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/AvaloniaXamlLoaderPortableXaml.cs
@@ -127,7 +127,19 @@ namespace Avalonia.Markup.Xaml
 
             using (var stream = assetLocator.Open(uri, baseUri))
             {
-                return Load(stream, rootInstance, uri);
+                try
+                {
+                    return Load(stream, rootInstance, uri);
+                }
+                catch (Exception e)
+                {
+                    var uriString = uri.ToString();
+                    if (!uri.IsAbsoluteUri)
+                    {
+                        uriString = new Uri(baseUri, uri).AbsoluteUri;
+                    }
+                    throw new Exception("Error loading xaml at " + uriString, e);
+                }
             }
         }
 

--- a/src/Markup/Avalonia.Markup.Xaml/AvaloniaXamlLoaderPortableXaml.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/AvaloniaXamlLoaderPortableXaml.cs
@@ -138,7 +138,7 @@ namespace Avalonia.Markup.Xaml
                     {
                         uriString = new Uri(baseUri, uri).AbsoluteUri;
                     }
-                    throw new Exception("Error loading xaml at " + uriString, e);
+                    throw new XamlLoadException("Error loading xaml at " + uriString, e);
                 }
             }
         }

--- a/src/Markup/Avalonia.Markup.Xaml/XamlLoadException.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlLoadException.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Avalonia.Markup.Xaml
+{
+    public class XamlLoadException: Exception
+    {
+        public XamlLoadException()
+        {
+        }
+
+        protected XamlLoadException(SerializationInfo info, StreamingContext context): base(info, context)
+        {
+        }
+
+        public XamlLoadException(string message): base(message)
+        {
+        }
+
+        public XamlLoadException(string message, Exception innerException): base(message, innerException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Add the uri to the error message, that way nested load errors can be diagnosed much quicker.