### PR TITLE
Remove usage of AddClassHandler that returns new lambda per invocation.

### DIFF
--- a/src/Avalonia.Base/AvaloniaObjectExtensions.cs
+++ b/src/Avalonia.Base/AvaloniaObjectExtensions.cs
@@ -192,9 +192,9 @@ namespace Avalonia
         {
             return observable.Subscribe(e =>
             {
-                if (e.Sender is TTarget)
+                if (e.Sender is TTarget target)
                 {
-                    action((TTarget)e.Sender, e);
+                    action(target, e);
                 }
             });
         }
@@ -207,6 +207,7 @@ namespace Avalonia
         /// <param name="observable">The property changed observable.</param>
         /// <param name="handler">Given a TTarget, returns the handler.</param>
         /// <returns>A disposable that can be used to terminate the subscription.</returns>
+        [Obsolete("Use overload taking Action<TTarget, AvaloniaPropertyChangedEventArgs>.")]
         public static IDisposable AddClassHandler<TTarget>(
             this IObservable<AvaloniaPropertyChangedEventArgs> observable,
             Func<TTarget, Action<AvaloniaPropertyChangedEventArgs>> handler)
@@ -238,9 +239,7 @@ namespace Avalonia
             Func<TTarget, Action<AvaloniaPropertyChangedEventArgs>> handler)
             where TTarget : class
         {
-            var target = e.Sender as TTarget;
-
-            if (target != null)
+            if (e.Sender is TTarget target)
             {
                 handler(target)(e);
             }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -723,29 +723,29 @@ namespace Avalonia.Controls
 
             PseudoClass<DataGrid, bool>(IsValidProperty, x => !x, ":invalid");
 
-            ItemsProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnItemsPropertyChanged(e));
-            CanUserResizeColumnsProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnCanUserResizeColumnsChanged(e));
-            ColumnWidthProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnColumnWidthChanged(e));
-            RowBackgroundProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnRowBackgroundChanged(e));
-            AlternatingRowBackgroundProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnRowBackgroundChanged(e));
-            FrozenColumnCountProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnFrozenColumnCountChanged(e));
-            GridLinesVisibilityProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnGridLinesVisibilityChanged(e));
-            HeadersVisibilityProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnHeadersVisibilityChanged(e));
-            HorizontalGridLinesBrushProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnHorizontalGridLinesBrushChanged(e));
-            IsReadOnlyProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnIsReadOnlyChanged(e));
-            MaxColumnWidthProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnMaxColumnWidthChanged(e));
-            MinColumnWidthProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnMinColumnWidthChanged(e));
-            RowHeightProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnRowHeightChanged(e));
-            RowHeaderWidthProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnRowHeaderWidthChanged(e));
-            SelectionModeProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnSelectionModeChanged(e));
-            VerticalGridLinesBrushProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnVerticalGridLinesBrushChanged(e));
-            SelectedIndexProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnSelectedIndexChanged(e));
-            SelectedItemProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnSelectedItemChanged(e));
-            IsEnabledProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.DataGrid_IsEnabledChanged(e));
-            AreRowGroupHeadersFrozenProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnAreRowGroupHeadersFrozenChanged(e));
-            RowDetailsTemplateProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnRowDetailsTemplateChanged(e));
-            RowDetailsVisibilityModeProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnRowDetailsVisibilityModeChanged(e));
-            AutoGenerateColumnsProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnAutoGenerateColumnsChanged(e));
+            ItemsProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnItemsPropertyChanged(e));
+            CanUserResizeColumnsProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnCanUserResizeColumnsChanged(e));
+            ColumnWidthProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnColumnWidthChanged(e));
+            RowBackgroundProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnRowBackgroundChanged(e));
+            AlternatingRowBackgroundProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnRowBackgroundChanged(e));
+            FrozenColumnCountProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnFrozenColumnCountChanged(e));
+            GridLinesVisibilityProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnGridLinesVisibilityChanged(e));
+            HeadersVisibilityProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnHeadersVisibilityChanged(e));
+            HorizontalGridLinesBrushProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnHorizontalGridLinesBrushChanged(e));
+            IsReadOnlyProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnIsReadOnlyChanged(e));
+            MaxColumnWidthProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnMaxColumnWidthChanged(e));
+            MinColumnWidthProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnMinColumnWidthChanged(e));
+            RowHeightProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnRowHeightChanged(e));
+            RowHeaderWidthProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnRowHeaderWidthChanged(e));
+            SelectionModeProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnSelectionModeChanged(e));
+            VerticalGridLinesBrushProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnVerticalGridLinesBrushChanged(e));
+            SelectedIndexProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnSelectedIndexChanged(e));
+            SelectedItemProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnSelectedItemChanged(e));
+            IsEnabledProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.DataGrid_IsEnabledChanged(e));
+            AreRowGroupHeadersFrozenProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnAreRowGroupHeadersFrozenChanged(e));
+            RowDetailsTemplateProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnRowDetailsTemplateChanged(e));
+            RowDetailsVisibilityModeProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnRowDetailsVisibilityModeChanged(e));
+            AutoGenerateColumnsProperty.Changed.AddClassHandler<DataGrid>((x, e) => x.OnAutoGenerateColumnsChanged(e));
         }
 
         /// <summary>
