### PR TITLE
Use IsPlatformNetCoreOnly property in Cake script

### DIFF
--- a/packages.cake
+++ b/packages.cake
@@ -225,7 +225,7 @@ public class Packages
 
         IList<NuSpecContent> coreFiles;
 
-        if (parameters.Platform != "NetCoreOnly") {
+        if (!parameters.IsPlatformNetCoreOnly) {
             var toolsContent = new[] { toolHostApp, toolHostAppNetFx };
             coreFiles = coreLibrariesNuSpecContent
                 .Concat(win32CoreLibrariesNuSpecContent).Concat(net45RuntimePlatform)
@@ -506,7 +506,7 @@ public class Packages
         NuspecNuGetSettings.AddRange(nuspecNuGetSettingsCore);
         NuspecNuGetSettings.AddRange(nuspecNuGetSettingsDesktop);
 
-        if (parameters.Platform != "NetCoreOnly") {
+        if (!parameters.IsPlatformNetCoreOnly) {
             NuspecNuGetSettings.Add(nuspecNuGetSettingInterop);
             NuspecNuGetSettings.AddRange(nuspecNuGetSettingsMobile);
         }


### PR DESCRIPTION
- What does the pull request do?
Uses correct property from parameters instead of string comparison.
- What is the current behavior?
Uses string comparison instead of parameters property.