### PR TITLE
fix color resource names

### DIFF
--- a/samples/ControlCatalog/Pages/ButtonPage.xaml
+++ b/samples/ControlCatalog/Pages/ButtonPage.xaml
@@ -18,7 +18,7 @@
             <Style>
               <Style.Resources>
                 <SolidColorBrush x:Key="ThemeBorderMidBrush">Red</SolidColorBrush>
-                <SolidColorBrush x:Key="ThemeControlDarkBrush">DarkRed</SolidColorBrush>
+                <SolidColorBrush x:Key="ThemeControlHighBrush">DarkRed</SolidColorBrush>
               </Style.Resources>
             </Style>
           </Button.Styles>          

--- a/src/Avalonia.Themes.Default/Accents/BaseLight.xaml
+++ b/src/Avalonia.Themes.Default/Accents/BaseLight.xaml
@@ -9,34 +9,34 @@
         <Color x:Key="ThemeAccentColor4">#33119EDA</Color>
 
         <Color x:Key="ThemeBackgroundColor">#FFFFFFFF</Color>
-        <Color x:Key="ThemeBorderLightColor">#FFAAAAAA</Color>
+        <Color x:Key="ThemeBorderLowColor">#FFAAAAAA</Color>
         <Color x:Key="ThemeBorderMidColor">#FF888888</Color>
-        <Color x:Key="ThemeBorderDarkColor">#FF333333</Color>
-        <Color x:Key="ThemeControlLightColor">#FFFFFFFF</Color>
+        <Color x:Key="ThemeBorderHighColor">#FF333333</Color>
+        <Color x:Key="ThemeControlLowColor">#FFFFFFFF</Color>
         <Color x:Key="ThemeControlMidColor">#FFAAAAAA</Color>
-        <Color x:Key="ThemeControlDarkColor">#FF888888</Color>
-        <Color x:Key="ThemeControlHighlightLightColor">#FFF0F0F0</Color>
+        <Color x:Key="ThemeControlHighColor">#FF888888</Color>
+        <Color x:Key="ThemeControlHighlightLowColor">#FFF0F0F0</Color>
         <Color x:Key="ThemeControlHighlightMidColor">#FFD0D0D0</Color>
-        <Color x:Key="ThemeControlHighlightDarkColor">#FF808080</Color>
+        <Color x:Key="ThemeControlHighlightHighColor">#FF808080</Color>
         <Color x:Key="ThemeForegroundColor">#FF000000</Color>
-        <Color x:Key="ThemeForegroundLightColor">#FF808080</Color>
+        <Color x:Key="ThemeForegroundLowColor">#FF808080</Color>
 
         <Color x:Key="HighlightColor">#FF086F9E</Color>
         <Color x:Key="ErrorColor">#FFFF0000</Color>
-        <Color x:Key="ErrorLightColor">#10FF0000</Color>
+        <Color x:Key="ErrorLowColor">#10FF0000</Color>
 
         <SolidColorBrush x:Key="ThemeBackgroundBrush" Color="{DynamicResource ThemeBackgroundColor}"></SolidColorBrush>
-        <SolidColorBrush x:Key="ThemeBorderLightBrush" Color="{DynamicResource ThemeBorderLightColor}"></SolidColorBrush>
+        <SolidColorBrush x:Key="ThemeBorderLowBrush" Color="{DynamicResource ThemeBorderLowColor}"></SolidColorBrush>
         <SolidColorBrush x:Key="ThemeBorderMidBrush" Color="{DynamicResource ThemeBorderMidColor}"></SolidColorBrush>
-        <SolidColorBrush x:Key="ThemeBorderDarkBrush" Color="{DynamicResource ThemeBorderDarkColor}"></SolidColorBrush>
-        <SolidColorBrush x:Key="ThemeControlLightBrush" Color="{DynamicResource ThemeControlLightColor}"></SolidColorBrush>
+        <SolidColorBrush x:Key="ThemeBorderHighBrush" Color="{DynamicResource ThemeBorderHighColor}"></SolidColorBrush>
+        <SolidColorBrush x:Key="ThemeControlLowBrush" Color="{DynamicResource ThemeControlLowColor}"></SolidColorBrush>
         <SolidColorBrush x:Key="ThemeControlMidBrush" Color="{DynamicResource ThemeControlMidColor}"></SolidColorBrush>
