### PR TITLE
Make sure System font can be used with all face variations

### DIFF
--- a/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
+++ b/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
@@ -28,7 +28,7 @@ namespace Avalonia.Skia
             // Replace 0 characters with zero-width spaces (200B)
             Text = Text.Replace((char)0, (char)0x200B);
 
-            SKTypeface skiaTypeface = TypefaceCache.Default;
+            SKTypeface skiaTypeface = null;
 
             if (typeface.FontFamily.Key != null)
             {
@@ -45,7 +45,7 @@ namespace Avalonia.Skia
                             familyName,
                             typeface.Style,
                             typeface.Weight);
-                        if (skiaTypeface != TypefaceCache.Default) break;
+                        if (skiaTypeface.FamilyName != TypefaceCache.DefaultFamilyName) break;
                     }
                 }
                 else

--- a/src/Skia/Avalonia.Skia/SKTypefaceCollection.cs
+++ b/src/Skia/Avalonia.Skia/SKTypefaceCollection.cs
@@ -47,7 +47,7 @@ namespace Avalonia.Skia
 
             if (!_fontFamilies.TryGetValue(typeface.FontFamily.Name, out var fontFamily))
             {
-                return TypefaceCache.Default;
+                return TypefaceCache.GetTypeface(TypefaceCache.DefaultFamilyName, typeface.Style, typeface.Weight);
             }
 
             var weight = (SKFontStyleWeight)typeface.Weight;

--- a/src/Skia/Avalonia.Skia/TypefaceCache.cs
+++ b/src/Skia/Avalonia.Skia/TypefaceCache.cs
@@ -12,8 +12,10 @@ namespace Avalonia.Skia
     /// </summary>
     internal static class TypefaceCache
     {
-        public static SKTypeface Default = CreateDefaultTypeface();
-        static readonly Dictionary<string, Dictionary<FontKey, SKTypeface>> Cache = new Dictionary<string, Dictionary<FontKey, SKTypeface>>();
+        public static readonly string DefaultFamilyName = CreateDefaultFamilyName();
+
+        private static readonly Dictionary<string, Dictionary<FontKey, SKTypeface>> s_cache =
+            new Dictionary<string, Dictionary<FontKey, SKTypeface>>();
 
         struct FontKey
         {
@@ -49,26 +51,26 @@ namespace Avalonia.Skia
             // Equals and GetHashCode ommitted
         }
 
-        private static SKTypeface CreateDefaultTypeface()
+        private static string CreateDefaultFamilyName()
         {
-            var defaultTypeface = SKTypeface.FromFamilyName(FontFamily.Default.Name) ?? SKTypeface.FromFamilyName(null);
+            var defaultTypeface = SKTypeface.CreateDefault();
 
-            return defaultTypeface;
+            return defaultTypeface.FamilyName;
         }
 
         private static SKTypeface GetTypeface(string name, FontKey key)
         {
             var familyKey = name;
 
-            if (!Cache.TryGetValue(familyKey, out var entry))
+            if (!s_cache.TryGetValue(familyKey, out var entry))
             {
-                Cache[familyKey] = entry = new Dictionary<FontKey, SKTypeface>();
+                s_cache[familyKey] = entry = new Dictionary<FontKey, SKTypeface>();
             }
 
             if (!entry.TryGetValue(key, out var typeface))
             {
-                typeface = SKTypeface.FromFamilyName(familyKey, key.Weight, SKFontStyleWidth.Normal, key.Slant)
-                           ?? Default;
+                typeface = SKTypeface.FromFamilyName(familyKey, key.Weight, SKFontStyleWidth.Normal, key.Slant) ??
+                           GetTypeface(DefaultFamilyName, key);
 
                 entry[key] = typeface;
             }
@@ -78,7 +80,7 @@ namespace Avalonia.Skia
 
         public static SKTypeface GetTypeface(string name, FontStyle style, FontWeight weight)
         {
-            SKFontStyleSlant skStyle = SKFontStyleSlant.Upright;
+            var skStyle = SKFontStyleSlant.Upright;
 
             switch (style)
             {
@@ -93,6 +95,5 @@ namespace Avalonia.Skia
 
             return GetTypeface(name, new FontKey((SKFontStyleWeight)weight, skStyle));
         }
-
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Fixes an issue with face variation resolution when the System's default font is used.

## What is the current behavior?
Currently, only the normal face is available when the System's default is used.

## What is the updated/expected behavior with this PR?
All supported face variations are available.

## How was the solution implemented (if it's not obvious)?
The System's default is loaded by name to allow a proper face matching.

## Fixed issues
Fixes #2667
