### PR TITLE
Make IFocusManager and IKeyboardDevice toplevel-specific

### DIFF
--- a/src/Android/Avalonia.Android/AndroidPlatform.cs
+++ b/src/Android/Avalonia.Android/AndroidPlatform.cs
@@ -46,7 +46,6 @@ namespace Avalonia.Android
             AvaloniaLocator.CurrentMutable
                 .Bind<IClipboard>().ToTransient<ClipboardImpl>()
                 .Bind<IStandardCursorFactory>().ToTransient<CursorFactory>()
-                .Bind<IKeyboardDevice>().ToSingleton<AndroidKeyboardDevice>()
                 .Bind<IPlatformSettings>().ToConstant(Instance)
                 .Bind<IPlatformThreadingInterface>().ToConstant(new AndroidThreadingInterface())
                 .Bind<ISystemDialogImpl>().ToTransient<SystemDialogImpl>()

--- a/src/Android/Avalonia.Android/Platform/Input/AndroidKeyboardDevice.cs
+++ b/src/Android/Avalonia.Android/Platform/Input/AndroidKeyboardDevice.cs
@@ -6,6 +6,7 @@ using Avalonia.Input;
 namespace Avalonia.Android.Platform.Input
 {
     public class AndroidKeyboardDevice : KeyboardDevice, IKeyboardDevice {
+        public static readonly KeyboardDevice Instance = new AndroidKeyboardDevice();
     private static readonly Dictionary<Keycode, Key> KeyDic = new Dictionary<Keycode, Key>
      {
          //   { Keycode.Cancel?, Key.Cancel },

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -65,6 +65,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         }
 
         public IMouseDevice MouseDevice => AndroidMouseDevice.Instance;
+        public IKeyboardDevice KeyboardDevice => AndroidKeyboardDevice.Instance;
 
         public Action Closed { get; set; }
 
@@ -117,6 +118,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         public void SetInputRoot(IInputRoot inputRoot)
         {
             InputRoot = inputRoot;
+            _keyboardHelper.FocusManager = inputRoot?.FocusManager;
         }
         
         public virtual void Show()

--- a/src/Android/Avalonia.Android/Platform/Specific/Helpers/AndroidKeyboardEventsHelper.cs
+++ b/src/Android/Avalonia.Android/Platform/Specific/Helpers/AndroidKeyboardEventsHelper.cs
@@ -120,21 +120,25 @@ namespace Avalonia.Android.Platform.Specific.Helpers
             _lastFocusedElement = element;
         }
 
-        public void ActivateAutoShowKeyboard()
-        {
-            var kbDevice = (KeyboardDevice.Instance as INotifyPropertyChanged);
+        private IFocusManager _focusManager;
 
-            //just in case we've called more than once the method
-            kbDevice.PropertyChanged -= KeyboardDevice_PropertyChanged;
-            kbDevice.PropertyChanged += KeyboardDevice_PropertyChanged;
-        }
-
-        private void KeyboardDevice_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        public IFocusManager FocusManager
         {
-            if (e.PropertyName == nameof(KeyboardDevice.FocusedElement))
+            get => _focusManager;
+            set
             {
-                UpdateKeyboardState(KeyboardDevice.Instance.FocusedElement);
+                if (_focusManager != null)
+                    _focusManager.FocusedElementChanged -= OnFocusedElementChanged;
+                _focusManager = value;
+                if (_focusManager != null)
+                    _focusManager.FocusedElementChanged += OnFocusedElementChanged;
+                UpdateKeyboardState(_focusManager?.FocusedElement);
             }
+        }
+        
+        private void OnFocusedElementChanged(object sender, EventArgs e)
+        {
+            UpdateKeyboardState(_focusManager?.FocusedElement);
         }
 
         public void Dispose()

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -3775,7 +3775,7 @@ namespace Avalonia.Controls
             {
                 bool focusLeftDataGrid = true;
                 bool dataGridWillReceiveRoutedEvent = true;
-                IVisual focusedObject = FocusManager.Instance.Current;
+                IVisual focusedObject = this.GetFocusManager()?.FocusedElement;
 
                 while (focusedObject != null)
                 {
@@ -4651,7 +4651,7 @@ namespace Avalonia.Controls
             if (!ctrl)
             {
                 // If Enter was used by a TextBox, we shouldn't handle the key
-                if (FocusManager.Instance.Current is TextBox focusedTextBox && focusedTextBox.AcceptsReturn)
+                if (this.GetFocusManager()?.FocusedElement is TextBox focusedTextBox && focusedTextBox.AcceptsReturn)
                 {
                     return false;
                 }

--- a/src/Avalonia.Controls.DataGrid/Utils/TreeHelper.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/TreeHelper.cs
@@ -54,7 +54,7 @@ namespace Avalonia.Controls.Utils
         /// <returns>True if the currently focused element is within the visual tree of the parent</returns>
         internal static bool ContainsFocusedElement(this IVisual element)
         {
-            return (element == null) ? false : element.ContainsChild(FocusManager.Instance.Current);
+            return (element == null) ? false : element.ContainsChild(element.GetFocusManager()?.FocusedElement);
         }
     }
 }

--- a/src/Avalonia.Controls/Application.cs
+++ b/src/Avalonia.Controls/Application.cs
@@ -83,18 +83,6 @@ namespace Avalonia
         public DataTemplates DataTemplates => _dataTemplates ?? (_dataTemplates = new DataTemplates());
 
         /// <summary>
-        /// Gets the application's focus manager.
-        /// </summary>
-        /// <value>
-        /// The application's focus manager.
-        /// </value>
-        public IFocusManager FocusManager
-        {
-            get;
-            private set;
-        }
-
-        /// <summary>
         /// Gets the application's input manager.
         /// </summary>
         /// <value>
@@ -372,14 +360,12 @@ namespace Avalonia
         public virtual void RegisterServices()
         {
             AvaloniaSynchronizationContext.InstallIfNeeded();
-            FocusManager = new FocusManager();
             InputManager = new InputManager();
 
             AvaloniaLocator.CurrentMutable
                 .Bind<IAccessKeyHandler>().ToTransient<AccessKeyHandler>()
                 .Bind<IGlobalDataTemplates>().ToConstant(this)
                 .Bind<IGlobalStyles>().ToConstant(this)
-                .Bind<IFocusManager>().ToConstant(FocusManager)
                 .Bind<IInputManager>().ToConstant(InputManager)
                 .Bind<IKeyboardNavigationHandler>().ToTransient<KeyboardNavigationHandler>()
                 .Bind<IStyler>().ToConstant(_styler)

--- a/src/Avalonia.Controls/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox.cs
@@ -1385,7 +1385,7 @@ namespace Avalonia.Controls
         /// otherwise, false.</returns>
         protected bool HasFocus()
         {
-            IVisual focused = FocusManager.Instance.Current;
+            IVisual focused = this.GetFocusManager()?.FocusedElement;
 
             while (focused != null)
             {

--- a/src/Avalonia.Controls/Calendar/Calendar.cs
+++ b/src/Avalonia.Controls/Calendar/Calendar.cs
@@ -1567,7 +1567,7 @@ namespace Avalonia.Controls
             base.OnPointerReleased(e);
             if (!HasFocusInternal && e.MouseButton == MouseButton.Left)
             {
-                FocusManager.Instance.Focus(this);
+                this.GetFocusManager().Focus(this);
             }
         }
 

--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -165,7 +165,7 @@ namespace Avalonia.Controls
                 var firstChild = Presenter?.Panel?.Children.FirstOrDefault(c => CanFocus(c));
                 if (firstChild != null)
                 {
-                    FocusManager.Instance?.Focus(firstChild, NavigationMethod.Directional);
+                    firstChild.Focus(NavigationMethod.Directional);
                     e.Handled = true;
                 }
             }

--- a/src/Avalonia.Controls/Embedding/EmbeddableControlRoot.cs
+++ b/src/Avalonia.Controls/Embedding/EmbeddableControlRoot.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Controls.Embedding
     {
         public EmbeddableControlRoot(IEmbeddableWindowImpl impl) : base(impl)
         {
-            impl.LostFocus += () => FocusManager.SetHasEffectiveFocus(false);
+            impl.LostFocus += () => FocusManager.HasEffectiveFocus = false;
         }
 
         public EmbeddableControlRoot() : this(PlatformManager.CreateEmbeddableWindow())

--- a/src/Avalonia.Controls/Embedding/EmbeddableControlRoot.cs
+++ b/src/Avalonia.Controls/Embedding/EmbeddableControlRoot.cs
@@ -8,14 +8,14 @@ using JetBrains.Annotations;
 
 namespace Avalonia.Controls.Embedding
 {
-    public class EmbeddableControlRoot : TopLevel, IStyleable, IFocusScope, INameScope, IDisposable
+    public class EmbeddableControlRoot : TopLevel, IStyleable, INameScope, IDisposable
     {
         public EmbeddableControlRoot(IEmbeddableWindowImpl impl) : base(impl)
         {
-            
+            impl.LostFocus += () => FocusManager.SetHasEffectiveFocus(false);
         }
 
-        public EmbeddableControlRoot() : base(PlatformManager.CreateEmbeddableWindow())
+        public EmbeddableControlRoot() : this(PlatformManager.CreateEmbeddableWindow())
         {
         }
 

--- a/src/Avalonia.Controls/Embedding/Offscreen/OffscreenTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Embedding/Offscreen/OffscreenTopLevelImpl.cs
@@ -61,5 +61,6 @@ namespace Avalonia.Controls.Embedding.Offscreen
 
         public Action Closed { get; set; }
         public abstract IMouseDevice MouseDevice { get; }
+        public abstract IKeyboardDevice KeyboardDevice { get; }
     }
 }

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -330,19 +330,21 @@ namespace Avalonia.Controls
         {
             if (!e.Handled)
             {
-                var focus = FocusManager.Instance;
+                var focus = this.GetFocusManager();
+                if(focus == null)
+                    return;
                 var direction = e.Key.ToNavigationDirection();
                 var container = Presenter?.Panel as INavigableContainer;
 
                 if (container == null ||
-                    focus.Current == null ||
+                    focus.FocusedElement == null ||
                     direction == null ||
                     direction.Value.IsTab())
                 {
                     return;
                 }
 
-                var current = focus.Current
+                var current = focus.FocusedElement
                     .GetSelfAndVisualAncestors()
                     .OfType<IInputElement>()
                     .FirstOrDefault(x => x.VisualParent == container);

--- a/src/Avalonia.Controls/MenuBase.cs
+++ b/src/Avalonia.Controls/MenuBase.cs
@@ -17,7 +17,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// Base class for menu controls.
     /// </summary>
-    public abstract class MenuBase : SelectingItemsControl, IFocusScope, IMenu
+    public abstract class MenuBase : SelectingItemsControl, IMenu
     {
         /// <summary>
         /// Defines the <see cref="IsOpen"/> property.

--- a/src/Avalonia.Controls/Platform/ITopLevelImpl.cs
+++ b/src/Avalonia.Controls/Platform/ITopLevelImpl.cs
@@ -107,5 +107,8 @@ namespace Avalonia.Platform
         /// </summary>
         [CanBeNull]
         IMouseDevice MouseDevice { get; }
+        
+        [CanBeNull]
+        IKeyboardDevice KeyboardDevice { get; }
     }
 }

--- a/src/Avalonia.Controls/Remote/RemoteServer.cs
+++ b/src/Avalonia.Controls/Remote/RemoteServer.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using Avalonia.Controls.Embedding;
 using Avalonia.Controls.Remote.Server;
+using Avalonia.Input;
 using Avalonia.Platform;
 using Avalonia.Remote.Protocol;
+using Avalonia.Threading;
 
 namespace Avalonia.Controls.Remote
 {
@@ -17,6 +19,7 @@ namespace Avalonia.Controls.Remote
             }
 #pragma warning disable 67
             public event Action LostFocus;
+            public Action GotFocus { get; set; }
 
         }
         

--- a/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
@@ -35,8 +35,6 @@ namespace Avalonia.Controls.Remote.Server
         {
             _transport = transport;
             _transport.OnMessage += OnMessage;
-
-            KeyboardDevice = AvaloniaLocator.Current.GetService<IKeyboardDevice>();
         }
 
         private static RawPointerEventType GetAvaloniaEventType (Avalonia.Remote.Protocol.Input.MouseButton button, bool pressed)
@@ -340,6 +338,6 @@ namespace Avalonia.Controls.Remote.Server
 
         public override IMouseDevice MouseDevice { get; } = new MouseDevice();
 
-        public IKeyboardDevice KeyboardDevice { get; }
+        public override IKeyboardDevice KeyboardDevice { get; } = new KeyboardDevice();
     }
 }

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -55,6 +55,8 @@ namespace Avalonia.Controls
         private readonly IPlatformRenderInterface _renderInterface;
         private Size _clientSize;
         private ILayoutManager _layoutManager;
+        
+        public IFocusManager FocusManager { get; private set; }
 
         /// <summary>
         /// Initializes static members of the <see cref="TopLevel"/> class.
@@ -87,7 +89,7 @@ namespace Avalonia.Controls
                 throw new InvalidOperationException(
                     "Could not create window implementation: maybe no windowing subsystem was initialized?");
             }
-
+            FocusManager = new FocusManager(this);
             PlatformImpl = impl;
 
             dependencyResolver = dependencyResolver ?? AvaloniaLocator.Current;
@@ -366,7 +368,7 @@ namespace Avalonia.Controls
         /// <param name="e">The event args.</param>
         private void HandleInput(RawInputEventArgs e)
         {
-            _inputManager.ProcessInput(e);
+            _inputManager.ProcessInput(e, FocusManager.FocusedElement);
         }
 
         private void SceneInvalidated(object sender, SceneInvalidatedEventArgs e)

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -392,7 +392,7 @@ namespace Avalonia.Controls
 
                     if (next != null)
                     {
-                        FocusManager.Instance.Focus(next, NavigationMethod.Directional);
+                        next.Focus(NavigationMethod.Directional);
                         e.Handled = true;
                     }
                 }

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -47,7 +47,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// A top-level window.
     /// </summary>
