### PR TITLE
[OSX] Allow access to NSView and NSWindow via platofom handle.

### DIFF
--- a/native/Avalonia.Native/inc/avalonia-native.h
+++ b/native/Avalonia.Native/inc/avalonia-native.h
@@ -212,10 +212,10 @@ AVNCOM(IAvnWindowBase, 02) : IUnknown
     virtual HRESULT GetSoftwareFramebuffer(AvnFramebuffer*ret) = 0;
     virtual HRESULT SetMainMenu(IAvnAppMenu* menu) = 0;
     virtual HRESULT ObtainMainMenu(IAvnAppMenu** retOut) = 0;
-    virtual HRESULT GetNSWindowHandle(void** ret) = 0;
-    virtual HRESULT GetNSWindowHandleRetained(void** ret) = 0;
-    virtual HRESULT GetNSViewHandle(void** ret) = 0;
-    virtual HRESULT GetNSViewHandleRetained(void** ret) = 0;
+    virtual HRESULT GetNSWindowHandle(void** ppv) = 0;
+    virtual HRESULT GetNSWindowHandleRetained(void** ppv) = 0;
+    virtual HRESULT GetNSViewHandle(void** ppv) = 0;
+    virtual HRESULT GetNSViewHandleRetained(void** ppv) = 0;
     virtual bool TryLock() = 0;
     virtual void Unlock() = 0;
 };

--- a/native/Avalonia.Native/inc/avalonia-native.h
+++ b/native/Avalonia.Native/inc/avalonia-native.h
@@ -212,6 +212,10 @@ AVNCOM(IAvnWindowBase, 02) : IUnknown
     virtual HRESULT GetSoftwareFramebuffer(AvnFramebuffer*ret) = 0;
     virtual HRESULT SetMainMenu(IAvnAppMenu* menu) = 0;
     virtual HRESULT ObtainMainMenu(IAvnAppMenu** retOut) = 0;
+    virtual HRESULT GetNSWindowHandle(void** ret) = 0;
+    virtual HRESULT GetNSWindowHandleRetained(void** ret) = 0;
+    virtual HRESULT GetNSViewHandle(void** ret) = 0;
+    virtual HRESULT GetNSViewHandleRetained(void** ret) = 0;
     virtual bool TryLock() = 0;
     virtual void Unlock() = 0;
 };

--- a/native/Avalonia.Native/inc/avalonia-native.h
+++ b/native/Avalonia.Native/inc/avalonia-native.h
@@ -212,10 +212,10 @@ AVNCOM(IAvnWindowBase, 02) : IUnknown
     virtual HRESULT GetSoftwareFramebuffer(AvnFramebuffer*ret) = 0;
     virtual HRESULT SetMainMenu(IAvnAppMenu* menu) = 0;
     virtual HRESULT ObtainMainMenu(IAvnAppMenu** retOut) = 0;
-    virtual HRESULT GetNSWindowHandle(void** ppv) = 0;
-    virtual HRESULT GetNSWindowHandleRetained(void** retOut) = 0;
-    virtual HRESULT GetNSViewHandle(void** retOut) = 0;
-    virtual HRESULT GetNSViewHandleRetained(void** retOut) = 0;
+    virtual HRESULT ObtainNSWindowHandle(void** retOut) = 0;
+    virtual HRESULT ObtainNSWindowHandleRetained(void** retOut) = 0;
+    virtual HRESULT ObtainNSViewHandle(void** retOut) = 0;
+    virtual HRESULT ObtainNSViewHandleRetained(void** retOut) = 0;
     virtual bool TryLock() = 0;
     virtual void Unlock() = 0;
 };

--- a/native/Avalonia.Native/inc/avalonia-native.h
+++ b/native/Avalonia.Native/inc/avalonia-native.h
@@ -213,9 +213,9 @@ AVNCOM(IAvnWindowBase, 02) : IUnknown
     virtual HRESULT SetMainMenu(IAvnAppMenu* menu) = 0;
     virtual HRESULT ObtainMainMenu(IAvnAppMenu** retOut) = 0;
     virtual HRESULT GetNSWindowHandle(void** ppv) = 0;
-    virtual HRESULT GetNSWindowHandleRetained(void** ppv) = 0;
-    virtual HRESULT GetNSViewHandle(void** ppv) = 0;
-    virtual HRESULT GetNSViewHandleRetained(void** ppv) = 0;
+    virtual HRESULT GetNSWindowHandleRetained(void** retOut) = 0;
+    virtual HRESULT GetNSViewHandle(void** retOut) = 0;
+    virtual HRESULT GetNSViewHandleRetained(void** retOut) = 0;
     virtual bool TryLock() = 0;
     virtual void Unlock() = 0;
 };

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -83,7 +83,7 @@ public:
         [Window setContentView: View];
     }
     
