### PR TITLE
restore correct implementation of SetSystemDecorations on Win32.

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -214,7 +214,9 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Enables or disables resizing of the window
+        /// Enables or disables resizing of the window.
+        /// Note that if <see cref="HasSystemDecorations"/> is set to False then this property
+        /// has no effect and should be treated as a recommendation for the user setting HasSystemDecorations.
         /// </summary>
         public bool CanResize
         {

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -287,6 +287,21 @@ namespace Avalonia.Win32
                 UnmanagedMethods.SetWindowPosFlags.SWP_NOZORDER | UnmanagedMethods.SetWindowPosFlags.SWP_NOACTIVATE);
 
             _decorated = value;
+
+            if(_decorated)
+            {
+                if (_resizable)
+                {
+                    // If we switch decorations back on we need to restore WS_SizeFrame.
+                    _resizable = false;
+                    CanResize(true);
+                }
+                else
+                {
+                    _resizable = true;
+                    CanResize(false);
+                }
+            }
         }
 
         public void Invalidate(Rect rect)
@@ -857,14 +872,18 @@ namespace Avalonia.Win32
                 return;
             }
 
-            var style = (UnmanagedMethods.WindowStyles)UnmanagedMethods.GetWindowLong(_hwnd, (int)UnmanagedMethods.WindowLongParam.GWL_STYLE);
-            
-            if (value)
-                style |= UnmanagedMethods.WindowStyles.WS_SIZEFRAME;
-            else
-                style &= ~(UnmanagedMethods.WindowStyles.WS_SIZEFRAME);
-            
-            UnmanagedMethods.SetWindowLong(_hwnd, (int)UnmanagedMethods.WindowLongParam.GWL_STYLE, (uint)style);
+            if (_decorated)
+            {
+                var style = (UnmanagedMethods.WindowStyles)UnmanagedMethods.GetWindowLong(_hwnd, (int)UnmanagedMethods.WindowLongParam.GWL_STYLE);
+
+                if (value)
+                    style |= UnmanagedMethods.WindowStyles.WS_SIZEFRAME;
+                else
+                    style &= ~(UnmanagedMethods.WindowStyles.WS_SIZEFRAME);
+
+                UnmanagedMethods.SetWindowLong(_hwnd, (int)UnmanagedMethods.WindowLongParam.GWL_STYLE, (uint)style);
+            }
+
             _resizable = value;
         }
     }

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -245,19 +245,13 @@ namespace Avalonia.Win32
                 return;
             }
 
-            var style = (UnmanagedMethods.WindowStyles)UnmanagedMethods.GetWindowLong(_hwnd, (int)UnmanagedMethods.WindowLongParam.GWL_STYLE);
+            var style = (UnmanagedMethods.WindowStyles)UnmanagedMethods.GetWindowLong(_hwnd, (int)UnmanagedMethods.WindowLongParam.GWL_STYLE);            
 
-            var systemDecorationStyles = UnmanagedMethods.WindowStyles.WS_OVERLAPPED
-                | UnmanagedMethods.WindowStyles.WS_CAPTION
-                | UnmanagedMethods.WindowStyles.WS_SYSMENU
-                | UnmanagedMethods.WindowStyles.WS_MINIMIZEBOX
-                | UnmanagedMethods.WindowStyles.WS_MAXIMIZEBOX;
-
-            style |= systemDecorationStyles;
+            style |= UnmanagedMethods.WindowStyles.WS_OVERLAPPEDWINDOW;
 
             if (!value)
             {
-                style ^= systemDecorationStyles;
+                style ^= UnmanagedMethods.WindowStyles.WS_OVERLAPPEDWINDOW;
             }
 
             UnmanagedMethods.RECT windowRect;


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
This fixes SetSystemDecorations on Win32.

- What is the current behavior?
This doesn't work, it leaves an empty titlebar and leave a weird margin around the window when maximized.

Introduced by #1522.

- What is the updated/expected behavior with this PR?
This restores this function as it was before, leaving intact the PRs new functionality of implementing CanResize.
