### PR TITLE
Make controls react to changes in brushes.

### DIFF
--- a/src/Avalonia.Controls/Border.cs
+++ b/src/Avalonia.Controls/Border.cs
@@ -43,9 +43,12 @@ namespace Avalonia.Controls
         /// </summary>
         static Border()
         {
-            AffectsRender<Border>(BorderThicknessProperty, CornerRadiusProperty);
+            AffectsRender<Border>(
+                BackgroundProperty,
+                BorderBrushProperty,
+                BorderThicknessProperty,
+                CornerRadiusProperty);
             AffectsMeasure<Border>(BorderThicknessProperty);
-            BrushAffectsRender<Border>(BackgroundProperty, BorderBrushProperty);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Border.cs
+++ b/src/Avalonia.Controls/Border.cs
@@ -43,8 +43,9 @@ namespace Avalonia.Controls
         /// </summary>
         static Border()
         {
-            AffectsRender(BackgroundProperty, BorderBrushProperty, BorderThicknessProperty, CornerRadiusProperty);
+            AffectsRender(BorderThicknessProperty, CornerRadiusProperty);
             AffectsMeasure(BorderThicknessProperty);
+            BrushAffectsRender<Border>(BackgroundProperty, BorderBrushProperty);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Panel.cs
+++ b/src/Avalonia.Controls/Panel.cs
@@ -30,6 +30,7 @@ namespace Avalonia.Controls
         /// </summary>
         static Panel()
         {
+            BrushAffectsRender<Panel>(BackgroundProperty);
             ClipToBoundsProperty.OverrideDefaultValue<Panel>(true);
         }
 

--- a/src/Avalonia.Controls/Panel.cs
+++ b/src/Avalonia.Controls/Panel.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Controls
         /// </summary>
         static Panel()
         {
-            BrushAffectsRender<Panel>(BackgroundProperty);
+            AffectsRender<Panel>(BackgroundProperty);
             ClipToBoundsProperty.OverrideDefaultValue<Panel>(true);
         }
 

--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -90,9 +90,8 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         static ContentPresenter()
         {
-            AffectsRender<ContentPresenter>(BorderThicknessProperty, CornerRadiusProperty);
+            AffectsRender<ContentPresenter>(BackgroundProperty, BorderBrushProperty, BorderThicknessProperty, CornerRadiusProperty);
             AffectsMeasure<ContentPresenter>(BorderThicknessProperty, PaddingProperty);
-            BrushAffectsRender<ContentPresenter>(BackgroundProperty, BorderBrushProperty);
             ContentProperty.Changed.AddClassHandler<ContentPresenter>(x => x.ContentChanged);
             ContentTemplateProperty.Changed.AddClassHandler<ContentPresenter>(x => x.ContentChanged);
             TemplatedParentProperty.Changed.AddClassHandler<ContentPresenter>(x => x.TemplatedParentChanged);

--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -90,8 +90,9 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         static ContentPresenter()
         {
-            AffectsRender(BackgroundProperty, BorderBrushProperty, BorderThicknessProperty, CornerRadiusProperty);
+            AffectsRender(BorderThicknessProperty, CornerRadiusProperty);
             AffectsMeasure(BorderThicknessProperty, PaddingProperty);
+            BrushAffectsRender<ContentPresenter>(BackgroundProperty, BorderBrushProperty);
             ContentProperty.Changed.AddClassHandler<ContentPresenter>(x => x.ContentChanged);
             ContentTemplateProperty.Changed.AddClassHandler<ContentPresenter>(x => x.ContentChanged);
             TemplatedParentProperty.Changed.AddClassHandler<ContentPresenter>(x => x.TemplatedParentChanged);

--- a/src/Avalonia.Controls/Shapes/Shape.cs
+++ b/src/Avalonia.Controls/Shapes/Shape.cs
@@ -30,11 +30,11 @@ namespace Avalonia.Controls.Shapes
         private Geometry _renderedGeometry;
         bool _calculateTransformOnArrange = false;
 
-
         static Shape()
         {
             AffectsMeasure(StretchProperty, StrokeThicknessProperty);
-            AffectsRender(FillProperty, StrokeProperty, StrokeDashArrayProperty);
+            AffectsRender(StrokeDashArrayProperty);
+            BrushAffectsRender<Shape>(FillProperty, StrokeProperty);
         }
 
         public Geometry DefiningGeometry

--- a/src/Avalonia.Controls/Shapes/Shape.cs
+++ b/src/Avalonia.Controls/Shapes/Shape.cs
@@ -33,8 +33,7 @@ namespace Avalonia.Controls.Shapes
         static Shape()
         {
             AffectsMeasure<Shape>(StretchProperty, StrokeThicknessProperty);
-            AffectsRender<Shape>(StrokeDashArrayProperty);
-            BrushAffectsRender<Shape>(FillProperty, StrokeProperty);
+            AffectsRender<Shape>(FillProperty, StrokeProperty, StrokeDashArrayProperty);
         }
 
         public Geometry DefiningGeometry

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -101,10 +101,11 @@ namespace Avalonia.Controls
         {
             ClipToBoundsProperty.OverrideDefaultValue<TextBlock>(true);
             AffectsRender<TextBlock>(
+                BackgroundProperty,
+                ForegroundProperty,
                 FontWeightProperty,
                 FontSizeProperty,
                 FontStyleProperty);
-            BrushAffectsRender<TextBlock>(BackgroundProperty, ForegroundProperty);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -99,10 +99,10 @@ namespace Avalonia.Controls
         static TextBlock()
         {
             ClipToBoundsProperty.OverrideDefaultValue<TextBlock>(true);
-            AffectsRender(ForegroundProperty);
             AffectsRender(FontWeightProperty);
             AffectsRender(FontSizeProperty);
             AffectsRender(FontStyleProperty);
+            BrushAffectsRender<TextBlock>(BackgroundProperty, ForegroundProperty);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -6,6 +6,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using Avalonia.LogicalTree;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Avalonia.Metadata;
 
 namespace Avalonia.Controls
@@ -65,7 +66,7 @@ namespace Avalonia.Controls
         public static readonly AttachedProperty<IBrush> ForegroundProperty =
             AvaloniaProperty.RegisterAttached<TextBlock, Control, IBrush>(
                 nameof(Foreground),
-                new SolidColorBrush(0xff000000),
+                Brushes.Black,
                 inherits: true);
 
         /// <summary>

--- a/src/Avalonia.Visuals/Media/Brush.cs
+++ b/src/Avalonia.Visuals/Media/Brush.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Media
             AvaloniaProperty.Register<Brush, double>(nameof(Opacity), 1.0);
 
         /// <inheritdoc/>
-        public event EventHandler Changed;
+        public event EventHandler Invalidated;
 
         /// <summary>
         /// Gets or sets the opacity of the brush.
@@ -63,14 +63,14 @@ namespace Avalonia.Media
         /// <param name="properties">The properties.</param>
         /// <remarks>
         /// After a call to this method in a brush's static constructor, any change to the
-        /// property will cause the <see cref="Changed"/> event to be raised on the brush.
+        /// property will cause the <see cref="Invalidated"/> event to be raised on the brush.
         /// </remarks>
         protected static void AffectsRender<T>(params AvaloniaProperty[] properties)
             where T : Brush
         {
             void Invalidate(AvaloniaPropertyChangedEventArgs e)
             {
-                (e.Sender as T)?.RaiseChanged(EventArgs.Empty);
+                (e.Sender as T)?.RaiseInvalidated(EventArgs.Empty);
             }
 
             foreach (var property in properties)
@@ -80,9 +80,9 @@ namespace Avalonia.Media
         }
 
         /// <summary>
-        /// Raises the <see cref="Changed"/> event.
+        /// Raises the <see cref="Invalidated"/> event.
         /// </summary>
         /// <param name="e">The event args.</param>
-        protected void RaiseChanged(EventArgs e) => Changed?.Invoke(this, e);
+        protected void RaiseInvalidated(EventArgs e) => Invalidated?.Invoke(this, e);
     }
 }

--- a/src/Avalonia.Visuals/Media/GradientBrush.cs
+++ b/src/Avalonia.Visuals/Media/GradientBrush.cs
@@ -80,18 +80,18 @@ namespace Avalonia.Media
                     brush._gradientStopsSubscription = newValue.TrackItemPropertyChanged(brush.GradientStopChanged);
                 }
 
-                brush.RaiseChanged(EventArgs.Empty);
+                brush.RaiseInvalidated(EventArgs.Empty);
             }
         }
 
         private void GradientStopsChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            RaiseChanged(EventArgs.Empty);
+            RaiseInvalidated(EventArgs.Empty);
         }
 
         private void GradientStopChanged(Tuple<object, PropertyChangedEventArgs> e)
         {
-            RaiseChanged(EventArgs.Empty);
+            RaiseInvalidated(EventArgs.Empty);
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/GradientBrush.cs
+++ b/src/Avalonia.Visuals/Media/GradientBrush.cs
@@ -1,7 +1,11 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using Avalonia.Collections;
 using Avalonia.Metadata;
 
 namespace Avalonia.Media
@@ -20,35 +24,74 @@ namespace Avalonia.Media
         /// <summary>
         /// Defines the <see cref="GradientStops"/> property.
         /// </summary>
-        public static readonly StyledProperty<IList<GradientStop>> GradientStopsProperty =
-            AvaloniaProperty.Register<GradientBrush, IList<GradientStop>>(nameof(GradientStops));
+        public static readonly StyledProperty<GradientStops> GradientStopsProperty =
+            AvaloniaProperty.Register<GradientBrush, GradientStops>(nameof(GradientStops));
+
+        private IDisposable _gradientStopsSubscription;
+
+        static GradientBrush()
+        {
+            GradientStopsProperty.Changed.Subscribe(GradientStopsChanged);
+            AffectsRender<LinearGradientBrush>(SpreadMethodProperty);
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GradientBrush"/> class.
         /// </summary>
         public GradientBrush()
         {
-            this.GradientStops = new List<GradientStop>();
+            this.GradientStops = new GradientStops();
         }
 
-        /// <summary>
-        /// Gets or sets the brush's spread method that defines how to draw a gradient that
-        /// doesn't fill the bounds of the destination control.
-        /// </summary>
+        /// <inheritdoc/>
         public GradientSpreadMethod SpreadMethod
         {
             get { return GetValue(SpreadMethodProperty); }
             set { SetValue(SpreadMethodProperty, value); }
         }
 
-        /// <summary>
-        /// Gets or sets the brush's gradient stops.
-        /// </summary>
+        /// <inheritdoc/>
         [Content]
-        public IList<GradientStop> GradientStops
+        public GradientStops GradientStops
         {
             get { return GetValue(GradientStopsProperty); }
             set { SetValue(GradientStopsProperty, value); }
+        }
+
+        /// <inheritdoc/>
+        IReadOnlyList<IGradientStop> IGradientBrush.GradientStops => GradientStops;
+
+        private static void GradientStopsChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            if (e.Sender is GradientBrush brush)
+            {
+                var oldValue = (GradientStops)e.OldValue;
+                var newValue = (GradientStops)e.NewValue;
+
+                if (oldValue != null)
+                {
+                    oldValue.CollectionChanged -= brush.GradientStopsChanged;
+                    brush._gradientStopsSubscription.Dispose();
+                }
+
+                if (newValue != null)
+                {
+                    newValue.CollectionChanged += brush.GradientStopsChanged;
+                    brush._gradientStopsSubscription = newValue.TrackItemPropertyChanged(brush.GradientStopChanged);
+                }
+
+                brush.RaiseChanged(EventArgs.Empty);
+            }
+        }
+
+        private void GradientStopsChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            RaiseChanged(EventArgs.Empty);
+        }
+
+        private void GradientStopChanged(Tuple<object, PropertyChangedEventArgs> e)
+        {
+            RaiseChanged(EventArgs.Empty);
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/GradientStop.cs
+++ b/src/Avalonia.Visuals/Media/GradientStop.cs
@@ -4,10 +4,22 @@
 namespace Avalonia.Media
 {
     /// <summary>
-    /// GradientStop
+    /// Describes the location and color of a transition point in a gradient.
     /// </summary>
-    public sealed class GradientStop
+    public sealed class GradientStop : AvaloniaObject, IGradientStop
     {
+        /// <summary>
+        /// Describes the <see cref="Offset"/> property.
+        /// </summary>
+        public static StyledProperty<double> OffsetProperty =
+            AvaloniaProperty.Register<GradientStop, double>(nameof(Offset));
+
+        /// <summary>
+        /// Describes the <see cref="Color"/> property.
+        /// </summary>
+        public static StyledProperty<Color> ColorProperty =
+            AvaloniaProperty.Register<GradientStop, Color>(nameof(Color));
+
         /// <summary>
         /// Initializes a new instance of the <see cref="GradientStop"/> class.
         /// </summary>
@@ -24,16 +36,18 @@ namespace Avalonia.Media
             Offset = offset;
         }
 
-        // TODO: Make these dependency properties.
+        /// <inheritdoc/>
+        public double Offset
+        {
+            get => GetValue(OffsetProperty);
+            set => SetValue(OffsetProperty, value);
+        }
 
-        /// <summary>
-        /// The offset
-        /// </summary>
-        public double Offset { get; set; }
-
-        /// <summary>
-        /// The color
-        /// </summary>
-        public Color Color { get; set; }
+        /// <inheritdoc/>
+        public Color Color
+        {
+            get => GetValue(ColorProperty);
+            set => SetValue(ColorProperty, value);
+        }
     }
 }

