### PR TITLE
Get rid of allocations in Rect.TransformToAABB

### DIFF
--- a/src/Avalonia.Visuals/Rect.cs
+++ b/src/Avalonia.Visuals/Rect.cs
@@ -371,12 +371,12 @@ namespace Avalonia
         /// <returns>The bounding box</returns>
         public Rect TransformToAABB(Matrix matrix)
         {
-            var points = new[]
+            ReadOnlySpan<Point> points = stackalloc Point[4]
             {
                 TopLeft.Transform(matrix),
                 TopRight.Transform(matrix),
                 BottomRight.Transform(matrix),
-                BottomLeft.Transform(matrix),
+                BottomLeft.Transform(matrix)
             };
 
             var left = double.MaxValue;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Removes all allocations from `Rect.TransformToAABB`. It is used all over the place and allocates a lot of garbage.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`Rect.TransformToAABB` allocates temporary arrays.

![image](https://user-images.githubusercontent.com/2588062/64068952-463eba00-cc40-11e9-870e-7071da2aa191.png)

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
No allocations.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Use C# 7.3 stackalloc into a `ReadOnlySpan` instead of allocating an array.

| Method |     Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
|    Old | 51.04 ns | 0.8519 ns | 0.7969 ns |  1.00 |    0.00 | 0.0210 |     - |     - |      88 B |
|    New | 44.57 ns | 0.3587 ns | 0.2995 ns |  0.87 |    0.02 |      - |     - |     - |         - |

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
