### PR TITLE
Handle all CollectionChanged cases in CarouselPresenter.

### DIFF
--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -120,7 +120,6 @@ namespace Avalonia.Controls.Presenters
                     break;
 
                 case NotifyCollectionChangedAction.Reset:
-                    if(!IsVirtualized)
                     {
                         var generator = ItemContainerGenerator;
                         var containers = generator.Containers.ToList();

--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -124,6 +124,8 @@ namespace Avalonia.Controls.Presenters
                         var containers = generator.Containers.ToList();
                         generator.Clear();
                         Panel.Children.RemoveAll(containers.Select(x => x.ContainerControl));
+
+                        PanelCreated(Panel);
                     }
                     break;
 

--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -115,7 +115,7 @@ namespace Avalonia.Controls.Presenters
                         var containers = generator.RemoveRange(e.OldStartingIndex, e.OldItems.Count);
                         Panel.Children.RemoveAll(containers.Select(x => x.ContainerControl));
 
-                        MoveToPage(-1, 0);
+                        MoveToPage(-1, SelectedIndex);
                     }
                     break;
 

--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -106,7 +106,6 @@ namespace Avalonia.Controls.Presenters
         /// <inheritdoc/>
         protected override void ItemsChanged(NotifyCollectionChangedEventArgs e)
         {
-            // TODO: Handle items changing.           
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Remove:
@@ -118,6 +117,35 @@ namespace Avalonia.Controls.Presenters
                     }
                     break;
 
+                case NotifyCollectionChangedAction.Reset:
+                    if(!IsVirtualized)
+                    {
+                        var generator = ItemContainerGenerator;
+                        var containers = generator.Containers.ToList();
+                        generator.Clear();
+                        Panel.Children.RemoveAll(containers.Select(x => x.ContainerControl));
+                    }
+                    break;
+
+                case NotifyCollectionChangedAction.Add:
+                    Panel.Children.InsertRange(e.NewStartingIndex, e.NewItems.OfType<IControl>());
+                    break;
+
+                case NotifyCollectionChangedAction.Replace:
+                    if (!IsVirtualized)
+                    {
+                        for (var i = 0; i < e.OldItems.Count; ++i)
+                        {
+                            var index = i + e.OldStartingIndex;
+                            var child = (IControl)e.NewItems[i];
+                            Panel.Children[index] = child;
+                        }
+                    }
+                    break;
+
+                case NotifyCollectionChangedAction.Move:
+                    Panel.Children.MoveRange(e.OldStartingIndex, e.OldItems.Count, e.NewStartingIndex);
+                    break;                   
             }
         }
 

--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -114,6 +114,8 @@ namespace Avalonia.Controls.Presenters
                         var generator = ItemContainerGenerator;
                         var containers = generator.RemoveRange(e.OldStartingIndex, e.OldItems.Count);
                         Panel.Children.RemoveAll(containers.Select(x => x.ContainerControl));
+
+                        MoveToPage(-1, 0);
                     }
                     break;
 
@@ -125,25 +127,9 @@ namespace Avalonia.Controls.Presenters
                         generator.Clear();
                         Panel.Children.RemoveAll(containers.Select(x => x.ContainerControl));
 
-                        PanelCreated(Panel);
+                        MoveToPage(-1, 0);
                     }
-                    break;
-
-                case NotifyCollectionChangedAction.Replace:
-                    if (!IsVirtualized)
-                    {
-                        for (var i = 0; i < e.OldItems.Count; ++i)
-                        {
-                            var index = i + e.OldStartingIndex;
-                            var child = (IControl)e.NewItems[i];
-                            Panel.Children[index] = child;
-                        }
-                    }
-                    break;
-
-                case NotifyCollectionChangedAction.Move:
-                    Panel.Children.MoveRange(e.OldStartingIndex, e.OldItems.Count, e.NewStartingIndex);
-                    break;                   
+                    break;     
             }
         }
 

--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -127,7 +127,7 @@ namespace Avalonia.Controls.Presenters
                         generator.Clear();
                         Panel.Children.RemoveAll(containers.Select(x => x.ContainerControl));
 
-                        MoveToPage(-1, 0);
+                        MoveToPage(-1, SelectedIndex >= 0 ? SelectedIndex : 0);
                     }
                     break;     
             }

--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -127,10 +127,6 @@ namespace Avalonia.Controls.Presenters
                     }
                     break;
 
