### PR TITLE
Don't override key/pointer events in Carousel.

### DIFF
--- a/src/Avalonia.Controls/Carousel.cs
+++ b/src/Avalonia.Controls/Carousel.cs
@@ -84,17 +84,5 @@ namespace Avalonia.Controls
                 --SelectedIndex;
             }
         }
-
-        /// <inheritdoc/>
-        protected override void OnKeyDown(KeyEventArgs e)
-        {
-            // Ignore key presses.
-        }
-
-        /// <inheritdoc/>
-        protected override void OnPointerPressed(PointerPressedEventArgs e)
-        {
-            // Ignore pointer presses.
-        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Remove the overrides of `OnKeyDown` and `OnPointerPressed` from `Carousel`. They were added 5 years ago when the codebase was very different and are now not needed and prevent gestures from being recognised on `Carousel`.

## Fixed issues

Fixes #3098.
