### PR TITLE
Make Cue Parse method explicitly typed.

### DIFF
--- a/src/Avalonia.Animation/Cue.cs
+++ b/src/Avalonia.Animation/Cue.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Animation
         /// <summary>
         /// Parses a string to a <see cref="Cue"/> object.
         /// </summary>
-        public static object Parse(string value, CultureInfo culture)
+        public static Cue Parse(string value, CultureInfo culture)
         {
             string v = value;
 
@@ -70,7 +70,7 @@ namespace Avalonia.Animation
         }
     }
 
-    public class CueTypeConverter : TypeConverter 
+    public class CueTypeConverter : TypeConverter
     {
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {


### PR DESCRIPTION
In order to avoid monstrosity like this: 
![image](https://user-images.githubusercontent.com/16554748/53239618-69a80b80-36d7-11e9-9dbe-3b265c1862ba.png)
