### PR TITLE
WIP: New API for visual tree traversal.

### DIFF
--- a/src/Avalonia.Base/Traversal/ITreeVisitor.cs
+++ b/src/Avalonia.Base/Traversal/ITreeVisitor.cs
@@ -1,0 +1,7 @@
+﻿namespace Avalonia.Traversal
+{
+    public interface ITreeVisitor<in T>
+    {
+        TreeVisit Visit(T target);
+    }
+}

--- a/src/Avalonia.Base/Traversal/ITreeVisitorWithResult.cs
+++ b/src/Avalonia.Base/Traversal/ITreeVisitorWithResult.cs
@@ -1,0 +1,7 @@
+﻿namespace Avalonia.Traversal
+{
+    public interface ITreeVisitorWithResult<in T, out TResult> : ITreeVisitor<T>
+    {
+        TResult Result { get; }
+    }
+}

--- a/src/Avalonia.Base/Traversal/LambdaTreeVisitor.cs
+++ b/src/Avalonia.Base/Traversal/LambdaTreeVisitor.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace Avalonia.Traversal
+{
+    public readonly struct LambdaTreeVisitor<T> : ITreeVisitor<T>
+    {
+        private readonly Func<T, TreeVisit> _operation;
+
+        public LambdaTreeVisitor(Func<T, TreeVisit> operation)
+        {
+            _operation = operation;
+        }
+
+        public TreeVisit Visit(T target)
+        {
+            return _operation(target);
+        }
+    }
+
+    public struct StatefulLambdaTreeVisitor<T, TState> : ITreeVisitor<T>
+    {
+        private readonly Func<T, TState, TreeVisit> _operation;
+        private TState _state;
+
+        public StatefulLambdaTreeVisitor(Func<T, TState, TreeVisit> operation, TState state)
+        {
+            _operation = operation;
+            _state = state;
+        }
+
+        public TreeVisit Visit(T target)
+        {
+            return _operation(target, _state);
+        }
+    }
+}

--- a/src/Avalonia.Base/Traversal/LambdaTreeVisitorWithResult.cs
+++ b/src/Avalonia.Base/Traversal/LambdaTreeVisitorWithResult.cs
@@ -1,0 +1,58 @@
+﻿using System;
+
+namespace Avalonia.Traversal
+{
+    public struct LambdaTreeVisitorWithResult<T> : ITreeVisitorWithResult<T, T>
+    {
+        private readonly Func<T, TreeVisit> _operation;
+
+        public LambdaTreeVisitorWithResult(Func<T, TreeVisit> operation)
+        {
+            _operation = operation;
+
+            Result = default;
+        }
+
+        public T Result { get; private set; }
+
+        public TreeVisit Visit(T target)
+        {
+            if (_operation(target) == TreeVisit.Stop)
+            {
+                Result = target;
+
+                return TreeVisit.Stop;
+            }
+
+            return TreeVisit.Continue;
+        }
+    }
+
+    public struct StatefulLambdaTreeVisitorWithResult<T, TState> : ITreeVisitorWithResult<T, T>
+    {
+        private readonly Func<T,TState, TreeVisit> _operation;
+        private TState _state;
+
+        public StatefulLambdaTreeVisitorWithResult(Func<T, TState, TreeVisit> operation, TState state)
+        {
+            _operation = operation;
+            _state = state;
+
+            Result = default;
+        }
+
+        public T Result { get; private set; }
+
+        public TreeVisit Visit(T target)
+        {
+            if (_operation(target, _state) == TreeVisit.Stop)
+            {
+                Result = target;
+
+                return TreeVisit.Stop;
+            }
+
+            return TreeVisit.Continue;
+        }
+    }
+}

--- a/src/Avalonia.Base/Traversal/TreeVisit.cs
+++ b/src/Avalonia.Base/Traversal/TreeVisit.cs
@@ -1,0 +1,8 @@
+﻿namespace Avalonia.Traversal
+{
+    public enum TreeVisit
+    {
+        Continue,
+        Stop
+    }
+}