--- a/src/Avalonia.Visuals/Media/GradientStops.cs
+++ b/src/Avalonia.Visuals/Media/GradientStops.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Collections;
+using Avalonia.Media.Immutable;
+
+namespace Avalonia.Media
+{
+    /// <summary>
+    /// A collection of <see cref="GradientStop"/>s.
+    /// </summary>
+    public class GradientStops : AvaloniaList<GradientStop>
+    {
+        public GradientStops()
+        {
+            ResetBehavior = ResetBehavior.Remove;
+        }
+
+        public IReadOnlyList<ImmutableGradientStop> ToImmutable()
+        {
+            return this.Select(x => new ImmutableGradientStop(x.Offset, x.Color)).ToList();
+        }
+    }
+}

--- a/src/Avalonia.Visuals/Media/IAffectsRender.cs
+++ b/src/Avalonia.Visuals/Media/IAffectsRender.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Avalonia.Media
+{
+    /// <summary>
+    /// Signals to a self-rendering control that changes to the resource should invoke
+    /// <see cref="Visual.InvalidateVisual"/>.
+    /// </summary>
+    public interface IAffectsRender
+    {
+        /// <summary>
+        /// Raised when the resource changes visually.
+        /// </summary>
+        event EventHandler Invalidated;
+    }
+}

