### PR TITLE
Use theme resources for ContextMenu and Expander default theme styles

### DIFF
--- a/src/Avalonia.Themes.Default/ContextMenu.xaml
+++ b/src/Avalonia.Themes.Default/ContextMenu.xaml
@@ -2,7 +2,7 @@
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}"/>
     <Setter Property="BorderThickness" Value="1"/>
     <Setter Property="Padding" Value="4,2"/>
-    <Setter Property="TextBlock.FontSize" Value="12" />
+    <Setter Property="TextBlock.FontSize" Value="{DynamicResource FontSizeNormal}" />
     <Setter Property="TextBlock.FontWeight" Value="Normal" />
     <Setter Property="Template">
     <ControlTemplate>

--- a/src/Avalonia.Themes.Default/ContextMenu.xaml
+++ b/src/Avalonia.Themes.Default/ContextMenu.xaml
@@ -1,5 +1,5 @@
 <Style xmlns="https://github.com/avaloniaui" Selector="ContextMenu">
-    <Setter Property="BorderBrush" Value="Gray"/>
+    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}"/>
     <Setter Property="BorderThickness" Value="1"/>
     <Setter Property="Padding" Value="4,2"/>
     <Setter Property="TextBlock.FontSize" Value="12" />

--- a/src/Avalonia.Themes.Default/Expander.xaml
+++ b/src/Avalonia.Themes.Default/Expander.xaml
@@ -89,7 +89,7 @@
         <Border BorderThickness="1">
           <Grid ColumnDefinitions="Auto,Auto">
             <Border Grid.Column="0" Width="20" Height="20" HorizontalAlignment="Center" VerticalAlignment="Center">
-              <Path Fill="Black"
+              <Path Fill="{DynamicResource ThemeForegroundBrush}"
                       HorizontalAlignment="Center"
                       VerticalAlignment="Center"
                       Data="M 0 2 L 4 6 L 0 10 Z" />


### PR DESCRIPTION
- What does the pull request do?
Fixes ContextMenu and Expander styles to use theme resources .
- What is the current behavior?
The ContextMenu and Expander style does not use theme resources for all elements.
- What is the updated/expected behavior with this PR?
The ContextMenu and Expander use theme resources for all elements.
- How was the solution implemented (if it's not obvious)?
Used DynamicResource to set resources for control styles.