### PR TITLE
Fix double dispose of bindings caused by animations

### DIFF
--- a/src/Avalonia.Animation/DisposeAnimationInstanceSubject.cs
+++ b/src/Avalonia.Animation/DisposeAnimationInstanceSubject.cs
@@ -2,14 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive.Linq;
 using Avalonia.Animation.Animators;
-using Avalonia.Animation.Utils;
-using Avalonia.Collections;
-using Avalonia.Data;
-using Avalonia.Reactive;
 
 namespace Avalonia.Animation
 {
@@ -46,6 +39,7 @@ namespace Avalonia.Animation
         public void OnError(Exception error)
         {
             _lastInstance?.Dispose();
+            _lastInstance = null;
         }
 
         void IObserver<bool>.OnNext(bool matchVal)
@@ -53,10 +47,16 @@ namespace Avalonia.Animation
             if (matchVal != _lastMatch)
             {
                 _lastInstance?.Dispose();
+
                 if (matchVal)
                 {
                     _lastInstance = _animator.Run(_animation, _control, _clock, _onComplete);
                 }
+                else
+                {
+                    _lastInstance = null;
+                }
+
                 _lastMatch = matchVal;
             }
         }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes double dispose issue in animation code. I also added assert to the binding removal, previously we had `AnonymousDisposable` that was hiding all double dispose errors.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Bindings get disposed multiple times.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Remove one problematic double dispose, future double disposals will result in debug assert or get ignored in release mode.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes https://github.com/AvaloniaUI/Avalonia/issues/3039