### PR TITLE
Allow `IDataTemplate` to return non `IControl`s.

### DIFF
--- a/src/Avalonia.Controls/Templates/IDataTemplate.cs
+++ b/src/Avalonia.Controls/Templates/IDataTemplate.cs
@@ -6,21 +6,7 @@ namespace Avalonia.Controls.Templates
     /// <summary>
     /// Interface representing a template used to build a control for a piece of data.
     /// </summary>
-    public interface IDataTemplate : ITemplate<object, IControl>
+    public interface IDataTemplate : IDataTemplate<object, IControl>
     {
-        /// <summary>
-        /// Gets a value indicating whether the data template supports recycling of the generated
-        /// control.
-        /// </summary>
-        bool SupportsRecycling { get; }
-
-        /// <summary>
-        /// Checks to see if this data template matches the specified data.
-        /// </summary>
-        /// <param name="data">The data.</param>
-        /// <returns>
-        /// True if the data template can build a control for the data, otherwise false.
-        /// </returns>
-        bool Match(object data);
     }
 }

--- a/src/Avalonia.Controls/Templates/IDataTemplate`1.cs
+++ b/src/Avalonia.Controls/Templates/IDataTemplate`1.cs
@@ -1,0 +1,26 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+namespace Avalonia.Controls.Templates
+{
+    /// <summary>
+    /// Interface representing a template used to build a control for a piece of data.
+    /// </summary>
+    public interface IDataTemplate<TParam, out TControl> : ITemplate<TParam, TControl>
+    {
+        /// <summary>
+        /// Gets a value indicating whether the data template supports recycling of the generated
+        /// control.
+        /// </summary>
+        bool SupportsRecycling { get; }
+
+        /// <summary>
+        /// Checks to see if this data template matches the specified data.
+        /// </summary>
+        /// <param name="data">The data.</param>
+        /// <returns>
+        /// True if the data template can build a control for the data, otherwise false.
+        /// </returns>
+        bool Match(TParam data);
+    }
+}

--- a/src/Avalonia.Controls/Templates/ITemplate`1.cs
+++ b/src/Avalonia.Controls/Templates/ITemplate`1.cs
@@ -9,7 +9,7 @@ namespace Avalonia.Controls
     /// Creates a control.
     /// </summary>
     /// <typeparam name="TControl">The type of control.</typeparam>
-    public interface ITemplate<TControl> : ITemplate where TControl : IControl
+    public interface ITemplate<out TControl> : ITemplate
     {
         /// <summary>
         /// Creates the control.

--- a/src/Avalonia.Controls/Templates/ITemplate`2.cs
+++ b/src/Avalonia.Controls/Templates/ITemplate`2.cs
@@ -8,7 +8,7 @@ namespace Avalonia.Controls.Templates
     /// </summary>
     /// <typeparam name="TParam">The type of the parameter.</typeparam>
     /// <typeparam name="TControl">The type of control.</typeparam>
-    public interface ITemplate<TParam, TControl> where TControl : IControl
+    public interface ITemplate<in TParam, out TControl>
     {
         /// <summary>
         /// Creates the control.


### PR DESCRIPTION
## What does the pull request do?

For #898, we're going to need data templates that return types that are non-`IControl`s. This PR :

- Relaxes the constraints on the `ITemplate.Build` method to allow building any type
- Adds an `IDataTemplate<TParam, TControl>` which can be used to build any type
- Makes the existing `IDataTemplate` interface be shorthand for `IDataTemplate<object, IControl>`

ping @kekekeks to see if this is what you were requesting.

## Questions

- Do we also need a generic `DataTemplates` collection?