### PR TITLE
[WIP] Introduced visuals that render themselves on the render thread

### DIFF
--- a/samples/ControlCatalog/MainView.xaml
+++ b/samples/ControlCatalog/MainView.xaml
@@ -37,6 +37,7 @@
       <TabItem Header="TreeView"><pages:TreeViewPage/></TabItem>
       <TabItem Header="TabControl"><pages:TabControlPage/></TabItem>
       <TabItem Header="Viewbox"><pages:ViewboxPage/></TabItem>
+      <TabItem Header="Time critical render"><pages:TimeCriticalRenderPage/></TabItem>
     </TabControl>
   </Grid>
 </UserControl>

--- a/samples/ControlCatalog/Pages/TimeCriticalRenderPage.cs
+++ b/samples/ControlCatalog/Pages/TimeCriticalRenderPage.cs
@@ -15,7 +15,8 @@ namespace ControlCatalog.Pages
         private TimeSpan _lastFps;
         private int _lastFpsFrame;
         private double _fps;
-        public bool HasNewFrame => true;
+        public bool HasRenderTimeCriticalContent => true;
+        public bool ThreadSafeHasNewFrame => true;
         Stopwatch _st = Stopwatch.StartNew();
 
         private Typeface _typeface = Typeface.Default;

--- a/samples/ControlCatalog/Pages/TimeCriticalRenderPage.cs
+++ b/samples/ControlCatalog/Pages/TimeCriticalRenderPage.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Diagnostics;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.LogicalTree;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+using Avalonia.VisualTree;
+
+namespace ControlCatalog.Pages
+{
+    public class TimeCriticalRenderPage : Control, IRenderTimeCriticalVisual
+    {
+        private int _frame;
+        private TimeSpan _lastFps;
+        private int _lastFpsFrame;
+        private double _fps;
+        public bool HasNewFrame => true;
+        Stopwatch _st = Stopwatch.StartNew();
+
+        private Typeface _typeface = Typeface.Default;
+
+        public void ThreadSafeRender(DrawingContext context, Size logicalSize, double scaling)
+        {
+            var nowTs = _st.Elapsed;
+            var now = DateTime.Now;
+            var fpsTimeDiff = (nowTs - _lastFps).TotalSeconds;
+            if (fpsTimeDiff > 1)
+            {
+                _fps = (_frame - _lastFpsFrame) / fpsTimeDiff;
+                _lastFpsFrame = _frame;
+                _lastFps = nowTs;
+            }
+
+            var text = $"Frame: {_frame}\nFPS: {_fps}\nNow: {now}";
+            text += $"\nTransform{context.CurrentTransform}";
+            text += $"\nContainer Transform{context.CurrentContainerTransform}";
+            var fmt = new FormattedText()
+            {
+                Text = text,
+                Typeface = _typeface
+            };
+            var back = new ImmutableSolidColorBrush(Colors.LightGray);
+            var textBrush = new ImmutableSolidColorBrush(Colors.Black);
+            context.FillRectangle(back, new Rect(logicalSize));
+            context.DrawText(textBrush, new Point(5, 5), fmt);
+            _frame++;
+        }
+    }
+}

--- a/src/Avalonia.Base/Avalonia.Base.csproj
+++ b/src/Avalonia.Base/Avalonia.Base.csproj
@@ -6,7 +6,7 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Avalonia.Build.Tasks\Avalonia.Build.Tasks.csproj"/>
+    <ProjectReference Include="..\Avalonia.Build.Tasks\Avalonia.Build.Tasks.csproj" />
   </ItemGroup>
   <Import Project="..\..\build\Base.props" />
   <Import Project="..\..\build\Binding.props" />

