### PR TITLE
Use Array.Empty instead of allocating empty arrays

### DIFF
--- a/src/Avalonia.Controls/AppBuilderBase.cs
+++ b/src/Avalonia.Controls/AppBuilderBase.cs
@@ -210,7 +210,7 @@ namespace Avalonia.Controls
             var platformClassName = assemblyName.Replace("Avalonia.", string.Empty) + "Platform";
             var platformClassFullName = assemblyName + "." + platformClassName;
             var platformClass = assembly.GetType(platformClassFullName);
-            var init = platformClass.GetRuntimeMethod("Initialize", new Type[0]);
+            var init = platformClass.GetRuntimeMethod("Initialize", Type.EmptyTypes);
             init.Invoke(null, null);
         };
 
@@ -245,7 +245,7 @@ namespace Avalonia.Controls
                                      select (from constructor in moduleType.GetTypeInfo().DeclaredConstructors
                                              where constructor.GetParameters().Length == 0 && !constructor.IsStatic
                                              select constructor).Single() into constructor
-                                     select (Action)(() => constructor.Invoke(new object[0]));
+                                     select (Action)(() => constructor.Invoke(Array.Empty<object>()));
             Delegate.Combine(moduleInitializers.ToArray()).DynamicInvoke();
         }
 

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -99,7 +99,7 @@ namespace Avalonia.Controls.Primitives
                 "SelectionChanged",
                 RoutingStrategies.Bubble);
 
-        private static readonly IList Empty = new object[0];
+        private static readonly IList Empty = Array.Empty<object>();
 
         private int _selectedIndex = -1;
         private object _selectedItem;

--- a/src/Avalonia.Controls/SystemDialog.cs
+++ b/src/Avalonia.Controls/SystemDialog.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Controls
                 throw new ArgumentNullException(nameof(parent));
             return ((await AvaloniaLocator.Current.GetService<ISystemDialogImpl>()
                  .ShowFileDialogAsync(this, parent?.PlatformImpl)) ??
-             new string[0]).FirstOrDefault();
+             Array.Empty<string>()).FirstOrDefault();
         }
     }
 

--- a/src/Avalonia.Remote.Protocol/DefaultMessageTypeResolver.cs
+++ b/src/Avalonia.Remote.Protocol/DefaultMessageTypeResolver.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Remote.Protocol
         public DefaultMessageTypeResolver(params Assembly[] assemblies)
         {
             foreach (var asm in
-                (assemblies ?? new Assembly[0]).Concat(new[]
+                (assemblies ?? Array.Empty<Assembly>()).Concat(new[]
                     {typeof(AvaloniaRemoteMessageGuidAttribute).GetTypeInfo().Assembly}))
             {
                 foreach (var t in asm.ExportedTypes)

--- a/src/Avalonia.Remote.Protocol/MetsysBson.cs
+++ b/src/Avalonia.Remote.Protocol/MetsysBson.cs
@@ -806,7 +806,7 @@ namespace Metsys.Bson
             {
                 return Activator.CreateInstance(typeof(List<>).MakeGenericType(itemType));
             }
-            if (type.GetConstructor(BindingFlags.Instance | BindingFlags.Public, null, new Type[0], null) != null)
+            if (type.GetConstructor(BindingFlags.Instance | BindingFlags.Public, null, Type.EmptyTypes, null) != null)
             {
                 return Activator.CreateInstance(type);
             }
@@ -853,7 +853,7 @@ namespace Metsys.Bson
                 return (IDictionary)Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(keyType, valueType));
             }
 
-            if (dictionaryType.GetConstructor(BindingFlags.Instance | BindingFlags.Public, null, new Type[0], null) != null)
+            if (dictionaryType.GetConstructor(BindingFlags.Instance | BindingFlags.Public, null, Type.EmptyTypes, null) != null)
             {
                 return (IDictionary)Activator.CreateInstance(dictionaryType);
             }

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
@@ -17,8 +17,8 @@ namespace Avalonia.Rendering.SceneGraph
     /// </summary>
     internal class VisualNode : IVisualNode
     {
-        private static readonly IReadOnlyList<IVisualNode> EmptyChildren = new IVisualNode[0];
-        private static readonly IReadOnlyList<IRef<IDrawOperation>> EmptyDrawOperations = new IRef<IDrawOperation>[0];
+        private static readonly IReadOnlyList<IVisualNode> EmptyChildren = Array.Empty<IVisualNode>();
+        private static readonly IReadOnlyList<IRef<IDrawOperation>> EmptyDrawOperations = Array.Empty<IRef<IDrawOperation>>();
 
         private Rect? _bounds;
         private double _opacity;

--- a/src/Windows/Avalonia.Win32/SystemDialogImpl.cs
+++ b/src/Windows/Avalonia.Win32/SystemDialogImpl.cs
@@ -21,7 +21,7 @@ namespace Avalonia.Win32
             var hWnd = parent?.Handle?.Handle ?? IntPtr.Zero;
             return Task.Factory.StartNew(() =>
             {
-                var result = new string[0];
+                var result = Array.Empty<string>();
 
                 Guid clsid = dialog is OpenFileDialog ? UnmanagedMethods.ShellIds.OpenFileDialog : UnmanagedMethods.ShellIds.SaveFileDialog;
                 Guid iid = UnmanagedMethods.ShellIds.IFileDialog;


### PR DESCRIPTION
## Changes
- Use `Array.Empty` instead of allocating empty arrays (and `Type.EmptyTypes` on reflection scenarios where it makes sense).