### PR TITLE
Fix flaky XAML tests.

### DIFF
--- a/tests/Avalonia.Markup.Xaml.UnitTests/Converters/ConverterTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Converters/ConverterTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Converters
 {
-    public class ConverterTests
+    public class ConverterTests : XamlTestBase
     {
         [Fact]
         public void Bug_2228_Relative_Uris_Should_Be_Correctly_Parsed()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Converters/NullableConverterTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Converters/NullableConverterTests.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Converters
         public Orientation? Orientation { get; set; }
     }
     
-    public class NullableConverterTests
+    public class NullableConverterTests : XamlTestBase
     {
         [Fact]
         public void Nullable_Types_Should_Still_Be_Converted_Properly()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Converters/ValueConverterTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Converters/ValueConverterTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Converters
 {
-    public class ValueConverterTests
+    public class ValueConverterTests : XamlTestBase
     {
         [Fact]
         public void ValueConverter_Special_Values_Work()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Data
 {
-    public class BindingTests
+    public class BindingTests : XamlTestBase
     {
         [Fact]
         public void Binding_With_Null_Path_Works()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests_Method.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests_Method.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Data
 {
-    public class BindingTests_Method
+    public class BindingTests_Method : XamlTestBase
     {
         [Fact]
         public void Binding_Method_To_Command_Works()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests_TemplatedParent.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests_TemplatedParent.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Data
 {
-    public class BindingTests_TemplatedParent
+    public class BindingTests_TemplatedParent : XamlTestBase
     {
         [Fact]
         public void TemplateBinding_With_Null_Path_Works()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/BindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/BindingExtensionTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 {
-    public class BindingExtensionTests
+    public class BindingExtensionTests : XamlTestBase
     {
 
         [Fact]

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/DynamicResourceExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/DynamicResourceExtensionTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 {
-    public class DynamicResourceExtensionTests
+    public class DynamicResourceExtensionTests : XamlTestBase
     {
         [Fact]
         public void DynamicResource_Can_Be_Assigned_To_Property()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/ResourceIncludeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/ResourceIncludeTests.cs
@@ -8,7 +8,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MakrupExtensions
 {
     public class ResourceIncludeTests
     {
-        public class StaticResourceExtensionTests
+        public class StaticResourceExtensionTests : XamlTestBase
         {
             [Fact]
             public void ResourceInclude_Loads_ResourceDictionary()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/StaticResourceExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/StaticResourceExtensionTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 {
-    public class StaticResourceExtensionTests
+    public class StaticResourceExtensionTests : XamlTestBase
     {
         [Fact]
         public void StaticResource_Can_Be_Assigned_To_Property()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/StyleTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests
 {
-    public class StyleTests
+    public class StyleTests : XamlTestBase
     {
         [Fact]
         public void Binding_Should_Be_Assigned_To_Setter_Value_Instead_Of_Bound()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
@@ -22,7 +22,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 {
-    public class BasicTests
+    public class BasicTests : XamlTestBase
     {
         [Fact]
         public void Simple_Property_Is_Set()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BindingTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BindingTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 {
-    public class BindingTests
+    public class BindingTests : XamlTestBase
     {
         [Fact]
         public void Binding_To_DataContext_Works()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BindingTests_RelativeSource.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BindingTests_RelativeSource.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 {
-    public class BindingTests_RelativeSource
+    public class BindingTests_RelativeSource : XamlTestBase
     {
         [Fact]
         public void Binding_To_DataContext_Works()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ControlBindingTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ControlBindingTests.cs
@@ -4,14 +4,13 @@
 using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
-using Avalonia.Layout;
 using Avalonia.Logging;
 using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 {
-    public class ControlBindingTests
+    public class ControlBindingTests : XamlTestBase
     {
         [Fact]
         public void Binding_ProgressBar_Value_To_Invalid_Value_Uses_FallbackValue()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/DataTemplateTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/DataTemplateTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 {
-    public class DataTemplateTests
+    public class DataTemplateTests : XamlTestBase
     {
         [Fact]
         public void DataTemplate_Can_Contain_Name()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/EventTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/EventTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 {
-    public class EventTests
+    public class EventTests : XamlTestBase
     {
         [Fact]
         public void Event_Is_Attached()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 {
-    public class StyleTests
+    public class StyleTests : XamlTestBase
     {
         [Fact]
         public void Color_Can_Be_Added_To_Style_Resources()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/TreeDataTemplateTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/TreeDataTemplateTests.cs
@@ -4,14 +4,13 @@
 using System.Linq;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
-using Avalonia.Markup.Data;
 using Avalonia.Markup.Xaml.Templates;
 using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 {
-    public class TreeDataTemplateTests
+    public class TreeDataTemplateTests : XamlTestBase
     {
         [Fact]
         public void Binding_Should_Be_Assigned_To_ItemsSource_Instead_Of_Bound()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/XamlIlTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/XamlIlTests.cs
@@ -5,10 +5,7 @@ using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Avalonia.Controls;
-using Avalonia.Controls.Presenters;
 using Avalonia.Data.Converters;
-using Avalonia.Input;
-using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.UnitTests;
@@ -18,7 +15,7 @@ using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests
 {
-    public class XamlIlTests
+    public class XamlIlTests : XamlTestBase
     {
         [Fact]
         public void Binding_Button_IsPressed_ShouldWork()

--- a/tests/Avalonia.Markup.Xaml.UnitTests/XamlTestBase.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/XamlTestBase.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Avalonia.Data;
+
+namespace Avalonia.Markup.Xaml.UnitTests
+{
+    public class XamlTestBase
+    {
+        public XamlTestBase()
+        {
+            // Ensure necessary assemblies are loaded.
+            var _ = typeof(TemplateBinding);
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Some XAML tests were failing intermittently under ncrunch (and possibly other test runners?) because XamlIL does not rebuild its assembly cache after it's built for the first time. If a test that didn't cause `Avalonia.Markup` to be loaded was run before a test that required it, the second test would fail complaining of a missing `TemplateBinding` or simiar.

## How was the solution implemented (if it's not obvious)?

Make tests that load XAML inherit from `XamlTestBase` which ensures that `Avalonia.Markup` is loaded.
