### PR TITLE
Fixes: Custom font string to FontFamily conversion

### DIFF
--- a/src/Avalonia.Visuals/Media/FontFamily.cs
+++ b/src/Avalonia.Visuals/Media/FontFamily.cs
@@ -77,10 +77,10 @@ namespace Avalonia.Media
         /// <summary>
         /// Implicit conversion of string to FontFamily
         /// </summary>
-        /// <param name="fontFamily"></param>
-        public static implicit operator FontFamily(string fontFamily)
+        /// <param name="s"></param>
+        public static implicit operator FontFamily(string s)
         {
-            return new FontFamily(fontFamily);
+            return Parse(s);
         }
 
         /// <summary>


### PR DESCRIPTION
- What does the pull request do?
Fixes custom font string to FontFamily conversion
- What is the current behavior?
Implicit string to font family conversion was only possible for installed fonts. And failed to convert custom fonts defined by an asset string.
- What is the updated/expected behavior with this PR?
Implicit string to font family conversion now uses Parse to convert and supports custom fonts that way.
