### PR TITLE
Fix Tapped and DoubleTapped gestures

### DIFF
--- a/src/Avalonia.Input/Gestures.cs
+++ b/src/Avalonia.Input/Gestures.cs
@@ -46,7 +46,7 @@ namespace Avalonia.Input
                 }
                 else if (s_lastPress?.IsAlive == true && e.ClickCount == 2 && s_lastPress.Target == e.Source)
                 {
-                    if (!ev.Handled)
+                    if (e.MouseButton != MouseButton.Right)
                     {
                         e.Source.RaiseEvent(new RoutedEventArgs(DoubleTappedEvent));
                     }
@@ -62,7 +62,7 @@ namespace Avalonia.Input
 
                 if (s_lastPress?.IsAlive == true && s_lastPress.Target == e.Source)
                 {
-                    if (!ev.Handled)
+                    if (e.MouseButton != MouseButton.Right)
                     {
                         ((IInteractive)s_lastPress.Target).RaiseEvent(new RoutedEventArgs(TappedEvent));
                     }

--- a/src/Avalonia.Input/Gestures.cs
+++ b/src/Avalonia.Input/Gestures.cs
@@ -18,6 +18,11 @@ namespace Avalonia.Input
             RoutingStrategies.Bubble,
             typeof(Gestures));
 
+        public static readonly RoutedEvent<RoutedEventArgs> RightTappedEvent = RoutedEvent.Register<RoutedEventArgs>(
+            "RightTapped",
+            RoutingStrategies.Bubble,
+            typeof(Gestures));
+
         public static readonly RoutedEvent<ScrollGestureEventArgs> ScrollGestureEvent =
             RoutedEvent.Register<ScrollGestureEventArgs>(
                 "ScrollGesture", RoutingStrategies.Bubble, typeof(Gestures));
@@ -62,10 +67,8 @@ namespace Avalonia.Input
 
                 if (s_lastPress?.IsAlive == true && s_lastPress.Target == e.Source)
                 {
-                    if (e.MouseButton != MouseButton.Right)
-                    {
-                        ((IInteractive)s_lastPress.Target).RaiseEvent(new RoutedEventArgs(TappedEvent));
-                    }
+                    var et = e.MouseButton != MouseButton.Right ? TappedEvent : RightTappedEvent;
+                    ((IInteractive)s_lastPress.Target).RaiseEvent(new RoutedEventArgs(et));
                 }
             }
         }

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests_Single.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests_Single.cs
@@ -9,8 +9,8 @@ using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.LogicalTree;
-using Avalonia.Markup.Data;
 using Avalonia.Styling;
+using Avalonia.UnitTests;
 using Avalonia.VisualTree;
 using Xunit;
 

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_Multiple.cs
@@ -13,7 +13,7 @@ using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Markup.Data;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Primitives

--- a/tests/Avalonia.Input.UnitTests/GesturesTests.cs
+++ b/tests/Avalonia.Input.UnitTests/GesturesTests.cs
@@ -23,12 +23,7 @@ namespace Avalonia.Interactivity.UnitTests
             };
             var result = new List<string>();
 
-            decorator.AddHandler(Border.PointerPressedEvent, (s, e) => result.Add("dp"));
-            decorator.AddHandler(Border.PointerReleasedEvent, (s, e) => result.Add("dr"));
-            decorator.AddHandler(Gestures.TappedEvent, (s, e) => result.Add("dt"));
-            border.AddHandler(Border.PointerPressedEvent, (s, e) => result.Add("bp"));
-            border.AddHandler(Border.PointerReleasedEvent, (s, e) => result.Add("br"));
-            border.AddHandler(Gestures.TappedEvent, (s, e) => result.Add("bt"));
+            AddHandlers(decorator, border, result, false);
 
             _mouse.Click(border);
 
@@ -36,7 +31,7 @@ namespace Avalonia.Interactivity.UnitTests
         }
 
         [Fact]
-        public void Tapped_Should_Be_Raised_Even_When_PointerPressed_Handled()
+        public void Tapped_Should_Be_Raised_Even_When_Pressed_Released_Handled()
         {
             Border border = new Border();
             var decorator = new Decorator
@@ -45,13 +40,45 @@ namespace Avalonia.Interactivity.UnitTests
             };
             var result = new List<string>();
 
-            border.AddHandler(Border.PointerPressedEvent, (s, e) => e.Handled = true);
-            decorator.AddHandler(Gestures.TappedEvent, (s, e) => result.Add("dt"));
-            border.AddHandler(Gestures.TappedEvent, (s, e) => result.Add("bt"));
+            AddHandlers(decorator, border, result, true);
 
             _mouse.Click(border);
 
