### PR TITLE
ImmediateRenderer fix for #2141

### DIFF
--- a/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
@@ -266,7 +266,14 @@ namespace Avalonia.Rendering
 
                 if (clipToBounds)
                 {
-                    clipRect = clipRect.Intersect(new Rect(visual.Bounds.Size));
+                    if (visual.RenderTransform != null)
+                    {
+                        clipRect = new Rect(visual.Bounds.Size);
+                    }
+                    else
+                    {
+                        clipRect = clipRect.Intersect(new Rect(visual.Bounds.Size));
+                    }
                 }
 
                 using (context.PushPostTransform(m))

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/ImmediateRendererTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/ImmediateRendererTests.cs
@@ -1,8 +1,11 @@
 ﻿using System.Collections.Generic;
 using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Rendering;
+using Avalonia.UnitTests;
 using Avalonia.VisualTree;
 using Moq;
 using Xunit;
@@ -93,6 +96,87 @@ namespace Avalonia.Visuals.UnitTests.Rendering
 
             //then new position
             Assert.Equal(new Rect(100, 100, 100, 100), invalidationCalls[2]);
+        }
+
+        [Fact]
+        public void Should_Render_Child_In_Parent_With_RenderTransform()
+        {
+            var targetMock = new Mock<Control>() { CallBase = true };
+            var target = targetMock.Object;
+            target.Width = 100;
+            target.Height = 50;
+            var child = new Panel()
+            {
+                RenderTransform = new RotateTransform() { Angle = 90 },
+                Children =
+                {
+                    new Panel()
+                    {
+                        Children =
+                        {
+                            target
+                        }
+                    }
+                }
+            };
+
+            var visualTarget = targetMock.As<IVisual>();
+            int rendered = 0;
+            visualTarget.Setup(v => v.Render(It.IsAny<DrawingContext>())).Callback(() => rendered++);
+
+            var root = new TestRoot(child);
+            root.Renderer = new ImmediateRenderer(root);
+
+            root.LayoutManager.ExecuteInitialLayoutPass(root);
+
+            root.Measure(new Size(50, 100));
+            root.Arrange(new Rect(new Size(50, 100)));
+
+            root.Renderer.Paint(root.Bounds);
+
+            Assert.Equal(1, rendered);
+        }
+
+        [Fact]
+        public void Should_Render_Child_In_Parent_With_RenderTransform2()
+        {
+            var targetMock = new Mock<Control>() { CallBase = true };
+            var target = targetMock.Object;
+
+            target.Width = 100;
+            target.Height = 50;
+            target.HorizontalAlignment = HorizontalAlignment.Center;
+            target.VerticalAlignment = VerticalAlignment.Center;
+
+            var child = new Panel()
+            {
+                RenderTransform = new RotateTransform() { Angle = 90 },
+                Children =
+                {
+                    new Panel()
+                    {
+                        Children =
+                        {
+                            target
+                        }
+                    }
+                }
+            };
+
+            var visualTarget = targetMock.As<IVisual>();
+            int rendered = 0;
+            visualTarget.Setup(v => v.Render(It.IsAny<DrawingContext>())).Callback(() => rendered++);
+
+            var root = new TestRoot(child);
+            root.Renderer = new ImmediateRenderer(root);
+
+            root.LayoutManager.ExecuteInitialLayoutPass(root);
+
+            root.Measure(new Size(300, 100));
+            root.Arrange(new Rect(new Size(300, 100)));
+            root.Renderer.Paint(root.Bounds);
+
+            Assert.Equal(1, rendered);
         }
     }
 }


### PR DESCRIPTION

- What does the pull request do?
fixes issue with immediate renderer #2141, when rendertransfrom in visual tree sometimes some controls are not rendered
- What is the current behavior?
not rendering as renderer assume control bounds are not in the visible part
- What is the updated/expected behavior with this PR?
takes in account render transform when calculates clip and fixes the issue
- How was the solution implemented (if it's not obvious)?

Checklist:

- [x] Added unit tests (if possible)?

If the pull request fixes issue(s) list them like this:

Fixes #2141