### PR TITLE
rename stackpanel Gap property to Spacing property.

### DIFF
--- a/samples/BindingDemo/MainWindow.xaml
+++ b/samples/BindingDemo/MainWindow.xaml
@@ -18,18 +18,18 @@
     <TabItem Header="Basic">
       <StackPanel Orientation="Vertical">
         <StackPanel Orientation="Horizontal">
-          <StackPanel Margin="18" Gap="4" Width="200">
+          <StackPanel Margin="18" Spacing="4" Width="200">
             <TextBlock FontSize="16" Text="Simple Bindings"/>
             <TextBox Watermark="Two Way" UseFloatingWatermark="True" Text="{Binding Path=StringValue}" Name="first"/>
             <TextBox Watermark="One Way" UseFloatingWatermark="True" Text="{Binding Path=StringValue, Mode=OneWay}"/>
             <TextBox Watermark="One Time" UseFloatingWatermark="True" Text="{Binding Path=StringValue, Mode=OneTime}"/>
           </StackPanel>
-          <StackPanel Margin="18" Gap="4" Width="200">
+          <StackPanel Margin="18" Spacing="4" Width="200">
             <TextBlock FontSize="16" Text="Collection Bindings"/>
             <TextBox Watermark="Items[1].StringValue" UseFloatingWatermark="True" Text="{Binding Path=Items[1].StringValue}"/>
             <Button Command="{Binding ShuffleItems}">Shuffle</Button>
           </StackPanel>
-          <StackPanel Margin="18" Gap="4" Width="200">
+          <StackPanel Margin="18" Spacing="4" Width="200">
             <TextBlock FontSize="16" Text="Negated Bindings"/>
             <TextBox Watermark="Boolean String" UseFloatingWatermark="True" Text="{Binding Path=BooleanString}"/>
             <CheckBox IsChecked="{Binding !BooleanString}">!BooleanString</CheckBox>
@@ -37,13 +37,13 @@
           </StackPanel>
         </StackPanel>
         <StackPanel Orientation="Horizontal">
-          <StackPanel Margin="18" Gap="4" Width="200" HorizontalAlignment="Left">
+          <StackPanel Margin="18" Spacing="4" Width="200" HorizontalAlignment="Left">
             <TextBlock FontSize="16" Text="Numeric Bindings"/>
             <TextBox Watermark="Double" UseFloatingWatermark="True" Text="{Binding Path=DoubleValue, Mode=TwoWay}"/>
             <TextBlock Text="{Binding Path=DoubleValue}"/>
             <ProgressBar Maximum="10" Value="{Binding DoubleValue}"/>
           </StackPanel>
-          <StackPanel Margin="18" Gap="4" Width="200" HorizontalAlignment="Left">
+          <StackPanel Margin="18" Spacing="4" Width="200" HorizontalAlignment="Left">
             <TextBlock FontSize="16" Text="Binding Sources"/>
             <TextBox Watermark="Value of first TextBox" UseFloatingWatermark="True" 
                      Text="{Binding #first.Text, Mode=TwoWay}"/>
@@ -52,7 +52,7 @@
             <TextBox Watermark="Value of SharedItem.StringValue (duplicate)" UseFloatingWatermark="True"
                      Text="{Binding StringValue, Source={StaticResource SharedItem}, Mode=TwoWay}"/>
           </StackPanel>
-          <StackPanel Margin="18" Gap="4" Width="200" HorizontalAlignment="Left">
+          <StackPanel Margin="18" Spacing="4" Width="200" HorizontalAlignment="Left">
             <TextBlock FontSize="16" Text="Scheduler"/>
             <TextBox Watermark="Background Thread" Text="{Binding CurrentTime, Mode=OneWay}"/>
             <TextBlock FontSize="16" Text="Stream Operator"/>
@@ -68,11 +68,11 @@
             <TextBlock Text="{Binding StringValue}"/>
           </DataTemplate>
         </StackPanel.DataTemplates>
-        <StackPanel Margin="18" Gap="4" Width="200">
+        <StackPanel Margin="18" Spacing="4" Width="200">
           <TextBlock FontSize="16" Text="Multiple"/>
           <ListBox Items="{Binding Items}" SelectionMode="Multiple" SelectedItems="{Binding SelectedItems}"/>
         </StackPanel>
-        <StackPanel Margin="18" Gap="4" Width="200">
+        <StackPanel Margin="18" Spacing="4" Width="200">
           <TextBlock FontSize="16" Text="Multiple"/>
           <ListBox Items="{Binding Items}" SelectionMode="Multiple" SelectedItems="{Binding SelectedItems}"/>
         </StackPanel>
@@ -87,16 +87,16 @@
     </TabItem>
     <TabItem Header="Property Validation">
       <StackPanel Orientation="Horizontal">
