### PR TITLE
Fix some issues in OneWayToSource and OneTime bindings

### DIFF
--- a/samples/BindingDemo/MainWindow.xaml
+++ b/samples/BindingDemo/MainWindow.xaml
@@ -24,6 +24,7 @@
             <TextBox Watermark="Two Way" UseFloatingWatermark="True" Text="{Binding Path=StringValue}" Name="first"/>
             <TextBox Watermark="One Way" UseFloatingWatermark="True" Text="{Binding Path=StringValue, Mode=OneWay}"/>
             <TextBox Watermark="One Time" UseFloatingWatermark="True" Text="{Binding Path=StringValue, Mode=OneTime}"/>
+            <TextBox Watermark="One Way to Source" UseFloatingWatermark="True" Text="{Binding Path=StringValue, Mode=OneWayToSource}"/>
           </StackPanel>
           <StackPanel Margin="18" Spacing="4" Width="200">
             <TextBlock FontSize="16" Text="Collection Bindings"/>

--- a/samples/BindingDemo/MainWindow.xaml
+++ b/samples/BindingDemo/MainWindow.xaml
@@ -24,7 +24,9 @@
             <TextBox Watermark="Two Way" UseFloatingWatermark="True" Text="{Binding Path=StringValue}" Name="first"/>
             <TextBox Watermark="One Way" UseFloatingWatermark="True" Text="{Binding Path=StringValue, Mode=OneWay}"/>
             <TextBox Watermark="One Time" UseFloatingWatermark="True" Text="{Binding Path=StringValue, Mode=OneTime}"/>
-            <TextBox Watermark="One Way to Source" UseFloatingWatermark="True" Text="{Binding Path=StringValue, Mode=OneWayToSource}"/>
+            <!-- Removed due to #2983: reinstate when that's fixed.
+              <TextBox Watermark="One Way to Source" UseFloatingWatermark="True" Text="{Binding Path=StringValue, Mode=OneWayToSource}"/>
+            -->
           </StackPanel>
           <StackPanel Margin="18" Spacing="4" Width="200">
             <TextBlock FontSize="16" Text="Collection Bindings"/>

--- a/src/Avalonia.Base/Data/Core/ExpressionNode.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNode.cs
@@ -8,8 +8,12 @@ namespace Avalonia.Data.Core
     public abstract class ExpressionNode
     {
         private static readonly object CacheInvalid = new object();
+
         protected static readonly WeakReference<object> UnsetReference = 
             new WeakReference<object>(AvaloniaProperty.UnsetValue);
+
+        protected static readonly WeakReference<object> NullReference =
+            new WeakReference<object>(null);
 
         private WeakReference<object> _target = UnsetReference;
         private Action<object> _subscriber;
@@ -98,7 +102,7 @@ namespace Avalonia.Data.Core
 
             if (notification == null)
             {
-                LastValue = new WeakReference<object>(value);
+                LastValue = value != null ? new WeakReference<object>(value) : NullReference;
 
                 if (Next != null)
                 {
@@ -111,7 +115,7 @@ namespace Avalonia.Data.Core
             }
             else
             {
-                LastValue = new WeakReference<object>(notification.Value);
+                LastValue = notification.Value != null ? new WeakReference<object>(notification.Value) : NullReference;
 
                 if (Next != null)
                 {

--- a/src/Avalonia.Base/Data/Core/ExpressionNode.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNode.cs
@@ -140,8 +140,8 @@ namespace Avalonia.Data.Core
             }
             else if (target != AvaloniaProperty.UnsetValue)
             {
-                StartListeningCore(_target);
                 _listening = true;
+                StartListeningCore(_target);
             }
             else
             {

--- a/src/Avalonia.Base/Data/Core/Plugins/InpcPropertyAccessorPlugin.cs
+++ b/src/Avalonia.Base/Data/Core/Plugins/InpcPropertyAccessorPlugin.cs
@@ -103,8 +103,8 @@ namespace Avalonia.Data.Core.Plugins
 
             protected override void SubscribeCore()
             {
-                SendCurrentValue();
                 SubscribeToChanges();
+                SendCurrentValue();
             }
 
             protected override void UnsubscribeCore()

--- a/src/Avalonia.Base/Data/Core/SettableNode.cs
+++ b/src/Avalonia.Base/Data/Core/SettableNode.cs
@@ -29,6 +29,11 @@ namespace Avalonia.Data.Core
 
             if (!isLastValueAlive)
             {
+                if (value == null && LastValue == NullReference)
+                {
+                    return true;
+                }
+
                 return false;
             }
 

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests.cs
@@ -199,6 +199,7 @@ namespace Avalonia.Markup.UnitTests.Data
         [Fact]
         public void OneWayToSource_Binding_Should_Not_StackOverflow_With_Null_Value()
         {
+            // Issue #2912
             var target = new TextBlock { Text = null };
             var binding = new Binding
             {

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests.cs
@@ -216,7 +216,7 @@ namespace Avalonia.Markup.UnitTests.Data
             // When running tests under NCrunch, NCrunch replaces the standard StackOverflowException
             // with its own, which will be caught by our code. Detect the stackoverflow anyway, by
             // making sure the target property was only set once.
-            Assert.Equal(1, source.FooSetCount);
+            Assert.Equal(2, source.FooSetCount);
         }
 
         [Fact]


### PR DESCRIPTION
While investigating #2912 I came across a few other issues:

- `OneTime` bindings are failing to release their subscription if the `DataContext` is unset when the binding is made.
- Combining `OneTime` and `OneWayToSource` bindings are causing an NRE. The NRE is being caught but it too results in a subscription being leaked.

The following fixes are included

- Fix expression nodes not knowing if last value is actually null or dead (fixes #2912) (courtesy of @MarchingCube)
- Make sure OneTime bindings unsubscribe:
  - `OneTime` bindings unsubscribe when the first value is pushed, meaning that they unsubscribe _during_ `ExpressionNode.StartListeningCore`. Make sure we handle this by:
    - Setting `_listening = true` before calling `StartListeningCore`
    - Subscribe to current value in `InpcPropertyAccessorPlugin` before sending current value, because we're unsubscribed when `SendCurrentValue` exits

## Checklist

- [x] Added unit tests (if possible)?
## Fixed issues

Fixes #2912