### PR TITLE
RepeatButton: start repeating process after delay for better user experience.

### DIFF
--- a/src/Avalonia.Controls/RepeatButton.cs
+++ b/src/Avalonia.Controls/RepeatButton.cs
@@ -12,6 +12,12 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<int> DelayProperty =
             AvaloniaProperty.Register<Button, int>(nameof(Delay), 100);
 
+        /// <summary>
+        /// Defines the <see cref="InitialDelay"/> property.
+        /// </summary>
+        public static readonly StyledProperty<int> InitialDelayProperty =
+            AvaloniaProperty.Register<Button, int>(nameof(InitialDelay), 300);
+
         private DispatcherTimer _repeatTimer;
 
         /// <summary>
@@ -23,18 +29,37 @@ namespace Avalonia.Controls
             set { SetValue(DelayProperty, value); }
         }
 
+        /// <summary>
+        /// Gets or sets the amount of time, in milliseconds, to wait before repeating begins.
+        /// </summary>
+        public int InitialDelay
+        {
+            get { return GetValue(InitialDelayProperty); }
+            set { SetValue(InitialDelayProperty, value); }
+        }
+
         private void StartTimer()
         {
             if (_repeatTimer == null)
             {
                 _repeatTimer = new DispatcherTimer();
-                _repeatTimer.Tick += (o, e) => OnClick();
+                _repeatTimer.Tick += RepeatTimerOnTick;
             }
 
             if (_repeatTimer.IsEnabled) return;
 
-            _repeatTimer.Interval = TimeSpan.FromMilliseconds(Delay);
+            _repeatTimer.Interval = TimeSpan.FromMilliseconds(InitialDelay);
             _repeatTimer.Start();
+        }
+
+        private void RepeatTimerOnTick(object sender, EventArgs e)
+        {
+            var interval = TimeSpan.FromMilliseconds(Delay);
+            if (_repeatTimer.Interval != interval)
+            {
+                _repeatTimer.Interval = interval;
+            }
+            OnClick();
         }
 
         private void StopTimer()

--- a/src/Avalonia.Controls/RepeatButton.cs
+++ b/src/Avalonia.Controls/RepeatButton.cs
@@ -7,35 +7,35 @@ namespace Avalonia.Controls
     public class RepeatButton : Button
     {
         /// <summary>
+        /// Defines the <see cref="Interval"/> property.
+        /// </summary>
+        public static readonly StyledProperty<int> IntervalProperty =
+            AvaloniaProperty.Register<Button, int>(nameof(Interval), 100);
+
+        /// <summary>
         /// Defines the <see cref="Delay"/> property.
         /// </summary>
         public static readonly StyledProperty<int> DelayProperty =
-            AvaloniaProperty.Register<Button, int>(nameof(Delay), 100);
-
-        /// <summary>
-        /// Defines the <see cref="InitialDelay"/> property.
-        /// </summary>
-        public static readonly StyledProperty<int> InitialDelayProperty =
-            AvaloniaProperty.Register<Button, int>(nameof(InitialDelay), 300);
+            AvaloniaProperty.Register<Button, int>(nameof(Delay), 300);
 
         private DispatcherTimer _repeatTimer;
 
         /// <summary>
         /// Gets or sets the amount of time, in milliseconds, of repeating clicks.
         /// </summary>
-        public int Delay
+        public int Interval
         {
-            get { return GetValue(DelayProperty); }
-            set { SetValue(DelayProperty, value); }
+            get { return GetValue(IntervalProperty); }
+            set { SetValue(IntervalProperty, value); }
         }
 
         /// <summary>
         /// Gets or sets the amount of time, in milliseconds, to wait before repeating begins.
         /// </summary>
-        public int InitialDelay
+        public int Delay
         {
-            get { return GetValue(InitialDelayProperty); }
-            set { SetValue(InitialDelayProperty, value); }
+            get { return GetValue(DelayProperty); }
+            set { SetValue(DelayProperty, value); }
         }
 
         private void StartTimer()
@@ -48,13 +48,13 @@ namespace Avalonia.Controls
 
             if (_repeatTimer.IsEnabled) return;
 
-            _repeatTimer.Interval = TimeSpan.FromMilliseconds(InitialDelay);
+            _repeatTimer.Interval = TimeSpan.FromMilliseconds(Delay);
             _repeatTimer.Start();
         }
 
         private void RepeatTimerOnTick(object sender, EventArgs e)
         {
-            var interval = TimeSpan.FromMilliseconds(Delay);
+            var interval = TimeSpan.FromMilliseconds(Interval);
             if (_repeatTimer.Interval != interval)
             {
                 _repeatTimer.Interval = interval;


### PR DESCRIPTION
I've added `InitialDelay` property to `RepeatButton` to wait specified amount of time before repeating process will be started.
So now there are two properties `InitialDelay` and `Delay`. In WPF and UWP this properties are called `Delay` and `Interval` respectively. 
Should we rename the properties of our `RepeatButton`?