-        <StackPanel Margin="18" Gap="4" MinWidth="200" DataContext="{Binding ExceptionDataValidation}">
+        <StackPanel Margin="18" Spacing="4" MinWidth="200" DataContext="{Binding ExceptionDataValidation}">
           <TextBlock FontSize="16" Text="Exception Validation"/>
           <TextBox Watermark="Less Than 10" UseFloatingWatermark="True" Text="{Binding Path=LessThan10}"/>
         </StackPanel>
-        <StackPanel Margin="18" Gap="4" MinWidth="200" DataContext="{Binding IndeiDataValidation}">
+        <StackPanel Margin="18" Spacing="4" MinWidth="200" DataContext="{Binding IndeiDataValidation}">
           <TextBlock FontSize="16" Text="INotifyDataErrorInfo Validation"/>
           <TextBox Watermark="Maximum" UseFloatingWatermark="True" Text="{Binding Path=Maximum}"/>
           <TextBox Watermark="Value" UseFloatingWatermark="True" Text="{Binding Path=Value}"/>
         </StackPanel>
-        <StackPanel Margin="18" Gap="4" MinWidth="200" DataContext="{Binding DataAnnotationsValidation}">
+        <StackPanel Margin="18" Spacing="4" MinWidth="200" DataContext="{Binding DataAnnotationsValidation}">
           <TextBlock FontSize="16" Text="Data Annotations Validation"/>
           <TextBox Watermark="Phone #" UseFloatingWatermark="True" Text="{Binding PhoneNumber}"/>
           <TextBox Watermark="Less Than 10" UseFloatingWatermark="True" Text="{Binding Path=LessThan10}"/>
@@ -104,7 +104,7 @@
       </StackPanel>
     </TabItem>
     <TabItem Header="Commands">
-      <StackPanel Margin="18" Gap="4" Width="200">
+      <StackPanel Margin="18" Spacing="4" Width="200">
         <Button Content="Button" Command="{Binding StringValueCommand}" CommandParameter="Button"/>
         <ToggleButton Content="ToggleButton" IsChecked="{Binding BooleanFlag, Mode=OneWay}" Command="{Binding StringValueCommand}" CommandParameter="ToggleButton"/>
         <CheckBox Content="CheckBox" IsChecked="{Binding !BooleanFlag, Mode=OneWay}" Command="{Binding StringValueCommand}" CommandParameter="CheckBox"/>

--- a/samples/ControlCatalog/Pages/AutoCompleteBoxPage.xaml
+++ b/samples/ControlCatalog/Pages/AutoCompleteBoxPage.xaml
@@ -1,12 +1,12 @@
 <UserControl xmlns="https://github.com/avaloniaui">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">AutoCompleteBox</TextBlock>
     <TextBlock Classes="h2">A control into which the user can input text</TextBlock>
 
     <StackPanel Orientation="Horizontal"
               Margin="0,16,0,0"
               HorizontalAlignment="Center"
-              Gap="8">
+              Spacing="8">
       <StackPanel Orientation="Vertical">
         <TextBlock Text="MinimumPrefixLength: 1"/>
         <AutoCompleteBox Width="200"

--- a/samples/ControlCatalog/Pages/BorderPage.xaml
+++ b/samples/ControlCatalog/Pages/BorderPage.xaml
@@ -1,12 +1,12 @@
 <UserControl xmlns="https://github.com/avaloniaui">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">Border</TextBlock>
     <TextBlock Classes="h2">A control which decorates a child with a border and background</TextBlock>
 
     <StackPanel Orientation="Vertical"
                 Margin="0,16,0,0"
                 HorizontalAlignment="Center"
-                Gap="16">
+                Spacing="16">
       <Border BorderBrush="{DynamicResource ThemeAccentBrush}" BorderThickness="2" Padding="16">
         <TextBlock>Border</TextBlock>
       </Border>

--- a/samples/ControlCatalog/Pages/ButtonPage.xaml
+++ b/samples/ControlCatalog/Pages/ButtonPage.xaml
@@ -1,14 +1,14 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">Button</TextBlock>
     <TextBlock Classes="h2">A button control</TextBlock>
 
     <StackPanel Orientation="Horizontal"
                 Margin="0,16,0,0"
                 HorizontalAlignment="Center"
-                Gap="16">
-      <StackPanel Orientation="Vertical" Gap="8" Width="150">
+                Spacing="16">
+      <StackPanel Orientation="Vertical" Spacing="8" Width="150">
         <Button>Button</Button>
         <Button Foreground="White">Foreground</Button>
         <Button Background="{DynamicResource ThemeAccentBrush}">Background</Button>
@@ -25,7 +25,7 @@
         </Button>
       </StackPanel>
 
