### PR TITLE
Only fire DoubleTapped on left button press.

### DIFF
--- a/src/Avalonia.Input/Gestures.cs
+++ b/src/Avalonia.Input/Gestures.cs
@@ -79,7 +79,7 @@ namespace Avalonia.Input
                 {
                     s_lastPress = new WeakReference<IInteractive>(e.Source);
                 }
-                else if (s_lastPress != null && e.ClickCount == 2 && e.MouseButton != MouseButton.Right)
+                else if (s_lastPress != null && e.ClickCount == 2 && e.MouseButton == MouseButton.Left)
                 {
                     if (s_lastPress.TryGetTarget(out var target) && target == e.Source)
                     {

--- a/tests/Avalonia.Input.UnitTests/GesturesTests.cs
+++ b/tests/Avalonia.Input.UnitTests/GesturesTests.cs
@@ -135,7 +135,7 @@ namespace Avalonia.Interactivity.UnitTests
         }
 
         [Fact]
-        public void DoubleTapped_Should_Be_Raised_For_Middle_Button()
+        public void DoubleTapped_Should_Not_Be_Raised_For_Middle_Button()
         {
             Border border = new Border();
             var decorator = new Decorator
@@ -149,7 +149,7 @@ namespace Avalonia.Interactivity.UnitTests
             _mouse.Click(border, MouseButton.Middle);
             _mouse.Down(border, MouseButton.Middle, clickCount: 2);
 
-            Assert.True(raised);
+            Assert.False(raised);
         }
 
         [Fact]


### PR DESCRIPTION
## What does the pull request do?

As #3325 suggests, `DoubleTapped` should only be fired on left clicks, not for every button but the right button.

## Fixed issues

Fixes #3325 