### PR TITLE
Fix DataGrid highlight color on white and dark theme v2

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
@@ -45,7 +45,7 @@
 
             <Path Name="SortIcon"
                   Grid.Column="1"
-                  Fill="#FF444444"
+                  Fill="{TemplateBinding Foreground}"
                   HorizontalAlignment="Left"
                   VerticalAlignment="Center"
                   Stretch="Uniform"
@@ -113,7 +113,7 @@
 
   <Style Selector="DataGridRow /template/ Rectangle#BackgroundRectangle">
     <Setter Property="IsVisible" Value="False"/>
-    <Setter Property="Fill" Value="#FFBADDE9" />
+    <Setter Property="Fill" Value="{DynamicResource HighlightBrush}" />
   </Style>
 
   <Style Selector="DataGridRow:pointerover /template/ Rectangle#BackgroundRectangle">
@@ -124,6 +124,10 @@
   <Style Selector="DataGridRow:selected /template/ Rectangle#BackgroundRectangle">
     <Setter Property="IsVisible" Value="True"/>
     <Setter Property="Opacity" Value="1"/>
+  </Style>
+
+  <Style Selector="DataGridRow:selected">
+    <Setter Property="Foreground" Value="{DynamicResource HighlightForegroundBrush}" />
   </Style>
 
   <Style Selector="DataGridRowHeader">
@@ -139,7 +143,7 @@
   </Style>
 
   <Style Selector="DataGridRowGroupHeader">
-    <Setter Property="Background" Value="#FFE4E8EA" />
+    <Setter Property="Background" Value="{DynamicResource ThemeControlMidHighBrush}" />
     <Setter Property="Height" Value="20"/>
     <Setter Property="Template">
       <ControlTemplate>
@@ -148,7 +152,6 @@
                                  ColumnDefinitions="Auto,Auto,Auto,Auto"
                                  RowDefinitions="Auto,*,Auto">
 
-          <Rectangle Grid.Column="1" Grid.ColumnSpan="5" Fill="#FFFFFFFF" Height="1"/>
           <Rectangle Grid.Column="1" Grid.Row="1" Name="IndentSpacer" />
           <ToggleButton Grid.Column="2" Grid.Row="1" Name="ExpanderButton" Margin="2,0,0,0"/>
 
@@ -169,7 +172,7 @@
     <Setter Property="Template">
       <ControlTemplate>
         <Border Grid.Column="0" Width="20" Height="20" Background="Transparent" HorizontalAlignment="Center" VerticalAlignment="Center">
-          <Path Fill="Black"
+          <Path Fill="{TemplateBinding Foreground}"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
                 Data="M 0 2 L 4 6 L 0 10 Z" />


### PR DESCRIPTION
## What does the pull request do?
Replacing hardcoded light theme values with dynamic theme values.


## Selection - Current / New Behavior
#### Before Light
![BeforeWhite](https://user-images.githubusercontent.com/14368203/73795109-c219d100-47a1-11ea-92ce-bc09347910ff.png)
#### After Light
![AfterWhite](https://user-images.githubusercontent.com/14368203/73795072-a8788980-47a1-11ea-810b-970058c61863.png)
#### Before Dark
![BeforeDark](https://user-images.githubusercontent.com/14368203/73795112-c34afe00-47a1-11ea-8198-e011cda8c8d1.png)
#### After Dark
![AfterDark](https://user-images.githubusercontent.com/14368203/73795068-a7475c80-47a1-11ea-834b-fa17dd11c0d4.png)

## Sort Indicator - Current / New Behavior
#### Before Dark
![BeforeDark](https://user-images.githubusercontent.com/14368203/74077970-a1a97b00-4a1c-11ea-99e2-1f31887b1d62.png)
#### After Dark
![AfterDark](https://user-images.githubusercontent.com/14368203/74077969-9fdfb780-4a1c-11ea-90ae-1360b43886d6.png)

## Group Header - Current / New Behavior
#### Before Light
![BeforeLight](https://user-images.githubusercontent.com/14368203/74086496-3d69d400-4a7b-11ea-9a8a-7c86dab8d266.png)
#### After Light
![AfterLight](https://user-images.githubusercontent.com/14368203/74086495-3ba01080-4a7b-11ea-81c9-270dbeef569d.png)
#### Before Dark
![BeforeDark](https://user-images.githubusercontent.com/14368203/74086489-317e1200-4a7b-11ea-821d-d6e1caaff2d7.png)
#### After Dark
![AfterDark](https://user-images.githubusercontent.com/14368203/74086492-34790280-4a7b-11ea-9428-98779d97dac2.png)


## Fixed issues
Fixes #2899 