### PR TITLE
Fix ItemsRepeater problems

### DIFF
--- a/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml
+++ b/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml
@@ -6,19 +6,20 @@
       <TextBlock Classes="h1">ItemsRepeater</TextBlock>
       <TextBlock Classes="h2">A data-driven collection control that incorporates a flexible layout system, custom views, and virtualization.</TextBlock>
     </StackPanel>
-    <StackPanel DockPanel.Dock="Right" Margin="8 0">
+    <StackPanel DockPanel.Dock="Right" Margin="8 0" Spacing="4">
       <ComboBox SelectedIndex="0" SelectionChanged="LayoutChanged">
         <ComboBoxItem>Stack - Vertical</ComboBoxItem>
         <ComboBoxItem>Stack - Horizontal</ComboBoxItem>
         <ComboBoxItem>UniformGrid - Vertical</ComboBoxItem>
         <ComboBoxItem>UniformGrid - Horizontal</ComboBoxItem>
       </ComboBox>
+      <Button Command="{Binding AddItem}">Add Item</Button>
     </StackPanel>
     <Border BorderThickness="1" BorderBrush="{DynamicResource ThemeBorderMidBrush}" Margin="0 0 0 16">
       <ScrollViewer Name="scroller"
                     HorizontalScrollBarVisibility="Auto"
                     VerticalScrollBarVisibility="Auto">
-        <ItemsRepeater Name="repeater" Items="{Binding}"/>
+        <ItemsRepeater Name="repeater" Items="{Binding Items}"/>
       </ScrollViewer>
     </Border>
   </DockPanel>

--- a/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml
+++ b/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml
@@ -19,7 +19,7 @@
       <ScrollViewer Name="scroller"
                     HorizontalScrollBarVisibility="Auto"
                     VerticalScrollBarVisibility="Auto">
-        <ItemsRepeater Name="repeater" Items="{Binding Items}"/>
+        <ItemsRepeater Name="repeater" Background="Transparent" Items="{Binding Items}"/>
       </ScrollViewer>
     </Border>
   </DockPanel>

--- a/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
+using ControlCatalog.ViewModels;
 
 namespace ControlCatalog.Pages
 {
@@ -16,7 +17,7 @@ namespace ControlCatalog.Pages
             this.InitializeComponent();
             _repeater = this.FindControl<ItemsRepeater>("repeater");
             _scroller = this.FindControl<ScrollViewer>("scroller");
-            DataContext = Enumerable.Range(1, 100000).Select(i => $"Item {i}" ).ToArray();
+            DataContext = new ItemsRepeaterPageViewModel();
         }
 
         private void InitializeComponent()

--- a/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
 using ControlCatalog.ViewModels;
@@ -17,6 +19,7 @@ namespace ControlCatalog.Pages
             this.InitializeComponent();
             _repeater = this.FindControl<ItemsRepeater>("repeater");
             _scroller = this.FindControl<ScrollViewer>("scroller");
+            _repeater.PointerPressed += RepeaterClick;
             DataContext = new ItemsRepeaterPageViewModel();
         }
 
@@ -67,6 +70,12 @@ namespace ControlCatalog.Pages
                     };
                     break;
             }
+        }
+
+        private void RepeaterClick(object sender, PointerPressedEventArgs e)
+        {
+            var item = (e.Source as TextBlock)?.DataContext as string;
+            ((ItemsRepeaterPageViewModel)DataContext).SelectedItem = item;
         }
     }
 }

--- a/samples/ControlCatalog/ViewModels/ItemsRepeaterPageViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/ItemsRepeaterPageViewModel.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.ObjectModel;
+using System.Linq;
+using ReactiveUI;
+
+namespace ControlCatalog.ViewModels
+{
+    public class ItemsRepeaterPageViewModel : ReactiveObject
+    {
+        private int newItemIndex = 1;
+
+        public ItemsRepeaterPageViewModel()
+        {
+            Items = new ObservableCollection<string>(
+                Enumerable.Range(1, 100000).Select(i => $"Item {i}"));
+        }
+
+        public ObservableCollection<string> Items { get; }
+
+        public void AddItem()
+        {
+            Items.Insert(0, $"New Item {newItemIndex++}");
+        }
+    }
+}

--- a/samples/ControlCatalog/ViewModels/ItemsRepeaterPageViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/ItemsRepeaterPageViewModel.cs
@@ -16,9 +16,12 @@ namespace ControlCatalog.ViewModels
 
         public ObservableCollection<string> Items { get; }
 
+        public string SelectedItem { get; set; }
+
         public void AddItem()
         {
-            Items.Insert(0, $"New Item {newItemIndex++}");
+            var index = SelectedItem != null ? Items.IndexOf(SelectedItem) : -1;
+            Items.Insert(index + 1, $"New Item {newItemIndex++}");
         }
     }
 }

--- a/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
+++ b/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
@@ -707,9 +707,9 @@ namespace Avalonia.Controls
             }
         }
 
-        private void InvalidateArrangeForLayout(object sender, EventArgs e) => InvalidateMeasure();
+        private void InvalidateMeasureForLayout(object sender, EventArgs e) => InvalidateMeasure();
 
-        private void InvalidateMeasureForLayout(object sender, EventArgs e) => InvalidateArrange();
+        private void InvalidateArrangeForLayout(object sender, EventArgs e) => InvalidateArrange();
 
         private VirtualizingLayoutContext GetLayoutContext()
         {

--- a/src/Avalonia.Controls/Repeater/ItemsSourceView.cs
+++ b/src/Avalonia.Controls/Repeater/ItemsSourceView.cs
@@ -35,9 +35,11 @@ namespace Avalonia.Controls
         {
             Contract.Requires<ArgumentNullException>(source != null);
 
-            _inner = source as IList;
-
-            if (_inner == null && source is IEnumerable<object> objectEnumerable)
+            if (source is IList list)
+            {
+                _inner = list;
+            }
+            else if (source is IEnumerable<object> objectEnumerable)
             {
                 _inner = new List<object>(objectEnumerable);
             }

--- a/src/Avalonia.Layout/UniformGridLayoutState.cs
+++ b/src/Avalonia.Layout/UniformGridLayoutState.cs
@@ -72,12 +72,6 @@ namespace Avalonia.Layout
 
                     _cachedFirstElement.Measure(availableSize);
 
-                    // This doesn't need to be done in the UWP version and I'm not sure why. If we
-                    // don't do this here, and we receive a recycled element then it will be shown
-                    // at its previous arrange point, but we don't want it shown at all until its
-                    // arranged.
-                    _cachedFirstElement.Arrange(new Rect(-10000.0, -10000.0, 0, 0));
-
                     SetSize(_cachedFirstElement, layoutItemWidth, LayoutItemHeight, availableSize, stretch, orientation, minRowSpacing, minColumnSpacing);
 
                     // See if we can move ownership to the flow algorithm. If we can, we do not need a local cache.


### PR DESCRIPTION
## What does the pull request do?

Fix the problems with updating `ItemsControl` described in #2804. A couple of facepalms here:

- `ItemsSourceView` was always constructing a new `List` even if the source was already an `IList`
- `Measure` and `Arrange` were swapped in `ItemsRepeater`
  - This seems to be what was causing a previous problem which was hacked around in f09683c. Removed that hack

Also updated the control catalog with an "Add Item" button to test adding items.

## Fixed issues

Fixes #2804 