### PR TITLE
[WIP] Make ApplicationLifetime aware of OnFrameworkInitializationCompleted

### DIFF
--- a/src/Avalonia.Controls/AppBuilderBase.cs
+++ b/src/Avalonia.Controls/AppBuilderBase.cs
@@ -20,7 +20,7 @@ namespace Avalonia.Controls
         private Action _optionsInitializers;
         private Func<Application> _appFactory;
         private IApplicationLifetime _lifetime;
-        
+
         /// <summary>
         /// Gets or sets the <see cref="IRuntimePlatform"/> instance.
         /// </summary>
@@ -35,12 +35,12 @@ namespace Avalonia.Controls
         /// Gets the <see cref="Application"/> instance being initialized.
         /// </summary>
         public Application Instance { get; private set; }
-        
+
         /// <summary>
         /// Gets the type of the Instance (even if it's not created yet)
         /// </summary>
         public Type ApplicationType { get; private set; }
-        
+
         /// <summary>
         /// Gets or sets a method to call the initialize the windowing subsystem.
         /// </summary>
@@ -68,7 +68,7 @@ namespace Avalonia.Controls
 
 
         public Action<TAppBuilder> AfterPlatformServicesSetupCallback { get; private set; } = builder => { };
-        
+
         protected AppBuilderBase(IRuntimePlatform platform, Action<TAppBuilder> platformServices)
         {
             RuntimePlatform = platform;
@@ -98,8 +98,8 @@ namespace Avalonia.Controls
             AfterSetupCallback = (Action<TAppBuilder>)Delegate.Combine(AfterSetupCallback, callback);
             return Self;
         }
-        
-        
+
+
         public TAppBuilder AfterPlatformServicesSetup(Action<TAppBuilder> callback)
         {
             AfterPlatformServicesSetupCallback = (Action<TAppBuilder>)Delegate.Combine(AfterPlatformServicesSetupCallback, callback);
@@ -123,9 +123,9 @@ namespace Avalonia.Controls
                 ((IClassicDesktopStyleApplicationLifetime)builder.Instance.ApplicationLifetime)
                     .MainWindow = window;
             });
-            
+
             // Copy-pasted because we can't call extension methods due to generic constraints
-            var lifetime = new ClassicDesktopStyleApplicationLifetime() {ShutdownMode = ShutdownMode.OnMainWindowClose};
+            var lifetime = new ClassicDesktopStyleApplicationLifetime() { ShutdownMode = ShutdownMode.OnMainWindowClose };
             SetupWithLifetime(lifetime);
             lifetime.Start(Array.Empty<string>());
         }
@@ -163,9 +163,10 @@ namespace Avalonia.Controls
         {
             _lifetime = lifetime;
             Setup();
+            lifetime.OnSetupCompleted();
             return Self;
         }
-        
+
         /// <summary>
         /// Specifies a windowing subsystem to use.
         /// </summary>
@@ -248,7 +249,7 @@ namespace Avalonia.Controls
             _optionsInitializers += () => { AvaloniaLocator.CurrentMutable.Bind<T>().ToConstant(options); };
             return Self;
         }
-        
+
         /// <summary>
         /// Configures platform-specific options
         /// </summary>
@@ -257,7 +258,7 @@ namespace Avalonia.Controls
             _optionsInitializers += () => { AvaloniaLocator.CurrentMutable.Bind<T>().ToFunc(options); };
             return Self;
         }
-        
+
         /// <summary>
         /// Sets up the platform-speciic services for the <see cref="Application"/>.
         /// </summary>

--- a/src/Avalonia.Controls/AppBuilderBase.cs
+++ b/src/Avalonia.Controls/AppBuilderBase.cs
@@ -163,7 +163,6 @@ namespace Avalonia.Controls
         {
             _lifetime = lifetime;
             Setup();
-            lifetime.OnSetupCompleted();
             return Self;
         }
 