-                case NotifyCollectionChangedAction.Add:
-                    Panel.Children.InsertRange(e.NewStartingIndex, e.NewItems.OfType<IControl>());
-                    break;
-
                 case NotifyCollectionChangedAction.Replace:
                     if (!IsVirtualized)
                     {

--- a/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
@@ -240,9 +240,9 @@ namespace Avalonia.Controls.Presenters
                 incc.CollectionChanged += ItemsCollectionChanged;
             }
 
-            ItemsChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            PanelCreated(Panel);
 
-            PanelCreated(Panel);            
+            ItemsChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));            
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
@@ -240,9 +240,9 @@ namespace Avalonia.Controls.Presenters
                 incc.CollectionChanged += ItemsCollectionChanged;
             }
 
-            PanelCreated(Panel);
-
             ItemsChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+
+            PanelCreated(Panel);            
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
@@ -242,7 +242,7 @@ namespace Avalonia.Controls.Presenters
 
             PanelCreated(Panel);
 
-            ItemsChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));            
+            ItemsChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
 
         /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
@@ -167,6 +167,34 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal("Bar", ((TextBlock)child).Text);
         }
 
+        [Fact]
+        public void Selected_Item_Changes_To_NextAvailable_Item_If_SelectedItem_Is_Removed_From_Middle()
+        {
+            var items = new ObservableCollection<string>
+            {
+               "Foo",
+               "Bar",
+               "FooBar"
+            };
+
+            var target = new Carousel
+            {
+                Template = new FuncControlTemplate<Carousel>(CreateTemplate),
+                Items = items,
+                IsVirtualized = false
+            };
+
+            target.ApplyTemplate();
+            target.Presenter.ApplyTemplate();
+
+            target.SelectedIndex = 1;
+
+            items.RemoveAt(1);
+
+            Assert.Equal(1, target.SelectedIndex);
+            Assert.Equal("FooBar", target.SelectedItem);
+        }
+
         private Control CreateTemplate(Carousel control)
         {
             return new CarouselPresenter

--- a/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
@@ -7,6 +7,7 @@ using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.LogicalTree;
+using Avalonia.VisualTree;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
@@ -51,7 +52,7 @@ namespace Avalonia.Controls.UnitTests
             Assert.Single(target.GetLogicalChildren());
 
             var child = target.GetLogicalChildren().Single();
-            
+
             Assert.IsType<TextBlock>(child);
             Assert.Equal("Foo", ((TextBlock)child).Text);
         }
@@ -107,7 +108,7 @@ namespace Avalonia.Controls.UnitTests
             var target = new Carousel
             {
                 Template = new FuncControlTemplate<Carousel>(CreateTemplate),
-                Items =  items,
+                Items = items,
                 IsVirtualized = false
             };
 
@@ -130,6 +131,50 @@ namespace Avalonia.Controls.UnitTests
 
             Assert.IsType<TextBlock>(child);
             Assert.Equal("Bar", ((TextBlock)child).Text);
+        }
+
+        [Fact]
+        public void Selected_Index_Is_Maintained_Carousel_Created_With_Non_Zero_SelectedIndex()
+        {
+            var items = new ObservableCollection<string>
+            {
+               "Foo",
+               "Bar",
+               "FooBar"
+            };
+
+            var target = new Carousel
+            {
+                Template = new FuncControlTemplate<Carousel>(CreateTemplate),
+                Items = items,
+                IsVirtualized = false,
+                SelectedIndex = 2
+            };
+
+            target.ApplyTemplate();
+            target.Presenter.ApplyTemplate();
+
+            Assert.Equal("FooBar", target.SelectedItem);
+
+            IVisual child = target;
+
+            while (true)
+            {
+                if (child.VisualChildren.FirstOrDefault() is TextBlock)
+                {
+                    break;
+                }
+
+                if (child.VisualChildren.Count == 0)
+                {
+                    break;
+
+                }
+                child = child.VisualChildren.FirstOrDefault().VisualChildren.FirstOrDefault();
+            }
+
+            Assert.IsType<TextBlock>(child);
+            Assert.Equal("FooBar", ((TextBlock)child).Text);
         }
 
         [Fact]

--- a/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using System.Collections.ObjectModel;
 using System.Linq;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
@@ -91,6 +92,79 @@ namespace Avalonia.Controls.UnitTests
             Assert.Single(target.ItemContainerGenerator.Containers);
             target.SelectedIndex = 1;
             Assert.Equal(2, target.ItemContainerGenerator.Containers.Count());
+        }
+
+        [Fact]
+        public void Selected_Item_Changes_To_First_Item_When_Items_Property_Changes()
+        {
+            var items = new ObservableCollection<string>
+            {
+               "Foo",
+               "Bar",
+               "FooBar"
+            };
+
+            var target = new Carousel
+            {
+                Template = new FuncControlTemplate<Carousel>(CreateTemplate),
+                Items =  items,
+                IsVirtualized = false
+            };
+
+            target.ApplyTemplate();
+            target.Presenter.ApplyTemplate();
+
+            Assert.Single(target.GetLogicalChildren());
+
+            var child = target.GetLogicalChildren().Single();
+
+            Assert.IsType<TextBlock>(child);
+            Assert.Equal("Foo", ((TextBlock)child).Text);
+
+            var newItems = items.ToList();
+            newItems.RemoveAt(0);
+
+            target.Items = newItems;
+
+            child = target.GetLogicalChildren().Single();
+
+            Assert.IsType<TextBlock>(child);
+            Assert.Equal("Bar", ((TextBlock)child).Text);
+        }
+
+        [Fact]
+        public void Selected_Item_Changes_To_Next_First_Item_When_Item_Removed_From_Beggining_Of_List()
+        {
+            var items = new ObservableCollection<string>
+            {
+               "Foo",
+               "Bar",
+               "FooBar"
+            };
+
+            var target = new Carousel
+            {
+                Template = new FuncControlTemplate<Carousel>(CreateTemplate),
+                Items = items,
+                IsVirtualized = false
+            };
+
+            target.ApplyTemplate();
+            target.Presenter.ApplyTemplate();
+
+            Assert.Single(target.GetLogicalChildren());
+
+            var child = target.GetLogicalChildren().Single();
+
+            Assert.IsType<TextBlock>(child);
+            Assert.Equal("Foo", ((TextBlock)child).Text);
+
+            items.RemoveAt(0);
+
+            child = target.GetLogicalChildren().Single();
+
+            Assert.IsType<TextBlock>(child);
+            Assert.Equal("Bar", ((TextBlock)child).Text);
         }
 
         private Control CreateTemplate(Carousel control)

--- a/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
@@ -156,22 +156,7 @@ namespace Avalonia.Controls.UnitTests
 
             Assert.Equal("FooBar", target.SelectedItem);
 
-            IVisual child = target;
-
-            while (true)
-            {
-                if (child.VisualChildren.FirstOrDefault() is TextBlock)
-                {
-                    break;
-                }
-
-                if (child.VisualChildren.Count == 0)
-                {
-                    break;
-
-                }
-                child = child.VisualChildren.FirstOrDefault().VisualChildren.FirstOrDefault();
-            }
+            var child = target.GetVisualDescendants().LastOrDefault();
 
             Assert.IsType<TextBlock>(child);
             Assert.Equal("FooBar", ((TextBlock)child).Text);

--- a/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
@@ -134,6 +134,43 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Selected_Item_Changes_To_First_Item_When_Items_Property_Changes_And_Virtualized()
+        {
+            var items = new ObservableCollection<string>
+            {
+               "Foo",
+               "Bar",
+               "FooBar"
+            };
+
+            var target = new Carousel
+            {
+                Template = new FuncControlTemplate<Carousel>(CreateTemplate),
+                Items = items
+            };
+
+            target.ApplyTemplate();
+            target.Presenter.ApplyTemplate();
+
+            Assert.Single(target.GetLogicalChildren());
+
+            var child = target.GetLogicalChildren().Single();
+
+            Assert.IsType<TextBlock>(child);
+            Assert.Equal("Foo", ((TextBlock)child).Text);
+
+            var newItems = items.ToList();
+            newItems.RemoveAt(0);
+
+            target.Items = newItems;
+
+            child = target.GetLogicalChildren().Single();
+
+            Assert.IsType<TextBlock>(child);
+            Assert.Equal("Bar", ((TextBlock)child).Text);
+        }
+
+        [Fact]
         public void Selected_Index_Is_Maintained_Carousel_Created_With_Non_Zero_SelectedIndex()
         {
             var items = new ObservableCollection<string>


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
fixes Carousel so it no longer can get out of sync with its items collection.

- What is the current behavior?
Currently if you replace the Items bound to a Carousel with a new Collection. Then you end up with null selected item.

Also if you remove an item from the list then you also ended up with an invalid selection.

Also if selectedindex is set to value >0 when template is applied, the item shown ends up being the first and not the selected index / item.

- What is the updated/expected behavior with this PR?
fixes this.

- How was the solution implemented (if it's not obvious)?

Checklist:

- [x ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

If the pull request fixes issue(s) list them like this:

Fixes #1569 