### PR TITLE
Implement Equals for ImmutableSolidColorBrush.

### DIFF
--- a/src/Avalonia.Visuals/Media/Immutable/ImmutableSolidColorBrush.cs
+++ b/src/Avalonia.Visuals/Media/Immutable/ImmutableSolidColorBrush.cs
@@ -1,12 +1,14 @@
 // Copyright (c) The Avalonia Project. All rights reserved.
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
+using System;
+
 namespace Avalonia.Media.Immutable
 {
     /// <summary>
     /// Fills an area with a solid color.
     /// </summary>
-    public readonly struct ImmutableSolidColorBrush : ISolidColorBrush
+    public readonly struct ImmutableSolidColorBrush : ISolidColorBrush, IEquatable<ImmutableSolidColorBrush>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableSolidColorBrush"/> class.
@@ -46,6 +48,35 @@ namespace Avalonia.Media.Immutable
         /// Gets the opacity of the brush.
         /// </summary>
         public double Opacity { get; }
+
+        public bool Equals(ImmutableSolidColorBrush other)
+        {
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            return Color == other.Color && Opacity == other.Opacity;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ImmutableSolidColorBrush other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Color.GetHashCode() * 397) ^ Opacity.GetHashCode();
+            }
+        }
+
+        public static bool operator ==(ImmutableSolidColorBrush left, ImmutableSolidColorBrush right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(ImmutableSolidColorBrush left, ImmutableSolidColorBrush right)
+        {
+            return !left.Equals(right);
+        }
 
         /// <summary>
         /// Returns a string representation of the brush.


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Another case of struct missing `IEquatable` implementation.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Everytime we set any sort of `Brush` property to a value from either `Brushes` or create immutable brush ourselves we would end up calling `ValueType.Equals` which will use reflection to do memberwise comparison (which is obviously way slower and requires allocation).

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
No extra dynamic allocations and reflection usage to compare brushes.