### PR TITLE
Fix Avalonia.Android output path in packages.cake.

### DIFF
--- a/packages.cake
+++ b/packages.cake
@@ -303,7 +303,7 @@ public class Packages
                 {
                     new NuSpecContent { Source = "Avalonia.Android.dll", Target = "lib/MonoAndroid10" }
                 },
-                BasePath = context.Directory("./src/Android/Avalonia.Android/bin/" + parameters.DirSuffix + "/monoandroid44/"),
+                BasePath = context.Directory("./src/Android/Avalonia.Android/bin/" + parameters.DirSuffix + "/monoandroid44/MonoAndroid44/"),
                 OutputDirectory = parameters.NugetRoot
             },
             ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
VS 15.8 changed the output directory for Android projects. We need this change to match the new behavior.
