### PR TITLE
Fix windows for Mono.Mac

### DIFF
--- a/src/OSX/Avalonia.MonoMac/WindowImpl.cs
+++ b/src/OSX/Avalonia.MonoMac/WindowImpl.cs
@@ -26,18 +26,19 @@ namespace Avalonia.MonoMac
             });
 
             Window.SetCanBecomeKeyAndMain();
-            
-            Window.DidResize += delegate
-            {
-                var windowState = Window.IsMiniaturized ? WindowState.Minimized
-                    : (IsZoomed ? WindowState.Maximized : WindowState.Normal);
+        }
 
-                if (windowState != _lastWindowState)
-                {
-                    _lastWindowState = windowState;
-                    WindowStateChanged?.Invoke(windowState);
-                }
-            };
+        
+        protected override void OnResized()
+        {
+            var windowState = Window.IsMiniaturized ? WindowState.Minimized
+                : (IsZoomed ? WindowState.Maximized : WindowState.Normal);
+
+            if (windowState != _lastWindowState)
+            {
+                _lastWindowState = windowState;
+                WindowStateChanged?.Invoke(windowState);
+            }
         }
 
         public WindowState WindowState
@@ -129,24 +130,47 @@ namespace Avalonia.MonoMac
         class ModalDisposable : IDisposable
         {
             readonly WindowImpl _impl;
+            readonly IntPtr _modalSession;
+            bool disposed;
 
-            public ModalDisposable(WindowImpl impl)
+            public ModalDisposable(WindowImpl impl, IntPtr modalSession)
             {
                 _impl = impl;
+                _modalSession = modalSession;
+            }
+
+            public void Continue()
+            {
+                if (disposed)
+                    return;
+
+                var response = (NSRunResponse)NSApplication.SharedApplication.RunModalSession(_modalSession);
+                if (response == NSRunResponse.Continues)
+                {
+                    Dispatcher.UIThread.Post(Continue, DispatcherPriority.ContextIdle);
+                }
+                else
+                {
+                    Logging.Logger.Log(Logging.LogEventLevel.Debug, "MonoMac", this, "Modal session ended");
+                }
             }
 
             public void Dispose()
             {
+                Logging.Logger.Log(Logging.LogEventLevel.Debug, "MonoMac", this, "ModalDisposable disposed");
                 _impl.Window.OrderOut(_impl.Window);
+                NSApplication.SharedApplication.EndModalSession(_modalSession);
+                disposed = true;
             }
         }
 
         public IDisposable ShowDialog()
         {
-            //TODO: Investigate how to return immediately. 
-            // May be add some magic to our run loop or something
-            NSApplication.SharedApplication.RunModalForWindow(Window);
-            return new ModalDisposable(this);
+            var session = NSApplication.SharedApplication.BeginModalSession(Window);
+            var disposable = new ModalDisposable(this, session);
+            Dispatcher.UIThread.Post(disposable.Continue, DispatcherPriority.ContextIdle);
+
+            return disposable;
         }
     }
 }


### PR DESCRIPTION
- This pull request correct the behavior of Mono.Mac window implementation.
- Currently dialogs do not work, do not display content and do not release other windows when closed and other windows do not react to system closed events.
- Dialogs now correctly render their content and release other windows and system level close events are handled correctly.