-            Assert.Equal(new[] { "bt", "dt" }, result);
+            Assert.Equal(new[] { "bp", "dp", "br", "dr", "bt", "dt" }, result);
+        }
+
+        [Fact]
+        public void Tapped_Should_Be_Raised_For_Middle_Button()
+        {
+            Border border = new Border();
+            var decorator = new Decorator
+            {
+                Child = border
+            };
+            var raised = false;
+
+            decorator.AddHandler(Gestures.TappedEvent, (s, e) => raised = true);
+
+            _mouse.Click(border, MouseButton.Middle);
+
+            Assert.True(raised);
+        }
+
+        [Fact]
+        public void Tapped_Should_Not_Be_Raised_For_Right_Button()
+        {
+            Border border = new Border();
+            var decorator = new Decorator
+            {
+                Child = border
+            };
+            var raised = false;
+
+            decorator.AddHandler(Gestures.TappedEvent, (s, e) => raised = true);
+
+            _mouse.Click(border, MouseButton.Right);
+
+            Assert.False(raised);
         }
 
         [Fact]
@@ -64,14 +91,7 @@ namespace Avalonia.Interactivity.UnitTests
             };
             var result = new List<string>();
 
-            decorator.AddHandler(Border.PointerPressedEvent, (s, e) => result.Add("dp"));
-            decorator.AddHandler(Border.PointerReleasedEvent, (s, e) => result.Add("dr"));
-            decorator.AddHandler(Gestures.TappedEvent, (s, e) => result.Add("dt"));
-            decorator.AddHandler(Gestures.DoubleTappedEvent, (s, e) => result.Add("ddt"));
-            border.AddHandler(Border.PointerPressedEvent, (s, e) => result.Add("bp"));
-            border.AddHandler(Border.PointerReleasedEvent, (s, e) => result.Add("br"));
-            border.AddHandler(Gestures.TappedEvent, (s, e) => result.Add("bt"));
-            border.AddHandler(Gestures.DoubleTappedEvent, (s, e) => result.Add("bdt"));
+            AddHandlers(decorator, border, result, false);
 
             _mouse.Click(border);
             _mouse.Down(border, clickCount: 2);
@@ -80,7 +100,7 @@ namespace Avalonia.Interactivity.UnitTests
         }
 
         [Fact]
-        public void DoubleTapped_Should_Not_Be_Rasied_if_Pressed_is_Handled()
+        public void DoubleTapped_Should_Be_Raised_Even_When_Pressed_Released_Handled()
         {
             Border border = new Border();
             var decorator = new Decorator
@@ -89,24 +109,83 @@ namespace Avalonia.Interactivity.UnitTests
             };
             var result = new List<string>();
 
-            decorator.AddHandler(Border.PointerPressedEvent, (s, e) =>
-            {
-                result.Add("dp");
-                e.Handled = true;
-            });
-
-            decorator.AddHandler(Border.PointerReleasedEvent, (s, e) => result.Add("dr"));
-            decorator.AddHandler(Gestures.TappedEvent, (s, e) => result.Add("dt"));
-            decorator.AddHandler(Gestures.DoubleTappedEvent, (s, e) => result.Add("ddt"));
-            border.AddHandler(Border.PointerPressedEvent, (s, e) => result.Add("bp"));
-            border.AddHandler(Border.PointerReleasedEvent, (s, e) => result.Add("br"));
-            border.AddHandler(Gestures.TappedEvent, (s, e) => result.Add("bt"));
-            border.AddHandler(Gestures.DoubleTappedEvent, (s, e) => result.Add("bdt"));
+            AddHandlers(decorator, border, result, true);
 
             _mouse.Click(border);
             _mouse.Down(border, clickCount: 2);
 
