### PR TITLE
Simplify FontFamily creation

### DIFF
--- a/src/Avalonia.Visuals/Media/Fonts/FamilyNameCollection.cs
+++ b/src/Avalonia.Visuals/Media/Fonts/FamilyNameCollection.cs
@@ -4,31 +4,28 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
+using System.Text;
 
 namespace Avalonia.Media.Fonts
 {
-    using System.Text;
-
     public class FamilyNameCollection : IEnumerable<string>
-    {    
+    {
         /// <summary>
         /// Initializes a new instance of the <see cref="FamilyNameCollection"/> class.
         /// </summary>
         /// <param name="familyNames">The family names.</param>
         /// <exception cref="ArgumentException">familyNames</exception>
-        public FamilyNameCollection(IEnumerable<string> familyNames)
+        public FamilyNameCollection(string familyNames)
         {
-            Contract.Requires<ArgumentNullException>(familyNames != null);
+            if (familyNames == null)
+            {
+                throw new ArgumentNullException(nameof(familyNames));
+            }
 
-            var names = new List<string>(familyNames);
+            Names = familyNames.Split(',').Select(x => x.Trim()).ToArray();
 
-            if (names.Count == 0) throw new ArgumentException($"{nameof(familyNames)} must not be empty.");
-
-            Names = new ReadOnlyCollection<string>(names);
-
-            PrimaryFamilyName = Names.First();
+            PrimaryFamilyName = Names[0];
 
             HasFallbacks = Names.Count > 1;
         }
@@ -55,7 +52,7 @@ namespace Avalonia.Media.Fonts
         /// <value>
         /// The names.
         /// </value>
-        internal ReadOnlyCollection<string> Names { get; }
+        internal IReadOnlyList<string> Names { get; }
 
         /// <inheritdoc />
         /// <summary>
@@ -95,7 +92,10 @@ namespace Avalonia.Media.Fonts
             {
                 builder.Append(Names[index]);
 
-                if (index == Names.Count - 1) break;
+                if (index == Names.Count - 1)
+                {
+                    break;
+                }
 
                 builder.Append(", ");
             }
@@ -123,7 +123,10 @@ namespace Avalonia.Media.Fonts
         /// </returns>
         public override bool Equals(object obj)
         {
-            if (!(obj is FamilyNameCollection other)) return false;
+            if (!(obj is FamilyNameCollection other))
+            {
+                return false;
+            }
 
             return other.ToString().Equals(ToString());
         }

--- a/src/Avalonia.Visuals/Media/Fonts/FontFamilyKey.cs
+++ b/src/Avalonia.Visuals/Media/Fonts/FontFamilyKey.cs
@@ -95,7 +95,7 @@ namespace Avalonia.Media.Fonts
         {
             if (!Source.IsAbsoluteUri && BaseUri != null)
             {
-                return BaseUri.Authority + Source;
+                return BaseUri.AbsoluteUri + Source.OriginalString;
             }
 
             return Source.ToString();

--- a/tests/Avalonia.Visuals.UnitTests/Media/FontFamilyTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/FontFamilyTests.cs
@@ -28,7 +28,7 @@ namespace Avalonia.Visuals.UnitTests.Media
         }
 
         [Fact]
-        public void Parse_Parses_FontFamily_With_Name()
+        public void Should_Parse_FontFamily_With_SystemFont_Name()
         {
             var fontFamily = FontFamily.Parse("Courier New");
 
@@ -36,7 +36,7 @@ namespace Avalonia.Visuals.UnitTests.Media
         }
 
         [Fact]
-        public void Parse_Parses_FontFamily_With_Names()
+        public void Should_Parse_FontFamily_With_Fallbacks()
         {
             var fontFamily = FontFamily.Parse("Courier New, Times New Roman");
 
@@ -48,7 +48,7 @@ namespace Avalonia.Visuals.UnitTests.Media
         }
 
         [Fact]
-        public void Parse_Parses_FontFamily_With_Resource_Folder()
+        public void Should_Parse_FontFamily_With_Resource_Folder()
         {
             var source = new Uri("resm:Avalonia.Visuals.UnitTests#MyFont");
 
@@ -62,7 +62,7 @@ namespace Avalonia.Visuals.UnitTests.Media
         }
 
         [Fact]
-        public void Parse_Parses_FontFamily_With_Resource_Filename()
+        public void Should_Parse_FontFamily_With_Resource_Filename()
         {
             var source = new Uri("resm:Avalonia.Visuals.UnitTests.MyFont.ttf#MyFont");
 
@@ -73,6 +73,33 @@ namespace Avalonia.Visuals.UnitTests.Media
             Assert.Equal("MyFont", fontFamily.Name);
 
             Assert.Equal(key, fontFamily.Key);
+        }
+
+        [Theory]
+        [InlineData("resm:Avalonia.Visuals.UnitTests/Assets/Fonts#MyFont")]
+        [InlineData("avares://Avalonia.Visuals.UnitTests/Assets/Fonts#MyFont")]
+        public void Should_Create_FontFamily_From_Uri(string name)
+        {
+            var fontFamily = new FontFamily(name);
+
+            Assert.Equal("MyFont", fontFamily.Name);
+
+            Assert.NotNull(fontFamily.Key);
+        }
+
+        [Theory]
+        [InlineData("resm:Avalonia.Visuals.UnitTests.Assets.Fonts", "#MyFont")]
+        [InlineData("avares://Avalonia.Visuals.UnitTests/Assets/Fonts", "#MyFont")]
+        [InlineData("avares://Avalonia.Visuals.UnitTests", "/Assets/Fonts#MyFont")]
+        public void Should_Create_FontFamily_From_Uri_With_Base_Uri(string @base, string name)
+        {
+            var baseUri = new Uri(@base);
+
+            var fontFamily = new FontFamily(baseUri, name);
+
+            Assert.Equal("MyFont", fontFamily.Name);
+
+            Assert.NotNull(fontFamily.Key);
         }
     }
 }

--- a/tests/Avalonia.Visuals.UnitTests/Media/FontFamilyTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/FontFamilyTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Media;
 using Avalonia.Media.Fonts;
@@ -12,18 +11,6 @@ namespace Avalonia.Visuals.UnitTests.Media
 {
     public class FontFamilyTests
     {
-        [Fact]
-        public void Exception_Should_Be_Thrown_If_Name_Is_Null()
-        {
-            Assert.Throws<ArgumentNullException>(() => new FontFamily((string)null));
-        }
-
-        [Fact]
-        public void Exception_Should_Be_Thrown_If_Names_Is_Null()
-        {
-            Assert.Throws<ArgumentNullException>(() => new FontFamily((IEnumerable<string>)null));
-        }
-
         [Fact]
         public void Should_Implicitly_Convert_String_To_FontFamily()
         {

--- a/tests/Avalonia.Visuals.UnitTests/Media/Fonts/FamilyNameCollectionTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/Fonts/FamilyNameCollectionTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
-using System.Linq;
 using Avalonia.Media.Fonts;
 using Xunit;
 
@@ -17,17 +16,11 @@ namespace Avalonia.Visuals.UnitTests.Media.Fonts
         }
 
         [Fact]
-        public void Exception_Should_Be_Thrown_If_Names_Is_Empty()
-        {
-            Assert.Throws<ArgumentException>(() => new FamilyNameCollection(Enumerable.Empty<string>()));
-        }
-
-        [Fact]
         public void Should_Be_Equal()
         {
-            var familyNames = new FamilyNameCollection(new[] { "Arial", "Times New Roman" });
+            var familyNames = new FamilyNameCollection("Arial, Times New Roman");
 
-            Assert.Equal(new FamilyNameCollection(new[] { "Arial", "Times New Roman" }), familyNames);
+            Assert.Equal(new FamilyNameCollection("Arial, Times New Roman"), familyNames);
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
FontFamily now follows WPF's scheme of creation.

## What is the current behavior?
Currently one has to pass name, source and base to the ctor of a FontFamily to load a custom font. It is also not clear what overload has to be used to load a custom font. Name and Source should be the same.

## What is the updated/expected behavior with this PR?
There are only two variants:
`public FontFamily(string name)`
`public FontFamily(Uri baseUri, string name)`
Both are able to construct a system font and also a custom font.

Some examples:
`new FontFamily("Arial")`
`new FontFamily("resm:Avalonia.Visuals.UnitTests/Assets/Fonts#MyFont")`
`new FontFamily(new Uri("resm:Avalonia.Visuals.UnitTests.Assets.Fonts"), "#MyFont")`
`new FontFamily(new Uri("avares://Avalonia.Visuals.UnitTests"), "/Assets/Fonts#MyFont")`

## Breaking changes
`public FontFamily(string name, Uri source, Uri baseUri = null)` removed
`public FontFamily(IEnumerable<string> names)` removed

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation