### PR TITLE
Fallback to GDI when ShCore.dll isnt found (win7/8).

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1031,6 +1031,9 @@ namespace Avalonia.Win32.Interop
         [DllImport("shcore.dll")]
         public static extern long GetDpiForMonitor(IntPtr hmonitor, MONITOR_DPI_TYPE dpiType, out uint dpiX, out uint dpiY);
 
+        [DllImport("gdi32.dll")]
+        public static extern int GetDeviceCaps(IntPtr hdc, DEVICECAP nIndex);
+
         [DllImport("shcore.dll")]
         public static extern void GetScaleFactorForMonitor(IntPtr hMon, out uint pScale);
 
@@ -1145,6 +1148,12 @@ namespace Avalonia.Win32.Interop
                 MONITOR_DEFAULTTOPRIMARY = 0x00000001,
                 MONITOR_DEFAULTTONEAREST = 0x00000002
             }
+        }
+
+        public enum DEVICECAP
+        {
+            HORZRES = 8,
+            DESKTOPHORZRES = 118
         }
 
         public enum PROCESS_DPI_AWARENESS

--- a/src/Windows/Avalonia.Win32/ScreenImpl.cs
+++ b/src/Windows/Avalonia.Win32/ScreenImpl.cs
@@ -32,8 +32,10 @@ namespace Avalonia.Win32
                             if (GetMonitorInfo(monitor, ref monitorInfo))
                             {
                                 var dpi = 1.0;
-                                
-                                if (UnmanagedMethods.ShCoreAvailable)
+
+                                var shcore = LoadLibrary("shcore.dll");
+                                var method = GetProcAddress(shcore, nameof(GetDpiForMonitor));
+                                if (method != IntPtr.Zero)
                                 { 
                                     GetDpiForMonitor(monitor, MONITOR_DPI_TYPE.MDT_EFFECTIVE_DPI, out var x, out _);
                                     dpi = (double)x;

--- a/src/Windows/Avalonia.Win32/ScreenImpl.cs
+++ b/src/Windows/Avalonia.Win32/ScreenImpl.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Avalonia.Platform;
+using Avalonia.Win32.Interop;
 using static Avalonia.Win32.Interop.UnmanagedMethods;
 
 namespace Avalonia.Win32
@@ -31,12 +32,13 @@ namespace Avalonia.Win32
                             if (GetMonitorInfo(monitor, ref monitorInfo))
                             {
                                 var dpi = 1.0;
-                                try
-                                {
+                                
+                                if (UnmanagedMethods.ShCoreAvailable)
+                                { 
                                     GetDpiForMonitor(monitor, MONITOR_DPI_TYPE.MDT_EFFECTIVE_DPI, out var x, out _);
                                     dpi = (double)x;
                                 }
-                                catch (DllNotFoundException)
+                                else
                                 {
                                     var hdc = GetDC(IntPtr.Zero);
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix by falling back to GDI functions to determine DPI on Windows 7/8.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When you open a menu on Windows 7, It crashes horribly with a `DllNotFoundException` due to shcore.dll missing (which is only a thing on win8.1 and above). 

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
It shouldn't crash anymore.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Handle `DllNotFoundException` and use GDI to determine DPI instead.

## Fixed issues
Fixes #3069 
