### PR TITLE
Fix deadlock in remote protocol.

### DIFF
--- a/src/Avalonia.Remote.Protocol/TransportConnectionWrapper.cs
+++ b/src/Avalonia.Remote.Protocol/TransportConnectionWrapper.cs
@@ -64,7 +64,7 @@ namespace Avalonia.Remote.Protocol
         
         public Task Send(object data)
         {
-            var tcs = new TaskCompletionSource<int>();
+            var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
             lock (_lock)
             {
                 if (!_workerIsAlive)
@@ -79,8 +79,9 @@ namespace Avalonia.Remote.Protocol
                 });
                 if (_signal != null)
                 {
-                    _signal.SetResult(0);
+                    var signal = _signal;
                     _signal = null;
+                    signal.SetResult(0);
                 }
             }
             return tcs.Task;


### PR DESCRIPTION
## What does the pull request do?

When using the Avalonia remote protocol to display a preview in a designer, we were seeing the previewer occasionally stop updating. This PR fixes a deadlock in `TransportConnectionWrapper` that was causing this.

## How was the solution implemented (if it's not obvious)?

The `TransportConnectionWrapper` producer-consumer queue was deadlocking due to `_signal` getting set to `null` while a worker was still waiting for it. Spoke with @kekekeks who suggested this fix.