--- a/src/Avalonia.Controls/Application.cs
+++ b/src/Avalonia.Controls/Application.cs
@@ -151,7 +151,7 @@ namespace Avalonia
 
         /// <inheritdoc/>
         IResourceNode IResourceNode.ResourceParent => null;
-        
+
         /// <summary>
         /// Application lifetime, use it for things like setting the main window and exiting the app from code
         /// Currently supported lifetimes are:
@@ -203,7 +203,7 @@ namespace Avalonia
 
         public virtual void OnFrameworkInitializationCompleted()
         {
-            
+            ApplicationLifetime?.OnFrameworkInitializationCompleted();
         }
 
         private void ThisResourcesChanged(object sender, ResourcesChangedEventArgs e)

--- a/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
@@ -81,12 +81,6 @@ namespace Avalonia.Controls.ApplicationLifetimes
         
         public int Start(string[] args)
         {
-            _windowLifetimeDisposable = new CompositeDisposable
-            {
-                Window.WindowOpenedEvent.AddClassHandler(typeof(Window), OnWindowOpened),
-                Window.WindowClosedEvent.AddClassHandler(typeof(Window), WindowClosedEvent)
-            };
-
             Startup?.Invoke(this, new ControlledApplicationLifetimeStartupEventArgs(args));
 
             _cts = new CancellationTokenSource();
@@ -118,6 +112,15 @@ namespace Avalonia.Controls.ApplicationLifetimes
                 _activeLifetime = null;
 
             _windowLifetimeDisposable?.Dispose();
+        }
+
+        public void OnSetupCompleted()
+        {
+            _windowLifetimeDisposable = new CompositeDisposable
+            {
+                Window.WindowOpenedEvent.AddClassHandler(typeof(Window), OnWindowOpened),
+                Window.WindowClosedEvent.AddClassHandler(typeof(Window), WindowClosedEvent)
+            };
         }
     }
 }

--- a/src/Avalonia.Controls/ApplicationLifetimes/IApplicationLifetime.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/IApplicationLifetime.cs
@@ -3,8 +3,8 @@ namespace Avalonia.Controls.ApplicationLifetimes
     public interface IApplicationLifetime
     {
         /// <summary>
-        /// This is called when the setup of the platform is completed.
+        /// This is called when the framework initialization process is completed.
         /// </summary>
-        void OnSetupCompleted();
+        void OnFrameworkInitializationCompleted();
     }
 }

--- a/src/Avalonia.Controls/ApplicationLifetimes/IApplicationLifetime.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/IApplicationLifetime.cs
@@ -2,6 +2,9 @@ namespace Avalonia.Controls.ApplicationLifetimes
 {
     public interface IApplicationLifetime
     {
-        
+        /// <summary>
+        /// This is called when the setup of the platform is completed.
+        /// </summary>
+        void OnSetupCompleted();
     }
 }

--- a/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
@@ -102,6 +102,11 @@ namespace Avalonia.LinuxFramebuffer
             ExitCode = e.ApplicationExitCode;
             _cts.Cancel();
         }
+
+        public void OnSetupCompleted()
+        {
+            
+        }
     }
 }
 

