### PR TITLE
Only publish distinct values from TypeNameAndClassSelector.ClassObserver.

### DIFF
--- a/src/Avalonia.Styling/Styling/TypeNameAndClassSelector.cs
+++ b/src/Avalonia.Styling/Styling/TypeNameAndClassSelector.cs
@@ -202,6 +202,7 @@ namespace Avalonia.Styling
         {
             readonly IList<string> _match;
             IAvaloniaReadOnlyList<string> _classes;
+            bool _value;
 
             public ClassObserver(IAvaloniaReadOnlyList<string> classes, IList<string> match)
             {
@@ -210,18 +211,29 @@ namespace Avalonia.Styling
             }
 
             protected override void Deinitialize() => _classes.CollectionChanged -= ClassesChanged;
-            protected override void Initialize() => _classes.CollectionChanged += ClassesChanged;
+
+            protected override void Initialize()
+            {
+                _value = GetResult();
+                _classes.CollectionChanged += ClassesChanged;
+            }
 
             protected override void Subscribed(IObserver<bool> observer, bool first)
             {
-                observer.OnNext(GetResult());
+                observer.OnNext(_value);
             }
 
             private void ClassesChanged(object sender, NotifyCollectionChangedEventArgs e)
             {
                 if (e.Action != NotifyCollectionChangedAction.Move)
                 {
-                    PublishNext(GetResult());
+                    var value = GetResult();
+
+                    if (value != _value)
+                    {
+                        PublishNext(GetResult());
+                        _value = value;
+                    }
                 }
             }
 

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_Class.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_Class.cs
@@ -1,6 +1,7 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using System;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -8,6 +9,7 @@ using Moq;
 using Avalonia.Controls;
 using Avalonia.Styling;
 using Xunit;
+using System.Collections.Generic;
 
 namespace Avalonia.Styling.UnitTests
 {
@@ -115,6 +117,28 @@ namespace Avalonia.Styling.UnitTests
             Assert.True(await activator.Take(1));
             control.Classes.Remove("bar");
             Assert.False(await activator.Take(1));
+        }
+
+        [Fact]
+        public void Only_Notifies_When_Result_Changes()
+        {
+            // Test for #1698
+            var control = new Control1
+            {
+                Classes = new Classes { "foo" },
+            };
+
+            var target = default(Selector).Class("foo");
+            var activator = target.Match(control).ObservableResult;
+            var result = new List<bool>();
+
+            using (activator.Subscribe(x => result.Add(x)))
+            {
+                control.Classes.Add("bar");
+                control.Classes.Remove("foo");
+            }
+
+            Assert.Equal(new[] { true, false }, result);
         }
 
         public class Control1 : TestControlBase


### PR DESCRIPTION
`TypeNameAndClassSelector.ClassObserver` was publishing the result of the class match every time the monitored control's classes changed, even if the result didn't change, causing the animation to be repeatedly triggered. Make sure we only publish distinct results.

Fixes #1698
