### PR TITLE
make sure pointer is always inside presenter

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -14,6 +14,7 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Metadata;
 using Avalonia.Data;
+using Avalonia.Utilities;
 
 namespace Avalonia.Controls
 {
@@ -656,7 +657,7 @@ namespace Avalonia.Controls
             {
                 var point = e.GetPosition(_presenter);
 
-                point = new Point(Math.Max(Math.Min(point.X, _presenter.Bounds.Width - 1), 0), Math.Max(Math.Min(point.Y, _presenter.Bounds.Height - 1), 0));
+                point = new Point(MathUtilities.Clamp(point.X, 0, _presenter.Bounds.Width - 1), MathUtilities.Clamp(point.Y, 0, _presenter.Bounds.Height - 1));
                 CaretIndex = SelectionEnd = _presenter.GetCaretIndex(point);
             }
         }

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -655,6 +655,8 @@ namespace Avalonia.Controls
             if (_presenter != null && e.Device.Captured == _presenter)
             {
                 var point = e.GetPosition(_presenter);
+
+                point = new Point(Math.Max(Math.Min(point.X, _presenter.Bounds.Width - 1), 0), Math.Max(Math.Min(point.Y, _presenter.Bounds.Height - 1), 0));
                 CaretIndex = SelectionEnd = _presenter.GetCaretIndex(point);
             }
         }

--- a/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
+++ b/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
@@ -121,7 +121,7 @@ namespace Avalonia.Skia
 
                 int offset = 0;
 
-                if (point.X >= (rects[line.Start].X + line.Width) / 2 && line.Length > 0)
+                if (point.X >= (rects[line.Start].X + line.Width) && line.Length > 0)
                 {
                     offset = line.TextLength > line.Length ?
                                     line.Length : (line.Length - 1);


### PR DESCRIPTION
- What does the pull request do?

fixes selection when pointer moves outside of textbox

- What is the current behavior?
- What is the updated/expected behavior with this PR?

see https://github.com/AvaloniaUI/Avalonia/issues/2065

- How was the solution implemented (if it's not obvious)?

normalize pointer to always be inside presenter

Checklist:

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

If the pull request fixes issue(s) list them like this:

https://github.com/AvaloniaUI/Avalonia/issues/2065
https://github.com/AvaloniaUI/Avalonia/issues/2065#issuecomment-435363861