### PR TITLE
Fix events for ContextMenu and Popup.

### DIFF
--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -1,7 +1,6 @@
 using System;
 using System.ComponentModel;
 using System.Linq;
-using System.Reactive.Linq;
 using Avalonia.Controls.Generators;
 using Avalonia.Controls.Platform;
 using Avalonia.Controls.Primitives;

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -7,6 +7,7 @@ using Avalonia.Controls.Platform;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 
 namespace Avalonia.Controls
@@ -90,9 +91,14 @@ namespace Avalonia.Controls
         /// <param name="control">The control.</param>
         public void Open(Control control)
         {
+            if (IsOpen)
+            {
+                return;
+            }
+
             if (_popup == null)
             {
-                _popup = new Popup()
+                _popup = new Popup
                 {
                     PlacementMode = PlacementMode.Pointer,
                     PlacementTarget = control,
@@ -107,7 +113,14 @@ namespace Avalonia.Controls
             ((ISetLogicalParent)_popup).SetParent(control);
             _popup.Child = this;
             _popup.IsOpen = true;
+
             IsOpen = true;
+
+            RaiseEvent(new RoutedEventArgs
+            {
+                RoutedEvent = MenuOpenedEvent,
+                Source = this,
+            });
         }
 
         /// <summary>
@@ -115,18 +128,32 @@ namespace Avalonia.Controls
         /// </summary>
         public override void Close()
         {
+            if (!IsOpen)
+            {
+                return;
+            }
+
             if (_popup != null && _popup.IsVisible)
             {
                 _popup.IsOpen = false;
             }
-
-            SelectedIndex = -1;
-            IsOpen = false;
         }
 
         protected override IItemContainerGenerator CreateItemContainerGenerator()
         {
             return new MenuItemContainerGenerator(this);
+        }
+
+        private void CloseCore()
+        {
+            SelectedIndex = -1;
+            IsOpen = false;
+
+            RaiseEvent(new RoutedEventArgs
+            {
+                RoutedEvent = MenuClosedEvent,
+                Source = this,
+            });
         }
 
         private void PopupOpened(object sender, EventArgs e)
@@ -145,8 +172,7 @@ namespace Avalonia.Controls
                     i.IsSubMenuOpen = false;
                 }
 
-                contextMenu.IsOpen = false;
-                contextMenu.SelectedIndex = -1;
+                contextMenu.CloseCore();
             }
         }
 

