### PR TITLE
Use Activated event if Initialized event has been already invoked

### DIFF
--- a/src/Avalonia.ReactiveUI/AvaloniaActivationForViewFetcher.cs
+++ b/src/Avalonia.ReactiveUI/AvaloniaActivationForViewFetcher.cs
@@ -32,12 +32,18 @@ namespace Avalonia
                     x => window.Initialized += x,
                     x => window.Initialized -= x)
                 .Select(args => true);
+            var windowActivated = Observable
+                .FromEventPattern(
+                    x => window.Activated += x,
+                    x => window.Activated -= x)
+                .Select(args => true);
             var windowUnloaded = Observable
                 .FromEventPattern(
                     x => window.Closed += x,
                     x => window.Closed -= x)
                 .Select(args => false);
             return windowLoaded
+                .Merge(windowActivated)
                 .Merge(windowUnloaded)
                 .DistinctUntilChanged();
         }


### PR DESCRIPTION
**What is the current behavior?**

Now `WhenActivated` uses `Activated` event if `Initialized` event has been already invoked earlier.
`WhenActivated` lambda won't get invoked if we load heavy XAML before using `WhenActivated`:
```csharp
AvaloniaXamlLoader.Load(this);
this.WhenActivated(() => {
  // won't get invoked
});
```
This works:
```csharp
this.WhenActivated(() => {
  // will get invoked
});
AvaloniaXamlLoader.Load(this);
```

**What is the updated/expected behavior with this PR?**

With changes in this PR `WhenActivated` will perform as expected in both cases.

**How was the solution implemented (if it's not obvious)?**

We listen to both `Activated` and `Initialized` events now.