### PR TITLE
Fix alignment of fixed-size controls in ContentPresenter

### DIFF
--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -221,7 +221,7 @@ namespace Avalonia.Controls.Presenters
         {
             var content = Content;
             var oldChild = Child;
-            var newChild = CreateChild();            
+            var newChild = CreateChild();
 
             // Remove the old child if we're not recycling it.
             if (oldChild != null && newChild != oldChild)
@@ -397,8 +397,6 @@ namespace Avalonia.Controls.Presenters
                     size = size.WithHeight(Math.Min(size.Height, DesiredSize.Height - padding.Top - padding.Bottom));
                 }
 
-                size = LayoutHelper.ApplyLayoutConstraints(Child, size);
-
                 if (useLayoutRounding)
                 {
                     size = new Size(
@@ -412,7 +410,6 @@ namespace Avalonia.Controls.Presenters
                 switch (horizontalContentAlignment)
                 {
                     case HorizontalAlignment.Center:
-                    case HorizontalAlignment.Stretch:
                         originX += (availableSizeMinusMargins.Width - size.Width) / 2;
                         break;
                     case HorizontalAlignment.Right:
@@ -423,7 +420,6 @@ namespace Avalonia.Controls.Presenters
                 switch (verticalContentAlignment)
                 {
                     case VerticalAlignment.Center:
-                    case VerticalAlignment.Stretch:
                         originY += (availableSizeMinusMargins.Height - size.Height) / 2;
                         break;
                     case VerticalAlignment.Bottom:

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_Layout.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_Layout.cs
@@ -81,6 +81,31 @@ namespace Avalonia.Controls.UnitTests.Presenters
         }
 
         [Fact]
+        public void Should_Correctly_Align_Child_With_Fixed_Size()
+        {
+            Border content;
+            var target = new ContentPresenter
+            {
+                HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                VerticalContentAlignment = VerticalAlignment.Stretch,
+                Content = content = new Border
+                {
+                    HorizontalAlignment = HorizontalAlignment.Left,
+                    VerticalAlignment = VerticalAlignment.Bottom,
+                    Width = 16,
+                    Height = 16,
+                },
+            };
+
+            target.UpdateChild();
+            target.Measure(new Size(100, 100));
+            target.Arrange(new Rect(0, 0, 100, 100));
+
+            // Check correct result for Issue #1447.
+            Assert.Equal(new Rect(0, 84, 16, 16), content.Bounds);
+        }
+
+        [Fact]
         public void Content_Can_Be_Stretched()
         {
             Border content;


### PR DESCRIPTION
Don't apply layout constraints to the child in `ContentPresenter.ArrangeOverride` - the child itself will take care of applying its own layout constraints - applying them in the `ContentPresenter` arrange causes #1447.

Fixes #1447 