### PR TITLE
Add CaretBrush Feature to Textbox

### DIFF
--- a/samples/ControlCatalog/Pages/TextBoxPage.xaml
+++ b/samples/ControlCatalog/Pages/TextBoxPage.xaml
@@ -26,6 +26,7 @@
         <TextBox Width="200" Text="Left aligned text" TextAlignment="Left" />
         <TextBox Width="200" Text="Center aligned text" TextAlignment="Center" />
         <TextBox Width="200" Text="Right aligned text" TextAlignment="Right" />
+        <TextBox Width="200" Text="Custom caret brush" CaretBrush="DarkOrange"/>
       </StackPanel>
 
       <StackPanel Orientation="Vertical" Spacing="8">

--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -19,6 +19,9 @@ namespace Avalonia.Controls.Presenters
         public static readonly StyledProperty<char> PasswordCharProperty =
             AvaloniaProperty.Register<TextPresenter, char>(nameof(PasswordChar));
 
+        public static readonly StyledProperty<IBrush> CaretBrushProperty =
+         AvaloniaProperty.Register<TextPresenter, IBrush>(nameof(CaretBrushProperty));
+
         public static readonly DirectProperty<TextPresenter, int> SelectionStartProperty =
             TextBox.SelectionStartProperty.AddOwner<TextPresenter>(
                 o => o.SelectionStart,
@@ -35,7 +38,7 @@ namespace Avalonia.Controls.Presenters
         private int _selectionEnd;
         private bool _caretBlink;
         private IBrush _highlightBrush;
-        
+
         static TextPresenter()
         {
             AffectsRender<TextPresenter>(PasswordCharProperty);
@@ -77,6 +80,12 @@ namespace Avalonia.Controls.Presenters
         {
             get => GetValue(PasswordCharProperty);
             set => SetValue(PasswordCharProperty, value);
+        }
+
+        public IBrush CaretBrush
+        {
+            get => GetValue(CaretBrushProperty);
+            set => SetValue(CaretBrushProperty, value);
         }
 
         public int SelectionStart
@@ -144,16 +153,21 @@ namespace Avalonia.Controls.Presenters
 
             if (selectionStart == selectionEnd)
             {
-                var backgroundColor = (((Control)TemplatedParent).GetValue(BackgroundProperty) as SolidColorBrush)?.Color;
-                var caretBrush = Brushes.Black;
+                var caretBrush = CaretBrush;
 
-                if (backgroundColor.HasValue)
+                if (caretBrush is null)
                 {
-                    byte red = (byte)~(backgroundColor.Value.R);
-                    byte green = (byte)~(backgroundColor.Value.G);
-                    byte blue = (byte)~(backgroundColor.Value.B);
+                    var backgroundColor = (((Control)TemplatedParent).GetValue(BackgroundProperty) as SolidColorBrush)?.Color;
+                    if (backgroundColor.HasValue)
+                    {
+                        byte red = (byte)~(backgroundColor.Value.R);
+                        byte green = (byte)~(backgroundColor.Value.G);
+                        byte blue = (byte)~(backgroundColor.Value.B);
 
-                    caretBrush = new SolidColorBrush(Color.FromRgb(red, green, blue));
+                        caretBrush = new SolidColorBrush(Color.FromRgb(red, green, blue));
+                    }
+                    else
+                        caretBrush = Brushes.Black;
                 }
 
                 if (_caretBlink)

--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -20,7 +20,7 @@ namespace Avalonia.Controls.Presenters
             AvaloniaProperty.Register<TextPresenter, char>(nameof(PasswordChar));
 
         public static readonly StyledProperty<IBrush> CaretBrushProperty =
-         AvaloniaProperty.Register<TextPresenter, IBrush>(nameof(CaretBrushProperty));
+            AvaloniaProperty.Register<TextPresenter, IBrush>(nameof(CaretBrushProperty));
 
         public static readonly DirectProperty<TextPresenter, int> SelectionStartProperty =
             TextBox.SelectionStartProperty.AddOwner<TextPresenter>(

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -39,7 +39,7 @@ namespace Avalonia.Controls
             AvaloniaProperty.Register<TextBox, char>(nameof(PasswordChar));
 
         public static readonly StyledProperty<IBrush> CaretBrushProperty =
-  AvaloniaProperty.Register<TextPresenter, IBrush>(nameof(CaretBrushProperty));
+            AvaloniaProperty.Register<TextPresenter, IBrush>(nameof(CaretBrushProperty));
 
         public static readonly DirectProperty<TextBox, int> SelectionStartProperty =
             AvaloniaProperty.RegisterDirect<TextBox, int>(

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -38,6 +38,9 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<char> PasswordCharProperty =
             AvaloniaProperty.Register<TextBox, char>(nameof(PasswordChar));
 
+        public static readonly StyledProperty<IBrush> CaretBrushProperty =
+  AvaloniaProperty.Register<TextPresenter, IBrush>(nameof(CaretBrushProperty));
+
         public static readonly DirectProperty<TextBox, int> SelectionStartProperty =
             AvaloniaProperty.RegisterDirect<TextBox, int>(
                 nameof(SelectionStart),
@@ -167,6 +170,12 @@ namespace Avalonia.Controls
         {
             get => GetValue(PasswordCharProperty);
             set => SetValue(PasswordCharProperty, value);
+        }
+
+        public IBrush CaretBrush
+        {
+            get => GetValue(CaretBrushProperty);
+            set => SetValue(CaretBrushProperty, value);
         }
 
         public int SelectionStart

--- a/src/Avalonia.Themes.Default/TextBox.xaml
+++ b/src/Avalonia.Themes.Default/TextBox.xaml
@@ -44,7 +44,8 @@
                                  SelectionEnd="{TemplateBinding SelectionEnd}"
                                  TextAlignment="{TemplateBinding TextAlignment}"
                                  TextWrapping="{TemplateBinding TextWrapping}"
-                                 PasswordChar="{TemplateBinding PasswordChar}"/>
+                                 PasswordChar="{TemplateBinding PasswordChar}"
+                                 CaretBrush="{TemplateBinding CaretBrush}"/>
                 </Panel>
               </ScrollViewer>
             </DataValidationErrors>


### PR DESCRIPTION
## What does the pull request do?
This PR adds CaretBrush property to TextBox to change the color of caret (blinking cursor when writing text in Textbox) like what we have in WPF

![CaretBrush](https://user-images.githubusercontent.com/18364158/59373482-0f948a00-8d4a-11e9-8253-b87c32cfb73f.png)


Aslo adds example to show this feature  in Control Catalog

## What is the current behavior?
Now caret brush is depends on background color of TextBox to make some contrast, and if background has no color then it gets default color (black)


## What is the updated/expected behavior with this PR?
Caret color can be changed by setting color name or brush to CaretBrush styled property like this:
`<TextBox Text="Custom caret brush" CaretBrush="DarkOrange"/>`

## Breaking changes
no Breaking changes


## Fixed issues

Adds feature requested  here #2628

