### PR TITLE
Add binding to Window.Position

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -184,6 +184,12 @@ namespace Avalonia.Controls
         /// </summary>
         private bool _shouldIgnoreMovements = false;
 
+        /// <summary>
+        /// Monitor position changes for the window so that we can update any
+        /// properties as necessary
+        /// </summary>
+        /// <param name="sender">Window that sent this event</param>
+        /// <param name="e">Args that have the new PixelPoint for the window position</param>
         private void Window_PositionChanged(object sender, PixelPointEventArgs e)
         {
             _shouldIgnoreMovements = true;

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -119,6 +119,14 @@ namespace Avalonia.Controls
         private object _dialogResult;
         private readonly Size _maxPlatformClientSize;
         private WindowStartupLocation _windowStartupLocation;
+        /// <summary>
+        /// We need to ignore PositionProperty.Change events when updating the dependency property for
+        /// Position. If we don't, on Windows, once we move the window position via
+        /// PlatformImpl?.Move(), it will call PositionChanged again _but_ with different #'s,
+        /// which we detect as a new change, and thus the effect keeps going and we move things again.
+        /// See case WndPrc -> UnmanagedMethods.WindowsMessage.WM_MOVE: in Avalonia.WIn32\WindowImpl.cs.
+        /// </summary>
+        private bool _shouldIgnoreMovements = false;
 
         /// <summary>
         /// Initializes static members of the <see cref="Window"/> class.
@@ -174,15 +182,6 @@ namespace Avalonia.Controls
             _maxPlatformClientSize = PlatformImpl?.MaxClientSize ?? default(Size);
             this.GetObservable(ClientSizeProperty).Skip(1).Subscribe(x => PlatformImpl?.Resize(x));
         }
-
-        /// <summary>
-        /// We need to ignore PositionProperty.Change events when updating the dependency property for
-        /// Position. If we don't, on Windows, once we move the window position via
-        /// PlatformImpl?.Move(), it will call PositionChanged again _but_ with different #'s,
-        /// which we detect as a new change, and thus the effect keeps going and we move things again.
-        /// See case WndPrc -> UnmanagedMethods.WindowsMessage.WM_MOVE: in Avalonia.WIn32\WindowImpl.cs.
-        /// </summary>
-        private bool _shouldIgnoreMovements = false;
 
         /// <summary>
         /// Monitor position changes for the window so that we can update any


### PR DESCRIPTION
## What does the pull request do?

Adds mechanisms so that users can bind to `Avalonia.Controls.Window.Position`.

## What is the current behavior?

Right now, you can't bind to `Window.Position`.

## What is the updated/expected behavior with this PR?

You can now bind to `Window.Position` with a `PixelPoint` property in your ViewModel, e.g. `<Window Position="{Binding SomeVariable}"> ... </Window>`.

## How was the solution implemented (if it's not obvious)?

I'll admit, this fix is kind of kooky, and there might be a better way.

First, I added a `StyledProperty` to `Window` for `Position`. (Should this be a `DirectProperty` instead...?) I monitor the event `Window.PositionChanged` so that I can update the dependency property value as needed. I also monitored the property change (`PositionProperty.Changed.AddClassHandler`) so that I could tell the Window to update via `Window.PlatformImpl`. 

Here's the strange part: on windows, we can't blindly update the dependency property in the `Window.PositionChanged` event handler, because when the dependency property changes (`SetValue(PositionProperty...)`), it causes `PositionProperty.Changed` to be called, which then triggers a move of the actual window. This is all well and good until on Windows this causes:

`PositionChanged?.Invoke(new PixelPoint((short)(ToInt32(lParam) & 0xffff), (short)(ToInt32(lParam) >> 16)));`

to be called, which then causes `Window.PositionChanged` to be called (with slightly different numbers, potentially!), which of course then causes a dependency property update, and things keep moving on forever. 

To stop that from happening, I added a bool to make sure that the window is _not_ moved additional times when I'm calling `SetValue(PositionProperty...)` from `Window.PositionChanged`.

...A better way to handle this would be to somehow call `SetValue` without actually triggering another `PositionProperty.Changed` event. I'm guessing there are better ways, but this way by opening this PR at least some discussion is started.

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes

None


## Fixed issues

Fixes #3494.
