### PR TITLE
Store LocalValues directly without creating a PriorityValue.

### DIFF
--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -225,7 +225,14 @@ namespace Avalonia
             }
             else if (_values != null)
             {
-                return _values.GetValue(property);
+                var result = _values.GetValue(property);
+
+                if (result == AvaloniaProperty.UnsetValue)
+                {
+                    result = GetDefaultValue(property);
+                }
+
+                return result;
             }
             else
             {
@@ -645,8 +652,8 @@ namespace Avalonia
         /// <returns>The default value.</returns>
         internal object GetDefaultValue(AvaloniaProperty property)
         {
-            if (property.Inherits && InheritanceParent is AvaloniaObject aobj && aobj._values != null)
-                return aobj._values.GetValue(property);
+            if (property.Inherits && InheritanceParent is AvaloniaObject aobj)
+                return aobj.GetValue(property);
             return ((IStyledPropertyAccessor) property).GetDefaultValue(GetType());
         }
 

--- a/src/Avalonia.Base/IPriorityValueOwner.cs
+++ b/src/Avalonia.Base/IPriorityValueOwner.cs
@@ -13,18 +13,19 @@ namespace Avalonia
         /// <summary>
         /// Called when a <see cref="PriorityValue"/>'s value changes.
         /// </summary>
-        /// <param name="sender">The source of the change.</param>
+        /// <param name="property">The the property that has changed.</param>
+        /// <param name="priority">The priority of the value.</param>
         /// <param name="oldValue">The old value.</param>
         /// <param name="newValue">The new value.</param>
-        void Changed(PriorityValue sender, object oldValue, object newValue);
+        void Changed(AvaloniaProperty property, int priority, object oldValue, object newValue);
 
         /// <summary>
         /// Called when a <see cref="BindingNotification"/> is received by a 
         /// <see cref="PriorityValue"/>.
         /// </summary>
-        /// <param name="sender">The source of the change.</param>
+        /// <param name="property">The the property that has changed.</param>
         /// <param name="notification">The notification.</param>
-        void BindingNotificationReceived(PriorityValue sender, BindingNotification notification);
+        void BindingNotificationReceived(AvaloniaProperty property, BindingNotification notification);
 
         /// <summary>
         /// Ensures that the current thread is the UI thread.

--- a/src/Avalonia.Base/PriorityValue.cs
+++ b/src/Avalonia.Base/PriorityValue.cs
@@ -281,12 +281,12 @@ namespace Avalonia
 
                 if (notification == null || notification.HasValue)
                 {
-                    notify(() => Owner?.Changed(this, old, Value));
+                    notify(() => Owner?.Changed(Property, ValuePriority, old, Value));
                 }
 
                 if (notification != null)
                 {
-                    Owner?.BindingNotificationReceived(this, notification);
+                    Owner?.BindingNotificationReceived(Property, notification);
                 }
             }
             else

--- a/src/Avalonia.Base/ValueStore.cs
+++ b/src/Avalonia.Base/ValueStore.cs
@@ -110,11 +110,6 @@ namespace Avalonia
                 result = (value is PriorityValue priorityValue) ? priorityValue.Value : value;
             }
 
-            if (result == AvaloniaProperty.UnsetValue)
-            {
-                result = _owner.GetDefaultValue(property);
-            }
-
             return result;
         }
 

