### PR TITLE
Add fix for monomac borderless windows being

### DIFF
--- a/src/OSX/Avalonia.MonoMac/WindowImpl.cs
+++ b/src/OSX/Avalonia.MonoMac/WindowImpl.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Platform;
 using MonoMac.AppKit;
 using MonoMac.CoreGraphics;
+using Avalonia.Threading;
 
 namespace Avalonia.MonoMac
 {
@@ -16,7 +17,14 @@ namespace Avalonia.MonoMac
 
         public WindowImpl()
         {
-            UpdateStyle();
+            // Post UpdateStyle to UIThread otherwise for as yet unknown reason.
+            // The window becomes transparent to mouse clicks except a 100x100 square
+            // at the top left. (danwalmsley)
+            Dispatcher.UIThread.Post(() =>
+            {
+                UpdateStyle();
+            });
+
             Window.SetCanBecomeKeyAndMain();
             
             Window.DidResize += delegate


### PR DESCRIPTION
transparent to mouse clicks when they shouldnt be.

This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
Fixes a bug in monomac backend where clicking mouse in a window which has HasSystemDecorations=false.

- What is the current behavior?
The mouse click is passed through the application to whatever is behind it, making the app unusable.
Popups, and other types of borderless windows are affected.

- What is the updated/expected behavior with this PR?
Now works.

- How was the solution implemented (if it's not obvious)?
Seems like an intricacy in the Mac apis. You don't seem to be able to update StyleMask property until after window is created and shown. So I deferred this by dispatching to UIThread and this fixes the issue. (This was a lucky find, I didn't find any documentation to help me find this)
