### PR TITLE
fixes/2042-opengl-using-pixelsize-struct

### DIFF
--- a/src/Avalonia.Native/GlPlatformFeature.cs
+++ b/src/Avalonia.Native/GlPlatformFeature.cs
@@ -100,12 +100,12 @@ namespace Avalonia.Native
 
         public IGlDisplay Display { get; }
 
-        public System.Drawing.Size PixelSize
+        public PixelSize Size
         {
             get
             {
                 var s = _session.GetPixelSize();
-                return new System.Drawing.Size(s.Width, s.Height);
+                return new PixelSize(s.Width, s.Height);
             }
         }
 

--- a/src/Avalonia.OpenGL/EglGlPlatformSurface.cs
+++ b/src/Avalonia.OpenGL/EglGlPlatformSurface.cs
@@ -7,8 +7,7 @@ namespace Avalonia.OpenGL
         public interface IEglWindowGlPlatformSurfaceInfo
         {
             IntPtr Handle { get; }
-            // TODO: Change to PixelSize struct once https://github.com/AvaloniaUI/Avalonia/pull/1889 is merged
-            System.Drawing.Size PixelSize { get; }
+            PixelSize Size { get; }
             double Scaling { get; }
         }
 
@@ -71,7 +70,7 @@ namespace Avalonia.OpenGL
                 }
 
                 public IGlDisplay Display => _context.Display;
-                public System.Drawing.Size PixelSize => _info.PixelSize;
+                public PixelSize Size => _info.Size;
                 public double Scaling => _info.Scaling;
             }
         }

--- a/src/Avalonia.OpenGL/IGlPlatformSurfaceRenderingSession.cs
+++ b/src/Avalonia.OpenGL/IGlPlatformSurfaceRenderingSession.cs
@@ -5,8 +5,7 @@ namespace Avalonia.OpenGL
     public interface IGlPlatformSurfaceRenderingSession : IDisposable
     {
         IGlDisplay Display { get; }
-        // TODO: Change to PixelSize struct once https://github.com/AvaloniaUI/Avalonia/pull/1889 is merged
-        System.Drawing.Size PixelSize { get; }
+        PixelSize Size { get; }
         double Scaling { get; }
     }
 }

--- a/src/Gtk/Avalonia.Gtk3/WindowBaseImpl.cs
+++ b/src/Gtk/Avalonia.Gtk3/WindowBaseImpl.cs
@@ -510,12 +510,12 @@ namespace Avalonia.Gtk3
                 : new ImmediateRenderer(root);
         }
 
-        System.Drawing.Size EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo.PixelSize
+        PixelSize EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo.Size
         {
             get
             {
                 var cs = ClientSize;
-                return new System.Drawing.Size((int)Math.Max(1, LastKnownScaleFactor * cs.Width),
+                return new PixelSize((int)Math.Max(1, LastKnownScaleFactor * cs.Width),
                     (int)Math.Max(1, LastKnownScaleFactor * ClientSize.Height));
             }
         }

--- a/src/Skia/Avalonia.Skia/GlRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/GlRenderTarget.cs
@@ -28,7 +28,7 @@ namespace Avalonia.Skia
             var gl = disp.GlInterface;
             gl.GetIntegerv(GL_FRAMEBUFFER_BINDING, out var fb);
 
-            var size = session.PixelSize;
+            var size = session.Size;
             var scaling = session.Scaling;
 
             GRBackendRenderTargetDesc desc = new GRBackendRenderTargetDesc

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -933,14 +933,14 @@ namespace Avalonia.Win32
 
             _topmost = value;
         }
-        
-        System.Drawing.Size EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo.PixelSize
+
+        PixelSize EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo.Size
         {
             get
             {
                 RECT rect;
                 GetClientRect(_hwnd, out rect);
-                return new System.Drawing.Size(
+                return new PixelSize(
                     Math.Max(1, rect.right - rect.left),
                     Math.Max(1, rect.bottom - rect.top));
             }


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
uses pixelsize in opengl code.

- What is the current behavior?
pixel size didn't exist when it was written and uses a .net type.

Fixes #2042 