### PR TITLE
Added `:not()` style selector.

### DIFF
--- a/src/Avalonia.Styling/Styling/NotSelector.cs
+++ b/src/Avalonia.Styling/Styling/NotSelector.cs
@@ -1,0 +1,72 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using System.Reactive.Linq;
+
+namespace Avalonia.Styling
+{
+    /// <summary>
+    /// The `:not()` style selector.
+    /// </summary>
+    internal class NotSelector : Selector
+    {
+        private readonly Selector _previous;
+        private readonly Selector _argument;
+        private string _selectorString;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotSelector"/> class.
+        /// </summary>
+        /// <param name="previous">The previous selector.</param>
+        /// <param name="argument">The selector to be not-ed.</param>
+        public NotSelector(Selector previous, Selector argument)
+        {
+            _previous = previous;
+            _argument = argument ?? throw new InvalidOperationException("Not selector must have a selector argument.");
+        }
+
+        /// <inheritdoc/>
+        public override bool InTemplate => _argument.InTemplate;
+
+        /// <inheritdoc/>
+        public override bool IsCombinator => false;
+
+        /// <inheritdoc/>
+        public override Type TargetType => _previous?.TargetType;
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            if (_selectorString == null)
+            {
+                _selectorString = ":not(" + _argument.ToString() + ")";
+            }
+
+            return _selectorString;
+        }
+
+        protected override SelectorMatch Evaluate(IStyleable control, bool subscribe)
+        {
+            var innerResult = _argument.Match(control, subscribe);
+
+            switch (innerResult.Result)
+            {
+                case SelectorMatchResult.AlwaysThisInstance:
+                    return SelectorMatch.NeverThisInstance;
+                case SelectorMatchResult.AlwaysThisType:
+                    return SelectorMatch.NeverThisType;
+                case SelectorMatchResult.NeverThisInstance:
+                    return SelectorMatch.AlwaysThisInstance;
+                case SelectorMatchResult.NeverThisType:
+                    return SelectorMatch.AlwaysThisType;
+                case SelectorMatchResult.Sometimes:
+                    return new SelectorMatch(innerResult.Activator.Select(x => !x));
+                default:
+                    throw new InvalidOperationException("Invalid SelectorMatchResult.");
+            }
+        }
+
+        protected override Selector MovePrevious() => _previous;
+    }
+}

--- a/src/Avalonia.Styling/Styling/Selectors.cs
+++ b/src/Avalonia.Styling/Styling/Selectors.cs
@@ -95,6 +95,17 @@ namespace Avalonia.Styling
         }
 
         /// <summary>
+        /// Returns a selector which inverts the results of selector argument.
+        /// </summary>
+        /// <param name="previous">The previous selector.</param>
+        /// <param name="argument">The selector to be not-ed.</param>
+        /// <returns>The selector.</returns>
+        public static Selector Not(this Selector previous, Func<Selector, Selector> argument)
+        {
+            return new NotSelector(previous, argument(null));
+        }
+
+        /// <summary>
         /// Returns a selector which matches a type.
         /// </summary>
         /// <param name="previous">The previous selector.</param>

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/SelectorParser.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/SelectorParser.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using Avalonia.Styling;
 using Avalonia.Utilities;
@@ -25,7 +26,7 @@ namespace Avalonia.Markup.Parsers
         /// </param>
         public SelectorParser(Func<string, string, Type> typeResolver)
         {
-            this._typeResolver = typeResolver;
+            _typeResolver = typeResolver;
         }
 
         /// <summary>
@@ -36,6 +37,11 @@ namespace Avalonia.Markup.Parsers
         public Selector Parse(string s)
         {
             var syntax = SelectorGrammar.Parse(s);
+            return Create(syntax);
+        }
+
+        private Selector Create(IEnumerable<SelectorGrammar.ISyntax> syntax)
+        {
             var result = default(Selector);
 
             foreach (var i in syntax)
@@ -97,6 +103,11 @@ namespace Avalonia.Markup.Parsers
                     case SelectorGrammar.TemplateSyntax template:
                         result = result.Template();
                         break;
+                    case SelectorGrammar.NotSyntax not:
+                        result = result.Not(x => Create(not.Argument));
+                        break;
+                    default:
+                        throw new NotSupportedException($"Unsupported selector grammar '{i.GetType()}'.");
                 }
             }
 

