### PR TITLE
Fix loading EGL functions on GLX.

### DIFF
--- a/src/Avalonia.X11/Glx/Glx.cs
+++ b/src/Avalonia.X11/Glx/Glx.cs
@@ -84,8 +84,24 @@ namespace Avalonia.X11.Glx
         [GlEntryPoint("glGetError")]
         public GlGetError GetError { get; }
 
-        public GlxInterface() : base(GlxGetProcAddress)
+        public GlxInterface() : base(SafeGetProcAddress)
         {
         }
+
+        // Ignores egl functions.
+        // On some Linux systems, glXGetProcAddress will return valid pointers for even EGL functions.
+        // This makes Skia try to load some data from EGL,
+        // which can then cause segmentation faults because they return garbage.
+        public static IntPtr SafeGetProcAddress(string proc, bool optional)
+        {
+            if (proc.StartsWith("egl"))
+            {
+                return IntPtr.Zero;
+            }
+
+            return GlxConverted(proc, optional);
+        }
+
+        private static readonly Func<string, bool, IntPtr> GlxConverted = ConvertNative(GlxGetProcAddress);
     }
 }

--- a/src/Avalonia.X11/Glx/Glx.cs
+++ b/src/Avalonia.X11/Glx/Glx.cs
@@ -94,7 +94,7 @@ namespace Avalonia.X11.Glx
         // which can then cause segmentation faults because they return garbage.
         public static IntPtr SafeGetProcAddress(string proc, bool optional)
         {
-            if (proc.StartsWith("egl"))
+            if (proc.StartsWith("egl", StringComparison.InvariantCulture))
             {
                 return IntPtr.Zero;
             }

--- a/src/Avalonia.X11/Glx/GlxDisplay.cs
+++ b/src/Avalonia.X11/Glx/GlxDisplay.cs
@@ -87,7 +87,7 @@ namespace Avalonia.X11.Glx
             ImmediateContext.MakeCurrent();
             var err = Glx.GetError();
             
-            GlInterface = new GlInterface(GlxInterface.GlxGetProcAddress);
+            GlInterface = new GlInterface(GlxInterface.SafeGetProcAddress);
             if (GlInterface.Version == null)
                 throw new OpenGlException("GL version string is null, aborting");
             if (GlInterface.Renderer == null)


### PR DESCRIPTION
## What does the pull request do?
This fixes apps refusing to run on Arch Linux. 

## What is the current behavior?
`glXGetProcAddress` always returns *something* for functions, even if they aren't available. Skia sees `!= null` as "is available" and ends up trying to call `eglQueryString` even if EGL is not available. It then promptly crashes.

## What is the updated/expected behavior with this PR?
When using GLX, trying to get a proc address for an `egl` function will always return `IntPtr.Zero`, so Skia doesn't try to call EGL functions.

## Checklist

- [ ] Added unit tests (if possible)? Think so?
- [ ] Added XML documentation to any related classes? Is this decent enough?
