### PR TITLE
Scaling of 1 on monitors >= FullHD

### DIFF
--- a/src/Avalonia.X11/X11Screens.cs
+++ b/src/Avalonia.X11/X11Screens.cs
@@ -11,7 +11,6 @@ namespace Avalonia.X11
 {
     class X11Screens  : IScreenImpl
     {
-        private const int FullHDWidth = 1920;
         private IX11Screens _impl;
 
         public X11Screens(IX11Screens impl)
@@ -219,6 +218,7 @@ namespace Avalonia.X11
 
     class X11Screen
     {
+        private const int FullHDWidth = 1920;
         public bool Primary { get; }
         public string Name { get; set; }
         public PixelRect Bounds { get; set; }

--- a/src/Avalonia.X11/X11Screens.cs
+++ b/src/Avalonia.X11/X11Screens.cs
@@ -99,6 +99,8 @@ namespace Avalonia.X11
                         {
                             if (mon.MWidth == 0)
                                 density = 1;
+                            else if (mon.Width <= 1920)
+                                density = 1;
                             else
                                 density = X11Screen.GuessPixelDensity(mon.Width, mon.MWidth);
                         }
@@ -237,7 +239,14 @@ namespace Avalonia.X11
             }
             else if (pixelDensity == null)
             {
-                PixelDensity = GuessPixelDensity(bounds.Width, physicalSize.Value.Width);
+                if (bounds.Width <= 1920)
+                {
+                    PixelDensity = 1;
+                }
+                else
+                {
+                    PixelDensity = GuessPixelDensity(bounds.Width, physicalSize.Value.Width);
+                }
             }
             else
             {

--- a/src/Avalonia.X11/X11Screens.cs
+++ b/src/Avalonia.X11/X11Screens.cs
@@ -11,6 +11,7 @@ namespace Avalonia.X11
 {
     class X11Screens  : IScreenImpl
     {
+        private const int FullHDWidth = 1920;
         private IX11Screens _impl;
 
         public X11Screens(IX11Screens impl)
@@ -98,8 +99,6 @@ namespace Avalonia.X11
                         if (_settings.NamedScaleFactors?.TryGetValue(name, out density) != true)
                         {
                             if (mon.MWidth == 0)
-                                density = 1;
-                            else if (mon.Width <= 1920)
                                 density = 1;
                             else
                                 density = X11Screen.GuessPixelDensity(mon.Width, mon.MWidth);
@@ -239,14 +238,7 @@ namespace Avalonia.X11
             }
             else if (pixelDensity == null)
             {
-                if (bounds.Width <= 1920)
-                {
-                    PixelDensity = 1;
-                }
-                else
-                {
-                    PixelDensity = GuessPixelDensity(bounds.Width, physicalSize.Value.Width);
-                }
+                PixelDensity = GuessPixelDensity(bounds.Width, physicalSize.Value.Width);
             }
             else
             {
@@ -256,6 +248,6 @@ namespace Avalonia.X11
         }
 
         public static double GuessPixelDensity(double pixelWidth, double mmWidth)
-            => Math.Max(1, Math.Round(pixelWidth / mmWidth * 25.4 / 96));
+            => pixelWidth <= FullHDWidth ? 1 : Math.Max(1, Math.Round(pixelWidth / mmWidth * 25.4 / 96));
     }
 }


### PR DESCRIPTION
## What does the pull request do?
It defaults to ScaleFactor = 1 on FullHD and below monitors.

## What is the current behavior?
We calculate the actual dpi of the monitor and small monitors with 1920x1080 pixels have a high dpi, and avalonia looks huge on it.

## What is the updated/expected behavior with this PR?
Assume FullHD and below are not hi dpi monitors.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->



