### PR TITLE
Fix TabItem styling

### DIFF
--- a/samples/ControlCatalog/SideBar.xaml
+++ b/samples/ControlCatalog/SideBar.xaml
@@ -63,13 +63,13 @@
     <Style Selector="TabControl.sidebar > TabItem:pointerover">
         <Setter Property="Opacity" Value="1"/>
     </Style>
-    <Style Selector="TabControl.sidebar > TabItem:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+    <Style Selector="TabControl.sidebar > TabItem:pointerover">
         <Setter Property="Background" Value="Transparent"/>
     </Style>
     <Style Selector="TabControl.sidebar > TabItem:selected">
         <Setter Property="Opacity" Value="1"/>
     </Style>
-    <Style Selector="TabControl.sidebar > TabItem:selected /template/ ContentPresenter#PART_ContentPresenter">
+    <Style Selector="TabControl.sidebar > TabItem:selected">
         <Setter Property="Background" Value="{DynamicResource ThemeAccentBrush2}"/>
     </Style>
 </Styles>

--- a/src/Avalonia.Themes.Default/TabItem.xaml
+++ b/src/Avalonia.Themes.Default/TabItem.xaml
@@ -24,19 +24,19 @@
     <Style Selector="TabItem:disabled">
         <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
     </Style>
-    <Style Selector="TabItem:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+    <Style Selector="TabItem:pointerover">
         <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightMidBrush}"/>
     </Style>
-    <Style Selector="TabItem:selected /template/ ContentPresenter#PART_ContentPresenter">
+    <Style Selector="TabItem:selected">
         <Setter Property="Background" Value="{DynamicResource ThemeAccentBrush4}"/>
     </Style>
-    <Style Selector="TabItem:selected:focus /template/ ContentPresenter#PART_ContentPresenter">
+    <Style Selector="TabItem:selected:focus">
         <Setter Property="Background" Value="{DynamicResource ThemeAccentBrush3}"/>
     </Style>
-    <Style Selector="TabItem:selected:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+    <Style Selector="TabItem:selected:pointerover">
         <Setter Property="Background" Value="{DynamicResource ThemeAccentBrush3}"/>
     </Style>
-    <Style Selector="TabItem:selected:focus:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+    <Style Selector="TabItem:selected:focus:pointerover">
         <Setter Property="Background" Value="{DynamicResource ThemeAccentBrush2}"/>
     </Style>
     <Style Selector="TabItem[TabStripPlacement=Right]">


### PR DESCRIPTION
## What does the pull request do?
It makes it easier to change the TabItems background on pointerover etc.
## What is the current behavior?
Currently one has to target the ContentPresenter within the template to change the background on pointerover etc.

## What is the updated/expected behavior with this PR?
`TabItem:pointerover`
instead of
`TabItem:pointerover /template/ ContentPresenter#PART_ContentPresenter`
