### PR TITLE
dont handle f10 key in accesskey handler

### DIFF
--- a/src/Avalonia.Input/AccessKeyHandler.cs
+++ b/src/Avalonia.Input/AccessKeyHandler.cs
@@ -231,15 +231,6 @@ namespace Avalonia.Input
                     }
 
                     break;
-
-                case Key.F10:
-                    _owner.ShowAccessKeys = _showingAccessKeys = true;
-                    if (MainMenu != null)
-                    {
-                        MainMenu.Open();
-                        e.Handled = true;
-                    }
-                    break;
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
AccessKeyHandler handles F10 keyup event, and opens menu and focuses it.

The problem is if you want to use F10 in your application, after loss of focus, hotkeys are no longer detected. Because the menu retains focus.

Since this is barely used this PR removes this, and allows anyone to use F10 in their application without trouble.


## What is the updated/expected behavior with this PR?
F10 can be handled without menu causing issues.

