### PR TITLE
Fix AvaloniaProperty registration type in ReactiveUserControl

### DIFF
--- a/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
+++ b/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
@@ -16,7 +16,7 @@ namespace Avalonia
     public class ReactiveUserControl<TViewModel> : UserControl, IViewFor<TViewModel> where TViewModel : class
     {
         public static readonly AvaloniaProperty<TViewModel> ViewModelProperty = AvaloniaProperty
-            .Register<ReactiveWindow<TViewModel>, TViewModel>(nameof(ViewModel));
+            .Register<ReactiveUserControl<TViewModel>, TViewModel>(nameof(ViewModel));
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReactiveUserControl{TViewModel}"/> class.


### PR DESCRIPTION
## What does the pull request do?

The `AvaloniaProperty` in `ReactiveUserControl<TViewModel>` is now registered for `ReactiveWindow<TViewModel>`, but should be registered for `ReactiveUserControl<TViewModel>` instead (https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.ReactiveUI/ReactiveUserControl.cs#L19). Thanks to @Naeron1984 for reporting this!