### PR TITLE
Fix ItemsRepeater not clearing focused elements on items source changed.

### DIFF
--- a/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml
+++ b/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml
@@ -15,6 +15,7 @@
       </ComboBox>
       <Button Command="{Binding AddItem}">Add Item</Button>
       <Button Command="{Binding RandomizeHeights}">Randomize Heights</Button>
+      <Button Command="{Binding ResetItems}">Reset items</Button>
     </StackPanel>
     <Border BorderThickness="1" BorderBrush="{DynamicResource ThemeBorderMidBrush}" Margin="0 0 0 16">
       <ScrollViewer Name="scroller"
@@ -23,7 +24,7 @@
         <ItemsRepeater Name="repeater" Background="Transparent" Items="{Binding Items}">
           <ItemsRepeater.ItemTemplate>
             <DataTemplate>
-              <TextBlock Height="{Binding Height}" Text="{Binding Text}"/>
+              <TextBlock Focusable="True" Height="{Binding Height}" Text="{Binding Text}"/>
             </DataTemplate>
           </ItemsRepeater.ItemTemplate>
         </ItemsRepeater>

--- a/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml.cs
@@ -20,6 +20,7 @@ namespace ControlCatalog.Pages
             _repeater = this.FindControl<ItemsRepeater>("repeater");
             _scroller = this.FindControl<ScrollViewer>("scroller");
             _repeater.PointerPressed += RepeaterClick;
+            _repeater.KeyDown += RepeaterOnKeyDown;
             DataContext = new ItemsRepeaterPageViewModel();
         }
 
@@ -76,6 +77,14 @@ namespace ControlCatalog.Pages
         {
             var item = (e.Source as TextBlock)?.DataContext as ItemsRepeaterPageViewModel.Item;
             ((ItemsRepeaterPageViewModel)DataContext).SelectedItem = item;
+        }
+
+        private void RepeaterOnKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.F5)
+            {
+                ((ItemsRepeaterPageViewModel)DataContext).ResetItems();
+            }
         }
     }
 }

--- a/samples/ControlCatalog/ViewModels/ItemsRepeaterPageViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/ItemsRepeaterPageViewModel.cs
@@ -7,25 +7,27 @@ namespace ControlCatalog.ViewModels
 {
     public class ItemsRepeaterPageViewModel : ReactiveObject
     {
-        private int newItemIndex = 1;
+        private int _newItemIndex = 1;
+        private int _newGenerationIndex = 0;
+        private ObservableCollection<Item> _items;
 
         public ItemsRepeaterPageViewModel()
         {
-            Items = new ObservableCollection<Item>(
-                Enumerable.Range(1, 100000).Select(i => new Item
-                {
-                    Text = $"Item {i.ToString()}",
-                }));
+            Items = CreateItems();
         }
 
-        public ObservableCollection<Item> Items { get; }
+        public ObservableCollection<Item> Items
+        {
+            get => _items;
+            set => this.RaiseAndSetIfChanged(ref _items, value);
+        }
 
         public Item SelectedItem { get; set; }
 
         public void AddItem()
         {
             var index = SelectedItem != null ? Items.IndexOf(SelectedItem) : -1;
-            Items.Insert(index + 1, new Item { Text = $"New Item {newItemIndex++}" });
+            Items.Insert(index + 1, new Item { Text = $"New Item {_newItemIndex++}" });
         }
 
         public void RandomizeHeights()
@@ -36,6 +38,24 @@ namespace ControlCatalog.ViewModels
             {
                 i.Height = random.Next(240) + 10;
             }
+        }
+
+        public void ResetItems()
+        {
+            Items = CreateItems();
+        }
+
+        private ObservableCollection<Item> CreateItems()
+        {
+            var suffix = _newGenerationIndex == 0 ? string.Empty : $"[{_newGenerationIndex.ToString()}]";
+
+            _newGenerationIndex++;
+
+            return new ObservableCollection<Item>(
+                Enumerable.Range(1, 100000).Select(i => new Item
+                {
+                    Text = $"Item {i.ToString()} {suffix}"
+                }));
         }
 
         public class Item : ReactiveObject

--- a/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
+++ b/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
@@ -565,7 +565,17 @@ namespace Avalonia.Controls
                 if (Layout is VirtualizingLayout virtualLayout)
                 {
                     var args = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
-                    virtualLayout.OnItemsChanged(GetLayoutContext(), newValue, args);
+
+                    _processingItemsSourceChange = args;
+
+                    try
+                    {
+                        virtualLayout.OnItemsChanged(GetLayoutContext(), newValue, args);
+                    }
+                    finally
+                    {
+                        _processingItemsSourceChange = null;
+                    }
                 }
                 else if (Layout is NonVirtualizingLayout nonVirtualLayout)
                 {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Ports fix from upstream: https://github.com/microsoft/microsoft-ui-xaml/pull/1548

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Focused elements are not recycled properly when setting new items source. Described in more detail in https://github.com/microsoft/microsoft-ui-xaml/issues/1447.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Items source can be changed and focused items will be recycled properly.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Ported fix only, we have no unit tests ported so far. Need to port unit tests eventually so we can have proper coverage as well.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
