### PR TITLE
[OSX] dont use cursor rects, to prevent crashing.

### DIFF
--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -369,12 +369,9 @@ public:
 
     virtual void UpdateCursor()
     {
-        [View resetCursorRects];
         if (cursor != nil)
         {
-             auto rect = [Window frame];
-             [View addCursorRect:rect cursor:cursor];
-             [cursor set];
+            [cursor set];
         }
     }
     
@@ -425,6 +422,7 @@ private:
     {
         WindowEvents = events;
         [Window setCanBecomeKeyAndMain];
+        [Window disableCursorRects];
     }
     
     virtual HRESULT Show () override


### PR DESCRIPTION
## What does the pull request do?
On OSX in certain circumstances app would crash when updating the mouse cursor. This was because we were abusing Cocoa apis :(

## What is the updated/expected behavior with this PR?
This has been fixed by disabling Rect based cursors (which we were not really using).

And simply setting the cursor.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
Fixes #3000
