### PR TITLE
Don't dispose visual nodes replaced with themselves.

### DIFF
--- a/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
@@ -148,7 +148,10 @@ namespace Avalonia.Rendering.SceneGraph
             EnsureChildrenCreated();
             var old = _children[index];
             _children[index] = node;
-            old.Dispose();
+            if (node != old)
+            {
+                old.Dispose(); 
+            }
         }
 
         /// <summary>
@@ -329,7 +332,7 @@ namespace Avalonia.Rendering.SceneGraph
                 _drawOperationsCloned = false;
             }
         }
-
+        
         public void Dispose()
         {
             foreach (var child in Children)


### PR DESCRIPTION
This fixes the crash @jp2masa found and mentioned in gitter.