### PR TITLE
Skia : Fixes NullReferenceException for DefaultTypeface and adds .otf support

### DIFF
--- a/samples/ControlCatalog/ControlCatalog.csproj
+++ b/samples/ControlCatalog/ControlCatalog.csproj
@@ -11,13 +11,13 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Assets\*" />
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="Assets\Fonts\SourceSansPro-Bold.ttf" />
     <EmbeddedResource Include="Assets\Fonts\SourceSansPro-BoldItalic.ttf" />
     <EmbeddedResource Include="Assets\Fonts\SourceSansPro-Italic.ttf" />
     <EmbeddedResource Include="Assets\Fonts\SourceSansPro-Regular.ttf" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Markup\Avalonia.Markup.Xaml\Avalonia.Markup.Xaml.csproj" />
     <ProjectReference Include="..\..\src\Markup\Avalonia.Markup\Avalonia.Markup.csproj" />

--- a/samples/ControlCatalog/ControlCatalog.csproj
+++ b/samples/ControlCatalog/ControlCatalog.csproj
@@ -12,6 +12,44 @@
     <EmbeddedResource Include="Assets\*" />
   </ItemGroup>
   <ItemGroup>
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-Black.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-BlackItalic.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-Bold.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-BoldItalic.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-ExtraBold.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-ExtraBoldItalic.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-ExtraLight.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-ExtraLightItalic.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-Italic.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-Light.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-LightItalic.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-Medium.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-MediumItalic.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-Regular.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-SemiBold.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-SemiBoldItalic.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-Thin.otf" />
+    <None Remove="Assets\Fonts\Montserrat\Montserrat-ThinItalic.otf" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-Black.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-BlackItalic.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-Bold.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-BoldItalic.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-ExtraBold.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-ExtraBoldItalic.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-ExtraLight.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-ExtraLightItalic.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-Italic.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-Light.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-LightItalic.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-Medium.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-MediumItalic.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-Regular.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-SemiBold.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-SemiBoldItalic.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-Thin.otf" />
+    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-ThinItalic.otf" />
     <EmbeddedResource Include="Assets\Fonts\SourceSansPro-Bold.ttf" />
     <EmbeddedResource Include="Assets\Fonts\SourceSansPro-BoldItalic.ttf" />
     <EmbeddedResource Include="Assets\Fonts\SourceSansPro-Italic.ttf" />

--- a/samples/ControlCatalog/ControlCatalog.csproj
+++ b/samples/ControlCatalog/ControlCatalog.csproj
@@ -18,7 +18,6 @@
     <EmbeddedResource Include="Assets\Fonts\SourceSansPro-Italic.ttf" />
     <EmbeddedResource Include="Assets\Fonts\SourceSansPro-Regular.ttf" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Markup\Avalonia.Markup.Xaml\Avalonia.Markup.Xaml.csproj" />
     <ProjectReference Include="..\..\src\Markup\Avalonia.Markup\Avalonia.Markup.csproj" />

--- a/samples/ControlCatalog/ControlCatalog.csproj
+++ b/samples/ControlCatalog/ControlCatalog.csproj
@@ -11,45 +11,8 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Assets\*" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-Black.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-BlackItalic.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-Bold.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-BoldItalic.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-ExtraBold.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-ExtraBoldItalic.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-ExtraLight.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-ExtraLightItalic.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-Italic.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-Light.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-LightItalic.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-Medium.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-MediumItalic.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-Regular.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-SemiBold.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-SemiBoldItalic.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-Thin.otf" />
-    <None Remove="Assets\Fonts\Montserrat\Montserrat-ThinItalic.otf" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-Black.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-BlackItalic.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-Bold.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-BoldItalic.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-ExtraBold.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-ExtraBoldItalic.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-ExtraLight.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-ExtraLightItalic.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-Italic.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-Light.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-LightItalic.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-Medium.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-MediumItalic.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-Regular.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-SemiBold.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-SemiBoldItalic.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-Thin.otf" />
-    <EmbeddedResource Include="Assets\Fonts\Montserrat\Montserrat-ThinItalic.otf" />
     <EmbeddedResource Include="Assets\Fonts\SourceSansPro-Bold.ttf" />
     <EmbeddedResource Include="Assets\Fonts\SourceSansPro-BoldItalic.ttf" />
     <EmbeddedResource Include="Assets\Fonts\SourceSansPro-Italic.ttf" />