--- a/tests/Avalonia.Controls.UnitTests/DesktopStyleApplicationLifetimeTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DesktopStyleApplicationLifetimeTests.cs
@@ -8,15 +8,15 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-
     public class DesktopStyleApplicationLifetimeTests
     {
         [Fact]
         public void Should_Set_ExitCode_After_Shutdown()
         {
             using (UnitTestApplication.Start(TestServices.MockThreadingInterface))
-            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                var lifetime = new ClassicDesktopStyleApplicationLifetime();
+
                 lifetime.Shutdown(1337);
 
                 var exitCode = lifetime.Start(Array.Empty<string>());
@@ -30,9 +30,10 @@ namespace Avalonia.Controls.UnitTests
         public void Should_Close_All_Remaining_Open_Windows_After_Explicit_Exit_Call()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
-            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
-                lifetime.OnSetupCompleted();
+                var lifetime = new ClassicDesktopStyleApplicationLifetime();
+
+                lifetime.OnFrameworkInitializationCompleted();
 
                 var windows = new List<Window> { new Window(), new Window(), new Window(), new Window() };
 
@@ -40,7 +41,9 @@ namespace Avalonia.Controls.UnitTests
                 {
                     window.Show();
                 }
+
                 Assert.Equal(4, lifetime.Windows.Count);
+
                 lifetime.Shutdown();
 
                 Assert.Empty(lifetime.Windows);
@@ -51,8 +54,9 @@ namespace Avalonia.Controls.UnitTests
         public void Should_Only_Exit_On_Explicit_Exit()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
-            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                var lifetime = new ClassicDesktopStyleApplicationLifetime();
+
                 lifetime.ShutdownMode = ShutdownMode.OnExplicitShutdown;
 
                 var hasExit = false;
@@ -85,9 +89,10 @@ namespace Avalonia.Controls.UnitTests
         public void Should_Exit_After_MainWindow_Closed()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
-            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
-                lifetime.OnSetupCompleted();
+                var lifetime = new ClassicDesktopStyleApplicationLifetime();
+
+                lifetime.OnFrameworkInitializationCompleted();
 
                 lifetime.ShutdownMode = ShutdownMode.OnMainWindowClose;
 
@@ -115,9 +120,10 @@ namespace Avalonia.Controls.UnitTests
         public void Should_Exit_After_Last_Window_Closed()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
-            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
-                lifetime.OnSetupCompleted();
+                var lifetime = new ClassicDesktopStyleApplicationLifetime();
+
+                lifetime.OnFrameworkInitializationCompleted();
 
                 lifetime.ShutdownMode = ShutdownMode.OnLastWindowClose;
 
@@ -147,9 +153,10 @@ namespace Avalonia.Controls.UnitTests
         public void Show_Should_Add_Window_To_OpenWindows()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
-            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
-                lifetime.OnSetupCompleted();
+                var lifetime = new ClassicDesktopStyleApplicationLifetime();
+
+                lifetime.OnFrameworkInitializationCompleted();
 
                 var window = new Window();
 
@@ -163,9 +170,10 @@ namespace Avalonia.Controls.UnitTests
         public void Window_Should_Be_Added_To_OpenWindows_Only_Once()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
-            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
-                lifetime.OnSetupCompleted();
+                var lifetime = new ClassicDesktopStyleApplicationLifetime();
+
+                lifetime.OnFrameworkInitializationCompleted();
 
                 var window = new Window();
 
@@ -183,9 +191,10 @@ namespace Avalonia.Controls.UnitTests
         public void Close_Should_Remove_Window_From_OpenWindows()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
-            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
-                lifetime.OnSetupCompleted();
+                var lifetime = new ClassicDesktopStyleApplicationLifetime();
+
+                lifetime.OnFrameworkInitializationCompleted();
 
                 var window = new Window();
 
@@ -201,16 +210,17 @@ namespace Avalonia.Controls.UnitTests
         public void Impl_Closing_Should_Remove_Window_From_OpenWindows()
         {
             var windowImpl = new Mock<IWindowImpl>();
-            windowImpl.SetupProperty(x => x.Closed);
+            windowImpl.SetupProperty(x => x.Closed, ()=> { });
             windowImpl.Setup(x => x.Scaling).Returns(1);
 
             var services = TestServices.StyledWindow.With(
                 windowingPlatform: new MockWindowingPlatform(() => windowImpl.Object));
 
             using (UnitTestApplication.Start(services))
-            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
-                lifetime.OnSetupCompleted();
+                var lifetime = new ClassicDesktopStyleApplicationLifetime();
+
+                lifetime.OnFrameworkInitializationCompleted();
 
                 var window = new Window();
 
@@ -222,5 +232,4 @@ namespace Avalonia.Controls.UnitTests
             }
         }
     }
