### PR TITLE
fix click on dropdown when dropdown in other popup fixes #2058

### DIFF
--- a/src/Avalonia.Controls/DropDown.cs
+++ b/src/Avalonia.Controls/DropDown.cs
@@ -145,7 +145,7 @@ namespace Avalonia.Controls
         {
             if (!e.Handled)
             {
-                if (((IVisual)e.Source).GetVisualRoot() is PopupRoot)
+                if (_popup?.PopupRoot != null && ((IVisual)e.Source).GetVisualRoot() == _popup?.PopupRoot)
                 {
                     if (UpdateSelectionFromEventSource(e.Source))
                     {


### PR DESCRIPTION

- What does the pull request do?
makes more precise handling on pointer pressed in dropdown and now dropdown can be put as part of a content of another popup
- What is the current behavior?

- What is the updated/expected behavior with this PR?
- How was the solution implemented (if it's not obvious)?

If the pull request fixes issue(s) list them like this:

Fixes #2058