### PR TITLE
Fix AlwaysSelected selected state.

### DIFF
--- a/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
@@ -128,6 +128,12 @@ namespace Avalonia.Controls.Generators
                 }
 
                 Dematerialized?.Invoke(this, new ItemContainerEventArgs(startingIndex, result));
+
+                if (toMove.Count > 0)
+                {
+                    var containers = toMove.Select(x => x.Value).ToList();
+                    Recycled?.Invoke(this, new ItemContainerEventArgs(containers[0].Index, containers));
+                }
             }
 
             return result;

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -979,13 +979,14 @@ namespace Avalonia.Controls.Primitives
             }
 
             var item = ElementAt(Items, index);
+            var itemChanged = !Equals(item, oldItem);
             var added = -1;
             HashSet<int> removed = null;
 
             _selectedIndex = index;
             _selectedItem = item;
 
-            if (oldIndex != index || _selection.HasMultiple)
+            if (oldIndex != index || itemChanged || _selection.HasMultiple)
             {
                 if (clear)
                 {
@@ -1022,7 +1023,7 @@ namespace Avalonia.Controls.Primitives
                     index);
             }
 
-            if (!Equals(item, oldItem))
+            if (itemChanged)
             {
                 RaisePropertyChanged(
                     SelectedItemProperty,

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_AutoSelect.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_AutoSelect.cs
@@ -102,6 +102,25 @@ namespace Avalonia.Controls.UnitTests.Primitives
             Assert.Null(target.SelectedItem);
         }
 
+        [Fact]
+        public void Removing_Selected_First_Item_Should_Select_Next_Item()
+        {
+            var items = new AvaloniaList<string>(new[] { "foo", "bar" });
+            var target = new TestSelector
+            {
+                Items = items,
+                Template = Template(),
+            };
+
+            target.ApplyTemplate();
+            target.Presenter.ApplyTemplate();
+            items.RemoveAt(0);
+
+            Assert.Equal(0, target.SelectedIndex);
+            Assert.Equal("bar", target.SelectedItem);
+            Assert.Equal(new[] { ":selected" }, target.Presenter.Panel.Children[0].Classes);
+        }
+
         private FuncControlTemplate Template()
         {
             return new FuncControlTemplate<SelectingItemsControl>((control, scope) =>


### PR DESCRIPTION
## What does the pull request do?

#2901 describes a problem where the selected state of item containers in a `ListBox` can get out of sync with the actual selected state of the `ListBox`. This fixes that problem.

Two things needed to be done here:

- When an item is removed, causing indexes to be reassigned, raise `Recycled` so that `SelectingItemsControl` knows to update the selection state
- Update selection state in `SelectingItemsControl` when the selected item changes, but the selected index does not (due to an item being removed)

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #2901 