### PR TITLE
Fix DataGrid highlight color on white and dark theme

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
@@ -45,7 +45,7 @@
 
             <Path Name="SortIcon"
                   Grid.Column="1"
-                  Fill="#FF444444"
+                  Fill="{TemplateBinding Foreground}"
                   HorizontalAlignment="Left"
                   VerticalAlignment="Center"
                   Stretch="Uniform"

--- a/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
@@ -112,19 +112,22 @@
   </Style>
 
   <Style Selector="DataGridRow /template/ Rectangle#BackgroundRectangle">
-    <Setter Property="IsVisible" Value="False"/>
-    <Setter Property="Fill" Value="#FFBADDE9" />
-  </Style>
+        <Setter Property="IsVisible" Value="False" />
+        <Setter Property="Fill" Value="{DynamicResource HighlightBrush}" />
+    </Style>
 
-  <Style Selector="DataGridRow:pointerover /template/ Rectangle#BackgroundRectangle">
-    <Setter Property="IsVisible" Value="True"/>
-    <Setter Property="Opacity" Value="0.5"/>
-  </Style>
+    <Style Selector="DataGridRow:pointerover /template/ Rectangle#BackgroundRectangle">
+        <Setter Property="IsVisible" Value="True" />
+        <Setter Property="Opacity" Value="0.5" />
+    </Style>
 
-  <Style Selector="DataGridRow:selected /template/ Rectangle#BackgroundRectangle">
-    <Setter Property="IsVisible" Value="True"/>
-    <Setter Property="Opacity" Value="1"/>
-  </Style>
+    <Style Selector="DataGridRow:selected /template/ Rectangle#BackgroundRectangle">
+        <Setter Property="IsVisible" Value="True" />
+        <Setter Property="Opacity" Value="1" />
+    </Style>
+    <Style Selector="DataGridRow:selected">
+        <Setter Property="Foreground" Value="{DynamicResource HighlightForegroundBrush}" />
+    </Style>
 
   <Style Selector="DataGridRowHeader">
     <Setter Property="Template">

--- a/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
@@ -112,22 +112,23 @@
   </Style>
 
   <Style Selector="DataGridRow /template/ Rectangle#BackgroundRectangle">
-        <Setter Property="IsVisible" Value="False" />
-        <Setter Property="Fill" Value="{DynamicResource HighlightBrush}" />
-    </Style>
+    <Setter Property="IsVisible" Value="False" />
+    <Setter Property="Fill" Value="{DynamicResource HighlightBrush}" />
+  </Style>
 
-    <Style Selector="DataGridRow:pointerover /template/ Rectangle#BackgroundRectangle">
-        <Setter Property="IsVisible" Value="True" />
-        <Setter Property="Opacity" Value="0.5" />
-    </Style>
+  <Style Selector="DataGridRow:pointerover /template/ Rectangle#BackgroundRectangle">
+    <Setter Property="IsVisible" Value="True" />
+    <Setter Property="Opacity" Value="0.5" />
+  </Style>
 
-    <Style Selector="DataGridRow:selected /template/ Rectangle#BackgroundRectangle">
-        <Setter Property="IsVisible" Value="True" />
-        <Setter Property="Opacity" Value="1" />
-    </Style>
-    <Style Selector="DataGridRow:selected">
-        <Setter Property="Foreground" Value="{DynamicResource HighlightForegroundBrush}" />
-    </Style>
+  <Style Selector="DataGridRow:selected /template/ Rectangle#BackgroundRectangle">
+    <Setter Property="IsVisible" Value="True" />
+    <Setter Property="Opacity" Value="1" />
+  </Style>
+  
+  <Style Selector="DataGridRow:selected">
+    <Setter Property="Foreground" Value="{DynamicResource HighlightForegroundBrush}" />
+  </Style>
 
   <Style Selector="DataGridRowHeader">
     <Setter Property="Template">

--- a/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
@@ -112,22 +112,22 @@
   </Style>
 
   <Style Selector="DataGridRow /template/ Rectangle#BackgroundRectangle">
-    <Setter Property="IsVisible" Value="False" />
-    <Setter Property="Fill" Value="{DynamicResource HighlightBrush}" />
+   <Setter Property="IsVisible" Value="False" />
+   <Setter Property="Fill" Value="{DynamicResource HighlightBrush}" />
   </Style>
 
   <Style Selector="DataGridRow:pointerover /template/ Rectangle#BackgroundRectangle">
-    <Setter Property="IsVisible" Value="True" />
-    <Setter Property="Opacity" Value="0.5" />
+   <Setter Property="IsVisible" Value="True" />
+   <Setter Property="Opacity" Value="0.5" />
   </Style>
 
   <Style Selector="DataGridRow:selected /template/ Rectangle#BackgroundRectangle">
-    <Setter Property="IsVisible" Value="True" />
-    <Setter Property="Opacity" Value="1" />
+   <Setter Property="IsVisible" Value="True" />
+   <Setter Property="Opacity" Value="1" />
   </Style>
   
   <Style Selector="DataGridRow:selected">
-    <Setter Property="Foreground" Value="{DynamicResource HighlightForegroundBrush}" />
+   <Setter Property="Foreground" Value="{DynamicResource HighlightForegroundBrush}" />
   </Style>
 
   <Style Selector="DataGridRowHeader">


### PR DESCRIPTION
## What does the pull request do?
The selected row background was okayish in light theme but unreadable in dark theme. This pull request fixes it.


## Current / New Behavior
### Before Light
![BeforeWhite](https://user-images.githubusercontent.com/14368203/73795109-c219d100-47a1-11ea-92ce-bc09347910ff.png)
### After Light
![AfterWhite](https://user-images.githubusercontent.com/14368203/73795072-a8788980-47a1-11ea-810b-970058c61863.png)
### Before Dark
![BeforeDark](https://user-images.githubusercontent.com/14368203/73795112-c34afe00-47a1-11ea-8198-e011cda8c8d1.png)
### After Dark
![AfterDark](https://user-images.githubusercontent.com/14368203/73795068-a7475c80-47a1-11ea-834b-fa17dd11c0d4.png)

## Sort Indicator - Dark only
### Before Dark (yes, there is a sort indicator)
![BeforeDark](https://user-images.githubusercontent.com/14368203/74077970-a1a97b00-4a1c-11ea-99e2-1f31887b1d62.png)
### After Dark
![AfterDark](https://user-images.githubusercontent.com/14368203/74077969-9fdfb780-4a1c-11ea-90ae-1360b43886d6.png)


## How was the solution implemented (if it's not obvious)?
I used the existing selection color brush. I also had to apply the selection foreground brush in order to make the text readable. I've chosen this method in order to avoid hardcoding a specific color value or add a new one. Makes it easier to maintain.





## Fixed issues
Fixes #2899 
