### PR TITLE
Fix adding TabItem with IsSelected = true

### DIFF
--- a/src/Avalonia.Controls/Generators/TabItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/TabItemContainerGenerator.cs
@@ -19,8 +19,6 @@ namespace Avalonia.Controls.Generators
         {
             var tabItem = (TabItem)base.CreateContainer(item);
 
-            tabItem.ParentTabControl = Owner;
-
             tabItem[~TabControl.TabStripPlacementProperty] = Owner[~TabControl.TabStripPlacementProperty];
 
             if (tabItem.HeaderTemplate == null)

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -358,7 +358,7 @@ namespace Avalonia.Controls.Primitives
             {
                 if ((container.ContainerControl as ISelectable)?.IsSelected == true)
                 {
-                    if (SelectedIndex == -1)
+                    if (SelectionMode.HasFlag(SelectionMode.Single))
                     {
                         SelectedIndex = container.Index;
                     }

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -358,16 +358,16 @@ namespace Avalonia.Controls.Primitives
             {
                 if ((container.ContainerControl as ISelectable)?.IsSelected == true)
                 {
-                    if (SelectionMode.HasFlag(SelectionMode.Single))
-                    {
-                        SelectedIndex = container.Index;
-                    }
-                    else
+                    if (SelectionMode.HasFlag(SelectionMode.Multiple))
                     {
                         if (_selection.Add(container.Index))
                         {
                             resetSelectedItems = true;
                         }
+                    }
+                    else
+                    {
+                        SelectedIndex = container.Index;
                     }
 
                     MarkContainerSelected(container.ContainerControl, true);

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -367,16 +367,16 @@ namespace Avalonia.Controls.Primitives
             {
                 if ((container.ContainerControl as ISelectable)?.IsSelected == true)
                 {
-                    if (SelectedIndex == -1)
-                    {
-                        SelectedIndex = container.Index;
-                    }
-                    else
+                    if (SelectionMode.HasFlag(SelectionMode.Multiple))
                     {
                         if (_selection.Add(container.Index))
                         {
                             resetSelectedItems = true;
                         }
+                    }
+                    else
+                    {
+                        SelectedIndex = container.Index;
                     }
 
                     MarkContainerSelected(container.ContainerControl, true);

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -367,16 +367,16 @@ namespace Avalonia.Controls.Primitives
             {
                 if ((container.ContainerControl as ISelectable)?.IsSelected == true)
                 {
-                    if (SelectionMode.HasFlag(SelectionMode.Multiple))
+                    if (SelectedIndex == -1)
+                    {
+                        SelectedIndex = container.Index;
+                    }
+                    else
                     {
                         if (_selection.Add(container.Index))
                         {
                             resetSelectedItems = true;
                         }
-                    }
-                    else
-                    {
-                        SelectedIndex = container.Index;
                     }
 
                     MarkContainerSelected(container.ContainerControl, true);

--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -146,6 +146,25 @@ namespace Avalonia.Controls
             return RegisterContentPresenter(presenter);
         }
 
+        protected override void OnContainersMaterialized(ItemContainerEventArgs e)
+        {
+            base.OnContainersMaterialized(e);
+
+            if (SelectedContent != null || SelectedIndex == -1)
+            {
+                return;
+            }
+
+            var container = (TabItem)ItemContainerGenerator.ContainerFromIndex(SelectedIndex);
+
+            if (container == null)
+            {
+                return;
+            }
+
+            UpdateSelectedContent(container);
+        }
+
         private void UpdateSelectedContent(AvaloniaPropertyChangedEventArgs e)
         {
             var index = (int)e.NewValue;
@@ -188,20 +207,6 @@ namespace Avalonia.Controls
             {
                 SelectedContent = item.Content;
             }
-        }
-
-        protected override Size MeasureOverride(Size availableSize)
-        {
-            var size = base.MeasureOverride(availableSize);
-
-            if (SelectedIndex != -1 && SelectedContent == null)
-            {
-                var container = (TabItem)ItemContainerGenerator.ContainerFromIndex(SelectedIndex);
-
-                UpdateSelectedContent(container);
-            }
-
-            return size;
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using Avalonia.Collections;
 using Avalonia.Controls.Generators;
-using Avalonia.Controls.Mixins;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
@@ -182,21 +181,13 @@ namespace Avalonia.Controls
 
             if (container == null)
             {
-                if (Items is AvaloniaList<object> items)
-                {
-                    container = items[index] as TabItem;
-                }
-            }
-
-            if (container == null)
-            {
                 return;
             }
 
             UpdateSelectedContent(container);
         }
 
-        private void UpdateSelectedContent(TabItem item)
+        private void UpdateSelectedContent(IContentControl item)
         {
             if (SelectedContentTemplate != item.ContentTemplate)
             {

--- a/src/Avalonia.Controls/TabItem.cs
+++ b/src/Avalonia.Controls/TabItem.cs
@@ -53,8 +53,6 @@ namespace Avalonia.Controls
             set { SetValue(IsSelectedProperty, value); }
         }
 
-        internal TabControl ParentTabControl { get; set; }
-
         private void UpdateHeader(AvaloniaPropertyChangedEventArgs obj)
         {
             if (Header == null)

--- a/src/Avalonia.Controls/TabItem.cs
+++ b/src/Avalonia.Controls/TabItem.cs
@@ -30,7 +30,6 @@ namespace Avalonia.Controls
         {
             SelectableMixin.Attach<TabItem>(IsSelectedProperty);
             FocusableProperty.OverrideDefaultValue(typeof(TabItem), true);
-            IsSelectedProperty.Changed.AddClassHandler<TabItem>((x, e) => x.UpdateSelectedContent(e));
             DataContextProperty.Changed.AddClassHandler<TabItem>((x, e) => x.UpdateHeader(e));
         }
 
@@ -82,24 +81,6 @@ namespace Avalonia.Controls
                     Header = obj.NewValue;
                 }
             }          
-        }
-
-        private void UpdateSelectedContent(AvaloniaPropertyChangedEventArgs e)
-        {
-            if (!IsSelected)
-            {
-                return;
-            }
-
-            if (ParentTabControl.SelectedContentTemplate != ContentTemplate)
-            {
-                ParentTabControl.SelectedContentTemplate = ContentTemplate;
-            }
-
-            if (ParentTabControl.SelectedContent != Content)
-            {
-                ParentTabControl.SelectedContent = Content;
-            }
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -1185,6 +1185,33 @@ namespace Avalonia.Controls.UnitTests.Primitives
             target.MoveSelection(NavigationDirection.Next, true);
         }
 
+        [Fact]
+        public void Pre_Selecting_Item_Should_Set_Selection_After_It_Was_Added_When_AlwaysSelected()
+        {
+            var target = new TestSelector(SelectionMode.AlwaysSelected)
+            {
+                Template = Template()
+            };
+
+            var second = new Item { IsSelected = true };
+
+            var items = new AvaloniaList<object>
+            {
+                new Item(),
+                second
+            };
+
+            target.Items = items;
+
+            target.ApplyTemplate();
+
+            target.Presenter.ApplyTemplate();
+
+            Assert.Equal(second, target.SelectedItem);
+
+            Assert.Equal(1, target.SelectedIndex);
+        }
+
         private FuncControlTemplate Template()
         {
             return new FuncControlTemplate<SelectingItemsControl>((control, scope) =>
@@ -1233,6 +1260,16 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
         private class TestSelector : SelectingItemsControl
         {
+            public TestSelector()
+            {
+                
+            }
+
+            public TestSelector(SelectionMode selectionMode)
+            {
+                SelectionMode = selectionMode;
+            }
+
             public new bool MoveSelection(NavigationDirection direction, bool wrap)
             {
                 return base.MoveSelection(direction, wrap);

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_Multiple.cs
@@ -1080,6 +1080,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             var target = new TestSelector
             {
                 Items = items,
+                SelectionMode = SelectionMode.Multiple,
                 Template = Template(),
             };
 

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Avalonia.Collections;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
@@ -42,6 +43,31 @@ namespace Avalonia.Controls.UnitTests
 
             Assert.Equal(0, target.SelectedIndex);
             Assert.Equal(selected, target.SelectedItem);
+        }
+
+        [Fact]
+        public void Pre_Selecting_TabItem_Should_Set_SelectedContent_After_It_Was_Added()
+        {
+            var target = new TabControl
+            {
+                Template = TabControlTemplate(),
+            };
+
+            const string secondContent = "Second";
+
+            var items = new AvaloniaList<object>
+            {
+                new TabItem { Header = "First"},
+                new TabItem { Header = "Second", Content = secondContent, IsSelected = true }
+            };
+
+            target.Items = items;
+
+            target.ApplyTemplate();
+
+            target.Measure(Size.Infinity);
+
+            Assert.Equal(secondContent, target.SelectedContent);
         }
 
         [Fact]

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -63,9 +63,7 @@ namespace Avalonia.Controls.UnitTests
 
             target.Items = items;
 
-            target.ApplyTemplate();
-
-            target.Measure(Size.Infinity);
+            ApplyTemplate(target);
 
             Assert.Equal(secondContent, target.SelectedContent);
         }


### PR DESCRIPTION
## What does the pull request do?
It fixes an issue with setting `IsSelected` on TabItem before the item was materialized.

## What is the current behavior?
The current version crashes when IsSelected is set on a TabItem before it was materialized.

## What is the updated/expected behavior with this PR?
Previously TabItem required a reference to the parent TabControl to properly update the selected content. This could result in a NullReferenceException when the parent wasn't set by the ItemContainerGenerator.


## How was the solution implemented (if it's not obvious)?
Previously the selected content was updated by the TabItem. Now the TabControl itself updates the content when the selection changes.


## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues
#3180
