### PR TITLE
Avoid initializing properties if there is no observer. Optimize access.

### DIFF
--- a/src/Avalonia.Base/AvaloniaProperty.cs
+++ b/src/Avalonia.Base/AvaloniaProperty.cs
@@ -493,6 +493,11 @@ namespace Avalonia
         }
 
         /// <summary>
+        /// True if <see cref="Initialized"/> has any observers.
+        /// </summary>
+        internal bool HasNotifyInitializedObservers => _initialized.HasObservers;
+
+        /// <summary>
         /// Notifies the <see cref="Initialized"/> observable.
         /// </summary>
         /// <param name="e">The observable arguments.</param>

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -105,11 +105,13 @@ namespace Avalonia.Controls
             get => _selectedItem;
             set
             {
+                var selectedItems = SelectedItems;
+
                 SetAndRaise(SelectedItemProperty, ref _selectedItem, value);
 
                 if (value != null)
                 {
-                    if (SelectedItems.Count != 1 || SelectedItems[0] != value)
+                    if (selectedItems.Count != 1 || selectedItems[0] != value)
                     {
                         _syncingSelectedItems = true;
                         SelectSingleItem(value);

--- a/tests/Avalonia.Benchmarks/Base/AvaloniaObjectInitializationBenchmark.cs
+++ b/tests/Avalonia.Benchmarks/Base/AvaloniaObjectInitializationBenchmark.cs
@@ -1,0 +1,15 @@
+﻿using Avalonia.Controls;
+using BenchmarkDotNet.Attributes;
+
+namespace Avalonia.Benchmarks.Base
+{
+    [MemoryDiagnoser]
+    public class AvaloniaObjectInitializationBenchmark
+    {
+        [Benchmark(OperationsPerInvoke = 1000)]
+        public Button InitializeButton()
+        {
+            return new Button();
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Quite simple optimization that avoids majority of memory allocations and perf hit caused by it when initializing `AvaloniaObject` instances.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
We are trying to raise initialized events even when there is no listener causing pointless allocations.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Only allocate when there is a listener.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
- Changed to use `HashSet` and a `List` instead of `Dictionary` for better memory footprint when creating new initialization data cache.
- use `IDirectPropertyAccessor` to avoid going through `AvaloniaObject.GetValue` that does extra checks and is not needed since all properties must be registered on the object (since we used `GetRegistered` before).
- Avoid doing any work and allocations when there is no `Initialized` subscribers.
- Cache `IsDirect` to avoid going through virtual function calls all the time.

Old:

|           Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
| InitializeButton | 4.871 ns | 0.0974 ns | 0.1042 ns | 0.0062 |     - |     - |       5 B |


New:

|           Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
| InitializeButton | 1.759 ns | 0.0178 ns | 0.0167 ns | 0.0016 |     - |     - |       1 B |

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #2897

cc: @ahopper 