### PR TITLE
Fix CarouselPresenter's handling of inserted items

### DIFF
--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -94,11 +94,6 @@ namespace Avalonia.Controls.Presenters
             set { SetValue(PageTransitionProperty, value); }
         }
 
-        protected override void PanelCreated(IPanel panel)
-        {
-            base.PanelCreated(panel);
-        }
-
         /// <inheritdoc/>
         protected override void ItemsChanged(NotifyCollectionChangedEventArgs e)
         {

--- a/src/Avalonia.Controls/Presenters/ItemContainerSync.cs
+++ b/src/Avalonia.Controls/Presenters/ItemContainerSync.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using Avalonia.Controls.Generators;
+using Avalonia.Controls.Utils;
+
+namespace Avalonia.Controls.Presenters
+{
+    internal static class ItemContainerSync
+    {
+        public static void ItemsChanged(
+            ItemsPresenterBase owner,
+            IEnumerable items,
+            NotifyCollectionChangedEventArgs e)
+        {
+            var generator = owner.ItemContainerGenerator;
+            var panel = owner.Panel;
+
+            if (panel == null)
+            {
+                return;
+            }
+
+            void Add()
+            {
+                if (e.NewStartingIndex + e.NewItems.Count < items.Count())
+                {
+                    generator.InsertSpace(e.NewStartingIndex, e.NewItems.Count);
+                }
+
+                AddContainers(owner, e.NewStartingIndex, e.NewItems);
+            }
+
+            void Remove()
+            {
+                RemoveContainers(panel, generator.RemoveRange(e.OldStartingIndex, e.OldItems.Count));
+            }
+
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Add:
+                    Add();
+                    break;
+
+                case NotifyCollectionChangedAction.Remove:
+                    Remove();
+                    break;
+
+                case NotifyCollectionChangedAction.Replace:
+                    RemoveContainers(panel, generator.Dematerialize(e.OldStartingIndex, e.OldItems.Count));
+                    var containers = AddContainers(owner, e.NewStartingIndex, e.NewItems);
+
+                    var i = e.NewStartingIndex;
+
+                    foreach (var container in containers)
+                    {
+                        panel.Children[i++] = container.ContainerControl;
+                    }
+
+                    break;
+
+                case NotifyCollectionChangedAction.Move:
+                    Remove();
+                    Add();
+                    break;
+
+                case NotifyCollectionChangedAction.Reset:
+                    RemoveContainers(panel, generator.Clear());
+
+                    if (items != null)
+                    {
+                        AddContainers(owner, 0, items);
+                    }
+
+                    break;
+            }
+        }
+
+        private static IList<ItemContainerInfo> AddContainers(
+            ItemsPresenterBase owner,
+            int index,
+            IEnumerable items)
+        {
+            var generator = owner.ItemContainerGenerator;
+            var result = new List<ItemContainerInfo>();
+            var panel = owner.Panel;
+
+            foreach (var item in items)
+            {
+                var i = generator.Materialize(index++, item, owner.MemberSelector);
+
+                if (i.ContainerControl != null)
+                {
+                    if (i.Index < panel.Children.Count)
+                    {
+                        // TODO: This will insert at the wrong place when there are null items.
+                        panel.Children.Insert(i.Index, i.ContainerControl);
+                    }
+                    else
+                    {
+                        panel.Children.Add(i.ContainerControl);
+                    }
+                }
+
+                result.Add(i);
+            }
+
+            return result;
+        }
+
+        private static void RemoveContainers(
+            IPanel panel,
+            IEnumerable<ItemContainerInfo> items)
+        {
+            foreach (var i in items)
+            {
+                if (i.ContainerControl != null)
+                {
+                    panel.Children.Remove(i.ContainerControl);
+                }
+            }
+        }
+    }
+}