-      <StackPanel Orientation="Vertical" Gap="8" Width="150">
+      <StackPanel Orientation="Vertical" Spacing="8" Width="150">
         <Button BorderThickness="0">No Border</Button>
         <Button BorderBrush="{DynamicResource ThemeAccentBrush}">Border Color</Button>
         <Button BorderBrush="{DynamicResource ThemeAccentBrush}" BorderThickness="4">Thick Border</Button>

--- a/samples/ControlCatalog/Pages/ButtonSpinnerPage.xaml
+++ b/samples/ControlCatalog/Pages/ButtonSpinnerPage.xaml
@@ -1,11 +1,11 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">ButtonSpinner</TextBlock>
     <TextBlock Classes="h2">The ButtonSpinner control allows you to add button spinners to any element and then respond to the Spin event to manipulate that element.</TextBlock>
 
-    <StackPanel Orientation="Vertical" Gap="8" Width="200" Margin="0,20,0,0">
+    <StackPanel Orientation="Vertical" Spacing="8" Width="200" Margin="0,20,0,0">
       <CheckBox Name="allowSpinCheck" IsChecked="True">AllowSpin</CheckBox>
       <CheckBox Name="showSpinCheck" IsChecked="True">ShowButtonSpinner</CheckBox>
       <ButtonSpinner Spin="OnSpin" Height="30"

--- a/samples/ControlCatalog/Pages/CalendarPage.xaml
+++ b/samples/ControlCatalog/Pages/CalendarPage.xaml
@@ -1,13 +1,13 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">Calendar</TextBlock>
     <TextBlock Classes="h2">A calendar control for selecting dates</TextBlock>
         
     <StackPanel Orientation="Horizontal"
                 Margin="0,16,0,0"
                 HorizontalAlignment="Center"
-                Gap="16">
+                Spacing="16">
       <StackPanel Orientation="Vertical">
         <TextBlock Text="SelectionMode: None"/>
         <Calendar SelectionMode="None"

--- a/samples/ControlCatalog/Pages/CanvasPage.xaml
+++ b/samples/ControlCatalog/Pages/CanvasPage.xaml
@@ -1,5 +1,5 @@
 <UserControl xmlns="https://github.com/avaloniaui">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">Canvas</TextBlock>
     <TextBlock Classes="h2">A panel which lays out its children by explicit coordinates</TextBlock>
     <Canvas Background="Yellow" Width="300" Height="400">

--- a/samples/ControlCatalog/Pages/CarouselPage.xaml
+++ b/samples/ControlCatalog/Pages/CarouselPage.xaml
@@ -1,9 +1,9 @@
 <UserControl xmlns="https://github.com/avaloniaui">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">Carousel</TextBlock>
     <TextBlock Classes="h2">An items control that displays its items as pages that fill the control.</TextBlock>
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 16 0 0" Gap="8">
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 16 0 0" Spacing="8">
       <Button Name="left" VerticalAlignment="Center" Padding="20">
         <Path Data="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z" Fill="Black"/>
       </Button>
@@ -20,7 +20,7 @@
       </Button>
     </StackPanel>
 
-    <StackPanel Orientation="Horizontal" Gap="4">
+    <StackPanel Orientation="Horizontal" Spacing="4">
       <TextBlock VerticalAlignment="Center">Transition</TextBlock>
       <DropDown Name="transition" SelectedIndex="1" VerticalAlignment="Center">
         <DropDownItem>None</DropDownItem>
@@ -29,7 +29,7 @@
       </DropDown>
     </StackPanel>
 
-    <StackPanel Orientation="Horizontal" Gap="4">
+    <StackPanel Orientation="Horizontal" Spacing="4">
       <TextBlock VerticalAlignment="Center">Orientation</TextBlock>
       <DropDown Name="orientation" SelectedIndex="1" VerticalAlignment="Center">
         <DropDownItem>Horizontal</DropDownItem>

--- a/samples/ControlCatalog/Pages/CheckBoxPage.xaml
+++ b/samples/ControlCatalog/Pages/CheckBoxPage.xaml
@@ -1,15 +1,15 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">CheckBox</TextBlock>
     <TextBlock Classes="h2">A check box control</TextBlock>
 
     <StackPanel Orientation="Horizontal"
                 Margin="0,16,0,0"
                 HorizontalAlignment="Center"
-                Gap="16">
+                Spacing="16">
       <StackPanel Orientation="Vertical"
-                  Gap="16">
+                  Spacing="16">
         <CheckBox>Unchecked</CheckBox>
         <CheckBox IsChecked="True">Checked</CheckBox>
         <CheckBox IsChecked="{x:Null}">Indeterminate</CheckBox>
@@ -17,7 +17,7 @@
       </StackPanel>
       <StackPanel Orientation="Vertical"
                   HorizontalAlignment="Center"
-                  Gap="16">
+                  Spacing="16">
         <CheckBox IsChecked="False" IsThreeState="True">Three State: Unchecked</CheckBox>
         <CheckBox IsChecked="True" IsThreeState="True">Three State: Checked</CheckBox>
         <CheckBox IsChecked="{x:Null}" IsThreeState="True">Three State: Indeterminate</CheckBox>

