### PR TITLE
[WIP] ForeignBitmap API with implementation for Skia backend

### DIFF
--- a/src/Avalonia.Visuals/Media/Imaging/ForeignBitmap.cs
+++ b/src/Avalonia.Visuals/Media/Imaging/ForeignBitmap.cs
@@ -1,0 +1,19 @@
+using System;
+using Avalonia.Platform;
+
+namespace Avalonia.Media.Imaging
+{
+    public class ForeignBitmap : Bitmap
+    {
+        public ForeignBitmap(IForeignBitmapImpl impl) : base(impl)
+        {
+            
+        }
+        
+        /// <summary>
+        /// Locks the bitmap, so underlying surface can be safely updated from the current thread
+        /// </summary>
+        /// <returns>IDisposable object for unlocking the bitmap</returns>
+        public IDisposable Lock() => ((IForeignBitmapImpl)PlatformImpl.Item).Lock();
+    }
+}

--- a/src/Avalonia.Visuals/Platform/IForeignBitmapImpl.cs
+++ b/src/Avalonia.Visuals/Platform/IForeignBitmapImpl.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Avalonia.Platform
+{
+    public interface IForeignBitmapImpl : IBitmapImpl
+    {
+        /// <summary>
+        /// Locks the bitmap, so underlying surface can be safely updated from the current thread
+        /// </summary>
+        /// <returns>IDisposable object for unlocking the bitmap</returns>
+        IDisposable Lock();
+    }
+}

--- a/src/Skia/Avalonia.Skia/ForeignBitmapImpl.cs
+++ b/src/Skia/Avalonia.Skia/ForeignBitmapImpl.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using System.Reactive.Disposables;
+using System.Threading;
+using Avalonia.Platform;
+using Avalonia.Skia.Helpers;
+using SkiaSharp;
+
+namespace Avalonia.Skia
+{
+    class ForeignBitmapImpl : IForeignBitmapImpl, IDrawableBitmapImpl
+    {
+        private SKImage _image;
+        private readonly bool _ownsImage;
+        private readonly object _lock = new object();
+        private int _version;
+
+        public ForeignBitmapImpl(SKImage image, Vector dpi, bool ownsImage)
+        {
+            _image = image;
+            _ownsImage = ownsImage;
+            Dpi = dpi;
+            PixelSize = new PixelSize(image.Width, image.Height);
+
+        }
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                if (_ownsImage)
+                {
+                    _image?.Dispose();
+                }
+
+                _image = null;
+            }
+        }
+
+        public Vector Dpi { get; }
+        public PixelSize PixelSize { get; }
+
+        public int Version
+        {
+            get
+            {
+                lock (_lock)
+                    return _version;
+            }
+        }
+
+        public void Save(string fileName)
+        {
+            lock (_image)
+                ImageSavingHelper.SaveImage(_image, fileName);
+        }
+
+        public void Save(Stream stream)
+        {
+            lock (_image)
+                ImageSavingHelper.SaveImage(_image, stream);
+        }
+
+        public void Draw(DrawingContextImpl context, SKRect sourceRect, SKRect destRect, SKPaint paint)
+        {
+            lock (_lock)
+                context.Canvas.DrawImage(_image, sourceRect, destRect, paint);
+        }
+
+        public IDisposable Lock()
+        {
+            Monitor.Enter(_lock);
+            return Disposable.Create(() =>
+            {
+                _version++;
+                Monitor.Exit(_lock);
+            });
+        }
+    }
+}

--- a/src/Skia/Avalonia.Skia/SkiaPlatform.cs
+++ b/src/Skia/Avalonia.Skia/SkiaPlatform.cs
@@ -1,7 +1,9 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using Avalonia.Media.Imaging;
 using Avalonia.Platform;
+using SkiaSharp;
 
 namespace Avalonia.Skia
 {
@@ -25,5 +27,17 @@ namespace Avalonia.Skia
         /// Default DPI.
         /// </summary>
         public static Vector DefaultDpi => new Vector(96.0f, 96.0f);
+
+        /// <summary>
+        /// Creates a ForeignBitmap from SKImage
+        /// </summary>
+        /// <param name="image">SKImage with bitmap contents</param>
+        /// <param name="dpi">Image DPI (e. g. 96:96)</param>
+        /// <param name="ownsImage">If this parameter is true, SKImage will be disposed with the ForeignBitmap instance</param>
+        /// <returns>ForeignBitmap instance associated with <see cref="image"/></returns>
+        public static ForeignBitmap CreateForeignBitmap(SKImage image, Vector dpi, bool ownsImage)
+        {
+            return new ForeignBitmap(new ForeignBitmapImpl(image, dpi, ownsImage));
+        }
     }
 }


### PR DESCRIPTION
Adds ForeignBitmap API that could be used for consuming backend-specific external images. Implementation for Skia allows converting existing `SKImage` to a usable `Bitmap` object

