### PR TITLE
fix bug introduced in dropdownitem the clears :selected psuedo class

### DIFF
--- a/src/Avalonia.Controls/DropDownItem.cs
+++ b/src/Avalonia.Controls/DropDownItem.cs
@@ -22,14 +22,13 @@ namespace Avalonia.Controls
         static DropDownItem()
         {
             FocusableProperty.OverrideDefaultValue<DropDownItem>(true);
-            IsFocusedProperty.Changed.Subscribe(x =>
-            {
-                var sender = x.Sender as IControl;
+        }
 
-                if (sender != null)
-                {
-                    ((IPseudoClasses)sender.Classes).Set(":selected", (bool)x.NewValue);
-                }
+        public DropDownItem()
+        {
+            this.GetObservable(DropDownItem.IsFocusedProperty).Subscribe(focused =>
+            {
+                PseudoClasses.Set(":selected", focused);                
             });
         }
 


### PR DESCRIPTION
- What does the pull request do?
fixes bug introduced by @CommonGuy in DropDownItem.cs

https://github.com/AvaloniaUI/Avalonia/commit/55da255d86e55c9c4a01a6c21e3e387c1a5b8722#diff-d348e2dbad70d25a4c4603258b2bb0f6R25

- What is the current behavior?
Any control that has IsFocusedProperty will get its :selected property cleared. This was meant to only apply to DropDownItem.

- What is the updated/expected behavior with this PR?
Fix the code so that it only applies to DropDownItem.
