### PR TITLE
Properly handle setting SelectedIndex from XAML

### DIFF
--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -304,6 +304,11 @@ namespace Avalonia.Controls.Primitives
         {
             base.ItemsCollectionChanged(sender, e);
 
+            if (_updateCount > 0)
+            {
+                return;
+            }
+
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
@@ -1071,13 +1076,16 @@ namespace Avalonia.Controls.Primitives
 
         private void UpdateFinished()
         {
-            if (_updateSelectedIndex != int.MinValue)
-            {
-                SelectedIndex = _updateSelectedIndex;
-            }
-            else if (_updateSelectedItem != null)
+            if (_updateSelectedItem != null)
             {
                 SelectedItem = _updateSelectedItem;
+            }
+            else
+            {
+                if (ItemCount > 0)
+                {
+                    SelectedIndex = _updateSelectedIndex != int.MinValue ? _updateSelectedIndex : 0;
+                }
             }
         }
 

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -1082,7 +1082,11 @@ namespace Avalonia.Controls.Primitives
             }
             else
             {
-                if (ItemCount > 0)
+                if (ItemCount == 0 && SelectedIndex != -1)
+                {
+                    SelectedIndex = -1;
+                }
+                else
                 {
                     SelectedIndex = _updateSelectedIndex != int.MinValue ? _updateSelectedIndex : 0;
                 }

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -110,6 +110,28 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
+        public void Setting_SelectedIndex_During_Initialize_Should_Select_Item_When_AlwaysSelected_Is_Used()
+        {
+            var listBox = new ListBox
+            {
+                SelectionMode = SelectionMode.Single | SelectionMode.AlwaysSelected
+            };
+
+            listBox.BeginInit();
+
+            listBox.SelectedIndex = 1;
+            var items = new AvaloniaList<string>();
+            listBox.Items = items;
+            items.Add("A");
+            items.Add("B");
+            items.Add("C");
+
+            listBox.EndInit();
+
+            Assert.Equal("B", listBox.SelectedItem);
+        }
+
+        [Fact]
         public void Setting_SelectedIndex_Before_ApplyTemplate_Should_Set_Item_IsSelected_True()
         {
             var items = new[]


### PR DESCRIPTION
## What does the pull request do?
It fixes an issue with SelectingItemsControl when someone tries to pre-select an item by setting SelectedIndex in XAML.

## What is the current behavior?
Setting SelectedIndex in XAML has no effect.

## What is the updated/expected behavior with this PR?
Setting SelectedIndex in XAML has the expected effect.

## How was the solution implemented (if it's not obvious)?
Currently, the selection is updated during initialization and that causes a reset of SelectedIndex every time an item is added. Now collection changes aren't handled during initialization and therefore the SelectedIndex is preserved. If no pre-selection is made the SelectedIndex is properly set to the first item.


## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues
#2987
