### PR TITLE
General fixes

### DIFF
--- a/src/Avalonia.Visuals/Platform/LockedFramebuffer.cs
+++ b/src/Avalonia.Visuals/Platform/LockedFramebuffer.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Platform
         {
             _onDispose = onDispose;
             Address = address;
-            Size = Size;
+            Size = size;
             RowBytes = rowBytes;
             Dpi = dpi;
             Format = format;

--- a/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs
@@ -143,23 +143,26 @@ namespace Avalonia.Skia
 
                 // Create bitmap using default platform settings
                 _bitmap = new SKBitmap(destinationInfo.Width, destinationInfo.Height);
+                SKColorType bitmapColorType;
 
                 if (!_bitmap.CanCopyTo(destinationInfo.ColorType))
                 {
+                    bitmapColorType = _bitmap.ColorType;
                     _bitmap.Dispose();
 
                     throw new Exception(
-                        $"Unable to create pixel format shim for conversion from {_bitmap.ColorType} to {destinationInfo.ColorType}");
+                        $"Unable to create pixel format shim for conversion from {bitmapColorType} to {destinationInfo.ColorType}");
                 }
 
                 Surface = SKSurface.Create(_bitmap.Info, _bitmap.GetPixels(), _bitmap.RowBytes);
 
                 if (Surface == null)
                 {
+                    bitmapColorType = _bitmap.ColorType;
                     _bitmap.Dispose();
 
                     throw new Exception(
-                        $"Unable to create pixel format shim surface for conversion from {_bitmap.ColorType} to {destinationInfo.ColorType}");
+                        $"Unable to create pixel format shim surface for conversion from {bitmapColorType} to {destinationInfo.ColorType}");
                 }
 
                 SurfaceCopyHandler = Disposable.Create(CopySurface);


### PR DESCRIPTION
- What does the pull request do?
fixes LockedFramebuffer.Size assigment from LockedFramebuffer constructor
fixes AccessViolationException during creating another Exception

- What is the current behavior?
LockedFramebuffer.Size is not set in constructor
_bitmap.ColorType

- What is the updated/expected behavior with this PR?
fully functional LockedFramebuffer
throwing proper Exception instead of AccessViolationException