### PR TITLE
Fix NRE when VirtualizingStackPanel used with ItemsControl.

### DIFF
--- a/src/Avalonia.Controls/Presenters/ItemVirtualizer.cs
+++ b/src/Avalonia.Controls/Presenters/ItemVirtualizer.cs
@@ -279,6 +279,6 @@ namespace Avalonia.Controls.Presenters
         /// <summary>
         /// Invalidates the current scroll.
         /// </summary>
-        protected void InvalidateScroll() => ((ILogicalScrollable)Owner).InvalidateScroll();
+        protected void InvalidateScroll() => ((ILogicalScrollable)Owner).InvalidateScroll?.Invoke();
     }
 }


### PR DESCRIPTION
There is no `ScrollViewer` in the template for `ItemsControl` which means that if a `VirtualizingStackPanel` is used for `ItemsControl.ItemsPanel` then `InvalidateScroll` won't be set. Just do nothing in this case.

Fixes #1829.