### PR TITLE
fix compiler services unsafe reference.

### DIFF
--- a/build/Base.props
+++ b/build/Base.props
@@ -1,5 +1,6 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What does the pull request do?
some apps were able to downgrade this reference and refusing to run on osx.

## What is the current behavior?
crash at start on osx with some apps.

## What is the updated/expected behavior with this PR?
explicit references from Avalonia to prevent a situation where we crash on load.


## How was the solution implemented (if it's not obvious)?
Add to base.props

