### PR TITLE
Added PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:
+
+- What does the pull request do?
+- What is the current behavior?
+- What is the updated/expected behavior with this PR?
+- How was the solution implemented (if it's not obvious)?
+
+Checklist:
+
+- [ ] Added unit tests (if possible)?
+- [ ] Added XML documentation to any related classes?
+- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
+
+If the pull request fixes issue(s) list them like this:
+
+Fixes #123
+Fixes #456


### PR DESCRIPTION
We're getting a lot more PRs submitted recently, which is great, but they're often harder to review than they could be because the submitter doesn't include a lot of relevant information in the PR description.

This PR adds a PR template to the repository. I don't want to add a load of bureaucracy to get in the way of submissions, just trying to remind contributors what info is useful for us as reviewers.