--- a/src/Avalonia.Visuals/Media/IGradientBrush.cs
+++ b/src/Avalonia.Visuals/Media/IGradientBrush.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Media
         /// <summary>
         /// Gets the brush's gradient stops.
         /// </summary>
-        IList<GradientStop> GradientStops { get; }
+        IReadOnlyList<IGradientStop> GradientStops { get; }
 
         /// <summary>
         /// Gets the brush's spread method that defines how to draw a gradient that doesn't fill

--- a/src/Avalonia.Visuals/Media/IGradientStop.cs
+++ b/src/Avalonia.Visuals/Media/IGradientStop.cs
@@ -1,0 +1,18 @@
+﻿namespace Avalonia.Media
+{
+    /// <summary>
+    /// Describes the location and color of a transition point in a gradient.
+    /// </summary>
+    public interface IGradientStop
+    {
+        /// <summary>
+        /// Gets the gradient stop color.
+        /// </summary>
+        Color Color { get; }
+
+        /// <summary>
+        /// Gets the gradient stop offset.
+        /// </summary>
+        double Offset { get; }
+    }
+}

--- a/src/Avalonia.Visuals/Media/IMutableBrush.cs
+++ b/src/Avalonia.Visuals/Media/IMutableBrush.cs
@@ -5,13 +5,8 @@ namespace Avalonia.Media
     /// <summary>
     /// Represents a mutable brush which can return an immutable clone of itself.
     /// </summary>
