### PR TITLE
Fix broken TreeView

### DIFF
--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -302,19 +302,6 @@ namespace Avalonia.Controls
         /// <param name="e">The details of the containers.</param>
         protected virtual void OnContainersRecycled(ItemContainerEventArgs e)
         {
-            var toRemove = new List<ILogical>();
-
-            foreach (var container in e.Containers)
-            {
-                // If the item is its own container, then it will be removed from the logical tree
-                // when it is removed from the Items collection.
-                if (container?.ContainerControl != container?.Item)
-                {
-                    toRemove.Add(container.ContainerControl);
-                }
-            }
-
-            LogicalChildren.RemoveAll(toRemove);
         }
 
         /// <summary>


### PR DESCRIPTION
## What does the pull request do?

Fixes a problem with `TreeView` (#2944) that was introduced in #2922 where items were erroneously removed from the logical tree when another item was removed from the tree view.

## How was the solution implemented (if it's not obvious)?

Removed the code in `ItemsControl.OnContainersRecycled` that was causing the `TreeView` problems.  This code was never actually called anywhere but from `TreeView` because a plain `ItemsControl` can't be used with virtualization (it uses untyped `ItemContainerGenerator` so items can't be recycled) and every other derived class derives from `SelectingItemsControl` which overrides this method and doesn't call the base implementation. In addition there were no unit tests covering this code.

## Fixed issues

Fixes #2944
