### PR TITLE
Avoid allocations when running UpdateIsEffectivelyEnabled.

### DIFF
--- a/src/Avalonia.Input/InputElement.cs
+++ b/src/Avalonia.Input/InputElement.cs
@@ -565,8 +565,12 @@ namespace Avalonia.Input
         {
             IsEffectivelyEnabled = IsEnabledCore && (parent?.IsEffectivelyEnabled ?? true);
 
+            // PERF-SENSITIVE: This is called on entire hierarchy and using foreach or LINQ
+            // will cause extra allocations and overhead.
+            
             var children = VisualChildren;
 
+            // ReSharper disable once ForCanBeConvertedToForeach
             for (int i = 0; i < children.Count; ++i)
             {
                 var child = children[i] as InputElement;

--- a/src/Avalonia.Input/InputElement.cs
+++ b/src/Avalonia.Input/InputElement.cs
@@ -565,9 +565,13 @@ namespace Avalonia.Input
         {
             IsEffectivelyEnabled = IsEnabledCore && (parent?.IsEffectivelyEnabled ?? true);
 
-            foreach (var child in this.GetVisualChildren().OfType<InputElement>())
+            var children = VisualChildren;
+
+            for (int i = 0; i < children.Count; ++i)
             {
-                child.UpdateIsEffectivelyEnabled(this);
+                var child = children[i] as InputElement;
+
+                child?.UpdateIsEffectivelyEnabled(this);
             }
         }
     }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Removes LINQ and enumerator allocations from `InputElement.UpdateIsEffectivelyEnabled`.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Plenty of allocations in `UpdateIsEffectivelyEnabled` due to:
- `GetVisualChildren` returning `IEnumerable` forcing us to use boxed enumerator.
- `OfType` LINQ causing extra allocations.

![image](https://user-images.githubusercontent.com/2588062/64682734-4762b900-d482-11e9-9df0-cdec8300445b.png)

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
No extra allocations.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
