### PR TITLE
Add Messagebox

### DIFF
--- a/Avalonia.sln
+++ b/Avalonia.sln
@@ -202,9 +202,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Controls.DataGrid"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Dialogs", "src\Avalonia.Dialogs\Avalonia.Dialogs.csproj", "{4D55985A-1EE2-4F25-AD39-6EA8BC04F8FB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.MessageBox", "src\Avalonia.MessageBox\Avalonia.MessageBox.csproj", "{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.FreeDesktop", "src\Avalonia.FreeDesktop\Avalonia.FreeDesktop.csproj", "{4D36CEC8-53F2-40A5-9A37-79AAE356E2DA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalonia.Controls.DataGrid.UnitTests", "tests\Avalonia.Controls.DataGrid.UnitTests\Avalonia.Controls.DataGrid.UnitTests.csproj", "{351337F5-D66F-461B-A957-4EF60BDB4BA6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Controls.DataGrid.UnitTests", "tests\Avalonia.Controls.DataGrid.UnitTests\Avalonia.Controls.DataGrid.UnitTests.csproj", "{351337F5-D66F-461B-A957-4EF60BDB4BA6}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -1873,6 +1875,30 @@ Global
 		{4D55985A-1EE2-4F25-AD39-6EA8BC04F8FB}.Release|iPhone.Build.0 = Release|Any CPU
 		{4D55985A-1EE2-4F25-AD39-6EA8BC04F8FB}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{4D55985A-1EE2-4F25-AD39-6EA8BC04F8FB}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Ad-Hoc|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Ad-Hoc|Any CPU.Build.0 = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Ad-Hoc|iPhone.Build.0 = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Ad-Hoc|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Ad-Hoc|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.AppStore|Any CPU.Build.0 = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.AppStore|iPhone.ActiveCfg = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.AppStore|iPhone.Build.0 = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.AppStore|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.AppStore|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Release|iPhone.Build.0 = Release|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{6C0808DF-8D0C-4EE9-A96E-DAA329C784A1}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{4D36CEC8-53F2-40A5-9A37-79AAE356E2DA}.Ad-Hoc|Any CPU.ActiveCfg = Debug|Any CPU
 		{4D36CEC8-53F2-40A5-9A37-79AAE356E2DA}.Ad-Hoc|Any CPU.Build.0 = Debug|Any CPU
 		{4D36CEC8-53F2-40A5-9A37-79AAE356E2DA}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU

--- a/samples/ControlCatalog/ControlCatalog.csproj
+++ b/samples/ControlCatalog/ControlCatalog.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\packages\Avalonia\Avalonia.csproj" />
+    <ProjectReference Include="..\..\src\Avalonia.MessageBox\Avalonia.MessageBox.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.ReactiveUI\Avalonia.ReactiveUI.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Controls.DataGrid\Avalonia.Controls.DataGrid.csproj" />
   </ItemGroup>

--- a/samples/ControlCatalog/MainView.xaml.cs
+++ b/samples/ControlCatalog/MainView.xaml.cs
@@ -26,6 +26,11 @@ namespace ControlCatalog
                 });
                 tabItems.Add(new TabItem()
                 {
+                    Header = "MessageBox",
+                    Content = new MessageBoxPage()
+                });
+                tabItems.Add(new TabItem()
+                {
                     Header = "Screens",
                     Content = new ScreenPage()
                 });

--- a/samples/ControlCatalog/Pages/MessageBoxPage.xaml
+++ b/samples/ControlCatalog/Pages/MessageBoxPage.xaml
@@ -1,0 +1,14 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ControlCatalog.Pages.MessageBoxPage">
+  <StackPanel Orientation="Vertical" Spacing="4" HorizontalAlignment="Left">
+        <TextBlock Classes="h1">MessageBox</TextBlock>
+        <TextBox Text="{Binding Caption}"/>
+        <TextBox Text="{Binding Message}"/>
+        <CheckBox IsChecked="{Binding ShowIcon}" Content="Show Example MessageBox Icon"/>
+        <Button Content="Show Standard MessageBox" Command="{Binding ShowOkCommand}" />
+        <Button Content="Show Ok / Cancel MessageBox" Command="{Binding ShowOkCancelCommand}" />
+        <Button Content="Show Yes / No MessageBox" Command="{Binding ShowYesNoCommand}" />
+        <Button Content="Show Yes / No / Cancel MessageBox" Command="{Binding ShowYesNoCancelCommand}" />
+    </StackPanel>
+</UserControl>

