### PR TITLE
Update portable.xaml to give better error info (again)

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml/AvaloniaXamlLoader.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/AvaloniaXamlLoader.cs
@@ -162,7 +162,8 @@ namespace Avalonia.Markup.Xaml
             var readerSettings = new XamlXmlReaderSettings()
             {
                 BaseUri = uri,
-                LocalAssembly = localAssembly
+                LocalAssembly = localAssembly,
+                ProvideLineInfo = true,
             };
 
             var context = IsDesignMode ? AvaloniaXamlSchemaContext.DesignInstance : AvaloniaXamlSchemaContext.Instance;


### PR DESCRIPTION
## What does the pull request do?

#2307 updated the portable.xaml submodule to include https://github.com/cwensley/Portable.Xaml/pull/140, but the changes were then lost in a subsequent merge. This re-applies that update along with a couple of new commits to the portable.xaml branch.

## What is the current behavior?

Designer does not get correct line info for errors.

## What is the updated/expected behavior with this PR?

Designer shows correct line info for errors. In conjunction with https://github.com/AvaloniaUI/AvaloniaVS/pull/84 should improve the designer experience a lot.
