### PR TITLE
FontManager implementation

### DIFF
--- a/Avalonia.sln
+++ b/Avalonia.sln
@@ -128,6 +128,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Props", "Props", "{F3AC8BC1
 		build\Base.props = build\Base.props
 		build\Binding.props = build\Binding.props
 		build\BuildTargets.targets = build\BuildTargets.targets
+		build\HarfBuzzSharp.props = build\HarfBuzzSharp.props
 		build\JetBrains.Annotations.props = build\JetBrains.Annotations.props
 		build\JetBrains.dotMemoryUnit.props = build\JetBrains.dotMemoryUnit.props
 		build\Magick.NET-Q16-AnyCPU.props = build\Magick.NET-Q16-AnyCPU.props
@@ -201,7 +202,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Controls.DataGrid"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Dialogs", "src\Avalonia.Dialogs\Avalonia.Dialogs.csproj", "{4D55985A-1EE2-4F25-AD39-6EA8BC04F8FB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalonia.FreeDesktop", "src\Avalonia.FreeDesktop\Avalonia.FreeDesktop.csproj", "{4D36CEC8-53F2-40A5-9A37-79AAE356E2DA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.FreeDesktop", "src\Avalonia.FreeDesktop\Avalonia.FreeDesktop.csproj", "{4D36CEC8-53F2-40A5-9A37-79AAE356E2DA}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution

--- a/build/HarfBuzzSharp.props
+++ b/build/HarfBuzzSharp.props
@@ -1,0 +1,6 @@
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PackageReference Include="HarfBuzzSharp" Version="2.6.1-rc.153" />
+    <PackageReference Condition="'$(IncludeLinuxSkia)' == 'true'" Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.6.1-rc.153" />
+  </ItemGroup>
+</Project>

--- a/build/SkiaSharp.props
+++ b/build/SkiaSharp.props
@@ -1,6 +1,6 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="1.68.0" />
-    <PackageReference Condition="'$(IncludeLinuxSkia)' == 'true'" Include="Avalonia.Skia.Linux.Natives" Version="1.68.0.2" />
+    <PackageReference Include="SkiaSharp" Version="1.68.1-rc.153" />
+    <PackageReference Condition="'$(IncludeLinuxSkia)' == 'true'" Include="SkiaSharp.NativeAssets.Linux" Version="1.68.1-rc.153" />
   </ItemGroup>
 </Project>

--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -297,7 +297,8 @@ namespace Avalonia.Controls.Presenters
                 return new FormattedText
                 {
                     Text = "X",
-                    Typeface = new Typeface(FontFamily, FontSize, FontStyle, FontWeight),
+                    Typeface = new Typeface(FontFamily, FontWeight, FontStyle),
+                    FontSize = FontSize,
                     TextAlignment = TextAlignment,
                     Constraint = availableSize,
                 }.Bounds.Size;

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -352,10 +352,11 @@ namespace Avalonia.Controls
             return new FormattedText
             {
                 Constraint = constraint,
-                Typeface = new Typeface(FontFamily, FontSize, FontStyle, FontWeight),
+                Typeface = new Typeface(FontFamily, FontWeight, FontStyle),
+                FontSize = FontSize,
                 Text = text ?? string.Empty,
                 TextAlignment = TextAlignment,
-                Wrapping = TextWrapping,
+                TextWrapping = TextWrapping,
             };
         }
 

