### PR TITLE
DataGrid - Fix remaining theme colors

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
@@ -113,7 +113,7 @@
 
   <Style Selector="DataGridRow /template/ Rectangle#BackgroundRectangle">
     <Setter Property="IsVisible" Value="False"/>
-    <Setter Property="Fill" Value="{DynamicResource HighlightBrush}" />
+    <Setter Property="Fill" Value="{DynamicResource ThemeAccentBrush2}" />
   </Style>
 
   <Style Selector="DataGridRow:pointerover /template/ Rectangle#BackgroundRectangle">

--- a/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
@@ -113,7 +113,7 @@
 
   <Style Selector="DataGridRow /template/ Rectangle#BackgroundRectangle">
     <Setter Property="IsVisible" Value="False"/>
-    <Setter Property="Fill" Value="{DynamicResource ThemeAccentBrush2}" />
+    <Setter Property="Fill" Value="{DynamicResource HighlightBrush}" />
   </Style>
 
   <Style Selector="DataGridRow:pointerover /template/ Rectangle#BackgroundRectangle">

--- a/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
@@ -202,7 +202,7 @@
     <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}" />
     <Setter Property="DropLocationIndicatorTemplate">
       <Template>
-        <Rectangle Fill="#FF3F4346" Width="2"/>
+        <Rectangle Fill="{DynamicResource ThemeBorderHighColor}" Width="2"/>
       </Template>
     </Setter>
     <Setter Property="Template">
@@ -215,11 +215,11 @@
             <DataGridColumnHeader Name="PART_TopLeftCornerHeader" Width="22" />
             <DataGridColumnHeadersPresenter Name="PART_ColumnHeadersPresenter" Grid.Column="1"/>
             <DataGridColumnHeader Name="PART_TopRightCornerHeader" Grid.Column="2"/>
-            <Rectangle Name="PART_ColumnHeadersAndRowsSeparator" Grid.ColumnSpan="3" VerticalAlignment="Bottom" StrokeThickness="1" Height="1" Fill="#FFC9CACA"/>
+            <Rectangle Name="PART_ColumnHeadersAndRowsSeparator" Grid.ColumnSpan="3" VerticalAlignment="Bottom" StrokeThickness="1" Height="1" Fill="{DynamicResource ThemeControlMidHighBrush}"/>
 
             <DataGridRowsPresenter Name="PART_RowsPresenter" Grid.ColumnSpan="2" Grid.Row="1" />
-            <Rectangle Name="BottomRightCorner" Fill="#FFE9EEF4" Grid.Column="2" Grid.Row="2" />
-            <Rectangle Name="BottomLeftCorner" Fill="#FFE9EEF4" Grid.Row="2" Grid.ColumnSpan="2" />
+            <Rectangle Name="BottomRightCorner" Fill="{DynamicResource ThemeControlMidHighBrush}" Grid.Column="2" Grid.Row="2" />
+            <Rectangle Name="BottomLeftCorner" Fill="{DynamicResource ThemeControlMidHighBrush}" Grid.Row="2" Grid.ColumnSpan="2" />
             <ScrollBar Name="PART_VerticalScrollbar" Orientation="Vertical" Grid.Column="2" Grid.Row="1" Width="{DynamicResource ScrollBarThickness}"/>
 
             <Grid Grid.Column="1" Grid.Row="2"


### PR DESCRIPTION
## What does the pull request do?
Replace remaining hardcoded brushes with theme brushes. I had to use similar theme brush values because the hardcoded brush values don't exist in theme resource dictionary.


#### Before Light
![image](https://user-images.githubusercontent.com/14368203/74441674-29054d00-4e68-11ea-9f74-af0d6ba5154e.png)
#### After Light
![image](https://user-images.githubusercontent.com/14368203/74438848-ef7e1300-4e62-11ea-9b09-99449d31d15d.png)
#### Before Dark
![image](https://user-images.githubusercontent.com/14368203/74441686-2d316a80-4e68-11ea-90bb-45360a2f2622.png)
#### After Dark
![image](https://user-images.githubusercontent.com/14368203/74438890-015fb600-4e63-11ea-9466-e99b7338b81a.png)