### PR TITLE
Fix memory leak caused by styles staying applied after window close

### DIFF
--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -269,17 +269,11 @@ namespace Avalonia.Controls
         /// </summary>
         protected virtual void HandleClosed()
         {
-            {
-                var e = new LogicalTreeAttachmentEventArgs(this);
+            var logicalArgs = new LogicalTreeAttachmentEventArgs(this);
+            ((ILogical)this).NotifyDetachedFromLogicalTree(logicalArgs);
 
-                ((ILogical)this).NotifyDetachedFromLogicalTree(e);
-            }
-
-            {
-                var e = new VisualTreeAttachmentEventArgs(this, this);
-
-                OnDetachedFromVisualTreeCore(e);
-            }
+            var visualArgs = new VisualTreeAttachmentEventArgs(this, this);
+            OnDetachedFromVisualTreeCore(visualArgs);
 
             (this as IInputRoot).MouseDevice?.TopLevelClosed(this);
             PlatformImpl = null;

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -269,6 +269,18 @@ namespace Avalonia.Controls
         /// </summary>
         protected virtual void HandleClosed()
         {
+            {
+                var e = new LogicalTreeAttachmentEventArgs(this);
+
+                ((ILogical)this).NotifyDetachedFromLogicalTree(e);
+            }
+
+            {
+                var e = new VisualTreeAttachmentEventArgs(this, this);
+
+                OnDetachedFromVisualTreeCore(e);
+            }
+
             (this as IInputRoot).MouseDevice?.TopLevelClosed(this);
             PlatformImpl = null;
             OnClosed(EventArgs.Empty);


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
As reported in https://github.com/AvaloniaUI/Avalonia/issues/3269 when creating windows we leak memory when opening new windows.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When closing a window we don't detach its elements from visual and logical trees. This causes some elements to stay subscribed to random objects, but more importantly styles stay applied. Styles act as global GC root so nothing gets collected as long as we have active styles.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
No style leaks after closing window.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->
We are now calling `OnDetachedFromVisualTree` and `OnDetachedFromLogicalTree` on `TopLevel`s. We didn't do it previously. But generally root elements live in a weird state, since top level controls report being attached despite us never calling `OnAttachedToLogicalTree`.

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/3269
