### PR TITLE
Reduce closure allocations for priority level and entry.

### DIFF
--- a/src/Avalonia.Base/PriorityBindingEntry.cs
+++ b/src/Avalonia.Base/PriorityBindingEntry.cs
@@ -129,6 +129,8 @@ namespace Avalonia
             }
             else
             {
+                // To avoid allocating closure in the outer scope we need to capture variables
+                // locally. This allows us to skip most of the allocations when on UI thread.
                 var instance = this;
                 var newValue = value;
 

--- a/src/Avalonia.Base/PriorityBindingEntry.cs
+++ b/src/Avalonia.Base/PriorityBindingEntry.cs
@@ -99,37 +99,40 @@ namespace Avalonia
 
         void IObserver<object>.OnNext(object value)
         {
-            void Signal()
+            void Signal(PriorityBindingEntry instance, object newValue)
             {
-                var notification = value as BindingNotification;
+                var notification = newValue as BindingNotification;
 
                 if (notification != null)
                 {
                     if (notification.HasValue || notification.ErrorType == BindingErrorType.Error)
                     {
-                        Value = notification.Value;
-                        _owner.Changed(this);
+                        instance.Value = notification.Value;
+                        instance._owner.Changed(instance);
                     }
 
                     if (notification.ErrorType != BindingErrorType.None)
                     {
-                        _owner.Error(this, notification);
+                        instance._owner.Error(instance, notification);
                     }
                 }
                 else
                 {
-                    Value = value;
-                    _owner.Changed(this);
+                    instance.Value = newValue;
+                    instance._owner.Changed(instance);
                 }
             }
 
             if (Dispatcher.UIThread.CheckAccess())
             {
-                Signal();
+                Signal(this, value);
             }
             else
             {
-                Dispatcher.UIThread.Post(Signal);
+                var instance = this;
+                var newValue = value;
+
+                Dispatcher.UIThread.Post(() => Signal(instance, newValue));
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
More cleanup of closure allocations.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Even after my changes to `PriorityBindingEntry` we were still allocating some closures. `PriorityLevel` also allocates a bit to do create unsubscribe disposable.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
No closure allocations in `PriorityBindingEntry`, `PriorityLevel` only allocates one custom disposable object and does not require extra delegates and closures.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Part of #2919