### PR TITLE
Fix autosizing on X11

### DIFF
--- a/samples/ControlCatalog.NetCore/ControlCatalog.NetCore.csproj
+++ b/samples/ControlCatalog.NetCore/ControlCatalog.NetCore.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Avalonia.Logging.Serilog\Avalonia.Logging.Serilog.csproj" />
     <ProjectReference Include="..\..\src\Linux\Avalonia.LinuxFramebuffer\Avalonia.LinuxFramebuffer.csproj" />
     <ProjectReference Include="..\ControlCatalog\ControlCatalog.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Desktop\Avalonia.Desktop.csproj" />

--- a/samples/ControlCatalog.NetCore/Program.cs
+++ b/samples/ControlCatalog.NetCore/Program.cs
@@ -51,7 +51,7 @@ namespace ControlCatalog.NetCore
                 .UsePlatformDetect()
                 .UseSkia()
                 .UseReactiveUI()
-                .LogToDebug(LogArea.Layout, LogEventLevel.Verbose);
+                .LogToDebug();
 
         static void ConsoleSilencer()
         {

--- a/samples/ControlCatalog.NetCore/Program.cs
+++ b/samples/ControlCatalog.NetCore/Program.cs
@@ -3,7 +3,11 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Avalonia;
+using Avalonia.Logging;
+using Avalonia.Logging.Serilog;
 using Avalonia.Skia;
+using Serilog;
+using Serilog.Filters;
 
 namespace ControlCatalog.NetCore
 {
@@ -43,7 +47,11 @@ namespace ControlCatalog.NetCore
         /// This method is needed for IDE previewer infrastructure
         /// </summary>
         public static AppBuilder BuildAvaloniaApp()
-            => AppBuilder.Configure<App>().UsePlatformDetect().UseSkia().UseReactiveUI();
+            => AppBuilder.Configure<App>()
+                .UsePlatformDetect()
+                .UseSkia()
+                .UseReactiveUI()
+                .LogToDebug(LogArea.Layout, LogEventLevel.Verbose);
 
         static void ConsoleSilencer()
         {

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -70,6 +70,8 @@ namespace Avalonia.Android.Platform.SkiaPlatform
 
         public Action<RawInputEventArgs> Input { get; set; }
 
+        public Size MinClientSize { get; protected set; }
+
         public Size MaxClientSize { get; protected set; }
 
         public Action<Rect> Paint { get; set; }

--- a/src/Avalonia.Controls/Platform/IWindowBaseImpl.cs
+++ b/src/Avalonia.Controls/Platform/IWindowBaseImpl.cs
@@ -55,9 +55,14 @@ namespace Avalonia.Platform
         /// Gets the platform window handle.
         /// </summary>
         IPlatformHandle Handle { get; }
-       
+
         /// <summary>
-        /// Gets the maximum size of a window on the system.
+        /// Gets the minimum client size of a window on the system.
+        /// </summary>
+        Size MinClientSize { get; }
+
+        /// <summary>
+        /// Gets the maximum client size of a window on the system.
         /// </summary>
         Size MaxClientSize { get; }
 

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -558,7 +558,19 @@ namespace Avalonia.Controls
         /// <inheritdoc/>
         protected override void HandleResized(Size clientSize)
         {
-            if (clientSize != DesiredSize)
+            var manuallySized = false;
+
+            if ((SizeToContent & SizeToContent.Width) != 0)
+            {
+                manuallySized |= clientSize.Width != DesiredSize.Width;
+            }
+
+            if ((SizeToContent & SizeToContent.Height) != 0)
+            {
+                manuallySized |= clientSize.Height != DesiredSize.Height;
+            }
+
+            if (manuallySized)
             {
                 Logger.Debug(
                     LogArea.Layout,

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using System.ComponentModel;
 using Avalonia.Utilities;
+using Avalonia.Logging;
 
 namespace Avalonia.Controls
 {
@@ -559,6 +560,12 @@ namespace Avalonia.Controls
         {
             if (clientSize != DesiredSize)
             {
+                Logger.Debug(
+                    LogArea.Layout,
+                    this,
+                    "Set SizeToContent = Manual due to resize to {Size} with desired size of {DesiredSize}",
+                    clientSize,
+                    DesiredSize);
                 SizeToContent = SizeToContent.Manual;
             }
 

--- a/src/Avalonia.Controls/WindowBase.cs
+++ b/src/Avalonia.Controls/WindowBase.cs
@@ -110,15 +110,6 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Whether an auto-size operation is in progress.
-        /// </summary>
-        protected bool AutoSizing
-        {
-            get;
-            private set;
-        }
-
-        /// <summary>
         /// Gets or sets the owner of the window.
         /// </summary>
         public WindowBase Owner
@@ -191,32 +182,13 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Begins an auto-resize operation.
-        /// </summary>
-        /// <returns>A disposable used to finish the operation.</returns>
-        /// <remarks>
-        /// When an auto-resize operation is in progress any resize events received will not be
-        /// cause the new size to be written to the <see cref="Layoutable.Width"/> and
-        /// <see cref="Layoutable.Height"/> properties.
-        /// </remarks>
-        protected IDisposable BeginAutoSizing()
-        {
-            AutoSizing = true;
-            return Disposable.Create(() => AutoSizing = false);
-        }
-
-        /// <summary>
         /// Carries out the arrange pass of the window.
         /// </summary>
         /// <param name="finalSize">The final window size.</param>
         /// <returns>The <paramref name="finalSize"/> parameter unchanged.</returns>
         protected override Size ArrangeOverride(Size finalSize)
         {
-            using (BeginAutoSizing())
-            {
-                PlatformImpl?.Resize(finalSize);
-            }
-
+            PlatformImpl?.Resize(finalSize);
             return base.ArrangeOverride(PlatformImpl?.ClientSize ?? default(Size));
         }
 
@@ -254,11 +226,6 @@ namespace Avalonia.Controls
         /// <param name="clientSize">The new client size.</param>
         protected override void HandleResized(Size clientSize)
         {
-            if (!AutoSizing)
-            {
-                Width = clientSize.Width;
-                Height = clientSize.Height;
-            }
             ClientSize = clientSize;
             LayoutManager.ExecuteLayoutPass();
             Renderer?.Resized(clientSize);

--- a/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
+++ b/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
@@ -43,6 +43,7 @@ namespace Avalonia.DesignerSupport.Remote
         public IPlatformHandle Handle { get; }
         public WindowState WindowState { get; set; }
         public Action<WindowState> WindowStateChanged { get; set; }
+        public Size MinClientSize => Size.Empty;
         public Size MaxClientSize { get; } = new Size(4096, 4096);
         public event Action LostFocus
         {

--- a/src/Avalonia.DesignerSupport/Remote/Stubs.cs
+++ b/src/Avalonia.DesignerSupport/Remote/Stubs.cs
@@ -18,6 +18,7 @@ namespace Avalonia.DesignerSupport.Remote
         public Action Deactivated { get; set; }
         public Action Activated { get; set; }
         public IPlatformHandle Handle { get; }
+        public Size MinClientSize { get; }
         public Size MaxClientSize { get; }
         public Size ClientSize { get; }
         public double Scaling { get; } = 1.0;

--- a/src/Avalonia.Layout/LayoutManager.cs
+++ b/src/Avalonia.Layout/LayoutManager.cs
@@ -183,7 +183,9 @@ namespace Avalonia.Layout
                 Arrange(parent);
             }
 
-            if (!control.IsArrangeValid && control.IsAttachedToVisualTree)
+            if (control.IsMeasureValid &&
+                !control.IsArrangeValid &&
+                control.IsAttachedToVisualTree)
             {
                 if (control is IEmbeddedLayoutRoot embeddedRoot)
                     control.Arrange(new Rect(embeddedRoot.AllocatedSize));

--- a/src/Avalonia.Layout/Layoutable.cs
+++ b/src/Avalonia.Layout/Layoutable.cs
@@ -309,6 +309,8 @@ namespace Avalonia.Layout
                 var previousDesiredSize = DesiredSize;
                 var desiredSize = default(Size);
 
+                Logger.Verbose(LogArea.Layout, this, "Measure started with constraint of {AvailableSize}", availableSize);
+
                 IsMeasureValid = true;
 
                 try
@@ -329,7 +331,7 @@ namespace Avalonia.Layout
                 DesiredSize = desiredSize;
                 _previousMeasure = availableSize;
 
-                Logger.Verbose(LogArea.Layout, this, "Measure requested {DesiredSize}", DesiredSize);
+                Logger.Verbose(LogArea.Layout, this, "Measure finished with desired size of {DesiredSize}", DesiredSize);
 
                 if (DesiredSize != previousDesiredSize)
                 {
@@ -351,18 +353,21 @@ namespace Avalonia.Layout
 
             if (!IsMeasureValid)
             {
+                Logger.Verbose(LogArea.Layout, this, "Arrange called without valid measure");
                 Measure(_previousMeasure ?? rect.Size);
             }
 
             if (!IsArrangeValid || _previousArrange != rect)
             {
-                Logger.Verbose(LogArea.Layout, this, "Arrange to {Rect} ", rect);
+                Logger.Verbose(LogArea.Layout, this, "Arrange started with bounds of {Bounds}", rect);
 
                 IsArrangeValid = true;
                 ArrangeCore(rect);
                 _previousArrange = rect;
 
                 LayoutUpdated?.Invoke(this, EventArgs.Empty);
+
+                Logger.Verbose(LogArea.Layout, this, "Arrange finished", rect);
             }
         }
 

--- a/src/Avalonia.Logging.Serilog/SerilogExtensions.cs
+++ b/src/Avalonia.Logging.Serilog/SerilogExtensions.cs
@@ -1,5 +1,8 @@
-﻿using Avalonia.Controls;
+﻿using System;
+using Avalonia.Controls;
 using Serilog;
+using Serilog.Configuration;
+using Serilog.Filters;
 using SerilogLevel = Serilog.Events.LogEventLevel;
 
 namespace Avalonia.Logging.Serilog
@@ -9,6 +12,8 @@ namespace Avalonia.Logging.Serilog
     /// </summary>
     public static class SerilogExtensions
     {
+        private const string DefaultTemplate = "[{Area}] {Message} ({SourceType} #{SourceHash})";
+
         /// <summary>
         /// Logs Avalonia events to the <see cref="System.Diagnostics.Debug"/> sink.
         /// </summary>
@@ -23,7 +28,31 @@ namespace Avalonia.Logging.Serilog
         {
             SerilogLogger.Initialize(new LoggerConfiguration()
                 .MinimumLevel.Is((SerilogLevel)level)
-                .WriteTo.Debug(outputTemplate: "{Area}: {Message}")
+                .Enrich.FromLogContext()
+                .WriteTo.Debug(outputTemplate: DefaultTemplate)
+                .CreateLogger());
+            return builder;
+        }
+
+        /// <summary>
+        /// Logs Avalonia events to the <see cref="System.Diagnostics.Debug"/> sink.
+        /// </summary>
+        /// <typeparam name="T">The application class type.</typeparam>
+        /// <param name="builder">The app builder instance.</param>
+        /// <param name="area">The area to log. Valid values are listed in <see cref="LogArea"/>.</param>
+        /// <param name="level">The minimum level to log.</param>
+        /// <returns>The app builder instance.</returns>
+        public static T LogToDebug<T>(
+            this T builder,
+            string area,
+            LogEventLevel level = LogEventLevel.Warning)
+                where T : AppBuilderBase<T>, new()
+        {
+            SerilogLogger.Initialize(new LoggerConfiguration()
+                .MinimumLevel.Is((SerilogLevel)level)
+                .Filter.ByIncludingOnly(Matching.WithProperty("Area", area))
+                .Enrich.FromLogContext()
+                .WriteTo.Debug(outputTemplate: DefaultTemplate)
                 .CreateLogger());
             return builder;
         }
@@ -42,7 +71,8 @@ namespace Avalonia.Logging.Serilog
         {
             SerilogLogger.Initialize(new LoggerConfiguration()
                 .MinimumLevel.Is((SerilogLevel)level)
-                .WriteTo.Trace(outputTemplate: "{Area}: {Message}")
+                .Enrich.FromLogContext()
+                .WriteTo.Trace(outputTemplate: DefaultTemplate)
                 .CreateLogger());
             return builder;
         }

--- a/src/Avalonia.Logging.Serilog/SerilogLogger.cs
+++ b/src/Avalonia.Logging.Serilog/SerilogLogger.cs
@@ -1,8 +1,9 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
-using System.Collections.Generic;
+using System;
 using Serilog;
+using Serilog.Context;
 using AvaloniaLogEventLevel = Avalonia.Logging.LogEventLevel;
 using SerilogLogEventLevel = Serilog.Events.LogEventLevel;
 
@@ -14,7 +15,6 @@ namespace Avalonia.Logging.Serilog
     public class SerilogLogger : ILogSink
     {
         private readonly ILogger _output;
-        private readonly Dictionary<string, ILogger> _areas = new Dictionary<string, ILogger>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SerilogLogger"/> class.
@@ -42,15 +42,15 @@ namespace Avalonia.Logging.Serilog
             string messageTemplate, 
             params object[] propertyValues)
         {
-            ILogger areaLogger;
+            Contract.Requires<ArgumentNullException>(area != null);
+            Contract.Requires<ArgumentNullException>(messageTemplate != null);
 
-            if (!_areas.TryGetValue(area, out areaLogger))
+            using (LogContext.PushProperty("Area", area))
+            using (LogContext.PushProperty("SourceType", source?.GetType()))
+            using (LogContext.PushProperty("SourceHash", source?.GetHashCode()))
             {
-                areaLogger = _output.ForContext("Area", area);
-                _areas.Add(area, areaLogger);
+                _output.Write((SerilogLogEventLevel)level, messageTemplate, propertyValues);
             }
-
-            areaLogger.Write((SerilogLogEventLevel)level, messageTemplate, propertyValues);
         }
     }
 }

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -301,6 +301,8 @@ namespace Avalonia.Native
             _native.BeginMoveDrag();
         }
 
+        public Size MinClientSize => Size.Empty;
+
         public Size MaxClientSize => _native.GetMaxClientSize().ToAvaloniaSize();
 
         public void SetTopmost(bool value)

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -798,6 +798,8 @@ namespace Avalonia.X11
 
         public IScreenImpl Screen => _platform.Screens;
 
+        public Size MinClientSize => Size.Empty;
+
         public Size MaxClientSize => _platform.X11Screens.Screens.Select(s => s.Bounds.Size.ToSize(s.PixelDensity))
             .OrderByDescending(x => x.Width + x.Height).FirstOrDefault();
 

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -391,6 +391,9 @@ namespace Avalonia.X11
 
                         Dispatcher.UIThread.RunJobs(DispatcherPriority.Layout);
                     }, DispatcherPriority.Layout);
+                if (_useRenderWindow)
+                    XConfigureResizeWindow(_x11.Display, _renderHandle, ev.ConfigureEvent.width,
+                        ev.ConfigureEvent.height);
             }
             else if (ev.type == XEventName.DestroyNotify && ev.AnyEvent.window == _handle)
             {
@@ -452,7 +455,7 @@ namespace Avalonia.X11
                     Scaling = newScaling;
                     ScalingChanged?.Invoke(Scaling);
                     SetMinMaxSize(_scaledMinMaxSize.minSize, _scaledMinMaxSize.maxSize);
-                    Resize(oldScaledSize, false);
+                    Resize(oldScaledSize, true);
                     return true;
                 }
 

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -391,9 +391,6 @@ namespace Avalonia.X11
 
                         Dispatcher.UIThread.RunJobs(DispatcherPriority.Layout);
                     }, DispatcherPriority.Layout);
-                if (_useRenderWindow)
-                    XConfigureResizeWindow(_x11.Display, _renderHandle, ev.ConfigureEvent.width,
-                        ev.ConfigureEvent.height);
             }
             else if (ev.type == XEventName.DestroyNotify && ev.AnyEvent.window == _handle)
             {
@@ -455,7 +452,7 @@ namespace Avalonia.X11
                     Scaling = newScaling;
                     ScalingChanged?.Invoke(Scaling);
                     SetMinMaxSize(_scaledMinMaxSize.minSize, _scaledMinMaxSize.maxSize);
-                    Resize(oldScaledSize, true);
+                    Resize(oldScaledSize, false);
                     return true;
                 }
 

--- a/src/Gtk/Avalonia.Gtk3/WindowBaseImpl.cs
+++ b/src/Gtk/Avalonia.Gtk3/WindowBaseImpl.cs
@@ -344,6 +344,8 @@ namespace Avalonia.Gtk3
             }
         }
 
