### PR TITLE
WIP: Add BuildCrossCheck integration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     displayName: 'Install Nuke'
     inputs:
       script: |
-         dotnet tool install --global Nuke.GlobalTool --version 0.12.3
+         dotnet tool install --global Nuke.GlobalTool --version 0.13.0
   - task: CmdLine@2
     displayName: 'Run Nuke'
     inputs:
@@ -57,7 +57,7 @@ jobs:
     displayName: 'Install Nuke'
     inputs:
       script: |
-       dotnet tool install --global Nuke.GlobalTool --version 0.12.3 
+       dotnet tool install --global Nuke.GlobalTool --version 0.13.0 
 
   - task: CmdLine@2
     displayName: 'Run Nuke'
@@ -99,7 +99,7 @@ jobs:
     displayName: 'Install Nuke'
     inputs:
       script: |
-       dotnet tool install --global Nuke.GlobalTool --version 0.12.3 
+       dotnet tool install --global Nuke.GlobalTool --version 0.13.0 
 
   - task: CmdLine@2
     displayName: 'Run Nuke'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,10 +71,10 @@ jobs:
     displayName: 'Upload MSBuild Log to BuildCrossCheck'
     inputs:
       env: 
-        SOURCE_FOLDER: $(Build.SourcesDirectory)
+        SOURCE_FOLDER: '$(Build.SourcesDirectory)'
         REPO_NAME: 'AvaloniaUI/Avalonia'
-        COMMIT_ID: $(Build.SourceVersion)
-        BCC_TOKEN: $(BCC-Key-Avalonia)
+        COMMIT_ID: '$(Build.SourceVersion)'
+        BCC_TOKEN: '$(BCC-Key-Avalonia)'
       script: |
         BCCMSBuildLog --input avalonia.binlog --output artifacts/checkrun.json --cloneRoot "%SOURCE_FOLDER%" --ownerRepo %REPO_NAME% --hash %COMMIT_ID%
         BCCSubmission -i artifacts/checkrun.json -h %COMMIT_ID% -t %BCC_TOKEN%

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install castxml
 
+  - script: echo '$(Build.Repository.Name)'
+
   - template: build/managed-build-and-test.yml
     parameters:
       target: CiAzureLinux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,14 +70,9 @@ jobs:
   - task: CmdLine@2
     displayName: 'Upload MSBuild Log to BuildCrossCheck'
     inputs:
-      env: 
-        SOURCE_FOLDER: '$(Build.SourcesDirectory)'
-        REPO_NAME: 'AvaloniaUI/Avalonia'
-        COMMIT_ID: '$(Build.SourceVersion)'
-        BCC_TOKEN: '$(BCC-Key-Avalonia)'
       script: |
-        BCCMSBuildLog --input avalonia.binlog --output artifacts/checkrun.json --cloneRoot "%SOURCE_FOLDER%" --ownerRepo %REPO_NAME% --hash %COMMIT_ID%
-        BCCSubmission -i artifacts/checkrun.json -h %COMMIT_ID% -t %BCC_TOKEN%
+        BCCMSBuildLog --input avalonia.binlog --output artifacts/checkrun.json --cloneRoot "$(Build.SourcesDirectory)" --ownerRepo "AvaloniaUI/Avalonia" --hash $(Build.SourceVersion)
+        BCCSubmission -i artifacts/checkrun.json -h $(Build.SourceVersion) -t $(BCC-Key-Avalonia)
     condition: not(canceled())
 
   - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,34 +10,14 @@ jobs:
         sudo apt-get update
         sudo apt-get install castxml
 
-  - task: CmdLine@2
-    displayName: 'Install Nuke'
-    inputs:
-      script: |
-         dotnet tool install --global Nuke.GlobalTool --version 0.13.0
-  - task: CmdLine@2
-    displayName: 'Run Nuke'
-    inputs:
-      script: |
-        export PATH="$PATH:$HOME/.dotnet/tools"
-        dotnet --info
-        printenv
-        nuke --target CiAzureLinux --configuration=Release
-
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: 'VSTest'
-      testResultsFiles: '$(Build.SourcesDirectory)/artifacts/test-results/*.trx'
-    condition: not(canceled())
+  - template: build/managed-build-and-test.yml
+      inputs:
+        target: CiAzureLinux
      
 - job: macOS
   pool:
     vmImage: 'xcode9-macos10.13'
   steps:
-  - task: DotNetCoreInstaller@0
-    inputs:
-      version: '2.1.403'
-
   - task: Xcode@5
     inputs:
       actions: 'build'
@@ -53,31 +33,9 @@ jobs:
     inputs:
       script: brew install castxml
 
-  - task: CmdLine@2
-    displayName: 'Install Nuke'
-    inputs:
-      script: |
-       dotnet tool install --global Nuke.GlobalTool --version 0.13.0 
-
-  - task: CmdLine@2
-    displayName: 'Run Nuke'
-    inputs:
-      script: |
-        export COREHOST_TRACE=0
-        export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-        export DOTNET_CLI_TELEMETRY_OPTOUT=1
-        which dotnet
-        dotnet --info
-        export PATH="$PATH:$HOME/.dotnet/tools"
-        dotnet --info
-        printenv
-        nuke --target CiAzureOSX --configuration Release
-
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: 'VSTest'
-      testResultsFiles: '$(Build.SourcesDirectory)/artifacts/test-results/*.trx'
-    condition: not(canceled())
+  - template: build/managed-build-and-test.yml
+      inputs:
+        target: CiAzureOSX
   
   - task: PublishBuildArtifacts@1
     inputs:
