### PR TITLE
Fix intermittent test failure introduced by font tests

### DIFF
--- a/tests/Avalonia.Visuals.UnitTests/Media/Fonts/FontFamilyLoaderTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/Fonts/FontFamilyLoaderTests.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Visuals.UnitTests.Media.Fonts
 {
     using System.Diagnostics;
 
-    public class FontFamilyLoaderTests
+    public class FontFamilyLoaderTests : IDisposable
     {
         private const string FontName = "#MyFont";
         private const string Assembly = "?assembly=Avalonia.Visuals.UnitTests";
@@ -35,7 +35,7 @@ namespace Avalonia.Visuals.UnitTests.Media.Fonts
             _testApplication = StartWithResources(fontAssets);
         }
 
-        ~FontFamilyLoaderTests()
+        public void Dispose()
         {
             _testApplication.Dispose();
         }


### PR DESCRIPTION
Fix the intermittent failure we've been seeing on CI that was introduced after #1564.

This moves the `FontFamilyLoaderTests` to use a `Dispose` method instead of a finalizer to correctly fit the XUnit test lifecycle and not cause crashes due to asynchronous running of the finalizer thread.