### PR TITLE
Add failing test for cross root reparenting.

### DIFF
--- a/tests/Avalonia.Visuals.UnitTests/Rendering/DeferredRendererTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/DeferredRendererTests.cs
@@ -370,6 +370,81 @@ namespace Avalonia.Visuals.UnitTests.Rendering
         }
 
         [Fact]
+        public void Should_Update_VisualNodes_When_Child_Moved_To_New_Parent_And_New_Root()
+        {
+            var dispatcher = new ImmediateDispatcher();
+            var loop = new Mock<IRenderLoop>();
+
+            Decorator moveFrom;
+            Decorator moveTo;
+            Canvas moveMe;
+
+            var root = new TestRoot
+            {
+                Child = new StackPanel
+                {
+                    Children =
+                    {
+                        (moveFrom = new Decorator
+                        {
+                            Child = moveMe = new Canvas(),
+                        })
+                    }
+                }
+            };
+
+            var otherRoot = new TestRoot
+            {
+                Child = new StackPanel
+                {
+                    Children =
+                    {
+                        (moveTo = new Decorator())
+                    }
+                }
+            };
+
+            var sceneBuilder = new SceneBuilder();
+            var target = new DeferredRenderer(
+                root,
+                loop.Object,
+                sceneBuilder: sceneBuilder,
+                dispatcher: dispatcher);
+
+            var otherSceneBuilder = new SceneBuilder();
+            var otherTarget = new DeferredRenderer(
+                otherRoot,
+                loop.Object,
+                sceneBuilder: otherSceneBuilder,
+                dispatcher: dispatcher);
+
+            root.Renderer = target;
+            otherRoot.Renderer = otherTarget;
+
+            target.Start();
+            otherTarget.Start();
+
+            RunFrame(target);
+            RunFrame(otherTarget);
+
+            moveFrom.Child = null;
+            moveTo.Child = moveMe;
+
+            RunFrame(target);
+            RunFrame(otherTarget);
+
+            var scene = target.UnitTestScene();
+            var otherScene = otherTarget.UnitTestScene();
+
+            var moveFromNode = (VisualNode)scene.FindNode(moveFrom);
+            var moveToNode = (VisualNode)otherScene.FindNode(moveTo);
+
+            Assert.Empty(moveFromNode.Children);
+            Assert.Equal(1, moveToNode.Children.Count);
+            Assert.Same(moveMe, moveToNode.Children[0].Visual);
+        }
+
+        [Fact]
         public void Should_Push_Opacity_For_Controls_With_Less_Than_1_Opacity()
         {
             var root = new TestRoot


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
As described in https://github.com/AvaloniaUI/Avalonia/issues/3179 reparenting controls across different visual roots does not work correctly. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Currently when we reparent control to a different root old renderer will still try to update that visual. It seems that we have no logic in place to actually handle the case when control moves to a different root. This will cause `SceneBuilder` to crash as it does not cope with a missing visual.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