--- a/src/Avalonia.Base/Threading/ThreadSafeObjectPool.cs
+++ b/src/Avalonia.Base/Threading/ThreadSafeObjectPool.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace Avalonia.Threading
+{
+    public class ThreadSafeObjectPool<T> where T : class, new()
+    {
+        private Stack<T> _stack = new Stack<T>();
+        private object _lock = new object();
+        public static ThreadSafeObjectPool<T> Default { get; } = new ThreadSafeObjectPool<T>();
+
+        public T Get()
+        {
+            lock (_lock)
+            {
+                if(_stack.Count == 0)
+                    return new T();
+                return _stack.Pop();
+            }
+        }
+
+        public void Return(T obj)
+        {
+            lock (_stack)
+            {
+                _stack.Push(obj);
+            }
+        }
+    }
+}

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -240,11 +240,12 @@ namespace Avalonia.Native
 
         public IRenderer CreateRenderer(IRenderRoot root)
         {
+            var loop = AvaloniaLocator.Current.GetService<IRenderLoop>();
             if (_deferredRendering)
-                return new DeferredRenderer(root, AvaloniaLocator.Current.GetService<IRenderLoop>(),
+                return new DeferredRenderer(root, loop,
                     rendererLock:
                     _gpu ? new AvaloniaNativeDeferredRendererLock(_native) : null);
-            return new ImmediateRenderer(root);
+            return new ImmediateRenderer(root, loop);
         }
 
         public virtual void Dispose()

--- a/src/Avalonia.Visuals/Media/DrawingContext.cs
+++ b/src/Avalonia.Visuals/Media/DrawingContext.cs
@@ -2,23 +2,26 @@ using System;
 using System.Collections.Generic;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
+using Avalonia.Threading;
 using Avalonia.Visuals.Media.Imaging;
 
 namespace Avalonia.Media
 {
     public sealed class DrawingContext : IDisposable
     {
+        private readonly bool _ownsImpl;
         private int _currentLevel;
 
 
-        static readonly Stack<Stack<PushedState>> StateStackPool = new Stack<Stack<PushedState>>();
-        static readonly Stack<Stack<TransformContainer>> TransformStackPool = new Stack<Stack<TransformContainer>>();
+        private static readonly ThreadSafeObjectPool<Stack<PushedState>> StateStackPool =
+            ThreadSafeObjectPool<Stack<PushedState>>.Default;
 
-        private Stack<PushedState> _states = StateStackPool.Count == 0 ? new Stack<PushedState>() : StateStackPool.Pop();
+        private static readonly ThreadSafeObjectPool<Stack<TransformContainer>> TransformStackPool =
+            ThreadSafeObjectPool<Stack<TransformContainer>>.Default;
 
-        private Stack<TransformContainer> _transformContainers = TransformStackPool.Count == 0
-            ? new Stack<TransformContainer>()
-            : TransformStackPool.Pop();
+        private Stack<PushedState> _states = StateStackPool.Get();
+
+        private Stack<TransformContainer> _transformContainers = TransformStackPool.Get();
 
         readonly struct TransformContainer
         {
@@ -34,6 +37,13 @@ namespace Avalonia.Media
 
         public DrawingContext(IDrawingContextImpl impl)
         {
+            PlatformImpl = impl;
+            _ownsImpl = true;
+        }
+        
+        public DrawingContext(IDrawingContextImpl impl, bool ownsImpl)
+        {
+            _ownsImpl = ownsImpl;
             PlatformImpl = impl;
         }
 
@@ -299,11 +309,14 @@ namespace Avalonia.Media
         {
             while (_states.Count != 0)
                 _states.Peek().Dispose();
-            StateStackPool.Push(_states);
+            StateStackPool.Return(_states);
             _states = null;
-            TransformStackPool.Push(_transformContainers);
+            if (_transformContainers.Count != 0)
+                throw new InvalidOperationException("Transform container stack is non-empty");
+            TransformStackPool.Return(_transformContainers);
             _transformContainers = null;
-            PlatformImpl.Dispose();
+            if (_ownsImpl)
+                PlatformImpl.Dispose();
         }
 
         private static bool PenIsVisible(Pen pen)

--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -231,6 +231,8 @@ namespace Avalonia.Rendering
                         }
 
                         var (scene, updated) = UpdateRenderLayersAndConsumeSceneIfNeeded(GetContext);
+                        if (scene == null)
+                            return;
                         using (scene)
                         {
                             var overlay = DrawDirtyRects || DrawFps;

--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -301,7 +301,7 @@ namespace Avalonia.Rendering
                 }
 
                 var hasCriticalRenderTimeVisualUpdates = Layers.Any(l =>
-                    l.LayerRoot is IRenderTimeCriticalVisual critical && critical.HasNewFrame);
+                    l.LayerRoot is IRenderTimeCriticalVisual critical && critical.ThreadSafeHasNewFrame);
                 if (hasCriticalRenderTimeVisualUpdates)
                 {
                     Layers.Update(scene, contextFactory());
@@ -372,7 +372,7 @@ namespace Avalonia.Rendering
                     var renderTarget = renderLayer.Bitmap;
                     var node = (VisualNode)scene.FindNode(layer.LayerRoot);
                     var critical = node.Visual as IRenderTimeCriticalVisual;
-                    if (criticalTimeRenderOnly && critical?.HasNewFrame != true)
+                    if (criticalTimeRenderOnly && critical?.ThreadSafeHasNewFrame != true)
                         continue;
                     
                     if (node != null)

--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -326,11 +326,8 @@ namespace Avalonia.Rendering
             using (var fullCtx = new DrawingContext(context, false))
             using (fullCtx.PushPostTransform(node.Transform))
             using (fullCtx.PushTransformContainer())
-                critical.ThreadSafeRender(fullCtx, node.Bounds.Size, scaling);
+                critical.ThreadSafeRender(fullCtx, node.VisualSize, scaling);
             context.Transform = savedTransform;
-
-            //critical.ThreadSafeRender()
-
         }
 
         private void Render(IDrawingContextImpl context, VisualNode node, IVisual layer, Rect clipBounds)

--- a/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
@@ -300,7 +300,7 @@ namespace Avalonia.Rendering
                 using (visual.OpacityMask != null ? context.PushOpacityMask(visual.OpacityMask, bounds) : default(DrawingContext.PushedState))
                 using (context.PushTransformContainer())
                 {
-                    if (visual is IRenderTimeCriticalVisual critical)
+                    if (visual is IRenderTimeCriticalVisual critical && critical.HasRenderTimeCriticalContent)
                     {
                         critical.ThreadSafeRender(context, bounds.Size, scaling);
                         info?.RenderTimeCriticalVisuals.Add(critical);
@@ -337,7 +337,7 @@ namespace Avalonia.Rendering
             }
         }
 
-        public bool NeedsUpdate => _lastRenderPassInfo?.RenderTimeCriticalVisuals.Any(v => v.HasNewFrame) == true;
+        public bool NeedsUpdate => _lastRenderPassInfo?.RenderTimeCriticalVisuals.Any(v => v.ThreadSafeHasNewFrame) == true;
         public void Update(TimeSpan time) => _root.InvalidateVisual();
         public void Render()
         {

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/IVisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/IVisualNode.cs
@@ -43,6 +43,11 @@ namespace Avalonia.Rendering.SceneGraph
         /// Gets the layout bounds for the node in global coordinates.
         /// </summary>
         Rect LayoutBounds { get; }
+        
+        /// <summary>
+        /// Gets the original visual size before transformations
+        /// </summary>
+        Size VisualSize { get; }
 
         /// <summary>
         /// Whether the node is clipped to <see cref="ClipBounds"/>.

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -181,6 +181,7 @@ namespace Avalonia.Rendering.SceneGraph
                     node.ClipBounds = clipBounds;
                     node.ClipToBounds = clipToBounds;
                     node.LayoutBounds = globalBounds;
+                    node.VisualSize = visual.Bounds.Size;
                     node.GeometryClip = visual.Clip?.PlatformImpl;
                     node.Opacity = opacity;
 

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -367,6 +367,8 @@ namespace Avalonia.Rendering.SceneGraph
 
         private static bool ShouldStartLayer(IVisual visual)
         {
+            if (visual is IRenderTimeCriticalVisual)
+                return true;
             if (visual.WantsLayer)
                 return true;
             var o = visual as IAvaloniaObject;

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -368,7 +368,7 @@ namespace Avalonia.Rendering.SceneGraph
 
         private static bool ShouldStartLayer(IVisual visual)
         {
-            if (visual is IRenderTimeCriticalVisual)
+            if (visual is IRenderTimeCriticalVisual critical && critical.HasRenderTimeCriticalContent)
                 return true;
             if (visual.WantsLayer)
                 return true;

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -367,6 +367,8 @@ namespace Avalonia.Rendering.SceneGraph
 
         private static bool ShouldStartLayer(IVisual visual)
         {
+            if (visual.WantsLayer)
+                return true;
             var o = visual as IAvaloniaObject;
             return visual.VisualChildren.Count > 0 &&
                 o != null &&

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
@@ -60,6 +60,9 @@ namespace Avalonia.Rendering.SceneGraph
 
         /// <inheritdoc/>
         public Rect LayoutBounds { get; set; }
+        
+        /// <inheritdoc/>
+        public Size VisualSize { get; set; }
 
         /// <inheritdoc/>
         public bool ClipToBounds { get; set; }
@@ -221,6 +224,7 @@ namespace Avalonia.Rendering.SceneGraph
                 ClipBounds = ClipBounds,
                 ClipToBounds = ClipToBounds,
                 LayoutBounds = LayoutBounds,
+                VisualSize = VisualSize,
                 GeometryClip = GeometryClip,
                 _opacity = Opacity,
                 OpacityMask = OpacityMask,

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
@@ -220,6 +220,7 @@ namespace Avalonia.Rendering.SceneGraph
                 Transform = Transform,
                 ClipBounds = ClipBounds,
                 ClipToBounds = ClipToBounds,
+                LayoutBounds = LayoutBounds,
                 GeometryClip = GeometryClip,
                 _opacity = Opacity,
                 OpacityMask = OpacityMask,

--- a/src/Avalonia.Visuals/Visual.cs
+++ b/src/Avalonia.Visuals/Visual.cs
@@ -90,10 +90,18 @@ namespace Avalonia
         public static readonly StyledProperty<int> ZIndexProperty =
             AvaloniaProperty.Register<Visual, int>(nameof(ZIndex));
 
+        /// <summary>
+        /// Defines the <see cref="WantsLayer"/> property.
+        /// </summary>
+        public static readonly DirectProperty<Visual, bool> WantsLayerProperty =
+            AvaloniaProperty.RegisterDirect<Visual, bool>("WantsLayer", o => o._wantsLayer,
+                (o, v) => o._wantsLayer = v);
+
         private Rect _bounds;
         private TransformedBounds? _transformedBounds;
         private IRenderRoot _visualRoot;
         private IVisual _visualParent;
+        private bool _wantsLayer;
 
         /// <summary>
         /// Initializes static members of the <see cref="Visual"/> class.
@@ -105,7 +113,8 @@ namespace Avalonia
                 ClipProperty,
                 ClipToBoundsProperty,
                 IsVisibleProperty,
-                OpacityProperty);
+                OpacityProperty,
+                WantsLayerProperty);
             RenderTransformProperty.Changed.Subscribe(RenderTransformChanged);
         }
 
@@ -237,6 +246,15 @@ namespace Avalonia
         {
             get;
             private set;
+        }
+
+        /// <summary>
+        /// Allows to explicitly force a rendering layer for a particular visual. Use with caution.
+        /// </summary>
+        public bool WantsLayer
+        {
+            get => GetValue(WantsLayerProperty);
+            set => SetValue(WantsLayerProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Visuals/VisualTree/IRenderTimeCriticalVisual.cs
+++ b/src/Avalonia.Visuals/VisualTree/IRenderTimeCriticalVisual.cs
@@ -1,0 +1,10 @@
+using Avalonia.Media;
+
+namespace Avalonia.VisualTree
+{
+    public interface IRenderTimeCriticalVisual
+    {
+        bool HasNewFrame { get; }
+        void ThreadSafeRender(DrawingContext context, Size logicalSize, double scaling);
+    }
+}

--- a/src/Avalonia.Visuals/VisualTree/IRenderTimeCriticalVisual.cs
+++ b/src/Avalonia.Visuals/VisualTree/IRenderTimeCriticalVisual.cs
@@ -4,8 +4,20 @@ namespace Avalonia.VisualTree
 {
     public interface IRenderTimeCriticalVisual
     {
+        /// <summary>
+        /// Checks if visual has time critical content. You need to call InvalidateVisual for this property to be re-queried.
+        /// </summary>
         bool HasRenderTimeCriticalContent { get; }
+        /// <summary>
+        /// Checks if visual has a new frame. This property can be read from any thread.
+        /// </summary>
         bool ThreadSafeHasNewFrame { get; }
+        /// <summary>
+        /// Draws the new frame during the render pass. That can happen on any thread
+        /// </summary>
+        /// <param name="context">DrawingContext. The available API is limited by stuff that can run on non-UI thread (brushes has to be immutable, no visual brush, etc)</param>
+        /// <param name="logicalSize">Logical size of the visual during the layout pass associated with the current frame</param>
+        /// <param name="scaling">DPI scaling of the target surface associated with the current frame</param>
         void ThreadSafeRender(DrawingContext context, Size logicalSize, double scaling);
     }
 }

--- a/src/Avalonia.Visuals/VisualTree/IRenderTimeCriticalVisual.cs
+++ b/src/Avalonia.Visuals/VisualTree/IRenderTimeCriticalVisual.cs
@@ -4,7 +4,8 @@ namespace Avalonia.VisualTree
 {
     public interface IRenderTimeCriticalVisual
     {
-        bool HasNewFrame { get; }
+        bool HasRenderTimeCriticalContent { get; }
+        bool ThreadSafeHasNewFrame { get; }
         void ThreadSafeRender(DrawingContext context, Size logicalSize, double scaling);
     }
 }

--- a/src/Avalonia.Visuals/VisualTree/IVisual.cs
+++ b/src/Avalonia.Visuals/VisualTree/IVisual.cs
@@ -127,5 +127,10 @@ namespace Avalonia.VisualTree
         /// common ancestor.
         /// </returns>
         Matrix? TransformToVisual(IVisual visual);
+        
+        /// <summary>
+        /// Allows to explicitly force a rendering layer for a particular visual. Use with caution.
+        /// </summary>
+        bool WantsLayer { get; }
     }
 }

--- a/src/Gtk/Avalonia.Gtk3/WindowBaseImpl.cs
+++ b/src/Gtk/Avalonia.Gtk3/WindowBaseImpl.cs
@@ -509,7 +509,7 @@ namespace Avalonia.Gtk3
             var loop = AvaloniaLocator.Current.GetService<IRenderLoop>();
             return Gtk3Platform.UseDeferredRendering
                 ? (IRenderer) new DeferredRenderer(root, loop)
-                : new ImmediateRenderer(root);
+                : new ImmediateRenderer(root, loop);
         }
 
         PixelSize EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo.Size

--- a/src/Skia/Avalonia.Skia/GlRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/GlRenderTarget.cs
@@ -35,6 +35,7 @@ namespace Avalonia.Skia
             gl.ClearStencil(0);
             gl.ClearColor(0, 0, 0, 0);
             gl.Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+            _grContext.ResetContext();
 
             GRBackendRenderTarget renderTarget =
                 new GRBackendRenderTarget(size.Width, size.Height, disp.SampleCount, disp.StencilSize,

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -148,7 +148,9 @@ namespace Avalonia.Win32
             if (customRendererFactory != null)
                 return customRendererFactory.Create(root, loop);
 
-            return Win32Platform.UseDeferredRendering ? (IRenderer)new DeferredRenderer(root, loop) : new ImmediateRenderer(root);
+            return Win32Platform.UseDeferredRendering
+                ? (IRenderer)new DeferredRenderer(root, loop)
+                : new ImmediateRenderer(root, loop);
         }
 
         public void Resize(Size value)

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/ImmediateRendererTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/ImmediateRendererTests.cs
@@ -62,6 +62,7 @@ namespace Avalonia.Visuals.UnitTests.Rendering
             var renderTarget = visual.As<IRenderTarget>();
 
             renderRoot.Setup(r => r.CreateRenderTarget()).Returns(renderTarget.Object);
+            renderRoot.SetupGet(r => r.RenderScaling).Returns(1);
             renderTarget.Setup(r => r.CreateDrawingContext(It.IsAny<IVisualBrushRenderer>())).Returns(Mock.Of<IDrawingContextImpl>());
 
             visual.As<IVisual>().Setup(v => v.Bounds).Returns(new Rect(0, 0, 400, 400));


### PR DESCRIPTION
This is needed for displaying things like video output, animated images, foreign content from WritableBitmap, etc. The common thing about these usage scenarios is that they don't need the UI thread, but need a steady frame rate. 
Since render thread timer ticks independently from UI thread the "render time critical" visuals can update themselves even if UI thread is completely blocked by the user code.

The API looks like this:
```cs
    public interface IRenderTimeCriticalVisual
    {
        bool HasNewFrame { get; }
        void ThreadSafeRender(DrawingContext context, Size logicalSize, double scaling);
    }
```

They are forced to have a separate layer since they are supposed to update very frequently.

This is DeferredRenderer implementation. For ImmediateRenderer I'm planning to connect it to the RenderLoop's Update and trigger Invalidate calls to the OS if the last frame had `IRenderTimeCriticalVisual` anywhere in the graph.