### PR TITLE
Fix OleDropTarget not being unregistered

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1098,7 +1098,10 @@ namespace Avalonia.Win32.Interop
         
         [DllImport("ole32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
         public static extern HRESULT RegisterDragDrop(IntPtr hwnd, IDropTarget target);
-        
+
+        [DllImport("ole32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
+        public static extern HRESULT RevokeDragDrop(IntPtr hwnd);
+
         [DllImport("ole32.dll", EntryPoint = "OleInitialize")]
         public static extern HRESULT OleInitialize(IntPtr val);
 

--- a/src/Windows/Avalonia.Win32/OleContext.cs
+++ b/src/Windows/Avalonia.Win32/OleContext.cs
@@ -7,9 +7,9 @@ using Avalonia.Win32.Interop;
 
 namespace Avalonia.Win32
 {
-    class OleContext
+    internal class OleContext
     {
-        private static OleContext fCurrent;
+        private static OleContext s_current;
 
         internal static OleContext Current
         {
@@ -18,12 +18,11 @@ namespace Avalonia.Win32
                 if (!IsValidOleThread())
                     return null;
 
-                if (fCurrent == null)
-                    fCurrent = new OleContext();
-                return fCurrent;
+                if (s_current == null)
+                    s_current = new OleContext();
+                return s_current;
             }
         }
-
 
         private OleContext()
         {
@@ -43,9 +42,21 @@ namespace Avalonia.Win32
         internal bool RegisterDragDrop(IPlatformHandle hwnd, IDropTarget target)
         {
             if (hwnd?.HandleDescriptor != "HWND" || target == null)
+            {
                 return false;
+            }
 
             return UnmanagedMethods.RegisterDragDrop(hwnd.Handle, target) == UnmanagedMethods.HRESULT.S_OK;
+        }
+
+        internal bool UnregisterDragDrop(IPlatformHandle hwnd)
+        {
+            if (hwnd?.HandleDescriptor != "HWND")
+            {
+                return false;
+            }
+
+            return UnmanagedMethods.RevokeDragDrop(hwnd.Handle) == UnmanagedMethods.HRESULT.S_OK;
         }
     }
 }

--- a/src/Windows/Avalonia.Win32/OleDropTarget.cs
+++ b/src/Windows/Avalonia.Win32/OleDropTarget.cs
@@ -6,7 +6,7 @@ using IDataObject = Avalonia.Input.IDataObject;
 
 namespace Avalonia.Win32
 {
-    class OleDropTarget : IDropTarget
+    internal class OleDropTarget : IDropTarget
     {
         private readonly IInputRoot _target;
         private readonly ITopLevelImpl _tl;

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -253,6 +253,11 @@ namespace Avalonia.Win32
 
         public void Dispose()
         {
+            if (_dropTarget != null)
+            {
+                OleContext.Current?.UnregisterDragDrop(Handle);
+                _dropTarget = null;
+            }
             if (_hwnd != IntPtr.Zero)
             {
                 UnmanagedMethods.DestroyWindow(_hwnd);


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Part of the fix for window memory leaks. This tackles another static GC root that we have. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Currently Win32 window will register `OleDropTarget` with the window and never unregisters it. And since drop target is a COM object it stays alive and keeps associated window alive as well.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
`OleDropTarget` instances are properly unregistered and get collected by GC after window has been closed.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
Partial fix for https://github.com/AvaloniaUI/Avalonia/issues/3269