### PR TITLE
Make resource key names consistent

### DIFF
--- a/src/Avalonia.Themes.Default/Accents/BaseLight.xaml
+++ b/src/Avalonia.Themes.Default/Accents/BaseLight.xaml
@@ -15,7 +15,7 @@
         <Color x:Key="ThemeControlLightColor">#FFFFFFFF</Color>
         <Color x:Key="ThemeControlMidColor">#FFAAAAAA</Color>
         <Color x:Key="ThemeControlDarkColor">#FF888888</Color>
-        <Color x:Key="ThemeControlHighlightLowColor">#FFF0F0F0</Color>
+        <Color x:Key="ThemeControlHighlightLightColor">#FFF0F0F0</Color>
         <Color x:Key="ThemeControlHighlightMidColor">#FFD0D0D0</Color>
         <Color x:Key="ThemeControlHighlightDarkColor">#FF808080</Color>
         <Color x:Key="ThemeForegroundColor">#FF000000</Color>
@@ -32,7 +32,7 @@
         <SolidColorBrush x:Key="ThemeControlLightBrush" Color="{DynamicResource ThemeControlLightColor}"></SolidColorBrush>
         <SolidColorBrush x:Key="ThemeControlMidBrush" Color="{DynamicResource ThemeControlMidColor}"></SolidColorBrush>
         <SolidColorBrush x:Key="ThemeControlDarkBrush" Color="{DynamicResource ThemeControlDarkColor}"></SolidColorBrush>
-        <SolidColorBrush x:Key="ThemeControlHighlightLowBrush" Color="{DynamicResource ThemeControlHighlightLowColor}"></SolidColorBrush>
+        <SolidColorBrush x:Key="ThemeControlHighlightLightBrush" Color="{DynamicResource ThemeControlHighlightLightColor}"></SolidColorBrush>
         <SolidColorBrush x:Key="ThemeControlHighlightMidBrush" Color="{DynamicResource ThemeControlHighlightMidColor}"></SolidColorBrush>
         <SolidColorBrush x:Key="ThemeControlHighlightDarkBrush" Color="{DynamicResource ThemeControlHighlightDarkColor}"></SolidColorBrush>
         <SolidColorBrush x:Key="ThemeForegroundBrush" Color="{DynamicResource ThemeForegroundColor}"></SolidColorBrush>


### PR DESCRIPTION
- What does the pull request do?
Makes resource key names consistent.
- What is the current behavior?
Some of the resource key names are inconsistent.
- What is the updated/expected behavior with this PR?
Makes resource key names consistent.
- How was the solution implemented (if it's not obvious)?
Renamed on color and brush  resource key names following key naming pattern.

I have checked and this resource was not used in AvaloniaUI. We probably should add this to breaking changes in 0.7 version release:
* Renamed theme resource from `ThemeControlHighlightLowColor` to `ThemeControlHighlightLightColor`.
* Renamed theme resource from `ThemeControlHighlightLowBrush` to `ThemeControlHighlightLightBrush`.