### PR TITLE
Update ReactiveUI to version 10.x

### DIFF
--- a/build/Microsoft.Reactive.Testing.props
+++ b/build/Microsoft.Reactive.Testing.props
@@ -1,5 +1,5 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="4.1.6" />
   </ItemGroup>
 </Project>

--- a/build/ReactiveUI.props
+++ b/build/ReactiveUI.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="9.1.1" />
+    <PackageReference Include="ReactiveUI" Version="9.0.1" />
   </ItemGroup>
 </Project>

--- a/build/ReactiveUI.props
+++ b/build/ReactiveUI.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="9.0.1" />
+    <PackageReference Include="ReactiveUI" Version="9.22.1" />
   </ItemGroup>
 </Project>

--- a/build/ReactiveUI.props
+++ b/build/ReactiveUI.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="10.2.2" />
+    <PackageReference Include="ReactiveUI" Version="9.0.1" />
   </ItemGroup>
 </Project>

--- a/build/ReactiveUI.props
+++ b/build/ReactiveUI.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="10.2.2" />
+    <PackageReference Include="ReactiveUI" Version="10.3.6" />
   </ItemGroup>
 </Project>

--- a/build/ReactiveUI.props
+++ b/build/ReactiveUI.props
@@ -1,5 +1,6 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="9.22.1" />
+    <PackageReference Include="ReactiveUI" Version="10.2.2" />
+    <PackageReference Include="System.Reactive.Compatibility" Version="4.1.6" />
   </ItemGroup>
 </Project>

--- a/build/ReactiveUI.props
+++ b/build/ReactiveUI.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="9.0.1" />
+    <PackageReference Include="ReactiveUI" Version="10.2.2" />
   </ItemGroup>
 </Project>

--- a/build/ReactiveUI.props
+++ b/build/ReactiveUI.props
@@ -1,6 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="10.2.2" />
-    <PackageReference Include="System.Reactive.Compatibility" Version="4.1.6" />
+    <PackageReference Include="ReactiveUI" Version="9.1.1" />
   </ItemGroup>
 </Project>

--- a/build/ReactiveUI.props
+++ b/build/ReactiveUI.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="10.3.1" />
+    <PackageReference Include="ReactiveUI" Version="10.2.2" />
   </ItemGroup>
 </Project>

--- a/build/Rx.props
+++ b/build/Rx.props
@@ -1,5 +1,5 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="4.0.0" />
+    <PackageReference Include="System.Reactive" Version="4.1.6" />
   </ItemGroup>
 </Project>

--- a/build/Rx.props
+++ b/build/Rx.props
@@ -1,7 +1,7 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="System.Reactive" Version="4.1.6" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Value="4.5.3" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Value="4.6.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/build/Rx.props
+++ b/build/Rx.props
@@ -1,7 +1,5 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="System.Reactive" Version="4.1.6" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/build/Rx.props
+++ b/build/Rx.props
@@ -1,5 +1,7 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="System.Reactive" Version="4.1.6" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Value="4.5.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Value="4.6.0" />
   </ItemGroup>
 </Project>

--- a/build/System.Memory.props
+++ b/build/System.Memory.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 </Project>

--- a/build/System.Memory.props
+++ b/build/System.Memory.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
 </Project>

--- a/build/System.Memory.props
+++ b/build/System.Memory.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.2" />
+    <PackageReference Include="System.Memory" Version="4.5.1" />
   </ItemGroup>
 </Project>

--- a/samples/BindingDemo/ViewModels/MainWindowViewModel.cs
+++ b/samples/BindingDemo/ViewModels/MainWindowViewModel.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
-using ReactiveUI;
+using System.Reactive;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using System.Threading;
+using ReactiveUI;
 
 namespace BindingDemo.ViewModels
 {
@@ -56,7 +57,7 @@ namespace BindingDemo.ViewModels
 
         public ObservableCollection<TestItem> Items { get; }
         public ObservableCollection<TestItem> SelectedItems { get; }
-        public ReactiveCommand ShuffleItems { get; }
+        public ReactiveCommand<Unit, Unit> ShuffleItems { get; }
 
         public string BooleanString
         {
@@ -89,7 +90,7 @@ namespace BindingDemo.ViewModels
         }
 
         public IObservable<string> CurrentTimeObservable { get; }
-        public ReactiveCommand StringValueCommand { get; }
+        public ReactiveCommand<object, Unit> StringValueCommand { get; }
 
         public DataAnnotationsErrorViewModel DataAnnotationsValidation { get; } = new DataAnnotationsErrorViewModel();
         public ExceptionErrorViewModel ExceptionDataValidation { get; } = new ExceptionErrorViewModel();

--- a/samples/RenderDemo/ViewModels/MainWindowViewModel.cs
+++ b/samples/RenderDemo/ViewModels/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reactive;
 using ReactiveUI;
 
 namespace RenderDemo.ViewModels
@@ -26,7 +27,7 @@ namespace RenderDemo.ViewModels
             set { this.RaiseAndSetIfChanged(ref drawFps, value); }
         }
 
