### PR TITLE
Remove TypeInfo usage in Avalonia.Styling.

### DIFF
--- a/src/Avalonia.Styling/LogicalTree/ControlLocator.cs
+++ b/src/Avalonia.Styling/LogicalTree/ControlLocator.cs
@@ -3,9 +3,6 @@
 
 using System;
 using System.Linq;
-using System.Reactive.Linq;
-using System.Reflection;
-using Avalonia.Controls;
 using Avalonia.Reactive;
 
 namespace Avalonia.LogicalTree
@@ -25,7 +22,7 @@ namespace Avalonia.LogicalTree
             private readonly ILogical _relativeTo;
             private readonly int _ancestorLevel;
             private readonly Type _ancestorType;
-            ILogical _value;
+            private ILogical _value;
 
             public ControlTracker(ILogical relativeTo, int ancestorLevel, Type ancestorType)
             {
@@ -69,7 +66,7 @@ namespace Avalonia.LogicalTree
             private void Update()
             {
                 _value = _relativeTo.GetLogicalAncestors()
-                    .Where(x => _ancestorType?.GetTypeInfo().IsAssignableFrom(x.GetType().GetTypeInfo()) ?? true)
+                    .Where(x => _ancestorType?.IsAssignableFrom(x.GetType()) ?? true)
                     .ElementAtOrDefault(_ancestorLevel);
             }
         }

--- a/src/Avalonia.Styling/Styling/Setter.cs
+++ b/src/Avalonia.Styling/Styling/Setter.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Reactive.Disposables;
-using System.Reflection;
 using Avalonia.Animation;
-using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Metadata;
 using Avalonia.Reactive;
@@ -92,14 +90,15 @@ namespace Avalonia.Styling
 
             if (binding == null)
             {
-                var template = value as ITemplate;
-                bool isPropertyOfTypeITemplate = typeof(ITemplate).GetTypeInfo()
-                    .IsAssignableFrom(Property.PropertyType.GetTypeInfo());
-
-                if (template != null && !isPropertyOfTypeITemplate)
+                if (value is ITemplate template)
                 {
-                    var materialized = template.Build();
-                    value = materialized;
+                    bool isPropertyOfTypeITemplate = typeof(ITemplate).IsAssignableFrom(Property.PropertyType);
+
+                    if (!isPropertyOfTypeITemplate)
+                    {
+                        var materialized = template.Build();
+                        value = materialized;
+                    }
                 }
 
                 if (activator == null)

--- a/src/Avalonia.Styling/Styling/TypeNameAndClassSelector.cs
+++ b/src/Avalonia.Styling/Styling/TypeNameAndClassSelector.cs
@@ -114,7 +114,7 @@ namespace Avalonia.Styling
                 }
                 else
                 {
-                    if (!TargetType.GetTypeInfo().IsAssignableFrom(controlType.GetTypeInfo()))
+                    if (!TargetType.IsAssignableFrom(controlType))
                     {
                         return SelectorMatch.NeverThisType;
                     }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Another `TypeInfo` refactor. This time `Avalonia.Styling`. Also made type check in `Setter` conditional since quite often it is not needed anyway.