### PR TITLE
allow animation of structs without typeConverter

### DIFF
--- a/src/Avalonia.Animation/AnimatorKeyFrame.cs
+++ b/src/Avalonia.Animation/AnimatorKeyFrame.cs
@@ -61,6 +61,10 @@ namespace Avalonia.Animation
             {
                 throw new ArgumentNullException($"KeyFrame value can't be null.");
             }
+            if(Value is T typedValue )
+            {
+                return typedValue;
+            }
             if (!typeConv.CanConvertTo(Value.GetType()))
             {
                 throw new InvalidCastException($"KeyFrame value doesnt match property type.");

--- a/src/Avalonia.Animation/AnimatorKeyFrame.cs
+++ b/src/Avalonia.Animation/AnimatorKeyFrame.cs
@@ -61,7 +61,7 @@ namespace Avalonia.Animation
             {
                 throw new ArgumentNullException($"KeyFrame value can't be null.");
             }
-            if(Value is T typedValue )
+            if(Value is T typedValue)
             {
                 return typedValue;
             }


### PR DESCRIPTION

- What does the pull request do?
Allows animation of properties like Thickness 
- What is the current behavior?
An exception is thrown here https://github.com/AvaloniaUI/Avalonia/blob/e467178642c2e81121b0d326f60af547e3e92b23/src/Avalonia.Animation/AnimatorKeyFrame.cs#L66

- What is the updated/expected behavior with this PR?
The animation works
- How was the solution implemented (if it's not obvious)?

Checklist:

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

an example of a ThicknessAnimator
```
public class ThicknessAnimator : Animator<Thickness>
    {
        /// <inheritdocs/>
        protected override Thickness DoInterpolation(double t, Thickness neutralValue)
        {
            var pair = GetKFPairAndIntraKFTime(t);
            Thickness y0, y1;

            var firstKF = pair.KFPair.FirstKeyFrame;
            var secondKF = pair.KFPair.SecondKeyFrame;

            if (firstKF.isNeutral)
                y0 = neutralValue;
            else
                y0 = firstKF.TargetValue;

            if (secondKF.isNeutral)
                y1 = neutralValue;
            else
                y1 = secondKF.TargetValue;

            // Do linear parametric interpolation 
            return new Thickness(y0.Left + (pair.IntraKFTime) * (y1.Left - y0.Left),
                y0.Top + (pair.IntraKFTime) * (y1.Top - y0.Top),
                y0.Right + (pair.IntraKFTime) * (y1.Right - y0.Right),
                y0.Bottom + (pair.IntraKFTime) * (y1.Bottom - y0.Bottom)
                );
        }
    }
```