### PR TITLE
Fix cross root reparenting

### DIFF
--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -51,7 +51,7 @@ namespace Avalonia.Rendering.SceneGraph
                 UpdateSize(scene);
             }
 
-            if (visual.VisualRoot != null)
+            if (visual.VisualRoot == scene.Root.Visual)
             {
                 if (node?.Parent != null &&
                     visual.VisualParent != null &&

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/DeferredRendererTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/DeferredRendererTests.cs
@@ -370,6 +370,81 @@ namespace Avalonia.Visuals.UnitTests.Rendering
         }
 
         [Fact]
+        public void Should_Update_VisualNodes_When_Child_Moved_To_New_Parent_And_New_Root()
+        {
+            var dispatcher = new ImmediateDispatcher();
+            var loop = new Mock<IRenderLoop>();
+
+            Decorator moveFrom;
+            Decorator moveTo;
+            Canvas moveMe;
+
+            var root = new TestRoot
+            {
+                Child = new StackPanel
+                {
+                    Children =
+                    {
+                        (moveFrom = new Decorator
+                        {
+                            Child = moveMe = new Canvas(),
+                        })
+                    }
+                }
+            };
+
+            var otherRoot = new TestRoot
+            {
+                Child = new StackPanel
+                {
+                    Children =
+                    {
+                        (moveTo = new Decorator())
+                    }
+                }
+            };
+
+            var sceneBuilder = new SceneBuilder();
+            var target = new DeferredRenderer(
+                root,
+                loop.Object,
+                sceneBuilder: sceneBuilder,
+                dispatcher: dispatcher);
+
+            var otherSceneBuilder = new SceneBuilder();
+            var otherTarget = new DeferredRenderer(
+                otherRoot,
+                loop.Object,
+                sceneBuilder: otherSceneBuilder,
+                dispatcher: dispatcher);
+
+            root.Renderer = target;
+            otherRoot.Renderer = otherTarget;
+
+            target.Start();
+            otherTarget.Start();
+
+            RunFrame(target);
+            RunFrame(otherTarget);
+
+            moveFrom.Child = null;
+            moveTo.Child = moveMe;
+
+            RunFrame(target);
+            RunFrame(otherTarget);
+
+            var scene = target.UnitTestScene();
+            var otherScene = otherTarget.UnitTestScene();
+
+            var moveFromNode = (VisualNode)scene.FindNode(moveFrom);
+            var moveToNode = (VisualNode)otherScene.FindNode(moveTo);
+
+            Assert.Empty(moveFromNode.Children);
+            Assert.Equal(1, moveToNode.Children.Count);
+            Assert.Same(moveMe, moveToNode.Children[0].Visual);
+        }
+
+        [Fact]
         public void Should_Push_Opacity_For_Controls_With_Less_Than_1_Opacity()
         {
             var root = new TestRoot


### PR DESCRIPTION
## What does the pull request do?

As described in #3179, cross-root reparenting of a control was broken. #3187 adds a unit test for this, while this PR fixes the issue.

When updating the scene for a window, moving a control to a different root should be the same as just removing the control.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #3179 
Merges #3187 