-            Assert.Equal(new[] { "bp", "dp", "br", "dr", "bt", "dt", "bp", "dp" }, result);
+            Assert.Equal(new[] { "bp", "dp", "br", "dr", "bt", "dt", "bp", "dp", "bdt", "ddt" }, result);
+        }
+
+        [Fact]
+        public void DoubleTapped_Should_Be_Raised_For_Middle_Button()
+        {
+            Border border = new Border();
+            var decorator = new Decorator
+            {
+                Child = border
+            };
+            var raised = false;
+
+            decorator.AddHandler(Gestures.DoubleTappedEvent, (s, e) => raised = true);
+
+            _mouse.Click(border, MouseButton.Middle);
+            _mouse.Down(border, MouseButton.Middle, clickCount: 2);
+
+            Assert.True(raised);
+        }
+
+        [Fact]
+        public void DoubleTapped_Should_Not_Be_Raised_For_Right_Button()
+        {
+            Border border = new Border();
+            var decorator = new Decorator
+            {
+                Child = border
+            };
+            var raised = false;
+
+            decorator.AddHandler(Gestures.DoubleTappedEvent, (s, e) => raised = true);
+
+            _mouse.Click(border, MouseButton.Right);
+            _mouse.Down(border, MouseButton.Right, clickCount: 2);
+
+            Assert.False(raised);
+        }
+
+        private void AddHandlers(
+            Decorator decorator,
+            Border border,
+            IList<string> result,
+            bool markHandled)
+        {
+            decorator.AddHandler(Border.PointerPressedEvent, (s, e) =>
+            {
+                result.Add("dp");
+
+                if (markHandled)
+                {
+                    e.Handled = true;
+                }
+            });
+
+            decorator.AddHandler(Border.PointerReleasedEvent, (s, e) =>
+            {
+                result.Add("dr");
+
+                if (markHandled)
+                {
+                    e.Handled = true;
+                }
+            });
+
+            border.AddHandler(Border.PointerPressedEvent, (s, e) => result.Add("bp"));
+            border.AddHandler(Border.PointerReleasedEvent, (s, e) => result.Add("br"));
+
+            decorator.AddHandler(Gestures.TappedEvent, (s, e) => result.Add("dt"));
+            decorator.AddHandler(Gestures.DoubleTappedEvent, (s, e) => result.Add("ddt"));
+            border.AddHandler(Gestures.TappedEvent, (s, e) => result.Add("bt"));
+            border.AddHandler(Gestures.DoubleTappedEvent, (s, e) => result.Add("bdt"));
         }
     }
 }

--- a/tests/Avalonia.Input.UnitTests/GesturesTests.cs
+++ b/tests/Avalonia.Input.UnitTests/GesturesTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Avalonia.Interactivity.UnitTests
 {
-    public class GestureTests
+    public class GesturesTests
     {
         private MouseTestHelper _mouse = new MouseTestHelper();
         

--- a/tests/Avalonia.Input.UnitTests/GesturesTests.cs
+++ b/tests/Avalonia.Input.UnitTests/GesturesTests.cs
@@ -82,6 +82,23 @@ namespace Avalonia.Interactivity.UnitTests
         }
 
         [Fact]
+        public void RightTapped_Should_Be_Raised_For_Right_Button()
+        {
+            Border border = new Border();
+            var decorator = new Decorator
+            {
+                Child = border
+            };
+            var raised = false;
+
+            decorator.AddHandler(Gestures.RightTappedEvent, (s, e) => raised = true);
+
+            _mouse.Click(border, MouseButton.Right);
+
+            Assert.True(raised);
+        }
+
+        [Fact]
         public void DoubleTapped_Should_Follow_Pointer_Pressed_Released_Pressed()
         {
             Border border = new Border();

--- a/tests/Avalonia.Interactivity.UnitTests/Avalonia.Interactivity.UnitTests.csproj
+++ b/tests/Avalonia.Interactivity.UnitTests/Avalonia.Interactivity.UnitTests.csproj
@@ -20,7 +20,7 @@
     <ProjectReference Include="..\..\src\Avalonia.Layout\Avalonia.Layout.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Visuals\Avalonia.Visuals.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Styling\Avalonia.Styling.csproj" />
-    <Compile Include="..\Avalonia.Controls.UnitTests\MouseTestHelper.cs" />
+    <ProjectReference Include="..\Avalonia.UnitTests\Avalonia.UnitTests.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/Avalonia.Interactivity.UnitTests/GestureTests.cs
+++ b/tests/Avalonia.Interactivity.UnitTests/GestureTests.cs
@@ -3,8 +3,8 @@
 
 using System.Collections.Generic;
 using Avalonia.Controls;
-using Avalonia.Controls.UnitTests;
 using Avalonia.Input;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Interactivity.UnitTests

--- a/tests/Avalonia.UnitTests/Avalonia.UnitTests.csproj
+++ b/tests/Avalonia.UnitTests/Avalonia.UnitTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>

--- a/tests/Avalonia.UnitTests/MouseTestHelper.cs
+++ b/tests/Avalonia.UnitTests/MouseTestHelper.cs
@@ -1,9 +1,8 @@
-using System.Reactive;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 
-namespace Avalonia.Controls.UnitTests
+namespace Avalonia.UnitTests
 {
     public class MouseTestHelper
     {


### PR DESCRIPTION
## What does the pull request do?

As described in #2730, `Tapped` and `DoubleTapped` were changed in #2580 to not be raised when the underlying point down/up events are marked as handled.

This prevents double-click events being raised on e.g. `ListBoxItem` which is a problem.

Checking with UWP, these events _are_ raised when the underlying pointer events are marked as handled. In addition there is a `RightTapped` event which is raised when a control is clicked with the right button. `Tapped` and `DoubleTapped` are only raised for left and middle clicks.

This PR fixes #2730 and adds `RightTapped`.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #2730 