### PR TITLE
Always run PublishTestArtifacts unless the build was canceled.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,7 @@ jobs:
     inputs:
       testResultsFormat: 'VSTest'
       testResultsFiles: '$(Build.SourcesDirectory)/artifacts/test-results/*.trx'
+    condition: not(canceled())
      
 - job: macOS
   pool:
@@ -77,6 +78,7 @@ jobs:
     inputs:
       testResultsFormat: 'VSTest'
       testResultsFiles: '$(Build.SourcesDirectory)/artifacts/test-results/*.trx'
+    condition: not(canceled())
   
   - task: PublishBuildArtifacts@1
     inputs:
@@ -111,6 +113,7 @@ jobs:
     inputs:
       testResultsFormat: 'VSTest'
       testResultsFiles: '$(Build.SourcesDirectory)/artifacts/test-results/*.trx'
+    condition: not(canceled())
 
   - task: PublishBuildArtifacts@1
     inputs:


### PR DESCRIPTION
This allows us to get our failed tests to show up in the PR test runs. Currently, the PublishTestResults task is skipped when the Cake step fails, which isn't super helpful when we have a failing test.