### PR TITLE
Bump version to 0.9.999 for CI builds.

### DIFF
--- a/build/SharedVersion.props
+++ b/build/SharedVersion.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Avalonia</Product>
-    <Version>0.8.999</Version>
+    <Version>0.9.999</Version>
     <Copyright>Copyright 2019 &#169; The AvaloniaUI Project</Copyright>
     <PackageProjectUrl>https://avaloniaui.net</PackageProjectUrl>
     <RepositoryUrl>https://github.com/AvaloniaUI/Avalonia/</RepositoryUrl>


### PR DESCRIPTION
Now that 0.9 is (nearly) out, bump version on master.

Is this all we need to do? I'm a bit behind on how our build infrasrtucture works.