--- a/samples/ControlCatalog/Pages/ContextMenuPage.xaml
+++ b/samples/ControlCatalog/Pages/ContextMenuPage.xaml
@@ -1,12 +1,12 @@
 <UserControl xmlns="https://github.com/avaloniaui">
-    <StackPanel Orientation="Vertical" Gap="4">
+    <StackPanel Orientation="Vertical" Spacing="4">
         <TextBlock Classes="h1">Context Menu</TextBlock>
         <TextBlock Classes="h2">A right click menu that can be applied to any control.</TextBlock>
 
         <StackPanel Orientation="Horizontal"
               Margin="0,16,0,0"
               HorizontalAlignment="Center"
-              Gap="16">
+              Spacing="16">
             <Border Background="{DynamicResource ThemeAccentBrush}"
               Padding="48,48,48,48">
                 <Border.ContextMenu>

--- a/samples/ControlCatalog/Pages/DatePickerPage.xaml
+++ b/samples/ControlCatalog/Pages/DatePickerPage.xaml
@@ -1,13 +1,13 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">DatePicker</TextBlock>
     <TextBlock Classes="h2">A control for selecting dates with a calendar drop-down</TextBlock>
         
     <StackPanel Orientation="Horizontal"
                 Margin="0,16,0,0"
                 HorizontalAlignment="Center"
-                Gap="16">
+                Spacing="16">
       <StackPanel Orientation="Vertical"
                   Width="200">
         <TextBlock Text="SelectedDateFormat: Short"/>

--- a/samples/ControlCatalog/Pages/DialogsPage.xaml
+++ b/samples/ControlCatalog/Pages/DialogsPage.xaml
@@ -1,5 +1,5 @@
 <UserControl xmlns="https://github.com/avaloniaui">
-  <StackPanel Orientation="Vertical" Gap="4" Margin="4">
+  <StackPanel Orientation="Vertical" Spacing="4" Margin="4">
       <Button Name="OpenFile">Open File</Button>
       <Button Name="SaveFile">Save File</Button>
       <Button Name="SelectFolder">Select Folder</Button>

--- a/samples/ControlCatalog/Pages/DragAndDropPage.xaml
+++ b/samples/ControlCatalog/Pages/DragAndDropPage.xaml
@@ -1,12 +1,12 @@
 <UserControl xmlns="https://github.com/avaloniaui">
-    <StackPanel Orientation="Vertical" Gap="4">
+    <StackPanel Orientation="Vertical" Spacing="4">
         <TextBlock Classes="h1">Drag+Drop</TextBlock>
         <TextBlock Classes="h2">Example of Drag+Drop capabilities</TextBlock>
 
         <StackPanel Orientation="Horizontal"
                 Margin="0,16,0,0"
                 HorizontalAlignment="Center"
-                Gap="16">
+                Spacing="16">
             <Border BorderBrush="{DynamicResource ThemeAccentBrush}" BorderThickness="2" Padding="16" Name="DragMe">
                 <TextBlock Name="DragState">Drag Me</TextBlock>
             </Border>

--- a/samples/ControlCatalog/Pages/DropDownPage.xaml
+++ b/samples/ControlCatalog/Pages/DropDownPage.xaml
@@ -1,9 +1,9 @@
 <UserControl xmlns="https://github.com/avaloniaui">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">DropDown</TextBlock>
     <TextBlock Classes="h2">A drop-down list.</TextBlock>
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 16 0 0" Gap="8">
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 16 0 0" Spacing="8">
       <DropDown SelectedIndex="0">
         <DropDownItem>Inline Items</DropDownItem>
         <DropDownItem>Inline Item 2</DropDownItem>

--- a/samples/ControlCatalog/Pages/ExpanderPage.xaml
+++ b/samples/ControlCatalog/Pages/ExpanderPage.xaml
@@ -1,12 +1,12 @@
 <UserControl xmlns="https://github.com/avaloniaui">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">Expander</TextBlock>
     <TextBlock Classes="h2">Expands to show nested content</TextBlock>
 
     <StackPanel Orientation="Vertical"
                 Margin="0,16,0,0"
                 HorizontalAlignment="Center"
-                Gap="16">
+                Spacing="16">
       <Expander Header="Expand Up" ExpandDirection="Up">
         <StackPanel>
           <TextBlock>Expanded content</TextBlock>

--- a/samples/ControlCatalog/Pages/ImagePage.xaml
+++ b/samples/ControlCatalog/Pages/ImagePage.xaml
@@ -1,12 +1,12 @@
 <UserControl xmlns="https://github.com/avaloniaui">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">Image</TextBlock>
     <TextBlock Classes="h2">Displays an image</TextBlock>
 
     <StackPanel Orientation="Horizontal"
                 Margin="0,16,0,0"
                 HorizontalAlignment="Center"
