### PR TITLE
Stop propagating the DataContext to a TabItem's content

### DIFF
--- a/src/Avalonia.Controls/Generators/TabItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/TabItemContainerGenerator.cs
@@ -48,11 +48,6 @@ namespace Avalonia.Controls.Generators
                 tabItem[~ContentControl.ContentTemplateProperty] = Owner[~TabControl.ContentTemplateProperty];
             }
 
-            if (tabItem.Content == null)
-            {
-                tabItem[~ContentControl.ContentProperty] = tabItem[~StyledElement.DataContextProperty];
-            }
-
             return tabItem;
         }
     }

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Avalonia.Collections;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
@@ -285,6 +286,25 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal("bar", content.Tag);
             Assert.Same(target, content.GetLogicalParent());
             Assert.Single(target.GetLogicalChildren(), content);
+        }
+
+        [Fact]
+        public void Should_Not_Propagate_DataContext_To_TabItem_Content()
+        {
+            var dataContext = "DataContext";
+
+            var tabItem = new TabItem();
+
+            var target = new TabControl
+            {
+                Template = TabControlTemplate(),
+                DataContext = dataContext,
+                Items = new AvaloniaList<object> { tabItem }
+            };
+
+            ApplyTemplate(target);
+
+            Assert.NotEqual(dataContext, tabItem.Content);
         }
 
         private IControlTemplate TabControlTemplate()


### PR DESCRIPTION
## What does the pull request do?
Fixes #2699


## What is the current behavior?
The DataContext propagates to the TabItem's content and causes a stack overflow in some situations.


## What is the updated/expected behavior with this PR?
The DataContext should no longer propagate to the TabItem's content


## How was the solution implemented (if it's not obvious)?
Without this fix the item generator binds the DataContext of a TabItem to the Content. That wasn't needed and could be removed without side effects.


## Checklist

- [x] Added unit tests (if possible)?


## Fixed issues
Fixes #2699
