### PR TITLE
ensure tooltips fit inside screen edges.

### DIFF
--- a/src/Avalonia.Controls/ToolTip.cs
+++ b/src/Avalonia.Controls/ToolTip.cs
@@ -234,11 +234,12 @@ namespace Avalonia.Controls
         {
             Close();
 
-            _popup = new PopupRoot { Content = this };
+            _popup = new PopupRoot { Content = this,  };
             ((ISetLogicalParent)_popup).SetParent(control);
             _popup.Position = Popup.GetPosition(control, GetPlacement(control), _popup,
                 GetHorizontalOffset(control), GetVerticalOffset(control));
             _popup.Show();
+            _popup.SnapInsideScreenEdges();
         }
 
         private void Close()


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
make sure tooltips don't render over screen edges.
- What is the current behavior?
tooltips can get cut off by screen edge.

- What is the updated/expected behavior with this PR?
tool tips open at the best position without overlapping edges.

- How was the solution implemented (if it's not obvious)?
same as obey screen edge solution in popup. tooltops use popup root directly so it just makes the call to snap to screen edges immiediately after opening.

Checklist:

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
