### PR TITLE
Fix PriorityValue allocating set and notify delegates.

### DIFF
--- a/src/Avalonia.Base/PriorityValue.cs
+++ b/src/Avalonia.Base/PriorityValue.cs
@@ -24,13 +24,11 @@ namespace Avalonia
     /// <see cref="IPriorityValueOwner.Changed"/> method on the 
     /// owner object is fired with the old and new values.
     /// </remarks>
-    internal class PriorityValue
+    internal sealed class PriorityValue : ISetAndNotifyHandler<(object,int)>
     {
         private readonly Type _valueType;
         private readonly SingleOrDictionary<int, PriorityLevel> _levels = new SingleOrDictionary<int, PriorityLevel>();
-
         private readonly Func<object, object> _validate;
-        private readonly SetAndNotifyCallback<(object, int)> _setAndNotifyCallback;
         private (object value, int priority) _value;
         private DeferredSetter<object> _setter;
 
@@ -52,7 +50,6 @@ namespace Avalonia
             _valueType = valueType;
             _value = (AvaloniaProperty.UnsetValue, int.MaxValue);
             _validate = validate;
-            _setAndNotifyCallback = SetAndNotify;
         }
 
         /// <summary>
@@ -257,10 +254,15 @@ namespace Avalonia
                 _setter = Owner.GetNonDirectDeferredSetter(Property);
             }
 
-            _setter.SetAndNotifyCallback(Property, _setAndNotifyCallback, ref _value, newValue);
+            _setter.SetAndNotifyCallback(Property, this, ref _value, newValue);
         }
 
-        private void SetAndNotify(AvaloniaProperty property, ref (object value, int priority) backing, (object value, int priority) update)
+        void ISetAndNotifyHandler<(object, int)>.HandleSetAndNotify(AvaloniaProperty property, ref (object, int) backing, (object, int) value)
+        {
+            SetAndNotify(ref backing, value);
+        }
+
+        private void SetAndNotify(ref (object value, int priority) backing, (object value, int priority) update)
         {
             var val = update.value;
             var notification = val as BindingNotification;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
When I was refactoring `DeferredSetter` (https://github.com/AvaloniaUI/Avalonia/pull/2362) I had to add a way of using custom set and notify handlers. I did that using a delegate, but now I figured it would be better to just use an interface for perf and memory issues.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Each `PriorityValue` has to allocate extra delegate for set and notify callbacks.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
`PriorityValue` just implements handler interface to avoid any extra allocations and perf hit.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Part of #2919