### PR TITLE
Optimize Interactive hierarchy traversal

### DIFF
--- a/src/Avalonia.Interactivity/InteractiveExtensions.cs
+++ b/src/Avalonia.Interactivity/InteractiveExtensions.cs
@@ -36,29 +36,5 @@ namespace Avalonia.Interactivity
                 routes,
                 handledEventsToo));
         }
-
-        /// <summary>
-        /// Gets the route for bubbling events from the specified interactive.
-        /// </summary>
-        /// <param name="interactive">The interactive.</param>
-        /// <returns>The event route.</returns>
-        internal static IEnumerable<IInteractive> GetBubbleEventRoute(this IInteractive interactive)
-        {
-            while (interactive != null)
-            {
-                yield return interactive;
-                interactive = interactive.InteractiveParent;
-            }
-        }
-
-        /// <summary>
-        /// Gets the route for tunneling events from the specified interactive.
-        /// </summary>
-        /// <param name="interactive">The interactive.</param>
-        /// <returns>The event route.</returns>
-        internal static IEnumerable<IInteractive> GetTunnelEventRoute(this IInteractive interactive)
-        {
-            return interactive.GetBubbleEventRoute().Reverse();
-        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Rewrite current `Interactive` hierarchy traversal to avoid all allocations.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Raising events causes a lot of allocations (arrays, LINQ, iterator blocks) causing pointless GC pressure .
![image](https://user-images.githubusercontent.com/2588062/66171044-25a2bf00-e647-11e9-9d6b-6277216a696f.png)


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
No allocations caused by traversal code.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Implemented generic `Interactive` traversal algorithm that can be configured to do pre/post/both traversal. Used for both bubbling and tunnelling paths. In release this code is equivalent to handwritten traversal.

Traversal is a bit specialized as it caches `RoutedEventArgs` to save stack space, but so far we have no other traversal needs so it will do.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
