### PR TITLE
Fix SelectingItemsControl init behavior

### DIFF
--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Linq;
 using Avalonia.Collections;
 using Avalonia.Controls.Generators;
@@ -240,17 +241,14 @@ namespace Avalonia.Controls.Primitives
         public override void BeginInit()
         {
             base.BeginInit();
-            ++_updateCount;
-            _updateSelectedIndex = int.MinValue;
+
+            InternalBeginInit();
         }
 
         /// <inheritdoc/>
         public override void EndInit()
         {
-            if (--_updateCount == 0)
-            {
-                UpdateFinished();
-            }
+            InternalEndInit();
 
             base.EndInit();
         }
@@ -437,7 +435,8 @@ namespace Avalonia.Controls.Primitives
         protected override void OnDataContextBeginUpdate()
         {
             base.OnDataContextBeginUpdate();
-            ++_updateCount;
+
+            InternalBeginInit();
         }
 
         /// <inheritdoc/>
@@ -445,10 +444,7 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnDataContextEndUpdate();
 
-            if (--_updateCount == 0)
-            {
-                UpdateFinished();
-            }
+            InternalEndInit();
         }
 
         protected override void OnKeyDown(KeyEventArgs e)
@@ -1115,6 +1111,26 @@ namespace Avalonia.Controls.Primitives
                         SelectedIndex = 0;
                     }
                 }
+            }
+        }
+
+        private void InternalBeginInit()
+        {
+            if (_updateCount == 0)
+            {
+                _updateSelectedIndex = int.MinValue;
+            }
+
+            ++_updateCount;
+        }
+
+        private void InternalEndInit()
+        {
+            Debug.Assert(_updateCount > 0);
+
+            if (--_updateCount == 0)
+            {
+                UpdateFinished();
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -130,6 +130,23 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
+        public void SelectedIndex_Should_Be_Minus_1_Without_Initialize()
+        {
+            var items = new[]
+            {
+                new Item(),
+                new Item(),
+            };
+
+            var target = new ListBox();
+            target.Items = items;
+            target.Template = Template();
+            target.DataContext = new object();
+
+            Assert.Equal(-1, target.SelectedIndex);
+        }
+
+        [Fact]
         public void SelectedIndex_Should_Be_0_After_Initialize_With_AlwaysSelected()
         {
             var items = new[]


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes issues with `SelectingItemsControl.BeginInit/EndInit` behaving slightly different than `SelectingItemsControl.OnDataContextBeginUpdate/EndUpdate` causing issues when creating controls from code behind and not using XAML.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
If user creates control derived from `SelectingItemsControl` (like `ComboBox` for instance) in code behind and does not call `BeginInit/EndInit` pair at least once then assigning `DataContext` will reset selection to 0 from whatever it was.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
`SelectingItemsControl` selection should not be overwritten randomly by `DataContext` changing.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Unifies behavior by sharing code between both normal init and data context one.

## Checklist

- [x] Added unit tests (if possible)?
