### PR TITLE
Make separator MenuItems non-focusable.

### DIFF
--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -99,13 +99,13 @@ namespace Avalonia.Controls
             SelectableMixin.Attach<MenuItem>(IsSelectedProperty);
             CommandProperty.Changed.Subscribe(CommandChanged);
             FocusableProperty.OverrideDefaultValue<MenuItem>(true);
+            HeaderProperty.Changed.AddClassHandler<MenuItem>(x => x.HeaderChanged);
             IconProperty.Changed.AddClassHandler<MenuItem>(x => x.IconChanged);
             IsSelectedProperty.Changed.AddClassHandler<MenuItem>(x => x.IsSelectedChanged);
             ItemsPanelProperty.OverrideDefaultValue<MenuItem>(DefaultPanel);
             ClickEvent.AddClassHandler<MenuItem>(x => x.OnClick);
             SubmenuOpenedEvent.AddClassHandler<MenuItem>(x => x.OnSubmenuOpened);
             IsSubMenuOpenProperty.Changed.AddClassHandler<MenuItem>(x => x.SubMenuOpenChanged);
-            PseudoClass<MenuItem, object>(HeaderProperty, x => x as string == "-", ":separator");
         }
 
         public MenuItem()
@@ -418,6 +418,24 @@ namespace Avalonia.Controls
             // HACK: Just set the IsEnabled property for the moment. This needs to be changed to
             // use IsEnabledCore etc. but it will do for now.
             IsEnabled = Command == null || Command.CanExecute(CommandParameter);
+        }
+
+        /// <summary>
+        /// Called when the <see cref="Header"/> property changes.
+        /// </summary>
+        /// <param name="e">The property change event.</param>
+        private void HeaderChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is string newValue && newValue == "-")
+            {
+                PseudoClasses.Add(":separator");
+                Focusable = false;
+            }
+            else if (e.OldValue is string oldValue && oldValue == "-")
+            {
+                PseudoClasses.Remove(":separator");
+                Focusable = true;
+            }
         }
 
         /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests
+{
+    public class MenuItemTests
+    {
+        [Fact]
+        public void Header_Of_Minus_Should_Apply_Separator_Pseudoclass()
+        {
+            var target = new MenuItem { Header = "-" };
+
+            Assert.True(target.Classes.Contains(":separator"));
+        }
+
+        [Fact]
+        public void Separator_Item_Should_Set_Focusable_False()
+        {
+            var target = new MenuItem { Header = "-" };
+
+            Assert.False(target.Focusable);
+        }
+    }
+}


### PR DESCRIPTION
Make separator `MenuItem`s non-focusable. Previously when a menu item was made a separator by giving it a header of `"-"`, it was still keyboard focusable.

Fixes #1894 