### PR TITLE
Additional `Start` method overload

### DIFF
--- a/samples/ControlCatalog.NetCore/Program.cs
+++ b/samples/ControlCatalog.NetCore/Program.cs
@@ -23,6 +23,7 @@ namespace ControlCatalog.NetCore
                         break;
                 }
             }
+
             if (args.Contains("--fbdev"))
                 AppBuilder.Configure<App>().InitializeWithLinuxFramebuffer(tl =>
                 {
@@ -30,7 +31,12 @@ namespace ControlCatalog.NetCore
                     System.Threading.ThreadPool.QueueUserWorkItem(_ => ConsoleSilencer());
                 });
             else
-                BuildAvaloniaApp().Start<MainWindow>();
+                BuildAvaloniaApp().Start(AppMain, args);
+        }
+
+        static void AppMain(Application app, string[] args)
+        {
+            app.Run(new MainWindow());
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/AppBuilderBase.cs
+++ b/src/Avalonia.Controls/AppBuilderBase.cs
@@ -145,6 +145,15 @@ namespace Avalonia.Controls
             Instance.Run(mainWindow);
         }
 
+        public delegate void AppMainDelegate(Application app, string[] args);
+
+        public void Start(AppMainDelegate main, string[] args)
+        {
+            Setup();
+            BeforeStartCallback(Self);
+            main(Instance, args);
+        }
+        
         /// <summary>
         /// Sets up the platform-specific services for the application, but does not run it.
         /// </summary>


### PR DESCRIPTION
Allows for the following entry point structure:
```cs
static void Main(string[] args)
{
       // Avalonia isn't set up at this point, don't use *anything* UI-related here
       // (including your view models)
       BuildAvaloniaApp().Start(AppMain, args);
}

static void AppMain(Application app, string[] args)
{
      // Avalonia is ready to go, setup your app if needed and call app.Run(window);
      app.Run(new MainWindow());
}
```