### PR TITLE
#1798 Fix binding checkbox with three state.

### DIFF
--- a/src/Avalonia.Controls/Primitives/ToggleButton.cs
+++ b/src/Avalonia.Controls/Primitives/ToggleButton.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Controls.Primitives
                 nameof(IsChecked),
                 o => o.IsChecked,
                 (o, v) => o.IsChecked = v,
-                unsetValue: false,
+                unsetValue: null,
                 defaultBindingMode: BindingMode.TwoWay);
 
         public static readonly StyledProperty<bool> IsThreeStateProperty =

--- a/tests/Avalonia.Controls.UnitTests/Primitives/ToggleButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/ToggleButtonTests.cs
@@ -44,14 +44,40 @@ namespace Avalonia.Controls.Primitives.UnitTests
             Assert.False(toggleButton.IsChecked);
         }
 
+        [Fact]
+        public void ToggleButton_ThreeState_Checked_Binds_To_Nullable_Bool()
+        {
+            var threeStateButton = new ToggleButton();
+            var source = new Class1();
+
+            threeStateButton.DataContext = source;
+            threeStateButton.Bind(ToggleButton.IsCheckedProperty, new Binding(nameof(Class1.NullableFoo)));
+
+            source.NullableFoo = true;
+            Assert.True(threeStateButton.IsChecked);
+
+            source.NullableFoo = false;
+            Assert.False(threeStateButton.IsChecked);
+
+            source.NullableFoo = null;
+            Assert.Null(threeStateButton.IsChecked);
+        }
+
         private class Class1 : NotifyingBase
         {
             private bool _foo;
+            private bool? nullableFoo;
 
             public bool Foo
             {
                 get { return _foo; }
                 set { _foo = value; RaisePropertyChanged(); }
+            }
+
+            public bool? NullableFoo
+            {
+                get { return nullableFoo; }
+                set { nullableFoo = value; RaisePropertyChanged(); }
             }
         }
     }


### PR DESCRIPTION
- What does the pull request do?
Allow set binded checkbox to null.
- What is the current behavior?
Null cannot be set in UI
- What is the updated/expected behavior with this PR?
Default value for checkbox is null now.

Checklist:

- [x] Added unit tests?

Fixes #1798