### PR TITLE
WeakEventHandlerManager: Ensure that weak refs with collected refs are compacted as well.

### DIFF
--- a/src/Avalonia.Base/Utilities/WeakEventHandlerManager.cs
+++ b/src/Avalonia.Base/Utilities/WeakEventHandlerManager.cs
@@ -183,11 +183,16 @@ namespace Avalonia.Utilities
                 for (int c = 0; c < _count; c++)
                 {
                     var r = _data[c];
+
+                    TSubscriber target = null;
+
+                    r.Subscriber?.TryGetTarget(out target);
+
                     //Mark current index as first empty
-                    if (r.Subscriber == null && empty == -1)
+                    if (target == null && empty == -1)
                         empty = c;
                     //If current element isn't null and we have an empty one
-                    if (r.Subscriber != null && empty != -1)
+                    if (target != null && empty != -1)
                     {
                         _data[c] = default;
                         _data[empty] = r;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
When writing new benchmarks I've noticed that everything just gets progressively slower after running for a few hundred times. After like 500 iterations of my new calendar benchmark we were spending 90% of time compacting handlers (had over one million handlers present).

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`Visual.AffectsRender` quite often just weakly subscribes and then no event is raised and unsubscribe is never called. Because we don't check for `WeakReference` target being collected we just skip over such references when compacting, since weak ref itself is not null. This leads us to accumulating huge numbers of such handlers in benchmarks and probably some user cases as well.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Collected targets of `WeakReference` will get properly compacted so our handler list won't grow indefinitely.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Inspect target of the weak reference as well when compacting.

Sidenote: I think our current weak event implementation does not scale too well, maybe we should investigate other solutions as well. We spend a lot of time doing reflection here and `Compact` gets expensive quite fast when we have a lot of objects.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation