### PR TITLE
[DO-NOT-MERGE] Compiled PropertyPath for setters

### DIFF
--- a/src/Avalonia.Base/AvaloniaProperty.cs
+++ b/src/Avalonia.Base/AvaloniaProperty.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Reactive.Subjects;
 using System.Reflection;
 using Avalonia.Data;
+using Avalonia.Data.Core;
 using Avalonia.Utilities;
 
 namespace Avalonia
@@ -14,7 +15,7 @@ namespace Avalonia
     /// <summary>
     /// Base class for avalonia properties.
     /// </summary>
-    public class AvaloniaProperty : IEquatable<AvaloniaProperty>
+    public class AvaloniaProperty : IEquatable<AvaloniaProperty>, IPropertyInfo
     {
         /// <summary>
         /// Represents an unset property value.
@@ -546,7 +547,10 @@ namespace Avalonia
             }
         }
 
-        
+        bool IPropertyInfo.CanGet => true;
+        bool IPropertyInfo.CanSet => true;
+        object IPropertyInfo.Get(object target) => ((AvaloniaObject)target).GetValue(this);
+        void IPropertyInfo.Set(object target, object value) => ((AvaloniaObject)target).SetValue(this, value);
     }
     /// <summary>
     /// Class representing the <see cref="AvaloniaProperty.UnsetValue"/>.

--- a/src/Avalonia.Base/Data/Core/ClrPropertyInfo.cs
+++ b/src/Avalonia.Base/Data/Core/ClrPropertyInfo.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Avalonia.Data.Core
+{
+    public class ClrPropertyInfo : IPropertyInfo
+    {
+        private readonly Func<object, object> _getter;
+        private readonly Action<object, object> _setter;
+
+        public ClrPropertyInfo(string name, Func<object, object> getter, Action<object, object> setter)
+        {
+            _getter = getter;
+            _setter = setter;
+            Name = name;
+        }
+
+        public string Name { get; }
+        public object Get(object target)
+        {
+            if (_getter == null)
+                throw new NotSupportedException("Property " + Name + " doesn't have a getter");
+            return _getter(target);
+        }
+
+        public void Set(object target, object value)
+        {
+            if (_setter == null)
+                throw new NotSupportedException("Property " + Name + " doesn't have a setter");
+            _setter(target, value);
+        }
+
+        public bool CanSet => _setter != null;
+        public bool CanGet => _getter != null;
+    }
+
+    public class ReflectionClrPropertyInfo : ClrPropertyInfo
+    {
+        static Action<object, object> CreateSetter(PropertyInfo info)
+        {
+            if (info.SetMethod == null)
+                return null;
+            var target = Expression.Parameter(typeof(object), "target");
+            var value = Expression.Parameter(typeof(object), "value");
+            return Expression.Lambda<Action<object, object>>(
+                    Expression.Call(Expression.Convert(target, info.DeclaringType), info.SetMethod,
+                        Expression.Convert(value, info.SetMethod.GetParameters()[0].ParameterType)),
+                    target, value)
+                .Compile();
+        }
+        
+        static Func<object, object> CreateGetter(PropertyInfo info)
+        {
+            if (info.GetMethod == null)
+                return null;
+            var target = Expression.Parameter(typeof(object), "target");
+            return Expression.Lambda<Func<object, object>>(
+                    Expression.Convert(Expression.Call(Expression.Convert(target, info.DeclaringType), info.GetMethod),
+                        typeof(object)))
+                .Compile();
+        }
+
+        public ReflectionClrPropertyInfo(PropertyInfo info) : base(info.Name,
+            CreateGetter(info), CreateSetter(info))
+        {
+            
+        }
+    }
+}

--- a/src/Avalonia.Base/Data/Core/IPropertyInfo.cs
+++ b/src/Avalonia.Base/Data/Core/IPropertyInfo.cs
@@ -1,0 +1,11 @@
+namespace Avalonia.Data.Core
+{
+    public interface IPropertyInfo
+    {
+        string Name { get; }
+        object Get(object target);
+        void Set(object target, object value);
+        bool CanSet { get; }
+        bool CanGet { get; }
+    }
+}

--- a/src/Avalonia.Base/Data/Core/PropertyPath.cs
+++ b/src/Avalonia.Base/Data/Core/PropertyPath.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Avalonia.Data.Core
+{
+    public class PropertyPath
+    {
+        public IReadOnlyList<IPropertyPathElement> Elements { get; }
+
+        public PropertyPath(IEnumerable<IPropertyPathElement> elements)
+        {
+            Elements = elements.ToList();
+        }
+    }
+
+    public class PropertyPathBuilder
+    {
+        readonly List<IPropertyPathElement> _elements = new List<IPropertyPathElement>();
+        
+        public PropertyPathBuilder Property(IPropertyInfo property)
+        {
+            _elements.Add(new PropertyPropertyPathElement(property));
+            return this;
+        }
+        
+
+        public PropertyPathBuilder ChildTraversal()
+        {
+            _elements.Add(new ChildTraversalPropertyPathElement());
+            return this;
+        }
+
+        public PropertyPathBuilder EnsureType(Type type)
+        {
+            _elements.Add(new EnsureTypePropertyPathElement(type));
+            return this;
+        }
+
+        public PropertyPathBuilder Cast(Type type)
+        {
+            _elements.Add(new CastTypePropertyPathElement(type));
+            return this;
+        }
+
+        public PropertyPath Build()
+        {
+            return new PropertyPath(_elements);
+        }
+    }
+
+    public interface IPropertyPathElement
+    {
+        
+    }
+
+    public class PropertyPropertyPathElement : IPropertyPathElement
+    {
+        public IPropertyInfo Property { get; }
+
+        public PropertyPropertyPathElement(IPropertyInfo property)
+        {
+            Property = property;
+        }
+    }
+
+    public class ChildTraversalPropertyPathElement : IPropertyPathElement
+    {
+        
+    }
+
+    public class EnsureTypePropertyPathElement : IPropertyPathElement
+    {
+        public Type Type { get; }
+
+        public EnsureTypePropertyPathElement(Type type)
+        {
+            Type = type;
+        }
+    }
+
+    public class CastTypePropertyPathElement : IPropertyPathElement
+    {
+        public CastTypePropertyPathElement(Type type)
+        {
+            Type = type;
+        }
+
+        public Type Type { get; }
+    }
+}

--- a/src/Avalonia.Base/Utilities/CharacterReader.cs
+++ b/src/Avalonia.Base/Utilities/CharacterReader.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Utilities
         }
 
         public bool End => _s.IsEmpty;
