### PR TITLE
Invalidate panel layout on attached property change.

### DIFF
--- a/src/Avalonia.Controls/Canvas.cs
+++ b/src/Avalonia.Controls/Canvas.cs
@@ -48,7 +48,7 @@ namespace Avalonia.Controls
         static Canvas()
         {
             ClipToBoundsProperty.OverrideDefaultValue<Canvas>(false);
-            AffectsCanvasArrange(LeftProperty, TopProperty, RightProperty, BottomProperty);
+            AffectsParentArrange<Canvas>(LeftProperty, TopProperty, RightProperty, BottomProperty);
         }
 
         /// <summary>
@@ -206,30 +206,6 @@ namespace Avalonia.Controls
             }
 
             return finalSize;
-        }
-
-        /// <summary>
-        /// Marks a property on a child as affecting the canvas' arrangement.
-        /// </summary>
-        /// <param name="properties">The properties.</param>
-        private static void AffectsCanvasArrange(params AvaloniaProperty[] properties)
-        {
-            foreach (var property in properties)
-            {
-                property.Changed.Subscribe(AffectsCanvasArrangeInvalidate);
-            }
-        }
-
-        /// <summary>
-        /// Calls <see cref="Layoutable.InvalidateArrange"/> on the parent of the control whose
-        /// property changed, if that parent is a canvas.
-        /// </summary>
-        /// <param name="e">The event args.</param>
-        private static void AffectsCanvasArrangeInvalidate(AvaloniaPropertyChangedEventArgs e)
-        {
-            var control = e.Sender as IControl;
-            var canvas = control?.VisualParent as Canvas;
-            canvas?.InvalidateArrange();
         }
     }
 }

--- a/src/Avalonia.Controls/DockPanel.cs
+++ b/src/Avalonia.Controls/DockPanel.cs
@@ -37,7 +37,7 @@ namespace Avalonia.Controls
         /// </summary>
         static DockPanel()
         {
-            AffectsArrange(DockProperty);
+            AffectsParentMeasure<DockPanel>(DockProperty);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -48,6 +48,11 @@ namespace Avalonia.Controls
 
         private RowDefinitions _rowDefinitions;
 
+        static Grid()
+        {
+            AffectsParentMeasure<Grid>(ColumnProperty, ColumnSpanProperty, RowProperty, RowSpanProperty);
+        }
+
         /// <summary>
         /// Gets or sets the columns definitions for the grid.
         /// </summary>

--- a/src/Avalonia.Controls/Panel.cs
+++ b/src/Avalonia.Controls/Panel.cs
@@ -73,6 +73,32 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
+        /// Marks a property on a child as affecting the parent panel's arrangement.
+        /// </summary>
+        /// <param name="properties">The properties.</param>
+        protected static void AffectsParentArrange<TPanel>(params AvaloniaProperty[] properties)
+            where TPanel : class, IPanel
+        {
+            foreach (var property in properties)
+            {
+                property.Changed.Subscribe(AffectsParentArrangeInvalidate<TPanel>);
+            }
+        }
+
+        /// <summary>
+        /// Marks a property on a child as affecting the parent panel's measurement.
+        /// </summary>
+        /// <param name="properties">The properties.</param>
+        protected static void AffectsParentMeasure<TPanel>(params AvaloniaProperty[] properties)
+            where TPanel : class, IPanel
+        {
+            foreach (var property in properties)
+            {
+                property.Changed.Subscribe(AffectsParentMeasureInvalidate<TPanel>);
+            }
+        }
+
+        /// <summary>
         /// Called when the <see cref="Children"/> collection changes.
         /// </summary>
         /// <param name="sender">The event sender.</param>
@@ -115,6 +141,22 @@ namespace Avalonia.Controls
             }
 
             InvalidateMeasure();
+        }
+
+        private static void AffectsParentArrangeInvalidate<TPanel>(AvaloniaPropertyChangedEventArgs e)
+            where TPanel : class, IPanel
+        {
+            var control = e.Sender as IControl;
+            var panel = control?.VisualParent as TPanel;
+            panel?.InvalidateArrange();
+        }
+
+        private static void AffectsParentMeasureInvalidate<TPanel>(AvaloniaPropertyChangedEventArgs e)
+            where TPanel : class, IPanel
+        {
+            var control = e.Sender as IControl;
+            var panel = control?.VisualParent as TPanel;
+            panel?.InvalidateMeasure();
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/DockPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DockPanelTests.cs
@@ -58,5 +58,29 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Rect(50, 350, 500, 50), target.Children[3].Bounds);
             Assert.Equal(new Rect(50, 50, 500, 300), target.Children[4].Bounds);
         }
+
+        [Fact]
+        public void Changing_Child_Dock_Invalidates_Measure()
+        {
+            Border child;
+            var target = new DockPanel
+            {
+                Children =
+                {
+                    (child = new Border
+                    {
+                        [DockPanel.DockProperty] = Dock.Left,
+                    }),
+                }
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(target.DesiredSize));
+            Assert.True(target.IsMeasureValid);
+
+            DockPanel.SetDock(child, Dock.Right);
+
+            Assert.False(target.IsMeasureValid);
+        }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/GridTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/GridTests.cs
@@ -154,5 +154,31 @@ namespace Avalonia.Controls.UnitTests
             GridAssert.ChildrenHeight(rowGrid, 200, 300, 300);
             GridAssert.ChildrenWidth(columnGrid, 200, 300, 300);
         }
+
+        [Fact]
+        public void Changing_Child_Column_Invalidates_Measure()
+        {
+            Border child;
+            var target = new Grid
+            {
+                ColumnDefinitions = new ColumnDefinitions("*,*"),
+                Children =
+                {
+                    (child = new Border
+                    {
+                        [Grid.ColumnProperty] = 0,
+                    }),
+                }
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(target.DesiredSize));
+            Assert.True(target.IsMeasureValid);
+
+            Grid.SetColumn(child, 1);
+
+            Assert.False(target.IsMeasureValid);
+        }
+
     }
 }


### PR DESCRIPTION
Previously setting e.g. `DockPanel.Dock` or `Grid.Column` on a control did not cause the panel's layout to be invalidated.

This was implemented correctly in `Canvas`, so took the implementation from there and generalized it as a pair of protected methods in `Panel`: `AffectsParentMeasure` and `AffectsParentArrange`.

Fixes #1865 