### PR TITLE
Add xmlns for ReactiveUI, move files to Avalonia.ReactiveUI namespace

### DIFF
--- a/samples/BindingDemo/App.xaml.cs
+++ b/samples/BindingDemo/App.xaml.cs
@@ -3,6 +3,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Logging.Serilog;
 using Avalonia.Markup.Xaml;
+using Avalonia.ReactiveUI;
 using Serilog;
 
 namespace BindingDemo

--- a/samples/ControlCatalog.Desktop/Program.cs
+++ b/samples/ControlCatalog.Desktop/Program.cs
@@ -4,6 +4,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Logging.Serilog;
 using Avalonia.Platform;
+using Avalonia.ReactiveUI;
 using Serilog;
 
 namespace ControlCatalog

--- a/samples/ControlCatalog.NetCore/Program.cs
+++ b/samples/ControlCatalog.NetCore/Program.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using Avalonia;
 using Avalonia.Skia;
+using Avalonia.ReactiveUI;
 
 namespace ControlCatalog.NetCore
 {

--- a/samples/RenderDemo/App.xaml.cs
+++ b/samples/RenderDemo/App.xaml.cs
@@ -4,6 +4,7 @@
 using Avalonia;
 using Avalonia.Logging.Serilog;
 using Avalonia.Markup.Xaml;
+using Avalonia.ReactiveUI;
 
 namespace RenderDemo
 {

--- a/samples/VirtualizationDemo/Program.cs
+++ b/samples/VirtualizationDemo/Program.cs
@@ -5,6 +5,7 @@ using System;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Logging.Serilog;
+using Avalonia.ReactiveUI;
 using Serilog;
 
 namespace VirtualizationDemo

--- a/src/Avalonia.ReactiveUI/AppBuilderExtensions.cs
+++ b/src/Avalonia.ReactiveUI/AppBuilderExtensions.cs
@@ -6,10 +6,15 @@ using Avalonia.Threading;
 using ReactiveUI;
 using Splat;
 
-namespace Avalonia
+namespace Avalonia.ReactiveUI
 {
     public static class AppBuilderExtensions
     {
+        /// <summary>
+        /// Initializes ReactiveUI framework to use with Avalonia. Registers Avalonia 
+        /// scheduler and Avalonia activation for view fetcher. Always remember to
+        /// call this method if you are using ReactiveUI in your application.
+        /// </summary>
         public static TAppBuilder UseReactiveUI<TAppBuilder>(this TAppBuilder builder)
             where TAppBuilder : AppBuilderBase<TAppBuilder>, new()
         {

--- a/src/Avalonia.ReactiveUI/Attributes.cs
+++ b/src/Avalonia.ReactiveUI/Attributes.cs
@@ -1,0 +1,8 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Avalonia.Metadata;
+
+[assembly: XmlnsDefinition("http://reactiveui.net", "Avalonia.ReactiveUI")]

--- a/src/Avalonia.ReactiveUI/AvaloniaActivationForViewFetcher.cs
+++ b/src/Avalonia.ReactiveUI/AvaloniaActivationForViewFetcher.cs
@@ -9,15 +9,24 @@ using Avalonia.VisualTree;
 using Avalonia.Controls;
 using ReactiveUI;
 
-namespace Avalonia
+namespace Avalonia.ReactiveUI
 {
+    /// <summary>
+    /// Determines when Avalonia IVisuals get activated.
+    /// </summary>
     public class AvaloniaActivationForViewFetcher : IActivationForViewFetcher
     {
+        /// <summary>
+        /// Returns affinity for view.
+        /// </summary>
         public int GetAffinityForView(Type view)
         {
             return typeof(IVisual).GetTypeInfo().IsAssignableFrom(view.GetTypeInfo()) ? 10 : 0;
         }
 
+        /// <summary>
+        /// Returns activation observable for activatable Avalonia view.
+        /// </summary>
         public IObservable<bool> GetActivationForView(IActivatable view)
         {
             if (!(view is IVisual visual)) return Observable.Return(false);
@@ -25,6 +34,9 @@ namespace Avalonia
             return GetActivationForVisual(visual);
         }
 
+        /// <summary>
+        /// Listens to Opened and Closed events for Avalonia windows.
+        /// </summary>
         private IObservable<bool> GetActivationForWindowBase(WindowBase window) 
         {
             var windowLoaded = Observable
@@ -42,6 +54,10 @@ namespace Avalonia
                 .DistinctUntilChanged();
         }
 
+        /// <summary>
+        /// Listens to AttachedToVisualTree and DetachedFromVisualTree 
+        /// events for Avalonia IVisuals.
+        /// </summary>
         private IObservable<bool> GetActivationForVisual(IVisual visual) 
         {
             var visualLoaded = Observable

--- a/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
+++ b/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
@@ -6,7 +6,7 @@ using Avalonia.VisualTree;
 using Avalonia.Controls;
 using ReactiveUI;
 
-namespace Avalonia
+namespace Avalonia.ReactiveUI
 {
     /// <summary>
     /// A ReactiveUI UserControl that implements <see cref="IViewFor{TViewModel}"/> 

--- a/src/Avalonia.ReactiveUI/ReactiveWindow.cs
+++ b/src/Avalonia.ReactiveUI/ReactiveWindow.cs
@@ -6,7 +6,7 @@ using Avalonia.VisualTree;
 using Avalonia.Controls;
 using ReactiveUI;
 
-namespace Avalonia 
+namespace Avalonia.ReactiveUI
 {
     /// <summary>
     /// A ReactiveUI Window that implements <see cref="IViewFor{TViewModel}"/>

--- a/src/Avalonia.ReactiveUI/RoutedViewHost.cs
+++ b/src/Avalonia.ReactiveUI/RoutedViewHost.cs
@@ -1,13 +1,17 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
 using System;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Avalonia.Animation;
 using Avalonia.Controls;
 using Avalonia.Styling;
+using Avalonia;
 using ReactiveUI;
 using Splat;
 
-namespace Avalonia
+namespace Avalonia.ReactiveUI
 {
     /// <summary>
     /// This control hosts the View associated with ReactiveUI RoutingState,
@@ -157,7 +161,7 @@ namespace Avalonia
                 return;
             }
     
-            var viewLocator = ViewLocator ?? ReactiveUI.ViewLocator.Current;
+            var viewLocator = ViewLocator ?? global::ReactiveUI.ViewLocator.Current;
             var view = viewLocator.ResolveView(viewModel);
             if (view == null) throw new Exception($"Couldn't find view for '{viewModel}'. Is it registered?");
     

--- a/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
@@ -11,6 +11,7 @@ using DynamicData;
 using Xunit;
 using Splat;
 using Avalonia.Markup.Xaml;
+using Avalonia.ReactiveUI;
 
 namespace Avalonia 
 {

--- a/tests/Avalonia.ReactiveUI.UnitTests/RoutedViewHostTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/RoutedViewHostTest.cs
@@ -14,6 +14,7 @@ using Avalonia.Markup.Xaml;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Reactive;
+using Avalonia.ReactiveUI;
 
 namespace Avalonia
 {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

- Added `[XmlnsDefinition]` for `xmlns:rxui="http://reactiveui.net"` to work, this makes `RoutedViewHost`, `ReactiveUserControl<T>` and `ReactiveWindow<T>` code snippets more copy-paste-friendly for new users who read ReactiveUI docs website;
- Added missing license headers and xml docs to files;
- Moved all classes from `Avalonia` to `Avalonia.ReactiveUI` namespace in the `Avalonia.ReactiveUI` package. This is a breaking change, unfortunately required for `xmlns:rxui="http://reactiveui.net"` to work.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Currently, if one copy-pastes an example from ReactiveUI API docs, the app won't compile, because we have no `xmlns` defined for `http://reactiveui.net` string which is used in all ReactiveUI examples, see:
- [ReactiveUserControl<TViewModel>](https://reactiveui.net/api/reactiveui/reactiveusercontrol_1/)
- [ReactiveWindow<TViewModel>](https://reactiveui.net/api/reactiveui/reactivewindow_1/)
- [ReactiveUI - Routing](https://reactiveui.net/docs/handbook/routing/)

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Examples from ReactiveUI API docs are now copy-paste friendly. 
This could help users coming from WPF, UWP or XF to quickly get started.

## Checklist

- [x] Added unit tests
- [x] Added XML documentation to any related classes

Going to submit a PR to Avalonia website with usage examples for all this stuff soon.

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

`.UseReactiveUI()`, `RoutedViewHost`, `ReactiveUserControl<TViewModel>`, `ReactiveWindow<TViewModel>` and friends have been moved from `Avalonia` namespace to `Avalonia.ReactiveUI` namespace, so worth adding some `using Avalonia.ReactiveUI;`s to existing C# and XAML files which reference those controls. For example:

```xml
<rxui:ReactiveWindow
    xmlns:rxui="http://reactiveui.net" 
    x:Class="ReactiveRouting.MainWindow"
    x:TypeArguments="vm:MainViewModel"
    xmlns:vm="clr-namespace:ReactiveRouting"
    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
    Title="ReactiveUI.Routing" Height="360" Width="620">
   <rxui:RoutedViewHost />
</rxui:ReactiveWindow>
```

Based on conversation with @kekekeks 