### PR TITLE
Fix url encoded path and filenames on Mac

### DIFF
--- a/native/Avalonia.Native/src/OSX/SystemDialogs.mm
+++ b/native/Avalonia.Native/src/OSX/SystemDialogs.mm
@@ -45,8 +45,7 @@ public:
                         {
                             auto url = [urls objectAtIndex:i];
                             
-                            auto string = [url absoluteString];
-                            string = [string substringFromIndex:7];
+                            auto string = [url path];
                             
                             strings[i] = (void*)[string UTF8String];
                         }
@@ -137,8 +136,7 @@ public:
                         {
                             auto url = [urls objectAtIndex:i];
                             
-                            auto string = [url absoluteString];
-                            string = [string substringFromIndex:7];
+                            auto string = [url path];
                             
                             strings[i] = (void*)[string UTF8String];
                         }
@@ -220,8 +218,7 @@ public:
                     
                     auto url = [panel URL];
                     
-                    auto string = [url absoluteString];
-                    string = [string substringFromIndex:7];     
+                    auto string = [url path];   
                     strings[0] = (void*)[string UTF8String];
                
                     events->OnCompleted(1, &strings[0]);


### PR DESCRIPTION
#2475

## What does the pull request do?
Return proper path and filenames on Mac


## What is the current behavior?
Paths with spaces and other special characters are url encoded


## What is the updated/expected behavior with this PR?
Paths are returned properly


## How was the solution implemented (if it's not obvious)?
`[url absoluteString]` was being read and then 7 characters were being removed from the start of the string resulting in a url encoded path

`[url path]` returns the path directly without the file:// protocol and without being url encoded

See https://stackoverflow.com/questions/16176911/nsurl-path-vs-absolutestring for an explanation


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
#2475 
