### PR TITLE
Fixed possible double events subscription

### DIFF
--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -360,17 +360,19 @@ namespace Avalonia.Controls
         private static void IsDefaultChanged(AvaloniaPropertyChangedEventArgs e)
         {
             var button = e.Sender as Button;
+            var wasDefault = (bool)e.OldValue;
             var isDefault = (bool)e.NewValue;
 
             if (button?.VisualRoot is IInputElement inputRoot)
             {
+                if (wasDefault)
+                {
+                    button.StopListeningForDefault(inputRoot);
+                }
+
                 if (isDefault)
                 {
                     button.ListenForDefault(inputRoot);
-                }
-                else
-                {
-                    button.StopListeningForDefault(inputRoot);
                 }
             }
         }
@@ -382,17 +384,19 @@ namespace Avalonia.Controls
         private static void IsCancelChanged(AvaloniaPropertyChangedEventArgs e)
         {
             var button = e.Sender as Button;
+            var wasCancelled = (bool)e.OldValue;
             var isCancel = (bool)e.NewValue;
 
             if (button?.VisualRoot is IInputElement inputRoot)
             {
+                if (wasCancelled)
+                {
+                    button.StopListeningForCancel(inputRoot);
+                }
+
                 if (isCancel)
                 {
                     button.ListenForCancel(inputRoot);
-                }
-                else
-                {
-                    button.StopListeningForCancel(inputRoot);
                 }
             }
         }

--- a/src/Avalonia.Controls/LayoutTransformControl.cs
+++ b/src/Avalonia.Controls/LayoutTransformControl.cs
@@ -161,9 +161,16 @@ namespace Avalonia.Controls
             //       workaround.
 
             var target = e.Sender as LayoutTransformControl;
+            var hasUsedRenderTransform = (bool)e.OldValue;
             var shouldUseRenderTransform = (bool)e.NewValue;
             if (target != null)
             {
+                if (hasUsedRenderTransform)
+                {
+                    _renderTransformChangedEvent?.Dispose();
+                    LayoutTransform = null;
+                }
+
                 if (shouldUseRenderTransform)
                 {
                     _renderTransformChangedEvent = RenderTransformProperty.Changed
@@ -176,11 +183,6 @@ namespace Avalonia.Controls
                                         target2.LayoutTransform = target2.RenderTransform;
                                     }
                                 });
-                }
-                else
-                {
-                    _renderTransformChangedEvent?.Dispose();
-                    LayoutTransform = null;
                 }
             }
         }


### PR DESCRIPTION
## What does the pull request do?
Does not allows subscribe on event twice if property value does not changed.
This very dangerous situation in WPF (because it often raise event even value does not changed) but almost impossible in Avalonia. I found only one case - if ```RaisePropertyChanged(Property, PropertyValue, PropertyValue);``` called directly.
I can not come up with case in real application with this bug. But if it happens i think it will hard to find problem.

## What is the current behavior?
Some methods can subscribe on event twice.

## What is the updated/expected behavior with this PR?
Correct unsubscription

## How was the solution implemented (if it's not obvious)?
I used old pattern for WPF:
```
if ((bool) e.OldValue)
    Unsubscribe();
if ((bool) e.NewValue)
    Subscribe();
```

This PR based on #2906