### PR TITLE
[Image] Measure is triggered when source or stretch property is changed.

### DIFF
--- a/src/Avalonia.Controls/Image.cs
+++ b/src/Avalonia.Controls/Image.cs
@@ -26,6 +26,7 @@ namespace Avalonia.Controls
         static Image()
         {
             AffectsRender<Image>(SourceProperty, StretchProperty);
+            AffectsMeasure<Image>(SourceProperty, StretchProperty);
         }
 
         /// <summary>


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
Images are now measured if the image source property changes, or the stretch property changes.

- What is the current behavior?
This doesn't happen meaning images in for instance a scrollviewer are not scrollable if loaded through binding.


Checklist:
- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

If the pull request fixes issue(s) list them like this:

Fixes #1921 
