### PR TITLE
Revert "Updated ReactiveUI to version 10.1.1"

### DIFF
--- a/build/ReactiveUI.props
+++ b/build/ReactiveUI.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="10.1.1" />
+    <PackageReference Include="reactiveui" Version="9.0.1" />
   </ItemGroup>
 </Project>

--- a/build/Rx.props
+++ b/build/Rx.props
@@ -1,5 +1,5 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="4.1.6" />
+    <PackageReference Include="System.Reactive" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/build/System.Memory.props
+++ b/build/System.Memory.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Memory" Version="4.5.1" />
   </ItemGroup>
 </Project>

--- a/samples/BindingDemo/ViewModels/MainWindowViewModel.cs
+++ b/samples/BindingDemo/ViewModels/MainWindowViewModel.cs
@@ -1,11 +1,10 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Reactive;
+using ReactiveUI;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using System.Threading;
-using ReactiveUI;
 
 namespace BindingDemo.ViewModels
 {
@@ -57,7 +56,7 @@ namespace BindingDemo.ViewModels
 
         public ObservableCollection<TestItem> Items { get; }
         public ObservableCollection<TestItem> SelectedItems { get; }
-        public ReactiveCommand<Unit, Unit> ShuffleItems { get; }
+        public ReactiveCommand ShuffleItems { get; }
 
         public string BooleanString
         {
@@ -90,7 +89,7 @@ namespace BindingDemo.ViewModels
         }
 
         public IObservable<string> CurrentTimeObservable { get; }
-        public ReactiveCommand<object, Unit> StringValueCommand { get; }
+        public ReactiveCommand StringValueCommand { get; }
 
         public DataAnnotationsErrorViewModel DataAnnotationsValidation { get; } = new DataAnnotationsErrorViewModel();
         public ExceptionErrorViewModel ExceptionDataValidation { get; } = new ExceptionErrorViewModel();

--- a/samples/RenderDemo/ViewModels/MainWindowViewModel.cs
+++ b/samples/RenderDemo/ViewModels/MainWindowViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reactive;
 using ReactiveUI;
 
 namespace RenderDemo.ViewModels
@@ -27,7 +26,7 @@ namespace RenderDemo.ViewModels
             set { this.RaiseAndSetIfChanged(ref drawFps, value); }
         }
 
-        public ReactiveCommand<Unit, bool> ToggleDrawDirtyRects { get; }
-        public ReactiveCommand<Unit, bool> ToggleDrawFps { get; }
+        public ReactiveCommand ToggleDrawDirtyRects { get; }
+        public ReactiveCommand ToggleDrawFps { get; }
     }
 }

--- a/samples/VirtualizationDemo/ViewModels/MainWindowViewModel.cs
+++ b/samples/VirtualizationDemo/ViewModels/MainWindowViewModel.cs
@@ -4,10 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reactive;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using ReactiveUI.Legacy;
 using ReactiveUI;
 using Avalonia.Layout;
 
@@ -18,7 +18,7 @@ namespace VirtualizationDemo.ViewModels
         private int _itemCount = 200;
         private string _newItemString = "New Item";
         private int _newItemIndex;
-        private AvaloniaList<ItemViewModel> _items;
+        private IReactiveList<ItemViewModel> _items;
         private string _prefix = "Item";
         private ScrollBarVisibility _horizontalScrollBarVisibility = ScrollBarVisibility.Auto;
         private ScrollBarVisibility _verticalScrollBarVisibility = ScrollBarVisibility.Auto;
