### PR TITLE
stackpanel copes with non-visible controls when arranging.

### DIFF
--- a/src/Avalonia.Controls/Notifications/ReversibleStackPanel.cs
+++ b/src/Avalonia.Controls/Notifications/ReversibleStackPanel.cs
@@ -39,6 +39,11 @@ namespace Avalonia.Controls
 
             foreach (Control child in children)
             {
+                if (!child.IsVisible)
+                {
+                    continue;
+                }
+
                 double childWidth = child.DesiredSize.Width;
                 double childHeight = child.DesiredSize.Height;
 

--- a/src/Avalonia.Controls/StackPanel.cs
+++ b/src/Avalonia.Controls/StackPanel.cs
@@ -251,7 +251,7 @@ namespace Avalonia.Controls
             {
                 var child = children[i];
 
-                if (child == null)
+                if (child == null || !child.IsVisible)
                 { continue; }
 
                 if (fHorizontal)

--- a/tests/Avalonia.Controls.UnitTests/StackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/StackPanelTests.cs
@@ -332,6 +332,31 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(sizeWithTwoChildren, sizeWithThreeChildren);
         }
 
+        [Theory]
+        [InlineData(Orientation.Horizontal)]
+        [InlineData(Orientation.Vertical)]
+        public void Only_Arrange_Visible_Children(Orientation orientation)
+        {
+
+            var hiddenPanel = new Panel { Width = 10, Height = 10, IsVisible = false };
+            var panel = new Panel { Width = 10, Height = 10 };
+
+            var target = new StackPanel
+            {
+                Spacing = 40,
+                Orientation = orientation,
+                Children =
+                {
+                    hiddenPanel,
+                    panel
+                }
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(target.DesiredSize));
+            Assert.Equal(new Rect(0, 0, 10, 10), panel.Bounds);
+        }
+
         private class TestControl : Control
         {
             public Size MeasureConstraint { get; private set; }


### PR DESCRIPTION
## What does the pull request do?
Fixes stackpanels arrange to cope with non-visible children.

This was introduced when we ported WPFs stackpanel, this happened because the WPF stackpanel holds and InternalChildren list, which has only visible items, and we didnt port that part.

## What is the current behavior?
arranges non-visible items, causing layout disaster. :)

## What is the updated/expected behavior with this PR?
only arranges visible items.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Fixed issues
Fixes #2972 
