### PR TITLE
Add support for Direct2D1 for Avalonia.DotNetCoreRuntime

### DIFF
--- a/src/Avalonia.DotNetCoreRuntime/Avalonia.DotNetCoreRuntime.csproj
+++ b/src/Avalonia.DotNetCoreRuntime/Avalonia.DotNetCoreRuntime.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\Gtk\Avalonia.Gtk3\Avalonia.Gtk3.csproj" />
     <ProjectReference Include="..\OSX\Avalonia.MonoMac\Avalonia.MonoMac.csproj" />
     <ProjectReference Include="..\Skia\Avalonia.Skia\Avalonia.Skia.csproj" />
+    <ProjectReference Include="..\Windows\Avalonia.Direct2D1\Avalonia.Direct2D1.csproj" />
     <ProjectReference Include="..\Windows\Avalonia.Win32\Avalonia.Win32.csproj" />
   </ItemGroup>  
   <Import Project="..\..\build\NetCore.props" />


### PR DESCRIPTION
- What does the pull request do?
Adds support for Direct2D1 for Avalonia.DotNetCoreRuntime.
- What is the current behavior?
Avalonia.DotNetCoreRuntime does not have support for Direct2D1 and you have add reference manually.
- What is the updated/expected behavior with this PR?
Able to use out of the box UseDirect2D1() in .NET Core projects.
- How was the solution implemented (if it's not obvious)?
Added Avalonia.Direct2D1 project reference to Avalonia.DotNetCoreRuntime.