### PR TITLE
Don't override UserControl.StyleKey.

### DIFF
--- a/src/Avalonia.Controls/UserControl.cs
+++ b/src/Avalonia.Controls/UserControl.cs
@@ -28,9 +28,6 @@ namespace Avalonia.Controls
         }
 
         /// <inheritdoc/>
-        Type IStyleable.StyleKey => typeof(UserControl);
-
-        /// <inheritdoc/>
         void INameScope.Register(string name, object element)
         {
             _nameScope.Register(name, element);

--- a/src/Avalonia.Themes.Default/UserControl.xaml
+++ b/src/Avalonia.Themes.Default/UserControl.xaml
@@ -1,4 +1,4 @@
-<Style xmlns="https://github.com/avaloniaui" Selector="UserControl">
+<Style xmlns="https://github.com/avaloniaui" Selector=":is(UserControl)">
   <Setter Property="Template">
     <ControlTemplate>
       <ContentPresenter Name="PART_ContentPresenter"


### PR DESCRIPTION
## What does the pull request do?

As described in #2280, it is difficult to style controls derived from `UserControl` because `UserControl.StyleKey` is pinned at `typeof(UserControl)`.

This PR changes things so that instead of pinning `UserControl.StyleKey` at `typeof(UserControl)`, the `UserControl` default template selector is changed to `:is(UserControl)`. This will allow controls derived from `UserControl` to be more easily styled.

## Fixed issues

Fixes #2280
