### PR TITLE
fix font fallback back to normal

### DIFF
--- a/src/Windows/Avalonia.Direct2D1/Media/Direct2D1FontCollectionCache.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Direct2D1FontCollectionCache.cs
@@ -22,6 +22,11 @@ namespace Avalonia.Direct2D1.Media
 
         public static Font GetFont(Typeface typeface)
         {
+            return GetFont(typeface, out string _);
+        }
+
+        public static Font GetFont(Typeface typeface, out string fontFamilyName)
+        {
             var fontFamily = typeface.FontFamily;
             var fontCollection = GetOrAddFontCollection(fontFamily);
 
@@ -29,6 +34,7 @@ namespace Avalonia.Direct2D1.Media
             {
                 if (fontCollection.FindFamilyName(familyName, out var index))
                 {
+                    fontFamilyName = familyName;
                     return fontCollection.GetFontFamily(index).GetFirstMatchingFont(
                         (FontWeight)typeface.Weight,
                         FontStretch.Normal,
@@ -37,6 +43,8 @@ namespace Avalonia.Direct2D1.Media
             }
 
             InstalledFontCollection.FindFamilyName(FontFamily.Default.Name, out var i);
+
+            fontFamilyName = FontFamily.Default.Name;
 
             return InstalledFontCollection.GetFontFamily(i).GetFirstMatchingFont(
                 (FontWeight)typeface.Weight,

--- a/src/Windows/Avalonia.Direct2D1/Media/FormattedTextImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/FormattedTextImpl.cs
@@ -22,9 +22,9 @@ namespace Avalonia.Direct2D1.Media
         {
             Text = text;
 
-            using (var font = Direct2D1FontCollectionCache.GetFont(typeface))
+            using (var font = Direct2D1FontCollectionCache.GetFont(typeface, out string fontFamilyName))
             using (var textFormat = new DWrite.TextFormat(Direct2D1Platform.DirectWriteFactory,
-                typeface.FontFamily.Name, font.FontFamily.FontCollection, (DWrite.FontWeight)typeface.Weight,
+                fontFamilyName, font.FontFamily.FontCollection, (DWrite.FontWeight)typeface.Weight,
                 (DWrite.FontStyle)typeface.Style, DWrite.FontStretch.Normal, (float)fontSize))
             {
                 textFormat.WordWrapping =


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes font fallback to find first matching font in FonFamily and only if not exist fallbacks to system default font

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Font fallbacks to system default font after first attempt to try find matching font in FontFamily.FontNames

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

fixes the problem
## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
fixes #3308 

@Gillibald 
