### PR TITLE
Fixed parameter order in OnSelectionChanged in AutoCompleteBox

### DIFF
--- a/src/Avalonia.Controls/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox.cs
@@ -704,7 +704,7 @@ namespace Avalonia.Controls
                 added.Add(e.NewValue);
             }
 
-            OnSelectionChanged(new SelectionChangedEventArgs(SelectionChangedEvent, removed, added));
+            OnSelectionChanged(new SelectionChangedEventArgs(SelectionChangedEvent, added, removed));
         }
 
         /// <summary>


### PR DESCRIPTION
Apparently Silverlight has different constructor argument order. 

Original bug report submitted by a friendly developer of PVS-Studio
