### PR TITLE
Hotfix for the DnD issue

### DIFF
--- a/samples/ControlCatalog/Pages/DragAndDropPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DragAndDropPage.xaml.cs
@@ -29,7 +29,7 @@ namespace ControlCatalog.Pages
             DataObject dragData = new DataObject();
             dragData.Set(DataFormats.Text, $"You have dragged text {++DragCount} times");
 
-            var result = await DragDrop.DoDragDrop(dragData, DragDropEffects.Copy);
+            var result = await DragDrop.DoDragDrop(e, dragData, DragDropEffects.Copy);
             switch(result)
             {
                 case DragDropEffects.Copy:

--- a/src/Avalonia.Controls/Platform/InProcessDragSource.cs
+++ b/src/Avalonia.Controls/Platform/InProcessDragSource.cs
@@ -33,9 +33,10 @@ namespace Avalonia.Platform
             _dragDrop = AvaloniaLocator.Current.GetService<IDragDropDevice>();
         }
 
-        public async Task<DragDropEffects> DoDragDrop(IDataObject data, DragDropEffects allowedEffects)
+        public async Task<DragDropEffects> DoDragDrop(PointerEventArgs triggerEvent, IDataObject data, DragDropEffects allowedEffects)
         {
             Dispatcher.UIThread.VerifyAccess();
+            triggerEvent.Pointer.Capture(null);
             if (_draggedData == null)
             {
                 _draggedData = data;

--- a/src/Avalonia.Input/DragDrop.cs
+++ b/src/Avalonia.Input/DragDrop.cs
@@ -45,10 +45,10 @@ namespace Avalonia.Input
         /// Starts a dragging operation with the given <see cref="IDataObject"/> and returns the applied drop effect from the target.
         /// <seealso cref="DataObject"/>
         /// </summary>
-        public static Task<DragDropEffects> DoDragDrop(IDataObject data, DragDropEffects allowedEffects)
+        public static Task<DragDropEffects> DoDragDrop(PointerEventArgs triggerEvent, IDataObject data, DragDropEffects allowedEffects)
         {
             var src = AvaloniaLocator.Current.GetService<IPlatformDragSource>();
-            return src?.DoDragDrop(data, allowedEffects) ?? Task.FromResult(DragDropEffects.None);
+            return src?.DoDragDrop(triggerEvent, data, allowedEffects) ?? Task.FromResult(DragDropEffects.None);
         }
     }
 }

--- a/src/Avalonia.Input/Platform/IPlatformDragSource.cs
+++ b/src/Avalonia.Input/Platform/IPlatformDragSource.cs
@@ -4,6 +4,6 @@ namespace Avalonia.Input.Platform
 {
     public interface IPlatformDragSource
     {
-        Task<DragDropEffects> DoDragDrop(IDataObject data, DragDropEffects allowedEffects);
+        Task<DragDropEffects> DoDragDrop(PointerEventArgs triggerEvent, IDataObject data, DragDropEffects allowedEffects);
     }
 }

--- a/src/Windows/Avalonia.Win32/DragSource.cs
+++ b/src/Windows/Avalonia.Win32/DragSource.cs
@@ -8,10 +8,11 @@ namespace Avalonia.Win32
 {
     class DragSource : IPlatformDragSource
     {
-        public Task<DragDropEffects> DoDragDrop(IDataObject data, DragDropEffects allowedEffects)
+        public Task<DragDropEffects> DoDragDrop(PointerEventArgs triggerEvent,
+            IDataObject data, DragDropEffects allowedEffects)
         {
             Dispatcher.UIThread.VerifyAccess();
-
+            triggerEvent.Pointer.Capture(null);
             OleDragSource src = new OleDragSource();
             DataObject dataObject = new DataObject(data);
             int allowed = (int)OleDropTarget.ConvertDropEffect(allowedEffects);


### PR DESCRIPTION
This change explicitly drops the pointer capture in DnD code. DnD is still broken as it was in 0.8, you'll just have less chances to observe the consequences.

"Fixes" #2795