### PR TITLE
Get rid of pointless allocations in PriorityBindingEntry

### DIFF
--- a/src/Avalonia.Base/PriorityBindingEntry.cs
+++ b/src/Avalonia.Base/PriorityBindingEntry.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using System.Runtime.ExceptionServices;
 using Avalonia.Data;
 using Avalonia.Threading;
 
@@ -10,9 +11,9 @@ namespace Avalonia
     /// <summary>
     /// A registered binding in a <see cref="PriorityValue"/>.
     /// </summary>
-    internal class PriorityBindingEntry : IDisposable
+    internal class PriorityBindingEntry : IDisposable, IObserver<object>
     {
-        private PriorityLevel _owner;
+        private readonly PriorityLevel _owner;
         private IDisposable _subscription;
 
         /// <summary>
@@ -85,7 +86,7 @@ namespace Avalonia
                 Description = ((IDescription)binding).Description;
             }
 
-            _subscription = binding.Subscribe(ValueChanged, Completed);
+            _subscription = binding.Subscribe(this);
         }
 
         /// <summary>
@@ -96,7 +97,7 @@ namespace Avalonia
             _subscription?.Dispose();
         }
 
-        private void ValueChanged(object value)
+        void IObserver<object>.OnNext(object value)
         {
             void Signal()
             {
@@ -132,7 +133,7 @@ namespace Avalonia
             }
         }
 
-        private void Completed()
+        void IObserver<object>.OnCompleted()
         {
             HasCompleted = true;
 
@@ -144,6 +145,11 @@ namespace Avalonia
             {
                 Dispatcher.UIThread.Post(() => _owner.Completed(this));
             }
+        }
+
+        void IObserver<object>.OnError(Exception error)
+        {
+            ExceptionDispatchInfo.Capture(error).Throw();
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Removes

## What is the current behavior?
`Action` and `Action<object>` allocation per `PriorityBindingEntry`. Numbers show below are just for opening ControlCatalog without actually doing anything.
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
![image](https://user-images.githubusercontent.com/2588062/64382139-27bc3280-d035-11e9-8a71-78a6e96e317b.png)
![image](https://user-images.githubusercontent.com/2588062/64382204-5934fe00-d035-11e9-9d7b-fc21a25e7e31.png)

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
![image](https://user-images.githubusercontent.com/2588062/64382090-0c512780-d035-11e9-8d51-20ea077106a0.png)


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Implement `IObserver<object>` interface, we are already providing `OnNext` and `OnCompleted`. I had to add `OnError` which behaves the same as current version (just rethrows exception).

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Part of #2919