### PR TITLE
Fix ItemsControl ItemTemplateProperty being subscribed in non-static ctor

### DIFF
--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -64,6 +64,7 @@ namespace Avalonia.Controls
         static ItemsControl()
         {
             ItemsProperty.Changed.AddClassHandler<ItemsControl>(x => x.ItemsChanged);
+            ItemTemplateProperty.Changed.AddClassHandler<ItemsControl>(x => x.ItemTemplateChanged);
         }
 
         /// <summary>
@@ -73,7 +74,6 @@ namespace Avalonia.Controls
         {
             PseudoClasses.Add(":empty");
             SubscribeToItems(_items);
-            ItemTemplateProperty.Changed.AddClassHandler<ItemsControl>(x => x.ItemTemplateChanged);
         }
 
         /// <summary>


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
When running memory profiler over my application I noticed that I had over 100k instances of `Action<AvaloniaPropertyChangedEventArgs>` after running for a while. I followed the trail and found that `ItemsControl` subscribes to `ItemTemplateProperty` in a normal ctor.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Every time we create a new `ItemsControl` or derived we subscribe to `ItemTemplateProperty` changes.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Moved the subscription to the static ctor, as I guess this was it's intended place.  I also checked the codebase if there are more cases like this, but fortunately this was the only place that had this bug.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

cc: @danwalmsley as I saw that you had memory leak issues as well lately
