### PR TITLE
Respect background/border in ItemsControl.

### DIFF
--- a/src/Avalonia.Themes.Default/ItemsControl.xaml
+++ b/src/Avalonia.Themes.Default/ItemsControl.xaml
@@ -1,10 +1,15 @@
 <Style xmlns="https://github.com/avaloniaui" Selector="ItemsControl">
   <Setter Property="Template">
     <ControlTemplate>
-      <ItemsPresenter Name="PART_ItemsPresenter"
-                      Items="{TemplateBinding Items}"
-                      ItemsPanel="{TemplateBinding ItemsPanel}"
-                      ItemTemplate="{TemplateBinding ItemTemplate}"/>
+      <Border Background="{TemplateBinding Background}"
+              BorderBrush="{TemplateBinding BorderBrush}"
+              BorderThickness="{TemplateBinding BorderThickness}"
+              Padding="{TemplateBinding Padding}">
+        <ItemsPresenter Name="PART_ItemsPresenter"
+                        Items="{TemplateBinding Items}"
+                        ItemsPanel="{TemplateBinding ItemsPanel}"
+                        ItemTemplate="{TemplateBinding ItemTemplate}"/>
+      </Border>
     </ControlTemplate>
   </Setter>
 </Style>


### PR DESCRIPTION
## What does the pull request do?

As #3431 describes, we're don't respect the `Background` property in the `ItemsControl` default template. We also don't respect the `BorderBrush`/`BorderThickness` properties. Fix that by wrapping the `ItemsPresenter` in a border in the default template.

## Fixed issues

Fixes #3431
