### PR TITLE
Fix PathMarkupParser

### DIFF
--- a/src/Avalonia.Visuals/Media/PathMarkupParser.cs
+++ b/src/Avalonia.Visuals/Media/PathMarkupParser.cs
@@ -83,7 +83,6 @@ namespace Avalonia.Media
         public void Parse(string pathData)
         {
             var normalizedPathData = NormalizeWhiteSpaces(pathData);
-
             var tokens = ParseTokens(normalizedPathData);
 
             CreateGeometry(tokens);
@@ -129,11 +128,14 @@ namespace Avalonia.Media
                     }
 
                     source[index++] = c;
+
                     skip = true;
+
                     continue;
                 }
 
                 skip = false;
+
                 source[index++] = c;
             }
 

--- a/tests/Avalonia.Visuals.UnitTests/Media/PathMarkupParserTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/PathMarkupParserTests.cs
@@ -7,6 +7,8 @@ using Xunit;
 
 namespace Avalonia.Visuals.UnitTests.Media
 {
+    using System.IO;
+
     public class PathMarkupParserTests
     {
         [Fact]
@@ -140,6 +142,7 @@ namespace Avalonia.Visuals.UnitTests.Media
         }       
 
         [Theory]
+        [InlineData("         M0 0")]
         [InlineData("F1 M24,14 A2,2,0,1,1,20,14 A2,2,0,1,1,24,14 z")] // issue #1107
         [InlineData("M0 0L10 10z")]
         [InlineData("M50 50 L100 100 L150 50")]
@@ -171,6 +174,19 @@ namespace Avalonia.Visuals.UnitTests.Media
                 parser.Parse(pathData);
 
                 Assert.True(true);
+            }
+        }
+
+        [Theory]
+        [InlineData("0 0")]
+        [InlineData("j")]
+        public void Throws_InvalidDataException_On_None_Defined_Command(string pathData)
+        {
+            var pathGeometry = new PathGeometry();
+            using (var context = new PathGeometryContext(pathGeometry))
+            using (var parser = new PathMarkupParser(context))
+            {
+                Assert.Throws<InvalidDataException>(() => parser.Parse(pathData));
             }
         }
     }


### PR DESCRIPTION
- What does the pull request do?
Fixes path data that contains extra whitespaces
- What is the current behavior?
Extra whitespaces are not removes
- What is the updated/expected behavior with this PR?
Extra whitespaces should get removed from the path data before parsing
- How was the solution implemented (if it's not obvious)?

Checklist:
- [x] Added unit tests (if possible)?