-
 }

--- a/tests/Avalonia.Controls.UnitTests/DesktopStyleApplicationLifetimeTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DesktopStyleApplicationLifetimeTests.cs
@@ -2,21 +2,20 @@ using System;
 using System.Collections.Generic;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Platform;
-using Avalonia.Threading;
 using Avalonia.UnitTests;
 using Moq;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    
+
     public class DesktopStyleApplicationLifetimeTests
     {
         [Fact]
         public void Should_Set_ExitCode_After_Shutdown()
         {
             using (UnitTestApplication.Start(TestServices.MockThreadingInterface))
-            using(var lifetime = new ClassicDesktopStyleApplicationLifetime())    
+            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
                 lifetime.Shutdown(1337);
 
@@ -25,14 +24,16 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Equal(1337, exitCode);
             }
         }
-        
-        
+
+
         [Fact]
         public void Should_Close_All_Remaining_Open_Windows_After_Explicit_Exit_Call()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
-            using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
+            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                lifetime.OnSetupCompleted();
+
                 var windows = new List<Window> { new Window(), new Window(), new Window(), new Window() };
 
                 foreach (var window in windows)
@@ -45,12 +46,12 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Empty(lifetime.Windows);
             }
         }
-        
+
         [Fact]
         public void Should_Only_Exit_On_Explicit_Exit()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
-            using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
+            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
                 lifetime.ShutdownMode = ShutdownMode.OnExplicitShutdown;
 
@@ -79,13 +80,15 @@ namespace Avalonia.Controls.UnitTests
                 Assert.True(hasExit);
             }
         }
-        
+
         [Fact]
         public void Should_Exit_After_MainWindow_Closed()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
-            using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
+            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                lifetime.OnSetupCompleted();
+
                 lifetime.ShutdownMode = ShutdownMode.OnMainWindowClose;
 
                 var hasExit = false;
@@ -112,8 +115,10 @@ namespace Avalonia.Controls.UnitTests
         public void Should_Exit_After_Last_Window_Closed()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
-            using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
+            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                lifetime.OnSetupCompleted();
+
                 lifetime.ShutdownMode = ShutdownMode.OnLastWindowClose;
 
                 var hasExit = false;
@@ -137,13 +142,15 @@ namespace Avalonia.Controls.UnitTests
                 Assert.True(hasExit);
             }
         }
-        
+
         [Fact]
         public void Show_Should_Add_Window_To_OpenWindows()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
-            using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
+            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                lifetime.OnSetupCompleted();
+
                 var window = new Window();
 
                 window.Show();
@@ -156,8 +163,10 @@ namespace Avalonia.Controls.UnitTests
         public void Window_Should_Be_Added_To_OpenWindows_Only_Once()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
-            using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
+            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                lifetime.OnSetupCompleted();
+
                 var window = new Window();
 
                 window.Show();
@@ -174,8 +183,10 @@ namespace Avalonia.Controls.UnitTests
         public void Close_Should_Remove_Window_From_OpenWindows()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
-            using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
+            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                lifetime.OnSetupCompleted();
+
                 var window = new Window();
 
                 window.Show();
@@ -185,7 +196,7 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Empty(lifetime.Windows);
             }
         }
-        
+
         [Fact]
         public void Impl_Closing_Should_Remove_Window_From_OpenWindows()
         {
@@ -197,8 +208,10 @@ namespace Avalonia.Controls.UnitTests
                 windowingPlatform: new MockWindowingPlatform(() => windowImpl.Object));
 
             using (UnitTestApplication.Start(services))
-            using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
+            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                lifetime.OnSetupCompleted();
+
                 var window = new Window();
 
                 window.Show();
@@ -209,5 +222,5 @@ namespace Avalonia.Controls.UnitTests
             }
         }
     }
-    
+
 }