-        public ReactiveCommand ToggleDrawDirtyRects { get; }
-        public ReactiveCommand ToggleDrawFps { get; }
+        public ReactiveCommand<Unit, bool> ToggleDrawDirtyRects { get; }
+        public ReactiveCommand<Unit, bool> ToggleDrawFps { get; }
     }
 }

--- a/samples/VirtualizationDemo/ViewModels/MainWindowViewModel.cs
+++ b/samples/VirtualizationDemo/ViewModels/MainWindowViewModel.cs
@@ -4,10 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
-using ReactiveUI.Legacy;
 using ReactiveUI;
 using Avalonia.Layout;
 
@@ -18,7 +18,7 @@ namespace VirtualizationDemo.ViewModels
         private int _itemCount = 200;
         private string _newItemString = "New Item";
         private int _newItemIndex;
-        private IReactiveList<ItemViewModel> _items;
+        private AvaloniaList<ItemViewModel> _items;
         private string _prefix = "Item";
         private ScrollBarVisibility _horizontalScrollBarVisibility = ScrollBarVisibility.Auto;
         private ScrollBarVisibility _verticalScrollBarVisibility = ScrollBarVisibility.Auto;
@@ -54,7 +54,7 @@ namespace VirtualizationDemo.ViewModels
         public AvaloniaList<ItemViewModel> SelectedItems { get; } 
             = new AvaloniaList<ItemViewModel>();
 
