### PR TITLE
Include content margin in ScrollContentPresenter.Extent

### DIFF
--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -224,7 +224,7 @@ namespace Avalonia.Controls.Presenters
                 CanVerticallyScroll ? Math.Max(Child.DesiredSize.Height, finalSize.Height) : finalSize.Height);
             ArrangeOverrideImpl(size, -Offset);
             Viewport = finalSize;
-            Extent = Child.Bounds.Size;
+            Extent = Child.Bounds.Size.Inflate(Child.Margin);
             return finalSize;
         }
 

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_Layout.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_Layout.cs
@@ -185,10 +185,5 @@ namespace Avalonia.Controls.UnitTests.Presenters
 
             Assert.Equal(new Rect(84, 0, 16, 16), content.Bounds);
         }
-
-        [Fact]
-        public void Padding_Is_Applied_To_TopLeft_Aligned_Content()
-        {
-        }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ScrollContentPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ScrollContentPresenterTests.cs
@@ -224,6 +224,26 @@ namespace Avalonia.Controls.UnitTests.Presenters
         }
 
         [Fact]
+        public void Extent_Should_Include_Content_Margin()
+        {
+            var target = new ScrollContentPresenter
+            {
+                Content = new Border
+                {
+                    Width = 100,
+                    Height = 100,
+                    Margin = new Thickness(5),
+                }
+            };
+
+            target.UpdateChild();
+            target.Measure(new Size(50, 50));
+            target.Arrange(new Rect(0, 0, 50, 50));
+
+            Assert.Equal(new Size(110, 110), target.Extent);
+        }
+
+        [Fact]
         public void Extent_Width_Should_Be_Arrange_Width_When_CanScrollHorizontally_False()
         {
             var child = new WrapPanel

--- a/tests/Avalonia.Layout.UnitTests/ArrangeTests.cs
+++ b/tests/Avalonia.Layout.UnitTests/ArrangeTests.cs
@@ -9,6 +9,22 @@ namespace Avalonia.Layout.UnitTests
     public class ArrangeTests
     {
         [Fact]
+        public void Bounds_Should_Not_Include_Margin()
+        {
+            var target = new Decorator
+            {
+                Width = 100,
+                Height = 100,
+                Margin = new Thickness(5),
+            };
+
+            Assert.False(target.IsMeasureValid);
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(target.DesiredSize));
+            Assert.Equal(new Rect(5, 5, 100, 100), target.Bounds);
+        }
+
+        [Fact]
         public void Margin_Should_Be_Subtracted_From_Arrange_FinalSize()
         {
             var target = new TestControl


### PR DESCRIPTION
Fixes #1408 

Also added an additional test to clarify that `Bounds` doesn't include the margin, and removed an empty test.