### PR TITLE
Support for d:DataContext, d:DesignWidth and d:DesignHeight

### DIFF
--- a/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
+++ b/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
@@ -18,7 +18,7 @@ namespace Avalonia.DesignerSupport
             Control control;
             using (PlatformManager.DesignerMode())
             {
-                var loader = new AvaloniaXamlLoader();
+                var loader = new AvaloniaXamlLoader() {IsDesignMode = true};
                 var stream = new MemoryStream(Encoding.UTF8.GetBytes(xaml));
 
 

--- a/src/Markup/Avalonia.Markup.Xaml/AvaloniaXamlLoader.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/AvaloniaXamlLoader.cs
@@ -21,6 +21,12 @@ namespace Avalonia.Markup.Xaml
     {
         private readonly AvaloniaXamlSchemaContext _context = GetContext();
 
+        public bool IsDesignMode
+        {
+            get => _context.IsDesignMode;
+            set => _context.IsDesignMode = value;
+        }
+
         private static AvaloniaXamlSchemaContext GetContext()
         {
             var result = AvaloniaLocator.Current.GetService<AvaloniaXamlSchemaContext>();
@@ -200,7 +206,7 @@ namespace Avalonia.Markup.Xaml
         internal static object LoadFromReader(XamlReader reader, AvaloniaXamlContext context = null, IAmbientProvider parentAmbientProvider = null)
         {
             var writer = AvaloniaXamlObjectWriter.Create(
-                                    reader.SchemaContext,
+                                    (AvaloniaXamlSchemaContext)reader.SchemaContext,
                                     context,
                                     parentAmbientProvider);
 

--- a/src/Markup/Avalonia.Markup.Xaml/PortableXaml/AvaloniaXamlSchemaContext.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/PortableXaml/AvaloniaXamlSchemaContext.cs
@@ -15,6 +15,7 @@ namespace Avalonia.Markup.Xaml.PortableXaml
 {
     internal class AvaloniaXamlSchemaContext : XamlSchemaContext
     {
+        public bool IsDesignMode { get; set; }
         public static AvaloniaXamlSchemaContext Create(IRuntimeTypeProvider typeProvider = null)
         {
             return new AvaloniaXamlSchemaContext(typeProvider ?? new AvaloniaRuntimeTypeProvider());
@@ -280,5 +281,20 @@ namespace Avalonia.Markup.Xaml.PortableXaml
                 return $"{MemberType}:{Type.Namespace}:{Type.Name}.{Member}";
             }
         }
+
+
+        public override bool TryGetCompatibleXamlNamespace(string xamlNamespace, out string compatibleNamespace)
+        {
+            //Forces XamlXmlReader to not ignore our namespace in design mode if mc:Ignorable is set
+            if (IsDesignMode &&
+                xamlNamespace == "http://schemas.microsoft.com/expression/blend/2008")
+            {
+                compatibleNamespace = xamlNamespace;
+                return true;
+            }
+
+            return base.TryGetCompatibleXamlNamespace(xamlNamespace, out compatibleNamespace);
+        }
+
     }
 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
@@ -924,6 +924,45 @@ do we need it?")]
             }
         }
 
+        [Fact]
+        public void Design_Mode_Properties_Should_Be_Ignored_At_Runtime_And_Set_In_Design_Mode()
+        {
+            using (UnitTestApplication.Start(TestServices.MockWindowingPlatform))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui' 
+    xmlns:d='http://schemas.microsoft.com/expression/blend/2008'
+    xmlns:mc='http://schemas.openxmlformats.org/markup-compatibility/2006'
+    mc:Ignorable='d'
+    d:DataContext='data-context'
+    d:DesignWidth='123'
+    d:DesignHeight='321'
+>
+
+</Window>";
+                foreach (var designMode in new[] {true, false})
+                {
+                    var loader = new AvaloniaXamlLoader {IsDesignMode = designMode};
+                    var obj = (Window)loader.Load(xaml);
+                    var context = Design.GetDataContext(obj);
+                    var width = Design.GetWidth(obj);
+                    var height = Design.GetHeight(obj);
+                    if (designMode)
+                    {
+                        Assert.Equal("data-context", context);
+                        Assert.Equal(123, width);
+                        Assert.Equal(321, height);
+                    }
+                    else
+                    {
+                        Assert.False(obj.IsSet(Design.DataContextProperty));
+                        Assert.False(obj.IsSet(Design.WidthProperty));
+                        Assert.False(obj.IsSet(Design.HeightProperty));
+                    }
+                }
+            }
+        }
+
         private class SelectedItemsViewModel : INotifyPropertyChanged
         {
             public string[] Items { get; set; }


### PR DESCRIPTION
Long delayed continuation of https://github.com/cwensley/Portable.Xaml/pull/88

Adds support for WPF/UWP/Xamarin.Forms syntax:

```xml
<Window xmlns='https://github.com/avaloniaui' 
    xmlns:d='http://schemas.microsoft.com/expression/blend/2008'
    xmlns:mc='http://schemas.openxmlformats.org/markup-compatibility/2006'
    mc:Ignorable='d'
    d:DataContext='data-context'
    d:DesignWidth='123'
    d:DesignHeight='321'
/>
```

Also *completely skips* parsing the content of these properties, so it fixes #1380