### PR TITLE
fix support for zooming in on previewer and hidpi preview.

### DIFF
--- a/src/Avalonia.Controls/Remote/RemoteWidget.cs
+++ b/src/Avalonia.Controls/Remote/RemoteWidget.cs
@@ -28,6 +28,8 @@ namespace Avalonia.Controls.Remote
             });
         }
 
+        public bool PreviewerMode { get; set; }
+
         private void OnMessage(object msg)
         {
             if (msg is FrameMessage frame)
@@ -44,13 +46,17 @@ namespace Avalonia.Controls.Remote
 
         protected override void ArrangeCore(Rect finalRect)
         {
-            _connection.Send(new ClientViewportAllocatedMessage
+            if (!PreviewerMode)
             {
-                Width = finalRect.Width,
-                Height = finalRect.Height,
-                DpiX = 96,
-                DpiY = 96 //TODO: Somehow detect the actual DPI
-            });
+                _connection.Send(new ClientViewportAllocatedMessage
+                {
+                    Width = finalRect.Width,
+                    Height = finalRect.Height,
+                    DpiX = 10 * 96,
+                    DpiY = 10 * 96 //TODO: Somehow detect the actual DPI
+                });
+            }
+
             base.ArrangeCore(finalRect);
         }
 

--- a/src/Avalonia.Controls/Remote/RemoteWidget.cs
+++ b/src/Avalonia.Controls/Remote/RemoteWidget.cs
@@ -11,11 +11,19 @@ namespace Avalonia.Controls.Remote
 {
     public class RemoteWidget : Control
     {
+        public enum SizingMode
+        {
+            Local,
+            Remote
+        }
+
         private readonly IAvaloniaRemoteTransportConnection _connection;
         private FrameMessage _lastFrame;
         private WriteableBitmap _bitmap;
         public RemoteWidget(IAvaloniaRemoteTransportConnection connection)
         {
+            Mode = SizingMode.Local;
+
             _connection = connection;
             _connection.OnMessage += (t, msg) => Dispatcher.UIThread.Post(() => OnMessage(msg));
             _connection.Send(new ClientSupportedPixelFormatsMessage
@@ -28,7 +36,7 @@ namespace Avalonia.Controls.Remote
             });
         }
 
-        public bool PreviewerMode { get; set; }
+        public SizingMode Mode { get; set; }
 
         private void OnMessage(object msg)
         {
@@ -46,7 +54,7 @@ namespace Avalonia.Controls.Remote
 
         protected override void ArrangeCore(Rect finalRect)
         {
-            if (!PreviewerMode)
+            if (Mode == SizingMode.Local)
             {
                 _connection.Send(new ClientViewportAllocatedMessage
                 {

--- a/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
@@ -85,7 +85,7 @@ namespace Avalonia.Controls.Remote.Server
             }
         }
 
-        protected void SetDpi(Vector dpi)
+        public void SetDpi(Vector dpi)
         {
             _dpi = dpi;
             RenderIfNeeded();

--- a/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
@@ -45,6 +45,13 @@ namespace Avalonia.Controls.Remote.Server
                     }
                     Dispatcher.UIThread.Post(RenderIfNeeded);
                 }
+                if(obj is ClientRenderInfoMessage renderInfo)
+                {
+                    lock(_lock)
+                    {
+                        _dpi = new Vector(renderInfo.DpiX, renderInfo.DpiY);
+                    }
+                }
                 if (obj is ClientSupportedPixelFormatsMessage supportedFormats)
                 {
                     lock (_lock)
@@ -74,7 +81,6 @@ namespace Avalonia.Controls.Remote.Server
                                     allocation = _pendingAllocation;
                                     _pendingAllocation = null;
                                 }
-                                _dpi = new Vector(allocation.DpiX, allocation.DpiY);
                                 ClientSize = new Size(allocation.Width, allocation.Height);
                                 RenderIfNeeded();
                             });

--- a/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
@@ -81,6 +81,7 @@ namespace Avalonia.Controls.Remote.Server
                                     allocation = _pendingAllocation;
                                     _pendingAllocation = null;
                                 }
+                                _dpi = new Vector(allocation.DpiX, allocation.DpiY);
                                 ClientSize = new Size(allocation.Width, allocation.Height);
                                 RenderIfNeeded();
                             });

--- a/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
@@ -50,6 +50,8 @@ namespace Avalonia.Controls.Remote.Server
                     lock(_lock)
                     {
                         _dpi = new Vector(renderInfo.DpiX, renderInfo.DpiY);
+                        _invalidated = true;
+                        RenderIfNeeded();
                     }
                 }
                 if (obj is ClientSupportedPixelFormatsMessage supportedFormats)

--- a/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
@@ -92,7 +92,7 @@ namespace Avalonia.Controls.Remote.Server
             }
         }
 
