### PR TITLE
Updated MSBuild.Sdk.Extras version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
     "msbuild-sdks": {
         "Microsoft.Build.Traversal": "1.0.43",
-        "MSBuild.Sdk.Extras": "1.6.46",
+        "MSBuild.Sdk.Extras": "1.6.65",
         "AggregatePackage.NuGet.Sdk" : "0.1.12"
     }
 }


### PR DESCRIPTION
## Changes
- Updated `MSBuild.Sdk.Extras` version. It fixes a problem with language targets path, which was causing problems on project loading in VS 2019.