### PR TITLE
Fixed stack panel children spacing

### DIFF
--- a/src/Avalonia.Controls/StackPanel.cs
+++ b/src/Avalonia.Controls/StackPanel.cs
@@ -233,6 +233,11 @@ namespace Avalonia.Controls
 
             foreach (Control child in Children)
             {
+                if (!child.IsVisible)
+                {
+                    continue;
+                }
+
                 double childWidth = child.DesiredSize.Width;
                 double childHeight = child.DesiredSize.Height;
 


### PR DESCRIPTION
## Changes

- Fixed stack panel children spacing. (if a children is not visible it should not add spacing).

This seems to be a regression introduced by https://github.com/AvaloniaUI/Avalonia/commit/7ac3556983050b29c8543321d51d272eecefb9b5.