### PR TITLE
Fix NRE in VisualNode.SortChildren.

### DIFF
--- a/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
@@ -179,6 +179,11 @@ namespace Avalonia.Rendering.SceneGraph
         /// <param name="scene">The scene that the node is a part of.</param>
         public void SortChildren(Scene scene)
         {
+            if (_children == null || _children.Count <= 1)
+            {
+                return;
+            }
+
             var keys = new List<long>();
 
             for (var i = 0; i < Visual.VisualChildren.Count; ++i)

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
@@ -184,7 +184,7 @@ namespace Avalonia.Rendering.SceneGraph
                 return;
             }
 
-            var keys = new List<long>();
+            var keys = new List<long>(Visual.VisualChildren.Count);
 
             for (var i = 0; i < Visual.VisualChildren.Count; ++i)
             {

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/VisualNodeTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/VisualNodeTests.cs
@@ -92,5 +92,14 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
             Assert.Same(node1.DrawOperations[0].Item, node2.DrawOperations[0].Item);
             Assert.NotSame(node1.DrawOperations[0], node2.DrawOperations[0]);
         }
+
+        [Fact]
+        public void SortChildren_Does_Not_Throw_On_Null_Children()
+        {
+            var node = new VisualNode(Mock.Of<IVisual>(), null);
+            var scene = new Scene(Mock.Of<IVisual>());
+
+            node.SortChildren(scene);
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Fix a `NullReferenceException` in `VisualNode.SortChildren` if `_children` is null.

## What is the current behavior?

Try to show notifications in ControlCatalog. Get a crash.

## How was the solution implemented (if it's not obvious)?

Add a null check. In addition if there are < 2 children, there's no sorting to be done.

## Checklist

- [x] Added unit tests (if possible)?
