### PR TITLE
Perf avoid repeated checks in getvalue

### DIFF
--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -208,20 +208,9 @@ namespace Avalonia
             {
                 return ((IDirectPropertyAccessor)GetRegistered(property)).GetValue(this);
             }
-            else if (_values != null)
-            {
-                var result = Values.GetValue(property);
-
-                if (result == AvaloniaProperty.UnsetValue)
-                {
-                    result = GetDefaultValue(property);
-                }
-
-                return result;
-            }
             else
             {
-                return GetDefaultValue(property);
+                return GetValueOrDefault(property);
             }
         }
 
@@ -598,8 +587,42 @@ namespace Avalonia
         private object GetDefaultValue(AvaloniaProperty property)
         {
             if (property.Inherits && InheritanceParent is AvaloniaObject aobj)
-                return aobj.GetValue(property);
+                return aobj.GetValueOrDefault(property);
             return ((IStyledPropertyAccessor) property).GetDefaultValue(GetType());
+        }
+
+        /// <summary>
+        /// Gets the value or default value for a property.
+        /// </summary>
+        /// <param name="property">The property.</param>
+        /// <returns>The default value.</returns>
+        private object GetValueOrDefault(AvaloniaProperty property)
+        {
+            var aobj = this;
+            if (aobj.Values != null)
+            {
+                var result = aobj.Values.GetValue(property);
+                if (result != AvaloniaProperty.UnsetValue)
+                {
+                    return result;
+                }
+            }
+            if (property.Inherits)
+            {
+                while(aobj.InheritanceParent is AvaloniaObject parent)
+                {
+                    aobj = parent;
+                    if (aobj.Values != null)
+                    {
+                        var result = aobj.Values.GetValue(property);
+                        if (result != AvaloniaProperty.UnsetValue)
+                        {
+                            return result;
+                        }
+                    }
+                }
+            }
+            return ((IStyledPropertyAccessor)property).GetDefaultValue(GetType());
         }
 
         /// <summary>

--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -210,7 +210,7 @@ namespace Avalonia
             }
             else
             {
-                return GetValueOrDefault(property);
+                return GetValueOrDefaultUnChecked(property);
             }
         }
 
@@ -596,7 +596,7 @@ namespace Avalonia
         /// </summary>
         /// <param name="property">The property.</param>
         /// <returns>The default value.</returns>
-        private object GetValueOrDefault(AvaloniaProperty property)
+        private object GetValueOrDefaultUnChecked(AvaloniaProperty property)
         {
             var aobj = this;
             if (aobj.Values != null)

--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -210,7 +210,7 @@ namespace Avalonia
             }
             else
             {
-                return GetValueOrDefaultUnChecked(property);
+                return GetValueOrDefaultUnchecked(property);
             }
         }
 
@@ -587,7 +587,7 @@ namespace Avalonia
         private object GetDefaultValue(AvaloniaProperty property)
         {
             if (property.Inherits && InheritanceParent is AvaloniaObject aobj)
-                return aobj.GetValueOrDefaultUnChecked(property);
+                return aobj.GetValueOrDefaultUnchecked(property);
             return ((IStyledPropertyAccessor) property).GetDefaultValue(GetType());
         }
 
@@ -596,7 +596,7 @@ namespace Avalonia
         /// </summary>
         /// <param name="property">The property.</param>
         /// <returns>The default value.</returns>
-        private object GetValueOrDefaultUnChecked(AvaloniaProperty property)
+        private object GetValueOrDefaultUnchecked(AvaloniaProperty property)
         {
             var aobj = this;
             if (aobj.Values != null)

--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -599,9 +599,10 @@ namespace Avalonia
         private object GetValueOrDefaultUnchecked(AvaloniaProperty property)
         {
             var aobj = this;
-            if (aobj._values != null)
+            var valuestore = aobj._values;
+            if (valuestore != null)
             {
-                var result = aobj._values.GetValue(property);
+                var result = valuestore.GetValue(property);
                 if (result != AvaloniaProperty.UnsetValue)
                 {
                     return result;
@@ -612,9 +613,10 @@ namespace Avalonia
                 while(aobj.InheritanceParent is AvaloniaObject parent)
                 {
                     aobj = parent;
-                    if (aobj._values != null)
+                    valuestore = aobj._values;
+                    if (valuestore != null)
                     {
-                        var result = aobj._values.GetValue(property);
+                        var result = valuestore.GetValue(property);
                         if (result != AvaloniaProperty.UnsetValue)
                         {
                             return result;

--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -587,7 +587,7 @@ namespace Avalonia
         private object GetDefaultValue(AvaloniaProperty property)
         {
             if (property.Inherits && InheritanceParent is AvaloniaObject aobj)
-                return aobj.GetValueOrDefault(property);
+                return aobj.GetValueOrDefaultUnChecked(property);
             return ((IStyledPropertyAccessor) property).GetDefaultValue(GetType());
         }
 

--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -610,7 +610,7 @@ namespace Avalonia
             }
             if (property.Inherits)
             {
-                while(aobj.InheritanceParent is AvaloniaObject parent)
+                while (aobj.InheritanceParent is AvaloniaObject parent)
                 {
                     aobj = parent;
                     valuestore = aobj._values;

--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -599,9 +599,9 @@ namespace Avalonia
         private object GetValueOrDefaultUnchecked(AvaloniaProperty property)
         {
             var aobj = this;
-            if (aobj.Values != null)
+            if (aobj._values != null)
             {
-                var result = aobj.Values.GetValue(property);
+                var result = aobj._values.GetValue(property);
                 if (result != AvaloniaProperty.UnsetValue)
                 {
                     return result;
@@ -612,9 +612,9 @@ namespace Avalonia
                 while(aobj.InheritanceParent is AvaloniaObject parent)
                 {
                     aobj = parent;
-                    if (aobj.Values != null)
+                    if (aobj._values != null)
                     {
-                        var result = aobj.Values.GetValue(property);
+                        var result = aobj._values.GetValue(property);
                         if (result != AvaloniaProperty.UnsetValue)
                         {
                             return result;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
It eliminates recursive calls to VerifyAccess(), .IsDirect and .Inherits for AvaloniaObject.GetValue and GetDefaultValue

Calls to VerifyAccess are reduced from approx 4,000,000 to 1,000,000 for ControlCatalog with DataGrid page visited


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
