### PR TITLE
Fix RadioButton bullet border at 1px.

### DIFF
--- a/src/Avalonia.Themes.Default/RadioButton.xaml
+++ b/src/Avalonia.Themes.Default/RadioButton.xaml
@@ -8,7 +8,7 @@
         <Grid ColumnDefinitions="Auto,*" Background="{TemplateBinding Background}">
           <Ellipse Name="border"
                    Stroke="{TemplateBinding BorderBrush}"
-                   StrokeThickness="{TemplateBinding BorderThickness}"
+                   StrokeThickness="1"
                    Width="18"
                    Height="18"
                    VerticalAlignment="Center"/>


### PR DESCRIPTION
This PR fixes the default template for the `RadioButton` control.

Previously it was not displaying a border around the "checked" state bullet because we were binding `StrokeThickness` to `BorderThickness` which is now a `Thickness`, and so the binding was failing.