--- a/src/Avalonia.Base/Traversal/TreeVisitMode.cs
+++ b/src/Avalonia.Base/Traversal/TreeVisitMode.cs
@@ -1,0 +1,8 @@
+﻿namespace Avalonia.Traversal
+{
+    public enum TreeVisitMode
+    {
+        ExcludeSelf,
+        IncludeSelf
+    }
+}

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -15,6 +15,7 @@ using Avalonia.Controls.Utils;
 using Avalonia.Input;
 using Avalonia.LogicalTree;
 using Avalonia.Metadata;
+using Avalonia.Traversal;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Controls
@@ -324,10 +325,15 @@ namespace Avalonia.Controls
                     return;
                 }
 
-                var current = focus.Current
-                    .GetSelfAndVisualAncestors()
-                    .OfType<IInputElement>()
-                    .FirstOrDefault(x => x.VisualParent == container);
+                var current = (IInputElement)VisualTreeOperations.FindAncestor(focus.Current, (target, parent) =>
+                {
+                    if (target is IInputElement inputElement && inputElement.VisualParent == parent)
+                    {
+                        return TreeVisit.Stop;
+                    }
+
+                    return TreeVisit.Continue;
+                }, container, TreeVisitMode.IncludeSelf);
 
                 if (current != null)
                 {

--- a/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
+++ b/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
@@ -149,9 +149,8 @@ namespace Avalonia.Controls.Notifications
         /// <param name="host">The <see cref="Window"/> that will be the host.</param>
         private void Install(Window host)
         {
-            var adornerLayer = host.GetVisualDescendants()
-                .OfType<VisualLayerManager>()
-                .FirstOrDefault()
+            var adornerLayer = VisualTreeOperations
+                .FindDescendantOfType<VisualLayerManager>(host)
                 ?.AdornerLayer;
 
             if (adornerLayer != null)

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -14,6 +14,7 @@ using Avalonia.LogicalTree;
 using Avalonia.Platform;
 using Avalonia.Rendering;
 using Avalonia.Styling;
+using Avalonia.Traversal;
 using Avalonia.Utilities;
 using Avalonia.VisualTree;
 using JetBrains.Annotations;
@@ -296,10 +297,7 @@ namespace Avalonia.Controls
         /// <param name="scaling">The window scaling.</param>
         protected virtual void HandleScalingChanged(double scaling)
         {
-            foreach (ILayoutable control in this.GetSelfAndVisualDescendants())
-            {
-                control.InvalidateMeasure();
-            }
+            VisualTreeOperations.VisitDescendants<InvalidateMeasureVisitor>(this, TreeVisitMode.IncludeSelf);
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Input/FocusManager.cs
+++ b/src/Avalonia.Input/FocusManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Interactivity;
+using Avalonia.Traversal;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Input
@@ -184,9 +185,15 @@ namespace Avalonia.Input
 
                 if (element == null || !CanFocus(element))
                 {
-                    element = element.GetSelfAndVisualAncestors()
-                        .OfType<IInputElement>()
-                        .FirstOrDefault(CanFocus);
+                    element = (IInputElement)VisualTreeOperations.FindAncestor(element, visual =>
+                    {
+                        if (visual is IInputElement inputElement && CanFocus(inputElement))
+                        {
+                            return TreeVisit.Stop;
+                        }
+
+                        return TreeVisit.Continue;
+                    }, TreeVisitMode.IncludeSelf);
                 }
 
                 if (element != null)

--- a/src/Avalonia.Input/Pointer.cs
+++ b/src/Avalonia.Input/Pointer.cs
@@ -55,9 +55,11 @@ namespace Avalonia.Input
                 Captured.DetachedFromVisualTree += OnCaptureDetached;
         }
 
-        IInputElement GetNextCapture(IVisual parent) =>
-            parent as IInputElement ?? parent.GetVisualAncestors().OfType<IInputElement>().FirstOrDefault();
-        
+        IInputElement GetNextCapture(IVisual parent)
+        {
+            return parent as IInputElement ?? VisualTreeOperations.FindAncestorOfType<IInputElement>(parent);
+        }
+
         private void OnCaptureDetached(object sender, VisualTreeAttachmentEventArgs e)
         {
             Capture(GetNextCapture(e.Parent));

--- a/src/Avalonia.Layout/Layoutable.cs
+++ b/src/Avalonia.Layout/Layoutable.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Logging;
+using Avalonia.Traversal;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Layout
@@ -694,12 +697,9 @@ namespace Avalonia.Layout
         }
 
         /// <inheritdoc/>
-        protected override sealed void OnVisualParentChanged(IVisual oldParent, IVisual newParent)
+        protected sealed override void OnVisualParentChanged(IVisual oldParent, IVisual newParent)
         {
-            foreach (ILayoutable i in this.GetSelfAndVisualDescendants())
-            {
-                i.InvalidateMeasure();
-            }
+            VisualTreeOperations.VisitDescendants<InvalidateMeasureVisitor>(this, TreeVisitMode.IncludeSelf);
 
             base.OnVisualParentChanged(oldParent, newParent);
         }
@@ -752,6 +752,19 @@ namespace Avalonia.Layout
             }
 
             return result;
+        }
+
+        public struct InvalidateMeasureVisitor : ITreeVisitor<IVisual>
+        {
+            public TreeVisit Visit(IVisual target)
+            {
+                if (target is ILayoutable layoutable)
+                {
+                    layoutable.InvalidateMeasure();
+                }
+
+                return TreeVisit.Continue;
+            }
         }
     }
 }

