### PR TITLE
Optimize FontFamily and members hashcode/equality.

### DIFF
--- a/src/Avalonia.Visuals/Media/FontFamily.cs
+++ b/src/Avalonia.Visuals/Media/FontFamily.cs
@@ -184,36 +184,25 @@ namespace Avalonia.Media
         {
             unchecked
             {
-                var hash = (int)2186146271;
-
-                if (Key != null)
-                {
-                    hash = (hash * 15768619) ^ Key.GetHashCode();
-                }
-                else
-                {
-                    hash = (hash * 15768619) ^ FamilyNames.GetHashCode();
-                }
-
-                if (Key != null)
-                {
-                    hash = (hash * 15768619) ^ Key.GetHashCode();
-                }
-
-                return hash;
+                return ((FamilyNames != null ? FamilyNames.GetHashCode() : 0) * 397) ^ (Key != null ? Key.GetHashCode() : 0);
             }
         }
 
         public override bool Equals(object obj)
         {
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
             if (!(obj is FontFamily other))
             {
                 return false;
             }
 
-            if (Key != null)
+            if (Key != other.Key)
             {
-                return other.FamilyNames.Equals(FamilyNames) && other.Key.Equals(Key);
+                return false;
             }
 
             return other.FamilyNames.Equals(FamilyNames);

--- a/src/Avalonia.Visuals/Media/FontFamily.cs
+++ b/src/Avalonia.Visuals/Media/FontFamily.cs
@@ -200,7 +200,7 @@ namespace Avalonia.Media
                 return false;
             }
 
-            if (Key != other.Key)
+            if (!Equals(Key, other.Key))
             {
                 return false;
             }

--- a/src/Avalonia.Visuals/Media/Fonts/FamilyNameCollection.cs
+++ b/src/Avalonia.Visuals/Media/Fonts/FamilyNameCollection.cs
@@ -111,7 +111,24 @@ namespace Avalonia.Media.Fonts
         /// </returns>
         public override int GetHashCode()
         {
-            return ToString().GetHashCode();
+            if (Count == 0)
+            {
+                return 0;
+            }
+
+            unchecked
+            {
+                int hash = 17;
+
+                for (var i = 0; i < Names.Count; i++)
+                {
+                    string name = Names[i];
+
+                    hash = hash * 23 + name.GetHashCode();
+                }
+
+                return hash;
+            }
         }
 
         /// <summary>
@@ -128,7 +145,20 @@ namespace Avalonia.Media.Fonts
                 return false;
             }
 
-            return other.ToString().Equals(ToString());
+            if (other.Count != Count)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < Count; i++)
+            {
+                if (Names[i] != other.Names[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         public int Count => Names.Count;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
New typed property value storage started using more equality checks and I noticed that inherited font properties were showing up as fairly expensive. This tries to make equality and hashcode allocation free and improves performance by avoiding extra work.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Current implementation for `FamilyNameCollection` will convert both arguments to a printable string and then compare said strings. This leads to many allocations when comparing objects.

And I think `FontFamily` hashcode is a bit broken since it ignores `FamilyNames` when `Key` is set. `Equals` takes `FamilyNames` differences into account. Maybe @Gillibald can explain this since after looking at `GetHashCode` on `FontFamily` I got completely confused.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
No dynamic allocations when comparing `FontFamily` instances. Avoid expensive equality checks when possible.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation