### PR TITLE
Remove :valid and :invalid pseudoclasses.

### DIFF
--- a/src/Avalonia.Base/Data/Converters/ObjectConverters.cs
+++ b/src/Avalonia.Base/Data/Converters/ObjectConverters.cs
@@ -1,0 +1,24 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+
+namespace Avalonia.Data.Converters
+{
+    /// <summary>
+    /// Provides a set of useful <see cref="IValueConverter"/>s for working with objects.
+    /// </summary>
+    public static class ObjectConverters
+    {
+        /// <summary>
+        /// A value converter that returns true if the input object is a null reference.
+        /// </summary>
+        public static readonly IValueConverter IsNull =
+            new FuncValueConverter<object, bool>(x => x is null);
+
+        /// <summary>
+        /// A value converter that returns true if the input object is not null.
+        /// </summary>
+        public static readonly IValueConverter IsNotNull =
+            new FuncValueConverter<object, bool>(x => !(x is null));
+    }
+}

--- a/src/Avalonia.Base/Data/Converters/StringConverters.cs
+++ b/src/Avalonia.Base/Data/Converters/StringConverters.cs
@@ -12,13 +12,13 @@ namespace Avalonia.Data.Converters
         /// <summary>
         /// A value converter that returns true if the input string is null or an empty string.
         /// </summary>
-        public static readonly IValueConverter NullOrEmpty =
+        public static readonly IValueConverter IsNullOrEmpty =
             new FuncValueConverter<string, bool>(string.IsNullOrEmpty);
 
         /// <summary>
         /// A value converter that returns true if the input string is not null or empty.
         /// </summary>
-        public static readonly IValueConverter NotNullOrEmpty =
+        public static readonly IValueConverter IsNotNullOrEmpty =
             new FuncValueConverter<string, bool>(x => !string.IsNullOrEmpty(x));
     }
 }

--- a/src/Avalonia.Controls/ContentControl.cs
+++ b/src/Avalonia.Controls/ContentControl.cs
@@ -45,8 +45,6 @@ namespace Avalonia.Controls
         static ContentControl()
         {
             ContentControlMixin.Attach<ContentControl>(ContentProperty, x => x.LogicalChildren);
-            PseudoClass<ContentControl, object>(ContentProperty, x => x != null, ":valid");
-            PseudoClass<ContentControl, object>(ContentProperty, x => x == null, ":invalid");
         }
 
         /// <summary>

--- a/src/Avalonia.Themes.Default/CheckBox.xaml
+++ b/src/Avalonia.Themes.Default/CheckBox.xaml
@@ -1,9 +1,10 @@
-<Styles xmlns="https://github.com/avaloniaui">
+<Styles xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <Style Selector="CheckBox">
     <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
     <Setter Property="Background" Value="Transparent"/>
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}"/>
     <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+    <Setter Property="Padding" Value="4,0,0,0"/>
     <Setter Property="VerticalContentAlignment" Value="Center"/>
     <Setter Property="HorizontalContentAlignment" Value="Left"/>
     <Setter Property="Template">
@@ -38,16 +39,14 @@
                             TextBlock.Foreground="{TemplateBinding Foreground}"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
                             Content="{TemplateBinding Content}"
-                            Margin="4,0,0,0"
+                            Margin="{TemplateBinding Padding}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            IsVisible="{TemplateBinding Content, Converter={x:Static ObjectConverters.IsNotNull}}"
                             Grid.Column="1"/>
         </Grid>
       </ControlTemplate>
     </Setter>
-  </Style>
-  <Style Selector="CheckBox:invalid /template/ ContentPresenter#PART_ContentPresenter">
-    <Setter Property="IsVisible" Value="False"/>
   </Style>
   <Style Selector="CheckBox:pointerover /template/ Border#border">
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}"/>

--- a/src/Avalonia.Themes.Default/TextBox.xaml
+++ b/src/Avalonia.Themes.Default/TextBox.xaml
@@ -23,7 +23,7 @@
                            Path="UseFloatingWatermark"/>
                   <Binding RelativeSource="{RelativeSource TemplatedParent}"
                            Path="Text"
-                           Converter="{x:Static StringConverters.NotNullOrEmpty}"/>
+                           Converter="{x:Static StringConverters.IsNotNullOrEmpty}"/>
                 </MultiBinding>
               </TextBlock.IsVisible>
             </TextBlock>
@@ -36,7 +36,7 @@
                   <TextBlock Name="watermark"
                              Opacity="0.5"
                              Text="{TemplateBinding Watermark}"
-                             IsVisible="{TemplateBinding Text, Converter={x:Static StringConverters.NullOrEmpty}}"/>
+                             IsVisible="{TemplateBinding Text, Converter={x:Static StringConverters.IsNullOrEmpty}}"/>
                   <TextPresenter Name="PART_TextPresenter"
                                  Text="{TemplateBinding Text, Mode=TwoWay}"
                                  CaretIndex="{TemplateBinding CaretIndex}"

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Converters.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_Converters.cs
@@ -22,14 +22,14 @@ namespace Avalonia.Markup.UnitTests.Data
 
             var target = new Binding(nameof(Class1.Foo))
             {
-                Converter = StringConverters.NullOrEmpty,
+                Converter = StringConverters.IsNullOrEmpty,
             };
 
             var expressionObserver = (BindingExpression)target.Initiate(
                 textBlock, 
                 TextBlock.TextProperty).Observable;
 
-            Assert.Same(StringConverters.NullOrEmpty, expressionObserver.Converter);
+            Assert.Same(StringConverters.IsNullOrEmpty, expressionObserver.Converter);
         }
 
         public class When_Binding_To_String
@@ -129,7 +129,7 @@ namespace Avalonia.Markup.UnitTests.Data
 
             var target = new Binding(nameof(Class1.Foo))
             {
-                Converter = StringConverters.NotNullOrEmpty,
+                Converter = StringConverters.IsNotNullOrEmpty,
                 StringFormat = "Hello {0}",
             };
 


### PR DESCRIPTION
`:valid` and `:invalid` pseudoclasses are being added to all `ContentControls` simply in order to show/hide the `ContentPresenter` in `CheckBox`. Instead of this, add some `ObjectConverters` and use them to set the visibility of the `ContentPresenter.`

Breaking change: also renamed the converters in `StringConverters` to add an `Is` prefix as the `ObjectConverters` didn't look right as just `ObjectConverters.Null` and `ObjectConverters.NotNull`: `ObjectConverters.IsNull` and `ObjectConverters.IsNotNull` read better.

Fixes #1999 