-        <SolidColorBrush x:Key="ThemeControlDarkBrush" Color="{DynamicResource ThemeControlDarkColor}"></SolidColorBrush>
-        <SolidColorBrush x:Key="ThemeControlHighlightLightBrush" Color="{DynamicResource ThemeControlHighlightLightColor}"></SolidColorBrush>
+        <SolidColorBrush x:Key="ThemeControlHighBrush" Color="{DynamicResource ThemeControlHighColor}"></SolidColorBrush>
+        <SolidColorBrush x:Key="ThemeControlHighlightLowBrush" Color="{DynamicResource ThemeControlHighlightLowColor}"></SolidColorBrush>
         <SolidColorBrush x:Key="ThemeControlHighlightMidBrush" Color="{DynamicResource ThemeControlHighlightMidColor}"></SolidColorBrush>
-        <SolidColorBrush x:Key="ThemeControlHighlightDarkBrush" Color="{DynamicResource ThemeControlHighlightDarkColor}"></SolidColorBrush>
+        <SolidColorBrush x:Key="ThemeControlHighlightHighBrush" Color="{DynamicResource ThemeControlHighlightHighColor}"></SolidColorBrush>
         <SolidColorBrush x:Key="ThemeForegroundBrush" Color="{DynamicResource ThemeForegroundColor}"></SolidColorBrush>
-        <SolidColorBrush x:Key="ThemeForegroundLightBrush" Color="{DynamicResource ThemeForegroundLightColor}"></SolidColorBrush>
+        <SolidColorBrush x:Key="ThemeForegroundLowBrush" Color="{DynamicResource ThemeForegroundLowColor}"></SolidColorBrush>
 
         <SolidColorBrush x:Key="HighlightBrush" Color="{DynamicResource HighlightColor}"></SolidColorBrush>
         <SolidColorBrush x:Key="ThemeAccentBrush" Color="{DynamicResource ThemeAccentColor}"></SolidColorBrush>
@@ -44,7 +44,7 @@
         <SolidColorBrush x:Key="ThemeAccentBrush3" Color="{DynamicResource ThemeAccentColor3}"></SolidColorBrush>
         <SolidColorBrush x:Key="ThemeAccentBrush4" Color="{DynamicResource ThemeAccentColor4}"></SolidColorBrush>
         <SolidColorBrush x:Key="ErrorBrush" Color="{DynamicResource ErrorColor}"></SolidColorBrush>
-        <SolidColorBrush x:Key="ErrorLightBrush" Color="{DynamicResource ErrorLightColor}"></SolidColorBrush>
+        <SolidColorBrush x:Key="ErrorLowBrush" Color="{DynamicResource ErrorLowColor}"></SolidColorBrush>
 
         <Thickness x:Key="ThemeBorderThickness">2</Thickness>
         <sys:Double x:Key="ThemeDisabledOpacity">0.5</sys:Double>

--- a/src/Avalonia.Themes.Default/Button.xaml
+++ b/src/Avalonia.Themes.Default/Button.xaml
@@ -1,7 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui">
   <Style Selector="Button">
     <Setter Property="Background" Value="{DynamicResource ThemeControlMidBrush}"/>
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLightBrush}"/>
+    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLowBrush}"/>
     <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
     <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
     <Setter Property="HorizontalContentAlignment" Value="Center"/>
@@ -26,7 +26,7 @@
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}"/>
   </Style>
   <Style Selector="Button:pressed  /template/ ContentPresenter">
-    <Setter Property="Background" Value="{DynamicResource ThemeControlDarkBrush}"/>
+    <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}"/>
   </Style>
   <Style Selector="Button:disabled">
     <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>

--- a/src/Avalonia.Themes.Default/ButtonSpinner.xaml
+++ b/src/Avalonia.Themes.Default/ButtonSpinner.xaml
@@ -1,6 +1,6 @@
 <Styles xmlns="https://github.com/avaloniaui">
   <Style Selector="ButtonSpinner">
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLightBrush}"/>
+    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLowBrush}"/>
     <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
     <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
     <Setter Property="VerticalContentAlignment" Value="Center"/>

--- a/src/Avalonia.Themes.Default/Calendar.xaml
+++ b/src/Avalonia.Themes.Default/Calendar.xaml
@@ -9,7 +9,7 @@
   <Style Selector="Calendar">
     <!--<Setter Property="Focusable" Value="False" />-->
     <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}" />
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderDarkBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}" />
     <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
     <Setter Property="HeaderBackground" Value="{DynamicResource ThemeAccentBrush2}" />
     <Setter Property="Template">

