### PR TITLE
Fix spurious button presses.

### DIFF
--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -245,7 +245,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerReleased(e);
 
-            if (e.MouseButton == MouseButton.Left)
+            if (IsPressed && e.MouseButton == MouseButton.Left)
             {
                 e.Device.Capture(null);
                 IsPressed = false;

--- a/src/Avalonia.Controls/DropDown.cs
+++ b/src/Avalonia.Controls/DropDown.cs
@@ -164,6 +164,7 @@ namespace Avalonia.Controls
                 else
                 {
                     IsDropDownOpen = !IsDropDownOpen;
+                    e.Handled = true;
                 }
             }
             base.OnPointerPressed(e);


### PR DESCRIPTION
Only raise a `Button` click event on pointer release when the button has been pressed first!

Also noticed we weren't marking the click that opens a `DropDown` as handled.

Fixes #1097 
Fixes #1459 

cc: @MarchingCube