### PR TITLE
fixes pathparser when there are trailing spaces

### DIFF
--- a/src/Avalonia.Visuals/Media/PathMarkupParser.cs
+++ b/src/Avalonia.Visuals/Media/PathMarkupParser.cs
@@ -107,7 +107,7 @@ namespace Avalonia.Media
             {
                 if(!ReadCommand(ref span, out var command, out var relative))
                 {
-                    return;
+                    break;
                 }
 
                 bool initialCommand = true;

--- a/tests/Avalonia.Visuals.UnitTests/Media/PathMarkupParserTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/PathMarkupParserTests.cs
@@ -9,6 +9,8 @@ namespace Avalonia.Visuals.UnitTests.Media
 {
     using System.Globalization;
     using System.IO;
+    using Avalonia.Platform;
+    using Moq;
 
     public class PathMarkupParserTests
     {
@@ -18,7 +20,7 @@ namespace Avalonia.Visuals.UnitTests.Media
             var pathGeometry = new PathGeometry();
             using (var context = new PathGeometryContext(pathGeometry))
             using (var parser = new PathMarkupParser(context))
-            {               
+            {
                 parser.Parse("M10 10");
 
                 var figure = pathGeometry.Figures[0];
@@ -200,6 +202,25 @@ namespace Avalonia.Visuals.UnitTests.Media
 
                 Assert.True(true);
             }
+        }
+
+        [Theory]
+        [InlineData("M0 0L10 10")]
+        [InlineData("M0 0L10 10z")]
+        [InlineData("M0 0L10 10 \n ")]
+        [InlineData("M0 0L10 10z \n ")]
+        [InlineData("M0 0L10 10 ")]
+        [InlineData("M0 0L10 10z ")]
+        public void Should_AlwaysEndFigure(string pathData)
+        {
+            var context = new Mock<IGeometryContext>();
+
+            using (var parser = new PathMarkupParser(context.Object))
+            {
+                parser.Parse(pathData);
+            }
+
+            context.Verify(v => v.EndFigure(It.IsAny<bool>()), Times.AtLeastOnce());
         }
 
         [Theory]


### PR DESCRIPTION
- What does the pull request do?
fixes pathparser when there are trailing spaces
- What is the current behavior?
path parser does not endfigure when there are trailing spaces and causing immediate exit of the application
- What is the updated/expected behavior with this PR?
Path parser will always endfigure
- How was the solution implemented (if it's not obvious)?

Checklist:

- [x] Added unit tests (if possible)?

If the pull request fixes issue(s) list them like this:

Fixes #1930 