### PR TITLE
fix win32 clipboard settext async.

### DIFF
--- a/src/Windows/Avalonia.Win32/ClipboardImpl.cs
+++ b/src/Windows/Avalonia.Win32/ClipboardImpl.cs
@@ -57,6 +57,9 @@ namespace Avalonia.Win32
             }
 
             await OpenClipboard();
+
+            UnmanagedMethods.EmptyClipboard();
+
             try
             {
                 var hGlobal = Marshal.StringToHGlobalUni(text);


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
Fixes Copy on Win32
- What is the current behavior?
copies text to clipboard but in a way that can only be pasted into text editors, not winforms type applications.

It is because EmptyClipboard should be called first.

- What is the updated/expected behavior with this PR?
Resolves.
