### PR TITLE
Fix render artifacts caused by unified timers

### DIFF
--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -85,6 +85,7 @@ namespace Avalonia.Rendering
             RenderTarget = renderTarget;
             _sceneBuilder = sceneBuilder ?? new SceneBuilder();
             Layers = new RenderLayers();
+            _lock = new ManagedDeferredRendererLock();
         }
 
         /// <inheritdoc/>

--- a/src/Shared/PlatformSupport/StandardRuntimePlatform.cs
+++ b/src/Shared/PlatformSupport/StandardRuntimePlatform.cs
@@ -89,9 +89,11 @@ namespace Avalonia.Shared.PlatformSupport
 #if DEBUG
                 if (Thread.CurrentThread.ManagedThreadId == GCThread?.ManagedThreadId)
                 {
-                    Console.Error.WriteLine("Native blob disposal from finalizer thread\nBacktrace: "
-                                            + Environment.StackTrace
-                                            + "\n\nBlob created by " + _backtrace);
+                    lock(_lock)
+                        if (!IsDisposed)
+                            Console.Error.WriteLine("Native blob disposal from finalizer thread\nBacktrace: "
+                                                    + Environment.StackTrace
+                                                    + "\n\nBlob created by " + _backtrace);
                 }
 #endif
                 DoDispose();

--- a/src/Windows/Avalonia.Win32/FramebufferManager.cs
+++ b/src/Windows/Avalonia.Win32/FramebufferManager.cs
@@ -5,7 +5,7 @@ using Avalonia.Win32.Interop;
 
 namespace Avalonia.Win32
 {
-    class FramebufferManager : IFramebufferPlatformSurface, IDisposable
+    class FramebufferManager : IFramebufferPlatformSurface
     {
         private readonly IntPtr _hwnd;
         private WindowFramebuffer _fb;
@@ -28,11 +28,6 @@ namespace Avalonia.Win32
                 _fb = new WindowFramebuffer(_hwnd, new PixelSize(width, height));
             }
             return _fb;
-        }
-
-        public void Dispose()
-        {
-            _fb?.Deallocate();
         }
     }
 }

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -13,6 +13,7 @@ using Avalonia.Input.Raw;
 using Avalonia.OpenGL;
 using Avalonia.Platform;
 using Avalonia.Rendering;
+using Avalonia.Threading;
 using Avalonia.Win32.Input;
 using Avalonia.Win32.Interop;
 using static Avalonia.Win32.Interop.UnmanagedMethods;
@@ -234,8 +235,6 @@ namespace Avalonia.Win32
 
         public void Dispose()
         {
-            _framebuffer?.Dispose();
-            _framebuffer = null;
             if (_hwnd != IntPtr.Zero)
             {
                 UnmanagedMethods.DestroyWindow(_hwnd);

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/DeferredRendererTests_HitTesting.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/DeferredRendererTests_HitTesting.cs
@@ -405,7 +405,8 @@ namespace Avalonia.Visuals.UnitTests.Rendering
                 root.Renderer = new DeferredRenderer(root, null);
                 root.Measure(Size.Infinity);
                 root.Arrange(new Rect(container.DesiredSize));
-
+                
+                root.Renderer.Paint(Rect.Empty);
                 var result = root.Renderer.HitTest(new Point(50, 150), root, null).First();
 
                 Assert.Equal(item1, result);
@@ -421,6 +422,7 @@ namespace Avalonia.Visuals.UnitTests.Rendering
                 container.InvalidateArrange();
                 container.Arrange(new Rect(container.DesiredSize));
 
+                root.Renderer.Paint(Rect.Empty);
                 result = root.Renderer.HitTest(new Point(50, 150), root, null).First();
                 Assert.Equal(item2, result);
 


### PR DESCRIPTION
Scene has to be consumed by `UpdateLayers` and `RenderToLayers` before producing a new one. After timers PR RenderLoop started to trigger UpdateScene requests way faster than they could be processed,  which caused some dirty rects to be lost.


PR also contains fixes for some issues that I've encountered during debugging, they are in separate commits:
- UnmanagedBlob was complaining about being disposed by finalized while actually being disposed long ago from a proper thread
- Forced deallocation of reused framebuffer blob from UI thread caused AccessViolationException in background one, now GC is responsible of collecting it.