### PR TITLE
Allow indexer bindings to be at the start of a binding path.

### DIFF
--- a/src/Markup/Avalonia.Markup/Data/Parsers/ArgumentListParser.cs
+++ b/src/Markup/Avalonia.Markup/Data/Parsers/ArgumentListParser.cs
@@ -51,10 +51,10 @@ namespace Avalonia.Markup.Data.Parsers
                     }
                 }
 
-                throw new ExpressionParseException(r.Position, "Expected ']'.");
+                throw new ExpressionParseException(r.Position, $"Expected '{close}'.");
             }
 
-            return null;
+            throw new ExpressionParseException(r.Position, $"Expected '{open}'.");
         }
     }
 }

--- a/tests/Avalonia.Markup.UnitTests/Data/ExpressionObserverTests_Indexer.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/ExpressionObserverTests_Indexer.cs
@@ -338,6 +338,18 @@ namespace Avalonia.Markup.UnitTests.Data
             GC.KeepAlive(data);
         }
 
+        [Fact]
+        public async Task Indexer_Only_Binding_Works()
+        {
+            var data = new[] { 1, 2, 3 };
+
+            var target = new ExpressionObserver(data, "[1]");
+
+            var value = await target.Take(1);
+
+            Assert.Equal(data[1], value);
+        }
+
         private class NonIntegerIndexer : NotifyingBase
         {
             private readonly Dictionary<string, string> _storage = new Dictionary<string, string>();


### PR DESCRIPTION
- What does the pull request do?

Allow indexers to be at the start of a binding path.

- What is the current behavior?

This is currently unsupported.

- What is the updated/expected behavior with this PR?

Indexers at the start of a binding path, such at `{Binding Path=[0]}` are now supported.

Checklist:


- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

If the pull request fixes issue(s) list them like this:

Fixes #1566