### PR TITLE
Dont freeze if someone implements window close cancellation.

### DIFF
--- a/src/Avalonia.Controls/WindowCollection.cs
+++ b/src/Avalonia.Controls/WindowCollection.cs
@@ -96,7 +96,7 @@ namespace Avalonia
         {
             while (_windows.Count > 0)
             {
-                _windows[0].Close();
+                _windows[0].Close(true);
             }
         }
 


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
If someone implements window close cancellation and calls Application.Exit the program will freeze.
This PR fixes that.

Application.Exit will now always exit no matter what.
