### PR TITLE
Use object for resource keys.

### DIFF
--- a/src/Avalonia.Controls/Application.cs
+++ b/src/Avalonia.Controls/Application.cs
@@ -362,7 +362,7 @@ namespace Avalonia
         }
 
         /// <inheritdoc/>
-        bool IResourceProvider.TryGetResource(string key, out object value)
+        bool IResourceProvider.TryGetResource(object key, out object value)
         {
             value = null;
             return (_resources?.TryGetResource(key, out value) ?? false) ||

--- a/src/Avalonia.Styling/Controls/IResourceProvider.cs
+++ b/src/Avalonia.Styling/Controls/IResourceProvider.cs
@@ -28,6 +28,6 @@ namespace Avalonia.Controls
         /// <returns>
         /// True if the resource if found, otherwise false.
         /// </returns>
-        bool TryGetResource(string key, out object value);
+        bool TryGetResource(object key, out object value);
     }
 }

--- a/src/Avalonia.Styling/Controls/ResourceDictionary.cs
+++ b/src/Avalonia.Styling/Controls/ResourceDictionary.cs
@@ -69,7 +69,7 @@ namespace Avalonia.Controls
         }
 
         /// <inheritdoc/>
-        public bool TryGetResource(string key, out object value)
+        public bool TryGetResource(object key, out object value)
         {
             if (TryGetValue(key, out value))
             {

--- a/src/Avalonia.Styling/Controls/ResourceProviderExtensions.cs
+++ b/src/Avalonia.Styling/Controls/ResourceProviderExtensions.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Controls
         /// <param name="control">The control.</param>
         /// <param name="key">The resource key.</param>
         /// <returns>The resource, or <see cref="AvaloniaProperty.UnsetValue"/> if not found.</returns>
-        public static object FindResource(this IResourceNode control, string key)
+        public static object FindResource(this IResourceNode control, object key)
         {
             if (control.TryFindResource(key, out var value))
             {
@@ -28,7 +28,7 @@ namespace Avalonia.Controls
         /// <param name="key">The resource key.</param>
         /// <param name="value">On return, contains the resource if found, otherwise null.</param>
         /// <returns>True if the resource was found; otherwise false.</returns>
-        public static bool TryFindResource(this IResourceNode control, string key, out object value)
+        public static bool TryFindResource(this IResourceNode control, object key, out object value)
         {
             Contract.Requires<ArgumentNullException>(control != null);
             Contract.Requires<ArgumentNullException>(key != null);
@@ -52,7 +52,7 @@ namespace Avalonia.Controls
             return false;
         }
 
-        public static IObservable<object> GetResourceObservable(this IResourceNode target, string key)
+        public static IObservable<object> GetResourceObservable(this IResourceNode target, object key)
         {
             return new ResourceObservable(target, key);
         }
@@ -60,9 +60,9 @@ namespace Avalonia.Controls
         private class ResourceObservable : LightweightObservableBase<object>
         {
             private readonly IResourceNode _target;
-            private readonly string _key;
+            private readonly object _key;
 
-            public ResourceObservable(IResourceNode target, string key)
+            public ResourceObservable(IResourceNode target, object key)
             {
                 _target = target;
                 _key = key;

--- a/src/Avalonia.Styling/StyledElement.cs
+++ b/src/Avalonia.Styling/StyledElement.cs
@@ -415,7 +415,7 @@ namespace Avalonia
         }
 
         /// <inheritdoc/>
-        bool IResourceProvider.TryGetResource(string key, out object value)
+        bool IResourceProvider.TryGetResource(object key, out object value)
         {
             value = null;
             return (_resources?.TryGetResource(key, out value) ?? false) ||

--- a/src/Avalonia.Styling/Styling/Style.cs
+++ b/src/Avalonia.Styling/Styling/Style.cs
@@ -171,7 +171,7 @@ namespace Avalonia.Styling
         }
 
         /// <inheritdoc/>
-        public bool TryGetResource(string key, out object result)
+        public bool TryGetResource(object key, out object result)
         {
             result = null;
             return _resources?.TryGetResource(key, out result) ?? false;

--- a/src/Avalonia.Styling/Styling/Styles.cs
+++ b/src/Avalonia.Styling/Styling/Styles.cs
@@ -178,7 +178,7 @@ namespace Avalonia.Styling
         }
 
         /// <inheritdoc/>
-        public bool TryGetResource(string key, out object value)
+        public bool TryGetResource(object key, out object value)
         {
             if (_resources != null && _resources.TryGetValue(key, out value))
             {

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/DynamicResourceExtension.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/DynamicResourceExtension.cs
@@ -26,7 +26,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
             ResourceKey = resourceKey;
         }
 
-        public string ResourceKey { get; set; }
+        public object ResourceKey { get; set; }
 
         public override object ProvideValue(IServiceProvider serviceProvider) => ProvideTypedValue(serviceProvider);
         

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ResourceInclude.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ResourceInclude.cs
@@ -47,7 +47,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
         bool IResourceProvider.HasResources => Loaded.HasResources;
 
         /// <inhertidoc/>
-        bool IResourceProvider.TryGetResource(string key, out object value)
+        bool IResourceProvider.TryGetResource(object key, out object value)
         {
             return Loaded.TryGetResource(key, out value);
         }

--- a/src/Markup/Avalonia.Markup.Xaml/Styling/StyleInclude.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Styling/StyleInclude.cs
@@ -86,7 +86,7 @@ namespace Avalonia.Markup.Xaml.Styling
         }
 
         /// <inheritdoc/>
-        public bool TryGetResource(string key, out object value) => Loaded.TryGetResource(key, out value);
+        public bool TryGetResource(object key, out object value) => Loaded.TryGetResource(key, out value);
 
         /// <inheritdoc/>
         void ISetStyleParent.NotifyResourcesChanged(ResourcesChangedEventArgs e)


### PR DESCRIPTION
## What does the pull request do?

`IResourceDictionary` was defined as an `IDictionary<object, object>` but in various places we only accepted a `string` as the resource key. Fix this inconsistency and always use `object` as a resource key.

## Breaking changes

A few methods changed their parameters from `string` -> `object`. This shouldn't really affect usage of the API though as it's relaxing a type requirement.

## Fixed issues

Fixes #2456
