### PR TITLE
Add None to StandardCursorTypes #2378

### DIFF
--- a/native/Avalonia.Native/inc/avalonia-native.h
+++ b/native/Avalonia.Native/inc/avalonia-native.h
@@ -144,6 +144,7 @@ enum AvnStandardCursorType
     CursorDragMove,
     CursorDragCopy,
     CursorDragLink,
+    CursorNone
 };
 
 enum AvnWindowEdge

--- a/native/Avalonia.Native/src/OSX/cursor.h
+++ b/native/Avalonia.Native/src/OSX/cursor.h
@@ -11,17 +11,23 @@ class Cursor : public ComSingleObject<IAvnCursor, &IID_IAvnCursor>
 {
 private:
     NSCursor * _native;
-
+    bool _isHidden;
 public:
     FORWARD_IUNKNOWN()
-    Cursor(NSCursor * cursor)
+    Cursor(NSCursor * cursor, bool isHidden = false)
     {
         _native = cursor;
+        _isHidden = isHidden;
     }
 
     NSCursor* GetNative()
     {
         return _native;
+    }
+    
+    bool IsHiden ()
+    {
+        return _isHidden;
     }
 };
 

--- a/native/Avalonia.Native/src/OSX/cursor.h
+++ b/native/Avalonia.Native/src/OSX/cursor.h
@@ -25,7 +25,7 @@ public:
         return _native;
     }
     
-    bool IsHiden ()
+    bool IsHidden ()
     {
         return _isHidden;
     }

--- a/native/Avalonia.Native/src/OSX/cursor.mm
+++ b/native/Avalonia.Native/src/OSX/cursor.mm
@@ -21,6 +21,7 @@ class CursorFactory : public ComSingleObject<IAvnCursorFactory, &IID_IAvnCursorF
     Cursor* resizeRightCursor = new Cursor([NSCursor resizeRightCursor]);
     Cursor* resizeWestEastCursor = new Cursor([NSCursor resizeLeftRightCursor]);
     Cursor* operationNotAllowedCursor = new Cursor([NSCursor operationNotAllowedCursor]);
+    Cursor* noCursor = new Cursor([NSCursor arrowCursor], true);
 
     std::map<AvnStandardCursorType, Cursor*> s_cursorMap =
     {
@@ -46,11 +47,13 @@ class CursorFactory : public ComSingleObject<IAvnCursorFactory, &IID_IAvnCursorF
         { CursorIbeam, IBeamCursor },
         { CursorLeftSide, resizeLeftCursor },
         { CursorRightSide, resizeRightCursor },
-        { CursorNo, operationNotAllowedCursor }
+        { CursorNo, operationNotAllowedCursor },
+        { CursorNone, noCursor }
     };
 
 public:
     FORWARD_IUNKNOWN()
+    
     virtual HRESULT GetCursor (AvnStandardCursorType cursorType, IAvnCursor** retOut) override
     {
         *retOut = s_cursorMap[cursorType];

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -353,6 +353,16 @@ public:
             Cursor* avnCursor = dynamic_cast<Cursor*>(cursor);
             this->cursor = avnCursor->GetNative();
             UpdateCursor();
+            
+            if(avnCursor->IsHiden())
+            {
+                [NSCursor hide];
+            }
+            else
+            {
+                [NSCursor unhide];
+            }
+            
             return S_OK;
         }
     }

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -354,7 +354,7 @@ public:
             this->cursor = avnCursor->GetNative();
             UpdateCursor();
             
-            if(avnCursor->IsHiden())
+            if(avnCursor->IsHidden())
             {
                 [NSCursor hide];
             }

--- a/src/Avalonia.Input/Cursors.cs
+++ b/src/Avalonia.Input/Cursors.cs
@@ -38,6 +38,7 @@ namespace Avalonia.Input
         DragMove,
         DragCopy,
         DragLink,
+        None,
 
         // Not available in GTK directly, see http://www.pixelbeat.org/programming/x_cursors/ 
         // We might enable them later, preferably, by loading pixmax direclty from theme with fallback image

--- a/src/Avalonia.X11/X11CursorFactory.cs
+++ b/src/Avalonia.X11/X11CursorFactory.cs
@@ -9,7 +9,7 @@ namespace Avalonia.X11
     class X11CursorFactory : IStandardCursorFactory
     {
         private static IntPtr _nullCursor;
-        
+
         private readonly IntPtr _display;
         private Dictionary<CursorFontShape, IntPtr> _cursors;
 
@@ -48,10 +48,10 @@ namespace Avalonia.X11
             _cursors = Enum.GetValues(typeof(CursorFontShape)).Cast<CursorFontShape>()
                 .ToDictionary(id => id, id => XLib.XCreateFontCursor(_display, id));
         }