--- a/tests/Avalonia.ReactiveUI.UnitTests/AutoSuspendHelperTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AutoSuspendHelperTest.cs
@@ -36,18 +36,14 @@ namespace Avalonia.ReactiveUI.UnitTests
             public string Example { get; set; }
         }
 
-        public class ExoticApplicationLifetimeWithoutLifecycleEvents : IDisposable, IApplicationLifetime
-        {
-            public void Dispose() { }
-            public void OnSetupCompleted() { }
-        }
+        public class ExoticApplicationLifetimeWithoutLifecycleEvents : ApplicationLifetime { }
 
         [Fact]
-        public void AutoSuspendHelper_Should_Immediately_Fire_IsLaunchingNew() 
+        public void AutoSuspendHelper_Should_Immediately_Fire_IsLaunchingNew()
         {
-            using (UnitTestApplication.Start(TestServices.MockWindowingPlatform)) 
-            using (var lifetime = new ClassicDesktopStyleApplicationLifetime())
+            using (UnitTestApplication.Start(TestServices.MockWindowingPlatform))
             {
+                var lifetime = new ClassicDesktopStyleApplicationLifetime();
                 var isLaunchingReceived = false;
                 var application = AvaloniaLocator.Current.GetService<Application>();
                 application.ApplicationLifetime = lifetime;
@@ -65,8 +61,8 @@ namespace Avalonia.ReactiveUI.UnitTests
         public void AutoSuspendHelper_Should_Throw_When_Not_Supported_Lifetime_Is_Used()
         {
             using (UnitTestApplication.Start(TestServices.MockWindowingPlatform))
-            using (var lifetime = new ExoticApplicationLifetimeWithoutLifecycleEvents()) 
             {
+                var lifetime = new ExoticApplicationLifetimeWithoutLifecycleEvents();
                 var application = AvaloniaLocator.Current.GetService<Application>();
                 application.ApplicationLifetime = lifetime;
                 Assert.Throws<NotSupportedException>(() => new AutoSuspendHelper(application.ApplicationLifetime));
@@ -84,11 +80,11 @@ namespace Avalonia.ReactiveUI.UnitTests
         }
 
         [Fact]
-        public void ShouldPersistState_Should_Fire_On_App_Exit_When_SuspensionDriver_Is_Initialized() 
+        public void ShouldPersistState_Should_Fire_On_App_Exit_When_SuspensionDriver_Is_Initialized()
         {
             using (UnitTestApplication.Start(TestServices.MockWindowingPlatform))
-            using (var lifetime = new ClassicDesktopStyleApplicationLifetime()) 
             {
+                var lifetime = new ClassicDesktopStyleApplicationLifetime();
                 var shouldPersistReceived = false;
                 var application = AvaloniaLocator.Current.GetService<Application>();
                 application.ApplicationLifetime = lifetime;

--- a/tests/Avalonia.ReactiveUI.UnitTests/AutoSuspendHelperTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AutoSuspendHelperTest.cs
@@ -39,6 +39,7 @@ namespace Avalonia.ReactiveUI.UnitTests
         public class ExoticApplicationLifetimeWithoutLifecycleEvents : IDisposable, IApplicationLifetime
         {
             public void Dispose() { }
+            public void OnSetupCompleted() { }
         }
 
         [Fact]


### PR DESCRIPTION
## What does the pull request do?
It allows a lifetime object to know when the framework has beed initialized to do work that is only safe to perform when all services are available.

## What is the current behavior?
Currently it is not possible for a lifetime object to know when the framework has been initialized. This causes some issues with the ClassicDesktopStyleApplicationLifetime. It subscribes to window events in its static ctor when not all services are available.

## What is the updated/expected behavior with this PR?
`IApplicationLifetime` has a new method `OnFrameworkInitializationCompleted()` that is called when the framwork is initialized.

## How was the solution implemented (if it's not obvious)?
`IApplicationLifetime.OnFrameworkInitializationCompleted()` was introduced and is called by the owning application when its `OnFrameworkInitializationCompleted()` is called.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
Fixes: #3224
