### PR TITLE
Make Avalonia compile on windows machines with VS2017 and VS2019

### DIFF
--- a/nukebuild/_build.csproj
+++ b/nukebuild/_build.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -13,6 +13,7 @@
     <PackageReference Include="Nuke.Common" Version="0.12.3" />
     <PackageReference Include="xunit.runner.console" Version="2.3.1" />
     <PackageReference Include="JetBrains.dotMemoryUnit" Version="3.0.20171219.105559" />
+    <PackageReference Include="vswhere" Version="2.6.7" Condition=" '$(OS)' == 'Windows_NT' " />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

It enables both Visual Studio 2019 and Visual Studio 2017 builds. It does this by using a Microsoft utility called VSWhere. 

Since the location of Visual Studio in 2017/2019 can change based on the users installation this utility will check the appropriate locations.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Only Visual Studio 2017 is supported.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
That if Visual Studio 2019 is available it will be used. At the moment the pre-release switch is turned on which will also get preview editions of Visual Studio 2019.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Using the Nuke VSWhere plugin, plus the NuGet inclusion.
