### PR TITLE
Make SelectingItemsControl.AlwaysSelect work with Reset.

### DIFF
--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -333,6 +333,11 @@ namespace Avalonia.Controls.Primitives
                 case NotifyCollectionChangedAction.Move:
                 case NotifyCollectionChangedAction.Reset:
                     SelectedIndex = IndexOf(Items, SelectedItem);
+
+                    if (AlwaysSelected && SelectedIndex == -1 && ItemCount > 0)
+                    {
+                        SelectedIndex = 0;
+                    }
                     break;
             }
         }

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_AutoSelect.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_AutoSelect.cs
@@ -1,6 +1,8 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.Collections.Specialized;
 using Avalonia.Collections;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
@@ -30,6 +32,24 @@ namespace Avalonia.Controls.UnitTests.Primitives
         public void First_Item_Should_Be_Selected_When_Added()
         {
             var items = new AvaloniaList<string>();
+            var target = new TestSelector
+            {
+                Items = items,
+                Template = Template(),
+            };
+
+            target.ApplyTemplate();
+            items.Add("foo");
+
+            Assert.Equal(0, target.SelectedIndex);
+            Assert.Equal("foo", target.SelectedItem);
+        }
+
+
+        [Fact]
+        public void First_Item_Should_Be_Selected_When_Reset()
+        {
+            var items = new ResetOnAdd();
             var target = new TestSelector
             {
                 Items = items,
@@ -98,6 +118,19 @@ namespace Avalonia.Controls.UnitTests.Primitives
             static TestSelector()
             {
                 SelectionModeProperty.OverrideDefaultValue<TestSelector>(SelectionMode.AlwaysSelected);
+            }
+        }
+
+        private class ResetOnAdd : List<string>, INotifyCollectionChanged
+        {
+            public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+            public new void Add(string item)
+            {
+                base.Add(item);
+                CollectionChanged?.Invoke(
+                    this,
+                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
             }
         }
     }


### PR DESCRIPTION
## What does the pull request do?

#2754 describes a case where the first item is not auto-selected on a `SelectingItemsControl` which has `AlwaysSelect = true` when the event action is `Reset`. Make sure this (unusual) case works.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #2754 

cc: @aguahombre