### PR TITLE
Use screen bounds if woking area is empty

### DIFF
--- a/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositioner.cs
@@ -100,6 +100,12 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
                                    ?? screens.FirstOrDefault(s => s.Bounds.Contains(parentGeometry.TopLeft))
                                    ?? screens.FirstOrDefault(s => s.Bounds.Intersects(parentGeometry))
                                    ?? screens.FirstOrDefault();
+
+                if (targetScreen != null && targetScreen.WorkingArea.IsEmpty)
+                {
+                    return targetScreen.Bounds;
+                }
+                
                 return targetScreen?.WorkingArea
                        ?? new Rect(0, 0, double.MaxValue, double.MaxValue);
             }


### PR DESCRIPTION
## What does the pull request do?
Use display bounds as working area if WM reports that workingArea is empty

## What is the current behavior?
In multi-monitor setup, XFWM4 incorrectly reports workingArea (sets to 0,0,0,0) on secondary monitor, while in primary works fine


## What is the updated/expected behavior with this PR?
Fixes popup rendering in multi-monitor configurations with some DE(Tested on XFWM4)

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes

Probably should doesn't break something

## Fixed issues

None