--- a/samples/ControlCatalog/Pages/MessageBoxPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/MessageBoxPage.xaml.cs
@@ -13,7 +13,7 @@ namespace ControlCatalog.Pages
     public class MessageBoxPage : UserControl
     {
         public string Caption { get; set; } = "Hello";
-        public string Message { get; set; } = "Welome to Avalonia!";
+        public string Message { get; set; } = "Welcome to Avalonia!";
         public bool ShowIcon { get; set; } = true;
         public ReactiveCommand<Unit, Unit> ShowOkCommand { get; }
         public ReactiveCommand<Unit, Unit> ShowOkCancelCommand { get; }
@@ -28,8 +28,8 @@ namespace ControlCatalog.Pages
 
             ShowOkCommand = ReactiveCommand.CreateFromTask(async () =>
             {
-               var result = await MessageBoxManager.Show(Message, Caption, MessageBoxButton.OK, ShowIcon ? ExampleIcon : null);
-               ShowResult(result);
+                var result = await MessageBoxManager.Show(Message, Caption, MessageBoxButton.OK, ShowIcon ? ExampleIcon : null);
+                ShowResult(result);
             });
             ShowOkCancelCommand = ReactiveCommand.CreateFromTask(async () =>
             {

--- a/samples/ControlCatalog/Pages/MessageBoxPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/MessageBoxPage.xaml.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Reactive;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media.Imaging;
+using Avalonia.MessageBox;
+using Avalonia.Platform;
+using ReactiveUI;
+
+namespace ControlCatalog.Pages
+{
+    public class MessageBoxPage : UserControl
+    {
+        public string Caption { get; set; } = "Hello";
+        public string Message { get; set; } = "Welome to Avalonia!";
+        public bool ShowIcon { get; set; } = true;
+        public ReactiveCommand<Unit, Unit> ShowOkCommand { get; }
+        public ReactiveCommand<Unit, Unit> ShowOkCancelCommand { get; }
+        public ReactiveCommand<Unit, Unit> ShowYesNoCommand { get; }
+        public ReactiveCommand<Unit, Unit> ShowYesNoCancelCommand { get; }
+        private Bitmap ExampleIcon;
+        public MessageBoxPage()
+        {
+            this.InitializeComponent();
+            var assets = AvaloniaLocator.Current.GetService<IAssetLoader>();
+            ExampleIcon = new Bitmap(assets.Open(new Uri("avares://ControlCatalog/Assets/test_icon.ico")));
+
+            ShowOkCommand = ReactiveCommand.CreateFromTask(async () =>
+            {
+               var result = await MessageBoxManager.Show(Message, Caption, MessageBoxButton.OK, ShowIcon ? ExampleIcon : null);
+               ShowResult(result);
+            });
+            ShowOkCancelCommand = ReactiveCommand.CreateFromTask(async () =>
+            {
+                var result = await MessageBoxManager.Show(Message, Caption, MessageBoxButton.OK | MessageBoxButton.Cancel, ShowIcon ? ExampleIcon : null);
+                ShowResult(result);
+            });
+            ShowYesNoCommand = ReactiveCommand.CreateFromTask(async () =>
+            {
+                var result = await MessageBoxManager.Show(Message, Caption, MessageBoxButton.Yes | MessageBoxButton.No, ShowIcon ? ExampleIcon : null);
+                ShowResult(result);
+            });
+            ShowYesNoCancelCommand = ReactiveCommand.CreateFromTask(async () =>
+            {
+                var result = await MessageBoxManager.Show(Message, Caption, MessageBoxButton.Yes | MessageBoxButton.No | MessageBoxButton.Cancel, ShowIcon ? ExampleIcon : null);
+                ShowResult(result);
+            });
+            DataContext = this;
+        }
+
+        private async void ShowResult(MessageBoxButton button)
+        {
+            await MessageBoxManager.Show($"You said '{button}'", "Result", MessageBoxButton.OK);
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/src/Avalonia.MessageBox/Avalonia.MessageBox.csproj
+++ b/src/Avalonia.MessageBox/Avalonia.MessageBox.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AvaloniaResource Include="**\*.xaml">
+      <SubType>Designer</SubType>
+    </AvaloniaResource>
+  </ItemGroup>
+
+  <Import Project="..\..\build\BuildTargets.targets" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\Avalonia.Diagnostics\Avalonia.Diagnostics.csproj" />
+    <ProjectReference Include="..\Markup\Avalonia.Markup.Xaml\Avalonia.Markup.Xaml.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Avalonia.MessageBox/MessageBoxButtons.cs
+++ b/src/Avalonia.MessageBox/MessageBoxButtons.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Avalonia.MessageBox
+{
+    /// <summary>
+    /// Message Box Buttons
+    /// </summary>
+    [Flags]
+    public enum MessageBoxButton
+    {
+        /// <summary>None, the user closed the message box</summary>
+        None = 0,
+        /// <summary>OK button</summary>
+        OK = 1,
+        /// <summary>Yes button</summary>
+        Yes = 2,
+        /// <summary>No button</summary>
+        No = 4,
+        /// <summary>Cancel button</summary>
+        Cancel = 8,
+    }
+}

--- a/src/Avalonia.MessageBox/MessageBoxDialog.xaml
+++ b/src/Avalonia.MessageBox/MessageBoxDialog.xaml
@@ -1,0 +1,65 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        MinWidth="400"
+        MaxWidth="1000"
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterOwner"
+        Title="{Binding Caption}"
+        x:Class="Avalonia.MessageBox.MessageBoxDialog">
+  <Window.Styles>
+    <Style Selector="Button">
+      <Setter Property="Margin" Value="5,0,0,0" />
+      <Setter Property="Padding" Value="10,1,10,1" />
+      <Setter Property="MinWidth" Value="75"/>
+      <Setter Property="MinHeight" Value="23" />
+      <Setter Property="HorizontalAlignment" Value="Center" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+  </Window.Styles>
+  <Grid RowDefinitions="Auto,Auto">
+    <Grid Margin="10,20,10,20" Grid.Row="0" ColumnDefinitions="Auto,*">
+      <Image Grid.Column="0"
+             Margin="0,0,10,0"
+             Height="32"
+             Width="32"
+             IsVisible="{Binding HasIcon}"
+             Source="{Binding MessageIcon}"/>
+      <TextBlock Grid.Column="1"
+                 VerticalAlignment="Center"
+                 Text="{Binding Message}"
+                 TextWrapping="Wrap" />
+    </Grid>
+    <Grid Grid.Row="1" Margin="5,0,5,5">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="Auto" />
+        <ColumnDefinition Width="Auto" />
+        <ColumnDefinition Width="Auto" />
+        <ColumnDefinition Width="Auto" />
+      </Grid.ColumnDefinitions>
+      <Button
+          Grid.Column="1"
+          Click="OnOkClick"
+          Content="Ok"
+          IsDefault="True"
+          IsVisible="{Binding HasOkButton}" />
+      <Button
+          Grid.Column="2"
+          Click="OnYesClick"
+          Content="Yes"
+          IsDefault="True"
+          IsVisible="{Binding HasYesButton}" />
+      <Button
+          Grid.Column="3"
+          Click="OnNoClick"
+          Content="No"
+          IsVisible="{Binding HasNoButton}" />
+      <Button
+          Grid.Column="4"
+          Click="OnCancelClick"
+          Content="Cancel"
+          IsCancel="True"
+          IsVisible="{Binding HasCancelButton}" />
+    </Grid>
+  </Grid>
+</Window>

--- a/src/Avalonia.MessageBox/MessageBoxDialog.xaml.cs
+++ b/src/Avalonia.MessageBox/MessageBoxDialog.xaml.cs
@@ -1,0 +1,57 @@
+// Copyright (c) The Avalonia Project. All rights reserved.
+// Licensed under the MIT license. See licence.md file in the project root for full license information.
+
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media.Imaging;
+
+namespace Avalonia.MessageBox
+{
+    public class MessageBoxDialog : Window
+    {
+        public MessageBoxButton Result;
+        public string Message { get; private set; }
+        public string Caption { get; private set; }
+        public MessageBoxButton Buttons { get; private set; }
+        public Bitmap MessageIcon { get; private set; }
+        public bool HasIcon => MessageIcon != null;
+        public bool HasOkButton => (Buttons & MessageBoxButton.OK) != 0;
+        public bool HasCancelButton => (Buttons & MessageBoxButton.Cancel) != 0;
+        public bool HasYesButton => (Buttons & MessageBoxButton.Yes) != 0;
+        public bool HasNoButton => (Buttons & MessageBoxButton.No) != 0;
+        public MessageBoxDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+        public void Setup(string message, string caption, MessageBoxButton buttons, Bitmap icon, Window owner)
+        {
+            Message = message;
+            Caption = caption;
+            Buttons = buttons;
+            MessageIcon = icon;
+            Icon = owner.Icon;
+            DataContext = this;
+        }
+        private void OnOkClick(object sender, RoutedEventArgs e)
+        {
+            Result = MessageBoxButton.OK;
+            Close();
+        }
+        private void OnCancelClick(object sender, RoutedEventArgs e)
+        {
+            Result = MessageBoxButton.Cancel;
+            Close();
+        }
+        private void OnYesClick(object sender, RoutedEventArgs e)
+        {
+            Result = MessageBoxButton.Yes;
+            Close();
+        }
+        private void OnNoClick(object sender, RoutedEventArgs e)
+        {
+            Result = MessageBoxButton.No;
+            Close();
+        }
+    }
+}

--- a/src/Avalonia.MessageBox/MessageBoxManager.cs
+++ b/src/Avalonia.MessageBox/MessageBoxManager.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Media.Imaging;
+
+namespace Avalonia.MessageBox
+{
+    public static class MessageBoxManager
+    {
+        public static async Task<MessageBoxButton> Show(string message, string caption,
+            MessageBoxButton buttons = MessageBoxButton.OK, Bitmap messageBoxIcon = null, Window? ownerWindow = null)
+        {
+            return await Create(message, caption, buttons, messageBoxIcon, ownerWindow);
+        }
+
+        private static async Task<MessageBoxButton> Create(string message, string caption,
+            MessageBoxButton buttons = MessageBoxButton.OK, Bitmap messageBoxIcon = null, Window? ownerWindow = null)
+        {
+            var dialog = new MessageBoxDialog();
+            dialog.Setup(message, caption, buttons, messageBoxIcon, ownerWindow ?? GetMainWindow);
+            await dialog.ShowDialog(ownerWindow ?? GetMainWindow);
+            return dialog.Result;
+        }
+
+        private static Window GetMainWindow =>
+            ((IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime).MainWindow;
+    }
+
+}


### PR DESCRIPTION
## What does the pull request do?
Adds the possibility to show managed/themed messageboxes for desktop applications. _Currently resizable due to Avalonia's limitation. However any developer self-implementation would suffer from the same problem so I don't see this as a blocking issue and can be changed once Avalonia supports toolwindow styles (e.g. hiding minimize / maximize buttons)._

```
MessageBoxButton result = await MessageBoxManager.Show(
    message: "Hello World!",
    caption: "Cool");

--------------------------------------------------------------

Bitmap QuestionMark = ....

MessageBoxButton result = await MessageBoxManager.Show(
    message: "Do you like messageboxes?",
    caption: "Question",
    buttons: MessageBoxButton.Yes | MessageBoxButton.No,
    messageBoxIcon: QuestionMark);
```

## Demo
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/14368203/74173909-e30f7580-4c2a-11ea-99b1-c41250b15f95.gif)


