### PR TITLE
Fix hang in ItemsControl.MoveSelection

### DIFF
--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -494,7 +494,7 @@ namespace Avalonia.Controls
             do
             {
                 result = container.GetControl(direction, c, wrap);
-                from ??= result;
+                from = from ?? result;
 
                 if (result?.Focusable == true)
                 {

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -489,18 +489,20 @@ namespace Avalonia.Controls
             bool wrap)
         {
             IInputElement result;
+            var c = from;
 
             do
             {
-                result = container.GetControl(direction, from, wrap);
+                result = container.GetControl(direction, c, wrap);
+                from ??= result;
 
                 if (result?.Focusable == true)
                 {
                     return result;
                 }
 
-                from = result;
-            } while (from != null);
+                c = result;
+            } while (c != null && c != from);
 
             return null;
         }

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -1000,6 +1000,26 @@ namespace Avalonia.Controls.UnitTests.Primitives
             Assert.Equal(new[] { "Bar" }, selectedItems);
         }
 
+        [Fact]
+        public void MoveSelection_Wrap_Does_Not_Hang_With_No_Focusable_Controls()
+        {
+            // Issue #3094.
+            var target = new TestSelector
+            {
+                Template = Template(),
+                Items = new[]
+                {
+                    new ListBoxItem { Focusable = false },
+                    new ListBoxItem { Focusable = false },
+                },
+                SelectedIndex = 0,
+            };
+
+            target.Measure(new Size(100, 100));
+            target.Arrange(new Rect(0, 0, 100, 100));
+            target.MoveSelection(NavigationDirection.Next, true);
+        }
+
         private FuncControlTemplate Template()
         {
             return new FuncControlTemplate<SelectingItemsControl>((control, scope) =>
@@ -1043,6 +1063,14 @@ namespace Avalonia.Controls.UnitTests.Primitives
         {
             public List<string> Items { get; set; } = new List<string>() { "a", "b", "c", "d", "e" };
             public string Selected { get; set; } = "b";
+        }
+
+        private class TestSelector : SelectingItemsControl
+        {
+            public new bool MoveSelection(NavigationDirection direction, bool wrap)
+            {
+                return base.MoveSelection(direction, wrap);
+            }
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Fixes a hang in `ItemsControl.MoveSelection` when called with `wrap = true` and no focusable controls. If there are no focusable controls, then `ItemsControl.GetNextControl` will loop forever looking for one.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #3094 