### PR TITLE
Add NuGet metadata to Directory.Build.props

### DIFF
--- a/build/SharedVersion.props
+++ b/build/SharedVersion.props
@@ -4,11 +4,16 @@
     <Product>Avalonia</Product>
     <Version>0.8.999</Version>
     <Copyright>Copyright 2019 &#169; The AvaloniaUI Project</Copyright>
-    <PackageLicenseUrl>https://github.com/AvaloniaUI/Avalonia/blob/master/licence.md</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/AvaloniaUI/Avalonia/</PackageProjectUrl>
+    <PackageProjectUrl>https://avaloniaui.net</PackageProjectUrl>
     <RepositoryUrl>https://github.com/AvaloniaUI/Avalonia/</RepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <LangVersion>latest</LangVersion>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageIconUrl>https://avatars2.githubusercontent.com/u/14075148?s=200</PackageIconUrl>
+    <PackageDescription>Avalonia is a WPF/UWP-inspired cross-platform XAML-based UI framework providing a flexible styling system and supporting a wide range of Operating Systems such as Windows (.NET Framework, .NET Core), Linux (via Xorg), MacOS and with experimental support for Android and iOS.</PackageDescription>
+    <PackageTags>avalonia;avaloniaui;mvvm;rx;reactive extensions;android;ios;mac;forms;wpf;net;netstandard;net461;uwp;xamarin</PackageTags>
+    <PackageReleaseNotes>https://github.com/AvaloniaUI/Avalonia/releases</PackageReleaseNotes>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
### What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

The goal of this PR is to include some metadata into each Avalonia NuGet package. The metadata includes package description, project logo, licensing information, tags. This will improve the look of the Avalonia NuGet page. 

### What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Currently, [Avalonia NuGet page](https://www.nuget.org/packages/Avalonia/) has no description and no image.

### What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Now Avalonia NuGet page should include the description, logo and other metadata.

### How was the solution implemented?
<!--- Include any information that might be of use to a reviewer here. -->

https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target

The changes from this PR should work if the `Directory.build.props` file is included into each project in the solution and the included properties are not overwritten elsewhere. I know Avalonia uses a lot of `*.build.props`  files and also the [Numerge](https://github.com/kekekeks/Numerge) utility, so need a review from experts in Avalonia packaging details. Thanks in advance!