### PR TITLE
Simple implementation of IScrollAnchorProvider.

### DIFF
--- a/src/Avalonia.Controls/IScrollAnchorProvider.cs
+++ b/src/Avalonia.Controls/IScrollAnchorProvider.cs
@@ -1,9 +1,29 @@
 ﻿namespace Avalonia.Controls
 {
+    /// <summary>
+    /// Specifies a contract for a scrolling control that supports scroll anchoring.
+    /// </summary>
     public interface IScrollAnchorProvider
     {
+        /// <summary>
+        /// The currently chosen anchor element to use for scroll anchoring.
+        /// </summary>
         IControl CurrentAnchor { get; }
+
+        /// <summary>
+        /// Registers a control as a potential scroll anchor candidate.
+        /// </summary>
+        /// <param name="element">
+        /// A control within the subtree of the <see cref="IScrollAnchorProvider"/>.
+        /// </param>
         void RegisterAnchorCandidate(IControl element);
+
+        /// <summary>
+        /// Unregisters a control as a potential scroll anchor candidate.
+        /// </summary>
+        /// <param name="element">
+        /// A control within the subtree of the <see cref="IScrollAnchorProvider"/>.
+        /// </param>
         void UnregisterAnchorCandidate(IControl element);
     }
 }

--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -136,7 +136,7 @@ namespace Avalonia.Controls.Presenters
         }
 
         /// <inheritdoc/>
-        IControl IScrollAnchorProvider.CurrentAnchor => _anchor.Item1;
+        IControl IScrollAnchorProvider.CurrentAnchor => _anchor.control;
 
         /// <summary>
         /// Attempts to bring a portion of the target visual into view by scrolling the content.

--- a/src/Avalonia.Controls/Repeater/ViewportManager.cs
+++ b/src/Avalonia.Controls/Repeater/ViewportManager.cs
@@ -236,14 +236,12 @@ namespace Avalonia.Controls
 
         public void OnElementPrepared(IControl element)
         {
-            // If we have an anchor element, we do not want the
-            // scroll anchor provider to start anchoring some other element.
-            ////element.CanBeScrollAnchor(true);
+            _scroller.RegisterAnchorCandidate(element);
         }
 
-        public void OnElementCleared(ILayoutable element)
+        public void OnElementCleared(IControl element)
         {
-            ////element.CanBeScrollAnchor(false);
+            _scroller.UnregisterAnchorCandidate(element);
         }
 
         public void OnOwnerMeasuring()

--- a/src/Avalonia.Controls/ScrollViewer.cs
+++ b/src/Avalonia.Controls/ScrollViewer.cs
@@ -318,6 +318,9 @@ namespace Avalonia.Controls
             get { return VerticalScrollBarVisibility != ScrollBarVisibility.Disabled; }
         }
 
+        /// <inheritdoc/>
+        public IControl CurrentAnchor => (Presenter as IScrollAnchorProvider)?.CurrentAnchor;
+
         /// <summary>
         /// Gets the maximum horizontal scrollbar value.
         /// </summary>
@@ -384,9 +387,6 @@ namespace Avalonia.Controls
             get { return _viewport.Height; }
         }
 
-        /// <inheritdoc/>
-        IControl IScrollAnchorProvider.CurrentAnchor => null; // TODO: Implement
-
         /// <summary>
         /// Scrolls to the top-left corner of the content.
         /// </summary>
@@ -443,14 +443,16 @@ namespace Avalonia.Controls
             control.SetValue(VerticalScrollBarVisibilityProperty, value);
         }
 
-        void IScrollAnchorProvider.RegisterAnchorCandidate(IControl element)
+        /// <inheritdoc/>
+        public void RegisterAnchorCandidate(IControl element)
         {
-            // TODO: Implement
+            (Presenter as IScrollAnchorProvider)?.RegisterAnchorCandidate(element);
         }
 
-        void IScrollAnchorProvider.UnregisterAnchorCandidate(IControl element)
+        /// <inheritdoc/>
+        public void UnregisterAnchorCandidate(IControl element)
         {
-            // TODO: Implement
+            (Presenter as IScrollAnchorProvider)?.UnregisterAnchorCandidate(element);
         }
 
         protected override bool RegisterContentPresenter(IContentPresenter presenter)

--- a/src/Avalonia.Layout/LayoutQueue.cs
+++ b/src/Avalonia.Layout/LayoutQueue.cs
@@ -77,7 +77,7 @@ namespace Avalonia.Layout
             {
                 if (_shouldEnqueue(item.Key))
                 {
-                    _loopQueueInfo[item.Key] = new Info() { Active = true, Count = item.Value.Count + 1 };
+                    _loopQueueInfo[item.Key] = new Info() { Active = true, Count = 0 };
                     _inner.Enqueue(item.Key);
                 }
             }


### PR DESCRIPTION
**Note: this PR targets #4040, retarget to master before merging**

## What does the pull request do?

A minimal implementation of [scroll anchoring](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.iscrollanchorprovider) which is intended to improve scrolling in the `ItemsPresenter` with items of differing heights/widths.

This functionality is defined in UWP but this PR doesn't attempt to implement all of UWP's features here, in particular:

- No equivalent of [`UIElement.CanBeScrollAnchor`](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.uielement.canbescrollanchor#Windows_UI_Xaml_UIElement_CanBeScrollAnchor): my thoughts here are that this functionality is too niche to deserve a property being added to every control
- No equivalent of [`ScrollViewer.AnchorRequested`](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.scrollviewer.anchorrequested): this can be added later when needed

Depends on #4040 