### PR TITLE
Update NumericUpDown Text when losing focus

### DIFF
--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -288,6 +288,13 @@ namespace Avalonia.Controls
         }
 
         /// <inheritdoc />
+        protected override void OnLostFocus(RoutedEventArgs e)
+        {
+            CommitInput();
+            base.OnLostFocus(e);
+        }
+
+        /// <inheritdoc />
         protected override void OnTemplateApplied(TemplateAppliedEventArgs e)
         {
             if (TextBox != null)


### PR DESCRIPTION
- What does the pull request do?
Updates the Text in a NumericUpDown when its focus is lost.
- What is the current behavior?
The Value is updated and clamped as expected, but the Text remains what it was when the user was still typing, which can be an invalid value. For example, if Maximum is set to 10 and the user typed 400, the Text will remain "400" but the Value will be set to 4 when ClipValueToMinMax is false and 10 when ClipValueToMinMax is true.
- What is the updated/expected behavior with this PR?
The Text will show the updated Value when the focus is lost.
- How was the solution implemented (if it's not obvious)?
The OnLostFocus() event is overridden and forces a text and value synchronization.