### PR TITLE
Fix first menu item showing as selected when shown

### DIFF
--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -1088,7 +1088,9 @@ namespace Avalonia.Controls.Primitives
                 }
                 else
                 {
-                    SelectedIndex = _updateSelectedIndex != int.MinValue ? _updateSelectedIndex : 0;
+                    SelectedIndex = _updateSelectedIndex != int.MinValue ? 
+                        _updateSelectedIndex : 
+                        AlwaysSelected ? 0 : -1;
                 }
             }
         }

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -110,6 +110,43 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
+        public void SelectedIndex_Should_Be_Minus_1_After_Initialize()
+        {
+            var items = new[]
+            {
+                new Item(),
+                new Item(),
+            };
+
+            var target = new ListBox();
+            target.BeginInit();
+            target.Items = items;
+            target.Template = Template();
+            target.EndInit();
+
+            Assert.Equal(-1, target.SelectedIndex);
+        }
+
+        [Fact]
+        public void SelectedIndex_Should_Be_0_After_Initialize_With_AlwaysSelected()
+        {
+            var items = new[]
+            {
+                new Item(),
+                new Item(),
+            };
+
+            var target = new ListBox();
+            target.BeginInit();
+            target.SelectionMode = SelectionMode.Single | SelectionMode.AlwaysSelected;
+            target.Items = items;
+            target.Template = Template();
+            target.EndInit();
+
+            Assert.Equal(0, target.SelectedIndex);
+        }
+
+        [Fact]
         public void Setting_SelectedIndex_During_Initialize_Should_Select_Item_When_AlwaysSelected_Is_Used()
         {
             var listBox = new ListBox


### PR DESCRIPTION
## What does the pull request do?

The first item in a menu is currently showing as selected when the menu is shown. This was caused by #3047 which selected the first item in a list when initialization completes even if no selection had been specified.

Fix this by only selecting the first item automatically if `AlwaysSelect` is true.

## Checklist

- [x] Added unit tests (if possible)?