-        public void SetDpi(Vector dpi)
+        protected void SetDpi(Vector dpi)
         {
             _dpi = dpi;
             RenderIfNeeded();

--- a/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
+++ b/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text;
 using Avalonia.Controls;
 using Avalonia.Controls.Platform;
+using Avalonia.Controls.Remote.Server;
 using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
 
@@ -12,7 +13,7 @@ namespace Avalonia.DesignerSupport
 {
     public class DesignWindowLoader
     {
-        public static Window LoadDesignerWindow(string xaml, string assemblyPath)
+        public static Window LoadDesignerWindow(string xaml, string assemblyPath, Vector dpi)
         {
             Window window;
             Control control;
@@ -69,6 +70,9 @@ namespace Avalonia.DesignerSupport
                 if (!window.IsSet(Window.SizeToContentProperty))
                     window.SizeToContent = SizeToContent.WidthAndHeight;
             }
+            
+            (window.PlatformImpl as RemoteServerTopLevelImpl).SetDpi(dpi);
+
             window.Show();
             Design.ApplyDesignModeProperties(window, control);
             return window;

--- a/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
+++ b/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Text;
 using Avalonia.Controls;
 using Avalonia.Controls.Platform;
-using Avalonia.Controls.Remote.Server;
 using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
 
@@ -70,7 +69,6 @@ namespace Avalonia.DesignerSupport
                 if (!window.IsSet(Window.SizeToContentProperty))
                     window.SizeToContent = SizeToContent.WidthAndHeight;
             }
-
             window.Show();
             Design.ApplyDesignModeProperties(window, control);
             return window;

--- a/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
+++ b/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
@@ -13,7 +13,7 @@ namespace Avalonia.DesignerSupport
 {
     public class DesignWindowLoader
     {
-        public static Window LoadDesignerWindow(string xaml, string assemblyPath, Vector dpi)
+        public static Window LoadDesignerWindow(string xaml, string assemblyPath)
         {
             Window window;
             Control control;
@@ -70,8 +70,6 @@ namespace Avalonia.DesignerSupport
                 if (!window.IsSet(Window.SizeToContentProperty))
                     window.SizeToContent = SizeToContent.WidthAndHeight;
             }
-            
-            (window.PlatformImpl as RemoteServerTopLevelImpl).SetDpi(dpi);
 
             window.Show();
             Design.ApplyDesignModeProperties(window, control);

--- a/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
+++ b/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Reflection;
@@ -191,7 +191,8 @@ namespace Avalonia.DesignerSupport.Remote
                 s_currentWindow = null;
                 try
                 {
-                    s_currentWindow = DesignWindowLoader.LoadDesignerWindow(xaml.Xaml, xaml.AssemblyPath);
+                    var dpi = s_viewportAllocatedMessage != null ? new Vector(s_viewportAllocatedMessage.DpiX, s_viewportAllocatedMessage.DpiY) : new Vector(96, 96);
+                    s_currentWindow = DesignWindowLoader.LoadDesignerWindow(xaml.Xaml, xaml.AssemblyPath, dpi);
                     s_transport.Send(new UpdateXamlResultMessage(){Handle = s_currentWindow.PlatformImpl?.Handle?.Handle.ToString()});
                 }
                 catch (Exception e)

--- a/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
+++ b/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Reflection;
@@ -15,6 +15,8 @@ namespace Avalonia.DesignerSupport.Remote
     {
         private static ClientSupportedPixelFormatsMessage s_supportedPixelFormats;
         private static ClientViewportAllocatedMessage s_viewportAllocatedMessage;
+        private static ClientRenderInfoMessage s_renderInfoMessage;
+
         private static IAvaloniaRemoteTransportConnection s_transport;
         class CommandLineArgs
         {
@@ -161,7 +163,8 @@ namespace Avalonia.DesignerSupport.Remote
             PreviewerWindowingPlatform.PreFlightMessages = new List<object>
             {
                 s_supportedPixelFormats,
-                s_viewportAllocatedMessage
+                s_viewportAllocatedMessage,
+                s_renderInfoMessage
             };
         }
 
@@ -171,6 +174,11 @@ namespace Avalonia.DesignerSupport.Remote
             if (obj is ClientSupportedPixelFormatsMessage formats)
             {
                 s_supportedPixelFormats = formats;
+                RebuildPreFlight();
+            }
+            if (obj is ClientRenderInfoMessage renderInfo)
+            {
+                s_renderInfoMessage = renderInfo;
                 RebuildPreFlight();
             }
             if (obj is ClientViewportAllocatedMessage viewport)
@@ -191,8 +199,7 @@ namespace Avalonia.DesignerSupport.Remote
                 s_currentWindow = null;
                 try
                 {
-                    var dpi = s_viewportAllocatedMessage != null ? new Vector(s_viewportAllocatedMessage.DpiX, s_viewportAllocatedMessage.DpiY) : new Vector(96, 96);
-                    s_currentWindow = DesignWindowLoader.LoadDesignerWindow(xaml.Xaml, xaml.AssemblyPath, dpi);
+                    s_currentWindow = DesignWindowLoader.LoadDesignerWindow(xaml.Xaml, xaml.AssemblyPath);
                     s_transport.Send(new UpdateXamlResultMessage(){Handle = s_currentWindow.PlatformImpl?.Handle?.Handle.ToString()});
                 }
                 catch (Exception e)

--- a/src/Avalonia.Remote.Protocol/ViewportMessages.cs
+++ b/src/Avalonia.Remote.Protocol/ViewportMessages.cs
@@ -37,6 +37,13 @@
         public PixelFormat[] Formats { get; set; }
     }
 
+    [AvaloniaRemoteMessageGuid("7A3c25d3-3652-438D-8EF1-86E942CC96C0")]
+    public class ClientRenderInfoMessage
+    {
+        public double DpiX { get; set; }
+        public double DpiY { get; set; }
+    }
+
     [AvaloniaRemoteMessageGuid("68014F8A-289D-4851-8D34-5367EDA7F827")]
     public class FrameReceivedMessage
     {


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

Fixes remote previewer hi dpi support.
currently a bug meant it was always initialized to 96 dpi on every frame.

So I made setdpi public and the remote host is able to set the dpi before the window.show method is called.