### PR TITLE
Queue caret update with correct priority.

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -244,7 +244,7 @@ namespace Avalonia.Controls.Presenters
                             var rect = FormattedText.HitTestTextPosition(caretIndex);
                             this.BringIntoView(rect);
                         },
-                        DispatcherPriority.Normal);
+                        DispatcherPriority.Render);
                 }
             }
         }


### PR DESCRIPTION
## What does the pull request do?

As described in #3070 our `TextBox` doesn't keep up with user input.

When trying to scroll the caret into view, if we need to wait for a layout first make sure that we queue the update with a lower priority then `Layout`. `Render` is the next lowest priority so use this.

Fixes #3070