-    public class Window : WindowBase, IStyleable, IFocusScope, ILayoutRoot, INameScope
+    public class Window : WindowBase, IStyleable, ILayoutRoot, INameScope
     {
         /// <summary>
         /// Defines the <see cref="SizeToContent"/> property.

--- a/src/Avalonia.Controls/WindowBase.cs
+++ b/src/Avalonia.Controls/WindowBase.cs
@@ -285,7 +285,7 @@ namespace Avalonia.Controls
 
             if (scope != null)
             {
-                FocusManager.Instance.SetFocusScope(scope);
+                FocusManager.SetFocusScope(scope);
             }
 
             IsActive = true;

--- a/src/Avalonia.Controls/WindowBase.cs
+++ b/src/Avalonia.Controls/WindowBase.cs
@@ -280,14 +280,7 @@ namespace Avalonia.Controls
         private void HandleActivated()
         {
             Activated?.Invoke(this, EventArgs.Empty);
-
-            var scope = this as IFocusScope;
-
-            if (scope != null)
-            {
-                FocusManager.SetFocusScope(scope);
-            }
-
+            FocusManager.SetHasEffectiveFocus(true);
             IsActive = true;
         }
 
@@ -297,7 +290,7 @@ namespace Avalonia.Controls
         private void HandleDeactivated()
         {
             IsActive = false;
-
+            FocusManager.SetHasEffectiveFocus(false);
             Deactivated?.Invoke(this, EventArgs.Empty);
         }
 

--- a/src/Avalonia.Controls/WindowBase.cs
+++ b/src/Avalonia.Controls/WindowBase.cs
@@ -280,7 +280,7 @@ namespace Avalonia.Controls
         private void HandleActivated()
         {
             Activated?.Invoke(this, EventArgs.Empty);
-            FocusManager.SetHasEffectiveFocus(true);
+            FocusManager.HasEffectiveFocus = true;
             IsActive = true;
         }
 
@@ -290,7 +290,7 @@ namespace Avalonia.Controls
         private void HandleDeactivated()
         {
             IsActive = false;
-            FocusManager.SetHasEffectiveFocus(false);
+            FocusManager.HasEffectiveFocus = false;
             Deactivated?.Invoke(this, EventArgs.Empty);
         }
 

--- a/src/Avalonia.DesignerSupport/Remote/PreviewerWindowingPlatform.cs
+++ b/src/Avalonia.DesignerSupport/Remote/PreviewerWindowingPlatform.cs
@@ -50,7 +50,6 @@ namespace Avalonia.DesignerSupport.Remote
             AvaloniaLocator.CurrentMutable
                 .Bind<IClipboard>().ToSingleton<ClipboardStub>()
                 .Bind<IStandardCursorFactory>().ToSingleton<CursorFactoryStub>()
-                .Bind<IKeyboardDevice>().ToConstant(Keyboard)
                 .Bind<IPlatformSettings>().ToConstant(instance)
                 .Bind<IPlatformThreadingInterface>().ToConstant(threading)
                 .Bind<IRenderLoop>().ToConstant(new RenderLoop())

--- a/src/Avalonia.DesignerSupport/Remote/Stubs.cs
+++ b/src/Avalonia.DesignerSupport/Remote/Stubs.cs
@@ -29,6 +29,7 @@ namespace Avalonia.DesignerSupport.Remote
         public Func<bool> Closing { get; set; }
         public Action Closed { get; set; }
         public IMouseDevice MouseDevice { get; } = new MouseDevice();
+        public IKeyboardDevice KeyboardDevice { get; } = new KeyboardDevice();
         public PixelPoint Position { get; set; }
         public Action<PixelPoint> PositionChanged { get; set; }
         public WindowState WindowState { get; set; }

--- a/src/Avalonia.Input/AccessKeyHandler.cs
+++ b/src/Avalonia.Input/AccessKeyHandler.cs
@@ -148,7 +148,7 @@ namespace Avalonia.Input
                 {
                     // TODO: Use FocusScopes to store the current element and restore it when context menu is closed.
                     // Save currently focused input element.
-                    _restoreFocusElement = FocusManager.Instance.Current;                    
+                    _restoreFocusElement = (sender as IVisual).GetFocusManager()?.FocusedElement;                  
 
                     // When Alt is pressed without a main menu, or with a closed main menu, show
                     // access key markers in the window (i.e. "_File").

--- a/src/Avalonia.Input/DragDropDevice.cs
+++ b/src/Avalonia.Input/DragDropDevice.cs
@@ -83,7 +83,7 @@ namespace Avalonia.Input
             }
         }
 
