### PR TITLE
fix devtools controls highlighting with immediaterenderer issue #1927

### DIFF
--- a/src/Avalonia.Controls/Primitives/AdornerLayer.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerLayer.cs
@@ -89,7 +89,7 @@ namespace Avalonia.Controls.Primitives
                 control.Clip = clip;
             }
 
-            clip.Rect = bounds.Clip.TransformToAABB(-bounds.Transform);
+            clip.Rect = bounds.Bounds;
         }
 
         private void ChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
- What does the pull request do?
 devtools highlighting works good with ImmediateRenderer
- What is the current behavior? not working
- What is the updated/expected behavior with this PR?
fix and work fine
- How was the solution implemented (if it's not obvious)?
Adorner.Clip was wrong and clipping the adorner completelly from ui, now it's set to proper value

If the pull request fixes issue(s) list them like this:

Fixes #1927