### PR TITLE
dont clear textbox selection when right clicking.

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -557,7 +557,7 @@ namespace Avalonia.Controls
             var index = CaretIndex = _presenter.GetCaretIndex(point);
             var text = Text;
 
-            if (text != null)
+            if (text != null && e.MouseButton == MouseButton.Left)
             {
                 switch (e.ClickCount)
                 {


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
Prevents loss of text selection in textbox when right clicking. For example someone may want to allow right click -> copy on context menu.
- What is the current behavior?
Any click clears selection.

- What is the updated/expected behavior with this PR?
We check to see if its a left click in order to update the selection.
- How was the solution implemented (if it's not obvious)?
