### PR TITLE
Fix Grid with Wrapping TextBlock

### DIFF
--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -272,7 +272,7 @@ namespace Avalonia.Controls
             //     - GridLayout doesn't hold any state, so you can drag the debugger execution
             //       arrow back to any statements and re-run them without any side-effect.
 
-            var measureCache = new Dictionary<Control, Size>();
+            var measureCache = new Dictionary<(Control, Size), Size>();
             var (safeColumns, safeRows) = GetSafeColumnRows();
             var columnLayout = new GridLayout(ColumnDefinitions);
             var rowLayout = new GridLayout(RowDefinitions);
@@ -312,14 +312,14 @@ namespace Avalonia.Controls
             // If a child has been measured, it will just return the desired size.
             Size MeasureOnce(Control child, Size size)
             {
-                if (measureCache.TryGetValue(child, out var desiredSize))
+                if (measureCache.TryGetValue((child, size), out var desiredSize))
                 {
                     return desiredSize;
                 }
 
                 child.Measure(size);
                 desiredSize = child.DesiredSize;
-                measureCache[child] = desiredSize;
+                measureCache[(child, size)] = desiredSize;
                 return desiredSize;
             }
         }


### PR DESCRIPTION
## What does the pull request do?

#2129 describes the erroneous behavior of `Grid` when it contains a `TextBlock` with wrapping in a star column. The problem was caused by Grid caching the measurement of the child control, and applying that cache to subsequent measurements of a different size.

## What is the current behavior?

In this example:

```xml
<Grid ColumnDefinitions="*, *">
    <TextBlock Grid.Column="1"
               VerticalAlignment="Center"
               Text="He determined to drop his litigation with the monastry, and relinguish his claims to the wood-cuting and fishery rihgts at once. He was the more ready to do this becuase the rights had becom much less valuable, and he had indeed the vaguest idea where the wood and river in quedtion were."
               TextWrapping="Wrap"/>
</Grid>
```

`Grid` truncates the `TextBlock` contents instead of wrapping them.

## What is the updated/expected behavior with this PR?

Running the above example now correctly causes the text to be wrapped.

## How was the solution implemented (if it's not obvious)?

Index `Grid`'s `measureCache` by `(child, constraint)` instead of just by child, so that when the child is measured with a different constraint the previously cached value is not reused.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #2129

cc: @walterlv 