### PR TITLE
Fix 1554 AutoCompleteBox MinimumPrefixLength issue

### DIFF
--- a/src/Avalonia.Controls/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox.cs
@@ -1954,6 +1954,10 @@ namespace Avalonia.Controls
             // 1. Minimum prefix length
             // 2. If a delay timer is in use, use it
             bool populateReady = newText.Length >= MinimumPrefixLength && MinimumPrefixLength >= 0;
+            if(populateReady && MinimumPrefixLength == 0 && String.IsNullOrEmpty(newText) && String.IsNullOrEmpty(SearchText))
+            {
+                populateReady = false;
+            }
             _userCalledPopulate = populateReady ? userInitiated : false;
 
             // Update the interface and values only as necessary


### PR DESCRIPTION
The issue was caused by the lack of a proper `TextChanged` event on the `TextBox`
I implemented a work around

Fixes #1554