### PR TITLE
 Call Initialized for attached properties.

### DIFF
--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -71,7 +71,8 @@ namespace Avalonia
         public AvaloniaObject()
         {
             VerifyAccess();
-            foreach (var property in AvaloniaPropertyRegistry.Instance.GetRegistered(this))
+
+            void Notify(AvaloniaProperty property)
             {
                 object value = property.IsDirect ?
                     ((IDirectPropertyAccessor)property).GetValue(this) :
@@ -85,6 +86,16 @@ namespace Avalonia
                     BindingPriority.Unset);
 
                 property.NotifyInitialized(e);
+            }
+
+            foreach (var property in AvaloniaPropertyRegistry.Instance.GetRegistered(this))
+            {
+                Notify(property);
+            }
+
+            foreach (var property in AvaloniaPropertyRegistry.Instance.GetRegisteredAttached(this.GetType()))
+            {
+                Notify(property);
             }
         }
 

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Attached.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Attached.cs
@@ -37,10 +37,14 @@ namespace Avalonia.Base.UnitTests
             Assert.True(raised);
         }
 
-        private class Class1 : AvaloniaObject
+        private class Base : AvaloniaObject
+        {
+        }
+
+        private class Class1 : Base
         {
             public static readonly AttachedProperty<string> FooProperty =
-                AvaloniaProperty.RegisterAttached<Class1, AvaloniaObject, string>(
+                AvaloniaProperty.RegisterAttached<Class1, Base, string>(
                     "Foo",
                     "foodefault",
                     validate: ValidateFoo);
@@ -56,13 +60,13 @@ namespace Avalonia.Base.UnitTests
             }
         }
 
-        private class Class2 : AvaloniaObject
+        private class Class2 : Base
         {
             public static readonly AttachedProperty<string> FooProperty =
                 Class1.FooProperty.AddOwner<Class2>();
         }
 
-        private class Class3 : AvaloniaObject
+        private class Class3 : Base
         {
         }
     }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Attached.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Attached.cs
@@ -24,10 +24,23 @@ namespace Avalonia.Base.UnitTests
             Assert.Throws<IndexOutOfRangeException>(() => target.SetValue(Class2.FooProperty, "throw"));
         }
 
+        [Fact]
+        public void AvaloniaProperty_Initialized_Is_Called_For_Attached_Property()
+        {
+            bool raised = false;
+
+            using (Class1.FooProperty.Initialized.Subscribe(x => raised = true))
+            {
+                new Class3();
+            }
+
+            Assert.True(raised);
+        }
+
         private class Class1 : AvaloniaObject
         {
             public static readonly AttachedProperty<string> FooProperty =
-                AvaloniaProperty.RegisterAttached<Class1, Class2, string>(
+                AvaloniaProperty.RegisterAttached<Class1, AvaloniaObject, string>(
                     "Foo",
                     "foodefault",
                     validate: ValidateFoo);
@@ -47,6 +60,10 @@ namespace Avalonia.Base.UnitTests
         {
             public static readonly AttachedProperty<string> FooProperty =
                 Class1.FooProperty.AddOwner<Class2>();
+        }
+
+        private class Class3 : AvaloniaObject
+        {
         }
     }
 }


### PR DESCRIPTION
`AvaloniaProperty.Initialized` should be called for each property registered on a class when an instance of that class is instantiated, both regular `AvaloniaProperty`s and attached.

#1499 broke `AvaloniaProperty.Initialized` for attached properties - they were no longer called.

This reinstates the correct behavior. Using an inner method to raise the event to avoid having to call LINQ's `Concat` method or similar to concatenate the two collections.

Fixes #1568.