### PR TITLE
Fix failing macOS CastXML task on Azure CI.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,9 @@ jobs:
   - task: CmdLine@2
     displayName: 'Install CastXML'
     inputs:
-      script: brew install castxml
+      script: |
+        brew update
+        brew install castxml
 
   - task: CmdLine@2
     displayName: 'Install Nuke'


### PR DESCRIPTION
Add a temporary workaround for Homebrew so that CI passes after CastXML.