-        
+
         public IPlatformHandle GetCursor(StandardCursorType cursorType)
         {
-            IntPtr handle;            
+            IntPtr handle;
             if (cursorType == StandardCursorType.None)
             {
                 handle = _nullCursor;
@@ -61,7 +61,7 @@ namespace Avalonia.X11
                 handle = s_mapping.TryGetValue(cursorType, out var shape)
                 ? _cursors[shape]
                 : _cursors[CursorFontShape.XC_top_left_arrow];
-            }            
+            }
             return new PlatformHandle(handle, "XCURSOR");
         }
 
@@ -71,7 +71,7 @@ namespace Avalonia.X11
             byte[] data = new byte[] { 0 };
             IntPtr window = XLib.XRootWindow(display, 0);
             IntPtr pixmap = XLib.XCreateBitmapFromData(display, window, data, 1, 1);
-            return XLib.XCreatePixmapCursor(display, pixmap, pixmap, ref color, ref color, 0, 0);                      
+            return XLib.XCreatePixmapCursor(display, pixmap, pixmap, ref color, ref color, 0, 0);
         }
     }
 }

--- a/src/Avalonia.X11/X11CursorFactory.cs
+++ b/src/Avalonia.X11/X11CursorFactory.cs
@@ -51,7 +51,7 @@ namespace Avalonia.X11
         
         public IPlatformHandle GetCursor(StandardCursorType cursorType)
         {
-            IntPtr handle;
+            IntPtr handle;            
             if (cursorType == StandardCursorType.None)
             {
                 handle = _nullCursor;
@@ -66,12 +66,12 @@ namespace Avalonia.X11
         }
 
         private static IntPtr GetNullCursor(IntPtr display)
-        {            
+        {
             XColor color = new XColor();
             byte[] data = new byte[] { 0 };
             IntPtr window = XLib.XRootWindow(display, 0);
-            IntPtr pixmap = XLib.XCreatePixmapFromBitmapData(display, window, data, 1, 1, IntPtr.Zero, IntPtr.Zero, 0);
-            return XLib.XCreatePixmapCursor(display, pixmap, pixmap, ref color, ref color, 0, 0);            
+            IntPtr pixmap = XLib.XCreateBitmapFromData(display, window, data, 1, 1);
+            return XLib.XCreatePixmapCursor(display, pixmap, pixmap, ref color, ref color, 0, 0);                      
         }
     }
 }

--- a/src/Avalonia.X11/XLib.cs
+++ b/src/Avalonia.X11/XLib.cs
@@ -322,6 +322,9 @@ namespace Avalonia.X11
             ref XColor foreground_color, ref XColor background_color, int x_hot, int y_hot);
 
         [DllImport(libX11)]
+        public static extern IntPtr XCreateBitmapFromData(IntPtr display, IntPtr drawable, byte[] data, int width, int height);
+
+        [DllImport(libX11)]
         public static extern IntPtr XCreatePixmapFromBitmapData(IntPtr display, IntPtr drawable, byte[] data, int width,
             int height, IntPtr fg, IntPtr bg, int depth);
 

--- a/src/Gtk/Avalonia.Gtk3/CursorFactory.cs
+++ b/src/Gtk/Avalonia.Gtk3/CursorFactory.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Gtk3
     <StandardCursorType, object>
         {
             {StandardCursorType.None, CursorType.Blank},
-            { StandardCursorType.AppStarting, CursorType.Watch},
+            {StandardCursorType.AppStarting, CursorType.Watch},
             {StandardCursorType.Arrow, CursorType.LeftPtr},
             {StandardCursorType.Cross, CursorType.Cross},
             {StandardCursorType.Hand, CursorType.Hand1},
@@ -37,7 +37,7 @@ namespace Avalonia.Gtk3
             {StandardCursorType.BottomRightCorner, CursorType.BottomRightCorner},
             {StandardCursorType.DragCopy, CursorType.CenterPtr},
             {StandardCursorType.DragMove, CursorType.Fleur},
-            {StandardCursorType.DragLink, CursorType.Cross},            
+            {StandardCursorType.DragLink, CursorType.Cross},
         };
 
         private static readonly Dictionary<StandardCursorType, IPlatformHandle> Cache =

