### PR TITLE
fix pointerover on mouse leaving window

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -619,7 +619,7 @@ namespace Avalonia.Win32
                         timestamp,
                         _owner,
                         RawPointerEventType.LeaveWindow,
-                        new Point(), WindowsKeyboardDevice.Instance.Modifiers);
+                        new Point(-1,-1), WindowsKeyboardDevice.Instance.Modifiers);
                     break;
 
                 case UnmanagedMethods.WindowsMessage.WM_NCLBUTTONDOWN:
@@ -634,7 +634,7 @@ namespace Avalonia.Win32
                             : msg == (int)UnmanagedMethods.WindowsMessage.WM_NCRBUTTONDOWN
                                 ? RawPointerEventType.RightButtonDown
                                 : RawPointerEventType.MiddleButtonDown,
-                        new Point(0, 0), GetMouseModifiers(wParam));
+                        PointToClient(PointFromLParam(lParam)), GetMouseModifiers(wParam));
                     break;
                 case WindowsMessage.WM_TOUCH:
                     var touchInputs = new TOUCHINPUT[wParam.ToInt32()];


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes #2946

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
On windows on leaving the window with the mouse or clicking on the non client area `MouseDevice` is left believing the mouse is at position 0,0 so any styles that apply pointerover and occupy the top left of the window will remain triggered.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
For WM_MOUSELEAVE -1,-1 is returned instead of 0,0 this windows message does not include mouse position.
For WM_NCLBUTTONDOWN etc the mouse position is now returned.
I tested the linux behaviour and it returns a position outside the client area for these actions

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #2946