### PR TITLE
Fix use of CoerceCaretIndex on Text change

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -214,9 +214,9 @@ namespace Avalonia.Controls
                 if (!_ignoreTextChanges)
                 {
                     var caretIndex = CaretIndex;
-                    SelectionStart = CoerceCaretIndex(SelectionStart, value?.Length ?? 0);
-                    SelectionEnd = CoerceCaretIndex(SelectionEnd, value?.Length ?? 0);
-                    CaretIndex = CoerceCaretIndex(caretIndex, value?.Length ?? 0);
+                    SelectionStart = CoerceCaretIndex(SelectionStart, value);
+                    SelectionEnd = CoerceCaretIndex(SelectionEnd, value);
+                    CaretIndex = CoerceCaretIndex(caretIndex, value);
 
                     if (SetAndRaise(TextProperty, ref _text, value) && !_isUndoingRedoing)
                     {
@@ -677,11 +677,15 @@ namespace Avalonia.Controls
             }
         }
 
-        private int CoerceCaretIndex(int value) => CoerceCaretIndex(value, Text?.Length ?? 0);
+        private int CoerceCaretIndex(int value) => CoerceCaretIndex(value, Text);
 
-        private int CoerceCaretIndex(int value, int length)
+        private int CoerceCaretIndex(int value, string text)
         {
-            var text = Text;
+            if (text == null)
+            {
+                return 0;
+            }
+            var length = text.Length;
 
             if (value < 0)
             {
@@ -691,7 +695,7 @@ namespace Avalonia.Controls
             {
                 return length;
             }
-            else if (value > 0 && text[value - 1] == '\r' && text[value] == '\n')
+            else if (value > 0 && text[value - 1] == '\r' && value < length && text[value] == '\n')
             {
                 return value + 1;
             }

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -385,6 +385,21 @@ namespace Avalonia.Controls.UnitTests
                 Assert.True(target.SelectionEnd <= "123".Length);
             }
         }
+        [Fact]
+        public void CoerceCaretIndex_Doesnt_Cause_Exception_with_malformed_line_ending()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var target = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "0123456789\r"
+                };
+                target.CaretIndex = 11;
+
+                Assert.True(true);
+            }
+        }
 
         private static TestServices Services => TestServices.MockThreadingInterface.With(
             standardCursorFactory: Mock.Of<IStandardCursorFactory>());


### PR DESCRIPTION
## What does the pull request do?
fixes exception on clicking in TextBox #2552

## What is the current behavior?
Under rare circumstances clicking at the end of a TextBox throws an exception

## What is the updated/expected behavior with this PR?
exception free clicking

## How was the solution implemented (if it's not obvious)?
The check for \r\n could fail if there was a \r at the end of the Text.
Calls to CoerceCaretIndex were using the previous text on Text changed which I can't believe was intended.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation



## Fixed issues

Fixes #2552

