### PR TITLE
Added Window.OnClosed and sealed HandleClosed.

### DIFF
--- a/src/Avalonia.Controls/Primitives/PopupRoot.cs
+++ b/src/Avalonia.Controls/Primitives/PopupRoot.cs
@@ -17,7 +17,7 @@ namespace Avalonia.Controls.Primitives
     /// <summary>
     /// The root window of a <see cref="Popup"/>.
     /// </summary>
-    public class PopupRoot : WindowBase, IInteractive, IHostedVisualTreeRoot, IDisposable, IStyleHost, IPopupHost
+    public sealed class PopupRoot : WindowBase, IInteractive, IHostedVisualTreeRoot, IDisposable, IStyleHost, IPopupHost
     {
         private readonly TopLevel _parent;
         private PopupPositionerParameters _positionerParameters;

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -271,7 +271,7 @@ namespace Avalonia.Controls
         {
             (this as IInputRoot).MouseDevice?.TopLevelClosed(this);
             PlatformImpl = null;
-            Closed?.Invoke(this, EventArgs.Empty);
+            OnClosed(EventArgs.Empty);
             Renderer?.Dispose();
             Renderer = null;
         }
@@ -316,6 +316,12 @@ namespace Avalonia.Controls
         /// </summary>
         /// <param name="e">The event args.</param>
         protected virtual void OnOpened(EventArgs e) => Opened?.Invoke(this, e);
+
+        /// <summary>
+        /// Raises the <see cref="Closed"/> event.
+        /// </summary>
+        /// <param name="e">The event args.</param>
+        protected virtual void OnClosed(EventArgs e) => Closed?.Invoke(this, e);
 
         /// <summary>
         /// Tries to get a service from an <see cref="IAvaloniaDependencyResolver"/>, logging a

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -557,7 +557,7 @@ namespace Avalonia.Controls
             return result;
         }
 
-        protected override void HandleClosed()
+        protected sealed override void HandleClosed()
         {
             RaiseEvent(new RoutedEventArgs(WindowClosedEvent));
 
@@ -565,7 +565,7 @@ namespace Avalonia.Controls
         }
 
         /// <inheritdoc/>
-        protected override void HandleResized(Size clientSize)
+        protected sealed override void HandleResized(Size clientSize)
         {
             if (!AutoSizing)
             {


### PR DESCRIPTION
## What does the pull request do?

`Window` had `OnClosing` and `OnOpened` virtual methods but no `OnClosed`. This PR adds that.

It also includes a change that I'd like feedback on: it seals `Window.HandleClosed` and `HandleResized`, because a user inheriting from `Window` shouldn't be messing with those (and `Window` is commonly used as a base class). This does leave open the question of whether we should seal those methods in `PopupRoot` too, and whether we should also seal `HandlePaint` and `HandleScalingChanged`? The `Handle*` methods are kind of internal APIs for communication with the platform impl.

## Fixed issues

Fixes #2965 