--- a/src/Avalonia.Visuals/VisualTree/VisualTreeOperations.cs
+++ b/src/Avalonia.Visuals/VisualTree/VisualTreeOperations.cs
@@ -1,0 +1,286 @@
+using System;
+using Avalonia.Traversal;
+
+namespace Avalonia.VisualTree
+{
+    /// <summary>
+    /// General purpose traversal operation on a visual tree.
+    /// </summary>
+    public static class VisualTreeOperations
+    {
+        public static void VisitDescendants<T>(IVisual target, T visitor, TreeVisitMode mode = default)
+            where T : struct, ITreeVisitor<IVisual>
+        {
+            var traverser = new VisualTreeTraverser<T>(visitor);
+
+            traverser.VisitDescendants(target, mode);
+        }
+
+        public static TResult VisitDescendants<T, TResult>(IVisual target, T visitor, TreeVisitMode mode = default)
+            where T : struct, ITreeVisitorWithResult<IVisual, TResult>
+        {
+            var traverser = new VisualTreeTraverser<T>(visitor);
+
+            traverser.VisitDescendants(target, mode);
+
+            return traverser.Visitor.Result;
+        }
+
+        public static void VisitDescendants<T>(IVisual target, TreeVisitMode mode = default)
+            where T : struct, ITreeVisitor<IVisual>
+        {
+            VisitDescendants<T>(target, default, mode);
+        }
+
+        public static TResult VisitDescendants<T, TResult>(IVisual target, TreeVisitMode mode = default)
+            where T : struct, ITreeVisitorWithResult<IVisual, TResult>
+        {
+            return VisitDescendants<T, TResult>(target, default, mode);
+        }
+
+        public static void VisitDescendants(IVisual target, Func<IVisual, TreeVisit> visitFunc, TreeVisitMode mode = default)
+        {
+            var visitor = MakeLambdaVisitor(visitFunc);
+
+            VisitDescendants(target, visitor, mode);
+        }
+
+        public static void VisitDescendants<TState>(IVisual target, Func<IVisual, TState, TreeVisit> visitFunc, TState state, TreeVisitMode mode = default)
+        {
+            var visitor = MakeLambdaVisitor(visitFunc, state);
+
+            VisitDescendants(target, visitor, mode);
+        }
+
+        public static TResult FindDescendant<T, TResult>(IVisual target, T visitor, TreeVisitMode mode = default)
+            where T : struct, ITreeVisitorWithResult<IVisual, TResult>
+        {
+            var traverser = new VisualTreeTraverser<T>(visitor);
+
+            traverser.VisitDescendants(target, mode);
+
+            return traverser.Visitor.Result;
+        }
+
+        public static TResult FindDescendant<T, TResult>(IVisual target, TreeVisitMode mode = default)
+            where T : struct, ITreeVisitorWithResult<IVisual, TResult>
+        {
+            return FindDescendant<T, TResult>(target, default, mode);
+        }
+
+        public static IVisual FindDescendant(IVisual target, Func<IVisual, TreeVisit> visitFunc, TreeVisitMode mode = default)
+        {
+            var visitor = MakeLambdaVisitorWithResult(visitFunc);
+
+            return FindDescendant<LambdaTreeVisitorWithResult<IVisual>, IVisual>(target, visitor, mode);
+        }
+
+        public static IVisual FindDescendant<TState>(IVisual target, Func<IVisual, TState, TreeVisit> visitFunc, TState state, TreeVisitMode mode = default)
+        {
+            var visitor = MakeLambdaVisitorWithResult(visitFunc, state);
+
+            return FindDescendant<StatefulLambdaTreeVisitorWithResult<IVisual, TState>, IVisual>(target, visitor, mode);
+        }
+
+        public static T FindDescendantOfType<T>(IVisual target, TreeVisitMode mode = default)
+        {
+            return FindDescendant<OfTypeFilter<T>, T>(target, mode);
+        }
+
+        public static void VisitAncestors<T>(IVisual target, T visitor, TreeVisitMode mode = default)
+            where T : struct, ITreeVisitor<IVisual>
+        {
+            var traverser = new VisualTreeTraverser<T>(visitor);
+
+            traverser.VisitAncestors(target, mode);
+        }
+
+        public static void VisitAncestors<T>(IVisual target, TreeVisitMode mode = default)
+            where T : struct, ITreeVisitor<IVisual>
+        {
+            VisitAncestors<T>(target, default, mode);
+        }
+
+        public static void VisitAncestors(IVisual target, Func<IVisual, TreeVisit> visitFunc, TreeVisitMode mode = default)
+        {
+            var visitor = MakeLambdaVisitor(visitFunc);
+
+            VisitAncestors(target, visitor, mode);
+        }
+
+        public static void VisitAncestors<TState>(IVisual target, Func<IVisual, TState, TreeVisit> visitFunc, TState state, TreeVisitMode mode = default)
+        {
+            var visitor = MakeLambdaVisitor(visitFunc, state);
+
+            VisitAncestors(target, visitor, mode);
+        }
+
+        public static TResult FindAncestor<T, TResult>(IVisual target, T visitor, TreeVisitMode mode = default)
+            where T : struct, ITreeVisitorWithResult<IVisual, TResult>
+        {
+            var traverser = new VisualTreeTraverser<T>(visitor);
+
+            traverser.VisitAncestors(target, mode);
+
+            return traverser.Visitor.Result;
+        }
+
+        public static TResult FindAncestor<T, TResult>(IVisual target, TreeVisitMode mode = default)
+            where T : struct, ITreeVisitorWithResult<IVisual, TResult>
+        {
+            return FindAncestor<T, TResult>(target, default, mode);
+        }
+
+        public static IVisual FindAncestor(IVisual target, Func<IVisual, TreeVisit> visitFunc, TreeVisitMode mode = default)
+        {
+            var visitor = MakeLambdaVisitorWithResult(visitFunc);
+
+            return FindAncestor<LambdaTreeVisitorWithResult<IVisual>, IVisual>(target, visitor, mode);
+        }
+
+        public static IVisual FindAncestor<TState>(IVisual target, Func<IVisual, TState, TreeVisit> visitFunc, TState state, TreeVisitMode mode = default)
+        {
+            var visitor = MakeLambdaVisitorWithResult(visitFunc, state);
+
+            return FindAncestor<StatefulLambdaTreeVisitorWithResult<IVisual, TState>, IVisual>(target, visitor, mode);
+        }
+
+        public static T FindAncestorOfType<T>(IVisual target, TreeVisitMode mode = default)
+        {
+            return FindAncestor<OfTypeFilter<T>, T>(target, mode);
+        }
+
+        public static LambdaTreeVisitor<IVisual> MakeLambdaVisitor(Func<IVisual, TreeVisit> visitFunc)
+        {
+            if (visitFunc is null)
+            {
+                throw new ArgumentNullException(nameof(visitFunc));
+            }
+
+            return new LambdaTreeVisitor<IVisual>(visitFunc);
+        }
+
+        public static StatefulLambdaTreeVisitor<IVisual, TState> MakeLambdaVisitor<TState>(Func<IVisual, TState, TreeVisit> visitFunc, TState state)
+        {
+            if (visitFunc is null)
+            {
+                throw new ArgumentNullException(nameof(visitFunc));
+            }
+
+            return new StatefulLambdaTreeVisitor<IVisual, TState>(visitFunc, state);
+        }
+
+        public static LambdaTreeVisitorWithResult<T> MakeLambdaVisitorWithResult<T>(Func<T, TreeVisit> visitFunc)
+        {
+            if (visitFunc is null)
+            {
+                throw new ArgumentNullException(nameof(visitFunc));
+            }
+
+            return new LambdaTreeVisitorWithResult<T>(visitFunc);
+        }
+
+        public static StatefulLambdaTreeVisitorWithResult<T, TState> MakeLambdaVisitorWithResult<T, TState>(Func<T, TState, TreeVisit> visitFunc, TState state)
+        {
+            if (visitFunc is null)
+            {
+                throw new ArgumentNullException(nameof(visitFunc));
+            }
+
+            return new StatefulLambdaTreeVisitorWithResult<T, TState>(visitFunc, state);
+        }
+
+        private struct OfTypeFilter<T> : ITreeVisitorWithResult<IVisual, T>
+        {
+            public TreeVisit Visit(IVisual target)
+            {
+                if (target is T result)
+                {
+                    Result = result;
+
+                    return TreeVisit.Stop;
+                }
+
+                return TreeVisit.Continue;
+            }
+
+            public T Result { get; private set; }
+        }
+    }
+
+    public struct VisualTreeTraverser<T> where T : struct, ITreeVisitor<IVisual>
+    {
+        private T _visitor;
+
+        public VisualTreeTraverser(T visitor)
+        {
+            _visitor = visitor;
+        }
+
+        public T Visitor => _visitor;
+
+        public void VisitAncestors(IVisual target, TreeVisitMode mode)
+        {
+            if (mode == TreeVisitMode.IncludeSelf)
+            {
+                if (_visitor.Visit(target) == TreeVisit.Stop)
+                {
+                    return;
+                }
+            }
+
+            IVisual parent = target.VisualParent;
+
+            while (parent != null)
+            {
+                if (_visitor.Visit(parent) == TreeVisit.Stop)
+                {
+                    return;
+                }
+
+                parent = parent.VisualParent;
+            }
+        }
+
+        public void VisitDescendants(IVisual target, TreeVisitMode mode)
+        {
+            if (mode == TreeVisitMode.IncludeSelf)
+            {
+                if (_visitor.Visit(target) == TreeVisit.Stop)
+                {
+                    return;
+                }
+            }
+
+            TraverseChildren(target);
+        }
+
+        private bool VisitDescendants(IVisual target)
+        {
+            if (_visitor.Visit(target) == TreeVisit.Stop)
+            {
+                return false;
+            }
+
+            return TraverseChildren(target);
+        }
+
+        private bool TraverseChildren(IVisual target)
+        {
+            var visualChildren = target.VisualChildren;
+            var visualCount = visualChildren.Count;
+
+            for (int i = 0; i < visualCount; i++)
+            {
+                var child = visualChildren[i];
+
+                if (!VisitDescendants(child))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/tests/Avalonia.Benchmarks/Traversal/VisualTreeTraversal.cs
+++ b/tests/Avalonia.Benchmarks/Traversal/VisualTreeTraversal.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using Avalonia.Benchmarks.Layout;
+using Avalonia.Controls;
+using Avalonia.Traversal;
+using Avalonia.UnitTests;
+using Avalonia.VisualTree;
+using BenchmarkDotNet.Attributes;
+
+namespace Avalonia.Benchmarks.Traversal
+{
+    [MemoryDiagnoser]
+    public class VisualTreeTraversal
+    {
+        private readonly TestRoot _root;
+        private readonly List<Control> _controls = new List<Control>();
+
+        public VisualTreeTraversal()
+        {
+            var panel = new StackPanel();
+            _root = new TestRoot { Child = panel, Renderer = new NullRenderer()};
+            _controls.Add(panel);
+            _controls = ControlHierarchyCreator.CreateChildren(_controls, panel, 3, 5, 5);
+            _root.LayoutManager.ExecuteInitialLayoutPass(_root);
+        }
+
+        [Benchmark]
+        public void Visit_Struct()
+        {
+            VisualTreeOperations.VisitDescendants<InvalidateVisualVisitor>(_root, TreeVisitMode.IncludeSelf);
+        }
+
+        [Benchmark]
+        public void Visit_Lambda()
+        {
+            VisualTreeOperations.VisitDescendants(_root, visual =>
+            {
+                visual.InvalidateVisual();
+
+                return TreeVisit.Continue;
+            }, TreeVisitMode.IncludeSelf);
+        }
+
+        [Benchmark(Baseline = true)]
+        public void Visit_IEnumerable()
+        {
+            foreach (IVisual visual in _root.GetSelfAndVisualDescendants())
+            {
+                visual.InvalidateVisual();
+            }
+        }
+
+        private struct InvalidateVisualVisitor : ITreeVisitor<IVisual>
+        {
+            public TreeVisit Visit(IVisual target)
+            {
+                target.InvalidateVisual();
+
+                return TreeVisit.Continue;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Implements sample API for doing performance visual tree traversal. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Only `IEnumerable` extension methods are used which leads to poor performance and many wasteful memory allocations.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Expose API for executing visual tree traversal. I need to figure out how to nicely generalize this to support logical tree as well. Since most of the operations are equivalent.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Design goal was - no LINQ, minimize indirections and avoid dynamic allocations. API allows user to invoke functions in multiple ways:
- struct visitors (you need to create struct implementing `ITreeVisitor<T>`)
- lambda visitors
    - stateless (encapsulates lambda that takes no state, useful when no external state is required)
    - stateful (encapsulates lambda and state, can be used to avoid closure allocations)

Struct visitors are fastest since generic metaprograming allows us to emit very efficient code equivalent to hand written traversal code. Lambda version incur some overhead due to the extra call indirection.

Old `IEnumerable` API should stay since it is still convenient to have it around and I guess that a lot of user code relies on it. We might want to emphasise that alternative traversal API should be used in high performance scenarios.

Framework code should generally not use `IEnumerable` API unless we are sure it will be never called frequently. New API is 6 to 10 times faster. If you have code that is on a hot path it is advised to implement struct visitor even in simple cases (it is 30% faster to use structs than lambdas).

|            Method |       Mean |      Error |     StdDev | Ratio |    Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |-----------:|-----------:|-----------:|------:|---------:|------:|------:|----------:|
|      Visit_Struct |   145.4 us |  1.9873 us |  1.8589 us |  0.12 |        - |     - |     - |         - |
|      Visit_Lambda |   189.9 us |  0.8357 us |  0.7817 us |  0.16 |        - |     - |     - |         - |
| Visit_IEnumerable | 1,179.8 us | 23.2581 us | 26.7840 us |  1.00 | 173.8281 |     - |     - |  734104 B |

Part of the code resides in `Avalonia.Base.Traversal` since I intend to use it for logical tree traversal as well.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