--- a/src/Avalonia.Controls/Menu.cs
+++ b/src/Avalonia.Controls/Menu.cs
@@ -40,37 +40,41 @@ namespace Avalonia.Controls
         /// <inheritdoc/>
         public override void Close()
         {
-            if (IsOpen)
+            if (!IsOpen)
             {
-                foreach (var i in ((IMenu)this).SubItems)
-                {
-                    i.Close();
-                }
-
-                IsOpen = false;
-                SelectedIndex = -1;
-
-                RaiseEvent(new RoutedEventArgs
-                {
-                    RoutedEvent = MenuClosedEvent,
-                    Source = this,
-                });
+                return;
             }
+
+            foreach (var i in ((IMenu)this).SubItems)
+            {
+                i.Close();
+            }
+
+            IsOpen = false;
+            SelectedIndex = -1;
+
+            RaiseEvent(new RoutedEventArgs
+            {
+                RoutedEvent = MenuClosedEvent,
+                Source = this,
+            });
         }
 
         /// <inheritdoc/>
         public override void Open()
         {
-            if (!IsOpen)
+            if (IsOpen)
             {
-                IsOpen = true;
-
-                RaiseEvent(new RoutedEventArgs
-                {
-                    RoutedEvent = MenuOpenedEvent,
-                    Source = this,
-                });
+                return;
             }
+
+            IsOpen = true;
+
+            RaiseEvent(new RoutedEventArgs
+            {
+                RoutedEvent = MenuOpenedEvent,
+                Source = this,
+            });
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/MenuBase.cs
+++ b/src/Avalonia.Controls/MenuBase.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using Avalonia.Controls.Generators;
 using Avalonia.Controls.Platform;
 using Avalonia.Controls.Primitives;
-using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;

--- a/src/Avalonia.Controls/MenuBase.cs
+++ b/src/Avalonia.Controls/MenuBase.cs
@@ -31,13 +31,13 @@ namespace Avalonia.Controls
         /// Defines the <see cref="MenuOpened"/> event.
         /// </summary>
         public static readonly RoutedEvent<RoutedEventArgs> MenuOpenedEvent =
-            RoutedEvent.Register<MenuItem, RoutedEventArgs>(nameof(MenuOpened), RoutingStrategies.Bubble);
+            RoutedEvent.Register<MenuBase, RoutedEventArgs>(nameof(MenuOpened), RoutingStrategies.Bubble);
 
         /// <summary>
         /// Defines the <see cref="MenuClosed"/> event.
         /// </summary>
         public static readonly RoutedEvent<RoutedEventArgs> MenuClosedEvent =
-            RoutedEvent.Register<MenuItem, RoutedEventArgs>(nameof(MenuClosed), RoutingStrategies.Bubble);
+            RoutedEvent.Register<MenuBase, RoutedEventArgs>(nameof(MenuClosed), RoutingStrategies.Bubble);
 
         private bool _isOpen;
 

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using Avalonia.Input;
 using Avalonia.Input.Raw;
 using Avalonia.Interactivity;
-using Avalonia.Layout;
 using Avalonia.LogicalTree;
 using Avalonia.Metadata;
 using Avalonia.VisualTree;

--- a/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
@@ -17,6 +17,60 @@ namespace Avalonia.Controls.UnitTests
         private MouseTestHelper _mouse = new MouseTestHelper();
 
         [Fact]
+        public void Opening_Raises_Single_Opened_Event()
+        {
+            using (Application())
+            {
+                var sut = new ContextMenu();
+                var target = new Panel
+                {
+                    ContextMenu = sut
+                };
+
+                new Window { Content = target };
+
+                int openedCount = 0;
+
+                sut.MenuOpened += (sender, args) =>
+                {
+                    openedCount++;
+                };
+
+                sut.Open(null);
+
+                Assert.Equal(1, openedCount);
+            }
+        }
+
+        [Fact]
+        public void Closing_Raises_Single_Closed_Event()
+        {
+            using (Application())
+            {
+                var sut = new ContextMenu();
+                var target = new Panel
+                {
+                    ContextMenu = sut
+                };
+
+                new Window { Content = target };
+
+                sut.Open(null);
+
+                int closedCount = 0;
+
+                sut.MenuClosed += (sender, args) =>
+                {
+                    closedCount++;
+                };
+
+                sut.Close();
+
+                Assert.Equal(1, closedCount);
+            }
+        }
+
+        [Fact]
         public void Clicking_On_Control_Toggles_ContextMenu()
         {
             using (Application())

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Linq;
 using Moq;
 using Avalonia.Controls.Presenters;
@@ -182,6 +183,53 @@ namespace Avalonia.Controls.UnitTests.Primitives
                 Assert.True(popupRoot.IsAttachedToLogicalTree);
                 root.Child = null;
                 Assert.False(((ILogical)target).IsAttachedToLogicalTree);
+            }
+        }
+
+        [Fact]
+        public void Popup_Open_Should_Raise_Single_Opened_Event()
+        {
+            using (CreateServices())
+            {
+                var window = new Window();
+                var target = new Popup();
+
+                window.Content = target;
+
+                int openedCount = 0;
+
+                target.Opened += (sender, args) =>
+                {
+                    openedCount++;
+                };
+
+                target.Open();
+
+                Assert.Equal(1, openedCount);
+            }
+        }
+
+        [Fact]
+        public void Popup_Close_Should_Raise_Single_Closed_Event()
+        {
+            using (CreateServices())
+            {
+                var window = new Window();
+                var target = new Popup();
+
+                window.Content = target;
+                target.Open();
+
+                int closedCount = 0;
+
+                target.Closed += (sender, args) =>
+                {
+                    closedCount++;
+                };
+
+                target.Close();
+
+                Assert.Equal(1, closedCount);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes opening and closing events for `ContextMenu` and `Popup`.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Events for `ContextMenu` opening or closing were not raised. `Popup` was raising `Closed` events twice.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Events for opening and closing should be raised properly now.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

@grokys As you did last menu rework.