### PR TITLE
Remove TypeInfo usage in Avalonia.Controls.

### DIFF
--- a/src/Avalonia.Controls/Templates/FuncDataTemplate.cs
+++ b/src/Avalonia.Controls/Templates/FuncDataTemplate.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Reactive.Linq;
-using System.Reflection;
 
 namespace Avalonia.Controls.Templates
 {
@@ -102,7 +101,7 @@ namespace Avalonia.Controls.Templates
         /// </returns>
         private static bool IsInstance(object o, Type t)
         {
-            return (o != null) && t.GetTypeInfo().IsAssignableFrom(o.GetType().GetTypeInfo());
+            return t.IsInstanceOfType(o);
         }
     }
 }

--- a/src/Avalonia.Controls/Templates/FuncTreeDataTemplate.cs
+++ b/src/Avalonia.Controls/Templates/FuncTreeDataTemplate.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections;
-using System.Reflection;
 using Avalonia.Data;
 
 namespace Avalonia.Controls.Templates
@@ -75,7 +74,7 @@ namespace Avalonia.Controls.Templates
         /// </returns>
         private static bool IsInstance(object o, Type t)
         {
-            return (o != null) && t.GetTypeInfo().IsAssignableFrom(o.GetType().GetTypeInfo());
+            return t.IsInstanceOfType(o);
         }
     }
 }

--- a/src/Avalonia.Controls/Utils/AncestorFinder.cs
+++ b/src/Avalonia.Controls/Utils/AncestorFinder.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Linq;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Reflection;
 
 namespace Avalonia.Controls.Utils
 {
@@ -13,14 +11,14 @@ namespace Avalonia.Controls.Utils
         class FinderNode : IDisposable
         {
             private readonly IStyledElement _control;
-            private readonly TypeInfo _ancestorType;
+            private readonly Type _ancestorType;
             public IObservable<IStyledElement> Observable => _subject;
             private readonly Subject<IStyledElement> _subject = new Subject<IStyledElement>();
 
             private FinderNode _child;
             private IDisposable _disposable;
 
-            public FinderNode(IStyledElement control, TypeInfo ancestorType)
+            public FinderNode(IStyledElement control, Type ancestorType)
             {
                 _control = control;
                 _ancestorType = ancestorType;
@@ -33,7 +31,7 @@ namespace Avalonia.Controls.Utils
 
             private void OnValueChanged(IStyledElement next)
             {
-                if (next == null || _ancestorType.IsAssignableFrom(next.GetType().GetTypeInfo()))
+                if (next == null || _ancestorType.IsAssignableFrom(next.GetType()))
                     _subject.OnNext(next);
                 else
                 {
@@ -63,7 +61,7 @@ namespace Avalonia.Controls.Utils
         {
             return new AnonymousObservable<IStyledElement>(observer =>
             {
-                var finder = new FinderNode(control, ancestorType.GetTypeInfo());
+                var finder = new FinderNode(control, ancestorType);
                 var subscription = finder.Observable.Subscribe(observer);
                 finder.Init();
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Removes `TypeInfo` usage in `Avalonia.Controls`. 

I actually left one usage in `AppBuilderBase.SetupAvaloniaModules` since it looks like LINQ query syntax fever dream and I don't want to touch it to avoid breaking something.

Not sure if I should just remove `FuncDataTemplate.IsInstance` and use `IsInstanceOfType` directly.