### PR TITLE
WIP: OSX style textbox keyboard shortcuts.

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -14,7 +14,6 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Metadata;
 using Avalonia.Data;
-using System.Runtime.InteropServices;
 
 namespace Avalonia.Controls
 {
@@ -372,24 +371,17 @@ namespace Avalonia.Controls
             bool handled = false;
             var modifiers = e.Modifiers;
 
-            var commandModifier = InputModifiers.Control;
-
-            if(RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                commandModifier = InputModifiers.Windows;
-            }
-
             switch (e.Key)
             {
                 case Key.A:
-                    if (modifiers == commandModifier)
+                    if (modifiers == InputModifiers.Control)
                     {
                         SelectAll();
                         handled = true;
                     }
                     break;
                 case Key.C:
-                    if (modifiers == commandModifier)
+                    if (modifiers == InputModifiers.Control)
                     {
                         if (!IsPasswordBox)
                         {
@@ -400,7 +392,7 @@ namespace Avalonia.Controls
                     break;
 
                 case Key.X:
-                    if (modifiers == commandModifier)
+                    if (modifiers == InputModifiers.Control)
                     {
                         if (!IsPasswordBox)
                         {
@@ -412,7 +404,7 @@ namespace Avalonia.Controls
                     break;
 
                 case Key.V:
-                    if (modifiers == commandModifier)
+                    if (modifiers == InputModifiers.Control)
                     {
                         Paste();
                         handled = true;
@@ -421,7 +413,7 @@ namespace Avalonia.Controls
                     break;
 
                 case Key.Z:
-                    if (modifiers == commandModifier)
+                    if (modifiers == InputModifiers.Control)
                     {
                         try
                         {
@@ -434,24 +426,9 @@ namespace Avalonia.Controls
                         }
                         handled = true;
                     }
-                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && 
-                                modifiers.HasFlag(commandModifier) && 
-                                modifiers.HasFlag(InputModifiers.Shift))
-                    {
-                        try
-                        {
-                            _isUndoingRedoing = true;
-                            _undoRedoHelper.Redo();
-                        }
-                        finally
-                        {
-                            _isUndoingRedoing = false;
-                        }
-                        handled = true;
-                    }
                     break;
                 case Key.Y:
-                    if (modifiers == commandModifier)
+                    if (modifiers == InputModifiers.Control)
                     {
                         try
                         {

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -14,6 +14,7 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Metadata;
 using Avalonia.Data;
+using System.Runtime.InteropServices;
 
 namespace Avalonia.Controls
 {
@@ -371,17 +372,24 @@ namespace Avalonia.Controls
             bool handled = false;
             var modifiers = e.Modifiers;
 
+            var commandModifier = InputModifiers.Control;
+
+            if(RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                commandModifier = InputModifiers.Windows;
+            }
+
             switch (e.Key)
             {
                 case Key.A:
-                    if (modifiers == InputModifiers.Control)
+                    if (modifiers == commandModifier)
                     {
                         SelectAll();
                         handled = true;
                     }
                     break;
                 case Key.C:
-                    if (modifiers == InputModifiers.Control)
+                    if (modifiers == commandModifier)
                     {
                         if (!IsPasswordBox)
                         {
@@ -392,7 +400,7 @@ namespace Avalonia.Controls
                     break;
 
                 case Key.X:
-                    if (modifiers == InputModifiers.Control)
+                    if (modifiers == commandModifier)
                     {
                         if (!IsPasswordBox)
                         {
@@ -404,7 +412,7 @@ namespace Avalonia.Controls
                     break;
 
                 case Key.V:
-                    if (modifiers == InputModifiers.Control)
+                    if (modifiers == commandModifier)
                     {
                         Paste();
                         handled = true;
@@ -413,7 +421,7 @@ namespace Avalonia.Controls
                     break;
 
                 case Key.Z:
-                    if (modifiers == InputModifiers.Control)
+                    if (modifiers == commandModifier)
                     {
                         try
                         {
@@ -426,9 +434,24 @@ namespace Avalonia.Controls
                         }
                         handled = true;
                     }
+                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && 
+                                modifiers.HasFlag(commandModifier) && 
+                                modifiers.HasFlag(InputModifiers.Shift))
+                    {
+                        try
+                        {
+                            _isUndoingRedoing = true;
+                            _undoRedoHelper.Redo();
+                        }
+                        finally
+                        {
+                            _isUndoingRedoing = false;
+                        }
+                        handled = true;
+                    }
                     break;
                 case Key.Y:
-                    if (modifiers == InputModifiers.Control)
+                    if (modifiers == commandModifier)
                     {
                         try
                         {

--- a/src/Avalonia.Input/IKeyboardDevice.cs
+++ b/src/Avalonia.Input/IKeyboardDevice.cs
@@ -14,9 +14,10 @@ namespace Avalonia.Input
         Control = 2,
         Shift = 4,
         Windows = 8,
-        LeftMouseButton = 16,
-        RightMouseButton = 32,
-        MiddleMouseButton = 64
+        Command = 16, // Special case CMD on OSX, CTRL on other platforms.
+        LeftMouseButton = 32,
+        RightMouseButton = 64,
+        MiddleMouseButton = 128
     }
 
     [Flags]

--- a/src/Gtk/Avalonia.Gtk3/WindowBaseImpl.cs
+++ b/src/Gtk/Avalonia.Gtk3/WindowBaseImpl.cs
@@ -122,7 +122,10 @@ namespace Avalonia.Gtk3
         {
             var rv = InputModifiers.None;
             if (state.HasFlag(GdkModifierType.ControlMask))
+            {
                 rv |= InputModifiers.Control;
+                rv |= InputModifiers.Command;
+            }
             if (state.HasFlag(GdkModifierType.ShiftMask))
                 rv |= InputModifiers.Shift;
             if (state.HasFlag(GdkModifierType.Mod1Mask))

--- a/src/OSX/Avalonia.MonoMac/TopLevelImpl.cs
+++ b/src/OSX/Avalonia.MonoMac/TopLevelImpl.cs
@@ -224,13 +224,16 @@ namespace Avalonia.MonoMac
             {
                 var rv = new InputModifiers();
                 if (mod.HasFlag(NSEventModifierMask.ControlKeyMask))
-                    rv |= InputModifiers.Control;
+                   {rv |= InputModifiers.Control;
                 if (mod.HasFlag(NSEventModifierMask.ShiftKeyMask))
                     rv |= InputModifiers.Shift;
                 if (mod.HasFlag(NSEventModifierMask.AlternateKeyMask))
                     rv |= InputModifiers.Alt;
                 if (mod.HasFlag(NSEventModifierMask.CommandKeyMask))
+                {
                     rv |= InputModifiers.Windows;
+                    rv = InputModifiers.Command;
+                }
 
                 if (_isLeftPressed)
                     rv |= InputModifiers.LeftMouseButton;

--- a/src/OSX/Avalonia.MonoMac/TopLevelImpl.cs
+++ b/src/OSX/Avalonia.MonoMac/TopLevelImpl.cs
@@ -232,7 +232,7 @@ namespace Avalonia.MonoMac
                 if (mod.HasFlag(NSEventModifierMask.CommandKeyMask))
                 {
                     rv |= InputModifiers.Windows;
-                    rv = InputModifiers.Command;
+                    rv |= InputModifiers.Command;
                 }
 
                 if (_isLeftPressed)

--- a/src/OSX/Avalonia.MonoMac/TopLevelImpl.cs
+++ b/src/OSX/Avalonia.MonoMac/TopLevelImpl.cs
@@ -224,7 +224,7 @@ namespace Avalonia.MonoMac
             {
                 var rv = new InputModifiers();
                 if (mod.HasFlag(NSEventModifierMask.ControlKeyMask))
-                   {rv |= InputModifiers.Control;
+                   rv |= InputModifiers.Control;
                 if (mod.HasFlag(NSEventModifierMask.ShiftKeyMask))
                     rv |= InputModifiers.Shift;
                 if (mod.HasFlag(NSEventModifierMask.AlternateKeyMask))

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
@@ -151,7 +151,10 @@ namespace Avalonia.Win32.Interop.Wpf
             if (state.HasFlag(ModifierKeys.Alt))
                 rv |= InputModifiers.Alt;
             if (state.HasFlag(ModifierKeys.Control))
+            {
                 rv |= InputModifiers.Control;
+                rv |= InputModifiers.Command;
+            }
             if (state.HasFlag(ModifierKeys.Shift))
                 rv |= InputModifiers.Shift;
             //TODO: mouse modifiers

--- a/src/Windows/Avalonia.Win32/Input/WindowsKeyboardDevice.cs
+++ b/src/Windows/Avalonia.Win32/Input/WindowsKeyboardDevice.cs
@@ -29,6 +29,7 @@ namespace Avalonia.Win32.Input
                 if (IsDown(Key.LeftCtrl) || IsDown(Key.RightCtrl))
                 {
                     result |= InputModifiers.Control;
+                    result |= InputModifiers.Command;
                 }
 
                 if (IsDown(Key.LeftShift) || IsDown(Key.RightShift))

--- a/src/Windows/Avalonia.Win32/OleDropTarget.cs
+++ b/src/Windows/Avalonia.Win32/OleDropTarget.cs
@@ -59,7 +59,10 @@ namespace Avalonia.Win32
             if (state.HasFlag(UnmanagedMethods.ModifierKeys.MK_SHIFT))
                 modifiers |= InputModifiers.Shift;
             if (state.HasFlag(UnmanagedMethods.ModifierKeys.MK_CONTROL))
+            {
                 modifiers |= InputModifiers.Control;
+                modifiers |= InputModifiers.Command;
+            }
             if (state.HasFlag(UnmanagedMethods.ModifierKeys.MK_ALT))
                 modifiers |= InputModifiers.Alt;
             return modifiers;


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
It adds OSX style textbox key gestures, for example on OSX the copy command will be CMD + C, not Control + C.
- What is the current behavior?
Windows style gestures on all platforms.

- What is the updated/expected behavior with this PR?
Mac users will now feel at home :)