### PR TITLE
Fix SelectedItemsChanged event arguments in SelectingItemsControl (cherry pick from master)

### DIFF
--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -871,8 +871,8 @@ namespace Avalonia.Controls.Primitives
                         RaisePropertyChanged(SelectedItemProperty, oldItem, item, BindingPriority.LocalValue);
                     }
 
-                    added = e.OldItems;
-                    removed = e.NewItems;
+                    added = e.NewItems;
+                    removed = e.OldItems;
                     break;
             }
 

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_Multiple.cs
@@ -541,6 +541,35 @@ namespace Avalonia.Controls.UnitTests.Primitives
             Assert.True(called);
         }
 
+        [Fact]
+        public void Replacing_SelectedItems_Should_Raise_SelectionChanged_With_CorrectItems()
+        {
+            var items = new[] { "foo", "bar", "baz" };
+
+            var target = new TestSelector
+            {
+                Items = items,
+                Template = Template(),
+                SelectedItem = "bar",
+            };
+
+            var called = false;
+
+            target.SelectionChanged += (s, e) =>
+            {
+                Assert.Equal(new[] { "foo",}, e.AddedItems.Cast<object>());
+                Assert.Equal(new[] { "bar" }, e.RemovedItems.Cast<object>());
+                called = true;
+            };
+
+            target.ApplyTemplate();
+            target.Presenter.ApplyTemplate();
+            target.SelectedItems[0] = "foo";
+
+            Assert.True(called);
+        }
+
+
         private FuncControlTemplate Template()
         {
             return new FuncControlTemplate<SelectingItemsControl>(control =>


### PR DESCRIPTION
- What does the pull request do?
Corrects the event arguments for replacing a selected item in SelectingItemsControl.
- What is the current behavior?
The arguments for the SelectedItemsChanged event are inverted.
- What is the updated/expected behavior with this PR?
Sets the arguments as expected.

Checklist:

- [x] Added unit tests

Cherry picked from PR #1913 