### PR TITLE
Don't reopen an already active submenu on hover.

### DIFF
--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -273,7 +273,8 @@ namespace Avalonia.Controls.Platform
 
             if (item.IsTopLevel)
             {
-                if (item.Parent.SelectedItem?.IsSubMenuOpen == true)
+                if (item != item.Parent.SelectedItem &&
+                    item.Parent.SelectedItem?.IsSubMenuOpen == true)
                 {
                     item.Parent.SelectedItem.Close();
                     SelectItemAndAncestors(item);


### PR DESCRIPTION
## What is the current behavior?
Currently, when you hover to an already open submenu's header, it'll reopen the submenu.

## What is the updated/expected behavior with this PR?
Now the active submenu should stay put even when hovered in and out.

## How was the solution implemented (if it's not obvious)?
Check if the target item is the same as the active one and bail out if so.