### PR TITLE
AvaloniaList: Allow for preallocating during `InsertRange` for more cases.

### DIFF
--- a/src/Avalonia.Base/Collections/AvaloniaList.cs
+++ b/src/Avalonia.Base/Collections/AvaloniaList.cs
@@ -327,6 +327,8 @@ namespace Avalonia.Collections
                     }
                     else
                     {
+                        EnsureCapacity(_inner.Count + list.Count);
+
                         using (IEnumerator<T> en = items.GetEnumerator())
                         {
                             int insertIndex = index;
@@ -549,6 +551,24 @@ namespace Avalonia.Collections
 
         /// <inheritdoc/>
         Delegate[] INotifyCollectionChangedDebug.GetCollectionChangedSubscribers() => _collectionChanged?.GetInvocationList();
+
+        private void EnsureCapacity(int capacity)
+        {
+            // Adapted from List<T> implementation.
+            var currentCapacity = _inner.Capacity;
+
+            if (currentCapacity < capacity)
+            {
+                var newCapacity = currentCapacity == 0 ? 4 : currentCapacity * 2;
+
+                if (newCapacity < capacity)
+                {
+                    newCapacity = capacity;
+                }
+
+                _inner.Capacity = newCapacity;
+            }
+        }
 
         /// <summary>
         /// Raises the <see cref="CollectionChanged"/> event with an add action.


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Optimizes `AvaloniaList.InsertRange` even further.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Currently when we `InsertRange` and given argument is not `ICollection<T>` we would insert items one by one which can lead to multiple inner list resized.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
When we don't have `ICollection<T>` but we have `IList` - make sure that we have enough space before trying to insert as it avoids extra reallocations (and we know how many elements we will be inserting).

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Mimics implementation from `List<T>` to allow for ensuring capacity.
And honestly at some point I might just drop `List<T>` completely and just rewrite to improve such cases even further (and save one allocation by not needing a `List` instance.) similar to `PooledList` implementation.