### PR TITLE
Fixed focused control display in DevTools.

### DIFF
--- a/src/Avalonia.Diagnostics/ViewModels/DevToolsViewModel.cs
+++ b/src/Avalonia.Diagnostics/ViewModels/DevToolsViewModel.cs
@@ -86,7 +86,7 @@ namespace Avalonia.Diagnostics.ViewModels
 
         private void UpdateFocusedControl()
         {
-            _focusedControl = KeyboardDevice.Instance.FocusedElement?.GetType().Name;
+            FocusedControl = KeyboardDevice.Instance.FocusedElement?.GetType().Name;
         }
     }
 }


### PR DESCRIPTION
When updating the focused control in DevTools we were setting the backing field for the `FocusedControl` property, meaning that a `PropertyChanged` event wasn't being sent, meaning that the UI wasn't updated. Fix that by setting the property instead.