### PR TITLE
Fix OSX CMD + Key Gestures

### DIFF
--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -963,7 +963,11 @@ NSArray* AllLoopModes = [NSArray arrayWithObjects: NSDefaultRunLoopMode, NSEvent
 
 - (BOOL)performKeyEquivalent:(NSEvent *)event
 {
-    return _lastKeyHandled;
+    bool result = _lastKeyHandled;
+    
+    _lastKeyHandled = false;
+    
+    return result;
 }
 
 - (void)keyDown:(NSEvent *)event


### PR DESCRIPTION
- What does the pull request do?
Fixes CMD + key gestures on osx.

- What is the current behavior?
Currently successive cmd + key gestures only work the first time, and are rejected after that, until another key has been pressed, its because the _lastKeyHandled flag gets stuck on.

- What is the updated/expected behavior with this PR?
This now works as the user expects.

- How was the solution implemented (if it's not obvious)?
performKeyEquivalent is called by osx to see if it should try to interpret the cmd + key gesture, it needs to return false here, so that Avalonia gets the chance to parse it, we have made performKeyEquivalent return the current value, at the same time as resetting it, so that the next time a CMD + key is pressed then we will be in the correct state.

Checklist:

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

If the pull request fixes issue(s) list them like this:

Fixes #2070 