### PR TITLE
Dispatcher's InvokeAsync check action is null #1400

### DIFF
--- a/src/Avalonia.Base/Threading/Dispatcher.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.cs
@@ -81,12 +81,14 @@ namespace Avalonia.Threading
         /// <inheritdoc/>
         public Task InvokeAsync(Action action, DispatcherPriority priority = DispatcherPriority.Normal)
         {
+            Contract.Requires<ArgumentNullException>(action != null);
             return _jobRunner?.InvokeAsync(action, priority);
         }
 
         /// <inheritdoc/>
         public void Post(Action action, DispatcherPriority priority = DispatcherPriority.Normal)
         {
+            Contract.Requires<ArgumentNullException>(action != null);
             _jobRunner?.Post(action, priority);
         }
 


### PR DESCRIPTION
https://github.com/AvaloniaUI/Avalonia/issues/1400

If the user gives the null to InvokeAsync, what is his intention