### PR TITLE
Avoid per-frame allocations for renderer lock.

### DIFF
--- a/src/Avalonia.Native/AvaloniaNativeDeferredRendererLock.cs
+++ b/src/Avalonia.Native/AvaloniaNativeDeferredRendererLock.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Native
             return null;
         }
 
-        private class UnlockDisposable : IDisposable
+        private sealed class UnlockDisposable : IDisposable
         {
             private IAvnWindowBase _window;
 

--- a/src/Avalonia.Native/AvaloniaNativeDeferredRendererLock.cs
+++ b/src/Avalonia.Native/AvaloniaNativeDeferredRendererLock.cs
@@ -1,5 +1,8 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
 using System;
-using System.Reactive.Disposables;
+using System.Threading;
 using Avalonia.Native.Interop;
 using Avalonia.Rendering;
 
@@ -13,11 +16,27 @@ namespace Avalonia.Native
         {
             _window = window;
         }
+
         public IDisposable TryLock()
         {
             if (_window.TryLock())
-                return Disposable.Create(() => _window.Unlock());
+                return new UnlockDisposable(_window);
             return null;
+        }
+
+        private class UnlockDisposable : IDisposable
+        {
+            private IAvnWindowBase _window;
+
+            public UnlockDisposable(IAvnWindowBase window)
+            {
+                _window = window;
+            }
+
+            public void Dispose()
+            {
+                Interlocked.Exchange(ref _window, null)?.Unlock();
+            }
         }
     }
 }

--- a/src/Avalonia.Visuals/Rendering/ManagedDeferredRendererLock.cs
+++ b/src/Avalonia.Visuals/Rendering/ManagedDeferredRendererLock.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Rendering
             return new UnlockDisposable(_lock);
         }
 
-        private class UnlockDisposable : IDisposable
+        private sealed class UnlockDisposable : IDisposable
         {
             private object _lock;
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Part of my effort on reducing allocations in Avalonia.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Every time we obtain a lock we allocate a delegate and `AnonymousDisposable`.

![image](https://user-images.githubusercontent.com/2588062/64133950-3bb82800-cdda-11e9-9c58-75941d580159.png)

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Less dynamic allocations when obtaining renderer lock.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Implement new disposable that allows us to avoid allocating extra actions. We still have to create new instance every time to avoid potential API safety issues (people retaining disposable, etc.)

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

@kekekeks - what do you think? `AvaloniaNativeDeferredRendererLock` has similar pattern. In worst case scenario (double dispose protection is desired we could still cache the delgate, effectively halving allocation amount).