### PR TITLE
Add ViewModelViewHost and AutoDataTemplateBindingHook

### DIFF
--- a/src/Avalonia.ReactiveUI/AppBuilderExtensions.cs
+++ b/src/Avalonia.ReactiveUI/AppBuilderExtensions.cs
@@ -21,9 +21,8 @@ namespace Avalonia.ReactiveUI
             return builder.AfterSetup(_ =>
             {
                 RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
-                Locator.CurrentMutable.Register(
-                    () => new AvaloniaActivationForViewFetcher(), 
-                    typeof(IActivationForViewFetcher));
+                Locator.CurrentMutable.RegisterConstant(new AvaloniaActivationForViewFetcher(), typeof(IActivationForViewFetcher));
+                Locator.CurrentMutable.RegisterConstant(new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));
             });
         }
     }

--- a/src/Avalonia.ReactiveUI/AutoDataTemplateBindingHook.cs
+++ b/src/Avalonia.ReactiveUI/AutoDataTemplateBindingHook.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
 using Avalonia.Controls;
+using Avalonia.Controls.Templates;
+using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
 using Avalonia.Markup.Xaml.Templates;
 using ReactiveUI;
@@ -14,19 +16,18 @@ namespace Avalonia.ReactiveUI
     /// </summary>
     public class AutoDataTemplateBindingHook : IPropertyBindingHook
     {
-        private static Lazy<DataTemplate> DefaultItemTemplate { get; } = new Lazy<DataTemplate>(() =>
+        private static Lazy<FuncDataTemplate> DefaultItemTemplate { get; } = new Lazy<FuncDataTemplate>(() =>
         {
-            var template = @"
-<DataTemplate xmlns='https://github.com/avaloniaui'
-              xmlns:reactiveUi='http://reactiveui.net'>
-    <reactiveUi:ViewModelViewHost
-        ViewModel='{Binding Mode=OneWay}'
-        VerticalContentAlignment='Stretch'
-        HorizontalContentAlignment='Stretch' />
-</DataTemplate>";
-            
-            var loader = new AvaloniaXamlLoader();
-            return (DataTemplate)loader.Load(template);
+            return new FuncDataTemplate<object>(x =>
+            {
+                var control = new ViewModelViewHost();
+                var context = control.GetObservable(Control.DataContextProperty);
+                control.Bind(ViewModelViewHost.ViewModelProperty, context);
+                control.HorizontalContentAlignment = HorizontalAlignment.Stretch;
+                control.VerticalContentAlignment = VerticalAlignment.Stretch;
+                return control;
+            },
+            true);
         });
 
         /// <inheritdoc/>

--- a/src/Avalonia.ReactiveUI/AutoDataTemplateBindingHook.cs
+++ b/src/Avalonia.ReactiveUI/AutoDataTemplateBindingHook.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Markup.Xaml.Templates;
+using ReactiveUI;
+
+namespace Avalonia.ReactiveUI
+{
+    /// <summary>
+    /// AutoDataTemplateBindingHook is a binding hook that checks ItemsControls
+    /// that don't have DataTemplates, and assigns a default DataTemplate that
+    /// loads the View associated with each ViewModel.
+    /// </summary>
+    public class AutoDataTemplateBindingHook : IPropertyBindingHook
+    {
+        private static Lazy<DataTemplate> DefaultItemTemplate { get; } = new Lazy<DataTemplate>(() =>
+        {
+            var template = @"
+<DataTemplate xmlns='https://github.com/avaloniaui'
+              xmlns:reactiveUi='http://reactiveui.net'>
+    <reactiveUi:ViewModelViewHost
+        ViewModel='{Binding Mode=OneWay}'
+        VerticalContentAlignment='Stretch'
+        HorizontalContentAlignment='Stretch' />
+</DataTemplate>";
+            
+            var loader = new AvaloniaXamlLoader();
+            return (DataTemplate)loader.Load(template);
+        });
+
+        /// <inheritdoc/>
+        public bool ExecuteHook(
+            object source, object target,
+            Func<IObservedChange<object, object>[]> getCurrentViewModelProperties,
+            Func<IObservedChange<object, object>[]> getCurrentViewProperties,
+            BindingDirection direction)
+        {
+            var viewProperties = getCurrentViewProperties();
+            var lastViewProperty = viewProperties.LastOrDefault();
+            if (lastViewProperty == null)
+                return true;
+            
+            var itemsControl = lastViewProperty.Sender as ItemsControl;
+            if (itemsControl == null)
+                return true;
+
+            var propertyName = viewProperties.Last().GetPropertyName();
+            if (propertyName != "Items" &&
+                propertyName != "ItemsSource")
+                return true;
+            
+            if (itemsControl.ItemTemplate != null)
+                return true;
+
+            itemsControl.ItemTemplate = DefaultItemTemplate.Value;
+            return true;
+        }
+    }
+}

--- a/src/Avalonia.ReactiveUI/AutoDataTemplateBindingHook.cs
+++ b/src/Avalonia.ReactiveUI/AutoDataTemplateBindingHook.cs
@@ -38,10 +38,7 @@ namespace Avalonia.ReactiveUI
         {
             var viewProperties = getCurrentViewProperties();
             var lastViewProperty = viewProperties.LastOrDefault();
-            if (lastViewProperty == null)
-                return true;
-            
-            var itemsControl = lastViewProperty.Sender as ItemsControl;
+            var itemsControl = lastViewProperty?.Sender as ItemsControl;
             if (itemsControl == null)
                 return true;
 

--- a/src/Avalonia.ReactiveUI/AutoDataTemplateBindingHook.cs
+++ b/src/Avalonia.ReactiveUI/AutoDataTemplateBindingHook.cs
@@ -16,19 +16,16 @@ namespace Avalonia.ReactiveUI
     /// </summary>
     public class AutoDataTemplateBindingHook : IPropertyBindingHook
     {
-        private static Lazy<FuncDataTemplate> DefaultItemTemplate { get; } = new Lazy<FuncDataTemplate>(() =>
+        private static FuncDataTemplate DefaultItemTemplate = new FuncDataTemplate<object>(x =>
         {
-            return new FuncDataTemplate<object>(x =>
-            {
-                var control = new ViewModelViewHost();
-                var context = control.GetObservable(Control.DataContextProperty);
-                control.Bind(ViewModelViewHost.ViewModelProperty, context);
-                control.HorizontalContentAlignment = HorizontalAlignment.Stretch;
-                control.VerticalContentAlignment = VerticalAlignment.Stretch;
-                return control;
-            },
-            true);
-        });
+            var control = new ViewModelViewHost();
+            var context = control.GetObservable(Control.DataContextProperty);
+            control.Bind(ViewModelViewHost.ViewModelProperty, context);
+            control.HorizontalContentAlignment = HorizontalAlignment.Stretch;
+            control.VerticalContentAlignment = VerticalAlignment.Stretch;
+            return control;
+        },
+        true);
 
         /// <inheritdoc/>
         public bool ExecuteHook(
@@ -51,7 +48,7 @@ namespace Avalonia.ReactiveUI
             if (itemsControl.ItemTemplate != null)
                 return true;
 
-            itemsControl.ItemTemplate = DefaultItemTemplate.Value;
+            itemsControl.ItemTemplate = DefaultItemTemplate;
             return true;
         }
     }

--- a/src/Avalonia.ReactiveUI/RoutedViewHost.cs
+++ b/src/Avalonia.ReactiveUI/RoutedViewHost.cs
@@ -53,7 +53,7 @@ namespace Avalonia.ReactiveUI
     /// ReactiveUI routing documentation website</see> for more info.
     /// </para>
     /// </remarks>
-    public class RoutedViewHost : TransitioningUserControl, IActivatable, IEnableLogger
+    public class RoutedViewHost : TransitioningContentControl, IActivatable, IEnableLogger
     {
         /// <summary>
         /// <see cref="AvaloniaProperty"/> for the <see cref="Router"/> property.

--- a/src/Avalonia.ReactiveUI/RoutedViewHost.cs
+++ b/src/Avalonia.ReactiveUI/RoutedViewHost.cs
@@ -53,33 +53,13 @@ namespace Avalonia.ReactiveUI
     /// ReactiveUI routing documentation website</see> for more info.
     /// </para>
     /// </remarks>
-    public class RoutedViewHost : UserControl, IActivatable, IEnableLogger
+    public class RoutedViewHost : TransitioningUserControl, IActivatable, IEnableLogger
     {
         /// <summary>
-        /// The router dependency property.
+        /// <see cref="AvaloniaProperty"/> for the <see cref="Router"/> property.
         /// </summary>
         public static readonly AvaloniaProperty<RoutingState> RouterProperty =
             AvaloniaProperty.Register<RoutedViewHost, RoutingState>(nameof(Router));
-        
-        /// <summary>
-        /// The default content property.
-        /// </summary> 
-        public static readonly AvaloniaProperty<object> DefaultContentProperty =
-            AvaloniaProperty.Register<RoutedViewHost, object>(nameof(DefaultContent));
-
-        /// <summary>
-        /// Fade in animation property.
-        /// </summary>
-        public static readonly AvaloniaProperty<IAnimation> FadeInAnimationProperty =
-            AvaloniaProperty.Register<RoutedViewHost, IAnimation>(nameof(DefaultContent),
-                CreateOpacityAnimation(0d, 1d, TimeSpan.FromSeconds(0.25)));
-
-        /// <summary>
-        /// Fade out animation property.
-        /// </summary>
-        public static readonly AvaloniaProperty<IAnimation> FadeOutAnimationProperty =
-            AvaloniaProperty.Register<RoutedViewHost, IAnimation>(nameof(DefaultContent),
-                CreateOpacityAnimation(1d, 0d, TimeSpan.FromSeconds(0.25)));
     
         /// <summary>
         /// Initializes a new instance of the <see cref="RoutedViewHost"/> class.
@@ -105,42 +85,6 @@ namespace Avalonia.ReactiveUI
         }
         
         /// <summary>
-        /// Gets or sets the content displayed whenever there is no page currently routed.
-        /// </summary>
-        public object DefaultContent
-        {
-            get => GetValue(DefaultContentProperty);
-            set => SetValue(DefaultContentProperty, value);
-        }
-
-        /// <summary>
-        /// Gets or sets the animation played when page appears.
-        /// </summary>
-        public IAnimation FadeInAnimation
-        {
-            get => GetValue(FadeInAnimationProperty);
-            set => SetValue(FadeInAnimationProperty, value);
-        }
-
-        /// <summary>
-        /// Gets or sets the animation played when page disappears.
-        /// </summary>
-        public IAnimation FadeOutAnimation
-        {
-            get => GetValue(FadeOutAnimationProperty);
-            set => SetValue(FadeOutAnimationProperty, value);
-        }
-    
-        /// <summary>
-        /// Duplicates the Content property with a private setter.
-        /// </summary>
-        public new object Content
-        {
-            get => base.Content;
-            private set => base.Content = value;
-        }
-
-        /// <summary>
         /// Gets or sets the ReactiveUI view locator used by this router.
         /// </summary>
         public IViewLocator ViewLocator { get; set; }
@@ -149,82 +93,29 @@ namespace Avalonia.ReactiveUI
         /// Invoked when ReactiveUI router navigates to a view model.
         /// </summary>
         /// <param name="viewModel">ViewModel to which the user navigates.</param>
-        /// <exception cref="Exception">
-        /// Thrown when ViewLocator is unable to find the appropriate view.
-        /// </exception>
-        private void NavigateToViewModel(IRoutableViewModel viewModel)
+        private void NavigateToViewModel(object viewModel)
         {
             if (viewModel == null)
             {
-                this.Log().Info("ViewModel is null, falling back to default content.");
-                UpdateContent(DefaultContent);
+                this.Log().Info("ViewModel is null. Falling back to default content.");
+                Content = DefaultContent;
                 return;
             }
     
             var viewLocator = ViewLocator ?? global::ReactiveUI.ViewLocator.Current;
-            var view = viewLocator.ResolveView(viewModel);
-            if (view == null) throw new Exception($"Couldn't find view for '{viewModel}'. Is it registered?");
-    
-            this.Log().Info($"Ready to show {view} with autowired {viewModel}.");
-            view.ViewModel = viewModel;
-            if (view is IStyledElement styled)
-                styled.DataContext = viewModel;
-            UpdateContent(view);
-        }
-    
-        /// <summary>
-        /// Updates the content with transitions.
-        /// </summary>
-        /// <param name="newContent">New content to set.</param>
-        private async void UpdateContent(object newContent)
-        {
-            if (FadeOutAnimation != null)
-                await FadeOutAnimation.RunAsync(this, Clock);
-            Content = newContent;
-            if (FadeInAnimation != null)
-                await FadeInAnimation.RunAsync(this, Clock);
-        }
-    
-        /// <summary>
-        /// Creates opacity animation for this routed view host.
-        /// </summary>
-        /// <param name="from">Opacity to start from.</param>
-        /// <param name="to">Opacity to finish with.</param>
-        /// <param name="duration">Duration of the animation.</param>
-        /// <returns>Animation object instance.</returns>
-        private static IAnimation CreateOpacityAnimation(double from, double to, TimeSpan duration) 
-        {
-            return new Avalonia.Animation.Animation
+            var viewInstance = viewLocator.ResolveView(viewModel);
+            if (viewInstance == null)
             {
-                Duration = duration,
-                Children =
-                {
-                    new KeyFrame
-                    {
-                        Setters =
-                        {
-                            new Setter
-                            {
-                                Property = OpacityProperty,
-                                Value = from
-                            }
-                        },
-                        Cue = new Cue(0d)
-                    },
-                    new KeyFrame
-                    {
-                        Setters =
-                        {
-                            new Setter
-                            {
-                                Property = OpacityProperty,
-                                Value = to
-                            }
-                        },
-                        Cue = new Cue(1d)
-                    }
-                }
-            };
+                this.Log().Warn($"Couldn't find view for '{viewModel}'. Is it registered? Falling back to default content.");
+                Content = DefaultContent;
+                return;
+            }
+    
+            this.Log().Info($"Ready to show {viewInstance} with autowired {viewModel}.");
+            viewInstance.ViewModel = viewModel;
+            if (viewInstance is IStyledElement styled)
+                styled.DataContext = viewModel;
+            Content = viewInstance;
         }
     }
 }