+        public Size MinClientSize => Size.Empty;
+
         public Size MaxClientSize
         {
             get

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -189,6 +189,17 @@ namespace Avalonia.Win32
             EnableWindow(_hwnd, _disabledBy.Count == 0);
         }
 
+        public Size MinClientSize
+        {
+            get
+            {
+                return (new Size(
+                    UnmanagedMethods.GetSystemMetrics(UnmanagedMethods.SystemMetric.SM_CXMINTRACK),
+                    UnmanagedMethods.GetSystemMetrics(UnmanagedMethods.SystemMetric.SM_CYMINTRACK))
+                    - BorderThickness) / Scaling;
+            }
+        }
+
         public Size MaxClientSize
         {
             get


### PR DESCRIPTION
## What does the pull request do?

Fixes auto-sizing windows on X11 (#1748).

## What is the current behavior?

The window initially shows at the correct size, but then the `SizeToContent` property is reset to `Manual` and subsequent changes to the window contents don't cause a resize of the window as expected.

Also fixes the following on all platforms:

- Makes sure that autosizing doesn't try to size the window smaller than the min window size or larger than the max window size

## How was the solution implemented (if it's not obvious)?

There was a confluence of a few different problems:

- Resize on X11 is an asynchronous operation. Previously we were relying on the fact that when a window was resized it would immediately fire a `Resized` event. We used the `BeginAutoSizing` method as a flag to say "we're auto-sizing now, any change in size isn't due to the user". When a resize event came in outside of a `BeginAutoSizing` block, we set `SizeToContent = Manual`. On X11 the resized event will not be fired immediately, it will be fired sometime later, causing auto-sizing to be broken there.
  - Solution: change the algorithm to assume that the user has resized the window if a resize event comes in for a size other than the requested size. For this to work, we also need to know the min client size for the window, because if we request less than that, we don't get the size we requested.
- `LayoutManager` was calling `Arrange` on controls that don't have a valid `Measure`, causing `Measure` to get called by `Arrange` with an old constraint
- The X11 backend was resizing the window with values other than the value that the `WindowBase` resizes it to (see inline comments: I'm not sure this was fixed correctly)

Also I improved logging because I had to rely on lots of logging to diagnose the layout problems.

## Checklist

- [ ] Added unit tests (if possible)?

## Breaking changes

Window `Width` and `Height` now work like the `Width` and `Height` properties for other controls, in that they will be `NaN` if a fixed size is not specified.
  - Thinking about it, this needs to be rethought, because it will break the case where someone sets `Width`/`Height` for their window in markup

## Fixed issues

Fixes #1748
