### PR TITLE
Add VisualNode to scene even for invisible controls

### DIFF
--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -240,6 +240,10 @@ namespace Avalonia.Rendering.SceneGraph
                     }
                 }
             }
+            else
+            {
+                contextImpl.BeginUpdate(node).Dispose();
+            }
         }
 
         private void UpdateSize(Scene scene)

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
@@ -218,7 +218,7 @@ namespace Avalonia.Rendering.SceneGraph
             if (first < _children?.Count)
             {
                 EnsureChildrenCreated();
-                for (int i = first; i < _children.Count - first; i++)
+                for (int i = first; i < _children.Count; i++)
                 {
                     _children[i].Dispose();
                 }

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests.cs
@@ -624,8 +624,9 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
                 var panelNode = (VisualNode)scene.FindNode(panel);
                 sceneBuilder.Update(scene, decorator);
 
-                Assert.Equal(1, panelNode.Children.Count);
+                Assert.Equal(2, panelNode.Children.Count);
                 Assert.False(panelNode.Children[0].Disposed);
+                Assert.False(panelNode.Children[1].Disposed);
             }
         }
 

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/VisualNodeTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/VisualNodeTests.cs
@@ -101,5 +101,24 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
 
             node.SortChildren(scene);
         }
+
+        [Fact]
+        public void TrimChildren_Should_Work_Correctly()
+        {
+            var parent = new VisualNode(Mock.Of<IVisual>(), null);
+            var child1 = new VisualNode(Mock.Of<IVisual>(), null);
+            var child2 = new VisualNode(Mock.Of<IVisual>(), null);
+            var child3 = new VisualNode(Mock.Of<IVisual>(), null);
+
+            parent.AddChild(child1);
+            parent.AddChild(child2);
+            parent.AddChild(child3);
+            parent.TrimChildren(2);
+
+            Assert.Equal(2, parent.Children.Count);
+            Assert.False(child1.Disposed);
+            Assert.False(child2.Disposed);
+            Assert.True(child3.Disposed);
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

#3115 describes an issue where making a control invisible can result in an active `VisualNode` being disposed. From the comment there:

- Parent `VisualNode` node has two children
- Parent visual node is reparented
- And the first control of the parent is made invisble
- `SceneBuilder.Update` is called on the parent node
- The first child node is skipped [because it's invisible](https://github.com/AvaloniaUI/Avalonia/blob/1d87c047ff69fb609f64f7d2166017c65e1d8ba9/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs#L161)
- The second child node is added to the parent node's `Children` collection, at index 0 this time. Now the parent has two instances of the the second node in its `Children`
- `VisualNode.TrimChildren` is called to trim the node at index 1. Unfortunately it's the same as the node at index 0, causing an active node to get disposed

In addition there was an off-by-N error in `VisualNode.TrimChildren` which actually masked this bug at times!

This PR does two things:

- Fix the off-by-N error in `TrimChildren`
- Add a `VisualNode` to the scene even for invisible controls. This prevents a node appearing in a `Children` collection twice

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Fixed issues

Fixes #3115 