### PR TITLE
Avoid constant boxing of StyledProperty default value.

### DIFF
--- a/src/Avalonia.Base/BoxedValue.cs
+++ b/src/Avalonia.Base/BoxedValue.cs
@@ -1,0 +1,28 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+namespace Avalonia
+{
+    /// <summary>
+    /// Represents boxed value of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">Type of stored value.</typeparam>
+    internal readonly struct BoxedValue<T>
+    {
+        public BoxedValue(T value)
+        {
+            Boxed = value;
+            Typed = value;
+        }
+
+        /// <summary>
+        /// Boxed value.
+        /// </summary>
+        public object Boxed { get; }
+
+        /// <summary>
+        /// Typed value.
+        /// </summary>
+        public T Typed { get; }
+    }
+}

--- a/src/Avalonia.Base/StyledPropertyBase.cs
+++ b/src/Avalonia.Base/StyledPropertyBase.cs
@@ -68,7 +68,7 @@ namespace Avalonia
         {
             Contract.Requires<ArgumentNullException>(type != null);
 
-            return GetMetadata(type).DefaultValue;
+            return GetMetadata(type).DefaultValue.Typed;
         }
 
         /// <summary>
@@ -164,7 +164,14 @@ namespace Avalonia
         }
 
         /// <inheritdoc/>
-        object IStyledPropertyAccessor.GetDefaultValue(Type type) => GetDefaultValue(type);
+        object IStyledPropertyAccessor.GetDefaultValue(Type type) => GetDefaultBoxedValue(type);
+
+        private object GetDefaultBoxedValue(Type type)
+        {
+            Contract.Requires<ArgumentNullException>(type != null);
+
+            return GetMetadata(type).DefaultValue.Boxed;
+        }
 
         [DebuggerHidden]
         private Func<IAvaloniaObject, TValue, TValue> Cast<THost>(Func<THost, TValue, TValue> validate)

--- a/src/Avalonia.Base/StyledPropertyMetadata`1.cs
+++ b/src/Avalonia.Base/StyledPropertyMetadata`1.cs
@@ -19,26 +19,26 @@ namespace Avalonia
         /// <param name="validate">A validation function.</param>
         /// <param name="defaultBindingMode">The default binding mode.</param>
         public StyledPropertyMetadata(
-            TValue defaultValue = default(TValue),
+            TValue defaultValue = default,
             Func<IAvaloniaObject, TValue, TValue> validate = null,
             BindingMode defaultBindingMode = BindingMode.Default)
                 : base(defaultBindingMode)
         {
-            DefaultValue = defaultValue;
+            DefaultValue = new BoxedValue<TValue>(defaultValue);
             Validate = validate;
         }
 
         /// <summary>
         /// Gets the default value for the property.
         /// </summary>
-        public TValue DefaultValue { get; private set; }
+        internal BoxedValue<TValue> DefaultValue { get; private set; }
 
         /// <summary>
         /// Gets the validation callback.
         /// </summary>
         public Func<IAvaloniaObject, TValue, TValue> Validate { get; private set; }
 
-        object IStyledPropertyMetadata.DefaultValue => DefaultValue;
+        object IStyledPropertyMetadata.DefaultValue => DefaultValue.Boxed;
 
         Func<IAvaloniaObject, object, object> IStyledPropertyMetadata.Validate => Cast(Validate);
 
@@ -47,11 +47,9 @@ namespace Avalonia
         {
             base.Merge(baseMetadata, property);
 
-            var src = baseMetadata as StyledPropertyMetadata<TValue>;
-
-            if (src != null)
+            if (baseMetadata is StyledPropertyMetadata<TValue> src)
             {
-                if (DefaultValue == null)
+                if (DefaultValue.Boxed == null)
                 {
                     DefaultValue = src.DefaultValue;
                 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Removes boxing allocations caused by calling `DefaultValue`.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Every time we call `DefaultValue` on a styled property holding a value type we box it.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Box only once and then return boxed value when requested.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Part of #2919