--- a/src/Avalonia.Controls/Presenters/ItemVirtualizerNone.cs
+++ b/src/Avalonia.Controls/Presenters/ItemVirtualizerNone.cs
@@ -60,53 +60,7 @@ namespace Avalonia.Controls.Presenters
         public override void ItemsChanged(IEnumerable items, NotifyCollectionChangedEventArgs e)
         {
             base.ItemsChanged(items, e);
-
-            var generator = Owner.ItemContainerGenerator;
-            var panel = Owner.Panel;
-
-            switch (e.Action)
-            {
-                case NotifyCollectionChangedAction.Add:
-                    if (e.NewStartingIndex + e.NewItems.Count < Items.Count())
-                    {
-                        generator.InsertSpace(e.NewStartingIndex, e.NewItems.Count);
-                    }
-
-                    AddContainers(e.NewStartingIndex, e.NewItems);
-                    break;
-
-                case NotifyCollectionChangedAction.Remove:
-                    RemoveContainers(generator.RemoveRange(e.OldStartingIndex, e.OldItems.Count));
-                    break;
-
-                case NotifyCollectionChangedAction.Replace:
-                    RemoveContainers(generator.Dematerialize(e.OldStartingIndex, e.OldItems.Count));
-                    var containers = AddContainers(e.NewStartingIndex, e.NewItems);
-
-                    var i = e.NewStartingIndex;
-
-                    foreach (var container in containers)
-                    {
-                        panel.Children[i++] = container.ContainerControl;
-                    }
-
-                    break;
-
-                case NotifyCollectionChangedAction.Move:
-                    // TODO: Handle move in a more efficient manner. At the moment we just
-                    // drop through to Reset to recreate all the containers.
-
-                case NotifyCollectionChangedAction.Reset:
-                    RemoveContainers(generator.Clear());
-
-                    if (Items != null)
-                    {
-                        AddContainers(0, Items);
-                    }
-
-                    break;
-            }
-
+            ItemContainerSync.ItemsChanged(Owner, items, e);
             Owner.InvalidateMeasure();
         }
 

--- a/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
@@ -7,6 +7,7 @@ using System.Collections.Specialized;
 using Avalonia.Collections;
 using Avalonia.Controls.Generators;
 using Avalonia.Controls.Templates;
+using Avalonia.Controls.Utils;
 using Avalonia.Styling;
 
 namespace Avalonia.Controls.Presenters
@@ -205,7 +206,13 @@ namespace Avalonia.Controls.Presenters
         /// has been set, the items collection has been modified, or the panel has been created.
         /// </summary>
         /// <param name="e">A description of the change.</param>
