### PR TITLE
Convert brush to immutable brush in D2D backend.

### DIFF
--- a/src/Windows/Avalonia.Direct2D1/Media/FormattedTextImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/FormattedTextImpl.cs
@@ -101,7 +101,7 @@ namespace Avalonia.Direct2D1.Media
                 if (span.ForegroundBrush != null)
                 {
                     TextLayout.SetDrawingEffect(
-                        new BrushWrapper(span.ForegroundBrush),
+                        new BrushWrapper(span.ForegroundBrush.ToImmutable()),
                         new DWrite.TextRange(span.StartIndex, span.Length));
                 }
             }


### PR DESCRIPTION
All brushes potentially used by the rendering thread must be immutable brushes, however brushes that come from spans in a `FormattedText` were not being made immutable. Fix that.

Fixes #1613.