--- a/src/Avalonia.Visuals/Media/Fonts/FamilyNameCollection.cs
+++ b/src/Avalonia.Visuals/Media/Fonts/FamilyNameCollection.cs
@@ -24,7 +24,10 @@ namespace Avalonia.Media.Fonts
 
             var names = new List<string>(familyNames);
 
-            if (names.Count == 0) throw new ArgumentException($"{nameof(familyNames)} must not be empty.");
+            if (names.Count == 0)
+            {
+                throw new ArgumentException($"{nameof(familyNames)} must not be empty.");
+            }
 
             Names = new ReadOnlyCollection<string>(names);
 
@@ -95,7 +98,10 @@ namespace Avalonia.Media.Fonts
             {
                 builder.Append(Names[index]);
 
-                if (index == Names.Count - 1) break;
+                if (index == Names.Count - 1)
+                {
+                    break;
+                }
 
                 builder.Append(", ");
             }
@@ -123,7 +129,10 @@ namespace Avalonia.Media.Fonts
         /// </returns>
         public override bool Equals(object obj)
         {
-            if (!(obj is FamilyNameCollection other)) return false;
+            if (!(obj is FamilyNameCollection other))
+            {
+                return false;
+            }
 
             return other.ToString().Equals(ToString());
         }

--- a/src/Avalonia.Visuals/Media/Fonts/FontFamilyKey.cs
+++ b/src/Avalonia.Visuals/Media/Fonts/FontFamilyKey.cs
@@ -17,7 +17,10 @@ namespace Avalonia.Media.Fonts
         /// <param name="source"></param>
         public FontFamilyKey(Uri source)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
 
             if (source.AbsolutePath.Contains(".ttf"))
             {
@@ -28,7 +31,17 @@ namespace Avalonia.Media.Fonts
             }
             else
             {
-                Location = source;
+                if (source.AbsolutePath.Contains(".otf"))
+                {
+                    var filePathWithoutExtension = source.AbsolutePath.Replace(".otf", string.Empty);
+                    var fileNameWithoutExtension = filePathWithoutExtension.Split('.').Last();
+                    FileName = fileNameWithoutExtension + ".otf";
+                    Location = new Uri(source.OriginalString.Replace("." + FileName, string.Empty), UriKind.RelativeOrAbsolute);
+                }
+                else
+                {
+                    Location = source;
+                }
             }
         }
 
@@ -77,11 +90,20 @@ namespace Avalonia.Media.Fonts
         /// </returns>
         public override bool Equals(object obj)
         {
-            if (!(obj is FontFamilyKey other)) return false;
+            if (!(obj is FontFamilyKey other))
+            {
+                return false;
+            }
 
-            if (Location != other.Location) return false;
+            if (Location != other.Location)
+            {
+                return false;
+            }
 
-            if (FileName != other.FileName) return false;
+            if (FileName != other.FileName)
+            {
+                return false;
+            }
 
             return true;
         }
@@ -94,7 +116,10 @@ namespace Avalonia.Media.Fonts
         /// </returns>
         public override string ToString()
         {
-            if (FileName == null) return Location.PathAndQuery;
+            if (FileName == null)
+            {
+                return Location.PathAndQuery;
+            }
 
             var builder = new UriBuilder(Location);
 

--- a/src/Avalonia.Visuals/Media/Fonts/FontFamilyLoader.cs
+++ b/src/Avalonia.Visuals/Media/Fonts/FontFamilyLoader.cs
@@ -34,7 +34,7 @@ namespace Avalonia.Media.Fonts
         {
             var availableAssets = s_assetLoader.GetAssets(location);
 
-            var matchingAssets = availableAssets.Where(x => x.absolutePath.EndsWith(".ttf"));
+            var matchingAssets = availableAssets.Where(x => x.absolutePath.EndsWith(".ttf") || x.absolutePath.EndsWith(".otf"));
 
             return matchingAssets.Select(x => GetAssetUri(x.absolutePath, x.assembly));
         }
@@ -52,8 +52,9 @@ namespace Avalonia.Media.Fonts
 
             var compareTo = location.AbsolutePath + "." + fileName.Split('*').First();
 
-            var matchingResources =
-                availableResources.Where(x => x.absolutePath.Contains(compareTo) && x.absolutePath.EndsWith(".ttf"));
+            var matchingResources = availableResources.Where(
+                x => x.absolutePath.Contains(compareTo)
+                     && (x.absolutePath.EndsWith(".ttf") || x.absolutePath.EndsWith(".otf")));
 
             return matchingResources.Select(x => GetAssetUri(x.absolutePath, x.assembly));
         }