-                Gap="16">
+                Spacing="16">
       <StackPanel Orientation="Vertical">
         <TextBlock>No Stretch</TextBlock>
         <Image Source="resm:ControlCatalog.Assets.delicate-arch-896885_640.jpg"

--- a/samples/ControlCatalog/Pages/MenuPage.xaml
+++ b/samples/ControlCatalog/Pages/MenuPage.xaml
@@ -1,12 +1,12 @@
 <UserControl xmlns="https://github.com/avaloniaui">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">Menu</TextBlock>
     <TextBlock Classes="h2">A window menu</TextBlock>
 
         <StackPanel Orientation="Horizontal"
               Margin="0,16,0,0"
               HorizontalAlignment="Center"
-              Gap="16">
+              Spacing="16">
             <Menu>
                 <MenuItem Header="_First">
                     <MenuItem Header="Standard _Menu Item"/>

--- a/samples/ControlCatalog/Pages/NumericUpDownPage.xaml
+++ b/samples/ControlCatalog/Pages/NumericUpDownPage.xaml
@@ -1,6 +1,6 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Margin="2" Classes="h1">Numeric up-down control</TextBlock>
     <TextBlock Margin="2" Classes="h2" TextWrapping="Wrap">Numeric up-down control provides a TextBox with button spinners that allow incrementing and decrementing numeric values by using the spinner buttons, keyboard up/down arrows, or mouse wheel.</TextBlock>
 
@@ -26,7 +26,7 @@
                   VerticalAlignment="Center" Margin="2">
           <DropDown.ItemTemplate>
             <DataTemplate>
-              <StackPanel Orientation="Horizontal" Gap="2">
+              <StackPanel Orientation="Horizontal" Spacing="2">
                 <TextBlock Text="{Binding Name}"/>
                 <TextBlock Text="-"/>
                 <TextBlock Text="{Binding Value}"/>
@@ -69,7 +69,7 @@
       </Grid>
     </Grid>
 
-    <StackPanel Margin="2,10,2,2" Orientation="Horizontal" Gap="10">
+    <StackPanel Margin="2,10,2,2" Orientation="Horizontal" Spacing="10">
       <TextBlock FontSize="14" FontWeight="Bold" VerticalAlignment="Center">Usage of NumericUpDown:</TextBlock>
       <NumericUpDown Name="upDown" Minimum="0" Maximum="10" Increment="0.5"
                      CultureInfo="en-US" VerticalAlignment="Center" Height="25" Width="100"

--- a/samples/ControlCatalog/Pages/ProgressBarPage.xaml
+++ b/samples/ControlCatalog/Pages/ProgressBarPage.xaml
@@ -1,5 +1,5 @@
 <UserControl xmlns="https://github.com/avaloniaui">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">ProgressBar</TextBlock>
     <TextBlock Classes="h2">A progress bar control</TextBlock>
 
@@ -7,8 +7,8 @@
       <StackPanel Orientation="Horizontal"
                   Margin="0,16,0,0"
                   HorizontalAlignment="Center"
-                  Gap="16">
-        <StackPanel Gap="16">
+                  Spacing="16">
+        <StackPanel Spacing="16">
           <ProgressBar Value="{Binding #hprogress.Value}" />
           <ProgressBar IsIndeterminate="True"/>
         </StackPanel>

--- a/samples/ControlCatalog/Pages/RadioButtonPage.xaml
+++ b/samples/ControlCatalog/Pages/RadioButtonPage.xaml
@@ -1,22 +1,22 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">RadioButton</TextBlock>
     <TextBlock Classes="h2">Allows the selection of a single option of many</TextBlock>
 
     <StackPanel Orientation="Horizontal"
                 Margin="0,16,0,0"
                 HorizontalAlignment="Center"
-                Gap="16">
+                Spacing="16">
       <StackPanel Orientation="Vertical"
-                  Gap="16">
+                  Spacing="16">
         <RadioButton IsChecked="True">Option 1</RadioButton>
         <RadioButton>Option 2</RadioButton>
         <RadioButton IsChecked="{x:Null}">Option 3</RadioButton>
         <RadioButton IsEnabled="False">Disabled</RadioButton>
       </StackPanel>
       <StackPanel Orientation="Vertical"
-                  Gap="16">
+                  Spacing="16">
         <RadioButton IsChecked="True" IsThreeState="True">Three States: Option 1</RadioButton>
         <RadioButton IsChecked="False" IsThreeState="True">Three States: Option 2</RadioButton>
         <RadioButton IsChecked="{x:Null}" IsThreeState="True">Three States: Option 3</RadioButton>

