### PR TITLE
feature: Support ReactiveUI WhenActivated

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -170,6 +170,7 @@ Task("Run-Unit-Tests-Impl")
     RunCoreTest("./tests/Avalonia.Styling.UnitTests", data.Parameters, false);
     RunCoreTest("./tests/Avalonia.Visuals.UnitTests", data.Parameters, false);
     RunCoreTest("./tests/Avalonia.Skia.UnitTests", data.Parameters, false);
+    RunCoreTest("./tests/Avalonia.ReactiveUI.UnitTests", data.Parameters, false);
     if (data.Parameters.IsRunningOnWindows)
     {
         RunCoreTest("./tests/Avalonia.Direct2D1.UnitTests", data.Parameters, false);

--- a/build/ReactiveUI.props
+++ b/build/ReactiveUI.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="reactiveui" Version="8.7.1" />
+    <PackageReference Include="reactiveui" Version="9.0.1" />
   </ItemGroup>
 </Project>

--- a/samples/VirtualizationDemo/ViewModels/MainWindowViewModel.cs
+++ b/samples/VirtualizationDemo/ViewModels/MainWindowViewModel.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using ReactiveUI.Legacy;
 using ReactiveUI;
 
 namespace VirtualizationDemo.ViewModels

--- a/src/Avalonia.ReactiveUI/AppBuilderExtensions.cs
+++ b/src/Avalonia.ReactiveUI/AppBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using Avalonia.Controls;
 using Avalonia.Threading;
 using ReactiveUI;
+using Splat;
 
 namespace Avalonia
 {
@@ -15,6 +16,9 @@ namespace Avalonia
             return builder.AfterSetup(_ =>
             {
                 RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
+                Locator.CurrentMutable.Register(
+                    () => new AvaloniaActivationForViewFetcher(), 
+                    typeof(IActivationForViewFetcher));
             });
         }
     }

--- a/src/Avalonia.ReactiveUI/Avalonia.ReactiveUI.csproj
+++ b/src/Avalonia.ReactiveUI/Avalonia.ReactiveUI.csproj
@@ -12,7 +12,6 @@
     <ProjectReference Include="..\Avalonia.Styling\Avalonia.Styling.csproj" />
     <ProjectReference Include="..\Avalonia.Visuals\Avalonia.Visuals.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="*" />
-  </ItemGroup>
+  <Import Project="..\..\build\Rx.props" />
+  <Import Project="..\..\build\ReactiveUI.props" />
 </Project>

--- a/src/Avalonia.ReactiveUI/Avalonia.ReactiveUI.csproj
+++ b/src/Avalonia.ReactiveUI/Avalonia.ReactiveUI.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\Avalonia.Styling\Avalonia.Styling.csproj" />
     <ProjectReference Include="..\Avalonia.Visuals\Avalonia.Visuals.csproj" />
   </ItemGroup>
-  <Import Project="..\..\build\Rx.props" />
-  <Import Project="..\..\build\ReactiveUI.props" />
+  <ItemGroup>
+    <PackageReference Include="ReactiveUI" Version="*" />
+  </ItemGroup>
 </Project>

--- a/src/Avalonia.ReactiveUI/AvaloniaActivationForViewFetcher.cs
+++ b/src/Avalonia.ReactiveUI/AvaloniaActivationForViewFetcher.cs
@@ -1,0 +1,38 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using System.Reflection;
+using System.Reactive.Linq;
+using Avalonia;
+using Avalonia.VisualTree;
+using ReactiveUI;
+
+namespace Avalonia
+{
+    public class AvaloniaActivationForViewFetcher : IActivationForViewFetcher
+    {
+        public int GetAffinityForView(Type view)
+        {
+            return typeof(IVisual).GetTypeInfo().IsAssignableFrom(view.GetTypeInfo()) ? 10 : 0;
+        }
+
+        public IObservable<bool> GetActivationForView(IActivatable view)
+        {
+            if (!(view is IVisual visual)) return Observable.Return(false);
+             var viewLoaded = Observable
+                .FromEventPattern<VisualTreeAttachmentEventArgs>(
+                    x => visual.AttachedToVisualTree += x,
+                    x => visual.DetachedFromVisualTree -= x)
+                .Select(args => true);
+             var viewUnloaded = Observable
+                .FromEventPattern<VisualTreeAttachmentEventArgs>(
+                    x => visual.DetachedFromVisualTree += x,
+                    x => visual.DetachedFromVisualTree -= x)
+                .Select(args => false);
+             return viewLoaded
+                .Merge(viewUnloaded)
+                .DistinctUntilChanged();
+        }
+    }
+}