--- a/src/Avalonia.ReactiveUI/TransitioningContentControl.cs
+++ b/src/Avalonia.ReactiveUI/TransitioningContentControl.cs
@@ -14,18 +14,11 @@ namespace Avalonia.ReactiveUI
     public class TransitioningContentControl : ContentControl, IStyleable
     {
         /// <summary>
-        /// <see cref="AvaloniaProperty"/> for the <see cref="FadeInAnimation"/> property.
+        /// <see cref="AvaloniaProperty"/> for the <see cref="PageTransition"/> property.
         /// </summary>
-        public static readonly AvaloniaProperty<IAnimation> FadeInAnimationProperty =
-            AvaloniaProperty.Register<TransitioningContentControl, IAnimation>(nameof(DefaultContent),
-                CreateOpacityAnimation(0d, 1d, TimeSpan.FromSeconds(0.25)));
-
-        /// <summary>
-        /// <see cref="AvaloniaProperty"/> for the <see cref="FadeOutAnimation"/> property.
-        /// </summary>
-        public static readonly AvaloniaProperty<IAnimation> FadeOutAnimationProperty =
-            AvaloniaProperty.Register<TransitioningContentControl, IAnimation>(nameof(DefaultContent),
-                CreateOpacityAnimation(1d, 0d, TimeSpan.FromSeconds(0.25)));
+        public static readonly AvaloniaProperty<IPageTransition> PageTransitionProperty =
+            AvaloniaProperty.Register<TransitioningContentControl, IPageTransition>(nameof(DefaultContent),
+                new CrossFade(TimeSpan.FromSeconds(0.5)));
 
         /// <summary>
         /// <see cref="AvaloniaProperty"/> for the <see cref="DefaultContent"/> property.
@@ -34,23 +27,14 @@ namespace Avalonia.ReactiveUI
             AvaloniaProperty.Register<TransitioningContentControl, object>(nameof(DefaultContent));
         
         /// <summary>
-        /// Gets or sets the animation played when content appears.
+        /// Gets or sets the animation played when content appears and disappears.
         /// </summary>
-        public IAnimation FadeInAnimation
+        public IPageTransition PageTransition
         {
-            get => GetValue(FadeInAnimationProperty);
-            set => SetValue(FadeInAnimationProperty, value);
+            get => GetValue(PageTransitionProperty);
+            set => SetValue(PageTransitionProperty, value);
         }
 
-        /// <summary>
-        /// Gets or sets the animation played when content disappears.
-        /// </summary>
-        public IAnimation FadeOutAnimation
-        {
-            get => GetValue(FadeOutAnimationProperty);
-            set => SetValue(FadeOutAnimationProperty, value);
-        }
-        
         /// <summary>
         /// Gets or sets the content displayed whenever there is no page currently routed.
         /// </summary>
@@ -81,53 +65,11 @@ namespace Avalonia.ReactiveUI
         /// <param name="content">New content to set.</param>
         private async void UpdateContentWithTransition(object content)
         {
-            if (FadeOutAnimation != null)
-                await FadeOutAnimation.RunAsync(this, Clock);
+            if (PageTransition != null)
+                await PageTransition.Start(this, null, true);
             base.Content = content;
-            if (FadeInAnimation != null)
-                await FadeInAnimation.RunAsync(this, Clock);
-        }
-        
-        /// <summary>
-        /// Creates opacity animation for this routed view host.
-        /// </summary>
-        /// <param name="from">Opacity to start from.</param>
-        /// <param name="to">Opacity to finish with.</param>
-        /// <param name="duration">Duration of the animation.</param>
-        /// <returns>Animation object instance.</returns>
-        private static IAnimation CreateOpacityAnimation(double from, double to, TimeSpan duration) 
-        {
-            return new Avalonia.Animation.Animation
-            {
-                Duration = duration,
-                Children =
-                {
-                    new KeyFrame
-                    {
-                        Setters =
-                        {
-                            new Setter
-                            {
-                                Property = OpacityProperty,
-                                Value = from
-                            }
-                        },
-                        Cue = new Cue(0d)
-                    },
-                    new KeyFrame
-                    {
-                        Setters =
-                        {
-                            new Setter
-                            {
-                                Property = OpacityProperty,
-                                Value = to
-                            }
-                        },
-                        Cue = new Cue(1d)
-                    }
-                }
-            };
+            if (PageTransition != null)
+                await PageTransition.Start(null, this, true);
         }
     }
 }