--- a/samples/ControlCatalog/Pages/SliderPage.xaml
+++ b/samples/ControlCatalog/Pages/SliderPage.xaml
@@ -1,9 +1,9 @@
 <UserControl xmlns="https://github.com/avaloniaui">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">Slider</TextBlock>
     <TextBlock Classes="h2">A control that lets the user select from a range of values by moving a Thumb control along a Track.</TextBlock>
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 16 0 0" Gap="16">
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 16 0 0" Spacing="16">
       <Slider Value="0"
               Minimum="0"
               Maximum="100"

--- a/samples/ControlCatalog/Pages/TextBoxPage.xaml
+++ b/samples/ControlCatalog/Pages/TextBoxPage.xaml
@@ -1,13 +1,13 @@
 <UserControl xmlns="https://github.com/avaloniaui">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">TextBox</TextBlock>
     <TextBlock Classes="h2">A control into which the user can input text</TextBlock>
 
     <StackPanel Orientation="Horizontal"
               Margin="0,16,0,0"
               HorizontalAlignment="Center"
-              Gap="16">
-      <StackPanel Orientation="Vertical" Gap="8">
+              Spacing="16">
+      <StackPanel Orientation="Vertical" Spacing="8">
         <TextBox Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit." Width="200" />
         <TextBox Watermark="ReadOnly" IsReadOnly="True" Text="This is read only"/>
         <TextBox Width="200" Watermark="Watermark" />
@@ -26,13 +26,13 @@
         <TextBox Width="200" Text="Right aligned text" TextAlignment="Right" />
       </StackPanel>
 
-      <StackPanel Orientation="Vertical" Gap="8">
+      <StackPanel Orientation="Vertical" Spacing="8">
         <TextBox AcceptsReturn="True" TextWrapping="Wrap" Width="200" Height="125"
                  Text="Multiline TextBox with TextWrapping.&#xD;&#xD;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus magna. Cras in mi at felis aliquet congue. Ut a est eget ligula molestie gravida. Curabitur massa. Donec eleifend, libero at sagittis mollis, tellus est malesuada tellus, at luctus turpis elit sit amet quam. Vivamus pretium ornare est." />
         <TextBox AcceptsReturn="True" Width="200" Height="125"
                  Text="Multiline TextBox with no TextWrapping.&#xD;&#xD;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus magna. Cras in mi at felis aliquet congue. Ut a est eget ligula molestie gravida. Curabitur massa. Donec eleifend, libero at sagittis mollis, tellus est malesuada tellus, at luctus turpis elit sit amet quam. Vivamus pretium ornare est." />
       </StackPanel>
-        <StackPanel Orientation="Vertical" Gap="8">
+        <StackPanel Orientation="Vertical" Spacing="8">
             <TextBox Width="200" Text="Custom font regular" FontWeight="Normal" FontStyle="Normal" FontFamily="resm:ControlCatalog.Assets.Fonts?assembly=ControlCatalog#Source Sans Pro"/>
                 <TextBox Width="200" Text="Custom font bold" FontWeight="Bold" FontStyle="Normal" FontFamily="resm:ControlCatalog.Assets.Fonts?assembly=ControlCatalog#Source Sans Pro"/>
                 <TextBox Width="200" Text="Custom font italic" FontWeight="Normal" FontStyle="Italic" FontFamily="resm:ControlCatalog.Assets.Fonts.SourceSansPro-Italic.ttf?assembly=ControlCatalog#Source Sans Pro"/>

--- a/samples/ControlCatalog/Pages/ToolTipPage.xaml
+++ b/samples/ControlCatalog/Pages/ToolTipPage.xaml
@@ -1,6 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui">
     <StackPanel Orientation="Vertical"
-                Gap="4">
+                Spacing="4">
         <TextBlock Classes="h1">ToolTip</TextBlock>
         <TextBlock Classes="h2">A control which pops up a hint when a control is hovered</TextBlock>
 

--- a/samples/ControlCatalog/Pages/TreeViewPage.xaml
+++ b/samples/ControlCatalog/Pages/TreeViewPage.xaml
@@ -1,12 +1,12 @@
 <UserControl xmlns="https://github.com/avaloniaui">
-  <StackPanel Orientation="Vertical" Gap="4">
+  <StackPanel Orientation="Vertical" Spacing="4">
     <TextBlock Classes="h1">TreeView</TextBlock>
     <TextBlock Classes="h2">Displays a hierachical tree of data.</TextBlock>
 
     <StackPanel Orientation="Horizontal"
               Margin="0,16,0,0"
               HorizontalAlignment="Center"
-              Gap="16">
+              Spacing="16">
       <TreeView Items="{Binding}" Width="250" Height="350">
         <TreeView.ItemTemplate>
           <TreeDataTemplate ItemsSource="{Binding Children}">

--- a/samples/VirtualizationDemo/MainWindow.xaml
+++ b/samples/VirtualizationDemo/MainWindow.xaml
@@ -6,7 +6,7 @@
         <StackPanel DockPanel.Dock="Right" 
                     Margin="16 0 0 0" 
                     MinWidth="150"
