### PR TITLE
freeze designer support assembly version.

### DIFF
--- a/src/Avalonia.DesignerSupport/Avalonia.DesignerSupport.csproj
+++ b/src/Avalonia.DesignerSupport/Avalonia.DesignerSupport.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <!-- WARNING! The designer support version number needs to be frozen 
+         To allow projects that implement designer functionality to still
+         work with newer versions of Avalonia. This version number only
+         need change when there are breaking changes to designer support api.
+    -->
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,11 +41,6 @@
     <ProjectReference Include="..\Avalonia.Visuals\Avalonia.Visuals.csproj" />
     <ProjectReference Include="..\Avalonia.Styling\Avalonia.Styling.csproj" />
     <ProjectReference Include="..\Avalonia.Themes.Default\Avalonia.Themes.Default.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="..\Shared\SharedAssemblyInfo.cs">
-      <Link>Properties\SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <Import Project="..\..\build\Microsoft.CSharp.props" />
   <Import Project="..\..\build\Rx.props" />


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
Fixes designer support version number.

- What is the current behavior?
if you use an ide that references a newer version of designer support than the project its loaded targets it will throw an exception like:

![image](https://user-images.githubusercontent.com/4672627/43273780-3eac720a-90f5-11e8-99e8-0f7e6fa6fc60.png)


- What is the updated/expected behavior with this PR?
Freeze the version number so that this doesn't happen. We can update this version number if the designer support becomes incompatible with older versions of Avalonia.

Fixes #1407 