### PR TITLE
Add ReactiveUserControl and ReactiveWindow

### DIFF
--- a/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
+++ b/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
@@ -1,0 +1,45 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using Avalonia;
+using Avalonia.VisualTree;
+using Avalonia.Controls;
+using ReactiveUI;
+
+namespace Avalonia
+{
+    /// <summary>
+    /// A ReactiveUI UserControl that implements <see cref="IViewFor{TViewModel}"/> 
+    /// and will activate your ViewModel automatically if it supports activation.
+    /// </summary>
+    /// <typeparam name="TViewModel">ViewModel type.</typeparam>
+    public class ReactiveUserControl<TViewModel> : UserControl, IViewFor<TViewModel> where TViewModel : class
+    {
+        public static readonly AvaloniaProperty<TViewModel> ViewModelProperty = AvaloniaProperty
+            .Register<ReactiveWindow<TViewModel>, TViewModel>(nameof(ViewModel));
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactiveUserControl{TViewModel}"/> class.
+        /// </summary>
+        public ReactiveUserControl()
+        {
+            DataContextChanged += (sender, args) => ViewModel = DataContext as TViewModel;
+            this.WhenActivated(disposables => {  /* activate ViewModel */ });
+        }
+
+        /// <summary>
+        /// The ViewModel.
+        /// </summary>
+        public TViewModel ViewModel
+        {
+            get => GetValue(ViewModelProperty);
+            set => SetValue(ViewModelProperty, value);
+        }
+
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (TViewModel)value;
+        }
+    }
+}

--- a/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
+++ b/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
@@ -24,7 +24,6 @@ namespace Avalonia
         public ReactiveUserControl()
         {
             DataContextChanged += (sender, args) => ViewModel = DataContext as TViewModel;
-            this.WhenActivated(disposables => {  /* activate ViewModel */ });
         }
 
         /// <summary>

--- a/src/Avalonia.ReactiveUI/ReactiveWindow.cs
+++ b/src/Avalonia.ReactiveUI/ReactiveWindow.cs
@@ -1,0 +1,45 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using Avalonia;
+using Avalonia.VisualTree;
+using Avalonia.Controls;
+using ReactiveUI;
+
+namespace Avalonia 
+{
+    /// <summary>
+    /// A ReactiveUI Window that implements <see cref="IViewFor{TViewModel}"/>
+    /// and will activate your ViewModel automatically if it supports activation.
+    /// </summary>
+    /// <typeparam name="TViewModel">ViewModel type.</typeparam>
+    public class ReactiveWindow<TViewModel> : Window, IViewFor<TViewModel> where TViewModel : class
+    {
+        public static readonly AvaloniaProperty<TViewModel> ViewModelProperty = AvaloniaProperty
+            .Register<ReactiveWindow<TViewModel>, TViewModel>(nameof(ViewModel));
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactiveWindow{TViewModel}"/> class.
+        /// </summary>
+        public ReactiveWindow()
+        {
+            DataContextChanged += (sender, args) => ViewModel = DataContext as TViewModel;
+            this.WhenActivated(disposables => { /* activate ViewModel */ });
+        }
+            
+        /// <summary>
+        /// The ViewModel.
+        /// </summary>
+        public TViewModel ViewModel
+        {
+            get => GetValue(ViewModelProperty);
+            set => SetValue(ViewModelProperty, value);
+        }
+
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (TViewModel)value;
+        }
+    }
+}

--- a/src/Avalonia.ReactiveUI/ReactiveWindow.cs
+++ b/src/Avalonia.ReactiveUI/ReactiveWindow.cs
@@ -24,7 +24,6 @@ namespace Avalonia
         public ReactiveWindow()
         {
             DataContextChanged += (sender, args) => ViewModel = DataContext as TViewModel;
-            this.WhenActivated(disposables => { /* activate ViewModel */ });
         }
             
         /// <summary>

--- a/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
@@ -70,12 +70,12 @@ namespace Avalonia
 
         public class ActivatableWindow : ReactiveWindow<ActivatableViewModel>
         {
-            public ActivatableWindow() { }
+            public ActivatableWindow() => this.WhenActivated(disposables => { });
         }
 
         public class ActivatableUserControl : ReactiveUserControl<ActivatableViewModel>
         {
-            public ActivatableUserControl() { }
+            public ActivatableUserControl() => this.WhenActivated(disposables => { });
         }
 
         public AvaloniaActivationForViewFetcherTest()

