### PR TITLE
Implement GroupName for RadioButton

### DIFF
--- a/samples/ControlCatalog/Pages/RadioButtonPage.xaml
+++ b/samples/ControlCatalog/Pages/RadioButtonPage.xaml
@@ -22,6 +22,19 @@
         <RadioButton IsChecked="{x:Null}" IsThreeState="True">Three States: Option 3</RadioButton>
         <RadioButton IsChecked="{x:Null}" IsThreeState="True" IsEnabled="False">Disabled</RadioButton>
       </StackPanel>
+      <StackPanel Orientation="Vertical"
+                  Spacing="16">
+        <RadioButton GroupName="A" IsChecked="True">Group A: Option 1</RadioButton>
+        <RadioButton GroupName="A" IsEnabled="False">Group A: Disabled</RadioButton>
+        <RadioButton GroupName="B">Group B: Option 1</RadioButton>
+        <RadioButton GroupName="B" IsChecked="{x:Null}">Group B: Option 3</RadioButton>
+      </StackPanel>
+      <StackPanel Orientation="Vertical"
+                  Spacing="16">
+        <RadioButton GroupName="A" IsChecked="True">Group A: Option 2</RadioButton>
+        <RadioButton GroupName="B">Group B: Option 2</RadioButton>
+        <RadioButton GroupName="B" IsChecked="{x:Null}">Group B: Option 4</RadioButton>
+      </StackPanel>
     </StackPanel>
   </StackPanel>
 </UserControl>

--- a/src/Avalonia.Controls/RadioButton.cs
+++ b/src/Avalonia.Controls/RadioButton.cs
@@ -2,17 +2,142 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Controls.Primitives;
+using Avalonia.Rendering;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Controls
 {
     public class RadioButton : ToggleButton
     {
+        private class RadioButtonGroupManager
+        {
+            public static readonly RadioButtonGroupManager Default = new RadioButtonGroupManager();
+            static readonly List<(WeakReference<IRenderRoot> Root, RadioButtonGroupManager Manager)> s_registeredVisualRoots
+                = new List<(WeakReference<IRenderRoot> Root, RadioButtonGroupManager Manager)>();
+
+            readonly Dictionary<string, List<WeakReference<RadioButton>>> s_registeredGroups
+                = new Dictionary<string, List<WeakReference<RadioButton>>>();
+
+            public static RadioButtonGroupManager GetOrCreateForRoot(IRenderRoot root)
+            {
+                if (root == null)
+                    return Default;
+                lock (s_registeredVisualRoots)
+                {
+                    int i = 0;
+                    while (i < s_registeredVisualRoots.Count)
+                    {
+                        var item = s_registeredVisualRoots[i].Root;
+                        if (!item.TryGetTarget(out var target))
+                        {
+                            s_registeredVisualRoots.RemoveAt(i);
+                            continue;
+                        }
+                        if (root == target)
+                            break;
+                        i++;
+                    }
+                    RadioButtonGroupManager manager;
+                    if (i >= s_registeredVisualRoots.Count)
+                    {
+                        manager = new RadioButtonGroupManager();
+                        s_registeredVisualRoots.Add((new WeakReference<IRenderRoot>(root), manager));
+                    }
+                    else
+                    {
+                        manager = s_registeredVisualRoots[i].Manager;
+                    }
+                    return manager;
+                }
+            }
+
+            public void Add(RadioButton radioButton)
+            {
+                lock (s_registeredGroups)
+                {
+                    string groupName = radioButton.GroupName;
+                    if (!s_registeredGroups.TryGetValue(groupName, out var group))
+                    {
+                        group = new List<WeakReference<RadioButton>>();
+                        s_registeredGroups.Add(groupName, group);
+                    }
+                    group.Add(new WeakReference<RadioButton>(radioButton));
+                }
+            }
+
+            public void Remove(RadioButton radioButton, string oldGroupName)
+            {
+                lock (s_registeredGroups)
+                {
+                    if (!string.IsNullOrEmpty(oldGroupName) && s_registeredGroups.TryGetValue(oldGroupName, out var group))
+                    {
+                        int i = 0;
+                        while (i < group.Count)
+                        {
+                            if (!group[i].TryGetTarget(out var button) || button == radioButton)
+                            {
+                                group.RemoveAt(i);
+                                continue;
+                            }
+                            i++;
+                        }
+                        if (group.Count == 0)
+                        {
+                            s_registeredGroups.Remove(oldGroupName);
+                        }
+                    }
+                }
+            }
+
+            public void SetChecked(RadioButton radioButton)
+            {
+                lock (s_registeredGroups)
+                {
+                    string groupName = radioButton.GroupName;
+                    if (s_registeredGroups.TryGetValue(groupName, out var group))
+                    {
+                        int i = 0;
+                        while (i < group.Count)
+                        {
+                            if (!group[i].TryGetTarget(out var current))
+                            {
+                                group.RemoveAt(i);
+                                continue;
+                            }
+                            if (current != radioButton && current.IsChecked.GetValueOrDefault())
+                                current.IsChecked = false;
+                            i++;
+                        }
+                        if (group.Count == 0)
+                        {
+                            s_registeredGroups.Remove(groupName);
+                        }
+                    }
+                }
+            }
+        }
+
+        public static readonly DirectProperty<RadioButton, string> GroupNameProperty =
+            AvaloniaProperty.RegisterDirect<RadioButton, string>(
+                nameof(GroupName),
+                o => o.GroupName,
+                (o, v) => o.GroupName = v);
+
+        private string _groupName;
+        private RadioButtonGroupManager _groupManager;
+
         public RadioButton()
         {
             this.GetObservable(IsCheckedProperty).Subscribe(IsCheckedChanged);
+        }
+
+        public string GroupName
+        {
+            get { return _groupName; }
+            set { SetGroupName(value); }
         }
 
         protected override void Toggle()
@@ -23,21 +148,77 @@ namespace Avalonia.Controls
             }
         }
 
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            if (!string.IsNullOrEmpty(GroupName))
+            {
+                var manager = RadioButtonGroupManager.GetOrCreateForRoot(e.Root);
+                if (manager != _groupManager)
+                {
+                    _groupManager.Remove(this, _groupName);
+                    _groupManager = manager;
+                    manager.Add(this);
+                }
+            }
+            base.OnAttachedToVisualTree(e);
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            if (!string.IsNullOrEmpty(GroupName) && _groupManager != null)
+            {
+                _groupManager.Remove(this, _groupName);
+            }
+        }
+
+        private void SetGroupName(string newGroupName)
+        {
+            string oldGroupName = GroupName;
+            if (newGroupName != oldGroupName)
+            {
+                if (!string.IsNullOrEmpty(oldGroupName) && _groupManager != null)
+                {
+                    _groupManager.Remove(this, oldGroupName);
+                }
+                _groupName = newGroupName;
+                if (!string.IsNullOrEmpty(newGroupName))
+                {
+                    if (_groupManager == null)
+                    {
+                        _groupManager = RadioButtonGroupManager.GetOrCreateForRoot(this.GetVisualRoot());
+                    }
+                    _groupManager.Add(this);
+                }
+            }
+        }
+
         private void IsCheckedChanged(bool? value)
         {
-            var parent = this.GetVisualParent();
-
-            if (value.GetValueOrDefault() && parent != null)
+            string groupName = GroupName;
+            if (string.IsNullOrEmpty(groupName))
             {
-                var siblings = parent
-                    .GetVisualChildren()
-                    .OfType<RadioButton>()
-                    .Where(x => x != this);
+                var parent = this.GetVisualParent();
 
-                foreach (var sibling in siblings)
+                if (value.GetValueOrDefault() && parent != null)
                 {
-                    if (sibling.IsChecked.GetValueOrDefault())
-                        sibling.IsChecked = false;
+                    var siblings = parent
+                        .GetVisualChildren()
+                        .OfType<RadioButton>()
+                        .Where(x => x != this);
+                    
+                    foreach (var sibling in siblings)
+                    {
+                        if (sibling.IsChecked.GetValueOrDefault())
+                            sibling.IsChecked = false;
+                    }
+                }
+            }
+            else
+            {
+                if (value.GetValueOrDefault() && _groupManager != null)
+                {
+                    _groupManager.SetChecked(this);
                 }
             }
         }

