### PR TITLE
fix hit testing skia formatted text.

### DIFF
--- a/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
+++ b/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
@@ -99,9 +99,17 @@ namespace Avalonia.Skia
         public TextHitTestResult HitTestPoint(Point point)
         {
             float y = (float)point.Y;
-            var line = _skiaLines.Find(l => l.Top <= y && (l.Top + l.Height) > y);
 
-            if (!line.Equals(default(AvaloniaFormattedTextLine)))
+            AvaloniaFormattedTextLine line = default;
+
+            int i = 0;
+
+            while(_skiaLines[i].Top < y && i < _skiaLines.Count)
+            {
+                line = _skiaLines[i++];
+            }            
+
+            if (!line.Equals(default))
             {
                 var rects = GetRects();
 

--- a/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
+++ b/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
@@ -102,14 +102,18 @@ namespace Avalonia.Skia
 
             AvaloniaFormattedTextLine line = default;
 
+            float nextTop = 0;
+
             foreach(var currentLine in _skiaLines)
             {
                 if(currentLine.Top <= y)
                 {
                     line = currentLine;
+                    nextTop = currentLine.Top + currentLine.Height;
                 }
                 else
                 {
+                    nextTop = currentLine.Top;
                     break;
                 }
             }
@@ -140,7 +144,7 @@ namespace Avalonia.Skia
                                     line.Length : (line.Length - 1);
                 }
 
-                if (y < line.Top + line.Height)
+                if (y < nextTop)
                 {
                     return new TextHitTestResult
                     {

--- a/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
+++ b/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
@@ -102,12 +102,17 @@ namespace Avalonia.Skia
 
             AvaloniaFormattedTextLine line = default;
 
-            int i = 0;
-
-            while(_skiaLines[i].Top < y && i < _skiaLines.Count)
+            foreach(var currentLine in _skiaLines)
             {
-                line = _skiaLines[i++];
-            }            
+                if(currentLine.Top <= y)
+                {
+                    line = currentLine;
+                }
+                else
+                {
+                    break;
+                }
+            }
 
             if (!line.Equals(default))
             {
@@ -135,12 +140,15 @@ namespace Avalonia.Skia
                                     line.Length : (line.Length - 1);
                 }
 
-                return new TextHitTestResult
+                if (y < line.Top + line.Height)
                 {
-                    IsInside = false,
-                    TextPosition = line.Start + offset,
-                    IsTrailing = Text.Length == (line.Start + offset + 1)
-                };
+                    return new TextHitTestResult
+                    {
+                        IsInside = false,
+                        TextPosition = line.Start + offset,
+                        IsTrailing = Text.Length == (line.Start + offset + 1)
+                    };
+                }
             }
 
             bool end = point.X > _bounds.Width || point.Y > _lines.Sum(l => l.Height);


### PR DESCRIPTION
## What does the pull request do?
in some circumstances depending on font and size, you can end up with formatted text lines where there are gaps in the hit testable areas.

This can cause the selection to be randomly reset as you cross those areas

## What is the current behavior?
buggy text selection.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
stable text selection

Fixes #3212 