-    virtual HRESULT GetNSWindowHandle(void** ret) override
+    virtual HRESULT ObtainNSWindowHandle(void** ret) override
     {
         if (ret == nullptr)
         {
@@ -95,7 +95,7 @@ public:
         return S_OK;
     }
     
-    virtual HRESULT GetNSWindowHandleRetained(void** ret) override
+    virtual HRESULT ObtainNSWindowHandleRetained(void** ret) override
     {
         if (ret == nullptr)
         {
@@ -107,7 +107,7 @@ public:
         return S_OK;
     }
     
-    virtual HRESULT GetNSViewHandle(void** ret) override
+    virtual HRESULT ObtainNSViewHandle(void** ret) override
     {
         if (ret == nullptr)
         {
@@ -119,7 +119,7 @@ public:
         return S_OK;
     }
     
-    virtual HRESULT GetNSViewHandleRetained(void** ret) override
+    virtual HRESULT ObtainNSViewHandleRetained(void** ret) override
     {
         if (ret == nullptr)
         {

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -83,6 +83,54 @@ public:
         [Window setContentView: View];
     }
     
+    virtual HRESULT GetNSWindowHandle(void** ret) override
+    {
+        if (ret == nullptr)
+        {
+            return E_POINTER;
+        }
+        
+        *ret =  (__bridge void*)Window;
+        
+        return S_OK;
+    }
+    
+    virtual HRESULT GetNSWindowHandleRetained(void** ret) override
+    {
+        if (ret == nullptr)
+        {
+            return E_POINTER;
+        }
+        
+        *ret =  (__bridge_retained void*)Window;
+        
+        return S_OK;
+    }
+    
+    virtual HRESULT GetNSViewHandle(void** ret) override
+    {
+        if (ret == nullptr)
+        {
+            return E_POINTER;
+        }
+        
+        *ret =  (__bridge void*)View;
+        
+        return S_OK;
+    }
+    
+    virtual HRESULT GetNSViewHandleRetained(void** ret) override
+    {
+        if (ret == nullptr)
+        {
+            return E_POINTER;
+        }
+        
+        *ret =  (__bridge_retained void*)View;
+        
+        return S_OK;
+    }
+    
     virtual AvnWindow* GetNSWindow() override
     {
         return Window;

--- a/src/Avalonia.Base/Platform/IMacOSTopLevelPlatformHandle.cs
+++ b/src/Avalonia.Base/Platform/IMacOSTopLevelPlatformHandle.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using System;
+
+namespace Avalonia.Platform
+{
+    public interface IMacOSTopLevelPlatformHandle
+    {
+        IntPtr NSView { get; }
+        IntPtr GetNSViewRetained();
+        IntPtr NSWindow { get; }
+        IntPtr GetNSWindowRetained();
+    }
+}

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -25,9 +25,9 @@ namespace Avalonia.Native
             _native = native;
         }
 
-        public IntPtr Handle => IntPtr.Zero;
+        public IntPtr Handle => NSWindow;
 
-        public string HandleDescriptor => "NOT SUPPORTED";
+        public string HandleDescriptor => "NSWindow";
 
         public IntPtr NSView => _native.ObtainNSViewHandle();
 

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -16,6 +16,34 @@ using Avalonia.Threading;
 
 namespace Avalonia.Native
 {
+    public class MacOSTopLevelWindowHandle : IPlatformHandle, IMacOSTopLevelPlatformHandle
+    {
+        IAvnWindowBase _native;
+
+        public MacOSTopLevelWindowHandle(IAvnWindowBase native)
+        {
+            _native = native;
+        }
+
+        public IntPtr Handle => IntPtr.Zero;
+
+        public string HandleDescriptor => "NOT SUPPORTED";
+
+        public IntPtr NSView => throw new NotImplementedException();
+
+        public IntPtr NSWindow => throw new NotImplementedException();
+
+        public IntPtr GetNSViewRetained()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IntPtr GetNSWindowRetained()
+        {
+            throw new NotImplementedException();
+        }
+    }
+
     public abstract class WindowBaseImpl : IWindowBaseImpl,
         IFramebufferPlatformSurface
     {
@@ -45,6 +73,9 @@ namespace Avalonia.Native
         protected void Init(IAvnWindowBase window, IAvnScreens screens)
         {
             _native = window;
+
+            Handle = new MacOSTopLevelWindowHandle(window);
+            
             _glSurface = new GlPlatformSurface(window);
             Screen = new ScreenImpl(screens);
             _savedLogicalSize = ClientSize;
@@ -349,6 +380,6 @@ namespace Avalonia.Native
 
         }
 
-        public IPlatformHandle Handle => new PlatformHandle(IntPtr.Zero, "NOT SUPPORTED");
+        public IPlatformHandle Handle { get; private set; }
     }
 }

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -29,18 +29,18 @@ namespace Avalonia.Native
 
         public string HandleDescriptor => "NOT SUPPORTED";
 
-        public IntPtr NSView => throw new NotImplementedException();
+        public IntPtr NSView => _native.ObtainNSViewHandle();
 
-        public IntPtr NSWindow => throw new NotImplementedException();
+        public IntPtr NSWindow => _native.ObtainNSWindowHandle();
 
         public IntPtr GetNSViewRetained()
         {
-            throw new NotImplementedException();
+            return _native.ObtainNSViewHandleRetained();
         }
 
         public IntPtr GetNSWindowRetained()
         {
-            throw new NotImplementedException();
+            return _native.ObtainNSWindowHandleRetained();
         }
     }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Implements PlatformImpl.Handle on OSX in a suitable way.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
No handle is available.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Returns an IMacOSTopLevelPlatformHandle instance, which allows you to get pointers to the NSWindow and NSView in safe way.

Fixes #3281 