--- a/src/Gtk/Avalonia.Gtk3/CursorFactory.cs
+++ b/src/Gtk/Avalonia.Gtk3/CursorFactory.cs
@@ -12,7 +12,8 @@ namespace Avalonia.Gtk3
         private static readonly Dictionary<StandardCursorType, object> CursorTypeMapping = new Dictionary
     <StandardCursorType, object>
         {
-            {StandardCursorType.AppStarting, CursorType.Watch},
+            {StandardCursorType.None, CursorType.Blank},
+            { StandardCursorType.AppStarting, CursorType.Watch},
             {StandardCursorType.Arrow, CursorType.LeftPtr},
             {StandardCursorType.Cross, CursorType.Cross},
             {StandardCursorType.Hand, CursorType.Hand1},
@@ -36,7 +37,7 @@ namespace Avalonia.Gtk3
             {StandardCursorType.BottomRightCorner, CursorType.BottomRightCorner},
             {StandardCursorType.DragCopy, CursorType.CenterPtr},
             {StandardCursorType.DragMove, CursorType.Fleur},
-            {StandardCursorType.DragLink, CursorType.Cross},
+            {StandardCursorType.DragLink, CursorType.Cross},            
         };
 
         private static readonly Dictionary<StandardCursorType, IPlatformHandle> Cache =

--- a/src/Gtk/Avalonia.Gtk3/GdkCursor.cs
+++ b/src/Gtk/Avalonia.Gtk3/GdkCursor.cs
@@ -2,6 +2,7 @@
 {
     enum GdkCursorType
     {
+        Blank = -2,
         CursorIsPixmap = -1,
         XCursor = 0,
         Arrow = 2,

--- a/src/Windows/Avalonia.Win32/CursorFactory.cs
+++ b/src/Windows/Avalonia.Win32/CursorFactory.cs
@@ -41,7 +41,8 @@ namespace Avalonia.Win32
         private static readonly Dictionary<StandardCursorType, int> CursorTypeMapping = new Dictionary
             <StandardCursorType, int>
         {
-            {StandardCursorType.AppStarting, 32650},
+            {StandardCursorType.None, 0},
+            { StandardCursorType.AppStarting, 32650},
             {StandardCursorType.Arrow, 32512},
             {StandardCursorType.Cross, 32515},
             {StandardCursorType.Hand, 32649},
@@ -69,7 +70,7 @@ namespace Avalonia.Win32
             // Fallback, should have been loaded from ole32.dll
             {StandardCursorType.DragMove, 32516},
             {StandardCursorType.DragCopy, 32516},
-            {StandardCursorType.DragLink, 32516},
+            {StandardCursorType.DragLink, 32516},            
         };
 
         private static readonly Dictionary<StandardCursorType, IPlatformHandle> Cache =

--- a/src/Windows/Avalonia.Win32/CursorFactory.cs
+++ b/src/Windows/Avalonia.Win32/CursorFactory.cs
@@ -42,7 +42,7 @@ namespace Avalonia.Win32
             <StandardCursorType, int>
         {
             {StandardCursorType.None, 0},
-            { StandardCursorType.AppStarting, 32650},
+            {StandardCursorType.AppStarting, 32650},
             {StandardCursorType.Arrow, 32512},
             {StandardCursorType.Cross, 32515},
             {StandardCursorType.Hand, 32649},
@@ -70,7 +70,7 @@ namespace Avalonia.Win32
             // Fallback, should have been loaded from ole32.dll
             {StandardCursorType.DragMove, 32516},
             {StandardCursorType.DragCopy, 32516},
-            {StandardCursorType.DragLink, 32516},            
+            {StandardCursorType.DragLink, 32516},
         };
 
         private static readonly Dictionary<StandardCursorType, IPlatformHandle> Cache =


### PR DESCRIPTION
## What does the pull request do?
Adds a None field to StandardCursorType for setting an invisible cursor (see #2378) and adds the corresponding implementations for Win32, X11 and GTK

## What is the current behavior?
StandardCursorType does not have a None field

## What is the updated/expected behavior with this PR?
Cursor can be set to StandardCursorType.None which makes the Cursor invisible

## How was the solution implemented (if it's not obvious)?

**Win32:**

From https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-setcursor:

> Type: HCURSOR: A handle to the cursor. The cursor must have been created by the CreateCursor function or loaded by the LoadCursor or LoadImage function. If this parameter is NULL, the cursor is removed from the screen.

**X11:**
X11 does not have a default None-Type-Cursor. Instead the cursor can be set to an invisible Bitmap.
Implementation was taken from https://github.com/aktau/hhpc/blob/master/hhpc.c#L105

**GTK3:**

From https://code.woboq.org/gtk/gtk/gdk/gdkcursor.h.html#GDK_BLANK_CURSOR:

> GDK_BLANK_CURSOR = -2,

## Checklist

- [ ] Added unit tests (if possible)?

Manually tested on Windows 10 and Ubuntu 18.04 (X11)

- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
None


## Fixed issues
Implements #2378
