### PR TITLE
Feature windows transparency

### DIFF
--- a/src/Avalonia.Controls/Platform/IWindowImpl.cs
+++ b/src/Avalonia.Controls/Platform/IWindowImpl.cs
@@ -38,6 +38,12 @@ namespace Avalonia.Platform
         void SetSystemDecorations(bool enabled);
 
         /// <summary>
+        /// Enables or disables window transparency (Every pixel painted by Transparent color will be transparent)
+        /// </summary>
+        /// <param name="enabled"></param>
+        void SetWindowTransparency(bool enabled);
+
+        /// <summary>
         /// Sets the icon of this window.
         /// </summary>
         void SetIcon(IWindowIconImpl icon);

--- a/src/Avalonia.Controls/Platform/IWindowImpl.cs
+++ b/src/Avalonia.Controls/Platform/IWindowImpl.cs
@@ -40,7 +40,6 @@ namespace Avalonia.Platform
         /// <summary>
         /// Enables or disables window transparency (Every pixel painted by Transparent color will be transparent)
         /// </summary>
-        /// <param name="enabled"></param>
         void SetWindowTransparency(bool enabled);
 
         /// <summary>

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -62,6 +62,12 @@ namespace Avalonia.Controls
             AvaloniaProperty.Register<Window, bool>(nameof(HasSystemDecorations), true);
 
         /// <summary>
+        /// Enables or disables system window transparency (Windows Only, can cause performance issues)
+        /// </summary>
+        public static readonly StyledProperty<bool> AllowsTransparencyProperty =
+            AvaloniaProperty.Register<Window, bool>(nameof(AllowsTransparency), false);
+
+        /// <summary>
         /// Enables or disables the taskbar icon
         /// </summary>
         public static readonly StyledProperty<bool> ShowInTaskbarProperty =
@@ -111,6 +117,8 @@ namespace Avalonia.Controls
             TitleProperty.Changed.AddClassHandler<Window>((s, e) => s.PlatformImpl?.SetTitle((string)e.NewValue));
             HasSystemDecorationsProperty.Changed.AddClassHandler<Window>(
                 (s, e) => s.PlatformImpl?.SetSystemDecorations((bool)e.NewValue));
+            AllowsTransparencyProperty.Changed.AddClassHandler<Window>(
+                            (s, e) => s.PlatformImpl?.SetWindowTransparency((bool)e.NewValue));
 
             ShowInTaskbarProperty.Changed.AddClassHandler<Window>((w, e) => w.PlatformImpl?.ShowTaskbarIcon((bool)e.NewValue));
 
@@ -191,6 +199,16 @@ namespace Avalonia.Controls
         {
             get { return GetValue(HasSystemDecorationsProperty); }
             set { SetValue(HasSystemDecorationsProperty, value); }
+        }
+
+        /// <summary>
+        /// Enables or disables system window transparency (Windows Only, can cause performance issues)
+        /// </summary>
+        /// 
+        public bool AllowsTransparency
+        {
+            get { return GetValue(AllowsTransparencyProperty); }
+            set { SetValue(AllowsTransparencyProperty, value); }
         }
 
         /// <summary>
@@ -428,7 +446,7 @@ namespace Avalonia.Controls
         /// </returns>
         public Task<TResult> ShowDialog<TResult>(IWindowImpl owner)
         {
-            if(owner == null)
+            if (owner == null)
                 throw new ArgumentNullException(nameof(owner));
 
             if (IsVisible)

--- a/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
+++ b/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
@@ -94,6 +94,10 @@ namespace Avalonia.DesignerSupport.Remote
         {
         }
 
+        public void SetWindowTransparency(bool enabled)
+        {
+        }
+
         public void SetIcon(IWindowIconImpl icon)
         {
         }

--- a/src/Avalonia.DesignerSupport/Remote/Stubs.cs
+++ b/src/Avalonia.DesignerSupport/Remote/Stubs.cs
@@ -95,6 +95,10 @@ namespace Avalonia.DesignerSupport.Remote
         {
         }
 
+        public void SetWindowTransparency(bool enabled)
+        {
+        }
+
         public void SetIcon(IWindowIconImpl icon)
         {
         }

--- a/src/Avalonia.Native/WindowImpl.cs
+++ b/src/Avalonia.Native/WindowImpl.cs
@@ -62,6 +62,10 @@ namespace Avalonia.Native
             _native.HasDecorations = enabled;
         }
 
+        public void SetWindowTransparency(bool enabled)
+        {
+        }
+
         public void SetTitleBarColor (Avalonia.Media.Color color)
         {
             _native.SetTitleBarColor(new AvnColor { Alpha = color.A, Red = color.R, Green = color.G, Blue = color.B });

--- a/src/Avalonia.Visuals/Media/KnownColors.cs
+++ b/src/Avalonia.Visuals/Media/KnownColors.cs
@@ -212,7 +212,7 @@ namespace Avalonia.Media
         Teal = 0xff008080,
         Thistle = 0xffd8bfd8,
         Tomato = 0xffff6347,
-        Transparent = 0x00ffffff,
+        Transparent = 0xffffffee,
         Turquoise = 0xff40e0d0,
         Violet = 0xffee82ee,
         Wheat = 0xfff5deb3,

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -717,6 +717,10 @@ namespace Avalonia.X11
             UpdateMotifHints();
         }
 
