### PR TITLE
enable drop shadow on win32 popups.

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -909,8 +909,17 @@ namespace Avalonia.Win32.Interop
 
         public enum ClassLongIndex : int
         {
-            GCL_HCURSOR = -12,
-            GCL_HICON = -14
+            GCLP_MENUNAME = -8,
+            GCLP_HBRBACKGROUND = -10,
+            GCLP_HCURSOR = -12,
+            GCLP_HICON = -14,
+            GCLP_HMODULE = -16,
+            GCL_CBWNDEXTRA = -18,
+            GCL_CBCLSEXTRA = -20,
+            GCLP_WNDPROC = -24,
+            GCL_STYLE = -26,
+            GCLP_HICONSM = -34,
+            GCW_ATOM = -32
         }
 
         [DllImport("user32.dll", EntryPoint = "SetClassLongPtr")]
@@ -928,6 +937,20 @@ namespace Avalonia.Win32.Interop
 
             return SetClassLong64(hWnd, nIndex, dwNewLong);
         }
+
+        public static IntPtr GetClassLongPtr(IntPtr hWnd, int nIndex)
+        {
+            if (IntPtr.Size > 4)
+                return GetClassLongPtr64(hWnd, nIndex);
+            else
+                return new IntPtr(GetClassLongPtr32(hWnd, nIndex));
+        }
+
+        [DllImport("user32.dll", EntryPoint = "GetClassLong")]
+        public static extern uint GetClassLongPtr32(IntPtr hWnd, int nIndex);
+
+        [DllImport("user32.dll", EntryPoint = "GetClassLongPtr")]
+        public static extern IntPtr GetClassLongPtr64(IntPtr hWnd, int nIndex);
 
         [DllImport("user32.dll", EntryPoint = "SetCursor")]
         internal static extern IntPtr SetCursor(IntPtr hCursor);

--- a/src/Windows/Avalonia.Win32/PopupImpl.cs
+++ b/src/Windows/Avalonia.Win32/PopupImpl.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Win32
                 UnmanagedMethods.WindowStyles.WS_EX_TOOLWINDOW |
                 UnmanagedMethods.WindowStyles.WS_EX_TOPMOST;
 
-            return UnmanagedMethods.CreateWindowEx(
+            var result = UnmanagedMethods.CreateWindowEx(
                 (int)exStyle,
                 atom,
                 null,
@@ -37,6 +37,14 @@ namespace Avalonia.Win32
                 IntPtr.Zero,
                 IntPtr.Zero,
                 IntPtr.Zero);
+
+            var classes = (int)UnmanagedMethods.GetClassLongPtr(result, (int)UnmanagedMethods.ClassLongIndex.GCL_STYLE);
+
+            classes |= (int)UnmanagedMethods.ClassStyles.CS_DROPSHADOW;
+
+            UnmanagedMethods.SetClassLong(result, UnmanagedMethods.ClassLongIndex.GCL_STYLE, new IntPtr(classes));
+
+            return result;
         }
 
         protected override IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -384,7 +384,7 @@ namespace Avalonia.Win32
         public void SetCursor(IPlatformHandle cursor)
         {
             var hCursor = cursor?.Handle ?? DefaultCursor;
-            UnmanagedMethods.SetClassLong(_hwnd, UnmanagedMethods.ClassLongIndex.GCL_HCURSOR, hCursor);
+            UnmanagedMethods.SetClassLong(_hwnd, UnmanagedMethods.ClassLongIndex.GCLP_HCURSOR, hCursor);
 
             if (_owner.IsPointerOver)
                 UnmanagedMethods.SetCursor(hCursor);


### PR DESCRIPTION
This template is not intended to be prescriptive, but to help us review pull requests it would be useful if you included as much of the following information as possible:

- What does the pull request do?
Adds a drop shadow on win32 to popups, this is consistent with wpf.

- What is the current behavior?
no drop shadow.

- What is the updated/expected behavior with this PR?
drop shadow shown only on popups.
