### PR TITLE
Fix occasional exception in tooltip

### DIFF
--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -1,6 +1,7 @@
 using System;
 using Avalonia.Input;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Controls
 {
@@ -79,7 +80,10 @@ namespace Avalonia.Controls
         {
             StopTimer();
 
-            ToolTip.SetIsOpen(control, true);
+            if ((control as IVisual).IsAttachedToVisualTree)
+            {
+                ToolTip.SetIsOpen(control, true);
+            }
         }
 
         private void Close(Control control)

--- a/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
@@ -17,6 +17,24 @@ namespace Avalonia.Controls.UnitTests
         private MouseTestHelper _mouseHelper = new MouseTestHelper();
 
         [Fact]
+        public void Should_Not_Open_On_Detached_Control()
+        {
+            //issue #3188
+            var control = new Decorator()
+            {
+                [ToolTip.TipProperty] = "Tip",
+                [ToolTip.ShowDelayProperty] = 0
+            };
+
+            Assert.False((control as IVisual).IsAttachedToVisualTree);
+
+            //here in issue #3188 exception is raised
+            _mouseHelper.Enter(control);
+
+            Assert.False(ToolTip.GetIsOpen(control));
+        }
+
+        [Fact]
         public void Should_Open_On_Pointer_Enter()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))

--- a/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using System.Reactive.Disposables;
+using Avalonia.Platform;
+using Avalonia.Threading;
+using Avalonia.UnitTests;
+using Avalonia.VisualTree;
+using Moq;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests
+{
+    public class TolTipTests
+    {
+        private MouseTestHelper _mouseHelper = new MouseTestHelper();
+
+        [Fact]
+        public void Should_Open_On_Pointer_Enter()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var window = new Window();
+
+                var target = new Decorator()
+                {
+                    [ToolTip.TipProperty] = "Tip",
+                    [ToolTip.ShowDelayProperty] = 0
+                };
+
+                window.Content = target;
+
+                window.ApplyTemplate();
+                window.Presenter.ApplyTemplate();
+
+                Assert.True((target as IVisual).IsAttachedToVisualTree);
+
+                _mouseHelper.Enter(target);
+
+                Assert.True(ToolTip.GetIsOpen(target));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Tooltip is possible to throw exception on specific situation if control is detached from visual tree after tip is triggered

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
application throw exception

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
fix the problem

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

tooltipservice should will not try open a tooltip on detached control

## Checklist

- [x] Added unit tests (if possible)?

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->
nope

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
FIxes #3188 