### PR TITLE
Reduce calls to ToArray in LightweightObservableBase PublishNext

### DIFF
--- a/src/Avalonia.Base/Reactive/LightweightObservableBase.cs
+++ b/src/Avalonia.Base/Reactive/LightweightObservableBase.cs
@@ -111,7 +111,7 @@ namespace Avalonia.Reactive
 
         protected abstract void Initialize();
         protected abstract void Deinitialize();
-       
+
         protected void PublishNext(T value)
         {
             if (Volatile.Read(ref _observers) != null)

--- a/src/Avalonia.Base/Reactive/LightweightObservableBase.cs
+++ b/src/Avalonia.Base/Reactive/LightweightObservableBase.cs
@@ -111,25 +111,38 @@ namespace Avalonia.Reactive
 
         protected abstract void Initialize();
         protected abstract void Deinitialize();
-
+       
         protected void PublishNext(T value)
         {
             if (Volatile.Read(ref _observers) != null)
             {
-                IObserver<T>[] observers;
-
+                IObserver<T>[] observers = null;
+                IObserver<T> singleObserver = null;
                 lock (this)
                 {
                     if (_observers == null)
                     {
                         return;
                     }
-                    observers = _observers.ToArray();
+                    if (_observers.Count == 1)
+                    {
+                        singleObserver = _observers[0];
+                    }
+                    else
+                    {
+                        observers = _observers.ToArray();
+                    }
                 }
-
-                foreach (var observer in observers)
+                if (singleObserver != null)
                 {
-                    observer.OnNext(value);
+                    singleObserver.OnNext(value);
+                }
+                else
+                {
+                    foreach (var observer in observers)
+                    {
+                        observer.OnNext(value);
+                    }
                 }
             }
         }

--- a/tests/Avalonia.Benchmarks/Data/BindingsBenchmark.cs
+++ b/tests/Avalonia.Benchmarks/Data/BindingsBenchmark.cs
@@ -19,6 +19,22 @@ namespace Avalonia.Benchmarks.Data
             instance.Bind(TestClass.IntValueProperty, binding);
         }
 
+        [Benchmark]
+        public void UpdateTwoWayBinding_Via_Binding()
+        {
+            var instance = new TestClass();
+
+            var binding = new Binding(nameof(TestClass.BoundValue), BindingMode.TwoWay)
+            {
+                Source = instance
+            };
+
+            instance.Bind(TestClass.IntValueProperty, binding);
+            for (int i = 0; i < 60; i++)
+            {
+                instance.IntValue = i;
+            }
+        }
         private class TestClass : AvaloniaObject
         {
             public static readonly StyledProperty<int> IntValueProperty =


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
LightweightObservableBase PublishNext currently calls ToArray to make a protected set of observers but in the vast majority of cases there is only one observer.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
An array is allocated on every call

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
No allocation on the common case of just one observer

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