-        public char Peek => _s[0];
+        public char PeekOneOrThrow => _s[0];
         public int Position { get; private set; }
         public char Take()
         {
@@ -38,7 +38,7 @@ namespace Avalonia.Utilities
 
         public bool TakeIf(char c)
         {
-            if (Peek == c)
+            if (PeekOneOrThrow == c)
             {
                 Take();
                 return true;
@@ -51,7 +51,7 @@ namespace Avalonia.Utilities
 
         public bool TakeIf(Func<char, bool> condition)
         {
-            if (condition(Peek))
+            if (condition(PeekOneOrThrow))
             {
                 Take();
                 return true;
@@ -81,6 +81,24 @@ namespace Avalonia.Utilities
             _s = _s.Slice(len);
             Position += len;
             return span;
+        }
+
+        public ReadOnlySpan<char> TryPeek(int count)
+        {
+            return _s.Slice(0, count);
+        }
+
+        public ReadOnlySpan<char> PeekWhitespace()
+        {
+            var trimmed = _s.TrimStart();
+            return _s.Slice(0, _s.Length - trimmed.Length);
+        }
+
+        public void Skip(int count)
+        {
+            if (_s.Length < count)
+                throw new IndexOutOfRangeException();
+            _s = _s.Slice(count);
         }
     }
 }

--- a/src/Avalonia.Base/Utilities/CharacterReader.cs
+++ b/src/Avalonia.Base/Utilities/CharacterReader.cs
@@ -85,6 +85,8 @@ namespace Avalonia.Utilities
 
         public ReadOnlySpan<char> TryPeek(int count)
         {
+            if (_s.Length < count)
+                return ReadOnlySpan<char>.Empty;
             return _s.Slice(0, count);
         }
 

--- a/src/Avalonia.Base/Utilities/IdentifierParser.cs
+++ b/src/Avalonia.Base/Utilities/IdentifierParser.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Utilities
     {
         public static ReadOnlySpan<char> ParseIdentifier(this ref CharacterReader r)
         {
-            if (IsValidIdentifierStart(r.Peek))
+            if (IsValidIdentifierStart(r.PeekOneOrThrow))
             {
                 return r.TakeWhile(IsValidIdentifierChar);
             }

--- a/src/Avalonia.Base/Utilities/KeywordParser.cs
+++ b/src/Avalonia.Base/Utilities/KeywordParser.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Avalonia.Utilities
+{
+#if !BUILDTASK
+    public
+#endif
+    static class KeywordParser
+    {
+        public static bool CheckKeyword(this ref CharacterReader r, string keyword)
+        {
+            return (CheckKeywordInternal(ref r, keyword) >= 0);
+        }
+        
+        static int CheckKeywordInternal(this ref CharacterReader r, string keyword)
+        {
+            var ws = r.PeekWhitespace();
+
+            var chars = r.TryPeek(ws.Length + keyword.Length);
+            if (chars.Slice(ws.Length).Equals(keyword.AsSpan(), StringComparison.Ordinal))
+                return chars.Length;
+            return -1;
+        }
+
+        public static bool TakeIfKeyword(this ref CharacterReader r, string keyword)
+        {
+            var l = CheckKeywordInternal(ref r, keyword);
+            if (l < 0)
+                return false;
+            r.Skip(l);
+            return true;
+        }
+    }
+}

--- a/src/Avalonia.Base/Utilities/KeywordParser.cs
+++ b/src/Avalonia.Base/Utilities/KeywordParser.cs
@@ -17,6 +17,8 @@ namespace Avalonia.Utilities
             var ws = r.PeekWhitespace();
 
             var chars = r.TryPeek(ws.Length + keyword.Length);
+            if (chars.IsEmpty)
+                return -1;
             if (SpanEquals(chars.Slice(ws.Length), keyword.AsSpan()))
                 return chars.Length;
             return -1;

--- a/src/Avalonia.Base/Utilities/KeywordParser.cs
+++ b/src/Avalonia.Base/Utilities/KeywordParser.cs
@@ -17,9 +17,19 @@ namespace Avalonia.Utilities
             var ws = r.PeekWhitespace();
 
             var chars = r.TryPeek(ws.Length + keyword.Length);
-            if (chars.Slice(ws.Length).Equals(keyword.AsSpan(), StringComparison.Ordinal))
+            if (SpanEquals(chars.Slice(ws.Length), keyword.AsSpan()))
                 return chars.Length;
             return -1;
+        }
+
+        static bool SpanEquals(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
+        {
+            if (left.Length != right.Length)
+                return false;
+            for(var c=0; c<left.Length;c++)
+                if (left[c] != right[c])
+                    return false;
+            return true;
         }
 
         public static bool TakeIfKeyword(this ref CharacterReader r, string keyword)

--- a/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
+++ b/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
@@ -30,6 +30,9 @@
       <Compile Include="../Markup/Avalonia.Markup\Markup\Parsers\SelectorGrammar.cs">
         <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
       </Compile>
+      <Compile Include="../Markup/Avalonia.Markup\Markup\Parsers\PropertyPathGrammar.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>
       <Compile Include="../Markup/Avalonia.Markup.Xaml/Parsers/PropertyParser.cs">
         <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
       </Compile>
@@ -38,11 +41,13 @@
       </Compile>
       <Compile Include="../Avalonia.Base/Utilities/CharacterReader.cs">
         <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
-      </Compile>      
+      </Compile>
       <Compile Include="../Avalonia.Base/Utilities/IdentifierParser.cs">
         <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
       </Compile>
-      
+      <Compile Include="../Avalonia.Base/Utilities/KeywordParser.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>      
       <Compile Remove="../Markup/Avalonia.Markup.Xaml/XamlIl\xamlil.github\**\obj\**\*.cs" />
       <Compile Remove="../Markup/Avalonia.Markup.Xaml/XamlIl\xamlil.github\src\XamlIl\TypeSystem\SreTypeSystem.cs" />
       <PackageReference Include="Avalonia.Unofficial.Cecil" Version="20190417.2.0" PrivateAssets="All" />

--- a/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
+++ b/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
@@ -49,13 +49,18 @@ namespace Avalonia.Build.Tasks
             if (avares.Resources.Count(CheckXamlName) == 0 && emres.Resources.Count(CheckXamlName) == 0)
                 // Nothing to do
                 return new CompileResult(true);
+
+            var clrPropertiesDef = new TypeDefinition("CompiledAvaloniaXaml", "XamlIlHelpers",
+                TypeAttributes.Class, asm.MainModule.TypeSystem.Object);
+            asm.MainModule.Types.Add(clrPropertiesDef);
             
             var xamlLanguage = AvaloniaXamlIlLanguage.Configure(typeSystem);
-            var compilerConfig = new XamlIlTransformerConfiguration(typeSystem,
+            var compilerConfig = new AvaloniaXamlIlCompilerConfiguration(typeSystem,
                 typeSystem.TargetAssembly,
                 xamlLanguage,
                 XamlIlXmlnsMappings.Resolve(typeSystem, xamlLanguage),
-                AvaloniaXamlIlLanguage.CustomValueConverter);
+                AvaloniaXamlIlLanguage.CustomValueConverter,
+                new XamlIlClrPropertyInfoEmitter(typeSystem.CreateTypeBuilder(clrPropertiesDef)));
 
 
             var contextDef = new TypeDefinition("CompiledAvaloniaXaml", "XamlIlContext", 

--- a/src/Avalonia.Styling/Styling/Setter.cs
+++ b/src/Avalonia.Styling/Styling/Setter.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Avalonia.Animation;
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Data.Core;
 using Avalonia.Metadata;
 using Avalonia.Reactive;
 
@@ -49,6 +50,11 @@ namespace Avalonia.Styling
             get;
             set;
         }
+        
+        /// <summary>
+        /// Gets or sets the property path
+        /// </summary>
+        public PropertyPath PropertyPath { get; set; }
 
         /// <summary>
         /// Gets or sets the property value.

--- a/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
+++ b/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
@@ -38,6 +38,7 @@
         <Compile Include="Templates\TemplateContent.cs" />
         <Compile Include="Templates\TreeDataTemplate.cs" />
         <Compile Include="XamlIl\AvaloniaXamlIlRuntimeCompiler.cs" />
+        <Compile Include="XamlIl\CompilerExtensions\AvaloniaXamlIlCompilerConfiguration.cs" />
         <Compile Include="XamlIl\CompilerExtensions\Transformers\AvaloniaBindingExtensionHackTransformer.cs" />
         <Compile Include="XamlIl\CompilerExtensions\Transformers\AvaloniaXamlIlAvaloniaPropertyResolver.cs" />
         <Compile Include="XamlIl\CompilerExtensions\Transformers\AvaloniaXamlIlConstructorServiceProviderTransformer.cs" />
@@ -55,6 +56,7 @@
         <Compile Include="XamlIl\CompilerExtensions\Transformers\IgnoredDirectivesTransformer.cs" />
         <Compile Include="XamlIl\CompilerExtensions\Transformers\AvaloniaXamlIlSelectorTransformer.cs" />
         <Compile Include="XamlIl\CompilerExtensions\Transformers\XNameTransformer.cs" />
+        <Compile Include="XamlIl\CompilerExtensions\XamlIlClrPropertyInfoHelper.cs" />
         <Compile Include="XamlIl\Runtime\IAvaloniaXamlIlParentStackProvider.cs" />
         <Compile Include="XamlIl\Runtime\IAvaloniaXamlIlXmlNamespaceInfoProviderV1.cs" />
         <Compile Include="XamlIl\Runtime\XamlIlRuntimeHelpers.cs" />

--- a/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
+++ b/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
@@ -45,6 +45,7 @@
         <Compile Include="XamlIl\CompilerExtensions\Transformers\AvaloniaXamlIlControlTemplateTargetTypeMetadataTransformer.cs" />
         <Compile Include="XamlIl\CompilerExtensions\Transformers\AvaloniaXamlIlDesignPropertiesTransformer.cs" />
         <Compile Include="XamlIl\CompilerExtensions\Transformers\AvaloniaXamlIlMetadataRemover.cs" />
+        <Compile Include="XamlIl\CompilerExtensions\Transformers\AvaloniaXamlIlPropertyPathTransformer.cs"/>
         <Compile Include="XamlIl\CompilerExtensions\Transformers\AvaloniaXamlIlTransformInstanceAttachedProperties.cs" />
         <Compile Include="XamlIl\CompilerExtensions\Transformers\AvaloniaXamlIlTransitionsTypeMetadataTransformer.cs" />
         <Compile Include="XamlIl\CompilerExtensions\Transformers\AvaloniaXamlIlWellKnownTypes.cs" />

--- a/src/Markup/Avalonia.Markup.Xaml/Parsers/PropertyParser.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Parsers/PropertyParser.cs
@@ -41,7 +41,7 @@ namespace Avalonia.Markup.Xaml.Parsers
                             throw new ExpressionParseException(r.Position, $"Expected ')'.");
                         }
 
-                        throw new ExpressionParseException(r.Position, $"Unexpected '{r.Peek}'.");
+                        throw new ExpressionParseException(r.Position, $"Unexpected '{r.PeekOneOrThrow}'.");
                     }
                 }
                 else if (!r.End && r.TakeIf(':'))

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/AvaloniaXamlIlRuntimeCompiler.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/AvaloniaXamlIlRuntimeCompiler.cs
@@ -114,11 +114,15 @@ namespace Avalonia.Markup.Xaml.XamlIl
 
             InitializeSre();
             var asm = localAssembly == null ? null : _sreTypeSystem.GetAssembly(localAssembly);
-            
-            var compiler = new AvaloniaXamlIlCompiler(new XamlIlTransformerConfiguration(_sreTypeSystem, asm,
-                _sreMappings, _sreXmlns, AvaloniaXamlIlLanguage.CustomValueConverter),
-                _sreContextType);
+
             var tb = _sreBuilder.DefineType("Builder_" + Guid.NewGuid().ToString("N") + "_" + uri);
+            var clrPropertyBuilder = tb.DefineNestedType("ClrProperties_" + Guid.NewGuid().ToString("N"));
+            
+            var compiler = new AvaloniaXamlIlCompiler(new AvaloniaXamlIlCompilerConfiguration(_sreTypeSystem, asm,
+                _sreMappings, _sreXmlns, AvaloniaXamlIlLanguage.CustomValueConverter,
+                new XamlIlClrPropertyInfoEmitter(_sreTypeSystem.CreateTypeBuilder(clrPropertyBuilder))), 
+                _sreContextType);
+            
 
             IXamlIlType overrideType = null;
             if (rootInstance != null)
@@ -129,6 +133,7 @@ namespace Avalonia.Markup.Xaml.XamlIl
             compiler.IsDesignMode = isDesignMode;
             compiler.ParseAndCompile(xaml, uri?.ToString(), null, _sreTypeSystem.CreateTypeBuilder(tb), overrideType);
             var created = tb.CreateTypeInfo();
+            clrPropertyBuilder.CreateTypeInfo();
 
             return LoadOrPopulate(created, rootInstance);
         }

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/AvaloniaXamlIlCompiler.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/AvaloniaXamlIlCompiler.cs
@@ -16,7 +16,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
         private readonly IXamlIlType _contextType;
         private readonly AvaloniaXamlIlDesignPropertiesTransformer _designTransformer;
 
