### PR TITLE
Reduce allocations when raising RoutedEvent.

### DIFF
--- a/src/Avalonia.Interactivity/RoutedEvent.cs
+++ b/src/Avalonia.Interactivity/RoutedEvent.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Reactive.Subjects;
 using System.Reflection;
-using System.Runtime.ExceptionServices;
 
 namespace Avalonia.Interactivity
 {
@@ -18,8 +17,8 @@ namespace Avalonia.Interactivity
 
     public class RoutedEvent
     {
-        private Subject<Tuple<object, RoutedEventArgs>> _raised = new Subject<Tuple<object, RoutedEventArgs>>();
-        private Subject<RoutedEventArgs> _routeFinished = new Subject<RoutedEventArgs>();
+        private readonly Subject<(object, RoutedEventArgs)> _raised = new Subject<(object, RoutedEventArgs)>();
+        private readonly Subject<RoutedEventArgs> _routeFinished = new Subject<RoutedEventArgs>();
 
         public RoutedEvent(
             string name,
@@ -38,31 +37,15 @@ namespace Avalonia.Interactivity
             RoutingStrategies = routingStrategies;
         }
 
-        public Type EventArgsType
-        {
-            get;
-            private set;
-        }
+        public Type EventArgsType { get; }
 
-        public string Name
-        {
-            get;
-            private set;
-        }
+        public string Name { get; }
 
-        public Type OwnerType
-        {
-            get;
-            private set;
-        }
+        public Type OwnerType { get; }
 
-        public RoutingStrategies RoutingStrategies
-        {
-            get;
-            private set;
-        }
+        public RoutingStrategies RoutingStrategies { get; }
 
-        public IObservable<Tuple<object, RoutedEventArgs>> Raised => _raised;
+        public IObservable<(object, RoutedEventArgs)> Raised => _raised;
         public IObservable<RoutedEventArgs> RouteFinished => _routeFinished;
 
         public static RoutedEvent<TEventArgs> Register<TOwner, TEventArgs>(
@@ -98,29 +81,20 @@ namespace Avalonia.Interactivity
         {
             return Raised.Subscribe(args =>
             {
-                var sender = args.Item1;
-                var e = args.Item2;
+                (object sender, RoutedEventArgs e) = args;
 
-                if (targetType.GetTypeInfo().IsAssignableFrom(sender.GetType().GetTypeInfo()) &&
-                    ((e.Route == RoutingStrategies.Direct) || (e.Route & routes) != 0) &&
+                if (targetType.IsInstanceOfType(sender) &&
+                    (e.Route == RoutingStrategies.Direct || (e.Route & routes) != 0) &&
                     (!e.Handled || handledEventsToo))
                 {
-                    try
-                    {
-                        handler.DynamicInvoke(sender, e);
-                    }
-                    catch (TargetInvocationException ex)
-                    {
-                        // Unwrap the inner exception.
-                        ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                    }
+                    handler(sender, e);
                 }
             });
         }
 
         internal void InvokeRaised(object sender, RoutedEventArgs e)
         {
-            _raised.OnNext(Tuple.Create(sender, e));
+            _raised.OnNext((sender, e));
         }
 
         internal void InvokeRouteFinished(RoutedEventArgs e)


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
First part of my work on improving `RoutedEvent` perf and memory footprint.

## What is the current behavior?
Thousands of temporary `Tuple` allocations, also handler was using `DynamicInvoke` even though we have directly invokable delegate available. (`DynamicInvoke` is quite horrible and I intend to remove it's usage from `RoutedEvent` wherever possible).

<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
![image](https://user-images.githubusercontent.com/2588062/64380089-98148500-d030-11e9-91dc-7d68ac4c3572.png)

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Zero `Tuple` allocations from the `RoutedEvent` code.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Use value tuples to remove allocations.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

`RoutedEvent.Raised` has different signature now (using value tuple now), this was used only once in the entire codebase and I guess user code is not using it (and potential fix is trivial).

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Part of #2919