### PR TITLE
Fix Combobox height if no item is selected

### DIFF
--- a/src/Avalonia.Themes.Default/ComboBox.xaml
+++ b/src/Avalonia.Themes.Default/ComboBox.xaml
@@ -4,6 +4,7 @@
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}"/>
     <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
     <Setter Property="Padding" Value="4"/>
+    <Setter Property="MinHeight" Value="26"/>
     <Setter Property="Template">
       <ControlTemplate>
         <Border Name="border"

--- a/src/Avalonia.Themes.Default/ComboBox.xaml
+++ b/src/Avalonia.Themes.Default/ComboBox.xaml
@@ -16,13 +16,6 @@
                             Margin="{TemplateBinding Padding}"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"/>
-            <TextBlock
-                            Name="emptyPlaceholder"
-                            Margin="{TemplateBinding Padding}"
-                            HorizontalAlignment="Left"
-                            VerticalAlignment="Center"
-                            Opacity="0"
-                            Text=" " />
             <ToggleButton Name="toggle"
                           BorderThickness="0"
                           Background="Transparent"
@@ -68,7 +61,13 @@
     <Style Selector="ComboBox:disabled /template/ Border#border">
     <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}" />
   </Style>
-  <Style Selector="ComboBox[SelectedIndex=-1] /template/ TextBlock#emptyPlaceholder">
-    <Setter Property="Opacity" Value="1" />
+  <Style Selector="ComboBox[SelectedIndex=-1] /template/ ContentControl">
+    <Setter Property="Content">
+      <Setter.Value>
+        <Template>
+          <TextBlock Text=" " />
+        </Template>
+      </Setter.Value>
+    </Setter>
   </Style>
 </Styles>

--- a/src/Avalonia.Themes.Default/ComboBox.xaml
+++ b/src/Avalonia.Themes.Default/ComboBox.xaml
@@ -4,7 +4,6 @@
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}"/>
     <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
     <Setter Property="Padding" Value="4"/>
-    <Setter Property="MinHeight" Value="26"/>
     <Setter Property="Template">
       <ControlTemplate>
         <Border Name="border"
@@ -17,6 +16,13 @@
                             Margin="{TemplateBinding Padding}"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"/>
+            <TextBlock
+                            Name="emptyPlaceholder"
+                            Margin="{TemplateBinding Padding}"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            Opacity="0"
+                            Text=" " />
             <ToggleButton Name="toggle"
                           BorderThickness="0"
                           Background="Transparent"
@@ -60,6 +66,9 @@
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}"/>
   </Style>
     <Style Selector="ComboBox:disabled /template/ Border#border">
-        <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}" />
-    </Style>
+    <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}" />
+  </Style>
+  <Style Selector="ComboBox[SelectedIndex=-1] /template/ TextBlock#emptyPlaceholder">
+    <Setter Property="Opacity" Value="1" />
+  </Style>
 </Styles>


### PR DESCRIPTION
## What does the pull request do?
Currently when the combobox has not selected an item, it has a different height comparing to a combobox with a selected item. This is ugly and forces developers to set a minheight themselves or preselect an item.

This PR shows an empty textblock if no item is selected which makes the Combobox height being the same as if an item is selected. 


## What is the current behavior?
![MinHeightBefore](https://user-images.githubusercontent.com/14368203/73796633-a4e70180-47a5-11ea-801f-97dbfcbc1b01.png)

## What is the updated/expected behavior with this PR?
![MinHeightAfter](https://user-images.githubusercontent.com/14368203/73796624-9e588a00-47a5-11ea-81bb-f14e1631cac7.png)


