### PR TITLE
Fix RenderDemo's AnimationsPage crash

### DIFF
--- a/samples/RenderDemo/MainWindow.xaml
+++ b/samples/RenderDemo/MainWindow.xaml
@@ -8,12 +8,13 @@
       <MenuItem Header="Rendering">
         <MenuItem Header="Draw Dirty Rects" Command="{Binding ToggleDrawDirtyRects}">
           <MenuItem.Icon>
-            <CheckBox BorderThickness="0" 
+            <CheckBox BorderThickness="0"
                       IsHitTestVisible="False"
                       IsChecked="{Binding DrawDirtyRects}"/>
           </MenuItem.Icon>
         </MenuItem>
-        <MenuItem Header="Draw FPS" Command="{Binding ToggleDrawFps}">
+        <MenuItem Header="Draw FPS"
+                  Command="{Binding ToggleDrawFps}">
           <MenuItem.Icon>
             <CheckBox BorderThickness="0"
                       IsHitTestVisible="False"
@@ -22,14 +23,19 @@
         </MenuItem>
       </MenuItem>
     </Menu>
-    
     <TabControl Classes="sidebar">
       <TabControl.PageTransition>
         <CrossFade Duration="0.25"/>
       </TabControl.PageTransition>
-      <TabItem Header="Animations"><pages:AnimationsPage/></TabItem>
-      <TabItem Header="Clipping"><pages:ClippingPage/></TabItem>
-      <TabItem Header="Drawing"><pages:DrawingPage/></TabItem>
+      <TabItem Header="Animations">
+        <pages:AnimationsPage/>
+      </TabItem>
+      <TabItem Header="Clipping">
+        <pages:ClippingPage/>
+      </TabItem>
+      <TabItem Header="Drawing">
+        <pages:DrawingPage/>
+      </TabItem>
     </TabControl>
   </DockPanel>
 </Window>

--- a/samples/RenderDemo/Pages/AnimationsPage.xaml
+++ b/samples/RenderDemo/Pages/AnimationsPage.xaml
@@ -1,12 +1,12 @@
-<UserControl 
-  xmlns="https://github.com/avaloniaui" 
-  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<UserControl
+xmlns="https://github.com/avaloniaui"
+xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <UserControl.Styles>
     <Styles>
       <Styles.Resources>
         <Template x:Key="Acorn">
-          <Path Fill="White" Stretch="Uniform" 
-          Data="F1 M 16.6309,18.6563C 17.1309,
+          <Path Fill="White" Stretch="Uniform"
+                Data="F1 M 16.6309,18.6563C 17.1309,
                 8.15625 29.8809,14.1563 29.8809,
                 14.1563C 30.8809,11.1563 34.1308,
                 11.4063 34.1308,11.4063C 33.5,12 
@@ -42,17 +42,17 @@
       </Style>
       <Style Selector="Border.Rect1:pointerover">
         <Style.Animations>
-          <Animation Duration="0:0:2.5" 
-                     RepeatCount="4" 
+          <Animation Duration="0:0:2.5"
+                     RepeatCount="4"
                      FillMode="None"
-                     PlaybackDirection="AlternateReverse" 
+                     PlaybackDirection="AlternateReverse"
                      Easing="SineEaseInOut">
             <KeyFrame Cue="20%">
               <Setter Property="RotateTransform.Angle" Value="45"/>
-             </KeyFrame>
+            </KeyFrame>
             <KeyFrame Cue="50%">
               <Setter Property="ScaleTransform.ScaleX" Value="1.5"/>
-             </KeyFrame>
+            </KeyFrame>
             <KeyFrame Cue="80%">
               <Setter Property="RotateTransform.Angle" Value="120"/>
             </KeyFrame>
@@ -70,7 +70,6 @@
         </Style.Animations>
       </Style>
       <Style Selector="Border.Rect3">
-        <Setter Property="Child" Value="{StaticResource Heart}"/>
         <Style.Animations>
           <Animation Duration="0:0:0.5"
                      Easing="QuadraticEaseInOut"
@@ -79,12 +78,13 @@
               <Setter Property="ScaleTransform.ScaleX" Value="0.8"/>
               <Setter Property="ScaleTransform.ScaleY" Value="0.8"/>
             </KeyFrame>
-           </Animation>
+          </Animation>
         </Style.Animations>
+        <Setter Property="Child" Value="{StaticResource Heart}"/>
       </Style>
       <Style Selector="Border.Rect4:pointerover">
         <Style.Animations>
-          <Animation Duration="0:0:3" Easing="BounceEaseInOut"> 
+          <Animation Duration="0:0:3" Easing="BounceEaseInOut">
             <KeyFrame Cue="48%">
               <Setter Property="TranslateTransform.Y" Value="-100"/>
             </KeyFrame>
@@ -108,7 +108,7 @@
   <Grid>
     <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" ClipToBounds="False">
       <StackPanel.Clock>
-          <Clock />
+        <Clock />
       </StackPanel.Clock>
       <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
         <TextBlock VerticalAlignment="Center">Hover to activate Transform Keyframe Animations.</TextBlock>

--- a/samples/RenderDemo/Pages/ClippingPage.xaml
+++ b/samples/RenderDemo/Pages/ClippingPage.xaml
@@ -1,5 +1,5 @@
-<UserControl 
-  xmlns="https://github.com/avaloniaui">
+<UserControl
+xmlns="https://github.com/avaloniaui">
   <Grid ColumnDefinitions="Auto" RowDefinitions="Auto,Auto">
     <Grid.Styles>
       <Styles>
@@ -17,7 +17,7 @@
         </Style>
       </Styles>
     </Grid.Styles>
-    <Border Name="clipped" 
+    <Border Name="clipped"
             Background="Yellow"
             Width="100"
             Height="100"
@@ -44,9 +44,9 @@
       <Border Name="clipChild" Background="{DynamicResource ThemeAccentBrush}" Margin="4">
         <!-- Setting opacity puts the TextBox on a new layer -->
         <TextBox Text="Avalonia" Opacity="0.9" VerticalAlignment="Center"/>
-          <Border.RenderTransform>
-            <RotateTransform/>
-          </Border.RenderTransform>
+        <Border.RenderTransform>
+          <RotateTransform/>
+        </Border.RenderTransform>
       </Border>
     </Border>
     <CheckBox Name="useMask" IsChecked="True" Grid.Row="1">Apply Geometry Clip</CheckBox>

--- a/samples/RenderDemo/Pages/DrawingPage.xaml
+++ b/samples/RenderDemo/Pages/DrawingPage.xaml
@@ -98,7 +98,7 @@
         </Border>
 
         <!-- For comparison -->
-        
+
         <Ellipse Grid.Row="2"
                  Grid.Column="0"
                  Width="100"
@@ -127,6 +127,6 @@
                  Stretch="UniformToFill"
                  Fill="Blue"
                  Margin="5" />
-        
+
     </Grid>
 </UserControl>


### PR DESCRIPTION
- What does the pull request do?
Temporarily fixes #1939 till the upstream Portable.Xaml is updated.
- What is the current behavior?
RenderDemo is broken.