### PR TITLE
end animation cleanly with correct value

### DIFF
--- a/src/Avalonia.Animation/AnimationInstance`1.cs
+++ b/src/Avalonia.Animation/AnimationInstance`1.cs
@@ -152,7 +152,7 @@ namespace Avalonia.Animation
                 }
 
                 //Calculate the current iteration number
-                _currentIteration = Math.Max(_repeatCount,(int)Math.Floor((double)((double)iterationTime.Ticks / iterationEndpoint.Ticks)) + 2);
+                _currentIteration = Math.Min(_repeatCount,(int)Math.Floor((double)((double)iterationTime.Ticks / iterationEndpoint.Ticks)) + 2);
             }
             else
             {

--- a/src/Avalonia.Animation/AnimationInstance`1.cs
+++ b/src/Avalonia.Animation/AnimationInstance`1.cs
@@ -133,6 +133,7 @@ namespace Avalonia.Animation
             DoPlayStates();
             var delayEndpoint = _delay;
             var iterationEndpoint = delayEndpoint + _duration;
+            var iterationTime = time;
 
             //determine if time is currently in the first iteration.
             if (time >= TimeSpan.Zero & time <= iterationEndpoint)
@@ -141,6 +142,9 @@ namespace Avalonia.Animation
             }
             else if (time > iterationEndpoint)
             {
+                //Subtract first iteration to properly get the subsequent iteration time
+                iterationTime -= iterationEndpoint;
+
                 if (!_iterationDelay & delayEndpoint > TimeSpan.Zero)
                 {
                     delayEndpoint = TimeSpan.Zero;
@@ -148,7 +152,7 @@ namespace Avalonia.Animation
                 }
 
                 //Calculate the current iteration number
-                _currentIteration = (int)Math.Floor((double)((double)time.Ticks / iterationEndpoint.Ticks))+1;
+                _currentIteration = Math.Max(_repeatCount,(int)Math.Floor((double)((double)iterationTime.Ticks / iterationEndpoint.Ticks)) + 2);
             }
             else
             {
@@ -173,20 +177,20 @@ namespace Avalonia.Animation
                     return;
                 }
             }
-            time = TimeSpan.FromTicks((long)(time.Ticks % iterationEndpoint.Ticks));
+            iterationTime = TimeSpan.FromTicks((long)(iterationTime.Ticks % iterationEndpoint.Ticks));
         
-            if (delayEndpoint > TimeSpan.Zero & time < delayEndpoint)
+            if (delayEndpoint > TimeSpan.Zero & iterationTime < delayEndpoint)
             {
                 DoDelay();
             }
             else
             {
                 // Offset the delay time            
-                time -= delayEndpoint;
+                iterationTime -= delayEndpoint;
                 iterationEndpoint -= delayEndpoint;
 
                 // Normalize time
-                var interpVal = (double)time.Ticks / iterationEndpoint.Ticks;
+                var interpVal = (double)iterationTime.Ticks / iterationEndpoint.Ticks;
 
                 if (isCurIterReverse)
                     interpVal = 1 - interpVal;

--- a/src/Avalonia.Animation/AnimationInstance`1.cs
+++ b/src/Avalonia.Animation/AnimationInstance`1.cs
@@ -163,7 +163,8 @@ namespace Avalonia.Animation
    
             if (!_isLooping)
             {
-                if ((_currentIteration > _repeatCount) || (time >= iterationEndpoint))
+                var totalTime = _repeatCount * _duration.Ticks + _delay.Ticks;
+                if (time.Ticks >= totalTime)
                 {
                     var easedTime = _easeFunc.Ease(isCurIterReverse?0.0:1.0);
                     _lastInterpValue = _interpolator(easedTime, _neutralValue);


### PR DESCRIPTION

- What does the pull request do?
ensures the correct value is applied at the end of an animation
- What is the current behavior?
an animation sometimes rolls back to a very early value, this is sometimes visible in control catalog.
- What is the updated/expected behavior with this PR?
animations stop on the correct value 
- How was the solution implemented (if it's not obvious)?

Checklist:

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

If the pull request fixes issue(s) list them like this:

Fixes #2020
