### PR TITLE
Prevent NRE in VisualNode.HitTest.

### DIFF
--- a/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
@@ -236,7 +236,7 @@ namespace Avalonia.Rendering.SceneGraph
         {
             foreach (var operation in DrawOperations)
             {
-                if (operation.Item.HitTest(p))
+                if (operation?.Item?.HitTest(p) == true)
                 {
                     return true;
                 }


### PR DESCRIPTION
## What does the pull request do?

#2758 reports a `NullReferenceException` in `VisualNode.HitTest`. Not sure how this is happening and we don't have a repro but the strack trace points to here. Defensively check for a null `Item` to prevent this.

## Fixed issues

Fixes #2758.
