### PR TITLE
Fixes/osx catalina menu bug

### DIFF
--- a/native/Avalonia.Native/src/OSX/app.mm
+++ b/native/Avalonia.Native/src/OSX/app.mm
@@ -1,16 +1,25 @@
 #include "common.h"
 @interface AvnAppDelegate : NSObject<NSApplicationDelegate>
 @end
+
 extern NSApplicationActivationPolicy AvnDesiredActivationPolicy = NSApplicationActivationPolicyRegular;
 @implementation AvnAppDelegate
 - (void)applicationWillFinishLaunching:(NSNotification *)notification
 {
-    [[NSApplication sharedApplication] setActivationPolicy: AvnDesiredActivationPolicy];
+    if([[NSApplication sharedApplication] activationPolicy] != AvnDesiredActivationPolicy)
+    {
+        for (NSRunningApplication * app in [NSRunningApplication runningApplicationsWithBundleIdentifier:@"com.apple.dock"]) {
+            [app activateWithOptions:NSApplicationActivateIgnoringOtherApps];
+            break;
+        }
+        
+        [[NSApplication sharedApplication] setActivationPolicy: AvnDesiredActivationPolicy];
+    }
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
-    [NSApp activateIgnoringOtherApps:true];
+    [[NSRunningApplication currentApplication] activateWithOptions:NSApplicationActivateIgnoringOtherApps];
 }
 
 @end
@@ -20,5 +29,4 @@ extern void InitializeAvnApp()
     NSApplication* app = [NSApplication sharedApplication];
     id delegate = [AvnAppDelegate new];
     [app setDelegate:delegate];
-    
 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Currently Catalina breaks app menu, it cant be selected when app launches. We are not the only ones, apple have broken many other apps.

This is a workaround provided by apple themselves to fix a similar issue from a while back.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Cant select app menu after launch on Catalina.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Can select menu after launch.


