### PR TITLE
WIP: Update build implementation

### DIFF
--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -1,19 +1,13 @@
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading;
-using System.Xml.Linq;
 using Nuke.Common;
-using Nuke.Common.Git;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.MSBuild;
 using Nuke.Common.Utilities;
-using static Nuke.Common.EnvironmentInfo;
 using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.IO.PathConstruction;
 using static Nuke.Common.Tooling.ProcessTasks;
@@ -66,22 +60,22 @@ partial class Build : NukeBuild
             ExecWait("Mono version:", "mono", "--version");
     }
 
-    Target Clean => _ => _.Executes(() =>
-    {
-        DeleteDirectories(Parameters.BuildDirs);
-        EnsureCleanDirectories(Parameters.BuildDirs);
-        EnsureCleanDirectory(Parameters.ArtifactsDir);
-        EnsureCleanDirectory(Parameters.NugetIntermediateRoot);
-        EnsureCleanDirectory(Parameters.NugetRoot);
-        EnsureCleanDirectory(Parameters.ZipRoot);
-        EnsureCleanDirectory(Parameters.TestResultsRoot);
-    });
+    Target Clean => _ => _
+        .Executes(() =>
+        {
+            DeleteDirectories(Parameters.BuildDirs);
+            EnsureCleanDirectories(Parameters.BuildDirs);
+            EnsureCleanDirectory(Parameters.ArtifactsDir);
+            EnsureCleanDirectory(Parameters.NugetIntermediateRoot);
+            EnsureCleanDirectory(Parameters.NugetRoot);
+            EnsureCleanDirectory(Parameters.ZipRoot);
+            EnsureCleanDirectory(Parameters.TestResultsRoot);
+        });
 
     Target Compile => _ => _
         .DependsOn(Clean)
         .Executes(() =>
         {
-
             if (Parameters.IsRunningOnWindows)
                 MSBuild(c => c
                     .SetSolutionFile(Parameters.MSBuildSolution)
@@ -93,7 +87,6 @@ partial class Build : NukeBuild
                     .SetToolsVersion(MSBuildToolsVersion._15_0)
                     .AddTargets("Build")
                 );
-
             else
                 DotNetBuild(c => c
                     .SetProjectFile(Parameters.MSBuildSolution)
@@ -105,7 +98,7 @@ partial class Build : NukeBuild
     void RunCoreTest(string project)
     {
         if(!project.EndsWith(".csproj"))
-            project = System.IO.Path.Combine(project, System.IO.Path.GetFileName(project)+".csproj");
+            project = Path.Combine(project, Path.GetFileName(project)+".csproj");
         Information("Running tests from " + project);
 
         var frameworks = ProjectModelTasks.ParseProject(project).GetTargetFrameworks();

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -20,14 +20,11 @@ using static Nuke.Common.Tools.MSBuild.MSBuildTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 using static Nuke.Common.Tools.Xunit.XunitTasks;
 
-
-/*
- Before editing this file, install support plugin for your IDE,
- running and debugging a particular target (optionally without deps) would be way easier
- ReSharper/Rider - https://plugins.jetbrains.com/plugin/10803-nuke-support
- VSCode - https://marketplace.visualstudio.com/items?itemName=nuke.support
- 
- */
+/// Support plugins are available for:
+///   - JetBrains ReSharper        https://nuke.build/resharper
+///   - JetBrains Rider            https://nuke.build/rider
+///   - Microsoft VisualStudio     https://nuke.build/visualstudio
+///   - Microsoft VSCode           https://nuke.build/vscode
 
 partial class Build : NukeBuild
 {   

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -107,17 +107,8 @@ partial class Build : NukeBuild
         if(!project.EndsWith(".csproj"))
             project = System.IO.Path.Combine(project, System.IO.Path.GetFileName(project)+".csproj");
         Information("Running tests from " + project);
-        XDocument xdoc;
-        using (var s = File.OpenRead(project))
-            xdoc = XDocument.Load(s);
 
-        List<string> frameworks = null;
-        var targets = xdoc.Root.Descendants("TargetFrameworks").FirstOrDefault();
-        if (targets != null)
-            frameworks = targets.Value.Split(';').Where(f => !string.IsNullOrWhiteSpace(f)).ToList();
-        else 
-            frameworks = new List<string> {xdoc.Root.Descendants("TargetFramework").First().Value};
-        
+        var frameworks = ProjectModelTasks.ParseProject(project).GetTargetFrameworks();
         foreach(var fw in frameworks)
         {
             Information("Running for " + fw);

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -16,6 +16,7 @@ using Nuke.Common.Utilities;
 using static Nuke.Common.EnvironmentInfo;
 using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.IO.PathConstruction;
+using static Nuke.Common.Tooling.ProcessTasks;
 using static Nuke.Common.Tools.MSBuild.MSBuildTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 using static Nuke.Common.Tools.Xunit.XunitTasks;
@@ -57,14 +58,12 @@ partial class Build : NukeBuild
 
         void ExecWait(string preamble, string command, string args)
         {
-            Console.WriteLine(preamble);
-            Process.Start(new ProcessStartInfo(command, args) {UseShellExecute = false}).WaitForExit();
+            Logger.Info(preamble);
+            StartProcess(command, args).AssertWaitForExit();
         }
         ExecWait("dotnet version:", "dotnet", "--version");
         if (Parameters.IsRunningOnUnix)
             ExecWait("Mono version:", "mono", "--version");
-
-
     }
 
     Target Clean => _ => _.Executes(() =>

--- a/nukebuild/_build.csproj
+++ b/nukebuild/_build.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="0.12.3" />
+    <PackageReference Include="Nuke.Common" Version="0.16.0" />
     <PackageReference Include="xunit.runner.console" Version="2.3.1" />
     <PackageReference Include="JetBrains.dotMemoryUnit" Version="3.0.20171219.105559" />
   </ItemGroup>


### PR DESCRIPTION
A few updates for the 0.16.0 release. Please test locally though, because I can't.

Notable changes:
- Parsing target frameworks is done using `Microsoft.Build` infrastructure, which should be more robust since it's not dependent on XML structure
- `MSBuild(solution)` is removed, all arguments are specified via fluent API
- `OnlyWhenDynamic` is checked immediately before target execution, which was the previous behavior. `OnlyWhenStatic` however is checked before _any_ execution, and thus allows to skip dependencies too via `WhenSkipped` ([more information](http://www.nuke.build/docs/authoring-builds/fundamentals.html#static-conditions--dependency-behavior))