### PR TITLE
AutoSuspendHelper: Don't throw when in design mode

### DIFF
--- a/src/Avalonia.ReactiveUI/AutoSuspendHelper.cs
+++ b/src/Avalonia.ReactiveUI/AutoSuspendHelper.cs
@@ -35,7 +35,12 @@ namespace Avalonia.ReactiveUI
             RxApp.SuspensionHost.IsResuming = Observable.Never<Unit>();
             RxApp.SuspensionHost.IsLaunchingNew = _isLaunchingNew;
 
-            if (lifetime is IControlledApplicationLifetime controlled)
+            if (Avalonia.Controls.Design.IsDesignMode)
+            {
+                this.Log().Debug("Design mode detected. AutoSuspendHelper won't persist app state.");
+                RxApp.SuspensionHost.ShouldPersistState = Observable.Never<IDisposable>();
+            }
+            else if (lifetime is IControlledApplicationLifetime controlled)
             {
                 this.Log().Debug("Using IControlledApplicationLifetime events to handle app exit.");
                 controlled.Exit += (sender, args) => OnControlledApplicationLifetimeExit();
@@ -47,11 +52,11 @@ namespace Avalonia.ReactiveUI
                 var message = $"Don't know how to detect app exit event for {type}.";
                 throw new NotSupportedException(message);
             }
-            else 
+            else
             {
                 var message = "ApplicationLifetime is null. "
                             + "Ensure you are initializing AutoSuspendHelper "
-                            + "when Avalonia application initialization is completed.";
+                            + "after Avalonia application initialization is completed.";
                 throw new ArgumentNullException(message);
             }
             

--- a/tests/Avalonia.ReactiveUI.UnitTests/AutoSuspendHelperTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AutoSuspendHelperTest.cs
@@ -61,6 +61,28 @@ namespace Avalonia.ReactiveUI.UnitTests
         }
 
         [Fact]
+        public void AutoSuspendHelper_Should_Throw_When_Not_Supported_Lifetime_Is_Used()
+        {
+            using (UnitTestApplication.Start(TestServices.MockWindowingPlatform))
+            using (var lifetime = new ExoticApplicationLifetimeWithoutLifecycleEvents()) 
+            {
+                var application = AvaloniaLocator.Current.GetService<Application>();
+                application.ApplicationLifetime = lifetime;
+                Assert.Throws<NotSupportedException>(() => new AutoSuspendHelper(application.ApplicationLifetime));
+            }
+        }
+
+        [Fact]
+        public void AutoSuspendHelper_Should_Throw_When_Lifetime_Is_Null()
+        {
+            using (UnitTestApplication.Start(TestServices.MockWindowingPlatform))
+            {
+                var application = AvaloniaLocator.Current.GetService<Application>();
+                Assert.Throws<ArgumentNullException>(() => new AutoSuspendHelper(application.ApplicationLifetime));
+            }
+        }
+
+        [Fact]
         public void ShouldPersistState_Should_Fire_On_App_Exit_When_SuspensionDriver_Is_Initialized() 
         {
             using (UnitTestApplication.Start(TestServices.MockWindowingPlatform))
@@ -80,18 +102,6 @@ namespace Avalonia.ReactiveUI.UnitTests
                 lifetime.Shutdown();
                 Assert.True(shouldPersistReceived);
                 Assert.Equal("Foo", RxApp.SuspensionHost.GetAppState<AppState>().Example);
-            }
-        }
-
-        [Fact]
-        public void AutoSuspendHelper_Should_Throw_For_Not_Supported_Lifetimes()
-        {
-            using (UnitTestApplication.Start(TestServices.MockWindowingPlatform))
-            using (var lifetime = new ExoticApplicationLifetimeWithoutLifecycleEvents()) 
-            {
-                var application = AvaloniaLocator.Current.GetService<Application>();
-                application.ApplicationLifetime = lifetime;
-                Assert.Throws<NotSupportedException>(() => new AutoSuspendHelper(application.ApplicationLifetime));
             }
         }
     }


### PR DESCRIPTION
### What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Fixes designer crash caused by `AutoSuspendHelper` as described at https://github.com/AvaloniaUI/Avalonia/issues/2790

### What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

`AutoSuspendHelper` crashes the designer process as the `ApplicationLifetime` property is null.

### What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

`AutoSuspendHelper` no longer crashes the designer process, an extra check is added.

### Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/2790

### Additional information

Open for suggestions on how to unit test the `Design.IsDesignMode` property with an internal setter.