--- a/tests/Avalonia.Controls.UnitTests/RadioButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/RadioButtonTests.cs
@@ -32,5 +32,43 @@ namespace Avalonia.Controls.UnitTests
             Assert.True(radioButton1.IsChecked);
             Assert.Null(radioButton2.IsChecked);
         }
+
+        [Fact]
+        public void RadioButton_In_Same_Group_Is_Unchecked()
+        {
+            var parent = new Panel();
+
+            var panel1 = new Panel();
+            var panel2 = new Panel();
+
+            parent.Children.Add(panel1);
+            parent.Children.Add(panel2);
+
+            var radioButton1 = new RadioButton();
+            radioButton1.GroupName = "A";
+            radioButton1.IsChecked = false;
+
+            var radioButton2 = new RadioButton();
+            radioButton2.GroupName = "A";
+            radioButton2.IsChecked = true;
+
+            var radioButton3 = new RadioButton();
+            radioButton3.GroupName = "A";
+            radioButton3.IsChecked = false;
+
+            panel1.Children.Add(radioButton1);
+            panel1.Children.Add(radioButton2);
+            panel2.Children.Add(radioButton3);
+
+            Assert.False(radioButton1.IsChecked);
+            Assert.True(radioButton2.IsChecked);
+            Assert.False(radioButton3.IsChecked);
+
+            radioButton3.IsChecked = true;
+
+            Assert.False(radioButton1.IsChecked);
+            Assert.False(radioButton2.IsChecked);
+            Assert.True(radioButton3.IsChecked);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1782

Explanation copied from the old PR #1824:

The problem is that this feature is very simple. So finding a completely different way of implementing it is very hard. Basically, what you need to implement this feature are two things:

1. A property to store the GroupName.
2. A centralized list so you can efficiently detect which radio buttons share the same group name.

In order to avoid the simplest implementation used by WPF, I created a RadioButtonGroupManager class that is attached to the IRenderRoot using WeakReferences. Whenever a RadioButton is added to a visual tree, it retrieves and updates the RadioButtonGroupManager of the current visual tree. Whenever a RadioButton is removed from the visual tree, it removes itself.

Note that RadioButtons not attached to a visual tree, but with the GroupName property set, get added to a global manager instance.

This also fixes a bug in my previous implementation where two radio buttons with the same group name, but in different windows would interfere with each other.

The main difference is that WPF uses a global list for all RadioButtons. I use a list for each visual tree.

If Avalonia provides a better mechanism to loosely attach an object to a visual root, I would like to use it instead of my custom and clunky implementation.