--- a/src/Avalonia.Themes.Default/CalendarButton.xaml
+++ b/src/Avalonia.Themes.Default/CalendarButton.xaml
@@ -7,7 +7,7 @@
 
 <Styles xmlns="https://github.com/avaloniaui">
   <Style Selector="CalendarButton">
-    <Setter Property="Foreground" Value="{DynamicResource ThemeBorderDarkBrush}" />
+    <Setter Property="Foreground" Value="{DynamicResource ThemeBorderHighBrush}" />
     <Setter Property="Background" Value="{DynamicResource ThemeAccentBrush2}" />
     <Setter Property="FontSize" Value="{DynamicResource FontSizeSmall}" />
     <Setter Property="HorizontalContentAlignment" Value="Center" />
@@ -68,7 +68,7 @@
     <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
   </Style>
   <Style Selector="CalendarButton:inactive /template/ ContentControl#Content">
-    <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundLightBrush}"/>
+    <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundLowBrush}"/>
   </Style>
 
 

--- a/src/Avalonia.Themes.Default/CalendarDayButton.xaml
+++ b/src/Avalonia.Themes.Default/CalendarDayButton.xaml
@@ -100,10 +100,10 @@
 
 
   <Style Selector="CalendarDayButton:inactive /template/ ContentControl#Content">
-    <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundLightBrush}"/>
+    <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundLowBrush}"/>
   </Style>
   <Style Selector="CalendarDayButton:today /template/ ContentControl#Content">
-    <Setter Property="Foreground" Value="{DynamicResource ThemeControlLightBrush}"/>
+    <Setter Property="Foreground" Value="{DynamicResource ThemeControlLowBrush}"/>
   </Style>
 
   <Style Selector="CalendarDayButton /template/ Path#BlackoutVisual">

--- a/src/Avalonia.Themes.Default/CalendarItem.xaml
+++ b/src/Avalonia.Themes.Default/CalendarItem.xaml
@@ -153,7 +153,7 @@
 
           <Rectangle Name="DisabledVisual"
                      Stretch="Fill"
-                     Fill="{DynamicResource ThemeControlLightBrush}"
+                     Fill="{DynamicResource ThemeControlLowBrush}"
                      Opacity="{DynamicResource ThemeDisabledOpacity}"
                      Margin="0,2,0,2" />
 

--- a/src/Avalonia.Themes.Default/CheckBox.xaml
+++ b/src/Avalonia.Themes.Default/CheckBox.xaml
@@ -50,7 +50,7 @@
     <Setter Property="IsVisible" Value="False"/>
   </Style>
   <Style Selector="CheckBox:pointerover /template/ Border#border">
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderDarkBrush}"/>
+    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}"/>
   </Style>
   <Style Selector="CheckBox /template/ Path#checkMark">
     <Setter Property="IsVisible" Value="False"/>

--- a/src/Avalonia.Themes.Default/DataValidationErrors.xaml
+++ b/src/Avalonia.Themes.Default/DataValidationErrors.xaml
@@ -24,7 +24,7 @@
               Background="Transparent">
         <Canvas.Styles>
           <Style Selector="ToolTip">
-            <Setter Property="Background" Value="{DynamicResource ErrorLightBrush}"/>
+            <Setter Property="Background" Value="{DynamicResource ErrorLowBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}"/>
           </Style>
         </Canvas.Styles>

--- a/src/Avalonia.Themes.Default/DatePicker.xaml
+++ b/src/Avalonia.Themes.Default/DatePicker.xaml
@@ -29,7 +29,7 @@
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
                         Margin="0"
-                        Background="{DynamicResource ThemeControlLightBrush}"
+                        Background="{DynamicResource ThemeControlLowBrush}"
                         ColumnDefinitions="*,*,*,*"
                         RowDefinitions="23*,19*,19*,19*"
                         ClipToBounds="False">
@@ -47,12 +47,12 @@
                             Grid.Row="1"
                             Grid.RowSpan="3"
                             BorderThickness="1"
-                            BorderBrush="{DynamicResource ThemeBorderDarkBrush}"
+                            BorderBrush="{DynamicResource ThemeBorderHighBrush}"
                             CornerRadius=".5" />
                     <Rectangle Grid.ColumnSpan="4"
                                Grid.RowSpan="1"
                                StrokeThickness="1"
-                               Stroke="{DynamicResource ThemeBorderDarkBrush}"
+                               Stroke="{DynamicResource ThemeBorderHighBrush}"
                                Fill="{DynamicResource ThemeAccentBrush}">
                     </Rectangle>
                     <TextBlock Margin="0,-1,0,0"
@@ -63,13 +63,13 @@
                                Grid.ColumnSpan="4"
                                Grid.RowSpan="3"
                                FontSize="{DynamicResource FontSizeSmall}"
-                               Foreground="{DynamicResource ThemeBorderDarkBrush}">
+                               Foreground="{DynamicResource ThemeBorderHighBrush}">
                                <TextBlock.Text>
                                  <Binding Source="{x:Static sys:DateTime.Today}" Path="Day"/>
                                </TextBlock.Text>
                     </TextBlock>
 
-                    <Ellipse HorizontalAlignment="Center" VerticalAlignment="Center" Fill="{DynamicResource ThemeControlLightBrush}" StrokeThickness="0" Grid.ColumnSpan="4" Width="3" Height="3"/>
+                    <Ellipse HorizontalAlignment="Center" VerticalAlignment="Center" Fill="{DynamicResource ThemeControlLowBrush}" StrokeThickness="0" Grid.ColumnSpan="4" Width="3" Height="3"/>
                   </Grid>
                 </ControlTemplate>
               </Setter>
@@ -123,7 +123,7 @@
   </Style>
 
   <Style Selector="DatePicker:focus /template/ TextBox#PART_TextBox">
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderDarkBrush}"/>
+    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}"/>
   </Style>
   
 </Styles>

--- a/src/Avalonia.Themes.Default/DropDown.xaml
+++ b/src/Avalonia.Themes.Default/DropDown.xaml
@@ -52,6 +52,6 @@
     </Setter>
   </Style>
   <Style Selector="DropDown:pointerover /template/ Border#border">
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderDarkBrush}"/>
+    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}"/>
   </Style>
 </Styles>

--- a/src/Avalonia.Themes.Default/Expander.xaml
+++ b/src/Avalonia.Themes.Default/Expander.xaml
@@ -108,7 +108,7 @@
     </Setter>
   </Style>
   <Style Selector="Expander /template/ ToggleButton#PART_toggle:pointerover /template/ Border">
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLightBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLowBrush}" />
   </Style>
   <Style Selector="Expander:down:expanded /template/ ToggleButton#PART_toggle /template/ Path">
     <Setter Property="RenderTransform">

--- a/src/Avalonia.Themes.Default/GridSplitter.xaml
+++ b/src/Avalonia.Themes.Default/GridSplitter.xaml
@@ -1,7 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui">
   <Style Selector="GridSplitter:vertical">
     <Setter Property="Width" Value="6"/>
-    <Setter Property="Background" Value="{DynamicResource ThemeControlLightBrush}"/>
+    <Setter Property="Background" Value="{DynamicResource ThemeControlLowBrush}"/>
     <Setter Property="Template">
       <ControlTemplate>
         <Border Background="{TemplateBinding Background}">
@@ -25,7 +25,7 @@
   </Style>
   <Style Selector="GridSplitter:horizontal">
     <Setter Property="Height" Value="6"/>
-    <Setter Property="Background" Value="{DynamicResource ThemeControlLightBrush}"/>
+    <Setter Property="Background" Value="{DynamicResource ThemeControlLowBrush}"/>
     <Setter Property="Template">
       <ControlTemplate>
         <Border Background="{TemplateBinding Background}">

--- a/src/Avalonia.Themes.Default/NumericUpDown.xaml
+++ b/src/Avalonia.Themes.Default/NumericUpDown.xaml
@@ -1,6 +1,6 @@
 <Styles xmlns="https://github.com/avaloniaui">
   <Style Selector="NumericUpDown">
-    <Setter Property="TemplatedControl.BorderBrush" Value="{DynamicResource ThemeBorderLightBrush}"/>
+    <Setter Property="TemplatedControl.BorderBrush" Value="{DynamicResource ThemeBorderLowBrush}"/>
     <Setter Property="TemplatedControl.BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
     <Setter Property="TemplatedControl.Background" Value="{DynamicResource ThemeBackgroundBrush}" />
     <Setter Property="TemplatedControl.Foreground" Value="{DynamicResource ThemeForegroundBrush}" />

--- a/src/Avalonia.Themes.Default/RadioButton.xaml
+++ b/src/Avalonia.Themes.Default/RadioButton.xaml
@@ -39,7 +39,7 @@
     </Setter>
   </Style>
   <Style Selector="RadioButton:pointerover /template/ Ellipse#border">
-    <Setter Property="Stroke" Value="{DynamicResource ThemeBorderDarkBrush}"/>
+    <Setter Property="Stroke" Value="{DynamicResource ThemeBorderHighBrush}"/>
   </Style>
   <Style Selector="RadioButton /template/ Ellipse#checkMark">
     <Setter Property="IsVisible" Value="False"/>

--- a/src/Avalonia.Themes.Default/RepeatButton.xaml
+++ b/src/Avalonia.Themes.Default/RepeatButton.xaml
@@ -3,7 +3,7 @@
         <Setter Property="Background"
                 Value="{DynamicResource ThemeControlMidBrush}" />
         <Setter Property="BorderBrush"
-                Value="{DynamicResource ThemeBorderLightBrush}" />
+                Value="{DynamicResource ThemeBorderLowBrush}" />
         <Setter Property="BorderThickness"
                 Value="{DynamicResource ThemeBorderThickness}" />
         <Setter Property="Foreground"
@@ -35,7 +35,7 @@
     </Style>
     <Style Selector="RepeatButton:pressed  /template/ ContentPresenter">
         <Setter Property="Background"
-                Value="{DynamicResource ThemeControlDarkBrush}" />
+                Value="{DynamicResource ThemeControlHighBrush}" />
     </Style>
     <Style Selector="RepeatButton:disabled">
         <Setter Property="Opacity"

--- a/src/Avalonia.Themes.Default/ScrollBar.xaml
+++ b/src/Avalonia.Themes.Default/ScrollBar.xaml
@@ -10,7 +10,7 @@
                                       Grid.Column="0">
                             <Path Data="M 0,4 C0,4 0,6 0,6 0,6 3.5,2.5 3.5,2.5 3.5,2.5 7,6 7,6 7,6 7,4 7,4 7,4 3.5,0.5 3.5,0.5 3.5,0.5 0,4 0,4 z"
                                   Stretch="Uniform"
-                                  Fill="{DynamicResource ThemeForegroundLightBrush}" />
+                                  Fill="{DynamicResource ThemeForegroundLowBrush}" />
                         </RepeatButton>
                         <Track Grid.Row="1"
                                Grid.Column="1"
@@ -30,7 +30,7 @@
                             <Thumb Name="thumb">
                                 <Thumb.Template>
                                     <ControlTemplate>
-                                        <Border Background="{DynamicResource ThemeControlDarkBrush}" />
+                                        <Border Background="{DynamicResource ThemeControlHighBrush}" />
                                     </ControlTemplate>
                                 </Thumb.Template>
                             </Thumb>
@@ -41,7 +41,7 @@
                                       Grid.Column="2">
                             <Path Data="M 0,2.5 C0,2.5 0,0.5 0,0.5 0,0.5 3.5,4 3.5,4 3.5,4 7,0.5 7,0.5 7,0.5 7,2.5 7,2.5 7,2.5 3.5,6 3.5,6 3.5,6 0,2.5 0,2.5 z"
                                   Stretch="Uniform"
-                                  Fill="{DynamicResource ThemeForegroundLightBrush}" />
+                                  Fill="{DynamicResource ThemeForegroundLowBrush}" />
                         </RepeatButton>
                     </Grid>
                 </Border>
@@ -61,7 +61,7 @@
                                       Grid.Column="0">
                             <Path Data="M 3.18,7 C3.18,7 5,7 5,7 5,7 1.81,3.5 1.81,3.5 1.81,3.5 5,0 5,0 5,0 3.18,0 3.18,0 3.18,0 0,3.5 0,3.5 0,3.5 3.18,7 3.18,7 z"
                                   Stretch="Uniform"
-                                  Fill="{DynamicResource ThemeForegroundLightBrush}" />
+                                  Fill="{DynamicResource ThemeForegroundLowBrush}" />
                         </RepeatButton>
                         <Track Grid.Row="1"
                                Grid.Column="1"
@@ -81,7 +81,7 @@
                             <Thumb Name="thumb">
                                 <Thumb.Template>
                                     <ControlTemplate>