-        public IReactiveList<ItemViewModel> Items
+        public AvaloniaList<ItemViewModel> Items
         {
             get { return _items; }
             private set { this.RaiseAndSetIfChanged(ref _items, value); }
@@ -93,11 +93,11 @@ namespace VirtualizationDemo.ViewModels
         public IEnumerable<ItemVirtualizationMode> VirtualizationModes => 
             Enum.GetValues(typeof(ItemVirtualizationMode)).Cast<ItemVirtualizationMode>();
 
-        public ReactiveCommand AddItemCommand { get; private set; }
-        public ReactiveCommand RecreateCommand { get; private set; }
-        public ReactiveCommand RemoveItemCommand { get; private set; }
-        public ReactiveCommand SelectFirstCommand { get; private set; }
-        public ReactiveCommand SelectLastCommand { get; private set; }
+        public ReactiveCommand<Unit, Unit> AddItemCommand { get; private set; }
+        public ReactiveCommand<Unit, Unit> RecreateCommand { get; private set; }
+        public ReactiveCommand<Unit, Unit> RemoveItemCommand { get; private set; }
+        public ReactiveCommand<Unit, Unit> SelectFirstCommand { get; private set; }
+        public ReactiveCommand<Unit, Unit> SelectLastCommand { get; private set; }
 
         public void RandomizeSize()
         {
@@ -123,7 +123,7 @@ namespace VirtualizationDemo.ViewModels
             {
                 var items = Enumerable.Range(0, count)
                     .Select(x => new ItemViewModel(x));
-                Items = new ReactiveList<ItemViewModel>(items);
+                Items = new AvaloniaList<ItemViewModel>(items);
             }
             else if (count > Items.Count)
             {
@@ -162,7 +162,7 @@ namespace VirtualizationDemo.ViewModels
             _prefix = _prefix == "Item" ? "Recreated" : "Item";
             var items = Enumerable.Range(0, _itemCount)
                 .Select(x => new ItemViewModel(x, _prefix));
-            Items = new ReactiveList<ItemViewModel>(items);
+            Items = new AvaloniaList<ItemViewModel>(items);
         }
 
         private void SelectItem(int index)

--- a/src/Avalonia.ReactiveUI/AvaloniaActivationForViewFetcher.cs
+++ b/src/Avalonia.ReactiveUI/AvaloniaActivationForViewFetcher.cs
@@ -27,7 +27,7 @@ namespace Avalonia.ReactiveUI
         /// <summary>
         /// Returns activation observable for activatable Avalonia view.
         /// </summary>
-        public IObservable<bool> GetActivationForView(IActivatableView view)
+        public IObservable<bool> GetActivationForView(IActivatable view)
         {
             if (!(view is IVisual visual)) return Observable.Return(false);
             if (view is WindowBase window) return GetActivationForWindowBase(window);

--- a/src/Avalonia.ReactiveUI/AvaloniaActivationForViewFetcher.cs
+++ b/src/Avalonia.ReactiveUI/AvaloniaActivationForViewFetcher.cs
@@ -27,7 +27,7 @@ namespace Avalonia.ReactiveUI
         /// <summary>
         /// Returns activation observable for activatable Avalonia view.
         /// </summary>
-        public IObservable<bool> GetActivationForView(IActivatable view)
+        public IObservable<bool> GetActivationForView(IActivatableView view)
         {
             if (!(view is IVisual visual)) return Observable.Return(false);
             if (view is WindowBase window) return GetActivationForWindowBase(window);

--- a/src/Avalonia.ReactiveUI/RoutedViewHost.cs
+++ b/src/Avalonia.ReactiveUI/RoutedViewHost.cs
@@ -53,7 +53,7 @@ namespace Avalonia.ReactiveUI
     /// ReactiveUI routing documentation website</see> for more info.
     /// </para>
     /// </remarks>
-    public class RoutedViewHost : TransitioningContentControl, IActivatableView, IEnableLogger
+    public class RoutedViewHost : TransitioningContentControl, IActivatable, IEnableLogger
     {
         /// <summary>
         /// <see cref="AvaloniaProperty"/> for the <see cref="Router"/> property.

--- a/src/Avalonia.ReactiveUI/RoutedViewHost.cs
+++ b/src/Avalonia.ReactiveUI/RoutedViewHost.cs
@@ -53,7 +53,7 @@ namespace Avalonia.ReactiveUI
     /// ReactiveUI routing documentation website</see> for more info.
     /// </para>
     /// </remarks>
-    public class RoutedViewHost : TransitioningContentControl, IActivatable, IEnableLogger
+    public class RoutedViewHost : TransitioningContentControl, IActivatableView, IEnableLogger
     {
         /// <summary>
         /// <see cref="AvaloniaProperty"/> for the <see cref="Router"/> property.

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_AttachedProperty.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_AttachedProperty.cs
@@ -121,6 +121,8 @@ namespace Avalonia.Markup.UnitTests.Parsers
             result.Item1.Subscribe(x => { });
 
             GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
 
             Assert.Null(result.Item2.Target);
         }

--- a/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
@@ -20,9 +20,9 @@ namespace Avalonia.ReactiveUI.UnitTests
 {
     public class AvaloniaActivationForViewFetcherTest
     {
-        public class TestUserControl : UserControl, IActivatable { }
+        public class TestUserControl : UserControl, IActivatableView { }
 
-        public class TestUserControlWithWhenActivated : UserControl, IActivatable
+        public class TestUserControlWithWhenActivated : UserControl, IActivatableView
         {
             public bool Active { get; private set; }
 
@@ -38,7 +38,7 @@ namespace Avalonia.ReactiveUI.UnitTests
             }
         }
 
-        public class TestWindowWithWhenActivated : Window, IActivatable
+        public class TestWindowWithWhenActivated : Window, IActivatableView
         {
             public bool Active { get; private set; }
 
@@ -54,7 +54,7 @@ namespace Avalonia.ReactiveUI.UnitTests
             }
         }
 
-        public class ActivatableViewModel : ISupportsActivation
+        public class ActivatableViewModel : IActivatableViewModel
         {
             public ViewModelActivator Activator { get; }
 

--- a/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AvaloniaActivationForViewFetcherTest.cs
@@ -20,9 +20,9 @@ namespace Avalonia.ReactiveUI.UnitTests
 {
     public class AvaloniaActivationForViewFetcherTest
     {
-        public class TestUserControl : UserControl, IActivatableView { }
+        public class TestUserControl : UserControl, IActivatable { }
 
-        public class TestUserControlWithWhenActivated : UserControl, IActivatableView
+        public class TestUserControlWithWhenActivated : UserControl, IActivatable
         {
             public bool Active { get; private set; }
 
@@ -38,7 +38,7 @@ namespace Avalonia.ReactiveUI.UnitTests
             }
         }
 
-        public class TestWindowWithWhenActivated : Window, IActivatableView
+        public class TestWindowWithWhenActivated : Window, IActivatable
         {
             public bool Active { get; private set; }
 
@@ -54,7 +54,7 @@ namespace Avalonia.ReactiveUI.UnitTests
             }
         }
 
-        public class ActivatableViewModel : IActivatableViewModel
+        public class ActivatableViewModel : ISupportsActivation
         {
             public ViewModelActivator Activator { get; }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

This is an attempt to upgrade ReactiveUI. We were delaying due to `System.Reactive` preview versions probably containing bugs that [reproduce only on MacOS](https://github.com/AvaloniaUI/Avalonia/pull/2930) causing Avalonia CI checks to fail. Another delay reason is that ReactiveUI 10.3.1 [contains a bug](https://github.com/AvaloniaUI/Avalonia/pull/3044) causing `RxApp.SuspensionHost` to not get initialized. The purpose of this PR is to try ReactiveUI 10.2.2 which neither seems to rely on preview versions of `System.Reactive` nor contains an issue with `RxApp.SuspensionHost`.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Currently, `Avalonia.ReactiveUI` depends on ReactiveUI 9.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

ReactiveUI 9 should be upgraded to ReactiveUI 10, only in case if the version is stable enough.