-        public void ProcessRawEvent(RawInputEventArgs e)
+        public void ProcessRawEvent(RawInputEventArgs e, IInputElement focusedElement)
         {
             if (!e.Handled && e is RawDragEvent margs)
                 ProcessRawEvent(margs);

--- a/src/Avalonia.Input/FocusManager.cs
+++ b/src/Avalonia.Input/FocusManager.cs
@@ -14,19 +14,16 @@ namespace Avalonia.Input
     /// </summary>
     public class FocusManager : IFocusManager
     {
-        /// <summary>
-        /// The focus scopes in which the focus is currently defined.
-        /// </summary>
-        private readonly Dictionary<IFocusScope, IInputElement> _focusScopes =
-            new Dictionary<IFocusScope, IInputElement>();
-
-        private IInputElement _focusedElement;
+        private readonly InputElement _root;
+        private IInputElement _logicalFocus;
+        private bool _hasEffectiveFocus;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FocusManager"/> class.
         /// </summary>
         public FocusManager(InputElement root)
         {
+            _root = root;
             root.AddHandler(InputElement.PointerPressedEvent,
                 new EventHandler<RoutedEventArgs>(OnPreviewPointerPressed),
                 RoutingStrategies.Tunnel);
@@ -35,28 +32,40 @@ namespace Avalonia.Input
         /// <summary>
         /// Gets the currently focused <see cref="IInputElement"/>.
         /// </summary>
-        public IInputElement FocusedElement
-        {
-            get => _focusedElement;
-            private set
-            {
-                _focusedElement = value;
-                FocusedElementChanged?.Invoke(this, EventArgs.Empty);
-            }
-        }
+        public IInputElement FocusedElement => _hasEffectiveFocus ? _logicalFocus : null;
 
         /// <summary>
         /// Is triggered when FocusedElement is changed
         /// </summary>
         public event EventHandler FocusedElementChanged;
-        
-        /// <summary>
-        /// Gets the current focus scope.
-        /// </summary>
-        public IFocusScope Scope
+
+
+        void UpdateFocus(Action cb, NavigationMethod method = NavigationMethod.Unspecified,
+            InputModifiers modifiers = default)
         {
-            get;
-            private set;
+            var lastFocus = FocusedElement;
+            cb();
+            
+            // For now reset the focus if control is detached from the root
+            // We can make the focus 
+            if (_logicalFocus != null && !_root.IsVisualAncestorOf(_logicalFocus))
+                _logicalFocus = null;
+            
+            if (lastFocus != FocusedElement)
+            {
+                lastFocus?.RaiseEvent(new RoutedEventArgs {RoutedEvent = InputElement.LostFocusEvent});
+                FocusedElement?.RaiseEvent(new GotFocusEventArgs
+                {
+                    RoutedEvent = InputElement.GotFocusEvent, NavigationMethod = method, InputModifiers = modifiers,
+                });
+            }
+
+            FocusedElementChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        public void SetHasEffectiveFocus(bool hasEffectiveFocus)
+        {
+            UpdateFocus(() => _hasEffectiveFocus = hasEffectiveFocus);
         }
 
         /// <summary>
@@ -65,104 +74,23 @@ namespace Avalonia.Input
         /// <param name="control">The control to focus.</param>
         /// <param name="method">The method by which focus was changed.</param>
         /// <param name="modifiers">Any input modifiers active at the time of focus.</param>
-        public void Focus(
+        public bool Focus(
             IInputElement control, 
             NavigationMethod method = NavigationMethod.Unspecified,
             InputModifiers modifiers = InputModifiers.None)
         {
-            if (control != null)
+            if (control != null && !_root.IsVisualAncestorOf(control))
+                throw new InvalidOperationException("Visual to focus isn't a child of the controlled focus root");
+            UpdateFocus(() =>
             {
-                var scope = GetFocusScopeAncestors(control)
-                    .FirstOrDefault();
-
-                if (scope != null)
+                _logicalFocus = control;
+                if (method == NavigationMethod.Pointer)
                 {
-                    Scope = scope;
-                    SetFocusedElement(scope, control, method, modifiers);
+                    // For now we assume that we have effective focus if there was a pointer event
+                    _hasEffectiveFocus = true;
                 }
-            }
-            else if (FocusedElement != null)
-            {
-                // If control is null, set focus to the topmost focus scope.
-                foreach (var scope in GetFocusScopeAncestors(FocusedElement).Reverse().ToList())
-                {
-                    IInputElement element;
-
-                    if (_focusScopes.TryGetValue(scope, out element) && element != null)
-                    {
-                        Focus(element, method);
-                        return;
-                    }
-                }
-
-                // Couldn't find a focus scope, clear focus.
-                SetFocusedElement(Scope, null);
-            }
-        }
-
-        /// <summary>
-        /// Sets the currently focused element in the specified scope.
-        /// </summary>
-        /// <param name="scope">The focus scope.</param>
-        /// <param name="element">The element to focus. May be null.</param>
-        /// <param name="method">The method by which focus was changed.</param>
-        /// <param name="modifiers">Any input modifiers active at the time of focus.</param>
-        /// <remarks>
-        /// If the specified scope is the current <see cref="Scope"/> then the keyboard focus
-        /// will change.
-        /// </remarks>
-        public void SetFocusedElement(
-            IFocusScope scope,
-            IInputElement element,
-            NavigationMethod method = NavigationMethod.Unspecified,
-            InputModifiers modifiers = InputModifiers.None)
-        {
-            Contract.Requires<ArgumentNullException>(scope != null);
-            
-            _focusScopes[scope] = element;
-
-            if (Scope == scope)
-            {
-                if (element != FocusedElement)
-                {
-                    var interactive = FocusedElement as IInteractive;
-                    FocusedElement = element;
-
-                    interactive?.RaiseEvent(new RoutedEventArgs {RoutedEvent = InputElement.LostFocusEvent,});
-
-                    interactive = element as IInteractive;
-
-                    interactive?.RaiseEvent(new GotFocusEventArgs
-                    {
-                        RoutedEvent = InputElement.GotFocusEvent,
-                        NavigationMethod = method,
-                        InputModifiers = modifiers,
-                    });
-                }
-            }
-        }
-
-        /// <summary>
-        /// Notifies the focus manager of a change in focus scope.
-        /// </summary>
-        /// <param name="scope">The new focus scope.</param>
-        public void SetFocusScope(IFocusScope scope)
-        {
-            Contract.Requires<ArgumentNullException>(scope != null);
-
-            IInputElement e;
-
-            if (!_focusScopes.TryGetValue(scope, out e))
-            {
-                // TODO: Make this do something useful, i.e. select the first focusable
-                // control, select a control that the user has specified to have default
-                // focus etc.
-                e = scope as IInputElement;
-                _focusScopes.Add(scope, e);
-            }
-
-            Scope = scope;
-            Focus(e);
+            }, method, modifiers);
+            return FocusedElement == control;
         }
 
         /// <summary>
@@ -171,27 +99,6 @@ namespace Avalonia.Input
         /// <param name="e">The element.</param>
         /// <returns>True if the element can be focused.</returns>
         private static bool CanFocus(IInputElement e) => e.Focusable && e.IsEnabledCore && e.IsVisible;
-
-        /// <summary>
-        /// Gets the focus scope ancestors of the specified control, traversing popups.
-        /// </summary>
-        /// <param name="control">The control.</param>
-        /// <returns>The focus scopes.</returns>
-        private static IEnumerable<IFocusScope> GetFocusScopeAncestors(IInputElement control)
-        {
-            while (control != null)
-            {
-                var scope = control as IFocusScope;
-
-                if (scope != null)
-                {
-                    yield return scope;
-                }
-
-                control = control.GetVisualParent<IInputElement>() ??
-                    ((control as IHostedVisualTreeRoot)?.Host as IInputElement);
-            }
-        }
 
         /// <summary>
         /// Global handler for pointer pressed events.

--- a/src/Avalonia.Input/FocusManager.cs
+++ b/src/Avalonia.Input/FocusManager.cs
@@ -40,14 +40,15 @@ namespace Avalonia.Input
         public event EventHandler FocusedElementChanged;
 
 
-        void UpdateFocus(Action cb, NavigationMethod method = NavigationMethod.Unspecified,
+        private void UpdateFocus(Action cb, NavigationMethod method = NavigationMethod.Unspecified,
             InputModifiers modifiers = default)
         {
             var lastFocus = FocusedElement;
             cb();
             
             // For now reset the focus if control is detached from the root
-            // We can make the focus 
+            // Later we can choose to transfer the focus to a parent focusable element
+            // like we do with pointer captures or to a parent scope once they are properly implemented
             if (_logicalFocus != null && !_root.IsVisualAncestorOf(_logicalFocus))
                 _logicalFocus = null;
             
@@ -63,9 +64,10 @@ namespace Avalonia.Input
             FocusedElementChanged?.Invoke(this, EventArgs.Empty);
         }
 
-        public void SetHasEffectiveFocus(bool hasEffectiveFocus)
+        public bool HasEffectiveFocus
         {
-            UpdateFocus(() => _hasEffectiveFocus = hasEffectiveFocus);
+            get => _hasEffectiveFocus;
+            set => UpdateFocus(() => _hasEffectiveFocus = value);
         }
 
         /// <summary>

--- a/src/Avalonia.Input/IFocusManager.cs
+++ b/src/Avalonia.Input/IFocusManager.cs
@@ -1,6 +1,8 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using System;
+
 namespace Avalonia.Input
 {
     /// <summary>
@@ -11,7 +13,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Gets the currently focused <see cref="IInputElement"/>.
         /// </summary>
-        IInputElement Current { get; }
+        IInputElement FocusedElement { get; }
 
         /// <summary>
         /// Gets the current focus scope.
@@ -38,5 +40,7 @@ namespace Avalonia.Input
         /// when it activates, e.g. when a Window is activated.
         /// </remarks>
         void SetFocusScope(IFocusScope scope);
+
+        event EventHandler FocusedElementChanged;
     }
 }

--- a/src/Avalonia.Input/IFocusManager.cs
+++ b/src/Avalonia.Input/IFocusManager.cs
@@ -16,30 +16,17 @@ namespace Avalonia.Input
         IInputElement FocusedElement { get; }
 
         /// <summary>
-        /// Gets the current focus scope.
-        /// </summary>
-        IFocusScope Scope { get; }
-
-        /// <summary>
         /// Focuses a control.
         /// </summary>
         /// <param name="control">The control to focus.</param>
         /// <param name="method">The method by which focus was changed.</param>
         /// <param name="modifiers">Any input modifiers active at the time of focus.</param>
-        void Focus(
+        bool Focus(
             IInputElement control, 
             NavigationMethod method = NavigationMethod.Unspecified,
             InputModifiers modifiers = InputModifiers.None);
 
-        /// <summary>
-        /// Notifies the focus manager of a change in focus scope.
-        /// </summary>
-        /// <param name="scope">The new focus scope.</param>
-        /// <remarks>
-        /// This should not be called by client code. It is called by an <see cref="IFocusScope"/>
-        /// when it activates, e.g. when a Window is activated.
-        /// </remarks>
-        void SetFocusScope(IFocusScope scope);
+        void SetHasEffectiveFocus(bool value);
 
         event EventHandler FocusedElementChanged;
     }

--- a/src/Avalonia.Input/IFocusManager.cs
+++ b/src/Avalonia.Input/IFocusManager.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Input
     public interface IFocusManager
     {
         /// <summary>
-        /// Gets the currently focused <see cref="IInputElement"/>.
+        /// Gets the currently focused <see cref="IInputElement"/> or null if <see cref="HasEffectiveFocus"/> == false
         /// </summary>
         IInputElement FocusedElement { get; }
 
@@ -26,8 +26,15 @@ namespace Avalonia.Input
             NavigationMethod method = NavigationMethod.Unspecified,
             InputModifiers modifiers = InputModifiers.None);
 
-        void SetHasEffectiveFocus(bool value);
+        /// <summary>
+        /// Gets or sets a value indicating whether this particular focus manager instance
+        /// has the effective input focus (i. e. the associated window is currently active)
+        /// </summary>
+        bool HasEffectiveFocus {get; set; }
 
+        /// <summary>
+        /// Fires when FocusedElement is changed
+        /// </summary>
         event EventHandler FocusedElementChanged;
     }
 }

--- a/src/Avalonia.Input/IFocusScope.cs
+++ b/src/Avalonia.Input/IFocusScope.cs
@@ -1,9 +1,0 @@
-// Copyright (c) The Avalonia Project. All rights reserved.
-// Licensed under the MIT license. See licence.md file in the project root for full license information.
-
-namespace Avalonia.Input
-{
-    public interface IFocusScope
-    {
-    }
-}

--- a/src/Avalonia.Input/IInputDevice.cs
+++ b/src/Avalonia.Input/IInputDevice.cs
@@ -11,6 +11,7 @@ namespace Avalonia.Input
         /// Processes raw event. Is called after preprocessing by InputManager
         /// </summary>
         /// <param name="ev"></param>
-        void ProcessRawEvent(RawInputEventArgs ev);
+        /// <param name="focusedElement"></param>
+        void ProcessRawEvent(RawInputEventArgs ev, IInputElement focusedElement);
     }
 }

