### PR TITLE
handle disposed nodes in visual tree.

### DIFF
--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -348,7 +348,10 @@ namespace Avalonia.Rendering
 
                     foreach (var child in node.Children)
                     {
-                        Render(context, (VisualNode)child, layer, clipBounds);
+                        if (!(child as VisualNode).Disposed)
+                        {
+                            Render(context, (VisualNode)child, layer, clipBounds);
+                        }
                     }
 
                     node.EndRender(context, isLayerRoot);

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/Scene.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/Scene.cs
@@ -152,7 +152,10 @@ namespace Avalonia.Rendering.SceneGraph
 
             foreach (var child in source.Children)
             {
-                result.AddChild(Clone((VisualNode)child, result, index));
+                if (!child.Disposed)
+                {
+                    result.AddChild(Clone((VisualNode)child, result, index));
+                }
             }
 
             return result;


### PR DESCRIPTION
## What does the pull request do?
Potential fix for UI freeze in 0.9 preview release.

Somehow we get disposed visual nodes remaining in the visual tree.

This fix means that the disposed nodes will be skipped, and not cloned on the next pass, so it self corrects/

## What is the current behavior?
This causes exceptions and renderer freezes remaining in constant loop.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
Fixes #3115 