-                    Gap="4">
+                    Spacing="4">
             <DropDown Items="{Binding VirtualizationModes}"
                       SelectedItem="{Binding VirtualizationMode}"/>
             <DropDown Items="{Binding Orientations}"

--- a/src/Avalonia.Controls/StackPanel.cs
+++ b/src/Avalonia.Controls/StackPanel.cs
@@ -13,10 +13,10 @@ namespace Avalonia.Controls
     public class StackPanel : Panel, INavigableContainer
     {
         /// <summary>
-        /// Defines the <see cref="Gap"/> property.
+        /// Defines the <see cref="Spacing"/> property.
         /// </summary>
-        public static readonly StyledProperty<double> GapProperty =
-            AvaloniaProperty.Register<StackPanel, double>(nameof(Gap));
+        public static readonly StyledProperty<double> SpacingProperty =
+            AvaloniaProperty.Register<StackPanel, double>(nameof(Spacing));
 
         /// <summary>
         /// Defines the <see cref="Orientation"/> property.
@@ -29,17 +29,17 @@ namespace Avalonia.Controls
         /// </summary>
         static StackPanel()
         {
-            AffectsMeasure(GapProperty);
+            AffectsMeasure(SpacingProperty);
             AffectsMeasure(OrientationProperty);
         }
 
         /// <summary>
-        /// Gets or sets the size of the gap to place between child controls.
+        /// Gets or sets the size of the spacing to place between child controls.
         /// </summary>
-        public double Gap
+        public double Spacing
         {
-            get { return GetValue(GapProperty); }
-            set { SetValue(GapProperty, value); }
+            get { return GetValue(SpacingProperty); }
+            set { SetValue(SpacingProperty, value); }
         }
 
         /// <summary>
@@ -152,7 +152,7 @@ namespace Avalonia.Controls
 
             double measuredWidth = 0;
             double measuredHeight = 0;
-            double gap = Gap;
+            double spacing = Spacing;
             bool hasVisibleChild = Children.Any(c => c.IsVisible);
 
             foreach (Control child in Children)
@@ -162,23 +162,23 @@ namespace Avalonia.Controls
 
                 if (Orientation == Orientation.Vertical)
                 {
-                    measuredHeight += size.Height + (child.IsVisible ? gap : 0);
+                    measuredHeight += size.Height + (child.IsVisible ? spacing : 0);
                     measuredWidth = Math.Max(measuredWidth, size.Width);
                 }
                 else
                 {
-                    measuredWidth += size.Width + (child.IsVisible ? gap : 0);   
+                    measuredWidth += size.Width + (child.IsVisible ? spacing : 0);   
                     measuredHeight = Math.Max(measuredHeight, size.Height);
                 }
             }
 
             if (Orientation == Orientation.Vertical)
             {
-                measuredHeight -= (hasVisibleChild ? gap : 0);
+                measuredHeight -= (hasVisibleChild ? spacing : 0);
             }
             else
             {
-                measuredWidth -= (hasVisibleChild ? gap : 0);
+                measuredWidth -= (hasVisibleChild ? spacing : 0);
             }
 
             return new Size(measuredWidth, measuredHeight);
@@ -194,7 +194,7 @@ namespace Avalonia.Controls
             var orientation = Orientation;
             double arrangedWidth = finalSize.Width;
             double arrangedHeight = finalSize.Height;
-            double gap = Gap;
+            double spacing = Spacing;
             bool hasVisibleChild = Children.Any(c => c.IsVisible);
 
             if (Orientation == Orientation.Vertical)
@@ -217,25 +217,25 @@ namespace Avalonia.Controls
                     Rect childFinal = new Rect(0, arrangedHeight, width, childHeight);
                     ArrangeChild(child, childFinal, finalSize, orientation);
                     arrangedWidth = Math.Max(arrangedWidth, childWidth);
-                    arrangedHeight += childHeight + (child.IsVisible ? gap : 0);
+                    arrangedHeight += childHeight + (child.IsVisible ? spacing : 0);
                 }
                 else
                 {
                     double height = Math.Max(childHeight, arrangedHeight);
                     Rect childFinal = new Rect(arrangedWidth, 0, childWidth, height);
                     ArrangeChild(child, childFinal, finalSize, orientation);
-                    arrangedWidth += childWidth + (child.IsVisible ? gap : 0);
+                    arrangedWidth += childWidth + (child.IsVisible ? spacing : 0);
                     arrangedHeight = Math.Max(arrangedHeight, childHeight);
                 }
             }
 
             if (orientation == Orientation.Vertical)
             {
-                arrangedHeight = Math.Max(arrangedHeight - (hasVisibleChild ? gap : 0), finalSize.Height);
+                arrangedHeight = Math.Max(arrangedHeight - (hasVisibleChild ? spacing : 0), finalSize.Height);
             }
             else
             {
-                arrangedWidth = Math.Max(arrangedWidth - (hasVisibleChild ? gap : 0), finalSize.Width);
+                arrangedWidth = Math.Max(arrangedWidth - (hasVisibleChild ? spacing : 0), finalSize.Width);
             }
 
             return new Size(arrangedWidth, arrangedHeight);

