### PR TITLE
Add GetPosition method to DragEventArgs

### DIFF
--- a/src/Avalonia.Input/DragDropDevice.cs
+++ b/src/Avalonia.Input/DragDropDevice.cs
@@ -19,11 +19,11 @@ namespace Avalonia.Input
             return null;
         }
         
-        private DragDropEffects RaiseDragEvent(Interactive target, RoutedEvent<DragEventArgs> routedEvent, DragDropEffects operation, IDataObject data)
+        private DragDropEffects RaiseDragEvent(Interactive target, Point targetLocation, RoutedEvent<DragEventArgs> routedEvent, DragDropEffects operation, IDataObject data)
         {
             if (target == null)
                 return DragDropEffects.None;
-            var args = new DragEventArgs(routedEvent, data)
+            var args = new DragEventArgs(routedEvent, data, target, targetLocation)
             {
                 RoutedEvent = routedEvent,
                 DragEffects = operation
@@ -35,7 +35,7 @@ namespace Avalonia.Input
         private DragDropEffects DragEnter(IInputElement inputRoot, Point point, IDataObject data, DragDropEffects effects)
         {
             _lastTarget = GetTarget(inputRoot, point);
-            return RaiseDragEvent(_lastTarget, DragDrop.DragEnterEvent, effects, data);
+            return RaiseDragEvent(_lastTarget, _lastTarget != null ? inputRoot.TranslatePoint(point, _lastTarget) : point, DragDrop.DragEnterEvent, effects, data);
         }
 
         private DragDropEffects DragOver(IInputElement inputRoot, Point point, IDataObject data, DragDropEffects effects)
@@ -43,13 +43,13 @@ namespace Avalonia.Input
             var target = GetTarget(inputRoot, point);
 
             if (target == _lastTarget)
-                return RaiseDragEvent(target, DragDrop.DragOverEvent, effects, data);
+                return RaiseDragEvent(target, _lastTarget != null ? inputRoot.TranslatePoint(point, _lastTarget) : point, DragDrop.DragOverEvent, effects, data);
             
             try
             {
                 if (_lastTarget != null)
                     _lastTarget.RaiseEvent(new RoutedEventArgs(DragDrop.DragLeaveEvent));
-                return RaiseDragEvent(target, DragDrop.DragEnterEvent, effects, data);
+                return RaiseDragEvent(target, _lastTarget != null ? inputRoot.TranslatePoint(point, _lastTarget) : point, DragDrop.DragEnterEvent, effects, data);
             }
             finally
             {
@@ -75,7 +75,7 @@ namespace Avalonia.Input
         {
             try
             {
-                return RaiseDragEvent(_lastTarget, DragDrop.DropEvent, effects, data);
+                return RaiseDragEvent(_lastTarget, _lastTarget != null ? inputRoot.TranslatePoint(point, _lastTarget) : point, DragDrop.DropEvent, effects, data);
             }
             finally 
             {

--- a/src/Avalonia.Input/DragDropDevice.cs
+++ b/src/Avalonia.Input/DragDropDevice.cs
@@ -19,11 +19,11 @@ namespace Avalonia.Input
             return null;
         }
         
-        private DragDropEffects RaiseDragEvent(Interactive target, Point targetLocation, RoutedEvent<DragEventArgs> routedEvent, DragDropEffects operation, IDataObject data)
+        private DragDropEffects RaiseDragEvent(Interactive target, IInputElement inputRoot, Point point, RoutedEvent<DragEventArgs> routedEvent, DragDropEffects operation, IDataObject data)
         {
             if (target == null)
                 return DragDropEffects.None;
-            var args = new DragEventArgs(routedEvent, data, target, targetLocation)
+            var args = new DragEventArgs(routedEvent, data, target, target != null ? inputRoot.TranslatePoint(point, target) : point)
             {
                 RoutedEvent = routedEvent,
                 DragEffects = operation
@@ -35,7 +35,7 @@ namespace Avalonia.Input
         private DragDropEffects DragEnter(IInputElement inputRoot, Point point, IDataObject data, DragDropEffects effects)
         {
             _lastTarget = GetTarget(inputRoot, point);
-            return RaiseDragEvent(_lastTarget, _lastTarget != null ? inputRoot.TranslatePoint(point, _lastTarget) : point, DragDrop.DragEnterEvent, effects, data);
+            return RaiseDragEvent(_lastTarget, inputRoot, point, DragDrop.DragEnterEvent, effects, data);
         }
 
         private DragDropEffects DragOver(IInputElement inputRoot, Point point, IDataObject data, DragDropEffects effects)
@@ -43,13 +43,13 @@ namespace Avalonia.Input
             var target = GetTarget(inputRoot, point);
 
             if (target == _lastTarget)
-                return RaiseDragEvent(target, _lastTarget != null ? inputRoot.TranslatePoint(point, _lastTarget) : point, DragDrop.DragOverEvent, effects, data);
+                return RaiseDragEvent(target, inputRoot, point, DragDrop.DragOverEvent, effects, data);
             
             try
             {
                 if (_lastTarget != null)
                     _lastTarget.RaiseEvent(new RoutedEventArgs(DragDrop.DragLeaveEvent));
-                return RaiseDragEvent(target, _lastTarget != null ? inputRoot.TranslatePoint(point, _lastTarget) : point, DragDrop.DragEnterEvent, effects, data);
+                return RaiseDragEvent(target, inputRoot, point, DragDrop.DragEnterEvent, effects, data);
             }
             finally
             {
@@ -75,7 +75,7 @@ namespace Avalonia.Input
         {
             try
             {
-                return RaiseDragEvent(_lastTarget, _lastTarget != null ? inputRoot.TranslatePoint(point, _lastTarget) : point, DragDrop.DropEvent, effects, data);
+                return RaiseDragEvent(_lastTarget, inputRoot, point, DragDrop.DropEvent, effects, data);
             }
             finally 
             {

--- a/src/Avalonia.Input/DragDropDevice.cs
+++ b/src/Avalonia.Input/DragDropDevice.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Input
         {
             if (target == null)
                 return DragDropEffects.None;
-            var args = new DragEventArgs(routedEvent, data, target, target != null ? inputRoot.TranslatePoint(point, target) : point)
+            var args = new DragEventArgs(routedEvent, data, target, inputRoot.TranslatePoint(point, target))
             {
                 RoutedEvent = routedEvent,
                 DragEffects = operation

--- a/src/Avalonia.Input/DragEventArgs.cs
+++ b/src/Avalonia.Input/DragEventArgs.cs
@@ -1,17 +1,40 @@
-﻿using Avalonia.Interactivity;
+﻿using System;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Input
 {
     public class DragEventArgs : RoutedEventArgs
     {
+        private Interactive _target;
+        private Point _targetLocation;
+
         public DragDropEffects DragEffects { get; set; }
 
         public IDataObject Data { get; private set; }
 
-        public DragEventArgs(RoutedEvent<DragEventArgs> routedEvent, IDataObject data)
+        public Point GetPosition(IVisual relativeTo)
+        {
+            var point = new Point(0, 0);
+
+            if (relativeTo == null)
+            {
+                throw new ArgumentNullException(nameof(relativeTo));
+            }
+
+            if (_target != null)
+            {
+                point = _target.TranslatePoint(_targetLocation, relativeTo);
+            }
+            return point;
+        }
+
+        public DragEventArgs(RoutedEvent<DragEventArgs> routedEvent, IDataObject data, Interactive target, Point targetLocation)
             : base(routedEvent)
         {
             this.Data = data;
+            this._target = target;
+            this._targetLocation = targetLocation;
         }
 
     }


### PR DESCRIPTION
- What does the pull request do?
Implements `Point GetPosition(IVisual relativeTo);` method for `DragEventArgs`.
- What is the current behavior?
Not implemented.
- What is the updated/expected behavior with this PR?
Adds functionality to drag and drop events to obtain mouse position.
- How was the solution implemented (if it's not obvious)?
Added GetPosition method to DragEventArgs type.

Fixes #1555 