### PR TITLE
Throw an exception when trying to re-show a closed window.

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -373,6 +373,11 @@ namespace Avalonia.Controls
         /// </summary>
         public override void Show()
         {
+            if (PlatformImpl == null)
+            {
+                throw new InvalidOperationException("Cannot re-show a closed window.");
+            }
+
             if (IsVisible)
             {
                 return;

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -371,6 +371,9 @@ namespace Avalonia.Controls
         /// <summary>
         /// Shows the window.
         /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The window has already been closed.
+        /// </exception>
         public override void Show()
         {
             if (PlatformImpl == null)
@@ -402,6 +405,9 @@ namespace Avalonia.Controls
         /// Shows the window as a dialog.
         /// </summary>
         /// <param name="owner">The dialog's owner window.</param>
+        /// <exception cref="InvalidOperationException">
+        /// The window has already been closed.
+        /// </exception>
         /// <returns>
         /// A task that can be used to track the lifetime of the dialog.
         /// </returns>


### PR DESCRIPTION
## What does the pull request do?

#2388 describes a but where `Window.Opened` is raised when trying to re-show a closed window, even though the window doesn't get shown.

## What is the current behavior?

The show fails silently and the `Opened` event is raised erroneously.

## What is the updated/expected behavior with this PR?

Calling `Show` or `ShowDialog` on a closed `Window` raises an `InvalidOperationException`.

## How was the solution implemented (if it's not obvious)?

When the window is closed `PlatformImpl` is set to null. Check for a null `PlatformImpl` when opening the window and throw if necessary.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?

## Fixed issues

Fixes #2388 

cc: @mat1jaczyyy
