### PR TITLE
Make Style an AvaloniaObject to fix Design.PreviewWith

### DIFF
--- a/src/Avalonia.Controls/Design.cs
+++ b/src/Avalonia.Controls/Design.cs
@@ -1,5 +1,6 @@
 
 using System.Runtime.CompilerServices;
+using Avalonia.Styling;
 
 namespace Avalonia.Controls
 {
@@ -45,23 +46,18 @@ namespace Avalonia.Controls
         {
             return control.GetValue(DataContextProperty);
         }
-
-        static readonly ConditionalWeakTable<object, Control> Substitutes = new ConditionalWeakTable<object, Control>();
-
+        
         public static readonly AttachedProperty<Control> PreviewWithProperty = AvaloniaProperty
-            .RegisterAttached<AvaloniaObject, Control>("PreviewWith", typeof (Design));
+            .RegisterAttached<IStyle, Control>("PreviewWith", typeof (Design));
 
-        public static void SetPreviewWith(object target, Control control)
+        public static void SetPreviewWith(IStyle target, Control control)
         {
-            Substitutes.Remove(target);
-            Substitutes.Add(target, control);
+            target.SetValue(PreviewWithProperty, control);
         }
 
-        public static Control GetPreviewWith(object target)
+        public static Control GetPreviewWith(IStyle target)
         {
-            Control rv;
-            Substitutes.TryGetValue(target, out rv);
-            return rv;
+            return target.GetValue(PreviewWithProperty);
         }
 
         public static void ApplyDesignModeProperties(Control target, Control source)

--- a/src/Avalonia.Controls/Design.cs
+++ b/src/Avalonia.Controls/Design.cs
@@ -48,14 +48,14 @@ namespace Avalonia.Controls
         }
         
         public static readonly AttachedProperty<Control> PreviewWithProperty = AvaloniaProperty
-            .RegisterAttached<IStyle, Control>("PreviewWith", typeof (Design));
+            .RegisterAttached<Style, Control>("PreviewWith", typeof (Design));
 
-        public static void SetPreviewWith(IStyle target, Control control)
+        public static void SetPreviewWith(Style target, Control control)
         {
             target.SetValue(PreviewWithProperty, control);
         }
 
-        public static Control GetPreviewWith(IStyle target)
+        public static Control GetPreviewWith(Style target)
         {
             return target.GetValue(PreviewWithProperty);
         }

--- a/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
+++ b/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
@@ -36,8 +36,7 @@ namespace Avalonia.DesignerSupport
                 var styles = loaded as Styles;
                 if (styles != null)
                 {
-                    var substitute = Design.GetPreviewWith(styles) ??
-                                     styles.Select(Design.GetPreviewWith).FirstOrDefault(s => s != null);
+                    var substitute = styles.OfType<Style>().Select(Design.GetPreviewWith).FirstOrDefault(s => s != null);
                     if (substitute != null)
                     {
                         substitute.Styles.AddRange(styles);

--- a/src/Avalonia.Styling/Styling/IStyle.cs
+++ b/src/Avalonia.Styling/Styling/IStyle.cs
@@ -8,7 +8,7 @@ namespace Avalonia.Styling
     /// <summary>
     /// Defines the interface for styles.
     /// </summary>
-    public interface IStyle : IResourceNode
+    public interface IStyle : IAvaloniaObject, IResourceNode
     {
         /// <summary>
         /// Attaches the style to a control if the style's selector matches.

--- a/src/Avalonia.Styling/Styling/IStyle.cs
+++ b/src/Avalonia.Styling/Styling/IStyle.cs
@@ -8,7 +8,7 @@ namespace Avalonia.Styling
     /// <summary>
     /// Defines the interface for styles.
     /// </summary>
-    public interface IStyle : IAvaloniaObject, IResourceNode
+    public interface IStyle : IResourceNode
     {
         /// <summary>
         /// Attaches the style to a control if the style's selector matches.

--- a/src/Avalonia.Styling/Styling/Style.cs
+++ b/src/Avalonia.Styling/Styling/Style.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Styling
     /// <summary>
     /// Defines a style.
     /// </summary>
-    public class Style : IStyle, ISetStyleParent
+    public class Style : AvaloniaObject, IStyle, ISetStyleParent
     {
         private static Dictionary<IStyleable, List<IDisposable>> _applied =
             new Dictionary<IStyleable, List<IDisposable>>();


### PR DESCRIPTION
Previously Design.PreviewWith worked because of a quirk in how OmniXAML set attached properties. Ever since we switched to Portable.Xaml, the Design.PreviewWith property hasn't worked since our XAML attached property support directly sets the attached property instead of calling the static methods. So, by making `IStyle` an `IAvaloniaObject`, we can set attached property values on it. This allows Design.PreviewWith to work again.

Fixes #1531