@@ -3533,7 +3533,7 @@ namespace Avalonia.Controls
                 if (AreColumnHeadersVisible &&
                     _vScrollBar != null && _vScrollBar.IsVisible)
                 {
-                    _topRightCornerHeader.IsVisible = true; ;
+                    _topRightCornerHeader.IsVisible = true;
                 }
                 else
                 {
@@ -5594,7 +5594,7 @@ namespace Avalonia.Controls
                     {
                         // This will trigger a call to this method via Cells_SizeChanged for 
                         // which no processing is needed.
-                        _vScrollBar.IsVisible = true; ;
+                        _vScrollBar.IsVisible = true;
                         if (_vScrollBar.DesiredSize.Width == 0)
                         {
                             // We need to know the width for the rest of layout to work correctly so measure it now

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -723,29 +723,29 @@ namespace Avalonia.Controls
 
             PseudoClass<DataGrid, bool>(IsValidProperty, x => !x, ":invalid");
 
-            ItemsProperty.Changed.AddClassHandler<DataGrid>(x => x.OnItemsPropertyChanged);
-            CanUserResizeColumnsProperty.Changed.AddClassHandler<DataGrid>(x => x.OnCanUserResizeColumnsChanged);
-            ColumnWidthProperty.Changed.AddClassHandler<DataGrid>(x => x.OnColumnWidthChanged);
-            RowBackgroundProperty.Changed.AddClassHandler<DataGrid>(x => x.OnRowBackgroundChanged);
-            AlternatingRowBackgroundProperty.Changed.AddClassHandler<DataGrid>(x => x.OnRowBackgroundChanged);
-            FrozenColumnCountProperty.Changed.AddClassHandler<DataGrid>(x => x.OnFrozenColumnCountChanged);
-            GridLinesVisibilityProperty.Changed.AddClassHandler<DataGrid>(x => x.OnGridLinesVisibilityChanged);
-            HeadersVisibilityProperty.Changed.AddClassHandler<DataGrid>(x => x.OnHeadersVisibilityChanged);
-            HorizontalGridLinesBrushProperty.Changed.AddClassHandler<DataGrid>(x => x.OnHorizontalGridLinesBrushChanged);
-            IsReadOnlyProperty.Changed.AddClassHandler<DataGrid>(x => x.OnIsReadOnlyChanged);
-            MaxColumnWidthProperty.Changed.AddClassHandler<DataGrid>(x => x.OnMaxColumnWidthChanged);
-            MinColumnWidthProperty.Changed.AddClassHandler<DataGrid>(x => x.OnMinColumnWidthChanged);
-            RowHeightProperty.Changed.AddClassHandler<DataGrid>(x => x.OnRowHeightChanged);
-            RowHeaderWidthProperty.Changed.AddClassHandler<DataGrid>(x => x.OnRowHeaderWidthChanged);
-            SelectionModeProperty.Changed.AddClassHandler<DataGrid>(x => x.OnSelectionModeChanged);
-            VerticalGridLinesBrushProperty.Changed.AddClassHandler<DataGrid>(x => x.OnVerticalGridLinesBrushChanged);
-            SelectedIndexProperty.Changed.AddClassHandler<DataGrid>(x => x.OnSelectedIndexChanged);
-            SelectedItemProperty.Changed.AddClassHandler<DataGrid>(x => x.OnSelectedItemChanged);
-            IsEnabledProperty.Changed.AddClassHandler<DataGrid>(x => x.DataGrid_IsEnabledChanged);
-            AreRowGroupHeadersFrozenProperty.Changed.AddClassHandler<DataGrid>(x => x.OnAreRowGroupHeadersFrozenChanged);
-            RowDetailsTemplateProperty.Changed.AddClassHandler<DataGrid>(x => x.OnRowDetailsTemplateChanged);
-            RowDetailsVisibilityModeProperty.Changed.AddClassHandler<DataGrid>(x => x.OnRowDetailsVisibilityModeChanged);
-            AutoGenerateColumnsProperty.Changed.AddClassHandler<DataGrid>(x => x.OnAutoGenerateColumnsChanged);
+            ItemsProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnItemsPropertyChanged(e));
+            CanUserResizeColumnsProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnCanUserResizeColumnsChanged(e));
+            ColumnWidthProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnColumnWidthChanged(e));
+            RowBackgroundProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnRowBackgroundChanged(e));
+            AlternatingRowBackgroundProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnRowBackgroundChanged(e));
+            FrozenColumnCountProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnFrozenColumnCountChanged(e));
+            GridLinesVisibilityProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnGridLinesVisibilityChanged(e));
+            HeadersVisibilityProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnHeadersVisibilityChanged(e));
+            HorizontalGridLinesBrushProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnHorizontalGridLinesBrushChanged(e));
+            IsReadOnlyProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnIsReadOnlyChanged(e));
+            MaxColumnWidthProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnMaxColumnWidthChanged(e));
+            MinColumnWidthProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnMinColumnWidthChanged(e));
+            RowHeightProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnRowHeightChanged(e));
+            RowHeaderWidthProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnRowHeaderWidthChanged(e));
+            SelectionModeProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnSelectionModeChanged(e));
+            VerticalGridLinesBrushProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnVerticalGridLinesBrushChanged(e));
+            SelectedIndexProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnSelectedIndexChanged(e));
+            SelectedItemProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnSelectedItemChanged(e));
+            IsEnabledProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.DataGrid_IsEnabledChanged(e));
+            AreRowGroupHeadersFrozenProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnAreRowGroupHeadersFrozenChanged(e));
+            RowDetailsTemplateProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnRowDetailsTemplateChanged(e));
+            RowDetailsVisibilityModeProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnRowDetailsVisibilityModeChanged(e));
+            AutoGenerateColumnsProperty.Changed.AddClassHandler<DataGrid>((x,e) => x.OnAutoGenerateColumnsChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls.DataGrid/DataGridCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCell.cs
@@ -29,7 +29,7 @@ namespace Avalonia.Controls
         static DataGridCell()
         {
             PointerPressedEvent.AddClassHandler<DataGridCell>(
-                x => x.DataGridCell_PointerPressed, handledEventsToo: true);
+                (x,e) => x.DataGridCell_PointerPressed(e), handledEventsToo: true);
         }
         public DataGridCell()
         { }

