### PR TITLE
Set defaultBindingMode as TwoWay for SelectedIndex

### DIFF
--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -54,7 +54,8 @@ namespace Avalonia.Controls.Primitives
                 nameof(SelectedIndex),
                 o => o.SelectedIndex,
                 (o, v) => o.SelectedIndex = v,
-                unsetValue: -1);
+                unsetValue: -1,
+                defaultBindingMode: BindingMode.TwoWay);
 
         /// <summary>
         /// Defines the <see cref="SelectedItem"/> property.

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -749,6 +749,40 @@ namespace Avalonia.Controls.UnitTests.Primitives
             Assert.Equal("b", target.SelectedItem);
         }
 
+        [Fact]
+        public void Mode_For_SelectedIndex_Is_TwoWay_By_Default()
+        {
+            var items = new[]
+            {
+                new Item(),
+                new Item(),
+                new Item(),
+            };
+
+            var vm = new MasterViewModel
+            {
+                Child = new ChildViewModel
+                {
+                    Items = items,
+                    SelectedIndex = 1,
+                }
+            };
+
+            var target = new SelectingItemsControl { DataContext = vm };
+            var itemsBinding = new Binding("Child.Items");
+            var selectedIndBinding = new Binding("Child.SelectedIndex");
+
+            target.Bind(SelectingItemsControl.ItemsProperty, itemsBinding);
+            target.Bind(SelectingItemsControl.SelectedIndexProperty, selectedIndBinding);
+
+            Assert.Equal(1, target.SelectedIndex);
+
+            target.SelectedIndex = 2;
+
+            Assert.Equal(2, target.SelectedIndex);
+            Assert.Equal(2, vm.Child.SelectedIndex);
+        }
+
         private FuncControlTemplate Template()
         {
             return new FuncControlTemplate<SelectingItemsControl>(control =>
@@ -785,6 +819,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
         {
             public IList<Item> Items { get; set; }
             public Item SelectedItem { get; set; }
+            public int SelectedIndex { get; set; }
         }
 
         private class RootWithItems : TestRoot


### PR DESCRIPTION
## What does the pull request do?

Set defaultBindingMode as `TwoWay` for SelectedIndex

## What is the current behavior?

DefaultBindingMode wasn't specified so it was `OneWay`.

## Checklist
- [x] Added unit tests (if possible)?

I changed helper class for test instead of creating new one to avoid additional noise. 
Not sure if test is really necessary although