### PR TITLE
Exclude snap directories in Managed Dialogs volume enumeration

### DIFF
--- a/src/Avalonia.FreeDesktop/LinuxMountedVolumeInfoListener.cs
+++ b/src/Avalonia.FreeDesktop/LinuxMountedVolumeInfoListener.cs
@@ -47,7 +47,8 @@ namespace Avalonia.FreeDesktop
 
             var fProcMounts = File.ReadAllLines(ProcMountsDir)
                                   .Select(x => x.Split(' '))
-                                  .Select(x => (x[0], x[1]));
+                                  .Select(x => (x[0], x[1]))
+                                  .Where(x => !x.Item2.StartsWith("/snap/", StringComparison.InvariantCultureIgnoreCase));
 
             var labelDirEnum = Directory.Exists(DevByLabelDir) ?
                                new DirectoryInfo(DevByLabelDir).GetFiles() : Enumerable.Empty<FileInfo>();


### PR DESCRIPTION
Fixes the issue on some linux distros that uses snap app package/virtualization where the managed dialogs are showing the tiny volume mounts that snap allocates for each package.