### PR TITLE
Call GtkImContextFilterKeypress after issuing the KeyDown event

### DIFF
--- a/src/Gtk/Avalonia.Gtk3/WindowBaseImpl.cs
+++ b/src/Gtk/Avalonia.Gtk3/WindowBaseImpl.cs
@@ -222,14 +222,14 @@ namespace Avalonia.Gtk3
         {
             var evnt = (GdkEventKey*) pev;
             _lastKbdEvent = evnt->time;
-            if (Native.GtkImContextFilterKeypress(_imContext, pev))
-                return true;
             var e = new RawKeyEventArgs(
                 Gtk3Platform.Keyboard,
                 evnt->time,
                 evnt->type == GdkEventType.KeyPress ? RawKeyEventType.KeyDown : RawKeyEventType.KeyUp,
                 Avalonia.Gtk.Common.KeyTransform.ConvertKey((GdkKey)evnt->keyval), GetModifierKeys((GdkModifierType)evnt->state));
             OnInput(e);
+            if (Native.GtkImContextFilterKeypress(_imContext, pev))
+                return true;
             return true;
         }
 


### PR DESCRIPTION
I'm writing an app in avalonia that depends on being able to accurately read all of the KeyDown and KeyUp events.
I'm doing my development on Linux but I'm also testing on windows.
I've found that in order to get the same sequence of events for Control.KeyDown, KeyUp and TextInput on Linux as I get on windows I need to have the KeyDown event issued before the call to GtkImContextFilterKeypress, as that call will then issue the TextInput event via the OnCommit callback in WindowBaseImpl.

The other effect of this change is that both the KeyDown and the TextInput event now get issued on Linux, whereas before the KeyDown event would never be issues if GtkImContextFilterKeypress returned true.

With this change I now get the same events issued to my app when it runs on Linux as I do when I run it on Windows.

Checklist:

- [ ] Added unit tests (if possible)?
  No unit tests -- all testing done manually.
- [ ] Added XML documentation to any related classes?
  No documentation needed.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
  No documentation needed.