--- a/src/Avalonia.Base/ValueStore.cs
+++ b/src/Avalonia.Base/ValueStore.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Avalonia.Data;
+using Avalonia.Utilities;
+
+namespace Avalonia
+{
+    internal class ValueStore : IPriorityValueOwner
+    {
+        private readonly AvaloniaObject _owner;
+        private readonly Dictionary<AvaloniaProperty, PriorityValue> _values =
+            new Dictionary<AvaloniaProperty, PriorityValue>();
+
+        public ValueStore(AvaloniaObject owner)
+        {
+            _owner = owner;
+        }
+
+        public IDisposable AddBinding(
+            AvaloniaProperty property,
+            IObservable<object> source,
+            BindingPriority priority)
+        {
+            if (!_values.TryGetValue(property, out PriorityValue v))
+            {
+                v = CreatePriorityValue(property);
+                _values.Add(property, v);
+            }
+
+            return v.Add(source, (int)priority);
+        }
+
+        public void AddValue(AvaloniaProperty property, object value, int priority)
+        {
+            var originalValue = value;
+
+            if (!TypeUtilities.TryConvertImplicit(property.PropertyType, value, out value))
+            {
+                throw new ArgumentException(string.Format(
+                    "Invalid value for Property '{0}': '{1}' ({2})",
+                    property.Name,
+                    originalValue,
+                    originalValue?.GetType().FullName ?? "(null)"));
+            }
+
+            if (!_values.TryGetValue(property, out PriorityValue v))
+            {
+                if (value == AvaloniaProperty.UnsetValue)
+                {
+                    return;
+                }
+
+                v = CreatePriorityValue(property);
+                _values.Add(property, v);
+            }
+
+            v.SetValue(value, priority);
+        }
+
+        public IDictionary<AvaloniaProperty, PriorityValue> GetSetValues() => _values;
+
+        public object GetValue(AvaloniaProperty property)
+        {
+            var result = AvaloniaProperty.UnsetValue;
+
+            if (_values.TryGetValue(property, out PriorityValue value))
+            {
+                result = value.Value;
+            }
+
+            if (result == AvaloniaProperty.UnsetValue)
+            {
+                result = _owner.GetDefaultValue(property);
+            }
+
+            return result;
+        }
+
+        public bool IsAnimating(AvaloniaProperty property)
+        {
+            return _values.TryGetValue(property, out PriorityValue value) ? value.IsAnimating : false;
+        }
+
+        public bool IsSet(AvaloniaProperty property)
+        {
+            if (_values.TryGetValue(property, out PriorityValue value))
+            {
+                return value.Value != AvaloniaProperty.UnsetValue;
+            }
+
+            return false;
+        }
+
+        public void Revalidate(AvaloniaProperty property)
+        {
+            if (_values.TryGetValue(property, out PriorityValue value))
+            {
+                value.Revalidate();
+            }
+        }
+
+        void IPriorityValueOwner.BindingNotificationReceived(AvaloniaProperty property, BindingNotification notification)
+        {
+            ((IPriorityValueOwner)_owner).BindingNotificationReceived(property, notification);
+        }
+
+        void IPriorityValueOwner.Changed(AvaloniaProperty property, int priority, object oldValue, object newValue)
+        {
+            ((IPriorityValueOwner)_owner).Changed(property, priority, oldValue, newValue);
+        }
+
+        void IPriorityValueOwner.VerifyAccess() => _owner.VerifyAccess();
+
+        private PriorityValue CreatePriorityValue(AvaloniaProperty property)
+        {
+            var validate = ((IStyledPropertyAccessor)property).GetValidationFunc(_owner.GetType());
+            Func<object, object> validate2 = null;
+
+            if (validate != null)
+            {
+                validate2 = v => validate(_owner, v);
+            }
+
+            PriorityValue result = new PriorityValue(
+                this,
+                property,
+                property.PropertyType,
+                validate2);
+
+            return result;
+        }
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/PriorityValueTests.cs
+++ b/tests/Avalonia.Base.UnitTests/PriorityValueTests.cs
@@ -167,7 +167,7 @@ namespace Avalonia.Base.UnitTests
 
             target.Add(Single("foo"), 0);
 
-            owner.Verify(x => x.Changed(target, AvaloniaProperty.UnsetValue, "foo"));
+            owner.Verify(x => x.Changed(target.Property, target.ValuePriority, AvaloniaProperty.UnsetValue, "foo"));
         }
 
         [Fact]
@@ -180,7 +180,7 @@ namespace Avalonia.Base.UnitTests
             target.Add(subject, 0);
             subject.OnNext("bar");
 
-            owner.Verify(x => x.Changed(target, "foo", "bar"));
+            owner.Verify(x => x.Changed(target.Property, target.ValuePriority, "foo", "bar"));
         }
 
         [Fact]


### PR DESCRIPTION
There are lots of cases of styled properties that have only a local value. Currently we are creating a `PriorityValue` for each set property on an `AvaloniaObject`, even if it is to store just a single local value.

This PR changes that: when a property has just a single local value it will be stored directly without creating a `PriorityValue`. When the property is bound to, or when a non-`LocalValue` is assigned to it, then a `PriorityValue` will be created as before.

This PR refactors the value dictionary into a `ValueStore` class to make this manageable. The overhead of this is non-zero, but in the figures below only represents about 0.5mb. I think this is an acceptable overhead for the sake of maintenance (yes, I did try a version where the code to manage this was placed directly in `AvaloniaObject`).

# Memory Usage

Memory usage was measured via the VS2017 diagnostic tools by running ControlCatalog in Release mode, opening all pages and then taking a memory snapshot:

Note that this PR depends on #1695:

On #1695:

|Objects|Heap Size (KB)|
|-----|------|
|1,086,578|63,557|

This PR:

|Objects|Heap Size (KB)|
|-----|------|
|966,731|56,749|

Depends on #1695 