### PR TITLE
Clear pointer-over state when TopLevel closed.

### DIFF
--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -269,8 +269,8 @@ namespace Avalonia.Controls
         /// </summary>
         protected virtual void HandleClosed()
         {
+            (this as IInputRoot).MouseDevice?.TopLevelClosed(this);
             PlatformImpl = null;
-
             Closed?.Invoke(this, EventArgs.Empty);
             Renderer?.Dispose();
             Renderer = null;

--- a/src/Avalonia.Input/IMouseDevice.cs
+++ b/src/Avalonia.Input/IMouseDevice.cs
@@ -16,6 +16,8 @@ namespace Avalonia.Input
         [Obsolete("Use PointerEventArgs.GetPosition")]
         PixelPoint Position { get; }
 
+        void TopLevelClosed(IInputRoot root);
+
         void SceneInvalidated(IInputRoot root, Rect rect);
     }
 }

--- a/src/Avalonia.Input/MouseDevice.cs
+++ b/src/Avalonia.Input/MouseDevice.cs
@@ -86,6 +86,11 @@ namespace Avalonia.Input
                 ProcessRawEvent(margs);
         }
 
+        public void TopLevelClosed(IInputRoot root)
+        {
+            ClearPointerOver(this, 0, root, PointerPointProperties.None, KeyModifiers.None);
+        }
+
         public void SceneInvalidated(IInputRoot root, Rect rect)
         {
             var clientPoint = root.PointToClient(Position);

--- a/tests/Avalonia.Controls.UnitTests/TopLevelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TopLevelTests.cs
@@ -224,6 +224,24 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
+        [Fact]
+        public void Close_Should_Notify_MouseDevice()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var impl = new Mock<ITopLevelImpl>();
+                var mouseDevice = new Mock<IMouseDevice>();
+                impl.SetupAllProperties();
+                impl.Setup(x => x.MouseDevice).Returns(mouseDevice.Object);
+
+                var target = new TestTopLevel(impl.Object);
+
+                impl.Object.Closed();
+
+                mouseDevice.Verify(x => x.TopLevelClosed(target));
+            }
+        }
+
         private FuncControlTemplate<TestTopLevel> CreateTemplate()
         {
             return new FuncControlTemplate<TestTopLevel>((x, scope) =>


### PR DESCRIPTION
## What does the pull request do?

Part of #2821 is that after clicking on a menu item once (and the menu closing) on subsequent openings of the menu the item is not highlighted. To repro on `master` in the Menu page in ControlCatalog:

- Click `Second`
- Click `Second Menu Item`
- Reopen `Second`
- Notice that hovering over the menu text of `SecondMenuItem` does not highlight the item any more

![Xc6OxxJNYm](https://user-images.githubusercontent.com/1775141/64195478-dcadee00-ce81-11e9-9803-63fa3119c689.gif)

This is because the pointer-over state is not being cleared when the menu is closed by clicking `Second Menu Item` the first time. On subsequent opens, `MouseDevice` already understands the menu item to have the pointer over it, so the pointer-over state is not set.

This PR fixes this by notifying `MouseDevice` when the `TopLevel` is closed so `MouseDevice` can then clear the pointer-over state.

## Checklist

- [x] Added unit tests (if possible)?