### PR TITLE
Fixed possible NullReferenceException in DefaultRenderLoop

### DIFF
--- a/src/Avalonia.Visuals/Rendering/DefaultRenderLoop.cs
+++ b/src/Avalonia.Visuals/Rendering/DefaultRenderLoop.cs
@@ -41,12 +41,12 @@ namespace Avalonia.Rendering
         {
             add
             {
+                _tick += value;
+
                 if (_subscriberCount++ == 0)
                 {
                     Start();
                 }
-
-                _tick += value;
             }
 
             remove


### PR DESCRIPTION
## Changes
- Fixed possible `NullReferenceException` in `DefaultRenderLoop`.

`_tick` was being set after calling `Start`, so it was null between that call and `_tick += value;`, and `InternalTick` could be called while `_tick` hadn't been set yet, causing a `NullReferenceException` on line 100.