--- a/src/Avalonia.Input/IInputElement.cs
+++ b/src/Avalonia.Input/IInputElement.cs
@@ -113,6 +113,13 @@ namespace Avalonia.Input
         void Focus();
 
         /// <summary>
+        /// Focuses the control.
+        /// <param name="method">The method by which focus was changed.</param>
+        /// <param name="modifiers">Any input modifiers active at the time of focus.</param>
+        /// </summary>
+        void Focus(NavigationMethod method, InputModifiers modifiers = InputModifiers.None);
+
+        /// <summary>
         /// Gets the key bindings for the element.
         /// </summary>
         List<KeyBinding> KeyBindings { get; }

--- a/src/Avalonia.Input/IInputElement.cs
+++ b/src/Avalonia.Input/IInputElement.cs
@@ -109,15 +109,11 @@ namespace Avalonia.Input
 
         /// <summary>
         /// Focuses the control.
-        /// </summary>
-        bool Focus();
-
-        /// <summary>
-        /// Focuses the control.
         /// <param name="method">The method by which focus was changed.</param>
         /// <param name="modifiers">Any input modifiers active at the time of focus.</param>
         /// </summary>
-        bool Focus(NavigationMethod method, InputModifiers modifiers = InputModifiers.None);
+        bool Focus(NavigationMethod method = NavigationMethod.Unspecified,
+            InputModifiers modifiers = InputModifiers.None);
 
         /// <summary>
         /// Gets the key bindings for the element.

--- a/src/Avalonia.Input/IInputElement.cs
+++ b/src/Avalonia.Input/IInputElement.cs
@@ -110,14 +110,14 @@ namespace Avalonia.Input
         /// <summary>
         /// Focuses the control.
         /// </summary>
-        void Focus();
+        bool Focus();
 
         /// <summary>
         /// Focuses the control.
         /// <param name="method">The method by which focus was changed.</param>
         /// <param name="modifiers">Any input modifiers active at the time of focus.</param>
         /// </summary>
-        void Focus(NavigationMethod method, InputModifiers modifiers = InputModifiers.None);
+        bool Focus(NavigationMethod method, InputModifiers modifiers = InputModifiers.None);
 
         /// <summary>
         /// Gets the key bindings for the element.

--- a/src/Avalonia.Input/IInputManager.cs
+++ b/src/Avalonia.Input/IInputManager.cs
@@ -33,6 +33,6 @@ namespace Avalonia.Input
         /// Processes a raw input event.
         /// </summary>
         /// <param name="e">The raw input event.</param>
-        void ProcessInput(RawInputEventArgs e);
+        void ProcessInput(RawInputEventArgs e, IInputElement focusedElement);
     }
 }

--- a/src/Avalonia.Input/IInputRoot.cs
+++ b/src/Avalonia.Input/IInputRoot.cs
@@ -35,5 +35,10 @@ namespace Avalonia.Input
         /// </summary>
         [CanBeNull]
         IMouseDevice MouseDevice { get; }
+        
+        /// <summary>
+        /// Gets the focus manager
+        /// </summary>
+        IFocusManager FocusManager { get; }
     }
 }

--- a/src/Avalonia.Input/IKeyboardDevice.cs
+++ b/src/Avalonia.Input/IKeyboardDevice.cs
@@ -27,13 +27,8 @@ namespace Avalonia.Input
         Toggled = 2,
     }
 
-    public interface IKeyboardDevice : IInputDevice, INotifyPropertyChanged
+    public interface IKeyboardDevice : IInputDevice
     {
-        IInputElement FocusedElement { get; }
-
-        void SetFocusedElement(
-            IInputElement element, 
-            NavigationMethod method,
-            InputModifiers modifiers);
+        
     }
 }

