### PR TITLE
WIP: Add GL support to Avalonia

### DIFF
--- a/Avalonia.sln
+++ b/Avalonia.sln
@@ -105,9 +105,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ControlCatalog.Desktop", "s
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ControlCatalog.iOS", "samples\ControlCatalog.iOS\ControlCatalog.iOS.csproj", "{57E0455D-D565-44BB-B069-EE1AA20F8337}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalonia.DesignerSupport.Tests", "tests\Avalonia.DesignerSupport.Tests\Avalonia.DesignerSupport.Tests.csproj", "{52F55355-D120-42AC-8116-8410A7D602FA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.DesignerSupport.Tests", "tests\Avalonia.DesignerSupport.Tests\Avalonia.DesignerSupport.Tests.csproj", "{52F55355-D120-42AC-8116-8410A7D602FA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalonia.DesignerSupport.TestApp", "tests\Avalonia.DesignerSupport.TestApp\Avalonia.DesignerSupport.TestApp.csproj", "{F1381F98-4D24-409A-A6C5-1C5B1E08BB08}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.DesignerSupport.TestApp", "tests\Avalonia.DesignerSupport.TestApp\Avalonia.DesignerSupport.TestApp.csproj", "{F1381F98-4D24-409A-A6C5-1C5B1E08BB08}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VirtualizationTest", "samples\VirtualizationTest\VirtualizationTest.csproj", "{FBCAF3D0-2808-4934-8E96-3F607594517B}"
 EndProject
@@ -183,6 +183,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.MonoMac", "src\OSX\Avalonia.MonoMac\Avalonia.MonoMac.csproj", "{CBFD5788-567D-401B-9DFA-74E4224025A0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalonia.Designer.HostApp.NetFX", "src\tools\Avalonia.Designer.HostApp.NetFX\Avalonia.Designer.HostApp.NetFX.csproj", "{4ADA61C8-D191-428D-9066-EF4F0D86520F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "OpenGL", "OpenGL", "{CBF8F277-1649-49D0-95FD-C0838A1EADD7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalonia.OpenGL", "src\OpenGL\Avalonia.OpenGL\Avalonia.OpenGL.csproj", "{C08B2F81-041B-444F-8837-16229CA0D11F}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -2469,6 +2473,46 @@ Global
 		{4ADA61C8-D191-428D-9066-EF4F0D86520F}.Release|NetCoreOnly.ActiveCfg = Release|Any CPU
 		{4ADA61C8-D191-428D-9066-EF4F0D86520F}.Release|x86.ActiveCfg = Release|Any CPU
 		{4ADA61C8-D191-428D-9066-EF4F0D86520F}.Release|x86.Build.0 = Release|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Ad-Hoc|Any CPU.ActiveCfg = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Ad-Hoc|Any CPU.Build.0 = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Ad-Hoc|iPhone.Build.0 = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Ad-Hoc|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Ad-Hoc|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Ad-Hoc|NetCoreOnly.ActiveCfg = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Ad-Hoc|NetCoreOnly.Build.0 = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Ad-Hoc|x86.ActiveCfg = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Ad-Hoc|x86.Build.0 = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.AppStore|Any CPU.Build.0 = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.AppStore|iPhone.ActiveCfg = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.AppStore|iPhone.Build.0 = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.AppStore|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.AppStore|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.AppStore|NetCoreOnly.ActiveCfg = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.AppStore|NetCoreOnly.Build.0 = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.AppStore|x86.ActiveCfg = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.AppStore|x86.Build.0 = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Debug|NetCoreOnly.ActiveCfg = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Debug|NetCoreOnly.Build.0 = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Debug|x86.Build.0 = Debug|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Release|iPhone.Build.0 = Release|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Release|NetCoreOnly.ActiveCfg = Release|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Release|NetCoreOnly.Build.0 = Release|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Release|x86.ActiveCfg = Release|Any CPU
+		{C08B2F81-041B-444F-8837-16229CA0D11F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2521,6 +2565,7 @@ Global
 		{F40FC0A2-1BC3-401C-BFC1-928EC4D4A9CE} = {9B9E3891-2366-4253-A952-D08BCEB71098}
 		{CBFD5788-567D-401B-9DFA-74E4224025A0} = {A59C4C0A-64DF-4621-B450-2BA00D6F61E2}
 		{4ADA61C8-D191-428D-9066-EF4F0D86520F} = {4ED8B739-6F4E-4CD4-B993-545E6B5CE637}
+		{C08B2F81-041B-444F-8837-16229CA0D11F} = {CBF8F277-1649-49D0-95FD-C0838A1EADD7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {87366D66-1391-4D90-8999-95A620AD786A}

--- a/build/Avalonia.Win32.Natives.props
+++ b/build/Avalonia.Win32.Natives.props
@@ -1,0 +1,5 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PackageReference Include="AvaloniaUI.Win32.Natives" Version="0.0.1" />
+  </ItemGroup>
+</Project>

--- a/packages.cake
+++ b/packages.cake
@@ -421,9 +421,6 @@ public class Packages
             new NuGetPackSettings()
             {
                 Id = "Avalonia.OpenGL",
-                Dependencies = new []
-                {
-                },
                 Files = new []
                 {
                     new NuSpecContent { Source = "Avalonia.OpenGL.dll", Target = "lib/netstandard2.0" }

--- a/packages.cake
+++ b/packages.cake
@@ -105,7 +105,7 @@ public class Packages
         });
 
         context.Information("Setting NuGet package dependencies versions:");
-
+        var Win32NativesVersion = packageVersions["AvaloniaUI.Win32.Natives"].FirstOrDefault().Item1;
         var SerilogVersion = packageVersions["Serilog"].FirstOrDefault().Item1;
         var SerilogSinksDebugVersion = packageVersions["Serilog.Sinks.Debug"].FirstOrDefault().Item1;
         var SerilogSinksTraceVersion = packageVersions["Serilog.Sinks.Trace"].FirstOrDefault().Item1;
@@ -121,6 +121,7 @@ public class Packages
         var SharpDXDirect3D9Version = packageVersions["SharpDX.Direct3D9"].FirstOrDefault().Item1;
         var SharpDXDXGIVersion = packageVersions["SharpDX.DXGI"].FirstOrDefault().Item1;
 
+        context.Information("Package: AvaloniaUI.Win32.Natives, version: {0}", Win32NativesVersion);
         context.Information("Package: Serilog, version: {0}", SerilogVersion);
         context.Information("Package: Sprache, version: {0}", SpracheVersion);
         context.Information("Package: System.Reactive, version: {0}", SystemReactiveVersion);
@@ -343,7 +344,10 @@ public class Packages
                 Id = "Avalonia.Win32",
                 Dependencies = new DependencyBuilder(this)
                 {
-                    new NuSpecDependency() { Id = "Avalonia", Version = parameters.Version }
+                    new NuSpecDependency() { Id = "Avalonia", Version = parameters.Version },
+                    new NuSpecDependency() { Id = "Avalonia.OpenGL", Version = parameters.Version }
+                    new NuSpecDependency() { Id = "Avalonia.Win32.Natives", Version = Win32NativesVersion, TargetFramework="netcoreapp2.0" },
+                    new NuSpecDependency() { Id = "Avalonia.Win32.Natives", Version = Win32NativesVersion, TargetFramework="net461" }
                 }.Deps(new string[]{null}, "System.Drawing.Common"),
                 Files = new []
                 {
@@ -416,6 +420,19 @@ public class Packages
             },
             new NuGetPackSettings()
             {
+                Id = "Avalonia.OpenGL",
+                Dependencies = new []
+                {
+                },
+                Files = new []
+                {
+                    new NuSpecContent { Source = "Avalonia.OpenGL.dll", Target = "lib/netstandard2.0" }
+                },
+                BasePath = context.Directory("./src/OpenGL/Avalonia.OpenGL/bin/" + parameters.DirSuffix + "/netstandard2.0"),
+                OutputDirectory = parameters.NugetRoot
+            },
+            new NuGetPackSettings()
+            {
                 Id = "Avalonia.MonoMac",
                 Dependencies = new DependencyBuilder(this)
                 {
@@ -439,6 +456,7 @@ public class Packages
                     new NuSpecDependency() { Id = "Avalonia.Direct2D1", Version = parameters.Version },
                     new NuSpecDependency() { Id = "Avalonia.Win32", Version = parameters.Version },
                     new NuSpecDependency() { Id = "Avalonia.Skia", Version = parameters.Version },
+                    new NuSpecDependency() { Id = "Avalonia.OpenGL", Version = parameters.Version },
                     new NuSpecDependency() { Id = "Avalonia.Gtk3", Version = parameters.Version },
                     new NuSpecDependency() { Id = "Avalonia.MonoMac", Version = parameters.Version }
                 },

--- a/packages.cake
+++ b/packages.cake
@@ -345,7 +345,7 @@ public class Packages
                 Dependencies = new DependencyBuilder(this)
                 {
                     new NuSpecDependency() { Id = "Avalonia", Version = parameters.Version },
-                    new NuSpecDependency() { Id = "Avalonia.OpenGL", Version = parameters.Version }
+                    new NuSpecDependency() { Id = "Avalonia.OpenGL", Version = parameters.Version },
                     new NuSpecDependency() { Id = "Avalonia.Win32.Natives", Version = Win32NativesVersion, TargetFramework="netcoreapp2.0" },
                     new NuSpecDependency() { Id = "Avalonia.Win32.Natives", Version = Win32NativesVersion, TargetFramework="net461" }
                 }.Deps(new string[]{null}, "System.Drawing.Common"),

--- a/src/OpenGL/Avalonia.OpenGL/Avalonia.OpenGL.csproj
+++ b/src/OpenGL/Avalonia.OpenGL/Avalonia.OpenGL.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/OpenGL/Avalonia.OpenGL/GlContextException.cs
+++ b/src/OpenGL/Avalonia.OpenGL/GlContextException.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+
+namespace Avalonia.OpenGL
+{
+    public class GlContextException : Exception
+    {
+        public GlContextException(string message) : base(message) { }
+    }
+}

--- a/src/OpenGL/Avalonia.OpenGL/GlRequest.cs
+++ b/src/OpenGL/Avalonia.OpenGL/GlRequest.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+namespace Avalonia.OpenGL
+{
+    public class GlRequest
+    {
+        /// <summary>
+        /// OpenGL API to use
+        /// </summary>
+        public GlApi Api { get; set; }
+
+        /// <summary>
+        /// OpenGL version to use
+        /// </summary>
+        public GlVersion Version { get; set; }
+
+        /// <summary>
+        /// Leave this unset if the GLVersion used is Latest
+        /// </summary>
+        public int GlMajor { get; set; }
+
+        /// <summary>
+        /// Leave this unset if the GlVersion used is Latest
+        /// </summary>
+        public int GlMinor { get; set; }
+    }
+
+    public enum GlApi
+    {
+        /// <summary>
+        /// Tries GL and if that fails tries GLES
+        /// </summary>
+        Auto,
+
+        /// <summary>
+        /// Tries GL
+        /// </summary>
+        Gl,
+
+        /// <summary>
+        /// Tries GLES
+        /// </summary>
+        Gles
+    }
+
+    public enum GlVersion
+    {
+        /// <summary>
+        /// Use the lates GL version 
+        /// </summary>
+        Latest,
+
+        /// <summary>
+        /// Use a specific GL version
+        /// </summary>
+        Specific
+    }
+}

--- a/src/OpenGL/Avalonia.OpenGL/IGlContext.cs
+++ b/src/OpenGL/Avalonia.OpenGL/IGlContext.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+
+namespace Avalonia.OpenGL
+{
+    /// <summary>
+    /// GL Context
+    /// </summary>
+    public interface IGlContext : IDisposable
+    {
+        /// <summary>
+        /// Sets the GL Surface for a Context
+        /// </summary>
+        IGlSurface Surface { get; }
+
+        /// <summary>
+        /// Swaps buffers
+        /// </summary>
+        void SwapBuffers();
+
+        /// <summary>
+        /// Makes this GL Context current
+        /// </summary>
+        void MakeCurrent();
+
+        IntPtr GetProcAddress(string functionName);
+
+        /// <returns>True if this Context is the current one. False otherwise.</returns>
+        bool IsCurrentContext();
+
+        /// <summary>
+        /// Recreates the current surface
+        /// </summary>
+        void RecreateSurface();
+    }
+}

--- a/src/OpenGL/Avalonia.OpenGL/IGlContextBuilder.cs
+++ b/src/OpenGL/Avalonia.OpenGL/IGlContextBuilder.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Avalonia.OpenGL
+{
+    public interface IGlContextBuilder
+    {
+        IGlContext Build(IEnumerable<object> surfaces);
+    }
+}

--- a/src/OpenGL/Avalonia.OpenGL/IGlSurface.cs
+++ b/src/OpenGL/Avalonia.OpenGL/IGlSurface.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+
+namespace Avalonia.OpenGL
+{
+    /// <summary>
+    /// GL renderable surface.
+    /// </summary>
+    public interface IGlSurface : IDisposable
+    {
+        IntPtr SurfaceHandle { get; }
+
+        /// <summary>
+        /// Get size of a surface.
+        /// </summary>
+        /// <returns>Size of a surface.</returns> 
+        (int width, int height) GetSize();
+
+        /// <summary>
+        /// Get dpi of a surface. 
+        /// </summary>
+        /// <returns>Dpi of a surface</returns> 
+        (int x, int y) GetDpi();
+    }
+}

--- a/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
+++ b/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\Avalonia.Layout\Avalonia.Layout.csproj" />
     <ProjectReference Include="..\..\Avalonia.Styling\Avalonia.Styling.csproj" />
     <ProjectReference Include="..\..\Avalonia.Visuals\Avalonia.Visuals.csproj" />
+    <ProjectReference Include="..\..\OpenGL\Avalonia.OpenGL\Avalonia.OpenGL.csproj" />
   </ItemGroup>
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\build\System.Drawing.Common.props" />
 </Project>

--- a/src/Windows/Avalonia.Win32/EGL/EGL.cs
+++ b/src/Windows/Avalonia.Win32/EGL/EGL.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Avalonia.Win32.EGL
+{
+    public static class EGL
+    {
+        public const int DEFAULT_DISPLAY = 0;
+        public const int CONTEXT_CLIENT_VERSION = 0x3098;
+        public const int CONTEXT_MINOR_VERSION = 0x30FB;
+        public const int NONE = 0x3038;
+
+        public const int PBUFFER_BIT = 0x0001;
+        public const int WINDOW_BIT = 0x0004;
+        public const int PIXMAP_BIT = 0x0002;
+
+        public const int COLOR_BUFFER_TYPE = 0x303F;
+        public const int SURFACE_TYPE = 0x3033;
+        public const int RENDERABLE_TYPE = 0x3040;
+
+        public const int RED_SIZE = 0x3024;
+        public const int GREEN_SIZE = 0x3023;
+        public const int BLUE_SIZE = 0x3022;
+        public const int ALPHA_SIZE = 0x3021;
+        public const int DEPTH_SIZE = 0x3025;
+        public const int STENCIL_SIZE = 0x3026;
+
+        public const int CONFIG_CAVEAT = 0x3027;
+
+        public const int OPENGL_BIT = 0x0008;
+        public const int OPENGL_API = 0x30A2;
+
+        public const int OPENGL_ES_BIT = 1;
+        public const int OPENGL_ES2_BIT = 0x0004;
+        public const int OPENGL_ES3_BIT = 0x00000040;
+        public const int OPENGL_ES_API = 0x30A0;
+
+        public const int WIDTH = 0x3057;
+        public const int HEIGHT = 0x3056;
+
+        public const int NO_SURFACE = 0;
+        public const int NO_DISPLAY = 0;
+        public const int NO_CONTEXT = 0;
+
+        public const int RGB_BUFFER = 0x308E;
+        public const int EXTENSIONS = 0x3055;
+        public const int CONFORMANT = 0x3042;
+
+        public const int PLATFORM_ANGLE_ANGLE = 0x3202;
+        public const int PLATFORM_ANGLE_TYPE_ANGLE = 0x3203;
+        public const int PLATFORM_ANGLE_TYPE_DEFAULT_ANGLE = 0x3206;
+        public const int PLATFORM_ANGLE_DEBUG_LAYERS_ENABLED = 0x3451;
+
+        public const int PLATFORM_ANGLE_DEVICE_TYPE_HARDWARE_ANGLE = 0x320A;
+        public const int TRUE = 1;
+
+        public const int PLATFORM_ANGLE_MAX_VERSION_MAJOR_ANGLE = 0x3204;
+        public const int PLATFORM_ANGLE_MAX_VERSION_MINOR_ANGLE = 0x3205;
+
+        public const int CONTEXT_FLAGS_KHR = 0x30FC;
+        public const int CONTEXT_OPENGL_DEBUG_BIT = 0x00000001;
+
+        private static class Native
+        {
+            public const string Library = "libEGL.dll";
+
+            [DllImport(Library)]
+            internal static extern IntPtr eglGetDisplay(IntPtr display_id);
+
+            [DllImport(Library)]
+            internal static extern bool eglInitialize(IntPtr dpy, out int major, out int minor);
+
+            [DllImport(Library)]
+            internal static extern IntPtr eglCreateContext(IntPtr dpy, IntPtr config, IntPtr share_context, int[] attrib_list);
+
+            [DllImport("libEGL.dll")]
+            internal static extern IntPtr eglGetCurrentContext();
+
+            [DllImport(Library)]
+            internal static extern bool eglChooseConfig(IntPtr dpy, int[] attrib_list, IntPtr[] configs, int config_size, out int num_config);
+
+            [DllImport(Library)]
+            internal static extern IntPtr eglCreatePbufferSurface(IntPtr dpy, IntPtr config, int[] attrib_list);
+
+            [DllImport(Library)]
+            internal static extern bool eglMakeCurrent(IntPtr dpy, IntPtr draw, IntPtr read, IntPtr ctx);
+
+            [DllImport(Library)]
+            internal static extern IntPtr eglGetProcAddress(string funcname);
+
+            [DllImport(Library)]
+            internal static extern bool eglSwapBuffers(IntPtr dpy, IntPtr surface);
+
+            [DllImport(Library)]
+            internal static extern IntPtr eglCreateWindowSurface(IntPtr dpy, IntPtr config, IntPtr win, int[] attrib_list);
+
+            [DllImport(Library)]
+            internal static extern int eglGetError();
+
+            [DllImport(Library)]
+            internal static extern bool eglBindAPI(uint api);
+
+            [DllImport(Library)]
+            internal static extern IntPtr eglQueryString(IntPtr dpy, int name);
+
+            [DllImport(Library)]
+            internal static extern IntPtr eglGetPlatformDisplayEXT(uint platform, IntPtr nativeDisplay, int[] attrib_list);
+
+            [DllImport(Library)]
+            internal static extern bool eglDestroySurface(IntPtr dpy, IntPtr surface);
+
+            [DllImport(Library)]
+            internal static extern bool eglGetConfigAttrib(IntPtr display, IntPtr config, int attribute, out int value);
+        }
+
+        public static IntPtr GetDisplay(IntPtr displayId)
+        {
+            return Native.eglGetDisplay(displayId);
+        }
+
+        public static bool Initialize(IntPtr display, out int major, out int minor)
+        {
+            return Native.eglInitialize(display, out major, out minor);
+        }
+
+        public static IntPtr CreateContext(IntPtr display, IntPtr config, IntPtr shareContext, int[] attributeList)
+        {
+            return Native.eglCreateContext(display, config, shareContext, attributeList);
+        }
+
+        public static bool ChooseConfig(IntPtr display, int[] attributeList, IntPtr[] configs, int configsSize, out int numConfigs)
+        {
+            return Native.eglChooseConfig(display, attributeList, configs, configsSize, out numConfigs);
+        }
+
+        public static IntPtr CreatePbufferSurface(IntPtr display, IntPtr config, int[] attributeList)
+        {
+            return Native.eglCreatePbufferSurface(display, config, attributeList);
+        }
+
+        public static IntPtr CreateWindowSurface(IntPtr display, IntPtr config, IntPtr window, int[] attributeList)
+        {
+            return Native.eglCreateWindowSurface(display, config, window, attributeList);
+        }
+
+        public static bool MakeCurrent(IntPtr display, IntPtr draw, IntPtr read, IntPtr context)
+        {
+            return Native.eglMakeCurrent(display, draw, read, context);
+        }
+
+        public static IntPtr GetProcAddress(string procName)
+        {
+            return Native.eglGetProcAddress(procName);
+        }
+
+        public static bool SwapBuffers(IntPtr display, IntPtr surface)
+        {
+            return Native.eglSwapBuffers(display, surface);
+        }
+
+        public static int GetError()
+        {
+            return Native.eglGetError();
+        }
+
+        public static bool BindAPI(uint api)
+        {
+            return Native.eglBindAPI(api);
+        }
+
+        public static string QueryString(IntPtr display, int name)
+        {
+            return Marshal.PtrToStringAnsi(Native.eglQueryString(display, name));
+        }
+
+        public static bool DestroySurface(IntPtr display, IntPtr surface)
+        {
+            return Native.eglDestroySurface(display, surface);
+        }
+
+        public static IntPtr GetCurrentContext()
+        {
+            return Native.eglGetCurrentContext();
+        }
+    }
+}

--- a/src/Windows/Avalonia.Win32/EGL/EglContext.cs
+++ b/src/Windows/Avalonia.Win32/EGL/EglContext.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using Avalonia.Logging;
+using Avalonia.OpenGL;
+using System;
+
+namespace Avalonia.Win32.EGL
+{
+    public class EglContext : IGlContext
+    {
+        private IntPtr _context = IntPtr.Zero;
+        private IntPtr _display = IntPtr.Zero;
+        private IntPtr _configId = IntPtr.Zero;
+
+        public IGlSurface Surface { get; private set; }
+
+        /// <inheritdoc />
+        public EglContext(IntPtr display, IntPtr configId, IGlSurface surface, IntPtr context)
+        {
+            _display = display;
+            _configId = configId;
+            Surface = surface;
+            _context = context;
+        }
+
+        /// <inheritdoc />
+        public IntPtr GetProcAddress(string functionName)
+        {
+            return EGL.GetProcAddress(functionName);
+        }
+
+        /// <inheritdoc />
+        public bool IsCurrentContext()
+        {
+            return EGL.GetCurrentContext() == _context;
+        }
+
+        /// <inheritdoc />
+        public void MakeCurrent()
+        {
+            EGL.MakeCurrent(_display, Surface.SurfaceHandle, Surface.SurfaceHandle, _context);
+        }
+
+        /// <inheritdoc />
+        public void SwapBuffers()
+        {
+            EGL.SwapBuffers(_display, Surface.SurfaceHandle);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Surface.Dispose();
+        }
+
+        /// <inheritdoc />
+        public void RecreateSurface()
+        {
+            EGL.MakeCurrent(_display, (IntPtr)EGL.NO_SURFACE, (IntPtr)EGL.NO_SURFACE, _context);
+            if (!EGL.DestroySurface(_display, Surface.SurfaceHandle))
+            {
+                var error = EGL.GetError();
+                Logger.Warning(LogArea.Visual, this, "Failed to destroy EGL surface with handle {handle}. Error: {error}", Surface.SurfaceHandle, error);
+            }
+
+            // TODO: More surface attributes?
+            var attributes = new int[]
+            {
+                EGL.NONE
+            };
+
+            var newSurface = EGL.CreateWindowSurface(_display, _configId, ((EglSurface)this.Surface).PlatformHandle.Handle, attributes);
+            if (newSurface == IntPtr.Zero)
+            {
+                var error = EGL.GetError();
+                Logger.Warning(LogArea.Visual, this, "Failed to create EGL surface. Error: {error}", error);
+            }
+
+            this.Surface = new EglSurface(newSurface, ((EglSurface)this.Surface).PlatformHandle);
+            EGL.MakeCurrent(_display, this.Surface.SurfaceHandle, this.Surface.SurfaceHandle, _context);
+        }
+    }
+}

--- a/src/Windows/Avalonia.Win32/EGL/EglContextBuilder.cs
+++ b/src/Windows/Avalonia.Win32/EGL/EglContextBuilder.cs
@@ -1,0 +1,239 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using Avalonia.OpenGL;
+using Avalonia.Platform;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Avalonia.Win32.EGL
+{
+    public enum EglApi
+    {
+        Gl,
+        Gles
+    }
+
+    public class EglContextBuilder : IGlContextBuilder
+    {
+        private readonly IntPtr _display = IntPtr.Zero;
+        private List<string> _extensions = new List<string>();
+        private readonly int _eglMajor;
+        private readonly int _eglMinor;
+        private readonly IntPtr _configId;
+        private readonly EglApi _eglApi;
+
+        public EglContextBuilder(GlRequest request)
+        {
+            _display = EGL.GetDisplay((IntPtr)EGL.DEFAULT_DISPLAY);
+
+            if (_display == IntPtr.Zero)
+                throw new GlContextException("Could not create EGL display object!");
+
+            if (!EGL.Initialize(_display, out _eglMajor, out _eglMinor))
+                throw new GlContextException("Could not initialize EGL!");
+
+            // EGL >= 1.4 lets us query extensions
+            if (_eglMajor >= 1 && _eglMinor >= 4)
+            {
+                _extensions.AddRange(EGL.QueryString(_display, EGL.EXTENSIONS).Split(' '));
+            }
+
+            _eglApi = BindAPI(_eglMajor, _eglMinor, request);
+            _configId = ChooseFbConfig(_display, _eglMajor, _eglMinor, request, _eglApi);
+        }
+
+        public IGlContext Build(IEnumerable<object> surfaces)
+        {
+            var hwnd = surfaces.FirstOrDefault(s => s is IPlatformHandle) as PlatformHandle;
+            if (hwnd == null)
+                throw new InvalidOperationException("Could not find a HWND to build a surface from!");
+
+            // TODO: More surface attributes?
+            var attributes = new int[]
+            {
+                EGL.NONE
+            };
+
+            var surface = EGL.CreateWindowSurface(_display, _configId, hwnd.Handle, attributes);
+
+            // TODO: Make the GL version configurable
+            return new EglContext(
+                _display,
+                _configId,
+                new EglSurface(surface, hwnd),
+                CreateContext(3, 0)
+            );
+        }
+
+        private static EglApi BindAPI(int eglMajor, int eglMinor, GlRequest request)
+        {
+            // EGL defaults to OPENGL_ES for eglBindAPI.
+            var eglApi = EglApi.Gles;
+
+            //If we have EGL >= 1.4, we can try desktop GL if our GlRequest is set to Auto
+            if (eglMajor >= 1 && eglMinor >= 4)
+            {
+                if (request.Api == GlApi.Auto)
+                {
+                    if (EGL.BindAPI(EGL.OPENGL_API))
+                    {
+                        eglApi = EglApi.Gl;
+                    }
+                    else if (EGL.BindAPI(EGL.OPENGL_ES_API))
+                    {
+                        eglApi = EglApi.Gles;
+                    }
+                    else
+                    {
+                        throw new GlContextException("Could not find a suitable OpenGL API to bind to!");
+                    }
+                }
+                else if (request.Api == GlApi.Gl)
+                {
+                    if (!EGL.BindAPI(EGL.OPENGL_API))
+                    {
+                        throw new GlContextException("Could not find a suitable OpenGL API to bind to!");
+                    }
+                }
+            }
+
+            return eglApi;
+        }
+
+        private static IntPtr ChooseFbConfig(IntPtr display, int major, int minor, GlRequest request, EglApi api)
+        {
+            var attributes = new List<int>();
+
+            if (major >= 1 && minor >= 2)
+            {
+                attributes.Add(EGL.COLOR_BUFFER_TYPE);
+                attributes.Add(EGL.RGB_BUFFER);
+            }
+
+            attributes.Add(EGL.SURFACE_TYPE);
+            attributes.Add(EGL.WINDOW_BIT);
+
+            // Add the Renderable type and Conformant attributes based on the selected API
+            if (api == EglApi.Gles)
+            {
+                if (major <= 1 && minor < 3)
+                {
+                    throw new GlContextException("No available pixel format!");
+                }
+
+                if (request.Version == GlVersion.Specific && request.GlMajor == 3)
+                {
+                    attributes.Add(EGL.RENDERABLE_TYPE);
+                    attributes.Add(EGL.OPENGL_ES3_BIT);
+
+                    attributes.Add(EGL.CONFORMANT);
+                    attributes.Add(EGL.OPENGL_ES3_BIT);
+                }
+                else if (request.Version == GlVersion.Specific && request.GlMajor == 2)
+                {
+                    attributes.Add(EGL.RENDERABLE_TYPE);
+                    attributes.Add(EGL.OPENGL_ES2_BIT);
+
+                    attributes.Add(EGL.CONFORMANT);
+                    attributes.Add(EGL.OPENGL_ES2_BIT);
+                }
+                else if (request.Version == GlVersion.Specific && request.GlMajor == 1)
+                {
+                    attributes.Add(EGL.RENDERABLE_TYPE);
+                    attributes.Add(EGL.OPENGL_ES_BIT);
+
+                    attributes.Add(EGL.CONFORMANT);
+                    attributes.Add(EGL.OPENGL_ES_BIT);
+                }
+                else
+                {
+                    attributes.Add(EGL.RENDERABLE_TYPE);
+                    attributes.Add(EGL.OPENGL_ES3_BIT);
+
+                    attributes.Add(EGL.CONFORMANT);
+                    attributes.Add(EGL.OPENGL_ES3_BIT);
+                }
+            }
+            else
+            {
+                if (major <= 1 && minor < 3)
+                {
+                    throw new GlContextException("No available pixel format!");
+                }
+
+                attributes.Add(EGL.RENDERABLE_TYPE);
+                attributes.Add(EGL.OPENGL_BIT);
+                attributes.Add(EGL.CONFORMANT);
+                attributes.Add(EGL.OPENGL_BIT);
+            }
+
+            // Use HW acceleration
+            attributes.Add(EGL.CONFIG_CAVEAT);
+            attributes.Add(EGL.NONE);
+
+            attributes.Add(EGL.RED_SIZE);
+            attributes.Add(8);
+
+            attributes.Add(EGL.GREEN_SIZE);
+            attributes.Add(8);
+
+            attributes.Add(EGL.BLUE_SIZE);
+            attributes.Add(8);
+
+            attributes.Add(EGL.ALPHA_SIZE);
+            attributes.Add(8);
+
+            attributes.Add(EGL.DEPTH_SIZE);
+            attributes.Add(24);
+
+            attributes.Add(EGL.STENCIL_SIZE);
+            attributes.Add(8);
+
+            attributes.Add(EGL.NONE);
+
+            var configIds = new IntPtr[1];
+            if (!EGL.ChooseConfig(display, attributes.ToArray(), configIds, 1, out var numConfigs))
+            {
+                throw new GlContextException("eglChooseConfig failed!");
+            }
+
+            if (numConfigs == 0)
+            {
+                throw new GlContextException("No available pixel format!");
+            }
+
+            return configIds[0];
+        }
+
+        private IntPtr CreateContext(int contextMajor, int contextMinor)
+        {
+            var attributes = new List<int>();
+
+            // EGL >= 1.5 or implementations with EGL_KHR_create_context can request a minor version as well
+            if ((_eglMajor >= 1 && _eglMinor >= 5) || _extensions.Contains("EGL_KHR_create_context"))
+            {
+                attributes.Add(EGL.CONTEXT_CLIENT_VERSION);
+                attributes.Add(contextMajor);
+                attributes.Add(EGL.CONTEXT_MINOR_VERSION);
+                attributes.Add(contextMinor);
+
+                // TODO: Robustness
+            }
+            else if ((_eglMajor >= 1 && _eglMinor >= 3) && _eglApi == EglApi.Gles)
+            {
+                attributes.Add(EGL.CONTEXT_CLIENT_VERSION);
+                attributes.Add(contextMajor);
+            }
+
+            attributes.Add(EGL.NONE);
+
+            var context = EGL.CreateContext(_display, _configId, (IntPtr)EGL.NO_CONTEXT, attributes.ToArray());
+            if (context == IntPtr.Zero)
+                throw new GlContextException($"Could not create OpenGL {contextMajor}.{contextMinor} context!");
+
+            return context;
+        }
+    }
+}

--- a/src/Windows/Avalonia.Win32/EGL/EglSurface.cs
+++ b/src/Windows/Avalonia.Win32/EGL/EglSurface.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using Avalonia.OpenGL;
+using Avalonia.Platform;
+using Avalonia.Win32.Interop;
+using System;
+
+namespace Avalonia.Win32.EGL
+{
+    public class EglSurface : IGlSurface, IDisposable
+    {
+        public IntPtr SurfaceHandle { get; }
+        public IPlatformHandle PlatformHandle { get; set; }
+
+        public EglSurface(IntPtr surfaceHandle, IPlatformHandle platformHandle)
+        {
+            SurfaceHandle = surfaceHandle;
+            PlatformHandle = platformHandle;
+        }
+
+        /// <inheritdoc />
+        public (int width, int height) GetSize()
+        {
+            UnmanagedMethods.GetClientRect(PlatformHandle.Handle, out UnmanagedMethods.RECT clientSize);
+
+            var width = clientSize.right - clientSize.left;
+            var height = clientSize.bottom - clientSize.top;
+
+            return (width, height);
+        }
+
+        public void Dispose()
+        {
+        }
+
+        /// <inheritdoc />
+        public (int x, int y) GetDpi()
+        {
+            if (UnmanagedMethods.ShCoreAvailable)
+            {
+                var monitor = UnmanagedMethods.MonitorFromWindow(
+                    PlatformHandle.Handle,
+                    UnmanagedMethods.MONITOR.MONITOR_DEFAULTTONEAREST);
+
+                if (UnmanagedMethods.GetDpiForMonitor(
+                        monitor,
+                        UnmanagedMethods.MONITOR_DPI_TYPE.MDT_EFFECTIVE_DPI,
+                        out var dpix,
+                        out var dpiy) == 0)
+                {
+                    return ((int)dpix, (int)dpiy);
+                }
+            }
+
+            return (96, 96);
+        }
+    }
+}


### PR DESCRIPTION
@grokys @jkoritzinsky @kekekeks @danwalmsley @MarchingCube

- What does the pull request do?

 Adds OpenGL context creation support to Avalonia, starting with ANGLE on Windows. It stubs out WGL. Linux and OSX are NYI.

 This includes *only* the OpenGL changes in #1586 mainly. I've modified things a bit to support requesting specific versions of GLES and moved the abstraction from `Avalonia.Visuals` to `Avalonia.OpenGL`

- Specific changes
 - Implemented Avalonia.OpenGL holding various interfaces like `IGlContext` and `IGlSurface`
 - Modified `Avalonia.Win32` with implementations for ANGLE (`EglContext` and `EglSurface`)
 - Modified `UseWin32` to take in an additional `bool` (defaulting to true) for enabling ANGLE
 - Stubbed out WGL support. I can do this in a follow up PR.
 
Note: OSX and Linux do not have implementations yet. Presumably on Linux one could use GLX and EGL where supported (Wayland etc), and whatever craziness must be done on OSX :-).

Checklist:

- [X] Added unit tests (if possible)?
- [X] Added XML documentation to any related classes?
- [ ] Re-add support for PBuffers to allow for off-screen surfaces 
- [ ] Properly dispose of the surface/context

I have a separate PR with the Skia changes in #1586 adapted to these changes, they are relatively minor. Hopefully this makes #1586 easier to review if this can land first. There's _really_ nice Skia cleanup items there.

I'd appreciate if someone could make sure I didn't fudge anything up in the build scripts, I'm new at this :-) 