### PR TITLE
skip unneeded drawing operations

### DIFF
--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -257,9 +257,12 @@ namespace Avalonia.Rendering
 
                     foreach (var operation in node.DrawOperations)
                     {
-                        _currentDraw = operation;
-                        operation.Item.Render(context);
-                        _currentDraw = null;
+                        if (!clipBounds.Intersect(operation.Item.Bounds).IsEmpty)
+                        {
+                            _currentDraw = operation;
+                            operation.Item.Render(context);
+                            _currentDraw = null;
+                        }
                     }
 
                     foreach (var child in node.Children)


### PR DESCRIPTION
- What does the pull request do?

it looks that huge amount of drawing operations can be skipped without any visual drawback
its not probably proper fix, just illustrates possible optimization

- What is the current behavior?
- What is the updated/expected behavior with this PR?
- How was the solution implemented (if it's not obvious)?

Checklist:

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
