### PR TITLE
Add Contract.RequireNotNull

### DIFF
--- a/src/Avalonia.Base/Avalonia.Base.csproj
+++ b/src/Avalonia.Base/Avalonia.Base.csproj
@@ -4,9 +4,10 @@
     <AssemblyName>Avalonia.Base</AssemblyName>
     <RootNamespace>Avalonia</RootNamespace>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <Nullable>Enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Avalonia.Build.Tasks\Avalonia.Build.Tasks.csproj"/>
+    <ProjectReference Include="..\Avalonia.Build.Tasks\Avalonia.Build.Tasks.csproj" />
   </ItemGroup>
   <Import Project="..\..\build\Base.props" />
   <Import Project="..\..\build\Binding.props" />

--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -166,7 +166,7 @@ namespace Avalonia
         /// <param name="property">The property.</param>
         public void ClearValue(AvaloniaProperty property)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
+            Contract.RequireNotNull(property);
             VerifyAccess();
 
             SetValue(property, AvaloniaProperty.UnsetValue);
@@ -210,7 +210,7 @@ namespace Avalonia
         /// <returns>The value.</returns>
         public object GetValue(AvaloniaProperty property)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
+            Contract.RequireNotNull(property);
             VerifyAccess();
 
             if (property.IsDirect)
@@ -231,9 +231,9 @@ namespace Avalonia
         /// <returns>The value.</returns>
         public T GetValue<T>(AvaloniaProperty<T> property)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
+            Contract.RequireNotNull(property);
 
-            return (T)GetValue((AvaloniaProperty)property);
+            return (T)GetValue((AvaloniaProperty)property);            
         }
 
         /// <summary>
@@ -243,7 +243,7 @@ namespace Avalonia
         /// <returns>True if the property is animating, otherwise false.</returns>
         public bool IsAnimating(AvaloniaProperty property)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
+            Contract.RequireNotNull(property);
             VerifyAccess();
 
             return _values?.IsAnimating(property) ?? false;
@@ -260,7 +260,7 @@ namespace Avalonia
         /// </remarks>
         public bool IsSet(AvaloniaProperty property)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
+            Contract.RequireNotNull(property);
             VerifyAccess();
 
             return _values?.IsSet(property) ?? false;
@@ -277,7 +277,7 @@ namespace Avalonia
             object value,
             BindingPriority priority = BindingPriority.LocalValue)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
+            Contract.RequireNotNull(property);
             VerifyAccess();
 
             if (property.IsDirect)
@@ -302,7 +302,7 @@ namespace Avalonia
             T value,
             BindingPriority priority = BindingPriority.LocalValue)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
+            Contract.RequireNotNull(property);
 
             SetValue((AvaloniaProperty)property, value, priority);
         }
@@ -321,8 +321,8 @@ namespace Avalonia
             IObservable<object> source,
             BindingPriority priority = BindingPriority.LocalValue)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
-            Contract.Requires<ArgumentNullException>(source != null);
+            Contract.RequireNotNull(property);
+            Contract.RequireNotNull(source);
 
             VerifyAccess();
 
@@ -378,7 +378,7 @@ namespace Avalonia
             IObservable<T> source,
             BindingPriority priority = BindingPriority.LocalValue)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
+            Contract.RequireNotNull(property);
 
             return Bind(property, source.Select(x => (object)x), priority);
         }
@@ -501,7 +501,7 @@ namespace Avalonia
             object newValue,
             BindingPriority priority = BindingPriority.LocalValue)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
