### PR TITLE
Allow multiple comma-separated style selectors

### DIFF
--- a/src/Avalonia.Styling/Styling/OrSelector.cs
+++ b/src/Avalonia.Styling/Styling/OrSelector.cs
@@ -1,0 +1,131 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Avalonia.Styling
+{
+    /// <summary>
+    /// The OR style selector.
+    /// </summary>
+    internal class OrSelector : Selector
+    {
+        private readonly IReadOnlyList<Selector> _selectors;
+        private string _selectorString;
+        private Type _targetType;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrSelector"/> class.
+        /// </summary>
+        /// <param name="selectors">The selectors to OR.</param>
+        public OrSelector(IReadOnlyList<Selector> selectors)
+        {
+            Contract.Requires<ArgumentNullException>(selectors != null);
+            Contract.Requires<ArgumentException>(selectors.Count > 1);
+
+            _selectors = selectors;
+        }
+
+        /// <inheritdoc/>
+        public override bool InTemplate => false;
+
+        /// <inheritdoc/>
+        public override bool IsCombinator => false;
+
+        /// <inheritdoc/>
+        public override Type TargetType
+        {
+            get
+            {
+                if (_targetType == null)
+                {
+                    _targetType = EvaluateTargetType();
+                }
+
+                return _targetType;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            if (_selectorString == null)
+            {
+                _selectorString = string.Join(", ", _selectors);
+            }
+
+            return _selectorString;
+        }
+
+        protected override SelectorMatch Evaluate(IStyleable control, bool subscribe)
+        {
+            var activators = new List<IObservable<bool>>();
+            var neverThisInstance = false;
+
+            foreach (var selector in _selectors)
+            {
+                var match = selector.Match(control, subscribe);
+
+                switch (match.Result)
+                {
+                    case SelectorMatchResult.AlwaysThisType:
+                    case SelectorMatchResult.AlwaysThisInstance:
+                        return match;
+                    case SelectorMatchResult.NeverThisInstance:
+                        neverThisInstance = true;
+                        break;
+                    case SelectorMatchResult.Sometimes:
+                        activators.Add(match.Activator);
+                        break;
+                }
+            }
+
+            if (activators.Count > 1)
+            {
+                return new SelectorMatch(StyleActivator.Or(activators));
+            }
+            else if (activators.Count == 1)
+            {
+                return new SelectorMatch(activators[0]);
+            }
+            else if (neverThisInstance)
+            {
+                return SelectorMatch.NeverThisInstance;
+            }
+            else
+            {
+                return SelectorMatch.NeverThisType;
+            }
+        }
+
+        protected override Selector MovePrevious() => null;
+
+        private Type EvaluateTargetType()
+        {
+            var result = default(Type);
+
+            foreach (var selector in _selectors)
+            {
+                if (selector.TargetType == null)
+                {
+                    return null;
+                }
+                else if (result == null)
+                {
+                    result = selector.TargetType;
+                }
+                else
+                {
+                    while (!result.IsAssignableFrom(selector.TargetType))
+                    {
+                        result = result.BaseType;
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+}
+

--- a/src/Avalonia.Styling/Styling/Selectors.cs
+++ b/src/Avalonia.Styling/Styling/Selectors.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Avalonia.Styling
 {
@@ -135,6 +137,26 @@ namespace Avalonia.Styling
         public static Selector OfType<T>(this Selector previous) where T : IStyleable
         {
             return previous.OfType(typeof(T));
+        }
+
+        /// <summary>
+        /// Returns a selector which ORs selectors.
+        /// </summary>
+        /// <param name="selectors">The selectors to be OR'd.</param>
+        /// <returns>The selector.</returns>
+        public static Selector Or(params Selector[] selectors)
+        {
+            return new OrSelector(selectors);
+        }
+
+        /// <summary>
+        /// Returns a selector which ORs selectors.
+        /// </summary>
+        /// <param name="selectors">The selectors to be OR'd.</param>
+        /// <returns>The selector.</returns>
+        public static Selector Or(IReadOnlyList<Selector> selectors)
+        {
+            return new OrSelector(selectors);
         }
 
         /// <summary>

--- a/src/Avalonia.Themes.Default/Separator.xaml
+++ b/src/Avalonia.Themes.Default/Separator.xaml
@@ -11,13 +11,7 @@
     </Setter>
   </Style>
 
-  <Style Selector="MenuItem > Separator">
-    <Setter Property="Background" Value="{DynamicResource ThemeControlMidBrush}"/>
-    <Setter Property="Margin" Value="29,1,0,1"/>
-    <Setter Property="Height" Value="1"/>
-  </Style>
-
-  <Style Selector="ContextMenu > Separator">
+  <Style Selector="MenuItem > Separator, ContextMenu > Separator">
     <Setter Property="Background" Value="{DynamicResource ThemeControlMidBrush}"/>
     <Setter Property="Margin" Value="29,1,0,1"/>
     <Setter Property="Height" Value="1"/>

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/SelectorParser.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/SelectorParser.cs
@@ -43,6 +43,7 @@ namespace Avalonia.Markup.Parsers
         private Selector Create(IEnumerable<SelectorGrammar.ISyntax> syntax)
         {
             var result = default(Selector);
+            var results = default(List<Selector>);
 
             foreach (var i in syntax)
             {
@@ -106,9 +107,28 @@ namespace Avalonia.Markup.Parsers
                     case SelectorGrammar.NotSyntax not:
                         result = result.Not(x => Create(not.Argument));
                         break;
+                    case SelectorGrammar.CommaSyntax comma:
+                        if (results == null)
+                        {
+                            results = new List<Selector>();
+                        }
+
+                        results.Add(result);
+                        result = null;
+                        break;
                     default:
                         throw new NotSupportedException($"Unsupported selector grammar '{i.GetType()}'.");
                 }
+            }
+
+            if (results != null)
+            {
+                if (result != null)
+                {
+                    results.Add(result);
+                }
+
+                result = results.Count > 1 ? Selectors.Or(results) : results[0];
             }
 
             return result;

--- a/tests/Avalonia.Markup.UnitTests/Parsers/SelectorGrammarTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/SelectorGrammarTests.cs
@@ -262,6 +262,22 @@ namespace Avalonia.Markup.UnitTests.Parsers
         }
 
         [Fact]
+        public void OfType_Comma_Is_Class()
+        {
+            var result = SelectorGrammar.Parse("TextBlock, :is(Button).foo");
+
+            Assert.Equal(
+                new SelectorGrammar.ISyntax[]
+                {
+                    new SelectorGrammar.OfTypeSyntax { TypeName = "TextBlock" },
+                    new SelectorGrammar.CommaSyntax(),
+                    new SelectorGrammar.IsSyntax { TypeName = "Button" },
+                    new SelectorGrammar.ClassSyntax { Class = "foo" },
+                },
+                result);
+        }
+
+        [Fact]
         public void Namespace_Alone_Fails()
         {
             Assert.Throws<ExpressionParseException>(() => SelectorGrammar.Parse("ns|"));

--- a/tests/Avalonia.Markup.UnitTests/Parsers/SelectorParserTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/SelectorParserTests.cs
@@ -15,6 +15,13 @@ namespace Avalonia.Markup.UnitTests.Parsers
         }
 
         [Fact]
+        public void Parses_Comma_Separated_Selectors()
+        {
+            var target = new SelectorParser((ns, type) => typeof(TextBlock));
+            var result = target.Parse("TextBlock, TextBlock:foo");
+        }
+
+        [Fact]
         public void Throws_If_OfType_Type_Not_Found()
         {
             var target = new SelectorParser((ns, type) => null);

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_Or.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_Or.cs
@@ -1,0 +1,106 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using Xunit;
+
+namespace Avalonia.Styling.UnitTests
+{
+    public class SelectorTests_Or
+    {
+        [Fact]
+        public void Or_Selector_Should_Have_Correct_String_Representation()
+        {
+            var target = Selectors.Or(
+                default(Selector).OfType<Control1>().Class("foo"),
+                default(Selector).OfType<Control2>().Class("bar"));
+
+            Assert.Equal("Control1.foo, Control2.bar", target.ToString());
+        }
+
+        [Fact]
+        public void Or_Selector_Matches_Control_Of_Correct_Type()
+        {
+            var target = Selectors.Or(
+                default(Selector).OfType<Control1>(),
+                default(Selector).OfType<Control2>().Class("bar"));
+            var control = new Control1();
+
+            Assert.Equal(SelectorMatchResult.AlwaysThisType, target.Match(control).Result);
+        }
+
+        [Fact]
+        public void Or_Selector_Matches_Control_Of_Correct_Type_With_Class()
+        {
+            var target = Selectors.Or(
+                default(Selector).OfType<Control1>(),
+                default(Selector).OfType<Control2>().Class("bar"));
+            var control = new Control2();
+
+            Assert.Equal(SelectorMatchResult.Sometimes, target.Match(control).Result);
+        }
+
+        [Fact]
+        public void Or_Selector_Doesnt_Match_Control_Of_Incorrect_Type()
+        {
+            var target = Selectors.Or(
+                default(Selector).OfType<Control1>(),
+                default(Selector).OfType<Control2>().Class("bar"));
+            var control = new Control3();
+
+            Assert.Equal(SelectorMatchResult.NeverThisType, target.Match(control).Result);
+        }
+
+        [Fact]
+        public void Or_Selector_Doesnt_Match_Control_With_Incorrect_Name()
+        {
+            var target = Selectors.Or(
+                default(Selector).OfType<Control1>().Name("foo"),
+                default(Selector).OfType<Control2>().Name("foo"));
+            var control = new Control1 { Name = "bar" };
+
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(control).Result);
+        }
+
+        [Fact]
+        public void Returns_Correct_TargetType_When_Types_Same()
+        {
+            var target = Selectors.Or(
+                default(Selector).OfType<Control1>().Class("foo"),
+                default(Selector).OfType<Control1>().Class("bar"));
+
+            Assert.Equal(typeof(Control1), target.TargetType);
+        }
+
+        [Fact]
+        public void Returns_Common_TargetType()
+        {
+            var target = Selectors.Or(
+                default(Selector).OfType<Control1>().Class("foo"),
+                default(Selector).OfType<Control2>().Class("bar"));
+
+            Assert.Equal(typeof(TestControlBase), target.TargetType);
+        }
+
+        [Fact]
+        public void Returns_Null_TargetType_When_A_Selector_Has_No_TargetType()
+        {
+            var target = Selectors.Or(
+                default(Selector).OfType<Control1>().Class("foo"),
+                default(Selector).Class("bar"));
+
+            Assert.Equal(null, target.TargetType);
+        }
+
+        public class Control1 : TestControlBase
+        {
+        }
+
+        public class Control2 : TestControlBase
+        {
+        }
+
+        public class Control3 : TestControlBase
+        {
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

#1742 mentions that CSS supports specifying multiple selectors for a style, separated by a `,`. This PR implements that feature for Avalonia.

It also uses this feature in the default theme for `Separator`.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
  - Coming soon

## Fixed issues

Fixes #1742
