### PR TITLE
Add SelectionModel change information

### DIFF
--- a/src/Avalonia.Controls/ISelectionModel.cs
+++ b/src/Avalonia.Controls/ISelectionModel.cs
@@ -43,5 +43,6 @@ namespace Avalonia.Controls
         void SelectRangeFromAnchorTo(IndexPath index);
         void SetAnchorIndex(int index);
         void SetAnchorIndex(int groupIndex, int index);
+        IDisposable Update();
     }
 }

--- a/src/Avalonia.Controls/IndexRange.cs
+++ b/src/Avalonia.Controls/IndexRange.cs
@@ -3,12 +3,17 @@
 //
 // Licensed to The Avalonia Project under MIT License, courtesy of The .NET Foundation.
 
+using System;
+using System.Collections.Generic;
+
 #nullable enable
 
 namespace Avalonia.Controls
 {
-    internal readonly struct IndexRange
+    internal readonly struct IndexRange : IEquatable<IndexRange>
     {
+        private static readonly IndexRange s_invalid = new IndexRange(int.MinValue, int.MinValue);
+
         public IndexRange(int begin, int end)
         {
             // Accept out of order begin/end pairs, just swap them.
@@ -25,11 +30,9 @@ namespace Avalonia.Controls
 
         public int Begin { get; }
         public int End { get; }
+        public int Count => (End - Begin) + 1;
 
-        public bool Contains(int index)
-        {
-            return index >= Begin && index <= End;
-        }
+        public bool Contains(int index) => index >= Begin && index <= End;
 
         public bool Split(int splitIndex, out IndexRange before, out IndexRange after)
         {
@@ -54,6 +57,164 @@ namespace Avalonia.Controls
         public bool Intersects(IndexRange other)
         {
             return (Begin <= other.End) && (End >= other.Begin);
-        }    
+        }
+
+        public bool Adjacent(IndexRange other)
+        {
+            return Begin == other.End + 1 || End == other.Begin - 1;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is IndexRange range && Equals(range);
+        }
+
+        public bool Equals(IndexRange other)
+        {
+            return Begin == other.Begin && End == other.End;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = 1903003160;
+            hashCode = hashCode * -1521134295 + Begin.GetHashCode();
+            hashCode = hashCode * -1521134295 + End.GetHashCode();
+            return hashCode;
+        }
+
+        public override string ToString() => $"[{Begin}..{End}]";
+
+        public static bool operator ==(IndexRange left, IndexRange right) => left.Equals(right);
+        public static bool operator !=(IndexRange left, IndexRange right) => !(left == right);
+
+        public static int Add(
+            IList<IndexRange> ranges,
+            IndexRange range,
+            IList<IndexRange>? added = null)
+        {
+            var result = 0;
+
+            for (var i = 0; i < ranges.Count && range != s_invalid; ++i)
+            {
+                var existing = ranges[i];
+
+                if (range.Intersects(existing) || range.Adjacent(existing))
+                {
+                    if (range.Begin < existing.Begin)
+                    {
+                        var add = new IndexRange(range.Begin, existing.Begin - 1);
+                        ranges[i] = new IndexRange(range.Begin, existing.End);
+                        added?.Add(add);
+                        result += add.Count;
+                    }
+
+                    range = range.End <= existing.End ?
+                        s_invalid :
+                        new IndexRange(existing.End + 1, range.End);
+                }
+                else if (range.End < existing.Begin)
+                {
+                    ranges.Insert(i, range);
+                    added?.Add(range);
+                    result += range.Count;
+                    range = s_invalid;
+                }
+            }
+
+            if (range != s_invalid)
+            {
+                ranges.Add(range);
+                added?.Add(range);
+                result += range.Count;
+            }
+
+            MergeRanges(ranges);
+            return result;
+        }
+
+        public static int Remove(
+            IList<IndexRange> ranges,
+            IndexRange range,
+            IList<IndexRange>? removed = null)
+        {
+            var result = 0;
+
+            for (var i = 0; i < ranges.Count; ++i)
+            {
+                var existing = ranges[i];
+
+                if (range.Intersects(existing))
+                {
+                    if (range.Begin <= existing.Begin && range.End >= existing.End)
+                    {
+                        ranges.RemoveAt(i--);
+                        removed?.Add(existing);
+                        result += existing.Count;
+                    }
+                    else if (range.Begin > existing.Begin && range.End >= existing.End)
+                    {
+                        ranges[i] = new IndexRange(existing.Begin, range.Begin - 1);
+                        removed?.Add(new IndexRange(range.Begin, existing.End));
+                        result += existing.End - (range.Begin - 1);
+                    }
+                    else if (range.Begin > existing.Begin && range.End < existing.End)
+                    {
+                        ranges[i] = new IndexRange(existing.Begin, range.Begin - 1);
+                        ranges.Insert(++i, new IndexRange(range.End + 1, existing.End));
+                        removed?.Add(range);
+                        result += range.Count;
+                    }
+                    else if (range.End <= existing.End)
+                    {
+                        var remove = new IndexRange(existing.Begin, range.End);
+                        ranges[i] = new IndexRange(range.End + 1, existing.End);
+                        removed?.Add(remove);
+                        result += remove.Count;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        public static IEnumerable<IndexRange> Subtract(
+            IndexRange lhs,
+            IEnumerable<IndexRange> rhs)
+        {
+            var result = new List<IndexRange> { lhs };
+            
+            foreach (var range in rhs)
+            {
+                Remove(result, range);
+            }
+
+            return result;
+        }
+
+        public static IEnumerable<int> EnumerateIndices(IEnumerable<IndexRange> ranges)
+        {
+            foreach (var range in ranges)
+            {
+                for (var i = range.Begin; i <= range.End; ++i)
+                {
+                    yield return i;
+                }
+            }
+        }
+
+        private static void MergeRanges(IList<IndexRange> ranges)
+        {
+            for (var i = ranges.Count - 2; i >= 0; --i)
+            {
+                var r = ranges[i];
+                var r1 = ranges[i + 1];
+
+                if (r.Intersects(r1) || r.End == r1.Begin - 1)
+                {
+                    ranges[i] = new IndexRange(r.Begin, r1.End);
+                    ranges.RemoveAt(i + 1);
+                }
+            }
+        }
     }
 }

--- a/src/Avalonia.Controls/IndexRange.cs
+++ b/src/Avalonia.Controls/IndexRange.cs
@@ -202,6 +202,18 @@ namespace Avalonia.Controls
             }
         }
 
+        public static int GetCount(IEnumerable<IndexRange> ranges)
+        {
+            var result = 0;
+
+            foreach (var range in ranges)
+            {
+                result += (range.End - range.Begin) + 1;
+            }
+
+            return result;
+        }
+
         private static void MergeRanges(IList<IndexRange> ranges)
         {
             for (var i = ranges.Count - 2; i >= 0; --i)

--- a/src/Avalonia.Controls/SelectedItems.cs
+++ b/src/Avalonia.Controls/SelectedItems.cs
@@ -6,44 +6,37 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using SelectedItemInfo = Avalonia.Controls.SelectionModel.SelectedItemInfo;
 
 #nullable enable
 
 namespace Avalonia.Controls
 {
-    internal class SelectedItems<T> : IReadOnlyList<T>
+    public interface ISelectedItemInfo
     {
-        private readonly List<SelectedItemInfo> _infos;
-        private readonly Func<List<SelectedItemInfo>, int, T> _getAtImpl;
+        public IndexPath Path { get; }
+    }
+
+    internal class SelectedItems<TValue, Tinfo> : IReadOnlyList<TValue>
+        where Tinfo : ISelectedItemInfo
+    {
+        private readonly List<Tinfo> _infos;
+        private readonly Func<List<Tinfo>, int, TValue> _getAtImpl;
 
         public SelectedItems(
-            List<SelectedItemInfo> infos,
-            Func<List<SelectedItemInfo>, int, T> getAtImpl)
+            List<Tinfo> infos,
+            int count,
+            Func<List<Tinfo>, int, TValue> getAtImpl)
         {
             _infos = infos;
             _getAtImpl = getAtImpl;
-
-            foreach (var info in infos)
-            {
-                var node = info.Node;
-
-                if (node != null)
-                {
-                    Count += node.SelectedCount;
-                }
-                else
-                {
-                    throw new InvalidOperationException("Selection changed after the SelectedIndices/Items property was read.");
-                }
-            }
+            Count = count;
         }
 
-        public T this[int index] => _getAtImpl(_infos, index);
+        public TValue this[int index] => _getAtImpl(_infos, index);
 
         public int Count { get; }
 
-        public IEnumerator<T> GetEnumerator()
+        public IEnumerator<TValue> GetEnumerator()
         {
             for (var i = 0; i < Count; ++i)
             {

--- a/src/Avalonia.Controls/SelectionModel.cs
+++ b/src/Avalonia.Controls/SelectionModel.cs
@@ -165,6 +165,7 @@ namespace Avalonia.Controls
                 if (_selectedItemsCached == null)
                 {
                     var selectedInfos = new List<SelectedItemInfo>();
+                    var count = 0;
 
                     if (_rootNode.Source != null)
                     {
@@ -176,6 +177,7 @@ namespace Avalonia.Controls
                                 if (currentInfo.Node.SelectedCount > 0)
                                 {
                                     selectedInfos.Add(new SelectedItemInfo(currentInfo.Node, currentInfo.Path));
+                                    count += currentInfo.Node.SelectedCount;
                                 }
                             });
                     }
@@ -185,8 +187,9 @@ namespace Avalonia.Controls
                     // the selected item at a particular index. This avoid having to create the storage and copying
                     // needed in a dumb vector. This also allows us to expose a tree of selected nodes into an 
                     // easier to consume flat vector view of objects.
-                    var selectedItems = new SelectedItems<object?> (
+                    var selectedItems = new SelectedItems<object?, SelectedItemInfo> (
                         selectedInfos,
+                        count,
                         (infos, index) =>
                         {
                             var currentIndex = 0;
@@ -233,6 +236,8 @@ namespace Avalonia.Controls
                 if (_selectedIndicesCached == null)
                 {
                     var selectedInfos = new List<SelectedItemInfo>();
+                    var count = 0;
+
                     SelectionTreeHelper.Traverse(
                         _rootNode,
                         false,
@@ -241,6 +246,7 @@ namespace Avalonia.Controls
                             if (currentInfo.Node.SelectedCount > 0)
                             {
                                 selectedInfos.Add(new SelectedItemInfo(currentInfo.Node, currentInfo.Path));
+                                count += currentInfo.Node.SelectedCount;
                             }
                         });
 
@@ -249,8 +255,9 @@ namespace Avalonia.Controls
                     // the IndexPath at a particular index. This avoid having to create the storage and copying
                     // needed in a dumb vector. This also allows us to expose a tree of selected nodes into an 
                     // easier to consume flat vector view of IndexPaths.
-                    var indices = new SelectedItems<IndexPath>(
+                    var indices = new SelectedItems<IndexPath, SelectedItemInfo>(
                         selectedInfos,
+                        count,
                         (infos, index) => // callback for GetAt(index)
                         {
                             var currentIndex = 0;
@@ -720,7 +727,7 @@ namespace Avalonia.Controls
             OnSelectionChanged(e);
         }
 
-        internal class SelectedItemInfo
+        internal class SelectedItemInfo : ISelectedItemInfo
         {
             public SelectedItemInfo(SelectionNode node, IndexPath path)
             {
@@ -730,6 +737,7 @@ namespace Avalonia.Controls
 
             public SelectionNode Node { get; }
             public IndexPath Path { get; }
+            public int Count => Node.SelectedCount;
         }
 
         private struct Operation : IDisposable

--- a/src/Avalonia.Controls/SelectionModel.cs
+++ b/src/Avalonia.Controls/SelectionModel.cs
@@ -324,6 +324,7 @@ namespace Avalonia.Controls
         public void Dispose()
         {
             ClearSelection(resetAnchor: false);
+            _rootNode.Cleanup();
             _rootNode.Dispose();
             _selectedIndicesCached = null;
             _selectedItemsCached = null;
@@ -764,6 +765,7 @@ namespace Avalonia.Controls
             }
 
             OnSelectionChanged(e);
+            _rootNode.Cleanup();
         }
 
         internal class SelectedItemInfo : ISelectedItemInfo

--- a/src/Avalonia.Controls/SelectionModel.cs
+++ b/src/Avalonia.Controls/SelectionModel.cs
@@ -17,6 +17,7 @@ namespace Avalonia.Controls
     {
         private readonly SelectionNode _rootNode;
         private bool _singleSelect;
+        private int _operationCount;
         private IReadOnlyList<IndexPath>? _selectedIndicesCached;
         private IReadOnlyList<object?>? _selectedItemsCached;
         private SelectionModelChildrenRequestedEventArgs? _childrenRequestedEventArgs;
@@ -509,6 +510,8 @@ namespace Avalonia.Controls
             ClearSelection(resetAnchor: true);
         }
 
+        public IDisposable Update() => new Operation(this);
+
         protected void OnPropertyChanged(string propertyName)
         {
             RaisePropertyChanged(propertyName);
@@ -732,19 +735,33 @@ namespace Avalonia.Controls
                 });
         }
 
-        private void BeginOperation() => _rootNode.BeginOperation();
+        private void BeginOperation()
+        {
+            if (_operationCount++ == 0)
+            {
+                _rootNode.BeginOperation();
+            }
+        }
 
         private void EndOperation()
         {
-            var changes = new List<SelectionNodeOperation>();
-            _rootNode.EndOperation(changes);
+            if (_operationCount == 0)
+            {
+                throw new AvaloniaInternalException("No selection operation in progress.");
+            }
 
             SelectionModelSelectionChangedEventArgs? e = null;
-            
-            if (changes.Count > 0)
+
+            if (--_operationCount == 0)
             {
-                var changeSet = new SelectionModelChangeSet(changes);
-                e = changeSet.CreateEventArgs();
+                var changes = new List<SelectionNodeOperation>();
+                _rootNode.EndOperation(changes);
+
+                if (changes.Count > 0)
+                {
+                    var changeSet = new SelectionModelChangeSet(changes);
+                    e = changeSet.CreateEventArgs();
+                }
             }
 
             OnSelectionChanged(e);

--- a/src/Avalonia.Controls/SelectionModel.cs
+++ b/src/Avalonia.Controls/SelectionModel.cs
@@ -36,13 +36,29 @@ namespace Avalonia.Controls
             get => _rootNode?.Source;
             set
             {
-                using (var operation = new Operation(this))
+                var wasNull = _rootNode.Source == null;
+
+                if (_rootNode.Source != null)
                 {
-                    ClearSelection(resetAnchor: true);
+                    using (var operation = new Operation(this))
+                    {
+                        ClearSelection(resetAnchor: true);
+                    }
                 }
 
                 _rootNode.Source = value;
+
                 RaisePropertyChanged("Source");
+
+                if (wasNull)
+                {
+                    var e = new SelectionModelSelectionChangedEventArgs(
+                        null,
+                        SelectedIndices,
+                        null,
+                        SelectedItems);
+                    OnSelectionChanged(e);
+                }
             }
         }
 

--- a/src/Avalonia.Controls/SelectionModelChangeSet.cs
+++ b/src/Avalonia.Controls/SelectionModelChangeSet.cs
@@ -14,61 +14,144 @@ namespace Avalonia.Controls
 
         public SelectionModelSelectionChangedEventArgs CreateEventArgs()
         {
+            var deselectedCount = 0;
+            var selectedCount = 0;
+
+            foreach (var change in _changes)
+            {
+                deselectedCount += change.DeselectedCount;
+                selectedCount += change.SelectedCount;
+            }
+
+            var deselectedIndices = new SelectedItems<IndexPath, SelectionNodeOperation>(
+                _changes,
+                deselectedCount,
+                GetDeselectedIndexAt);
+            var selectedIndices = new SelectedItems<IndexPath, SelectionNodeOperation>(
+                _changes,
+                selectedCount,
+                GetSelectedIndexAt);
+            var deselectedItems = new SelectedItems<object, SelectionNodeOperation>(
+                _changes,
+                deselectedCount,
+                GetDeselectedItemAt);
+            var selectedItems = new SelectedItems<object, SelectionNodeOperation>(
+                _changes,
+                selectedCount,
+                GetSelectedItemAt);
+
             return new SelectionModelSelectionChangedEventArgs(
-                CreateIndices(x => x.DeselectedRanges),
-                CreateIndices(x => x.SelectedRanges),
-                CreateItems(x => x.DeselectedRanges),
-                CreateItems(x => x.SelectedRanges));
+                deselectedIndices,
+                selectedIndices,
+                deselectedItems,
+                selectedItems);
         }
 
-        private IEnumerable<IndexPath> CreateIndices(Func<SelectionNodeOperation, List<IndexRange>?> selector)
+        private IndexPath GetDeselectedIndexAt(
+            List<SelectionNodeOperation> infos,
+            int index)
         {
-            if (_changes == null)
-            {
-                yield break;
-            }
-
-            foreach (var i in _changes)
-            {
-                var ranges = selector(i);
-
-                if (ranges != null)
-                {
-                    foreach (var j in ranges)
-                    {
-                        for (var k = j.Begin; k <= j.End; ++k)
-                        {
-                            yield return i.Path.CloneWithChildIndex(k);
-                        }
-                    }
-                }
-            }
+            static int GetCount(SelectionNodeOperation info) => info.DeselectedCount;
+            static List<IndexRange> GetRanges(SelectionNodeOperation info) => info.DeselectedRanges;
+            return GetIndexAt(infos, index, GetCount, GetRanges);
         }
 
-        private IEnumerable<object> CreateItems(Func<SelectionNodeOperation, List<IndexRange>?> selector)
+        private IndexPath GetSelectedIndexAt(
+            List<SelectionNodeOperation> infos,
+            int index)
         {
-            if (_changes == null)
+            static int GetCount(SelectionNodeOperation info) => info.SelectedCount;
+            static List<IndexRange> GetRanges(SelectionNodeOperation info) => info.SelectedRanges;
+            return GetIndexAt(infos, index, GetCount, GetRanges);
+        }
+
+        private object GetDeselectedItemAt(
+            List<SelectionNodeOperation> infos,
+            int index)
+        {
+            static int GetCount(SelectionNodeOperation info) => info.DeselectedCount;
+            static List<IndexRange> GetRanges(SelectionNodeOperation info) => info.DeselectedRanges;
+            return GetItemAt(infos, index, GetCount, GetRanges);
+        }
+
+        private object GetSelectedItemAt(
+            List<SelectionNodeOperation> infos,
+            int index)
+        {
+            static int GetCount(SelectionNodeOperation info) => info.SelectedCount;
+            static List<IndexRange> GetRanges(SelectionNodeOperation info) => info.SelectedRanges;
+            return GetItemAt(infos, index, GetCount, GetRanges);
+        }
+
+        private IndexPath GetIndexAt(
+            List<SelectionNodeOperation> infos,
+            int index,
+            Func<SelectionNodeOperation, int> getCount,
+            Func<SelectionNodeOperation, List<IndexRange>> getRanges)
+        {
+            var currentIndex = 0;
+            IndexPath path = default;
+
+            foreach (var info in infos)
             {
-                yield break;
-            }
+                var currentCount = getCount(info);
 
-            var result = new List<object>();
-
-            foreach (var i in _changes)
-            {
-                var ranges = selector(i);
-
-                if (ranges != null && i.Items != null)
+                if (index >= currentIndex && index < currentIndex + currentCount)
                 {
-                    foreach (var j in ranges)
-                    {
-                        for (var k = j.Begin; k <= j.End; ++k)
-                        {
-                            yield return i.Items.GetAt(k);
-                        }
-                    }
+                    int targetIndex = GetIndexAt(getRanges(info), index - currentIndex);
+                    path = info.Path.CloneWithChildIndex(targetIndex);
+                    break;
                 }
+
+                currentIndex += currentCount;
             }
+
+            return path;
+        }
+
+        private object GetItemAt(
+            List<SelectionNodeOperation> infos,
+            int index,
+            Func<SelectionNodeOperation, int> getCount,
+            Func<SelectionNodeOperation, List<IndexRange>> getRanges)
+        {
+            var currentIndex = 0;
+            object item = null;
+
+            foreach (var info in infos)
+            {
+                var currentCount = getCount(info);
+
+                if (index >= currentIndex && index < currentIndex + currentCount)
+                {
+                    int targetIndex = GetIndexAt(getRanges(info), index - currentIndex);
+                    item = info.Items.GetAt(targetIndex);
+                    break;
+                }
+
+                currentIndex += currentCount;
+            }
+
+            return item;
+        }
+
+        private int GetIndexAt(List<IndexRange> ranges, int index)
+        {
+            var currentIndex = 0;
+
+            foreach (var range in ranges)
+            {
+                var currentCount = (range.End - range.Begin) + 1;
+
+                if (index >= currentIndex && index < currentIndex + currentCount)
+                {
+                    return range.Begin + (index - currentIndex);
+                }
+
+                currentIndex += currentCount;
+            }
+
+            throw new IndexOutOfRangeException();
         }
     }
 }

--- a/src/Avalonia.Controls/SelectionModelChangeSet.cs
+++ b/src/Avalonia.Controls/SelectionModelChangeSet.cs
@@ -16,30 +16,38 @@ namespace Avalonia.Controls
 
         public SelectionModelSelectionChangedEventArgs CreateEventArgs()
         {
-            var deselectedCount = 0;
-            var selectedCount = 0;
+            var deselectedIndexCount = 0;
+            var selectedIndexCount = 0;
+            var deselectedItemCount = 0;
+            var selectedItemCount = 0;
 
             foreach (var change in _changes)
             {
-                deselectedCount += change.DeselectedCount;
-                selectedCount += change.SelectedCount;
+                deselectedIndexCount += change.DeselectedCount;
+                selectedIndexCount += change.SelectedCount;
+
+                if (change.Items != null)
+                {
+                    deselectedItemCount += change.DeselectedCount;
+                    selectedItemCount += change.SelectedCount;
+                }
             }
 
             var deselectedIndices = new SelectedItems<IndexPath, SelectionNodeOperation>(
                 _changes,
-                deselectedCount,
+                deselectedIndexCount,
                 GetDeselectedIndexAt);
             var selectedIndices = new SelectedItems<IndexPath, SelectionNodeOperation>(
                 _changes,
-                selectedCount,
+                selectedIndexCount,
                 GetSelectedIndexAt);
             var deselectedItems = new SelectedItems<object?, SelectionNodeOperation>(
                 _changes,
-                deselectedCount,
+                deselectedItemCount,
                 GetDeselectedItemAt);
             var selectedItems = new SelectedItems<object?, SelectionNodeOperation>(
                 _changes,
-                selectedCount,
+                selectedItemCount,
                 GetSelectedItemAt);
 
             return new SelectionModelSelectionChangedEventArgs(
@@ -71,7 +79,7 @@ namespace Avalonia.Controls
             List<SelectionNodeOperation> infos,
             int index)
         {
-            static int GetCount(SelectionNodeOperation info) => info.DeselectedCount;
+            static int GetCount(SelectionNodeOperation info) => info.Items != null ? info.DeselectedCount : 0;
             static List<IndexRange>? GetRanges(SelectionNodeOperation info) => info.DeselectedRanges;
             return GetItemAt(infos, index, GetCount, GetRanges);
         }
@@ -80,7 +88,7 @@ namespace Avalonia.Controls
             List<SelectionNodeOperation> infos,
             int index)
         {
-            static int GetCount(SelectionNodeOperation info) => info.SelectedCount;
+            static int GetCount(SelectionNodeOperation info) => info.Items != null ? info.SelectedCount : 0;
             static List<IndexRange>? GetRanges(SelectionNodeOperation info) => info.SelectedRanges;
             return GetItemAt(infos, index, GetCount, GetRanges);
         }

--- a/src/Avalonia.Controls/SelectionModelChangeSet.cs
+++ b/src/Avalonia.Controls/SelectionModelChangeSet.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+#nullable enable
+
+namespace Avalonia.Controls
+{
+    internal class SelectionModelChangeSet
+    {
+        private SelectionNode _owner;
+        private List<IndexRange>? _selected;
+        private List<IndexRange>? _deselected;
+
+        public SelectionModelChangeSet(SelectionNode owner) => _owner = owner;
+
+        public bool IsTracking { get; private set; }
+        public bool HasChanges => _selected?.Count > 0 || _deselected?.Count > 0;
+        public IEnumerable<IndexPath> SelectedIndices => EnumerateIndices(_selected);
+        public IEnumerable<IndexPath> DeselectedIndices => EnumerateIndices(_deselected);
+        public IEnumerable<object> SelectedItems => EnumerateItems(_selected);
+        public IEnumerable<object> DeselectedItems => EnumerateItems(_deselected);
+
+        public void BeginOperation()
+        {
+            if (IsTracking)
+            {
+                throw new AvaloniaInternalException("SelectionModel change operation already in progress.");
+            }
+
+            IsTracking = true;
+            _selected?.Clear();
+            _deselected?.Clear();
+        }
+
+        public void EndOperation() => IsTracking = false;
+
+        public void Selected(IndexRange range)
+        {
+            if (!IsTracking)
+            {
+                return;
+            }
+
+            Add(range, ref _selected, _deselected);
+        }
+
+        public void Selected(IEnumerable<IndexRange> ranges)
+        {
+            if (!IsTracking)
+            {
+                return;
+            }
+
+            foreach (var range in ranges)
+            {
+                Selected(range);
+            }
+        }
+
+        public void Deselected(IndexRange range)
+        {
+            if (!IsTracking)
+            {
+                return;
+            }
+
+            Add(range, ref _deselected, _selected);
+        }
+
+        public void Deselected(IEnumerable<IndexRange> ranges)
+        {
+            if (!IsTracking)
+            {
+                return;
+            }
+
+            foreach (var range in ranges)
+            {
+                Deselected(range);
+            }
+        }
+
+        private static void Add(
+            IndexRange range,
+            ref List<IndexRange>? add,
+            List<IndexRange>? remove)
+        {
+            if (remove != null)
+            {
+                var removed = new List<IndexRange>();
+                IndexRange.Remove(remove, range, removed);
+                var selected = IndexRange.Subtract(range, removed);
+
+                if (selected.Any())
+                {
+                    add ??= new List<IndexRange>();
+
+                    foreach (var r in selected)
+                    {
+                        IndexRange.Add(add, r);
+                    }
+                }
+            }
+            else
+            {
+                add ??= new List<IndexRange>();
+                IndexRange.Add(add, range);
+            }
+        }
+
+        private IEnumerable<IndexPath> EnumerateIndices(IEnumerable<IndexRange>? ranges)
+        {
+            var path = _owner.IndexPath;
+
+            if (ranges != null)
+            {
+                foreach (var range in ranges)
+                {
+                    for (var i = range.Begin; i <= range.End; ++i)
+                    {
+                        yield return path.CloneWithChildIndex(i);
+                    }
+                }
+            }
+        }
+
+        private IEnumerable<object> EnumerateItems(IEnumerable<IndexRange>? ranges)
+        {
+            var items = _owner.ItemsSourceView;
+
+            if (ranges != null && items != null)
+            {
+                foreach (var range in ranges)
+                {
+                    for (var i = range.Begin; i <= range.End; ++i)
+                    {
+                        yield return items.GetAt(i);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Avalonia.Controls/SelectionModelChangeSet.cs
+++ b/src/Avalonia.Controls/SelectionModelChangeSet.cs
@@ -21,14 +21,12 @@ namespace Avalonia.Controls
                 CreateItems(x => x.SelectedRanges));
         }
 
-        private IReadOnlyList<IndexPath> CreateIndices(Func<SelectionNodeOperation, List<IndexRange>?> selector)
+        private IEnumerable<IndexPath> CreateIndices(Func<SelectionNodeOperation, List<IndexRange>?> selector)
         {
             if (_changes == null)
             {
-                return Array.Empty<IndexPath>();
+                yield break;
             }
-
-            var result = new List<IndexPath>();
 
             foreach (var i in _changes)
             {
@@ -40,20 +38,18 @@ namespace Avalonia.Controls
                     {
                         for (var k = j.Begin; k <= j.End; ++k)
                         {
-                            result.Add(i.Path.CloneWithChildIndex(k));
+                            yield return i.Path.CloneWithChildIndex(k);
                         }
                     }
                 }
             }
-
-            return result;
         }
 
-        private IReadOnlyList<object> CreateItems(Func<SelectionNodeOperation, List<IndexRange>?> selector)
+        private IEnumerable<object> CreateItems(Func<SelectionNodeOperation, List<IndexRange>?> selector)
         {
             if (_changes == null)
             {
-                return Array.Empty<object>();
+                yield break;
             }
 
             var result = new List<object>();
@@ -68,13 +64,11 @@ namespace Avalonia.Controls
                     {
                         for (var k = j.Begin; k <= j.End; ++k)
                         {
-                            result.Add(i.Items.GetAt(k));
+                            yield return i.Items.GetAt(k);
                         }
                     }
                 }
             }
-
-            return result;
         }
     }
 }

--- a/src/Avalonia.Controls/SelectionModelChangeSet.cs
+++ b/src/Avalonia.Controls/SelectionModelChangeSet.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Avalonia.Controls
 {
     internal class SelectionModelChangeSet
@@ -31,11 +33,11 @@ namespace Avalonia.Controls
                 _changes,
                 selectedCount,
                 GetSelectedIndexAt);
-            var deselectedItems = new SelectedItems<object, SelectionNodeOperation>(
+            var deselectedItems = new SelectedItems<object?, SelectionNodeOperation>(
                 _changes,
                 deselectedCount,
                 GetDeselectedItemAt);
-            var selectedItems = new SelectedItems<object, SelectionNodeOperation>(
+            var selectedItems = new SelectedItems<object?, SelectionNodeOperation>(
                 _changes,
                 selectedCount,
                 GetSelectedItemAt);
@@ -52,7 +54,7 @@ namespace Avalonia.Controls
             int index)
         {
             static int GetCount(SelectionNodeOperation info) => info.DeselectedCount;
-            static List<IndexRange> GetRanges(SelectionNodeOperation info) => info.DeselectedRanges;
+            static List<IndexRange>? GetRanges(SelectionNodeOperation info) => info.DeselectedRanges;
             return GetIndexAt(infos, index, GetCount, GetRanges);
         }
 
@@ -61,25 +63,25 @@ namespace Avalonia.Controls
             int index)
         {
             static int GetCount(SelectionNodeOperation info) => info.SelectedCount;
-            static List<IndexRange> GetRanges(SelectionNodeOperation info) => info.SelectedRanges;
+            static List<IndexRange>? GetRanges(SelectionNodeOperation info) => info.SelectedRanges;
             return GetIndexAt(infos, index, GetCount, GetRanges);
         }
 
-        private object GetDeselectedItemAt(
+        private object? GetDeselectedItemAt(
             List<SelectionNodeOperation> infos,
             int index)
         {
             static int GetCount(SelectionNodeOperation info) => info.DeselectedCount;
-            static List<IndexRange> GetRanges(SelectionNodeOperation info) => info.DeselectedRanges;
+            static List<IndexRange>? GetRanges(SelectionNodeOperation info) => info.DeselectedRanges;
             return GetItemAt(infos, index, GetCount, GetRanges);
         }
 
-        private object GetSelectedItemAt(
+        private object? GetSelectedItemAt(
             List<SelectionNodeOperation> infos,
             int index)
         {
             static int GetCount(SelectionNodeOperation info) => info.SelectedCount;
-            static List<IndexRange> GetRanges(SelectionNodeOperation info) => info.SelectedRanges;
+            static List<IndexRange>? GetRanges(SelectionNodeOperation info) => info.SelectedRanges;
             return GetItemAt(infos, index, GetCount, GetRanges);
         }
 
@@ -87,7 +89,7 @@ namespace Avalonia.Controls
             List<SelectionNodeOperation> infos,
             int index,
             Func<SelectionNodeOperation, int> getCount,
-            Func<SelectionNodeOperation, List<IndexRange>> getRanges)
+            Func<SelectionNodeOperation, List<IndexRange>?> getRanges)
         {
             var currentIndex = 0;
             IndexPath path = default;
@@ -109,14 +111,14 @@ namespace Avalonia.Controls
             return path;
         }
 
-        private object GetItemAt(
+        private object? GetItemAt(
             List<SelectionNodeOperation> infos,
             int index,
             Func<SelectionNodeOperation, int> getCount,
-            Func<SelectionNodeOperation, List<IndexRange>> getRanges)
+            Func<SelectionNodeOperation, List<IndexRange>?> getRanges)
         {
             var currentIndex = 0;
-            object item = null;
+            object? item = null;
 
             foreach (var info in infos)
             {
@@ -125,7 +127,7 @@ namespace Avalonia.Controls
                 if (index >= currentIndex && index < currentIndex + currentCount)
                 {
                     int targetIndex = GetIndexAt(getRanges(info), index - currentIndex);
-                    item = info.Items.GetAt(targetIndex);
+                    item = info.Items?.GetAt(targetIndex);
                     break;
                 }
 
@@ -135,20 +137,23 @@ namespace Avalonia.Controls
             return item;
         }
 
-        private int GetIndexAt(List<IndexRange> ranges, int index)
+        private int GetIndexAt(List<IndexRange>? ranges, int index)
         {
             var currentIndex = 0;
 
-            foreach (var range in ranges)
+            if (ranges != null)
             {
-                var currentCount = (range.End - range.Begin) + 1;
-
-                if (index >= currentIndex && index < currentIndex + currentCount)
+                foreach (var range in ranges)
                 {
-                    return range.Begin + (index - currentIndex);
-                }
+                    var currentCount = (range.End - range.Begin) + 1;
 
-                currentIndex += currentCount;
+                    if (index >= currentIndex && index < currentIndex + currentCount)
+                    {
+                        return range.Begin + (index - currentIndex);
+                    }
+
+                    currentIndex += currentCount;
+                }
             }
 
             throw new IndexOutOfRangeException();

--- a/src/Avalonia.Controls/SelectionModelSelectionChangedEventArgs.cs
+++ b/src/Avalonia.Controls/SelectionModelSelectionChangedEventArgs.cs
@@ -12,73 +12,36 @@ namespace Avalonia.Controls
 {
     public class SelectionModelSelectionChangedEventArgs : EventArgs
     {
-        private readonly IEnumerable<IndexPath>? _deselectedIndicesSource;
-        private readonly IEnumerable<IndexPath>? _selectedIndicesSource;
-        private readonly IEnumerable<object>? _deselectedItemsSource;
-        private readonly IEnumerable<object>? _selectedItemsSource;
-        private IReadOnlyList<IndexPath>? _deselectedIndices;
-        private IReadOnlyList<IndexPath>? _selectedIndices;
-        private IReadOnlyList<object>? _deselectedItems;
-        private IReadOnlyList<object>? _selectedItems;
-
         public SelectionModelSelectionChangedEventArgs(
             IReadOnlyList<IndexPath>? deselectedIndices,
             IReadOnlyList<IndexPath>? selectedIndices,
             IReadOnlyList<object>? deselectedItems,
             IReadOnlyList<object>? selectedItems)
         {
-            _deselectedIndices = deselectedIndices ?? Array.Empty<IndexPath>();
-            _selectedIndices = selectedIndices ?? Array.Empty<IndexPath>();
-            _deselectedItems = deselectedItems ?? Array.Empty<object>();
-            _selectedItems= selectedItems ?? Array.Empty<object>();
-        }
-
-        public SelectionModelSelectionChangedEventArgs(
-            IEnumerable<IndexPath>? deselectedIndices,
-            IEnumerable<IndexPath>? selectedIndices,
-            IEnumerable<object>? deselectedItems,
-            IEnumerable<object>? selectedItems)
-        {
-            static void Set<T>(IEnumerable<T>? source, ref IEnumerable<T>? sourceField, ref IReadOnlyList<T>? field)
-            {
-                if (source != null)
-                {
-                    sourceField = source;
-                }
-                else
-                {
-                    field = Array.Empty<T>();
-                }
-            }
-
-            Set(deselectedIndices, ref _deselectedIndicesSource, ref _deselectedIndices);
-            Set(selectedIndices, ref _selectedIndicesSource, ref _selectedIndices);
-            Set(deselectedItems, ref _deselectedItemsSource, ref _deselectedItems);
-            Set(selectedItems, ref _selectedItemsSource, ref _selectedItems);
+            DeselectedIndices = deselectedIndices ?? Array.Empty<IndexPath>();
+            SelectedIndices = selectedIndices ?? Array.Empty<IndexPath>();
+            DeselectedItems = deselectedItems ?? Array.Empty<object>();
+            SelectedItems= selectedItems ?? Array.Empty<object>();
         }
 
         /// <summary>
         /// Gets the indices of the items that were removed from the selection.
         /// </summary>
-        public IReadOnlyList<IndexPath> DeselectedIndices
-            => _deselectedIndices ??= new List<IndexPath>(_deselectedIndicesSource);
+        public IReadOnlyList<IndexPath> DeselectedIndices { get; }
 
         /// <summary>
         /// Gets the indices of the items that were added to the selection.
         /// </summary>
-        public IReadOnlyList<IndexPath> SelectedIndices
-            => _selectedIndices ??= new List<IndexPath>(_selectedIndicesSource);
+        public IReadOnlyList<IndexPath> SelectedIndices { get; }
 
         /// <summary>
         /// Gets the items that were removed from the selection.
         /// </summary>
-        public IReadOnlyList<object> DeselectedItems
-            => _deselectedItems ??= new List<object>(_deselectedItemsSource);
+        public IReadOnlyList<object> DeselectedItems { get; }
 
         /// <summary>
         /// Gets the items that were added to the selection.
         /// </summary>
-        public IReadOnlyList<object> SelectedItems
-            => _selectedItems ??= new List<object>(_selectedItemsSource);
+        public IReadOnlyList<object> SelectedItems { get; }
     }
 }

--- a/src/Avalonia.Controls/SelectionModelSelectionChangedEventArgs.cs
+++ b/src/Avalonia.Controls/SelectionModelSelectionChangedEventArgs.cs
@@ -12,49 +12,73 @@ namespace Avalonia.Controls
 {
     public class SelectionModelSelectionChangedEventArgs : EventArgs
     {
-        private readonly IEnumerable<IndexPath> _selectedIndicesSource;
-        private readonly IEnumerable<IndexPath> _deselectedIndicesSource;
-        private readonly IEnumerable<object> _selectedItemsSource;
-        private readonly IEnumerable<object> _deselectedItemsSource;
-        private List<IndexPath>? _selectedIndices;
-        private List<IndexPath>? _deselectedIndices;
-        private List<object>? _selectedItems;
-        private List<object>? _deselectedItems;
+        private readonly IEnumerable<IndexPath>? _deselectedIndicesSource;
+        private readonly IEnumerable<IndexPath>? _selectedIndicesSource;
+        private readonly IEnumerable<object>? _deselectedItemsSource;
+        private readonly IEnumerable<object>? _selectedItemsSource;
+        private IReadOnlyList<IndexPath>? _deselectedIndices;
+        private IReadOnlyList<IndexPath>? _selectedIndices;
+        private IReadOnlyList<object>? _deselectedItems;
+        private IReadOnlyList<object>? _selectedItems;
 
         public SelectionModelSelectionChangedEventArgs(
-            IEnumerable<IndexPath> deselectedIndices,
-            IEnumerable<IndexPath> selectedIndices,
-            IEnumerable<object> deselectedItems,
-            IEnumerable<object> selectedItems)
+            IReadOnlyList<IndexPath>? deselectedIndices,
+            IReadOnlyList<IndexPath>? selectedIndices,
+            IReadOnlyList<object>? deselectedItems,
+            IReadOnlyList<object>? selectedItems)
         {
-            _selectedIndicesSource = selectedIndices;
-            _deselectedIndicesSource = deselectedIndices;
-            _selectedItemsSource = selectedItems;
-            _deselectedItemsSource = deselectedItems;
+            _deselectedIndices = deselectedIndices ?? Array.Empty<IndexPath>();
+            _selectedIndices = selectedIndices ?? Array.Empty<IndexPath>();
+            _deselectedItems = deselectedItems ?? Array.Empty<object>();
+            _selectedItems= selectedItems ?? Array.Empty<object>();
         }
 
-        /// <summary>
-        /// Gets the indices of the items that were added to the selection.
-        /// </summary>
-        public IReadOnlyList<IndexPath> SelectedIndices =>
-            _selectedIndices ?? (_selectedIndices = new List<IndexPath>(_selectedIndicesSource));
+        public SelectionModelSelectionChangedEventArgs(
+            IEnumerable<IndexPath>? deselectedIndices,
+            IEnumerable<IndexPath>? selectedIndices,
+            IEnumerable<object>? deselectedItems,
+            IEnumerable<object>? selectedItems)
+        {
+            static void Set<T>(IEnumerable<T>? source, ref IEnumerable<T>? sourceField, ref IReadOnlyList<T>? field)
+            {
+                if (source != null)
+                {
+                    sourceField = source;
+                }
+                else
+                {
+                    field = Array.Empty<T>();
+                }
+            }
+
+            Set(deselectedIndices, ref _deselectedIndicesSource, ref _deselectedIndices);
+            Set(selectedIndices, ref _selectedIndicesSource, ref _selectedIndices);
+            Set(deselectedItems, ref _deselectedItemsSource, ref _deselectedItems);
+            Set(selectedItems, ref _selectedItemsSource, ref _selectedItems);
+        }
 
         /// <summary>
         /// Gets the indices of the items that were removed from the selection.
         /// </summary>
-        public IReadOnlyList<IndexPath> DeselectedIndices =>
-            _deselectedIndices ?? (_deselectedIndices = new List<IndexPath>(_deselectedIndicesSource));
+        public IReadOnlyList<IndexPath> DeselectedIndices
+            => _deselectedIndices ??= new List<IndexPath>(_deselectedIndicesSource);
 
         /// <summary>
-        /// Gets the items that were added to the selection.
+        /// Gets the indices of the items that were added to the selection.
         /// </summary>
-        public IReadOnlyList<object> SelectedItems =>
-            _selectedItems ?? (_selectedItems = new List<object>(_selectedItemsSource));
+        public IReadOnlyList<IndexPath> SelectedIndices
+            => _selectedIndices ??= new List<IndexPath>(_selectedIndicesSource);
 
         /// <summary>
         /// Gets the items that were removed from the selection.
         /// </summary>
-        public IReadOnlyList<object> DeselectedItems =>
-            _deselectedItems ?? (_deselectedItems = new List<object>(_deselectedItemsSource));
+        public IReadOnlyList<object> DeselectedItems
+            => _deselectedItems ??= new List<object>(_deselectedItemsSource);
+
+        /// <summary>
+        /// Gets the items that were added to the selection.
+        /// </summary>
+        public IReadOnlyList<object> SelectedItems
+            => _selectedItems ??= new List<object>(_selectedItemsSource);
     }
 }

--- a/src/Avalonia.Controls/SelectionModelSelectionChangedEventArgs.cs
+++ b/src/Avalonia.Controls/SelectionModelSelectionChangedEventArgs.cs
@@ -15,13 +15,13 @@ namespace Avalonia.Controls
         public SelectionModelSelectionChangedEventArgs(
             IReadOnlyList<IndexPath>? deselectedIndices,
             IReadOnlyList<IndexPath>? selectedIndices,
-            IReadOnlyList<object>? deselectedItems,
-            IReadOnlyList<object>? selectedItems)
+            IReadOnlyList<object?>? deselectedItems,
+            IReadOnlyList<object?>? selectedItems)
         {
             DeselectedIndices = deselectedIndices ?? Array.Empty<IndexPath>();
             SelectedIndices = selectedIndices ?? Array.Empty<IndexPath>();
-            DeselectedItems = deselectedItems ?? Array.Empty<object>();
-            SelectedItems= selectedItems ?? Array.Empty<object>();
+            DeselectedItems = deselectedItems ?? Array.Empty<object?>();
+            SelectedItems= selectedItems ?? Array.Empty<object?>();
         }
 
         /// <summary>
@@ -37,11 +37,11 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets the items that were removed from the selection.
         /// </summary>
-        public IReadOnlyList<object> DeselectedItems { get; }
+        public IReadOnlyList<object?> DeselectedItems { get; }
 
         /// <summary>
         /// Gets the items that were added to the selection.
         /// </summary>
-        public IReadOnlyList<object> SelectedItems { get; }
+        public IReadOnlyList<object?> SelectedItems { get; }
     }
 }

--- a/src/Avalonia.Controls/SelectionModelSelectionChangedEventArgs.cs
+++ b/src/Avalonia.Controls/SelectionModelSelectionChangedEventArgs.cs
@@ -4,6 +4,7 @@
 // Licensed to The Avalonia Project under MIT License, courtesy of The .NET Foundation.
 
 using System;
+using System.Collections.Generic;
 
 #nullable enable
 
@@ -11,5 +12,49 @@ namespace Avalonia.Controls
 {
     public class SelectionModelSelectionChangedEventArgs : EventArgs
     {
+        private readonly IEnumerable<IndexPath> _selectedIndicesSource;
+        private readonly IEnumerable<IndexPath> _deselectedIndicesSource;
+        private readonly IEnumerable<object> _selectedItemsSource;
+        private readonly IEnumerable<object> _deselectedItemsSource;
+        private List<IndexPath>? _selectedIndices;
+        private List<IndexPath>? _deselectedIndices;
+        private List<object>? _selectedItems;
+        private List<object>? _deselectedItems;
+
+        public SelectionModelSelectionChangedEventArgs(
+            IEnumerable<IndexPath> deselectedIndices,
+            IEnumerable<IndexPath> selectedIndices,
+            IEnumerable<object> deselectedItems,
+            IEnumerable<object> selectedItems)
+        {
+            _selectedIndicesSource = selectedIndices;
+            _deselectedIndicesSource = deselectedIndices;
+            _selectedItemsSource = selectedItems;
+            _deselectedItemsSource = deselectedItems;
+        }
+
+        /// <summary>
+        /// Gets the indices of the items that were added to the selection.
+        /// </summary>
+        public IReadOnlyList<IndexPath> SelectedIndices =>
+            _selectedIndices ?? (_selectedIndices = new List<IndexPath>(_selectedIndicesSource));
+
+        /// <summary>
+        /// Gets the indices of the items that were removed from the selection.
+        /// </summary>
+        public IReadOnlyList<IndexPath> DeselectedIndices =>
+            _deselectedIndices ?? (_deselectedIndices = new List<IndexPath>(_deselectedIndicesSource));
+
+        /// <summary>
+        /// Gets the items that were added to the selection.
+        /// </summary>
+        public IReadOnlyList<object> SelectedItems =>
+            _selectedItems ?? (_selectedItems = new List<object>(_selectedItemsSource));
+
+        /// <summary>
+        /// Gets the items that were removed from the selection.
+        /// </summary>
+        public IReadOnlyList<object> DeselectedItems =>
+            _deselectedItems ?? (_deselectedItems = new List<object>(_deselectedItemsSource));
     }
 }

--- a/src/Avalonia.Controls/SelectionNode.cs
+++ b/src/Avalonia.Controls/SelectionNode.cs
@@ -48,8 +48,11 @@ namespace Avalonia.Controls
             {
                 if (_source != value)
                 {
-                    ClearSelection();
-                    UnhookCollectionChangedHandler();
+                    if (_source != null)
+                    {
+                        ClearSelection();
+                        UnhookCollectionChangedHandler();
+                    }
 
                     _source = value;
 

--- a/src/Avalonia.Controls/SelectionNode.cs
+++ b/src/Avalonia.Controls/SelectionNode.cs
@@ -342,17 +342,29 @@ namespace Avalonia.Controls
             }
         }
 
-        public void Cleanup()
+        public bool Cleanup()
         {
-            foreach (var child in _childrenNodes)
-            {
-                child?.Cleanup();
+            var result = SelectedCount == 0;
 
-                if (child?.SelectedCount == 0)
+            for (var i = 0; i < _childrenNodes.Count; ++i)
+            {
+                var child = _childrenNodes[i];
+
+                if (child != null)
                 {
-                    child.Dispose();
+                    if (child.Cleanup())
+                    {
+                        child.Dispose();
+                        _childrenNodes[i] = null;
+                    }
+                    else
+                    {
+                        result = false;
+                    }
                 }
             }
+
+            return result;
         }
 
         public bool Select(int index, bool select)

--- a/src/Avalonia.Controls/SelectionNode.cs
+++ b/src/Avalonia.Controls/SelectionNode.cs
@@ -342,6 +342,19 @@ namespace Avalonia.Controls
             }
         }
 
+        public void Cleanup()
+        {
+            foreach (var child in _childrenNodes)
+            {
+                child?.Cleanup();
+
+                if (child?.SelectedCount == 0)
+                {
+                    child.Dispose();
+                }
+            }
+        }
+
         public bool Select(int index, bool select)
         {
             return Select(index, select, raiseOnSelectionChanged: true);
@@ -453,16 +466,6 @@ namespace Avalonia.Controls
 
             SelectedCount = 0;
             AnchorIndex = -1;
-
-            // This will throw away all the children SelectionNodes
-            // causing them to be unhooked from their data source. This
-            // essentially cleans up the tree.
-            foreach (var child in _childrenNodes)
-            {
-                child?.Dispose();
-            }
-
-            _childrenNodes.Clear();
         }
 
         private bool Select(int index, bool select, bool raiseOnSelectionChanged)

--- a/src/Avalonia.Controls/SelectionNodeOperation.cs
+++ b/src/Avalonia.Controls/SelectionNodeOperation.cs
@@ -6,11 +6,13 @@ using System.Linq;
 
 namespace Avalonia.Controls
 {
-    internal class SelectionNodeOperation
+    internal class SelectionNodeOperation : ISelectedItemInfo
     {
         private readonly SelectionNode _owner;
         private List<IndexRange>? _selected;
         private List<IndexRange>? _deselected;
+        private int _selectedCount = -1;
+        private int _deselectedCount = -1;
 
         public SelectionNodeOperation(SelectionNode owner)
         {
@@ -23,9 +25,36 @@ namespace Avalonia.Controls
         public IndexPath Path => _owner.IndexPath;
         public ItemsSourceView? Items => _owner.ItemsSourceView;
 
+        public int SelectedCount
+        {
+            get
+            {
+                if (_selectedCount == -1)
+                {
+                    _selectedCount = (_selected != null) ? IndexRange.GetCount(_selected) : 0;
+                }
+
+                return _selectedCount;
+            }
+        }
+
+        public int DeselectedCount
+        {
+            get
+            {
+                if (_deselectedCount == -1)
+                {
+                    _deselectedCount = (_deselected != null) ? IndexRange.GetCount(_deselected) : 0;
+                }
+
+                return _deselectedCount;
+            }
+        }
+
         public void Selected(IndexRange range)
         {
             Add(range, ref _selected, _deselected);
+            _selectedCount = -1;
         }
 
         public void Selected(IEnumerable<IndexRange> ranges)
@@ -39,6 +68,7 @@ namespace Avalonia.Controls
         public void Deselected(IndexRange range)
         {
             Add(range, ref _deselected, _selected);
+            _deselectedCount = -1;
         }
 
         public void Deselected(IEnumerable<IndexRange> ranges)

--- a/src/Avalonia.Controls/SelectionNodeOperation.cs
+++ b/src/Avalonia.Controls/SelectionNodeOperation.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+#nullable enable
+
+namespace Avalonia.Controls
+{
+    internal class SelectionNodeOperation
+    {
+        private readonly SelectionNode _owner;
+        private List<IndexRange>? _selected;
+        private List<IndexRange>? _deselected;
+
+        public SelectionNodeOperation(SelectionNode owner)
+        {
+            _owner = owner;
+        }
+
+        public bool HasChanges => _selected?.Count > 0 || _deselected?.Count > 0;
+        public List<IndexRange>? SelectedRanges => _selected;
+        public List<IndexRange>? DeselectedRanges => _deselected;
+        public IndexPath Path => _owner.IndexPath;
+        public ItemsSourceView? Items => _owner.ItemsSourceView;
+
+        public void Selected(IndexRange range)
+        {
+            Add(range, ref _selected, _deselected);
+        }
+
+        public void Selected(IEnumerable<IndexRange> ranges)
+        {
+            foreach (var range in ranges)
+            {
+                Selected(range);
+            }
+        }
+
+        public void Deselected(IndexRange range)
+        {
+            Add(range, ref _deselected, _selected);
+        }
+
+        public void Deselected(IEnumerable<IndexRange> ranges)
+        {
+            foreach (var range in ranges)
+            {
+                Deselected(range);
+            }
+        }
+
+        private static void Add(
+            IndexRange range,
+            ref List<IndexRange>? add,
+            List<IndexRange>? remove)
+        {
+            if (remove != null)
+            {
+                var removed = new List<IndexRange>();
+                IndexRange.Remove(remove, range, removed);
+                var selected = IndexRange.Subtract(range, removed);
+
+                if (selected.Any())
+                {
+                    add ??= new List<IndexRange>();
+
+                    foreach (var r in selected)
+                    {
+                        IndexRange.Add(add, r);
+                    }
+                }
+            }
+            else
+            {
+                add ??= new List<IndexRange>();
+                IndexRange.Add(add, range);
+            }
+        }
+    }
+}

--- a/tests/Avalonia.Controls.UnitTests/IndexRangeTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/IndexRangeTests.cs
@@ -1,0 +1,307 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests
+{
+    public class IndexRangeTests
+    {
+        [Fact]
+        public void Add_Should_Add_Range_To_Empty_List()
+        {
+            var ranges = new List<IndexRange>();
+            var selected = new List<IndexRange>();
+            var result = IndexRange.Add(ranges, new IndexRange(0, 4), selected);
+
+            Assert.Equal(5, result);
+            Assert.Equal(new[] { new IndexRange(0, 4) }, ranges);
+            Assert.Equal(new[] { new IndexRange(0, 4) }, selected);
+        }
+
+        [Fact]
+        public void Add_Should_Add_Non_Intersecting_Range_At_End()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(0, 4) };
+            var selected = new List<IndexRange>();
+            var result = IndexRange.Add(ranges, new IndexRange(8, 10), selected);
+
+            Assert.Equal(3, result);
+            Assert.Equal(new[] { new IndexRange(0, 4), new IndexRange(8, 10) }, ranges);
+            Assert.Equal(new[] { new IndexRange(8, 10) }, selected);
+        }
+
+        [Fact]
+        public void Add_Should_Add_Non_Intersecting_Range_At_Beginning()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(8, 10) };
+            var selected = new List<IndexRange>();
+            var result = IndexRange.Add(ranges, new IndexRange(0, 4), selected);
+
+            Assert.Equal(5, result);
+            Assert.Equal(new[] { new IndexRange(0, 4), new IndexRange(8, 10) }, ranges);
+            Assert.Equal(new[] { new IndexRange(0, 4) }, selected);
+        }
+
+        [Fact]
+        public void Add_Should_Add_Non_Intersecting_Range_In_Middle()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(0, 4), new IndexRange(14, 16) };
+            var selected = new List<IndexRange>();
+            var result = IndexRange.Add(ranges, new IndexRange(8, 10), selected);
+
+            Assert.Equal(3, result);
+            Assert.Equal(new[] { new IndexRange(0, 4), new IndexRange(8, 10), new IndexRange(14, 16) }, ranges);
+            Assert.Equal(new[] { new IndexRange(8, 10) }, selected);
+        }
+
+        [Fact]
+        public void Add_Should_Add_Intersecting_Range_Start()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(8, 10) };
+            var selected = new List<IndexRange>();
+            var result = IndexRange.Add(ranges, new IndexRange(6, 9), selected);
+
+            Assert.Equal(2, result);
+            Assert.Equal(new[] { new IndexRange(6, 10) }, ranges);
+            Assert.Equal(new[] { new IndexRange(6, 7) }, selected);
+        }
+
+        [Fact]
+        public void Add_Should_Add_Intersecting_Range_End()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(8, 10) };
+            var selected = new List<IndexRange>();
+            var result = IndexRange.Add(ranges, new IndexRange(9, 12), selected);
+
+            Assert.Equal(2, result);
+            Assert.Equal(new[] { new IndexRange(8, 12) }, ranges);
+            Assert.Equal(new[] { new IndexRange(11, 12) }, selected);
+        }
+
+        [Fact]
+        public void Add_Should_Add_Intersecting_Range_Both()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(8, 10) };
+            var selected = new List<IndexRange>();
+            var result = IndexRange.Add(ranges, new IndexRange(6, 12), selected);
+
+            Assert.Equal(4, result);
+            Assert.Equal(new[] { new IndexRange(6, 12) }, ranges);
+            Assert.Equal(new[] { new IndexRange(6, 7), new IndexRange(11, 12) }, selected);
+        }
+
+        [Fact]
+        public void Add_Should_Join_Two_Intersecting_Ranges()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(8, 10), new IndexRange(12, 14) };
+            var selected = new List<IndexRange>();
+            var result = IndexRange.Add(ranges, new IndexRange(8, 14), selected);
+
+            Assert.Equal(1, result);
+            Assert.Equal(new[] { new IndexRange(8, 14) }, ranges);
+            Assert.Equal(new[] { new IndexRange(11, 11) }, selected);
+        }
+
+        [Fact]
+        public void Add_Should_Join_Two_Intersecting_Ranges_And_Add_Ranges()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(8, 10), new IndexRange(12, 14) };
+            var selected = new List<IndexRange>();
+            var result = IndexRange.Add(ranges, new IndexRange(6, 18), selected);
+
+            Assert.Equal(7, result);
+            Assert.Equal(new[] { new IndexRange(6, 18) }, ranges);
+            Assert.Equal(new[] { new IndexRange(6, 7), new IndexRange(11, 11), new IndexRange(15, 18) }, selected);
+        }
+
+        [Fact]
+        public void Add_Should_Not_Add_Already_Selected_Range()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(8, 10) };
+            var selected = new List<IndexRange>();
+            var result = IndexRange.Add(ranges, new IndexRange(9, 10), selected);
+
+            Assert.Equal(0, result);
+            Assert.Equal(new[] { new IndexRange(8, 10) }, ranges);
+            Assert.Empty(selected);
+        }
+
+        [Fact]
+        public void Remove_Should_Remove_Entire_Range()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(8, 10) };
+            var deselected = new List<IndexRange>();
+            var result = IndexRange.Remove(ranges, new IndexRange(8, 10), deselected);
+
+            Assert.Equal(3, result);
+            Assert.Empty(ranges);
+            Assert.Equal(new[] { new IndexRange(8, 10) }, deselected);
+        }
+
+        [Fact]
+        public void Remove_Should_Remove_Start_Of_Range()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(8, 12) };
+            var deselected = new List<IndexRange>();
+            var result = IndexRange.Remove(ranges, new IndexRange(8, 10), deselected);
+
+            Assert.Equal(3, result);
+            Assert.Equal(new[] { new IndexRange(11, 12) }, ranges);
+            Assert.Equal(new[] { new IndexRange(8, 10) }, deselected);
+        }
+
+        [Fact]
+        public void Remove_Should_Remove_End_Of_Range()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(8, 12) };
+            var deselected = new List<IndexRange>();
+            var result = IndexRange.Remove(ranges, new IndexRange(10, 12), deselected);
+
+            Assert.Equal(3, result);
+            Assert.Equal(new[] { new IndexRange(8, 9) }, ranges);
+            Assert.Equal(new[] { new IndexRange(10, 12) }, deselected);
+        }
+
+        [Fact]
+        public void Remove_Should_Remove_Overlapping_End_Of_Range()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(8, 12) };
+            var deselected = new List<IndexRange>();
+            var result = IndexRange.Remove(ranges, new IndexRange(10, 14), deselected);
+
+            Assert.Equal(3, result);
+            Assert.Equal(new[] { new IndexRange(8, 9) }, ranges);
+            Assert.Equal(new[] { new IndexRange(10, 12) }, deselected);
+        }
+
+        [Fact]
+        public void Remove_Should_Remove_Middle_Of_Range()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(10, 20) };
+            var deselected = new List<IndexRange>();
+            var result = IndexRange.Remove(ranges, new IndexRange(12, 16), deselected);
+
+            Assert.Equal(5, result);
+            Assert.Equal(new[] { new IndexRange(10, 11), new IndexRange(17, 20) }, ranges);
+            Assert.Equal(new[] { new IndexRange(12, 16) }, deselected);
+        }
+
+        [Fact]
+        public void Remove_Should_Remove_Multiple_Ranges()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(8, 10), new IndexRange(12, 14), new IndexRange(16, 18) };
+            var deselected = new List<IndexRange>();
+            var result = IndexRange.Remove(ranges, new IndexRange(6, 15), deselected);
+
+            Assert.Equal(6, result);
+            Assert.Equal(new[] { new IndexRange(16, 18) }, ranges);
+            Assert.Equal(new[] { new IndexRange(8, 10), new IndexRange(12, 14) }, deselected);
+        }
+
+        [Fact]
+        public void Remove_Should_Remove_Multiple_And_Partial_Ranges_1()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(8, 10), new IndexRange(12, 14), new IndexRange(16, 18) };
+            var deselected = new List<IndexRange>();
+            var result = IndexRange.Remove(ranges, new IndexRange(9, 15), deselected);
+
+            Assert.Equal(5, result);
+            Assert.Equal(new[] { new IndexRange(8, 8), new IndexRange(16, 18) }, ranges);
+            Assert.Equal(new[] { new IndexRange(9, 10), new IndexRange(12, 14) }, deselected);
+        }
+
+        [Fact]
+        public void Remove_Should_Remove_Multiple_And_Partial_Ranges_2()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(8, 10), new IndexRange(12, 14), new IndexRange(16, 18) };
+            var deselected = new List<IndexRange>();
+            var result = IndexRange.Remove(ranges, new IndexRange(8, 13), deselected);
+
+            Assert.Equal(5, result);
+            Assert.Equal(new[] { new IndexRange(14, 14), new IndexRange(16, 18) }, ranges);
+            Assert.Equal(new[] { new IndexRange(8, 10), new IndexRange(12, 13) }, deselected);
+        }
+
+        [Fact]
+        public void Remove_Should_Remove_Multiple_And_Partial_Ranges_3()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(8, 10), new IndexRange(12, 14), new IndexRange(16, 18) };
+            var deselected = new List<IndexRange>();
+            var result = IndexRange.Remove(ranges, new IndexRange(9, 13), deselected);
+
+            Assert.Equal(4, result);
+            Assert.Equal(new[] { new IndexRange(8, 8), new IndexRange(14, 14), new IndexRange(16, 18) }, ranges);
+            Assert.Equal(new[] { new IndexRange(9, 10), new IndexRange(12, 13) }, deselected);
+        }
+
+        [Fact]
+        public void Remove_Should_Do_Nothing_For_Unselected_Range()
+        {
+            var ranges = new List<IndexRange> { new IndexRange(8, 10) };
+            var deselected = new List<IndexRange>();
+            var result = IndexRange.Remove(ranges, new IndexRange(2, 4), deselected);
+
+            Assert.Equal(0, result);
+            Assert.Equal(new[] { new IndexRange(8, 10) }, ranges);
+            Assert.Empty(deselected);
+        }
+
+        [Fact]
+        public void Stress_Test()
+        {
+            const int iterations = 100;
+            var random = new Random(0);
+            var selection = new List<IndexRange>();
+            var expected = new List<int>();
+
+            IndexRange Generate()
+            {
+                var start = random.Next(100);
+                return new IndexRange(start, start + random.Next(20));
+            }
+
+            for (var i = 0; i < iterations; ++i)
+            {
+                var toAdd = random.Next(5);
+
+                for (var j = 0; j < toAdd; ++j)
+                {
+                    var range = Generate();
+                    IndexRange.Add(selection, range);
+
+                    for (var k = range.Begin; k <= range.End; ++k)
+                    {
+                        if (!expected.Contains(k))
+                        {
+                            expected.Add(k);
+                        }
+                    }
+
+                    var actual = IndexRange.EnumerateIndices(selection).ToList();
+                    expected.Sort();
+                    Assert.Equal(expected, actual);
+                }
+
+                var toRemove = random.Next(5);
+
+                for (var j = 0; j < toRemove; ++j)
+                {
+                    var range = Generate();
+                    IndexRange.Remove(selection, range);
+
+                    for (var k = range.Begin; k <= range.End; ++k)
+                    {
+                        expected.Remove(k);
+                    }
+
+                    var actual = IndexRange.EnumerateIndices(selection).ToList();
+                    Assert.Equal(expected, actual);
+                }
+
+                selection.Clear();
+                expected.Clear();
+            }
+        }
+    }
+}

