### PR TITLE
Quickfix: Flip the sign on the outgoing carousel animation.

### DIFF
--- a/src/Avalonia.Visuals/Animation/PageSlide.cs
+++ b/src/Avalonia.Visuals/Animation/PageSlide.cs
@@ -97,7 +97,7 @@ namespace Avalonia.Animation
                         new Setter
                         {
                             Property = translateProperty,
-                            Value = forward ? distance : -distance
+                            Value = forward ? -distance : distance
                         }
                     )
                     {


### PR DESCRIPTION
Should fix the wrong direction that the carousel is animating into