### PR TITLE
Fix selectors with classes in addition to name/type.

### DIFF
--- a/.ncrunch/Avalonia.Desktop.v3.ncrunchproject
+++ b/.ncrunch/Avalonia.Desktop.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/.ncrunch/Avalonia.net461.v3.ncrunchproject
+++ b/.ncrunch/Avalonia.net461.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/Avalonia.v3.ncrunchsolution
+++ b/Avalonia.v3.ncrunchsolution
@@ -2,6 +2,7 @@
   <Settings>
     <AdditionalFilesToIncludeForSolution>
       <Value>tests\TestFiles\**.*</Value>
+      <Value>src\Avalonia.Build.Tasks\bin\Debug\netstandard2.0\Avalonia.Build.Tasks.dll</Value>
     </AdditionalFilesToIncludeForSolution>
     <AllowParallelTestExecution>True</AllowParallelTestExecution>
     <ProjectConfigStoragePathRelativeToSolutionDir>.ncrunch</ProjectConfigStoragePathRelativeToSolutionDir>

--- a/src/Avalonia.Styling/Styling/TypeNameAndClassSelector.cs
+++ b/src/Avalonia.Styling/Styling/TypeNameAndClassSelector.cs
@@ -116,11 +116,9 @@ namespace Avalonia.Styling
                 }
             }
 
-            if (Name != null)
+            if (Name != null && control.Name != Name)
             {
-                return control.Name == Name ? 
-                    SelectorMatch.AlwaysThisInstance :
-                    SelectorMatch.NeverThisInstance;
+                return SelectorMatch.NeverThisInstance;
             }
 
             if (_classes.IsValueCreated && _classes.Value.Count > 0)
@@ -130,17 +128,13 @@ namespace Avalonia.Styling
                     var observable = new ClassObserver(control.Classes, _classes.Value);
                     return new SelectorMatch(observable);
                 }
-                else
+                else if (!Matches(control.Classes))
                 {
-                    return Matches(control.Classes) ?
-                        SelectorMatch.AlwaysThisInstance :
-                        SelectorMatch.NeverThisInstance;
+                    return SelectorMatch.NeverThisInstance;
                 }
             }
-            else
-            {
-                return SelectorMatch.AlwaysThisType;
-            }
+
+            return Name == null ? SelectorMatch.AlwaysThisType : SelectorMatch.AlwaysThisInstance;
         }
 
         protected override Selector MovePrevious() => _previous;

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_Multiple.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_Multiple.cs
@@ -86,6 +86,44 @@ namespace Avalonia.Styling.UnitTests
         }
 
         [Fact]
+        public void Named_Class_Template_Child_Of_Control()
+        {
+            var template = new FuncControlTemplate(parent =>
+            {
+                return new Border
+                {
+                    Name = "border",
+                };
+            });
+
+            var control = new Button
+            {
+                Template = template,
+            };
+
+            control.ApplyTemplate();
+
+            var selector = default(Selector)
+                .OfType<Button>()
+                .Template()
+                .Name("border")
+                .Class("foo");
+
+            var border = (Border)((IVisual)control).VisualChildren.Single();
+            var values = new List<bool>();
+            var match = selector.Match(border);
+
+            Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            match.Activator.Subscribe(x => values.Add(x));
+
+            Assert.Equal(new[] { false }, values);
+            border.Classes.AddRange(new[] { "foo" });
+            Assert.Equal(new[] { false, true }, values);
+            border.Classes.Remove("foo");
+            Assert.Equal(new[] { false, true, false }, values);
+        }
+
+        [Fact]
         public void TargetType_OfType()
         {
             var selector = default(Selector).OfType<Button>();


### PR DESCRIPTION
`TreeViewItem` currently has a bug where its expanders are displayed permanently expanded:

![image](https://user-images.githubusercontent.com/1775141/51247118-7163ea00-198c-11e9-9fb5-78730d1f3462.png)

This was introduced in #2088: the `TreeViewItem` style selector `TreeViewItem /template/ ToggleButton#expander:checked` was permanently active. This was because of a mistake in `TypeNameAndClassSelector` where it would return a positive result if the `TargetType` or `Name` selectors matched without ever checking the `Class` selector.

This PR adds a unit test for this case and fixes the bug.

Also updates NCrunch configuration to allow NCrunch to work again.