### PR TITLE
Do not fire key event before mouse has moved (drag/drop)

### DIFF
--- a/src/Avalonia.Controls/Platform/InProcessDragSource.cs
+++ b/src/Avalonia.Controls/Platform/InProcessDragSource.cs
@@ -147,7 +147,10 @@ namespace Avalonia.Platform
                 e.Handled = true;
             }
             else if (e.Key == Key.LeftCtrl || e.Key == Key.RightCtrl || e.Key == Key.LeftAlt || e.Key == Key.RightAlt)
-                RaiseEventAndUpdateCursor(RawDragEventType.DragOver, _lastRoot, _lastPosition, e.Modifiers);
+            {
+                if (_lastRoot != null)
+                    RaiseEventAndUpdateCursor(RawDragEventType.DragOver, _lastRoot, _lastPosition, e.Modifiers);
+            }
         }
 
         private void ProcessMouseEvents(RawMouseEventArgs e)


### PR DESCRIPTION
## What does the pull request do?
Fixes a simple nullref bug.


## What is the current behavior?
Current behavior will attempt to raise an event if a modifier key is down before any mouse movement has occurred. 


## What is the updated/expected behavior with this PR?
Repro for this issue is simply to hold down alt and attempt to drag something (can use ControlCatalog.NetCore). Without the fix, a nullreferenceexception occurs. With fix, no nullref occurs. The field _lastRoot is null until mouse movement occurs. This also follows the same pattern as the dragleave event trigger right above it, which checks for null.


## How was the solution implemented (if it's not obvious)?
Just check for null.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
None


## Fixed issues
Fixes #2419 