### PR TITLE
Fix Grid star row/column sizing at design time

### DIFF
--- a/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
+++ b/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
@@ -69,7 +69,17 @@ namespace Avalonia.DesignerSupport
                 }
 
                 if (!window.IsSet(Window.SizeToContentProperty))
-                    window.SizeToContent = SizeToContent.WidthAndHeight;
+                {
+                    if (double.IsNaN(window.Width))
+                    {
+                        window.SizeToContent |= SizeToContent.Width;
+                    }
+
+                    if (double.IsNaN(window.Height))
+                    {
+                        window.SizeToContent |= SizeToContent.Height;
+                    }
+                }
             }
             window.Show();
             Design.ApplyDesignModeProperties(window, control);


### PR DESCRIPTION
## What does the pull request do?

As #2862 describes, `Grid` star sizing was broken at design-time.

Always setting `SizeToContext = WidthAndHeight` in `DesignWindowLoader` was causing `Grid` to default to `Auto` sizing for `Star` rows/columns at design-time. This PR changes `DesignWindowLoader` to only set `SizeToContent` for non-set width/height.

## Fixed issues

Fixes #2862
