### PR TITLE
Fix nested multibindings

### DIFF
--- a/src/Markup/Avalonia.Markup/Data/MultiBinding.cs
+++ b/src/Markup/Avalonia.Markup/Data/MultiBinding.cs
@@ -61,7 +61,7 @@ namespace Avalonia.Data
 
             var targetType = targetProperty?.PropertyType ?? typeof(object);
             var children = Bindings.Select(x => x.Initiate(target, null));
-            var input = children.Select(x => x.Subject).CombineLatest().Select(x => ConvertValue(x, targetType));
+            var input = children.Select(x => x.Observable).CombineLatest().Select(x => ConvertValue(x, targetType));
             var mode = Mode == BindingMode.Default ?
                 targetProperty?.GetMetadata(target.GetType()).DefaultBindingMode : Mode;
 

--- a/tests/Avalonia.Markup.UnitTests/Data/MultiBindingTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/MultiBindingTests.cs
@@ -42,6 +42,37 @@ namespace Avalonia.Markup.UnitTests.Data
         }
 
         [Fact]
+        public async Task Nested_MultiBinding_Should_Be_Set_Up()
+        {
+            var source = new { A = 1, B = 2, C = 3 };
+            var binding = new MultiBinding
+            {
+                Converter = new ConcatConverter(),
+                Bindings =
+                {
+                    new Binding { Path = "A" },
+                    new MultiBinding
+                    {
+                        Converter = new ConcatConverter(),
+                        Bindings =
+                        {
+                            new Binding { Path = "B"},
+                            new Binding { Path = "C"}
+                        }
+                    }
+                }
+            };
+
+            var target = new Mock<IAvaloniaObject>().As<IControl>();
+            target.Setup(x => x.GetValue(Control.DataContextProperty)).Returns(source);
+
+            var observable = binding.Initiate(target.Object, null).Observable;
+            var result = await observable.Take(1);
+
+            Assert.Equal("1,2,3", result);
+        }
+
+        [Fact]
         public void Should_Return_FallbackValue_When_Converter_Returns_UnsetValue()
         {
             var target = new TextBlock();


### PR DESCRIPTION

- What does the pull request do?
fixes nested multibindings support like:
``` xaml
<MultiBinding Converter="Converter">
<Binding Path="A" />
  <MultiBinding Converter="Converter">
    <Binding Path="B" />
   <Binding Path="C" />
 </MultiBinding
</MultiBinding>
```
- What is the current behavior?
not working - strange internal reactive exception
- What is the updated/expected behavior with this PR?
unit test and fix for nested multibindings to work again

Checklist:

- [x] Added unit tests (if possible)?