--- a/tests/Avalonia.Markup.UnitTests/Parsers/SelectorGrammarTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/SelectorGrammarTests.cs
@@ -201,6 +201,67 @@ namespace Avalonia.Markup.UnitTests.Parsers
         }
 
         [Fact]
+        public void Not_OfType()
+        {
+            var result = SelectorGrammar.Parse(":not(Button)");
+
+            Assert.Equal(
+                new SelectorGrammar.ISyntax[]
+                {
+                    new SelectorGrammar.NotSyntax
+                    {
+                        Argument = new SelectorGrammar.ISyntax[]
+                        {
+                            new SelectorGrammar.OfTypeSyntax { TypeName = "Button" },
+                        },
+                    }
+                },
+                result);
+        }
+
+        [Fact]
+        public void OfType_Not_Class()
+        {
+            var result = SelectorGrammar.Parse("Button:not(.foo)");
+
+            Assert.Equal(
+                new SelectorGrammar.ISyntax[]
+                {
+                    new SelectorGrammar.OfTypeSyntax { TypeName = "Button" },
+                    new SelectorGrammar.NotSyntax
+                    {
+                        Argument = new SelectorGrammar.ISyntax[]
+                        {
+                            new SelectorGrammar.ClassSyntax { Class = "foo" },
+                        },
+                    }
+                },
+                result);
+        }
+
+        [Fact]
+        public void Is_Descendent_Not_OfType_Class()
+        {
+            var result = SelectorGrammar.Parse(":is(Control) :not(Button.foo)");
+
+            Assert.Equal(
+                new SelectorGrammar.ISyntax[]
+                {
+                    new SelectorGrammar.IsSyntax { TypeName = "Control" },
+                    new SelectorGrammar.DescendantSyntax { },
+                    new SelectorGrammar.NotSyntax
+                    {
+                        Argument = new SelectorGrammar.ISyntax[]
+                        {
+                            new SelectorGrammar.OfTypeSyntax { TypeName = "Button" },
+                            new SelectorGrammar.ClassSyntax { Class = "foo" },
+                        },
+                    }
+                },
+                result);
+        }
+
+        [Fact]
         public void Namespace_Alone_Fails()
         {
             Assert.Throws<ExpressionParseException>(() => SelectorGrammar.Parse("ns|"));
@@ -222,6 +283,18 @@ namespace Avalonia.Markup.UnitTests.Parsers
         public void Invalid_Class_Fails()
         {
             Assert.Throws<ExpressionParseException>(() => SelectorGrammar.Parse(".%foo"));
+        }
+
+        [Fact]
+        public void Not_Without_Argument_Fails()
+        {
+            Assert.Throws<ExpressionParseException>(() => SelectorGrammar.Parse(":not()"));
+        }
+
+        [Fact]
+        public void Not_Without_Closing_Parenthesis_Fails()
+        {
+            Assert.Throws<ExpressionParseException>(() => SelectorGrammar.Parse(":not(Button"));
         }
     }
 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
@@ -198,5 +198,33 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
                     ex.InnerException.Message);
             }
         }