-        private AvaloniaXamlIlCompiler(XamlIlTransformerConfiguration configuration) : base(configuration, true)
+        private AvaloniaXamlIlCompiler(AvaloniaXamlIlCompilerConfiguration configuration) : base(configuration, true)
         {
             _configuration = configuration;
 
@@ -57,14 +57,14 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
 
         }
 
-        public AvaloniaXamlIlCompiler(XamlIlTransformerConfiguration configuration,
+        public AvaloniaXamlIlCompiler(AvaloniaXamlIlCompilerConfiguration configuration,
             IXamlIlTypeBuilder contextTypeBuilder) : this(configuration)
         {
             _contextType = CreateContextType(contextTypeBuilder);
         }
 
         
-        public AvaloniaXamlIlCompiler(XamlIlTransformerConfiguration configuration,
+        public AvaloniaXamlIlCompiler(AvaloniaXamlIlCompilerConfiguration configuration,
             IXamlIlType contextType) : this(configuration)
         {
             _contextType = contextType;

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/AvaloniaXamlIlCompiler.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/AvaloniaXamlIlCompiler.cs
@@ -44,6 +44,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
 
             InsertBefore<XamlIlContentConvertTransformer>(
                 new AvaloniaXamlIlSelectorTransformer(),
+                new AvaloniaXamlIlPropertyPathTransformer(),
                 new AvaloniaXamlIlSetterTransformer(),
                 new AvaloniaXamlIlControlTemplateTargetTypeMetadataTransformer(),
                 new AvaloniaXamlIlConstructorServiceProviderTransformer(),

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/AvaloniaXamlIlCompilerConfiguration.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/AvaloniaXamlIlCompilerConfiguration.cs
@@ -1,0 +1,21 @@
+using XamlIl.Transform;
+using XamlIl.TypeSystem;
+
+namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
+{
+    class AvaloniaXamlIlCompilerConfiguration : XamlIlTransformerConfiguration
+    {
+        public XamlIlClrPropertyInfoEmitter ClrPropertyEmitter { get; }
+
+        public AvaloniaXamlIlCompilerConfiguration(IXamlIlTypeSystem typeSystem, 
+            IXamlIlAssembly defaultAssembly, 
+            XamlIlLanguageTypeMappings typeMappings,
+            XamlIlXmlnsMappings xmlnsMappings,
+            XamlIlValueConverter customValueConverter,
+            XamlIlClrPropertyInfoEmitter clrPropertyEmitter) : base(typeSystem, defaultAssembly, typeMappings, xmlnsMappings, customValueConverter)
+        {
+            ClrPropertyEmitter = clrPropertyEmitter;
+            AddExtra(ClrPropertyEmitter);
+        }
+    }
+}

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/AvaloniaXamlIlLanguage.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/AvaloniaXamlIlLanguage.cs
@@ -50,7 +50,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                 },
                 InnerServiceProviderFactoryMethod =
                     runtimeHelpers.FindMethod(m => m.Name == "CreateInnerServiceProviderV1"),
-                ProvideValueTargetPropertyEmitter = XamlIlAvaloniaPropertyHelper.Emit,
+                ProvideValueTargetPropertyEmitter = XamlIlAvaloniaPropertyHelper.EmitProvideValueTarget,
             };
             rv.CustomAttributeResolver = new AttributeResolver(typeSystem, rv);
             return rv;

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/Transformers/AvaloniaXamlIlPropertyPathTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/Transformers/AvaloniaXamlIlPropertyPathTransformer.cs
@@ -17,7 +17,8 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             if (node is XamlIlAstXamlPropertyValueNode pv
                 && pv.Values.Count == 1
                 && pv.Values[0] is XamlIlAstTextNode text
-                && pv.Property.GetClrProperty().Getter.ReturnType.Equals(context.GetAvaloniaTypes().PropertyPath)
+                && pv.Property.GetClrProperty().Getter?.ReturnType
+                    .Equals(context.GetAvaloniaTypes().PropertyPath) == true
             )
             {
                 var parentScope = context.ParentNodes().OfType<AvaloniaXamlIlTargetTypeMetadataNode>()

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/Transformers/AvaloniaXamlIlPropertyPathTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/Transformers/AvaloniaXamlIlPropertyPathTransformer.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Markup.Parsers;
+using XamlIl;
+using XamlIl.Ast;
+using XamlIl.Transform;
+using XamlIl.Transform.Transformers;
+using XamlIl.TypeSystem;
+
+namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
+{
+    class AvaloniaXamlIlPropertyPathTransformer : IXamlIlAstTransformer
+    {
+        public IXamlIlAstNode Transform(XamlIlAstTransformationContext context, IXamlIlAstNode node)
+        {
+            if (node is XamlIlAstXamlPropertyValueNode pv
+                && pv.Values.Count == 1
+                && pv.Values[0] is XamlIlAstTextNode text
+                && pv.Property.GetClrProperty().Getter.ReturnType.Equals(context.GetAvaloniaTypes().PropertyPath)
+            )
+            {
+                var parentScope = context.ParentNodes().OfType<AvaloniaXamlIlTargetTypeMetadataNode>()
+                    .FirstOrDefault();
+                if(parentScope == null)
+                    throw new XamlIlParseException("No target type scope found for property path", text);
+                if (parentScope.ScopeType != AvaloniaXamlIlTargetTypeMetadataNode.ScopeTypes.Style)
+                    throw new XamlIlParseException("PropertyPath is currently only valid for styles", pv);
+
+
+                IEnumerable<PropertyPathGrammar.ISyntax> parsed;
+                try
+                {
+                    parsed = PropertyPathGrammar.Parse(text.Text);
+                }
+                catch (Exception e)
+                {
+                    throw new XamlIlParseException("Unable to parse PropertyPath: " + e.Message, text);
+                }
+
+                var elements = new List<IXamlIlPropertyPathElementNode>();
+                IXamlIlType currentType = parentScope.TargetType.GetClrType();
+                
+                
+                var expectProperty = true;
+                var expectCast = true;
+                var expectTraversal = false;
+                var types = context.GetAvaloniaTypes();
+                
+                IXamlIlType GetType(string ns, string name)
+                {
+                    return XamlIlTypeReferenceResolver.ResolveType(context, $"{ns}:{name}", false,
+                        text, true).GetClrType();
+                }
+
+                void HandleProperty(string name, string typeNamespace, string typeName)
+                {
+                    if(!expectProperty || currentType == null)
+                        throw new XamlIlParseException("Unexpected property node", text);
+
+                    var propertySearchType =
+                        typeName != null ? GetType(typeNamespace, typeName) : currentType;
+
+                    IXamlIlPropertyPathElementNode prop = null;
+                    var avaloniaPropertyFieldName = name + "Property";
+                    var avaloniaPropertyField = propertySearchType.GetAllFields().FirstOrDefault(f =>
+                        f.IsStatic && f.IsPublic && f.Name == avaloniaPropertyFieldName);
+                    if (avaloniaPropertyField != null)
+                    {
+                        prop = new XamlIlAvaloniaPropertyPropertyPathElementNode(avaloniaPropertyField,
+                            XamlIlAvaloniaPropertyHelper.GetAvaloniaPropertyType(avaloniaPropertyField, types, text));
+                    }
+                    else
+                    {
+                        var clrProperty = propertySearchType.GetAllProperties().FirstOrDefault(p => p.Name == name);
+                        prop = new XamlIClrPropertyPathElementNode(clrProperty);
+                    }
+
+                    if (prop == null)
+                        throw new XamlIlParseException(
+                            $"Unable to resolve property {name} on type {propertySearchType.GetFqn()}",
+                            text);
+                    
+                    currentType = prop.Type;
+                    elements.Add(prop);
+                    expectProperty = false;
+                    expectTraversal = expectCast = true;
+                }
+                
+                foreach (var ge in parsed)
+                {
+                    if (ge is PropertyPathGrammar.ChildTraversalSyntax)
+                    {
+                        if (!expectTraversal)
+                            throw new XamlIlParseException("Unexpected child traversal .", text);
+                        elements.Add(new XamlIlChildTraversalPropertyPathElementNode());
+                        expectTraversal = expectCast = false;
+                        expectProperty = true;
+                    }
+                    else if (ge is PropertyPathGrammar.EnsureTypeSyntax ets)
+                    {
+                        if(!expectCast)
+                            throw new XamlIlParseException("Unexpected cast node", text);
+                        currentType = GetType(ets.TypeNamespace, ets.TypeName);
+                        elements.Add(new XamlIlCastPropertyPathElementNode(currentType, true));
+                        expectProperty = false;
+                        expectCast = expectTraversal = true;
+                    }
+                    else if (ge is PropertyPathGrammar.CastTypeSyntax cts)
+                    {
+                        if(!expectCast)
+                            throw new XamlIlParseException("Unexpected cast node", text);
+                        //TODO: Check if cast can be done
+                        currentType = GetType(cts.TypeNamespace, cts.TypeName);
+                        elements.Add(new XamlIlCastPropertyPathElementNode(currentType, false));
+                        expectProperty = false;
+                        expectCast = expectTraversal = true;
+                    }
+                    else if (ge is PropertyPathGrammar.PropertySyntax ps)
+                    {
+                        HandleProperty(ps.Name, null, null);
+                    }
+                    else if (ge is PropertyPathGrammar.TypeQualifiedPropertySyntax tqps)
+                    {
+                        HandleProperty(tqps.Name, tqps.TypeNamespace, tqps.TypeName);
+                    }
+                    else
+                        throw new XamlIlParseException("Unexpected node " + ge, text);
+                    
+                }
+                var propertyPathNode = new XamlIlPropertyPathNode(text, elements, types);
+                if (propertyPathNode.Type == null)
+                    throw new XamlIlParseException("Unexpected end of the property path", text);
+                pv.Values[0] = propertyPathNode;
+            }
+
+            return node;
+        }
+
+        interface IXamlIlPropertyPathElementNode
+        {
+            void Emit(XamlIlEmitContext context, IXamlIlEmitter codeGen);
+            IXamlIlType Type { get; }
+        }
+
+        class XamlIlChildTraversalPropertyPathElementNode : IXamlIlPropertyPathElementNode
+        {
+            public void Emit(XamlIlEmitContext context, IXamlIlEmitter codeGen)
+                => codeGen.EmitCall(
+                    context.GetAvaloniaTypes()
+                        .PropertyPathBuilder.FindMethod(m => m.Name == "ChildTraversal"));
+
+            public IXamlIlType Type => null;
+        }
+        
+        class XamlIlAvaloniaPropertyPropertyPathElementNode : IXamlIlPropertyPathElementNode
+        {
+            private readonly IXamlIlField _field;
+
+            public XamlIlAvaloniaPropertyPropertyPathElementNode(IXamlIlField field, IXamlIlType propertyType)
+            {
+                _field = field;
+                Type = propertyType;
+            }
+
+            public void Emit(XamlIlEmitContext context, IXamlIlEmitter codeGen)
+                => codeGen
+                    .Ldsfld(_field)
+                    .EmitCall(context.GetAvaloniaTypes()
+                        .PropertyPathBuilder.FindMethod(m => m.Name == "Property"));
+
+            public IXamlIlType Type { get; }
+        }
+        
+        class XamlIClrPropertyPathElementNode : IXamlIlPropertyPathElementNode
+        {
+            private readonly IXamlIlProperty _property;
+
+            public XamlIClrPropertyPathElementNode(IXamlIlProperty property)
+            {
+                _property = property;
+            }
+
+            public void Emit(XamlIlEmitContext context, IXamlIlEmitter codeGen)
+            {
+                context.Configuration.GetExtra<XamlIlClrPropertyInfoEmitter>()
+                    .Emit(context, codeGen, _property);
+
+                codeGen.EmitCall(context.GetAvaloniaTypes()
+                    .PropertyPathBuilder.FindMethod(m => m.Name == "Property"));
+            }
+
+            public IXamlIlType Type => _property.Getter?.ReturnType ?? _property.Setter?.Parameters[0];
+        }
+
+        class XamlIlCastPropertyPathElementNode : IXamlIlPropertyPathElementNode
+        {
+            private readonly IXamlIlType _type;
+            private readonly bool _ensureType;
+
+            public XamlIlCastPropertyPathElementNode(IXamlIlType type, bool ensureType)
+            {
+                _type = type;
+                _ensureType = ensureType;
+            }
+            
+            public void Emit(XamlIlEmitContext context, IXamlIlEmitter codeGen)
+            {
+                codeGen
+                    .Ldtype(_type)
+                    .EmitCall(context.GetAvaloniaTypes()
+                        .PropertyPathBuilder.FindMethod(m => m.Name == (_ensureType ? "EnsureType" : "Cast")));
+            }
+
+            public IXamlIlType Type => _type;
+        }
+
+        class XamlIlPropertyPathNode : XamlIlAstNode, IXamlIlPropertyPathNode, IXamlIlAstEmitableNode
+        {
+            private readonly List<IXamlIlPropertyPathElementNode> _elements;
+            private readonly AvaloniaXamlIlWellKnownTypes _types;
+
+            public XamlIlPropertyPathNode(IXamlIlLineInfo lineInfo,
+                List<IXamlIlPropertyPathElementNode> elements,
+                AvaloniaXamlIlWellKnownTypes types) : base(lineInfo)
+            {
+                _elements = elements;
+                _types = types;
+                Type = new XamlIlAstClrTypeReference(this, types.PropertyPath, false);
+            }
+
+            public IXamlIlAstTypeReference Type { get; }
+            public IXamlIlType PropertyType => _elements.LastOrDefault()?.Type;
+            public XamlIlNodeEmitResult Emit(XamlIlEmitContext context, IXamlIlEmitter codeGen)
+            {
+                codeGen
+                    .Newobj(_types.PropertyPathBuilder.FindConstructor());
+                foreach(var e in _elements)
+                    e.Emit(context, codeGen);
+                codeGen.EmitCall(_types.PropertyPathBuilder.FindMethod(m => m.Name == "Build"));
+                return XamlIlNodeEmitResult.Type(0, _types.PropertyPath);
+            }
+        }
+    }
+
+    interface IXamlIlPropertyPathNode : IXamlIlAstValueNode
+    {
+        IXamlIlType PropertyType { get; }
+    }
+}

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/Transformers/AvaloniaXamlIlSetterTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/Transformers/AvaloniaXamlIlSetterTransformer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Avalonia.Data.Core;
 using XamlIl;
 using XamlIl.Ast;
 using XamlIl.Transform;
@@ -33,29 +34,39 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                 throw new XamlIlParseException(
                     "Can not resolve parent Style Selector type", node);
 
-
+            IXamlIlType propType = null;
             var property = @on.Children.OfType<XamlIlAstXamlPropertyValueNode>()
                 .FirstOrDefault(x => x.Property.GetClrProperty().Name == "Property");
-            if (property == null)
-                throw new XamlIlParseException("Setter without a property is not valid", node);
-
-            var propertyName = property.Values.OfType<XamlIlAstTextNode>().FirstOrDefault()?.Text;
-            if (propertyName == null)
-                throw new XamlIlParseException("Setter.Property must be a string", node);
-
-
-            var avaloniaPropertyNode = XamlIlAvaloniaPropertyHelper.CreateNode(context, propertyName,
-                new XamlIlAstClrTypeReference(selector, selector.TargetType, false), property.Values[0]);
-            property.Values = new List<IXamlIlAstValueNode>
+            if (property != null)
             {
-                avaloniaPropertyNode
-            };
+
+                var propertyName = property.Values.OfType<XamlIlAstTextNode>().FirstOrDefault()?.Text;
+                if (propertyName == null)
+                    throw new XamlIlParseException("Setter.Property must be a string", node);
+
+
+                var avaloniaPropertyNode = XamlIlAvaloniaPropertyHelper.CreateNode(context, propertyName,
+                    new XamlIlAstClrTypeReference(selector, selector.TargetType, false), property.Values[0]);
+                property.Values = new List<IXamlIlAstValueNode> {avaloniaPropertyNode};
+                propType = avaloniaPropertyNode.AvaloniaPropertyType;
+            }
+            else
+            {
+                var propertyPath = on.Children.OfType<XamlIlAstXamlPropertyValueNode>()
+                    .FirstOrDefault(x => x.Property.GetClrProperty().Name == "PropertyPath");
+                if (propertyPath == null)
+                    throw new XamlIlParseException("Setter without a property or property path is not valid", node);
+                if (propertyPath.Values[0] is IXamlIlPropertyPathNode ppn
+                    && ppn.PropertyType != null)
+                    propType = ppn.PropertyType;
+                else
+                    throw new XamlIlParseException("Unable to get the property path property type", node);
+            }
 
             var valueProperty = on.Children
                 .OfType<XamlIlAstXamlPropertyValueNode>().FirstOrDefault(p => p.Property.GetClrProperty().Name == "Value");
             if (valueProperty?.Values?.Count == 1 && valueProperty.Values[0] is XamlIlAstTextNode)
             {
-                var propType = avaloniaPropertyNode.AvaloniaPropertyType;
                 if (!XamlIlTransformHelpers.TryGetCorrectlyTypedValue(context, valueProperty.Values[0],
                         propType, out var converted))
                     throw new XamlIlParseException(

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -19,26 +19,30 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlIlType Transitions { get; }
         public IXamlIlType AssignBindingAttribute { get; }
         public IXamlIlType UnsetValueType { get; }
+        public IXamlIlType IPropertyInfo { get; }
+        public IXamlIlType ClrPropertyInfo { get; }
         
-        public AvaloniaXamlIlWellKnownTypes(XamlIlAstTransformationContext ctx)
+        public AvaloniaXamlIlWellKnownTypes(XamlIlTransformerConfiguration cfg)
         {
-            XamlIlTypes = ctx.Configuration.WellKnownTypes;
-            AvaloniaObject = ctx.Configuration.TypeSystem.GetType("Avalonia.AvaloniaObject");
-            IAvaloniaObject = ctx.Configuration.TypeSystem.GetType("Avalonia.IAvaloniaObject");
-            AvaloniaObjectExtensions = ctx.Configuration.TypeSystem.GetType("Avalonia.AvaloniaObjectExtensions");
-            AvaloniaProperty = ctx.Configuration.TypeSystem.GetType("Avalonia.AvaloniaProperty");
-            AvaloniaPropertyT = ctx.Configuration.TypeSystem.GetType("Avalonia.AvaloniaProperty`1");
-            BindingPriority = ctx.Configuration.TypeSystem.GetType("Avalonia.Data.BindingPriority");
-            IBinding = ctx.Configuration.TypeSystem.GetType("Avalonia.Data.IBinding");
-            IDisposable = ctx.Configuration.TypeSystem.GetType("System.IDisposable");
-            Transitions = ctx.Configuration.TypeSystem.GetType("Avalonia.Animation.Transitions");
-            AssignBindingAttribute = ctx.Configuration.TypeSystem.GetType("Avalonia.Data.AssignBindingAttribute");
+            XamlIlTypes = cfg.WellKnownTypes;
+            AvaloniaObject = cfg.TypeSystem.GetType("Avalonia.AvaloniaObject");
+            IAvaloniaObject = cfg.TypeSystem.GetType("Avalonia.IAvaloniaObject");
+            AvaloniaObjectExtensions = cfg.TypeSystem.GetType("Avalonia.AvaloniaObjectExtensions");
+            AvaloniaProperty = cfg.TypeSystem.GetType("Avalonia.AvaloniaProperty");
+            AvaloniaPropertyT = cfg.TypeSystem.GetType("Avalonia.AvaloniaProperty`1");
+            BindingPriority = cfg.TypeSystem.GetType("Avalonia.Data.BindingPriority");
+            IBinding = cfg.TypeSystem.GetType("Avalonia.Data.IBinding");
+            IDisposable = cfg.TypeSystem.GetType("System.IDisposable");
+            Transitions = cfg.TypeSystem.GetType("Avalonia.Animation.Transitions");
+            AssignBindingAttribute = cfg.TypeSystem.GetType("Avalonia.Data.AssignBindingAttribute");
             AvaloniaObjectBindMethod = AvaloniaObjectExtensions.FindMethod("Bind", IDisposable, false, IAvaloniaObject,
                 AvaloniaProperty,
-                IBinding, ctx.Configuration.WellKnownTypes.Object);
-            UnsetValueType = ctx.Configuration.TypeSystem.GetType("Avalonia.UnsetValueType");
+                IBinding, cfg.WellKnownTypes.Object);
+            UnsetValueType = cfg.TypeSystem.GetType("Avalonia.UnsetValueType");
             AvaloniaObjectSetValueMethod = AvaloniaObject.FindMethod("SetValue", XamlIlTypes.Void,
                 false, AvaloniaProperty, XamlIlTypes.Object, BindingPriority);
+            IPropertyInfo = cfg.TypeSystem.GetType("Avalonia.Data.Core.IPropertyInfo");
+            ClrPropertyInfo = cfg.TypeSystem.GetType("Avalonia.Data.Core.ClrPropertyInfo");
         }
     }
 
@@ -48,7 +52,15 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         {
             if (ctx.TryGetItem<AvaloniaXamlIlWellKnownTypes>(out var rv))
                 return rv;
-            ctx.SetItem(rv = new AvaloniaXamlIlWellKnownTypes(ctx));
+            ctx.SetItem(rv = new AvaloniaXamlIlWellKnownTypes(ctx.Configuration));
+            return rv;
+        }
+        
+        public static AvaloniaXamlIlWellKnownTypes GetAvaloniaTypes(this XamlIlEmitContext ctx)
+        {
+            if (ctx.TryGetItem<AvaloniaXamlIlWellKnownTypes>(out var rv))
+                return rv;
+            ctx.SetItem(rv = new AvaloniaXamlIlWellKnownTypes(ctx.Configuration));
             return rv;
         }
     }

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -21,6 +21,8 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlIlType UnsetValueType { get; }
         public IXamlIlType IPropertyInfo { get; }
         public IXamlIlType ClrPropertyInfo { get; }
+        public IXamlIlType PropertyPath { get; }
+        public IXamlIlType PropertyPathBuilder { get; }
         
         public AvaloniaXamlIlWellKnownTypes(XamlIlTransformerConfiguration cfg)
         {
@@ -43,6 +45,8 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                 false, AvaloniaProperty, XamlIlTypes.Object, BindingPriority);
             IPropertyInfo = cfg.TypeSystem.GetType("Avalonia.Data.Core.IPropertyInfo");
             ClrPropertyInfo = cfg.TypeSystem.GetType("Avalonia.Data.Core.ClrPropertyInfo");
+            PropertyPath = cfg.TypeSystem.GetType("Avalonia.Data.Core.PropertyPath");
+            PropertyPathBuilder = cfg.TypeSystem.GetType("Avalonia.Data.Core.PropertyPathBuilder");
         }
     }
 

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/XamlIlAvaloniaPropertyHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/XamlIlAvaloniaPropertyHelper.cs
@@ -94,6 +94,26 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                 context.Configuration.TypeSystem.GetType("Avalonia.AvaloniaProperty"),
                 clrProperty);
         }
