### PR TITLE
Make sure Application.ResourcesChanged is raised.

### DIFF
--- a/src/Avalonia.Controls/Application.cs
+++ b/src/Avalonia.Controls/Application.cs
@@ -122,11 +122,11 @@ namespace Avalonia
                 if (_resources != null)
                 {
                     hadResources = _resources.Count > 0;
-                    _resources.ResourcesChanged -= ResourcesChanged;
+                    _resources.ResourcesChanged -= ThisResourcesChanged;
                 }
 
                 _resources = value;
-                _resources.ResourcesChanged += ResourcesChanged;
+                _resources.ResourcesChanged += ThisResourcesChanged;
 
                 if (hadResources || _resources.Count > 0)
                 {
@@ -342,6 +342,11 @@ namespace Avalonia
             AvaloniaLocator.CurrentMutable
                 .Bind<IGlobalClock>().ToConstant(clock)
                 .GetService<IRenderLoop>()?.Add(clock);
+        }
+
+        private void ThisResourcesChanged(object sender, ResourcesChangedEventArgs e)
+        {
+            ResourcesChanged?.Invoke(this, e);
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/ApplicationTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ApplicationTests.cs
@@ -113,5 +113,21 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Throws<ArgumentNullException>(() => { Application.Current.Run(null); });
             }
         }
+
+        [Fact]
+        public void Raises_ResourcesChanged_When_Event_Handler_Added_After_Resources_Has_Been_Accessed()
+        {
+            // Test for #1765.
+            using (UnitTestApplication.Start())
+            {
+                var resources = Application.Current.Resources;
+                var raised = false;
+
+                Application.Current.ResourcesChanged += (s, e) => raised = true;
+                resources["foo"] = "bar";
+
+                Assert.True(raised);
+            }
+        }
     }
 }


### PR DESCRIPTION
Previously if `Application.ResourcesChanged` was null when `Resources` was created, adding the handler via `_resources.ResourcesChanged += ResourcesChanged` did nothing because `ResourcesChanged` was null, so we were essentially saying `_resources.ResourcesChanged += null`, which is a no-op.

Fixes #1765 