### PR TITLE
Fixes/x11 backend cope with 0size window

### DIFF
--- a/src/Avalonia.X11/X11Framebuffer.cs
+++ b/src/Avalonia.X11/X11Framebuffer.cs
@@ -14,6 +14,10 @@ namespace Avalonia.X11
 
         public X11Framebuffer(IntPtr display, IntPtr xid, int depth, int width, int height, double factor)
         {
+            // HACK! Please fix renderer, should never ask for 0x0 bitmap.
+            width = Math.Max(1, width);
+            height = Math.Max(1, height);
+
             _display = display;
             _xid = xid;
             _depth = depth;

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -102,7 +102,7 @@ namespace Avalonia.X11
                 valueMask |= SetWindowValuemask.ColorMap;   
             }
 
-            int defaultWidth = 300, defaultHeight = 200;
+            int defaultWidth = 0, defaultHeight = 0;
 
             if (!_popup && Screen != null)
             {
@@ -116,6 +116,10 @@ namespace Avalonia.X11
                     defaultHeight = (int)(monitor.WorkingArea.Height * 0.7d);
                 }
             }
+
+            // check if the calculated size is zero then compensate to hardcoded resolution
+            defaultWidth = Math.Max(defaultWidth, 300);
+            defaultHeight = Math.Max(defaultHeight, 200);
 
             _handle = XCreateWindow(_x11.Display, _x11.RootWindow, 10, 10, defaultWidth, defaultHeight, 0,
                 depth,
@@ -133,7 +137,7 @@ namespace Avalonia.X11
                 _renderHandle = _handle;
                 
             Handle = new PlatformHandle(_handle, "XID");
-            _realSize = new PixelSize(300, 200);
+            _realSize = new PixelSize(defaultWidth, defaultHeight);
             platform.Windows[_handle] = OnEvent;
             XEventMask ignoredMask = XEventMask.SubstructureRedirectMask
                                      | XEventMask.ResizeRedirectMask

--- a/src/Shared/PlatformSupport/StandardRuntimePlatform.cs
+++ b/src/Shared/PlatformSupport/StandardRuntimePlatform.cs
@@ -75,7 +75,7 @@ namespace Avalonia.Shared.PlatformSupport
                         lock (_btlock)
                             Backtraces.Remove(_backtrace);
 #endif
-                        _plat.Free(_address, Size);
+                        _plat?.Free(_address, Size);
                         GC.RemoveMemoryPressure(Size);
                         IsDisposed = true;
                         _address = IntPtr.Zero;

--- a/src/Shared/PlatformSupport/StandardRuntimePlatform.cs
+++ b/src/Shared/PlatformSupport/StandardRuntimePlatform.cs
@@ -52,11 +52,13 @@ namespace Avalonia.Shared.PlatformSupport
             
             public UnmanagedBlob(StandardRuntimePlatform plat, int size)
             {
-                if (size <= 0)
-                    throw new ArgumentException("Positive number required", nameof(size));
-                _plat = plat;
-                _address = plat.Alloc(size);
-                GC.AddMemoryPressure(size);
+                if (size > 0)
+                {
+                    _plat = plat;
+                    _address = plat.Alloc(size);
+                    GC.AddMemoryPressure(size);
+                }
+
                 Size = size;
 #if DEBUG
                 _backtrace = Environment.StackTrace;
@@ -75,7 +77,7 @@ namespace Avalonia.Shared.PlatformSupport
                         lock (_btlock)
                             Backtraces.Remove(_backtrace);
 #endif
-                        _plat.Free(_address, Size);
+                        _plat?.Free(_address, Size);
                         GC.RemoveMemoryPressure(Size);
                         IsDisposed = true;
                         _address = IntPtr.Zero;

--- a/src/Shared/PlatformSupport/StandardRuntimePlatform.cs
+++ b/src/Shared/PlatformSupport/StandardRuntimePlatform.cs
@@ -52,13 +52,11 @@ namespace Avalonia.Shared.PlatformSupport
             
             public UnmanagedBlob(StandardRuntimePlatform plat, int size)
             {
-                if (size > 0)
-                {
-                    _plat = plat;
-                    _address = plat.Alloc(size);
-                    GC.AddMemoryPressure(size);
-                }
-
+                if (size <= 0)
+                    throw new ArgumentException("Positive number required", nameof(size));
+                _plat = plat;
+                _address = plat.Alloc(size);
+                GC.AddMemoryPressure(size);
                 Size = size;
 #if DEBUG
                 _backtrace = Environment.StackTrace;
@@ -77,7 +75,7 @@ namespace Avalonia.Shared.PlatformSupport
                         lock (_btlock)
                             Backtraces.Remove(_backtrace);
 #endif
-                        _plat?.Free(_address, Size);
+                        _plat.Free(_address, Size);
                         GC.RemoveMemoryPressure(Size);
                         IsDisposed = true;
                         _address = IntPtr.Zero;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Currently on NixOS and WSL probably other Unixes if we are using SW rendering and window size initially states 0x0 we crash in finalizer thread.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Dont crash, and allow X11 to recover with sensible window size.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Firstly prevent exception in UnmanagedBlob finalizer.
Add a hack that prevents renderer from allocating a blob less than 1x1. Later it can be fixed in renderer, but this is too risky and big a mod right now.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/2856

