### PR TITLE
Fixes #1479

### DIFF
--- a/src/Avalonia.Controls/Utils/UndoRedoHelper.cs
+++ b/src/Avalonia.Controls/Utils/UndoRedoHelper.cs
@@ -59,7 +59,7 @@ namespace Avalonia.Controls.Utils
 
         public void UpdateLastState()
         {
-            _states.Last.Value = _host.UndoRedoState;
+            UpdateLastState(_host.UndoRedoState);
         }
 
         public void DiscardRedo()
@@ -94,6 +94,7 @@ namespace Avalonia.Controls.Utils
         public void Clear()
         {
             _states.Clear();
+            _currentNode = null;
         }
 
         bool WeakTimer.IWeakTimerSubscriber.Tick()


### PR DESCRIPTION
1) changed UpdateLastState to call UpdateLastState(TState) so that its the only one that has last update control
2) Clear function clean up the states, however currentNode by definition is depends upon one of the state value, hence made that also null, since there is nothing now to link
Fixes #1479