### PR TITLE
Fix binding both SelectedItem and SelectedItems.

### DIFF
--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -66,7 +66,11 @@ namespace Avalonia.Controls
         }
 
         /// <inheritdoc/>
-        public new IList SelectedItems => base.SelectedItems;
+        public new IList SelectedItems
+        {
+            get => base.SelectedItems;
+            set => base.SelectedItems = value;
+        }
 
         /// <summary>
         /// Gets or sets the selection mode.

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -112,7 +112,7 @@ namespace Avalonia.Controls.Primitives
         private bool _syncingSelectedItems;
         private int _updateCount;
         private int _updateSelectedIndex;
-        private IList _updateSelectedItems;
+        private object _updateSelectedItem;
 
         /// <summary>
         /// Initializes static members of the <see cref="SelectingItemsControl"/> class.
@@ -160,7 +160,7 @@ namespace Avalonia.Controls.Primitives
                 else
                 {
                     _updateSelectedIndex = value;
-                    _updateSelectedItems = null;
+                    _updateSelectedItem = null;
                 }
             }
         }
@@ -183,7 +183,7 @@ namespace Avalonia.Controls.Primitives
                 }
                 else
                 {
-                    _updateSelectedItems = new AvaloniaList<object>(value);
+                    _updateSelectedItem = value;
                     _updateSelectedIndex = int.MinValue;
                 }
             }
@@ -1075,9 +1075,9 @@ namespace Avalonia.Controls.Primitives
             {
                 SelectedIndex = _updateSelectedIndex;
             }
-            else if (_updateSelectedItems != null)
+            else if (_updateSelectedItem != null)
             {
-                SelectedItems = _updateSelectedItems;
+                SelectedItem = _updateSelectedItem;
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -921,6 +921,26 @@ namespace Avalonia.Controls.UnitTests.Primitives
             Assert.True(raised);
         }
 
+        [Fact]
+        public void Can_Set_Both_SelectedItem_And_SelectedItems_During_Initialization()
+        {
+            // Issue #2969.
+            var target = new ListBox();
+            var selectedItems = new List<object>();
+
+            target.BeginInit();
+            target.Template = Template();
+            target.Items = new[] { "Foo", "Bar", "Baz" };
+            target.SelectedItems = selectedItems;
+            target.SelectedItem = "Bar";
+            target.EndInit();
+
+            Assert.Equal("Bar", target.SelectedItem);
+            Assert.Equal(1, target.SelectedIndex);
+            Assert.Same(selectedItems, target.SelectedItems);
+            Assert.Equal(new[] { "Bar" }, selectedItems);
+        }
+
         private FuncControlTemplate Template()
         {
             return new FuncControlTemplate<SelectingItemsControl>((control, scope) =>


### PR DESCRIPTION
## What does the pull request do?

Fix for issue #2969:

> The binding for SelectedItem overrides the SelectedItems binding on this line:

> https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs#L186

## What is the current behavior?

Binding both `SelectedItem` and `SelectedItems` causes the binding for `SelectedItems` to be ignored.

## What is the updated/expected behavior with this PR?

Binding both `SelectedItem` and `SelectedItems` works.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #2969.