--- a/tests/Avalonia.Controls.UnitTests/SelectionModelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SelectionModelTests.cs
@@ -1466,6 +1466,33 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(1, raised);
         }
 
+        [Fact]
+        public void Can_Batch_Update()
+        {
+            var target = new SelectionModel();
+            var raised = 0;
+
+            target.Source = Enumerable.Range(0, 10).ToList();
+            target.Select(1);
+
+            target.SelectionChanged += (s, e) =>
+            {
+                Assert.Equal(new[] { new IndexPath(1) }, e.DeselectedIndices);
+                Assert.Equal(new object[] { 1 }, e.DeselectedItems);
+                Assert.Equal(new[] { new IndexPath(4) }, e.SelectedIndices);
+                Assert.Equal(new object[] { 4 }, e.SelectedItems);
+                ++raised;
+            };
+
+            using (target.Update())
+            {
+                target.Deselect(1);
+                target.Select(4);
+            }
+
+            Assert.Equal(1, raised);
+        }
+
         private int GetSubscriberCount(AvaloniaList<object> list)
         {
             return ((INotifyCollectionChangedDebug)list).GetCollectionChangedSubscribers()?.Length ?? 0;

--- a/tests/Avalonia.Controls.UnitTests/SelectionModelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SelectionModelTests.cs
@@ -1185,6 +1185,29 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Clearing_Nested_Selection_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel();
+            var raised = 0;
+
+            target.Source = CreateNestedData(1, 2, 3);
+            target.Select(1, 1);
+
+            target.SelectionChanged += (s, e) =>
+            {
+                Assert.Equal(new[] { new IndexPath(1, 1) }, e.DeselectedIndices);
+                Assert.Equal(new object[] { 4 }, e.DeselectedItems);
+                Assert.Empty(e.SelectedIndices);
+                Assert.Empty(e.SelectedItems);
+                ++raised;
+            };
+
+            target.ClearSelection();
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
         public void Changing_Source_Raises_SelectionChanged()
         {
             var target = new SelectionModel();

--- a/tests/Avalonia.Controls.UnitTests/SelectionModelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SelectionModelTests.cs
@@ -1424,6 +1424,48 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(2, raised);
         }
 
+        [Fact]
+        public void Raises_SelectionChanged_With_No_Source()
+        {
+            var target = new SelectionModel();
+            var raised = 0;
+
+            target.SelectionChanged += (s, e) =>
+            {
+                Assert.Empty(e.DeselectedIndices);
+                Assert.Empty(e.DeselectedItems);
+                Assert.Equal(new[] { new IndexPath(1) }, e.SelectedIndices);
+                Assert.Empty(e.SelectedItems);
+                ++raised;
+            };
+
+            target.Select(1);
+
+            Assert.Equal(new[] { new IndexPath(1) }, target.SelectedIndices);
+            Assert.Empty(target.SelectedItems);
+        }
+
+        [Fact]
+        public void Raises_SelectionChanged_With_Items_After_Source_Is_Set()
+        {
+            var target = new SelectionModel();
+            var raised = 0;
+
+            target.Select(1);
+            target.SelectionChanged += (s, e) =>
+            {
+                Assert.Empty(e.DeselectedIndices);
+                Assert.Empty(e.DeselectedItems);
+                Assert.Equal(new[] { new IndexPath(1) }, e.SelectedIndices);
+                Assert.Equal(new[] { "bar" }, e.SelectedItems);
+                ++raised;
+            };
+
+            target.Source = new[] { "foo", "bar", "baz" };
+
+            Assert.Equal(1, raised);
+        }
+
         private int GetSubscriberCount(AvaloniaList<object> list)
         {
             return ((INotifyCollectionChangedDebug)list).GetCollectionChangedSubscribers()?.Length ?? 0;

--- a/tests/Avalonia.Controls.UnitTests/SelectionModelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SelectionModelTests.cs
@@ -931,6 +931,21 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Should_Listen_For_Changes_After_Deselect()
+        {
+            var target = new SelectionModel();
+            var data = CreateNestedData(1, 2, 3);
+
+            target.Source = data;
+            target.Select(1, 0);
+            target.Deselect(1, 0);
+            target.Select(1, 0);
+            ((AvaloniaList<object>)data[1]).Insert(0, "foo");
+
+            Assert.Equal(new IndexPath(1, 1), target.SelectedIndex);
+        }
+
+        [Fact]
         public void Selecting_Item_Raises_SelectionChanged()
         {
             var target = new SelectionModel();

--- a/tests/Avalonia.Controls.UnitTests/SelectionModelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SelectionModelTests.cs
@@ -1392,6 +1392,38 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(3, target.SelectedItems.Count);
         }
 
+        [Fact]
+        public void Not_Enumerating_Changes_Does_Not_Prevent_Further_Operations()
+        {
+            var data = new[] { "foo", "bar", "baz" };
+            var target = new SelectionModel { Source = data };
+
+            target.SelectionChanged += (s, e) => { };
+
+            target.SelectAll();
+            target.ClearSelection();
+        }
+
+        [Fact]
+        public void Can_Change_Selection_From_SelectionChanged()
+        {
+            var data = new[] { "foo", "bar", "baz" };
+            var target = new SelectionModel { Source = data };
+            var raised = 0;
+
+            target.SelectionChanged += (s, e) => 
+            {
+                if (raised++ == 0)
+                {
+                    target.ClearSelection();
+                }
+            };
+
+            target.SelectAll();
+
+            Assert.Equal(2, raised);
+        }
+
         private int GetSubscriberCount(AvaloniaList<object> list)
         {
             return ((INotifyCollectionChangedDebug)list).GetCollectionChangedSubscribers()?.Length ?? 0;

--- a/tests/Avalonia.Controls.UnitTests/SelectionModelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SelectionModelTests.cs
@@ -931,6 +931,423 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Selecting_Item_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel();
+            var raised = 0;
+
+            target.Source = Enumerable.Range(0, 10).ToList();
+            target.SelectionChanged += (s, e) =>
+            {
+                Assert.Empty(e.DeselectedIndices);
+                Assert.Empty(e.DeselectedItems);
+                Assert.Equal(new[] { new IndexPath(4) }, e.SelectedIndices);
+                Assert.Equal(new object[] { 4 }, e.SelectedItems);
+                ++raised;
+            };
+
+            target.Select(4);
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void Selecting_Already_Selected_Item_Doesnt_Raise_SelectionChanged()
+        {
+            var target = new SelectionModel();
+            var raised = 0;
+
+            target.Source = Enumerable.Range(0, 10).ToList();
+            target.Select(4);
+            target.SelectionChanged += (s, e) => ++raised;
+            target.Select(4);
+
+            Assert.Equal(0, raised);
+        }
+
+        [Fact]
+        public void SingleSelecting_Item_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel { SingleSelect = true };
+            var raised = 0;
+
+            target.Source = Enumerable.Range(0, 10).ToList();
+            target.Select(3);
+
+            target.SelectionChanged += (s, e) =>
+            {
+                Assert.Equal(new[] { new IndexPath(3) }, e.DeselectedIndices);
+                Assert.Equal(new object[] { 3 }, e.DeselectedItems);
+                Assert.Equal(new[] { new IndexPath(4) }, e.SelectedIndices);
+                Assert.Equal(new object[] { 4 }, e.SelectedItems);
+                ++raised;
+            };
+
+            target.Select(4);
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void SingleSelecting_Already_Selected_Item_Doesnt_Raise_SelectionChanged()
+        {
+            var target = new SelectionModel { SingleSelect = true };
+            var raised = 0;
+
+            target.Source = Enumerable.Range(0, 10).ToList();
+            target.Select(4);
+            target.SelectionChanged += (s, e) => ++raised;
+            target.Select(4);
+
+            Assert.Equal(0, raised);
+        }
+
+        [Fact]
+        public void Selecting_Item_With_Group_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel();
+            var raised = 0;
+
+            target.Source = CreateNestedData(1, 2, 3);
+            target.SelectionChanged += (s, e) =>
+            {
+                Assert.Empty(e.DeselectedIndices);
+                Assert.Empty(e.DeselectedItems);
+                Assert.Equal(new[] { new IndexPath(1, 1) }, e.SelectedIndices);
+                Assert.Equal(new object[] { 4 }, e.SelectedItems);
+                ++raised;
+            };
+
+            target.Select(1, 1);
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void SelectAt_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel();
+            var raised = 0;
+
+            target.Source = CreateNestedData(1, 2, 3);
+            target.SelectionChanged += (s, e) =>
+            {
+                Assert.Empty(e.DeselectedIndices);
+                Assert.Empty(e.DeselectedItems);
+                Assert.Equal(new[] { new IndexPath(1, 1) }, e.SelectedIndices);
+                Assert.Equal(new object[] { 4 }, e.SelectedItems);
+                ++raised;
+            };
+
+            target.SelectAt(new IndexPath(1, 1));
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void SelectAll_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel { SingleSelect = true };
+            var raised = 0;
+
+            target.Source = Enumerable.Range(0, 10).ToList();
+            target.SelectionChanged += (s, e) =>
+            {
+                var expected = Enumerable.Range(0, 10);
+                Assert.Empty(e.DeselectedIndices);
+                Assert.Empty(e.DeselectedItems);
+                Assert.Equal(expected.Select(x => new IndexPath(x)), e.SelectedIndices);
+                Assert.Equal(expected, e.SelectedItems.Cast<int>());
+                ++raised;
+            };
+
+            target.SelectAll();
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void SelectAll_With_Already_Selected_Items_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel { SingleSelect = true };
+            var raised = 0;
+
+            target.Source = Enumerable.Range(0, 10).ToList();
+            target.Select(4);
+
+            target.SelectionChanged += (s, e) =>
+            {
+                var expected = Enumerable.Range(0, 10).Except(new[] { 4 });
+                Assert.Empty(e.DeselectedIndices);
+                Assert.Empty(e.DeselectedItems);
+                Assert.Equal(expected.Select(x => new IndexPath(x)), e.SelectedIndices);
+                Assert.Equal(expected, e.SelectedItems.Cast<int>());
+                ++raised;
+            };
+
+            target.SelectAll();
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void SelectRangeFromAnchor_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel();
+            var raised = 0;
+
+            target.Source = Enumerable.Range(0, 10).ToList();
+            target.SelectionChanged += (s, e) =>
+            {
+                var expected = Enumerable.Range(4, 3);
+                Assert.Empty(e.DeselectedIndices);
+                Assert.Empty(e.DeselectedItems);
+                Assert.Equal(expected.Select(x => new IndexPath(x)), e.SelectedIndices);
+                Assert.Equal(expected, e.SelectedItems.Cast<int>());
+                ++raised;
+            };
+
+            target.AnchorIndex = new IndexPath(4);
+            target.SelectRangeFromAnchor(6);
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void SelectRangeFromAnchor_With_Group_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel();
+            var raised = 0;
+
+            target.Source = CreateNestedData(1, 2, 10);
+            target.SelectionChanged += (s, e) =>
+            {
+                var expected = Enumerable.Range(11, 6);
+                Assert.Empty(e.DeselectedIndices);
+                Assert.Empty(e.DeselectedItems);
+                Assert.Equal(expected.Select(x => new IndexPath(x / 10, x % 10)), e.SelectedIndices);
+                Assert.Equal(expected, e.SelectedItems.Cast<int>());
+                ++raised;
+            };
+
+            target.AnchorIndex = new IndexPath(1, 1);
+            target.SelectRangeFromAnchor(1, 6);
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void SelectRangeFromAnchorTo_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel();
+            var raised = 0;
+
+            target.Source = CreateNestedData(1, 2, 10);
+            target.SelectionChanged += (s, e) =>
+            {
+                var expected = Enumerable.Range(11, 6);
+                Assert.Empty(e.DeselectedIndices);
+                Assert.Empty(e.DeselectedItems);
+                Assert.Equal(expected.Select(x => new IndexPath(x / 10, x % 10)), e.SelectedIndices);
+                Assert.Equal(expected, e.SelectedItems.Cast<int>());
+                ++raised;
+            };
+
+            target.AnchorIndex = new IndexPath(1, 1);
+            target.SelectRangeFromAnchorTo(new IndexPath(1, 6));
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void ClearSelection_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel();
+            var raised = 0;
+
+            target.Source = Enumerable.Range(0, 10).ToList();
+            target.Select(4);
+            target.Select(5);
+
+            target.SelectionChanged += (s, e) =>
+            {
+                var expected = Enumerable.Range(4, 2);
+                Assert.Equal(expected.Select(x => new IndexPath(x)), e.DeselectedIndices);
+                Assert.Equal(expected, e.DeselectedItems.Cast<int>());
+                Assert.Empty(e.SelectedIndices);
+                Assert.Empty(e.SelectedItems);
+                ++raised;
+            };
+
+            target.ClearSelection();
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void Changing_Source_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel();
+            var raised = 0;
+
+            target.Source = Enumerable.Range(0, 10).ToList();
+            target.Select(4);
+            target.Select(5);
+
+            target.SelectionChanged += (s, e) =>
+            {
+                var expected = Enumerable.Range(4, 2);
+                Assert.Equal(expected.Select(x => new IndexPath(x)), e.DeselectedIndices);
+                Assert.Equal(expected, e.DeselectedItems.Cast<int>());
+                Assert.Empty(e.SelectedIndices);
+                Assert.Empty(e.SelectedItems);
+                ++raised;
+            };
+
+            target.Source = Enumerable.Range(20, 10).ToList();
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void Setting_SelectedIndex_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel();
+            var raised = 0;
+
+            target.Source = Enumerable.Range(0, 10).ToList();
+            target.Select(4);
+            target.Select(5);
+
+            target.SelectionChanged += (s, e) =>
+            {
+                Assert.Equal(new[] { new IndexPath(4), new IndexPath(5) }, e.DeselectedIndices);
+                Assert.Equal(new object[] { 4, 5 }, e.DeselectedItems);
+                Assert.Equal(new[] { new IndexPath(6) }, e.SelectedIndices);
+                Assert.Equal(new object[] { 6 }, e.SelectedItems);
+                ++raised;
+            };
+
+            target.SelectedIndex = new IndexPath(6);
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void Removing_Selected_Item_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel();
+            var data = new ObservableCollection<int>(Enumerable.Range(0, 10));
+            var raised = 0;
+
+            target.Source = data;
+            target.Select(4);
+            target.Select(5);
+
+            target.SelectionChanged += (s, e) =>
+            {
+                Assert.Empty(e.DeselectedIndices);
+                Assert.Equal(new object[] { 4 }, e.DeselectedItems);
+                Assert.Empty(e.SelectedIndices);
+                Assert.Empty(e.SelectedItems);
+                ++raised;
+            };
+
+            data.Remove(4);
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void Removing_Selected_Child_Item_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel();
+            var data = CreateNestedData(1, 2, 3);
+            var raised = 0;
+
+            target.Source = data;
+            target.SelectRange(new IndexPath(0), new IndexPath(1, 1));
+
+            target.SelectionChanged += (s, e) =>
+            {
+                Assert.Empty(e.DeselectedIndices);
+                Assert.Equal(new object[] { 1}, e.DeselectedItems);
+                Assert.Empty(e.SelectedIndices);
+                Assert.Empty(e.SelectedItems);
+                ++raised;
+            };
+
+            ((AvaloniaList<object>)data[0]).RemoveAt(1);
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void Removing_Selected_Item_With_Children_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel();
+            var data = CreateNestedData(1, 2, 3);
+            var raised = 0;
+
+            target.Source = data;
+            target.SelectRange(new IndexPath(0), new IndexPath(1, 1));
+
+            target.SelectionChanged += (s, e) =>
+            {
+                Assert.Empty(e.DeselectedIndices);
+                Assert.Equal(new object[] { 0, 1, 2 }, e.DeselectedItems);
+                Assert.Empty(e.SelectedIndices);
+                Assert.Empty(e.SelectedItems);
+                ++raised;
+            };
+
+            data.RemoveAt(0);
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void Removing_Unselected_Item_Before_Selected_Item_Raises_SelectionChanged()
+        {
+            var target = new SelectionModel();
+            var data = new ObservableCollection<int>(Enumerable.Range(0, 10));
+            var raised = 0;
+
+            target.Source = data;
+            target.Select(8);
+
+            target.SelectionChanged += (s, e) =>
+            {
+                Assert.Empty(e.DeselectedIndices);
+                Assert.Empty(e.DeselectedItems);
+                Assert.Empty(e.SelectedIndices);
+                Assert.Empty(e.SelectedItems);
+                ++raised;
+            };
+
+            data.Remove(6);
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void Removing_Unselected_Item_After_Selected_Item_Doesnt_Raise_SelectionChanged()
+        {
+            var target = new SelectionModel();
+            var data = new ObservableCollection<int>(Enumerable.Range(0, 10));
+            var raised = 0;
+
+            target.Source = data;
+            target.Select(4);
+
+            target.SelectionChanged += (s, e) => ++raised;
+
+            data.Remove(6);
+
+            Assert.Equal(0, raised); 
+        }
+
+        [Fact]
         public void Disposing_Unhooks_CollectionChanged_Handlers()
         {
             var data = CreateNestedData(2, 2, 2);


### PR DESCRIPTION
## What does the pull request do?

`SelectionModel` as ported from WinUI (#3469) has no information about what changed in a `SelectionChanged` event. This adds that information along with unit tests.

WinUI issue: https://github.com/microsoft/microsoft-ui-xaml/issues/1645

Part of #3469