--- a/tests/Avalonia.ReactiveUI.UnitTests/Avalonia.ReactiveUI.UnitTests.csproj
+++ b/tests/Avalonia.ReactiveUI.UnitTests/Avalonia.ReactiveUI.UnitTests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  <Import Project="..\..\build\UnitTests.NetCore.targets" />
+  <Import Project="..\..\build\Moq.props" />
+  <Import Project="..\..\build\XUnit.props" />
+  <Import Project="..\..\build\Rx.props" />
+  <Import Project="..\..\build\Microsoft.Reactive.Testing.props" />
+  <ItemGroup>
+    <ProjectReference Include="../../src/Avalonia.ReactiveUI/Avalonia.ReactiveUI.csproj"/>
+  </ItemGroup>
+</Project>

--- a/tests/Avalonia.ReactiveUI.UnitTests/Avalonia.ReactiveUI.UnitTests.csproj
+++ b/tests/Avalonia.ReactiveUI.UnitTests/Avalonia.ReactiveUI.UnitTests.csproj
@@ -8,6 +8,7 @@
   <Import Project="..\..\build\Rx.props" />
   <Import Project="..\..\build\Microsoft.Reactive.Testing.props" />
   <ItemGroup>
-    <ProjectReference Include="../../src/Avalonia.ReactiveUI/Avalonia.ReactiveUI.csproj"/>
+    <ProjectReference Include="..\Avalonia.UnitTests\Avalonia.UnitTests.csproj" />
+    <ProjectReference Include="..\..\src\Avalonia.ReactiveUI\Avalonia.ReactiveUI.csproj"/>
   </ItemGroup>
 </Project>

--- a/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
@@ -4,6 +4,7 @@ using System.Reactive.Disposables;
 using Avalonia.Controls;
 using Avalonia.Rendering;
 using Avalonia.Platform;
+using Avalonia.UnitTests;
 using Avalonia;
 using ReactiveUI;
 using DynamicData;
