### PR TITLE
fix manged file dialogs on windows

### DIFF
--- a/src/Avalonia.Dialogs/ManagedFileChooserViewModel.cs
+++ b/src/Avalonia.Dialogs/ManagedFileChooserViewModel.cs
@@ -255,7 +255,7 @@ namespace Avalonia.Dialogs
                     {
                         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                         {
-                            infos = infos.Where(i => (i.Attributes & (FileAttributes.Hidden | FileAttributes.System)) != 0);
+                            infos = infos.Where(i => (i.Attributes & (FileAttributes.Hidden | FileAttributes.System)) == 0);
                         }
                         else
                         {

--- a/src/Windows/Avalonia.Win32/WindowsMountedVolumeInfoListener.cs
+++ b/src/Windows/Avalonia.Win32/WindowsMountedVolumeInfoListener.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Win32
     internal class WindowsMountedVolumeInfoListener : IDisposable
     {
         private readonly CompositeDisposable _disposables;
-        private readonly ObservableCollection<MountedVolumeInfo> _targetObs;
+        private readonly ObservableCollection<MountedVolumeInfo> _targetObs = new ObservableCollection<MountedVolumeInfo>();
         private bool _beenDisposed = false;
         private ObservableCollection<MountedVolumeInfo> mountedDrives;
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Managed file dialogs crash on opening on windows

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
run control catalog with managed dialogs enabled on windows and click file open on the dialog page

It also corrects the 'is hidden' logic which was showing only hidden files by default.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues

Fixes #2875

