### PR TITLE
Optimizations to the main layout loop

### DIFF
--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -210,7 +210,11 @@ namespace Avalonia
         /// <returns>The value.</returns>
         public object GetValue(AvaloniaProperty property)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
+            if (property is null)
+            {
+                throw new ArgumentNullException(nameof(property));
+            }
+
             VerifyAccess();
 
             if (property.IsDirect)
@@ -231,7 +235,10 @@ namespace Avalonia
         /// <returns>The value.</returns>
         public T GetValue<T>(AvaloniaProperty<T> property)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
+            if (property is null)
+            {
+                throw new ArgumentNullException(nameof(property));
+            }
 
             return (T)GetValue((AvaloniaProperty)property);
         }

--- a/src/Avalonia.Base/AvaloniaProperty.cs
+++ b/src/Avalonia.Base/AvaloniaProperty.cs
@@ -28,6 +28,8 @@ namespace Avalonia
         private readonly Dictionary<Type, PropertyMetadata> _metadata;
         private readonly Dictionary<Type, PropertyMetadata> _metadataCache = new Dictionary<Type, PropertyMetadata>();
 
+        private bool _hasMetadataOverrides;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AvaloniaProperty"/> class.
         /// </summary>
@@ -446,15 +448,27 @@ namespace Avalonia
         ///
         public PropertyMetadata GetMetadata(Type type)
         {
-            Contract.Requires<ArgumentNullException>(type != null);
+            if (!_hasMetadataOverrides)
+            {
+                return _defaultMetadata;
+            }
 
-            PropertyMetadata result;
-            Type currentType = type;
+            return GetMetadataWithOverrides(type);
+        }
 
