### PR TITLE
Add unit test and fix #2149.

### DIFF
--- a/src/Avalonia.Base/Data/Core/ExpressionNode.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNode.cs
@@ -147,6 +147,7 @@ namespace Avalonia.Data.Core
         private void StopListening()
         {
             StopListeningCore();
+            _listening = false;
         }
 
         private BindingNotification TargetNullNotification()

--- a/tests/Avalonia.Base.UnitTests/Data/Core/ExpressionObserverTests_Property.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/ExpressionObserverTests_Property.cs
@@ -563,6 +563,19 @@ namespace Avalonia.Base.UnitTests.Data.Core
             Assert.Null(result.Item2.Target);
         }
 
+        [Fact]
+        public void Should_Not_Throw_Exception_On_Unsubscribe_When_Already_Unsubscribed()
+        {
+            var source = new Class1 { Foo = "foo" };
+            var target = new PropertyAccessorNode("Foo", false);
+            Assert.NotNull(target);
+            target.Target = new WeakReference(source);
+            target.Subscribe(_ => { });
+            target.Unsubscribe();
+            target.Unsubscribe();
+            Assert.True(true);
+        }
+
         private interface INext
         {
             int PropertyChangedSubscriptionCount { get; }


### PR DESCRIPTION
- What does the pull request do?
Prevent `ExpressionNode` from doubly-calling `StopListeningCore`.
- What is the current behavior?
`ExpressionNode` can sometimes call `StopListeningCore` if it is doubly-`Unsubscribe`d from.
- What is the updated/expected behavior with this PR?
`StopListeningCore` will not be called if the node has already stopped listening.

Checklist:

- [x] Added unit tests (if possible)?

Fixes #2149.
Supersedes #2151.