### PR TITLE
fixes an occasional crash with popup root "SnapInsideScreenEdges"

### DIFF
--- a/src/Avalonia.Controls/Primitives/PopupRoot.cs
+++ b/src/Avalonia.Controls/Primitives/PopupRoot.cs
@@ -83,9 +83,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public void SnapInsideScreenEdges()
         {
-            var window = this.GetSelfAndLogicalAncestors().OfType<Window>().First();
-            
-            var screen = window.Screens.ScreenFromPoint(Position);
+            var screen = Application.Current.MainWindow.Screens.ScreenFromPoint(Position);
 
             var screenX = Position.X + Bounds.Width - screen.Bounds.X;
             var screenY = Position.Y + Bounds.Height - screen.Bounds.Y;

--- a/src/Avalonia.Controls/Primitives/PopupRoot.cs
+++ b/src/Avalonia.Controls/Primitives/PopupRoot.cs
@@ -83,19 +83,22 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public void SnapInsideScreenEdges()
         {
-            var screen = Application.Current.MainWindow.Screens.ScreenFromPoint(Position);
+            var screen = Application.Current.MainWindow?.Screens.ScreenFromPoint(Position);
 
-            var screenX = Position.X + Bounds.Width - screen.Bounds.X;
-            var screenY = Position.Y + Bounds.Height - screen.Bounds.Y;
-
-            if (screenX > screen.Bounds.Width)
+            if (screen != null)
             {
-                Position = Position.WithX(Position.X - (screenX - screen.Bounds.Width));
-            }
+                var screenX = Position.X + Bounds.Width - screen.Bounds.X;
+                var screenY = Position.Y + Bounds.Height - screen.Bounds.Y;
 
-            if (screenY > screen.Bounds.Height)
-            {
-                Position = Position.WithY(Position.Y - (screenY - screen.Bounds.Height));
+                if (screenX > screen.Bounds.Width)
+                {
+                    Position = Position.WithX(Position.X - (screenX - screen.Bounds.Width));
+                }
+
+                if (screenY > screen.Bounds.Height)
+                {
+                    Position = Position.WithY(Position.Y - (screenY - screen.Bounds.Height));
+                }
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
@@ -64,7 +64,10 @@ namespace Avalonia.Controls.UnitTests
                 {
                     ContextMenu = sut
                 };
-                new Window { Content = target };
+
+                var window = new Window { Content = target };
+
+                Avalonia.Application.Current.MainWindow = window;
 
                 target.RaiseEvent(new PointerReleasedEventArgs
                 {


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
Fixes a crash when trying to get hold of the screens class, was done by traversing tree and 
this wouldn't work in some cases like when a popup isn't attached to visual tree.

- What is the current behavior?
crash

- What is the updated/expected behavior with this PR?
Accesses screens class by not traversing the tree, goes via Application.Current.MainWindow
