### PR TITLE
Fix devtools

### DIFF
--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -436,7 +436,7 @@ namespace Avalonia
         /// Gets all priority values set on the object.
         /// </summary>
         /// <returns>A collection of property/value tuples.</returns>
-        internal IDictionary<AvaloniaProperty, PriorityValue> GetSetValues() => Values?.GetSetValues();
+        internal IDictionary<AvaloniaProperty, object> GetSetValues() => Values?.GetSetValues();
 
         /// <summary>
         /// Forces revalidation of properties when a property value changes.

--- a/src/Avalonia.Base/Diagnostics/AvaloniaObjectExtensions.cs
+++ b/src/Avalonia.Base/Diagnostics/AvaloniaObjectExtensions.cs
@@ -23,15 +23,24 @@ namespace Avalonia.Diagnostics
         {
             var set = o.GetSetValues();
 
-            PriorityValue value;
-
-            if (set.TryGetValue(property, out value))
+            if (set.TryGetValue(property, out var obj))
             {
-                return new AvaloniaPropertyValue(
-                    property,
-                    o.GetValue(property),
-                    (BindingPriority)value.ValuePriority,
-                    value.GetDiagnostic());
+                if (obj is PriorityValue value)
+                {
+                    return new AvaloniaPropertyValue(
+                        property,
+                        o.GetValue(property),
+                        (BindingPriority)value.ValuePriority,
+                        value.GetDiagnostic());
+                }
+                else
+                {
+                    return new AvaloniaPropertyValue(
+                        property,
+                        obj,
+                        BindingPriority.LocalValue,
+                        "Local value");
+                }
             }
             else
             {

--- a/src/Avalonia.Base/ValueStore.cs
+++ b/src/Avalonia.Base/ValueStore.cs
@@ -100,7 +100,7 @@ namespace Avalonia
             _owner.PriorityValueChanged(property, priority, oldValue, newValue);
         }
 
-        public IDictionary<AvaloniaProperty, PriorityValue> GetSetValues() => throw new NotImplementedException();
+        public IDictionary<AvaloniaProperty, object> GetSetValues() => _values;
 
         public object GetValue(AvaloniaProperty property)
         {

--- a/src/Avalonia.Diagnostics/ViewModels/DevToolsViewModel.cs
+++ b/src/Avalonia.Diagnostics/ViewModels/DevToolsViewModel.cs
@@ -31,6 +31,7 @@ namespace Avalonia.Diagnostics.ViewModels
                 }
             };
 
+            SelectedTab = 0;
             root.GetObservable(TopLevel.PointerOverElementProperty)
                 .Subscribe(x => PointerOverElement = x?.GetType().Name);
         }


### PR DESCRIPTION
Oops! #1703 broke devtools. This PR fixes it:

- Make `AvaloniaObject.GetDiagnostic` work again: I'd stubbed out `ValueStore.GetSetValues()` with a `NotImplementedException` and then forgot to implement
- Show logical tree page when devtools is shown