### PR TITLE
Call SetProcessDPIAware() on Win32 backend

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -976,6 +976,9 @@ namespace Avalonia.Win32.Interop
         [DllImport("shcore.dll")]
         public static extern void GetScaleFactorForMonitor(IntPtr hMon, out uint pScale);
 
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool SetProcessDPIAware();
+
         [DllImport("user32.dll")]
         public static extern IntPtr MonitorFromPoint(POINT pt, MONITOR dwFlags);
 

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -77,6 +77,8 @@ namespace Avalonia.Win32
 
         public static void Initialize(bool deferredRendering = true)
         {
+            UnmanagedMethods.SetProcessDPIAware();
+
             AvaloniaLocator.CurrentMutable
                 .Bind<IClipboard>().ToSingleton<ClipboardImpl>()
                 .Bind<IStandardCursorFactory>().ToConstant(CursorFactory.Instance)


### PR DESCRIPTION
I perhaps have seen this due to the fact I recently updated to the new windows release (1809).

I have my monitor set to scaling of 200% but avalonia was only detecting scaling of 1.

I found this quote "Raymond Chen said that a call to SetProcessDPIAware will be necessary to get a monitor's true DPI setting in Vista" 

https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-setprocessdpiaware

It turns out that unless you call this then Windows assumes your app doesnt understand DPI and as in my case Im not told the correct dpi.

This PR adds the call so that the application is given the true DPI.

- What does the pull request do?
Adds a call to SetProcessDPIAware () to ensure on all windows systems we get the true DPI.

- What is the current behavior?
On some versions of windows and certain monitors we are not given the true dpi.

- What is the updated/expected behavior with this PR?
We tell win32 that the application is dpi aware and so get the correct DPI all the time.

- How was the solution implemented (if it's not obvious)?

Checklist:

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

If the pull request fixes issue(s) list them like this:

Fixes #1958 