### PR TITLE
Fix make monitorinfo a struct

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1062,7 +1062,7 @@ namespace Avalonia.Win32.Interop
             public RECT rcWork;
             public int dwFlags;
 
-            public static MONITORINFO NewMONITORINFO()
+            public static MONITORINFO CreateMONITORINFO()
             {
                 return new MONITORINFO() { cbSize = Marshal.SizeOf<MONITORINFO>() };
             }

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1055,12 +1055,17 @@ namespace Avalonia.Win32.Interop
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal class MONITORINFO
+        internal struct MONITORINFO
         {
-            public int cbSize = Marshal.SizeOf<MONITORINFO>();
-            public RECT rcMonitor = new RECT();
-            public RECT rcWork = new RECT();
-            public int dwFlags = 0;
+            public int cbSize;
+            public RECT rcMonitor;
+            public RECT rcWork;
+            public int dwFlags;
+
+            public static MONITORINFO NewMONITORINFO()
+            {
+                return new MONITORINFO() { cbSize = Marshal.SizeOf<MONITORINFO>() };
+            }
 
             public enum MonitorOptions : uint
             {

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1062,7 +1062,7 @@ namespace Avalonia.Win32.Interop
             public RECT rcWork;
             public int dwFlags;
 
-            public static MONITORINFO CreateMONITORINFO()
+            public static MONITORINFO Create()
             {
                 return new MONITORINFO() { cbSize = Marshal.SizeOf<MONITORINFO>() };
             }

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -987,7 +987,7 @@ namespace Avalonia.Win32.Interop
         
         [DllImport("user32", EntryPoint = "GetMonitorInfoW", ExactSpelling = true, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool GetMonitorInfo([In] IntPtr hMonitor, [Out] MONITORINFO lpmi);
+        public static extern bool GetMonitorInfo([In] IntPtr hMonitor, ref MONITORINFO lpmi);
 
         [return: MarshalAs(UnmanagedType.Bool)]
         [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "PostMessageW")]

--- a/src/Windows/Avalonia.Win32/ScreenImpl.cs
+++ b/src/Windows/Avalonia.Win32/ScreenImpl.cs
@@ -26,7 +26,7 @@ namespace Avalonia.Win32
                     EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero,
                         (IntPtr monitor, IntPtr hdcMonitor, ref Rect lprcMonitor, IntPtr data) =>
                         {
-                            MONITORINFO monitorInfo = MONITORINFO.NewMONITORINFO();
+                            MONITORINFO monitorInfo = MONITORINFO.CreateMONITORINFO();
                             if (GetMonitorInfo(monitor,ref monitorInfo))
                             {
                                 RECT bounds = monitorInfo.rcMonitor;

--- a/src/Windows/Avalonia.Win32/ScreenImpl.cs
+++ b/src/Windows/Avalonia.Win32/ScreenImpl.cs
@@ -26,7 +26,7 @@ namespace Avalonia.Win32
                     EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero,
                         (IntPtr monitor, IntPtr hdcMonitor, ref Rect lprcMonitor, IntPtr data) =>
                         {
-                            MONITORINFO monitorInfo = new MONITORINFO();
+                            MONITORINFO monitorInfo = MONITORINFO.NewMONITORINFO();
                             if (GetMonitorInfo(monitor, monitorInfo))
                             {
                                 RECT bounds = monitorInfo.rcMonitor;

--- a/src/Windows/Avalonia.Win32/ScreenImpl.cs
+++ b/src/Windows/Avalonia.Win32/ScreenImpl.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Win32
                         (IntPtr monitor, IntPtr hdcMonitor, ref Rect lprcMonitor, IntPtr data) =>
                         {
                             MONITORINFO monitorInfo = MONITORINFO.NewMONITORINFO();
-                            if (GetMonitorInfo(monitor, monitorInfo))
+                            if (GetMonitorInfo(monitor,ref monitorInfo))
                             {
                                 RECT bounds = monitorInfo.rcMonitor;
                                 RECT workingArea = monitorInfo.rcWork;

--- a/src/Windows/Avalonia.Win32/ScreenImpl.cs
+++ b/src/Windows/Avalonia.Win32/ScreenImpl.cs
@@ -26,7 +26,7 @@ namespace Avalonia.Win32
                     EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero,
                         (IntPtr monitor, IntPtr hdcMonitor, ref Rect lprcMonitor, IntPtr data) =>
                         {
-                            MONITORINFO monitorInfo = MONITORINFO.CreateMONITORINFO();
+                            MONITORINFO monitorInfo = MONITORINFO.Create();
                             if (GetMonitorInfo(monitor,ref monitorInfo))
                             {
                                 RECT bounds = monitorInfo.rcMonitor;

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -837,7 +837,7 @@ namespace Avalonia.Win32
 
             if (monitor != IntPtr.Zero)
             {
-                MONITORINFO monitorInfo = new MONITORINFO();
+                MONITORINFO monitorInfo = MONITORINFO.NewMONITORINFO();
 
                 if (GetMonitorInfo(monitor, monitorInfo))
                 {

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -837,7 +837,7 @@ namespace Avalonia.Win32
 
             if (monitor != IntPtr.Zero)
             {
-                MONITORINFO monitorInfo = MONITORINFO.CreateMONITORINFO();
+                MONITORINFO monitorInfo = MONITORINFO.Create();
 
                 if (GetMonitorInfo(monitor,ref monitorInfo))
                 {

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -837,7 +837,7 @@ namespace Avalonia.Win32
 
             if (monitor != IntPtr.Zero)
             {
-                MONITORINFO monitorInfo = MONITORINFO.NewMONITORINFO();
+                MONITORINFO monitorInfo = MONITORINFO.CreateMONITORINFO();
 
                 if (GetMonitorInfo(monitor,ref monitorInfo))
                 {

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -839,7 +839,7 @@ namespace Avalonia.Win32
             {
                 MONITORINFO monitorInfo = MONITORINFO.NewMONITORINFO();
 
-                if (GetMonitorInfo(monitor, monitorInfo))
+                if (GetMonitorInfo(monitor,ref monitorInfo))
                 {
                     RECT rcMonitorArea = monitorInfo.rcMonitor;
 


### PR DESCRIPTION
- What does the pull request do?
Passes MONITORINFO as a struct to overcome shortcomings in CoreRT
- What is the current behavior?
MONITORINFO is a class that CoreRT can't currently marshall
- What is the updated/expected behavior with this PR?
WindowsStartupLocation, menus and tooltips should work on windows CoreRT build

If the pull request fixes issue(s) list them like this:

Fixes #1923 