-        protected abstract void ItemsChanged(NotifyCollectionChangedEventArgs e);
+        /// <remarks>
+        /// The panel is guaranteed to be created when this method is called.
+        /// </remarks>
+        protected virtual void ItemsChanged(NotifyCollectionChangedEventArgs e)
+        {
+            ItemContainerSync.ItemsChanged(this, Items, e);
+        }
 
         /// <summary>
         /// Creates the <see cref="Panel"/> when <see cref="ApplyTemplate"/> is called for the first

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -325,14 +325,19 @@ namespace Avalonia.Controls.Primitives
 
             if (_updateCount == 0)
             {
+                var newIndex = -1;
+
                 if (SelectedIndex != -1)
                 {
-                    SelectedIndex = IndexOf((IEnumerable)e.NewValue, SelectedItem);
+                    newIndex = IndexOf((IEnumerable)e.NewValue, SelectedItem);
                 }
-                else if (AlwaysSelected && Items != null && Items.Cast<object>().Any())
+
+                if (AlwaysSelected && Items != null && Items.Cast<object>().Any())
                 {
-                    SelectedIndex = 0;
+                    newIndex = 0;
                 }
+
+                SelectedIndex = newIndex;
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
@@ -77,25 +77,6 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
-        public void Should_Not_Remove_NonCurrent_Page_When_IsVirtualized_False()
-        {
-            var target = new Carousel
-            {
-                Template = new FuncControlTemplate<Carousel>(CreateTemplate),
-                Items = new[] { "foo", "bar" },
-                IsVirtualized = false,
-                SelectedIndex = 0,
-            };
-
-            target.ApplyTemplate();
-            target.Presenter.ApplyTemplate();
-
-            Assert.Single(target.ItemContainerGenerator.Containers);
-            target.SelectedIndex = 1;
-            Assert.Equal(2, target.ItemContainerGenerator.Containers.Count());
-        }
-
-        [Fact]
         public void Selected_Item_Changes_To_First_Item_When_Items_Property_Changes()
         {
             var items = new ObservableCollection<string>
@@ -115,9 +96,9 @@ namespace Avalonia.Controls.UnitTests
             target.ApplyTemplate();
             target.Presenter.ApplyTemplate();
 
-            Assert.Single(target.GetLogicalChildren());
+            Assert.Equal(3, target.GetLogicalChildren().Count());
 
-            var child = target.GetLogicalChildren().Single();
+            var child = target.GetLogicalChildren().First();
 
             Assert.IsType<TextBlock>(child);
             Assert.Equal("Foo", ((TextBlock)child).Text);
@@ -127,7 +108,7 @@ namespace Avalonia.Controls.UnitTests
 
             target.Items = newItems;
 
-            child = target.GetLogicalChildren().Single();
+            child = target.GetLogicalChildren().First();
 
             Assert.IsType<TextBlock>(child);
             Assert.Equal("Bar", ((TextBlock)child).Text);
@@ -146,7 +127,8 @@ namespace Avalonia.Controls.UnitTests
             var target = new Carousel
             {
                 Template = new FuncControlTemplate<Carousel>(CreateTemplate),
-                Items = items
+                Items = items,
+                IsVirtualized = true,
             };
 
             target.ApplyTemplate();
@@ -190,9 +172,9 @@ namespace Avalonia.Controls.UnitTests
             target.ApplyTemplate();
             target.Presenter.ApplyTemplate();
 
-            Assert.Single(target.GetLogicalChildren());
+            Assert.Equal(3, target.GetLogicalChildren().Count());
 
-            var child = target.GetLogicalChildren().Single();
+            var child = target.GetLogicalChildren().First();
 
             Assert.IsType<TextBlock>(child);
             Assert.Equal("Foo", ((TextBlock)child).Text);
@@ -254,16 +236,16 @@ namespace Avalonia.Controls.UnitTests
             target.ApplyTemplate();
             target.Presenter.ApplyTemplate();
 
-            Assert.Single(target.GetLogicalChildren());
+            Assert.Equal(3, target.GetLogicalChildren().Count());
 
-            var child = target.GetLogicalChildren().Single();
+            var child = target.GetLogicalChildren().First();
 
             Assert.IsType<TextBlock>(child);
             Assert.Equal("Foo", ((TextBlock)child).Text);
 
             items.RemoveAt(0);
 
-            child = target.GetLogicalChildren().Single();
+            child = target.GetLogicalChildren().First();
 
             Assert.IsType<TextBlock>(child);
             Assert.Equal("Bar", ((TextBlock)child).Text);

--- a/tests/Avalonia.Controls.UnitTests/Presenters/CarouselPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/CarouselPresenterTests.cs
@@ -193,6 +193,113 @@ namespace Avalonia.Controls.UnitTests.Presenters
             Assert.Empty(target.Panel.Children);            
         }
 
+        [Fact]
+        public void Should_Handle_Inserting_Items_At_SelectedItem()
+        {
+            ObservableCollection<string> items = new ObservableCollection<string>
+            {
+                "item1",
+                "item2",
+                "item3",
+            };
+
+            var target = new CarouselPresenter
+            {
+                Items = items,
+                SelectedIndex = 0,
+                IsVirtualized = false,
+            };
+
+            target.ApplyTemplate();
+            target.SelectedIndex = 1;
+
+            items.Insert(1, "item1a");
+
+            var containers = target.ItemContainerGenerator.Containers.Select(x => (x.Index, (string)x.Item));
+
+            Assert.Equal(
+                new[]
+                {
+                    (0, "item1"),
+                    (1, "item1a"),
+                    (2, "item2"),
+                },
+                containers);
+
+            var visibleContainer = (ContentPresenter)target.Panel.Children.Single(x => x.IsVisible);
+            Assert.Equal("item1a", visibleContainer.Content);
+        }
+
+        [Fact]
+        public void Should_Handle_Inserting_Items_Before_SelectedItem()
+        {
+            ObservableCollection<string> items = new ObservableCollection<string>
+            {
+                "item1",
+                "item2",
+                "item3",
+            };
+
+            var target = new CarouselPresenter
+            {
+                Items = items,
+                SelectedIndex = 0,
+                IsVirtualized = false,
+            };
+
+            target.ApplyTemplate();
+            target.SelectedIndex = 2;
+
+            items.Insert(1, "item1a");
+
+            var actual = target.ItemContainerGenerator.Containers.Select(x => (x.Index, (string)x.Item));
+
+            Assert.Equal(
+                new[]
+                {
+                    (0, "item1"),
+                    (3, "item3"),
+                },
+                actual);
+
+            var visibleContainer = (ContentPresenter)target.Panel.Children.Single(x => x.IsVisible);
+            Assert.Equal("item3", visibleContainer.Content);
+        }
+
+        [Fact]
+        public void Should_Handle_Inserting_Items_After_SelectedItem()
+        {
+            ObservableCollection<string> items = new ObservableCollection<string>
+            {
+                "item1",
+                "item2",
+                "item3",
+            };
+
+            var target = new CarouselPresenter
+            {
+                Items = items,
+                SelectedIndex = 0,
+                IsVirtualized = false,
+            };
+
+            target.ApplyTemplate();
+            target.SelectedIndex = 1;
+            target.SelectedIndex = 0;
+
+            items.Insert(1, "item1a");
+
+            var actual = target.ItemContainerGenerator.Containers.Select(x => (x.Index, (string)x.Item));
+
+            Assert.Equal(
+                new[]
+                {
+                    (0, "item1"),
+                    (2, "item2"),
+                },
+                actual);
+        }
+
         private class TestItem : ContentControl
         {
         }

--- a/tests/Avalonia.Controls.UnitTests/Presenters/CarouselPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/CarouselPresenterTests.cs
@@ -8,6 +8,7 @@ using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Templates;
 using Xunit;
 using System.Collections.ObjectModel;
+using System.Collections;
 
 namespace Avalonia.Controls.UnitTests.Presenters
 {
@@ -49,255 +50,672 @@ namespace Avalonia.Controls.UnitTests.Presenters
             Assert.IsType<ItemContainerGenerator<TestItem>>(target.ItemContainerGenerator);
         }
 
-        [Fact]
-        public void Setting_SelectedIndex_Should_Show_Page()
+        public class Virtualized
         {
-            var target = new CarouselPresenter
+            [Fact]
+            public void Should_Initially_Materialize_Selected_Container()
             {
-                Items = new[] { "foo", "bar" },
-                SelectedIndex = 0,
-            };
-
-            target.ApplyTemplate();
-
-            Assert.IsType<ContentPresenter>(target.Panel.Children[0]);
-            Assert.Equal("foo", ((ContentPresenter)target.Panel.Children[0]).Content);
-        }
-
-        [Fact]
-        public void Changing_SelectedIndex_Should_Show_Page()
-        {
-            var target = new CarouselPresenter
-            {
-                Items = new[] { "foo", "bar" },
-                SelectedIndex = 0,
-            };
-
-            target.ApplyTemplate();
-            target.SelectedIndex = 1;
-
-            Assert.IsType<ContentPresenter>(target.Panel.Children[0]);
-            Assert.Equal("bar", ((ContentPresenter)target.Panel.Children[0]).Content);
-        }
-
-        [Fact]
-        public void Should_Remove_NonCurrent_Page_When_IsVirtualized_True()
-        {
-            var target = new CarouselPresenter
-            {
-                Items = new[] { "foo", "bar" },
-                IsVirtualized = true,
-                SelectedIndex = 0,
-            };
-
-            target.ApplyTemplate();
-            Assert.Single(target.ItemContainerGenerator.Containers);
-            target.SelectedIndex = 1;
-            Assert.Single(target.ItemContainerGenerator.Containers);
-        }
-
-        [Fact]
-        public void Should_Not_Remove_NonCurrent_Page_When_IsVirtualized_False()
-        {
-            var target = new CarouselPresenter
-            {
-                Items = new[] { "foo", "bar" },
-                IsVirtualized = false,
-                SelectedIndex = 0,
-            };
-
-            target.ApplyTemplate();
-            Assert.Single(target.ItemContainerGenerator.Containers);
-            Assert.Single(target.Panel.Children);
-            target.SelectedIndex = 1;
-            Assert.Equal(2, target.ItemContainerGenerator.Containers.Count());
-            Assert.Equal(2, target.Panel.Children.Count);
-            target.SelectedIndex = 0;
-            Assert.Equal(2, target.ItemContainerGenerator.Containers.Count());
-            Assert.Equal(2, target.Panel.Children.Count);
-        }
-
-        [Fact]
-        public void Should_Remove_Controls_When_IsVirtualized_Is_False()
-        {
-            ObservableCollection<string> items = new ObservableCollection<string>();
-            
-            var target = new CarouselPresenter
-            {
-                Items = items,              
-                SelectedIndex = 0,
-                IsVirtualized = false,
-            };
-
-            target.ApplyTemplate();
-            target.SelectedIndex = 0;
-            items.Add("foo");
-            target.SelectedIndex = 0;
-
-            Assert.Single(target.ItemContainerGenerator.Containers);
-            Assert.Single(target.Panel.Children);
-
-            items.Add("bar");
-            Assert.Single(target.ItemContainerGenerator.Containers);
-            Assert.Single(target.Panel.Children);
-
-            target.SelectedIndex = 1;
-            Assert.Equal(2, target.ItemContainerGenerator.Containers.Count());
-            Assert.Equal(2, target.Panel.Children.Count);            
-
-            items.Remove(items[0]);
-            Assert.Single(target.ItemContainerGenerator.Containers);
-            Assert.Single(target.Panel.Children);            
-
-            items.Remove(items[0]);
-            Assert.Empty(target.ItemContainerGenerator.Containers);
-            Assert.Empty(target.Panel.Children);            
-        }
-
-        [Fact]
-        public void Should_Have_Correct_ItemsContainer_Index()
-        {
-            ObservableCollection<string> items = new ObservableCollection<string>();
-
-            var target = new CarouselPresenter
-            {
-                Items = items,
-                SelectedIndex = 0,
-                IsVirtualized = false,
-            };
-
-            target.ApplyTemplate();
-            target.SelectedIndex = 0;
-            items.Add("foo");
-            target.SelectedIndex = 0;
-
-            Assert.Single(target.ItemContainerGenerator.Containers);
-            Assert.Single(target.Panel.Children);
-
-            items.Add("bar");
-            Assert.Single(target.ItemContainerGenerator.Containers);
-            Assert.Single(target.Panel.Children);
-
-            target.SelectedIndex = 1;
-            Assert.Equal(2, target.ItemContainerGenerator.Containers.Count());
-            Assert.Equal(2, target.Panel.Children.Count);
-            Assert.Equal(0, target.ItemContainerGenerator.Containers.First().Index);
-
-            items.Remove(items[0]);
-            Assert.Single(target.ItemContainerGenerator.Containers);
-            Assert.Single(target.Panel.Children);
-            Assert.Equal(0, target.ItemContainerGenerator.Containers.First().Index);
-
-            items.Remove(items[0]);
-            Assert.Empty(target.ItemContainerGenerator.Containers);
-            Assert.Empty(target.Panel.Children);            
-        }
-
-        [Fact]
-        public void Should_Handle_Inserting_Items_At_SelectedItem()
-        {
-            ObservableCollection<string> items = new ObservableCollection<string>
-            {
-                "item1",
-                "item2",
-                "item3",
-            };
-
-            var target = new CarouselPresenter
-            {
-                Items = items,
-                SelectedIndex = 0,
-                IsVirtualized = false,
-            };
-
-            target.ApplyTemplate();
-            target.SelectedIndex = 1;
-
-            items.Insert(1, "item1a");
-
-            var containers = target.ItemContainerGenerator.Containers.Select(x => (x.Index, (string)x.Item));
-
-            Assert.Equal(
-                new[]
+                var target = new CarouselPresenter
                 {
-                    (0, "item1"),
-                    (1, "item1a"),
-                    (2, "item2"),
-                },
-                containers);
+                    Items = new[] { "foo", "bar" },
+                    SelectedIndex = 0,
+                    IsVirtualized = true,
+                };
 
-            var visibleContainer = (ContentPresenter)target.Panel.Children.Single(x => x.IsVisible);
-            Assert.Equal("item1a", visibleContainer.Content);
+                target.ApplyTemplate();
+
+                AssertSingle(target);
+            }
+
+            [Fact]
+            public void Should_Initially_Materialize_Nothing_If_No_Selected_Container()
+            {
+                var target = new CarouselPresenter
+                {
+                    Items = new[] { "foo", "bar" },
+                    IsVirtualized = true,
+                };
+
+                target.ApplyTemplate();
+
+                Assert.Empty(target.Panel.Children);
+                Assert.Empty(target.ItemContainerGenerator.Containers);
+            }
+
+            [Fact]
+            public void Switching_To_Virtualized_Should_Reset_Containers()
+            {
+                var target = new CarouselPresenter
+                {
+                    Items = new[] { "foo", "bar" },
+                    SelectedIndex = 0,
+                    IsVirtualized = false,
+                };
+
+                target.ApplyTemplate();
+                target.IsVirtualized = true;
+
+                AssertSingle(target);
+            }
+
+            [Fact]
+            public void Changing_SelectedIndex_Should_Show_Page()
+            {
+                var target = new CarouselPresenter
+                {
+                    Items = new[] { "foo", "bar" },
+                    SelectedIndex = 0,
+                    IsVirtualized = true,
+                };
+
+                target.ApplyTemplate();
+                AssertSingle(target);
+
+                target.SelectedIndex = 1;
+                AssertSingle(target);
+            }
+
+            [Fact]
+            public void Should_Remove_NonCurrent_Page()
+            {
+                var target = new CarouselPresenter
+                {
+                    Items = new[] { "foo", "bar" },
+                    IsVirtualized = true,
+                    SelectedIndex = 0,
+                };
+
+                target.ApplyTemplate();
+                AssertSingle(target);
+
+                target.SelectedIndex = 1;
+                AssertSingle(target);
+
+            }
+
+            [Fact]
+            public void Should_Handle_Inserting_Item_At_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 1,
+                    IsVirtualized = true,
+                };
+
+                target.ApplyTemplate();
+
+                items.Insert(1, "item1a");
+                AssertSingle(target);
+            }
+
+            [Fact]
+            public void Should_Handle_Inserting_Item_Before_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 2,
+                    IsVirtualized = true,
+                };
+
+                target.ApplyTemplate();
+
+                items.Insert(1, "item1a");
+                AssertSingle(target);
+            }
+
+            [Fact]
+            public void Should_Do_Nothing_When_Inserting_Item_After_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 1,
+                    IsVirtualized = true,
+                };
+
+                target.ApplyTemplate();
+                var child = AssertSingle(target);
+                items.Insert(2, "after");
+                Assert.Same(child, AssertSingle(target));
+            }
+
+            [Fact]
+            public void Should_Handle_Removing_Item_At_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 1,
+                    IsVirtualized = true,
+                };
+
+                target.ApplyTemplate();
+
+                items.RemoveAt(1);
+                AssertSingle(target);
+            }
+
+            [Fact]
+            public void Should_Handle_Removing_Item_Before_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 1,
+                    IsVirtualized = true,
+                };
+
+                target.ApplyTemplate();
+
+                items.RemoveAt(0);
+                AssertSingle(target);
+            }
+
+            [Fact]
+            public void Should_Do_Nothing_When_Removing_Item_After_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 1,
+                    IsVirtualized = true,
+                };
+
+                target.ApplyTemplate();
+                var child = AssertSingle(target);
+                items.RemoveAt(2);
+                Assert.Same(child, AssertSingle(target));
+            }
+
+            [Fact]
+            public void Should_Handle_Removing_SelectedItem_When_Its_Last()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 2,
+                    IsVirtualized = true,
+                };
+
+                target.ApplyTemplate();
+
+                items.RemoveAt(2);
+                Assert.Equal(1, target.SelectedIndex);
+                AssertSingle(target);
+            }
+
+            [Fact]
+            public void Should_Handle_Removing_Last_Item()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 0,
+                    IsVirtualized = true,
+                };
+
+                target.ApplyTemplate();
+
+                items.RemoveAt(0);
+                Assert.Empty(target.Panel.Children);
+                Assert.Empty(target.ItemContainerGenerator.Containers);
+            }
+
+            [Fact]
+            public void Should_Handle_Replacing_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 1,
+                    IsVirtualized = true,
+                };
+
+                target.ApplyTemplate();
+
+                items[1] = "replaced";
+                AssertSingle(target);
+            }
+
+            [Fact]
+            public void Should_Do_Nothing_When_Replacing_Non_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 1,
+                    IsVirtualized = true,
+                };
+
+                target.ApplyTemplate();
+                var child = AssertSingle(target);
+                items[0] = "replaced";
+                Assert.Same(child, AssertSingle(target));
+            }
+
+            [Fact]
+            public void Should_Handle_Moving_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 1,
+                    IsVirtualized = true,
+                };
+
+                target.ApplyTemplate();
+
+                items.Move(1, 0);
+                AssertSingle(target);
+            }
+
+            private static IControl AssertSingle(CarouselPresenter target)
+            {
+                var items = (IList)target.Items;
+                var index = target.SelectedIndex;
+                var content = items[index];
+                var child = Assert.Single(target.Panel.Children);
+                var presenter = Assert.IsType<ContentPresenter>(child);
+                var container = Assert.Single(target.ItemContainerGenerator.Containers);
+                var visible = Assert.Single(target.Panel.Children.Where(x => x.IsVisible));
+
+                Assert.Same(child, container.ContainerControl);
+                Assert.Same(child, visible);
+                Assert.Equal(content, presenter.Content);
+                Assert.Equal(content, container.Item);
+                Assert.Equal(index, container.Index);
+
+                return child;
+            }
         }
 
