### PR TITLE
 Don't throw when disposing completed binding.

### DIFF
--- a/src/Avalonia.Base/PriorityBindingEntry.cs
+++ b/src/Avalonia.Base/PriorityBindingEntry.cs
@@ -51,6 +51,11 @@ namespace Avalonia
         }
 
         /// <summary>
+        /// Gets a value indicating whether the binding has completed.
+        /// </summary>
+        public bool HasCompleted { get; private set; }
+
+        /// <summary>
         /// The current value of the binding.
         /// </summary>
         public object Value
@@ -129,6 +134,8 @@ namespace Avalonia
 
         private void Completed()
         {
+            HasCompleted = true;
+
             if (Dispatcher.UIThread.CheckAccess())
             {
                 _owner.Completed(this);

--- a/src/Avalonia.Base/PriorityLevel.cs
+++ b/src/Avalonia.Base/PriorityLevel.cs
@@ -112,12 +112,16 @@ namespace Avalonia
 
             return Disposable.Create(() =>
             {
-                Bindings.Remove(node);
-                entry.Dispose();
-
-                if (entry.Index >= ActiveBindingIndex)
+                if (!entry.HasCompleted)
                 {
-                    ActivateFirstBinding();
+                    Bindings.Remove(node);
+
+                    entry.Dispose();
+
+                    if (entry.Index >= ActiveBindingIndex)
+                    {
+                        ActivateFirstBinding();
+                    }
                 }
             });
         }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Binding.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Binding.cs
@@ -479,6 +479,18 @@ namespace Avalonia.Base.UnitTests
             Assert.False(source.SetterCalled);
         }
 
+        [Fact]
+        public void Disposing_Completed_Binding_Does_Not_Throw()
+        {
+            var target = new Class1();
+            var source = new Subject<string>();
+            var subscription = target.Bind(Class1.FooProperty, source);
+
+            source.OnCompleted();
+
+            subscription.Dispose();
+        }
+
         /// <summary>
         /// Returns an observable that returns a single value but does not complete.
         /// </summary>


### PR DESCRIPTION
Previously, if a binding completed and then `Dispose` was called on the subscription returned from `Bind` an exception would be thrown. Fix this; do nothing in this case.