### PR TITLE
Don't pass GrContext to RenderTargetBitmap

### DIFF
--- a/samples/RenderDemo/MainWindow.xaml
+++ b/samples/RenderDemo/MainWindow.xaml
@@ -38,6 +38,9 @@
       <TabItem Header="SkCanvas">
         <pages:CustomSkiaPage/>
       </TabItem>
+      <TabItem Header="RenderTargetBitmap">
+        <pages:RenderTargetBitmapPage/>
+      </TabItem>
     </TabControl>
   </DockPanel>
 </Window>

--- a/samples/RenderDemo/Pages/RenderTargetBitmapPage.cs
+++ b/samples/RenderDemo/Pages/RenderTargetBitmapPage.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.LogicalTree;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using Avalonia.Visuals.Media.Imaging;
+
+namespace RenderDemo.Pages
+{
+    public class RenderTargetBitmapPage : Control
+    {
+        private RenderTargetBitmap _bitmap;
+
+        protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
+        {
+            _bitmap = new RenderTargetBitmap(new PixelSize(200, 200), new Vector(96, 96));
+            base.OnAttachedToLogicalTree(e);
+        }
+
+        protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)
+        {
+            _bitmap.Dispose();
+            _bitmap = null;
+            base.OnDetachedFromLogicalTree(e);
+        }
+
+        readonly Stopwatch _st = Stopwatch.StartNew();
+        public override void Render(DrawingContext context)
+        {
+            using (var ctxi = _bitmap.CreateDrawingContext(null))
+            using(var ctx = new DrawingContext(ctxi, false))
+            using (ctx.PushPostTransform(Matrix.CreateTranslation(-100, -100)
+                                         * Matrix.CreateRotation(_st.Elapsed.TotalSeconds)
+                                         * Matrix.CreateTranslation(100, 100)))
+            {
+                ctxi.Clear(default);
+                ctx.FillRectangle(Brushes.Fuchsia, new Rect(50, 50, 100, 100));
+            }
+
+            context.DrawImage(_bitmap, 1, 
+                new Rect(0, 0, 200, 200), 
+                new Rect(0, 0, 200, 200));
+            Dispatcher.UIThread.Post(InvalidateVisual, DispatcherPriority.Background);
+            base.Render(context);
+        }
+    }
+}

--- a/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
+++ b/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
@@ -111,8 +111,7 @@ namespace Avalonia.Skia
                 Width = size.Width,
                 Height = size.Height,
                 Dpi = dpi,
-                DisableTextLcdRendering = false,
-                GrContext = GrContext
+                DisableTextLcdRendering = false
             };
 
             return new SurfaceRenderTarget(createInfo);


### PR DESCRIPTION
It seems that our RTB implementation has some threading and/or memory corruption issues. When OpenGL acceleration is enabled, it causes either lockup or segfaults. 

I heavily suspect that we can't have concurrent access to objects created with the same GrContext.

For now I'm disabling HW-accelerated rendering of Skia's RTBs.

Also added RTB page to RenderDemo to make it easier to test.