### PR TITLE
[X11] Properly set property type for TARGETS clipboard response

### DIFF
--- a/src/Avalonia.X11/X11Clipboard.cs
+++ b/src/Avalonia.X11/X11Clipboard.cs
@@ -79,7 +79,7 @@ namespace Avalonia.X11
                     atoms = atoms.Concat(new[] {_x11.Atoms.TARGETS, _x11.Atoms.MULTIPLE})
                         .ToArray();
                     XChangeProperty(_x11.Display, window, property,
-                        target, 32, PropertyMode.Replace, atoms, atoms.Length);
+                        _x11.Atoms.XA_ATOM, 32, PropertyMode.Replace, atoms, atoms.Length);
                     return property;
                 }
                 else if(target == _x11.Atoms.SAVE_TARGETS && _x11.Atoms.SAVE_TARGETS != IntPtr.Zero)


### PR DESCRIPTION
An attempt to fix the issue described in https://github.com/zkSNACKs/WalletWasabi/issues/2026

`xclip -o -selection clipboard -t TARGETS` now returns:
```
STRING
UTF8_STRING
UTF16_STRING
TARGETS
MULTIPLE
```