### PR TITLE
Improve Button and ToggleButton styling

### DIFF
--- a/src/Avalonia.Themes.Default/Button.xaml
+++ b/src/Avalonia.Themes.Default/Button.xaml
@@ -22,10 +22,10 @@
       </ControlTemplate>
     </Setter>
   </Style>
-  <Style Selector="Button:pointerover /template/ ContentPresenter">
+  <Style Selector="Button:pointerover">
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}"/>
   </Style>
-  <Style Selector="Button:pressed  /template/ ContentPresenter">
+  <Style Selector="Button:pressed">
     <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}"/>
   </Style>
   <Style Selector="Button:disabled">

--- a/src/Avalonia.Themes.Default/ToggleButton.xaml
+++ b/src/Avalonia.Themes.Default/ToggleButton.xaml
@@ -22,14 +22,14 @@
       </ControlTemplate>
     </Setter>
   </Style>
-  <Style Selector="ToggleButton:checked /template/ ContentPresenter">
+  <Style Selector="ToggleButton:checked">
     <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}"/>
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}"/>
   </Style>
-  <Style Selector="ToggleButton:pointerover /template/ ContentPresenter">
+  <Style Selector="ToggleButton:pointerover">
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}"/>
   </Style>
-  <Style Selector="ToggleButton:pressed  /template/ ContentPresenter">
+  <Style Selector="ToggleButton:pressed">
     <Setter Property="Background" Value="{DynamicResource ThemeControlHighBrush}"/>
   </Style>
   <Style Selector="ToggleButton:disabled">


### PR DESCRIPTION
## What does the pull request do?
This PR makes it easier to change the Button and ToggleButton's Background and BorderBrush on pressed, pointerover and checked etc.

## What is the current behavior?
Currently one has to target the ContentPresenter within the template to change these properties

## What is the updated/expected behavior with this PR?
Target this:
`Button:pressed`
instead of:
`Button:pressed /template/ ContentPresenter`

## Breaking changes
No breaking changes, targeting ContentPressenter or Button itself both still work
##Fixed issues
Closes #1102 


Note: its the same PR #2642 but because it has some problems with commits I closed it and opened this.