@@ -95,24 +53,10 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps:
-  - task: CmdLine@2
-    displayName: 'Install Nuke'
-    inputs:
-      script: |
-       dotnet tool install --global Nuke.GlobalTool --version 0.13.0 
-
-  - task: CmdLine@2
-    displayName: 'Run Nuke'
-    inputs:
-      script: |
-        set PATH=%PATH%;%USERPROFILE%\.dotnet\tools
-        nuke --target CiAzureWindows --configuration Release
-      
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: 'VSTest'
-      testResultsFiles: '$(Build.SourcesDirectory)/artifacts/test-results/*.trx'
-    condition: not(canceled())
+  
+  - template: build/managed-build-and-test.yml
+      inputs:
+        target: CiAzureWindows
 
   - task: PublishBuildArtifacts@1
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,6 +78,7 @@ jobs:
       script: |
         BCCMSBuildLog --input avalonia.binlog --output artifacts/checkrun.json --cloneRoot "%SOURCE_FOLDER%" --ownerRepo %REPO_NAME% --hash %COMMIT_ID%
         BCCSubmission -i artifacts/checkrun.json -h %COMMIT_ID% -t %BCC_TOKEN%
+    condition: not(canceled())
 
   - task: PublishBuildArtifacts@1
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,6 @@
+variables:
+- group: BuildCrossCheck
+
 jobs:
 - job: Linux
   pool:
@@ -57,6 +60,24 @@ jobs:
   - template: build/managed-build-and-test.yml
       inputs:
         target: CiAzureWindows
+  - task: gep13.chocolatey-azuredevops.chocolatey-azuredevops.ChocolateyCommand@0
+    displayName: 'Install BuildCrossCheck'
+    inputs:
+      command: install
+      installPackageId: 'BCC-MSBuildLog BCC-Submission'
+      installInstallArgs: '--no-progress '
+
+  - task: CmdLine@2
+    displayName: 'Upload MSBuild Log to BuildCrossCheck'
+    inputs:
+      env: 
+        SOURCE_FOLDER: $(Build.SourcesDirectory)
+        REPO_NAME: 'AvaloniaUI/Avalonia'
+        COMMIT_ID: $(Build.SourceVersion)
+        BCC_TOKEN: $(BCC-Key-Avalonia)
+      script: |
+        BCCMSBuildLog --input avalonia.binlog --output artifacts/checkrun.json --cloneRoot "%SOURCE_FOLDER%" --ownerRepo %REPO_NAME% --hash %COMMIT_ID%
+        BCCSubmission -i artifacts/checkrun.json -h %COMMIT_ID% -t %BCC_TOKEN%
 
   - task: PublishBuildArtifacts@1
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,9 +14,9 @@ jobs:
         sudo apt-get install castxml
 
   - template: build/managed-build-and-test.yml
-      inputs:
-        target: CiAzureLinux
-     
+    parameters:
+      target: CiAzureLinux
+
 - job: macOS
   pool:
     vmImage: 'xcode9-macos10.13'
@@ -37,8 +37,8 @@ jobs:
       script: brew install castxml
 
   - template: build/managed-build-and-test.yml
-      inputs:
-        target: CiAzureOSX
+    parameters:
+      target: CiAzureOSX
   
   - task: PublishBuildArtifacts@1
     inputs:
@@ -58,8 +58,8 @@ jobs:
   steps:
   
   - template: build/managed-build-and-test.yml
-      inputs:
-        target: CiAzureWindows
+    parameters:
+      target: CiAzureWindows
   - task: gep13.chocolatey-azuredevops.chocolatey-azuredevops.ChocolateyCommand@0
     displayName: 'Install BuildCrossCheck'
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,8 +13,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install castxml
 
-  - script: echo '$(Build.Repository.Name)'
-
   - template: build/managed-build-and-test.yml
     parameters:
       target: CiAzureLinux
@@ -63,17 +61,22 @@ jobs:
     parameters:
       target: CiAzureWindows
   - task: gep13.chocolatey-azuredevops.chocolatey-azuredevops.ChocolateyCommand@0
-    displayName: 'Install BuildCrossCheck'
+    displayName: 'Install BuildCrossCheck Submission'
     inputs:
       command: install
-      installPackageId: 'BCC-MSBuildLog BCC-Submission'
-      installInstallArgs: '--no-progress '
+      installPackageId: 'BCC-Submission'
+
+  - task: gep13.chocolatey-azuredevops.chocolatey-azuredevops.ChocolateyCommand@0
+    displayName: 'Install BuildCrossCheck MSBuildLog'
+    inputs:
+      command: install
+      installPackageId: 'BCC-MSBuildLog'
 
   - task: CmdLine@2
     displayName: 'Upload MSBuild Log to BuildCrossCheck'
     inputs:
       script: |