--- a/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
@@ -67,7 +67,7 @@ namespace Avalonia.Controls
 
         static DataGridColumnHeader()
         {
-            AreSeparatorsVisibleProperty.Changed.AddClassHandler<DataGridColumnHeader>(x => x.OnAreSeparatorsVisibleChanged);
+            AreSeparatorsVisibleProperty.Changed.AddClassHandler<DataGridColumnHeader>((x,e) => x.OnAreSeparatorsVisibleChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -116,10 +116,10 @@ namespace Avalonia.Controls
 
         static DataGridRow()
         {
-            HeaderProperty.Changed.AddClassHandler<DataGridRow>(x => x.OnHeaderChanged);
-            DetailsTemplateProperty.Changed.AddClassHandler<DataGridRow>(x => x.OnDetailsTemplateChanged);
-            AreDetailsVisibleProperty.Changed.AddClassHandler<DataGridRow>(x => x.OnAreDetailsVisibleChanged);
-            PointerPressedEvent.AddClassHandler<DataGridRow>(x => x.DataGridRow_PointerPressed, handledEventsToo: true);
+            HeaderProperty.Changed.AddClassHandler<DataGridRow>((x, e) => x.OnHeaderChanged(e));
+            DetailsTemplateProperty.Changed.AddClassHandler<DataGridRow>((x, e) => x.OnDetailsTemplateChanged(e));
+            AreDetailsVisibleProperty.Changed.AddClassHandler<DataGridRow>((x, e) => x.OnAreDetailsVisibleChanged(e));
+            PointerPressedEvent.AddClassHandler<DataGridRow>((x, e) => x.DataGridRow_PointerPressed(e), handledEventsToo: true);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
@@ -109,7 +109,7 @@ namespace Avalonia.Controls
 
         static DataGridRowGroupHeader()
         {
-            SublevelIndentProperty.Changed.AddClassHandler<DataGridRowGroupHeader>(x => x.OnSublevelIndentChanged);
+            SublevelIndentProperty.Changed.AddClassHandler<DataGridRowGroupHeader>((x,e) => x.OnSublevelIndentChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox.cs
@@ -805,15 +805,15 @@ namespace Avalonia.Controls
         {
             FocusableProperty.OverrideDefaultValue<AutoCompleteBox>(true);
 
-            MinimumPopulateDelayProperty.Changed.AddClassHandler<AutoCompleteBox>(x => x.OnMinimumPopulateDelayChanged);
-            IsDropDownOpenProperty.Changed.AddClassHandler<AutoCompleteBox>(x => x.OnIsDropDownOpenChanged);
-            SelectedItemProperty.Changed.AddClassHandler<AutoCompleteBox>(x => x.OnSelectedItemPropertyChanged);
-            TextProperty.Changed.AddClassHandler<AutoCompleteBox>(x => x.OnTextPropertyChanged);
-            SearchTextProperty.Changed.AddClassHandler<AutoCompleteBox>(x => x.OnSearchTextPropertyChanged);
-            FilterModeProperty.Changed.AddClassHandler<AutoCompleteBox>(x => x.OnFilterModePropertyChanged);
-            ItemFilterProperty.Changed.AddClassHandler<AutoCompleteBox>(x => x.OnItemFilterPropertyChanged);
-            ItemsProperty.Changed.AddClassHandler<AutoCompleteBox>(x => x.OnItemsPropertyChanged);
-            IsEnabledProperty.Changed.AddClassHandler<AutoCompleteBox>(x => x.OnControlIsEnabledChanged);
+            MinimumPopulateDelayProperty.Changed.AddClassHandler<AutoCompleteBox>((x,e) => x.OnMinimumPopulateDelayChanged(e));
+            IsDropDownOpenProperty.Changed.AddClassHandler<AutoCompleteBox>((x,e) => x.OnIsDropDownOpenChanged(e));
+            SelectedItemProperty.Changed.AddClassHandler<AutoCompleteBox>((x,e) => x.OnSelectedItemPropertyChanged(e));
+            TextProperty.Changed.AddClassHandler<AutoCompleteBox>((x,e) => x.OnTextPropertyChanged(e));
+            SearchTextProperty.Changed.AddClassHandler<AutoCompleteBox>((x,e) => x.OnSearchTextPropertyChanged(e));
+            FilterModeProperty.Changed.AddClassHandler<AutoCompleteBox>((x,e) => x.OnFilterModePropertyChanged(e));
+            ItemFilterProperty.Changed.AddClassHandler<AutoCompleteBox>((x,e) => x.OnItemFilterPropertyChanged(e));
+            ItemsProperty.Changed.AddClassHandler<AutoCompleteBox>((x,e) => x.OnItemsPropertyChanged(e));
+            IsEnabledProperty.Changed.AddClassHandler<AutoCompleteBox>((x,e) => x.OnControlIsEnabledChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Calendar/Calendar.cs
+++ b/src/Avalonia.Controls/Calendar/Calendar.cs
@@ -2057,18 +2057,17 @@ namespace Avalonia.Controls
 
         static Calendar()
         {
-            IsEnabledProperty.Changed.AddClassHandler<Calendar>(x => x.OnIsEnabledChanged);
-            FirstDayOfWeekProperty.Changed.AddClassHandler<Calendar>(x => x.OnFirstDayOfWeekChanged);
-            IsTodayHighlightedProperty.Changed.AddClassHandler<Calendar>(x => x.OnIsTodayHighlightedChanged);
-            DisplayModeProperty.Changed.AddClassHandler<Calendar>(x => x.OnDisplayModePropertyChanged);
-            SelectionModeProperty.Changed.AddClassHandler<Calendar>(x => x.OnSelectionModeChanged);
-            SelectedDateProperty.Changed.AddClassHandler<Calendar>(x => x.OnSelectedDateChanged);
-            DisplayDateProperty.Changed.AddClassHandler<Calendar>(x => x.OnDisplayDateChanged);
-            DisplayDateStartProperty.Changed.AddClassHandler<Calendar>(x => x.OnDisplayDateStartChanged);
-            DisplayDateEndProperty.Changed.AddClassHandler<Calendar>(x => x.OnDisplayDateEndChanged);
-            KeyDownEvent.AddClassHandler<Calendar>(x => x.Calendar_KeyDown);
-            KeyUpEvent.AddClassHandler<Calendar>(x => x.Calendar_KeyUp);
-            
+            IsEnabledProperty.Changed.AddClassHandler<Calendar>((x,e) => x.OnIsEnabledChanged(e));
+            FirstDayOfWeekProperty.Changed.AddClassHandler<Calendar>((x,e) => x.OnFirstDayOfWeekChanged(e));
+            IsTodayHighlightedProperty.Changed.AddClassHandler<Calendar>((x,e) => x.OnIsTodayHighlightedChanged(e));
+            DisplayModeProperty.Changed.AddClassHandler<Calendar>((x,e) => x.OnDisplayModePropertyChanged(e));
+            SelectionModeProperty.Changed.AddClassHandler<Calendar>((x,e) => x.OnSelectionModeChanged(e));
+            SelectedDateProperty.Changed.AddClassHandler<Calendar>((x,e) => x.OnSelectedDateChanged(e));
+            DisplayDateProperty.Changed.AddClassHandler<Calendar>((x,e) => x.OnDisplayDateChanged(e));
+            DisplayDateStartProperty.Changed.AddClassHandler<Calendar>((x,e) => x.OnDisplayDateStartChanged(e));
+            DisplayDateEndProperty.Changed.AddClassHandler<Calendar>((x,e) => x.OnDisplayDateEndChanged(e));
+            KeyDownEvent.AddClassHandler<Calendar>((x,e) => x.Calendar_KeyDown(e));
+            KeyUpEvent.AddClassHandler<Calendar>((x,e) => x.Calendar_KeyUp(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Calendar/DatePicker.cs
+++ b/src/Avalonia.Controls/Calendar/DatePicker.cs
@@ -393,14 +393,14 @@ namespace Avalonia.Controls
         {
             FocusableProperty.OverrideDefaultValue<DatePicker>(true);
 
-            DisplayDateProperty.Changed.AddClassHandler<DatePicker>(x => x.OnDisplayDateChanged);
-            DisplayDateStartProperty.Changed.AddClassHandler<DatePicker>(x => x.OnDisplayDateStartChanged);
-            DisplayDateEndProperty.Changed.AddClassHandler<DatePicker>(x => x.OnDisplayDateEndChanged);
-            IsDropDownOpenProperty.Changed.AddClassHandler<DatePicker>(x => x.OnIsDropDownOpenChanged);
-            SelectedDateProperty.Changed.AddClassHandler<DatePicker>(x => x.OnSelectedDateChanged);
-            SelectedDateFormatProperty.Changed.AddClassHandler<DatePicker>(x => x.OnSelectedDateFormatChanged);
-            CustomDateFormatStringProperty.Changed.AddClassHandler<DatePicker>(x => x.OnCustomDateFormatStringChanged);
-            TextProperty.Changed.AddClassHandler<DatePicker>(x => x.OnTextChanged);
+            DisplayDateProperty.Changed.AddClassHandler<DatePicker>((x,e) => x.OnDisplayDateChanged(e));
+            DisplayDateStartProperty.Changed.AddClassHandler<DatePicker>((x,e) => x.OnDisplayDateStartChanged(e));
+            DisplayDateEndProperty.Changed.AddClassHandler<DatePicker>((x,e) => x.OnDisplayDateEndChanged(e));
+            IsDropDownOpenProperty.Changed.AddClassHandler<DatePicker>((x,e) => x.OnIsDropDownOpenChanged(e));
+            SelectedDateProperty.Changed.AddClassHandler<DatePicker>((x,e) => x.OnSelectedDateChanged(e));
+            SelectedDateFormatProperty.Changed.AddClassHandler<DatePicker>((x,e) => x.OnSelectedDateFormatChanged(e));
+            CustomDateFormatStringProperty.Changed.AddClassHandler<DatePicker>((x,e) => x.OnCustomDateFormatStringChanged(e));
+            TextProperty.Changed.AddClassHandler<DatePicker>((x,e) => x.OnTextChanged(e));
         }
         /// <summary>
         /// Initializes a new instance of the

--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -65,8 +65,8 @@ namespace Avalonia.Controls
         {
             ItemsPanelProperty.OverrideDefaultValue<ComboBox>(DefaultPanel);
             FocusableProperty.OverrideDefaultValue<ComboBox>(true);
-            SelectedItemProperty.Changed.AddClassHandler<ComboBox>(x => x.SelectedItemChanged);
-            KeyDownEvent.AddClassHandler<ComboBox>(x => x.OnKeyDown, Interactivity.RoutingStrategies.Tunnel);
+            SelectedItemProperty.Changed.AddClassHandler<ComboBox>((x,e) => x.SelectedItemChanged(e));
+            KeyDownEvent.AddClassHandler<ComboBox>((x, e) => x.OnKeyDown(e), Interactivity.RoutingStrategies.Tunnel);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/ContentControl.cs
+++ b/src/Avalonia.Controls/ContentControl.cs
@@ -43,7 +43,7 @@ namespace Avalonia.Controls
 
         static ContentControl()
         {
-            ContentProperty.Changed.AddClassHandler<ContentControl>(x => x.ContentChanged);
+            ContentProperty.Changed.AddClassHandler<ContentControl>((x, e) => x.ContentChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/DataValidationErrors.cs
+++ b/src/Avalonia.Controls/DataValidationErrors.cs
@@ -56,7 +56,7 @@ namespace Avalonia.Controls
         {
             ErrorsProperty.Changed.Subscribe(ErrorsChanged);
             HasErrorsProperty.Changed.Subscribe(HasErrorsChanged);
-            TemplatedParentProperty.Changed.AddClassHandler<DataValidationErrors>(x => x.OnTemplatedParentChange);
+            TemplatedParentProperty.Changed.AddClassHandler<DataValidationErrors>((x, e) => x.OnTemplatedParentChange(e));
         }
 
         private void OnTemplatedParentChange(AvaloniaPropertyChangedEventArgs e)

--- a/src/Avalonia.Controls/Decorator.cs
+++ b/src/Avalonia.Controls/Decorator.cs
@@ -29,7 +29,7 @@ namespace Avalonia.Controls
         static Decorator()
         {
             AffectsMeasure<Decorator>(ChildProperty, PaddingProperty);
-            ChildProperty.Changed.AddClassHandler<Decorator>(x => x.ChildChanged);
+            ChildProperty.Changed.AddClassHandler<Decorator>((x, e) => x.ChildChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Expander.cs
+++ b/src/Avalonia.Controls/Expander.cs
@@ -37,7 +37,7 @@ namespace Avalonia.Controls
 
             PseudoClass<Expander>(IsExpandedProperty, ":expanded");
 
-            IsExpandedProperty.Changed.AddClassHandler<Expander>(x => x.OnIsExpandedChanged);
+            IsExpandedProperty.Changed.AddClassHandler<Expander>((x, e) => x.OnIsExpandedChanged(e));
         }
 
         public IPageTransition ContentTransition

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -64,8 +64,8 @@ namespace Avalonia.Controls
         /// </summary>
         static ItemsControl()
         {
-            ItemsProperty.Changed.AddClassHandler<ItemsControl>(x => x.ItemsChanged);
-            ItemTemplateProperty.Changed.AddClassHandler<ItemsControl>(x => x.ItemTemplateChanged);
+            ItemsProperty.Changed.AddClassHandler<ItemsControl>((x, e) => x.ItemsChanged(e));
+            ItemTemplateProperty.Changed.AddClassHandler<ItemsControl>((x, e) => x.ItemTemplateChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/LayoutTransformControl.cs
+++ b/src/Avalonia.Controls/LayoutTransformControl.cs
@@ -28,11 +28,13 @@ namespace Avalonia.Controls
             ClipToBoundsProperty.OverrideDefaultValue<LayoutTransformControl>(true);
 
             LayoutTransformProperty.Changed
-                .AddClassHandler<LayoutTransformControl>(x => x.OnLayoutTransformChanged);
+                .AddClassHandler<LayoutTransformControl>((x, e) => x.OnLayoutTransformChanged(e));
 
             ChildProperty.Changed
-                .AddClassHandler<LayoutTransformControl>(x => x.OnChildChanged);
-            UseRenderTransformProperty.Changed.AddClassHandler<LayoutTransformControl>(x => x.OnUseRenderTransformPropertyChanged);
+                .AddClassHandler<LayoutTransformControl>((x, e) => x.OnChildChanged(e));
+
+            UseRenderTransformProperty.Changed
+                .AddClassHandler<LayoutTransformControl>((x, e) => x.OnUseRenderTransformPropertyChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/MenuBase.cs
+++ b/src/Avalonia.Controls/MenuBase.cs
@@ -64,7 +64,7 @@ namespace Avalonia.Controls
         /// </summary>
         static MenuBase()
         {
-            MenuItem.SubmenuOpenedEvent.AddClassHandler<MenuBase>(x => x.OnSubmenuOpened);
+            MenuItem.SubmenuOpenedEvent.AddClassHandler<MenuBase>((x, e) => x.OnSubmenuOpened(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -102,13 +102,13 @@ namespace Avalonia.Controls
             SelectableMixin.Attach<MenuItem>(IsSelectedProperty);
             CommandProperty.Changed.Subscribe(CommandChanged);
             FocusableProperty.OverrideDefaultValue<MenuItem>(true);
-            HeaderProperty.Changed.AddClassHandler<MenuItem>(x => x.HeaderChanged);
-            IconProperty.Changed.AddClassHandler<MenuItem>(x => x.IconChanged);
-            IsSelectedProperty.Changed.AddClassHandler<MenuItem>(x => x.IsSelectedChanged);
+            HeaderProperty.Changed.AddClassHandler<MenuItem>((x, e) => x.HeaderChanged(e));
+            IconProperty.Changed.AddClassHandler<MenuItem>((x, e) => x.IconChanged(e));
+            IsSelectedProperty.Changed.AddClassHandler<MenuItem>((x, e) => x.IsSelectedChanged(e));
             ItemsPanelProperty.OverrideDefaultValue<MenuItem>(DefaultPanel);
-            ClickEvent.AddClassHandler<MenuItem>(x => x.OnClick);
-            SubmenuOpenedEvent.AddClassHandler<MenuItem>(x => x.OnSubmenuOpened);
-            IsSubMenuOpenProperty.Changed.AddClassHandler<MenuItem>(x => x.SubMenuOpenChanged);
+            ClickEvent.AddClassHandler<MenuItem>((x, e) => x.OnClick(e));
+            SubmenuOpenedEvent.AddClassHandler<MenuItem>((x, e) => x.OnSubmenuOpened(e));
+            IsSubMenuOpenProperty.Changed.AddClassHandler<MenuItem>((x, e) => x.SubMenuOpenChanged(e));
         }
 
         public MenuItem()

--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -46,8 +46,8 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         static CarouselPresenter()
         {
-            IsVirtualizedProperty.Changed.AddClassHandler<CarouselPresenter>(x => x.IsVirtualizedChanged);
-            SelectedIndexProperty.Changed.AddClassHandler<CarouselPresenter>(x => x.SelectedIndexChanged);
+            IsVirtualizedProperty.Changed.AddClassHandler<CarouselPresenter>((x, e) => x.IsVirtualizedChanged(e));
+            SelectedIndexProperty.Changed.AddClassHandler<CarouselPresenter>((x, e) => x.SelectedIndexChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -94,9 +94,9 @@ namespace Avalonia.Controls.Presenters
         {
             AffectsRender<ContentPresenter>(BackgroundProperty, BorderBrushProperty, BorderThicknessProperty, CornerRadiusProperty);
             AffectsMeasure<ContentPresenter>(BorderThicknessProperty, PaddingProperty);
-            ContentProperty.Changed.AddClassHandler<ContentPresenter>(x => x.ContentChanged);
-            ContentTemplateProperty.Changed.AddClassHandler<ContentPresenter>(x => x.ContentChanged);
-            TemplatedParentProperty.Changed.AddClassHandler<ContentPresenter>(x => x.TemplatedParentChanged);
+            ContentProperty.Changed.AddClassHandler<ContentPresenter>((x, e) => x.ContentChanged(e));
+            ContentTemplateProperty.Changed.AddClassHandler<ContentPresenter>((x, e) => x.ContentChanged(e));
+            TemplatedParentProperty.Changed.AddClassHandler<ContentPresenter>((x, e) => x.TemplatedParentChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
@@ -35,7 +35,7 @@ namespace Avalonia.Controls.Presenters
                 KeyboardNavigationMode.Once);
 
             VirtualizationModeProperty.Changed
-                .AddClassHandler<ItemsPresenter>(x => x.VirtualizationModeChanged);
+                .AddClassHandler<ItemsPresenter>((x,e) => x.VirtualizationModeChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
@@ -35,7 +35,7 @@ namespace Avalonia.Controls.Presenters
                 KeyboardNavigationMode.Once);
 
             VirtualizationModeProperty.Changed
-                .AddClassHandler<ItemsPresenter>((x,e) => x.VirtualizationModeChanged(e));
+                .AddClassHandler<ItemsPresenter>((x, e) => x.VirtualizationModeChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
@@ -45,7 +45,7 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         static ItemsPresenterBase()
         {
-            TemplatedParentProperty.Changed.AddClassHandler<ItemsPresenterBase>(x => x.TemplatedParentChanged);
+            TemplatedParentProperty.Changed.AddClassHandler<ItemsPresenterBase>((x,e) => x.TemplatedParentChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -73,7 +73,7 @@ namespace Avalonia.Controls.Presenters
         static ScrollContentPresenter()
         {
             ClipToBoundsProperty.OverrideDefaultValue(typeof(ScrollContentPresenter), true);
-            ChildProperty.Changed.AddClassHandler<ScrollContentPresenter>((x,e) => x.ChildChanged(e));
+            ChildProperty.Changed.AddClassHandler<ScrollContentPresenter>((x, e) => x.ChildChanged(e));
             AffectsArrange<ScrollContentPresenter>(OffsetProperty);
         }
 
@@ -246,7 +246,7 @@ namespace Avalonia.Controls.Presenters
                 if (isLogical)
                     _activeLogicalGestureScrolls?.TryGetValue(e.Id, out delta);
                 delta += e.Delta;
-                
+
                 if (Extent.Height > Viewport.Height)
                 {
                     double dy;
@@ -293,7 +293,7 @@ namespace Avalonia.Controls.Presenters
             }
         }
 
-        private void OnScrollGestureEnded(object sender, ScrollGestureEndedEventArgs e) 
+        private void OnScrollGestureEnded(object sender, ScrollGestureEndedEventArgs e)
             => _activeLogicalGestureScrolls?.Remove(e.Id);
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -73,7 +73,7 @@ namespace Avalonia.Controls.Presenters
         static ScrollContentPresenter()
         {
             ClipToBoundsProperty.OverrideDefaultValue(typeof(ScrollContentPresenter), true);
-            ChildProperty.Changed.AddClassHandler<ScrollContentPresenter>(x => x.ChildChanged);
+            ChildProperty.Changed.AddClassHandler<ScrollContentPresenter>((x,e) => x.ChildChanged(e));
             AffectsArrange<ScrollContentPresenter>(OffsetProperty);
         }
 

--- a/src/Avalonia.Controls/Primitives/HeaderedContentControl.cs
+++ b/src/Avalonia.Controls/Primitives/HeaderedContentControl.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         static HeaderedContentControl()
         {
-            ContentProperty.Changed.AddClassHandler<HeaderedContentControl>(x => x.HeaderChanged);
+            ContentProperty.Changed.AddClassHandler<HeaderedContentControl>((x, e) => x.HeaderChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/HeaderedItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/HeaderedItemsControl.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         static HeaderedItemsControl()
         {
-            HeaderProperty.Changed.AddClassHandler<HeaderedItemsControl>(x => x.HeaderChanged);
+            HeaderProperty.Changed.AddClassHandler<HeaderedItemsControl>((x, e) => x.HeaderChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/HeaderedSelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/HeaderedSelectingItemsControl.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         static HeaderedSelectingItemsControl()
         {
-            HeaderProperty.Changed.AddClassHandler<HeaderedSelectingItemsControl>(x => x.HeaderChanged);
+            HeaderProperty.Changed.AddClassHandler<HeaderedSelectingItemsControl>((x, e) => x.HeaderChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -93,8 +93,8 @@ namespace Avalonia.Controls.Primitives
         static Popup()
         {
             IsHitTestVisibleProperty.OverrideDefaultValue<Popup>(false);
-            ChildProperty.Changed.AddClassHandler<Popup>(x => x.ChildChanged);
-            IsOpenProperty.Changed.AddClassHandler<Popup>(x => x.IsOpenChanged);
+            ChildProperty.Changed.AddClassHandler<Popup>((x, e) => x.ChildChanged(e));
+            IsOpenProperty.Changed.AddClassHandler<Popup>((x, e) => x.IsOpenChanged(e));
         }
 
         public Popup()

--- a/src/Avalonia.Controls/Primitives/ScrollBar.cs
+++ b/src/Avalonia.Controls/Primitives/ScrollBar.cs
@@ -58,8 +58,8 @@ namespace Avalonia.Controls.Primitives
             PseudoClass<ScrollBar, Orientation>(OrientationProperty, o => o == Orientation.Vertical, ":vertical");
             PseudoClass<ScrollBar, Orientation>(OrientationProperty, o => o == Orientation.Horizontal, ":horizontal");
 
-            Thumb.DragDeltaEvent.AddClassHandler<ScrollBar>(o => o.OnThumbDragDelta, RoutingStrategies.Bubble);
-            Thumb.DragCompletedEvent.AddClassHandler<ScrollBar>(o => o.OnThumbDragComplete, RoutingStrategies.Bubble);
+            Thumb.DragDeltaEvent.AddClassHandler<ScrollBar>((x, e) => x.OnThumbDragDelta(e), RoutingStrategies.Bubble);
+            Thumb.DragCompletedEvent.AddClassHandler<ScrollBar>((x, e) => x.OnThumbDragComplete(e), RoutingStrategies.Bubble);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -119,7 +119,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         static SelectingItemsControl()
         {
-            IsSelectedChangedEvent.AddClassHandler<SelectingItemsControl>((x,e) => x.ContainerSelectionChanged(e));
+            IsSelectedChangedEvent.AddClassHandler<SelectingItemsControl>((x, e) => x.ContainerSelectionChanged(e));
         }
 
         /// <summary>
@@ -1088,8 +1088,8 @@ namespace Avalonia.Controls.Primitives
                 }
                 else
                 {
-                    SelectedIndex = _updateSelectedIndex != int.MinValue ? 
-                        _updateSelectedIndex : 
+                    SelectedIndex = _updateSelectedIndex != int.MinValue ?
+                        _updateSelectedIndex :
                         AlwaysSelected ? 0 : -1;
                 }
             }

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -119,7 +119,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         static SelectingItemsControl()
         {
-            IsSelectedChangedEvent.AddClassHandler<SelectingItemsControl>(x => x.ContainerSelectionChanged);
+            IsSelectedChangedEvent.AddClassHandler<SelectingItemsControl>((x,e) => x.ContainerSelectionChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/TemplatedControl.cs
+++ b/src/Avalonia.Controls/Primitives/TemplatedControl.cs
@@ -99,7 +99,7 @@ namespace Avalonia.Controls.Primitives
         static TemplatedControl()
         {
             ClipToBoundsProperty.OverrideDefaultValue<TemplatedControl>(true);
-            TemplateProperty.Changed.AddClassHandler<TemplatedControl>(x => x.OnTemplateChanged);
+            TemplateProperty.Changed.AddClassHandler<TemplatedControl>((x, e) => x.OnTemplateChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/Thumb.cs
+++ b/src/Avalonia.Controls/Primitives/Thumb.cs
@@ -22,9 +22,9 @@ namespace Avalonia.Controls.Primitives
 
         static Thumb()
         {
-            DragStartedEvent.AddClassHandler<Thumb>(x => x.OnDragStarted, RoutingStrategies.Bubble);
-            DragDeltaEvent.AddClassHandler<Thumb>(x => x.OnDragDelta, RoutingStrategies.Bubble);
-            DragCompletedEvent.AddClassHandler<Thumb>(x => x.OnDragCompleted, RoutingStrategies.Bubble);
+            DragStartedEvent.AddClassHandler<Thumb>((x,e) => x.OnDragStarted(e), RoutingStrategies.Bubble);
+            DragDeltaEvent.AddClassHandler<Thumb>((x, e) => x.OnDragDelta(e), RoutingStrategies.Bubble);
+            DragCompletedEvent.AddClassHandler<Thumb>((x, e) => x.OnDragCompleted(e), RoutingStrategies.Bubble);
         }
 
         public event EventHandler<VectorEventArgs> DragStarted

--- a/src/Avalonia.Controls/Primitives/Track.cs
+++ b/src/Avalonia.Controls/Primitives/Track.cs
@@ -48,9 +48,9 @@ namespace Avalonia.Controls.Primitives
         {
             PseudoClass<Track, Orientation>(OrientationProperty, o => o == Orientation.Vertical, ":vertical");
             PseudoClass<Track, Orientation>(OrientationProperty, o => o == Orientation.Horizontal, ":horizontal");
-            ThumbProperty.Changed.AddClassHandler<Track>(x => x.ThumbChanged);
-            IncreaseButtonProperty.Changed.AddClassHandler<Track>(x => x.ButtonChanged);
-            DecreaseButtonProperty.Changed.AddClassHandler<Track>(x => x.ButtonChanged);
+            ThumbProperty.Changed.AddClassHandler<Track>((x,e) => x.ThumbChanged(e));
+            IncreaseButtonProperty.Changed.AddClassHandler<Track>((x, e) => x.ButtonChanged(e));
+            DecreaseButtonProperty.Changed.AddClassHandler<Track>((x, e) => x.ButtonChanged(e));
             AffectsArrange<Track>(MinimumProperty, MaximumProperty, ValueProperty, OrientationProperty);
         }
 

--- a/src/Avalonia.Controls/ProgressBar.cs
+++ b/src/Avalonia.Controls/ProgressBar.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 
+using System;
 using Avalonia.Controls.Primitives;
 using Avalonia.Layout;
 
@@ -38,8 +39,8 @@ namespace Avalonia.Controls
             PseudoClass<ProgressBar, Orientation>(OrientationProperty, o => o == Orientation.Horizontal, ":horizontal");
             PseudoClass<ProgressBar>(IsIndeterminateProperty, ":indeterminate");
 
-            ValueProperty.Changed.AddClassHandler<ProgressBar>(x => x.UpdateIndicatorWhenPropChanged);
-            IsIndeterminateProperty.Changed.AddClassHandler<ProgressBar>(x => x.UpdateIndicatorWhenPropChanged);
+            ValueProperty.Changed.AddClassHandler<ProgressBar>((x,e) => x.UpdateIndicatorWhenPropChanged(e));
+            IsIndeterminateProperty.Changed.AddClassHandler<ProgressBar>((x,e) => x.UpdateIndicatorWhenPropChanged(e));
         }
 
         public bool IsIndeterminate

--- a/src/Avalonia.Controls/ProgressBar.cs
+++ b/src/Avalonia.Controls/ProgressBar.cs
@@ -39,8 +39,8 @@ namespace Avalonia.Controls
             PseudoClass<ProgressBar, Orientation>(OrientationProperty, o => o == Orientation.Horizontal, ":horizontal");
             PseudoClass<ProgressBar>(IsIndeterminateProperty, ":indeterminate");
 
-            ValueProperty.Changed.AddClassHandler<ProgressBar>((x,e) => x.UpdateIndicatorWhenPropChanged(e));
-            IsIndeterminateProperty.Changed.AddClassHandler<ProgressBar>((x,e) => x.UpdateIndicatorWhenPropChanged(e));
+            ValueProperty.Changed.AddClassHandler<ProgressBar>((x, e) => x.UpdateIndicatorWhenPropChanged(e));
+            IsIndeterminateProperty.Changed.AddClassHandler<ProgressBar>((x, e) => x.UpdateIndicatorWhenPropChanged(e));
         }
 
         public bool IsIndeterminate

--- a/src/Avalonia.Controls/ScrollViewer.cs
+++ b/src/Avalonia.Controls/ScrollViewer.cs
@@ -163,8 +163,8 @@ namespace Avalonia.Controls
         {
             AffectsValidation(ExtentProperty, OffsetProperty);
             AffectsValidation(ViewportProperty, OffsetProperty);
-            HorizontalScrollBarVisibilityProperty.Changed.AddClassHandler<ScrollViewer>(x => x.ScrollBarVisibilityChanged);
-            VerticalScrollBarVisibilityProperty.Changed.AddClassHandler<ScrollViewer>(x => x.ScrollBarVisibilityChanged);
+            HorizontalScrollBarVisibilityProperty.Changed.AddClassHandler<ScrollViewer>((x, e) => x.ScrollBarVisibilityChanged(e));
+            VerticalScrollBarVisibilityProperty.Changed.AddClassHandler<ScrollViewer>((x, e) => x.ScrollBarVisibilityChanged(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Slider.cs
+++ b/src/Avalonia.Controls/Slider.cs
@@ -45,9 +45,9 @@ namespace Avalonia.Controls
             OrientationProperty.OverrideDefaultValue(typeof(Slider), Orientation.Horizontal);
             PseudoClass<Slider, Orientation>(OrientationProperty, o => o == Orientation.Vertical, ":vertical");
             PseudoClass<Slider, Orientation>(OrientationProperty, o => o == Orientation.Horizontal, ":horizontal");
-            Thumb.DragStartedEvent.AddClassHandler<Slider>(x => x.OnThumbDragStarted, RoutingStrategies.Bubble);
-            Thumb.DragDeltaEvent.AddClassHandler<Slider>(x => x.OnThumbDragDelta, RoutingStrategies.Bubble);
-            Thumb.DragCompletedEvent.AddClassHandler<Slider>(x => x.OnThumbDragCompleted, RoutingStrategies.Bubble);
+            Thumb.DragStartedEvent.AddClassHandler<Slider>((x, e) => x.OnThumbDragStarted(e), RoutingStrategies.Bubble);
+            Thumb.DragDeltaEvent.AddClassHandler<Slider>((x, e) => x.OnThumbDragDelta(e), RoutingStrategies.Bubble);
+            Thumb.DragCompletedEvent.AddClassHandler<Slider>((x, e) => x.OnThumbDragCompleted(e), RoutingStrategies.Bubble);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/TabItem.cs
+++ b/src/Avalonia.Controls/TabItem.cs
@@ -30,8 +30,8 @@ namespace Avalonia.Controls
         {
             SelectableMixin.Attach<TabItem>(IsSelectedProperty);
             FocusableProperty.OverrideDefaultValue(typeof(TabItem), true);
-            IsSelectedProperty.Changed.AddClassHandler<TabItem>(x => x.UpdateSelectedContent);
-            DataContextProperty.Changed.AddClassHandler<TabItem>(x => x.UpdateHeader);
+            IsSelectedProperty.Changed.AddClassHandler<TabItem>((x, e) => x.UpdateSelectedContent(e));
+            DataContextProperty.Changed.AddClassHandler<TabItem>((x, e) => x.UpdateHeader(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -54,7 +54,7 @@ namespace Avalonia.Controls
             SelectableMixin.Attach<TreeViewItem>(IsSelectedProperty);
             FocusableProperty.OverrideDefaultValue<TreeViewItem>(true);
             ItemsPanelProperty.OverrideDefaultValue<TreeViewItem>(DefaultPanel);
-            RequestBringIntoViewEvent.AddClassHandler<TreeViewItem>(x => x.OnRequestBringIntoView);
+            RequestBringIntoViewEvent.AddClassHandler<TreeViewItem>((x, e) => x.OnRequestBringIntoView(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/WindowBase.cs
+++ b/src/Avalonia.Controls/WindowBase.cs
@@ -47,7 +47,7 @@ namespace Avalonia.Controls
         static WindowBase()
         {
             IsVisibleProperty.OverrideDefaultValue<WindowBase>(false);
-            IsVisibleProperty.Changed.AddClassHandler<WindowBase>(x => x.IsVisibleChanged);
+            IsVisibleProperty.Changed.AddClassHandler<WindowBase>((x,e) => x.IsVisibleChanged(e));
 
             
             TopmostProperty.Changed.AddClassHandler<WindowBase>((w, e) => w.PlatformImpl?.SetTopmost((bool)e.NewValue));

--- a/src/Avalonia.Input/InputElement.cs
+++ b/src/Avalonia.Input/InputElement.cs
@@ -169,18 +169,18 @@ namespace Avalonia.Input
         {
             IsEnabledProperty.Changed.Subscribe(IsEnabledChanged);
 
-            GotFocusEvent.AddClassHandler<InputElement>(x => x.OnGotFocus);
-            LostFocusEvent.AddClassHandler<InputElement>(x => x.OnLostFocus);
-            KeyDownEvent.AddClassHandler<InputElement>(x => x.OnKeyDown);
-            KeyUpEvent.AddClassHandler<InputElement>(x => x.OnKeyUp);
-            TextInputEvent.AddClassHandler<InputElement>(x => x.OnTextInput);
-            PointerEnterEvent.AddClassHandler<InputElement>(x => x.OnPointerEnterCore);
-            PointerLeaveEvent.AddClassHandler<InputElement>(x => x.OnPointerLeaveCore);
-            PointerMovedEvent.AddClassHandler<InputElement>(x => x.OnPointerMoved);
-            PointerPressedEvent.AddClassHandler<InputElement>(x => x.OnPointerPressed);
-            PointerReleasedEvent.AddClassHandler<InputElement>(x => x.OnPointerReleased);
-            PointerCaptureLostEvent.AddClassHandler<InputElement>(x => x.OnPointerCaptureLost);
-            PointerWheelChangedEvent.AddClassHandler<InputElement>(x => x.OnPointerWheelChanged);
+            GotFocusEvent.AddClassHandler<InputElement>((x, e) => x.OnGotFocus(e));
+            LostFocusEvent.AddClassHandler<InputElement>((x, e) => x.OnLostFocus(e));
+            KeyDownEvent.AddClassHandler<InputElement>((x, e) => x.OnKeyDown(e));
+            KeyUpEvent.AddClassHandler<InputElement>((x, e) => x.OnKeyUp(e));
+            TextInputEvent.AddClassHandler<InputElement>((x, e) => x.OnTextInput(e));
+            PointerEnterEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerEnterCore(e));
+            PointerLeaveEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerLeaveCore(e));
+            PointerMovedEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerMoved(e));
+            PointerPressedEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerPressed(e));
+            PointerReleasedEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerReleased(e));
+            PointerCaptureLostEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerCaptureLost(e));
+            PointerWheelChangedEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerWheelChanged(e));
 
             PseudoClass<InputElement, bool>(IsEffectivelyEnabledProperty, x => !x, ":disabled");
             PseudoClass<InputElement>(IsFocusedProperty, ":focus");

--- a/src/Avalonia.Interactivity/RoutedEvent.cs
+++ b/src/Avalonia.Interactivity/RoutedEvent.cs
@@ -113,24 +113,38 @@ namespace Avalonia.Interactivity
             Contract.Requires<ArgumentNullException>(ownerType != null);
         }
 
+        [Obsolete("Use overload taking Action<TTarget, TEventArgs>.")]
         public IDisposable AddClassHandler<TTarget>(
             Func<TTarget, Action<TEventArgs>> handler,
             RoutingStrategies routes = RoutingStrategies.Direct | RoutingStrategies.Bubble,
             bool handledEventsToo = false)
-                where TTarget : class, IInteractive
+            where TTarget : class, IInteractive
         {
-            EventHandler<RoutedEventArgs> adapter = (sender, e) =>
+            void Adapter(object sender, RoutedEventArgs e)
             {
-                var target = sender as TTarget;
-                var args = e as TEventArgs;
-
-                if (target != null && args != null)
+                if (sender is TTarget target && e is TEventArgs args)
                 {
                     handler(target)(args);
                 }
-            };
+            }
 
-            return AddClassHandler(typeof(TTarget), adapter, routes, handledEventsToo);
+            return AddClassHandler(typeof(TTarget), Adapter, routes, handledEventsToo);
+        }
+
+        public IDisposable AddClassHandler<TTarget>(
+            Action<TTarget, TEventArgs> handler,
+            RoutingStrategies routes = RoutingStrategies.Direct | RoutingStrategies.Bubble,
+            bool handledEventsToo = false) where TTarget : class, IInteractive
+        {
+            void Adapter(object sender, RoutedEventArgs e)
+            {
+                if (sender is TTarget target && e is TEventArgs args)
+                {
+                    handler(target, args);
+                }
+            }
+
+            return AddClassHandler(typeof(TTarget), Adapter, routes, handledEventsToo);
         }
     }
 }

--- a/src/Avalonia.Styling/StyledElement.cs
+++ b/src/Avalonia.Styling/StyledElement.cs
@@ -73,7 +73,7 @@ namespace Avalonia
         /// </summary>
         static StyledElement()
         {
-            DataContextProperty.Changed.AddClassHandler<StyledElement>(x => x.OnDataContextChangedCore);
+            DataContextProperty.Changed.AddClassHandler<StyledElement>((x,e) => x.OnDataContextChangedCore(e));
         }
 
         /// <summary>

--- a/src/Avalonia.Visuals/Media/Geometry.cs
+++ b/src/Avalonia.Visuals/Media/Geometry.cs
@@ -22,7 +22,7 @@ namespace Avalonia.Media
 
         static Geometry()
         {
-            TransformProperty.Changed.AddClassHandler<Geometry>(x => x.TransformChanged);
+            TransformProperty.Changed.AddClassHandler<Geometry>((x,e) => x.TransformChanged(e));
         }
 
         /// <summary>

--- a/tests/Avalonia.Interactivity.UnitTests/InteractiveTests.cs
+++ b/tests/Avalonia.Interactivity.UnitTests/InteractiveTests.cs
@@ -331,7 +331,7 @@ namespace Avalonia.Interactivity.UnitTests
 
             var target = CreateTree(ev, null, 0);
 
-            ev.AddClassHandler<TestInteractive>(x => x.ClassHandler, RoutingStrategies.Bubble);
+            ev.AddClassHandler<TestInteractive>((x, e) => x.ClassHandler(e), RoutingStrategies.Bubble);
 
             var args = new RoutedEventArgs(ev, target);
             target.RaiseEvent(args);


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Cleanup codebase to always use `AddClassHandler` variant that does not force extra allocations per value change.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Every time value changes we allocate new delegate per subscriber. This quickly adds up for frequent events (input for example).

Sample trace from ControlCatalog:
![image](https://user-images.githubusercontent.com/2588062/66437219-85271300-ea29-11e9-9f65-c3c1afcb65fc.png)


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Sample trace after this change:
![image](https://user-images.githubusercontent.com/2588062/66437239-92440200-ea29-11e9-87ae-253d67646dd0.png)


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Properties already had proper handler, for events I added a new one that does not force allocations. Marked allocating `AddClassHandler` methods obsolete.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Part of https://github.com/AvaloniaUI/Avalonia/issues/2919