### PR TITLE
Fix NRE in Deffered Renderer

### DIFF
--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -256,9 +256,9 @@ namespace Avalonia.Rendering
 
                         var (scene, updated) = UpdateRenderLayersAndConsumeSceneIfNeeded(GetContext);
 
-                        if (scene?.Item != null)
+                        using (scene)
                         {
-                            using (scene)
+                            if (scene?.Item != null)
                             {
                                 var overlay = DrawDirtyRects || DrawFps;
                                 if (DrawDirtyRects)
@@ -267,7 +267,7 @@ namespace Avalonia.Rendering
                                     RenderOverlay(scene.Item, GetContext());
                                 if (updated || forceComposite || overlay)
                                     RenderComposite(scene.Item, GetContext());
-                            }
+                             }
                         }
                     }
                     finally

--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -256,7 +256,7 @@ namespace Avalonia.Rendering
 
                         var (scene, updated) = UpdateRenderLayersAndConsumeSceneIfNeeded(GetContext);
 
-                        if (scene != null)
+                        if (scene?.Item != null)
                         {
                             using (scene)
                             {

--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -255,15 +255,19 @@ namespace Avalonia.Rendering
                         }
 
                         var (scene, updated) = UpdateRenderLayersAndConsumeSceneIfNeeded(GetContext);
-                        using (scene)
+
+                        if (scene != null)
                         {
-                            var overlay = DrawDirtyRects || DrawFps;
-                            if (DrawDirtyRects)
-                                _dirtyRectsDisplay.Tick();
-                            if (overlay)
-                                RenderOverlay(scene.Item, GetContext());
-                            if (updated || forceComposite || overlay)
-                                RenderComposite(scene.Item, GetContext());
+                            using (scene)
+                            {
+                                var overlay = DrawDirtyRects || DrawFps;
+                                if (DrawDirtyRects)
+                                    _dirtyRectsDisplay.Tick();
+                                if (overlay)
+                                    RenderOverlay(scene.Item, GetContext());
+                                if (updated || forceComposite || overlay)
+                                    RenderComposite(scene.Item, GetContext());
+                            }
                         }
                     }
                     finally


### PR DESCRIPTION
## What does the pull request do?

Prevents NRE in deffered renderer as described in https://github.com/AvaloniaUI/Avalonia/issues/2284

## What is the current behavior?

null check missing.

## Fixed issues

If the pull request fixes issue(s) list them like this:

Fixes #2284 