--- a/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
+++ b/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
@@ -28,7 +28,7 @@ namespace Avalonia.Skia
             // Replace 0 characters with zero-width spaces (200B)
             Text = Text.Replace((char)0, (char)0x200B);
 
-            SKTypeface skiaTypeface = TypefaceCache.Default;
+            SKTypeface skiaTypeface = TypefaceCache.DefaultTypeface;
 
             if (typeface.FontFamily.Key != null)
             {
@@ -45,7 +45,7 @@ namespace Avalonia.Skia
                             familyName,
                             typeface.Style,
                             typeface.Weight);
-                        if (skiaTypeface != TypefaceCache.Default) break;
+                        if (skiaTypeface != TypefaceCache.DefaultTypeface) break;
                     }
                 }
                 else

--- a/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
+++ b/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
@@ -45,7 +45,10 @@ namespace Avalonia.Skia
                             familyName,
                             typeface.Style,
                             typeface.Weight);
-                        if (skiaTypeface != TypefaceCache.DefaultTypeface) break;
+                        if (skiaTypeface != TypefaceCache.DefaultTypeface)
+                        {
+                            break;
+                        }
                     }
                 }
                 else

--- a/src/Skia/Avalonia.Skia/SKTypefaceCollection.cs
+++ b/src/Skia/Avalonia.Skia/SKTypefaceCollection.cs
@@ -33,7 +33,7 @@ namespace Avalonia.Skia
 
             var key = new FontKey(typeface.FontFamily.Name, (SKFontStyleWeight)typeface.Weight, skStyle);
 
-            return _cachedTypefaces.TryGetValue(key, out var skTypeface) ? skTypeface : TypefaceCache.Default;
+            return _cachedTypefaces.TryGetValue(key, out var skTypeface) ? skTypeface : TypefaceCache.DefaultTypeface;
         }
 
         private struct FontKey

--- a/src/Skia/Avalonia.Skia/TypefaceCache.cs
+++ b/src/Skia/Avalonia.Skia/TypefaceCache.cs
@@ -12,8 +12,15 @@ namespace Avalonia.Skia
     /// </summary>
     internal static class TypefaceCache
     {
-        public static SKTypeface Default = SKTypeface.FromFamilyName(FontFamily.Default.Name);
+        public static SKTypeface DefaultTypeface = CreateDefaultTypeface();
         static readonly Dictionary<string, Dictionary<FontKey, SKTypeface>> Cache = new Dictionary<string, Dictionary<FontKey, SKTypeface>>();
+
+        private static SKTypeface CreateDefaultTypeface()
+        {
+            var defaultTypeface = SKTypeface.FromFamilyName(FontFamily.Default.Name);
+
+            return defaultTypeface ?? SKTypeface.FromFamilyName(null);
+        }
 
         struct FontKey
         {
@@ -62,9 +69,9 @@ namespace Avalonia.Skia
             {
                 typeface = SKTypeface.FromFamilyName(familyKey, key.Weight, SKFontStyleWidth.Normal, key.Slant);
 
-                if (typeface.FamilyName != name)
+                if (typeface?.FamilyName != name)
                 {
-                    typeface = Default;
+                    typeface = DefaultTypeface;
                 }
 
                 entry[key] = typeface;
@@ -90,6 +97,5 @@ namespace Avalonia.Skia
 
             return GetTypeface(name, new FontKey((SKFontStyleWeight)weight, skStyle));
         }
-
     }
 }


### PR DESCRIPTION
- What does the pull request do?
It fixes an issue that causes crashes on some systems when our defined default typeface can't be resolved.  Now it should use the system's default in that case. It also adds .otf support.
- What is the current behavior?
The application crashes when the default can't be found.
- What is the updated/expected behavior with this PR?
The application should be able to resolve at least the system's default font.
- How was the solution implemented (if it's not obvious)?