@@ -15,23 +16,6 @@ namespace Avalonia
     public class AvaloniaActivationForViewFetcherTest
     {
         public class TestUserControl : UserControl, IActivatable { }
-
-        public class FakeRenderDecorator : Decorator, IRenderRoot
-        {
-            public Size ClientSize => new Size(100, 100);
-
-            public IRenderer Renderer { get; }
-
-            public double RenderScaling => 1;
-
-            public IRenderTarget CreateRenderTarget() => null;
-
-            public void Invalidate(Rect rect) { }
-
-            public Point PointToClient(Point point) => point;
-
-            public Point PointToScreen(Point point) => point;
-        }
 
         public class TestUserControlWithWhenActivated : UserControl, IActivatable
         {
@@ -60,7 +44,7 @@ namespace Avalonia
                 .Bind(out var activated)
                 .Subscribe();
 
-            var fakeRenderedDecorator = new FakeRenderDecorator();
+            var fakeRenderedDecorator = new TestRoot();
             fakeRenderedDecorator.Child = userControl;
             Assert.True(activated[0]);
             Assert.Equal(1, activated.Count);
@@ -94,7 +78,7 @@ namespace Avalonia
             var userControl = new TestUserControlWithWhenActivated();
             Assert.False(userControl.Active);
 
-            var fakeRenderedDecorator = new FakeRenderDecorator();
+            var fakeRenderedDecorator = new TestRoot();
             fakeRenderedDecorator.Child = userControl;
             Assert.True(userControl.Active);
 

--- a/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
@@ -49,7 +49,7 @@ namespace Avalonia
         }
 
         [Fact]
-        public void VisualElementIsActivatedAndDeactivated()
+        public void Visual_Element_Is_Activated_And_Deactivated()
         {
             var userControl = new TestUserControl();
             var activationForViewFetcher = new AvaloniaActivationForViewFetcher();
@@ -72,7 +72,7 @@ namespace Avalonia
         }
 
         [Fact]
-        public void GetAffinityForViewShouldReturnNonZeroForVisualElements() 
+        public void Get_Affinity_For_View_Should_Return_Non_Zero_For_Visual_Elements() 
         {
             var userControl = new TestUserControl();
             var activationForViewFetcher = new AvaloniaActivationForViewFetcher();
@@ -85,7 +85,7 @@ namespace Avalonia
         }
 
         [Fact]
-        public void ActivationForViewFetcherShouldSupportWhenActivated()
+        public void Activation_For_View_Fetcher_Should_Support_When_Activated()
         {
             Locator.CurrentMutable.RegisterConstant(
                 new AvaloniaActivationForViewFetcher(), 

--- a/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
@@ -72,24 +72,34 @@ namespace Avalonia
         }
 
         [Fact]
+        public void GetAffinityForViewShouldReturnNonZeroForVisualElements() 
+        {
+            var userControl = new TestUserControl();
+            var activationForViewFetcher = new AvaloniaActivationForViewFetcher();
+
+            var forUserControl = activationForViewFetcher.GetAffinityForView(userControl.GetType());
+            var forNonUserControl = activationForViewFetcher.GetAffinityForView(typeof(object));
+
+            Assert.NotEqual(0, forUserControl);
+            Assert.Equal(0, forNonUserControl);
+        }
+
+        [Fact]
         public void ActivationForViewFetcherShouldSupportWhenActivated()
         {
-            var locator = new ModernDependencyResolver();
-            locator.InitializeSplat();
-            locator.InitializeReactiveUI();
-            locator.RegisterConstant(new AvaloniaActivationForViewFetcher(), typeof(IActivationForViewFetcher));
-            using (locator.WithResolver()) 
-            {
-                var userControl = new TestUserControlWithWhenActivated();
-                Assert.False(userControl.Active);
+            Locator.CurrentMutable.RegisterConstant(
+                new AvaloniaActivationForViewFetcher(), 
+                typeof(IActivationForViewFetcher));
 
-                var fakeRenderedDecorator = new FakeRenderDecorator();
-                fakeRenderedDecorator.Child = userControl;
-                Assert.True(userControl.Active);
+            var userControl = new TestUserControlWithWhenActivated();
+            Assert.False(userControl.Active);
 
-                fakeRenderedDecorator.Child = null;
-                Assert.False(userControl.Active);
-            }
+            var fakeRenderedDecorator = new FakeRenderDecorator();
+            fakeRenderedDecorator.Child = userControl;
+            Assert.True(userControl.Active);
+
+            fakeRenderedDecorator.Child = null;
+            Assert.False(userControl.Active);
         }
     }
 }


### PR DESCRIPTION
Heavily based on https://github.com/reactiveui/ReactiveUI/pull/1748
See https://github.com/reactiveui/ReactiveUI/pull/1748#issuecomment-427612442

**What does the pull request do?**

This PR adds ReactiveUI <a href="https://reactiveui.net/docs/handbook/when-activated/">WhenActivated</a> and type-safe bindings support for AvaloniaUI views.

> WhenActivated is a way to track disposables. Besides that, it can be used to defer the setup of a ViewModel until it's truly required. WhenActivated also gives us an ability to start or stop reacting to hot observables, like a background task that periodically pings a network endpoint or an observable updating users current location. — <a href="https://reactiveui.net/docs/handbook/when-activated/">ReactiveUI Docs</a>

**What is the current behavior?**

Currently, I get an exception when I try to use `WhenActivated` feature with Avalonia.

**What is the updated/expected behavior with this PR?**

<a href="https://reactiveui.net/docs/handbook/when-activated/">WhenActivated</a> will work with AvaloniaUI as expected. See https://github.com/AvaloniaUI/Avalonia/issues/1852

**How was the solution implemented?**

I've implemented and registered an interface to let ReactiveUI know abount the lifecycle of `IVisual`. 

**Checklist:**

- [x] Add `IActivationForViewFetcher` implementation
- [x] Register `IActivationForViewFetcher` implementation
- [x] Add unit tests (brought some from https://github.com/reactiveui/ReactiveUI/pull/1748)