-        [Fact]
-        public void Should_Handle_Inserting_Items_Before_SelectedItem()
+        public class NonVirtualized
         {
-            ObservableCollection<string> items = new ObservableCollection<string>
+            [Fact]
+            public void Should_Initially_Materialize_All_Containers()
             {
-                "item1",
-                "item2",
-                "item3",
-            };
-
-            var target = new CarouselPresenter
-            {
-                Items = items,
-                SelectedIndex = 0,
-                IsVirtualized = false,
-            };
-
-            target.ApplyTemplate();
-            target.SelectedIndex = 2;
-
-            items.Insert(1, "item1a");
-
-            var actual = target.ItemContainerGenerator.Containers.Select(x => (x.Index, (string)x.Item));
-
-            Assert.Equal(
-                new[]
+                var target = new CarouselPresenter
                 {
-                    (0, "item1"),
-                    (3, "item3"),
-                },
-                actual);
+                    Items = new[] { "foo", "bar" },
+                    IsVirtualized = false,
+                };
 
-            var visibleContainer = (ContentPresenter)target.Panel.Children.Single(x => x.IsVisible);
-            Assert.Equal("item3", visibleContainer.Content);
-        }
+                target.ApplyTemplate();
+                AssertAll(target);
+            }
 
-        [Fact]
-        public void Should_Handle_Inserting_Items_After_SelectedItem()
-        {
-            ObservableCollection<string> items = new ObservableCollection<string>
+            [Fact]
+            public void Should_Initially_Show_Selected_Item()
             {
-                "item1",
-                "item2",
-                "item3",
-            };
-
-            var target = new CarouselPresenter
-            {
-                Items = items,
-                SelectedIndex = 0,
-                IsVirtualized = false,
-            };
-
-            target.ApplyTemplate();
-            target.SelectedIndex = 1;
-            target.SelectedIndex = 0;
-
-            items.Insert(1, "item1a");
-
-            var actual = target.ItemContainerGenerator.Containers.Select(x => (x.Index, (string)x.Item));
-
-            Assert.Equal(
-                new[]
+                var target = new CarouselPresenter
                 {
-                    (0, "item1"),
-                    (2, "item2"),
-                },
-                actual);
+                    Items = new[] { "foo", "bar" },
+                    SelectedIndex = 1,
+                    IsVirtualized = false,
+                };
+
+                target.ApplyTemplate();
+                AssertAll(target);
+            }
+
+            [Fact]
+            public void Switching_To_Non_Virtualized_Should_Reset_Containers()
+            {
+                var target = new CarouselPresenter
+                {
+                    Items = new[] { "foo", "bar" },
+                    SelectedIndex = 0,
+                    IsVirtualized = true,
+                };
+
+                target.ApplyTemplate();
+                target.IsVirtualized = false;
+
+                AssertAll(target);
+            }
+
+            [Fact]
+            public void Changing_SelectedIndex_Should_Show_Page()
+            {
+                var target = new CarouselPresenter
+                {
+                    Items = new[] { "foo", "bar" },
+                    SelectedIndex = 0,
+                    IsVirtualized = false,
+                };
+
+                target.ApplyTemplate();
+                AssertAll(target);
+
+                target.SelectedIndex = 1;
+                AssertAll(target);
+            }
+
+            [Fact]
+            public void Should_Handle_Inserting_Item_At_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 1,
+                    IsVirtualized = false,
+                };
+
+                target.ApplyTemplate();
+
+                items.Insert(1, "item1a");
+                AssertAll(target);
+            }
+
+            [Fact]
+            public void Should_Handle_Inserting_Item_Before_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 2,
+                    IsVirtualized = false,
+                };
+
+                target.ApplyTemplate();
+
+                items.Insert(1, "item1a");
+                AssertAll(target);
+            }
+
+            [Fact]
+            public void Should_Do_Handle_Inserting_Item_After_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 1,
+                    IsVirtualized = false,
+                };
+
+                target.ApplyTemplate();
+                items.Insert(2, "after");
+                AssertAll(target);
+            }
+
+            [Fact]
+            public void Should_Handle_Removing_Item_At_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 1,
+                    IsVirtualized = false,
+                };
+
+                target.ApplyTemplate();
+
+                items.RemoveAt(1);
+                AssertAll(target);
+            }
+
+            [Fact]
+            public void Should_Handle_Removing_Item_Before_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 1,
+                    IsVirtualized = false,
+                };
+
+                target.ApplyTemplate();
+
+                items.RemoveAt(0);
+                AssertAll(target);
+            }
+
+            [Fact]
+            public void Should_Handle_Removing_Item_After_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 1,
+                    IsVirtualized = false,
+                };
+
+                target.ApplyTemplate();
+                items.RemoveAt(2);
+                AssertAll(target);
+            }
+
+            [Fact]
+            public void Should_Handle_Removing_SelectedItem_When_Its_Last()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 2,
+                    IsVirtualized = false,
+                };
+
+                target.ApplyTemplate();
+
+                items.RemoveAt(2);
+                Assert.Equal(1, target.SelectedIndex);
+                AssertAll(target);
+            }
+
+            [Fact]
+            public void Should_Handle_Removing_Last_Item()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 0,
+                    IsVirtualized = false,
+                };
+
+                target.ApplyTemplate();
+
+                items.RemoveAt(0);
+                Assert.Empty(target.Panel.Children);
+                Assert.Empty(target.ItemContainerGenerator.Containers);
+            }
+
+            [Fact]
+            public void Should_Handle_Replacing_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 1,
+                    IsVirtualized = false,
+                };
+
+                target.ApplyTemplate();
+
+                items[1] = "replaced";
+                AssertAll(target);
+            }
+
+            [Fact]
+            public void Should_Handle_Moving_SelectedItem()
+            {
+                var items = new ObservableCollection<string>
+                {
+                    "item0",
+                    "item1",
+                    "item2",
+                };
+
+                var target = new CarouselPresenter
+                {
+                    Items = items,
+                    SelectedIndex = 1,
+                    IsVirtualized = false,
+                };
+
+                target.ApplyTemplate();
+
+                items.Move(1, 0);
+                AssertAll(target);
+            }
+
+            private static void AssertAll(CarouselPresenter target)
+            {
+                var items = (IList)target.Items;
+
+                Assert.Equal(items?.Count ?? 0, target.Panel.Children.Count);
+                Assert.Equal(items?.Count ?? 0, target.ItemContainerGenerator.Containers.Count());
+
+                for (var i = 0; i < items?.Count; ++i)
+                {
+                    var content = items[i];
+                    var child = target.Panel.Children[i];
+                    var presenter = Assert.IsType<ContentPresenter>(child);
+                    var container = target.ItemContainerGenerator.ContainerFromIndex(i);
+
+                    Assert.Same(child, container);
+                    Assert.Equal(i == target.SelectedIndex, child.IsVisible);
+                    Assert.Equal(content, presenter.Content);
+                    Assert.Equal(i, target.ItemContainerGenerator.IndexFromContainer(container));
+                }
+            }
         }
 
         private class TestItem : ContentControl


### PR DESCRIPTION
## What does the pull request do?

Fixes `CarouselPresenter`'s handling of changes to the underlying `Items` collection.

## What is the current behavior?

The behavior in #2432 was caused by `CarouselPresenter` not handling inserted items correctly (or at all).

## What is the updated/expected behavior with this PR?

Now handles changes to the underlying `Items` collection correctly, in both virtualized and non-virtualized modes.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #2432 