### PR TITLE
support high dpi on avalonia remote previewer.

### DIFF
--- a/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
@@ -102,6 +102,12 @@ namespace Avalonia.Controls.Remote.Server
         
         FrameMessage RenderFrame(int width, int height, ProtocolPixelFormat? format)
         {
+            var scalingX = _dpi.X / 96.0;
+            var scalingY = _dpi.Y / 96.0;
+
+            width = (int)(width * scalingX);
+            height = (int)(height * scalingY);
+
             var fmt = format ?? ProtocolPixelFormat.Rgba8888;
             var bpp = fmt == ProtocolPixelFormat.Rgb565 ? 2 : 4;
             var data = new byte[width * height * bpp];


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
Adds support for HiDPI or scaling via Avalonia Previewer.

- What is the current behavior?
It was overlooked to take into account dpi when creating the bitmaps for remote previewer.

- What is the updated/expected behavior with this PR?
Simply allocated the correct size bitmap for rendering into.
