### PR TITLE
fix #2166 black area on windows

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -153,17 +153,20 @@ namespace Avalonia.Win32
 
         public void Resize(Size value)
         {
-            if (value != ClientSize)
+            var clientRect = ClientSize;
+            if (value != clientRect)
             {
                 value *= Scaling;
-                
+                UnmanagedMethods.RECT windowRect;
+                UnmanagedMethods.GetWindowRect(_hwnd, out windowRect);
+
                 UnmanagedMethods.SetWindowPos(
                     _hwnd,
                     IntPtr.Zero,
                     0,
                     0,
-                    (int)value.Width,
-                    (int)value.Height,
+                    (int)(value.Width + (windowRect.Width - clientRect.Width)),
+                    (int)(value.Height + (windowRect.Height - clientRect.Height)),
                     UnmanagedMethods.SetWindowPosFlags.SWP_RESIZE);
             }
         }


### PR DESCRIPTION
- What does the pull request do
prevents black areas and hit test failing on windows where width or height are specified

- How was the solution implemented (if it's not obvious)?
the actual desired window size is requested from windows rather than the client size

Checklist:

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

If the pull request fixes issue(s) list them like this:

Fixes #2166 
