### PR TITLE
Upgrade ReactiveUI dependency to 8.0.0 stable.

### DIFF
--- a/build/ReactiveUI.props
+++ b/build/ReactiveUI.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="reactiveui" Version="8.0.0-alpha0073" />
+    <PackageReference Include="reactiveui" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We should update to a stable version of ReactiveUI since there is now one released that we can use.