### PR TITLE
Add RoutedEventRegistry: GetRoutedEvents and GetRoutedEventsOf

### DIFF
--- a/src/Avalonia.Interactivity/RoutedEvent.cs
+++ b/src/Avalonia.Interactivity/RoutedEvent.cs
@@ -72,7 +72,9 @@ namespace Avalonia.Interactivity
         {
             Contract.Requires<ArgumentNullException>(name != null);
 
-            return new RoutedEvent<TEventArgs>(name, routingStrategy, typeof(TOwner));
+            var routedEvent = new RoutedEvent<TEventArgs>(name, routingStrategy, typeof(TOwner));
+            RoutedEventRegistry.Instance.Register(typeof(TOwner), routedEvent);
+            return routedEvent;
         }
 
         public static RoutedEvent<TEventArgs> Register<TEventArgs>(
@@ -83,7 +85,9 @@ namespace Avalonia.Interactivity
         {
             Contract.Requires<ArgumentNullException>(name != null);
 
-            return new RoutedEvent<TEventArgs>(name, routingStrategy, ownerType);
+            var routedEvent = new RoutedEvent<TEventArgs>(name, routingStrategy, ownerType);
+            RoutedEventRegistry.Instance.Register(ownerType, routedEvent);
+            return routedEvent;
         }
 
         public IDisposable AddClassHandler(

--- a/src/Avalonia.Interactivity/RoutedEventRegistry.cs
+++ b/src/Avalonia.Interactivity/RoutedEventRegistry.cs
@@ -1,0 +1,90 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Avalonia.Interactivity
+{
+    /// <summary>
+    /// Tracks registered <see cref="RoutedEvent"/>s.
+    /// </summary>
+    public class RoutedEventRegistry
+    {
+        private readonly Dictionary<Type, List<RoutedEvent>> _registeredRoutedEvents =
+            new Dictionary<Type, List<RoutedEvent>>();
+
+        /// <summary>
+        /// Gets the <see cref="RoutedEventRegistry"/> instance.
+        /// </summary>
+        public static RoutedEventRegistry Instance { get; }
+            = new RoutedEventRegistry();
+
+        /// <summary>
+        /// Registers a <see cref="RoutedEvent"/> on a type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="event">The event.</param>
+        /// <remarks>
+        /// You won't usually want to call this method directly, instead use the
+        /// <see cref="RoutedEvent.Register{TOwner, TEventArgs}(string, RoutingStrategies)"/>
+        /// method.
+        /// </remarks>
+        public void Register(Type type, RoutedEvent @event)
+        {
+            Contract.Requires<ArgumentNullException>(type != null);
+            Contract.Requires<ArgumentNullException>(@event != null);
+
+            if (!_registeredRoutedEvents.TryGetValue(type, out var list))
+            {
+                list = new List<RoutedEvent>();
+                _registeredRoutedEvents.Add(type, list);
+            }
+            list.Add(@event);
+        }
+
+        /// <summary>
+        /// Returns all routed events, that are currently registered in the event registry.
+        /// </summary>
+        /// <returns>All routed events, that are currently registered in the event registry.</returns>
+        public IEnumerable<RoutedEvent> GetAllRegistered()
+        {
+            foreach (var events in _registeredRoutedEvents.Values)
+            {
+                foreach (var e in events)
+                {
+                    yield return e;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns all routed events registered with the provided type.
+        /// If the type is not found or does not provide any routed events, an empty list is returned.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>All routed events registered with the provided type.</returns>
+        public IReadOnlyList<RoutedEvent> GetRegistered(Type type)
+        {
+            Contract.Requires<ArgumentNullException>(type != null);
+
+            if (_registeredRoutedEvents.TryGetValue(type, out var events))
+            {
+                return events;
+            }
+
+            return Array.Empty<RoutedEvent>();
+        }
+
+        /// <summary>
+        /// Returns all routed events registered with the provided type.         
+        /// If the type is not found or does not provide any routed events, an empty list is returned.
+        /// </summary>
+        /// <typeparam name="TOwner">The type.</typeparam>
+        /// <returns>All routed events registered with the provided type.</returns>
+        public IReadOnlyList<RoutedEvent> GetRegistered<TOwner>()
+        {
+            return GetRegistered(typeof(TOwner));
+        }
+    }
+}

--- a/tests/Avalonia.Interactivity.UnitTests/RoutedEventRegistryTests.cs
+++ b/tests/Avalonia.Interactivity.UnitTests/RoutedEventRegistryTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Xunit;
+
+namespace Avalonia.Interactivity.UnitTests
+{
+    public class RoutedEventRegistryTests
+    {
+        [Fact]
+        public void Pointer_Events_Should_Be_Registered()
+        {
+            var expectedEvents = new List<RoutedEvent> { InputElement.PointerPressedEvent, InputElement.PointerReleasedEvent }; 
+            var registeredEvents = RoutedEventRegistry.Instance.GetRegistered<InputElement>();
+            Assert.Contains(registeredEvents, expectedEvents.Contains);
+        }
+
+        [Fact]
+        public void ClickEvent_Should_Be_Registered_On_Button()
+        {
+            var expectedEvents = new List<RoutedEvent> { Button.ClickEvent };
+            var registeredEvents = RoutedEventRegistry.Instance.GetRegistered<Button>();
+            Assert.Contains(registeredEvents, expectedEvents.Contains);
+        }
+
+        [Fact]
+        public void ClickEvent_Should_Not_Be_Registered_On_ContentControl()
+        {
+            // force ContentControl type to be loaded
+            new ContentControl();
+            var expectedEvents = new List<RoutedEvent> { Button.ClickEvent };
+            var registeredEvents = RoutedEventRegistry.Instance.GetRegistered<ContentControl>();
+            Assert.DoesNotContain(registeredEvents, expectedEvents.Contains);
+        }
+
+        [Fact]
+        public void InputElement_Events_Should_Not_Be_Registered_On_Button()
+        {
+            // force Button type to be loaded
+            new Button();
+            var expectedEvents = new List<RoutedEvent> { InputElement.PointerPressedEvent, InputElement.PointerReleasedEvent };
+            var registeredEvents = RoutedEventRegistry.Instance.GetRegistered<Button>();
+            Assert.DoesNotContain(registeredEvents, expectedEvents.Contains);
+        }
+    }
+}


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
It adds `RoutedEventRegistry`. This class provides an API to get all registered `RoutedEvents` or all events registered on a specified type.
- What is the current behavior?
No such API is available.
- What is the updated/expected behavior with this PR?
n/a
- How was the solution implemented (if it's not obvious)?
n/a

Checklist:

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

If the pull request fixes issue(s) list them like this:

Fixes #1846 