+
+        [Fact]
+        public void Style_Can_Use_Not_Selector()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+             xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <Window.Styles>
+        <Style Selector='Border:not(.foo)'>
+            <Setter Property='Background' Value='Red'/>
+        </Style>
+    </Window.Styles>
+    <StackPanel>
+        <Border Name='foo' Classes='foo bar'/>
+        <Border Name='notFoo' Classes='bar'/>
+    </StackPanel>
+</Window>";
+                var loader = new AvaloniaXamlLoader();
+                var window = (Window)loader.Load(xaml);
+                var foo = window.FindControl<Border>("foo");
+                var notFoo = window.FindControl<Border>("notFoo");
+
+                Assert.Null(foo.Background);
+                Assert.Equal(Colors.Red, ((ISolidColorBrush)notFoo.Background).Color);
+            }
+        }
     }
 }

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_Not.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_Not.cs
@@ -1,0 +1,114 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Xunit;
+
+namespace Avalonia.Styling.UnitTests
+{
+    public class SelectorTests_Not
+    {
+        [Fact]
+        public void Not_Selector_Should_Have_Correct_String_Representation()
+        {
+            var target = default(Selector).Not(x => x.Class("foo"));
+
+            Assert.Equal(":not(.foo)", target.ToString());
+        }
+
+        [Fact]
+        public void Not_OfType_Matches_Control_Of_Incorrect_Type()
+        {
+            var control = new Control1();
+            var target = default(Selector).Not(x => x.OfType<Control1>());
+
+            Assert.Equal(SelectorMatchResult.NeverThisType, target.Match(control).Result);
+        }
+        
+        [Fact]
+        public void Not_OfType_Doesnt_Match_Control_Of_Correct_Type()
+        {
+            var control = new Control2();
+            var target = default(Selector).Not(x => x.OfType<Control1>());
+
+            Assert.Equal(SelectorMatchResult.AlwaysThisType, target.Match(control).Result);
+        }
+
+        [Fact]
+        public async Task Not_Class_Doesnt_Match_Control_With_Class()
+        {
+            var control = new Control1
+            {
+                Classes = new Classes { "foo" },
+            };
+
+            var target = default(Selector).Not(x => x.Class("foo"));
+            var match = target.Match(control);
+
+            Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            Assert.False(await match.Activator.Take(1));
+        }
+
+        [Fact]
+        public async Task Not_Class_Matches_Control_Without_Class()
+        {
+            var control = new Control1
+            {
+                Classes = new Classes { "bar" },
+            };
+
+            var target = default(Selector).Not(x => x.Class("foo"));
+            var match = target.Match(control);
+
+            Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            Assert.True(await match.Activator.Take(1));
+        }
+
+        [Fact]
+        public async Task OfType_Not_Class_Matches_Control_Without_Class()
+        {
+            var control = new Control1
+            {
+                Classes = new Classes { "bar" },
+            };
+
+            var target = default(Selector).OfType<Control1>().Not(x => x.Class("foo"));
+            var match = target.Match(control);
+
+            Assert.Equal(SelectorMatchResult.Sometimes, match.Result);
+            Assert.True(await match.Activator.Take(1));
+        }
+
+        [Fact]
+        public void OfType_Not_Class_Doesnt_Match_Control_Of_Wrong_Type()
+        {
+            var control = new Control2
+            {
+                Classes = new Classes { "foo" },
+            };
+
+            var target = default(Selector).OfType<Control1>().Not(x => x.Class("foo"));
+            var match = target.Match(control);
+
+            Assert.Equal(SelectorMatchResult.NeverThisType, match.Result);
+        }
+
+        [Fact]
+        public void Returns_Correct_TargetType()
+        {
+            var target = default(Selector).OfType<Control1>().Not(x => x.Class("foo"));
+
+            Assert.Equal(typeof(Control1), target.TargetType);
+        }
+
+        public class Control1 : TestControlBase
+        {
+        }
+
+        public class Control2 : TestControlBase
+        {
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

This PR adds a `:not()` style selector which can be used to invert logic in selectors (similar to the [`:not()'` selector in CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/:not)).

## What is the updated/expected behavior with this PR?

One can add negation to selectors. Usage should be the same as CSS `:not()` selector except:

- Doesn't affect specificity rules (we don't have those (yet)) 
- Only a single inner selector is allowed (this could be fixed when we address #1742)

Some examples:

- `TextBlock:not(.h1)`
- `CheckBox:not(#default)`
- `Button:not(:pressed) /template/ ContentPresenter`

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] User documentation added by https://github.com/AvaloniaUI/avaloniaui.net/pull/42