### PR TITLE
Check if an exception was thrown before entering the mainloop.

### DIFF
--- a/src/Avalonia.Native/PlatformThreadingInterface.cs
+++ b/src/Avalonia.Native/PlatformThreadingInterface.cs
@@ -60,6 +60,7 @@ namespace Avalonia.Native
 
         public void RunLoop(CancellationToken cancellationToken)
         {
+            _exceptionDispatchInfo?.Throw();
             var l = new object();
             _exceptionCancellationSource = new CancellationTokenSource();
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
It ensures exceptions on osx will be rethrown, if they occurred before mainloop runs.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Exceptions are rethrown only if mainloop is already running. So throwing an exception in MainWindow.xaml.cs ctor for example would get swallowed.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Exceptions re-thrown, added a check at beggining of mainloop, not idea but will suffice for now.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
