### PR TITLE
Fixes a bug in AvaloniaPropertyRegistry

### DIFF
--- a/src/Avalonia.Base/AvaloniaPropertyRegistry.cs
+++ b/src/Avalonia.Base/AvaloniaPropertyRegistry.cs
@@ -13,7 +13,7 @@ namespace Avalonia
     /// </summary>
     public class AvaloniaPropertyRegistry
     {
-        private readonly IList<AvaloniaProperty> _properties =
+        private readonly List<AvaloniaProperty> _properties =
             new List<AvaloniaProperty>();
         private readonly Dictionary<Type, Dictionary<int, AvaloniaProperty>> _registered =
             new Dictionary<Type, Dictionary<int, AvaloniaProperty>>();
@@ -29,6 +29,11 @@ namespace Avalonia
         /// </summary>
         public static AvaloniaPropertyRegistry Instance { get; }
             = new AvaloniaPropertyRegistry();
+
+        /// <summary>
+        /// Gets a list of all registered properties.
+        /// </summary>
+        internal IReadOnlyList<AvaloniaProperty> Properties => _properties;
 
         /// <summary>
         /// Gets all non-attached <see cref="AvaloniaProperty"/>s registered on a type.
@@ -250,8 +255,7 @@ namespace Avalonia
             {
                 inner.Add(property.Id, property);
             }
-
-            _properties.Add(property);
+            
             _attachedCache.Clear();
         }
     }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaPropertyRegistryTests.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaPropertyRegistryTests.cs
@@ -20,6 +20,18 @@ namespace Avalonia.Base.UnitTests
         }
 
         [Fact]
+        public void Registered_Properties_Count_Reflects_Newly_Added_Attached_Property()
+        {
+            var registry = new AvaloniaPropertyRegistry();
+            var metadata = new StyledPropertyMetadata<int>();
+            var property = new AttachedProperty<int>("test", typeof(object), metadata, true);
+            registry.Register(typeof(object), property);
+            registry.RegisterAttached(typeof(AvaloniaPropertyRegistryTests), property);
+
+            Assert.Equal(1, registry.Properties.Count);
+        }
+
+        [Fact]
         public void GetRegistered_Returns_Registered_Properties()
         {
             string[] names = AvaloniaPropertyRegistry.Instance.GetRegistered(typeof(Class1))


### PR DESCRIPTION
Fixed a bug where properties would be added multiple times to the global AvaloniaPropertyRegistry._properties list.