@@ -28,12 +28,11 @@ namespace VirtualizationDemo.ViewModels
         public MainWindowViewModel()
         {
             this.WhenAnyValue(x => x.ItemCount).Subscribe(ResizeItems);
+            RecreateCommand = ReactiveCommand.Create(() => Recreate());
 
-            RecreateCommand = ReactiveCommand.Create(Recreate);
+            AddItemCommand = ReactiveCommand.Create(() => AddItem());
 
-            AddItemCommand = ReactiveCommand.Create(AddItem);
-
-            RemoveItemCommand = ReactiveCommand.Create(Remove);
+            RemoveItemCommand = ReactiveCommand.Create(() => Remove());
 
             SelectFirstCommand = ReactiveCommand.Create(() => SelectItem(0));
 
@@ -55,7 +54,7 @@ namespace VirtualizationDemo.ViewModels
         public AvaloniaList<ItemViewModel> SelectedItems { get; } 
             = new AvaloniaList<ItemViewModel>();
 
-        public AvaloniaList<ItemViewModel> Items
+        public IReactiveList<ItemViewModel> Items
         {
             get { return _items; }
             private set { this.RaiseAndSetIfChanged(ref _items, value); }
@@ -94,11 +93,11 @@ namespace VirtualizationDemo.ViewModels
         public IEnumerable<ItemVirtualizationMode> VirtualizationModes => 
             Enum.GetValues(typeof(ItemVirtualizationMode)).Cast<ItemVirtualizationMode>();
 
-        public ReactiveCommand<Unit, Unit> AddItemCommand { get; private set; }
-        public ReactiveCommand<Unit, Unit> RecreateCommand { get; private set; }
-        public ReactiveCommand<Unit, Unit> RemoveItemCommand { get; private set; }
-        public ReactiveCommand<Unit, Unit> SelectFirstCommand { get; private set; }
-        public ReactiveCommand<Unit, Unit> SelectLastCommand { get; private set; }
+        public ReactiveCommand AddItemCommand { get; private set; }
+        public ReactiveCommand RecreateCommand { get; private set; }
+        public ReactiveCommand RemoveItemCommand { get; private set; }
+        public ReactiveCommand SelectFirstCommand { get; private set; }
+        public ReactiveCommand SelectLastCommand { get; private set; }
 
         public void RandomizeSize()
         {
@@ -124,7 +123,7 @@ namespace VirtualizationDemo.ViewModels
             {
                 var items = Enumerable.Range(0, count)
                     .Select(x => new ItemViewModel(x));
-                Items = new AvaloniaList<ItemViewModel>(items);
+                Items = new ReactiveList<ItemViewModel>(items);
             }
             else if (count > Items.Count)
             {
@@ -163,7 +162,7 @@ namespace VirtualizationDemo.ViewModels
             _prefix = _prefix == "Item" ? "Recreated" : "Item";
             var items = Enumerable.Range(0, _itemCount)
                 .Select(x => new ItemViewModel(x, _prefix));
-            Items = new AvaloniaList<ItemViewModel>(items);
+            Items = new ReactiveList<ItemViewModel>(items);
         }
 
         private void SelectItem(int index)

--- a/src/Avalonia.ReactiveUI/AvaloniaActivationForViewFetcher.cs
+++ b/src/Avalonia.ReactiveUI/AvaloniaActivationForViewFetcher.cs
@@ -27,7 +27,7 @@ namespace Avalonia.ReactiveUI
         /// <summary>
         /// Returns activation observable for activatable Avalonia view.
         /// </summary>
-        public IObservable<bool> GetActivationForView(IActivatableView view)
+        public IObservable<bool> GetActivationForView(IActivatable view)
         {
             if (!(view is IVisual visual)) return Observable.Return(false);
             if (view is WindowBase window) return GetActivationForWindowBase(window);

--- a/src/Avalonia.ReactiveUI/RoutedViewHost.cs
+++ b/src/Avalonia.ReactiveUI/RoutedViewHost.cs
@@ -53,7 +53,7 @@ namespace Avalonia.ReactiveUI
     /// ReactiveUI routing documentation website</see> for more info.
     /// </para>
     /// </remarks>
-    public class RoutedViewHost : TransitioningContentControl, IActivatableView, IEnableLogger
+    public class RoutedViewHost : TransitioningContentControl, IActivatable, IEnableLogger
     {
         /// <summary>
         /// <see cref="AvaloniaProperty"/> for the <see cref="Router"/> property.

--- a/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
@@ -20,9 +20,9 @@ namespace Avalonia.ReactiveUI.UnitTests
 {
     public class AvaloniaActivationForViewFetcherTest
     {
-        public class TestUserControl : UserControl, IActivatableView { }
+        public class TestUserControl : UserControl, IActivatable { }
 
-        public class TestUserControlWithWhenActivated : UserControl, IActivatableView
+        public class TestUserControlWithWhenActivated : UserControl, IActivatable
         {
             public bool Active { get; private set; }
 
@@ -38,7 +38,7 @@ namespace Avalonia.ReactiveUI.UnitTests
             }
         }
 
-        public class TestWindowWithWhenActivated : Window, IActivatableView
+        public class TestWindowWithWhenActivated : Window, IActivatable
         {
             public bool Active { get; private set; }
 
@@ -54,7 +54,7 @@ namespace Avalonia.ReactiveUI.UnitTests
             }
         }
 
-        public class ActivatableViewModel : IActivatableViewModel
+        public class ActivatableViewModel : ISupportsActivation
         {
             public ViewModelActivator Activator { get; }
 


### PR DESCRIPTION
Reverts AvaloniaUI/Avalonia#2930

too many breaking changes before the 0.9 release.

breaking compatibility with lots of dependencies....

also seems to depend on preview version of System.Reactive.... 

 error NU1605:  AvaloniaDemo -> ReactiveUI 10.1.1 -> System.Reactive (>= 4.2.0-preview.625)