### PR TITLE
Fix TemplateBinding.Converter.

### DIFF
--- a/src/Markup/Avalonia.Markup/Data/TemplateBinding.cs
+++ b/src/Markup/Avalonia.Markup/Data/TemplateBinding.cs
@@ -100,7 +100,9 @@ namespace Avalonia.Data
                         CultureInfo.CurrentCulture);
                 }
 
-                _target.TemplatedParent.SetValue(Property, value, BindingPriority.TemplatedParent);
+                // Use LocalValue priority here, as TemplatedParent doesn't make sense on controls
+                // that aren't template children.
+                _target.TemplatedParent.SetValue(Property, value, BindingPriority.LocalValue);
             }
         }
 
@@ -171,7 +173,7 @@ namespace Avalonia.Data
         {
             if (e.Property == Property)
             {
-                PublishNext(_target.TemplatedParent.GetValue(Property));
+                PublishValue();
             }
         }
     }

--- a/tests/Avalonia.Markup.UnitTests/Data/TemplateBindingTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/TemplateBindingTests.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace Avalonia.Markup.UnitTests.Data
+{
+    public class TemplateBindingTests
+    {
+        [Fact]
+        public void OneWay_Binding_Should_Be_Set_Up()
+        {
+            var source = new Button
+            {
+                Template = new FuncControlTemplate<Button>(parent =>
+                    new ContentPresenter
+                    {
+                        [~ContentPresenter.ContentProperty] = new TemplateBinding(ContentControl.ContentProperty)
+                    }),
+            };
+
+            source.ApplyTemplate();
+
+            var target = (ContentPresenter)source.GetVisualChildren().Single();
+
+            Assert.Null(target.Content);
+            source.Content = "foo";
+            Assert.Equal("foo", target.Content);
+            source.Content = "bar";
+            Assert.Equal("bar", target.Content);
+        }
+
+        [Fact]
+        public void TwoWay_Binding_Should_Be_Set_Up()
+        {
+            var source = new Button
+            {
+                Template = new FuncControlTemplate<Button>(parent =>
+                    new ContentPresenter
+                    {
+                        [~ContentPresenter.ContentProperty] = new TemplateBinding(ContentControl.ContentProperty)
+                        {
+                            Mode = BindingMode.TwoWay,
+                        }
+                    }),
+            };
+
+            source.ApplyTemplate();
+
+            var target = (ContentPresenter)source.GetVisualChildren().Single();
+
+            Assert.Null(target.Content);
+            source.Content = "foo";
+            Assert.Equal("foo", target.Content);
+            target.Content = "bar";
+            Assert.Equal("bar", source.Content);
+        }
+
+        [Fact]
+        public void Converter_Should_Be_Used()
+        {
+            var source = new Button
+            {
+                Template = new FuncControlTemplate<Button>(parent =>
+                    new ContentPresenter
+                    {
+                        [~ContentPresenter.ContentProperty] = new TemplateBinding(ContentControl.ContentProperty)
+                        {
+                            Mode = BindingMode.TwoWay,
+                            Converter = new PrefixConverter(),
+                            ConverterParameter = "Hello ",
+                        }
+                    }),
+            };
+
+            source.ApplyTemplate();
+
+            var target = (ContentPresenter)source.GetVisualChildren().Single();
+
+            Assert.Null(target.Content);
+            source.Content = "foo";
+            Assert.Equal("Hello foo", target.Content);
+            target.Content = "Hello bar";
+            Assert.Equal("bar", source.Content);
+        }
+
+        private class PrefixConverter : IValueConverter
+        {
+            public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            {
+                if (value != null && parameter != null)
+                {
+                    return parameter.ToString() + value;
+                }
+
+                return null;
+            }
+
+            public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            {
+                if (value != null && parameter != null)
+                {
+                    var s = value.ToString();
+                    var prefix = parameter.ToString();
+
+                    if (s.StartsWith(prefix) == true)
+                    {
+                        return s.Substring(prefix.Length);
+                    }
+
+                    return s;
+                }
+
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
#1695 broke `TemplateBinding`s with converters, resulting in #1737. This PR makes sure that `PublishValue` is called from `TemplatedParentPropertyChanged`, which does the converter stuff.

Also:

- Add some unit tests
- Make `TwoWay` bindings back to the parent control work at `LocalValue` priority - `TemplatedParent` doesn't make sense on controls that aren't template children.

Fixes #1737