### PR TITLE
Fix Crash when items are switched between 2 ListBoxes several times.

### DIFF
--- a/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
@@ -62,7 +62,8 @@ namespace Avalonia.Controls.Generators
             var i = selector != null ? selector.Select(item) : item;
             var container = new ItemContainerInfo(CreateContainer(i), item, index);
 
-            _containers.Add(container.Index, container);
+            if (_containers.Any(a => a.Key != container.Index))
+                _containers.Add(container.Index, container);
             Materialized?.Invoke(this, new ItemContainerEventArgs(container));
 
             return container;
@@ -75,7 +76,8 @@ namespace Avalonia.Controls.Generators
 
             for (int i = startingIndex; i < startingIndex + count; ++i)
             {
-                result.Add(_containers[i]);
+                if (_containers.Count > i)
+                    result.Add(_containers[i]);
                 _containers.Remove(i);
             }
 

--- a/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
@@ -62,8 +62,10 @@ namespace Avalonia.Controls.Generators
             var i = selector != null ? selector.Select(item) : item;
             var container = new ItemContainerInfo(CreateContainer(i), item, index);
 
-            if (_containers.Any(a => a.Key != container.Index))
+            if (!_containers.Any(a => a.Key == container.Index))
                 _containers.Add(container.Index, container);
+            else
+                _containers[container.Index] = container;
             Materialized?.Invoke(this, new ItemContainerEventArgs(container));
 
             return container;


### PR DESCRIPTION
- What does the pull request do?
This is a follow-up fix for an issue introduced after the fix #1711 for #1709. This PR Fixes an app crash when an item (or more) are swapped between two ListBoxes bound to their respective Observable/Reactive lists provided that those ListBoxes have an `:empty` style with ControlTemplate applied.
- What is the current behavior?
Swapping an item (or more) several times between two bound ListBoxes that have `:empty` style applied cause the application to crash with exception `System.Collections.Generic.KeyNotFoundException: 'The given key was not present in the dictionary.'`
- What is the updated/expected behavior with this PR?
The application doesn't crash for the above-mentioned scenario and the items swap fine between the two listboxes.