### PR TITLE
unittest and fix for problems in derivedlist

### DIFF
--- a/src/Avalonia.Base/Collections/AvaloniaListExtensions.cs
+++ b/src/Avalonia.Base/Collections/AvaloniaListExtensions.cs
@@ -104,7 +104,12 @@ namespace Avalonia.Collections
                     case NotifyCollectionChangedAction.Move:
                     case NotifyCollectionChangedAction.Replace:
                         Remove(e.OldStartingIndex, e.OldItems);
-                        Add(e.NewStartingIndex, e.NewItems);
+                        int newIndex = e.NewStartingIndex;
+                        if(newIndex > e.OldStartingIndex)
+                        {
+                            newIndex -= e.OldItems.Count;
+                        }
+                        Add(newIndex, e.NewItems);
                         break;
 
                     case NotifyCollectionChangedAction.Remove:

--- a/tests/Avalonia.Base.UnitTests/Collections/AvaloniaListExtenionsTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Collections/AvaloniaListExtenionsTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Avalonia.Collections;
 using Xunit;
 
@@ -82,13 +81,31 @@ namespace Avalonia.Base.UnitTests.Collections
             Assert.Equal(source, result);
         }
 
-        [Fact]
-        public void CreateDerivedList_Handles_MoveRange()
+        [Theory]
+        [InlineData(0, 2, 3)]
+        [InlineData(0, 2, 4)]
+        [InlineData(0, 2, 5)]
+        [InlineData(0, 4, 4)]
+        [InlineData(1, 2, 0)]
+        [InlineData(1, 2, 4)]
+        [InlineData(1, 2, 5)]
+        [InlineData(1, 4, 0)]
+        [InlineData(2, 2, 0)]
+        [InlineData(2, 2, 1)]
+        [InlineData(2, 2, 3)]
+        [InlineData(2, 2, 4)]
+        [InlineData(2, 2, 5)]
+        [InlineData(4, 2, 0)]
+        [InlineData(4, 2, 1)]
+        [InlineData(4, 2, 3)]
+        [InlineData(5, 1, 0)]
+        [InlineData(5, 1, 3)]
+        public void CreateDerivedList_Handles_MoveRange(int oldIndex, int count, int newIndex)
         {
-            var source = new AvaloniaList<int>(new[] { 0, 1, 2, 3 });
+            var source = new AvaloniaList<int>(new[] { 0, 1, 2, 3, 4, 5 });
             var target = source.CreateDerivedList(x => new Wrapper(x));
 
-            source.MoveRange(1, 2, 0);
+            source.MoveRange(oldIndex, count, newIndex);
 
             var result = target.Select(x => x.Value).ToList();
 


### PR DESCRIPTION
- What does the pull request do?
failing tests for derivedlist/ list extensions
- What is the current behavior?
derived list or extensions for moverange throw OutOfRangeExceptions and don't work properly.
Noticeable  in devtool when pointing over elements of scrolling virtualized listbox - exceptions List index out of range are thrown pretty often
- What is the updated/expected behavior with this PR?
add failing tests for problem scenarios
- How was the solution implemented (if it's not obvious)?

Checklist:

- [x] Added unit tests (if possible)?