--- a/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
@@ -23,7 +23,8 @@ namespace Avalonia
 
             public TestUserControlWithWhenActivated()
             {
-                this.WhenActivated(disposables => {
+                this.WhenActivated(disposables => 
+                {
                     Active = true;
                     Disposable
                         .Create(() => Active = false)
@@ -38,13 +39,50 @@ namespace Avalonia
 
             public TestWindowWithWhenActivated()
             {
-                this.WhenActivated(disposables => {
+                this.WhenActivated(disposables => 
+                {
                     Active = true;
                     Disposable
                         .Create(() => Active = false)
                         .DisposeWith(disposables);
                 });
             }
+        }
+
+        public class ActivatableViewModel : ISupportsActivation
+        {
+            public ViewModelActivator Activator { get; }
+
+            public bool IsActivated { get; private set; }
+
+            public ActivatableViewModel() 
+            {
+                Activator = new ViewModelActivator();
+                this.WhenActivated(disposables => 
+                {
+                    IsActivated = true;
+                    Disposable
+                        .Create(() => IsActivated = false)
+                        .DisposeWith(disposables);
+                });
+            }
+        }
+
+        public class ActivatableWindow : ReactiveWindow<ActivatableViewModel>
+        {
+            public ActivatableWindow() { }
+        }
+
+        public class ActivatableUserControl : ReactiveUserControl<ActivatableViewModel>
+        {
+            public ActivatableUserControl() { }
+        }
+
+        public AvaloniaActivationForViewFetcherTest()
+        {
+            Locator.CurrentMutable.RegisterConstant(
+                new AvaloniaActivationForViewFetcher(), 
+                typeof(IActivationForViewFetcher));
         }
 
         [Fact]
@@ -86,10 +124,6 @@ namespace Avalonia
         [Fact]
         public void Activation_For_View_Fetcher_Should_Support_When_Activated()
         {
-            Locator.CurrentMutable.RegisterConstant(
-                new AvaloniaActivationForViewFetcher(), 
-                typeof(IActivationForViewFetcher));
-
             var userControl = new TestUserControlWithWhenActivated();
             Assert.False(userControl.Active);
 
@@ -104,10 +138,6 @@ namespace Avalonia
         [Fact]
         public void Activation_For_View_Fetcher_Should_Support_Windows() 
         {
-            Locator.CurrentMutable.RegisterConstant(
-                new AvaloniaActivationForViewFetcher(), 
-                typeof(IActivationForViewFetcher));
-
             using (var application = UnitTestApplication.Start(TestServices.MockWindowingPlatform)) 
             {
                 var window = new TestWindowWithWhenActivated();
@@ -119,6 +149,38 @@ namespace Avalonia
                 window.Close();
                 Assert.False(window.Active);
             }
+        }
+
+        [Fact]
+        public void Activatable_Window_View_Model_Is_Activated_And_Deactivated() 
+        {
+            using (var application = UnitTestApplication.Start(TestServices.MockWindowingPlatform)) 
+            {
+                var viewModel = new ActivatableViewModel();
+                var window = new ActivatableWindow { ViewModel = viewModel };
+                Assert.False(viewModel.IsActivated);
+
+                window.Show();
+                Assert.True(viewModel.IsActivated);
+
+                window.Close();
+                Assert.False(viewModel.IsActivated);
+            }
+        }
+
+        [Fact]
+        public void Activatable_User_Control_View_Model_Is_Activated_And_Deactivated() 
+        {
+            var root = new TestRoot();
+            var viewModel = new ActivatableViewModel();
+            var control = new ActivatableUserControl { ViewModel = viewModel };
+            Assert.False(viewModel.IsActivated);
+
+            root.Child = control;
+            Assert.True(viewModel.IsActivated);
+
+            root.Child = null;
+            Assert.False(viewModel.IsActivated);
         }
     }
 }


### PR DESCRIPTION
**What does the pull request do?**

The pull request adds `ReactiveUserControl<TViewModel>` and `ReactiveWindow<TViewModel>` controls.

**What is the current behavior?**

There is no ReactiveUI controls that can encapsulate `IViewFor<TViewModel>` behavior, so devs have to implement that interface quite manually, <a href="https://github.com/worldbeater/ReactiveMvvm/blob/89439602c41a303265ffe576d4ffe238cc6c7aa9/ReactiveMvvm.Avalonia/Views/FeedbackView.xaml.cs">see an example</a>.

**What is the updated/expected behavior with this PR?**

Now, users can do this:
```cs
public class FeedbackView : ReactiveWindow<FeedbackViewModel>
{
    public FeedbackView()
    {
        this.WhenActivated(disposables => { });
        AvaloniaXamlLoader.Load(this);
    }
}
```
And ViewModel that implements the `ISupportsActivation` interface will get activated <a href="https://reactiveui.net/docs/handbook/when-activated/">automagically</a>.

**How was the solution implemented?**

I took the idea from <a href="https://github.com/reactiveui/ReactiveUI/issues/348">here</a> and <a href="https://github.com/reactiveui/ReactiveUI/blob/4a7b6c7cb35efe4e936b6779e2ad60964894e1d0/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs">here</a> and implemented it using an `AvaloniaProperty`.

Closes https://github.com/AvaloniaUI/Avalonia/issues/1852