### PR TITLE
Fix crashes related to null geometries.

### DIFF
--- a/src/Avalonia.Controls/Shapes/Shape.cs
+++ b/src/Avalonia.Controls/Shapes/Shape.cs
@@ -195,7 +195,7 @@ namespace Avalonia.Controls.Shapes
             if (deferCalculateTransform)
             {
                 _calculateTransformOnArrange = true;
-                return DefiningGeometry.Bounds.Size;
+                return DefiningGeometry?.Bounds.Size ?? Size.Empty;
             }
             else
             {
@@ -217,17 +217,22 @@ namespace Avalonia.Controls.Shapes
 
         private Size CalculateShapeSizeAndSetTransform(Size availableSize)
         {
-            // This should probably use GetRenderBounds(strokeThickness) but then the calculations
-            // will multiply the stroke thickness as well, which isn't correct.
-            var (size, transform) = CalculateSizeAndTransform(availableSize, DefiningGeometry.Bounds, Stretch);
-
-            if (_transform != transform)
+            if (DefiningGeometry != null)
             {
-                _transform = transform;
-                _renderedGeometry = null;
+                // This should probably use GetRenderBounds(strokeThickness) but then the calculations
+                // will multiply the stroke thickness as well, which isn't correct.
+                var (size, transform) = CalculateSizeAndTransform(availableSize, DefiningGeometry.Bounds, Stretch);
+
+                if (_transform != transform)
+                {
+                    _transform = transform;
+                    _renderedGeometry = null;
+                }
+
+                return size;
             }
 
-            return size;
+            return Size.Empty;
         }
 
         internal static (Size, Matrix) CalculateSizeAndTransform(Size availableSize, Rect shapeBounds, Stretch Stretch)

--- a/src/Avalonia.Visuals/Media/DrawingContext.cs
+++ b/src/Avalonia.Visuals/Media/DrawingContext.cs
@@ -109,6 +109,8 @@ namespace Avalonia.Media
         /// <param name="geometry">The geometry.</param>
         public void DrawGeometry(IBrush brush, Pen pen, Geometry geometry)
         {
+            Contract.Requires<ArgumentNullException>(geometry != null);
+
             if (brush != null || PenIsVisible(pen))
             {
                 PlatformImpl.DrawGeometry(brush, pen, geometry.PlatformImpl);

--- a/src/Avalonia.Visuals/Media/GeometryDrawing.cs
+++ b/src/Avalonia.Visuals/Media/GeometryDrawing.cs
@@ -31,7 +31,10 @@
 
         public override void Draw(DrawingContext context)
         {
-            context.DrawGeometry(Brush, Pen, Geometry);
+            if (Geometry != null)
+            {
+                context.DrawGeometry(Brush, Pen, Geometry);
+            }
         }
 
         public override Rect GetBounds()

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/GeometryNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/GeometryNode.cs
@@ -89,9 +89,14 @@ namespace Avalonia.Rendering.SceneGraph
         /// <inheritdoc/>
         public override bool HitTest(Point p)
         {
-            p *= Transform.Invert();
-            return (Brush != null && Geometry.FillContains(p)) || 
-                (Pen != null && Geometry.StrokeContains(Pen, p));
+            if (Transform.HasInverse)
+            {
+                p *= Transform.Invert();
+                return (Brush != null && Geometry.FillContains(p)) ||
+                    (Pen != null && Geometry.StrokeContains(Pen, p));
+            }
+
+            return false;
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/Shapes/PathTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Shapes/PathTests.cs
@@ -1,0 +1,16 @@
+﻿using Avalonia.Controls.Shapes;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests.Shapes
+{
+    public class PathTests
+    {
+        [Fact]
+        public void Path_With_Null_Data_Does_Not_Throw_On_Measure()
+        {
+            var target = new Path();
+
+            target.Measure(Size.Infinity);
+        }
+    }
+}

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/DrawOperationTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/DrawOperationTests.cs
@@ -61,6 +61,19 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
             Assert.Equal(1, bitmap.RefCount);
         }
 
+        [Fact]
+        public void HitTest_On_Geometry_Node_With_Zero_Transform_Does_Not_Throw()
+        {
+            var geometry = Mock.Of<IGeometryImpl>();
+            var geometryNode = new GeometryNode(
+                new Matrix(),
+                Brushes.Black,
+                null,
+                geometry);
+
+            geometryNode.HitTest(new Point());
+        }
+
         private class TestDrawOperation : DrawOperation
         {
             public TestDrawOperation(Rect bounds, Matrix transform, Pen pen)


### PR DESCRIPTION
## What does the pull request do?

Fixes two cases of exceptions being thrown when using `null` geometries: #2053 and #2335.

## What is the current behavior?

- If a null geometry is used in a `DrawingPresenter` an exception is thrown when the mouse moves over it (#2053)
- If a non-invertible transform is used for a `GeometryNode` an exception is thrown in `HitTest` (#2053)
- If a null geometry is used in a `Path`, an exception is thrown at layout time (#2335)

## What is the updated/expected behavior with this PR?

Both cases work without exceptions being thrown.

## How was the solution implemented (if it's not obvious)?

- Don't draw a null geometry in `GeometryDrawing` and additionally add a guard to `DrawingContext.DrawGeometry` to detect having a null `Geometry` passed, as we do for `DrawImage`, `DrawText` etc.
- Don't try to invert a non-invertible transform in `GeometryNode.HitTest`
- Check for a null `DefiningGeometry` in `Path`

## Checklist

- [x] Added unit tests
  - Not for `DrawingPresenter` as this should be gone at some point soon (drawings should be displayed in an `Image`)

## Fixed issues

Fixes #2053
Fixes #2335

cc: @ahopper @MarchingCube 
