### PR TITLE
remove file:// from strings returned by mac file dialogs.

### DIFF
--- a/src/OSX/Avalonia.MonoMac/SystemDialogsImpl.cs
+++ b/src/OSX/Avalonia.MonoMac/SystemDialogsImpl.cs
@@ -25,9 +25,9 @@ namespace Avalonia.MonoMac
                 else
                 {
                     if (panel is NSOpenPanel openPanel)
-                        tcs.SetResult(openPanel.Urls.Select(url => url.AbsoluteString).ToArray());
+                        tcs.SetResult(openPanel.Urls.Select(url => url.AbsoluteString.Replace("file://", "")).ToArray());
                     else
-                        tcs.SetResult(new[] { panel.Url.AbsoluteString });
+                        tcs.SetResult(new[] { panel.Url.AbsoluteString.Replace("file://", "") });
                 }
                 panel.OrderOut(panel);
                 keyWindow?.MakeKeyAndOrderFront(keyWindow);


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
makes the urls returned by Mac file dialogs consistent with other platforms and compatible with .net file apis.

- What is the current behavior?
file locations come prepended with file://

- What is the updated/expected behavior with this PR?
resolved.

Fixes #1766