### PR TITLE
Better support dynamic menus

### DIFF
--- a/samples/ControlCatalog/App.xaml
+++ b/samples/ControlCatalog/App.xaml
@@ -14,6 +14,11 @@
       <Setter Property="FontSize" Value="13"/>
     </Style>
 
-    <StyleInclude Source="resm:ControlCatalog.SideBar.xaml"/>
+      <Style Selector="TextBlock.h3">
+          <Setter Property="Foreground" Value="#a2a2a2"/>
+          <Setter Property="FontSize" Value="13"/>
+      </Style>
+
+      <StyleInclude Source="resm:ControlCatalog.SideBar.xaml"/>
   </Application.Styles>
 </Application>

--- a/samples/ControlCatalog/Pages/MenuPage.xaml
+++ b/samples/ControlCatalog/Pages/MenuPage.xaml
@@ -7,29 +7,44 @@
               Margin="0,16,0,0"
               HorizontalAlignment="Center"
               Spacing="16">
-            <Menu>
-                <MenuItem Header="_First">
-                    <MenuItem Header="Standard _Menu Item"/>
-                    <Separator/>
-                    <MenuItem Header="Menu with _Submenu">
-                        <MenuItem Header="Submenu _1"/>
-                        <MenuItem Header="Submenu _2"/>
+            <StackPanel>
+                <TextBlock Classes="h3" Margin="4 8">Defined in XAML</TextBlock>
+                <Menu>
+                    <MenuItem Header="_First">
+                        <MenuItem Header="Standard _Menu Item"/>
+                        <Separator/>
+                        <MenuItem Header="Menu with _Submenu">
+                            <MenuItem Header="Submenu _1"/>
+                            <MenuItem Header="Submenu _2"/>
+                        </MenuItem>
+                        <MenuItem Header="Menu Item with _Icon">
+                            <MenuItem.Icon>
+                                <Image Source="resm:ControlCatalog.Assets.github_icon.png"/>
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Header="Menu Item with _Checkbox">
+                            <MenuItem.Icon>
+                                <CheckBox BorderThickness="0" IsHitTestVisible="False" IsChecked="True"/>
+                            </MenuItem.Icon>
+                        </MenuItem>
                     </MenuItem>
-                    <MenuItem Header="Menu Item with _Icon">
-                        <MenuItem.Icon>
-                            <Image Source="resm:ControlCatalog.Assets.github_icon.png"/>
-                        </MenuItem.Icon>
+                    <MenuItem Header="_Second">
+                        <MenuItem Header="Second _Menu Item"/>
                     </MenuItem>
-                    <MenuItem Header="Menu Item with _Checkbox">
-                        <MenuItem.Icon>
-                            <CheckBox BorderThickness="0" IsHitTestVisible="False" IsChecked="True"/>
-                        </MenuItem.Icon>
-                    </MenuItem>
-                </MenuItem>
-                <MenuItem Header="_Second">
-                    <MenuItem Header="Second _Menu Item"/>
-                </MenuItem>
-            </Menu>
+                </Menu>
+            </StackPanel>
+
+            <StackPanel>
+                <TextBlock Classes="h3" Margin="4 8">Dyanamically generated</TextBlock>
+                <Menu Items="{Binding}">
+                    <Menu.Styles>
+                        <Style Selector="MenuItem">
+                            <Setter Property="Header" Value="{Binding Header}"/>
+                            <Setter Property="Items" Value="{Binding Items}"/>
+                        </Style>
+                    </Menu.Styles>
+                </Menu>
+            </StackPanel>
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/samples/ControlCatalog/Pages/MenuPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/MenuPage.xaml.cs
@@ -14,16 +14,26 @@ namespace ControlCatalog.Pages
                 new MenuItemViewModel
                 {
                     Header = "_File",
-                    Items =
+                    Items = new[]
                     {
                         new MenuItemViewModel { Header = "_Open..." },
                         new MenuItemViewModel { Header = "Save" },
+                        new MenuItemViewModel { Header = "-" },
+                        new MenuItemViewModel
+                        {
+                            Header = "Recent",
+                            Items = new[]
+                            {
+                                new MenuItemViewModel { Header = "File1.txt" },
+                                new MenuItemViewModel { Header = "File2.txt" },
+                            }
+                        },
                     }
                 },
                 new MenuItemViewModel
                 {
                     Header = "_Edit",
-                    Items =
+                    Items = new[]
                     {
                         new MenuItemViewModel { Header = "_Copy" },
                         new MenuItemViewModel { Header = "_Paste" },
@@ -41,6 +51,6 @@ namespace ControlCatalog.Pages
     public class MenuItemViewModel
     {
         public string Header { get; set; }
-        public IList<MenuItemViewModel> Items { get; } = new List<MenuItemViewModel>();
+        public IList<MenuItemViewModel> Items { get; set; }
     }
 }

--- a/samples/ControlCatalog/Pages/MenuPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/MenuPage.xaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
@@ -8,11 +9,38 @@ namespace ControlCatalog.Pages
         public MenuPage()
         {
             this.InitializeComponent();
+            DataContext = new[]
+            {
+                new MenuItemViewModel
+                {
+                    Header = "_File",
+                    Items =
+                    {
+                        new MenuItemViewModel { Header = "_Open..." },
+                        new MenuItemViewModel { Header = "Save" },
+                    }
+                },
+                new MenuItemViewModel
+                {
+                    Header = "_Edit",
+                    Items =
+                    {
+                        new MenuItemViewModel { Header = "_Copy" },
+                        new MenuItemViewModel { Header = "_Paste" },
+                    }
+                }
+            };
         }
 
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
         }
