### PR TITLE
Implemented Skia geometry hit testing

### DIFF
--- a/Avalonia.sln
+++ b/Avalonia.sln
@@ -150,7 +150,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Props", "Props", "{F3AC8BC1
 		build\Rx.props = build\Rx.props
 		build\Serilog.props = build\Serilog.props
 		build\SharpDX.props = build\SharpDX.props
-		build\SkiaSharp.Desktop.props = build\SkiaSharp.Desktop.props
 		build\SkiaSharp.props = build\SkiaSharp.props
 		build\Splat.props = build\Splat.props
 		build\Sprache.props = build\Sprache.props
@@ -187,6 +186,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.MonoMac", "src\OSX\Avalonia.MonoMac\Avalonia.MonoMac.csproj", "{CBFD5788-567D-401B-9DFA-74E4224025A0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalonia.Designer.HostApp.NetFX", "src\tools\Avalonia.Designer.HostApp.NetFX\Avalonia.Designer.HostApp.NetFX.csproj", "{4ADA61C8-D191-428D-9066-EF4F0D86520F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Skia.UnitTests", "tests\Avalonia.Skia.UnitTests\Avalonia.Skia.UnitTests.csproj", "{E1240B49-7B4B-4371-A00E-068778C5CF0B}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -2537,6 +2538,46 @@ Global
 		{4ADA61C8-D191-428D-9066-EF4F0D86520F}.Release|NetCoreOnly.ActiveCfg = Release|Any CPU
 		{4ADA61C8-D191-428D-9066-EF4F0D86520F}.Release|x86.ActiveCfg = Release|Any CPU
 		{4ADA61C8-D191-428D-9066-EF4F0D86520F}.Release|x86.Build.0 = Release|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Ad-Hoc|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Ad-Hoc|Any CPU.Build.0 = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Ad-Hoc|iPhone.Build.0 = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Ad-Hoc|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Ad-Hoc|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Ad-Hoc|NetCoreOnly.ActiveCfg = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Ad-Hoc|NetCoreOnly.Build.0 = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Ad-Hoc|x86.ActiveCfg = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Ad-Hoc|x86.Build.0 = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.AppStore|Any CPU.Build.0 = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.AppStore|iPhone.ActiveCfg = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.AppStore|iPhone.Build.0 = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.AppStore|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.AppStore|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.AppStore|NetCoreOnly.ActiveCfg = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.AppStore|NetCoreOnly.Build.0 = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.AppStore|x86.ActiveCfg = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.AppStore|x86.Build.0 = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Debug|NetCoreOnly.ActiveCfg = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Debug|NetCoreOnly.Build.0 = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Debug|x86.Build.0 = Debug|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Release|iPhone.Build.0 = Release|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Release|NetCoreOnly.ActiveCfg = Release|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Release|NetCoreOnly.Build.0 = Release|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Release|x86.ActiveCfg = Release|Any CPU
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2591,6 +2632,7 @@ Global
 		{050CC912-FF49-4A8B-B534-9544017446DD} = {4ED8B739-6F4E-4CD4-B993-545E6B5CE637}
 		{F40FC0A2-1BC3-401C-BFC1-928EC4D4A9CE} = {9B9E3891-2366-4253-A952-D08BCEB71098}
 		{4ADA61C8-D191-428D-9066-EF4F0D86520F} = {4ED8B739-6F4E-4CD4-B993-545E6B5CE637}
+		{E1240B49-7B4B-4371-A00E-068778C5CF0B} = {C5A00AC3-B34C-4564-9BDD-2DA473EF4D8B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {87366D66-1391-4D90-8999-95A620AD786A}

--- a/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Text;
 using Avalonia.Controls.Platform.Surfaces;
 using Avalonia.Media;
@@ -51,7 +52,7 @@ namespace Avalonia.Skia
             public void Dispose()
             {
                 using (var tmp = _bitmap.Copy(_nfo.ColorType))
-                    tmp.CopyPixelsTo(_fb, _nfo.BytesPerPixel * _nfo.Height * _rowBytes, _rowBytes);
+                    tmp.CopyPixelsTo(_fb, _nfo.BytesSize, _nfo.RowBytes);
                 _bitmap.Dispose();
             }
             

--- a/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Text;
 using Avalonia.Controls.Platform.Surfaces;
 using Avalonia.Media;
@@ -52,7 +51,7 @@ namespace Avalonia.Skia
             public void Dispose()
             {
                 using (var tmp = _bitmap.Copy(_nfo.ColorType))
-                    tmp.CopyPixelsTo(_fb, _nfo.BytesSize, _nfo.RowBytes);
+                    tmp.CopyPixelsTo(_fb, _nfo.BytesPerPixel * _nfo.Height * _rowBytes, _rowBytes);
                 _bitmap.Dispose();
             }
             

--- a/src/Skia/Avalonia.Skia/GeometryImpl.cs
+++ b/src/Skia/Avalonia.Skia/GeometryImpl.cs
@@ -40,8 +40,8 @@ namespace Avalonia.Skia
         public IGeometryImpl Intersect(IGeometryImpl geometry)
         {
             var result = EffectivePath.Op(((GeometryImpl) geometry).EffectivePath, SKPathOp.Intersect);
-            
-            return new StreamGeometryImpl(result);
+
+            return result == null ? null : new StreamGeometryImpl(result);
         }
 
         /// <inheritdoc />

--- a/src/Skia/Avalonia.Skia/GeometryImpl.cs
+++ b/src/Skia/Avalonia.Skia/GeometryImpl.cs
@@ -1,18 +1,62 @@
-using System;
 using Avalonia.Media;
 using Avalonia.Platform;
 using SkiaSharp;
 
 namespace Avalonia.Skia
 {
-    abstract class GeometryImpl : IGeometryImpl
+    /// <summary>
+    /// A Skia implementation of <see cref="IGeometryImpl"/>.
+    /// </summary>
+    public abstract class GeometryImpl : IGeometryImpl
     {
+        /// <inheritdoc />
         public abstract Rect Bounds { get; }
         public abstract SKPath EffectivePath { get; }
-        public abstract bool FillContains(Point point);
-        public abstract Rect GetRenderBounds(Pen pen);
-        public abstract IGeometryImpl Intersect(IGeometryImpl geometry);
-        public abstract bool StrokeContains(Pen pen, Point point);
-        public abstract ITransformedGeometryImpl WithTransform(Matrix transform);
+
+        /// <inheritdoc />
+        public bool FillContains(Point point)
+        {
+            return EffectivePath.Contains((float)point.X, (float)point.Y);
+        }
+
+        /// <inheritdoc />
+        public bool StrokeContains(Pen pen, Point point)
+        {
+            using (var paint = new SKPaint())
+            {
+                paint.IsStroke = true;
+                paint.StrokeWidth = (float)(pen?.Thickness ?? 0);
+
+                using (var strokePath = new SKPath())
+                {
+                    paint.GetFillPath(EffectivePath, strokePath);
+                    
+                    return strokePath.Contains((float) point.X, (float) point.Y);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public IGeometryImpl Intersect(IGeometryImpl geometry)
+        {
+            var result = EffectivePath.Op(((GeometryImpl) geometry).EffectivePath, SKPathOp.Intersect);
+            
+            return new StreamGeometryImpl(result);
+        }
+
+        /// <inheritdoc />
+        public Rect GetRenderBounds(Pen pen)
+        {
+            var strokeThickness = pen?.Thickness ?? 0;
+            
+            // TODO: This is not precise, but calculating precise bounds for stroke can be quite expensive.
+            return Bounds.Inflate(strokeThickness);
+        }
+        
+        /// <inheritdoc />
+        public ITransformedGeometryImpl WithTransform(Matrix transform)
+        {
+            return new TransformedGeometryImpl(this, transform);
+        }
     }
 }

--- a/src/Skia/Avalonia.Skia/StreamGeometryImpl.cs
+++ b/src/Skia/Avalonia.Skia/StreamGeometryImpl.cs
@@ -1,90 +1,99 @@
-using System;
 using Avalonia.Media;
 using Avalonia.Platform;
 using SkiaSharp;
 
 namespace Avalonia.Skia
 {
-    class StreamGeometryImpl : GeometryImpl, IStreamGeometryImpl
+    /// <summary>
+    /// A Skia implementation of a <see cref="IStreamGeometryImpl"/>.
+    /// </summary>
+    public class StreamGeometryImpl : GeometryImpl, IStreamGeometryImpl
     {
-        Rect _bounds;
-        SKPath _path;
+        private Rect _bounds;
+        private readonly SKPath _effectivePath;
 
-        public override SKPath EffectivePath => _path;
-
-        public override Rect GetRenderBounds(Pen pen)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamGeometryImpl"/> class.
+        /// </summary>
+        /// <param name="path">An existing Skia <see cref="SKPath"/>.</param>
+        /// <param name="bounds">Precomputed path bounds.</param>
+        public StreamGeometryImpl(SKPath path, Rect bounds)
         {
-            return GetRenderBounds(pen?.Thickness ?? 0);
+            _effectivePath = path;
+            _bounds = bounds;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamGeometryImpl"/> class.
+        /// </summary>
+        /// <param name="path">An existing Skia <see cref="SKPath"/>.</param>
+        public StreamGeometryImpl(SKPath path) : this(path, path.TightBounds.ToAvaloniaRect())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamGeometryImpl"/> class.
+        /// </summary>
+        public StreamGeometryImpl() : this(CreateEmptyPath(), Rect.Empty)
+        {
+        }
+        
+        /// <inheritdoc />
+        public override SKPath EffectivePath => _effectivePath;
+
+        /// <inheritdoc />
         public override Rect Bounds => _bounds;
 
+        /// <inheritdoc />
         public IStreamGeometryImpl Clone()
         {
-            return new StreamGeometryImpl
-            {
-                _path = _path?.Clone(),
-                _bounds = Bounds
-            };
+            return new StreamGeometryImpl(_effectivePath?.Clone(), Bounds);
         }
 
+        /// <inheritdoc />
         public IStreamGeometryContextImpl Open()
         {
-            _path = new SKPath();
-            _path.FillType = SKPathFillType.EvenOdd;
-
             return new StreamContext(this);
         }
 
-        public override bool FillContains(Point point)
+        /// <summary>
+        /// Create new empty <see cref="SKPath"/>.
+        /// </summary>
+        /// <returns>Empty <see cref="SKPath"/></returns>
+        private static SKPath CreateEmptyPath()
         {
-            // TODO: Not supported by SkiaSharp yet, so use expanded Rect
-            // return EffectivePath.Contains(point.X, point.Y);
-            return GetRenderBounds(0).Contains(point);
+            return new SKPath
+            {
+                FillType = SKPathFillType.EvenOdd
+            };
         }
 
-        public override bool StrokeContains(Pen pen, Point point)
-        {
-            // TODO: Not supported by SkiaSharp yet, so use expanded Rect
-            // return EffectivePath.Contains(point.X, point.Y);
-            return GetRenderBounds(0).Contains(point);
-        }
-
-        public override IGeometryImpl Intersect(IGeometryImpl geometry)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override ITransformedGeometryImpl WithTransform(Matrix transform)
-        {
-            return new TransformedGeometryImpl(this, transform);
-        }
-
-        private Rect GetRenderBounds(double strokeThickness)
-        {
-            // TODO: Calculate properly.
-            return Bounds.Inflate(strokeThickness);
-        }
-
-        class StreamContext : IStreamGeometryContextImpl
+        /// <summary>
+        /// A Skia implementation of a <see cref="IStreamGeometryContextImpl"/>.
+        /// </summary>
+        private class StreamContext : IStreamGeometryContextImpl
         {
             private readonly StreamGeometryImpl _geometryImpl;
-            private SKPath _path;
+            private readonly SKPath _path;
 
-            Point _currentPoint;
+            /// <summary>
+            /// Initializes a new instance of the <see cref="StreamContext"/> class.
+            /// <param name="geometryImpl">Geometry to operate on.</param>
+            /// </summary>
             public StreamContext(StreamGeometryImpl geometryImpl)
             {
                 _geometryImpl = geometryImpl;
-                _path = _geometryImpl._path;
+                _path = _geometryImpl._effectivePath;
             }
-
+            
+            /// <inheritdoc />
+            /// <remarks>Will update bounds of passed geometry.</remarks>
             public void Dispose()
             {
-                SKRect rc;
-                _path.GetBounds(out rc);
-                _geometryImpl._bounds = rc.ToAvaloniaRect();
+                _geometryImpl._bounds = _path.TightBounds.ToAvaloniaRect();
             }
 
+            /// <inheritdoc />
             public void ArcTo(Point point, Size size, double rotationAngle, bool isLargeArc, SweepDirection sweepDirection)
             {
                 _path.ArcTo(
@@ -95,33 +104,33 @@ namespace Avalonia.Skia
                     sweepDirection == SweepDirection.Clockwise ? SKPathDirection.Clockwise : SKPathDirection.CounterClockwise,
                     (float)point.X,
                     (float)point.Y);
-                _currentPoint = point;
             }
 
+            /// <inheritdoc />
             public void BeginFigure(Point startPoint, bool isFilled)
             {
                 _path.MoveTo((float)startPoint.X, (float)startPoint.Y);
-                _currentPoint = startPoint;
             }
 
+            /// <inheritdoc />
             public void CubicBezierTo(Point point1, Point point2, Point point3)
             {
                 _path.CubicTo((float)point1.X, (float)point1.Y, (float)point2.X, (float)point2.Y, (float)point3.X, (float)point3.Y);
-                _currentPoint = point3;
             }
 
+            /// <inheritdoc />
             public void QuadraticBezierTo(Point point1, Point point2)
             {
                 _path.QuadTo((float)point1.X, (float)point1.Y, (float)point2.X, (float)point2.Y);
-                _currentPoint = point2;
             }
 
+            /// <inheritdoc />
             public void LineTo(Point point)
             {
                 _path.LineTo((float)point.X, (float)point.Y);
-                _currentPoint = point;
             }
 
+            /// <inheritdoc />
             public void EndFigure(bool isClosed)
             {
                 if (isClosed)
@@ -130,6 +139,7 @@ namespace Avalonia.Skia
                 }
             }
 
+            /// <inheritdoc />
             public void SetFillRule(FillRule fillRule)
             {
                 _path.FillType = fillRule == FillRule.EvenOdd ? SKPathFillType.EvenOdd : SKPathFillType.Winding;

--- a/src/Skia/Avalonia.Skia/TransformedGeometryImpl.cs
+++ b/src/Skia/Avalonia.Skia/TransformedGeometryImpl.cs
@@ -1,59 +1,40 @@
-using System;
-using Avalonia.Media;
 using Avalonia.Platform;
 using SkiaSharp;
 
 namespace Avalonia.Skia
 {
-    class TransformedGeometryImpl : GeometryImpl, ITransformedGeometryImpl
+    /// <summary>
+    /// A Skia implementation of a <see cref="ITransformedGeometryImpl"/>.
+    /// </summary>
+    public class TransformedGeometryImpl : GeometryImpl, ITransformedGeometryImpl
     {
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="TransformedGeometryImpl"/> class.
+        /// </summary>
+        /// <param name="source">Source geometry.</param>
+        /// <param name="transform">Transform of new geometry.</param>
         public TransformedGeometryImpl(GeometryImpl source, Matrix transform)
         {
             SourceGeometry = source;
             Transform = transform;
-            EffectivePath = source.EffectivePath.Clone();
-            EffectivePath.Transform(transform.ToSKMatrix());
+
+            var transformedPath = source.EffectivePath.Clone();
+            transformedPath.Transform(transform.ToSKMatrix());
+
+            EffectivePath = transformedPath;
+            Bounds = transformedPath.TightBounds.ToAvaloniaRect();
         }
 
+        /// <inheritdoc />
         public override SKPath EffectivePath { get; }
 
+        /// <inheritdoc />
         public IGeometryImpl SourceGeometry { get; }
 
+        /// <inheritdoc />
         public Matrix Transform { get; }
 
-        public override Rect Bounds => SourceGeometry.Bounds.TransformToAABB(Transform);
-
-        public override bool FillContains(Point point)
-        {
-            // TODO: Not supported by SkiaSharp yet, so use expanded Rect
-            return GetRenderBounds(0).Contains(point);
-        }
-
-        public override Rect GetRenderBounds(Pen pen)
-        {
-            return GetRenderBounds(pen.Thickness);
-        }
-
-        public override IGeometryImpl Intersect(IGeometryImpl geometry)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override bool StrokeContains(Pen pen, Point point)
-        {
-            // TODO: Not supported by SkiaSharp yet, so use expanded Rect
-            return GetRenderBounds(0).Contains(point);
-        }
-
-        public override ITransformedGeometryImpl WithTransform(Matrix transform)
-        {
-            return new TransformedGeometryImpl(this, transform);
-        }
-
-        public Rect GetRenderBounds(double strokeThickness)
-        {
-            // TODO: Calculate properly.
-            return Bounds.Inflate(strokeThickness);
-        }
+        /// <inheritdoc />
+        public override Rect Bounds { get; }
     }
 }

--- a/src/Skia/Avalonia.Skia/readme.md
+++ b/src/Skia/Avalonia.Skia/readme.md
@@ -4,9 +4,6 @@ BitmapImpl
 - constructor from Width/Height
 - Save
 
-StreamGeometryImpl
-- Hit testing in Geometry missing as SkiaSharp does not expose this
-
 DrawingContextImpl
 - Alpha support missing as SkiaSharp does not expose this
 - Gradient Shader caching?

--- a/tests/Avalonia.RenderTests/Media/BitmapTests.cs
+++ b/tests/Avalonia.RenderTests/Media/BitmapTests.cs
@@ -67,7 +67,7 @@ namespace Avalonia.Direct2D1.RenderTests.Media
         
         [Theory]
         [InlineData(PixelFormat.Rgba8888), InlineData(PixelFormat.Bgra8888),
-#if SKIA
+#if AVALONIA_SKIA
              InlineData(PixelFormat.Rgb565)
 #endif
             ]

--- a/tests/Avalonia.Skia.UnitTests/Avalonia.Skia.UnitTests.csproj
+++ b/tests/Avalonia.Skia.UnitTests/Avalonia.Skia.UnitTests.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+  </PropertyGroup>
+  <Import Project="..\..\build\UnitTests.NetCore.targets" />
+  <Import Project="..\..\build\Moq.props" />
+  <Import Project="..\..\build\XUnit.props" />
+  <Import Project="..\..\build\Rx.props" />
+  <Import Project="..\..\build\Microsoft.Reactive.Testing.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Avalonia.Animation\Avalonia.Animation.csproj" />
+    <ProjectReference Include="..\..\src\Avalonia.Base\Avalonia.Base.csproj" />
+    <ProjectReference Include="..\..\src\Avalonia.Controls\Avalonia.Controls.csproj" />
+    <ProjectReference Include="..\..\src\Avalonia.Input\Avalonia.Input.csproj" />
+    <ProjectReference Include="..\..\src\Avalonia.Interactivity\Avalonia.Interactivity.csproj" />
+    <ProjectReference Include="..\..\src\Avalonia.Layout\Avalonia.Layout.csproj" />
+    <ProjectReference Include="..\..\src\Avalonia.Visuals\Avalonia.Visuals.csproj" />
+    <ProjectReference Include="..\..\src\Avalonia.Styling\Avalonia.Styling.csproj" />
+    <ProjectReference Include="..\..\src\Skia\Avalonia.Skia\Avalonia.Skia.csproj" />
+    <ProjectReference Include="..\Avalonia.UnitTests\Avalonia.UnitTests.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Avalonia.Skia.UnitTests/HitTesting.cs
+++ b/tests/Avalonia.Skia.UnitTests/HitTesting.cs
@@ -1,0 +1,79 @@
+﻿using Avalonia.Controls.Shapes;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Rendering;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Skia.UnitTests
+{
+    public class HitTesting
+    {
+        [Fact]
+        public void Hit_Test_Should_Respect_Fill()
+        {
+            using (AvaloniaLocator.EnterScope())
+            {
+                SkiaPlatform.Initialize();
+
+                var root = new TestRoot
+                {
+                    Width = 100,
+                    Height = 100,
+                    Child = new Ellipse
+                    {
+                        Width = 100,
+                        Height = 100,
+                        Fill = Brushes.Red,
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        VerticalAlignment = VerticalAlignment.Center
+                    }
+                };
+
+                root.Renderer = new DeferredRenderer(root, null);
+                root.Measure(Size.Infinity);
+                root.Arrange(new Rect(root.DesiredSize));
+
+                var outsideResult = root.Renderer.HitTest(new Point(10, 10), root, null);
+                var insideResult = root.Renderer.HitTest(new Point(50, 50), root, null);
+
+                Assert.Empty(outsideResult);
+                Assert.Equal(new[] {root.Child}, insideResult);
+            }
+        }
+
+        [Fact]
+        public void Hit_Test_Should_Respect_Stroke()
+        {
+            using (AvaloniaLocator.EnterScope())
+            {
+                SkiaPlatform.Initialize();
+
+                var root = new TestRoot
+                {
+                    Width = 100,
+                    Height = 100,
+                    Child = new Ellipse
+                    {
+                        Width = 100,
+                        Height = 100,
+                        Stroke = Brushes.Red,
+                        StrokeThickness = 5,
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        VerticalAlignment = VerticalAlignment.Center
+                    }
+                };
+
+                root.Renderer = new DeferredRenderer(root, null);
+                root.Measure(Size.Infinity);
+                root.Arrange(new Rect(root.DesiredSize));
+
+                var outsideResult = root.Renderer.HitTest(new Point(50, 50), root, null);
+                var insideResult = root.Renderer.HitTest(new Point(1, 50), root, null);
+
+                Assert.Empty(outsideResult);
+                Assert.Equal(new[] { root.Child }, insideResult);
+            }
+        }
+    }
+}

--- a/tests/Avalonia.Skia.UnitTests/Properties/AssemblyInfo.cs
+++ b/tests/Avalonia.Skia.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System.Reflection;
+using Xunit;
+
+// Don't run tests in parallel.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
- What does the pull request do?
Implements proper hit testing for Skia based geometry classes (`IGeometryImpl`). Additionally it cleans up geometry classes and adds documentation to them.
- What is the current behavior?
Skia based geometries only perform bounds check, which prevents clickable UI elements (curves, filled/stroked ellipses, etc.) from working correctly, as bounding box checks are not sufficient for them. For Direct2D backend everything works as expected.
- What is the updated/expected behavior with this PR?
Skia based geometries hit test correctly for both stroke and fill. Additionally geometry bounds also represent path bounds without control points (`Bounds` vs `TightBounds` in Skia).
- How was the solution implemented (if it's not obvious)?
I have moved the bulk of the logic to `GeometryImpl` class, as both `StreamGeometryImpl` and `TransformedGeometryImpl` classes had plenty of duplicated code. Should be easier to maintain in the long run.

Checklist:

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

Note: I have added specific hit test unit test project just for Skia. I guess ultimately those should be shared with Direct2D (similar to RenderTests), but I am not sure if I should do it as a part of this PR, simply to avoid creating a lot of noise with this restructure.