### PR TITLE
fix exception when carousel items set to null.

### DIFF
--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -125,8 +125,8 @@ namespace Avalonia.Controls.Presenters
                         var containers = generator.Containers.ToList();
                         generator.Clear();
                         Panel.Children.RemoveAll(containers.Select(x => x.ContainerControl));
-
-                        MoveToPage(-1, SelectedIndex >= 0 ? SelectedIndex : 0);
+                        
+                        MoveToPage(-1, SelectedIndex >= 0 ? SelectedIndex : e.NewStartingIndex);
                     }
                     break;     
             }

--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -125,8 +125,22 @@ namespace Avalonia.Controls.Presenters
                         var containers = generator.Containers.ToList();
                         generator.Clear();
                         Panel.Children.RemoveAll(containers.Select(x => x.ContainerControl));
+
+                        var newIndex = SelectedIndex;
+
+                        if(SelectedIndex < 0)
+                        {
+                            if(Items != null && Items.Count() > 0)
+                            {
+                                newIndex = 0;
+                            }
+                            else
+                            {
+                                newIndex = -1;
+                            }
+                        }
                         
-                        MoveToPage(-1, SelectedIndex >= 0 ? SelectedIndex : e.NewStartingIndex);
+                        MoveToPage(-1, newIndex);
                     }
                     break;     
             }

--- a/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
@@ -171,6 +171,41 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Selected_Index_Changes_To_When_Items_Assigned_Null()
+        {
+            var items = new ObservableCollection<string>
+            {
+               "Foo",
+               "Bar",
+               "FooBar"
+            };
+
+            var target = new Carousel
+            {
+                Template = new FuncControlTemplate<Carousel>(CreateTemplate),
+                Items = items,
+                IsVirtualized = false
+            };
+
+            target.ApplyTemplate();
+            target.Presenter.ApplyTemplate();
+
+            Assert.Single(target.GetLogicalChildren());
+
+            var child = target.GetLogicalChildren().Single();
+
+            Assert.IsType<TextBlock>(child);
+            Assert.Equal("Foo", ((TextBlock)child).Text);
+
+            target.Items = null;
+
+            var numChildren = target.GetLogicalChildren().Count();
+
+            Assert.Equal(0, numChildren);
+            Assert.Equal(-1, target.SelectedIndex);
+        }
+
+        [Fact]
         public void Selected_Index_Is_Maintained_Carousel_Created_With_Non_Zero_SelectedIndex()
         {
             var items = new ObservableCollection<string>


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
fixes a minor bug in carousel.

- What is the current behavior?
exception thrown if a carousel is assigned null items.

- What is the updated/expected behavior with this PR?
no longer crashes.