--- a/src/Avalonia.Visuals/Media/FontFamily.cs
+++ b/src/Avalonia.Visuals/Media/FontFamily.cs
@@ -5,12 +5,16 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Media.Fonts;
-using Avalonia.Platform;
 
 namespace Avalonia.Media
 {
     public class FontFamily
     {
+        static FontFamily()
+        {
+            Default = new FontFamily(FontManager.Default.DefaultFontFamilyName);
+        }
+
         /// <inheritdoc />
         /// <summary>
         /// Initializes a new instance of the <see cref="T:Avalonia.Media.FontFamily" /> class.
@@ -30,9 +34,7 @@ namespace Avalonia.Media
         {
             if (string.IsNullOrEmpty(name))
             {
-                FamilyNames = new FamilyNameCollection(string.Empty);
-
-                return;
+                throw new ArgumentNullException(nameof(name));
             }
 
             var fontFamilySegment = GetFontFamilyIdentifier(name);
@@ -53,13 +55,13 @@ namespace Avalonia.Media
         /// <summary>
         /// Represents the default font family
         /// </summary>
-        public static FontFamily Default => new FontFamily(string.Empty);
+        public static FontFamily Default { get; }
 
         /// <summary>
         /// Represents all font families in the system. This can be an expensive call depending on platform implementation.
         /// </summary>
         public static IEnumerable<FontFamily> SystemFontFamilies =>
-            AvaloniaLocator.Current.GetService<IPlatformRenderInterface>().InstalledFontNames.Select(name => new FontFamily(name));
+            FontManager.Default.GetInstalledFontFamilyNames().Select(name => new FontFamily(name));
 
         /// <summary>
         /// Gets the primary family name of the font family.
@@ -181,7 +183,14 @@ namespace Avalonia.Media
             {
                 var hash = (int)2186146271;
 
-                hash = (hash * 15768619) ^ FamilyNames.GetHashCode();
+                if (Key != null)
+                {
+                    hash = (hash * 15768619) ^ Key.GetHashCode();
+                }
+                else
+                {
+                    hash = (hash * 15768619) ^ FamilyNames.GetHashCode();
+                }
 
                 if (Key != null)
                 {

--- a/src/Avalonia.Visuals/Media/FontFamily.cs
+++ b/src/Avalonia.Visuals/Media/FontFamily.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Media
     {
         static FontFamily()
         {
-            Default = new FontFamily(FontManager.Default.DefaultFontFamilyName);
+            Default = new FontFamily(FontManager.DefaultFontFamilyName);
         }
 
         /// <inheritdoc />
@@ -60,8 +60,11 @@ namespace Avalonia.Media
         /// <summary>
         /// Represents all font families in the system. This can be an expensive call depending on platform implementation.
         /// </summary>
+        /// <remarks>
+        /// Consider using the new <see cref="FontManager"/> instead.
+        /// </remarks>
         public static IEnumerable<FontFamily> SystemFontFamilies =>
-            FontManager.Default.GetInstalledFontFamilyNames().Select(name => new FontFamily(name));
+            FontManager.GetInstalledFontFamilyNames().Select(name => new FontFamily(name));
 
         /// <summary>
         /// Gets the primary family name of the font family.

--- a/src/Avalonia.Visuals/Media/FontFamily.cs
+++ b/src/Avalonia.Visuals/Media/FontFamily.cs
@@ -8,11 +8,11 @@ using Avalonia.Media.Fonts;
 
 namespace Avalonia.Media
 {
-    public class FontFamily
+    public sealed class FontFamily
     {
         static FontFamily()
         {
-            Default = new FontFamily(FontManager.DefaultFontFamilyName);
+            Default = new FontFamily(FontManager.Default.DefaultFontFamilyName);
         }
 
         /// <inheritdoc />
@@ -64,7 +64,7 @@ namespace Avalonia.Media
         /// Consider using the new <see cref="FontManager"/> instead.
         /// </remarks>
         public static IEnumerable<FontFamily> SystemFontFamilies =>
-            FontManager.GetInstalledFontFamilyNames().Select(name => new FontFamily(name));
+            FontManager.Default.GetInstalledFontFamilyNames().Select(name => new FontFamily(name));
 
         /// <summary>
         /// Gets the primary family name of the font family.

--- a/src/Avalonia.Visuals/Media/FontManager.cs
+++ b/src/Avalonia.Visuals/Media/FontManager.cs
@@ -1,99 +1,55 @@
 ﻿// Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Avalonia.Platform;
 
 namespace Avalonia.Media
 {
-    public abstract class FontManager : IFontManagerImpl
+    public static class FontManager
     {
-        public static readonly FontManager Default = CreateDefaultFontManger();
+        private static readonly IFontManagerImpl s_platformImpl = GetPlatformImpl();
 
-        /// <inheritdoc cref="IFontManagerImpl"/>
-        public string DefaultFontFamilyName { get; protected set; }
+        /// <inheritdoc cref="IFontManagerImpl.DefaultFontFamilyName"/>
+        public static string DefaultFontFamilyName => s_platformImpl.DefaultFontFamilyName;
 
-        private static FontManager CreateDefaultFontManger()
+        /// <inheritdoc cref="IFontManagerImpl.GetInstalledFontFamilyNames"/>
+        public static IEnumerable<string> GetInstalledFontFamilyNames(bool checkForUpdates = false) =>
+            s_platformImpl.GetInstalledFontFamilyNames(checkForUpdates);
+
+        /// <inheritdoc cref="IFontManagerImpl.GetTypeface"/>
+        public static Typeface GetTypeface(FontFamily fontFamily, FontWeight fontWeight, FontStyle fontStyle) =>
+            s_platformImpl.GetTypeface(fontFamily, fontWeight, fontStyle);
+
+        /// <inheritdoc cref="IFontManagerImpl.MatchCharacter"/>
+        public static Typeface MatchCharacter(int codepoint, FontWeight fontWeight = default,
+            FontStyle fontStyle = default,
+            FontFamily fontFamily = null, CultureInfo culture = null) =>
+            s_platformImpl.MatchCharacter(codepoint, fontWeight, fontStyle, fontFamily, culture);
+
+        private static IFontManagerImpl GetPlatformImpl()
         {
             var platformImpl = AvaloniaLocator.Current.GetService<IFontManagerImpl>();
 
-            if(platformImpl == null)
-            {
-                return new EmptyFontManager();
-            }
-
-            return new PlatformFontManger(platformImpl);
+            return platformImpl ?? new EmptyFontManagerImpl();
         }
 
-        /// <inheritdoc cref="IFontManagerImpl"/>
-        public abstract IEnumerable<string> GetInstalledFontFamilyNames(bool checkForUpdates = false);
-
-        /// <inheritdoc cref="IFontManagerImpl"/>
-        public abstract IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface);
-
-        /// <inheritdoc cref="IFontManagerImpl"/>
-        public abstract Typeface GetTypeface(FontFamily fontFamily, FontWeight fontWeight, FontStyle fontStyle);
-
-        /// <inheritdoc cref="IFontManagerImpl"/>
-        public abstract Typeface MatchCharacter(int codepoint, FontWeight fontWeight = default,
-            FontStyle fontStyle = default,
-            FontFamily fontFamily = null, CultureInfo culture = null);
-
-        private class PlatformFontManger : FontManager
+        private class EmptyFontManagerImpl : IFontManagerImpl
         {
-            private readonly IFontManagerImpl _platformImpl;
+            public string DefaultFontFamilyName => "Arial";
 
-            public PlatformFontManger(IFontManagerImpl platformImpl)
+            public IEnumerable<string> GetInstalledFontFamilyNames(bool checkForUpdates = false) => new[] { "Arial" };
+
+            public Typeface GetTypeface(FontFamily fontFamily, FontWeight fontWeight, FontStyle fontStyle)
             {
-                _platformImpl = platformImpl;
-
-                DefaultFontFamilyName = _platformImpl.DefaultFontFamilyName;
+                return new Typeface(fontFamily, fontWeight, fontStyle);
             }
 
-            public override IEnumerable<string> GetInstalledFontFamilyNames(bool checkForUpdates = false) =>
-                _platformImpl.GetInstalledFontFamilyNames(checkForUpdates);
-
-            public override IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface) => _platformImpl.CreateGlyphTypeface(typeface);
-
-            public override Typeface GetTypeface(FontFamily fontFamily, FontWeight fontWeight, FontStyle fontStyle) =>
-                _platformImpl.GetTypeface(fontFamily, fontWeight, fontStyle);
-
-            public override Typeface MatchCharacter(int codepoint, FontWeight fontWeight = default,
-                FontStyle fontStyle = default,
-                FontFamily fontFamily = null, CultureInfo culture = null) =>
-                _platformImpl.MatchCharacter(codepoint, fontWeight, fontStyle, fontFamily, culture);
-        }
-
-        private class EmptyFontManager : FontManager
-        {
-            private readonly string[] _defaultFontFamilies = { "Arial" };
-
-            public EmptyFontManager()
-            {
-                DefaultFontFamilyName = "Arial";
-            }
-
-            public override IEnumerable<string> GetInstalledFontFamilyNames(bool checkForUpdates = false)
-            {
-                return _defaultFontFamilies;
-            }
-
-            public override IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface)
-            {
-                throw new NotSupportedException();
-            }
-
-            public override Typeface GetTypeface(FontFamily fontFamily, FontWeight fontWeight, FontStyle fontStyle)
-            {
-                throw new NotSupportedException();
-            }
-
-            public override Typeface MatchCharacter(int codepoint, FontWeight fontWeight = default, FontStyle fontStyle = default,
+            public Typeface MatchCharacter(int codepoint, FontWeight fontWeight = default, FontStyle fontStyle = default,
                 FontFamily fontFamily = null, CultureInfo culture = null)
             {
-                throw new NotSupportedException();
+                return null;
             }
         }
     }

--- a/src/Avalonia.Visuals/Media/FontManager.cs
+++ b/src/Avalonia.Visuals/Media/FontManager.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Platform;
+
+namespace Avalonia.Media
+{
+    public abstract class FontManager : IFontManagerImpl
+    {
+        public static readonly FontManager Default = CreateDefaultFontManger();
+
+        /// <inheritdoc cref="IFontManagerImpl"/>
+        public string DefaultFontFamilyName { get; protected set; }
+
+        private static FontManager CreateDefaultFontManger()
+        {
+            var platformImpl = AvaloniaLocator.Current.GetService<IFontManagerImpl>();
+
+            if(platformImpl == null)
+            {
+                return new EmptyFontManager();
+            }
+
+            return new PlatformFontManger(platformImpl);
+        }
+
+        /// <inheritdoc cref="IFontManagerImpl"/>
+        public abstract IEnumerable<string> GetInstalledFontFamilyNames(bool checkForUpdates = false);
+
+        /// <inheritdoc cref="IFontManagerImpl"/>
+        public abstract IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface);
+
+        /// <inheritdoc cref="IFontManagerImpl"/>
+        public abstract Typeface GetTypeface(FontFamily fontFamily, FontWeight fontWeight, FontStyle fontStyle);
+
+        /// <inheritdoc cref="IFontManagerImpl"/>
+        public abstract Typeface MatchCharacter(int codepoint, FontWeight fontWeight = default,
+            FontStyle fontStyle = default,
+            FontFamily fontFamily = null, CultureInfo culture = null);
+
+        private class PlatformFontManger : FontManager
+        {
+            private readonly IFontManagerImpl _platformImpl;
+
+            public PlatformFontManger(IFontManagerImpl platformImpl)
+            {
+                _platformImpl = platformImpl;
+
+                DefaultFontFamilyName = _platformImpl.DefaultFontFamilyName;
+            }
+
+            public override IEnumerable<string> GetInstalledFontFamilyNames(bool checkForUpdates = false) =>
+                _platformImpl.GetInstalledFontFamilyNames(checkForUpdates);
+
+            public override IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface) => _platformImpl.CreateGlyphTypeface(typeface);
+
+            public override Typeface GetTypeface(FontFamily fontFamily, FontWeight fontWeight, FontStyle fontStyle) =>
+                _platformImpl.GetTypeface(fontFamily, fontWeight, fontStyle);
+
+            public override Typeface MatchCharacter(int codepoint, FontWeight fontWeight = default,
+                FontStyle fontStyle = default,
+                FontFamily fontFamily = null, CultureInfo culture = null) =>
+                _platformImpl.MatchCharacter(codepoint, fontWeight, fontStyle, fontFamily, culture);
+        }
+
+        private class EmptyFontManager : FontManager
+        {
+            private readonly string[] _defaultFontFamilies = { "Arial" };
+
+            public EmptyFontManager()
+            {
+                DefaultFontFamilyName = "Arial";
+            }
+
+            public override IEnumerable<string> GetInstalledFontFamilyNames(bool checkForUpdates = false)
+            {
+                return _defaultFontFamilies;
+            }
+
+            public override IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override Typeface GetTypeface(FontFamily fontFamily, FontWeight fontWeight, FontStyle fontStyle)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override Typeface MatchCharacter(int codepoint, FontWeight fontWeight = default, FontStyle fontStyle = default,
+                FontFamily fontFamily = null, CultureInfo culture = null)
+            {
+                throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/src/Avalonia.Visuals/Media/Fonts/FamilyNameCollection.cs
+++ b/src/Avalonia.Visuals/Media/Fonts/FamilyNameCollection.cs
@@ -9,7 +9,7 @@ using System.Text;
 
 namespace Avalonia.Media.Fonts
 {
-    public class FamilyNameCollection : IReadOnlyList<string>
+    public sealed class FamilyNameCollection : IReadOnlyList<string>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FamilyNameCollection"/> class.

--- a/src/Avalonia.Visuals/Media/Fonts/FamilyNameCollection.cs
+++ b/src/Avalonia.Visuals/Media/Fonts/FamilyNameCollection.cs
@@ -9,7 +9,7 @@ using System.Text;
 
 namespace Avalonia.Media.Fonts
 {
-    public class FamilyNameCollection : IEnumerable<string>
+    public class FamilyNameCollection : IReadOnlyList<string>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FamilyNameCollection"/> class.
@@ -130,5 +130,9 @@ namespace Avalonia.Media.Fonts
 
             return other.ToString().Equals(ToString());
         }
+
+        public int Count => Names.Count;
+
+        public string this[int index] => Names[index];
     }
 }

--- a/src/Avalonia.Visuals/Media/FormattedText.cs
+++ b/src/Avalonia.Visuals/Media/FormattedText.cs
@@ -16,9 +16,10 @@ namespace Avalonia.Media
         private IFormattedTextImpl _platformImpl;
         private IReadOnlyList<FormattedTextStyleSpan> _spans;
         private Typeface _typeface;
+        private double _fontSize;
         private string _text;
         private TextAlignment _textAlignment;
-        private TextWrapping _wrapping;
+        private TextWrapping _textWrapping;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FormattedText"/> class.
@@ -35,6 +36,31 @@ namespace Avalonia.Media
         public FormattedText(IPlatformRenderInterface platform)
         {
             _platform = platform;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="text"></param>
+        /// <param name="typeface"></param>
+        /// <param name="fontSize"></param>
+        /// <param name="textAlignment"></param>
+        /// <param name="textWrapping"></param>
+        /// <param name="constraint"></param>
+        public FormattedText(string text, Typeface typeface, double fontSize, TextAlignment textAlignment,
+            TextWrapping textWrapping, Size constraint)
+        {
+            _text = text;
+
+            _typeface = typeface;
+
+            _fontSize = fontSize;
+
+            _textAlignment = textAlignment;
+
+            _textWrapping = textWrapping;
+
+            _constraint = constraint;
         }
 
         /// <summary>
@@ -59,6 +85,16 @@ namespace Avalonia.Media
         {
             get => _typeface;
             set => Set(ref _typeface, value);
+        }
+
+
+        /// <summary>
+        /// Gets or sets the font size.
+        /// </summary>
+        public double FontSize
+        {
+            get => _fontSize;
+            set => Set(ref _fontSize, value);
         }
 
         /// <summary>
@@ -92,10 +128,10 @@ namespace Avalonia.Media
         /// <summary>
         /// Gets or sets the text wrapping.
         /// </summary>
-        public TextWrapping Wrapping
+        public TextWrapping TextWrapping
         {
-            get => _wrapping;
-            set => Set(ref _wrapping, value);
+            get => _textWrapping;
+            set => Set(ref _textWrapping, value);
         }
 
         /// <summary>
@@ -110,8 +146,9 @@ namespace Avalonia.Media
                     _platformImpl = _platform.CreateFormattedText(
                         _text,
                         _typeface,
+                        _fontSize,
                         _textAlignment,
-                        _wrapping,
+                        _textWrapping,
                         _constraint,
                         _spans);
                 }

--- a/src/Avalonia.Visuals/Media/GlyphTypeface.cs
+++ b/src/Avalonia.Visuals/Media/GlyphTypeface.cs
@@ -7,7 +7,7 @@ using Avalonia.Platform;
 
 namespace Avalonia.Media
 {
-    public class GlyphTypeface : IDisposable
+    public sealed class GlyphTypeface : IDisposable
     {
         private static readonly IPlatformRenderInterface s_platformRenderInterface =
             AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();

--- a/src/Avalonia.Visuals/Media/GlyphTypeface.cs
+++ b/src/Avalonia.Visuals/Media/GlyphTypeface.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+
+using Avalonia.Platform;
+
+namespace Avalonia.Media
+{
+    public class GlyphTypeface : IDisposable
+    {
+        public GlyphTypeface(Typeface typeface) : this(FontManager.Default.CreateGlyphTypeface(typeface))
+        {
+        }
+
+        public GlyphTypeface(IGlyphTypefaceImpl platformImpl)
+        {
+            PlatformImpl = platformImpl;
+        }
+
+        public IGlyphTypefaceImpl PlatformImpl { get; }
+
+        /// <summary>
+        ///     Gets the font design units per em.
+        /// </summary>
+        public short DesignEmHeight => PlatformImpl.DesignEmHeight;
+
+        /// <summary>
+        ///     Gets the recommended distance above the baseline in design em size. 
+        /// </summary>
+        public int Ascent => PlatformImpl.Ascent;
+
+        /// <summary>
+        ///     Gets the recommended distance under the baseline in design em size. 
+        /// </summary>
+        public int Descent => PlatformImpl.Descent;
+
+        /// <summary>
+        ///      Gets the recommended additional space between two lines of text in design em size. 
+        /// </summary>
+        public int LineGap => PlatformImpl.LineGap;
+
+        /// <summary>
+        ///     Gets the recommended line height.
+        /// </summary>
+        public int LineHeight => Descent - Ascent + LineGap;
+
+        /// <summary>
+        ///     Gets a value that indicates the distance of the underline from the baseline in design em size.
+        /// </summary>
+        public int UnderlinePosition => PlatformImpl.UnderlinePosition;
+
+        /// <summary>
+        ///     Gets a value that indicates the thickness of the underline in design em size.
+        /// </summary>
+        public int UnderlineThickness => PlatformImpl.UnderlineThickness;
+
+        /// <summary>
+        ///     Gets a value that indicates the distance of the strikethrough from the baseline in design em size.
+        /// </summary>
+        public int StrikethroughPosition => PlatformImpl.StrikethroughPosition;
+
+        /// <summary>
+        ///     Gets a value that indicates the thickness of the underline in design em size.
+        /// </summary>
+        public int StrikethroughThickness => PlatformImpl.StrikethroughThickness;
+
+        /// <summary>
+        ///     Returns an glyph index for the specified codepoint.
+        /// </summary>
+        /// <remarks>
+        ///     Returns <c>0</c> if a glyph isn't found.
+        /// </remarks>
+        /// <param name="codepoint">The codepoint.</param>
+        /// <returns>
+        ///     A glyph index.
+        /// </returns>
+        public ushort GetGlyph(uint codepoint) => PlatformImpl.GetGlyph(codepoint);
+
+        /// <summary>
+        ///     Returns an array of glyph indices. Codepoints that are not represented by the font are returned as <code>0</code>.
+        /// </summary>
+        /// <param name="codepoints">The codepoints to map.</param>
+        /// <returns></returns>
+        public ushort[] GetGlyphs(ReadOnlySpan<uint> codepoints) => PlatformImpl.GetGlyphs(codepoints);
+
+        /// <summary>
+        ///     Returns the glyph advance for the specified glyph.
+        /// </summary>
+        /// <param name="glyph">The glyph.</param>
+        /// <returns>
+        ///     The advance.
+        /// </returns>
+        public int GetGlyphAdvance(ushort glyph) => PlatformImpl.GetGlyphAdvance(glyph);
+
+        /// <summary>
+        ///     Returns an array of glyph advances in design em size.
+        /// </summary>
+        /// <param name="glyphs">The glyph indices.</param>
+        /// <returns></returns>
+        public int[] GetGlyphAdvances(ReadOnlySpan<ushort> glyphs) => PlatformImpl.GetGlyphAdvances(glyphs);
+
+        void IDisposable.Dispose()
+        {
+            PlatformImpl?.Dispose();
+        }
+    }
+}

--- a/src/Avalonia.Visuals/Media/GlyphTypeface.cs
+++ b/src/Avalonia.Visuals/Media/GlyphTypeface.cs
@@ -9,7 +9,10 @@ namespace Avalonia.Media
 {
     public class GlyphTypeface : IDisposable
     {
-        public GlyphTypeface(Typeface typeface) : this(FontManager.Default.CreateGlyphTypeface(typeface))
+        private static readonly IPlatformRenderInterface s_platformRenderInterface =
+            AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+
+        public GlyphTypeface(Typeface typeface) : this(s_platformRenderInterface.CreateGlyphTypeface(typeface))
         {
         }
 

--- a/src/Avalonia.Visuals/Media/Typeface.cs
+++ b/src/Avalonia.Visuals/Media/Typeface.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Media
     /// <summary>
     /// Represents a typeface.
     /// </summary>
-    [DebuggerDisplay("Name = {FontFamily.Name}, Style = {Style}, Weight = {Weight}")]
+    [DebuggerDisplay("Name = {FontFamily.Name}, Weight = {Weight}, Style = {Style}")]
     public class Typeface : IEquatable<Typeface>
     {
         public static readonly Typeface Default = new Typeface(FontFamily.Default);

--- a/src/Avalonia.Visuals/Media/Typeface.cs
+++ b/src/Avalonia.Visuals/Media/Typeface.cs
@@ -1,39 +1,38 @@
-﻿using System;
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
 
 namespace Avalonia.Media
 {
     /// <summary>
     /// Represents a typeface.
     /// </summary>
-    public class Typeface
+    [DebuggerDisplay("Name = {FontFamily.Name}, Style = {Style}, Weight = {Weight}")]
+    public class Typeface : IEquatable<Typeface>
     {
         public static readonly Typeface Default = new Typeface(FontFamily.Default);
+
+        private GlyphTypeface _glyphTypeface;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Typeface"/> class.
         /// </summary>
         /// <param name="fontFamily">The font family.</param>
-        /// <param name="fontSize">The font size, in DIPs.</param>
-        /// <param name="style">The font style.</param>
         /// <param name="weight">The font weight.</param>
-        public Typeface(
-            FontFamily fontFamily, 
-            double fontSize = 12, 
-            FontStyle style = FontStyle.Normal,
-            FontWeight weight = FontWeight.Normal)
+        /// <param name="style">The font style.</param>
+        public Typeface([NotNull]FontFamily fontFamily,
+            FontWeight weight = FontWeight.Normal,
+            FontStyle style = FontStyle.Normal)
         {
-            if (fontSize <= 0)
-            {
-                throw new ArgumentException("Font size must be > 0.");
-            }
-
             if (weight <= 0)
             {
                 throw new ArgumentException("Font weight must be > 0.");
             }
 
             FontFamily = fontFamily;
-            FontSize = fontSize;
             Style = style;
             Weight = weight;
         }
@@ -42,15 +41,12 @@ namespace Avalonia.Media
         /// Initializes a new instance of the <see cref="Typeface"/> class.
         /// </summary>
         /// <param name="fontFamilyName">The name of the font family.</param>
-        /// <param name="fontSize">The font size, in DIPs.</param>
         /// <param name="style">The font style.</param>
         /// <param name="weight">The font weight.</param>
-        public Typeface(
-            string fontFamilyName,
-            double fontSize = 12,
-            FontStyle style = FontStyle.Normal,
-            FontWeight weight = FontWeight.Normal)
-            : this(new FontFamily(fontFamilyName), fontSize, style, weight)
+        public Typeface(string fontFamilyName,
+            FontWeight weight = FontWeight.Normal,
+            FontStyle style = FontStyle.Normal)
+            : this(new FontFamily(fontFamilyName), weight, style)
         {
         }
 
@@ -58,11 +54,6 @@ namespace Avalonia.Media
         /// Gets the font family.
         /// </summary>
         public FontFamily FontFamily { get; }
-
-        /// <summary>
-        /// Gets the size of the font in DIPs.
-        /// </summary>
-        public double FontSize { get; }
 
         /// <summary>
         /// Gets the font style.
@@ -73,5 +64,59 @@ namespace Avalonia.Media
         /// Gets the font weight.
         /// </summary>
         public FontWeight Weight { get; }
+
+        /// <summary>
+        /// Gets the glyph typeface.
+        /// </summary>
+        /// <value>
+        /// The glyph typeface.
+        /// </value>
+        public GlyphTypeface GlyphTypeface => _glyphTypeface ?? (_glyphTypeface = new GlyphTypeface(this));
+
+        public static bool operator !=(Typeface a, Typeface b)
+        {
+            return !(a == b);
+        }
+
+        public static bool operator ==(Typeface a, Typeface b)
+        {
+            if (ReferenceEquals(a, b))
+            {
+                return true;
+            }
+
+            return !(a is null) && a.Equals(b);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Typeface typeface)
+            {
+                return Equals(typeface);
+            }
+
+            return false;
+        }
+
+        public bool Equals(Typeface other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            return FontFamily.Equals(other.FontFamily) && Style == other.Style && Weight == other.Weight;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (FontFamily != null ? FontFamily.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (int)Style;
+                hashCode = (hashCode * 397) ^ (int)Weight;
+                return hashCode;
+            }
+        }
     }
 }

--- a/src/Avalonia.Visuals/Platform/IFontManagerImpl.cs
+++ b/src/Avalonia.Visuals/Platform/IFontManagerImpl.cs
@@ -21,15 +21,6 @@ namespace Avalonia.Platform
         IEnumerable<string> GetInstalledFontFamilyNames(bool checkForUpdates = false);
 
         /// <summary>
-        ///     Creates a glyph typeface for specified typeface.
-        /// </summary>
-        /// <param name="typeface">The typeface.</param>
-        /// <returns>
-        ///     The glyph typeface implementation.
-        /// </returns>
-        IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface);
-
-        /// <summary>
         ///     Get a typeface from specified parameters.
         /// </summary>
         /// <param name="fontFamily">The font family.</param>

--- a/src/Avalonia.Visuals/Platform/IFontManagerImpl.cs
+++ b/src/Avalonia.Visuals/Platform/IFontManagerImpl.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Media;
+
+namespace Avalonia.Platform
+{
+    public interface IFontManagerImpl
+    {
+        /// <summary>
+        ///     Gets the system's default font family's name.
+        /// </summary>
+        string DefaultFontFamilyName { get; }
+
+        /// <summary>
+        ///     Get all installed fonts in the system.
+        /// <param name="checkForUpdates">If <c>true</c> the font collection is updated.</param>
+        /// </summary>
+        IEnumerable<string> GetInstalledFontFamilyNames(bool checkForUpdates = false);
+
+        /// <summary>
+        ///     Creates a glyph typeface for specified typeface.
+        /// </summary>
+        /// <param name="typeface">The typeface.</param>
+        /// <returns>
+        ///     The glyph typeface implementation.
+        /// </returns>
+        IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface);
+
+        /// <summary>
+        ///     Get a typeface from specified parameters.
+        /// </summary>
+        /// <param name="fontFamily">The font family.</param>
+        /// <param name="fontWeight">The font weight.</param>
+        /// <param name="fontStyle">The font style.</param>
+        /// <returns>
+        ///     The typeface.
+        /// </returns>
+        Typeface GetTypeface(FontFamily fontFamily, FontWeight fontWeight, FontStyle fontStyle);
+
+        /// <summary>
+        ///     Tries to match a specified character to a typeface that supports specified font properties.
+        /// </summary>
+        /// <param name="codepoint">The codepoint to match against.</param>
+        /// <param name="fontWeight">The font weight.</param>
+        /// <param name="fontStyle">The font style.</param>
+        /// <param name="fontFamily">The font family. This is optional and used for fallback lookup.</param>
+        /// <param name="culture">The culture.</param>
+        /// <returns>
+        ///     The typeface.
+        /// </returns>
+        Typeface MatchCharacter(int codepoint, FontWeight fontWeight = default, FontStyle fontStyle = default,
+            FontFamily fontFamily = null, CultureInfo culture = null);
+    }
+}

--- a/src/Avalonia.Visuals/Platform/IGlyphTypefaceImpl.cs
+++ b/src/Avalonia.Visuals/Platform/IGlyphTypefaceImpl.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+
+namespace Avalonia.Platform
+{
+    public interface IGlyphTypefaceImpl : IDisposable
+    {
+        /// <summary>
+        ///     Gets the font design units per em.
+        /// </summary>
+        short DesignEmHeight { get; }
+
+        /// <summary>
+        ///     Gets the recommended distance above the baseline in design em size. 
+        /// </summary>
+        int Ascent { get; }
+
+        /// <summary>
+        ///     Gets the recommended distance under the baseline in design em size. 
+        /// </summary>
+        int Descent { get; }
+
+        /// <summary>
+        ///      Gets the recommended additional space between two lines of text in design em size. 
+        /// </summary>
+        int LineGap { get; }
+
+        /// <summary>
+        ///     Gets a value that indicates the distance of the underline from the baseline in design em size.
+        /// </summary>
+        int UnderlinePosition { get; }
+
+        /// <summary>
+        ///     Gets a value that indicates the thickness of the underline in design em size.
+        /// </summary>
+        int UnderlineThickness { get; }
+
+        /// <summary>
+        ///     Gets a value that indicates the distance of the strikethrough from the baseline in design em size.
+        /// </summary>
+        int StrikethroughPosition { get; }
+
+        /// <summary>
+        ///     Gets a value that indicates the thickness of the underline in design em size.
+        /// </summary>
+        int StrikethroughThickness { get; }
+
+        /// <summary>
+        ///     Returns an glyph index for the specified codepoint.
+        /// </summary>
+        /// <remarks>
+        ///     Returns <c>0</c> if a glyph isn't found.
+        /// </remarks>
+        /// <param name="codepoint">The codepoint.</param>
+        /// <returns>
+        ///     A glyph index.
+        /// </returns>
+        ushort GetGlyph(uint codepoint);
+
+        /// <summary>
+        ///     Returns an array of glyph indices. Codepoints that are not represented by the font are returned as <code>0</code>.
+        /// </summary>
+        /// <param name="codepoints">The codepoints to map.</param>
+        /// <returns>
+        ///     An array of glyph indices.
+        /// </returns>
+        ushort[] GetGlyphs(ReadOnlySpan<uint> codepoints);
+
+        /// <summary>
+        ///     Returns the glyph advance for the specified glyph.
+        /// </summary>
+        /// <param name="glyph">The glyph.</param>
+        /// <returns>
+        ///     The advance.
+        /// </returns>
+        int GetGlyphAdvance(ushort glyph);
+
+        /// <summary>
+        ///     Returns an array of glyph advances in design em size.
+        /// </summary>
+        /// <param name="glyphs">The glyph indices.</param>
+        /// <returns>
+        ///     An array of glyph advances.
+        /// </returns>
+        int[] GetGlyphAdvances(ReadOnlySpan<ushort> glyphs);
+    }
+}

--- a/src/Avalonia.Visuals/Platform/IPlatformRenderInterface.cs
+++ b/src/Avalonia.Visuals/Platform/IPlatformRenderInterface.cs
@@ -111,5 +111,14 @@ namespace Avalonia.Platform
         /// <param name="stride">The number of bytes per row.</param>
         /// <returns>An <see cref="IBitmapImpl"/>.</returns>
         IBitmapImpl LoadBitmap(PixelFormat format, IntPtr data, PixelSize size, Vector dpi, int stride);
+
+        /// <summary>
+        ///     Creates a glyph typeface for specified typeface.
+        /// </summary>
+        /// <param name="typeface">The typeface.</param>
+        /// <returns>
+        ///     The glyph typeface implementation.
+        /// </returns>
+        IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface);
     }
 }

--- a/src/Avalonia.Visuals/Platform/IPlatformRenderInterface.cs
+++ b/src/Avalonia.Visuals/Platform/IPlatformRenderInterface.cs
@@ -14,15 +14,11 @@ namespace Avalonia.Platform
     public interface IPlatformRenderInterface
     {
         /// <summary>
-        /// Get all installed fonts in the system
-        /// </summary>
-        IEnumerable<string> InstalledFontNames { get; }
-
-        /// <summary>
         /// Creates a formatted text implementation.
         /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="typeface">The base typeface.</param>
+        /// <param name="fontSize">The font size.</param>
         /// <param name="textAlignment">The text alignment.</param>
         /// <param name="wrapping">The text wrapping mode.</param>
         /// <param name="constraint">The text layout constraints.</param>
@@ -31,6 +27,7 @@ namespace Avalonia.Platform
         IFormattedTextImpl CreateFormattedText(
             string text,
             Typeface typeface,
+            double fontSize,
             TextAlignment textAlignment,
             TextWrapping wrapping,
             Size constraint,

--- a/src/Avalonia.Visuals/Rendering/RendererBase.cs
+++ b/src/Avalonia.Visuals/Rendering/RendererBase.cs
@@ -7,7 +7,8 @@ namespace Avalonia.Rendering
 {
     public class RendererBase
     {
-        private static readonly Typeface s_fpsTypeface = new Typeface("Arial", 18);
+        private static readonly Typeface s_fpsTypeface = new Typeface("Arial");
+        private static int s_fontSize = 18;
         private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
         private int _framesThisSecond;
         private int _fps;
@@ -18,7 +19,8 @@ namespace Avalonia.Rendering
         {
             _fpsText = new FormattedText
             {
-                Typeface = s_fpsTypeface
+                Typeface = s_fpsTypeface,
+                FontSize = s_fontSize
             };
         }
 

--- a/src/Skia/Avalonia.Skia/Avalonia.Skia.csproj
+++ b/src/Skia/Avalonia.Skia/Avalonia.Skia.csproj
@@ -12,5 +12,6 @@
   </ItemGroup>
   
   <Import Project="..\..\..\build\SkiaSharp.props" />
+  <Import Project="..\..\..\build\HarfBuzzSharp.props" />
   <Import Project="..\..\Shared\RenderHelpers\RenderHelpers.projitems" Label="Shared" />
 </Project>

--- a/src/Skia/Avalonia.Skia/FontKey.cs
+++ b/src/Skia/Avalonia.Skia/FontKey.cs
@@ -1,0 +1,40 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using Avalonia.Media;
+
+namespace Avalonia.Skia
+{
+    internal readonly struct FontKey : IEquatable<FontKey>
+    {
+        public readonly FontStyle Style;
+        public readonly FontWeight Weight;
+
+        public FontKey(FontWeight weight, FontStyle style)
+        {
+            Style = style;
+            Weight = weight;
+        }
+
+        public override int GetHashCode()
+        {
+            var hash = 17;
+            hash = hash * 31 + (int)Style;
+            hash = hash * 31 + (int)Weight;
+
+            return hash;
+        }
+
+        public override bool Equals(object other)
+        {
+            return other is FontKey key && Equals(key);
+        }
+
+        public bool Equals(FontKey other)
+        {
+            return Style == other.Style &&
+                   Weight == other.Weight;
+        }
+    }
+}

--- a/src/Skia/Avalonia.Skia/FontManagerImpl.cs
+++ b/src/Skia/Avalonia.Skia/FontManagerImpl.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Media;
+using Avalonia.Platform;
+using SkiaSharp;
+
+namespace Avalonia.Skia
+{
+    internal class FontManagerImpl : IFontManagerImpl
+    {
+        private SKFontManager _skFontManager = SKFontManager.Default;
+
+        private readonly ConcurrentDictionary<Typeface, GlyphTypefaceImpl> _glyphTypefaceCache =
+            new ConcurrentDictionary<Typeface, GlyphTypefaceImpl>();
+
+        public FontManagerImpl()
+        {
+            DefaultFontFamilyName = SKTypeface.Default.FamilyName;
+        }
+
+        public string DefaultFontFamilyName { get; }
+
+        public IEnumerable<string> GetInstalledFontFamilyNames(bool checkForUpdates = false)
+        {
+            if (checkForUpdates)
+            {
+                _skFontManager = SKFontManager.CreateDefault();
+            }
+
+            return _skFontManager.FontFamilies;
+        }
+
+        public IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface)
+        {
+            return _glyphTypefaceCache.GetOrAdd(typeface, new GlyphTypefaceImpl(typeface));
+        }
+
+        public Typeface GetTypeface(FontFamily fontFamily, FontWeight fontWeight, FontStyle fontStyle)
+        {
+            return TypefaceCache.Get(fontFamily.Name, fontWeight, fontStyle).Typeface;
+        }
+
+        public Typeface MatchCharacter(int codepoint, FontWeight fontWeight = default, FontStyle fontStyle = default,
+            FontFamily fontFamily = null, CultureInfo culture = null)
+        {
+            var fontFamilyName = FontFamily.Default.Name;
+
+            if (culture == null)
+            {
+                culture = CultureInfo.CurrentUICulture;
+            }
+
+            if (fontFamily != null)
+            {
+                foreach (var familyName in fontFamily.FamilyNames)
+                {
+                    var skTypeface = _skFontManager.MatchCharacter(familyName, (SKFontStyleWeight)fontWeight,
+                        SKFontStyleWidth.Normal,
+                        (SKFontStyleSlant)fontStyle,
+                        new[] { culture.TwoLetterISOLanguageName, culture.ThreeLetterISOLanguageName }, codepoint);
+
+                    if (skTypeface == null)
+                    {
+                        continue;
+                    }
+
+                    fontFamilyName = familyName;
+
+                    break;
+                }
+            }
+            else
+            {
+                var skTypeface = _skFontManager.MatchCharacter(null, (SKFontStyleWeight)fontWeight, SKFontStyleWidth.Normal,
+                    (SKFontStyleSlant)fontStyle,
+                    new[] { culture.TwoLetterISOLanguageName, culture.ThreeLetterISOLanguageName }, codepoint);
+
+                if (skTypeface != null)
+                {
+                    fontFamilyName = skTypeface.FamilyName;
+                }
+            }
+
+            return GetTypeface(fontFamilyName, fontWeight, fontStyle);
+        }
+    }
+}

--- a/src/Skia/Avalonia.Skia/FontManagerImpl.cs
+++ b/src/Skia/Avalonia.Skia/FontManagerImpl.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using Avalonia.Media;
@@ -13,9 +12,6 @@ namespace Avalonia.Skia
     internal class FontManagerImpl : IFontManagerImpl
     {
         private SKFontManager _skFontManager = SKFontManager.Default;
-
-        private readonly ConcurrentDictionary<Typeface, GlyphTypefaceImpl> _glyphTypefaceCache =
-            new ConcurrentDictionary<Typeface, GlyphTypefaceImpl>();
 
         public FontManagerImpl()
         {
@@ -32,11 +28,6 @@ namespace Avalonia.Skia
             }
 
             return _skFontManager.FontFamilies;
-        }
-
-        public IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface)
-        {
-            return _glyphTypefaceCache.GetOrAdd(typeface, new GlyphTypefaceImpl(typeface));
         }
 
         public Typeface GetTypeface(FontFamily fontFamily, FontWeight fontWeight, FontStyle fontStyle)

--- a/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
+++ b/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
@@ -18,6 +18,7 @@ namespace Avalonia.Skia
         public FormattedTextImpl(
             string text,
             Typeface typeface,
+            double fontSize,
             TextAlignment textAlignment,
             TextWrapping wrapping,
             Size constraint,
@@ -28,47 +29,22 @@ namespace Avalonia.Skia
             // Replace 0 characters with zero-width spaces (200B)
             Text = Text.Replace((char)0, (char)0x200B);
 
-            SKTypeface skiaTypeface = null;
+            var entry = TypefaceCache.Get(typeface.FontFamily, typeface.Weight, typeface.Style);
 
-            if (typeface.FontFamily.Key != null)
+            _paint = new SKPaint
             {
-                var typefaces = SKTypefaceCollectionCache.GetOrAddTypefaceCollection(typeface.FontFamily);
-                skiaTypeface = typefaces.GetTypeFace(typeface);
-            }
-            else
-            {
-                if (typeface.FontFamily.FamilyNames.HasFallbacks)
-                {
-                    foreach (var familyName in typeface.FontFamily.FamilyNames)
-                    {
-                        skiaTypeface = TypefaceCache.GetTypeface(
-                            familyName,
-                            typeface.Style,
-                            typeface.Weight);
-                        if (skiaTypeface.FamilyName != TypefaceCache.DefaultFamilyName) break;
-                    }
-                }
-                else
-                {
-                    skiaTypeface = TypefaceCache.GetTypeface(
-                        typeface.FontFamily.Name,
-                        typeface.Style,
-                        typeface.Weight);
-                }
-            }
-
-            _paint = new SKPaint();
+                TextEncoding = SKTextEncoding.Utf16,
+                IsStroke = false,
+                IsAntialias = true,
+                LcdRenderText = true,
+                SubpixelText = true,
+                Typeface = entry.SKTypeface,
+                TextSize = (float)fontSize,
+                TextAlign = textAlignment.ToSKTextAlign()
+            };
 
             //currently Skia does not measure properly with Utf8 !!!
             //Paint.TextEncoding = SKTextEncoding.Utf8;
-            _paint.TextEncoding = SKTextEncoding.Utf16;
-            _paint.IsStroke = false;
-            _paint.IsAntialias = true;
-            _paint.LcdRenderText = true;
-            _paint.SubpixelText = true;
-            _paint.Typeface = skiaTypeface;
-            _paint.TextSize = (float)typeface.FontSize;
-            _paint.TextAlign = textAlignment.ToSKTextAlign();
 
             _wrapping = wrapping;
             _constraint = constraint;

--- a/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs
+++ b/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs
@@ -10,7 +10,7 @@ using SkiaSharp;
 
 namespace Avalonia.Skia
 {
-    internal class GlyphTypefaceImpl : IGlyphTypefaceImpl
+    public class GlyphTypefaceImpl : IGlyphTypefaceImpl
     {
         private bool _isDisposed;
 

--- a/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs
+++ b/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs
@@ -1,0 +1,179 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Avalonia.Media;
+using Avalonia.Platform;
+using HarfBuzzSharp;
+using SkiaSharp;
+
+namespace Avalonia.Skia
+{
+    internal class GlyphTypefaceImpl : IGlyphTypefaceImpl
+    {
+        private bool _isDisposed;
+
+        public GlyphTypefaceImpl(Typeface typeface)
+        {
+            Typeface = TypefaceCache.Get(typeface.FontFamily, typeface.Weight, typeface.Style).SKTypeface;
+
+            Face = new Face(GetTable)
+            {
+                UnitsPerEm = Typeface.UnitsPerEm
+            };
+
+            Font = new Font(Face);
+
+            Font.SetFunctionsOpenType();
+
+            Font.GetScale(out var xScale, out _);
+
+            DesignEmHeight = (short)xScale;
+
+            if (!Font.TryGetHorizontalFontExtents(out var fontExtents))
+            {
+                Font.TryGetVerticalFontExtents(out fontExtents);
+            }
+
+            Ascent = -fontExtents.Ascender;
+
+            Descent = -fontExtents.Descender;
+
+            LineGap = fontExtents.LineGap;
+
+            if (Font.OpenTypeMetrics.TryGetPosition(OpenTypeMetricsTag.UnderlineOffset, out var underlinePosition))
+            {
+                UnderlinePosition = underlinePosition;
+            }
+
+            if (Font.OpenTypeMetrics.TryGetPosition(OpenTypeMetricsTag.UnderlineSize, out var underlineThickness))
+            {
+                UnderlineThickness = underlineThickness;
+            }
+
+            if (Font.OpenTypeMetrics.TryGetPosition(OpenTypeMetricsTag.StrikeoutOffset, out var strikethroughPosition))
+            {
+                StrikethroughPosition = strikethroughPosition;
+            }
+
+            if (Font.OpenTypeMetrics.TryGetPosition(OpenTypeMetricsTag.StrikeoutSize, out var strikethroughThickness))
+            {
+                StrikethroughThickness = strikethroughThickness;
+            }
+        }
+
+        public Face Face { get; }
+
+        public Font Font { get; }
+
+        public SKTypeface Typeface { get; }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public short DesignEmHeight { get; }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int Ascent { get; }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int Descent { get; }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int LineGap { get; }
+
+        //ToDo: Get these values from HarfBuzz
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int UnderlinePosition { get; }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int UnderlineThickness { get; }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int StrikethroughPosition { get; }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int StrikethroughThickness { get; }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public ushort GetGlyph(uint codepoint)
+        {
+            if (Font.TryGetGlyph(codepoint, out var glyph))
+            {
+                return (ushort)glyph;
+            }
+
+            return 0;
+        }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public ushort[] GetGlyphs(ReadOnlySpan<uint> codepoints)
+        {
+            var glyphs = new ushort[codepoints.Length];
+
+            for (var i = 0; i < codepoints.Length; i++)
+            {
+                if (Font.TryGetGlyph(codepoints[i], out var glyph))
+                {
+                    glyphs[i] = (ushort)glyph;
+                }
+            }
+
+            return glyphs;
+        }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int GetGlyphAdvance(ushort glyph)
+        {
+            return Font.GetHorizontalGlyphAdvance(glyph);
+        }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int[] GetGlyphAdvances(ReadOnlySpan<ushort> glyphs)
+        {
+            var glyphIndices = new uint[glyphs.Length];
+
+            for (var i = 0; i < glyphs.Length; i++)
+            {
+                glyphIndices[i] = glyphs[i];
+            }
+
+            return Font.GetHorizontalGlyphAdvances(glyphIndices);
+        }
+
+        private Blob GetTable(Face face, Tag tag)
+        {
+            var size = Typeface.GetTableSize(tag);
+
+            var data = Marshal.AllocCoTaskMem(size);
+
+            var releaseDelegate = new ReleaseDelegate(() => Marshal.FreeCoTaskMem(data));
+
+            return Typeface.TryGetTableData(tag, 0, size, data) ?
+                new Blob(data, size, MemoryMode.ReadOnly, releaseDelegate) : null;
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+
+            if (!disposing)
+            {
+                return;
+            }
+
+            Font?.Dispose();
+            Face?.Dispose();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
+++ b/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Avalonia.Controls.Platform.Surfaces;
@@ -17,6 +18,9 @@ namespace Avalonia.Skia
     /// </summary>
     internal class PlatformRenderInterface : IPlatformRenderInterface
     {
+        private readonly ConcurrentDictionary<Typeface, GlyphTypefaceImpl> _glyphTypefaceCache =
+            new ConcurrentDictionary<Typeface, GlyphTypefaceImpl>();
+
         private readonly ICustomSkiaGpu _customSkiaGpu;
 
         private GRContext GrContext { get; }
@@ -149,6 +153,11 @@ namespace Avalonia.Skia
         public IWriteableBitmapImpl CreateWriteableBitmap(PixelSize size, Vector dpi, PixelFormat? format = null)
         {
             return new WriteableBitmapImpl(size, dpi, format);
+        }
+
+        public IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface)
+        {
+            return _glyphTypefaceCache.GetOrAdd(typeface, new GlyphTypefaceImpl(typeface));
         }
     }
 }

--- a/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
+++ b/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
@@ -21,8 +21,6 @@ namespace Avalonia.Skia
 
         private GRContext GrContext { get; }
 
-        public IEnumerable<string> InstalledFontNames => SKFontManager.Default.FontFamilies;
-
         public PlatformRenderInterface(ICustomSkiaGpu customSkiaGpu)
         {
             if (customSkiaGpu != null)
@@ -52,12 +50,13 @@ namespace Avalonia.Skia
         public IFormattedTextImpl CreateFormattedText(
             string text,
             Typeface typeface,
+            double fontSize,
             TextAlignment textAlignment,
             TextWrapping wrapping,
             Size constraint,
             IReadOnlyList<FormattedTextStyleSpan> spans)
         {
-            return new FormattedTextImpl(text, typeface, textAlignment, wrapping, constraint, spans);
+            return new FormattedTextImpl(text, typeface,fontSize, textAlignment, wrapping, constraint, spans);
         }
 
         public IGeometryImpl CreateEllipseGeometry(Rect rect) => new EllipseGeometryImpl(rect);

--- a/src/Skia/Avalonia.Skia/SKTypefaceCollection.cs
+++ b/src/Skia/Avalonia.Skia/SKTypefaceCollection.cs
@@ -4,114 +4,59 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-
 using Avalonia.Media;
-
-using SkiaSharp;
 
 namespace Avalonia.Skia
 {
     internal class SKTypefaceCollection
     {
-        private readonly ConcurrentDictionary<string, ConcurrentDictionary<FontKey, SKTypeface>> _fontFamilies =
-            new ConcurrentDictionary<string, ConcurrentDictionary<FontKey, SKTypeface>>();
+        private readonly ConcurrentDictionary<string, ConcurrentDictionary<FontKey, TypefaceCollectionEntry>> _fontFamilies =
+            new ConcurrentDictionary<string, ConcurrentDictionary<FontKey, TypefaceCollectionEntry>>();
 
-        public void AddTypeFace(SKTypeface typeface)
+        public void AddEntry(string familyName, FontKey key, TypefaceCollectionEntry entry)
         {
-            var key = new FontKey((SKFontStyleWeight)typeface.FontWeight, typeface.FontSlant);
-
-            if (!_fontFamilies.TryGetValue(typeface.FamilyName, out var fontFamily))
+            if (!_fontFamilies.TryGetValue(familyName, out var fontFamily))
             {
-                fontFamily = new ConcurrentDictionary<FontKey, SKTypeface>();
+                fontFamily = new ConcurrentDictionary<FontKey, TypefaceCollectionEntry>();
 
-                _fontFamilies.TryAdd(typeface.FamilyName, fontFamily);
+                _fontFamilies.TryAdd(familyName, fontFamily);
             }
 
-            fontFamily.TryAdd(key, typeface);
+            fontFamily.TryAdd(key, entry);
         }
 
-        public SKTypeface GetTypeFace(Typeface typeface)
+        public TypefaceCollectionEntry Get(string familyName, FontWeight fontWeight, FontStyle fontStyle)
         {
-            var styleSlant = SKFontStyleSlant.Upright;
+            var key = new FontKey(fontWeight, fontStyle);
 
-            switch (typeface.Style)
-            {
-                case FontStyle.Italic:
-                    styleSlant = SKFontStyleSlant.Italic;
-                    break;
-
-                case FontStyle.Oblique:
-                    styleSlant = SKFontStyleSlant.Oblique;
-                    break;
-            }
-
-            if (!_fontFamilies.TryGetValue(typeface.FontFamily.Name, out var fontFamily))
-            {
-                return TypefaceCache.GetTypeface(TypefaceCache.DefaultFamilyName, typeface.Style, typeface.Weight);
-            }
-
-            var weight = (SKFontStyleWeight)typeface.Weight;
-
-            var key = new FontKey(weight, styleSlant);
-
-            return fontFamily.GetOrAdd(key, GetFallback(fontFamily, key));
+            return _fontFamilies.TryGetValue(familyName, out var fontFamily) ?
+                fontFamily.GetOrAdd(key, GetFallback(fontFamily, key)) :
+                null;
         }
 
-        private static SKTypeface GetFallback(IDictionary<FontKey, SKTypeface> fontFamily, FontKey key)
+        private static TypefaceCollectionEntry GetFallback(IDictionary<FontKey, TypefaceCollectionEntry> fontFamily, FontKey key)
         {
             var keys = fontFamily.Keys.Where(
-                x => ((int)x.Weight <= (int)key.Weight || (int)x.Weight > (int)key.Weight) && x.Slant == key.Slant).ToArray();
+                x => ((int)x.Weight <= (int)key.Weight || (int)x.Weight > (int)key.Weight) && x.Style == key.Style).ToArray();
 
             if (!keys.Any())
             {
                 keys = fontFamily.Keys.Where(
-                    x => x.Weight == key.Weight && (x.Slant >= key.Slant || x.Slant < key.Slant)).ToArray();
+                    x => x.Weight == key.Weight && (x.Style >= key.Style || x.Style < key.Style)).ToArray();
 
                 if (!keys.Any())
                 {
                     keys = fontFamily.Keys.Where(
                         x => ((int)x.Weight <= (int)key.Weight || (int)x.Weight > (int)key.Weight) &&
-                             (x.Slant >= key.Slant || x.Slant < key.Slant)).ToArray();
+                             (x.Style >= key.Style || x.Style < key.Style)).ToArray();
                 }
             }
 
             key = keys.FirstOrDefault();
 
-            fontFamily.TryGetValue(key, out var typeface);
+            fontFamily.TryGetValue(key, out var entry);
 
-            return typeface;
-        }
-
-        private struct FontKey
-        {
-            public readonly SKFontStyleSlant Slant;
-            public readonly SKFontStyleWeight Weight;
-
-            public FontKey(SKFontStyleWeight weight, SKFontStyleSlant slant)
-            {
-                Slant = slant;
-                Weight = weight;
-            }
-
-            public override int GetHashCode()
-            {
-                var hash = 17;
-                hash = (hash * 31) + (int)Slant;
-                hash = (hash * 31) + (int)Weight;
-
-                return hash;
-            }
-
-            public override bool Equals(object other)
-            {
-                return other is FontKey key && this.Equals(key);
-            }
-
-            private bool Equals(FontKey other)
-            {
-                return Slant == other.Slant &&
-                       Weight == other.Weight;
-            }
+            return entry;
         }
     }
 }

--- a/src/Skia/Avalonia.Skia/SKTypefaceCollectionCache.cs
+++ b/src/Skia/Avalonia.Skia/SKTypefaceCollectionCache.cs
@@ -45,9 +45,13 @@ namespace Avalonia.Skia
             {
                 var assetStream = assetLoader.Open(asset);
 
-                var typeface = SKTypeface.FromStream(assetStream);
+                var skTypeface = SKTypeface.FromStream(assetStream);
 
-                typeFaceCollection.AddTypeFace(typeface);
+                var typeface = new Typeface(fontFamily, (FontWeight)skTypeface.FontWeight, (FontStyle)skTypeface.FontSlant);
+
+                var entry = new TypefaceCollectionEntry(typeface, skTypeface);
+
+                typeFaceCollection.AddEntry(skTypeface.FamilyName, new FontKey(typeface.Weight, typeface.Style), entry);
             }
 
             return typeFaceCollection;

--- a/src/Skia/Avalonia.Skia/SkiaPlatform.cs
+++ b/src/Skia/Avalonia.Skia/SkiaPlatform.cs
@@ -25,6 +25,11 @@ namespace Avalonia.Skia
 
             AvaloniaLocator.CurrentMutable
                 .Bind<IPlatformRenderInterface>().ToConstant(renderInterface);
+
+            var fontManager = new FontManagerImpl();
+
+            AvaloniaLocator.CurrentMutable
+                .Bind<IFontManagerImpl>().ToConstant(fontManager);
         }
 
         /// <summary>

--- a/src/Skia/Avalonia.Skia/TypefaceCache.cs
+++ b/src/Skia/Avalonia.Skia/TypefaceCache.cs
@@ -1,7 +1,7 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using Avalonia.Media;
 using SkiaSharp;
 
@@ -12,88 +12,36 @@ namespace Avalonia.Skia
     /// </summary>
     internal static class TypefaceCache
     {
-        public static readonly string DefaultFamilyName = CreateDefaultFamilyName();
+        private static readonly ConcurrentDictionary<string, ConcurrentDictionary<FontKey, TypefaceCollectionEntry>> s_cache =
+            new ConcurrentDictionary<string, ConcurrentDictionary<FontKey, TypefaceCollectionEntry>>();
 
-        private static readonly Dictionary<string, Dictionary<FontKey, SKTypeface>> s_cache =
-            new Dictionary<string, Dictionary<FontKey, SKTypeface>>();
-
-        struct FontKey
+        public static TypefaceCollectionEntry Get(FontFamily fontFamily, FontWeight fontWeight, FontStyle fontStyle)
         {
-            public readonly SKFontStyleSlant Slant;
-            public readonly SKFontStyleWeight Weight;
-
-            public FontKey(SKFontStyleWeight weight, SKFontStyleSlant slant)
+            if (fontFamily.Key != null)
             {
-                Slant = slant;
-                Weight = weight;
+                return SKTypefaceCollectionCache.GetOrAddTypefaceCollection(fontFamily)
+                    .Get(fontFamily.Name, fontWeight, fontStyle);
             }
 
-            public override int GetHashCode()
-            {
-                int hash = 17;
-                hash = hash * 31 + (int)Slant;
-                hash = hash * 31 + (int)Weight;
+            var typefaceCollection = s_cache.GetOrAdd(fontFamily.Name, new ConcurrentDictionary<FontKey, TypefaceCollectionEntry>());
 
-                return hash;
+            var key = new FontKey(fontWeight, fontStyle);
+
+            if (typefaceCollection.TryGetValue(key, out var entry))
+            {
+                return entry;
             }
 
-            public override bool Equals(object other)
-            {
-                return other is FontKey ? Equals((FontKey)other) : false;
-            }
+            var skTypeface = SKTypeface.FromFamilyName(fontFamily.Name, (SKFontStyleWeight)fontWeight,
+                                 SKFontStyleWidth.Normal, (SKFontStyleSlant)fontStyle) ?? SKTypeface.Default;
 
-            public bool Equals(FontKey other)
-            {
-                return Slant == other.Slant &&
-                       Weight == other.Weight;
-            }
+            var typeface = new Typeface(fontFamily.Name, fontWeight, fontStyle);
 
-            // Equals and GetHashCode ommitted
-        }
+            entry = new TypefaceCollectionEntry(typeface, skTypeface);
 
-        private static string CreateDefaultFamilyName()
-        {
-            var defaultTypeface = SKTypeface.CreateDefault();
+            typefaceCollection[key] = entry;
 
-            return defaultTypeface.FamilyName;
-        }
-
-        private static SKTypeface GetTypeface(string name, FontKey key)
-        {
-            var familyKey = name;
-
-            if (!s_cache.TryGetValue(familyKey, out var entry))
-            {
-                s_cache[familyKey] = entry = new Dictionary<FontKey, SKTypeface>();
-            }
-
-            if (!entry.TryGetValue(key, out var typeface))
-            {
-                typeface = SKTypeface.FromFamilyName(familyKey, key.Weight, SKFontStyleWidth.Normal, key.Slant) ??
-                           GetTypeface(DefaultFamilyName, key);
-
-                entry[key] = typeface;
-            }
-
-            return typeface;
-        }
-
-        public static SKTypeface GetTypeface(string name, FontStyle style, FontWeight weight)
-        {
-            var skStyle = SKFontStyleSlant.Upright;
-
-            switch (style)
-            {
-                case FontStyle.Italic:
-                    skStyle = SKFontStyleSlant.Italic;
-                    break;
-
-                case FontStyle.Oblique:
-                    skStyle = SKFontStyleSlant.Oblique;
-                    break;
-            }
-
-            return GetTypeface(name, new FontKey((SKFontStyleWeight)weight, skStyle));
+            return entry;
         }
     }
 }

--- a/src/Skia/Avalonia.Skia/TypefaceCollectionEntry.cs
+++ b/src/Skia/Avalonia.Skia/TypefaceCollectionEntry.cs
@@ -1,0 +1,19 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using Avalonia.Media;
+using SkiaSharp;
+
+namespace Avalonia.Skia
+{
+    internal class TypefaceCollectionEntry
+    {
+        public TypefaceCollectionEntry(Typeface typeface, SKTypeface skTypeface)
+        {
+            Typeface = typeface;
+            SKTypeface = skTypeface;
+        }
+        public Typeface Typeface { get; }
+        public SKTypeface SKTypeface { get; }
+    }
+}

--- a/src/Windows/Avalonia.Direct2D1/Avalonia.Direct2D1.csproj
+++ b/src/Windows/Avalonia.Direct2D1/Avalonia.Direct2D1.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
   <Import Project="..\..\..\build\Rx.props" />
   <Import Project="..\..\..\build\SharpDX.props" />
+  <Import Project="..\..\..\build\HarfBuzzSharp.props" />
   <Import Project="..\..\Shared\RenderHelpers\RenderHelpers.projitems" Label="Shared" />
   <Import Project="..\..\..\build\JetBrains.Annotations.props" />
 </Project>

--- a/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
+++ b/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Avalonia.Controls;
@@ -27,6 +28,8 @@ namespace Avalonia.Direct2D1
 {
     public class Direct2D1Platform : IPlatformRenderInterface
     {
+        private readonly ConcurrentDictionary<Typeface, GlyphTypefaceImpl> _glyphTypefaceCache =
+            new ConcurrentDictionary<Typeface, GlyphTypefaceImpl>();
         private static readonly Direct2D1Platform s_instance = new Direct2D1Platform();
 
         public static SharpDX.Direct3D11.Device Direct3D11Device { get; private set; }
@@ -189,6 +192,11 @@ namespace Avalonia.Direct2D1
         public IBitmapImpl LoadBitmap(PixelFormat format, IntPtr data, PixelSize size, Vector dpi, int stride)
         {
             return new WicBitmapImpl(format, data, size, dpi, stride);
+        }
+
+        public IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface)
+        {
+            return _glyphTypefaceCache.GetOrAdd(typeface, new GlyphTypefaceImpl(typeface));
         }
     }
 }

--- a/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
+++ b/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
@@ -41,20 +41,6 @@ namespace Avalonia.Direct2D1
 
         public static SharpDX.DXGI.Device1 DxgiDevice { get; private set; }
 
-        public IEnumerable<string> InstalledFontNames
-        {
-            get
-            {
-                var cache = Direct2D1FontCollectionCache.s_installedFontCollection;
-                var length = cache.FontFamilyCount;
-                for (int i = 0; i < length; i++)
-                {
-                    var names = cache.GetFontFamily(i).FamilyNames;
-                    yield return names.GetString(0);
-                }
-            }
-        }
-
         private static readonly object s_initLock = new object();
         private static bool s_initialized = false;
 
@@ -120,6 +106,7 @@ namespace Avalonia.Direct2D1
         {
             InitializeDirect2D();
             AvaloniaLocator.CurrentMutable.Bind<IPlatformRenderInterface>().ToConstant(s_instance);
+            AvaloniaLocator.CurrentMutable.Bind<IFontManagerImpl>().ToConstant(new FontManagerImpl());
             SharpDX.Configuration.EnableReleaseOnFinalizer = true;
         }
 
@@ -131,6 +118,7 @@ namespace Avalonia.Direct2D1
         public IFormattedTextImpl CreateFormattedText(
             string text,
             Typeface typeface,
+            double fontSize,
             TextAlignment textAlignment,
             TextWrapping wrapping,
             Size constraint,
@@ -139,6 +127,7 @@ namespace Avalonia.Direct2D1
             return new FormattedTextImpl(
                 text,
                 typeface,
+                fontSize,
                 textAlignment,
                 wrapping,
                 constraint,

--- a/src/Windows/Avalonia.Direct2D1/Media/Direct2D1FontCollectionCache.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Direct2D1FontCollectionCache.cs
@@ -1,62 +1,61 @@
 using System.Collections.Concurrent;
 using Avalonia.Media;
 using Avalonia.Media.Fonts;
+using SharpDX.DirectWrite;
+using FontFamily = Avalonia.Media.FontFamily;
+using FontStyle = SharpDX.DirectWrite.FontStyle;
+using FontWeight = SharpDX.DirectWrite.FontWeight;
 
 namespace Avalonia.Direct2D1.Media
 {
     internal static class Direct2D1FontCollectionCache
     {
-        private static readonly ConcurrentDictionary<FontFamilyKey, SharpDX.DirectWrite.FontCollection> s_cachedCollections;
-        internal static readonly SharpDX.DirectWrite.FontCollection s_installedFontCollection;
+        private static readonly ConcurrentDictionary<FontFamilyKey, FontCollection> s_cachedCollections;
+        internal static readonly FontCollection InstalledFontCollection;
 
         static Direct2D1FontCollectionCache()
         {
-            s_cachedCollections = new ConcurrentDictionary<FontFamilyKey, SharpDX.DirectWrite.FontCollection>();
+            s_cachedCollections = new ConcurrentDictionary<FontFamilyKey, FontCollection>();
 
-            s_installedFontCollection = Direct2D1Platform.DirectWriteFactory.GetSystemFontCollection(false);
+            InstalledFontCollection = Direct2D1Platform.DirectWriteFactory.GetSystemFontCollection(false);
         }
 
-        public static SharpDX.DirectWrite.TextFormat GetTextFormat(Typeface typeface)
+        public static Font GetFont(Typeface typeface)
         {
             var fontFamily = typeface.FontFamily;
             var fontCollection = GetOrAddFontCollection(fontFamily);
-            var fontFamilyName = FontFamily.Default.Name;
 
-            // Should this be cached?
             foreach (var familyName in fontFamily.FamilyNames)
             {
-                if (!fontCollection.FindFamilyName(familyName, out _))
+                if (fontCollection.FindFamilyName(familyName, out var index))
                 {
-                    continue;
+                    return fontCollection.GetFontFamily(index).GetFirstMatchingFont(
+                        (FontWeight)typeface.Weight,
+                        FontStretch.Normal,
+                        (FontStyle)typeface.Style);
                 }
-
-                fontFamilyName = familyName;
-
-                break;
             }
 
-            return new SharpDX.DirectWrite.TextFormat(
-                Direct2D1Platform.DirectWriteFactory, 
-                fontFamilyName, 
-                fontCollection, 
-                (SharpDX.DirectWrite.FontWeight)typeface.Weight,
-                (SharpDX.DirectWrite.FontStyle)typeface.Style, 
-                SharpDX.DirectWrite.FontStretch.Normal, 
-                (float)typeface.FontSize);
+            InstalledFontCollection.FindFamilyName(FontFamily.Default.Name, out var i);
+
+            return InstalledFontCollection.GetFontFamily(i).GetFirstMatchingFont(
+                (FontWeight)typeface.Weight,
+                FontStretch.Normal,
+                (FontStyle)typeface.Style);
         }
 
-        private static SharpDX.DirectWrite.FontCollection GetOrAddFontCollection(FontFamily fontFamily)
+        private static FontCollection GetOrAddFontCollection(FontFamily fontFamily)
         {
-            return fontFamily.Key == null ? s_installedFontCollection : s_cachedCollections.GetOrAdd(fontFamily.Key, CreateFontCollection);
+            return fontFamily.Key == null ? InstalledFontCollection : s_cachedCollections.GetOrAdd(fontFamily.Key, CreateFontCollection);
         }
 
-        private static SharpDX.DirectWrite.FontCollection CreateFontCollection(FontFamilyKey key)
+        private static FontCollection CreateFontCollection(FontFamilyKey key)
         {
             var assets = FontFamilyLoader.LoadFontAssets(key);
 
             var fontLoader = new DWriteResourceFontLoader(Direct2D1Platform.DirectWriteFactory, assets);
 
-            return new SharpDX.DirectWrite.FontCollection(Direct2D1Platform.DirectWriteFactory, fontLoader, fontLoader.Key);
+            return new FontCollection(Direct2D1Platform.DirectWriteFactory, fontLoader, fontLoader.Key);
         }
     }
 }

--- a/src/Windows/Avalonia.Direct2D1/Media/FontManagerImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/FontManagerImpl.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Media;
+using Avalonia.Platform;
+using SharpDX.DirectWrite;
+using FontFamily = Avalonia.Media.FontFamily;
+using FontStyle = Avalonia.Media.FontStyle;
+using FontWeight = Avalonia.Media.FontWeight;
+
+namespace Avalonia.Direct2D1.Media
+{
+    internal class FontManagerImpl : IFontManagerImpl
+    {
+        private readonly ConcurrentDictionary<Typeface, GlyphTypefaceImpl> _glyphTypefaceCache =
+            new ConcurrentDictionary<Typeface, GlyphTypefaceImpl>();
+
+        public FontManagerImpl()
+        {
+            //ToDo: Implement a real lookup of the system's default font.
+            DefaultFontFamilyName = "segoe ui";
+        }
+
+        public string DefaultFontFamilyName { get; }
+
+        public IEnumerable<string> GetInstalledFontFamilyNames(bool checkForUpdates = false)
+        {
+            var familyCount = Direct2D1FontCollectionCache.InstalledFontCollection.FontFamilyCount;
+
+            var fontFamilies = new string[familyCount];
+
+            for (var i = 0; i < familyCount; i++)
+            {
+                fontFamilies[i] = Direct2D1FontCollectionCache.InstalledFontCollection.GetFontFamily(i).FamilyNames.GetString(0);
+            }
+
+            return fontFamilies;
+        }
+
+        public IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface)
+        {
+            return _glyphTypefaceCache.GetOrAdd(typeface, new GlyphTypefaceImpl(typeface));
+        }
+
+        public Typeface GetTypeface(FontFamily fontFamily, FontWeight fontWeight, FontStyle fontStyle)
+        {
+            //ToDo: Implement caching.
+            return new Typeface(fontFamily, fontWeight, fontStyle);
+        }
+
+        public Typeface MatchCharacter(int codepoint, FontWeight fontWeight = default, FontStyle fontStyle = default,
+            FontFamily fontFamily = null, CultureInfo culture = null)
+        {
+            var fontFamilyName = FontFamily.Default.Name;
+
+            var familyCount = Direct2D1FontCollectionCache.InstalledFontCollection.FontFamilyCount;
+
+            for (var i = 0; i < familyCount; i++)
+            {
+                var font = Direct2D1FontCollectionCache.InstalledFontCollection.GetFontFamily(i)
+                    .GetMatchingFonts((SharpDX.DirectWrite.FontWeight)fontWeight, FontStretch.Normal,
+                        (SharpDX.DirectWrite.FontStyle)fontStyle).GetFont(0);
+
+                if (!font.HasCharacter(codepoint))
+                {
+                    continue;
+                }
+
+                fontFamilyName = font.FontFamily.FamilyNames.GetString(0);
+
+                break;
+            }
+
+            return GetTypeface(new FontFamily(fontFamilyName), fontWeight, fontStyle);
+        }
+    }
+}

--- a/src/Windows/Avalonia.Direct2D1/Media/FontManagerImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/FontManagerImpl.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using Avalonia.Media;
@@ -15,9 +14,6 @@ namespace Avalonia.Direct2D1.Media
 {
     internal class FontManagerImpl : IFontManagerImpl
     {
-        private readonly ConcurrentDictionary<Typeface, GlyphTypefaceImpl> _glyphTypefaceCache =
-            new ConcurrentDictionary<Typeface, GlyphTypefaceImpl>();
-
         public FontManagerImpl()
         {
             //ToDo: Implement a real lookup of the system's default font.
@@ -38,11 +34,6 @@ namespace Avalonia.Direct2D1.Media
             }
 
             return fontFamilies;
-        }
-
-        public IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface)
-        {
-            return _glyphTypefaceCache.GetOrAdd(typeface, new GlyphTypefaceImpl(typeface));
         }
 
         public Typeface GetTypeface(FontFamily fontFamily, FontWeight fontWeight, FontStyle fontStyle)

--- a/src/Windows/Avalonia.Direct2D1/Media/FormattedTextImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/FormattedTextImpl.cs
@@ -14,6 +14,7 @@ namespace Avalonia.Direct2D1.Media
         public FormattedTextImpl(
             string text,
             Typeface typeface,
+            double fontSize,
             TextAlignment textAlignment,
             TextWrapping wrapping,
             Size constraint,
@@ -21,20 +22,20 @@ namespace Avalonia.Direct2D1.Media
         {
             Text = text;
 
-            using (var textFormat = Direct2D1FontCollectionCache.GetTextFormat(typeface))
+            using (var font = Direct2D1FontCollectionCache.GetFont(typeface))
+            using (var textFormat = new DWrite.TextFormat(Direct2D1Platform.DirectWriteFactory,
+                typeface.FontFamily.Name, font.FontFamily.FontCollection, (DWrite.FontWeight)typeface.Weight,
+                (DWrite.FontStyle)typeface.Style, DWrite.FontStretch.Normal, (float)fontSize))
             {
                 textFormat.WordWrapping =
                     wrapping == TextWrapping.Wrap ? DWrite.WordWrapping.Wrap : DWrite.WordWrapping.NoWrap;
 
                 TextLayout = new DWrite.TextLayout(
-                                 Direct2D1Platform.DirectWriteFactory,
-                                 Text ?? string.Empty,
-                                 textFormat,
-                                 (float)constraint.Width,
-                                 (float)constraint.Height)
-                             {
-                                 TextAlignment = textAlignment.ToDirect2D()
-                             };
+                    Direct2D1Platform.DirectWriteFactory,
+                    Text ?? string.Empty,
+                    textFormat,
+                    (float)constraint.Width,
+                    (float)constraint.Height) { TextAlignment = textAlignment.ToDirect2D() };
             }
 
             if (spans != null)

--- a/src/Windows/Avalonia.Direct2D1/Media/GlyphTypefaceImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/GlyphTypefaceImpl.cs
@@ -9,7 +9,7 @@ using SharpDX.DirectWrite;
 
 namespace Avalonia.Direct2D1.Media
 {
-    internal class GlyphTypefaceImpl : IGlyphTypefaceImpl
+    public class GlyphTypefaceImpl : IGlyphTypefaceImpl
     {
         private bool _isDisposed;
 

--- a/src/Windows/Avalonia.Direct2D1/Media/GlyphTypefaceImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/GlyphTypefaceImpl.cs
@@ -1,0 +1,188 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+using Avalonia.Media;
+using Avalonia.Platform;
+using HarfBuzzSharp;
+using SharpDX.DirectWrite;
+
+namespace Avalonia.Direct2D1.Media
+{
+    internal class GlyphTypefaceImpl : IGlyphTypefaceImpl
+    {
+        private bool _isDisposed;
+
+        public GlyphTypefaceImpl(Typeface typeface)
+        {
+            DWFont = Direct2D1FontCollectionCache.GetFont(typeface);
+
+            FontFace = new FontFace(DWFont);
+
+            Face = new Face(GetTable);
+
+            Font = new HarfBuzzSharp.Font(Face);
+
+            Font.SetFunctionsOpenType();
+
+            Font.GetScale(out var xScale, out _);
+
+            DesignEmHeight = (short)xScale;
+
+            if (!Font.TryGetHorizontalFontExtents(out var fontExtents))
+            {
+                Font.TryGetVerticalFontExtents(out fontExtents);
+            }
+
+            Ascent = -fontExtents.Ascender;
+
+            Descent = -fontExtents.Descender;
+
+            LineGap = fontExtents.LineGap;
+
+            if (Font.OpenTypeMetrics.TryGetPosition(OpenTypeMetricsTag.UnderlineOffset, out var underlinePosition))
+            {
+                UnderlinePosition = underlinePosition;
+            }
+
+            if (Font.OpenTypeMetrics.TryGetPosition(OpenTypeMetricsTag.UnderlineSize, out var underlineThickness))
+            {
+                UnderlineThickness = underlineThickness;
+            }
+
+            if (Font.OpenTypeMetrics.TryGetPosition(OpenTypeMetricsTag.StrikeoutOffset, out var strikethroughPosition))
+            {
+                StrikethroughPosition = strikethroughPosition;
+            }
+
+            if (Font.OpenTypeMetrics.TryGetPosition(OpenTypeMetricsTag.StrikeoutSize, out var strikethroughThickness))
+            {
+                StrikethroughThickness = strikethroughThickness;
+            }
+        }
+
+        private Blob GetTable(Face face, Tag tag)
+        {
+            var dwTag = (int)SwapBytes(tag);
+
+            if (FontFace.TryGetFontTable(dwTag, out var tableData, out _))
+            {
+                return new Blob(tableData.Pointer, tableData.Size, MemoryMode.ReadOnly, () => { });
+            }
+
+            return null;
+        }
+
+        private static uint SwapBytes(uint x)
+        {
+            x = (x >> 16) | (x << 16);
+
+            return ((x & 0xFF00FF00) >> 8) | ((x & 0x00FF00FF) << 8);
+        }
+
+        public SharpDX.DirectWrite.Font DWFont { get; }
+
+        public FontFace FontFace { get; }
+
+        public Face Face { get; }
+
+        public HarfBuzzSharp.Font Font { get; }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public short DesignEmHeight { get; }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int Ascent { get; }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int Descent { get; }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int LineGap { get; }
+
+        //ToDo: Read font table for these values
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int UnderlinePosition { get; }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int UnderlineThickness { get; }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int StrikethroughPosition { get; }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int StrikethroughThickness { get; }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public ushort GetGlyph(uint codepoint)
+        {
+            if (Font.TryGetGlyph(codepoint, out var glyph))
+            {
+                return (ushort)glyph;
+            }
+
+            return 0;
+        }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public ushort[] GetGlyphs(ReadOnlySpan<uint> codepoints)
+        {
+            var glyphs = new ushort[codepoints.Length];
+
+            for (var i = 0; i < codepoints.Length; i++)
+            {
+                if (Font.TryGetGlyph(codepoints[i], out var glyph))
+                {
+                    glyphs[i] = (ushort)glyph;
+                }
+            }
+
+            return glyphs;
+        }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int GetGlyphAdvance(ushort glyph)
+        {
+            return Font.GetHorizontalGlyphAdvance(glyph);
+        }
+
+        /// <inheritdoc cref="IGlyphTypefaceImpl"/>
+        public int[] GetGlyphAdvances(ReadOnlySpan<ushort> glyphs)
+        {
+            var glyphIndices = new uint[glyphs.Length];
+
+            for (var i = 0; i < glyphs.Length; i++)
+            {
+                glyphIndices[i] = glyphs[i];
+            }
+
+            return Font.GetHorizontalGlyphAdvances(glyphIndices);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+
+            if (!disposing)
+            {
+                return;
+            }
+
+            Font?.Dispose();
+            Face?.Dispose();
+            FontFace?.Dispose();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}
+

--- a/tests/Avalonia.Layout.UnitTests/FullLayoutTests.cs
+++ b/tests/Avalonia.Layout.UnitTests/FullLayoutTests.cs
@@ -175,6 +175,7 @@ namespace Avalonia.Layout.UnitTests
                 x.CreateFormattedText(
                     It.IsAny<string>(),
                     It.IsAny<Typeface>(),
+                    It.IsAny<double>(),
                     It.IsAny<TextAlignment>(),
                     It.IsAny<TextWrapping>(),
                     It.IsAny<Size>(),

--- a/tests/Avalonia.RenderTests/Media/FormattedTextImplTests.cs
+++ b/tests/Avalonia.RenderTests/Media/FormattedTextImplTests.cs
@@ -53,7 +53,8 @@ namespace Avalonia.Direct2D1.RenderTests.Media
         {
             var r = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
             return r.CreateFormattedText(text,
-                new Typeface(fontFamily, fontSize, fontStyle, fontWeight),
+                new Typeface(fontFamily, fontWeight, fontStyle),
+                fontSize,
                 textAlignment,
                 wrapping,
                 widthConstraint == -1 ? Size.Infinity : new Size(widthConstraint, double.PositiveInfinity),

--- a/tests/Avalonia.UnitTests/MockPlatformRenderInterface.cs
+++ b/tests/Avalonia.UnitTests/MockPlatformRenderInterface.cs
@@ -9,11 +9,10 @@ namespace Avalonia.UnitTests
 {
     public class MockPlatformRenderInterface : IPlatformRenderInterface
     {
-        public IEnumerable<string> InstalledFontNames => new string[0];
-
         public IFormattedTextImpl CreateFormattedText(
             string text,
             Typeface typeface,
+            double fontSize,
             TextAlignment textAlignment,
             TextWrapping wrapping,
             Size constraint,

--- a/tests/Avalonia.UnitTests/MockPlatformRenderInterface.cs
+++ b/tests/Avalonia.UnitTests/MockPlatformRenderInterface.cs
@@ -78,5 +78,10 @@ namespace Avalonia.UnitTests
         {
             throw new NotImplementedException();
         }
+
+        public IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface)
+        {
+            return Mock.Of<IGlyphTypefaceImpl>();
+        }
     }
 }

--- a/tests/Avalonia.UnitTests/TestServices.cs
+++ b/tests/Avalonia.UnitTests/TestServices.cs
@@ -169,6 +169,7 @@ namespace Avalonia.UnitTests
                 x.CreateFormattedText(
                     It.IsAny<string>(),
                     It.IsAny<Typeface>(),
+                    It.IsAny<double>(),
                     It.IsAny<TextAlignment>(),
                     It.IsAny<TextWrapping>(),
                     It.IsAny<Size>(),

--- a/tests/Avalonia.Visuals.UnitTests/Media/FontFamilyTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/FontFamilyTests.cs
@@ -19,12 +19,48 @@ namespace Avalonia.Visuals.UnitTests.Media
             Assert.Equal(new FontFamily("Arial"), fontFamily);
         }
 
-        [Fact]
-        public void Should_Be_Equal()
+        [InlineData("Font A")]
+        [InlineData("Font A, Font B")]
+        [InlineData("resm: Avalonia.Visuals.UnitTests#MyFont")]
+        [InlineData("avares://Avalonia.Visuals.UnitTests/Assets/Fonts#MyFont")]
+        [Theory]
+        public void Should_Have_Equal_Hash(string s)
         {
-            var fontFamily = new FontFamily("Arial");
+            var fontFamily = new FontFamily(s);
 
-            Assert.Equal(new FontFamily("Arial"), fontFamily);
+            Assert.Equal(new FontFamily(s).GetHashCode(), fontFamily.GetHashCode());
+        }
+
+        [InlineData("Font A, Font B", "Font B, Font A")]
+        [InlineData("Font A, Font B", "Font A, Font C")]
+        [Theory]
+        public void Should_Not_Have_Equal_Hash(string a, string b)
+        {
+            var fontFamily = new FontFamily(b);
+
+            Assert.NotEqual(new FontFamily(a).GetHashCode(), fontFamily.GetHashCode());
+        }
+
+        [InlineData("Font A")]
+        [InlineData("Font A, Font B")]
+        [InlineData("resm: Avalonia.Visuals.UnitTests#MyFont")]
+        [InlineData("avares://Avalonia.Visuals.UnitTests/Assets/Fonts#MyFont")]
+        [Theory]
+        public void Should_Be_Equal(string s)
+        {
+            var fontFamily = new FontFamily(s);
+
+            Assert.Equal(new FontFamily(s), fontFamily);
+        }
+
+        [InlineData("Font A, Font B", "Font B, Font A")]
+        [InlineData("Font A, Font B", "Font A, Font C")]
+        [Theory]
+        public void Should_Not_Be_Equal(string a, string b)
+        {
+            var fontFamily = new FontFamily(b);
+
+            Assert.NotEqual(new FontFamily(a), fontFamily);
         }
 
         [Fact]

--- a/tests/Avalonia.Visuals.UnitTests/Media/TypefaceTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/TypefaceTests.cs
@@ -7,15 +7,21 @@ namespace Avalonia.Visuals.UnitTests.Media
     public class TypefaceTests
     {
         [Fact]
-        public void Exception_Should_Be_Thrown_If_FontSize_LessThanEqualTo_0()
+        public void Exception_Should_Be_Thrown_If_FontWeight_LessThanEqualTo_Zero()
         {
-            Assert.Throws<ArgumentException>(() => new Typeface("foo", 0));
+            Assert.Throws<ArgumentException>(() => new Typeface("foo", 0, (FontStyle)12));
         }
 
         [Fact]
-        public void Exception_Should_Be_Thrown_If_FontWeight_LessThanEqualTo_0()
+        public void Should_Be_Equal()
         {
-            Assert.Throws<ArgumentException>(() => new Typeface("foo", 12, weight: 0));
+            Assert.Equal(new Typeface("Font A"), new Typeface("Font A"));
+        }
+
+        [Fact]
+        public void Should_Have_Equal_Hash()
+        {
+            Assert.Equal(new Typeface("Font A").GetHashCode(), new Typeface("Font A").GetHashCode());
         }
     }
 }

--- a/tests/Avalonia.Visuals.UnitTests/VisualTree/MockRenderInterface.cs
+++ b/tests/Avalonia.Visuals.UnitTests/VisualTree/MockRenderInterface.cs
@@ -13,6 +13,7 @@ namespace Avalonia.Visuals.UnitTests.VisualTree
         public IFormattedTextImpl CreateFormattedText(
             string text,
             Typeface typeface,
+            double fontSize,
             TextAlignment textAlignment,
             TextWrapping wrapping,
             Size constraint,

--- a/tests/Avalonia.Visuals.UnitTests/VisualTree/MockRenderInterface.cs
+++ b/tests/Avalonia.Visuals.UnitTests/VisualTree/MockRenderInterface.cs
@@ -52,6 +52,11 @@ namespace Avalonia.Visuals.UnitTests.VisualTree
             throw new NotImplementedException();
         }
 
+        public IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface)
+        {
+            throw new NotImplementedException();
+        }
+
         public IWriteableBitmapImpl CreateWriteableBitmap(PixelSize size, Vector dpi, PixelFormat? fmt)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
## What does the pull request do?
This introduces a font manager that is responsible for managing installed fonts and the default font. This also introduces the new GlyphTypeface that is needed for GlyphRun etc.

## What is the current behavior?
Currently, there is no way to know which font is loaded as the default because we use an empty string.

## What is the updated/expected behavior with this PR?
It will be possible to know the default font at runtime. The font manager also introduces font fallback that will be used by the new text layout.

## How was the solution implemented (if it's not obvious)?
There is a new interface `IFontManagerImpl` that should be implemented per platform. Currently, there is one implementation for Direct2D1 and one for Skia.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes

`FontSize` is no longer part of the `Typeface`