### PR TITLE
Fix drag and drop not working on .Net Core 2.2+ in ControlCatalog

### DIFF
--- a/samples/ControlCatalog.NetCore/Program.cs
+++ b/samples/ControlCatalog.NetCore/Program.cs
@@ -4,22 +4,16 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using Avalonia;
-using Avalonia.Controls;
-using Avalonia.LinuxFramebuffer.Output;
-using Avalonia.Skia;
 using Avalonia.ReactiveUI;
 using Avalonia.Dialogs;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace ControlCatalog.NetCore
 {
     static class Program
     {
-
+        [STAThread]
         static int Main(string[] args)
         {
-            Thread.CurrentThread.TrySetApartmentState(ApartmentState.STA);
             if (args.Contains("--wait-for-attach"))
             {
                 Console.WriteLine("Attach debugger and use 'Set next statement'");


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
After switching my project to .Net Core 3 I found that drag and drop from the OS does not work anymore (drag and drop within the app was still working fine).
This change allows for using ControlCatalog drag and drop examples on all .Net Core versions.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
ControlCatalog drag and drop only works on .Net Core 2.1.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
ControlCatalog drag and drop works on all platforms.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Looks like that calling `Thread.CurrentThread.TrySetApartmentState(ApartmentState.STA)` does not work anymore in newer versions of .Net Core. Only way of making it work is using https://docs.microsoft.com/en-us/dotnet/api/system.stathreadattribute?view=netcore-3.0 (which is the intended way anyway).

There was a bug in old CoreCLR that broke `STAThread` usage but it was fixed over one and half year ago ((https://github.com/dotnet/coreclr/pull/15652)).

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->
Since this is sample. even if this stops working on ancient .Net Core 2.1 builds - do we care? (I would say no).

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #2165
