### PR TITLE
WIP: Make ShowDialog respect WindowStartupLocation.

### DIFF
--- a/samples/ControlCatalog/Pages/DialogsPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DialogsPage.xaml.cs
@@ -36,10 +36,13 @@ namespace ControlCatalog.Pages
                 };
             this.FindControl<Button>("Dialog").Click += delegate
                 {
-                    new MainWindow().ShowDialog(GetWindow());
+                    var window = new Window();
+                    window.Height = 200;
+                    window.Width = 200;
+                    window.Content = new TextBlock { Text = "Hello world!" };
+                    window.WindowStartupLocation = WindowStartupLocation.CenterScreen;
+                    window.ShowDialog(GetWindow());
                 };
-
-
         }
 
         Window GetWindow() => (Window)this.VisualRoot;


### PR DESCRIPTION
`SetWindowStartupLocation` needs to be called _after_ the window is shown as is done in `Show`. In addition, the owner window needs to be passed so we can get the correct screen.

Renamed the `parent` parameter to `ShowDialog` to `owner` as its `WindowStartupLocation.CenterOwner` not `CenterParent`.

TODO: @kekekeks can we now remove `Window.Owner`? We're always passing the window owner into `ShowDialog` so it looks to me like it wouldn't be needed?