### PR TITLE
Synchronize DataContext with ReactiveUI.IViewFor.ViewModel property

### DIFF
--- a/src/Avalonia.ReactiveUI/RoutedViewHost.cs
+++ b/src/Avalonia.ReactiveUI/RoutedViewHost.cs
@@ -163,6 +163,8 @@ namespace Avalonia
     
             this.Log().Info($"Ready to show {view} with autowired {viewModel}.");
             view.ViewModel = viewModel;
+            if (view is IStyledElement styled)
+                styled.DataContext = viewModel;
             UpdateContent(view);
         }
     

--- a/tests/Avalonia.ReactiveUI.UnitTests/RoutedViewHostTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/RoutedViewHostTest.cs
@@ -50,7 +50,7 @@ namespace Avalonia
         }
 
         [Fact]
-        public void RoutedViewHostShouldStayInSyncWithRoutingState() 
+        public void RoutedViewHost_Should_Stay_In_Sync_With_RoutingState() 
         {
             var screen = new ScreenViewModel();
             var defaultContent = new TextBlock();
@@ -71,19 +71,25 @@ namespace Avalonia
             Assert.Equal(typeof(TextBlock), host.Content.GetType());
             Assert.Equal(defaultContent, host.Content);
 
+            var first = new FirstRoutableViewModel();
             screen.Router.Navigate
-                .Execute(new FirstRoutableViewModel())
+                .Execute(first)
                 .Subscribe();
 
             Assert.NotNull(host.Content);
             Assert.Equal(typeof(FirstRoutableView), host.Content.GetType());
+            Assert.Equal(first, ((FirstRoutableView)host.Content).DataContext);
+            Assert.Equal(first, ((FirstRoutableView)host.Content).ViewModel);
 
+            var second = new SecondRoutableViewModel();
             screen.Router.Navigate
-                .Execute(new SecondRoutableViewModel())
+                .Execute(second)
                 .Subscribe();
 
             Assert.NotNull(host.Content);
             Assert.Equal(typeof(SecondRoutableView), host.Content.GetType());
+            Assert.Equal(second, ((SecondRoutableView)host.Content).DataContext);
+            Assert.Equal(second, ((SecondRoutableView)host.Content).ViewModel);
 
             screen.Router.NavigateBack
                 .Execute(Unit.Default)
@@ -91,6 +97,8 @@ namespace Avalonia
 
             Assert.NotNull(host.Content);
             Assert.Equal(typeof(FirstRoutableView), host.Content.GetType());
+            Assert.Equal(first, ((FirstRoutableView)host.Content).DataContext);
+            Assert.Equal(first, ((FirstRoutableView)host.Content).ViewModel);
 
             screen.Router.NavigateBack
                 .Execute(Unit.Default)


### PR DESCRIPTION
#### What does the pull request do?

Encountered an issue while building an application with view model-based routing from Avalonia.ReactiveUI package — `DataContext` won't get updated with a view model when a user navigates to it, but `IViewFor<T>.ViewModel` property will. This PR fixes it and now ReactiveUI routing works with markup bindings as well, `DataContext` is updated with the view model when navigation occurs.

#### How was the solution implemented (if it's not obvious)?

If `IViewFor` implements `IStyledElement` (has `IStyledElement.DataContext` property), then the router updates the `DataContext` property with the view model to which a user navigates to.

## Checklist

- [x] Added unit tests
- [x] Added XML documentation to any related classes