### PR TITLE
don't reset data template on attached to visual tree, but on attached…

### DIFF
--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -197,13 +197,6 @@ namespace Avalonia.Controls.Presenters
             }
         }
 
-        /// <inheritdoc/>
-        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
-        {
-            base.OnAttachedToVisualTree(e);
-            _dataTemplate = null;
-        }
-
         /// <summary>
         /// Updates the <see cref="Child"/> control based on the control's <see cref="Content"/>.
         /// </summary>
@@ -268,6 +261,7 @@ namespace Avalonia.Controls.Presenters
         protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
         {
             base.OnAttachedToLogicalTree(e);
+            _dataTemplate = null;
             _createdChild = false;
             InvalidateMeasure();
         }


### PR DESCRIPTION
… to logical tree

This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
fixes behavior of contentpresenter that look wrong
- What is the current behavior?
reset contentpresenter data template when attached to visual tree
- What is the updated/expected behavior with this PR?
reset datatemplate when attached to logical tree
- How was the solution implemented (if it's not obvious)?


