### PR TITLE
Support invoking a task in the dispatcher.

### DIFF
--- a/src/Avalonia.Base/Threading/Dispatcher.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.cs
@@ -93,6 +93,20 @@ namespace Avalonia.Threading
         }
 
         /// <inheritdoc/>
+        public Task InvokeAsync(Func<Task> function, DispatcherPriority priority = DispatcherPriority.Normal)
+        {
+            Contract.Requires<ArgumentNullException>(function != null);
+            return _jobRunner.InvokeAsync(function, priority).Unwrap();
+        }
+
+        /// <inheritdoc/>
+        public Task<TResult> InvokeAsync<TResult>(Func<Task<TResult>> function, DispatcherPriority priority = DispatcherPriority.Normal)
+        {
+            Contract.Requires<ArgumentNullException>(function != null);
+            return _jobRunner.InvokeAsync(function, priority).Unwrap();
+        }
+
+        /// <inheritdoc/>
         public void Post(Action action, DispatcherPriority priority = DispatcherPriority.Normal)
         {
             Contract.Requires<ArgumentNullException>(action != null);

--- a/src/Avalonia.Base/Threading/IDispatcher.cs
+++ b/src/Avalonia.Base/Threading/IDispatcher.cs
@@ -40,5 +40,23 @@ namespace Avalonia.Threading
         /// <param name="function">The method.</param>
         /// <param name="priority">The priority with which to invoke the method.</param>
         Task<TResult> InvokeAsync<TResult>(Func<TResult> function, DispatcherPriority priority = DispatcherPriority.Normal);
+
+        /// <summary>
+        /// Queues the specified work to run on the dispatcher thread and returns a proxy for the
+        /// task returned by <paramref name="function"/>.
+        /// </summary>
+        /// <param name="function">The work to execute asynchronously.</param>
+        /// <param name="priority">The priority with which to invoke the method.</param>
+        /// <returns>A task that represents a proxy for the task returned by <paramref name="function"/>.</returns>
+        Task InvokeAsync(Func<Task> function, DispatcherPriority priority = DispatcherPriority.Normal);
+
+        /// <summary>
+        /// Queues the specified work to run on the dispatcher thread and returns a proxy for the
+        /// task returned by <paramref name="function"/>.
+        /// </summary>
+        /// <param name="function">The work to execute asynchronously.</param>
+        /// <param name="priority">The priority with which to invoke the method.</param>
+        /// <returns>A task that represents a proxy for the task returned by <paramref name="function"/>.</returns>
+        Task<TResult> InvokeAsync<TResult>(Func<Task<TResult>> function, DispatcherPriority priority = DispatcherPriority.Normal);
     }
 }

--- a/tests/Avalonia.UnitTests/ImmediateDispatcher.cs
+++ b/tests/Avalonia.UnitTests/ImmediateDispatcher.cs
@@ -9,28 +9,45 @@ namespace Avalonia.UnitTests
     /// </summary>
     public class ImmediateDispatcher : IDispatcher
     {
+        /// <inheritdoc/>
         public bool CheckAccess()
         {
             return true;
         }
 
+        /// <inheritdoc/>
         public void Post(Action action, DispatcherPriority priority = DispatcherPriority.Normal)
         {
             action();
         }
 
+        /// <inheritdoc/>
         public Task InvokeAsync(Action action, DispatcherPriority priority = DispatcherPriority.Normal)
         {
             action();
-            return Task.FromResult<object>(null);
+            return Task.CompletedTask;
         }
 
+        /// <inheritdoc/>
         public Task<TResult> InvokeAsync<TResult>(Func<TResult> function, DispatcherPriority priority = DispatcherPriority.Normal)
         {
             var result = function();
             return Task.FromResult(result);
         }
 
+        /// <inheritdoc/>
+        public Task InvokeAsync(Func<Task> function, DispatcherPriority priority = DispatcherPriority.Normal)
+        {
+            return function();
+        }
+        
+        /// <inheritdoc/>
+        public Task<TResult> InvokeAsync<TResult>(Func<Task<TResult>> function, DispatcherPriority priority = DispatcherPriority.Normal)
+        {
+            return function();
+        }
+        
+        /// <inheritdoc/>
         public void VerifyAccess()
         {
         }


### PR DESCRIPTION
- What does the pull request do?

Following #1810, add support for asynchronous methods (esp. async delegates).

- What is the current behavior?

Async delegates are not transparently scheduled if used in the dispatcher.

The following code would return a `Task<Task>` instead of a single task that could be awaited:

```csharp
Task task1 = await Dispatcher.UIThread.InvokeAsync(async () =>
{
    await Task.Delay(1000);
});
```

Especially visible if the async method is supposed to return a value:

```csharp
Task<int> task2 = await Dispatcher.UIThread.InvokeAsync(async () =>
{
    await Task.Delay(1000);
    return 42;
});
```


- What is the updated/expected behavior with this PR?

Task can be queued and awaited asynchronously:
```csharp
await Dispatcher.UIThread.InvokeAsync(async () =>
{
    await Task.Delay(1000);
}); // return void

int integer = await Dispatcher.UIThread.InvokeAsync(async () =>
{
    await Task.Delay(1000);
    return 42;
});
```

- How was the solution implemented (if it's not obvious)?

Add an overload of `InvokeAsync` and refactored the `JobRunner` class.

Checklist:

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation