### PR TITLE
Fix Style subscriptions not being removed at all.

### DIFF
--- a/src/Avalonia.Styling/Styling/Style.cs
+++ b/src/Avalonia.Styling/Styling/Style.cs
@@ -143,6 +143,7 @@ namespace Avalonia.Styling
                     }
 
                     controlSubscriptions.Add(subs);
+                    controlSubscriptions.Add(Disposable.Create(() => Subscriptions.Remove(subs)));
                     Subscriptions.Add(subs);
                 }
 
@@ -159,8 +160,9 @@ namespace Avalonia.Styling
                     var sub = setter.Apply(this, control, null);
                     subs.Add(sub);
                 }
-                
+
                 controlSubscriptions.Add(subs);
+                controlSubscriptions.Add(Disposable.Create(() => Subscriptions.Remove(subs)));
                 Subscriptions.Add(subs);
                 return true;
             }
@@ -223,7 +225,7 @@ namespace Avalonia.Styling
         {
             if (!_applied.TryGetValue(control, out var subscriptions))
             {
-                subscriptions = new CompositeDisposable(2);
+                subscriptions = new CompositeDisposable(3);
                 subscriptions.Add(control.StyleDetach.Subscribe(ControlDetach));
                 _applied.Add(control, subscriptions);
             }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Another round of my memory profiling showed literally millions of `CompositeDisposable` instances not  being freed. After some digging around I found it was the FocusAdorner style that had enormous amount of `Subscriptions`, which was caused by it matching any `Control` and the `Subscriptions` never being removed from (the style subscriptions were disposed in `ControlDetach`, but the disposable instance was still kept in `Subscriptions`).

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`Style` leaks `CompositeDisposable` every time it matches.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
I am not sure about the best solution to this problem, my first idea was to just add an extra disposable (sic) that will remove the instances from the `Subscriptions` list.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

cc: @danwalmsley as this also affects memory footprint of the application, especially if you have a lot of dynamic elements that get added and removed.
