### PR TITLE
Remove negative margin from popup hosts.

### DIFF
--- a/src/Avalonia.Themes.Default/OverlayPopupHost.xaml
+++ b/src/Avalonia.Themes.Default/OverlayPopupHost.xaml
@@ -2,7 +2,7 @@
   <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}"/>
   <Setter Property="Template">
     <ControlTemplate>
-      <VisualLayerManager IsPopup="True" Margin="-1 -1 0 0">
+      <VisualLayerManager IsPopup="True">
         <ContentPresenter Name="PART_ContentPresenter"
                           Background="{TemplateBinding Background}"
                           ContentTemplate="{TemplateBinding ContentTemplate}"

--- a/src/Avalonia.Themes.Default/PopupRoot.xaml
+++ b/src/Avalonia.Themes.Default/PopupRoot.xaml
@@ -2,7 +2,7 @@
   <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}"/>
   <Setter Property="Template">
     <ControlTemplate>
-      <VisualLayerManager IsPopup="True" Margin="-1 -1 0 0">
+      <VisualLayerManager IsPopup="True">
         <ContentPresenter Name="PART_ContentPresenter"
                           Background="{TemplateBinding Background}"
                           ContentTemplate="{TemplateBinding ContentTemplate}"


### PR DESCRIPTION
## What does the pull request do?

Remove negative margin from `PopupRoot` and `OverlayPopupHost` templates. This was causing the top and left sides of popup content to be truncated:

Before:

![image](https://user-images.githubusercontent.com/1775141/65970547-1107d080-e467-11e9-8b86-a9e3b65a0fcb.png)

![image](https://user-images.githubusercontent.com/1775141/65970567-182ede80-e467-11e9-87d1-a3f0dadb4b4b.png)


After:

![image](https://user-images.githubusercontent.com/1775141/65970462-e87fd680-e466-11e9-9266-b59c19c56d58.png)

![image](https://user-images.githubusercontent.com/1775141/65970479-f0d81180-e466-11e9-8d16-132a4421d586.png)
 
I'm not 100% sure why this margin was there, it seems to come from https://github.com/AvaloniaUI/Avalonia/commit/c4ab6648338e14489c27e5aef49f2f863e34c3c7, maybe @donandren remembers?

## Fixed issues

Fixes #2821 