### PR TITLE
Remove list allocations from the general case of Selector.Match

### DIFF
--- a/src/Avalonia.Base/Utilities/ValueSingleOrList.cs
+++ b/src/Avalonia.Base/Utilities/ValueSingleOrList.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+
+namespace Avalonia.Utilities
+{
+    /// <summary>
+    /// A list like struct optimized for holding zero or one items.
+    /// </summary>
+    /// <typeparam name="T">The type of items held in the list.</typeparam>
+    /// <remarks>
+    /// Once more than value has been added to this storage it will switch to using <see cref="List"/> internally.
+    /// </remarks>
+    public ref struct ValueSingleOrList<T>
+    {
+        private bool _isSingleSet;
+
+        /// <summary>
+        /// Single contained value. Only valid if <see cref="IsSingle"/> is set.
+        /// </summary>
+        public T Single { get; private set; }
+
+        /// <summary>
+        /// List of values.
+        /// </summary>
+        public List<T> List { get; private set; }
+
+        /// <summary>
+        /// If this struct is backed by a list.
+        /// </summary>
+        public bool HasList => List != null;
+
+        /// <summary>
+        /// If this struct contains only single value and storage was not promoted to a list.
+        /// </summary>
+        public bool IsSingle => List == null && _isSingleSet;
+
+        /// <summary>
+        /// Adds a value.
+        /// </summary>
+        /// <param name="value">Value to add.</param>
+        public void Add(T value)
+        {
+            if (List != null)
+            {
+                List.Add(value);
+            }
+            else
+            {
+                if (!_isSingleSet)
+                {
+                    Single = value;
+
+                    _isSingleSet = true;
+                }
+                else
+                {
+                    List = new List<T>();
+
+                    List.Add(Single);
+                    List.Add(value);
+
+                    Single = default;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes a value.
+        /// </summary>
+        /// <param name="value">Value to remove.</param>
+        public bool Remove(T value)
+        {
+            if (List != null)
+            {
+                return List.Remove(value);
+            }
+
+            if (!_isSingleSet)
+            {
+                return false;
+            }
+
+            if (EqualityComparer<T>.Default.Equals(Single, value))
+            {
+                Single = default;
+
+                _isSingleSet = false;
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Avalonia.Styling/Styling/Selector.cs
+++ b/src/Avalonia.Styling/Styling/Selector.cs
@@ -41,7 +41,9 @@ namespace Avalonia.Styling
         /// <returns>A <see cref="SelectorMatch"/>.</returns>
         public SelectorMatch Match(IStyleable control, bool subscribe = true)
         {
-            var inputs = new List<IObservable<bool>>();
+            List<IObservable<bool>> inputs = null;
+            IObservable<bool> singleInput = null;
+
             var selector = this;
             var alwaysThisType = true;
             var hitCombinator = false;
@@ -66,15 +68,36 @@ namespace Avalonia.Styling
                 }
                 else if (match.Result == SelectorMatchResult.Sometimes)
                 {
-                    inputs.Add(match.Activator);
+                    if (inputs != null)
+                    {
+                        inputs.Add(match.Activator);
+                    }
+                    else
+                    {
+                        if (singleInput == null)
+                        {
+                            singleInput = match.Activator;
+                        }
+                        else
+                        {
+                            inputs = new List<IObservable<bool>>();
+
+                            inputs.Add(singleInput);
+                            inputs.Add(match.Activator);
+                        }
+                    }
                 }
 
                 selector = selector.MovePrevious();
             }
 
-            if (inputs.Count > 0)
+            if (inputs != null)
             {
                 return new SelectorMatch(StyleActivator.And(inputs));
+            }
+            else if (singleInput != null)
+            {
+                return new SelectorMatch(singleInput);
             }
             else
             {

--- a/src/Avalonia.Styling/Styling/Selector.cs
+++ b/src/Avalonia.Styling/Styling/Selector.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Avalonia.Utilities;
 
 namespace Avalonia.Styling
 {
@@ -42,8 +43,7 @@ namespace Avalonia.Styling
         /// <returns>A <see cref="SelectorMatch"/>.</returns>
         public SelectorMatch Match(IStyleable control, bool subscribe = true)
         {
-            List<IObservable<bool>> inputs = null;
-            IObservable<bool> singleInput = null;
+            ValueSingleOrList<IObservable<bool>> inputs = default;
 
             var selector = this;
             var alwaysThisType = true;
@@ -71,40 +71,23 @@ namespace Avalonia.Styling
                 {
                     Debug.Assert(match.Activator != null);
 
-                    if (inputs != null)
-                    {
-                        inputs.Add(match.Activator);
-                    }
-                    else
-                    {
-                        if (singleInput == null)
-                        {
-                            singleInput = match.Activator;
-                        }
-                        else
-                        {
-                            inputs = new List<IObservable<bool>>();
-
-                            inputs.Add(singleInput);
-                            inputs.Add(match.Activator);
-                        }
-                    }
+                    inputs.Add(match.Activator);
                 }
 
                 selector = selector.MovePrevious();
             }
 
-            if (inputs != null)
+            if (inputs.HasList)
             {
-                return new SelectorMatch(StyleActivator.And(inputs));
+                return new SelectorMatch(StyleActivator.And(inputs.List));
             }
-            else if (singleInput != null)
+            else if (inputs.IsSingle)
             {
-                return new SelectorMatch(singleInput);
+                return new SelectorMatch(inputs.Single);
             }
             else
             {
-                return alwaysThisType && !hitCombinator ? 
+                return alwaysThisType && !hitCombinator ?
                     SelectorMatch.AlwaysThisType :
                     SelectorMatch.AlwaysThisInstance;
             }

--- a/src/Avalonia.Styling/Styling/Selector.cs
+++ b/src/Avalonia.Styling/Styling/Selector.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Avalonia.Styling
 {
@@ -68,6 +69,8 @@ namespace Avalonia.Styling
                 }
                 else if (match.Result == SelectorMatchResult.Sometimes)
                 {
+                    Debug.Assert(match.Activator != null);
+
                     if (inputs != null)
                     {
                         inputs.Add(match.Activator);

--- a/tests/Avalonia.Benchmarks/Styling/SelectorBenchmark.cs
+++ b/tests/Avalonia.Benchmarks/Styling/SelectorBenchmark.cs
@@ -1,0 +1,52 @@
+﻿using Avalonia.Controls;
+using Avalonia.Styling;
+using BenchmarkDotNet.Attributes;
+
+namespace Avalonia.Benchmarks.Styling
+{
+    [MemoryDiagnoser]
+    public class SelectorBenchmark
+    {
+        private readonly Control _notMatchingControl;
+        private readonly Calendar _matchingControl;
+        private readonly Selector _isCalendarSelector;
+        private readonly Selector _classSelector;
+
+        public SelectorBenchmark()
+        {
+            _notMatchingControl = new Control();
+            _matchingControl = new Calendar();
+
+            const string className = "selector-class";
+
+            _matchingControl.Classes.Add(className);
+
+            _isCalendarSelector = Selectors.Is<Calendar>(null);
+            _classSelector = Selectors.Class(null, className);
+        }
+
+        [Benchmark]
+        public SelectorMatch IsSelector_NoMatch()
+        {
+            return _isCalendarSelector.Match(_notMatchingControl);
+        }
+
+        [Benchmark]
+        public SelectorMatch IsSelector_Match()
+        {
+            return _isCalendarSelector.Match(_matchingControl);
+        }
+
+        [Benchmark]
+        public SelectorMatch ClassSelector_NoMatch()
+        {
+            return _classSelector.Match(_notMatchingControl);
+        }
+
+        [Benchmark]
+        public SelectorMatch ClassSelector_Match()
+        {
+            return _classSelector.Match(_matchingControl);
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
I did a quick investigation in ControlCatalog and found out that only like 10% of `Selector.Match`  calls ended up in a branch needing `input` list. And after that less than 1% of total calls actually had more than one item in it.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
We allocate new `List` for each `Selector.Match` call.

|                Method |     Mean |   Error |  StdDev |   Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------- |---------:|--------:|--------:|---------:|-------:|------:|------:|----------:|
| ClassSelector_NoMatch | 119.5 ns | 2.40 ns | 3.66 ns | 117.2 ns | 0.0572 |     - |     - |     240 B |
|   ClassSelector_Match | 116.5 ns | 1.26 ns | 1.18 ns | 116.0 ns | 0.0572 |     - |     - |     240 B |

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
We only allocate new `List` when we actually need it.


|                Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
| ClassSelector_NoMatch | 43.76 ns | 0.427 ns | 0.378 ns | 0.0363 |     - |     - |     152 B |
|   ClassSelector_Match | 45.08 ns | 0.778 ns | 0.728 ns | 0.0363 |     - |     - |     152 B |

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Matching starts with no buffer and one empty stack spot for eventual input.

When first input is encountered we store it on stack in `singleInput`. This handles majority of cases and avoids allocating.

When we encounter another input then we allocate new `List` and store both previous and current inputs in it. We end up with `List` that has capacity of 4. For now I assumed we don't need to do anything fancy in this case, eventually we might want to investigate array pooling (when benchmarking proves that this is an actual bottleneck somewhere).

Added simple benchmark that I was using to check the performance in the common case.
