### PR TITLE
Changed IScreenImpl.AllScreens return type so that it's not array

### DIFF
--- a/samples/ControlCatalog/Pages/ScreenPage.cs
+++ b/samples/ControlCatalog/Pages/ScreenPage.cs
@@ -23,7 +23,7 @@ namespace ControlCatalog.Pages
         {
             base.Render(context);
             Window w = (Window)VisualRoot;
-            Screen[] screens = w.Screens.All;
+            var screens = w.Screens.All;
             var scaling = ((IRenderRoot)w).RenderScaling;
 
             Pen p = new Pen(Brushes.Black);

--- a/src/Avalonia.Controls/Platform/IScreenImpl.cs
+++ b/src/Avalonia.Controls/Platform/IScreenImpl.cs
@@ -1,9 +1,11 @@
-﻿namespace Avalonia.Platform
+﻿using System.Collections.Generic;
+
+namespace Avalonia.Platform
 {
     public interface IScreenImpl
     {
         int ScreenCount { get; }
 
-        Screen[] AllScreens { get; }
+        IReadOnlyList<Screen> AllScreens { get; }
     }
 }

--- a/src/Avalonia.Controls/Screens.cs
+++ b/src/Avalonia.Controls/Screens.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Avalonia.Platform;
 using Avalonia.Utilities;
 using Avalonia.VisualTree;
@@ -10,7 +11,7 @@ namespace Avalonia.Controls
         private readonly IScreenImpl _iScreenImpl;
 
         public int ScreenCount => _iScreenImpl.ScreenCount;
-        public Screen[] All => _iScreenImpl?.AllScreens;
+        public IReadOnlyList<Screen> All => _iScreenImpl?.AllScreens;
         public Screen Primary => All.FirstOrDefault(x => x.Primary);
 
         public Screens(IScreenImpl iScreenImpl)

--- a/src/Avalonia.DesignerSupport/Remote/Stubs.cs
+++ b/src/Avalonia.DesignerSupport/Remote/Stubs.cs
@@ -156,7 +156,7 @@ namespace Avalonia.DesignerSupport.Remote
     {
         public int ScreenCount => 1;
 
-        public Screen[] AllScreens { get; } =
-            {new Screen(new PixelRect(0, 0, 4000, 4000), new PixelRect(0, 0, 4000, 4000), true)};
+        public IReadOnlyList<Screen> AllScreens { get; } =
+            new Screen[] { new Screen(new PixelRect(0, 0, 4000, 4000), new PixelRect(0, 0, 4000, 4000), true) };
     }
 }

--- a/src/Avalonia.Native/ScreenImpl.cs
+++ b/src/Avalonia.Native/ScreenImpl.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using Avalonia.Native.Interop;
 using Avalonia.Platform;
 
@@ -18,7 +19,7 @@ namespace Avalonia.Native
 
         public int ScreenCount => _native.GetScreenCount();
 
-        public Screen[] AllScreens
+        public IReadOnlyList<Screen> AllScreens
         {
             get
             {

--- a/src/Avalonia.X11/X11Screens.cs
+++ b/src/Avalonia.X11/X11Screens.cs
@@ -156,7 +156,7 @@ namespace Avalonia.X11
 
         public int ScreenCount => _impl.Screens.Length;
 
-        public Screen[] AllScreens =>
+        public IReadOnlyList<Screen> AllScreens =>
             _impl.Screens.Select(s => new Screen(s.Bounds, s.WorkingArea, s.Primary)).ToArray();
     }
 

--- a/src/Gtk/Avalonia.Gtk3/ScreenImpl.cs
+++ b/src/Gtk/Avalonia.Gtk3/ScreenImpl.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Avalonia.Gtk3.Interop;
 using Avalonia.Platform;
 
@@ -8,11 +9,11 @@ namespace Avalonia.Gtk3
     {
         public int ScreenCount
         {
-            get => AllScreens.Length;
+            get => _allScreens.Length;
         }
         
         private Screen[] _allScreens;
-        public Screen[] AllScreens
+        public IReadOnlyList<Screen> AllScreens
         {
             get
             {

--- a/src/Windows/Avalonia.Win32/ScreenImpl.cs
+++ b/src/Windows/Avalonia.Win32/ScreenImpl.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using Avalonia.Platform;
 using static Avalonia.Win32.Interop.UnmanagedMethods;
 
@@ -15,7 +16,7 @@ namespace Avalonia.Win32
         }
 
         private Screen[] _allScreens;
-        public  Screen[] AllScreens
+        public IReadOnlyList<Screen> AllScreens
         {
             get
             {


### PR DESCRIPTION
## Changes
- Changed `IScreenImpl.AllScreens` return type so that it's not array. (It's now ~`IEnumerable<Screen>`~`IReadOnlyList<Screen>`).

This is a binary breaking change, but I believe it's important. ~Also, I replaced array with `IEnumerable<Screen>` because there's already a `ScreenCount` property, and I think there's no specific order for the screens.~