### PR TITLE
Fix "{Binding .}" syntax

### DIFF
--- a/src/Markup/Avalonia.Markup/Markup/Parsers/ExpressionParser.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/ExpressionParser.cs
@@ -106,6 +106,11 @@ namespace Avalonia.Markup.Parsers
             {
                 return State.Indexer;
             }
+            else if (ParseDot(ref r))
+            {
+                nodes.Add(new EmptyExpressionNode());
+                return State.End;
+            }
             else
             {
                 var identifier = r.ParseIdentifier();
@@ -315,6 +320,11 @@ namespace Avalonia.Markup.Parsers
         private static bool ParseSharp(ref CharacterReader r)
         {
             return !r.End && r.TakeIf('#');
+        }
+
+        private static bool ParseDot(ref CharacterReader r)
+        {
+            return !r.End && r.TakeIf('.');
         }
 
         private enum State

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests.cs
@@ -273,6 +273,39 @@ namespace Avalonia.Markup.UnitTests.Data
             Assert.Equal(42, target.Value);
         }
 
+        [Fact]
+        public void Null_Path_Should_Bind_To_DataContext()
+        {
+            var target = new TextBlock { DataContext = "foo" };
+            var binding = new Binding();
+
+            target.Bind(TextBlock.TextProperty, binding);
+
+            Assert.Equal("foo", target.Text);
+        }
+
+        [Fact]
+        public void Empty_Path_Should_Bind_To_DataContext()
+        {
+            var target = new TextBlock { DataContext = "foo" };
+            var binding = new Binding { Path = string.Empty };
+
+            target.Bind(TextBlock.TextProperty, binding);
+
+            Assert.Equal("foo", target.Text);
+        }
+
+        [Fact]
+        public void Dot_Path_Should_Bind_To_DataContext()
+        {
+            var target = new TextBlock { DataContext = "foo" };
+            var binding = new Binding { Path = "." };
+
+            target.Bind(TextBlock.TextProperty, binding);
+
+            Assert.Equal("foo", target.Text);
+        }
+
         /// <summary>
         /// Tests a problem discovered with ListBox with selection.
         /// </summary>

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionNodeBuilderTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionNodeBuilderTests.cs
@@ -37,6 +37,15 @@ namespace Avalonia.Markup.UnitTests.Parsers
         }
 
         [Fact]
+        public void Should_Build_Dot()
+        {
+            var result = ToList(ExpressionObserverBuilder.Parse("."));
+
+            Assert.Equal(1, result.Count);
+            Assert.IsType<EmptyExpressionNode>(result[0]);
+        }
+
+        [Fact]
         public void Should_Build_Property_Chain()
         {
             var result = ToList(ExpressionObserverBuilder.Parse("Foo.Bar.Baz"));

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionNodeBuilderTests_Errors.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionNodeBuilderTests_Errors.cs
@@ -31,6 +31,13 @@ namespace Avalonia.Markup.UnitTests.Parsers
         }
 
         [Fact]
+        public void Expression_Cannot_Start_With_Period_Then_Token()
+        {
+            Assert.Throws<ExpressionParseException>(
+                () => ExpressionObserverBuilder.Parse(".Bar"));
+        }
+
+        [Fact]
         public void Expression_Cannot_Have_Empty_Indexer()
         {
             Assert.Throws<ExpressionParseException>(


### PR DESCRIPTION
## What does the pull request do?

Allows the `{Binding .}` syntax as described in #1898. This was a regression introduced when new binding parser was merged.

## What is the current behavior?

`{Binding .}` is not accepted.

## What is the updated/expected behavior with this PR?

`{Binding .}` works to bind to `DataContext`.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #1898
