### PR TITLE
Clear TextBox undo stack on binding change.

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -85,6 +85,7 @@ namespace Avalonia.Controls
         private int _selectionEnd;
         private TextPresenter _presenter;
         private UndoRedoHelper<UndoRedoState> _undoRedoHelper;
+        private bool _isUndoingRedoing;
         private bool _ignoreTextChanges;
         private static readonly string[] invalidCharacters = new String[1]{"\u007f"};
 
@@ -199,7 +200,7 @@ namespace Avalonia.Controls
                 {
                     CaretIndex = CoerceCaretIndex(CaretIndex, value?.Length ?? 0);
 
-                    if (SetAndRaise(TextProperty, ref _text, value))
+                    if (SetAndRaise(TextProperty, ref _text, value) && !_isUndoingRedoing)
                     {
                         _undoRedoHelper.Clear();
                     }
@@ -368,14 +369,30 @@ namespace Avalonia.Controls
                 case Key.Z:
                     if (modifiers == InputModifiers.Control)
                     {
-                        _undoRedoHelper.Undo();
+                        try
+                        {
+                            _isUndoingRedoing = true;
+                            _undoRedoHelper.Undo();
+                        }
+                        finally
+                        {
+                            _isUndoingRedoing = false;
+                        }
                         handled = true;
                     }
                     break;
                 case Key.Y:
                     if (modifiers == InputModifiers.Control)
                     {
-                        _undoRedoHelper.Redo();
+                        try
+                        {
+                            _isUndoingRedoing = true;
+                            _undoRedoHelper.Redo();
+                        }
+                        finally
+                        {
+                            _isUndoingRedoing = false;
+                        }
                         handled = true;
                     }
                     break;

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -198,7 +198,11 @@ namespace Avalonia.Controls
                 if (!_ignoreTextChanges)
                 {
                     CaretIndex = CoerceCaretIndex(CaretIndex, value?.Length ?? 0);
-                    SetAndRaise(TextProperty, ref _text, value);
+
+                    if (SetAndRaise(TextProperty, ref _text, value))
+                    {
+                        _undoRedoHelper.Clear();
+                    }
                 }
             }
         }

--- a/src/Avalonia.Controls/Utils/UndoRedoHelper.cs
+++ b/src/Avalonia.Controls/Utils/UndoRedoHelper.cs
@@ -10,7 +10,6 @@ namespace Avalonia.Controls.Utils
     class UndoRedoHelper<TState> : WeakTimer.IWeakTimerSubscriber where TState : struct, IEquatable<TState>
     {
         private readonly IUndoRedoHost _host;
-        bool _undoRedoing;
 
         public interface IUndoRedoHost
         {
@@ -33,19 +32,10 @@ namespace Avalonia.Controls.Utils
 
         public void Undo()
         {
-            _undoRedoing = true;
-
-            try
+            if (_currentNode?.Previous != null)
             {
-                if (_currentNode?.Previous != null)
-                {
-                    _currentNode = _currentNode.Previous;
-                    _host.UndoRedoState = _currentNode.Value;
-                }
-            }
-            finally
-            {
-                _undoRedoing = false;
+                _currentNode = _currentNode.Previous;
+                _host.UndoRedoState = _currentNode.Value;
             }
         }
 
@@ -80,19 +70,10 @@ namespace Avalonia.Controls.Utils
 
         public void Redo()
         {
-            _undoRedoing = true;
-
-            try
+            if (_currentNode?.Next != null)
             {
-                if (_currentNode?.Next != null)
-                {
-                    _currentNode = _currentNode.Next;
-                    _host.UndoRedoState = _currentNode.Value;
-                }
-            }
-            finally
-            {
-                _undoRedoing = false;
+                _currentNode = _currentNode.Next;
+                _host.UndoRedoState = _currentNode.Value;
             }
         }
 
@@ -112,7 +93,7 @@ namespace Avalonia.Controls.Utils
 
         public void Clear()
         {
-            if (!_undoRedoing) _states.Clear();
+            _states.Clear();
         }
 
         bool WeakTimer.IWeakTimerSubscriber.Tick()

--- a/src/Avalonia.Controls/Utils/UndoRedoHelper.cs
+++ b/src/Avalonia.Controls/Utils/UndoRedoHelper.cs
@@ -10,6 +10,7 @@ namespace Avalonia.Controls.Utils
     class UndoRedoHelper<TState> : WeakTimer.IWeakTimerSubscriber where TState : struct, IEquatable<TState>
     {
         private readonly IUndoRedoHost _host;
+        bool _undoRedoing;
 
         public interface IUndoRedoHost
         {
@@ -32,10 +33,19 @@ namespace Avalonia.Controls.Utils
 
         public void Undo()
         {
-            if (_currentNode?.Previous != null)
+            _undoRedoing = true;
+
+            try
             {
-                _currentNode = _currentNode.Previous;
-                _host.UndoRedoState = _currentNode.Value;
+                if (_currentNode?.Previous != null)
+                {
+                    _currentNode = _currentNode.Previous;
+                    _host.UndoRedoState = _currentNode.Value;
+                }
+            }
+            finally
+            {
+                _undoRedoing = false;
             }
         }
 
@@ -70,10 +80,19 @@ namespace Avalonia.Controls.Utils
 
         public void Redo()
         {
-            if (_currentNode?.Next != null)
+            _undoRedoing = true;
+
+            try
             {
-                _currentNode = _currentNode.Next;
-                _host.UndoRedoState = _currentNode.Value;
+                if (_currentNode?.Next != null)
+                {
+                    _currentNode = _currentNode.Next;
+                    _host.UndoRedoState = _currentNode.Value;
+                }
+            }
+            finally
+            {
+                _undoRedoing = false;
             }
         }
 
@@ -89,6 +108,11 @@ namespace Avalonia.Controls.Utils
                 if (_states.Count > Limit)
                     _states.RemoveFirst();
             }
+        }
+
+        public void Clear()
+        {
+            if (!_undoRedoing) _states.Clear();
         }
 
         bool WeakTimer.IWeakTimerSubscriber.Tick()


### PR DESCRIPTION
This makes `TextBox` act like WPF's `TextBox` where the undo/redo stack is cleared when a change is made from non-user input such as from a binding.

Fixes #336