### PR TITLE
Use styled properties in Expander.

### DIFF
--- a/src/Avalonia.Controls/Expander.cs
+++ b/src/Avalonia.Controls/Expander.cs
@@ -13,18 +13,11 @@ namespace Avalonia.Controls
 
     public class Expander : HeaderedContentControl
     {
-        public static readonly DirectProperty<Expander, IPageTransition> ContentTransitionProperty =
-            AvaloniaProperty.RegisterDirect<Expander, IPageTransition>(
-                nameof(ContentTransition),
-                o => o.ContentTransition,
-                (o, v) => o.ContentTransition = v);
+        public static readonly StyledProperty<IPageTransition> ContentTransitionProperty =
+            AvaloniaProperty.Register<Expander, IPageTransition>(nameof(ContentTransition));
 
-        public static readonly DirectProperty<Expander, ExpandDirection> ExpandDirectionProperty =
-            AvaloniaProperty.RegisterDirect<Expander, ExpandDirection>(
-                nameof(ExpandDirection),
-                o => o.ExpandDirection,
-                (o, v) => o.ExpandDirection = v,
-                ExpandDirection.Down);
+        public static readonly StyledProperty<ExpandDirection> ExpandDirectionProperty =
+            AvaloniaProperty.Register<Expander, ExpandDirection>(nameof(ExpandDirection), ExpandDirection.Down);
 
         public static readonly DirectProperty<Expander, bool> IsExpandedProperty =
             AvaloniaProperty.RegisterDirect<Expander, bool>(
@@ -32,6 +25,8 @@ namespace Avalonia.Controls
                 o => o.IsExpanded,
                 (o, v) => o.IsExpanded = v,
                 defaultBindingMode: Data.BindingMode.TwoWay);
+
+        private bool _isExpanded;
 
         static Expander()
         {
@@ -47,14 +42,14 @@ namespace Avalonia.Controls
 
         public IPageTransition ContentTransition
         {
-            get { return _contentTransition; }
-            set { SetAndRaise(ContentTransitionProperty, ref _contentTransition, value); }
+            get => GetValue(ContentTransitionProperty);
+            set => SetValue(ContentTransitionProperty, value);
         }
 
         public ExpandDirection ExpandDirection
         {
-            get { return _expandDirection; }
-            set { SetAndRaise(ExpandDirectionProperty, ref _expandDirection, value); }
+            get => GetValue(ExpandDirectionProperty);
+            set => SetValue(ExpandDirectionProperty, value);
         }
 
         public bool IsExpanded
@@ -79,9 +74,5 @@ namespace Avalonia.Controls
                 }
             }
         }
-
-        private IPageTransition _contentTransition;
-        private ExpandDirection _expandDirection;
-        private bool _isExpanded;
     }
 }


### PR DESCRIPTION
## What does the pull request do?

`Expander.ContentTransition` was defined as a direct property, but was also getting set by a style in the default `Expander` theme, causing #2508. Changed it to be a styled property, along with `ExpandDirection`.

## What is the current behavior?

When the `ContentTransition` property was set in the markup declaring the control, it was overwritten by the value from the style which gets applied when the control finishes initializing.

## What is the updated/expected behavior with this PR?

The `StyledProperty` respects the correct priority of the content transition defined in the style and uses the content transition set when declaring the control.

## Fixed issues

Fixes #2508

cc: @donandren 