### PR TITLE
Fixed a bug when calling AvaloniaProperty.AddOwner

### DIFF
--- a/src/Avalonia.Base/AvaloniaPropertyRegistry.cs
+++ b/src/Avalonia.Base/AvaloniaPropertyRegistry.cs
@@ -13,8 +13,8 @@ namespace Avalonia
     /// </summary>
     public class AvaloniaPropertyRegistry
     {
-        private readonly List<AvaloniaProperty> _properties =
-            new List<AvaloniaProperty>();
+        private readonly Dictionary<int, AvaloniaProperty> _properties =
+            new Dictionary<int, AvaloniaProperty>();
         private readonly Dictionary<Type, Dictionary<int, AvaloniaProperty>> _registered =
             new Dictionary<Type, Dictionary<int, AvaloniaProperty>>();
         private readonly Dictionary<Type, Dictionary<int, AvaloniaProperty>> _attached =
@@ -33,7 +33,7 @@ namespace Avalonia
         /// <summary>
         /// Gets a list of all registered properties.
         /// </summary>
-        internal IReadOnlyList<AvaloniaProperty> Properties => _properties;
+        internal IReadOnlyCollection<AvaloniaProperty> Properties => _properties.Values;
 
         /// <summary>
         /// Gets all non-attached <see cref="AvaloniaProperty"/>s registered on a type.
@@ -220,7 +220,11 @@ namespace Avalonia
                 inner.Add(property.Id, property);
             }
 
-            _properties.Add(property);
+            if (!_properties.ContainsKey(property.Id))
+            {
+                _properties.Add(property.Id, property);
+            }
+            
             _registeredCache.Clear();
         }
 

--- a/tests/Avalonia.Base.UnitTests/AvaloniaPropertyRegistryTests.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaPropertyRegistryTests.cs
@@ -27,6 +27,7 @@ namespace Avalonia.Base.UnitTests
             var property = new AttachedProperty<int>("test", typeof(object), metadata, true);
             registry.Register(typeof(object), property);
             registry.RegisterAttached(typeof(AvaloniaPropertyRegistryTests), property);
+            property.AddOwner<Class4>();
 
             Assert.Equal(1, registry.Properties.Count);
         }
@@ -148,6 +149,10 @@ namespace Avalonia.Base.UnitTests
         }
 
         private class AttachedOwner2 : AttachedOwner
+        {
+        }
+
+        private class Class4 : AvaloniaObject
         {
         }
     }


### PR DESCRIPTION
This PR replaces AvaloniaPropertyRegistry's property list with a dictionary, since instantiating AvaloniaPropertyRegistry in unit tests can lead to property IDs not being contiguous.