### PR TITLE
Only generate containers on the fly if virtualized.

### DIFF
--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -210,7 +210,7 @@ namespace Avalonia.Controls.Presenters
         {
             var container = ItemContainerGenerator.ContainerFromIndex(index);
 
-            if (container == null)
+            if (container == null && IsVirtualized)
             {
                 var item = Items.Cast<object>().ElementAt(index);
                 var materialized = ItemContainerGenerator.Materialize(index, item, MemberSelector);

--- a/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/CarouselTests.cs
@@ -153,6 +153,29 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Selected_Item_Changes_To_First_Item_When_Item_Added()
+        {
+            var items = new ObservableCollection<string>();
+            var target = new Carousel
+            {
+                Template = new FuncControlTemplate<Carousel>(CreateTemplate),
+                Items = items,
+                IsVirtualized = false
+            };
+
+            target.ApplyTemplate();
+            target.Presenter.ApplyTemplate();
+
+            Assert.Equal(-1, target.SelectedIndex);
+            Assert.Empty(target.GetLogicalChildren());
+
+            items.Add("Foo");
+
+            Assert.Equal(0, target.SelectedIndex);
+            Assert.Single(target.GetLogicalChildren());
+        }
+
+        [Fact]
         public void Selected_Index_Changes_To_When_Items_Assigned_Null()
         {
             var items = new ObservableCollection<string>


### PR DESCRIPTION
## What does the pull request do?

Prevents the exception with `Carousel` in #2507.

## What is the current behavior?

Crashes when the first item is added to the carousel and virtualization is disabled.

## How was the solution implemented (if it's not obvious)?

Don't create containers on the fly if virtualization is disabled.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #2507
