### PR TITLE
Fix OneWayToSource binding

### DIFF
--- a/src/Avalonia.Base/Data/BindingOperations.cs
+++ b/src/Avalonia.Base/Data/BindingOperations.cs
@@ -65,7 +65,11 @@ namespace Avalonia.Data
                         return Disposable.Empty;
                     }
                 case BindingMode.OneWayToSource:
-                    return target.GetObservable(property).Subscribe(binding.Subject);
+                    return Observable.CombineLatest(
+                        binding.Observable,
+                        target.GetObservable(property),
+                        (_, v) => v)
+                    .Subscribe(x => binding.Subject.OnNext(x));
                 default:
                     throw new ArgumentException("Invalid binding mode.");
             }

--- a/src/Avalonia.Base/Data/Core/PropertyAccessorNode.cs
+++ b/src/Avalonia.Base/Data/Core/PropertyAccessorNode.cs
@@ -59,8 +59,8 @@ namespace Avalonia.Data.Core
                     $"Could not find a matching property accessor for {PropertyName}.");
             }
 
-            accessor.Subscribe(ValueChanged);
             _accessor = accessor;
+            accessor.Subscribe(ValueChanged);
         }
 
         protected override void StopListeningCore()

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests.cs
@@ -101,6 +101,28 @@ namespace Avalonia.Markup.UnitTests.Data
         }
 
         [Fact]
+        public void OneWayToSource_Binding_Should_React_To_DataContext_Changed()
+        {
+            var target = new TextBlock { Text = "bar" };
+            var binding = new Binding
+            {
+                Path = "Foo",
+                Mode = BindingMode.OneWayToSource,
+            };
+
+            target.Bind(TextBox.TextProperty, binding);
+
+            var source = new Source { Foo = "foo" };
+            target.DataContext = source;
+
+            Assert.Equal("bar", source.Foo);
+            target.Text = "baz";
+            Assert.Equal("baz", source.Foo);
+            source.Foo = "quz";
+            Assert.Equal("baz", target.Text);
+        }
+
+        [Fact]
         public void Default_BindingMode_Should_Be_Used()
         {
             var source = new Source { Foo = "foo" };

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BindingTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BindingTests.cs
@@ -329,6 +329,33 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
                 Assert.Equal("Hello world", textBlock.Text); 
             }
-        } 
+        }
+
+        [Fact]
+        public void Binding_OneWayToSource_Works()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        ShowInTaskbar='{Binding ShowInTaskbar, Mode=OneWayToSource}'>
+</Window>";
+                var loader = new AvaloniaXamlLoader();
+                var window = (Window)loader.Load(xaml);
+                var viewModel = new WindowViewModel();
+
+                window.DataContext = viewModel;
+                window.ApplyTemplate();
+
+                Assert.True(window.ShowInTaskbar);
+                Assert.True(viewModel.ShowInTaskbar);
+            }
+        }
+
+        private class WindowViewModel
+        {
+            public bool ShowInTaskbar { get; set; }
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

#2470 was caused by the fact that a `OneWayToSource` binding doesn't re-write its value when the `DataContext` changes. Because the binding is set up in the constructor and the `DataContext` set afterwards, the value ends up never being written to the view model.

## How was the solution implemented (if it's not obvious)?

In `BindingOperations`, trigger a write to the binding when either side of the binding changes (instead of simply when the bound property changes).

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #2470