### PR TITLE
Failing unit tests for SelectingItemsControl events

### DIFF
--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -524,7 +524,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
             SelectionChangedEventArgs receivedArgs = null;
 
-            target.SelectionChanged += (_, args) => receivedArgs = null;
+            target.SelectionChanged += (_, args) => receivedArgs = args;
 
             var removed = items[1];
 

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -522,10 +522,19 @@ namespace Avalonia.Controls.UnitTests.Primitives
             Assert.Equal(items[1], target.SelectedItem);
             Assert.Equal(1, target.SelectedIndex);
 
+            SelectionChangedEventArgs receivedArgs = null;
+
+            target.SelectionChanged += (_, args) => receivedArgs = null;
+
+            var removed = items[1];
+
             items.RemoveAt(1);
 
             Assert.Null(target.SelectedItem);
             Assert.Equal(-1, target.SelectedIndex);
+            Assert.NotNull(receivedArgs);
+            Assert.Empty(receivedArgs.AddedItems);
+            Assert.Equal(new[] { removed }, receivedArgs.RemovedItems);
         }
 
         [Fact]

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_Multiple.cs
@@ -698,7 +698,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
             SelectionChangedEventArgs receivedArgs = null;
 
-            target.SelectionChanged += (_, args) => receivedArgs = null;
+            target.SelectionChanged += (_, args) => receivedArgs = args;
 
             void VerifyAdded(string selection)
             {
@@ -863,7 +863,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
             SelectionChangedEventArgs receivedArgs = null;
 
-            target.SelectionChanged += (_, args) => receivedArgs = null;
+            target.SelectionChanged += (_, args) => receivedArgs = args;
 
             void VerifyAdded(params string[] selection)
             {
@@ -957,7 +957,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
             SelectionChangedEventArgs receivedArgs = null;
 
-            target.SelectionChanged += (_, e) => receivedArgs = e;
+            target.SelectionChanged += (_, args) => receivedArgs = args;
 
             target.SelectAll();
 

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_Multiple.cs
@@ -684,6 +684,57 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
+        public void Ctrl_Selecting_Raises_SelectionChanged_Events()
+        {
+            var target = new ListBox
+            {
+                Template = Template(),
+                Items = new[] { "Foo", "Bar", "Baz", "Qux" },
+                SelectionMode = SelectionMode.Multiple,
+            };
+
+            target.ApplyTemplate();
+            target.Presenter.ApplyTemplate();
+
+            SelectionChangedEventArgs receivedArgs = null;
+
+            target.SelectionChanged += (_, args) => receivedArgs = null;
+
+            void VerifyAdded(string selection)
+            {
+                Assert.NotNull(receivedArgs);
+                Assert.Equal(new[] { selection }, receivedArgs.AddedItems);
+                Assert.Empty(receivedArgs.RemovedItems);
+            }
+
+            void VerifyRemoved(string selection)
+            {
+                Assert.NotNull(receivedArgs);
+                Assert.Equal(new[] { selection }, receivedArgs.RemovedItems);
+                Assert.Empty(receivedArgs.AddedItems);
+            }
+
+            _helper.Click((Interactive)target.Presenter.Panel.Children[1]);
+
+            VerifyAdded("Bar");
+
+            receivedArgs = null;
+            _helper.Click((Interactive)target.Presenter.Panel.Children[2], modifiers: InputModifiers.Control);
+
+            VerifyAdded("Baz");
+
+            receivedArgs = null;
+            _helper.Click((Interactive)target.Presenter.Panel.Children[3], modifiers: InputModifiers.Control);
+
+            VerifyAdded("Qux");
+
+            receivedArgs = null;
+            _helper.Click((Interactive)target.Presenter.Panel.Children[1], modifiers: InputModifiers.Control);
+
+            VerifyRemoved("Bar");
+        }
+
+        [Fact]
         public void Ctrl_Selecting_SelectedItem_With_Multiple_Selection_Active_Sets_SelectedItem_To_Next_Selection()
         {
             var target = new ListBox
@@ -798,6 +849,52 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
+        public void Shift_Selecting_Raises_SelectionChanged_Events()
+        {
+            var target = new ListBox
+            {
+                Template = Template(),
+                Items = new[] { "Foo", "Bar", "Baz", "Qux" },
+                SelectionMode = SelectionMode.Multiple,
+            };
+
+            target.ApplyTemplate();
+            target.Presenter.ApplyTemplate();
+
+            SelectionChangedEventArgs receivedArgs = null;
+
+            target.SelectionChanged += (_, args) => receivedArgs = null;
+
+            void VerifyAdded(params string[] selection)
+            {
+                Assert.NotNull(receivedArgs);
+                Assert.Equal(selection, receivedArgs.AddedItems);
+                Assert.Empty(receivedArgs.RemovedItems);
+            }
+
+            void VerifyRemoved(string selection)
+            {
+                Assert.NotNull(receivedArgs);
+                Assert.Equal(new[] { selection }, receivedArgs.RemovedItems);
+                Assert.Empty(receivedArgs.AddedItems);
+            }
+
+            _helper.Click((Interactive)target.Presenter.Panel.Children[1]);
+
+            VerifyAdded("Bar");
+
+            receivedArgs = null;
+            _helper.Click((Interactive)target.Presenter.Panel.Children[3], modifiers: InputModifiers.Shift);
+
+            VerifyAdded("Baz" ,"Qux");
+
+            receivedArgs = null;
+            _helper.Click((Interactive)target.Presenter.Panel.Children[2], modifiers: InputModifiers.Shift);
+
+            VerifyRemoved("Qux");
+        }
+
+        [Fact]
         public void Duplicate_Items_Are_Added_To_SelectedItems_In_Order()
         {
             var target = new ListBox
@@ -843,6 +940,30 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
             Assert.Equal(0, target.SelectedIndex);
             Assert.Equal("Foo", target.SelectedItem);
+        }
+
+        [Fact]
+        public void SelectAll_Raises_SelectionChanged_Event()
+        {
+            var target = new TestSelector
+            {
+                Template = Template(),
+                Items = new[] { "Foo", "Bar", "Baz" },
+                SelectionMode = SelectionMode.Multiple,
+            };
+
+            target.ApplyTemplate();
+            target.Presenter.ApplyTemplate();
+
+            SelectionChangedEventArgs receivedArgs = null;
+
+            target.SelectionChanged += (_, e) => receivedArgs = e;
+
+            target.SelectAll();
+
+            Assert.NotNull(receivedArgs);
+            Assert.Equal(target.Items, receivedArgs.AddedItems);
+            Assert.Empty(receivedArgs.RemovedItems);
         }
 
         [Fact]


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This is more of a investigation and not a typical PR.

When investigating a few UI freezes in my project at work I've discovered that `ListBox.SelectedItems` is quite problematic since it spams with single item change events causing a flurry of side effects. For example we have one list that contains 10k elements and when pressing `Ctrl+A` collection bound to `SelectedItems` will raise 10k `CollectionChanged` events. WPF is struggling with the same issue due to https://github.com/dotnet/corefx/issues/10752.

So both in Avalonia and WPF `SelectedItems` serves as merely a convenience helper for pure MVVM user and shouldn't be used for anything bigger since it lacks any control over grouping of sent/received events. One could buffer said events, but it introduces another level of complexity and potential bugs.

`SelectionChanged` event on `ListBox` can be used to achieve better results by writing a bit of code behind code since this one is supposed to batch changes (and it does so in WPF). This leads us to Avalonia which has `SelectionChanged` event which is only fired for a few operations (like selecting a single item) and nothing is raised for multiple selection scenarios or even removing items. And I think even after getting these events to raise at all, in current state we would also raise too many events.

I reckon `TreeView` has the same issue since it has similar implementation to `SelectableItemsControl`.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`SelectingItemsControl.SelectionChange` is not raised when changing selection.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
`SelectingItemsControl.SelectionChange` is raised for all operations that would change selection and it raises meaningful events (batched as a whole operation and not sending an event for each add/remove).

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user 