### PR TITLE
Cache GridLayouts from the last Measure

### DIFF
--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -195,6 +195,16 @@ namespace Avalonia.Controls
         private GridLayout.MeasureResult _rowMeasureCache;
 
         /// <summary>
+        /// Gets the row layout as of the last measure.
+        /// </summary>
+        private GridLayout _rowLayoutCache;
+
+        /// <summary>
+        /// Gets the column layout as of the last measure.
+        /// </summary>
+        private GridLayout _columnLayoutCache;
+
+        /// <summary>
         /// Measures the grid.
         /// </summary>
         /// <param name="constraint">The available size.</param>
@@ -253,6 +263,9 @@ namespace Avalonia.Controls
             // Cache the measure result and return the desired size.
             _columnMeasureCache = columnResult;
             _rowMeasureCache = rowResult;
+            _rowLayoutCache = rowLayout;
+            _columnLayoutCache = columnLayout;
+
             return new Size(columnResult.DesiredLength, rowResult.DesiredLength);
 
             // Measure each child only once.
@@ -299,13 +312,11 @@ namespace Avalonia.Controls
             //       arrow back to any statements and re-run them without any side-effect.
 
             var (safeColumns, safeRows) = GetSafeColumnRows();
-            var columnLayout = new GridLayout(ColumnDefinitions);
-            var rowLayout = new GridLayout(RowDefinitions);
-
+            var columnLayout = _columnLayoutCache;
+            var rowLayout = _rowLayoutCache;
             // Calculate for arrange result.
             var columnResult = columnLayout.Arrange(finalSize.Width, _columnMeasureCache);
             var rowResult = rowLayout.Arrange(finalSize.Height, _rowMeasureCache);
-
             // Arrange the children.
             foreach (var child in Children.OfType<Control>())
             {
@@ -315,7 +326,6 @@ namespace Avalonia.Controls
                 var y = Enumerable.Range(0, row).Sum(r => rowResult.LengthList[r]);
                 var width = Enumerable.Range(column, columnSpan).Sum(c => columnResult.LengthList[c]);
                 var height = Enumerable.Range(row, rowSpan).Sum(r => rowResult.LengthList[r]);
-
                 child.Arrange(new Rect(x, y, width, height));
             }
 


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
This PR caches `GridLayout` from `Grid.MeasureOverride` so that `Grid.ArrangeOverride` has access to it. 

The problem in #1759 stems from a fractional measurement in `GridLayout.Arrange` invalidating the cached `GridLayout.MeasuredResult`. 

This causes the code to hit a faulty path where it tries to do a fresh `GridLayout.Measure`, only it doesn't have the `_additionalConventions` field populated because the `GridLayout` is newed up every `Grid.ArrangeOverride` rather than caching the result from `Grid.MeasureOverride`.


- What is the current behavior?
Grid layout on non 100% scaling causes auto rows/column to measure as zero.

- What is the updated/expected behavior with this PR?
Grid layout works on non 100% monitor scaling.

- How was the solution implemented (if it's not obvious)?
Rather than creating a new `GridLayout` in `ArrangeOverride`, I cache the one used in `MeasureOverride` which has the additional conventions added.

Checklist:

- [ ] Added unit tests (if possible)? _I don't know how to add a test that exhibits this issue given it only occurs on non 100% scaling_
- [x] Added XML documentation to any related classes?

Fixes #1759 