-    public interface IMutableBrush : IBrush
+    public interface IMutableBrush : IBrush, IAffectsRender
     {
-        /// <summary>
-        /// Raised when the brush changes visually.
-        /// </summary>
-        event EventHandler Changed;
-
         /// <summary>
         /// Creates an immutable clone of the brush.
         /// </summary>

--- a/src/Avalonia.Visuals/Media/IMutableBrush.cs
+++ b/src/Avalonia.Visuals/Media/IMutableBrush.cs
@@ -1,10 +1,17 @@
-﻿namespace Avalonia.Media
+﻿using System;
+
+namespace Avalonia.Media
 {
     /// <summary>
     /// Represents a mutable brush which can return an immutable clone of itself.
     /// </summary>
     public interface IMutableBrush : IBrush
     {
+        /// <summary>
+        /// Raised when the brush changes visually.
+        /// </summary>
+        event EventHandler Changed;
+
         /// <summary>
         /// Creates an immutable clone of the brush.
         /// </summary>

--- a/src/Avalonia.Visuals/Media/ImageBrush.cs
+++ b/src/Avalonia.Visuals/Media/ImageBrush.cs
@@ -2,19 +2,25 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using Avalonia.Media.Imaging;
+using Avalonia.Media.Immutable;
 
 namespace Avalonia.Media
 {
     /// <summary>
     /// Paints an area with an <see cref="IBitmap"/>.
     /// </summary>
-    public class ImageBrush : TileBrush, IImageBrush, IMutableBrush
+    public class ImageBrush : TileBrush, IImageBrush
     {
         /// <summary>
         /// Defines the <see cref="Visual"/> property.
         /// </summary>
         public static readonly StyledProperty<IBitmap> SourceProperty =
             AvaloniaProperty.Register<ImageBrush, IBitmap>(nameof(Source));
+
+        static ImageBrush()
+        {
+            AffectsRender<ImageBrush>(SourceProperty);
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImageBrush"/> class.
@@ -42,9 +48,9 @@ namespace Avalonia.Media
         }
 
         /// <inheritdoc/>
-        IBrush IMutableBrush.ToImmutable()
+        public override IBrush ToImmutable()
         {
-            return new Immutable.ImmutableImageBrush(this);
+            return new ImmutableImageBrush(this);
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/Immutable/ImmutableGradientBrush.cs
+++ b/src/Avalonia.Visuals/Media/Immutable/ImmutableGradientBrush.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace Avalonia.Media.Immutable
 {
@@ -15,7 +14,7 @@ namespace Avalonia.Media.Immutable
         /// <param name="opacity">The opacity of the brush.</param>
         /// <param name="spreadMethod">The spread method.</param>
         protected ImmutableGradientBrush(
-            IList<GradientStop> gradientStops,
+            IReadOnlyList<ImmutableGradientStop> gradientStops,
             double opacity,
             GradientSpreadMethod spreadMethod)
         {
@@ -28,14 +27,14 @@ namespace Avalonia.Media.Immutable
         /// Initializes a new instance of the <see cref="ImmutableGradientBrush"/> class.
         /// </summary>
         /// <param name="source">The brush from which this brush's properties should be copied.</param>
-        protected ImmutableGradientBrush(IGradientBrush source)
-            : this(source.GradientStops.ToList(), source.Opacity, source.SpreadMethod)
+        protected ImmutableGradientBrush(GradientBrush source)
+            : this(source.GradientStops.ToImmutable(), source.Opacity, source.SpreadMethod)
         {
 
         }
 
         /// <inheritdoc/>
-        public IList<GradientStop> GradientStops { get; }
+        public IReadOnlyList<IGradientStop> GradientStops { get; }
 
         /// <inheritdoc/>
         public double Opacity { get; }

--- a/src/Avalonia.Visuals/Media/Immutable/ImmutableGradientStop.cs
+++ b/src/Avalonia.Visuals/Media/Immutable/ImmutableGradientStop.cs
@@ -1,0 +1,20 @@
+﻿namespace Avalonia.Media.Immutable
+{
+    /// <summary>
+    /// Describes the location and color of a transition point in a gradient.
+    /// </summary>
+    public class ImmutableGradientStop : IGradientStop
+    {
+        public ImmutableGradientStop(double offset, Color color)
+        {
+            Offset = offset;
+            Color = color;
+        }
+
+        /// <inheritdoc/>
+        public double Offset { get; }
+
+        /// <inheritdoc/>
+        public Color Color { get; }
+    }
+}

--- a/src/Avalonia.Visuals/Media/Immutable/ImmutableLinearGradientBrush.cs
+++ b/src/Avalonia.Visuals/Media/Immutable/ImmutableLinearGradientBrush.cs
@@ -16,7 +16,7 @@ namespace Avalonia.Media.Immutable
         /// <param name="startPoint">The start point for the gradient.</param>
         /// <param name="endPoint">The end point for the gradient.</param>
         public ImmutableLinearGradientBrush(
-            IList<GradientStop> gradientStops,
+            IReadOnlyList<ImmutableGradientStop> gradientStops,
             double opacity = 1,
             GradientSpreadMethod spreadMethod = GradientSpreadMethod.Pad,
             RelativePoint? startPoint = null,
@@ -31,7 +31,7 @@ namespace Avalonia.Media.Immutable
         /// Initializes a new instance of the <see cref="ImmutableLinearGradientBrush"/> class.
         /// </summary>
         /// <param name="source">The brush from which this brush's properties should be copied.</param>
-        public ImmutableLinearGradientBrush(ILinearGradientBrush source)
+        public ImmutableLinearGradientBrush(LinearGradientBrush source)
             : base(source)
         {
             StartPoint = source.StartPoint;

--- a/src/Avalonia.Visuals/Media/Immutable/ImmutableRadialGradientBrush.cs
+++ b/src/Avalonia.Visuals/Media/Immutable/ImmutableRadialGradientBrush.cs
@@ -21,7 +21,7 @@ namespace Avalonia.Media.Immutable
         /// The horizontal and vertical radius of the outermost circle of the radial gradient.
         /// </param>
         public ImmutableRadialGradientBrush(
-            IList<GradientStop> gradientStops,
+            IReadOnlyList<ImmutableGradientStop> gradientStops,
             double opacity = 1,
             GradientSpreadMethod spreadMethod = GradientSpreadMethod.Pad,
             RelativePoint? center = null,
@@ -38,7 +38,7 @@ namespace Avalonia.Media.Immutable
         /// Initializes a new instance of the <see cref="ImmutableRadialGradientBrush"/> class.
         /// </summary>
         /// <param name="source">The brush from which this brush's properties should be copied.</param>
-        public ImmutableRadialGradientBrush(IRadialGradientBrush source)
+        public ImmutableRadialGradientBrush(RadialGradientBrush source)
             : base(source)
         {
             Center = source.Center;

--- a/src/Avalonia.Visuals/Media/LinearGradientBrush.cs
+++ b/src/Avalonia.Visuals/Media/LinearGradientBrush.cs
@@ -1,12 +1,14 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using Avalonia.Media.Immutable;
+
 namespace Avalonia.Media
 {
     /// <summary>
     /// A brush that draws with a linear gradient.
     /// </summary>
-    public sealed class LinearGradientBrush : GradientBrush, ILinearGradientBrush, IMutableBrush
+    public sealed class LinearGradientBrush : GradientBrush, ILinearGradientBrush
     {
         /// <summary>
         /// Defines the <see cref="StartPoint"/> property.
@@ -23,6 +25,11 @@ namespace Avalonia.Media
             AvaloniaProperty.Register<LinearGradientBrush, RelativePoint>(
                 nameof(EndPoint), 
                 RelativePoint.BottomRight);
+
+        static LinearGradientBrush()
+        {
+            AffectsRender<LinearGradientBrush>(StartPointProperty, EndPointProperty);
+        }
 
         /// <summary>
         /// Gets or sets the start point for the gradient.
@@ -43,9 +50,9 @@ namespace Avalonia.Media
         }
 
         /// <inheritdoc/>
-        IBrush IMutableBrush.ToImmutable()
+        public override IBrush ToImmutable()
         {
-            return new Immutable.ImmutableLinearGradientBrush(this);
+            return new ImmutableLinearGradientBrush(this);
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/RadialGradientBrush.cs
+++ b/src/Avalonia.Visuals/Media/RadialGradientBrush.cs
@@ -1,12 +1,14 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using Avalonia.Media.Immutable;
+
 namespace Avalonia.Media
 {
     /// <summary>
     /// Paints an area with a radial gradient.
     /// </summary>
-    public sealed class RadialGradientBrush : GradientBrush, IRadialGradientBrush, IMutableBrush
+    public sealed class RadialGradientBrush : GradientBrush, IRadialGradientBrush
     {
         /// <summary>
         /// Defines the <see cref="Center"/> property.
@@ -63,9 +65,9 @@ namespace Avalonia.Media
         }
 
         /// <inheritdoc/>
-        IBrush IMutableBrush.ToImmutable()
+        public override IBrush ToImmutable()
         {
-            return new Immutable.ImmutableRadialGradientBrush(this);
+            return new ImmutableRadialGradientBrush(this);
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/SolidColorBrush.cs
+++ b/src/Avalonia.Visuals/Media/SolidColorBrush.cs
@@ -1,18 +1,25 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using Avalonia.Media.Immutable;
+
 namespace Avalonia.Media
 {
     /// <summary>
     /// Fills an area with a solid color.
     /// </summary>
-    public class SolidColorBrush : Brush, ISolidColorBrush, IMutableBrush
+    public class SolidColorBrush : Brush, ISolidColorBrush
     {
         /// <summary>
         /// Defines the <see cref="Color"/> property.
         /// </summary>
         public static readonly StyledProperty<Color> ColorProperty =
             AvaloniaProperty.Register<SolidColorBrush, Color>(nameof(Color));
+
+        static SolidColorBrush()
+        {
+            AffectsRender<SolidColorBrush>(ColorProperty);
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SolidColorBrush"/> class.
@@ -75,9 +82,9 @@ namespace Avalonia.Media
         }
 
         /// <inheritdoc/>
-        IBrush IMutableBrush.ToImmutable()
+        public override IBrush ToImmutable()
         {
-            return new Immutable.ImmutableSolidColorBrush(this);
+            return new ImmutableSolidColorBrush(this);
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/TileBrush.cs
+++ b/src/Avalonia.Visuals/Media/TileBrush.cs
@@ -79,6 +79,13 @@ namespace Avalonia.Media
 
         static TileBrush()
         {
+            AffectsRender<TileBrush>(
+                AlignmentXProperty,
+                AlignmentYProperty,
+                DestinationRectProperty,
+                SourceRectProperty,
+                StretchProperty,
+                TileModeProperty);
             RenderOptions.BitmapInterpolationModeProperty.OverrideDefaultValue<TileBrush>(BitmapInterpolationMode.Default);
         }
 

--- a/src/Avalonia.Visuals/Media/VisualBrush.cs
+++ b/src/Avalonia.Visuals/Media/VisualBrush.cs
@@ -1,6 +1,7 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using Avalonia.Media.Immutable;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Media
@@ -8,13 +9,18 @@ namespace Avalonia.Media
     /// <summary>
     /// Paints an area with an <see cref="IVisual"/>.
     /// </summary>
-    public class VisualBrush : TileBrush, IVisualBrush, IMutableBrush
+    public class VisualBrush : TileBrush, IVisualBrush
     {
         /// <summary>
         /// Defines the <see cref="Visual"/> property.
         /// </summary>
         public static readonly StyledProperty<IVisual> VisualProperty =
             AvaloniaProperty.Register<VisualBrush, IVisual>(nameof(Visual));
+
+        static VisualBrush()
+        {
+            AffectsRender<VisualBrush>(VisualProperty);
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VisualBrush"/> class.
@@ -42,9 +48,9 @@ namespace Avalonia.Media
         }
 
         /// <inheritdoc/>
-        IBrush IMutableBrush.ToImmutable()
+        public override IBrush ToImmutable()
         {
-            return new Immutable.ImmutableVisualBrush(this);
+            return new ImmutableVisualBrush(this);
         }
     }
 }

--- a/src/Avalonia.Visuals/Visual.cs
+++ b/src/Avalonia.Visuals/Visual.cs
@@ -338,45 +338,20 @@ namespace Avalonia
         /// FrameworkPropertyMetadata.AffectsRender flag.
         /// </remarks>
         protected static void AffectsRender<T>(params AvaloniaProperty[] properties)
-            where T : class, IVisual
-        {
-            void Invalidate(AvaloniaPropertyChangedEventArgs e)
-            {
-                (e.Sender as T)?.InvalidateVisual();
-            }
-
-            foreach (var property in properties)
-            {
-                property.Changed.Subscribe(Invalidate);
-            }
-        }
-
-        /// <summary>
-        /// Indicates that a brush property change should cause <see cref="InvalidateVisual"/> to be
-        /// called.
-        /// </summary>
-        /// <param name="properties">The properties.</param>
-        /// <remarks>
-        /// This method should be called in a control's static constructor with each property
-        /// on the control which when changed should cause a redraw. It not only triggers an
-        /// invalidation when the property itself changes, but also when the brush raises
-        /// the <see cref="IMutableBrush.Changed"/> event.
-        /// </remarks>
-        protected static void BrushAffectsRender<T>(params AvaloniaProperty<IBrush>[] properties)
             where T : Visual
         {
             void Invalidate(AvaloniaPropertyChangedEventArgs e)
             {
                 if (e.Sender is T sender)
                 {
-                    if (e.OldValue is IMutableBrush oldValue)
+                    if (e.OldValue is IAffectsRender oldValue)
                     {
-                        oldValue.Changed -= sender.BrushChanged;
+                        oldValue.Invalidated -= sender.AffectsRenderInvalidated;
                     }
 
-                    if (e.NewValue is IMutableBrush newValue)
+                    if (e.NewValue is IAffectsRender newValue)
                     {
-                        newValue.Changed += sender.BrushChanged;
+                        newValue.Invalidated += sender.AffectsRenderInvalidated;
                     }
 
                     sender.InvalidateVisual();
@@ -582,7 +557,7 @@ namespace Avalonia
             OnVisualParentChanged(old, value);
         }
 
-        private void BrushChanged(object sender, EventArgs e) => InvalidateVisual();
+        private void AffectsRenderInvalidated(object sender, EventArgs e) => InvalidateVisual();
 
         /// <summary>
         /// Called when the <see cref="VisualChildren"/> collection changes.

--- a/tests/Avalonia.Controls.UnitTests/BorderTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/BorderTests.cs
@@ -1,6 +1,10 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using Avalonia.Media;
+using Avalonia.Rendering;
+using Avalonia.UnitTests;
+using Moq;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
@@ -41,6 +45,23 @@ namespace Avalonia.Controls.UnitTests
             target.Arrange(new Rect(0, 0, 100, 100));
 
             Assert.Equal(new Rect(6, 6, 0, 0), content.Bounds);
+        }
+
+        [Fact]
+        public void Changing_Background_Brush_Color_Should_Invalidate_Visual()
+        {
+            var target = new Border()
+            {
+                Background = new SolidColorBrush(Colors.Red),
+            };
+
+            var root = new TestRoot(target);
+            var renderer = Mock.Get(root.Renderer);
+            renderer.ResetCalls();
+
+            ((SolidColorBrush)target.Background).Color = Colors.Green;
+
+            renderer.Verify(x => x.AddDirty(target), Times.Once);
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/PanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/PanelTests.cs
@@ -3,7 +3,11 @@
 
 using System.Linq;
 using Avalonia.LogicalTree;
+using Avalonia.Media;
+using Avalonia.Rendering;
+using Avalonia.UnitTests;
 using Avalonia.VisualTree;
+using Moq;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
@@ -114,6 +118,23 @@ namespace Avalonia.Controls.UnitTests
 
             Assert.Equal(new[] { child2, child1 }, panel.GetLogicalChildren());
             Assert.Equal(new[] { child2, child1 }, panel.GetVisualChildren());
+        }
+
+        [Fact]
+        public void Changing_Background_Brush_Color_Should_Invalidate_Visual()
+        {
+            var target = new Panel()
+            {
+                Background = new SolidColorBrush(Colors.Red),
+            };
+
+            var root = new TestRoot(target);
+            var renderer = Mock.Get(root.Renderer);
+            renderer.ResetCalls();
+
+            ((SolidColorBrush)target.Background).Color = Colors.Green;
+
+            renderer.Verify(x => x.AddDirty(target), Times.Once);
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_Standalone.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_Standalone.cs
@@ -13,6 +13,7 @@ using System;
 using System.Linq;
 using Xunit;
 using Avalonia.Rendering;
+using Avalonia.Media;
 
 namespace Avalonia.Controls.UnitTests.Presenters
 {
@@ -203,5 +204,22 @@ namespace Avalonia.Controls.UnitTests.Presenters
             Assert.NotEqual(foo, logicalChildren.First());
         }
 
+
+        [Fact]
+        public void Changing_Background_Brush_Color_Should_Invalidate_Visual()
+        {
+            var target = new ContentPresenter()
+            {
+                Background = new SolidColorBrush(Colors.Red),
+            };
+
+            var root = new TestRoot(target);
+            var renderer = Mock.Get(root.Renderer);
+            renderer.ResetCalls();
+
+            ((SolidColorBrush)target.Background).Color = Colors.Green;
+
+            renderer.Verify(x => x.AddDirty(target), Times.Once);
+        }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/Shapes/RectangleTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Shapes/RectangleTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Avalonia.Controls.Shapes;
+using Avalonia.Media;
+using Avalonia.UnitTests;
+using Moq;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests.Shapes
+{
+    public class RectangleTests
+    {
+        [Fact]
+        public void Changing_Fill_Brush_Color_Should_Invalidate_Visual()
+        {
+            var target = new Rectangle()
+            {
+                Fill = new SolidColorBrush(Colors.Red),
+            };
+
+            var root = new TestRoot(target);
+            var renderer = Mock.Get(root.Renderer);
+            renderer.ResetCalls();
+
+            ((SolidColorBrush)target.Fill).Color = Colors.Green;
+
+            renderer.Verify(x => x.AddDirty(target), Times.Once);
+        }
+
+        [Fact]
+        public void Changing_Stroke_Brush_Color_Should_Invalidate_Visual()
+        {
+            var target = new Rectangle()
+            {
+                Stroke = new SolidColorBrush(Colors.Red),
+            };
+
+            var root = new TestRoot(target);
+            var renderer = Mock.Get(root.Renderer);
+            renderer.ResetCalls();
+
+            ((SolidColorBrush)target.Stroke).Color = Colors.Green;
+
+            renderer.Verify(x => x.AddDirty(target), Times.Once);
+        }
+    }
+}

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -2,6 +2,10 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using Avalonia.Data;
+using Avalonia.Media;
+using Avalonia.Rendering;
+using Avalonia.UnitTests;
+using Moq;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
@@ -24,6 +28,40 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(
                 "",
                 textBlock.Text);
+        }
+
+        [Fact]
+        public void Changing_Background_Brush_Color_Should_Invalidate_Visual()
+        {
+            var target = new TextBlock()
+            {
+                Background = new SolidColorBrush(Colors.Red),
+            };
+
+            var root = new TestRoot(target);
+            var renderer = Mock.Get(root.Renderer);
+            renderer.ResetCalls();
+
+            ((SolidColorBrush)target.Background).Color = Colors.Green;
+
+            renderer.Verify(x => x.AddDirty(target), Times.Once);
+        }
+
+        [Fact]
+        public void Changing_Foreground_Brush_Color_Should_Invalidate_Visual()
+        {
+            var target = new TextBlock()
+            {
+                Foreground = new SolidColorBrush(Colors.Red),
+            };
+
+            var root = new TestRoot(target);
+            var renderer = Mock.Get(root.Renderer);
+            renderer.ResetCalls();
+
+            ((SolidColorBrush)target.Foreground).Color = Colors.Green;
+
+            renderer.Verify(x => x.AddDirty(target), Times.Once);
         }
     }
 }

--- a/tests/Avalonia.RenderTests/Controls/CustomRenderTests.cs
+++ b/tests/Avalonia.RenderTests/Controls/CustomRenderTests.cs
@@ -124,7 +124,7 @@ namespace Avalonia.Direct2D1.RenderTests.Controls
                     {
                         StartPoint = new RelativePoint(0, 0, RelativeUnit.Relative),
                         EndPoint = new RelativePoint(1, 1, RelativeUnit.Relative),
-                        GradientStops = new[]
+                        GradientStops =
                         {
                             new GradientStop(Color.FromUInt32(0xffffffff), 0),
                             new GradientStop(Color.FromUInt32(0x00ffffff), 1)

--- a/tests/Avalonia.RenderTests/Media/LinearGradientBrushTests.cs
+++ b/tests/Avalonia.RenderTests/Media/LinearGradientBrushTests.cs
@@ -36,7 +36,7 @@ namespace Avalonia.Direct2D1.RenderTests.Media
                     {
                         StartPoint = new RelativePoint(0, 0.5, RelativeUnit.Relative),
                         EndPoint = new RelativePoint(1, 0.5, RelativeUnit.Relative),
-                        GradientStops = new[]
+                        GradientStops =
                         {
                             new GradientStop { Color = Colors.Red, Offset = 0 },
                             new GradientStop { Color = Colors.Blue, Offset = 1 }
@@ -63,7 +63,7 @@ namespace Avalonia.Direct2D1.RenderTests.Media
                     {
                         StartPoint = new RelativePoint(0.5, 0, RelativeUnit.Relative),
                         EndPoint = new RelativePoint(0.5, 1, RelativeUnit.Relative),
-                        GradientStops = new[]
+                        GradientStops =
                         {
                             new GradientStop { Color = Colors.Red, Offset = 0 },
                             new GradientStop { Color = Colors.Blue, Offset = 1 }

--- a/tests/Avalonia.RenderTests/Media/RadialGradientBrushTests.cs
+++ b/tests/Avalonia.RenderTests/Media/RadialGradientBrushTests.cs
@@ -34,7 +34,7 @@ namespace Avalonia.Direct2D1.RenderTests.Media
                 {
                     Background = new RadialGradientBrush
                     {
-                        GradientStops = new[]
+                        GradientStops =
                         {
                             new GradientStop { Color = Colors.Red, Offset = 0 },
                             new GradientStop { Color = Colors.Blue, Offset = 1 }

--- a/tests/Avalonia.RenderTests/OpacityMaskTests.cs
+++ b/tests/Avalonia.RenderTests/OpacityMaskTests.cs
@@ -29,7 +29,7 @@ namespace Avalonia.Direct2D1.RenderTests
                 {
                     StartPoint = new RelativePoint(0, 0, RelativeUnit.Relative),
                     EndPoint = new RelativePoint(1, 1, RelativeUnit.Relative),
-                    GradientStops = new List<GradientStop>
+                    GradientStops =
                     {
                         new GradientStop(Color.FromUInt32(0xffffffff), 0),
                         new GradientStop(Color.FromUInt32(0x00ffffff), 1)
@@ -65,7 +65,7 @@ namespace Avalonia.Direct2D1.RenderTests
                 {
                     StartPoint = new RelativePoint(0, 0, RelativeUnit.Relative),
                     EndPoint = new RelativePoint(1, 1, RelativeUnit.Relative),
-                    GradientStops = new List<GradientStop>
+                    GradientStops =
                     {
                         new GradientStop(Color.FromUInt32(0xffffffff), 0),
                         new GradientStop(Color.FromUInt32(0x00ffffff), 1)

--- a/tests/Avalonia.UnitTests/TestRoot.cs
+++ b/tests/Avalonia.UnitTests/TestRoot.cs
@@ -19,6 +19,13 @@ namespace Avalonia.UnitTests
 
         public TestRoot()
         {
+            Renderer = Mock.Of<IRenderer>();
+        }
+
+        public TestRoot(IControl child)
+            : this()
+        {
+            Child = child;
         }
 
         event EventHandler<NameScopeEventArgs> INameScope.Registered

--- a/tests/Avalonia.Visuals.UnitTests/Media/ImageBrushTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/ImageBrushTests.cs
@@ -11,14 +11,14 @@ namespace Avalonia.Visuals.UnitTests.Media
     public class ImageBrushTests
     {
         [Fact]
-        public void Changing_Source_Raises_Changed()
+        public void Changing_Source_Raises_Invalidated()
         {
             var bitmap1 = Mock.Of<IBitmap>();
             var bitmap2 = Mock.Of<IBitmap>();
             var target = new ImageBrush(bitmap1);
             var raised = false;
 
-            target.Changed += (s, e) => raised = true;
+            target.Invalidated += (s, e) => raised = true;
             target.Source = bitmap2;
 
             Assert.True(raised);

--- a/tests/Avalonia.Visuals.UnitTests/Media/ImageBrushTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/ImageBrushTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Moq;
+using Xunit;
+
+namespace Avalonia.Visuals.UnitTests.Media
+{
+    public class ImageBrushTests
+    {
+        [Fact]
+        public void Changing_Source_Raises_Changed()
+        {
+            var bitmap1 = Mock.Of<IBitmap>();
+            var bitmap2 = Mock.Of<IBitmap>();
+            var target = new ImageBrush(bitmap1);
+            var raised = false;
+
+            target.Changed += (s, e) => raised = true;
+            target.Source = bitmap2;
+
+            Assert.True(raised);
+        }
+    }
+}

--- a/tests/Avalonia.Visuals.UnitTests/Media/LinearGradientBrushTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/LinearGradientBrushTests.cs
@@ -9,7 +9,7 @@ namespace Avalonia.Visuals.UnitTests.Media
     public class LinearGradientBrushTests
     {
         [Fact]
-        public void Changing_StartPoint_Raises_Changed()
+        public void Changing_StartPoint_Raises_Invalidated()
         {
             var bitmap1 = Mock.Of<IBitmap>();
             var bitmap2 = Mock.Of<IBitmap>();
@@ -17,14 +17,14 @@ namespace Avalonia.Visuals.UnitTests.Media
             var raised = false;
 
             target.StartPoint = new RelativePoint();
-            target.Changed += (s, e) => raised = true;
+            target.Invalidated += (s, e) => raised = true;
             target.StartPoint = new RelativePoint(10, 10, RelativeUnit.Absolute);
 
             Assert.True(raised);
         }
 
         [Fact]
-        public void Changing_EndPoint_Raises_Changed()
+        public void Changing_EndPoint_Raises_Invalidated()
         {
             var bitmap1 = Mock.Of<IBitmap>();
             var bitmap2 = Mock.Of<IBitmap>();
@@ -32,14 +32,14 @@ namespace Avalonia.Visuals.UnitTests.Media
             var raised = false;
 
             target.EndPoint = new RelativePoint();
-            target.Changed += (s, e) => raised = true;
+            target.Invalidated += (s, e) => raised = true;
             target.EndPoint = new RelativePoint(10, 10, RelativeUnit.Absolute);
 
             Assert.True(raised);
         }
 
         [Fact]
-        public void Changing_GradientStops_Raises_Changed()
+        public void Changing_GradientStops_Raises_Invalidated()
         {
             var bitmap1 = Mock.Of<IBitmap>();
             var bitmap2 = Mock.Of<IBitmap>();
@@ -47,14 +47,14 @@ namespace Avalonia.Visuals.UnitTests.Media
             var raised = false;
 
             target.GradientStops = new GradientStops { new GradientStop(Colors.Red, 0) };
-            target.Changed += (s, e) => raised = true;
+            target.Invalidated += (s, e) => raised = true;
             target.GradientStops = new GradientStops { new GradientStop(Colors.Green, 0) };
 
             Assert.True(raised);
         }
 
         [Fact]
-        public void Adding_GradientStop_Raises_Changed()
+        public void Adding_GradientStop_Raises_Invalidated()
         {
             var bitmap1 = Mock.Of<IBitmap>();
             var bitmap2 = Mock.Of<IBitmap>();
@@ -62,14 +62,14 @@ namespace Avalonia.Visuals.UnitTests.Media
             var raised = false;
 
             target.GradientStops = new GradientStops { new GradientStop(Colors.Red, 0) };
-            target.Changed += (s, e) => raised = true;
+            target.Invalidated += (s, e) => raised = true;
             target.GradientStops.Add(new GradientStop(Colors.Green, 1));
 
             Assert.True(raised);
         }
 
         [Fact]
-        public void Changing_GradientStop_Offset_Raises_Changed()
+        public void Changing_GradientStop_Offset_Raises_Invalidated()
         {
             var bitmap1 = Mock.Of<IBitmap>();
             var bitmap2 = Mock.Of<IBitmap>();
@@ -77,7 +77,7 @@ namespace Avalonia.Visuals.UnitTests.Media
             var raised = false;
 
             target.GradientStops = new GradientStops { new GradientStop(Colors.Red, 0) };
-            target.Changed += (s, e) => raised = true;
+            target.Invalidated += (s, e) => raised = true;
             target.GradientStops[0].Offset = 0.5;
 
             Assert.True(raised);

--- a/tests/Avalonia.Visuals.UnitTests/Media/LinearGradientBrushTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/LinearGradientBrushTests.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Moq;
+using Xunit;
+
+namespace Avalonia.Visuals.UnitTests.Media
+{
+    public class LinearGradientBrushTests
+    {
+        [Fact]
+        public void Changing_StartPoint_Raises_Changed()
+        {
+            var bitmap1 = Mock.Of<IBitmap>();
+            var bitmap2 = Mock.Of<IBitmap>();
+            var target = new LinearGradientBrush();
+            var raised = false;
+
+            target.StartPoint = new RelativePoint();
+            target.Changed += (s, e) => raised = true;
+            target.StartPoint = new RelativePoint(10, 10, RelativeUnit.Absolute);
+
+            Assert.True(raised);
+        }
+
+        [Fact]
+        public void Changing_EndPoint_Raises_Changed()
+        {
+            var bitmap1 = Mock.Of<IBitmap>();
+            var bitmap2 = Mock.Of<IBitmap>();
+            var target = new LinearGradientBrush();
+            var raised = false;
+
+            target.EndPoint = new RelativePoint();
+            target.Changed += (s, e) => raised = true;
+            target.EndPoint = new RelativePoint(10, 10, RelativeUnit.Absolute);
+
+            Assert.True(raised);
+        }
+
+        [Fact]
+        public void Changing_GradientStops_Raises_Changed()
+        {
+            var bitmap1 = Mock.Of<IBitmap>();
+            var bitmap2 = Mock.Of<IBitmap>();
+            var target = new LinearGradientBrush();
+            var raised = false;
+
+            target.GradientStops = new GradientStops { new GradientStop(Colors.Red, 0) };
+            target.Changed += (s, e) => raised = true;
+            target.GradientStops = new GradientStops { new GradientStop(Colors.Green, 0) };
+
+            Assert.True(raised);
+        }
+
+        [Fact]
+        public void Adding_GradientStop_Raises_Changed()
+        {
+            var bitmap1 = Mock.Of<IBitmap>();
+            var bitmap2 = Mock.Of<IBitmap>();
+            var target = new LinearGradientBrush();
+            var raised = false;
+
+            target.GradientStops = new GradientStops { new GradientStop(Colors.Red, 0) };
+            target.Changed += (s, e) => raised = true;
+            target.GradientStops.Add(new GradientStop(Colors.Green, 1));
+
+            Assert.True(raised);
+        }
+
+        [Fact]
+        public void Changing_GradientStop_Offset_Raises_Changed()
+        {
+            var bitmap1 = Mock.Of<IBitmap>();
+            var bitmap2 = Mock.Of<IBitmap>();
+            var target = new LinearGradientBrush();
+            var raised = false;
+
+            target.GradientStops = new GradientStops { new GradientStop(Colors.Red, 0) };
+            target.Changed += (s, e) => raised = true;
+            target.GradientStops[0].Offset = 0.5;
+
+            Assert.True(raised);
+        }
+    }
+}

--- a/tests/Avalonia.Visuals.UnitTests/Media/SolidColorBrushTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/SolidColorBrushTests.cs
@@ -7,12 +7,12 @@ namespace Avalonia.Visuals.UnitTests.Media
     public class SolidColorBrushTests
     {
         [Fact]
-        public void Changing_Color_Raises_Changed()
+        public void Changing_Color_Raises_Invalidated()
         {
             var target = new SolidColorBrush(Colors.Red);
             var raised = false;
 
-            target.Changed += (s, e) => raised = true;
+            target.Invalidated += (s, e) => raised = true;
             target.Color = Colors.Green;
 
             Assert.True(raised);

--- a/tests/Avalonia.Visuals.UnitTests/Media/SolidColorBrushTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/SolidColorBrushTests.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Avalonia.Media;
+using Xunit;
+
+namespace Avalonia.Visuals.UnitTests.Media
+{
+    public class SolidColorBrushTests
+    {
+        [Fact]
+        public void Changing_Color_Raises_Changed()
+        {
+            var target = new SolidColorBrush(Colors.Red);
+            var raised = false;
+
+            target.Changed += (s, e) => raised = true;
+            target.Color = Colors.Green;
+
+            Assert.True(raised);
+        }
+    }
+}


### PR DESCRIPTION
Previously when a property on a brush was changed (e.g. `SolidColorBrush.Color`), the control that used the brush didn't invalidate itself. This PR makes that happen. This is the first step towards being able to animate brushes.

There are a few steps to this:

- Added a `IMutableBrush.Changed` event that is triggered when a property that affects the rendering of the brush changes
- Added a `Brush.AffectsRender` property similar to that on `Visual` which raises the `Changed` event
- Make `GradientBrush.GradientStops` an `AvaloniaList` so changes to it can be monitored and raise the `Changed` event
- Added a `BrushAffectsRender` method to listen for changes on an `IBrush` property of a control and invalidate the control

Note that only controls that do their own rendering need to call `BrushAffectsRender` - templated controls have no visual representation of their own so they don't need to call it.