### PR TITLE
add singleitem psuedo class on items control.

### DIFF
--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -364,6 +364,7 @@ namespace Avalonia.Controls
 
             var collection = sender as ICollection;
             PseudoClasses.Set(":empty", collection == null || collection.Count == 0);
+            PseudoClasses.Set(":singleitem", collection != null && collection.Count == 1);
         }
 
         /// <summary>
@@ -421,6 +422,8 @@ namespace Avalonia.Controls
         private void SubscribeToItems(IEnumerable items)
         {
             PseudoClasses.Set(":empty", items == null || items.Count() == 0);
+            PseudoClasses.Set(":singleitem", items != null && items.Count() == 1);
+
 
             var incc = items as INotifyCollectionChanged;
 

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -424,7 +424,6 @@ namespace Avalonia.Controls
             PseudoClasses.Set(":empty", items == null || items.Count() == 0);
             PseudoClasses.Set(":singleitem", items != null && items.Count() == 1);
 
-
             var incc = items as INotifyCollectionChanged;
 
             if (incc != null)


### PR DESCRIPTION
- What does the pull request do?
Adds `:singleitem` pseudo class to itemscontrol when Items.Count == 1.

Styling stuff based on a single item is incredibly difficult otherwise.

- What is the current behavior?
none,.

Checklist:
- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