-        BCCMSBuildLog --input avalonia.binlog --output artifacts/checkrun.json --cloneRoot "$(Build.SourcesDirectory)" --ownerRepo "AvaloniaUI/Avalonia" --hash $(Build.SourceVersion)
+        BCCMSBuildLog --input avalonia.binlog --output artifacts/checkrun.json --cloneRoot "$(Build.SourcesDirectory)" --ownerRepo "$(Build.Repository.Name)" --hash $(Build.SourceVersion)
         BCCSubmission -i artifacts/checkrun.json -h $(Build.SourceVersion) -t $(BCC-Key-Avalonia)
     condition: not(canceled())
 

--- a/build/managed-build-and-test.yml
+++ b/build/managed-build-and-test.yml
@@ -1,0 +1,22 @@
+parameters:
+    target: ''
+
+steps:
+  - task: DotNetCoreInstaller@0
+    inputs:
+      version: '2.1.403'
+  - task: CmdLine@2
+    displayName: 'Install Nuke'
+    inputs:
+      script: |
+       dotnet tool install --global Nuke.GlobalTool --version 0.13.0 
+  - task: CmdLine@2
+    displayName: 'Run Nuke'
+    inputs:
+      script: |
+        nuke --target ${{ parameters.target }} --configuration Release
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'VSTest'
+      testResultsFiles: '$(Build.SourcesDirectory)/artifacts/test-results/*.trx'
+    condition: not(canceled())

--- a/build/managed-build-and-test.yml
+++ b/build/managed-build-and-test.yml
@@ -1,10 +1,6 @@
 parameters:
     target: ''
 
-variables:
-  - name: target
-    value: ${{ parameters.target }}
-
 steps:
   - task: DotNetCoreInstaller@0
     inputs:
@@ -18,7 +14,7 @@ steps:
     displayName: 'Run Nuke'
     inputs:
       script: |
-        nuke --target $(target) --configuration Release
+        nuke --target ${{ parameters.target }} --configuration Release
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: 'VSTest'

--- a/build/managed-build-and-test.yml
+++ b/build/managed-build-and-test.yml
@@ -1,6 +1,10 @@
 parameters:
     target: ''
 
+variables:
+  - name: target
+    value: ${{ parameters.target }}
+
 steps:
   - task: DotNetCoreInstaller@0
     inputs:
@@ -14,7 +18,7 @@ steps:
     displayName: 'Run Nuke'
     inputs:
       script: |
-        nuke --target ${{ parameters.target }} --configuration Release
+        nuke --target $(target) --configuration Release
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: 'VSTest'

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -76,7 +76,7 @@ partial class Build : NukeBuild
 
             if (Parameters.IsRunningOnWindows)
                 MSBuild(Parameters.MSBuildSolution, c => c
-                    .SetArgumentConfigurator(a => a.Add("/r"))
+                    .EnableRestore()
                     .SetConfiguration(Parameters.Configuration)
                     .SetVerbosity(MSBuildVerbosity.Minimal)
                     .AddProperty("PackageVersion", Parameters.Version)

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -76,6 +76,7 @@ partial class Build : NukeBuild
 
             if (Parameters.IsRunningOnWindows)
                 MSBuild(Parameters.MSBuildSolution, c => c
+                    .SetArgumentConfigurator(a => Parameters.GenerateBinaryLog ? a.Add($"/bl:avalonia.binlog") : a)
                     .EnableRestore()
                     .SetConfiguration(Parameters.Configuration)
                     .SetVerbosity(MSBuildVerbosity.Minimal)

--- a/nukebuild/BuildParameters.cs
+++ b/nukebuild/BuildParameters.cs
@@ -45,6 +45,7 @@ public partial class Build
         public bool IsMyGetRelease { get; }
         public bool IsNuGetRelease { get; }
         public bool PublishTestResults { get; }
+        public bool GenerateBinaryLog { get; }
         public string Version { get; }
         public AbsolutePath ArtifactsDir { get; }
         public AbsolutePath NugetIntermediateRoot { get; }
@@ -113,6 +114,7 @@ public partial class Build
                 }
 
                 PublishTestResults = true;
+                GenerateBinaryLog = true;
             }
 
             // DIRECTORIES

--- a/nukebuild/_build.csproj
+++ b/nukebuild/_build.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="0.12.3" />
+    <PackageReference Include="Nuke.Common" Version="0.13.0" />
     <PackageReference Include="xunit.runner.console" Version="2.3.1" />
     <PackageReference Include="JetBrains.dotMemoryUnit" Version="3.0.20171219.105559" />
   </ItemGroup>


### PR DESCRIPTION
- Add the BuildCrossCheck GitHub Check to our PRs to have MSBuild errors and warnings be attached to the file they are triggered by and visible in a GitHub Check.
- Upgrade Nuke to 0.13.0
- Refactor azure-pipelines.yml to reduce duplication.

TODO:

- [ ] Move BuildCrossCheck into a template file
- [x] Try to use a variable instead of a specific value for the BuildCrossCheck repo name.