+    }
+
+    public class MenuItemViewModel
+    {
+        public string Header { get; set; }
+        public IList<MenuItemViewModel> Items { get; } = new List<MenuItemViewModel>();
     }
 }

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -105,6 +105,7 @@ namespace Avalonia.Controls
             ClickEvent.AddClassHandler<MenuItem>(x => x.OnClick);
             SubmenuOpenedEvent.AddClassHandler<MenuItem>(x => x.OnSubmenuOpened);
             IsSubMenuOpenProperty.Changed.AddClassHandler<MenuItem>(x => x.SubMenuOpenChanged);
+            PseudoClass<MenuItem, object>(HeaderProperty, x => x as string == "-", ":separator");
         }
 
         public MenuItem()
@@ -357,10 +358,21 @@ namespace Avalonia.Controls
         {
             base.OnTemplateApplied(e);
 
-            _popup = e.NameScope.Get<Popup>("PART_Popup");
-            _popup.DependencyResolver = DependencyResolver.Instance;
-            _popup.Opened += PopupOpened;
-            _popup.Closed += PopupClosed;
+            if (_popup != null)
+            {
+                _popup.Opened -= PopupOpened;
+                _popup.Closed -= PopupClosed;
+                _popup.DependencyResolver = null;
+            }
+
+            _popup = e.NameScope.Find<Popup>("PART_Popup");
+
+            if (_popup != null)
+            {
+                _popup.DependencyResolver = DependencyResolver.Instance;
+                _popup.Opened += PopupOpened;
+                _popup.Closed += PopupClosed;
+            }
         }
 
         /// <summary>

--- a/src/Avalonia.Themes.Default/MenuItem.xaml
+++ b/src/Avalonia.Themes.Default/MenuItem.xaml
@@ -73,7 +73,17 @@
       </ControlTemplate>
     </Setter>
   </Style>
-  
+
+  <Style Selector="MenuItem:separator">
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Separator Background="{DynamicResource ThemeControlMidBrush}"
+                   Margin="29,1,0,1"
+                   Height="1"/>
+      </ControlTemplate>
+    </Setter>
+  </Style>
+
   <Style Selector="Menu > MenuItem">
     <Setter Property="Template">
       <ControlTemplate>


### PR DESCRIPTION
It was previously impossible to create a separator in a menu using bindings and `DataTemplates`. This PR 
adds a feature whereby a `MenuItem` with a `Header` of `"-"` gets a `:separator` pseudoclass which makes it be styled as a separator.

This mirrors how WinForms works (https://stackoverflow.com/a/1349861), which is pretty convenient, as opposed to how WPF works (https://stackoverflow.com/a/31214028) which is anything but.

Also adds a menu using `DataTemplates` to the ControlCatalog Menu page. Given our lack of documentation we can at least point people here...