### PR TITLE
Force recursion into child scene graph nodes when Opacity changes.

### DIFF
--- a/src/Avalonia.Visuals/Rendering/SceneGraph/IVisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/IVisualNode.cs
@@ -70,6 +70,11 @@ namespace Avalonia.Rendering.SceneGraph
         IReadOnlyList<IRef<IDrawOperation>> DrawOperations { get; }
 
         /// <summary>
+        /// Gets the opacity of the scene graph node.
+        /// </summary>
+        double Opacity { get; }
+
+        /// <summary>
         /// Sets up the drawing context for rendering the node's geometry.
         /// </summary>
         /// <param name="context">The drawing context.</param>

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -170,8 +170,9 @@ namespace Avalonia.Rendering.SceneGraph
                     var clipBounds = bounds.TransformToAABB(contextImpl.Transform).Intersect(clip);
 
                     forceRecurse = forceRecurse ||
-                        node.Transform != contextImpl.Transform ||
-                        node.ClipBounds != clipBounds;
+                        node.ClipBounds != clipBounds ||
+                        node.Opacity != opacity ||
+                        node.Transform != contextImpl.Transform;
 
                     node.Transform = contextImpl.Transform;
                     node.ClipBounds = clipBounds;

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
@@ -67,9 +67,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <inheritdoc/>
         public bool HasAncestorGeometryClip { get; }
 
-        /// <summary>
-        /// Gets or sets the opacity of the scene graph node.
-        /// </summary>
+        /// <inheritdoc/>
         public double Opacity
         {
             get { return _opacity; }

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests.cs
@@ -657,6 +657,43 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
         }
 
         [Fact]
+        public void Setting_Opacity_Should_Add_Descendent_Bounds_To_DirtyRects()
+        {
+            using (TestApplication())
+            {
+                Decorator decorator;
+                Border border;
+                var tree = new TestRoot
+                {
+                    Child = decorator = new Decorator
+                    {
+                        Child = border = new Border
+                        {
+                            Background = Brushes.Red,
+                            Width = 100,
+                            Height = 100,
+                        }
+                    }
+                };
+
+                tree.Measure(Size.Infinity);
+                tree.Arrange(new Rect(tree.DesiredSize));
+
+                var scene = new Scene(tree);
+                var sceneBuilder = new SceneBuilder();
+                sceneBuilder.UpdateAll(scene);
+
+                decorator.Opacity = 0.5;
+                scene = scene.CloneScene();
+                sceneBuilder.Update(scene, decorator);
+
+                Assert.NotEmpty(scene.Layers.Single().Dirty);
+                var dirty = scene.Layers.Single().Dirty.Single();
+                Assert.Equal(new Rect(0, 0, 100, 100), dirty);
+            }
+        }
+
+        [Fact]
         public void Should_Set_GeometryClip()
         {
             using (TestApplication())


### PR DESCRIPTION
When the `Opacity` of a control changed, the dirty rect wasn't getting added if the node itself had no drawing operations. Because `Opacity` affects the control and its descendants, we need to update all descendant controls too.

Fixes #1420 