### PR TITLE
Fix osx popup positioning

### DIFF
--- a/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositionerPopupImplHelper.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositionerPopupImplHelper.cs
@@ -43,8 +43,8 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             _moveResize(new PixelPoint((int)devicePoint.X, (int)devicePoint.Y), virtualSize, _parent.Scaling);
         }
 
-        public Point TranslatePoint(Point pt) => pt * _parent.Scaling;
+        public virtual Point TranslatePoint(Point pt) => pt * _parent.Scaling;
 
-        public Size TranslateSize(Size size) => size * _parent.Scaling;
+        public virtual Size TranslateSize(Size size) => size * _parent.Scaling;
     }
 }

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositionerPopupImplHelper.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositionerPopupImplHelper.cs
@@ -32,7 +32,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             {
                 // Popup positioner operates with abstract coordinates, but in our case they are pixel ones
                 var point = _parent.PointToScreen(default);
-                var size = PixelSize.FromSize(_parent.ClientSize, _parent.Scaling);
+                var size = TranslateSize(_parent.ClientSize);
                 return new Rect(point.X, point.Y, size.Width, size.Height);
 
             }

--- a/src/Avalonia.Native/AvaloniaNativePlatform.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatform.cs
@@ -1,7 +1,6 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 using System;
-using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using Avalonia.Controls.Platform;
 using Avalonia.Input;

--- a/src/Avalonia.Native/OsxManagedPopupPositionerPopupImplHelper.cs
+++ b/src/Avalonia.Native/OsxManagedPopupPositionerPopupImplHelper.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+using Avalonia.Controls.Primitives.PopupPositioning;
+using Avalonia.Platform;
+
+namespace Avalonia.Native
+{
+    class OsxManagedPopupPositionerPopupImplHelper : ManagedPopupPositionerPopupImplHelper
+    {
+        public OsxManagedPopupPositionerPopupImplHelper(IWindowBaseImpl parent, MoveResizeDelegate moveResize) : base(parent, moveResize)
+        {
+
+        }
+        public override Point TranslatePoint(Point pt) => pt;
+
+        public override Size TranslateSize(Size size) => size;
+    }
+}

--- a/src/Avalonia.Native/PopupImpl.cs
+++ b/src/Avalonia.Native/PopupImpl.cs
@@ -22,7 +22,7 @@ namespace Avalonia.Native
             {
                 Init(factory.CreatePopup(e), factory.CreateScreens());
             }
-            PopupPositioner = new ManagedPopupPositioner(new ManagedPopupPositionerPopupImplHelper(parent, MoveResize));
+            PopupPositioner = new ManagedPopupPositioner(new OsxManagedPopupPositionerPopupImplHelper(parent, MoveResize));
         }
 
         private void MoveResize(PixelPoint position, Size size, double scaling)


### PR DESCRIPTION
## What does the pull request do?
Fixes popup positioning for OSX

## What is the current behavior?
Since popup rework it was providing incorrect coordinates.

## What is the updated/expected behavior with this PR?
provide osx with expected coordinates.

## How was the solution implemented (if it's not obvious)?
don't * by scaling on OSX only, this is because osx tries to be clever and hide "Retina" display res from us, so screen coordinates on osx are != pixel coordinates.
## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
#2923 