### PR TITLE
[ControlCatalog] Use star sized row instead of auto row to prevent infinite space measure

### DIFF
--- a/samples/ControlCatalog/Pages/DataGridPage.xaml
+++ b/samples/ControlCatalog/Pages/DataGridPage.xaml
@@ -11,7 +11,7 @@
       <Setter Property="Background" Value="{Binding Path=GDP, Mode=OneWay, Converter={StaticResource GDPConverter}}" />
     </Style>
   </UserControl.Styles>
-  <Grid RowDefinitions="Auto,Auto">
+  <Grid RowDefinitions="Auto,*">
     <StackPanel Orientation="Vertical" Spacing="4" Grid.Row="0">
       <TextBlock Classes="h1">DataGrid</TextBlock>
       <TextBlock Classes="h2">A control for displaying and interacting with a data source.</TextBlock>


### PR DESCRIPTION
## What does the pull request do?
It changes the DataGridPage to prevent measuring the DataGrid with infinite space.
## What is the current behavior?
Currently `RowDefinitions="Auto, Auto"` is used

## What is the updated/expected behavior with this PR?
The DataGrid is no longer measured with infinite height and therefore is able to properly lazy load data.

## How was the solution implemented (if it's not obvious)?
`RowDefinitions="Auto, *"` fixes the issue

@grokys @jmacato