### PR TITLE
Enable adding event handlers to Gestures events.

### DIFF
--- a/src/Avalonia.Input/Gestures.cs
+++ b/src/Avalonia.Input/Gestures.cs
@@ -39,6 +39,36 @@ namespace Avalonia.Input
             InputElement.PointerReleasedEvent.RouteFinished.Subscribe(PointerReleased);
         }
 
+        public static void AddTappedHandler(IInteractive element, EventHandler<RoutedEventArgs> handler)
+        {
+            element.AddHandler(TappedEvent, handler);
+        }
+
+        public static void AddDoubleTappedHandler(IInteractive element, EventHandler<RoutedEventArgs> handler)
+        {
+            element.AddHandler(DoubleTappedEvent, handler);
+        }
+
+        public static void AddRightTappedHandler(IInteractive element, EventHandler<RoutedEventArgs> handler)
+        {
+            element.AddHandler(RightTappedEvent, handler);
+        }
+
+        public static void RemoveTappedHandler(IInteractive element, EventHandler<RoutedEventArgs> handler)
+        {
+            element.RemoveHandler(TappedEvent, handler);
+        }
+
+        public static void RemoveDoubleTappedHandler(IInteractive element, EventHandler<RoutedEventArgs> handler)
+        {
+            element.RemoveHandler(DoubleTappedEvent, handler);
+        }
+
+        public static void RemoveRightTappedHandler(IInteractive element, EventHandler<RoutedEventArgs> handler)
+        {
+            element.RemoveHandler(RightTappedEvent, handler);
+        }
+
         private static void PointerPressed(RoutedEventArgs ev)
         {
             if (ev.Route == RoutingStrategies.Bubble)

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/EventTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/EventTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
-using System;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -12,16 +11,37 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
     public class EventTests : XamlTestBase
     {
         [Fact]
-        public void Event_Is_Attached()
+        public void Event_Is_Assigned()
         {
             var xaml = @"<Button xmlns='https://github.com/avaloniaui' Click='OnClick'/>";
             var loader = new AvaloniaXamlLoader();
             var target = new MyButton();
 
             loader.Load(xaml, rootInstance: target);
-            RaiseClick(target);
 
-            Assert.True(target.Clicked);
+            target.RaiseEvent(new RoutedEventArgs
+            {
+                RoutedEvent = Button.ClickEvent,
+            });
+
+            Assert.True(target.WasClicked);
+        }
+
+        [Fact]
+        public void Attached_Event_Is_Assigned()
+        {
+            var xaml = @"<Button xmlns='https://github.com/avaloniaui' Gestures.Tapped='OnTapped'/>";
+            var loader = new AvaloniaXamlLoader();
+            var target = new MyButton();
+
+            loader.Load(xaml, rootInstance: target);
+
+            target.RaiseEvent(new RoutedEventArgs
+            {
+                RoutedEvent = Gestures.TappedEvent,
+            });
+
+            Assert.True(target.WasTapped);
         }
 
         [Fact]
@@ -34,23 +54,13 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
             XamlTestHelpers.AssertThrowsXamlException(() => loader.Load(xaml, rootInstance: target));
         }
 
-        private void RaiseClick(MyButton target)
-        {
-            target.RaiseEvent(new KeyEventArgs
-            {
-                RoutedEvent = Button.KeyDownEvent,
-                Key = Key.Enter,
-            });
-        }
-
         public class MyButton : Button
         {
-            public bool Clicked { get; private set; }
+            public bool WasClicked { get; private set; }
+            public bool WasTapped { get; private set; }
 
-            public void OnClick(object sender, RoutedEventArgs e)
-            {
-                Clicked = true;
-            }
+            public void OnClick(object sender, RoutedEventArgs e) => WasClicked = true;
+            public void OnTapped(object sender, RoutedEventArgs e) => WasTapped = true;
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Added the `Add*Handler` and `Remove*Handler`  events required by XAML in order to use attached event syntax. Added unit test to ensure this works.

## What is the current behavior?

Trying to add e.g. `Gestures.Tapped` using attached event syntax in XAML fails.

## What is the updated/expected behavior with this PR?

Attached event syntax for `Gestures` events works.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #2948 