### PR TITLE
Fix attached member namespace resolution

### DIFF
--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
@@ -82,6 +82,21 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
         }
 
         [Fact]
+        public void Attached_Property_Is_Set_On_Control_Outside_Avalonia_Namspace()
+        {
+            // Test for issue #1548
+            var xaml =
+@"<UserControl xmlns='https://github.com/avaloniaui'
+    xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+  <local:TestControl Grid.Column='2' />
+</UserControl>";
+
+            var target = AvaloniaXamlLoader.Parse<UserControl>(xaml);
+
+            Assert.Equal(2, Grid.GetColumn((TestControl)target.Content));
+        }
+
+        [Fact]
         public void Attached_Property_With_Namespace_Is_Set()
         {
             var xaml =


### PR DESCRIPTION
When an attached property appears without a namespace, Portable.Xaml was looking up the type using the namespace for the current element instead of using the default namespace, causing #1548.

This PR adds a failing test and fixes it by cherry-picking the relevant fix from https://github.com/cwensley/Portable.Xaml/pull/96 into our fork.