### PR TITLE
KeyInterop public access modification

### DIFF
--- a/src/Windows/Avalonia.Win32/Input/KeyInterop.cs
+++ b/src/Windows/Avalonia.Win32/Input/KeyInterop.cs
@@ -8,7 +8,7 @@ using Avalonia.Win32.Interop;
 
 namespace Avalonia.Win32.Input
 {
-    static class KeyInterop
+    public static class KeyInterop
     {
         private static readonly Dictionary<Key, int> s_virtualKeyFromKey = new Dictionary<Key, int>
         {


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
  Itmakes Avalonia.Win32.Interop.KeyInterop.cs public
- What is the current behavior?
  currently it is not public 
- What is the updated/expected behavior with this PR?
  developers will now be able to access this class to convert key to virtual key or vicevrsa.
- How was the solution implemented (if it's not obvious)?
  Just added a public modifier to the class KeyInterop.cs
Checklist:

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

If the pull request fixes issue(s) list them like this: