### PR TITLE
Fix Grid shared scope not being updated when resizing row/column definitions

### DIFF
--- a/src/Avalonia.Controls/ColumnDefinition.cs
+++ b/src/Avalonia.Controls/ColumnDefinition.cs
@@ -31,7 +31,9 @@ namespace Avalonia.Controls
         /// </summary>
         static ColumnDefinition()
         {
-            AffectsParentMeasure(WidthProperty, MinWidthProperty, MaxWidthProperty);
+            AffectsParentMeasure(MinWidthProperty, MaxWidthProperty);
+
+            WidthProperty.Changed.AddClassHandler<DefinitionBase>(OnUserSizePropertyChanged);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/DefinitionBase.cs
+++ b/src/Avalonia.Controls/DefinitionBase.cs
@@ -116,7 +116,7 @@ namespace Avalonia.Controls
         }
 
         /// <remarks>
-        /// This method needs to be internal to be accessable from derived classes.
+        /// Notifies parent <see cref="Grid"/> or size scope that definition size has been changed.
         /// </remarks>
         internal static void OnUserSizePropertyChanged(DefinitionBase definition, AvaloniaPropertyChangedEventArgs e)
         {

--- a/src/Avalonia.Controls/DefinitionBase.cs
+++ b/src/Avalonia.Controls/DefinitionBase.cs
@@ -7,9 +7,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-
-using Avalonia;
-using Avalonia.Collections;
 using Avalonia.Utilities;
 
 namespace Avalonia.Controls
@@ -115,6 +112,36 @@ namespace Avalonia.Controls
             else
             {
                 d.ClearValue(PrivateSharedSizeScopeProperty);
+            }
+        }
+
+        /// <remarks>
+        /// This method needs to be internal to be accessable from derived classes.
+        /// </remarks>
+        internal static void OnUserSizePropertyChanged(DefinitionBase definition, AvaloniaPropertyChangedEventArgs e)
+        {
+            if (definition.Parent == null)
+            {
+                return;
+            }
+
+            if (definition._sharedState != null)
+            {
+                definition._sharedState.Invalidate();
+            }
+            else
+            {
+                GridUnitType oldUnitType = ((GridLength)e.OldValue).GridUnitType;
+                GridUnitType newUnitType = ((GridLength)e.NewValue).GridUnitType;
+
+                if (oldUnitType != newUnitType)
+                {
+                    definition.Parent.Invalidate();
+                }
+                else
+                {
+                    definition.Parent.InvalidateMeasure();
+                }
             }
         }
 

--- a/src/Avalonia.Controls/RowDefinition.cs
+++ b/src/Avalonia.Controls/RowDefinition.cs
@@ -31,7 +31,9 @@ namespace Avalonia.Controls
         /// </summary>
         static RowDefinition()
         {
-            AffectsParentMeasure(HeightProperty, MaxHeightProperty, MinHeightProperty);
+            AffectsParentMeasure(MaxHeightProperty, MinHeightProperty);
+
+            HeightProperty.Changed.AddClassHandler<DefinitionBase>(OnUserSizePropertyChanged);
         }
 
         /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/GridTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/GridTests.cs
@@ -1173,6 +1173,41 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Size_Group_Definition_Resizes_Are_Tracked()
+        {
+            var grids = new[] {
+                CreateGrid(("A", new GridLength(5, GridUnitType.Pixel)), (null, new GridLength())),
+                CreateGrid(("A", new GridLength(5, GridUnitType.Pixel)), (null, new GridLength())) };
+            var scope = new Grid();
+            foreach (var xgrids in grids)
+                scope.Children.Add(xgrids);
+
+            var root = new Grid();
+            root.UseLayoutRounding = false;
+            root.SetValue(Grid.IsSharedSizeScopeProperty, true);
+            root.Children.Add(scope);
+
+            root.Measure(new Size(50, 50));
+            root.Arrange(new Rect(new Point(), new Point(50, 50)));
+
+            PrintColumnDefinitions(grids[0]);
+            Assert.Equal(5, grids[0].ColumnDefinitions[0].ActualWidth);
+            Assert.Equal(5, grids[1].ColumnDefinitions[0].ActualWidth);
+
+            grids[0].ColumnDefinitions[0].Width = new GridLength(10, GridUnitType.Pixel);
+
+            foreach (Grid grid in grids)
+            {
+                grid.Measure(new Size(50, 50));
+                grid.Arrange(new Rect(new Point(), new Point(50, 50)));
+            }
+
+            PrintColumnDefinitions(grids[0]);
+            Assert.Equal(10, grids[0].ColumnDefinitions[0].ActualWidth);
+            Assert.Equal(10, grids[1].ColumnDefinitions[0].ActualWidth);
+        }
+
+        [Fact]
         public void Collection_Changes_Are_Tracked()
         {
             var grid = CreateGrid(


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
When porting `Grid` from WPF part that was updating shared scopes was not ported. This caused some issues that were fixed by https://github.com/AvaloniaUI/Avalonia/pull/3157, but shared scope problem persisted.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When trying to resize shared scope rows/columns nothing happens.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Users can now freely resize shared scope rows/columns and change will propagate properly.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
 https://github.com/dotnet/wpf/blob/ac9d1b7a6b0ee7c44fd2875a1174b820b3940619/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DefinitionBase.cs#L151-L175 was skipped when porting from WPF. This caused whole set of subtle bugs when resizing either shared or not shared rows/columns.

This removes part of https://github.com/AvaloniaUI/Avalonia/pull/3157 as `Width` / `Height` need more logic to properly update `Grid`.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
