### PR TITLE
Fix RenderLayers.Clear not clearing inner collection

### DIFF
--- a/src/Avalonia.Visuals/Rendering/RenderLayers.cs
+++ b/src/Avalonia.Visuals/Rendering/RenderLayers.cs
@@ -8,8 +8,8 @@ namespace Avalonia.Rendering
 {
     public class RenderLayers : IEnumerable<RenderLayer>
     {
-        private List<RenderLayer> _inner = new List<RenderLayer>();
-        private Dictionary<IVisual, RenderLayer> _index = new Dictionary<IVisual, RenderLayer>();
+        private readonly List<RenderLayer> _inner = new List<RenderLayer>();
+        private readonly Dictionary<IVisual, RenderLayer> _index = new Dictionary<IVisual, RenderLayer>();
         
         public int Count => _inner.Count;
         public RenderLayer this[IVisual layerRoot] => _index[layerRoot];
@@ -56,6 +56,7 @@ namespace Avalonia.Rendering
             }
 
             _index.Clear();
+            _inner.Clear();
         }
 
         public bool TryGetValue(IVisual layerRoot, out RenderLayer value)


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Small fix in `RenderLayers.Clear`. `_inner` collection is not being cleared when `Clear` is called.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`RenderLayers` can potentially retain references if you call `Clear` and retain instance.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
`RenderLayers` are "clear" after calling `Clear`.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
