### PR TITLE
Fixed Window.Close, so that Closing is only invoked once

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -302,18 +302,17 @@ namespace Avalonia.Controls
 
         internal void Close(bool ignoreCancel)
         {
-            var cancelClosing = false;
             try
             {
-                cancelClosing = HandleClosing();
+                if (!ignoreCancel && HandleClosing())
+                {
+                    return;
+                }
             }
             finally
             {
-                if (ignoreCancel || !cancelClosing)
-                {                  
-                    PlatformImpl?.Dispose();
-                    HandleClosed();
-                }
+                PlatformImpl?.Dispose();
+                HandleClosed();
             }
         }
 
@@ -324,6 +323,7 @@ namespace Avalonia.Controls
         {
             var args = new CancelEventArgs();
             Closing?.Invoke(this, args);
+
             return args.Cancel;
         }
 

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -189,6 +189,27 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Closing_Should_Only_Be_Invoked_Once()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var window = new Window();
+                var count = 0;
+
+                window.Closing +=
+                    (sender, e) =>
+                    {
+                        count++;
+                    };
+
+                window.Show();
+                window.Close();
+
+                Assert.Equal(1, count);
+            }
+        }
+
+        [Fact]
         public void Showing_Should_Start_Renderer()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))


### PR DESCRIPTION
## Changes
- Fixed `Window.Close`, so that `Closing` is only invoked once.

## Current behavior
- `Window.Closing` is invoked twice.

## Updated behavior
- `Window.Closing` is only invoked once.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avaloniaui.net with user documentation