--- a/src/Avalonia.Input/InputElement.cs
+++ b/src/Avalonia.Input/InputElement.cs
@@ -406,10 +406,14 @@ namespace Avalonia.Input
         /// <inheritdoc/>
         protected override void OnDetachedFromVisualTreeCore(VisualTreeAttachmentEventArgs e)
         {
+            // We are saving the instance here since we won't get any focus managers
+            // once control is actually detached
+            
+            var focusManager = this.GetFocusManager();
             base.OnDetachedFromVisualTreeCore(e);
             if (IsFocused)
             {
-                this.GetFocusManager()?.Focus(null);
+                focusManager?.Focus(null);
             }
         }
 

--- a/src/Avalonia.Input/InputElement.cs
+++ b/src/Avalonia.Input/InputElement.cs
@@ -399,17 +399,27 @@ namespace Avalonia.Input
         /// </summary>
         public void Focus()
         {
-            FocusManager.Instance?.Focus(this);
+            this.GetFocusManager()?.Focus(this);
+        }
+        
+        /// <summary>
+        /// Focuses the control.
+        /// <param name="method">The method by which focus was changed.</param>
+        /// <param name="modifiers">Any input modifiers active at the time of focus.</param>
+        /// </summary>
+        public void Focus(NavigationMethod method, InputModifiers modifiers = InputModifiers.None)
+        {
+            this.GetFocusManager()?.Focus(this, method, modifiers);
         }
 
         /// <inheritdoc/>
         protected override void OnDetachedFromVisualTreeCore(VisualTreeAttachmentEventArgs e)
         {
+            var focusManager = this.GetFocusManager();
             base.OnDetachedFromVisualTreeCore(e);
-
             if (IsFocused)
             {
-                FocusManager.Instance.Focus(null);
+                focusManager?.Focus(null);
             }
         }
 

--- a/src/Avalonia.Input/InputElement.cs
+++ b/src/Avalonia.Input/InputElement.cs
@@ -394,26 +394,22 @@ namespace Avalonia.Input
         public GestureRecognizerCollection GestureRecognizers
             => _gestureRecognizers ?? (_gestureRecognizers = new GestureRecognizerCollection(this));
 
-        /// <summary>
-        /// Focuses the control.
-        /// </summary>
-        public bool Focus() => this.GetFocusManager()?.Focus(this) == true;
 
         /// <summary>
         /// Focuses the control.
         /// <param name="method">The method by which focus was changed.</param>
         /// <param name="modifiers">Any input modifiers active at the time of focus.</param>
         /// </summary>
-        public bool Focus(NavigationMethod method, InputModifiers modifiers = InputModifiers.None) => this.GetFocusManager()?.Focus(this, method, modifiers) == true;
+        public bool Focus(NavigationMethod method = NavigationMethod.Unspecified,
+            InputModifiers modifiers = InputModifiers.None) => this.GetFocusManager()?.Focus(this, method, modifiers) == true;
 
         /// <inheritdoc/>
         protected override void OnDetachedFromVisualTreeCore(VisualTreeAttachmentEventArgs e)
         {
-            var focusManager = this.GetFocusManager();
             base.OnDetachedFromVisualTreeCore(e);
             if (IsFocused)
             {
-                focusManager?.Focus(null);
+                this.GetFocusManager()?.Focus(null);
             }
         }
 

--- a/src/Avalonia.Input/InputElement.cs
+++ b/src/Avalonia.Input/InputElement.cs
@@ -397,20 +397,14 @@ namespace Avalonia.Input
         /// <summary>
         /// Focuses the control.
         /// </summary>
-        public void Focus()
-        {
-            this.GetFocusManager()?.Focus(this);
-        }
-        
+        public bool Focus() => this.GetFocusManager()?.Focus(this) == true;
+
         /// <summary>
         /// Focuses the control.
         /// <param name="method">The method by which focus was changed.</param>
         /// <param name="modifiers">Any input modifiers active at the time of focus.</param>
         /// </summary>
-        public void Focus(NavigationMethod method, InputModifiers modifiers = InputModifiers.None)
-        {
-            this.GetFocusManager()?.Focus(this, method, modifiers);
-        }
+        public bool Focus(NavigationMethod method, InputModifiers modifiers = InputModifiers.None) => this.GetFocusManager()?.Focus(this, method, modifiers) == true;
 
         /// <inheritdoc/>
         protected override void OnDetachedFromVisualTreeCore(VisualTreeAttachmentEventArgs e)

--- a/src/Avalonia.Input/InputExtensions.cs
+++ b/src/Avalonia.Input/InputExtensions.cs
@@ -48,5 +48,19 @@ namespace Avalonia.Input
                    element.IsEnabledCore &&
                    element.IsAttachedToVisualTree;
         }
+        
+        /// <summary>
+        /// Gets the IFocusManager instance for an <see cref="IVisual"/>.
+        /// </summary>
+        /// <param name="visual">The visual.</param>
+        /// <returns>
+        /// The focus manager or null if the visual is not rooted.
+        /// </returns>
+        public static IFocusManager GetFocusManager(this IVisual visual)
+        {
+            Contract.Requires<ArgumentNullException>(visual != null);
+
+            return (visual as IInputRoot ?? visual.VisualRoot as IInputRoot)?.FocusManager;
+        }
     }
 }

--- a/src/Avalonia.Input/InputExtensions.cs
+++ b/src/Avalonia.Input/InputExtensions.cs
@@ -50,7 +50,7 @@ namespace Avalonia.Input
         }
         
         /// <summary>
-        /// Gets the IFocusManager instance for an <see cref="IVisual"/>.
+        /// Gets the <see cref="IFocusManager"/> instance for an <see cref="IVisual"/>.
         /// </summary>
         /// <param name="visual">The visual.</param>
         /// <returns>

--- a/src/Avalonia.Input/InputManager.cs
+++ b/src/Avalonia.Input/InputManager.cs
@@ -32,10 +32,10 @@ namespace Avalonia.Input
         public IObservable<RawInputEventArgs> PostProcess => _postProcess;
 
         /// <inheritdoc/>
-        public void ProcessInput(RawInputEventArgs e)
+        public void ProcessInput(RawInputEventArgs e, IInputElement focusedElement)
         {
             _preProcess.OnNext(e);
-            e.Device?.ProcessRawEvent(e);
+            e.Device?.ProcessRawEvent(e, focusedElement);
             _process.OnNext(e);
             _postProcess.OnNext(e);
         }

