### PR TITLE
Add missing annotations dependency.

### DIFF
--- a/packages.cake
+++ b/packages.cake
@@ -120,6 +120,7 @@ public class Packages
         var SharpDXDirect3D11Version = packageVersions["SharpDX.Direct3D11"].FirstOrDefault().Item1;
         var SharpDXDirect3D9Version = packageVersions["SharpDX.Direct3D9"].FirstOrDefault().Item1;
         var SharpDXDXGIVersion = packageVersions["SharpDX.DXGI"].FirstOrDefault().Item1;
+        var SystemComponentModelAnnotationsVersion = packageVersions["System.ComponentModel.Annotations"].FirstOrDefault().Item1;
 
         context.Information("Package: Serilog, version: {0}", SerilogVersion);
         context.Information("Package: Sprache, version: {0}", SpracheVersion);
@@ -238,6 +239,7 @@ public class Packages
                     new NuSpecDependency() { Id = "Sprache", Version = SpracheVersion },
                     new NuSpecDependency() { Id = "System.Reactive", Version = SystemReactiveVersion },
                     new NuSpecDependency() { Id = "Avalonia.Remote.Protocol", Version = parameters.Version },
+                    new NuSpecDependency() { Id = "System.ComponentModel.Annotations", Version = SystemComponentModelAnnotationsVersion },
                     //.NET Core
                     new NuSpecDependency() { Id = "System.Threading.ThreadPool", TargetFramework = "netcoreapp2.0", Version = "4.3.0" },
                     new NuSpecDependency() { Id = "Microsoft.Extensions.DependencyModel", TargetFramework = "netcoreapp2.0", Version = "1.1.0" },


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?

Adds a package dependency on `System.ComponentModel.Annotations` to the NuGet package.
- What is the current behavior?
Some bindings in .NET framework apps fail because this assembly is not present.
- What is the updated/expected behavior with this PR?
These bindings will correctly function.

If the pull request fixes issue(s) list them like this:

Fixes #1550 
May also be a fix for #1605 