-                                        <Border Background="{DynamicResource ThemeControlDarkBrush}" />
+                                        <Border Background="{DynamicResource ThemeControlHighBrush}" />
                                     </ControlTemplate>
                                 </Thumb.Template>
                             </Thumb>
@@ -92,7 +92,7 @@
                                       Grid.Column="2">
                             <Path Data="M 1.81,7 C1.81,7 0,7 0,7 0,7 3.18,3.5 3.18,3.5 3.18,3.5 0,0 0,0 0,0 1.81,0 1.81,0 1.81,0 5,3.5 5,3.5 5,3.5 1.81,7 1.81,7 z"
                                   Stretch="Uniform"
-                                  Fill="{DynamicResource ThemeForegroundLightBrush}" />
+                                  Fill="{DynamicResource ThemeForegroundLowBrush}" />
                         </RepeatButton>
                     </Grid>
                 </Border>

--- a/src/Avalonia.Themes.Default/Slider.xaml
+++ b/src/Avalonia.Themes.Default/Slider.xaml
@@ -76,11 +76,11 @@
   </Style>
   <Style Selector="Slider /template/ Border#TrackBackground">
     <Setter Property="BorderThickness" Value="2"/>
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLightBrush}"/>
+    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLowBrush}"/>
   </Style>
   <Style Selector="Slider /template/ RepeatButton.repeattrack">
     <Setter Property="Background" Value="Transparent"/>
-    <Setter Property="Foreground" Value="{DynamicResource ThemeBorderLightBrush}"/>
+    <Setter Property="Foreground" Value="{DynamicResource ThemeBorderLowBrush}"/>
     <Setter Property="Template">
         <ControlTemplate>
             <Border Background="{TemplateBinding Background}" />

--- a/src/Avalonia.Themes.Default/TabStripItem.xaml
+++ b/src/Avalonia.Themes.Default/TabStripItem.xaml
@@ -2,7 +2,7 @@
   <Style Selector="TabStripItem">
     <Setter Property="Background" Value="Transparent"/>
     <Setter Property="FontSize" Value="{DynamicResource FontSizeLarge}"/>
-    <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundLightBrush}"/>
+    <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundLowBrush}"/>
     <Setter Property="Template">
       <ControlTemplate>
         <ContentPresenter Name="PART_ContentPresenter"

--- a/src/Avalonia.Themes.Default/TextBox.xaml
+++ b/src/Avalonia.Themes.Default/TextBox.xaml
@@ -54,10 +54,10 @@
     </Setter>
   </Style>
   <Style Selector="TextBox:pointerover /template/ Border#border">
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderDarkBrush}"/>
+    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}"/>
   </Style>
   <Style Selector="TextBox:focus /template/ Border#border">
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderDarkBrush}"/>
+    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}"/>
   </Style>
   <Style Selector="TextBox:error /template/ Border#border">
     <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}"/>

--- a/src/Avalonia.Themes.Default/ToggleButton.xaml
+++ b/src/Avalonia.Themes.Default/ToggleButton.xaml
@@ -1,7 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui">
   <Style Selector="ToggleButton">
     <Setter Property="Background" Value="{DynamicResource ThemeControlMidBrush}"/>
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLightBrush}"/>
+    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLowBrush}"/>
     <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
     <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
     <Setter Property="Padding" Value="4"/>
@@ -23,14 +23,14 @@
     </Setter>
   </Style>
   <Style Selector="ToggleButton:checked /template/ ContentPresenter">
-    <Setter Property="Background" Value="{DynamicResource ThemeControlDarkBrush}"/>
+    <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}"/>
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}"/>
   </Style>
   <Style Selector="ToggleButton:pointerover /template/ ContentPresenter">
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}"/>
   </Style>
   <Style Selector="ToggleButton:pressed  /template/ ContentPresenter">
-    <Setter Property="Background" Value="{DynamicResource ThemeControlDarkBrush}"/>
+    <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}"/>
   </Style>
   <Style Selector="ToggleButton:disabled">
     <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>


### PR DESCRIPTION
Consider that you want to implement a DarkTheme

currently we have a light theme with resources named Light and Dark

This means in your dark theme, you would end up assigning colors like Black to a variable named Light and a color like White to a variable named Dark.

UWP take the approach of naming colors Low, Mid, High, etc.

This makes the same change.