### PR TITLE
Fix incorrect dirty rects for text drawn with an offset

### DIFF
--- a/src/Avalonia.Visuals/Rendering/SceneGraph/TextNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/TextNode.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Rendering.SceneGraph
             Point origin,
             IFormattedTextImpl text,
             IDictionary<IVisual, Scene> childScenes = null)
-            : base(text.Bounds, transform, null)
+            : base(text.Bounds.Translate(origin), transform, null)
         {
             Transform = transform;
             Foreground = foreground?.ToImmutable();

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/TextNodeTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/TextNodeTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Avalonia.Platform;
+using Avalonia.Rendering.SceneGraph;
+using Moq;
+using Xunit;
+
+namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
+{
+    public class TextNodeTests
+    {
+        [Fact]
+        public void Bounds_Should_Be_Offset_By_Origin()
+        {
+            var target = new TextNode(
+                Matrix.Identity,
+                null,
+                new Point(10, 10),
+                Mock.Of<IFormattedTextImpl>(x => x.Bounds == new Rect(5, 5, 50, 50)));
+
+            Assert.Equal(new Rect(15, 15, 50, 50), target.Bounds);
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Fixes dirty rects for text drawn with offset.

## What is the current behavior?

As described in #2381, the offset is not taken into account when calculating a `TextNode`'s bounds.

## Checklist

- [x ] Added unit tests (if possible)?

## Fixed issues

Fixes #2381

cc: @ahopper 
