### PR TITLE
Added the ScrollToHome() and ScrollToEnd() methods to ScrollViewer.

### DIFF
--- a/src/Avalonia.Controls/ScrollViewer.cs
+++ b/src/Avalonia.Controls/ScrollViewer.cs
@@ -250,6 +250,22 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
+        /// Scrolls to the top-left corner of the content.
+        /// </summary>
+        public void ScrollToHome()
+        {
+            Offset = new Vector(double.NegativeInfinity, double.NegativeInfinity);
+        }
+
+        /// <summary>
+        /// Scrolls to the bottom-left corner of the content.
+        /// </summary>
+        public void ScrollToEnd()
+        {
+            Offset = new Vector(double.NegativeInfinity, double.PositiveInfinity);
+        }
+
+        /// <summary>
         /// Gets a value indicating whether the viewer can scroll horizontally.
         /// </summary>
         protected bool CanHorizontallyScroll

--- a/tests/Avalonia.Controls.UnitTests/ScrollViewerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ScrollViewerTests.cs
@@ -65,6 +65,30 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Vector(10, 10), target.Offset);
         }
 
+        [Fact]
+        public void Test_ScrollToHome()
+        {
+            var target = new ScrollViewer();
+            target.SetValue(ScrollViewer.ExtentProperty, new Size(50, 50));
+            target.SetValue(ScrollViewer.ViewportProperty, new Size(10, 10));
+            target.Offset = new Vector(25, 25);
+            target.ScrollToHome();
+
+            Assert.Equal(new Vector(0, 0), target.Offset);
+        }
+
+        [Fact]
+        public void Test_ScrollToEnd()
+        {
+            var target = new ScrollViewer();
+            target.SetValue(ScrollViewer.ExtentProperty, new Size(50, 50));
+            target.SetValue(ScrollViewer.ViewportProperty, new Size(10, 10));
+            target.Offset = new Vector(25, 25);
+            target.ScrollToEnd();
+
+            Assert.Equal(new Vector(0, 40), target.Offset);
+        }
+
         private Control CreateTemplate(ScrollViewer control, INameScope scope)
         {
             return new Grid


### PR DESCRIPTION
## What does the pull request do?
This is a small update to the `ScrollViewer` class. It includes two convenience methods, `ScrollToHome()` and `ScrollToEnd()`, that scroll it to the top and bottom of the content, respectively. These are part of [WPF's ScrollViewer](https://github.com/dotnet/wpf/blob/master/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ScrollViewer.cs#L124). I use them a lot in that framework, and I missed having them in Avalonia.

## What is the current behavior?
The current way to do this is to set the `Offset` property manually. People who haven't looked at the source for Avalonia or WPF may not know what this property is, or what to set it to in order to reach the top or bottom of the content.

## What is the updated/expected behavior with this PR?
I've added two unit tests, `Test_ScrollToHome` and `Test_ScrollToEnd` in the `Avalonia.Controls.UnitTests` project that validate it.

## How was the solution implemented (if it's not obvious)?
It was mostly ported over from WPF. They do it via "SetOffset" commands, so I just made them work with the Offset property in Avalonia's ScrollViewer.

## Checklist
- [ X ] Added unit tests (if possible)?
- [ X ] Added XML documentation to any related classes?
- [  ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
None

## Fixed issues
None that I saw
