### PR TITLE
[OSX] null check to prevent NRE when window closes.

### DIFF
--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -353,6 +353,11 @@ namespace Avalonia.Native
 
         public void SetCursor(IPlatformHandle cursor)
         {
+            if (_native == null)
+            {
+                return;
+            }
+            
             var newCursor = cursor as AvaloniaNativeCursor;
             newCursor = newCursor ?? (_cursorFactory.GetCursor(StandardCursorType.Arrow) as AvaloniaNativeCursor);
             _native.Cursor = newCursor.Cursor;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
When managed file dialog was closing, a swallowed NRE meant closed event wasnt fired and dialog would leave user stuck at await.

This would have been much more obvious if https://github.com/SharpGenTools/SharpGenTools/issues/91

was resolved.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
null check so we dont throw an exception and leave user waiting forever.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
