### PR TITLE
Added option to Win32Platform.cs to force EGL (or throw an exception, if unavailable)

### DIFF
--- a/src/Avalonia.OpenGL/EglGlPlatformFeature.cs
+++ b/src/Avalonia.OpenGL/EglGlPlatformFeature.cs
@@ -15,21 +15,26 @@ namespace Avalonia.OpenGL
             if (feature != null)
                 AvaloniaLocator.CurrentMutable.Bind<IWindowingPlatformGlFeature>().ToConstant(feature);
         }
-        
+
+        public static EglGlPlatformFeature Create()
+        {
+            var disp = new EglDisplay();
+            var ctx = disp.CreateContext(null);
+            return new EglGlPlatformFeature
+            {
+                Display = disp,
+                ImmediateContext = ctx,
+                DeferredContext = (EglContext)disp.CreateContext(ctx)
+            };
+        }
+
         public static EglGlPlatformFeature TryCreate()
         {
             try
             {
-                var disp = new EglDisplay();
-                var ctx = disp.CreateContext(null);
-                return new EglGlPlatformFeature
-                {
-                    Display = disp,
-                    ImmediateContext = ctx,
-                    DeferredContext = (EglContext)disp.CreateContext(ctx)
-                };
+                return Create();
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 Logger.Error("OpenGL", null, "Unable to initialize EGL-based rendering: {0}", e);
                 return null;

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -27,11 +27,11 @@ namespace Avalonia
     {
         public static T UseWin32<T>(
             this T builder,
-            bool deferredRendering = true, bool allowEgl = false) 
+            bool deferredRendering = true, bool allowEgl = false, bool forceEgl = false)
                 where T : AppBuilderBase<T>, new()
         {
             return builder.UseWindowingSubsystem(
-                () => Win32.Win32Platform.Initialize(deferredRendering, allowEgl),
+                () => Win32.Win32Platform.Initialize(deferredRendering, allowEgl, forceEgl),
                 "Win32");
         }
     }
@@ -66,7 +66,7 @@ namespace Avalonia.Win32
             Initialize(true);
         }
 
-        public static void Initialize(bool deferredRendering = true, bool allowEgl = false)
+        public static void Initialize(bool deferredRendering = true, bool allowEgl = false, bool forceEgl = false)
         {
             AvaloniaLocator.CurrentMutable
                 .Bind<IClipboard>().ToSingleton<ClipboardImpl>()
@@ -80,8 +80,10 @@ namespace Avalonia.Win32
                 .Bind<IWindowingPlatform>().ToConstant(s_instance)
                 .Bind<PlatformHotkeyConfiguration>().ToSingleton<PlatformHotkeyConfiguration>()
                 .Bind<IPlatformIconLoader>().ToConstant(s_instance);
-            if (allowEgl)
-                Win32GlManager.Initialize();
+
+            if (allowEgl || forceEgl)
+                Win32GlManager.Initialize(forceEgl);
+
             UseDeferredRendering = deferredRendering;
             _uiThread = Thread.CurrentThread;
 


### PR DESCRIPTION
This PR adds an option to Win32Platform.cs to force EGL-based rendering.
If the Skia backend is selected, the application will not silently fall back to software rendering, but throw an exception instead.