### PR TITLE
Couple of small Serilog improvements

### DIFF
--- a/src/Avalonia.Logging.Serilog/SerilogExtensions.cs
+++ b/src/Avalonia.Logging.Serilog/SerilogExtensions.cs
@@ -1,5 +1,8 @@
-﻿using Avalonia.Controls;
+﻿using System;
+using Avalonia.Controls;
 using Serilog;
+using Serilog.Configuration;
+using Serilog.Filters;
 using SerilogLevel = Serilog.Events.LogEventLevel;
 
 namespace Avalonia.Logging.Serilog
@@ -9,6 +12,8 @@ namespace Avalonia.Logging.Serilog
     /// </summary>
     public static class SerilogExtensions
     {
+        private const string DefaultTemplate = "[{Area}] {Message} ({SourceType} #{SourceHash})";
+
         /// <summary>
         /// Logs Avalonia events to the <see cref="System.Diagnostics.Debug"/> sink.
         /// </summary>
@@ -23,7 +28,31 @@ namespace Avalonia.Logging.Serilog
         {
             SerilogLogger.Initialize(new LoggerConfiguration()
                 .MinimumLevel.Is((SerilogLevel)level)
-                .WriteTo.Debug(outputTemplate: "{Area}: {Message}")
+                .Enrich.FromLogContext()
+                .WriteTo.Debug(outputTemplate: DefaultTemplate)
+                .CreateLogger());
+            return builder;
+        }
+
+        /// <summary>
+        /// Logs Avalonia events to the <see cref="System.Diagnostics.Debug"/> sink.
+        /// </summary>
+        /// <typeparam name="T">The application class type.</typeparam>
+        /// <param name="builder">The app builder instance.</param>
+        /// <param name="area">The area to log. Valid values are listed in <see cref="LogArea"/>.</param>
+        /// <param name="level">The minimum level to log.</param>
+        /// <returns>The app builder instance.</returns>
+        public static T LogToDebug<T>(
+            this T builder,
+            string area,
+            LogEventLevel level = LogEventLevel.Warning)
+                where T : AppBuilderBase<T>, new()
+        {
+            SerilogLogger.Initialize(new LoggerConfiguration()
+                .MinimumLevel.Is((SerilogLevel)level)
+                .Filter.ByIncludingOnly(Matching.WithProperty("Area", area))
+                .Enrich.FromLogContext()
+                .WriteTo.Debug(outputTemplate: DefaultTemplate)
                 .CreateLogger());
             return builder;
         }
@@ -42,7 +71,31 @@ namespace Avalonia.Logging.Serilog
         {
             SerilogLogger.Initialize(new LoggerConfiguration()
                 .MinimumLevel.Is((SerilogLevel)level)
-                .WriteTo.Trace(outputTemplate: "{Area}: {Message}")
+                .Enrich.FromLogContext()
+                .WriteTo.Trace(outputTemplate: DefaultTemplate)
+                .CreateLogger());
+            return builder;
+        }
+
+        /// <summary>
+        /// Logs Avalonia events to the <see cref="System.Diagnostics.Trace"/> sink.
+        /// </summary>
+        /// <typeparam name="T">The application class type.</typeparam>
+        /// <param name="builder">The app builder instance.</param>
+        /// <param name="area">The area to log. Valid values are listed in <see cref="LogArea"/>.</param>
+        /// <param name="level">The minimum level to log.</param>
+        /// <returns>The app builder instance.</returns>
+        public static T LogToTrace<T>(
+            this T builder,
+            string area,
+            LogEventLevel level = LogEventLevel.Warning)
+                where T : AppBuilderBase<T>, new()
+        {
+            SerilogLogger.Initialize(new LoggerConfiguration()
+                .MinimumLevel.Is((SerilogLevel)level)
+                .Filter.ByIncludingOnly(Matching.WithProperty("Area", area))
+                .Enrich.FromLogContext()
+                .WriteTo.Trace(outputTemplate: DefaultTemplate)
                 .CreateLogger());
             return builder;
         }


### PR DESCRIPTION
## What does the pull request do?

Ports a couple of changes from #2383 to improve logging:

- Add overloads of the logging `AppBuilder` methods that take an area, so that e.g. just layout events can be logged if needed
- Use `LogContext` to push additional properties instead of creating an `ILogger` for each area
- Push the source object type and hash to the log context too
- Include the source type and has in the default log message
