### PR TITLE
xamlil: add F# constructor patterns for AvaloniaXamlLoader search

### DIFF
--- a/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
+++ b/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
@@ -234,8 +234,7 @@ namespace Avalonia.Build.Tasks
                                 var i = method.Body.Instructions;
                                 for (var c = 1; c < i.Count; c++)
                                 {
-                                    if (i[c - 1].OpCode == OpCodes.Ldarg_0
-                                        && i[c].OpCode == OpCodes.Call)
+                                    if (i[c].OpCode == OpCodes.Call)
                                     {
                                         var op = i[c].Operand as MethodReference;
                                         


### PR DESCRIPTION
## What does the pull request do?

I'm trying to update to the latest version with XAMLIL.
F# functions indeed look a little bit different in IL.
here's the decompiled ctor of the offending class built against v0.8:

```C#
 public Cursor()
    {
        ((Control)this)..ctor();
        this.@this.contents = this;
        cursor_timer = null;
        bgbrush = new SolidColorBrush(Colors.Black);
        fgbrush = new SolidColorBrush(Colors.White);
        spbrush = new SolidColorBrush(Colors.Red);
        fgpaint = new SKPaint();
        bgpaint = new SKPaint();
        sppaint = new SKPaint();
        fbs = new Dictionary<Tuple<double, double, double>, RenderTargetBitmap>();
        init@25-6 = 1;
        IActivatable val = LanguagePrimitives.IntrinsicFunctions.CheckThis(this.@this.contents);
        IDisposable head = Model.Notify("SetCursorAnimation", new xaml.-ctor@117-36(this));
        Cursor o = LanguagePrimitives.IntrinsicFunctions.CheckThis(this.@this.contents);
        if (init@25-7 < 2)
        {
            LanguagePrimitives.IntrinsicFunctions.FailStaticInit();
        }
        IDisposable head2 = o.GetObservable(PosXProp).Subscribe(new xaml.-ctor@122-37(this).Invoke);
        Cursor o2 = LanguagePrimitives.IntrinsicFunctions.CheckThis(this.@this.contents);
        if (init@25-7 < 3)
        {
            LanguagePrimitives.IntrinsicFunctions.FailStaticInit();
        }
        IDisposable head3 = o2.GetObservable(PosYProp).Subscribe(new xaml.-ctor@123-38(this).Invoke);
        Cursor o3 = LanguagePrimitives.IntrinsicFunctions.CheckThis(this.@this.contents);
        if (init@25-7 < 4)
        {
            LanguagePrimitives.IntrinsicFunctions.FailStaticInit();
        }
        IEnumerable<IDisposable> xs = FSharpList<IDisposable>.Cons(head, FSharpList<IDisposable>.Cons(head2, FSharpList<IDisposable>.Cons(head3, FSharpList<IDisposable>.Cons(o3.GetObservable(RenderTickProp).Subscribe(new xaml.-ctor@124-39(this).Invoke), FSharpList<IDisposable>.Empty))));
        IDisposable disposable = ViewForMixins.WhenActivated(val, (Action<CompositeDisposable>)new xaml.-ctor@115-40(xs).Invoke, null);
        AvaloniaXamlLoader.Load(LanguagePrimitives.IntrinsicFunctions.CheckThis(this.@this.contents));
    }
```

and the offending IL sequence:

```MSIL
        // AvaloniaXamlLoader.Load(LanguagePrimitives.IntrinsicFunctions.CheckThis(this.@this.contents));
        IL_01c7: ldarg.0
        IL_01c8: ldfld class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<class FVim.Cursor> FVim.Cursor::this
        IL_01cd: call instance !0 class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<class FVim.Cursor>::get_contents()
        IL_01d2: call !!0 [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::CheckThis<class FVim.Cursor>(!!0)
        IL_01d7: call void [Avalonia.Markup.Xaml]Avalonia.Markup.Xaml.AvaloniaXamlLoader::Load(object)
```

## What is the current behavior?

 Getting the errors:
Avalonia error XAMLIL: No call to AvaloniaXamlLoader.Load(this) call found anywhere in the type FVim.Cursor and type seems to have custom constructors.


## What is the updated/expected behavior with this PR?
Avalonia + F# custom controls should compile and run.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
None I guess.


## Fixed issues
None.