+            Contract.RequireNotNull(property);
             VerifyAccess();
 
             AvaloniaPropertyChangedEventArgs e = new AvaloniaPropertyChangedEventArgs(
@@ -762,7 +762,7 @@ namespace Avalonia
         /// </remarks>
         private void ParentPropertyChanged(object sender, AvaloniaPropertyChangedEventArgs e)
         {
-            Contract.Requires<ArgumentNullException>(e != null);
+            Contract.RequireNotNull(e);
 
             if (e.Property.Inherits && !IsSet(e.Property))
             {

--- a/src/Avalonia.Base/AvaloniaObjectExtensions.cs
+++ b/src/Avalonia.Base/AvaloniaObjectExtensions.cs
@@ -41,9 +41,6 @@ namespace Avalonia
         /// </remarks>
         public static IObservable<object> GetObservable(this IAvaloniaObject o, AvaloniaProperty property)
         {
-            Contract.Requires<ArgumentNullException>(o != null);
-            Contract.Requires<ArgumentNullException>(property != null);
-
             return new AvaloniaPropertyObservable<object>(o, property);
         }
 
@@ -62,9 +59,6 @@ namespace Avalonia
         /// </remarks>
         public static IObservable<T> GetObservable<T>(this IAvaloniaObject o, AvaloniaProperty<T> property)
         {
-            Contract.Requires<ArgumentNullException>(o != null);
-            Contract.Requires<ArgumentNullException>(property != null);
-
             return new AvaloniaPropertyObservable<T>(o, property);
         }
 
@@ -83,9 +77,6 @@ namespace Avalonia
             this IAvaloniaObject o, 
             AvaloniaProperty property)
         {
-            Contract.Requires<ArgumentNullException>(o != null);
-            Contract.Requires<ArgumentNullException>(property != null);
-
             return new AvaloniaPropertyChangedObservable(o, property);
         }
 
@@ -153,10 +144,6 @@ namespace Avalonia
             IBinding binding,
             object anchor = null)
         {
-            Contract.Requires<ArgumentNullException>(target != null);
-            Contract.Requires<ArgumentNullException>(property != null);
-            Contract.Requires<ArgumentNullException>(binding != null);
-
             var metadata = property.GetMetadata(target.GetType()) as IDirectPropertyMetadata;
 
             var result = binding.Initiate(

--- a/src/Avalonia.Base/AvaloniaProperty.cs
+++ b/src/Avalonia.Base/AvaloniaProperty.cs
@@ -43,10 +43,10 @@ namespace Avalonia
             PropertyMetadata metadata,
             Action<IAvaloniaObject, bool> notifying = null)
         {
-            Contract.Requires<ArgumentNullException>(name != null);
-            Contract.Requires<ArgumentNullException>(valueType != null);
-            Contract.Requires<ArgumentNullException>(ownerType != null);
-            Contract.Requires<ArgumentNullException>(metadata != null);
+            Contract.RequireNotNull(name);
+            Contract.RequireNotNull(valueType);
+            Contract.RequireNotNull(ownerType);
+            Contract.RequireNotNull(metadata);
 
             if (name.Contains("."))
             {
@@ -78,8 +78,8 @@ namespace Avalonia
             Type ownerType,
             PropertyMetadata metadata)
         {
-            Contract.Requires<ArgumentNullException>(source != null);
-            Contract.Requires<ArgumentNullException>(ownerType != null);
+            Contract.RequireNotNull(source);
+            Contract.RequireNotNull(ownerType);
 
             _initialized = source._initialized;
             _changed = source._changed;
@@ -266,7 +266,7 @@ namespace Avalonia
             Action<IAvaloniaObject, bool> notifying = null)
                 where TOwner : IAvaloniaObject
         {
-            Contract.Requires<ArgumentNullException>(name != null);
+            Contract.RequireNotNull(name);
 
             var metadata = new StyledPropertyMetadata<TValue>(
                 defaultValue,
@@ -303,7 +303,7 @@ namespace Avalonia
             Func<THost, TValue, TValue> validate = null)
                 where THost : IAvaloniaObject
         {
-            Contract.Requires<ArgumentNullException>(name != null);
+            Contract.RequireNotNull(name);
 
             var metadata = new StyledPropertyMetadata<TValue>(
                 defaultValue,
@@ -338,7 +338,7 @@ namespace Avalonia
             Func<THost, TValue, TValue> validate = null)
                 where THost : IAvaloniaObject
         {
-            Contract.Requires<ArgumentNullException>(name != null);
+            Contract.RequireNotNull(name);
 
             var metadata = new StyledPropertyMetadata<TValue>(
                 defaultValue,
@@ -377,7 +377,7 @@ namespace Avalonia
             bool enableDataValidation = false)
                 where TOwner : IAvaloniaObject
         {
-            Contract.Requires<ArgumentNullException>(name != null);
+            Contract.RequireNotNull(name);
 
             var metadata = new DirectPropertyMetadata<TValue>(
                 unsetValue: unsetValue,
@@ -446,7 +446,7 @@ namespace Avalonia
         ///
         public PropertyMetadata GetMetadata(Type type)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
+            Contract.RequireNotNull(type);
 
             PropertyMetadata result;
             Type currentType = type;
@@ -522,8 +522,8 @@ namespace Avalonia
         /// <param name="metadata">The metadata.</param>
         protected void OverrideMetadata(Type type, PropertyMetadata metadata)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
-            Contract.Requires<ArgumentNullException>(metadata != null);
+            Contract.RequireNotNull(type);
+            Contract.RequireNotNull(metadata);
 
             if (_metadata.ContainsKey(type))
             {

--- a/src/Avalonia.Base/AvaloniaPropertyRegistry.cs
+++ b/src/Avalonia.Base/AvaloniaPropertyRegistry.cs
@@ -47,7 +47,7 @@ namespace Avalonia
         /// <returns>A collection of <see cref="AvaloniaProperty"/> definitions.</returns>
         public IEnumerable<AvaloniaProperty> GetRegistered(Type type)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
+            Contract.RequireNotNull(type);
 
             if (_registeredCache.TryGetValue(type, out var result))
             {
@@ -81,7 +81,7 @@ namespace Avalonia
         /// <returns>A collection of <see cref="AvaloniaProperty"/> definitions.</returns>
         public IEnumerable<AvaloniaProperty> GetRegisteredAttached(Type type)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
+            Contract.RequireNotNull(type);
 
             if (_attachedCache.TryGetValue(type, out var result))
             {
@@ -112,7 +112,7 @@ namespace Avalonia
         /// <returns>A collection of <see cref="AvaloniaProperty"/> definitions.</returns>
         public IEnumerable<AvaloniaProperty> GetRegisteredInherited(Type type)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
+            Contract.RequireNotNull(type);
 
             if (_inheritedCache.TryGetValue(type, out var result))
             {
@@ -152,7 +152,7 @@ namespace Avalonia
         /// <returns>A collection of <see cref="AvaloniaProperty"/> definitions.</returns>
         public IEnumerable<AvaloniaProperty> GetRegistered(AvaloniaObject o)
         {
-            Contract.Requires<ArgumentNullException>(o != null);
+            Contract.RequireNotNull(o);
 
             return GetRegistered(o.GetType());
         }
@@ -170,8 +170,8 @@ namespace Avalonia
         /// </exception>
         public AvaloniaProperty FindRegistered(Type type, string name)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
-            Contract.Requires<ArgumentNullException>(name != null);
+            Contract.RequireNotNull(type);
+            Contract.RequireNotNull(name);
 
             if (name.Contains('.'))
             {
@@ -194,8 +194,8 @@ namespace Avalonia
         /// </exception>
         public AvaloniaProperty FindRegistered(AvaloniaObject o, string name)
         {
-            Contract.Requires<ArgumentNullException>(o != null);
-            Contract.Requires<ArgumentNullException>(name != null);
+            Contract.RequireNotNull(o);
+            Contract.RequireNotNull(name);
 
             return FindRegistered(o.GetType(), name);
         }
@@ -218,8 +218,8 @@ namespace Avalonia
         /// <returns>True if the property is registered, otherwise false.</returns>
         public bool IsRegistered(Type type, AvaloniaProperty property)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
-            Contract.Requires<ArgumentNullException>(property != null);
+            Contract.RequireNotNull(type);
+            Contract.RequireNotNull(property);
 
             return Instance.GetRegistered(type).Any(x => x == property) ||
                 Instance.GetRegisteredAttached(type).Any(x => x == property);
@@ -233,8 +233,8 @@ namespace Avalonia
         /// <returns>True if the property is registered, otherwise false.</returns>
         public bool IsRegistered(object o, AvaloniaProperty property)
         {
-            Contract.Requires<ArgumentNullException>(o != null);
-            Contract.Requires<ArgumentNullException>(property != null);
+            Contract.RequireNotNull(o);
+            Contract.RequireNotNull(property);
 
             return IsRegistered(o.GetType(), property);
         }
@@ -251,8 +251,8 @@ namespace Avalonia
         /// </remarks>
         public void Register(Type type, AvaloniaProperty property)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
-            Contract.Requires<ArgumentNullException>(property != null);
+            Contract.RequireNotNull(type);
+            Contract.RequireNotNull(property);
 
             if (!_registered.TryGetValue(type, out var inner))
             {
@@ -287,8 +287,8 @@ namespace Avalonia
         /// </remarks>
         public void RegisterAttached(Type type, AvaloniaProperty property)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
-            Contract.Requires<ArgumentNullException>(property != null);
+            Contract.RequireNotNull(type);
+            Contract.RequireNotNull(property);
 
             if (!property.IsAttached)
             {
@@ -314,7 +314,7 @@ namespace Avalonia
 
         internal void NotifyInitialized(AvaloniaObject o)
         {
-            Contract.Requires<ArgumentNullException>(o != null);
+            Contract.RequireNotNull(o);
 
             var type = o.GetType();
 

--- a/src/Avalonia.Base/Collections/AvaloniaList.cs
+++ b/src/Avalonia.Base/Collections/AvaloniaList.cs
@@ -303,7 +303,7 @@ namespace Avalonia.Collections
         /// <param name="items">The items.</param>
         public virtual void InsertRange(int index, IEnumerable<T> items)
         {
-            Contract.Requires<ArgumentNullException>(items != null);
+            Contract.RequireNotNull(items);
 
             bool willRaiseCollectionChanged = _collectionChanged != null;
             bool hasValidation = Validate != null;
@@ -462,7 +462,7 @@ namespace Avalonia.Collections
         /// <param name="items">The items.</param>
         public virtual void RemoveAll(IEnumerable<T> items)
         {
-            Contract.Requires<ArgumentNullException>(items != null);
+            Contract.RequireNotNull(items);
 
             foreach (var i in items)
             {

--- a/src/Avalonia.Base/Collections/NotifyCollectionChangedExtensions.cs
+++ b/src/Avalonia.Base/Collections/NotifyCollectionChangedExtensions.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Collections
         public static IObservable<NotifyCollectionChangedEventArgs> GetWeakCollectionChangedObservable(
             this INotifyCollectionChanged collection)
         {
-            Contract.Requires<ArgumentNullException>(collection != null);
+            Contract.RequireNotNull(collection);
 
             return new WeakCollectionChangedObservable(new WeakReference<INotifyCollectionChanged>(collection));
         }
@@ -36,8 +36,8 @@ namespace Avalonia.Collections
             this INotifyCollectionChanged collection, 
             NotifyCollectionChangedEventHandler handler)
         {
-            Contract.Requires<ArgumentNullException>(collection != null);
-            Contract.Requires<ArgumentNullException>(handler != null);
+            Contract.RequireNotNull(collection);
+            Contract.RequireNotNull(handler);
 
             return collection.GetWeakCollectionChangedObservable()
                 .Subscribe(e => handler(collection, e));
@@ -55,8 +55,8 @@ namespace Avalonia.Collections
             this INotifyCollectionChanged collection,
             Action<NotifyCollectionChangedEventArgs> handler)
         {
-            Contract.Requires<ArgumentNullException>(collection != null);
-            Contract.Requires<ArgumentNullException>(handler != null);
+            Contract.RequireNotNull(collection);
+            Contract.RequireNotNull(handler);
 
             return collection.GetWeakCollectionChangedObservable().Subscribe(handler);
         }

--- a/src/Avalonia.Base/Contract.cs
+++ b/src/Avalonia.Base/Contract.cs
@@ -56,68 +56,6 @@ namespace Avalonia
     {
     }
 
-    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
-    internal sealed class AllowNullAttribute : Attribute { }
-
-    /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
-    internal sealed class DisallowNullAttribute : Attribute { }
-
-    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
-    internal sealed class MaybeNullAttribute : Attribute { }
-
-    /// <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
-    internal sealed class NotNullAttribute : Attribute { }
-
-    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
-    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-    internal sealed class MaybeNullWhenAttribute : Attribute
-    {
-        /// <summary>Initializes the attribute with the specified return value condition.</summary>
-        /// <param name="returnValue">
-        /// The return value condition. If the method returns this value, the associated parameter may be null.
-        /// </param>
-        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
-
-        /// <summary>Gets the return value condition.</summary>
-        public bool ReturnValue { get; }
-    }
-
-    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
-    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-    internal sealed class NotNullWhenAttribute : Attribute
-    {
-        /// <summary>Initializes the attribute with the specified return value condition.</summary>
-        /// <param name="returnValue">
-        /// The return value condition. If the method returns this value, the associated parameter will not be null.
-        /// </param>
-        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
-
-        /// <summary>Gets the return value condition.</summary>
-        public bool ReturnValue { get; }
-    }
-
-    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
-    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
-    internal sealed class NotNullIfNotNullAttribute : Attribute
-    {
-        /// <summary>Initializes the attribute with the associated parameter name.</summary>
-        /// <param name="parameterName">
-        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
-        /// </param>
-        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
-
-        /// <summary>Gets the associated parameter name.</summary>
-        public string ParameterName { get; }
-    }
-
-    /// <summary>Applied to a method that will never return under any circumstance.</summary>
-    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
-    internal sealed class DoesNotReturnAttribute : Attribute { }
-
     /// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
     [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
     internal sealed class DoesNotReturnIfAttribute : Attribute

--- a/src/Avalonia.Base/Contract.cs
+++ b/src/Avalonia.Base/Contract.cs
@@ -25,13 +25,111 @@ namespace Avalonia
         /// </typeparam>
         /// <param name="condition">The precondition.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [ContractAnnotation("condition:false=>stop")]
-        public static void Requires<TException>(bool condition) where TException : Exception, new()
+        [ContractAnnotation("condition:false=>stop")]        
+        public static void Requires<TException>([DoesNotReturnIf(false)] bool condition) where TException : Exception, new()
         {
             if (!condition)
             {
                 throw new TException();
             }
         }
+
+        /// <summary>
+        /// Specifies a precondition.
+        /// </summary>
+        /// <typeparam name="TException">
+        /// The exception to throw if <paramref name="condition"/> is false.
+        /// </typeparam>
+        /// <param name="obj">The precondition.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [ContractAnnotation("condition:false=>stop")]
+        public static void RequireNotNull([EnsuresNotNull] object obj)
+        {
+            if (obj is null)
+            {
+                throw new ArgumentNullException();
+            }
+        }
+    }
+
+    internal class EnsuresNotNullAttribute : Attribute
+    {
+    }
+
+    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class AllowNullAttribute : Attribute { }
+
+    /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class DisallowNullAttribute : Attribute { }
+
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class MaybeNullAttribute : Attribute { }
+
+    /// <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class NotNullAttribute : Attribute { }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class MaybeNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter may be null.
+        /// </param>
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    internal sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class DoesNotReturnAttribute : Attribute { }
+
+    /// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified parameter value.</summary>
+        /// <param name="parameterValue">
+        /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+        /// the associated parameter matches this value.
+        /// </param>
+        public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+
+        /// <summary>Gets the condition parameter value.</summary>
+        public bool ParameterValue { get; }
     }
 }

--- a/src/Avalonia.Base/Data/BindingNotification.cs
+++ b/src/Avalonia.Base/Data/BindingNotification.cs
@@ -209,7 +209,7 @@ namespace Avalonia.Data
         /// <param name="type">The error type.</param>
         public void AddError(Exception e, BindingErrorType type)
         {
-            Contract.Requires<ArgumentNullException>(e != null);
+            Contract.RequireNotNull(e);
             Contract.Requires<ArgumentException>(type != BindingErrorType.None);
 
             Error = Error != null ? new AggregateException(Error, e) : e;

--- a/src/Avalonia.Base/Data/BindingOperations.cs
+++ b/src/Avalonia.Base/Data/BindingOperations.cs
@@ -31,9 +31,9 @@ namespace Avalonia.Data
             InstancedBinding binding,
             object anchor)
         {
-            Contract.Requires<ArgumentNullException>(target != null);
-            Contract.Requires<ArgumentNullException>(property != null);
-            Contract.Requires<ArgumentNullException>(binding != null);
+            Contract.RequireNotNull(target);
+            Contract.RequireNotNull(property);
+            Contract.RequireNotNull(binding);
 
             var mode = binding.Mode;
 

--- a/src/Avalonia.Base/Data/Converters/StringFormatMultiValueConverter.cs
+++ b/src/Avalonia.Base/Data/Converters/StringFormatMultiValueConverter.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Data.Converters
         /// </param>
         public StringFormatMultiValueConverter(string format, IMultiValueConverter inner)
         {
-            Contract.Requires<ArgumentNullException>(format != null);
+            Contract.RequireNotNull(format);
 
             Format = format;
             Inner = inner;

--- a/src/Avalonia.Base/Data/Converters/StringFormatValueConverter.cs
+++ b/src/Avalonia.Base/Data/Converters/StringFormatValueConverter.cs
@@ -17,7 +17,7 @@ namespace Avalonia.Data.Converters
         /// </param>
         public StringFormatValueConverter(string format, IValueConverter inner)
         {
-            Contract.Requires<ArgumentNullException>(format != null);
+            Contract.RequireNotNull(format);
 
             Format = format;
             Inner = inner;

--- a/src/Avalonia.Base/Data/Core/BindingExpression.cs
+++ b/src/Avalonia.Base/Data/Core/BindingExpression.cs
@@ -76,9 +76,9 @@ namespace Avalonia.Data.Core
             object converterParameter = null,
             BindingPriority priority = BindingPriority.LocalValue)
         {
-            Contract.Requires<ArgumentNullException>(inner != null);
-            Contract.Requires<ArgumentNullException>(targetType != null);
-            Contract.Requires<ArgumentNullException>(converter != null);
+            Contract.RequireNotNull(inner);
+            Contract.RequireNotNull(targetType);
+            Contract.RequireNotNull(converter);
 
             _inner = inner;
             _targetType = targetType;

--- a/src/Avalonia.Base/Data/Core/ExpressionNode.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNode.cs
@@ -29,7 +29,7 @@ namespace Avalonia.Data.Core
             get { return _target; }
             set
             {
-                Contract.Requires<ArgumentNullException>(value != null);
+                Contract.RequireNotNull(value);
 
                 _target.TryGetTarget(out var oldTarget);
                 value.TryGetTarget(out object newTarget);

--- a/src/Avalonia.Base/Data/Core/ExpressionObserver.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionObserver.cs
@@ -94,7 +94,7 @@ namespace Avalonia.Data.Core
             ExpressionNode node,
             string description)
         {
-            Contract.Requires<ArgumentNullException>(rootObservable != null);
+            Contract.RequireNotNull(rootObservable);
             
             _node = node;
             Description = description;
@@ -116,8 +116,8 @@ namespace Avalonia.Data.Core
             IObservable<Unit> update,
             string description)
         {
-            Contract.Requires<ArgumentNullException>(rootGetter != null);
-            Contract.Requires<ArgumentNullException>(update != null);
+            Contract.RequireNotNull(rootGetter);
+            Contract.RequireNotNull(update);
             Description = description;
             _node = node;
             _node.Target = new WeakReference<object>(rootGetter());
@@ -158,7 +158,7 @@ namespace Avalonia.Data.Core
             bool enableDataValidation = false,
             string description = null)
         {
-            Contract.Requires<ArgumentNullException>(rootObservable != null);
+            Contract.RequireNotNull(rootObservable);
             return new ExpressionObserver(
                 rootObservable.Select(o => (object)o),
                 Parse(expression, enableDataValidation),
@@ -182,7 +182,7 @@ namespace Avalonia.Data.Core
             bool enableDataValidation = false,
             string description = null)
         {
-            Contract.Requires<ArgumentNullException>(rootGetter != null);
+            Contract.RequireNotNull(rootGetter);
 
             return new ExpressionObserver(
                 () => rootGetter(),

--- a/src/Avalonia.Base/Data/Core/Plugins/AvaloniaPropertyAccessorPlugin.cs
+++ b/src/Avalonia.Base/Data/Core/Plugins/AvaloniaPropertyAccessorPlugin.cs
@@ -33,8 +33,8 @@ namespace Avalonia.Data.Core.Plugins
         /// </returns>
         public IPropertyAccessor Start(WeakReference<object> reference, string propertyName)
         {
-            Contract.Requires<ArgumentNullException>(reference != null);
-            Contract.Requires<ArgumentNullException>(propertyName != null);
+            Contract.RequireNotNull(reference);
+            Contract.RequireNotNull(propertyName);
 
             reference.TryGetTarget(out object instance);
             var o = (AvaloniaObject)instance;
@@ -84,8 +84,8 @@ namespace Avalonia.Data.Core.Plugins
 
             public Accessor(WeakReference<AvaloniaObject> reference, AvaloniaProperty property)
             {
-                Contract.Requires<ArgumentNullException>(reference != null);
-                Contract.Requires<ArgumentNullException>(property != null);
+                Contract.RequireNotNull(reference);
+                Contract.RequireNotNull(property);
 
                 _reference = reference;
                 _property = property;

--- a/src/Avalonia.Base/Data/Core/Plugins/InpcPropertyAccessorPlugin.cs
+++ b/src/Avalonia.Base/Data/Core/Plugins/InpcPropertyAccessorPlugin.cs
@@ -30,8 +30,8 @@ namespace Avalonia.Data.Core.Plugins
         /// </returns>
         public IPropertyAccessor Start(WeakReference<object> reference, string propertyName)
         {
-            Contract.Requires<ArgumentNullException>(reference != null);
-            Contract.Requires<ArgumentNullException>(propertyName != null);
+            Contract.RequireNotNull(reference);
+            Contract.RequireNotNull(propertyName);
 
             reference.TryGetTarget(out object instance);
             var p = instance.GetType().GetRuntimeProperties().FirstOrDefault(x => x.Name == propertyName);
@@ -56,8 +56,8 @@ namespace Avalonia.Data.Core.Plugins
 
             public Accessor(WeakReference<object> reference,  PropertyInfo property)
             {
-                Contract.Requires<ArgumentNullException>(reference != null);
-                Contract.Requires<ArgumentNullException>(property != null);
+                Contract.RequireNotNull(reference);
+                Contract.RequireNotNull(property);
 
                 _reference = reference;
                 _property = property;

--- a/src/Avalonia.Base/Data/Core/Plugins/MethodAccessorPlugin.cs
+++ b/src/Avalonia.Base/Data/Core/Plugins/MethodAccessorPlugin.cs
@@ -11,8 +11,8 @@ namespace Avalonia.Data.Core.Plugins
 
         public IPropertyAccessor Start(WeakReference<object> reference, string methodName)
         {
-            Contract.Requires<ArgumentNullException>(reference != null);
-            Contract.Requires<ArgumentNullException>(methodName != null);
+            Contract.RequireNotNull(reference);
+            Contract.RequireNotNull(methodName);
 
             reference.TryGetTarget(out object instance);
             var method = instance.GetType().GetRuntimeMethods().FirstOrDefault(x => x.Name == methodName);
@@ -39,8 +39,8 @@ namespace Avalonia.Data.Core.Plugins
         {
             public Accessor(WeakReference<object> reference, MethodInfo method)
             {
-                Contract.Requires<ArgumentNullException>(reference != null);
-                Contract.Requires<ArgumentNullException>(method != null);
+                Contract.RequireNotNull(reference);
+                Contract.RequireNotNull(method);
 
                 var paramTypes = method.GetParameters().Select(param => param.ParameterType).ToArray();
                 var returnType = method.ReturnType;

--- a/src/Avalonia.Base/Data/Core/Plugins/PropertyAccessorBase.cs
+++ b/src/Avalonia.Base/Data/Core/Plugins/PropertyAccessorBase.cs
@@ -33,7 +33,7 @@ namespace Avalonia.Data.Core.Plugins
         /// <inheritdoc/>
         public void Subscribe(Action<object> listener)
         {
-            Contract.Requires<ArgumentNullException>(listener != null);
+            Contract.RequireNotNull(listener);
 
             if (_listener != null)
             {

--- a/src/Avalonia.Base/Data/InstancedBinding.cs
+++ b/src/Avalonia.Base/Data/InstancedBinding.cs
@@ -31,7 +31,7 @@ namespace Avalonia.Data
         /// </remarks>
         public InstancedBinding(ISubject<object> subject, BindingMode mode, BindingPriority priority)
         {
-            Contract.Requires<ArgumentNullException>(subject != null);
+            Contract.RequireNotNull(subject);
 
             Mode = mode;
             Priority = priority;
@@ -93,7 +93,7 @@ namespace Avalonia.Data
             IObservable<object> observable,
             BindingPriority priority = BindingPriority.LocalValue)
         {
-            Contract.Requires<ArgumentNullException>(observable != null);
+            Contract.RequireNotNull(observable);
 
             return new InstancedBinding(observable, BindingMode.OneTime, priority);
         }
@@ -108,7 +108,7 @@ namespace Avalonia.Data
             IObservable<object> observable,
             BindingPriority priority = BindingPriority.LocalValue)
         {
-            Contract.Requires<ArgumentNullException>(observable != null);
+            Contract.RequireNotNull(observable);
 
             return new InstancedBinding(observable, BindingMode.OneWay, priority);
         }
@@ -123,7 +123,7 @@ namespace Avalonia.Data
             ISubject<object> subject,
             BindingPriority priority = BindingPriority.LocalValue)
         {
-            Contract.Requires<ArgumentNullException>(subject != null);
+            Contract.RequireNotNull(subject);
 
             return new InstancedBinding(subject, BindingMode.OneWayToSource, priority);
         }
@@ -138,7 +138,7 @@ namespace Avalonia.Data
             ISubject<object> subject,
             BindingPriority priority = BindingPriority.LocalValue)
         {
-            Contract.Requires<ArgumentNullException>(subject != null);
+            Contract.RequireNotNull(subject);
 
             return new InstancedBinding(subject, BindingMode.TwoWay, priority);
         }

--- a/src/Avalonia.Base/DirectProperty.cs
+++ b/src/Avalonia.Base/DirectProperty.cs
@@ -33,7 +33,7 @@ namespace Avalonia
             DirectPropertyMetadata<TValue> metadata)
             : base(name, typeof(TOwner), metadata)
         {
-            Contract.Requires<ArgumentNullException>(getter != null);
+            Contract.RequireNotNull(getter);
 
             Getter = getter;
             Setter = setter;
@@ -53,7 +53,7 @@ namespace Avalonia
             DirectPropertyMetadata<TValue> metadata)
             : base(source, typeof(TOwner), metadata)
         {
-            Contract.Requires<ArgumentNullException>(getter != null);
+            Contract.RequireNotNull(getter);
 
             Getter = getter;
             Setter = setter;

--- a/src/Avalonia.Base/PriorityBindingEntry.cs
+++ b/src/Avalonia.Base/PriorityBindingEntry.cs
@@ -71,7 +71,7 @@ namespace Avalonia
         /// <param name="binding">The binding.</param>
         public void Start(IObservable<object> binding)
         {
-            Contract.Requires<ArgumentNullException>(binding != null);
+            Contract.RequireNotNull(binding);
 
             if (_subscription != null)
             {

--- a/src/Avalonia.Base/PriorityLevel.cs
+++ b/src/Avalonia.Base/PriorityLevel.cs
@@ -44,7 +44,7 @@ namespace Avalonia
             PriorityValue owner,
             int priority)
         {
-            Contract.Requires<ArgumentNullException>(owner != null);
+            Contract.RequireNotNull(owner);
 
             Owner = owner;
             Priority = priority;
@@ -103,7 +103,7 @@ namespace Avalonia
         /// <returns>A disposable used to remove the binding.</returns>
         public IDisposable Add(IObservable<object> binding)
         {
-            Contract.Requires<ArgumentNullException>(binding != null);
+            Contract.RequireNotNull(binding);
 
             var entry = new PriorityBindingEntry(this, _nextIndex++);
             var node = Bindings.AddFirst(entry);

--- a/src/Avalonia.Base/Reactive/LightweightObservableBase.cs
+++ b/src/Avalonia.Base/Reactive/LightweightObservableBase.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Reactive
 
         public IDisposable Subscribe(IObserver<T> observer)
         {
-            Contract.Requires<ArgumentNullException>(observer != null);
+            Contract.RequireNotNull(observer);
             Dispatcher.UIThread.VerifyAccess();
 
             var first = false;

--- a/src/Avalonia.Base/Reactive/SingleSubscriberObservableBase.cs
+++ b/src/Avalonia.Base/Reactive/SingleSubscriberObservableBase.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Reactive
 
         public IDisposable Subscribe(IObserver<T> observer)
         {
-            Contract.Requires<ArgumentNullException>(observer != null);
+            Contract.RequireNotNull(observer);
             Dispatcher.UIThread.VerifyAccess();
 
             if (_observer != null)

--- a/src/Avalonia.Base/StyledPropertyBase.cs
+++ b/src/Avalonia.Base/StyledPropertyBase.cs
@@ -29,8 +29,8 @@ namespace Avalonia
             Action<IAvaloniaObject, bool> notifying = null)
                 : base(name, ownerType, metadata, notifying)
         {
-            Contract.Requires<ArgumentNullException>(name != null);
-            Contract.Requires<ArgumentNullException>(ownerType != null);
+            Contract.RequireNotNull(name);
+            Contract.RequireNotNull(ownerType);
 
             if (name.Contains("."))
             {
@@ -66,7 +66,7 @@ namespace Avalonia
         /// <returns>The default value.</returns>
         public TValue GetDefaultValue(Type type)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
+            Contract.RequireNotNull(type);
 
             return GetMetadata(type).DefaultValue.Typed;
         }
@@ -159,7 +159,7 @@ namespace Avalonia
         /// <inheritdoc/>
         Func<IAvaloniaObject, object, object> IStyledPropertyAccessor.GetValidationFunc(Type type)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
+            Contract.RequireNotNull(type);
             return ((IStyledPropertyMetadata)base.GetMetadata(type)).Validate;
         }
 
@@ -168,7 +168,7 @@ namespace Avalonia
 
         private object GetDefaultBoxedValue(Type type)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
+            Contract.RequireNotNull(type);
 
             return GetMetadata(type).DefaultValue.Boxed;
         }

--- a/src/Avalonia.Base/Threading/Dispatcher.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.cs
@@ -80,36 +80,31 @@ namespace Avalonia.Threading
 
         /// <inheritdoc/>
         public Task InvokeAsync(Action action, DispatcherPriority priority = DispatcherPriority.Normal)
-        {
-            Contract.Requires<ArgumentNullException>(action != null);
+        {            
             return _jobRunner.InvokeAsync(action, priority);
         }
         
         /// <inheritdoc/>
         public Task<TResult> InvokeAsync<TResult>(Func<TResult> function, DispatcherPriority priority = DispatcherPriority.Normal)
-        {
-            Contract.Requires<ArgumentNullException>(function != null);
+        {           
             return _jobRunner.InvokeAsync(function, priority);
         }
 
         /// <inheritdoc/>
         public Task InvokeAsync(Func<Task> function, DispatcherPriority priority = DispatcherPriority.Normal)
-        {
-            Contract.Requires<ArgumentNullException>(function != null);
+        {            
             return _jobRunner.InvokeAsync(function, priority).Unwrap();
         }
 
         /// <inheritdoc/>
         public Task<TResult> InvokeAsync<TResult>(Func<Task<TResult>> function, DispatcherPriority priority = DispatcherPriority.Normal)
-        {
-            Contract.Requires<ArgumentNullException>(function != null);
+        {            
             return _jobRunner.InvokeAsync(function, priority).Unwrap();
         }
 
         /// <inheritdoc/>
         public void Post(Action action, DispatcherPriority priority = DispatcherPriority.Normal)
-        {
-            Contract.Requires<ArgumentNullException>(action != null);
+        {            
             _jobRunner.Post(action, priority);
         }
 

--- a/src/Avalonia.Base/Utilities/WeakObservable.cs
+++ b/src/Avalonia.Base/Utilities/WeakObservable.cs
@@ -26,8 +26,8 @@ namespace Avalonia.Utilities
             string eventName)
             where TEventArgs : EventArgs
         {
-            Contract.Requires<ArgumentNullException>(target != null);
-            Contract.Requires<ArgumentNullException>(eventName != null);
+            Contract.RequireNotNull(target);
+            Contract.RequireNotNull(eventName);
 
             return Observable.Create<EventPattern<object, TEventArgs>>(observer =>
             {

--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
@@ -588,7 +588,7 @@ namespace Avalonia.Controls
 
         public IControl GetCellContent(DataGridRow dataGridRow)
         {
-            Contract.Requires<ArgumentNullException>(dataGridRow != null);
+            Contract.RequireNotNull(dataGridRow);
             if (OwningGrid == null)
             {
                 throw DataGridError.DataGrid.NoOwningGrid(GetType());
@@ -606,7 +606,7 @@ namespace Avalonia.Controls
 
         public IControl GetCellContent(object dataItem)
         {
-            Contract.Requires<ArgumentNullException>(dataItem != null);
+            Contract.RequireNotNull(dataItem);
             if (OwningGrid == null)
             {
                 throw DataGridError.DataGrid.NoOwningGrid(GetType());

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridFrozenGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridFrozenGrid.cs
@@ -26,7 +26,7 @@ namespace Avalonia.Controls.Primitives
         /// <returns>true if the grid is frozen; otherwise, false. The default is true.</returns>
         public static bool GetIsFrozen(Control element)
         {
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(element);
             return element.GetValue(IsFrozenProperty);
         }
 
@@ -38,7 +38,7 @@ namespace Avalonia.Controls.Primitives
         /// <exception cref="T:System.ArgumentNullException"><paramref name="element" /> is null.</exception>
         public static void SetIsFrozen(Control element, bool value)
         {
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(element);
             element.SetValue(IsFrozenProperty, value);
         }
     }

--- a/src/Avalonia.Controls/Application.cs
+++ b/src/Avalonia.Controls/Application.cs
@@ -104,7 +104,7 @@ namespace Avalonia
             get => _resources ?? (Resources = new ResourceDictionary());
             set
             {
-                Contract.Requires<ArgumentNullException>(value != null);
+                Contract.RequireNotNull(value);
 
                 var hadResources = false;
 

--- a/src/Avalonia.Controls/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox.cs
@@ -1272,7 +1272,7 @@ namespace Avalonia.Controls
         /// that contains the event data.</param>
         protected override void OnKeyDown(KeyEventArgs e)
         {
-            Contract.Requires<ArgumentNullException>(e != null);
+            Contract.RequireNotNull(e);
 
             base.OnKeyDown(e);
 

--- a/src/Avalonia.Controls/Avalonia.Controls.csproj
+++ b/src/Avalonia.Controls/Avalonia.Controls.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Avalonia.Animation\Avalonia.Animation.csproj" />

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -73,7 +73,7 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<bool> IsPressedProperty =
             AvaloniaProperty.Register<Button, bool>(nameof(IsPressed));
 
-        private ICommand _command;
+        private ICommand? _command;
         private bool _commandCanExecute = true;
 
         /// <summary>

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -73,7 +73,7 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<bool> IsPressedProperty =
             AvaloniaProperty.Register<Button, bool>(nameof(IsPressed));
 
-        private ICommand? _command;
+        private ICommand _command;
         private bool _commandCanExecute = true;
 
         /// <summary>

--- a/src/Avalonia.Controls/Calendar/Calendar.cs
+++ b/src/Avalonia.Controls/Calendar/Calendar.cs
@@ -768,7 +768,7 @@ namespace Avalonia.Controls
         }
         private static void UpdateDisplayDate(Calendar c, DateTime addedDate, DateTime removedDate)
         {
-            Contract.Requires<ArgumentNullException>(c != null);
+            Contract.RequireNotNull(c);
 
             // If DisplayDate < DisplayDateStart, DisplayDate = DisplayDateStart
             if (DateTime.Compare(addedDate, c.DisplayDateRangeStart) < 0)

--- a/src/Avalonia.Controls/Calendar/CalendarDateRange.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarDateRange.cs
@@ -65,7 +65,7 @@ namespace Avalonia.Controls
         /// <returns>Inherited code: Requires comment 2.</returns>
         internal bool ContainsAny(CalendarDateRange range)
         {
-            Contract.Requires<ArgumentNullException>(range != null);
+            Contract.RequireNotNull(range);
 
             int start = DateTime.Compare(Start, range.Start);
 

--- a/src/Avalonia.Controls/Calendar/CalendarItem.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarItem.cs
@@ -528,7 +528,7 @@ namespace Avalonia.Controls.Primitives
             for (int childIndex = Calendar.ColumnsPerMonth; childIndex < count; childIndex++)
             {
                 CalendarDayButton childButton = MonthView.Children[childIndex] as CalendarDayButton;
-                Contract.Requires<ArgumentNullException>(childButton != null);
+                Contract.RequireNotNull(childButton);
 
                 childButton.Index = childIndex;
                 SetButtonState(childButton, dateToAdd);
@@ -565,7 +565,7 @@ namespace Avalonia.Controls.Primitives
                     for (int i = childIndex; i < count; i++)
                     {
                         childButton = MonthView.Children[i] as CalendarDayButton;
-                        Contract.Requires<ArgumentNullException>(childButton != null);
+                        Contract.RequireNotNull(childButton);
                         // button needs a content to occupy the necessary space
                         // for the content presenter
                         childButton.Content = i.ToString(DateTimeHelper.GetCurrentDateFormat());
@@ -661,7 +661,7 @@ namespace Avalonia.Controls.Primitives
             foreach (object child in YearView.Children)
             {
                 CalendarButton childButton = child as CalendarButton;
-                Contract.Requires<ArgumentNullException>(childButton != null);
+                Contract.RequireNotNull(childButton);
                 // There should be no time component. Time is 12:00 AM
                 DateTime day = new DateTime(_currentMonth.Year, count + 1, 1);
                 childButton.DataContext = day;
@@ -757,7 +757,7 @@ namespace Avalonia.Controls.Primitives
             foreach (object child in YearView.Children)
             {
                 CalendarButton childButton = child as CalendarButton;
-                Contract.Requires<ArgumentNullException>(childButton != null);
+                Contract.RequireNotNull(childButton);
                 year = decade + count;
 
                 if (year <= DateTime.MaxValue.Year && year >= DateTime.MinValue.Year)
@@ -967,7 +967,7 @@ namespace Avalonia.Controls.Primitives
                     if (b.IsEnabled && !b.IsBlackout)
                     {
                         DateTime selectedDate = (DateTime)b.DataContext;
-                        Contract.Requires<ArgumentNullException>(selectedDate != null);
+                        Contract.RequireNotNull(selectedDate);
                         _isMouseLeftButtonDown = true;
                         // null check is added for unit tests
                         if (e != null)
@@ -1143,7 +1143,7 @@ namespace Avalonia.Controls.Primitives
                 if (_isControlPressed && Owner.SelectionMode == CalendarSelectionMode.MultipleRange)
                 {
                     CalendarDayButton b = sender as CalendarDayButton;
-                    Contract.Requires<ArgumentNullException>(b != null);
+                    Contract.RequireNotNull(b);
 
                     if (b.IsSelected)
                     {
@@ -1163,7 +1163,7 @@ namespace Avalonia.Controls.Primitives
         private void Month_CalendarButtonMouseDown(object sender, PointerPressedEventArgs e)
         {
             CalendarButton b = sender as CalendarButton;
-            Contract.Requires<ArgumentNullException>(b != null);
+            Contract.RequireNotNull(b);
 
             _isMouseLeftButtonDownYearView = true;
 
@@ -1202,7 +1202,7 @@ namespace Avalonia.Controls.Primitives
             if (_isMouseLeftButtonDownYearView)
             {
                 CalendarButton b = sender as CalendarButton;
-                Contract.Requires<ArgumentNullException>(b != null);
+                Contract.RequireNotNull(b);
                 UpdateYearViewSelection(b);
             }
         }

--- a/src/Avalonia.Controls/Calendar/DatePicker.cs
+++ b/src/Avalonia.Controls/Calendar/DatePicker.cs
@@ -841,7 +841,7 @@ namespace Avalonia.Controls
         private void Calendar_KeyDown(object sender, KeyEventArgs e)
         {
             Calendar c = sender as Calendar;
-            Contract.Requires<ArgumentNullException>(c != null);
+            Contract.RequireNotNull(c);
 
             if (!e.Handled && (e.Key == Key.Enter || e.Key == Key.Space || e.Key == Key.Escape) && c.DisplayMode == CalendarMode.Month)
             {

--- a/src/Avalonia.Controls/ControlExtensions.cs
+++ b/src/Avalonia.Controls/ControlExtensions.cs
@@ -20,7 +20,7 @@ namespace Avalonia.Controls
         /// <param name="control">The control.</param>
         public static void BringIntoView(this IControl control)
         {
-            Contract.Requires<ArgumentNullException>(control != null);
+            Contract.RequireNotNull(control);
 
             control.BringIntoView(new Rect(control.Bounds.Size));
         }
@@ -32,7 +32,7 @@ namespace Avalonia.Controls
         /// <param name="rect">The area of the control to being into view.</param>
         public static void BringIntoView(this IControl control, Rect rect)
         {
-            Contract.Requires<ArgumentNullException>(control != null);
+            Contract.RequireNotNull(control);
 
             if (control.IsEffectivelyVisible)
             {
@@ -56,8 +56,8 @@ namespace Avalonia.Controls
         /// <returns>The control or null if not found.</returns>
         public static T FindControl<T>(this IControl control, string name) where T : class, IControl
         {
-            Contract.Requires<ArgumentNullException>(control != null);
-            Contract.Requires<ArgumentNullException>(name != null);
+            Contract.RequireNotNull(control);
+            Contract.RequireNotNull(name);
 
             var nameScope = control.FindNameScope();
 
@@ -77,7 +77,7 @@ namespace Avalonia.Controls
         /// <param name="value">True to add the pseudoclass or false to remove.</param>
         public static void Set(this IPseudoClasses classes, string name, bool value)
         {
-            Contract.Requires<ArgumentNullException>(classes != null);
+            Contract.RequireNotNull(classes);
 
             if (value)
             {
@@ -98,7 +98,7 @@ namespace Avalonia.Controls
         /// <returns>A disposable used to cancel the subscription.</returns>
         public static IDisposable Set(this IPseudoClasses classes, string name, IObservable<bool> trigger)
         {
-            Contract.Requires<ArgumentNullException>(classes != null);
+            Contract.RequireNotNull(classes);
 
             return trigger.Subscribe(x => classes.Set(name, x));
         }

--- a/src/Avalonia.Controls/DefinitionBase.cs
+++ b/src/Avalonia.Controls/DefinitionBase.cs
@@ -327,7 +327,7 @@ namespace Avalonia.Controls
         /// </remarks>
         private static string SharedSizeGroupPropertyValueValid(Control _, string value)
         {
-            Contract.Requires<ArgumentNullException>(value != null);
+            Contract.RequireNotNull(value);
 
             string id = (string)value;
 

--- a/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Controls.Generators
         /// <param name="owner">The owner control.</param>
         public ItemContainerGenerator(IControl owner)
         {
-            Contract.Requires<ArgumentNullException>(owner != null);
+            Contract.RequireNotNull(owner);
 
             Owner = owner;
         }

--- a/src/Avalonia.Controls/Generators/ItemContainerGenerator`1.cs
+++ b/src/Avalonia.Controls/Generators/ItemContainerGenerator`1.cs
@@ -25,8 +25,8 @@ namespace Avalonia.Controls.Generators
             AvaloniaProperty contentTemplateProperty)
             : base(owner)
         {
-            Contract.Requires<ArgumentNullException>(owner != null);
-            Contract.Requires<ArgumentNullException>(contentProperty != null);
+            Contract.RequireNotNull(owner);
+            Contract.RequireNotNull(contentProperty);
 
             ContentProperty = contentProperty;
             ContentTemplateProperty = contentTemplateProperty;

--- a/src/Avalonia.Controls/Generators/TreeItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/TreeItemContainerGenerator.cs
@@ -33,11 +33,11 @@ namespace Avalonia.Controls.Generators
             TreeContainerIndex index)
             : base(owner, contentProperty, contentTemplateProperty)
         {
-            Contract.Requires<ArgumentNullException>(owner != null);
-            Contract.Requires<ArgumentNullException>(contentProperty != null);
-            Contract.Requires<ArgumentNullException>(itemsProperty != null);
-            Contract.Requires<ArgumentNullException>(isExpandedProperty != null);
-            Contract.Requires<ArgumentNullException>(index != null);
+            Contract.RequireNotNull(owner);
+            Contract.RequireNotNull(contentProperty);
+            Contract.RequireNotNull(itemsProperty);
+            Contract.RequireNotNull(isExpandedProperty);
+            Contract.RequireNotNull(index);
 
             ItemsProperty = itemsProperty;
             IsExpandedProperty = isExpandedProperty;

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -48,7 +48,7 @@ namespace Avalonia.Controls
         /// <param name="value">Column property value.</param>
         public static void SetColumn(Control element, int value)
         {
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(element);
             element.SetValue(ColumnProperty, value);
         }
 
@@ -59,7 +59,7 @@ namespace Avalonia.Controls
         /// <returns>Column property value.</returns>
         public static int GetColumn(Control element)
         {
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(element);
             return element.GetValue(ColumnProperty);
         }
 
@@ -70,7 +70,7 @@ namespace Avalonia.Controls
         /// <param name="value">Row property value.</param>
         public static void SetRow(Control element, int value)
         {
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(element);
             element.SetValue(RowProperty, value);
         }
 
@@ -81,7 +81,7 @@ namespace Avalonia.Controls
         /// <returns>Row property value.</returns>
         public static int GetRow(Control element)
         {
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(element);
             return element.GetValue(RowProperty);
         }
 
@@ -92,7 +92,7 @@ namespace Avalonia.Controls
         /// <param name="value">ColumnSpan property value.</param>
         public static void SetColumnSpan(Control element, int value)
         {
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(element);
             element.SetValue(ColumnSpanProperty, value);
         }
 
@@ -103,7 +103,7 @@ namespace Avalonia.Controls
         /// <returns>ColumnSpan property value.</returns>
         public static int GetColumnSpan(Control element)
         {
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(element);
             return element.GetValue(ColumnSpanProperty);
         }
 
@@ -114,7 +114,7 @@ namespace Avalonia.Controls
         /// <param name="value">RowSpan property value.</param>
         public static void SetRowSpan(Control element, int value)
         {
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(element);
             element.SetValue(RowSpanProperty, value);
         }
 
@@ -125,7 +125,7 @@ namespace Avalonia.Controls
         /// <returns>RowSpan property value.</returns>
         public static int GetRowSpan(Control element)
         {
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(element);
             return element.GetValue(RowSpanProperty);
         }
 
@@ -136,7 +136,7 @@ namespace Avalonia.Controls
         /// <param name="value">IsSharedSizeScope property value.</param>
         public static void SetIsSharedSizeScope(Control element, bool value)
         {
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(element);
             element.SetValue(IsSharedSizeScopeProperty, value);
         }
 
@@ -147,7 +147,7 @@ namespace Avalonia.Controls
         /// <returns>IsSharedSizeScope property value.</returns>
         public static bool GetIsSharedSizeScope(Control element)
         {
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(element);
             return element.GetValue(IsSharedSizeScopeProperty);
         }
 

--- a/src/Avalonia.Controls/MenuBase.cs
+++ b/src/Avalonia.Controls/MenuBase.cs
@@ -54,7 +54,7 @@ namespace Avalonia.Controls
         /// <param name="interactionHandler">The menu interaction handler.</param>
         public MenuBase(IMenuInteractionHandler interactionHandler)
         {
-            Contract.Requires<ArgumentNullException>(interactionHandler != null);
+            Contract.RequireNotNull(interactionHandler);
 
             InteractionHandler = interactionHandler;
         }

--- a/src/Avalonia.Controls/MenuItemAccessKeyHandler.cs
+++ b/src/Avalonia.Controls/MenuItemAccessKeyHandler.cs
@@ -41,7 +41,7 @@ namespace Avalonia.Controls
         /// </remarks>
         public void SetOwner(IInputRoot owner)
         {
-            Contract.Requires<ArgumentNullException>(owner != null);
+            Contract.RequireNotNull(owner);
 
             if (_owner != null)
             {

--- a/src/Avalonia.Controls/Mixins/SelectableMixin.cs
+++ b/src/Avalonia.Controls/Mixins/SelectableMixin.cs
@@ -43,7 +43,7 @@ namespace Avalonia.Controls.Mixins
         public static void Attach<TControl>(AvaloniaProperty<bool> isSelected)
             where TControl : class, IControl
         {
-            Contract.Requires<ArgumentNullException>(isSelected != null);
+            Contract.RequireNotNull(isSelected);
 
             isSelected.Changed.Subscribe(x =>
             {

--- a/src/Avalonia.Controls/Repeater/ItemsSourceView.cs
+++ b/src/Avalonia.Controls/Repeater/ItemsSourceView.cs
@@ -33,7 +33,7 @@ namespace Avalonia.Controls
         /// <param name="source">The data source.</param>
         public ItemsSourceView(IEnumerable source)
         {
-            Contract.Requires<ArgumentNullException>(source != null);
+            Contract.RequireNotNull(source);
 
             if (source is IList list)
             {

--- a/src/Avalonia.Controls/Templates/FuncDataTemplate.cs
+++ b/src/Avalonia.Controls/Templates/FuncDataTemplate.cs
@@ -71,7 +71,7 @@ namespace Avalonia.Controls.Templates
             bool supportsRecycling = false)
             : base(build)
         {
-            Contract.Requires<ArgumentNullException>(match != null);
+            Contract.RequireNotNull(match);
 
             _match = match;
             SupportsRecycling = supportsRecycling;

--- a/src/Avalonia.Controls/Templates/FuncTemplate`1.cs
+++ b/src/Avalonia.Controls/Templates/FuncTemplate`1.cs
@@ -20,7 +20,7 @@ namespace Avalonia.Controls.Templates
         /// <param name="func">The function used to create the control.</param>
         public FuncTemplate(Func<TControl> func)
         {
-            Contract.Requires<ArgumentNullException>(func != null);
+            Contract.RequireNotNull(func);
 
             _func = func;
         }

--- a/src/Avalonia.Controls/Templates/FuncTemplate`2.cs
+++ b/src/Avalonia.Controls/Templates/FuncTemplate`2.cs
@@ -21,7 +21,7 @@ namespace Avalonia.Controls.Templates
         /// <param name="func">The function used to create the control.</param>
         public FuncTemplate(Func<TParam, INameScope, TControl> func)
         {
-            Contract.Requires<ArgumentNullException>(func != null);
+            Contract.RequireNotNull(func);
 
             _func = func;
         }

--- a/src/Avalonia.Controls/Utils/IEnumerableUtils.cs
+++ b/src/Avalonia.Controls/Utils/IEnumerableUtils.cs
@@ -37,7 +37,7 @@ namespace Avalonia.Controls.Utils
 
         public static int IndexOf(this IEnumerable items, object item)
         {
-            Contract.Requires<ArgumentNullException>(items != null);
+            Contract.RequireNotNull(items);
 
             var list = items as IList;
 
@@ -65,7 +65,7 @@ namespace Avalonia.Controls.Utils
 
         public static object ElementAt(this IEnumerable items, int index)
         {
-            Contract.Requires<ArgumentNullException>(items != null);
+            Contract.RequireNotNull(items);
 
             var list = items as IList;
 

--- a/src/Avalonia.Diagnostics/Models/EventChainLink.cs
+++ b/src/Avalonia.Diagnostics/Models/EventChainLink.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Diagnostics.Models
     {
         public EventChainLink(object handler, bool handled, RoutingStrategies route)
         {
-            Contract.Requires<ArgumentNullException>(handler != null);
+            Contract.RequireNotNull(handler);
 
             Handler = handler;
             Handled = handled;

--- a/src/Avalonia.Diagnostics/ViewModels/EventTreeNode.cs
+++ b/src/Avalonia.Diagnostics/ViewModels/EventTreeNode.cs
@@ -19,8 +19,8 @@ namespace Avalonia.Diagnostics.ViewModels
         public EventTreeNode(EventOwnerTreeNode parent, RoutedEvent @event, EventsViewModel vm)
             : base(parent, @event.Name)
         {
-            Contract.Requires<ArgumentNullException>(@event != null);
-            Contract.Requires<ArgumentNullException>(vm != null);
+            Contract.RequireNotNull(@event);
+            Contract.RequireNotNull(vm);
 
             _event = @event;
             _parentViewModel = vm;

--- a/src/Avalonia.Diagnostics/ViewModels/FiredEvent.cs
+++ b/src/Avalonia.Diagnostics/ViewModels/FiredEvent.cs
@@ -15,8 +15,8 @@ namespace Avalonia.Diagnostics.ViewModels
 
         public FiredEvent(RoutedEventArgs eventArgs, EventChainLink originator)
         {
-            Contract.Requires<ArgumentNullException>(eventArgs != null);
-            Contract.Requires<ArgumentNullException>(originator != null);
+            Contract.RequireNotNull(eventArgs);
+            Contract.RequireNotNull(originator);
 
             _eventArgs = eventArgs;
             Originator = originator;

--- a/src/Avalonia.Diagnostics/Views/PropertyChangedExtensions.cs
+++ b/src/Avalonia.Diagnostics/Views/PropertyChangedExtensions.cs
@@ -12,8 +12,8 @@ namespace Avalonia.Diagnostics.Views
     {
         public static IObservable<T> GetObservable<T>(this INotifyPropertyChanged source, string propertyName)
         {
-            Contract.Requires<ArgumentNullException>(source != null);
-            Contract.Requires<ArgumentNullException>(propertyName != null);
+            Contract.RequireNotNull(source);
+            Contract.RequireNotNull(propertyName);
 
             var property = source.GetType().GetTypeInfo().GetDeclaredProperty(propertyName);
 

--- a/src/Avalonia.FreeDesktop/LinuxMountedVolumeInfoProvider.cs
+++ b/src/Avalonia.FreeDesktop/LinuxMountedVolumeInfoProvider.cs
@@ -9,7 +9,7 @@ namespace Avalonia.FreeDesktop
     {
         public IDisposable Listen(ObservableCollection<MountedVolumeInfo> mountedDrives)
         {
-            Contract.Requires<ArgumentNullException>(mountedDrives != null);
+            Contract.RequireNotNull(mountedDrives);
             return new LinuxMountedVolumeInfoListener(ref mountedDrives);
         }
     }

--- a/src/Avalonia.Input/AccessKeyHandler.cs
+++ b/src/Avalonia.Input/AccessKeyHandler.cs
@@ -89,7 +89,7 @@ namespace Avalonia.Input
         /// </remarks>
         public void SetOwner(IInputRoot owner)
         {
-            Contract.Requires<ArgumentNullException>(owner != null);
+            Contract.RequireNotNull(owner);
 
             if (_owner != null)
             {

--- a/src/Avalonia.Input/FocusManager.cs
+++ b/src/Avalonia.Input/FocusManager.cs
@@ -108,7 +108,7 @@ namespace Avalonia.Input
             NavigationMethod method = NavigationMethod.Unspecified,
             InputModifiers modifiers = InputModifiers.None)
         {
-            Contract.Requires<ArgumentNullException>(scope != null);
+            Contract.RequireNotNull(scope);
 
             _focusScopes[scope] = element;
 
@@ -124,7 +124,7 @@ namespace Avalonia.Input
         /// <param name="scope">The new focus scope.</param>
         public void SetFocusScope(IFocusScope scope)
         {
-            Contract.Requires<ArgumentNullException>(scope != null);
+            Contract.RequireNotNull(scope);
 
             IInputElement e;
 

--- a/src/Avalonia.Input/InputExtensions.cs
+++ b/src/Avalonia.Input/InputExtensions.cs
@@ -25,7 +25,7 @@ namespace Avalonia.Input
         /// </returns>
         public static IEnumerable<IInputElement> GetInputElementsAt(this IInputElement element, Point p)
         {
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(element);
 
             return element.GetVisualsAt(p, s_hitTestDelegate).Cast<IInputElement>();
         }

--- a/src/Avalonia.Input/KeyboardNavigationHandler.cs
+++ b/src/Avalonia.Input/KeyboardNavigationHandler.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Input
         /// </remarks>
         public void SetOwner(IInputRoot owner)
         {
-            Contract.Requires<ArgumentNullException>(owner != null);
+            Contract.RequireNotNull(owner);
 
             if (_owner != null)
             {
@@ -52,7 +52,7 @@ namespace Avalonia.Input
             IInputElement element,
             NavigationDirection direction)
         {
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(element);
 
             var customHandler = element.GetSelfAndVisualAncestors()
                 .OfType<ICustomKeyboardNavigation>()
@@ -100,7 +100,7 @@ namespace Avalonia.Input
             NavigationDirection direction,
             InputModifiers modifiers = InputModifiers.None)
         {
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(element);
 
             var next = GetNext(element, direction);
 

--- a/src/Avalonia.Input/MouseDevice.cs
+++ b/src/Avalonia.Input/MouseDevice.cs
@@ -68,7 +68,7 @@ namespace Avalonia.Input
         /// <returns>The mouse position in the control's coordinates.</returns>
         public Point GetPosition(IVisual relativeTo)
         {
-            Contract.Requires<ArgumentNullException>(relativeTo != null);
+            Contract.RequireNotNull(relativeTo);
 
             if (relativeTo.VisualRoot == null)
             {
@@ -124,7 +124,7 @@ namespace Avalonia.Input
         
         private void ProcessRawEvent(RawPointerEventArgs e)
         {
-            Contract.Requires<ArgumentNullException>(e != null);
+            Contract.RequireNotNull(e);
 
             var mouse = (IMouseDevice)e.Device;
 
@@ -165,8 +165,8 @@ namespace Avalonia.Input
         private void LeaveWindow(IMouseDevice device, ulong timestamp, IInputRoot root, PointerPointProperties properties,
             KeyModifiers inputModifiers)
         {
-            Contract.Requires<ArgumentNullException>(device != null);
-            Contract.Requires<ArgumentNullException>(root != null);
+            Contract.RequireNotNull(device);
+            Contract.RequireNotNull(root);
 
             ClearPointerOver(this, timestamp, root, properties, inputModifiers);
         }
@@ -198,8 +198,8 @@ namespace Avalonia.Input
             PointerPointProperties properties,
             KeyModifiers inputModifiers)
         {
-            Contract.Requires<ArgumentNullException>(device != null);
-            Contract.Requires<ArgumentNullException>(root != null);
+            Contract.RequireNotNull(device);
+            Contract.RequireNotNull(root);
 
             var hit = HitTest(root, p);
 
@@ -234,8 +234,8 @@ namespace Avalonia.Input
         private bool MouseMove(IMouseDevice device, ulong timestamp, IInputRoot root, Point p, PointerPointProperties properties,
             KeyModifiers inputModifiers)
         {
-            Contract.Requires<ArgumentNullException>(device != null);
-            Contract.Requires<ArgumentNullException>(root != null);
+            Contract.RequireNotNull(device);
+            Contract.RequireNotNull(root);
 
             IInputElement source;
 
@@ -259,8 +259,8 @@ namespace Avalonia.Input
         private bool MouseUp(IMouseDevice device, ulong timestamp, IInputRoot root, Point p, PointerPointProperties props,
             KeyModifiers inputModifiers)
         {
-            Contract.Requires<ArgumentNullException>(device != null);
-            Contract.Requires<ArgumentNullException>(root != null);
+            Contract.RequireNotNull(device);
+            Contract.RequireNotNull(root);
 
             var hit = HitTest(root, p);
 
@@ -281,8 +281,8 @@ namespace Avalonia.Input
             PointerPointProperties props,
             Vector delta, KeyModifiers inputModifiers)
         {
-            Contract.Requires<ArgumentNullException>(device != null);
-            Contract.Requires<ArgumentNullException>(root != null);
+            Contract.RequireNotNull(device);
+            Contract.RequireNotNull(root);
 
             var hit = HitTest(root, p);
 
@@ -300,7 +300,7 @@ namespace Avalonia.Input
 
         private IInteractive GetSource(IVisual hit)
         {
-            Contract.Requires<ArgumentNullException>(hit != null);
+            Contract.RequireNotNull(hit);
 
             return _pointer.Captured ??
                 (hit as IInteractive) ??
@@ -309,7 +309,7 @@ namespace Avalonia.Input
 
         private IInputElement HitTest(IInputElement root, Point p)
         {
-            Contract.Requires<ArgumentNullException>(root != null);
+            Contract.RequireNotNull(root);
 
             return _pointer.Captured ?? root.InputHitTest(p);
         }
@@ -326,8 +326,8 @@ namespace Avalonia.Input
             PointerPointProperties properties,
             KeyModifiers inputModifiers)
         {
-            Contract.Requires<ArgumentNullException>(device != null);
-            Contract.Requires<ArgumentNullException>(root != null);
+            Contract.RequireNotNull(device);
+            Contract.RequireNotNull(root);
 
             var element = root.PointerOverElement;
             var e = CreateSimpleEvent(InputElement.PointerLeaveEvent, timestamp, element, properties, inputModifiers);
@@ -371,8 +371,8 @@ namespace Avalonia.Input
             PointerPointProperties properties,
             KeyModifiers inputModifiers)
         {
-            Contract.Requires<ArgumentNullException>(device != null);
-            Contract.Requires<ArgumentNullException>(root != null);
+            Contract.RequireNotNull(device);
+            Contract.RequireNotNull(root);
 
             var element = root.InputHitTest(p);
 
@@ -395,9 +395,9 @@ namespace Avalonia.Input
             PointerPointProperties properties,
             KeyModifiers inputModifiers)
         {
-            Contract.Requires<ArgumentNullException>(device != null);
-            Contract.Requires<ArgumentNullException>(root != null);
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(device);
+            Contract.RequireNotNull(root);
+            Contract.RequireNotNull(element);
 
             IInputElement branch = null;
 

--- a/src/Avalonia.Input/Navigation/TabNavigation.cs
+++ b/src/Avalonia.Input/Navigation/TabNavigation.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Input.Navigation
             NavigationDirection direction,
             bool outsideElement = false)
         {
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(element);
             Contract.Requires<ArgumentException>(
                 direction == NavigationDirection.Next ||
                 direction == NavigationDirection.Previous);

--- a/src/Avalonia.Input/Raw/RawInputEventArgs.cs
+++ b/src/Avalonia.Input/Raw/RawInputEventArgs.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Input.Raw
         /// <param name="timestamp">The event timestamp.</param>
         public RawInputEventArgs(IInputDevice device, ulong timestamp)
         {
-            Contract.Requires<ArgumentNullException>(device != null);
+            Contract.RequireNotNull(device);
 
             Device = device;
             Timestamp = timestamp;

--- a/src/Avalonia.Input/Raw/RawPointerEventArgs.cs
+++ b/src/Avalonia.Input/Raw/RawPointerEventArgs.cs
@@ -46,8 +46,8 @@ namespace Avalonia.Input.Raw
             RawInputModifiers inputModifiers)
             : base(device, timestamp)
         {
-            Contract.Requires<ArgumentNullException>(device != null);
-            Contract.Requires<ArgumentNullException>(root != null);
+            Contract.RequireNotNull(device);
+            Contract.RequireNotNull(root);
 
             Root = root;
             Position = position;

--- a/src/Avalonia.Interactivity/Interactive.cs
+++ b/src/Avalonia.Interactivity/Interactive.cs
@@ -39,8 +39,8 @@ namespace Avalonia.Interactivity
             RoutingStrategies routes = RoutingStrategies.Direct | RoutingStrategies.Bubble,
             bool handledEventsToo = false)
         {
-            Contract.Requires<ArgumentNullException>(routedEvent != null);
-            Contract.Requires<ArgumentNullException>(handler != null);
+            Contract.RequireNotNull(routedEvent);
+            Contract.RequireNotNull(handler);
 
             var subscription = new EventSubscription
             {
@@ -67,8 +67,8 @@ namespace Avalonia.Interactivity
             RoutingStrategies routes = RoutingStrategies.Direct | RoutingStrategies.Bubble,
             bool handledEventsToo = false) where TEventArgs : RoutedEventArgs
         {
-            Contract.Requires<ArgumentNullException>(routedEvent != null);
-            Contract.Requires<ArgumentNullException>(handler != null);
+            Contract.RequireNotNull(routedEvent);
+            Contract.RequireNotNull(handler);
 
             // EventHandler delegate is not covariant, this forces us to create small wrapper
             // that will cast our type erased instance and invoke it.
@@ -107,8 +107,8 @@ namespace Avalonia.Interactivity
         /// <param name="handler">The handler.</param>
         public void RemoveHandler(RoutedEvent routedEvent, Delegate handler)
         {
-            Contract.Requires<ArgumentNullException>(routedEvent != null);
-            Contract.Requires<ArgumentNullException>(handler != null);
+            Contract.RequireNotNull(routedEvent);
+            Contract.RequireNotNull(handler);
 
             List<EventSubscription> subscriptions = null;
 
@@ -136,7 +136,7 @@ namespace Avalonia.Interactivity
         /// <param name="e">The event args.</param>
         public void RaiseEvent(RoutedEventArgs e)
         {
-            Contract.Requires<ArgumentNullException>(e != null);
+            Contract.RequireNotNull(e);
 
             e.Source = e.Source ?? this;
 
@@ -166,7 +166,7 @@ namespace Avalonia.Interactivity
         /// <param name="e">The event args.</param>
         private void BubbleEvent(RoutedEventArgs e)
         {
-            Contract.Requires<ArgumentNullException>(e != null);
+            Contract.RequireNotNull(e);
 
             e.Route = RoutingStrategies.Bubble;
 
@@ -182,7 +182,7 @@ namespace Avalonia.Interactivity
         /// <param name="e">The event args.</param>
         private void TunnelEvent(RoutedEventArgs e)
         {
-            Contract.Requires<ArgumentNullException>(e != null);
+            Contract.RequireNotNull(e);
 
             e.Route = RoutingStrategies.Tunnel;
 
@@ -198,7 +198,7 @@ namespace Avalonia.Interactivity
         /// <param name="e">The event args.</param>
         private void RaiseEventImpl(RoutedEventArgs e)
         {
-            Contract.Requires<ArgumentNullException>(e != null);
+            Contract.RequireNotNull(e);
 
             e.RoutedEvent.InvokeRaised(this, e);
 

--- a/src/Avalonia.Interactivity/RoutedEvent.cs
+++ b/src/Avalonia.Interactivity/RoutedEvent.cs
@@ -26,9 +26,9 @@ namespace Avalonia.Interactivity
             Type eventArgsType,
             Type ownerType)
         {
-            Contract.Requires<ArgumentNullException>(name != null);
-            Contract.Requires<ArgumentNullException>(eventArgsType != null);
-            Contract.Requires<ArgumentNullException>(ownerType != null);
+            Contract.RequireNotNull(name);
+            Contract.RequireNotNull(eventArgsType);
+            Contract.RequireNotNull(ownerType);
             Contract.Requires<InvalidCastException>(typeof(RoutedEventArgs).GetTypeInfo().IsAssignableFrom(eventArgsType.GetTypeInfo()));
 
             EventArgsType = eventArgsType;
@@ -53,7 +53,7 @@ namespace Avalonia.Interactivity
             RoutingStrategies routingStrategy)
                 where TEventArgs : RoutedEventArgs
         {
-            Contract.Requires<ArgumentNullException>(name != null);
+            Contract.RequireNotNull(name);
 
             var routedEvent = new RoutedEvent<TEventArgs>(name, routingStrategy, typeof(TOwner));
             RoutedEventRegistry.Instance.Register(typeof(TOwner), routedEvent);
@@ -66,7 +66,7 @@ namespace Avalonia.Interactivity
             Type ownerType)
                 where TEventArgs : RoutedEventArgs
         {
-            Contract.Requires<ArgumentNullException>(name != null);
+            Contract.RequireNotNull(name);
 
             var routedEvent = new RoutedEvent<TEventArgs>(name, routingStrategy, ownerType);
             RoutedEventRegistry.Instance.Register(ownerType, routedEvent);
@@ -109,8 +109,8 @@ namespace Avalonia.Interactivity
         public RoutedEvent(string name, RoutingStrategies routingStrategies, Type ownerType)
             : base(name, routingStrategies, typeof(TEventArgs), ownerType)
         {
-            Contract.Requires<ArgumentNullException>(name != null);
-            Contract.Requires<ArgumentNullException>(ownerType != null);
+            Contract.RequireNotNull(name);
+            Contract.RequireNotNull(ownerType);
         }
 
         public IDisposable AddClassHandler<TTarget>(

--- a/src/Avalonia.Interactivity/RoutedEventRegistry.cs
+++ b/src/Avalonia.Interactivity/RoutedEventRegistry.cs
@@ -32,8 +32,8 @@ namespace Avalonia.Interactivity
         /// </remarks>
         public void Register(Type type, RoutedEvent @event)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
-            Contract.Requires<ArgumentNullException>(@event != null);
+            Contract.RequireNotNull(type);
+            Contract.RequireNotNull(@event);
 
             if (!_registeredRoutedEvents.TryGetValue(type, out var list))
             {
@@ -66,7 +66,7 @@ namespace Avalonia.Interactivity
         /// <returns>All routed events registered with the provided type.</returns>
         public IReadOnlyList<RoutedEvent> GetRegistered(Type type)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
+            Contract.RequireNotNull(type);
 
             if (_registeredRoutedEvents.TryGetValue(type, out var events))
             {

--- a/src/Avalonia.Layout/LayoutManager.cs
+++ b/src/Avalonia.Layout/LayoutManager.cs
@@ -20,7 +20,7 @@ namespace Avalonia.Layout
         /// <inheritdoc/>
         public void InvalidateMeasure(ILayoutable control)
         {
-            Contract.Requires<ArgumentNullException>(control != null);
+            Contract.RequireNotNull(control);
             Dispatcher.UIThread.VerifyAccess();
 
             if (!control.IsAttachedToVisualTree)
@@ -41,7 +41,7 @@ namespace Avalonia.Layout
         /// <inheritdoc/>
         public void InvalidateArrange(ILayoutable control)
         {
-            Contract.Requires<ArgumentNullException>(control != null);
+            Contract.RequireNotNull(control);
             Dispatcher.UIThread.VerifyAccess();
 
             if (!control.IsAttachedToVisualTree)

--- a/src/Avalonia.Logging.Serilog/SerilogLogger.cs
+++ b/src/Avalonia.Logging.Serilog/SerilogLogger.cs
@@ -42,8 +42,8 @@ namespace Avalonia.Logging.Serilog
             string messageTemplate,
             params object[] propertyValues)
         {
-            Contract.Requires<ArgumentNullException>(area != null);
-            Contract.Requires<ArgumentNullException>(messageTemplate != null);
+            Contract.RequireNotNull(area);
+            Contract.RequireNotNull(messageTemplate);
 
             using (LogContext.PushProperty("Area", area))
             using (LogContext.PushProperty("SourceType", source?.GetType()))

--- a/src/Avalonia.Native/MacOSMountedVolumeInfoProvider.cs
+++ b/src/Avalonia.Native/MacOSMountedVolumeInfoProvider.cs
@@ -72,7 +72,7 @@ namespace Avalonia.Native
     {
         public IDisposable Listen(ObservableCollection<MountedVolumeInfo> mountedDrives)
         {
-            Contract.Requires<ArgumentNullException>(mountedDrives != null);
+            Contract.RequireNotNull(mountedDrives);
             return new MacOSMountedVolumeInfoListener(mountedDrives);
         }
     }

--- a/src/Avalonia.Styling/Controls/NameScope.cs
+++ b/src/Avalonia.Styling/Controls/NameScope.cs
@@ -35,7 +35,7 @@ namespace Avalonia.Controls
         /// <returns>The value of the NameScope attached property.</returns>
         public static INameScope GetNameScope(StyledElement styled)
         {
-            Contract.Requires<ArgumentNullException>(styled != null);
+            Contract.RequireNotNull(styled);
 
             return styled.GetValue(NameScopeProperty);
         }
@@ -47,7 +47,7 @@ namespace Avalonia.Controls
         /// <param name="value">The value to set.</param>
         public static void SetNameScope(StyledElement styled, INameScope value)
         {
-            Contract.Requires<ArgumentNullException>(styled != null);
+            Contract.RequireNotNull(styled);
 
             styled.SetValue(NameScopeProperty, value);
         }
@@ -57,8 +57,8 @@ namespace Avalonia.Controls
         {
             if (IsCompleted)
                 throw new InvalidOperationException("NameScope is completed, no further registrations are allowed");
-            Contract.Requires<ArgumentNullException>(name != null);
-            Contract.Requires<ArgumentNullException>(element != null);
+            Contract.RequireNotNull(name);
+            Contract.RequireNotNull(element);
 
             object existing;
 
@@ -97,7 +97,7 @@ namespace Avalonia.Controls
         /// <inheritdoc />
         public object Find(string name)
         {
-            Contract.Requires<ArgumentNullException>(name != null);
+            Contract.RequireNotNull(name);
 
             object result;
             _inner.TryGetValue(name, out result);

--- a/src/Avalonia.Styling/Controls/NameScopeExtensions.cs
+++ b/src/Avalonia.Styling/Controls/NameScopeExtensions.cs
@@ -23,8 +23,8 @@ namespace Avalonia.Controls
         public static T Find<T>(this INameScope nameScope, string name)
             where T : class
         {
-            Contract.Requires<ArgumentNullException>(nameScope != null);
-            Contract.Requires<ArgumentNullException>(name != null);
+            Contract.RequireNotNull(nameScope);
+            Contract.RequireNotNull(name);
 
             var result = nameScope.Find(name);
 
@@ -47,8 +47,8 @@ namespace Avalonia.Controls
         public static T Find<T>(this ILogical anchor, string name)
             where T : class
         {
-            Contract.Requires<ArgumentNullException>(anchor != null);
-            Contract.Requires<ArgumentNullException>(name != null);
+            Contract.RequireNotNull(anchor);
+            Contract.RequireNotNull(name);
             var styledAnchor = anchor as StyledElement;
             if (styledAnchor == null)
                 return null;
@@ -67,8 +67,8 @@ namespace Avalonia.Controls
         public static T Get<T>(this INameScope nameScope, string name)
             where T : class
         {
-            Contract.Requires<ArgumentNullException>(nameScope != null);
-            Contract.Requires<ArgumentNullException>(name != null);
+            Contract.RequireNotNull(nameScope);
+            Contract.RequireNotNull(name);
 
             var result = nameScope.Find(name);
 
@@ -97,8 +97,8 @@ namespace Avalonia.Controls
         public static T Get<T>(this ILogical anchor, string name)
             where T : class
         {
-            Contract.Requires<ArgumentNullException>(anchor != null);
-            Contract.Requires<ArgumentNullException>(name != null);
+            Contract.RequireNotNull(anchor);
+            Contract.RequireNotNull(name);
                
             var nameScope = (anchor as INameScope) ?? NameScope.GetNameScope((StyledElement)anchor);
             if (nameScope == null)
@@ -110,7 +110,7 @@ namespace Avalonia.Controls
         
         public static INameScope FindNameScope(this ILogical control)
         {
-            Contract.Requires<ArgumentNullException>(control != null);
+            Contract.RequireNotNull(control);
 
             var scope = control.GetSelfAndLogicalAncestors()
                 .OfType<StyledElement>()

--- a/src/Avalonia.Styling/Controls/ResourceProviderExtensions.cs
+++ b/src/Avalonia.Styling/Controls/ResourceProviderExtensions.cs
@@ -30,8 +30,8 @@ namespace Avalonia.Controls
         /// <returns>True if the resource was found; otherwise false.</returns>
         public static bool TryFindResource(this IResourceNode control, object key, out object value)
         {
-            Contract.Requires<ArgumentNullException>(control != null);
-            Contract.Requires<ArgumentNullException>(key != null);
+            Contract.RequireNotNull(control);
+            Contract.RequireNotNull(key);
 
             var current = control;
 

--- a/src/Avalonia.Styling/LogicalTree/LogicalExtensions.cs
+++ b/src/Avalonia.Styling/LogicalTree/LogicalExtensions.cs
@@ -11,7 +11,7 @@ namespace Avalonia.LogicalTree
     {
         public static IEnumerable<ILogical> GetLogicalAncestors(this ILogical logical)
         {
-            Contract.Requires<ArgumentNullException>(logical != null);
+            Contract.RequireNotNull(logical);
 
             logical = logical.LogicalParent;
 

--- a/src/Avalonia.Styling/LogicalTree/LogicalTreeAttachmentEventArgs.cs
+++ b/src/Avalonia.Styling/LogicalTree/LogicalTreeAttachmentEventArgs.cs
@@ -18,7 +18,7 @@ namespace Avalonia.LogicalTree
         /// <param name="root">The root of the logical tree.</param>
         public LogicalTreeAttachmentEventArgs(IStyleHost root)
         {
-            Contract.Requires<ArgumentNullException>(root != null);
+            Contract.RequireNotNull(root);
 
             Root = root;
         }

--- a/src/Avalonia.Styling/StyledElement.cs
+++ b/src/Avalonia.Styling/StyledElement.cs
@@ -217,7 +217,7 @@ namespace Avalonia
             get { return _styles ?? (Styles = new Styles()); }
             set
             {
-                Contract.Requires<ArgumentNullException>(value != null);
+                Contract.RequireNotNull(value);
 
                 if (_styles != value)
                 {
@@ -247,7 +247,7 @@ namespace Avalonia
             get => _resources ?? (Resources = new ResourceDictionary());
             set
             {
-                Contract.Requires<ArgumentNullException>(value != null);
+                Contract.RequireNotNull(value);
 
                 var hadResources = false;
 
@@ -544,9 +544,9 @@ namespace Avalonia
             string className)
                 where TOwner : class, IStyledElement
         {
-            Contract.Requires<ArgumentNullException>(property != null);
-            Contract.Requires<ArgumentNullException>(selector != null);
-            Contract.Requires<ArgumentNullException>(className != null);
+            Contract.RequireNotNull(property);
+            Contract.RequireNotNull(selector);
+            Contract.RequireNotNull(className);
 
             if (string.IsNullOrWhiteSpace(className))
             {

--- a/src/Avalonia.Styling/Styling/ActivatedObservable.cs
+++ b/src/Avalonia.Styling/Styling/ActivatedObservable.cs
@@ -31,7 +31,7 @@ namespace Avalonia.Styling
             string description)
             : base(activator, AvaloniaProperty.UnsetValue, description)
         {
-            Contract.Requires<ArgumentNullException>(source != null);
+            Contract.RequireNotNull(source);
 
             Source = source;
         }

--- a/src/Avalonia.Styling/Styling/ActivatedValue.cs
+++ b/src/Avalonia.Styling/Styling/ActivatedValue.cs
@@ -33,7 +33,7 @@ namespace Avalonia.Styling
             object value,
             string description)
         {
-            Contract.Requires<ArgumentNullException>(activator != null);
+            Contract.RequireNotNull(activator);
 
             Activator = activator;
             Value = value;

--- a/src/Avalonia.Styling/Styling/OrSelector.cs
+++ b/src/Avalonia.Styling/Styling/OrSelector.cs
@@ -21,7 +21,7 @@ namespace Avalonia.Styling
         /// <param name="selectors">The selectors to OR.</param>
         public OrSelector(IReadOnlyList<Selector> selectors)
         {
-            Contract.Requires<ArgumentNullException>(selectors != null);
+            Contract.RequireNotNull(selectors);
             Contract.Requires<ArgumentException>(selectors.Count > 1);
 
             _selectors = selectors;

--- a/src/Avalonia.Styling/Styling/PropertyEqualsSelector.cs
+++ b/src/Avalonia.Styling/Styling/PropertyEqualsSelector.cs
@@ -20,7 +20,7 @@ namespace Avalonia.Styling
 
         public PropertyEqualsSelector(Selector previous, AvaloniaProperty property, object value)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
+            Contract.RequireNotNull(property);
 
             _previous = previous;
             _property = property;

--- a/src/Avalonia.Styling/Styling/SelectorMatch.cs
+++ b/src/Avalonia.Styling/Styling/SelectorMatch.cs
@@ -72,7 +72,7 @@ namespace Avalonia.Styling
         /// <param name="match">The match activator.</param>
         public SelectorMatch(IObservable<bool> match)
         {
-            Contract.Requires<ArgumentNullException>(match != null);
+            Contract.RequireNotNull(match);
 
             Result = SelectorMatchResult.Sometimes;
             Activator = match;

--- a/src/Avalonia.Styling/Styling/Selectors.cs
+++ b/src/Avalonia.Styling/Styling/Selectors.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Styling
         /// <returns>The selector.</returns>
         public static Selector Class(this Selector previous, string name)
         {
-            Contract.Requires<ArgumentNullException>(name != null);
+            Contract.RequireNotNull(name);
             Contract.Requires<ArgumentException>(!string.IsNullOrWhiteSpace(name));
 
             var tac = previous as TypeNameAndClassSelector;
@@ -64,7 +64,7 @@ namespace Avalonia.Styling
         /// <returns>The selector.</returns>
         public static Selector Is(this Selector previous, Type type)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
+            Contract.RequireNotNull(type);
 
             return TypeNameAndClassSelector.Is(previous, type);
         }
@@ -88,7 +88,7 @@ namespace Avalonia.Styling
         /// <returns>The selector.</returns>
         public static Selector Name(this Selector previous, string name)
         {
-            Contract.Requires<ArgumentNullException>(name != null);
+            Contract.RequireNotNull(name);
             Contract.Requires<ArgumentException>(!string.IsNullOrWhiteSpace(name));
 
             var tac = previous as TypeNameAndClassSelector;
@@ -134,7 +134,7 @@ namespace Avalonia.Styling
         /// <returns>The selector.</returns>
         public static Selector OfType(this Selector previous, Type type)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
+            Contract.RequireNotNull(type);
 
             return TypeNameAndClassSelector.OfType(previous, type);
         }
@@ -180,7 +180,7 @@ namespace Avalonia.Styling
         /// <returns>The selector.</returns>
         public static Selector PropertyEquals<T>(this Selector previous, AvaloniaProperty<T> property, object value)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
+            Contract.RequireNotNull(property);
 
             return new PropertyEqualsSelector(previous, property, value);
         }
@@ -194,7 +194,7 @@ namespace Avalonia.Styling
         /// <returns>The selector.</returns>
         public static Selector PropertyEquals(this Selector previous, AvaloniaProperty property, object value)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
+            Contract.RequireNotNull(property);
 
             return new PropertyEqualsSelector(previous, property, value);
         }

--- a/src/Avalonia.Styling/Styling/Setter.cs
+++ b/src/Avalonia.Styling/Styling/Setter.cs
@@ -78,7 +78,7 @@ namespace Avalonia.Styling
         /// <param name="activator">An optional activator.</param>
         public IDisposable Apply(IStyle style, IStyleable control, IObservable<bool> activator)
         {
-            Contract.Requires<ArgumentNullException>(control != null);
+            Contract.RequireNotNull(control);
 
             var description = style?.ToString();
 

--- a/src/Avalonia.Styling/Styling/Style.cs
+++ b/src/Avalonia.Styling/Styling/Style.cs
@@ -53,7 +53,7 @@ namespace Avalonia.Styling
             get => _resources ?? (Resources = new ResourceDictionary());
             set
             {
-                Contract.Requires<ArgumentNullException>(value != null);
+                Contract.RequireNotNull(value);
 
                 var hadResources = false;
 

--- a/src/Avalonia.Styling/Styling/Styler.cs
+++ b/src/Avalonia.Styling/Styling/Styler.cs
@@ -19,8 +19,8 @@ namespace Avalonia.Styling
 
         private void ApplyStyles(IStyleable control, IStyleHost styleHost)
         {
-            Contract.Requires<ArgumentNullException>(control != null);
-            Contract.Requires<ArgumentNullException>(styleHost != null);
+            Contract.RequireNotNull(control);
+            Contract.RequireNotNull(styleHost);
 
             var parentContainer = styleHost.StylingParent;
 

--- a/src/Avalonia.Styling/Styling/Styles.cs
+++ b/src/Avalonia.Styling/Styling/Styles.cs
@@ -83,7 +83,7 @@ namespace Avalonia.Styling
             get => _resources ?? (Resources = new ResourceDictionary());
             set
             {
-                Contract.Requires<ArgumentNullException>(value != null);
+                Contract.RequireNotNull(value);
 
                 var hadResources = false;
 

--- a/src/Avalonia.Visuals/Media/Brush.cs
+++ b/src/Avalonia.Visuals/Media/Brush.cs
@@ -38,7 +38,7 @@ namespace Avalonia.Media
         /// <returns>The <see cref="Color"/>.</returns>
         public static IBrush Parse(string s)
         {
-            Contract.Requires<ArgumentNullException>(s != null);
+            Contract.RequireNotNull(s);
             Contract.Requires<FormatException>(s.Length > 0);
 
             if (s[0] == '#')

--- a/src/Avalonia.Visuals/Media/BrushExtensions.cs
+++ b/src/Avalonia.Visuals/Media/BrushExtensions.cs
@@ -18,7 +18,7 @@ namespace Avalonia.Media
         /// </returns>
         public static IBrush ToImmutable(this IBrush brush)
         {
-            Contract.Requires<ArgumentNullException>(brush != null);
+            Contract.RequireNotNull(brush);
 
             return (brush as IMutableBrush)?.ToImmutable() ?? brush;
         }
@@ -33,7 +33,7 @@ namespace Avalonia.Media
         /// </returns>
         public static ImmutableDashStyle ToImmutable(this IDashStyle style)
         {
-            Contract.Requires<ArgumentNullException>(style != null);
+            Contract.RequireNotNull(style);
 
             return style as ImmutableDashStyle ?? ((DashStyle)style).ToImmutable();
         }
@@ -48,7 +48,7 @@ namespace Avalonia.Media
         /// </returns>
         public static ImmutablePen ToImmutable(this IPen pen)
         {
-            Contract.Requires<ArgumentNullException>(pen != null);
+            Contract.RequireNotNull(pen);
 
             return pen as ImmutablePen ?? ((Pen)pen).ToImmutable();
         }

--- a/src/Avalonia.Visuals/Media/DrawingContext.cs
+++ b/src/Avalonia.Visuals/Media/DrawingContext.cs
@@ -83,7 +83,7 @@ namespace Avalonia.Media
         /// <param name="bitmapInterpolationMode">The bitmap interpolation mode.</param>
         public void DrawImage(IBitmap source, double opacity, Rect sourceRect, Rect destRect, BitmapInterpolationMode bitmapInterpolationMode = default)
         {
-            Contract.Requires<ArgumentNullException>(source != null);
+            Contract.RequireNotNull(source);
 
             PlatformImpl.DrawImage(source.PlatformImpl, opacity, sourceRect, destRect, bitmapInterpolationMode);
         }
@@ -110,7 +110,7 @@ namespace Avalonia.Media
         /// <param name="geometry">The geometry.</param>
         public void DrawGeometry(IBrush brush, IPen pen, Geometry geometry)
         {
-            Contract.Requires<ArgumentNullException>(geometry != null);
+            Contract.RequireNotNull(geometry);
 
             if (brush != null || PenIsVisible(pen))
             {
@@ -146,7 +146,7 @@ namespace Avalonia.Media
         /// <param name="text">The text.</param>
         public void DrawText(IBrush foreground, Point origin, FormattedText text)
         {
-            Contract.Requires<ArgumentNullException>(text != null);
+            Contract.RequireNotNull(text);
 
             if (foreground != null)
             {
@@ -241,7 +241,7 @@ namespace Avalonia.Media
         /// <returns>A disposable used to undo the clip geometry.</returns>
         public PushedState PushGeometryClip(Geometry clip)
         {
-            Contract.Requires<ArgumentNullException>(clip != null);
+            Contract.RequireNotNull(clip);
             PlatformImpl.PushGeometryClip(clip.PlatformImpl);
             return new PushedState(this, PushedState.PushedStateType.GeometryClip);
         }

--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -53,7 +53,7 @@ namespace Avalonia.Rendering
             IDispatcher dispatcher = null,
             IDeferredRendererLock rendererLock = null)
         {
-            Contract.Requires<ArgumentNullException>(root != null);
+            Contract.RequireNotNull(root);
 
             _dispatcher = dispatcher ?? Dispatcher.UIThread;
             _root = root;
@@ -77,8 +77,8 @@ namespace Avalonia.Rendering
             IRenderTarget renderTarget,
             ISceneBuilder sceneBuilder = null)
         {
-            Contract.Requires<ArgumentNullException>(root != null);
-            Contract.Requires<ArgumentNullException>(renderTarget != null);
+            Contract.RequireNotNull(root);
+            Contract.RequireNotNull(renderTarget);
 
             _root = root;
             RenderTarget = renderTarget;

--- a/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Rendering
         /// <param name="root">The control to render.</param>
         public ImmediateRenderer(IVisual root)
         {
-            Contract.Requires<ArgumentNullException>(root != null);
+            Contract.RequireNotNull(root);
 
             _root = root;
             _renderRoot = root as IRenderRoot;
@@ -218,7 +218,7 @@ namespace Avalonia.Rendering
            Point p,
            Func<IVisual, bool> filter)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            Contract.RequireNotNull(visual);
 
             if (filter?.Invoke(visual) != false)
             {

--- a/src/Avalonia.Visuals/Rendering/RenderLoop.cs
+++ b/src/Avalonia.Visuals/Rendering/RenderLoop.cs
@@ -60,7 +60,7 @@ namespace Avalonia.Rendering
         /// <inheritdoc/>
         public void Add(IRenderLoopTask i)
         {
-            Contract.Requires<ArgumentNullException>(i != null);
+            Contract.RequireNotNull(i);
             Dispatcher.UIThread.VerifyAccess();
 
             _items.Add(i);
@@ -74,7 +74,7 @@ namespace Avalonia.Rendering
         /// <inheritdoc/>
         public void Remove(IRenderLoopTask i)
         {
-            Contract.Requires<ArgumentNullException>(i != null);
+            Contract.RequireNotNull(i);
             Dispatcher.UIThread.VerifyAccess();
 
             _items.Remove(i);

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/DeferredDrawingContextImpl.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/DeferredDrawingContextImpl.cs
@@ -51,7 +51,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// </returns>
         public UpdateState BeginUpdate(VisualNode node)
         {
-            Contract.Requires<ArgumentNullException>(node != null);
+            Contract.RequireNotNull(node);
 
             if (_node != null)
             {

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/Scene.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/Scene.cs
@@ -31,7 +31,7 @@ namespace Avalonia.Rendering.SceneGraph
 
         private Scene(VisualNode root, Dictionary<IVisual, IVisualNode> index, SceneLayers layers, int generation)
         {
-            Contract.Requires<ArgumentNullException>(root != null);
+            Contract.RequireNotNull(root);
 
             var renderRoot = root.Visual as IRenderRoot;
 
@@ -73,7 +73,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <param name="node">The node.</param>
         public void Add(IVisualNode node)
         {
-            Contract.Requires<ArgumentNullException>(node != null);
+            Contract.RequireNotNull(node);
 
             _index.Add(node.Visual, node);
         }
@@ -137,7 +137,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <param name="node">The node.</param>
         public void Remove(IVisualNode node)
         {
-            Contract.Requires<ArgumentNullException>(node != null);
+            Contract.RequireNotNull(node);
 
             _index.Remove(node.Visual);
 

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -18,7 +18,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <inheritdoc/>
         public void UpdateAll(Scene scene)
         {
-            Contract.Requires<ArgumentNullException>(scene != null);
+            Contract.RequireNotNull(scene);
             Dispatcher.UIThread.VerifyAccess();
 
             UpdateSize(scene);
@@ -34,8 +34,8 @@ namespace Avalonia.Rendering.SceneGraph
         /// <inheritdoc/>
         public bool Update(Scene scene, IVisual visual)
         {
-            Contract.Requires<ArgumentNullException>(scene != null);
-            Contract.Requires<ArgumentNullException>(visual != null);
+            Contract.RequireNotNull(scene);
+            Contract.RequireNotNull(visual);
 
             Dispatcher.UIThread.VerifyAccess();
 

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneLayers.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneLayers.cs
@@ -68,7 +68,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <returns>The created layer.</returns>
         public SceneLayer Add(IVisual layerRoot)
         {
-            Contract.Requires<ArgumentNullException>(layerRoot != null);
+            Contract.RequireNotNull(layerRoot);
 
             var distance = layerRoot.CalculateDistanceFromAncestor(_root);
             var layer = new SceneLayer(layerRoot, distance);
@@ -105,7 +105,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// </returns>
         public bool Exists(IVisual layerRoot)
         {
-            Contract.Requires<ArgumentNullException>(layerRoot != null);
+            Contract.RequireNotNull(layerRoot);
 
             return _index.ContainsKey(layerRoot);
         }
@@ -129,7 +129,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <returns>The layer.</returns>
         public SceneLayer GetOrAdd(IVisual layerRoot)
         {
-            Contract.Requires<ArgumentNullException>(layerRoot != null);
+            Contract.RequireNotNull(layerRoot);
 
             SceneLayer result;
 
@@ -148,7 +148,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <returns>True if a matching layer was removed, otherwise false.</returns>
         public bool Remove(IVisual layerRoot)
         {
-            Contract.Requires<ArgumentNullException>(layerRoot != null);
+            Contract.RequireNotNull(layerRoot);
 
             SceneLayer layer;
 
@@ -167,7 +167,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <returns>True if the layer was part of the scene, otherwise false.</returns>
         public bool Remove(SceneLayer layer)
         {
-            Contract.Requires<ArgumentNullException>(layer != null);
+            Contract.RequireNotNull(layer);
 
             _index.Remove(layer.LayerRoot);
             return _inner.Remove(layer);

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
@@ -35,7 +35,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <param name="parent">The parent scene graph node, if any.</param>
         public VisualNode(IVisual visual, IVisualNode parent)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            Contract.RequireNotNull(visual);
 
             Visual = visual;
             Parent = parent;

--- a/src/Avalonia.Visuals/Visual.cs
+++ b/src/Avalonia.Visuals/Visual.cs
@@ -289,7 +289,7 @@ namespace Avalonia
         /// <param name="context">The drawing context.</param>
         public virtual void Render(DrawingContext context)
         {
-            Contract.Requires<ArgumentNullException>(context != null);
+            Contract.RequireNotNull(context);
         }
 
         /// <summary>

--- a/src/Avalonia.Visuals/VisualTree/VisualExtensions.cs
+++ b/src/Avalonia.Visuals/VisualTree/VisualExtensions.cs
@@ -24,7 +24,7 @@ namespace Avalonia.VisualTree
         /// </returns>
         public static int CalculateDistanceFromAncestor(this IVisual visual, IVisual ancestor)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            Contract.RequireNotNull(visual);
 
             var result = 0;
 
@@ -45,7 +45,7 @@ namespace Avalonia.VisualTree
         /// <returns>The common ancestor, or null if not found.</returns>
         public static IVisual FindCommonVisualAncestor(this IVisual visual, IVisual target)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            Contract.RequireNotNull(visual);
 
             return visual.GetSelfAndVisualAncestors().Intersect(target.GetSelfAndVisualAncestors())
                 .FirstOrDefault();
@@ -58,7 +58,7 @@ namespace Avalonia.VisualTree
         /// <returns>The visual's ancestors.</returns>
         public static IEnumerable<IVisual> GetVisualAncestors(this IVisual visual)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            Contract.RequireNotNull(visual);
 
             visual = visual.VisualParent;
 
@@ -76,7 +76,7 @@ namespace Avalonia.VisualTree
         /// <returns>The visual and its ancestors.</returns>
         public static IEnumerable<IVisual> GetSelfAndVisualAncestors(this IVisual visual)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            Contract.RequireNotNull(visual);
 
             yield return visual;
 
@@ -94,7 +94,7 @@ namespace Avalonia.VisualTree
         /// <returns>The visuals at the requested point.</returns>
         public static IVisual GetVisualAt(this IVisual visual, Point p)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            Contract.RequireNotNull(visual);
 
             return visual.GetVisualsAt(p).FirstOrDefault();
         }
@@ -109,7 +109,7 @@ namespace Avalonia.VisualTree
             this IVisual visual,
             Point p)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            Contract.RequireNotNull(visual);
 
             return visual.GetVisualsAt(p, x => x.IsVisible);
         }
@@ -129,7 +129,7 @@ namespace Avalonia.VisualTree
             Point p,
             Func<IVisual, bool> filter)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            Contract.RequireNotNull(visual);
 
             var root = visual.GetVisualRoot();
             var rootPoint = visual.TranslatePoint(p, root);
@@ -217,7 +217,7 @@ namespace Avalonia.VisualTree
         /// </returns>
         public static IRenderRoot GetVisualRoot(this IVisual visual)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            Contract.RequireNotNull(visual);
 
             return visual as IRenderRoot ?? visual.VisualRoot;
         }

--- a/src/Avalonia.Visuals/VisualTreeAttachmentEventArgs.cs
+++ b/src/Avalonia.Visuals/VisualTreeAttachmentEventArgs.cs
@@ -20,8 +20,8 @@ namespace Avalonia
         /// <param name="root">The root visual.</param>
         public VisualTreeAttachmentEventArgs(IVisual parent, IRenderRoot root)
         {
-            Contract.Requires<ArgumentNullException>(parent != null);
-            Contract.Requires<ArgumentNullException>(root != null);
+            Contract.RequireNotNull(parent);
+            Contract.RequireNotNull(root);
 
             Parent = parent;
             Root = root;

--- a/src/Markup/Avalonia.Markup.Xaml/AvaloniaXamlLoader.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/AvaloniaXamlLoader.cs
@@ -37,7 +37,7 @@ namespace Avalonia.Markup.Xaml
         /// <returns>The loaded object.</returns>
         public object Load(Uri uri, Uri baseUri = null)
         {
-            Contract.Requires<ArgumentNullException>(uri != null);
+            Contract.RequireNotNull(uri);
 
             var assetLocator = AvaloniaLocator.Current.GetService<IAssetLoader>();
 
@@ -79,7 +79,7 @@ namespace Avalonia.Markup.Xaml
         /// <returns>The loaded object.</returns>
         public object Load(string xaml, Assembly localAssembly = null, object rootInstance = null)
         {
-            Contract.Requires<ArgumentNullException>(xaml != null);
+            Contract.RequireNotNull(xaml);
 
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(xaml)))
             {

--- a/src/Markup/Avalonia.Markup/Data/Binding.cs
+++ b/src/Markup/Avalonia.Markup/Data/Binding.cs
@@ -106,7 +106,7 @@ namespace Avalonia.Data
             object anchor = null,
             bool enableDataValidation = false)
         {
-            Contract.Requires<ArgumentNullException>(target != null);
+            Contract.RequireNotNull(target);
             anchor = anchor ?? DefaultAnchor?.Target;
             
             enableDataValidation = enableDataValidation && Priority == BindingPriority.LocalValue;
@@ -222,7 +222,7 @@ namespace Avalonia.Data
             bool targetIsDataContext,
             object anchor)
         {
-            Contract.Requires<ArgumentNullException>(target != null);
+            Contract.RequireNotNull(target);
 
             if (!(target is IStyledElement))
             {
@@ -258,7 +258,7 @@ namespace Avalonia.Data
             string elementName,
             ExpressionNode node)
         {
-            Contract.Requires<ArgumentNullException>(target != null);
+            Contract.RequireNotNull(target);
 
             NameScope.TryGetTarget(out var scope);
             if (scope == null)
@@ -275,7 +275,7 @@ namespace Avalonia.Data
             RelativeSource relativeSource,
             ExpressionNode node)
         {
-            Contract.Requires<ArgumentNullException>(target != null);
+            Contract.RequireNotNull(target);
 
             IObservable<object> controlLocator;
 
@@ -307,7 +307,7 @@ namespace Avalonia.Data
             object source,
             ExpressionNode node)
         {
-            Contract.Requires<ArgumentNullException>(source != null);
+            Contract.RequireNotNull(source);
 
             return new ExpressionObserver(source, node);
         }
@@ -316,7 +316,7 @@ namespace Avalonia.Data
             IAvaloniaObject target,
             ExpressionNode node)
         {
-            Contract.Requires<ArgumentNullException>(target != null);
+            Contract.RequireNotNull(target);
             
             var result = new ExpressionObserver(
                 () => target.GetValue(StyledElement.TemplatedParentProperty),

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/ExpressionObserverBuilder.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/ExpressionObserverBuilder.cs
@@ -48,7 +48,7 @@ namespace Avalonia.Markup.Parsers
             string description = null,
             Func<string, string, Type> typeResolver = null)
         {
-            Contract.Requires<ArgumentNullException>(rootObservable != null);
+            Contract.RequireNotNull(rootObservable);
             return new ExpressionObserver(
                 rootObservable,
                 Parse(expression, enableDataValidation, typeResolver).Node,
@@ -64,7 +64,7 @@ namespace Avalonia.Markup.Parsers
             string description = null,
             Func<string, string, Type> typeResolver = null)
         {
-            Contract.Requires<ArgumentNullException>(rootGetter != null);
+            Contract.RequireNotNull(rootGetter);
 
             return new ExpressionObserver(
                 rootGetter,

--- a/src/Windows/Avalonia.Win32/WindowsMountedVolumeInfoProvider.cs
+++ b/src/Windows/Avalonia.Win32/WindowsMountedVolumeInfoProvider.cs
@@ -8,7 +8,7 @@ namespace Avalonia.Win32
     {
         public IDisposable Listen(ObservableCollection<MountedVolumeInfo> mountedDrives)
         {
-            Contract.Requires<ArgumentNullException>(mountedDrives != null);
+            Contract.RequireNotNull(mountedDrives);
             return new WindowsMountedVolumeInfoListener(mountedDrives);
         }
     }


### PR DESCRIPTION
Suggest to review Contract.cs first, everything else is just moving to new api.

Your first question will likely be, why not leave api as is, and use the doesnt return when false annotation. I tried this and it didnt work for me.

## What does the pull request do?
Before we enable nullable reference types on our projects, iv added this method which will be compatible with the NRT analysis.


## What is the current behavior?
Contract.Require(x!=null) confuses the analysis.

## What is the updated/expected behavior with this PR?
Because Contract.RequireNotNull has an annotation that roslyn recognises, we get rid of alot of warnings can can concentrate on addressing actual NRT issues.


