### PR TITLE
Don't test tree view item type by comparing GetType().

### DIFF
--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -173,7 +173,7 @@ namespace Avalonia.Controls
         {
             var result = 0;
 
-            while (logical != null && logical.GetType() != typeof(T))
+            while (logical != null && !(logical is T))
             {
                 ++result;
                 logical = logical.LogicalParent;


### PR DESCRIPTION
## What does the pull request do?

As #2971 describes, there's an incorrect type comparison in `TreeViewItem` that prevents deriving from `TreeView`. Use `is` instead of comparing types as that issue suggests.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #2971
