### PR TITLE
Add static method to open devtools.

### DIFF
--- a/src/Avalonia.Diagnostics/DevTools.xaml.cs
+++ b/src/Avalonia.Diagnostics/DevTools.xaml.cs
@@ -28,6 +28,11 @@ namespace Avalonia
         {
             Diagnostics.DevTools.Attach(control, gesture);
         }
+
+        public static void OpenDevTools(this TopLevel control)
+        {
+            Diagnostics.DevTools.OpenDevTools(control);
+        }
     }
 }
 
@@ -73,7 +78,7 @@ namespace Avalonia.Diagnostics
                 RoutingStrategies.Tunnel);
         }
 
-        private static void OpenDevTools(TopLevel control)
+        internal static void OpenDevTools(TopLevel control)
         {
             if (s_open.TryGetValue(control, out var devToolsWindow))
             {


### PR DESCRIPTION
## What does the pull request do?
simply add a static method to make it easy for apps to open dev tools.


## What is the current behavior?
Currently you have to rely on hotkey, or you cant easily open the dev tools.


## What is the updated/expected behavior with this PR?
allow users to call static method and have full control of how dev tools can be opened.


## Fixed issues
#2860 
