### PR TITLE
Fixes/password char crash

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -223,11 +223,11 @@ namespace Avalonia.Controls.Presenters
 
             if (PasswordChar != default(char))
             {
-                result = base.CreateFormattedText(constraint, new string(PasswordChar, Text.Length));
+                result = base.CreateFormattedText(constraint, new string(PasswordChar, text?.Length ?? 0));
             }
             else
             {
-                result = base.CreateFormattedText(constraint, Text);
+                result = base.CreateFormattedText(constraint, text);
             }
 
             var selectionStart = SelectionStart;

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -111,6 +111,8 @@ namespace Avalonia.Controls
         /// </summary>
         public TextBlock()
         {
+            _text = string.Empty;
+
             Observable.Merge(
                 this.GetObservable(TextProperty).Select(_ => Unit.Default),
                 this.GetObservable(TextAlignmentProperty).Select(_ => Unit.Default),

--- a/tests/Avalonia.Controls.UnitTests/Presenters/TextPresenter_Tests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/TextPresenter_Tests.cs
@@ -23,5 +23,18 @@ namespace Avalonia.Controls.UnitTests.Presenters
 
             Assert.NotNull(target.FormattedText);
         }
+
+        [Fact]
+        public void Text_presenter_replaces_formatted_text_with_password_char()
+        {
+            var target = new TextPresenter
+            {
+                PasswordChar = '*',
+                Text = "Test"
+            };
+
+            Assert.NotNull(target.FormattedText);
+            Assert.Equal("****", target.FormattedText.Text);
+        }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/Presenters/TextPresenter_Tests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/TextPresenter_Tests.cs
@@ -1,0 +1,27 @@
+﻿using Avalonia.Controls.Presenters;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests.Presenters
+{
+    public class TextPresenter_Tests
+    {
+        [Fact]
+        public void TextPresenter_can_contain_null_with_password_char_set()
+        {
+            var target = new TextPresenter
+            {
+                PasswordChar = '*'
+            };
+
+            Assert.NotNull(target.FormattedText);
+        }
+
+        [Fact]
+        public void TextPresenter_can_contain_null_without_password_char_set()
+        {
+            var target = new TextPresenter();
+
+            Assert.NotNull(target.FormattedText);
+        }
+    }
+}

--- a/tests/Avalonia.Controls.UnitTests/Presenters/TextPresenter_Tests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/TextPresenter_Tests.cs
@@ -6,7 +6,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
     public class TextPresenter_Tests
     {
         [Fact]
-        public void TextPresenter_can_contain_null_with_password_char_set()
+        public void TextPresenter_Can_Contain_Null_With_Password_Char_Set()
         {
             var target = new TextPresenter
             {
@@ -17,7 +17,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
         }
 
         [Fact]
-        public void TextPresenter_can_contain_null_without_password_char_set()
+        public void TextPresenter_Can_Contain_Null_WithOut_Password_Char_Set()
         {
             var target = new TextPresenter();
 
@@ -25,7 +25,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
         }
 
         [Fact]
-        public void Text_presenter_replaces_formatted_text_with_password_char()
+        public void Text_Presenter_Replaces_Formatted_Text_With_Password_Char()
         {
             var target = new TextPresenter
             {

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -15,5 +15,15 @@ namespace Avalonia.Controls.UnitTests
                 BindingMode.OneWay,
                 TextBlock.TextProperty.GetMetadata(typeof(TextBlock)).DefaultBindingMode);
         }
+
+        [Fact]
+        public void Default_Text_Value_Should_Be_EmptyString()
+        {
+            var textBlock = new TextBlock();
+
+            Assert.Equal(
+                "",
+                textBlock.Text);
+        }
     }
 }


### PR DESCRIPTION
- What does the pull request do?
It fixes a bug with the password char property on Textpresenter.
- What is the current behavior?
If the text property hasn't been set and the user clicks inside a textbox with password char set, then the application crashes.

Also default value of text property on Textblock, TextBox etc is null in WPF its "", so updated that too.

- What is the updated/expected behavior with this PR?
Fixes crash, and makes unset text property value same as WPF.

Checklist:

- [x] Added unit tests (if possible)?

If the pull request fixes issue(s) list them like this:

Fixes #1597
