### PR TITLE
Fix ItemsRepeater overflow in ControlCatalog.

### DIFF
--- a/samples/ControlCatalog/MainView.xaml
+++ b/samples/ControlCatalog/MainView.xaml
@@ -24,7 +24,6 @@
       <TabItem Header="CheckBox"><pages:CheckBoxPage/></TabItem>
       <TabItem Header="ComboBox"><pages:ComboBoxPage/></TabItem>
       <TabItem Header="ContextMenu"><pages:ContextMenuPage/></TabItem>
-      <!-- DataGrid is our special snowflake -->  
       <TabItem Header="DataGrid" 
                ScrollViewer.VerticalScrollBarVisibility="Disabled"
                ScrollViewer.HorizontalScrollBarVisibility="Disabled">
@@ -34,12 +33,15 @@
       <TabItem Header="Drag+Drop"><pages:DragAndDropPage/></TabItem>
       <TabItem Header="Expander"><pages:ExpanderPage/></TabItem>
       <TabItem Header="Image"><pages:ImagePage/></TabItem>
-      <TabItem Header="ItemsRepeater"><pages:ItemsRepeaterPage/></TabItem>
+      <TabItem Header="ItemsRepeater"
+               ScrollViewer.VerticalScrollBarVisibility="Disabled">
+        <pages:ItemsRepeaterPage/>
+      </TabItem>
       <TabItem Header="LayoutTransformControl"><pages:LayoutTransformControlPage/></TabItem>
       <TabItem Header="ListBox"><pages:ListBoxPage/></TabItem>
       <TabItem Header="Menu"><pages:MenuPage/></TabItem>
       <TabItem Header="Notifications"><pages:NotificationsPage/></TabItem>
-	  <TabItem Header="NumericUpDown"><pages:NumericUpDownPage/></TabItem>
+	    <TabItem Header="NumericUpDown"><pages:NumericUpDownPage/></TabItem>
       <TabItem Header="Pointers (Touch)"><pages:PointersPage/></TabItem>
       <TabItem Header="ProgressBar"><pages:ProgressBarPage/></TabItem>
       <TabItem Header="RadioButton"><pages:RadioButtonPage/></TabItem>
@@ -50,12 +52,12 @@
       <TabItem Header="ToolTip"><pages:ToolTipPage/></TabItem>
       <TabItem Header="TreeView"><pages:TreeViewPage/></TabItem>
       <TabItem Header="Viewbox"><pages:ViewboxPage/></TabItem>
-    <TabControl.Tag>
+      <TabControl.Tag>
         <ComboBox x:Name="Themes" SelectedIndex="0" Width="100" Margin="8" HorizontalAlignment="Right" VerticalAlignment="Bottom">
             <ComboBoxItem>Light</ComboBoxItem>
             <ComboBoxItem>Dark</ComboBoxItem>
         </ComboBox>
-    </TabControl.Tag>
+      </TabControl.Tag>
     </TabControl>
   </Grid>
 </UserControl>


### PR DESCRIPTION
## What does the pull request do?

Fixes the display of `ItemsRepeater` in ControlCatalog.

## What is the current behavior?

The `ItemsRepeater` extends below the bottom of the window:

![image](https://user-images.githubusercontent.com/1775141/64714966-da6e1400-d4bf-11e9-81f1-ef01490c0505.png)

## What is the updated/expected behavior with this PR?

![image](https://user-images.githubusercontent.com/1775141/64715012-f7a2e280-d4bf-11e9-9dd0-cfd6c6b57717.png)

## How was the solution implemented (if it's not obvious)?

Remove the `ScrollViewer` from the `TabControl.sideBar` template: it was causing the `ItemsRepeater` to be arranged with infinite size.
