### PR TITLE
Fix SelectingItemsControl

### DIFF
--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -39,7 +39,7 @@ namespace Avalonia.Controls.Presenters
             Carousel.PageTransitionProperty.AddOwner<CarouselPresenter>();
 
         private int _selectedIndex = -1;
-       // private Task _current;
+        // private Task _current;
         private Task _currentTransition;
         private int _queuedTransitionIndex = -1;
 
@@ -130,10 +130,10 @@ namespace Avalonia.Controls.Presenters
 
 #pragma warning disable 4014
                         var newIndex = SelectedIndex;
-                        
-                        if(SelectedIndex < 0)
+
+                        if (SelectedIndex < 0)
                         {
-                            if(Items != null && Items.Count() > 0)
+                            if (Items != null && Items.Count() > 0)
                             {
                                 newIndex = 0;
                             }
@@ -142,11 +142,11 @@ namespace Avalonia.Controls.Presenters
                                 newIndex = -1;
                             }
                         }
-                        
+
                         MoveToPage(-1, newIndex);
 #pragma warning restore 4014
                     }
-                    break;     
+                    break;
             }
         }
 
@@ -226,7 +226,7 @@ namespace Avalonia.Controls.Presenters
                     int fromIndex = (int)e.OldValue;
                     int toIndex = (int)e.NewValue;
 
-                    for (;;)
+                    for (; ; )
                     {
                         _currentTransition = MoveToPage(fromIndex, toIndex);
                         await _currentTransition;

--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -115,11 +115,6 @@ namespace Avalonia.Controls.Presenters
                         var containers = generator.RemoveRange(e.OldStartingIndex, e.OldItems.Count);
                         Panel.Children.RemoveAll(containers.Select(x => x.ContainerControl));
 
-                        if(SelectedIndex >= Items.Count())
-                        {
-                            SelectedIndex = Items.Count() - 1;
-                        }
-
 #pragma warning disable 4014
                         MoveToPage(-1, SelectedIndex);
 #pragma warning restore 4014

--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -39,7 +39,7 @@ namespace Avalonia.Controls.Presenters
             Carousel.PageTransitionProperty.AddOwner<CarouselPresenter>();
 
         private int _selectedIndex = -1;
-        // private Task _current;
+       // private Task _current;
         private Task _currentTransition;
         private int _queuedTransitionIndex = -1;
 
@@ -131,9 +131,9 @@ namespace Avalonia.Controls.Presenters
 #pragma warning disable 4014
                         var newIndex = SelectedIndex;
 
-                        if (SelectedIndex < 0)
+                        if(SelectedIndex < 0)
                         {
-                            if (Items != null && Items.Count() > 0)
+                            if(Items != null && Items.Count() > 0)
                             {
                                 newIndex = 0;
                             }
@@ -142,11 +142,11 @@ namespace Avalonia.Controls.Presenters
                                 newIndex = -1;
                             }
                         }
-
+                        
                         MoveToPage(-1, newIndex);
 #pragma warning restore 4014
                     }
-                    break;
+                    break;     
             }
         }
 
@@ -226,7 +226,7 @@ namespace Avalonia.Controls.Presenters
                     int fromIndex = (int)e.OldValue;
                     int toIndex = (int)e.NewValue;
 
-                    for (; ; )
+                    for (;;)
                     {
                         _currentTransition = MoveToPage(fromIndex, toIndex);
                         await _currentTransition;

--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -115,9 +115,9 @@ namespace Avalonia.Controls.Presenters
                         var containers = generator.RemoveRange(e.OldStartingIndex, e.OldItems.Count);
                         Panel.Children.RemoveAll(containers.Select(x => x.ContainerControl));
 
-                        if(SelectedIndex > containers.Count())
+                        if(SelectedIndex >= Items.Count())
                         {
-                            SelectedIndex = containers.Count();
+                            SelectedIndex = Items.Count() - 1;
                         }
 
 #pragma warning disable 4014

--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -115,6 +115,11 @@ namespace Avalonia.Controls.Presenters
                         var containers = generator.RemoveRange(e.OldStartingIndex, e.OldItems.Count);
                         Panel.Children.RemoveAll(containers.Select(x => x.ContainerControl));
 
+                        if(SelectedIndex > containers.Count())
+                        {
+                            SelectedIndex = containers.Count();
+                        }
+
 #pragma warning disable 4014
                         MoveToPage(-1, SelectedIndex);
 #pragma warning restore 4014
@@ -130,7 +135,7 @@ namespace Avalonia.Controls.Presenters
 
 #pragma warning disable 4014
                         var newIndex = SelectedIndex;
-
+                        
                         if(SelectedIndex < 0)
                         {
                             if(Items != null && Items.Count() > 0)

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -355,18 +355,12 @@ namespace Avalonia.Controls.Primitives
                 case NotifyCollectionChangedAction.Replace:
                     var selectedIndex = SelectedIndex;
 
-                    var items = Items?.Cast<object>();
-                    if (selectedIndex >= items.Count())
-                    {
-                        selectedIndex = SelectedIndex = items.Count() - 1;
-                    }
-
                     if (selectedIndex >= e.OldStartingIndex &&
                         selectedIndex < e.OldStartingIndex + e.OldItems.Count)
                     {
                         if (!AlwaysSelected)
                         {
-                            SelectedIndex = -1;
+                            selectedIndex = SelectedIndex = -1;
                         }
                         else
                         {
@@ -374,6 +368,11 @@ namespace Avalonia.Controls.Primitives
                         }
                     }
 
+                    var items = Items?.Cast<object>();
+                    if (selectedIndex >= items.Count())
+                    {
+                        selectedIndex = SelectedIndex = items.Count() - 1;
+                    }
                     break;
 
                 case NotifyCollectionChangedAction.Reset:

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -355,6 +355,12 @@ namespace Avalonia.Controls.Primitives
                 case NotifyCollectionChangedAction.Replace:
                     var selectedIndex = SelectedIndex;
 
+                    var items = Items?.Cast<object>();
+                    if (selectedIndex >= items.Count())
+                    {
+                        selectedIndex = SelectedIndex = items.Count() - 1;
+                    }
+
                     if (selectedIndex >= e.OldStartingIndex &&
                         selectedIndex < e.OldStartingIndex + e.OldItems.Count)
                     {

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -150,6 +150,34 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
+        public void SelectedIndex_Item_Is_Updated_As_Items_Removed_When_Last_Item_Is_Selected()
+        {
+            var items = new ObservableCollection<string>
+            {
+               "Foo",
+               "Bar",
+               "FooBar"
+            };
+
+            var target = new SelectingItemsControl
+            {
+                Items = items,
+                Template = Template(),
+            };
+
+            target.ApplyTemplate();
+            target.SelectedItem = items[2];
+
+            Assert.Equal(items[2], target.SelectedItem);
+            Assert.Equal(2, target.SelectedIndex);
+
+            items.RemoveAt(0);
+
+            Assert.Equal(items[1], target.SelectedItem);
+            Assert.Equal(1, target.SelectedIndex);
+        }
+
+        [Fact]
         public void Setting_SelectedItem_To_Not_Present_Item_Should_Clear_Selection()
         {
             var items = new[]


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
Fixes a bug where SelectedIndex is not updated correctly on selecting items control.

- What is the current behavior?
If your selectedIndex is the last item in the list, and you remove an item, then selected index
isn't updated and you get exceptions because its pointing to items.count (instead of items.count -1)

- What is the updated/expected behavior with this PR?
resolves this issue.

Checklist:

- [x ] Added unit tests (if possible)?
