### PR TITLE
Use '0000000' for build number formatting and "cibuild" because it's …

### DIFF
--- a/nukebuild/BuildParameters.cs
+++ b/nukebuild/BuildParameters.cs
@@ -109,7 +109,7 @@ public partial class Build
                 if (!IsNuGetRelease)
                 {
                     // Use AssemblyVersion with Build as version
-                    Version += "-build" + Environment.GetEnvironmentVariable("BUILD_BUILDID") + "-beta";
+                    Version += "-cibuild" + int.Parse(Environment.GetEnvironmentVariable("BUILD_BUILDID")).ToString("0000000") + "-beta";
                 }
 
                 PublishTestResults = true;


### PR DESCRIPTION
Should fix our build numbers