### PR TITLE
Resolve g_application_id_is_valid Gtk3 warning

### DIFF
--- a/src/Gtk/Avalonia.Gtk3/Gtk3Platform.cs
+++ b/src/Gtk/Avalonia.Gtk3/Gtk3Platform.cs
@@ -66,7 +66,7 @@ namespace Avalonia.Gtk3
                 DisplayClassName =
                     Utf8Buffer.StringFromPtr(Native.GTypeName(Marshal.ReadIntPtr(Marshal.ReadIntPtr(disp))));
 
-                using (var utf = new Utf8Buffer("avalonia.app." + Guid.NewGuid()))
+                using (var utf = new Utf8Buffer($"avalonia.app.a{Guid.NewGuid().ToString("N")}"))
                     App = Native.GtkApplicationNew(utf, 0);
                 //Mark current thread as UI thread
                 s_tlsMarker = true;


### PR DESCRIPTION
This resolves the following warning thrown when starting an Avalonia application on Linux:

```sh
(dotnet:16553): Gtk-CRITICAL **: 21:04:19.624: gtk_application_new: assertion 'application_id == NULL || g_application_id_is_valid (application_id)' failed
```

There were two issues here. From [g_application_id_is_valid ()](https://developer.gnome.org/gio/unstable/GApplication.html#g-application-id-is-valid) reference:

> Each element must only contain the ASCII characters [A-Z][a-z][0-9]_-, with - discouraged in new application identifiers.  

Thus I added a `.ToString("N")` to remove `-` characters. This will produce a guid string, like this: `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` instead of this: `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.

> Each element must not begin with a digit.

Thus I added an `a` character, as Avalonia, before ToStringing the `Guid`.

Fixes the first part of https://github.com/AvaloniaUI/Avalonia/issues/1800 and https://github.com/zkSNACKs/WalletWasabi/issues/564
Might helps for https://github.com/AvaloniaUI/Avalonia/issues/1603