### PR TITLE
set Scroll before calling base.OnTemplateApplied.

### DIFF
--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -151,8 +151,8 @@ namespace Avalonia.Controls
 
         protected override void OnTemplateApplied(TemplateAppliedEventArgs e)
         {
-            base.OnTemplateApplied(e);
             Scroll = e.NameScope.Find<IScrollable>("PART_ScrollViewer");
+            base.OnTemplateApplied(e);
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
@@ -48,6 +48,26 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void ListBox_Should_Find_Scrollviewer_In_Template()
+        {
+            var target = new ListBox
+            {
+                Template = ListBoxTemplate(),
+            };
+
+            ScrollViewer viewer = null;
+
+            target.TemplateApplied += (sender, e) =>
+            {
+                viewer = target.Scroll as ScrollViewer;
+            };
+
+            Prepare(target);
+
+            Assert.NotNull(viewer);
+        }
+
+        [Fact]
         public void ListBoxItem_Containers_Should_Be_Generated()
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Sets the scroll property before calling base template applied on listbox.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
currently, using  ontemplateapplied, event to get what you think is an initialised listbox gives you a listbox with a null scroll property.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
init scroll property before event gets fired.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
