### PR TITLE
Map gdk keys for left and right ctrl, shift and alt

### DIFF
--- a/src/Gtk/Avalonia.Gtk3/KeyTransform.cs
+++ b/src/Gtk/Avalonia.Gtk3/KeyTransform.cs
@@ -156,12 +156,12 @@ namespace Avalonia.Gtk.Common
             { GdkKey.R4, Key.F24 },
             { GdkKey.Num_Lock, Key.NumLock },
             { GdkKey.Scroll_Lock, Key.Scroll },
-            //{ GdkKey.?, Key.LeftShift }
-            //{ GdkKey.?, Key.RightShift }
-            //{ GdkKey.?, Key.LeftCtrl }
-            //{ GdkKey.?, Key.RightCtrl }
-            //{ GdkKey.?, Key.LeftAlt }
-            //{ GdkKey.?, Key.RightAlt }
+            { GdkKey.Shift_L, Key.LeftShift },
+            { GdkKey.Shift_R, Key.RightShift },
+            { GdkKey.Control_L, Key.LeftCtrl },
+            { GdkKey.Control_R, Key.RightCtrl },
+            { GdkKey.Alt_L, Key.LeftAlt },
+            { GdkKey.Alt_R, Key.RightAlt },
             //{ GdkKey.?, Key.BrowserBack }
             //{ GdkKey.?, Key.BrowserForward }
             //{ GdkKey.?, Key.BrowserRefresh }

--- a/src/Gtk/Avalonia.Gtk3/KeyTransform.cs
+++ b/src/Gtk/Avalonia.Gtk3/KeyTransform.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Gtk.Common
             { GdkKey.Clear, Key.Clear },
             { GdkKey.Return, Key.Return },
             { GdkKey.Pause, Key.Pause },
-            //{ GdkKey.?, Key.CapsLock }
+            { GdkKey.Caps_Lock, Key.CapsLock },
             //{ GdkKey.?, Key.HangulMode }
             //{ GdkKey.?, Key.JunjaMode }
             //{ GdkKey.?, Key.FinalMode }
@@ -27,7 +27,7 @@ namespace Avalonia.Gtk.Common
             //{ GdkKey.?, Key.ImeModeChange }
             { GdkKey.space, Key.Space },
             { GdkKey.Prior, Key.Prior },
-            //{ GdkKey.?, Key.PageDown }
+            { GdkKey.Page_Down, Key.PageDown },
             { GdkKey.End, Key.End },
             { GdkKey.KP_End, Key.End },
             { GdkKey.Home, Key.Home },
@@ -114,16 +114,16 @@ namespace Avalonia.Gtk.Common
             //{ GdkKey.?, Key.RWin }
             //{ GdkKey.?, Key.Apps }
             //{ GdkKey.?, Key.Sleep }
-            //{ GdkKey.?, Key.NumPad0 }
-            //{ GdkKey.?, Key.NumPad1 }
-            //{ GdkKey.?, Key.NumPad2 }
-            //{ GdkKey.?, Key.NumPad3 }
-            //{ GdkKey.?, Key.NumPad4 }
-            //{ GdkKey.?, Key.NumPad5 }
-            //{ GdkKey.?, Key.NumPad6 }
-            //{ GdkKey.?, Key.NumPad7 }
-            //{ GdkKey.?, Key.NumPad8 }
-            //{ GdkKey.?, Key.NumPad9 }
+            { GdkKey.KP_0, Key.NumPad0 },
+            { GdkKey.KP_1, Key.NumPad1 },
+            { GdkKey.KP_2, Key.NumPad2 },
+            { GdkKey.KP_3, Key.NumPad3 },
+            { GdkKey.KP_4, Key.NumPad4 },
+            { GdkKey.KP_5, Key.NumPad5 },
+            { GdkKey.KP_6, Key.NumPad6 },
+            { GdkKey.KP_7, Key.NumPad7 },
+            { GdkKey.KP_8, Key.NumPad8 },
+            { GdkKey.KP_9, Key.NumPad9 },
             { GdkKey.multiply, Key.Multiply },
             //{ GdkKey.?, Key.Add }
             //{ GdkKey.?, Key.Separator }


### PR DESCRIPTION
- What does the pull request do?
Maps the gdk keys for left shift, right shift, left control, right control, left alt and right alt to the corresponding Avalonia.Input.Key so that the Key member of the KeyEventArgs of the KeyDown and KeyUp events are not None.
- What is the current behavior?
The keys are not mapped so the the Key member of the KeyEventArgs of the KeyDown and KeyUp events are set to None.
- What is the updated/expected behavior with this PR?
The the Key member of the KeyEventArgs of the KeyDown and KeyUp events are set to the expected enum member (matches behaviour in windows).
- How was the solution implemented (if it's not obvious)?
It is obvious

Checklist:

- [ ] Added unit tests (if possible)?
   I did not add unit tests -- I don't think there are any for this code yet.
- [ ] Added XML documentation to any related classes?
   This doesn't seem to need documentation.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
   Don't think this is necessary in this case
