### PR TITLE
Remove Cake packages.config.

### DIFF
--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-    <package id="Cake" version="0.30.0" />
-</packages>


### PR DESCRIPTION
We had a file left over from when we were using Cake as our build orchestrator. This PR removes it.