### PR TITLE
Snapshot TextBox undo text after paste.

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -390,8 +390,10 @@ namespace Avalonia.Controls
             {
                 return;
             }
+
             _undoRedoHelper.Snapshot();
             HandleTextInput(text);
+            _undoRedoHelper.Snapshot();
         }
 
         protected override void OnKeyDown(KeyEventArgs e)


### PR DESCRIPTION
## What does the pull request do?

#2732 describes a problem where quickly pasting and undoing causes an undo to undo the wrong thing. The issue suggests that this is caused by holding down the ctrl key but I found no evidence of this: it seems that the problem is caused simply when pasting and then undoing quickly.

Problem seems to be that that the undo text is added on a timer, and so the text added by paste doesn't get registered with the undo stack until the timer fires. Manually snapshotting the text after a paste seems to fix the problem.

Fixes #2732
