### PR TITLE
Polish menu templates

### DIFF
--- a/src/Avalonia.Themes.Default/ContextMenu.xaml
+++ b/src/Avalonia.Themes.Default/ContextMenu.xaml
@@ -11,19 +11,11 @@
               BorderThickness="{TemplateBinding BorderThickness}"
               Padding="{TemplateBinding Padding}">
           <ScrollViewer>
-            <Panel>
               <ItemsPresenter Name="PART_ItemsPresenter"
                               Items="{TemplateBinding Items}"
                               ItemsPanel="{TemplateBinding ItemsPanel}"
                               ItemTemplate="{TemplateBinding ItemTemplate}"
                               KeyboardNavigation.TabNavigation="Continue"/>
-              <Rectangle Name="iconSeparator"
-                         Fill="{DynamicResource ThemeControlMidBrush}"
-                         HorizontalAlignment="Left"
-                         IsHitTestVisible="False"
-                         Margin="29,2,0,2"
-                         Width="1"/>
-              </Panel>
           </ScrollViewer>
       </Border>
     </ControlTemplate>

--- a/src/Avalonia.Themes.Default/MenuItem.xaml
+++ b/src/Avalonia.Themes.Default/MenuItem.xaml
@@ -4,14 +4,14 @@
   <Style Selector="MenuItem">
     <Setter Property="Background" Value="Transparent"/>
     <Setter Property="BorderThickness" Value="1"/>
-    <Setter Property="Padding" Value="6,0"/>
+    <Setter Property="Padding" Value="6 0"/>
     <Setter Property="Template">
       <ControlTemplate>
         <Border Name="root"
                 Background="{TemplateBinding Background}"
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}">
-          <Grid ColumnDefinitions="22,13,*,20">
+          <Grid ColumnDefinitions="20,5,*,20">
             <ContentPresenter Name="icon"
                               Content="{TemplateBinding Icon}"
                               Width="16"
@@ -50,20 +50,12 @@
               <Border Background="{TemplateBinding Background}"
                       BorderBrush="{DynamicResource ThemeBorderMidBrush}"
                       BorderThickness="{TemplateBinding BorderThickness}">
-                <ScrollViewer>
-                  <Panel>
+                <ScrollViewer>                  
                     <ItemsPresenter Name="PART_ItemsPresenter"
                                     Items="{TemplateBinding Items}"
                                     ItemsPanel="{TemplateBinding ItemsPanel}"
                                     ItemTemplate="{TemplateBinding ItemTemplate}"
-                                    Margin="2"/>
-                    <Rectangle Name="iconSeparator"
-                               Fill="{DynamicResource ThemeControlMidBrush}"
-                               HorizontalAlignment="Left"
-                               IsHitTestVisible="False"
-                               Margin="29,2,0,2"
-                               Width="1"/>
-                  </Panel>
+                                    Margin="4 2"/>                                      
                 </ScrollViewer>
               </Border>
             </Popup>
@@ -77,13 +69,14 @@
     <Setter Property="Template">
       <ControlTemplate>
         <Separator Background="{DynamicResource ThemeControlMidBrush}"
-                   Margin="29,1,0,1"
+                   Margin="20,1,0,1"
                    Height="1"/>
       </ControlTemplate>
     </Setter>
   </Style>
 
   <Style Selector="Menu > MenuItem">
+    <Setter Property="Padding" Value="6 0"/>
     <Setter Property="Template">
       <ControlTemplate>
         <Border Name="root"
@@ -108,19 +101,11 @@
                       BorderBrush="{DynamicResource ThemeBorderMidBrush}"
                       BorderThickness="{TemplateBinding BorderThickness}">
                 <ScrollViewer>
-                  <Panel>
-                    <ItemsPresenter Name="PART_ItemsPresenter"
+                  <ItemsPresenter Name="PART_ItemsPresenter"
                                     Items="{TemplateBinding Items}"
                                     ItemsPanel="{TemplateBinding ItemsPanel}"
                                     ItemTemplate="{TemplateBinding ItemTemplate}"
                                     Margin="2"/>
-                    <Rectangle Name="iconSeparator"
-                               Fill="{DynamicResource ThemeControlMidBrush}"
-                               HorizontalAlignment="Left"
-                               IsHitTestVisible="False"
-                               Margin="29,2,0,2"
-                               Width="1"/>
-                  </Panel>
                 </ScrollViewer>
               </Border>
             </Popup>


### PR DESCRIPTION
Currently looks like...
https://files.gitter.im/AvaloniaUI/avalonia-core/nLRs/image.png
![image](https://user-images.githubusercontent.com/4672627/67244139-febef800-f450-11e9-9938-dc2b273e251f.png)


this PR polishes to remove vertical seperator and sorts out spacing.
![image](https://user-images.githubusercontent.com/4672627/67244070-d636fe00-f450-11e9-90eb-018fb3417c44.png)

Looks more like typical windows menu items and Visual Studio menu items.
