### PR TITLE
Register ToolTip attached properties correctly.

### DIFF
--- a/src/Avalonia.Controls/ToolTip.cs
+++ b/src/Avalonia.Controls/ToolTip.cs
@@ -34,25 +34,25 @@ namespace Avalonia.Controls
         /// Defines the ToolTip.Placement property.
         /// </summary>
         public static readonly AttachedProperty<PlacementMode> PlacementProperty =
-            AvaloniaProperty.RegisterAttached<Popup, Control, PlacementMode>("Placement", defaultValue: PlacementMode.Pointer);
+            AvaloniaProperty.RegisterAttached<ToolTip, Control, PlacementMode>("Placement", defaultValue: PlacementMode.Pointer);
 
         /// <summary>
         /// Defines the ToolTip.HorizontalOffset property.
         /// </summary>
         public static readonly AttachedProperty<double> HorizontalOffsetProperty =
-            AvaloniaProperty.RegisterAttached<Popup, Control, double>("HorizontalOffset");
+            AvaloniaProperty.RegisterAttached<ToolTip, Control, double>("HorizontalOffset");
 
         /// <summary>
         /// Defines the ToolTip.VerticalOffset property.
         /// </summary>
         public static readonly AttachedProperty<double> VerticalOffsetProperty =
-            AvaloniaProperty.RegisterAttached<Popup, Control, double>("VerticalOffset", 20);
+            AvaloniaProperty.RegisterAttached<ToolTip, Control, double>("VerticalOffset", 20);
 
         /// <summary>
         /// Defines the ToolTip.ShowDelay property.
         /// </summary>
         public static readonly AttachedProperty<int> ShowDelayProperty =
-            AvaloniaProperty.RegisterAttached<Popup, Control, int>("ShowDelay", 400);
+            AvaloniaProperty.RegisterAttached<ToolTip, Control, int>("ShowDelay", 400);
 
         /// <summary>
         /// Stores the curernt <see cref="ToolTip"/> instance in the control.


### PR DESCRIPTION
Was previously registering them with `Popup` as the owner, which was causing two properties with the same name to get registered, confusing XAML.

We should probably put in a check to make sure this doesn't happen, but this fixes the problem for now.

Fixes #1573