### PR TITLE
Fix searching for merged resources in Styles

### DIFF
--- a/src/Avalonia.Styling/Styling/Styles.cs
+++ b/src/Avalonia.Styling/Styling/Styles.cs
@@ -180,7 +180,7 @@ namespace Avalonia.Styling
         /// <inheritdoc/>
         public bool TryGetResource(object key, out object value)
         {
-            if (_resources != null && _resources.TryGetValue(key, out value))
+            if (_resources != null && _resources.TryGetResource(key, out value))
             {
                 return true;
             }

--- a/tests/Avalonia.Styling.UnitTests/StylesTests.cs
+++ b/tests/Avalonia.Styling.UnitTests/StylesTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using Avalonia.Controls;
 using Xunit;
 
 namespace Avalonia.Styling.UnitTests
@@ -110,6 +111,29 @@ namespace Avalonia.Styling.UnitTests
             style2.Resources.Add("foo", "bar");
 
             Assert.False(raised);
+        }
+
+
+        [Fact]
+        public void Finds_Resource_In_Merged_Dictionary()
+        {
+            var target = new Styles
+            {
+                Resources = new ResourceDictionary
+                {
+                    MergedDictionaries =
+                    {
+                        new ResourceDictionary
+                        {
+                            { "foo", "bar" },
+                        }
+                    }
+                }
+            };
+
+            var result = target.FindResource("foo");
+
+            Assert.Equal("bar", result);
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Fix searching for merged resources in `Styles` as described in #2584 

## What is the current behavior?

Resources in merged dictionaries under `Styles` are not found.

## How was the solution implemented (if it's not obvious)?

Call `TryGetResource` instead of `TryGetValue` as diagnosed in the issue 👍 

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #2584 