--- a/src/Avalonia.Input/KeyboardDevice.cs
+++ b/src/Avalonia.Input/KeyboardDevice.cs
@@ -9,68 +9,13 @@ using Avalonia.VisualTree;
 
 namespace Avalonia.Input
 {
-    public class KeyboardDevice : IKeyboardDevice, INotifyPropertyChanged
+    public class KeyboardDevice : IKeyboardDevice
     {
-        private IInputElement _focusedElement;
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        public static IKeyboardDevice Instance => AvaloniaLocator.Current.GetService<IKeyboardDevice>();
-
-        public IInputManager InputManager => AvaloniaLocator.Current.GetService<IInputManager>();
-
-        public IFocusManager FocusManager => AvaloniaLocator.Current.GetService<IFocusManager>();
-
-        public IInputElement FocusedElement
-        {
-            get
-            {
-                return _focusedElement;
-            }
-
-            private set
-            {
-                _focusedElement = value;
-                RaisePropertyChanged();
-            }
-        }
-
-        public void SetFocusedElement(
-            IInputElement element, 
-            NavigationMethod method,
-            InputModifiers modifiers)
-        {
-            if (element != FocusedElement)
-            {
-                var interactive = FocusedElement as IInteractive;
-                FocusedElement = element;
-
-                interactive?.RaiseEvent(new RoutedEventArgs
-                {
-                    RoutedEvent = InputElement.LostFocusEvent,
-                });
-
-                interactive = element as IInteractive;
-
-                interactive?.RaiseEvent(new GotFocusEventArgs
-                {
-                    RoutedEvent = InputElement.GotFocusEvent,
-                    NavigationMethod = method,
-                    InputModifiers = modifiers,
-                });
-            }
-        }
-
-        protected void RaisePropertyChanged([CallerMemberName] string propertyName = "")
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        public void ProcessRawEvent(RawInputEventArgs e)
+        public void ProcessRawEvent(RawInputEventArgs e, IInputElement focusedElement)
         {
             if(e.Handled)
                 return;
-            IInputElement element = FocusedElement;
+            IInputElement element = focusedElement;
 
             if (element != null)
             {

--- a/src/Avalonia.Input/KeyboardNavigationHandler.cs
+++ b/src/Avalonia.Input/KeyboardNavigationHandler.cs
@@ -109,7 +109,7 @@ namespace Avalonia.Input
                 var method = direction == NavigationDirection.Next ||
                              direction == NavigationDirection.Previous ?
                              NavigationMethod.Tab : NavigationMethod.Directional;
-                FocusManager.Instance.Focus(next, method, modifiers);
+                next.Focus(method, modifiers);
             }
         }
 
@@ -120,7 +120,7 @@ namespace Avalonia.Input
         /// <param name="e">The event args.</param>
         protected virtual void OnKeyDown(object sender, KeyEventArgs e)
         {
-            var current = FocusManager.Instance.Current;
+            var current = (sender as IInputElement).GetFocusManager()?.FocusedElement;
 
             if (current != null && e.Key == Key.Tab)
             {

--- a/src/Avalonia.Input/MouseDevice.cs
+++ b/src/Avalonia.Input/MouseDevice.cs
@@ -80,7 +80,7 @@ namespace Avalonia.Input
             return rootPoint * transform.Value;
         }
 
-        public void ProcessRawEvent(RawInputEventArgs e)
+        public void ProcessRawEvent(RawInputEventArgs e, IInputElement focusedElement)
         {
             if (!e.Handled && e is RawPointerEventArgs margs)
                 ProcessRawEvent(margs);

--- a/src/Avalonia.Input/PointerEventArgs.cs
+++ b/src/Avalonia.Input/PointerEventArgs.cs
@@ -41,7 +41,7 @@ namespace Avalonia.Input
                 _ev = ev;
             }
             
-            public void ProcessRawEvent(RawInputEventArgs ev) => throw new NotSupportedException();
+            public void ProcessRawEvent(RawInputEventArgs ev, IInputElement focusedElement) => throw new NotSupportedException();
 
             public IInputElement Captured => _ev.Pointer.Captured;
             public void Capture(IInputElement control)

--- a/src/Avalonia.Input/TouchDevice.cs
+++ b/src/Avalonia.Input/TouchDevice.cs
@@ -25,7 +25,7 @@ namespace Avalonia.Input
             return modifiers;
         }
         
-        public void ProcessRawEvent(RawInputEventArgs ev)
+        public void ProcessRawEvent(RawInputEventArgs ev, IInputElement focusedElement)
         {
             var args = (RawTouchEventArgs)ev;
             if (!_pointers.TryGetValue(args.TouchPointId, out var pointer))

--- a/src/Avalonia.Native/AvaloniaNativePlatform.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatform.cs
@@ -75,8 +75,6 @@ namespace Avalonia.Native
                 .ToConstant(new PlatformThreadingInterface(_factory.CreatePlatformThreadingInterface()))
                 .Bind<IStandardCursorFactory>().ToConstant(new CursorFactory(_factory.CreateCursorFactory()))
                 .Bind<IPlatformIconLoader>().ToSingleton<IconLoader>()
-                .Bind<IKeyboardDevice>().ToConstant(KeyboardDevice)
-                .Bind<IMouseDevice>().ToConstant(MouseDevice)
                 .Bind<IPlatformSettings>().ToConstant(this)
                 .Bind<IWindowingPlatform>().ToConstant(this)
                 .Bind<IClipboard>().ToConstant(new ClipboardImpl(_factory.CreateClipboard()))

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -23,8 +23,6 @@ namespace Avalonia.Native
         private object _syncRoot = new object();
         private bool _deferredRendering = false;
         private bool _gpu = false;
-        private readonly IMouseDevice _mouse;
-        private readonly IKeyboardDevice _keyboard;
         private readonly IStandardCursorFactory _cursorFactory;
         private Size _savedLogicalSize;
         private Size _lastRenderedLogicalSize;
@@ -36,8 +34,6 @@ namespace Avalonia.Native
             _gpu = opts.UseGpu;
             _deferredRendering = opts.UseDeferredRendering;
 
-            _keyboard = AvaloniaLocator.Current.GetService<IKeyboardDevice>();
-            _mouse = AvaloniaLocator.Current.GetService<IMouseDevice>();
             _cursorFactory = AvaloniaLocator.Current.GetService<IStandardCursorFactory>();
         }
 
@@ -91,6 +87,7 @@ namespace Avalonia.Native
         public Action<Size> Resized { get; set; }
         public Action Closed { get; set; }
         public IMouseDevice MouseDevice => AvaloniaNativePlatform.MouseDevice;
+        public IKeyboardDevice KeyboardDevice => AvaloniaNativePlatform.KeyboardDevice;
 
 
         class FramebufferWrapper : ILockedFramebuffer
@@ -197,7 +194,7 @@ namespace Avalonia.Native
         {
             Dispatcher.UIThread.RunJobs(DispatcherPriority.Input + 1);
 
-            var args = new RawTextInputEventArgs(_keyboard, timeStamp, text);
+            var args = new RawTextInputEventArgs(KeyboardDevice, timeStamp, text);
 
             Input?.Invoke(args);
 
@@ -208,7 +205,7 @@ namespace Avalonia.Native
         {
             Dispatcher.UIThread.RunJobs(DispatcherPriority.Input + 1);
 
-            var args = new RawKeyEventArgs(_keyboard, timeStamp, (RawKeyEventType)type, (Key)key, (InputModifiers)modifiers);
+            var args = new RawKeyEventArgs(KeyboardDevice, timeStamp, (RawKeyEventType)type, (Key)key, (InputModifiers)modifiers);
 
             Input?.Invoke(args);
 
@@ -222,11 +219,11 @@ namespace Avalonia.Native
             switch (type)
             {
                 case AvnRawMouseEventType.Wheel:
-                    Input?.Invoke(new RawMouseWheelEventArgs(_mouse, timeStamp, _inputRoot, point.ToAvaloniaPoint(), new Vector(delta.X, delta.Y), (InputModifiers)modifiers));
+                    Input?.Invoke(new RawMouseWheelEventArgs(MouseDevice, timeStamp, _inputRoot, point.ToAvaloniaPoint(), new Vector(delta.X, delta.Y), (InputModifiers)modifiers));
                     break;
 
                 default:
-                    Input?.Invoke(new RawPointerEventArgs(_mouse, timeStamp, _inputRoot, (RawPointerEventType)type, point.ToAvaloniaPoint(), (InputModifiers)modifiers));
+                    Input?.Invoke(new RawPointerEventArgs(MouseDevice, timeStamp, _inputRoot, (RawPointerEventType)type, point.ToAvaloniaPoint(), (InputModifiers)modifiers));
                     break;
             }
         }

--- a/src/Avalonia.Visuals/VisualTree/VisualExtensions.cs
+++ b/src/Avalonia.Visuals/VisualTree/VisualExtensions.cs
@@ -215,7 +215,7 @@ namespace Avalonia.VisualTree
 
             return visual as IRenderRoot ?? visual.VisualRoot;
         }
-
+        
         /// <summary>
         /// Tests whether an <see cref="IVisual"/> is an ancestor of another visual.
         /// </summary>

--- a/src/Avalonia.X11/X11Platform.cs
+++ b/src/Avalonia.X11/X11Platform.cs
@@ -43,7 +43,6 @@ namespace Avalonia.X11
                 .Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(60))
                 .Bind<IRenderLoop>().ToConstant(new RenderLoop())
                 .Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration(InputModifiers.Control))
-                .Bind<IKeyboardDevice>().ToFunc(() => KeyboardDevice)
                 .Bind<IStandardCursorFactory>().ToConstant(new X11CursorFactory(Display))
                 .Bind<IClipboard>().ToConstant(new X11Clipboard(this))
                 .Bind<IPlatformSettings>().ToConstant(new PlatformSettingsStub())

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -782,6 +782,7 @@ namespace Avalonia.X11
         }
 
         public IMouseDevice MouseDevice => _mouse;
+        public IKeyboardDevice KeyboardDevice => _keyboard;
        
         public void Activate()
         {

--- a/src/Gtk/Avalonia.Gtk3/Gtk3Platform.cs
+++ b/src/Gtk/Avalonia.Gtk3/Gtk3Platform.cs
@@ -75,7 +75,6 @@ namespace Avalonia.Gtk3
             AvaloniaLocator.CurrentMutable.Bind<IWindowingPlatform>().ToConstant(Instance)
                 .Bind<IClipboard>().ToSingleton<ClipboardImpl>()
                 .Bind<IStandardCursorFactory>().ToConstant(new CursorFactory())
-                .Bind<IKeyboardDevice>().ToConstant(Keyboard)
                 .Bind<IPlatformSettings>().ToConstant(Instance)
                 .Bind<IPlatformThreadingInterface>().ToConstant(Instance)
                 .Bind<ISystemDialogImpl>().ToSingleton<SystemDialog>()

--- a/src/Gtk/Avalonia.Gtk3/WindowBaseImpl.cs
+++ b/src/Gtk/Avalonia.Gtk3/WindowBaseImpl.cs
@@ -368,6 +368,7 @@ namespace Avalonia.Gtk3
         } 
 
         public IMouseDevice MouseDevice => Gtk3Platform.Mouse;
+        public IKeyboardDevice KeyboardDevice => Gtk3Platform.Keyboard;
 
         public double Scaling => LastKnownScaleFactor = (int) (Native.GtkWidgetGetScaleFactor?.Invoke(GtkWidget) ?? 1);
 

--- a/src/Linux/Avalonia.LinuxFramebuffer/FramebufferToplevelImpl.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/FramebufferToplevelImpl.cs
@@ -61,6 +61,7 @@ namespace Avalonia.LinuxFramebuffer
 
         public Size ClientSize => _fb.PixelSize;
         public IMouseDevice MouseDevice => LinuxFramebufferPlatform.MouseDevice;