--- a/src/Avalonia.ReactiveUI/TransitioningContentControl.cs
+++ b/src/Avalonia.ReactiveUI/TransitioningContentControl.cs
@@ -11,27 +11,27 @@ namespace Avalonia.ReactiveUI
     /// <summary>
     /// A ContentControl that animates the transition when its content is changed.
     /// </summary>
-    public class TransitioningUserControl : UserControl
+    public class TransitioningContentControl : ContentControl, IStyleable
     {
         /// <summary>
         /// <see cref="AvaloniaProperty"/> for the <see cref="FadeInAnimation"/> property.
         /// </summary>
         public static readonly AvaloniaProperty<IAnimation> FadeInAnimationProperty =
-            AvaloniaProperty.Register<TransitioningUserControl, IAnimation>(nameof(DefaultContent),
+            AvaloniaProperty.Register<TransitioningContentControl, IAnimation>(nameof(DefaultContent),
                 CreateOpacityAnimation(0d, 1d, TimeSpan.FromSeconds(0.25)));
 
         /// <summary>
         /// <see cref="AvaloniaProperty"/> for the <see cref="FadeOutAnimation"/> property.
         /// </summary>
         public static readonly AvaloniaProperty<IAnimation> FadeOutAnimationProperty =
-            AvaloniaProperty.Register<TransitioningUserControl, IAnimation>(nameof(DefaultContent),
+            AvaloniaProperty.Register<TransitioningContentControl, IAnimation>(nameof(DefaultContent),
                 CreateOpacityAnimation(1d, 0d, TimeSpan.FromSeconds(0.25)));
 
         /// <summary>
         /// <see cref="AvaloniaProperty"/> for the <see cref="DefaultContent"/> property.
         /// </summary>
         public static readonly AvaloniaProperty<object> DefaultContentProperty =
-            AvaloniaProperty.Register<TransitioningUserControl, object>(nameof(DefaultContent));
+            AvaloniaProperty.Register<TransitioningContentControl, object>(nameof(DefaultContent));
         
         /// <summary>
         /// Gets or sets the animation played when content appears.
@@ -68,6 +68,12 @@ namespace Avalonia.ReactiveUI
             get => base.Content;
             set => UpdateContentWithTransition(value);
         }
+        
+        /// <summary>
+        /// TransitioningContentControl uses the default ContentControl 
+        /// template from Avalonia default theme.
+        /// </summary>
+        Type IStyleable.StyleKey => typeof(ContentControl);
 
         /// <summary>
         /// Updates the content with transitions.

--- a/src/Avalonia.ReactiveUI/TransitioningContentControl.cs
+++ b/src/Avalonia.ReactiveUI/TransitioningContentControl.cs
@@ -17,7 +17,7 @@ namespace Avalonia.ReactiveUI
         /// <see cref="AvaloniaProperty"/> for the <see cref="PageTransition"/> property.
         /// </summary>
         public static readonly AvaloniaProperty<IPageTransition> PageTransitionProperty =
-            AvaloniaProperty.Register<TransitioningContentControl, IPageTransition>(nameof(DefaultContent),
+            AvaloniaProperty.Register<TransitioningContentControl, IPageTransition>(nameof(PageTransition),
                 new CrossFade(TimeSpan.FromSeconds(0.5)));
 
         /// <summary>

--- a/src/Avalonia.ReactiveUI/TransitioningUserControl.cs
+++ b/src/Avalonia.ReactiveUI/TransitioningUserControl.cs
@@ -1,0 +1,127 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Styling;
+
+namespace Avalonia.ReactiveUI
+{
+    /// <summary>
+    /// A ContentControl that animates the transition when its content is changed.
+    /// </summary>
+    public class TransitioningUserControl : UserControl
+    {
+        /// <summary>
+        /// <see cref="AvaloniaProperty"/> for the <see cref="FadeInAnimation"/> property.
+        /// </summary>
+        public static readonly AvaloniaProperty<IAnimation> FadeInAnimationProperty =
+            AvaloniaProperty.Register<TransitioningUserControl, IAnimation>(nameof(DefaultContent),
+                CreateOpacityAnimation(0d, 1d, TimeSpan.FromSeconds(0.25)));
+
+        /// <summary>
+        /// <see cref="AvaloniaProperty"/> for the <see cref="FadeOutAnimation"/> property.
+        /// </summary>
+        public static readonly AvaloniaProperty<IAnimation> FadeOutAnimationProperty =
+            AvaloniaProperty.Register<TransitioningUserControl, IAnimation>(nameof(DefaultContent),
+                CreateOpacityAnimation(1d, 0d, TimeSpan.FromSeconds(0.25)));
+
+        /// <summary>
+        /// <see cref="AvaloniaProperty"/> for the <see cref="DefaultContent"/> property.
+        /// </summary>
+        public static readonly AvaloniaProperty<object> DefaultContentProperty =
+            AvaloniaProperty.Register<TransitioningUserControl, object>(nameof(DefaultContent));
+        
+        /// <summary>
+        /// Gets or sets the animation played when content appears.
+        /// </summary>
+        public IAnimation FadeInAnimation
+        {
+            get => GetValue(FadeInAnimationProperty);
+            set => SetValue(FadeInAnimationProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the animation played when content disappears.
+        /// </summary>
+        public IAnimation FadeOutAnimation
+        {
+            get => GetValue(FadeOutAnimationProperty);
+            set => SetValue(FadeOutAnimationProperty, value);
+        }
+        
+        /// <summary>
+        /// Gets or sets the content displayed whenever there is no page currently routed.
+        /// </summary>
+        public object DefaultContent
+        {
+            get => GetValue(DefaultContentProperty);
+            set => SetValue(DefaultContentProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the content with animation.
+        /// </summary>
+        public new object Content
+        {
+            get => base.Content;
+            set => UpdateContentWithTransition(value);
+        }
+
+        /// <summary>
+        /// Updates the content with transitions.
+        /// </summary>
+        /// <param name="content">New content to set.</param>
+        private async void UpdateContentWithTransition(object content)
+        {
+            if (FadeOutAnimation != null)
+                await FadeOutAnimation.RunAsync(this, Clock);
+            base.Content = content;
+            if (FadeInAnimation != null)
+                await FadeInAnimation.RunAsync(this, Clock);
+        }
+        
+        /// <summary>
+        /// Creates opacity animation for this routed view host.
+        /// </summary>
+        /// <param name="from">Opacity to start from.</param>
+        /// <param name="to">Opacity to finish with.</param>
+        /// <param name="duration">Duration of the animation.</param>
+        /// <returns>Animation object instance.</returns>
+        private static IAnimation CreateOpacityAnimation(double from, double to, TimeSpan duration) 
+        {
+            return new Avalonia.Animation.Animation
+            {
+                Duration = duration,
+                Children =
+                {
+                    new KeyFrame
+                    {
+                        Setters =
+                        {
+                            new Setter
+                            {
+                                Property = OpacityProperty,
+                                Value = from
+                            }
+                        },
+                        Cue = new Cue(0d)
+                    },
+                    new KeyFrame
+                    {
+                        Setters =
+                        {
+                            new Setter
+                            {
+                                Property = OpacityProperty,
+                                Value = to
+                            }
+                        },
+                        Cue = new Cue(1d)
+                    }
+                }
+            };
+        }
+    }
+}

--- a/src/Avalonia.ReactiveUI/ViewModelViewHost.cs
+++ b/src/Avalonia.ReactiveUI/ViewModelViewHost.cs
@@ -13,7 +13,7 @@ namespace Avalonia.ReactiveUI
     /// the ViewModel property and display it. This control is very useful
     /// inside a DataTemplate to display the View associated with a ViewModel.
     /// </summary>
-    public class ViewModelViewHost : TransitioningUserControl, IViewFor, IEnableLogger
+    public class ViewModelViewHost : TransitioningContentControl, IViewFor, IEnableLogger
     {
         /// <summary>
         /// <see cref="AvaloniaProperty"/> for the <see cref="ViewModel"/> property.

--- a/src/Avalonia.ReactiveUI/ViewModelViewHost.cs
+++ b/src/Avalonia.ReactiveUI/ViewModelViewHost.cs
@@ -1,0 +1,75 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using ReactiveUI;
+using Splat;
+
+namespace Avalonia.ReactiveUI 
+{
+    /// <summary>
+    /// This content control will automatically load the View associated with
+    /// the ViewModel property and display it. This control is very useful
+    /// inside a DataTemplate to display the View associated with a ViewModel.
+    /// </summary>
+    public class ViewModelViewHost : TransitioningUserControl, IViewFor, IEnableLogger
+    {
+        /// <summary>
+        /// <see cref="AvaloniaProperty"/> for the <see cref="ViewModel"/> property.
+        /// </summary>
+        public static readonly AvaloniaProperty<object> ViewModelProperty =
+            AvaloniaProperty.Register<ViewModelViewHost, object>(nameof(ViewModel));
+        
+        /// <summary>
+        /// Gets or sets the ViewModel to display.
+        /// </summary>
+        public object ViewModel
+        {
+            get => GetValue(ViewModelProperty);
+            set => SetValue(ViewModelProperty, value);
+        }
+        
+        /// <summary>
+        /// Gets or sets the view locator.
+        /// </summary>
+        public IViewLocator ViewLocator { get; set; }
+
+        /// <summary>
+        /// Updates the Content when ViewModel changes.
+        /// </summary>
+        /// <param name="e">Property changed event arguments.</param>
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            if (e.Property.Name == nameof(ViewModel)) NavigateToViewModel(e.NewValue);
+            base.OnPropertyChanged(e);
+        }
+        
+        /// <summary>
+        /// Invoked when ReactiveUI router navigates to a view model.
+        /// </summary>
+        /// <param name="viewModel">ViewModel to which the user navigates.</param>
+        private void NavigateToViewModel(object viewModel)
+        {
+            if (viewModel == null)
+            {
+                this.Log().Info("ViewModel is null. Falling back to default content.");
+                Content = DefaultContent;
+                return;
+            }
+    
+            var viewLocator = ViewLocator ?? global::ReactiveUI.ViewLocator.Current;
+            var viewInstance = viewLocator.ResolveView(viewModel);
+            if (viewInstance == null)
+            {
+                this.Log().Warn($"Couldn't find view for '{viewModel}'. Is it registered? Falling back to default content.");
+                Content = DefaultContent;
+                return;
+            }
+    
+            this.Log().Info($"Ready to show {viewInstance} with autowired {viewModel}.");
+            viewInstance.ViewModel = viewModel;
+            if (viewInstance is IStyledElement styled)
+                styled.DataContext = viewModel;
+            Content = viewInstance;
+        }
+    }
+}

--- a/src/Avalonia.ReactiveUI/ViewModelViewHost.cs
+++ b/src/Avalonia.ReactiveUI/ViewModelViewHost.cs
@@ -1,6 +1,8 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using System;
+using System.Reactive.Disposables;
 using ReactiveUI;
 using Splat;
 
@@ -18,7 +20,20 @@ namespace Avalonia.ReactiveUI
         /// </summary>
         public static readonly AvaloniaProperty<object> ViewModelProperty =
             AvaloniaProperty.Register<ViewModelViewHost, object>(nameof(ViewModel));
-        
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ViewModelViewHost"/> class.
+        /// </summary>
+        public ViewModelViewHost()
+        {
+            this.WhenActivated(disposables =>
+            {
+                this.WhenAnyValue(x => x.ViewModel)
+                    .Subscribe(NavigateToViewModel)
+                    .DisposeWith(disposables);
+            });
+        }
+
         /// <summary>
         /// Gets or sets the ViewModel to display.
         /// </summary>
@@ -33,16 +48,6 @@ namespace Avalonia.ReactiveUI
         /// </summary>
         public IViewLocator ViewLocator { get; set; }
 
-        /// <summary>
-        /// Updates the Content when ViewModel changes.
-        /// </summary>
-        /// <param name="e">Property changed event arguments.</param>
-        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs e)
-        {
-            if (e.Property.Name == nameof(ViewModel)) NavigateToViewModel(e.NewValue);
-            base.OnPropertyChanged(e);
-        }
-        
         /// <summary>
         /// Invoked when ReactiveUI router navigates to a view model.
         /// </summary>

--- a/src/Avalonia.Visuals/Animation/CrossFade.cs
+++ b/src/Avalonia.Visuals/Animation/CrossFade.cs
@@ -14,8 +14,8 @@ namespace Avalonia.Animation
     /// </summary>
     public class CrossFade : IPageTransition
     {
-        private Animation _fadeOutAnimation;
-        private Animation _fadeInAnimation;
+        private readonly Animation _fadeOutAnimation;
+        private readonly Animation _fadeInAnimation;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CrossFade"/> class.
@@ -61,10 +61,10 @@ namespace Avalonia.Animation
                             new Setter
                             {
                                 Property = Visual.OpacityProperty,
-                                Value = 0d
+                                Value = 1d
                             }
                         },
-                        Cue = new Cue(0d)
+                        Cue = new Cue(1d)
                     }
 
                 }

--- a/tests/Avalonia.ReactiveUI.UnitTests/Attributes.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/Attributes.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+// Required to avoid InvalidOperationException sometimes thrown
+// from Splat.MemoizingMRUCache.cs which is not thread-safe.
+// Thrown when trying to access WhenActivated concurrently.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Avalonia.ReactiveUI.UnitTests/Attributes.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/Attributes.cs
@@ -1,3 +1,6 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
 using Xunit;
 
 // Required to avoid InvalidOperationException sometimes thrown

--- a/tests/Avalonia.ReactiveUI.UnitTests/AutoDataTemplateBindingHookTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AutoDataTemplateBindingHookTest.cs
@@ -1,0 +1,56 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using Xunit;
+using ReactiveUI;
+using Avalonia.ReactiveUI;
+using Avalonia.UnitTests;
+using Avalonia.Controls;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Splat;
+
+namespace Avalonia.ReactiveUI.UnitTests
+{
+    public class AutoDataTemplateBindingHookTest
+    {
+        public class NestedViewModel : ReactiveObject { }
+
+        public class NestedView : ReactiveUserControl<NestedViewModel> { }
+
+        public class ExampleViewModel : ReactiveObject 
+        {
+            public ObservableCollection<NestedViewModel> Items { get; } = new ObservableCollection<NestedViewModel>();
+        }
+
+        public class ExampleView : ReactiveUserControl<ExampleViewModel>
+        {
+            public ListBox List { get; } = new ListBox();
+
+            public ExampleView()
+            {
+                Content = List;
+                ViewModel = new ExampleViewModel();
+                this.OneWayBind(ViewModel, x => x.Items, x => x.List.Items);
+            }
+        }
+
+        public AutoDataTemplateBindingHookTest() 
+        {
+            Locator.CurrentMutable.RegisterConstant(new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));
+            Locator.CurrentMutable.Register(() => new ExampleView(), typeof(IViewFor<ExampleViewModel>));
+        }
+
+        [Fact]
+        public void Should_Apply_Data_Template_Binding_When_No_Template_Is_Set()
+        {
+            var view = new ExampleView();
+            var root = new TestRoot 
+            { 
+                Child = view
+            };
+            Assert.NotNull(view.List.ItemTemplate);
+        }
+    }
+}

--- a/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
@@ -13,7 +13,7 @@ using Splat;
 using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
-namespace Avalonia 
+namespace Avalonia.ReactiveUI.UnitTests
 {
     public class AvaloniaActivationForViewFetcherTest
     {

--- a/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
 using System;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;

--- a/tests/Avalonia.ReactiveUI.UnitTests/ReactiveUserControlTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/ReactiveUserControlTest.cs
@@ -1,0 +1,34 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using Avalonia.Controls;
+using Avalonia.UnitTests;
+using ReactiveUI;
+using Splat;
+using Xunit;
+
+namespace Avalonia.ReactiveUI.UnitTests
+{
+    public class ReactiveUserControlTest
+    {
+        public class ExampleViewModel : ReactiveObject { }
+
+        public class ExampleView : ReactiveUserControl<ExampleViewModel> { }
+
+        [Fact]
+        public void Data_Context_Should_Stay_In_Sync_With_Reactive_User_Control_View_Model() 
+        {
+            var view = new ExampleView();
+            var viewModel = new ExampleViewModel();
+            Assert.Null(view.ViewModel);
+
+            view.DataContext = viewModel;
+            Assert.Equal(view.ViewModel, viewModel);
+            Assert.Equal(view.DataContext, viewModel);
+
+            view.DataContext = null;
+            Assert.Null(view.ViewModel);
+            Assert.Null(view.DataContext);
+        }
+    }
+}

--- a/tests/Avalonia.ReactiveUI.UnitTests/ReactiveWindowTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/ReactiveWindowTest.cs
@@ -1,0 +1,37 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using Avalonia.Controls;
+using Avalonia.UnitTests;
+using ReactiveUI;
+using Splat;
+using Xunit;
+
+namespace Avalonia.ReactiveUI.UnitTests
+{
+    public class ReactiveWindowTest
+    {
+        public class ExampleViewModel : ReactiveObject { }
+
+        public class ExampleWindow : ReactiveWindow<ExampleViewModel> { }
+
+        [Fact]
+        public void Data_Context_Should_Stay_In_Sync_With_Reactive_Window_View_Model() 
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var view = new ExampleWindow();
+                var viewModel = new ExampleViewModel();
+                Assert.Null(view.ViewModel);
+
+                view.DataContext = viewModel;
+                Assert.Equal(view.ViewModel, viewModel);
+                Assert.Equal(view.DataContext, viewModel);
+
+                view.DataContext = null;
+                Assert.Null(view.ViewModel);
+                Assert.Null(view.DataContext);
+            }
+        }
+    }
+}

--- a/tests/Avalonia.ReactiveUI.UnitTests/RoutedViewHostTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/RoutedViewHostTest.cs
@@ -62,8 +62,7 @@ namespace Avalonia.ReactiveUI.UnitTests
             { 
                 Router = screen.Router,
                 DefaultContent = defaultContent,
-                FadeOutAnimation = null,
-                FadeInAnimation = null
+                PageTransition = null
             };
 
             var root = new TestRoot 

--- a/tests/Avalonia.ReactiveUI.UnitTests/RoutedViewHostTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/RoutedViewHostTest.cs
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 using System.Reactive;
 using Avalonia.ReactiveUI;
 
-namespace Avalonia
+namespace Avalonia.ReactiveUI.UnitTests
 {
     public class RoutedViewHostTest
     {

--- a/tests/Avalonia.ReactiveUI.UnitTests/RoutedViewHostTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/RoutedViewHostTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
 using System;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;

--- a/tests/Avalonia.ReactiveUI.UnitTests/TransitioningContentControlTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/TransitioningContentControlTest.cs
@@ -28,8 +28,7 @@ namespace Avalonia.ReactiveUI.UnitTests
         {
             var target = new TransitioningContentControl
             {
-                FadeInAnimation = null,
-                FadeOutAnimation = null,
+                PageTransition = null,
                 Template = GetTemplate(),
                 Content = "Foo"
             };

--- a/tests/Avalonia.ReactiveUI.UnitTests/TransitioningContentControlTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/TransitioningContentControlTest.cs
@@ -1,0 +1,64 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Templates;
+using Avalonia.UnitTests;
+using Avalonia.VisualTree;
+using ReactiveUI;
+using Splat;
+using Xunit;
+
+namespace Avalonia.ReactiveUI.UnitTests
+{
+    public class TransitioningContentControlTest
+    {
+        [Fact]
+        public void Transitioning_Control_Should_Derive_Template_From_Content_Control()
+        {
+            var target = new TransitioningContentControl();
+            var stylable = (IStyledElement)target;
+            Assert.Equal(typeof(ContentControl),stylable.StyleKey);
+        }
+
+        [Fact]
+        public void Transitioning_Control_Template_Should_Be_Instantiated() 
+        {
+            var target = new TransitioningContentControl
+            {
+                FadeInAnimation = null,
+                FadeOutAnimation = null,
+                Template = GetTemplate(),
+                Content = "Foo"
+            };
+            target.ApplyTemplate();
+            ((ContentPresenter)target.Presenter).UpdateChild();
+
+            var child = ((IVisual)target).VisualChildren.Single();
+            Assert.IsType<Border>(child);
+            child = child.VisualChildren.Single();
+            Assert.IsType<ContentPresenter>(child);
+            child = child.VisualChildren.Single();
+            Assert.IsType<TextBlock>(child);
+        }
+
+        private FuncControlTemplate GetTemplate()
+        {
+            return new FuncControlTemplate<ContentControl>(parent =>
+            {
+                return new Border
+                {
+                    Background = new Media.SolidColorBrush(0xffffffff),
+                    Child = new ContentPresenter
+                    {
+                        Name = "PART_ContentPresenter",
+                        [~ContentPresenter.ContentProperty] = parent[~ContentControl.ContentProperty],
+                        [~ContentPresenter.ContentTemplateProperty] = parent[~ContentControl.ContentTemplateProperty],
+                    }
+                };
+            });
+        }
+    }
+}

--- a/tests/Avalonia.ReactiveUI.UnitTests/ViewModelViewHostTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/ViewModelViewHostTest.cs
@@ -33,8 +33,7 @@ namespace Avalonia.ReactiveUI.UnitTests
             var host = new ViewModelViewHost 
             {
                 DefaultContent = defaultContent,
-                FadeOutAnimation = null,
-                FadeInAnimation = null
+                PageTransition = null
             };
 
             var root = new TestRoot 

--- a/tests/Avalonia.ReactiveUI.UnitTests/ViewModelViewHostTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/ViewModelViewHostTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
 using Avalonia.Controls;
 using Avalonia.UnitTests;
 using ReactiveUI;

--- a/tests/Avalonia.ReactiveUI.UnitTests/ViewModelViewHostTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/ViewModelViewHostTest.cs
@@ -1,0 +1,72 @@
+using Avalonia.Controls;
+using Avalonia.UnitTests;
+using ReactiveUI;
+using Splat;
+using Xunit;
+
+namespace Avalonia.ReactiveUI.UnitTests
+{
+    public class ViewModelViewHostTest
+    {
+        public class FirstViewModel { }
+
+        public class FirstView : ReactiveUserControl<FirstViewModel> { }
+
+        public class SecondViewModel : ReactiveObject { }
+
+        public class SecondView : ReactiveUserControl<SecondViewModel> { }
+
+        public ViewModelViewHostTest()
+        {
+            Locator.CurrentMutable.RegisterConstant(new AvaloniaActivationForViewFetcher(), typeof(IActivationForViewFetcher));
+            Locator.CurrentMutable.Register(() => new FirstView(), typeof(IViewFor<FirstViewModel>));
+            Locator.CurrentMutable.Register(() => new SecondView(), typeof(IViewFor<SecondViewModel>));
+        }
+
+        [Fact]
+        public void ViewModelViewHost_View_Should_Stay_In_Sync_With_ViewModel() 
+        {
+            var defaultContent = new TextBlock();
+            var host = new ViewModelViewHost 
+            {
+                DefaultContent = defaultContent,
+                FadeOutAnimation = null,
+                FadeInAnimation = null
+            };
+
+            var root = new TestRoot 
+            { 
+                Child = host 
+            };
+            
+            Assert.NotNull(host.Content);
+            Assert.Equal(typeof(TextBlock), host.Content.GetType());
+            Assert.Equal(defaultContent, host.Content);
+
+            var first = new FirstViewModel();
+            host.ViewModel = first;
+            Assert.NotNull(host.Content);
+            Assert.Equal(typeof(FirstView), host.Content.GetType());
+            Assert.Equal(first, ((FirstView)host.Content).DataContext);
+            Assert.Equal(first, ((FirstView)host.Content).ViewModel);
+
+            var second = new SecondViewModel();
+            host.ViewModel = second;
+            Assert.NotNull(host.Content);
+            Assert.Equal(typeof(SecondView), host.Content.GetType());
+            Assert.Equal(second, ((SecondView)host.Content).DataContext);
+            Assert.Equal(second, ((SecondView)host.Content).ViewModel);
+
+            host.ViewModel = null;
+            Assert.NotNull(host.Content);
+            Assert.Equal(typeof(TextBlock), host.Content.GetType());
+            Assert.Equal(defaultContent, host.Content);
+
+            host.ViewModel = first;
+            Assert.NotNull(host.Content);
+            Assert.Equal(typeof(FirstView), host.Content.GetType());
+            Assert.Equal(first, ((FirstView)host.Content).DataContext);
+            Assert.Equal(first, ((FirstView)host.Content).ViewModel);
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Adds [ViewModelViewHost](https://reactiveui.net/docs/handbook/view-location/) and [AutoDataTemplateBindingHook](https://github.com/reactiveui/ReactiveUI/blob/781cea984f79d42d3ae3e3fb3133f4882338d7c0/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs) implementations compatible with Avalonia. This makes the [View Location](https://reactiveui.net/docs/handbook/view-location/) ReactiveUI feature available for Avalonia developers. The `ViewModelViewHost` control is capable of embedding the appropriate view based on provided view model instance type, and the `AutoDataTemplateBindingHook` class is responsible for automatic data template resolution, also based on bound view model instance type.

Additionally it [resolves](https://github.com/AvaloniaUI/Avalonia/pull/2560#discussion_r288335385) the `CrossFade` bug preventing the animation from being fired when an animated item is appearing.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Avalonia and ReactiveUI users can't use `ViewModelViewHost` and  `AutoDataTemplateBindingHook`.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Avalonia and ReactiveUI users can use `ViewModelViewHost` and  `AutoDataTemplateBindingHook`. This simplifies porting existing ReactiveUI-powered apps from WPF to Avalonia.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

Heavily based on [ViewModelViewHost](https://github.com/reactiveui/ReactiveUI/blob/17d5bfaf62d776f5572f790169f2765fc40d1b48/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs) and [AutoDataTemplateBindingHook](https://github.com/reactiveui/ReactiveUI/blob/781cea984f79d42d3ae3e3fb3133f4882338d7c0/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs) for Windows.

## Checklist

- [x] Add `TransitioningUserControl`
- [x] Add `ViewModelViewHost`
- [x] Add unit tests for `ViewModelViewHost`
- [x] Add `AutoDataTemplateBindingHook`
- [x] Add unit tests for `AutoDataTemplateBindingHook`
- [x] Ensure it all works in real-world apps

## Checklist [2](https://github.com/AvaloniaUI/Avalonia/pull/2560#discussion_r288224892)

- [x] Make `TransitioningUserControl` be `TransitioningContentControl`
- [x] Use `IPageTransition` instead of specifying fade-in(out) animations manually