### PR TITLE
Fix WeakEventHandlerManager unsubscribe

### DIFF
--- a/src/Avalonia.Base/Utilities/WeakEventHandlerManager.cs
+++ b/src/Avalonia.Base/Utilities/WeakEventHandlerManager.cs
@@ -162,7 +162,7 @@ namespace Avalonia.Utilities
                 {
                     var reference = _data[c].Subscriber;
 
-                    if (reference != null && reference.TryGetTarget(out TSubscriber instance) && instance == (TSubscriber)s.Target)
+                    if (reference != null && reference.TryGetTarget(out TSubscriber instance) && Equals(instance, s.Target))
                     {
                         _data[c] = default;
                         removed = true;

--- a/src/Avalonia.Base/Utilities/WeakEventHandlerManager.cs
+++ b/src/Avalonia.Base/Utilities/WeakEventHandlerManager.cs
@@ -161,9 +161,8 @@ namespace Avalonia.Utilities
                 for (int c = 0; c < _count; ++c)
                 {
                     var reference = _data[c].Subscriber;
-                    TSubscriber instance;
 
-                    if (reference != null && reference.TryGetTarget(out instance) && instance == s)
+                    if (reference != null && reference.TryGetTarget(out TSubscriber instance) && instance == (TSubscriber)s.Target)
                     {
                         _data[c] = default;
                         removed = true;

--- a/tests/Avalonia.Base.UnitTests/WeakEventHandlerManagerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/WeakEventHandlerManagerTests.cs
@@ -36,7 +36,7 @@ namespace Avalonia.Base.UnitTests
         }
 
         [Fact]
-        public void EventShoudBePassedToSubscriber()
+        public void EventShouldBePassedToSubscriber()
         {
             bool handled = false;
             var subscriber = new Subscriber(() => handled = true);
@@ -47,7 +47,23 @@ namespace Avalonia.Base.UnitTests
             Assert.True(handled);
         }
 
- 
+        [Fact]
+        public void EventShouldNotBeRaisedAfterUnsubscribe()
+        {
+            bool handled = false;
+            var subscriber = new Subscriber(() => handled = true);
+            var source = new EventSource();
+            WeakEventHandlerManager.Subscribe<EventSource, EventArgs, Subscriber>(source, "Event",
+                subscriber.OnEvent);
+
+            WeakEventHandlerManager.Unsubscribe<EventArgs, Subscriber>(source, "Event",
+                subscriber.OnEvent);
+
+            source.Fire();
+
+            Assert.False(handled);
+        }
+
         [Fact]
         public void EventHandlerShouldNotBeKeptAlive()
         {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This line was producing a warning that this comparison is fishy, and indeed it was broken.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Events are still raised after unsubscribe. Only the target object getting GCd will stop the subscription.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
No events being raised for unsubscribed handlers.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
