### PR TITLE
Fix #1448

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -40,11 +40,6 @@ namespace Avalonia.Controls.Presenters
             _caretTimer.Interval = TimeSpan.FromMilliseconds(500);
             _caretTimer.Tick += CaretTimerTick;
 
-            Observable.Merge(
-                this.GetObservable(SelectionStartProperty),
-                this.GetObservable(SelectionEndProperty))
-                .Subscribe(_ => InvalidateFormattedText());
-
             this.GetObservable(CaretIndexProperty)
                 .Subscribe(CaretIndexChanged);
         }


### PR DESCRIPTION
fixes #1448 
@grokys Why do we need formatted text invalidation on `SelectionStart` and `SelectionEnd` changes?
Removing this subscription seems to fix the issue.