+        public IKeyboardDevice KeyboardDevice => LinuxFramebufferPlatform.KeyboardDevice;
         public double Scaling => 1;
         public IEnumerable<object> Surfaces => new object[] {_fb};
         public Action<RawInputEventArgs> Input { get; set; }

--- a/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
@@ -33,7 +33,6 @@ namespace Avalonia.LinuxFramebuffer
             Threading = new InternalPlatformThreadingInterface();
             AvaloniaLocator.CurrentMutable
                 .Bind<IStandardCursorFactory>().ToTransient<CursorFactoryStub>()
-                .Bind<IKeyboardDevice>().ToConstant(KeyboardDevice)
                 .Bind<IPlatformSettings>().ToSingleton<PlatformSettings>()
                 .Bind<IPlatformThreadingInterface>().ToConstant(Threading)
                 .Bind<IRenderLoop>().ToConstant(new RenderLoop())

--- a/src/Windows/Avalonia.Win32.Interop/WinForms/WinFormsAvaloniaControlHost.cs
+++ b/src/Windows/Avalonia.Win32.Interop/WinForms/WinFormsAvaloniaControlHost.cs
@@ -22,7 +22,7 @@ namespace Avalonia.Win32.Embedding
             UnmanagedMethods.SetParent(WindowHandle, Handle);
             _root.Prepare();
             if (_root.IsFocused)
-                FocusManager.Instance.Focus(null);
+                _root.FocusManager.Focus(null);
             _root.GotFocus += RootGotFocus;
             // ReSharper disable once PossibleNullReferenceException
             // Always non-null at this point
@@ -38,14 +38,14 @@ namespace Avalonia.Win32.Embedding
 
         void Unfocus()
         {
-            var focused = (IVisual)FocusManager.Instance.Current;
+            var focused = (IVisual)_root.FocusManager.FocusedElement;
             if (focused == null)
                 return;
             while (focused.VisualParent != null)
                 focused = focused.VisualParent;
 
             if (focused == _root)
-                KeyboardDevice.Instance.SetFocusedElement(null, NavigationMethod.Unspecified, InputModifiers.None);
+                _root.FocusManager.Focus(null);
         }
 
         private void PlatformImpl_LostFocus()

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
@@ -60,7 +60,7 @@ namespace Avalonia.Win32.Interop.Wpf
             _ttl = this;
             _surfaces = new object[] {new WritableBitmapSurface(this), new Direct2DImageSurface(this)};
             _mouse = new WpfMouseDevice(this);
-            _keyboard = AvaloniaLocator.Current.GetService<IKeyboardDevice>();
+            _keyboard = new Avalonia.Input.KeyboardDevice();
 
             ControlRoot = new CustomControlRoot(this);
             SnapsToDevicePixels = true;
@@ -100,6 +100,7 @@ namespace Avalonia.Win32.Interop.Wpf
 
         Size ITopLevelImpl.ClientSize => _finalSize;
         IMouseDevice ITopLevelImpl.MouseDevice => _mouse;
+        IKeyboardDevice ITopLevelImpl.KeyboardDevice => _keyboard;
 
         double ITopLevelImpl.Scaling => PresentationSource.FromVisual(this)?.CompositionTarget?.TransformToDevice.M11 ?? 1;
 

--- a/src/Windows/Avalonia.Win32/Input/WindowsKeyboardDevice.cs
+++ b/src/Windows/Avalonia.Win32/Input/WindowsKeyboardDevice.cs
@@ -44,12 +44,7 @@ namespace Avalonia.Win32.Input
                 return result;
             }
         }
-
-        public void WindowActivated(Window window)
-        {
-            SetFocusedElement(window, NavigationMethod.Unspecified, InputModifiers.None);
-        }
-
+        
         public string StringFromVirtualKey(uint virtualKey)
         {
             StringBuilder result = new StringBuilder(256);

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -80,7 +80,6 @@ namespace Avalonia.Win32
             AvaloniaLocator.CurrentMutable
                 .Bind<IClipboard>().ToSingleton<ClipboardImpl>()
                 .Bind<IStandardCursorFactory>().ToConstant(CursorFactory.Instance)
-                .Bind<IKeyboardDevice>().ToConstant(WindowsKeyboardDevice.Instance)
                 .Bind<IPlatformSettings>().ToConstant(s_instance)
                 .Bind<IPlatformThreadingInterface>().ToConstant(s_instance)
                 .Bind<IRenderLoop>().ToConstant(new RenderLoop())

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -206,6 +206,7 @@ namespace Avalonia.Win32
         }
 
         public IMouseDevice MouseDevice => WindowsMouseDevice.Instance;
+        public IKeyboardDevice KeyboardDevice => WindowsKeyboardDevice.Instance;
 
         public WindowState WindowState
         {

--- a/src/iOS/Avalonia.iOS/TopLevelImpl.cs
+++ b/src/iOS/Avalonia.iOS/TopLevelImpl.cs
@@ -21,9 +21,8 @@ namespace Avalonia.iOS
 
         public TopLevelImpl()
         {
-            _keyboardHelper = new KeyboardEventsHelper<TopLevelImpl>(this);
+            _keyboardHelper = new KeyboardEventsHelper<TopLevelImpl>(this, KeyboardDevice);
             AutoresizingMask = UIViewAutoresizing.All;
-            _keyboardHelper.ActivateAutoShowKeyboard();
         }
 
         [Export("hasText")]
@@ -53,6 +52,7 @@ namespace Avalonia.iOS
         public Size ClientSize => Bounds.Size.ToAvalonia();
 
         public IMouseDevice MouseDevice => iOSPlatform.MouseDevice;
+        public IKeyboardDevice KeyboardDevice => iOSPlatform.KeyboardDevice;
 
         public IRenderer CreateRenderer(IRenderRoot root)
         {
@@ -66,7 +66,11 @@ namespace Avalonia.iOS
 
         public void Invalidate(Rect rect) => SetNeedsDisplay();
 
-        public void SetInputRoot(IInputRoot inputRoot) => _inputRoot = inputRoot;
+        public void SetInputRoot(IInputRoot inputRoot)
+        {
+            _inputRoot = inputRoot;
+            _keyboardHelper.FocusManager = inputRoot.FocusManager;
+        }
 
         public Point PointToClient(PixelPoint point) => point.ToPoint(1);
 

--- a/src/iOS/Avalonia.iOS/iOSPlatform.cs
+++ b/src/iOS/Avalonia.iOS/iOSPlatform.cs
@@ -36,7 +36,6 @@ namespace Avalonia.iOS
                 // TODO: what does this look like for iOS??
                 //.Bind<ISystemDialogImpl>().ToTransient<SystemDialogImpl>()
                 .Bind<IStandardCursorFactory>().ToTransient<CursorFactory>()
-                .Bind<IKeyboardDevice>().ToConstant(KeyboardDevice)
                 .Bind<IPlatformSettings>().ToSingleton<PlatformSettings>()
                 .Bind<IPlatformThreadingInterface>().ToConstant(PlatformThreadingInterface.Instance)
                 .Bind<IPlatformIconLoader>().ToSingleton<PlatformIconLoader>()

--- a/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
@@ -526,7 +526,7 @@ namespace Avalonia.Controls.UnitTests
 
                 Assert.Equal(
                     target.Presenter.Panel.Children[1],
-                    FocusManager.Instance.Current);
+                    target.GetFocusManager()?.FocusedElement);
             }
         }
 
@@ -562,7 +562,7 @@ namespace Avalonia.Controls.UnitTests
 
                 Assert.Equal(
                     target.Presenter.Panel.Children[2],
-                    FocusManager.Instance.Current);
+                    target.GetFocusManager().FocusedElement);
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/Platform/DefaultMenuInteractionHandlerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Platform/DefaultMenuInteractionHandlerTests.cs
@@ -240,7 +240,7 @@ namespace Avalonia.Controls.UnitTests.Platform
                 target.KeyDown(item, e);
                 
                 Mock.Get(parentItem).Verify(x => x.Close());
-                Mock.Get(parentItem).Verify(x => x.Focus());
+                Mock.Get(parentItem).Verify(x => x.Focus(NavigationMethod.Unspecified, InputModifiers.None));
                 Assert.True(e.Handled);
             }
 
@@ -331,7 +331,7 @@ namespace Avalonia.Controls.UnitTests.Platform
                 target.KeyDown(item, e);
 
                 Mock.Get(parentItem).Verify(x => x.Close());
-                Mock.Get(parentItem).Verify(x => x.Focus());
+                Mock.Get(parentItem).Verify(x => x.Focus(NavigationMethod.Unspecified, InputModifiers.None));
                 Assert.True(e.Handled);
             }
 

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -445,7 +445,6 @@ namespace Avalonia.Controls.UnitTests
         }
 
         private static TestServices FocusServices => TestServices.MockThreadingInterface.With(
-            focusManager: new FocusManager(),
             keyboardDevice: () => new KeyboardDevice(),
             keyboardNavigation: new KeyboardNavigationHandler(),
             inputManager: new InputManager(),

--- a/tests/Avalonia.Controls.UnitTests/TopLevelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TopLevelTests.cs
@@ -186,7 +186,7 @@ namespace Avalonia.Controls.UnitTests
                     Key.A, InputModifiers.None);
                 impl.Object.Input(input);
 
