### PR TITLE
Fix spurious unmanaged memory leak warnings

### DIFF
--- a/src/Shared/PlatformSupport/StandardRuntimePlatform.cs
+++ b/src/Shared/PlatformSupport/StandardRuntimePlatform.cs
@@ -92,7 +92,7 @@ namespace Avalonia.Shared.PlatformSupport
             public void Dispose()
             {
 #if DEBUG
-                if (Thread.CurrentThread.ManagedThreadId == GCThread?.ManagedThreadId)
+                if (Thread.CurrentThread.ManagedThreadId == GCThread?.ManagedThreadId && !IsDisposed)
                 {
                     Console.Error.WriteLine("Native blob disposal from finalizer thread\nBacktrace: "
                                             + Environment.StackTrace
@@ -106,7 +106,10 @@ namespace Avalonia.Shared.PlatformSupport
             ~UnmanagedBlob()
             {
 #if DEBUG
-                Console.Error.WriteLine("Undisposed native blob created by " + _backtrace);
+                if (!IsDisposed)
+                {
+                    Console.Error.WriteLine("Undisposed native blob created by " + _backtrace); 
+                }
 #endif
                 DoDispose();
             }


### PR DESCRIPTION
- What does the pull request do?
Add `IsDisposed` checks around the finalizer-leak-checks in `UnmanagedBlob`.
- What is the current behavior?
`UnmanagedBlob` prints leak warnings whenever it is disposed on the finalizer thread, even if it was already disposed before on a user thread.
- What is the updated/expected behavior with this PR?
`UnmanagedBlob` only prints leak warnings if it is not already disposed before it hits the finalizer thread.

Checklist:

- [ ] Added unit tests (if possible)? N/A
- [ ] Added XML documentation to any related classes? N/A
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation. N/A

I've done a good amount of testing with this fix, and I can't get it to print for any layers or framebuffers in the `DeferredRenderer`. So, I strongly believe that we don't have any leaks in DeferredRenderer.

Fixes #1187.
Fixes #1314.