### PR TITLE
Respect RenderTransform in GetPosition.

### DIFF
--- a/src/Avalonia.Input/MouseDevice.cs
+++ b/src/Avalonia.Input/MouseDevice.cs
@@ -84,18 +84,14 @@ namespace Avalonia.Input
         {
             Contract.Requires<ArgumentNullException>(relativeTo != null);
 
-            Point p = default(Point);
-            IVisual v = relativeTo;
-            IVisual root = null;
-
-            while (v != null)
+            if (relativeTo.VisualRoot == null)
             {
-                p += v.Bounds.Position;
-                root = v;
-                v = v.VisualParent;
+                throw new InvalidOperationException("Control is not attached to visual tree.");
             }
 
-            return root.PointToClient(Position) - p;
+            var rootPoint = relativeTo.VisualRoot.PointToClient(Position);
+            var transform = relativeTo.VisualRoot.TransformToVisual(relativeTo);
+            return rootPoint * transform.Value;
         }
 
         public void ProcessRawEvent(RawInputEventArgs e)

--- a/tests/Avalonia.Input.UnitTests/MouseDeviceTests.cs
+++ b/tests/Avalonia.Input.UnitTests/MouseDeviceTests.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Input.Raw;
 using Avalonia.Interactivity;
+using Avalonia.Media;
 using Avalonia.Rendering;
 using Avalonia.UnitTests;
 using Avalonia.VisualTree;
@@ -184,6 +185,33 @@ namespace Avalonia.Input.UnitTests
             }
         }
 
+
+        [Fact]
+        public void GetPosition_Should_Respect_Control_RenderTransform()
+        {
+            var renderer = new Mock<IRenderer>();
+
+            using (TestApplication(renderer.Object))
+            {
+                var inputManager = InputManager.Instance;
+
+                var root = new TestRoot
+                {
+                    MouseDevice = new MouseDevice(),
+                    Child = new Border
+                    {
+                        Background = Brushes.Black,
+                        RenderTransform = new TranslateTransform(10, 0),
+                    }
+                };
+
+                SendMouseMove(inputManager, root, new Point(11, 11));
+
+                var result = root.MouseDevice.GetPosition(root.Child);
+                Assert.Equal(new Point(1, 11), result);
+            }
+        }
+
         private void AddEnterLeaveHandlers(
             EventHandler<PointerEventArgs> handler,
             params IControl[] controls)
@@ -195,14 +223,14 @@ namespace Avalonia.Input.UnitTests
             }
         }
 
-        private void SendMouseMove(IInputManager inputManager, TestRoot root)
+        private void SendMouseMove(IInputManager inputManager, TestRoot root, Point p = new Point())
         {
             inputManager.ProcessInput(new RawMouseEventArgs(
                 root.MouseDevice,
                 0,
                 root,
                 RawMouseEventType.Move,
-                new Point(),
+                p,
                 InputModifiers.None));
         }
 


### PR DESCRIPTION
## What does the pull request do?

As described in #1558 `MouseDevice.GetPosition` did not respect a control's render transform.

## What is the updated/expected behavior with this PR?

`MouseDevice.GetPosition` and the methods that use it such as `PointerEventArgs.GetPosition` now respect render transforms.

## How was the solution implemented (if it's not obvious)?

Use `TransformToVisual` to calculate the mouse position, this method respects render transforms.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #1558 
