### PR TITLE
Upgrade ReactiveUI and System.Reactive

### DIFF
--- a/build/ReactiveUI.props
+++ b/build/ReactiveUI.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="reactiveui" Version="9.0.1" />
+    <PackageReference Include="reactiveui" Version="10.0.1" />
   </ItemGroup>
 </Project>

--- a/build/Rx.props
+++ b/build/Rx.props
@@ -1,5 +1,5 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="4.0.0" />
+    <PackageReference Include="System.Reactive" Version="4.1.6" />
   </ItemGroup>
 </Project>

--- a/samples/BindingDemo/ViewModels/MainWindowViewModel.cs
+++ b/samples/BindingDemo/ViewModels/MainWindowViewModel.cs
@@ -5,6 +5,7 @@ using ReactiveUI;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using System.Threading;
+using System.Reactive;
 
 namespace BindingDemo.ViewModels
 {
@@ -56,7 +57,7 @@ namespace BindingDemo.ViewModels
 
         public ObservableCollection<TestItem> Items { get; }
         public ObservableCollection<TestItem> SelectedItems { get; }
-        public ReactiveCommand ShuffleItems { get; }
+        public ReactiveCommand<Unit, Unit> ShuffleItems { get; }
 
         public string BooleanString
         {
@@ -89,7 +90,7 @@ namespace BindingDemo.ViewModels
         }
 
         public IObservable<string> CurrentTimeObservable { get; }
-        public ReactiveCommand StringValueCommand { get; }
+        public ReactiveCommand<object, Unit> StringValueCommand { get; }
 
         public DataAnnotationsErrorViewModel DataAnnotationsValidation { get; } = new DataAnnotationsErrorViewModel();
         public ExceptionErrorViewModel ExceptionDataValidation { get; } = new ExceptionErrorViewModel();

--- a/samples/RenderDemo/ViewModels/MainWindowViewModel.cs
+++ b/samples/RenderDemo/ViewModels/MainWindowViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using ReactiveUI;
+using System.Reactive;
 
 namespace RenderDemo.ViewModels
 {
@@ -26,7 +27,7 @@ namespace RenderDemo.ViewModels
             set { this.RaiseAndSetIfChanged(ref drawFps, value); }
         }
 
-        public ReactiveCommand ToggleDrawDirtyRects { get; }
-        public ReactiveCommand ToggleDrawFps { get; }
+        public ReactiveCommand<Unit, bool> ToggleDrawDirtyRects { get; }
+        public ReactiveCommand<Unit, bool> ToggleDrawFps { get; }
     }
 }

--- a/src/Avalonia.ReactiveUI/AvaloniaActivationForViewFetcher.cs
+++ b/src/Avalonia.ReactiveUI/AvaloniaActivationForViewFetcher.cs
@@ -27,7 +27,7 @@ namespace Avalonia.ReactiveUI
         /// <summary>
         /// Returns activation observable for activatable Avalonia view.
         /// </summary>
-        public IObservable<bool> GetActivationForView(IActivatable view)
+        public IObservable<bool> GetActivationForView(IActivatableView view)
         {
             if (!(view is IVisual visual)) return Observable.Return(false);
             if (view is WindowBase window) return GetActivationForWindowBase(window);

--- a/src/Avalonia.ReactiveUI/RoutedViewHost.cs
+++ b/src/Avalonia.ReactiveUI/RoutedViewHost.cs
@@ -53,7 +53,7 @@ namespace Avalonia.ReactiveUI
     /// ReactiveUI routing documentation website</see> for more info.
     /// </para>
     /// </remarks>
-    public class RoutedViewHost : TransitioningContentControl, IActivatable, IEnableLogger
+    public class RoutedViewHost : TransitioningContentControl, IActivatableView, IEnableLogger
     {
         /// <summary>
         /// <see cref="AvaloniaProperty"/> for the <see cref="Router"/> property.

--- a/tests/Avalonia.LeakTests/Avalonia.LeakTests.csproj
+++ b/tests/Avalonia.LeakTests/Avalonia.LeakTests.csproj
@@ -23,6 +23,9 @@
     <Compile Remove="testproject/**/*.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+  </ItemGroup>
+  <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>

--- a/tests/Avalonia.LeakTests/Avalonia.LeakTests.csproj
+++ b/tests/Avalonia.LeakTests/Avalonia.LeakTests.csproj
@@ -23,7 +23,7 @@
     <Compile Remove="testproject/**/*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.0.4" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/Avalonia.LeakTests/app.config
+++ b/tests/Avalonia.LeakTests/app.config
@@ -10,6 +10,10 @@
         <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.2.1510.2205" newVersion="4.2.1510.2205"/>
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.5.2.0"/>
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>

--- a/tests/Avalonia.LeakTests/app.config
+++ b/tests/Avalonia.LeakTests/app.config
@@ -10,10 +10,6 @@
         <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.2.1510.2205" newVersion="4.2.1510.2205"/>
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.5.2.0"/>
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>

--- a/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
@@ -20,9 +20,9 @@ namespace Avalonia.ReactiveUI.UnitTests
 {
     public class AvaloniaActivationForViewFetcherTest
     {
-        public class TestUserControl : UserControl, IActivatable { }
+        public class TestUserControl : UserControl, IActivatableView { }
 
-        public class TestUserControlWithWhenActivated : UserControl, IActivatable
+        public class TestUserControlWithWhenActivated : UserControl, IActivatableView
         {
             public bool Active { get; private set; }
 
@@ -38,7 +38,7 @@ namespace Avalonia.ReactiveUI.UnitTests
             }
         }
 
-        public class TestWindowWithWhenActivated : Window, IActivatable
+        public class TestWindowWithWhenActivated : Window, IActivatableView
         {
             public bool Active { get; private set; }
 
@@ -54,7 +54,7 @@ namespace Avalonia.ReactiveUI.UnitTests
             }
         }
 
-        public class ActivatableViewModel : ISupportsActivation
+        public class ActivatableViewModel : IActivatableViewModel
         {
             public ViewModelActivator Activator { get; }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

ReactiveUI 10 released with [a few breaking changes](https://github.com/reactiveui/ReactiveUI/releases/tag/10.0.1), so worth upgrading the packages.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

`Avalonia.ReactiveUI` depends on an older version of `ReactiveUI`, and that causes issues when sharing code between a .NET Standard library that references latest `ReactiveUI` and with a library that references `Avalonia.ReactiveUI`.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

This PR upgrades the following packages:
`System.Reactive`: `4.0.0` -> `4.1.6`
`ReactiveUI`: `9.0.1` -> `10.0.1`


## Checklist

- [x] Correct unit tests
- [x] Correct XML documentation for any related classes