+        public void SetWindowTransparency(bool enabled)
+        {
+        }
+
 
         public void Resize(Size clientSize) => Resize(clientSize, false);
 

--- a/src/Gtk/Avalonia.Gtk3/WindowImpl.cs
+++ b/src/Gtk/Avalonia.Gtk3/WindowImpl.cs
@@ -78,6 +78,9 @@ namespace Avalonia.Gtk3
         }
 
         public void SetSystemDecorations(bool enabled) => Native.GtkWindowSetDecorated(GtkWidget, enabled);
+        public void SetWindowTransparency(bool enabled)
+        {
+        }
 
         public void SetIcon(IWindowIconImpl icon) => Native.GtkWindowSetIcon(GtkWidget, (Pixbuf) icon);
 

--- a/src/Windows/Avalonia.Win32/EmbeddedWindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/EmbeddedWindowImpl.cs
@@ -14,10 +14,10 @@ namespace Avalonia.Win32
         private static IntPtr DefaultParentWindow = CreateParentWindow();
         private static UnmanagedMethods.WndProc _wndProcDelegate;
 
-        protected override IntPtr CreateWindowOverride(ushort atom)
+        protected override IntPtr CreateWindowOverride(ushort atom, bool layered = false)
         {
             var hWnd = UnmanagedMethods.CreateWindowEx(
-                0,
+                layered ? 0x00080000 : 0,
                 atom,
                 null,
                 (int)UnmanagedMethods.WindowStyles.WS_CHILD,

--- a/src/Windows/Avalonia.Win32/EmbeddedWindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/EmbeddedWindowImpl.cs
@@ -14,10 +14,10 @@ namespace Avalonia.Win32
         private static IntPtr DefaultParentWindow = CreateParentWindow();
         private static UnmanagedMethods.WndProc _wndProcDelegate;
 
-        protected override IntPtr CreateWindowOverride(ushort atom, bool layered = false)
+        protected override IntPtr CreateWindowOverride(ushort atom)
         {
             var hWnd = UnmanagedMethods.CreateWindowEx(
-                layered ? 0x00080000 : 0,
+                0,
                 atom,
                 null,
                 (int)UnmanagedMethods.WindowStyles.WS_CHILD,

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -277,6 +277,13 @@ namespace Avalonia.Win32.Interop
         }
 
         [Flags]
+        public enum LayeredWindowFlags : uint
+        {
+            LWA_COLORKEY = 1,
+            LWA_ALPHA = 2,
+        }
+
+        [Flags]
         public enum WindowStyles : uint
         {
             WS_BORDER = 0x800000,
@@ -677,9 +684,9 @@ namespace Avalonia.Win32.Interop
         [DllImport("user32.dll")]
         public static extern bool EnumDisplayMonitors(IntPtr hdc, IntPtr lprcClip,
                                                       MonitorEnumDelegate lpfnEnum, IntPtr dwData);
-        
+
         public delegate bool MonitorEnumDelegate(IntPtr hMonitor, IntPtr hdcMonitor, ref Rect lprcMonitor, IntPtr dwData);
-        
+
         [DllImport("user32.dll", SetLastError = true)]
         public static extern IntPtr GetDC(IntPtr hWnd);
 
@@ -767,7 +774,7 @@ namespace Avalonia.Win32.Interop
 
         public static uint GetWindowLong(IntPtr hWnd, int nIndex)
         {
-            if(IntPtr.Size == 4)
+            if (IntPtr.Size == 4)
             {
                 return GetWindowLong32b(hWnd, nIndex);
             }
@@ -794,7 +801,7 @@ namespace Avalonia.Win32.Interop
                 return (uint)SetWindowLong64b(hWnd, nIndex, new IntPtr((uint)value)).ToInt32();
             }
         }
-        
+
         public static IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr handle)
         {
             if (IntPtr.Size == 4)
@@ -836,9 +843,23 @@ namespace Avalonia.Win32.Interop
 
         [DllImport("user32.dll")]
         public static extern bool PeekMessage(out MSG lpMsg, IntPtr hWnd, uint wMsgFilterMin, uint wMsgFilterMax, uint wRemoveMsg);
-        
+
         [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "RegisterClassExW")]
         public static extern ushort RegisterClassEx(ref WNDCLASSEX lpwcx);
+        [DllImport("user32.dll")]
+        public static extern bool SetLayeredWindowAttributes(IntPtr hwnd, COLORREF crKey, byte bAlpha, uint dwFlags);
+
+        // Alternate
+        [StructLayout(LayoutKind.Sequential)]
+        public struct COLORREF
+        {
+            public uint ColorDWORD;
+
+            public COLORREF(Avalonia.Media.Color color)
+            {
+                ColorDWORD = (uint)color.R + (((uint)color.G) << 8) + (((uint)color.B) << 16);
+            }
+        }
 
         [DllImport("user32.dll")]
         public static extern bool ReleaseCapture();
@@ -959,7 +980,7 @@ namespace Avalonia.Win32.Interop
         internal static extern int CoCreateInstance(ref Guid clsid,
             IntPtr ignore1, int ignore2, ref Guid iid, [MarshalAs(UnmanagedType.IUnknown), Out] out object pUnkOuter);
 
-        
+
         [DllImport("shell32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern int SHCreateItemFromParsingName([MarshalAs(UnmanagedType.LPWStr)] string pszPath, IntPtr pbc, ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out IShellItem ppv);
 
@@ -1030,7 +1051,7 @@ namespace Avalonia.Win32.Interop
 
         [DllImport("user32.dll")]
         public static extern IntPtr MonitorFromWindow(IntPtr hwnd, MONITOR dwFlags);
-        
+
         [DllImport("user32", EntryPoint = "GetMonitorInfoW", ExactSpelling = true, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool GetMonitorInfo([In] IntPtr hMonitor, ref MONITORINFO lpmi);
@@ -1043,7 +1064,7 @@ namespace Avalonia.Win32.Interop
         public static extern int SetDIBitsToDevice(IntPtr hdc, int XDest, int YDest, uint
                 dwWidth, uint dwHeight, int XSrc, int YSrc, uint uStartScan, uint cScanLines,
             IntPtr lpvBits, [In] ref BITMAPINFOHEADER lpbmi, uint fuColorUse);
-        
+
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool CloseHandle(IntPtr hObject);
@@ -1064,12 +1085,12 @@ namespace Avalonia.Win32.Interop
             uint dwMaximumSizeLow,
             string lpName);
 
-        [DllImport("msvcrt.dll", EntryPoint="memcpy", SetLastError = false, CallingConvention=CallingConvention.Cdecl)]
-        public static extern IntPtr CopyMemory(IntPtr dest, IntPtr src, UIntPtr count); 
-        
+        [DllImport("msvcrt.dll", EntryPoint = "memcpy", SetLastError = false, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr CopyMemory(IntPtr dest, IntPtr src, UIntPtr count);
+
         [DllImport("ole32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
         public static extern HRESULT RegisterDragDrop(IntPtr hwnd, IDropTarget target);
-        
+
         [DllImport("ole32.dll", EntryPoint = "OleInitialize")]
         public static extern HRESULT OleInitialize(IntPtr val);
 
@@ -1134,9 +1155,9 @@ namespace Avalonia.Win32.Interop
             MDT_ANGULAR_DPI = 1,
             MDT_RAW_DPI = 2,
             MDT_DEFAULT = MDT_EFFECTIVE_DPI
-        } 
+        }
 
-        public enum ClipboardFormat 
+        public enum ClipboardFormat
         {
             /// <summary>
             /// Text format. Each line ends with a carriage return/linefeed (CR-LF) combination. A null character signals the end of the data. Use this format for ANSI text.
@@ -1318,7 +1339,7 @@ namespace Avalonia.Win32.Interop
             OFN_NOREADONLYRETURN = 0x00008000,
             OFN_OVERWRITEPROMPT = 0x00000002
         }
-        
+
         public enum HRESULT : uint
         {
             S_FALSE = 0x0001,

--- a/src/Windows/Avalonia.Win32/PopupImpl.cs
+++ b/src/Windows/Avalonia.Win32/PopupImpl.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Win32
             UnmanagedMethods.ShowWindow(Handle.Handle, UnmanagedMethods.ShowWindowCommand.ShowNoActivate);
         }
 
-        protected override IntPtr CreateWindowOverride(ushort atom)
+        protected override IntPtr CreateWindowOverride(ushort atom, bool layered = false)
         {
             UnmanagedMethods.WindowStyles style =
                 UnmanagedMethods.WindowStyles.WS_POPUP |

--- a/src/Windows/Avalonia.Win32/PopupImpl.cs
+++ b/src/Windows/Avalonia.Win32/PopupImpl.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Win32
             UnmanagedMethods.ShowWindow(Handle.Handle, UnmanagedMethods.ShowWindowCommand.ShowNoActivate);
         }
 
-        protected override IntPtr CreateWindowOverride(ushort atom, bool layered = false)
+        protected override IntPtr CreateWindowOverride(ushort atom)
         {
             UnmanagedMethods.WindowStyles style =
                 UnmanagedMethods.WindowStyles.WS_POPUP |


### PR DESCRIPTION
## What does the pull request do?
Enables support for Windows transparency using layered window 

## What is the current behavior?
On Windows you can't have any kind of transparency outside the window


## What is the updated/expected behavior with this PR?
Lets developers to choose if to allow transparency for specific windows
Any pixel painted by the color "Transparent" will be invisible

## How was the solution implemented (if it's not obvious)?
I added new property to Window control - "AllowWindowTransparency" when enabled the window's extended style will be changed to layered (in addition to it's previous style) and the layered attributes will be set that Transparent color will be invisible


## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #2306
Fixes #987
-->
