### PR TITLE
Use CondtionalWeakTable to avoid FocusManager becoming a GC root

### DIFF
--- a/src/Avalonia.Input/FocusManager.cs
+++ b/src/Avalonia.Input/FocusManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 
@@ -17,8 +18,8 @@ namespace Avalonia.Input
         /// <summary>
         /// The focus scopes in which the focus is currently defined.
         /// </summary>
-        private readonly Dictionary<IFocusScope, IInputElement> _focusScopes =
-            new Dictionary<IFocusScope, IInputElement>();
+        private readonly ConditionalWeakTable<IFocusScope, IInputElement> _focusScopes =
+            new ConditionalWeakTable<IFocusScope, IInputElement>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FocusManager"/> class.
@@ -110,7 +111,18 @@ namespace Avalonia.Input
         {
             Contract.Requires<ArgumentNullException>(scope != null);
 
-            _focusScopes[scope] = element;
+            if (_focusScopes.TryGetValue(scope, out IInputElement existingElement))
+            {
+                if (element != existingElement)
+                {
+                    _focusScopes.Remove(scope);
+                    _focusScopes.Add(scope, element);
+                }
+            }
+            else
+            {
+                _focusScopes.Add(scope, element);
+            }
 
             if (Scope == scope)
             {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Another fix for memory leaks caused by `Window` instances staying alive after being closed. This time `FocusManager` is adjusted to only use weak references so it won't keep closed windows alive.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`FocusManager` keeps all opened `Window` instances alive.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
After closing a `Window` and removing user references it should be garbage collected.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Pretty much drop in replacement of `Dictionary` with `ConditionalWeakTable`. `ConditionalWeakTable` has no replace functionality so I had to first check if key already exists and if yes - remove and add again with new value.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
Potential fix for #3269, needs to be checked more thoroughly since we might still have more GC roots depending on usage.