-                inputManagerMock.Verify(x => x.ProcessInput(input));
+                inputManagerMock.Verify(x => x.ProcessInput(input, null));
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
@@ -572,7 +572,6 @@ namespace Avalonia.Controls.UnitTests
         {
             using (UnitTestApplication.Start(TestServices.RealFocus))
             {
-                var focus = FocusManager.Instance;
                 var navigation = AvaloniaLocator.Current.GetService<IKeyboardNavigationHandler>();
                 var data = CreateTestTreeData();
 
@@ -591,6 +590,7 @@ namespace Avalonia.Controls.UnitTests
                         Children = { target, button },
                     }
                 };
+                var focus = root.GetFocusManager();
 
                 CreateNodeDataTemplate(target);
                 ApplyTemplates(target);
@@ -601,13 +601,13 @@ namespace Avalonia.Controls.UnitTests
 
                 target.SelectedItem = item;
                 node.Focus();
-                Assert.Same(node, focus.Current);
+                Assert.Same(node, focus.FocusedElement);
 
-                navigation.Move(focus.Current, NavigationDirection.Next);
-                Assert.Same(button, focus.Current);
+                navigation.Move(focus.FocusedElement, NavigationDirection.Next);
+                Assert.Same(button, focus.FocusedElement);
 
-                navigation.Move(focus.Current, NavigationDirection.Next);
-                Assert.Same(node, focus.Current);
+                navigation.Move(focus.FocusedElement, NavigationDirection.Next);
+                Assert.Same(node, focus.FocusedElement);
             }
         }
 

--- a/tests/Avalonia.Input.UnitTests/InputElement_Focus.cs
+++ b/tests/Avalonia.Input.UnitTests/InputElement_Focus.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Input.UnitTests
 
                 target.Focus();
 
-                Assert.Same(target, FocusManager.Instance.Current);
+                Assert.Same(target, target.GetFocusManager().FocusedElement);
             }
         }
 
@@ -42,7 +42,8 @@ namespace Avalonia.Input.UnitTests
                 target.Focus();
                 root.Child = null;
 
-                Assert.Null(FocusManager.Instance.Current);
+                Assert.Null(root.GetFocusManager().FocusedElement);
+                Assert.False(target.IsFocused);
             }
         }
     }

--- a/tests/Avalonia.Input.UnitTests/MouseDeviceTests.cs
+++ b/tests/Avalonia.Input.UnitTests/MouseDeviceTests.cs
@@ -231,7 +231,7 @@ namespace Avalonia.Input.UnitTests
                 root,
                 RawPointerEventType.Move,
                 p,
-                InputModifiers.None));
+                InputModifiers.None), null);
         }
 
         private void SetHit(Mock<IRenderer> renderer, IControl hit)

--- a/tests/Avalonia.UnitTests/TestRoot.cs
+++ b/tests/Avalonia.UnitTests/TestRoot.cs
@@ -20,7 +20,7 @@ namespace Avalonia.UnitTests
         public TestRoot()
         {
             FocusManager = new FocusManager(this);
-            FocusManager.SetHasEffectiveFocus(true);
+            FocusManager.HasEffectiveFocus = true;
             Renderer = Mock.Of<IRenderer>();
         }
 

--- a/tests/Avalonia.UnitTests/TestRoot.cs
+++ b/tests/Avalonia.UnitTests/TestRoot.cs
@@ -19,6 +19,7 @@ namespace Avalonia.UnitTests
 
         public TestRoot()
         {
+            FocusManager = new FocusManager(this);
             Renderer = Mock.Of<IRenderer>();
         }
 
@@ -63,6 +64,7 @@ namespace Avalonia.UnitTests
         public IInputElement PointerOverElement { get; set; }
 
         public IMouseDevice MouseDevice { get; set; }
+        public IFocusManager FocusManager { get; }
 
         public bool ShowAccessKeys { get; set; }
 

--- a/tests/Avalonia.UnitTests/TestRoot.cs
+++ b/tests/Avalonia.UnitTests/TestRoot.cs
@@ -13,13 +13,14 @@ using Moq;
 
 namespace Avalonia.UnitTests
 {
-    public class TestRoot : Decorator, IFocusScope, ILayoutRoot, IInputRoot, INameScope, IRenderRoot, IStyleRoot
+    public class TestRoot : Decorator, ILayoutRoot, IInputRoot, INameScope, IRenderRoot, IStyleRoot
     {
         private readonly NameScope _nameScope = new NameScope();
 
         public TestRoot()
         {
             FocusManager = new FocusManager(this);
+            FocusManager.SetHasEffectiveFocus(true);
             Renderer = Mock.Of<IRenderer>();
         }
 

--- a/tests/Avalonia.UnitTests/TestServices.cs
+++ b/tests/Avalonia.UnitTests/TestServices.cs
@@ -48,8 +48,6 @@ namespace Avalonia.UnitTests
             windowingPlatform: new MockWindowingPlatform());
 
         public static readonly TestServices RealFocus = new TestServices(
-            focusManager: new FocusManager(),
-            keyboardDevice: () => new KeyboardDevice(),
             keyboardNavigation: new KeyboardNavigationHandler(),
             inputManager: new InputManager());
         
@@ -58,10 +56,8 @@ namespace Avalonia.UnitTests
 
         public TestServices(
             IAssetLoader assetLoader = null,
-            IFocusManager focusManager = null,
             IGlobalClock globalClock = null,
             IInputManager inputManager = null,
-            Func<IKeyboardDevice> keyboardDevice = null,
             IKeyboardNavigationHandler keyboardNavigation = null,
             Func<IMouseDevice> mouseDevice = null,
             IRuntimePlatform platform = null,
@@ -76,10 +72,8 @@ namespace Avalonia.UnitTests
             IWindowingPlatform windowingPlatform = null)
         {
             AssetLoader = assetLoader;
-            FocusManager = focusManager;
             GlobalClock = globalClock;
             InputManager = inputManager;
-            KeyboardDevice = keyboardDevice;
             KeyboardNavigation = keyboardNavigation;
             MouseDevice = mouseDevice;
             Platform = platform;
@@ -95,9 +89,7 @@ namespace Avalonia.UnitTests
 
         public IAssetLoader AssetLoader { get; }
         public IInputManager InputManager { get; }
-        public IFocusManager FocusManager { get; }
         public IGlobalClock GlobalClock { get; }
-        public Func<IKeyboardDevice> KeyboardDevice { get; }
         public IKeyboardNavigationHandler KeyboardNavigation { get; }
         public Func<IMouseDevice> MouseDevice { get; }
         public IRuntimePlatform Platform { get; }
@@ -112,7 +104,6 @@ namespace Avalonia.UnitTests
 
         public TestServices With(
             IAssetLoader assetLoader = null,
-            IFocusManager focusManager = null,
             IGlobalClock globalClock = null,
             IInputManager inputManager = null,
             Func<IKeyboardDevice> keyboardDevice = null,
@@ -131,10 +122,8 @@ namespace Avalonia.UnitTests
         {
             return new TestServices(
                 assetLoader: assetLoader ?? AssetLoader,
-                focusManager: focusManager ?? FocusManager,
                 globalClock: globalClock ?? GlobalClock,
                 inputManager: inputManager ?? InputManager,
-                keyboardDevice: keyboardDevice ?? KeyboardDevice,
                 keyboardNavigation: keyboardNavigation ?? KeyboardNavigation,
                 mouseDevice: mouseDevice ?? MouseDevice,
                 platform: platform ?? Platform,

--- a/tests/Avalonia.UnitTests/UnitTestApplication.cs
+++ b/tests/Avalonia.UnitTests/UnitTestApplication.cs
@@ -52,11 +52,9 @@ namespace Avalonia.UnitTests
         {
             AvaloniaLocator.CurrentMutable
                 .Bind<IAssetLoader>().ToConstant(Services.AssetLoader)
-                .Bind<IFocusManager>().ToConstant(Services.FocusManager)
                 .Bind<IGlobalClock>().ToConstant(Services.GlobalClock)
                 .BindToSelf<IGlobalStyles>(this)
                 .Bind<IInputManager>().ToConstant(Services.InputManager)
-                .Bind<IKeyboardDevice>().ToConstant(Services.KeyboardDevice?.Invoke())
                 .Bind<IKeyboardNavigationHandler>().ToConstant(Services.KeyboardNavigation)
                 .Bind<IMouseDevice>().ToConstant(Services.MouseDevice?.Invoke())
                 .Bind<IRuntimePlatform>().ToConstant(Services.Platform)


### PR DESCRIPTION
That's mostly needed for upcoming input methods support. Also, reduces the number of global variables.


Problems:

- not sure how to hide caret when window is deactivated
- breaking change