--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -200,7 +200,7 @@ namespace Avalonia.Controls
         private void UpdateAdd(IControl child)
         {
             var bounds = Bounds;
-            var gap = Gap;
+            var spacing = Spacing;
 
             child.Measure(_availableSpace);
             ++_averageCount;
@@ -208,13 +208,13 @@ namespace Avalonia.Controls
             if (Orientation == Orientation.Vertical)
             {
                 var height = child.DesiredSize.Height;
-                _takenSpace += height + gap;
+                _takenSpace += height + spacing;
                 AddToAverageItemSize(height);
             }
             else
             {
                 var width = child.DesiredSize.Width;
-                _takenSpace += width + gap;
+                _takenSpace += width + spacing;
                 AddToAverageItemSize(width);
             }
         }
@@ -222,18 +222,18 @@ namespace Avalonia.Controls
         private void UpdateRemove(IControl child)
         {
             var bounds = Bounds;
-            var gap = Gap;
+            var spacing = Spacing;
 
             if (Orientation == Orientation.Vertical)
             {
                 var height = child.DesiredSize.Height;
-                _takenSpace -= height + gap;
+                _takenSpace -= height + spacing;
                 RemoveFromAverageItemSize(height);
             }
             else
             {
                 var width = child.DesiredSize.Width;
-                _takenSpace -= width + gap;
+                _takenSpace -= width + spacing;
                 RemoveFromAverageItemSize(width);
             }
 

--- a/src/Avalonia.Diagnostics/DevTools.xaml
+++ b/src/Avalonia.Diagnostics/DevTools.xaml
@@ -7,7 +7,7 @@
 
     <ContentControl Content="{Binding Content}" Grid.Row="1"/> 
     
-    <StackPanel Gap="4" Orientation="Horizontal" Grid.Row="2">
+    <StackPanel Spacing="4" Orientation="Horizontal" Grid.Row="2">
       <TextBlock>Hold Ctrl+Shift over a control to inspect.</TextBlock>
       <Separator Width="8"/>
       <TextBlock>Focused:</TextBlock>

--- a/src/Avalonia.Diagnostics/Views/TreePageView.xaml
+++ b/src/Avalonia.Diagnostics/Views/TreePageView.xaml
@@ -5,7 +5,7 @@
       <TreeView.DataTemplates>
         <TreeDataTemplate DataType="vm:TreeNode"
                           ItemsSource="{Binding Children}">
-          <StackPanel Orientation="Horizontal" Gap="8">
+          <StackPanel Orientation="Horizontal" Spacing="8">
             <TextBlock Text="{Binding Type}"/>
             <TextBlock Text="{Binding Classes}"/>
           </StackPanel>

--- a/tests/Avalonia.Controls.UnitTests/StackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/StackPanelTests.cs
@@ -54,11 +54,11 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
-        public void Lays_Out_Children_Vertically_With_Gap()
+        public void Lays_Out_Children_Vertically_With_Spacing()
         {
             var target = new StackPanel
             {
-                Gap = 10,
+                Spacing = 10,
                 Children =
                 {
                     new Border { Height = 20, Width = 120 },
@@ -77,11 +77,11 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
-        public void Lays_Out_Children_Horizontally_With_Gap()
+        public void Lays_Out_Children_Horizontally_With_Spacing()
         {
             var target = new StackPanel
             {
-                Gap = 10,
+                Spacing = 10,
                 Orientation = Orientation.Horizontal,
                 Children =
                 {
@@ -150,11 +150,11 @@ namespace Avalonia.Controls.UnitTests
         [Theory]
         [InlineData(Orientation.Horizontal)]
         [InlineData(Orientation.Vertical)]
-        public void Gap_Not_Added_For_Invisible_Children(Orientation orientation)
+        public void Spacing_Not_Added_For_Invisible_Children(Orientation orientation)
         {
             var targetThreeChildrenOneInvisble = new StackPanel
             {
-                Gap = 40,
+                Spacing = 40,
                 Orientation = orientation,
                 Children =
                 {
@@ -165,7 +165,7 @@ namespace Avalonia.Controls.UnitTests
             };
             var targetTwoChildrenNoneInvisible = new StackPanel
             {
-                Gap = 40,
+                Spacing = 40,
                 Orientation = orientation,
                 Children =
                 {


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
Renames the Gap property in StackPanel to spacing, just like in UWP.

Fixes #1374 