+
+        public static IXamlIlType GetAvaloniaPropertyType(IXamlIlField field,
+            AvaloniaXamlIlWellKnownTypes types, IXamlIlLineInfo lineInfo)
+        {
+            var avaloniaPropertyType = field.FieldType;
+            while (avaloniaPropertyType != null)
+            {
+                if (avaloniaPropertyType.GenericTypeDefinition?.Equals(types.AvaloniaPropertyT) == true)
+                {
+                    return avaloniaPropertyType.GenericArguments[0];
+                }
+
+                avaloniaPropertyType = avaloniaPropertyType.BaseType;
+            }
+
+            throw new XamlIlParseException(
+                $"{field.Name}'s type {field.FieldType} doesn't inherit from  AvaloniaProperty<T>, make sure to use typed properties",
+                lineInfo);
+
+        }
     }
 
     interface IXamlIlAvaloniaPropertyNode : IXamlIlAstValueNode
@@ -132,22 +152,8 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             IXamlIlLineInfo lineInfo, IXamlIlField field) : base(lineInfo)
         {
             _field = field;
-            var avaloniaPropertyType = field.FieldType;
-            while (avaloniaPropertyType != null)
-            {
-                if (avaloniaPropertyType.GenericTypeDefinition?.Equals(types.AvaloniaPropertyT) == true)
-                {
-                    AvaloniaPropertyType = avaloniaPropertyType.GenericArguments[0];
-                    return;
-                }
-
-                avaloniaPropertyType = avaloniaPropertyType.BaseType;
-            }
-
-            throw new XamlIlParseException(
-                $"{field.Name}'s type {field.FieldType} doesn't inherit from AvaloniaProperty<T>, make sure to use typed properties",
-                lineInfo);
-
+            AvaloniaPropertyType = XamlIlAvaloniaPropertyHelper.GetAvaloniaPropertyType(field,
+                types, lineInfo);
         }
         
         

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/XamlIlAvaloniaPropertyHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/XamlIlAvaloniaPropertyHelper.cs
@@ -15,6 +15,20 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
 {
     class XamlIlAvaloniaPropertyHelper
     {
+        public static bool EmitProvideValueTarget(XamlIlEmitContext context, IXamlIlEmitter emitter,
+            XamlIlAstClrProperty property)
+        {
+            if (Emit(context, emitter, property))
+                return true;
+            var foundClr = property.DeclaringType.Properties.FirstOrDefault(p => p.Name == property.Name);
+            if (foundClr == null)
+                return false;
+            context
+                .Configuration.GetExtra<XamlIlClrPropertyInfoEmitter>()
+                .Emit(context, emitter, foundClr);
+            return true;
+        }
+        
         public static bool Emit(XamlIlEmitContext context, IXamlIlEmitter emitter, XamlIlAstClrProperty property)
         {
             if (property is IXamlIlAvaloniaProperty ap)

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/XamlIlClrPropertyInfoHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/CompilerExtensions/XamlIlClrPropertyInfoHelper.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers;
+using XamlIl.Ast;
+using XamlIl.Transform;
+using XamlIl.TypeSystem;
+
+namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
+{
+    class XamlIlClrPropertyInfoHelper
+    {
+        
+        class ClrPropertyInfoNode : XamlIlAstNode, IXamlIlAstValueNode
+        {
+            public ClrPropertyInfoNode(AvaloniaXamlIlWellKnownTypes types, IXamlIlLineInfo lineInfo) :
+                base(lineInfo)
+            {
+                Type = new XamlIlAstClrTypeReference(this, types.XamlIlTypes.Object, false);
+            }
+
+            public IXamlIlAstTypeReference Type { get; }
+        }
+    }
+
+    class XamlIlClrPropertyInfoEmitter
+    {
+        private readonly IXamlIlTypeBuilder _builder;
+
+        private Dictionary<string, List<(IXamlIlProperty prop, IXamlIlMethod get)>> _fields
+            = new Dictionary<string, List<(IXamlIlProperty prop, IXamlIlMethod get)>>();
+        
+        public XamlIlClrPropertyInfoEmitter(IXamlIlTypeBuilder builder)
+        {
+            _builder = builder;
+        }
+
+        static string GetKey(IXamlIlProperty property) 
+            => property.Getter.DeclaringType.GetFullName() + "." + property.Name;
+
+        public IXamlIlType Emit(XamlIlEmitContext context, IXamlIlEmitter codeGen, IXamlIlProperty property)
+        {
+            var types = context.GetAvaloniaTypes();
+            IXamlIlMethod Get()
+            {
+                var key = GetKey(property);
+                if (!_fields.TryGetValue(key, out var lst))
+                    _fields[key] = lst = new List<(IXamlIlProperty prop, IXamlIlMethod get)>();
+
+                foreach (var cached in lst)
+                {
+                    if (
+                        ((cached.prop.Getter == null && property.Getter == null) ||
+                         cached.prop.Getter?.Equals(property.Getter) == true) &&
+                        ((cached.prop.Setter == null && property.Setter == null) ||
+                         cached.prop.Setter?.Equals(property.Setter) == true)
+                    )
+                        return cached.get;
+                }
+
+                var name = lst.Count == 0 ? key : key + "_" + Guid.NewGuid().ToString("N");
+                
+                var field = _builder.DefineField(types.IPropertyInfo, name + "!Field", false, true);
+
+                var getter = property.Getter == null ?
+                    null :
+                    _builder.DefineMethod(types.XamlIlTypes.Object,
+                        new[] {types.XamlIlTypes.Object}, name + "!Getter", false, true, false);
+                if (getter != null)
+                {
+                    getter.Generator
+                        .Ldarg_0()
+                        .Castclass(property.Getter.DeclaringType)
+                        .EmitCall(property.Getter);
+                    if (property.Getter.ReturnType.IsValueType)
+                        getter.Generator.Box(property.Getter.ReturnType);
+                    getter.Generator.Ret();
+                }
+
+                var setter = property.Setter == null ?
+                    null :
+                    _builder.DefineMethod(types.XamlIlTypes.Void,
+                        new[] {types.XamlIlTypes.Object, types.XamlIlTypes.Object},
+                        name + "!Setter", false, true, false);
+                if (setter != null)
+                {
+                    setter.Generator
+                        .Ldarg_0()
+                        .Castclass(property.Setter.DeclaringType)
+                        .Ldarg(1);
+                    if (property.Setter.Parameters[0].IsValueType)
+                        setter.Generator.Unbox_Any(property.Setter.Parameters[0]);
+                    else
+                        setter.Generator.Castclass(property.Setter.Parameters[0]);
+                    setter.Generator
+                        .EmitCall(property.Setter, true)
+                        .Ret();
+                }
+
+                var get = _builder.DefineMethod(types.IPropertyInfo, Array.Empty<IXamlIlType>(),
+                    name + "!Property", true, true, false);
+
+
+                var ctor = types.ClrPropertyInfo.Constructors.First(c =>
+                    c.Parameters.Count == 3 && c.IsStatic == false);
+                
+                var cacheMiss = get.Generator.DefineLabel();
+                get.Generator
+                    .Ldsfld(field)
+                    .Brfalse(cacheMiss)
+                    .Ldsfld(field)
+                    .Ret()
+                    .MarkLabel(cacheMiss)
+                    .Ldstr(property.Name);
+
+                void EmitFunc(IXamlIlEmitter emitter, IXamlIlMethod method, IXamlIlType del)
+                {
+                    if (method == null)
+                        emitter.Ldnull();
+                    else
+                    {
+                        emitter
+                            .Ldnull()
+                            .Ldftn(method)
+                            .Newobj(del.Constructors.First(c =>
+                                c.Parameters.Count == 2 &&
+                                c.Parameters[0].Equals(context.Configuration.WellKnownTypes.Object)));
+                    }
+                }
+
+                EmitFunc(get.Generator, getter, ctor.Parameters[1]);
+                EmitFunc(get.Generator, setter, ctor.Parameters[2]);
+                get.Generator
+                    .Newobj(ctor)
+                    .Stsfld(field)
+                    .Ldsfld(field)
+                    .Ret();
+
+                lst.Add((property, get));
+                return get;
+            }
+
+            codeGen.EmitCall(Get());
+            return types.IPropertyInfo;
+        }
+    }
+}

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/ArgumentListParser.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/ArgumentListParser.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Markup.Parsers
     {
         public static IList<string> ParseArguments(this ref CharacterReader r, char open, char close, char delimiter = ',')
         {
-            if (r.Peek == open)
+            if (r.PeekOneOrThrow == open)
             {
                 var result = new List<string>();
 

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/ExpressionParser.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/ExpressionParser.cs
@@ -304,7 +304,7 @@ namespace Avalonia.Markup.Parsers
 
         private static bool PeekOpenBracket(ref CharacterReader r)
         {
-            return !r.End && r.Peek == '[';
+            return !r.End && r.PeekOneOrThrow == '[';
         }
 
         private static bool ParseStreamOperator(ref CharacterReader r)

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/PropertyPathGrammar.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/PropertyPathGrammar.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Data.Core;
+using Avalonia.Utilities;
+
+namespace Avalonia.Markup.Parsers
+{
+#if !BUILDTASK
+    public
+#endif
+    class PropertyPathGrammar
+    {
+        private enum State
+        {
+            Start,
+            Next,
+            AfterProperty,
+            End
+        }
+
+        public static IEnumerable<ISyntax> Parse(string s)
+        {
+            var r = new CharacterReader(s.AsSpan());
+            return Parse(ref r);
+        }
+
+        private static IEnumerable<ISyntax> Parse(ref CharacterReader r)
+        {
+            var state = State.Start;
+            var parsed = new List<ISyntax>();
+            while (state != State.End)
+            {
+                ISyntax syntax = null;
+                if (state == State.Start)
+                    (state, syntax) = ParseStart(ref r);
+                else if (state == State.Next)
+                    (state, syntax) = ParseNext(ref r);
+                else if (state == State.AfterProperty)
+                    (state, syntax) = ParseAfterProperty(ref r);
+                
+                
+                if (syntax != null)
+                {
+                    parsed.Add(syntax);
+                }
+            }
+
+            if (state != State.End && r.End)
+            {
+                throw new ExpressionParseException(r.Position, "Unexpected end of property path");
+            }
+
+            return parsed;
+        }
+        
+        private static (State, ISyntax) ParseNext(ref CharacterReader r)
+        {
+            r.SkipWhitespace();
+            if (r.End)
+                return (State.End, null);
+            
+            return ParseStart(ref r);
+        }
+        
+        private static (State, ISyntax) ParseStart(ref CharacterReader r)
+        {
+            r.SkipWhitespace();
+
+            if (r.TakeIf('('))
+                return ParseTypeQualifiedProperty(ref r);
+
+            return ParseProperty(ref r);
+        }
+
+        private static (State, ISyntax) ParseTypeQualifiedProperty(ref CharacterReader r)
+        {
+            r.SkipWhitespace();
+            const string error =
+                "Unable to parse qualified property name, expected `(ns:TypeName.PropertyName)` or `(TypeName.PropertyName)` after `(`";
+
+            var typeName = ParseXamlIdentifier(ref r);
+            
+            
+            if (!r.TakeIf('.'))
+                throw new ExpressionParseException(r.Position, error);
+
+            var propertyName = r.ParseIdentifier();
+            if (propertyName.IsEmpty)
+                throw new ExpressionParseException(r.Position, error);
+
+            r.SkipWhitespace();
+            if (!r.TakeIf(')'))
+                throw new ExpressionParseException(r.Position,
+                    "Expected ')' after qualified property name "
+                    + typeName.ns + ':' + typeName.name +
+                    "." + propertyName.ToString());
+
+            return (State.AfterProperty,
+                new TypeQualifiedPropertySyntax
+                {
+                    Name = propertyName.ToString(),
+                    TypeName = typeName.name,
+                    TypeNamespace = typeName.ns
+                });
+        }
+
+        static (string ns, string name) ParseXamlIdentifier(ref CharacterReader r)
+        {
+            var ident = r.ParseIdentifier();
+            if (ident.IsEmpty)
+                throw new ExpressionParseException(r.Position, "Expected identifier");
+            if (r.TakeIf(':'))
+            {
+                var part2 = r.ParseIdentifier();
+                if (part2.IsEmpty)
+                    throw new ExpressionParseException(r.Position,
+                        "Expected the rest of the identifier after " + ident.ToString() + ":");
+                return (ident.ToString(), part2.ToString());
+            }
+
+            return (null, ident.ToString());
+        }
+        
+        private static (State, ISyntax) ParseProperty(ref CharacterReader r)
+        {
+            r.SkipWhitespace();
+            var prop = r.ParseIdentifier();
+            if (prop.IsEmpty)
+                throw new ExpressionParseException(r.Position, "Unable to parse property name");
+            return (State.AfterProperty, new PropertySyntax {Name = prop.ToString()});
+        }
+
+
+        private static (State, ISyntax) ParseAfterProperty(ref CharacterReader r)
+        {
+            r.SkipWhitespace();
+            if (r.End)
+                return (State.End, null);
+            if (r.TakeIf('.'))
+                return (State.Next, ChildTraversalSyntax.Instance);
+            if (r.TakeIfKeyword(":="))
+                return ParseEnsureType(ref r);
+
+            if (r.TakeIfKeyword(":>") || r.TakeIfKeyword("as "))
+                return ParseCastType(ref r);
+            
+            throw new ExpressionParseException(r.Position, "Unexpected character " + r.PeekOneOrThrow + " after property name");
+        }
+
+        private static (State, ISyntax) ParseEnsureType(ref CharacterReader r)
+        {
+            r.SkipWhitespace();
+            var type = ParseXamlIdentifier(ref r);
+            return (State.AfterProperty, new EnsureTypeSyntax {TypeName = type.name, TypeNamespace = type.ns});
+        }
+        
+        private static (State, ISyntax) ParseCastType(ref CharacterReader r)
+        {
+            r.SkipWhitespace();
+            var type = ParseXamlIdentifier(ref r);
+            return (State.AfterProperty, new CastTypeSyntax {TypeName = type.name, TypeNamespace = type.ns});
+        }
+
+        public interface ISyntax
+        {
+            
+        }
+
+        public class PropertySyntax : ISyntax
+        {
+            public string Name { get; set; }
+
+            public override bool Equals(object obj)
+                => obj is PropertySyntax other
+                   && other.Name == Name;
+        }
+        
+        public class TypeQualifiedPropertySyntax : ISyntax
+        {
+            public string Name { get; set; }
+            public string TypeName { get; set; }
+            public string TypeNamespace { get; set; }
+
+            public override bool Equals(object obj)
+                => obj is TypeQualifiedPropertySyntax other
+                   && other.Name == Name
+                   && other.TypeName == TypeName
+                   && other.TypeNamespace == TypeNamespace;
+        }
+        
+        public class ChildTraversalSyntax : ISyntax
+        {
+            public static ChildTraversalSyntax Instance { get;  } = new ChildTraversalSyntax();
+            public override bool Equals(object obj) => obj is ChildTraversalSyntax;
+        }
+        
+        public class EnsureTypeSyntax : ISyntax
+        {
+            public string TypeName { get; set; }
+            public string TypeNamespace { get; set; }
+            public override bool Equals(object obj)
+                => obj is EnsureTypeSyntax other
+                   && other.TypeName == TypeName
+                   && other.TypeNamespace == TypeNamespace;
+        }
+        
+        public class CastTypeSyntax : ISyntax
+        {
+            public string TypeName { get; set; }
+            public string TypeNamespace { get; set; }
+            public override bool Equals(object obj)
+                => obj is CastTypeSyntax other
+                   && other.TypeName == TypeName
+                   && other.TypeNamespace == TypeNamespace;
+        }
+    }
+}

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/SelectorGrammar.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/SelectorGrammar.cs
@@ -123,7 +123,7 @@ namespace Avalonia.Markup.Parsers
             {
                 return (State.Class, null);
             }
-            else if (r.TakeIf(char.IsWhiteSpace) || r.Peek == '>')
+            else if (r.TakeIf(char.IsWhiteSpace) || r.PeekOneOrThrow == '>')
             {
                 return (State.Traversal, null);
             }
@@ -139,7 +139,7 @@ namespace Avalonia.Markup.Parsers
             {
                 return (State.Start, new CommaSyntax());
             }
-            else if (end.HasValue && !r.End && r.Peek == end.Value)
+            else if (end.HasValue && !r.End && r.PeekOneOrThrow == end.Value)
             {
                 return (State.End, null);
             }
@@ -262,7 +262,7 @@ namespace Avalonia.Markup.Parsers
 
             if (!r.TakeIf('='))
             {
-                throw new ExpressionParseException(r.Position, $"Expected '=', got '{r.Peek}'");
+                throw new ExpressionParseException(r.Position, $"Expected '=', got '{r.PeekOneOrThrow}'");
             }
 
             var value = r.TakeUntil(']');
@@ -281,7 +281,7 @@ namespace Avalonia.Markup.Parsers
 
             if (namespaceOrTypeName.IsEmpty)
             {
-                throw new ExpressionParseException(r.Position, $"Expected an identifier, got '{r.Peek}");
+                throw new ExpressionParseException(r.Position, $"Expected an identifier, got '{r.PeekOneOrThrow}");
             }
 
             if (!r.End && r.TakeIf('|'))
@@ -311,7 +311,7 @@ namespace Avalonia.Markup.Parsers
             }
             else if (!r.TakeIf(')'))
             {
-                throw new ExpressionParseException(r.Position, $"Expected '{c}', got '{r.Peek}'.");
+                throw new ExpressionParseException(r.Position, $"Expected '{c}', got '{r.PeekOneOrThrow}'.");
             }
         }
 

--- a/tests/Avalonia.Base.UnitTests/Data/Core/PropertyPathGrammarTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/PropertyPathGrammarTests.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Markup.Parsers;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Data.Core
+{
+    public class PropertyPathGrammarTests
+    {
+        static void Check(string s, params PropertyPathGrammar.ISyntax[] expected)
+        {
+            var parsed = PropertyPathGrammar.Parse(s).ToList();
+            Assert.Equal(expected.Length, parsed.Count);
+            for (var c = 0; c < parsed.Count; c++)
+                Assert.Equal(expected[c], parsed[c]);
+        }
+
+        [Fact]
+        public void PropertyPath_Should_Support_Simple_Properties()
+        {
+            Check("SomeProperty", new PropertyPathGrammar.PropertySyntax {Name = "SomeProperty"});
+        }
+
+        [Fact]
+        public void PropertyPath_Should_Ignore_Trailing_Whitespace()
+        {
+            Check("  SomeProperty   ", new PropertyPathGrammar.PropertySyntax {Name = "SomeProperty"});
+        }
+
+        [Fact]
+        public void PropertyPath_Should_Support_Qualified_Properties()
+        {
+            Check(" ( somens:SomeType.SomeProperty ) ",
+                new PropertyPathGrammar.TypeQualifiedPropertySyntax()
+                {
+                    Name = "SomeProperty", TypeName = "SomeType", TypeNamespace = "somens"
+                });
+        }
+        
+        [Fact]
+        public void PropertyPath_Should_Support_Property_Paths()
+        {
+            Check(" ( somens:SomeType.SomeProperty ).Child . SubChild ",
+                new PropertyPathGrammar.TypeQualifiedPropertySyntax()
+                {
+                    Name = "SomeProperty", TypeName = "SomeType", TypeNamespace = "somens"
+                },
+                PropertyPathGrammar.ChildTraversalSyntax.Instance,
+                new PropertyPathGrammar.PropertySyntax {Name = "Child"},
+                PropertyPathGrammar.ChildTraversalSyntax.Instance,
+                new PropertyPathGrammar.PropertySyntax {Name = "SubChild"}
+            );
+        }
+        
+        [Fact]
+        public void PropertyPath_Should_Support_Casts()
+        {
+            Check(" ( somens:SomeType.SomeProperty ) :> SomeType.Child as somens:SomeType . SubChild ",
+                new PropertyPathGrammar.TypeQualifiedPropertySyntax()
+                {
+                    Name = "SomeProperty", TypeName = "SomeType", TypeNamespace = "somens"
+                },
+                new PropertyPathGrammar.CastTypeSyntax
+                {
+                    TypeName = "SomeType"
+                },
+                PropertyPathGrammar.ChildTraversalSyntax.Instance,
+                new PropertyPathGrammar.PropertySyntax {Name = "Child"},
+                new PropertyPathGrammar.CastTypeSyntax
+                {
+                    TypeName = "SomeType",
+                    TypeNamespace = "somens"
+                },
+                PropertyPathGrammar.ChildTraversalSyntax.Instance,
+                new PropertyPathGrammar.PropertySyntax {Name = "SubChild"}
+            );
+        }
+        
+        [Fact]
+        public void PropertyPath_Should_Support_Ensure_Type()
+        {
+            Check(" ( somens:SomeType.SomeProperty ) := SomeType.Child := somens:SomeType . SubChild ",
+                new PropertyPathGrammar.TypeQualifiedPropertySyntax()
+                {
+                    Name = "SomeProperty", TypeName = "SomeType", TypeNamespace = "somens"
+                },
+                new PropertyPathGrammar.EnsureTypeSyntax
+                {
+                    TypeName = "SomeType"
+                },
+                PropertyPathGrammar.ChildTraversalSyntax.Instance,
+                new PropertyPathGrammar.PropertySyntax {Name = "Child"},
+                new PropertyPathGrammar.EnsureTypeSyntax
+                {
+                    TypeName = "SomeType",
+                    TypeNamespace = "somens"
+                },
+                PropertyPathGrammar.ChildTraversalSyntax.Instance,
+                new PropertyPathGrammar.PropertySyntax {Name = "SubChild"}
+            );
+        }
+    }
+}

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/XamlIlTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/XamlIlTests.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Data.Converters;
+using Avalonia.Data.Core;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
@@ -234,6 +235,17 @@ namespace Avalonia.Markup.Xaml.UnitTests
                 Assert.Equal(100, XamlIlBugTestsStaticClassWithAttachedProperty.GetTestInt(tb));
             }
         }
+
+        [Fact]
+        public void Provide_Value_Target_Should_Provide_Clr_Property_Info()
+        {
+            var parsed = AvaloniaXamlLoader.Parse<XamlIlClassWithClrPropertyWithValue>(@"
+<XamlIlClassWithClrPropertyWithValue 
+    xmlns='clr-namespace:Avalonia.Markup.Xaml.UnitTests'
+    Count='{XamlIlCheckClrPropertyInfo ExpectedPropertyName=Count}'
+/>", typeof(XamlIlClassWithClrPropertyWithValue).Assembly);
+            Assert.Equal(6, parsed.Count);
+        }
     }
     
     public class XamlIlBugTestsEventHandlerCodeBehind : Window
@@ -313,5 +325,23 @@ namespace Avalonia.Markup.Xaml.UnitTests
         {
             return (int)control.GetValue(TestIntProperty);
         }
+    }
+
+    public class XamlIlCheckClrPropertyInfoExtension
+    {
+        public string ExpectedPropertyName { get; set; }
+
+        public object ProvideValue(IServiceProvider prov)
+        {
+            var pvt = prov.GetService<IProvideValueTarget>();
+            var info = (ClrPropertyInfo)pvt.TargetProperty;
+            var v = (int)info.Get(pvt.TargetObject);
+            return v + 1;
+        }
+    }
+
+    public class XamlIlClassWithClrPropertyWithValue
+    {
+        public int Count { get; set; }= 5;
     }
 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/XamlIlTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/XamlIlTests.cs
@@ -11,6 +11,7 @@ using Avalonia.Data.Core;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
+using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.UnitTests;
 using Avalonia.VisualTree;
@@ -245,6 +246,53 @@ namespace Avalonia.Markup.Xaml.UnitTests
     Count='{XamlIlCheckClrPropertyInfo ExpectedPropertyName=Count}'
 />", typeof(XamlIlClassWithClrPropertyWithValue).Assembly);
             Assert.Equal(6, parsed.Count);
+        }
+
+        [Fact]
+        public void Should_Provide_PropertyPath_For_Setters()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var parsed = AvaloniaXamlLoader.Parse<Style>(@"
+<Style Selector='Animatable' xmlns='https://github.com/avaloniaui'>
+    <Setter PropertyPath=':>Visual.Bounds.BottomRight.X' Value='0' />
+    <Setter PropertyPath=':>Visual.RenderTransform:=ScaleTransform.ScaleX' Value='0' />
+    <Setter PropertyPath='(Visual.RenderTransform):=ScaleTransform.ScaleX' Value='0' />
+</Style>");
+                var s1e = ((Setter)parsed.Setters[0]).PropertyPath.Elements;
+                var s2e = ((Setter)parsed.Setters[1]).PropertyPath.Elements;
+                var s3e = ((Setter)parsed.Setters[2]).PropertyPath.Elements;
+                
+                Assert.Equal(typeof(Visual), ((CastTypePropertyPathElement)s1e[0]).Type);
+                Assert.IsType<ChildTraversalPropertyPathElement>(s1e[1]);
+                Assert.Equal("Bounds", ((AvaloniaProperty)((PropertyPropertyPathElement)s1e[2]).Property).Name);
+                Assert.IsType<ChildTraversalPropertyPathElement>(s1e[3]);
+                var bottomRight = ((PropertyPropertyPathElement)s1e[4]).Property;
+                Assert.IsType<ChildTraversalPropertyPathElement>(s1e[5]);
+                var pointX = ((PropertyPropertyPathElement)s1e[6]).Property;
+                
+                var orect = (object)(new Rect(100, 100, 200, 200));
+                var point = bottomRight.Get(orect);
+                var x = pointX.Get(point);
+                Assert.Equal(300, (double)x);
+                
+                Assert.Equal(typeof(Visual), ((CastTypePropertyPathElement)s2e[0]).Type);
+                Assert.IsType<ChildTraversalPropertyPathElement>(s2e[1]);
+                Assert.Equal("RenderTransform", ((AvaloniaProperty)((PropertyPropertyPathElement)s2e[2]).Property).Name);
+                Assert.Equal(typeof(ScaleTransform), ((EnsureTypePropertyPathElement)s2e[3]).Type);
+                Assert.IsType<ChildTraversalPropertyPathElement>(s2e[4]);
+                Assert.Equal("ScaleX", ((AvaloniaProperty)((PropertyPropertyPathElement)s2e[5]).Property).Name);
+
+
+                var s3fqp = (AvaloniaProperty)((PropertyPropertyPathElement)s3e[0]).Property;
+                Assert.Equal("RenderTransform", s3fqp.Name);
+                Assert.Equal(typeof(Visual), s3fqp.OwnerType);
+                Assert.Equal(typeof(ScaleTransform), ((EnsureTypePropertyPathElement)s3e[1]).Type);
+                Assert.IsType<ChildTraversalPropertyPathElement>(s3e[2]);
+                Assert.Equal("ScaleX", ((AvaloniaProperty)((PropertyPropertyPathElement)s3e[3]).Property).Name);
+                
+                
+            }
         }
     }
     


### PR DESCRIPTION
Currently intended for use in animations.
@jmacato 

For now they are quite simple, but already support syntax like
`(Visual.RenderTransform):=ScaleTransform.ScaleX`
`MyProperty :> MyModelType .Foo.Bar`
`MyProperty as MyModelType .Foo.Bar`
Where `:>` and `as` are cast operators, and `:=` is type ensuring operator
Type ensuring is needed for animations to be able to switch a property value type somewhere along the path
E. g. if `RenderTransform` isn't a `ScaleTransform`, set `RenderTransform` to a fresh instance of `ScaleTransform`
Casts are needed for bindings to ensure that property has a correct type to continue.



`IPropertyInfo` and `ClrPropertyInfo` provide *reflection-free* access to regular CLR properties. This is backed by compile time property accessor generation. `ReflectionClrPropertyInfo` uses provides same interface via reflection and is not used by compiler.

I've also made AvaloniaProperty to implement `IPropertyInfo` for convenience purposes