-            if (_metadataCache.TryGetValue(type, out result))
+        private PropertyMetadata GetMetadataWithOverrides(Type type)
+        {
+            if (type is null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            if (_metadataCache.TryGetValue(type, out PropertyMetadata result))
             {
                 return result;
             }
+
+            Type currentType = type;
 
             while (currentType != null)
             {
@@ -535,6 +549,8 @@ namespace Avalonia
             metadata.Merge(baseMetadata, this);
             _metadata.Add(type, metadata);
             _metadataCache.Clear();
+
+            _hasMetadataOverrides = true;
         }
 
         [DebuggerHidden]

--- a/src/Avalonia.Base/AvaloniaProperty.cs
+++ b/src/Avalonia.Base/AvaloniaProperty.cs
@@ -459,37 +459,6 @@ namespace Avalonia
             return GetMetadataWithOverrides(type);
         }
 
-        private PropertyMetadata GetMetadataWithOverrides(Type type)
-        {
-            if (type is null)
-            {
-                throw new ArgumentNullException(nameof(type));
-            }
-
-            if (_metadataCache.TryGetValue(type, out PropertyMetadata result))
-            {
-                return result;
-            }
-
-            Type currentType = type;
-
-            while (currentType != null)
-            {
-                if (_metadata.TryGetValue(currentType, out result))
-                {
-                    _metadataCache[type] = result;
-
-                    return result;
-                }
-
-                currentType = currentType.GetTypeInfo().BaseType;
-            }
-
-            _metadataCache[type] = _defaultMetadata;
-
-            return _defaultMetadata;
-        }
-
         /// <summary>
         /// Checks whether the <paramref name="value"/> is valid for the property.
         /// </summary>
@@ -554,6 +523,37 @@ namespace Avalonia
             _metadataCache.Clear();
 
             _hasMetadataOverrides = true;
+        }
+
+        private PropertyMetadata GetMetadataWithOverrides(Type type)
+        {
+            if (type is null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            if (_metadataCache.TryGetValue(type, out PropertyMetadata result))
+            {
+                return result;
+            }
+
+            Type currentType = type;
+
+            while (currentType != null)
+            {
+                if (_metadata.TryGetValue(currentType, out result))
+                {
+                    _metadataCache[type] = result;
+
+                    return result;
+                }
+
+                currentType = currentType.GetTypeInfo().BaseType;
+            }
+
+            _metadataCache[type] = _defaultMetadata;
+
+            return _defaultMetadata;
         }
 
         [DebuggerHidden]

--- a/src/Avalonia.Base/AvaloniaProperty.cs
+++ b/src/Avalonia.Base/AvaloniaProperty.cs
@@ -94,6 +94,9 @@ namespace Avalonia
             Id = source.Id;
             _defaultMetadata = source._defaultMetadata;
 
+            // Properties that have different owner can't use fast path for metadata.
+            _hasMetadataOverrides = true;
+
             if (metadata != null)
             {
                 _metadata.Add(ownerType, metadata);

--- a/src/Avalonia.Layout/LayoutHelper.cs
+++ b/src/Avalonia.Layout/LayoutHelper.cs
@@ -21,8 +21,11 @@ namespace Avalonia.Layout
         /// <returns>The control's size.</returns>
         public static Size ApplyLayoutConstraints(ILayoutable control, Size constraints)
         {
-            double width = (control.Width > 0) ? control.Width : constraints.Width;
-            double height = (control.Height > 0) ? control.Height : constraints.Height;
+            var controlWidth = control.Width;
+            var controlHeight = control.Height;
+
+            double width = (controlWidth > 0) ? controlWidth : constraints.Width;
+            double height = (controlHeight > 0) ? controlHeight : constraints.Height;
             width = Math.Min(width, control.MaxWidth);
             width = Math.Max(width, control.MinWidth);
             height = Math.Min(height, control.MaxHeight);

--- a/src/Avalonia.Layout/LayoutManager.cs
+++ b/src/Avalonia.Layout/LayoutManager.cs
@@ -15,8 +15,14 @@ namespace Avalonia.Layout
     {
         private readonly LayoutQueue<ILayoutable> _toMeasure = new LayoutQueue<ILayoutable>(v => !v.IsMeasureValid);
         private readonly LayoutQueue<ILayoutable> _toArrange = new LayoutQueue<ILayoutable>(v => !v.IsArrangeValid);
+        private readonly Action _executeLayoutPass;
         private bool _queued;
         private bool _running;
+
+        public LayoutManager()
+        {
+            _executeLayoutPass = QueueLayoutPass;
+        }
 
         /// <inheritdoc/>
         public void InvalidateMeasure(ILayoutable control)
@@ -215,7 +221,7 @@ namespace Avalonia.Layout
         {
             if (!_queued && !_running)
             {
-                Dispatcher.UIThread.Post(ExecuteLayoutPass, DispatcherPriority.Layout);
+                Dispatcher.UIThread.Post(_executeLayoutPass, DispatcherPriority.Layout);
                 _queued = true;
             }
         }

--- a/src/Avalonia.Layout/LayoutManager.cs
+++ b/src/Avalonia.Layout/LayoutManager.cs
@@ -21,7 +21,7 @@ namespace Avalonia.Layout
 
         public LayoutManager()
         {
-            _executeLayoutPass = QueueLayoutPass;
+            _executeLayoutPass = ExecuteLayoutPass;
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Layout/LayoutQueue.cs
+++ b/src/Avalonia.Layout/LayoutQueue.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Avalonia.Layout
 {
@@ -18,9 +17,11 @@ namespace Avalonia.Layout
             _shouldEnqueue = shouldEnqueue;
         }
 
-        private Func<T, bool> _shouldEnqueue;
-        private Queue<T> _inner = new Queue<T>();
-        private Dictionary<T, Info> _loopQueueInfo = new Dictionary<T, Info>();
+        private readonly Func<T, bool> _shouldEnqueue;
+        private readonly Queue<T> _inner = new Queue<T>();
+        private readonly Dictionary<T, Info> _loopQueueInfo = new Dictionary<T, Info>();
+        private readonly List<KeyValuePair<T, Info>> _notFinalizedBuffer = new List<KeyValuePair<T, Info>>();
+
         private int _maxEnqueueCountPerLoop = 1;
 
         public int Count => _inner.Count;
@@ -60,13 +61,19 @@ namespace Avalonia.Layout
 
         public void EndLoop()
         {
-            var notfinalized = _loopQueueInfo.Where(v => v.Value.Count >= _maxEnqueueCountPerLoop).ToArray();
+            foreach (KeyValuePair<T, Info> info in _loopQueueInfo)
+            {
+                if (info.Value.Count >= _maxEnqueueCountPerLoop)
+                {
+                    _notFinalizedBuffer.Add(info);
+                }
+            }
 
             _loopQueueInfo.Clear();
 
-            //prevent layout cycle but add to next layout the non arranged/measured items that might have caused cycle
-            //one more time as a final attempt
-            foreach (var item in notfinalized)
+            // Prevent layout cycle but add to next layout the non arranged/measured items that might have caused cycle
+            // one more time as a final attempt.
+            foreach (var item in _notFinalizedBuffer)
             {
                 if (_shouldEnqueue(item.Key))
                 {
@@ -74,6 +81,8 @@ namespace Avalonia.Layout
                     _inner.Enqueue(item.Key);
                 }
             }
+
+            _notFinalizedBuffer.Clear();
         }
     }
 }

--- a/src/Avalonia.Layout/Layoutable.cs
+++ b/src/Avalonia.Layout/Layoutable.cs
@@ -518,17 +518,25 @@ namespace Avalonia.Layout
                 var width = measured.Width;
                 var height = measured.Height;
 
-                if (!double.IsNaN(Width))
                 {
-                    width = Width;
+                    double widthCache = Width;
+
+                    if (!double.IsNaN(widthCache))
+                    {
+                        width = widthCache;
+                    }
                 }
 
                 width = Math.Min(width, MaxWidth);
                 width = Math.Max(width, MinWidth);
 
-                if (!double.IsNaN(Height))
                 {
-                    height = Height;
+                    double heightCache = Height;
+
+                    if (!double.IsNaN(heightCache))
+                    {
+                        height = Height;
+                    }
                 }
 
                 height = Math.Min(height, MaxHeight);
@@ -601,6 +609,7 @@ namespace Avalonia.Layout
                 var verticalAlignment = VerticalAlignment;
                 var size = availableSizeMinusMargins;
                 var scale = GetLayoutScale();
+                var useLayoutRounding = UseLayoutRounding;
 
                 if (horizontalAlignment != HorizontalAlignment.Stretch)
                 {
@@ -614,7 +623,7 @@ namespace Avalonia.Layout
 
                 size = LayoutHelper.ApplyLayoutConstraints(this, size);
 
-                if (UseLayoutRounding)
+                if (useLayoutRounding)
                 {
                     size = new Size(
                         Math.Ceiling(size.Width * scale) / scale, 
@@ -648,7 +657,7 @@ namespace Avalonia.Layout
                         break;
                 }
 
-                if (UseLayoutRounding)
+                if (useLayoutRounding)
                 {
                     originX = Math.Floor(originX * scale) / scale;
                     originY = Math.Floor(originY * scale) / scale;

--- a/src/Avalonia.Layout/Layoutable.cs
+++ b/src/Avalonia.Layout/Layoutable.cs
@@ -570,11 +570,12 @@ namespace Avalonia.Layout
             double width = 0;
             double height = 0;
 
-            var visualCount = VisualChildren.Count;
+            var visualChildren = VisualChildren;
+            var visualCount = visualChildren.Count;
 
             for (var i = 0; i < visualCount; i++)
             {
-                IVisual visual = VisualChildren[i];
+                IVisual visual = visualChildren[i];
 
                 if (visual is ILayoutable layoutable)
                 {
@@ -676,11 +677,12 @@ namespace Avalonia.Layout
         {
             var arrangeRect = new Rect(finalSize);
 
-            var visualCount = VisualChildren.Count;
+            var visualChildren = VisualChildren;
+            var visualCount = visualChildren.Count;
 
             for (var i = 0; i < visualCount; i++)
             {
-                IVisual visual = VisualChildren[i];
+                IVisual visual = visualChildren[i];
 
                 if (visual is ILayoutable layoutable)
                 {

--- a/src/Avalonia.Layout/Layoutable.cs
+++ b/src/Avalonia.Layout/Layoutable.cs
@@ -562,11 +562,18 @@ namespace Avalonia.Layout
             double width = 0;
             double height = 0;
 
-            foreach (ILayoutable child in this.GetVisualChildren())
+            var visualCount = VisualChildren.Count;
+
+            for (var i = 0; i < visualCount; i++)
             {
-                child.Measure(availableSize);
-                width = Math.Max(width, child.DesiredSize.Width);
-                height = Math.Max(height, child.DesiredSize.Height);
+                IVisual visual = VisualChildren[i];
+
+                if (visual is ILayoutable layoutable)
+                {
+                    layoutable.Measure(availableSize);
+                    width = Math.Max(width, layoutable.DesiredSize.Width);
+                    height = Math.Max(height, layoutable.DesiredSize.Height);
+                }
             }
 
             return new Size(width, height);
@@ -658,9 +665,18 @@ namespace Avalonia.Layout
         /// <returns>The actual size used.</returns>
         protected virtual Size ArrangeOverride(Size finalSize)
         {
-            foreach (ILayoutable child in this.GetVisualChildren().OfType<ILayoutable>())
+            var arrangeRect = new Rect(finalSize);
+
+            var visualCount = VisualChildren.Count;
+
+            for (var i = 0; i < visualCount; i++)
             {
-                child.Arrange(new Rect(finalSize));
+                IVisual visual = VisualChildren[i];
+
+                if (visual is ILayoutable layoutable)
+                {
+                    layoutable.Arrange(arrangeRect);
+                }
             }
 
             return finalSize;

--- a/src/Avalonia.Layout/Layoutable.cs
+++ b/src/Avalonia.Layout/Layoutable.cs
@@ -535,7 +535,7 @@ namespace Avalonia.Layout
 
                     if (!double.IsNaN(heightCache))
                     {
-                        height = Height;
+                        height = heightCache;
                     }
                 }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
When profiling my recent grid splitter PR I noticed that layout loop is doing a lot of unnecessary work (insane amount of property metadata calls, uncached delegates, etc.). This PR focuses on fixing low hanging fruit that brings benefits across entire application. 

I am using existing benchmark setup in `Avalonia.Benchmark` but I had to change few things to make it actually usable for consistent benchmarking (I will try to clean it up and submit it soon).

Benchmark creates around 6k controls and measures/arranges them all.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

|    Method |     Mean |     Error |    StdDev |    Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |---------:|----------:|----------:|---------:|------:|------:|----------:|
| Remeasure | 18.11 ms | 0.2199 ms | 0.1949 ms | 156.2500 |     - |     - | 725.62 KB |

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

|    Method |     Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |---------:|----------:|----------:|------:|------:|------:|----------:|
| Remeasure | 10.63 ms | 0.2108 ms | 0.1972 ms |     - |     - |     - |      40 B |

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
I did split most of my work into separate commits to make the review easier. Notable parts are:
- removal of all LINQ from `LayoutQueue` plus keeping extra item buffer around so we don't have to allocate a new one per loop cycle.
- remove LINQ from visual children iteration in `Layoutable` (both arrange and measure overrides methods).
- remove a few `GetValue` calls from arrange and measure functions in `Layoutable`. This saves a lot of lookups as these functions are called very frequently and `GetValue` is quite expensive.
- Also I noticed that current use of `Contract.Requires` produces quite bad code so I decided to remove it from the hot path for now. Might need to be addressed again when we enable nullable reference types.
- In the end I wanted to check why `GetValue` is so expensive - `GetMetadata` call is a big factor due to metadata overrides and extra dictionary lookups caused by it. I noticed that most of the properties used in the layout do not have overrides so I implemented a fast path that does no dictionary lookups and caching if there are no overrides present.
- In the end all these small things combined lead to quite significant improvements (metadata change is the biggest factor).

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
