### PR TITLE
gpu rendering is the defaults on avalonia native

### DIFF
--- a/src/Avalonia.Native/AvaloniaNativePlatform.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatform.cs
@@ -120,7 +120,7 @@ namespace Avalonia.Native
     {
         public AvaloniaNativeMacOptions MacOptions { get; set; }
         public bool UseDeferredRendering { get; set; } = true;
-        public bool UseGpu { get; set; } = false;
+        public bool UseGpu { get; set; } = true;
         internal AvaloniaNativeOptions(IAvaloniaNativeFactory factory)
         {
             var mac = factory.GetMacOptions();

--- a/src/Gtk/Avalonia.Gtk3/Gtk3Platform.cs
+++ b/src/Gtk/Avalonia.Gtk3/Gtk3Platform.cs
@@ -148,8 +148,8 @@ namespace Avalonia.Gtk3
 
     public class Gtk3PlatformOptions
     {
-        public bool? UseDeferredRendering { get; set; } = true;
-        public bool? UseGpuAcceleration { get; set; };
+        public bool? UseDeferredRendering { get; set; }
+        public bool? UseGpuAcceleration { get; set; }
         public ICustomGtk3NativeLibraryResolver CustomResolver { get; set; }
     }
 }

--- a/src/Gtk/Avalonia.Gtk3/Gtk3Platform.cs
+++ b/src/Gtk/Avalonia.Gtk3/Gtk3Platform.cs
@@ -149,7 +149,7 @@ namespace Avalonia.Gtk3
     public class Gtk3PlatformOptions
     {
         public bool? UseDeferredRendering { get; set; } = true;
-        public bool? UseGpuAcceleration { get; set; } = true;
+        public bool? UseGpuAcceleration { get; set; };
         public ICustomGtk3NativeLibraryResolver CustomResolver { get; set; }
     }
 }

--- a/src/Gtk/Avalonia.Gtk3/Gtk3Platform.cs
+++ b/src/Gtk/Avalonia.Gtk3/Gtk3Platform.cs
@@ -148,8 +148,8 @@ namespace Avalonia.Gtk3
 
     public class Gtk3PlatformOptions
     {
-        public bool? UseDeferredRendering { get; set; }
-        public bool? UseGpuAcceleration { get; set; }
+        public bool? UseDeferredRendering { get; set; } = true;
+        public bool? UseGpuAcceleration { get; set; } = true;
         public ICustomGtk3NativeLibraryResolver CustomResolver { get; set; }
     }
 }


### PR DESCRIPTION
- What does the pull request do?
enables gpu rendering by default on osx and deffered renderer on all.
- What is the current behavior?
windows = gpu, Linux = sw, mac = sw

- What is the updated/expected behavior with this PR?

Windows, Mac,= GPU and if not available falls back to software  (on Linux / mac)
Linux = SW + Deffered.


Not enabled on linux due to reports of issues with nvidia cards.

Mac isnt usable without gpu
