### PR TITLE
Fixes/dont raise gestures on handled events

### DIFF
--- a/src/Avalonia.Input/Gestures.cs
+++ b/src/Avalonia.Input/Gestures.cs
@@ -38,7 +38,10 @@ namespace Avalonia.Input
                 }
                 else if (s_lastPress?.IsAlive == true && e.ClickCount == 2 && s_lastPress.Target == e.Source)
                 {
-                    e.Source.RaiseEvent(new RoutedEventArgs(DoubleTappedEvent));
+                    if (!ev.Handled)
+                    {
+                        e.Source.RaiseEvent(new RoutedEventArgs(DoubleTappedEvent));
+                    }
                 }
             }
         }
@@ -51,7 +54,10 @@ namespace Avalonia.Input
 
                 if (s_lastPress?.IsAlive == true && s_lastPress.Target == e.Source)
                 {
-                    ((IInteractive)s_lastPress.Target).RaiseEvent(new RoutedEventArgs(TappedEvent));
+                    if (!ev.Handled)
+                    {
+                        ((IInteractive)s_lastPress.Target).RaiseEvent(new RoutedEventArgs(TappedEvent));
+                    }
                 }
             }
         }

--- a/tests/Avalonia.Interactivity.UnitTests/GestureTests.cs
+++ b/tests/Avalonia.Interactivity.UnitTests/GestureTests.cs
@@ -78,5 +78,36 @@ namespace Avalonia.Interactivity.UnitTests
 
             Assert.Equal(new[] { "bp", "dp", "br", "dr", "bt", "dt", "bp", "dp", "bdt", "ddt" }, result);
         }
+
+        [Fact]
+        public void DoubleTapped_Should_Not_Be_Rasied_if_Pressed_is_Handled()
+        {
+            Border border = new Border();
+            var decorator = new Decorator
+            {
+                Child = border
+            };
+            var result = new List<string>();
+
+            decorator.AddHandler(Border.PointerPressedEvent, (s, e) =>
+            {
+                result.Add("dp");
+                e.Handled = true;
+            });
+
+            decorator.AddHandler(Border.PointerReleasedEvent, (s, e) => result.Add("dr"));
+            decorator.AddHandler(Gestures.TappedEvent, (s, e) => result.Add("dt"));
+            decorator.AddHandler(Gestures.DoubleTappedEvent, (s, e) => result.Add("ddt"));
+            border.AddHandler(Border.PointerPressedEvent, (s, e) => result.Add("bp"));
+            border.AddHandler(Border.PointerReleasedEvent, (s, e) => result.Add("br"));
+            border.AddHandler(Gestures.TappedEvent, (s, e) => result.Add("bt"));
+            border.AddHandler(Gestures.DoubleTappedEvent, (s, e) => result.Add("bdt"));
+
+            border.RaiseEvent(new PointerPressedEventArgs());
+            border.RaiseEvent(new PointerReleasedEventArgs());
+            border.RaiseEvent(new PointerPressedEventArgs { ClickCount = 2 });
+
+            Assert.Equal(new[] { "bp", "dp", "br", "dr", "bt", "dt", "bp", "dp" }, result);
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Its a bit of a follow up for: https://github.com/AvaloniaUI/Avalonia/pull/2469

basically DefaultMenuInteraction handles the button presses, but Gestures dont check if an event was handled and raises tapped and double tapped events regardless.

This leads to wierd behavior in Wasabi where if someone opens the menu and presses again to close menu, this triggers a double tapped event. Since our menu is position in our titlebar the titlebar thinks that a double tapped is received and causes window to maximize. 


## What is the current behavior?
BUG: we ignore handled flag and raise gesture anyway.


## What is the updated/expected behavior with this PR?
We dont raise gestures when an overlaying control has handled the pressed / click events.

## Checklist

- [ x] Added unit tests (if possible)?

no issues were opened for this.
