### PR TITLE
fix popup root snap inside screen edges.

### DIFF
--- a/src/Avalonia.Controls/Primitives/PopupRoot.cs
+++ b/src/Avalonia.Controls/Primitives/PopupRoot.cs
@@ -91,12 +91,12 @@ namespace Avalonia.Controls.Primitives
 
                 if (screenX > screen.Bounds.Width)
                 {
-                    Position = Position.WithX(Position.X - screenX - bounds.Width);
+                    Position = Position.WithX(Position.X - (screenX - screen.Bounds.Width));
                 }
 
                 if (screenY > screen.Bounds.Height)
                 {
-                    Position = Position.WithY(Position.Y - screenY - bounds.Height);
+                    Position = Position.WithY(Position.Y - (screenY - screen.Bounds.Height));
                 }
             }
         }


### PR DESCRIPTION
## What does the pull request do?

Fixes accidentally introduced bug https://github.com/AvaloniaUI/Avalonia/commit/4ec2b1c554d729fac656a1622be305ca390c291a#diff-c19caf380fae83532e5fb9144772a0f0L94

## What is the current behavior?
popups and context menus near screen edges dont show.

## What is the updated/expected behavior with this PR?
normally working context menus and popups with ObeyScreenEdges = true.

