### PR TITLE
fix WrapPanel issue #3165 item width/height should trigger new measure

### DIFF
--- a/src/Avalonia.Controls/WrapPanel.cs
+++ b/src/Avalonia.Controls/WrapPanel.cs
@@ -42,7 +42,7 @@ namespace Avalonia.Controls
         /// </summary>
         static WrapPanel()
         {
-            AffectsMeasure<WrapPanel>(OrientationProperty);
+            AffectsMeasure<WrapPanel>(OrientationProperty, ItemWidthProperty, ItemHeightProperty);
         }
 
         /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/WrapPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WrapPanelTests.cs
@@ -12,14 +12,14 @@ namespace Avalonia.Controls.UnitTests
         public void Lays_Out_Horizontally_On_Separate_Lines()
         {
             var target = new WrapPanel()
-                         {
-                            Width = 100,
-                            Children =
+            {
+                Width = 100,
+                Children =
                             {
                                 new Border { Height = 50, Width = 100 },
                                 new Border { Height = 50, Width = 100 },
                             }
-                         };
+            };
 
             target.Measure(Size.Infinity);
             target.Arrange(new Rect(target.DesiredSize));
@@ -33,14 +33,14 @@ namespace Avalonia.Controls.UnitTests
         public void Lays_Out_Horizontally_On_A_Single_Line()
         {
             var target = new WrapPanel()
-                         {
-                            Width = 200,
-                            Children =
+            {
+                Width = 200,
+                Children =
                             {
                                 new Border { Height = 50, Width = 100 },
                                 new Border { Height = 50, Width = 100 },
                             }
-                         };
+            };
 
             target.Measure(Size.Infinity);
             target.Arrange(new Rect(target.DesiredSize));
@@ -54,15 +54,15 @@ namespace Avalonia.Controls.UnitTests
         public void Lays_Out_Vertically_Children_On_A_Single_Line()
         {
             var target = new WrapPanel()
-                         {
-                            Orientation = Orientation.Vertical,
-                            Height = 120,
-                            Children =
+            {
+                Orientation = Orientation.Vertical,
+                Height = 120,
+                Children =
                             {
                                 new Border { Height = 50, Width = 100 },
                                 new Border { Height = 50, Width = 100 },
                             }
-                         };
+            };
 
             target.Measure(Size.Infinity);
             target.Arrange(new Rect(target.DesiredSize));
@@ -76,15 +76,15 @@ namespace Avalonia.Controls.UnitTests
         public void Lays_Out_Vertically_On_Separate_Lines()
         {
             var target = new WrapPanel()
-                         {
-                            Orientation = Orientation.Vertical,
-                            Height = 60,
-                            Children =
+            {
+                Orientation = Orientation.Vertical,
+                Height = 60,
+                Children =
                             {
                                 new Border { Height = 50, Width = 100 },
                                 new Border { Height = 50, Width = 100 },
                             }
-                         };
+            };
 
             target.Measure(Size.Infinity);
             target.Arrange(new Rect(target.DesiredSize));
@@ -98,17 +98,17 @@ namespace Avalonia.Controls.UnitTests
         public void Applies_ItemWidth_And_ItemHeight_Properties()
         {
             var target = new WrapPanel()
-                        {
-                            Orientation = Orientation.Horizontal,
-                            Width = 50,
-                            ItemWidth = 20,
-                            ItemHeight = 15,
-                            Children =
+            {
+                Orientation = Orientation.Horizontal,
+                Width = 50,
+                ItemWidth = 20,
+                ItemHeight = 15,
+                Children =
                             {
                                 new Border(),
                                 new Border(),
                             }
-                        };
+            };
 
             target.Measure(Size.Infinity);
             target.Arrange(new Rect(target.DesiredSize));
@@ -116,6 +116,34 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Size(50, 15), target.Bounds.Size);
             Assert.Equal(new Rect(0, 0, 20, 15), target.Children[0].Bounds);
             Assert.Equal(new Rect(20, 0, 20, 15), target.Children[1].Bounds);
+        }
+
+        [Fact]
+        void ItemWidth_Trigger_InvalidateMeasure()
+        {
+            var target = new WrapPanel();
+
+            target.Measure(new Size(10, 10));
+
+            Assert.True(target.IsMeasureValid);
+
+            target.ItemWidth = 1;
+
+            Assert.False(target.IsMeasureValid);
+        }
+
+        [Fact]
+        void ItemHeight_Trigger_InvalidateMeasure()
+        {
+            var target = new WrapPanel();
+
+            target.Measure(new Size(10, 10));
+
+            Assert.True(target.IsMeasureValid);
+
+            target.ItemHeight = 1;
+
+            Assert.False(target.IsMeasureValid);
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
WrapPanel trigger measure after item width/height changed

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
it doesn't

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
fix it

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->
Nope

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
FIxes #3165 