### PR TITLE
Add Textbox.HorizontalContentAlignment and VerticalContentAlignment

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -14,6 +14,7 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Metadata;
 using Avalonia.Data;
+using Avalonia.Layout;
 using Avalonia.Utilities;
 
 namespace Avalonia.Controls
@@ -71,6 +72,18 @@ namespace Avalonia.Controls
 
         public static readonly StyledProperty<TextAlignment> TextAlignmentProperty =
             TextBlock.TextAlignmentProperty.AddOwner<TextBox>();
+
+        /// <summary>
+        /// Defines the <see cref="HorizontalAlignment"/> property.
+        /// </summary>
+        public static readonly StyledProperty<HorizontalAlignment> HorizontalContentAlignmentProperty =
+            AvaloniaProperty.Register<TextBox, HorizontalAlignment>(nameof(HorizontalContentAlignment));
+
+        /// <summary>
+        /// Defines the <see cref="VerticalAlignment"/> property.
+        /// </summary>
+        public static readonly StyledProperty<VerticalAlignment> VerticalContentAlignmentProperty =
+            AvaloniaProperty.Register<TextBox, VerticalAlignment>(nameof(VerticalContentAlignment));
 
         public static readonly StyledProperty<TextWrapping> TextWrappingProperty =
             TextBlock.TextWrappingProperty.AddOwner<TextBox>();
@@ -260,6 +273,17 @@ namespace Avalonia.Controls
                     }
                 }
             }
+        }
+
+        public HorizontalAlignment HorizontalContentAlignment
+        {
+            get { return GetValue(HorizontalContentAlignmentProperty); }
+            set { SetValue(HorizontalContentAlignmentProperty, value); }
+        }
+        public VerticalAlignment VerticalContentAlignment
+        {
+            get { return GetValue(VerticalContentAlignmentProperty); }
+            set { SetValue(VerticalContentAlignmentProperty, value); }
         }
 
         public TextAlignment TextAlignment

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -283,6 +283,7 @@ namespace Avalonia.Controls
             get { return GetValue(HorizontalContentAlignmentProperty); }
             set { SetValue(HorizontalContentAlignmentProperty, value); }
         }
+
         /// <summary>
         /// Gets or sets the vertical alignment of the content within the control.
         /// </summary>

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -275,11 +275,17 @@ namespace Avalonia.Controls
             }
         }
 
+        /// <summary>
+        /// Gets or sets the horizontal alignment of the content within the control.
+        /// </summary>
         public HorizontalAlignment HorizontalContentAlignment
         {
             get { return GetValue(HorizontalContentAlignmentProperty); }
             set { SetValue(HorizontalContentAlignmentProperty, value); }
         }
+        /// <summary>
+        /// Gets or sets the vertical alignment of the content within the control.
+        /// </summary>
         public VerticalAlignment VerticalContentAlignment
         {
             get { return GetValue(VerticalContentAlignmentProperty); }

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -77,13 +77,13 @@ namespace Avalonia.Controls
         /// Defines the <see cref="HorizontalAlignment"/> property.
         /// </summary>
         public static readonly StyledProperty<HorizontalAlignment> HorizontalContentAlignmentProperty =
-            AvaloniaProperty.Register<TextBox, HorizontalAlignment>(nameof(HorizontalContentAlignment));
+            ContentControl.HorizontalContentAlignmentProperty.AddOwner<TextBox>();
 
         /// <summary>
         /// Defines the <see cref="VerticalAlignment"/> property.
         /// </summary>
         public static readonly StyledProperty<VerticalAlignment> VerticalContentAlignmentProperty =
-            AvaloniaProperty.Register<TextBox, VerticalAlignment>(nameof(VerticalContentAlignment));
+            ContentControl.VerticalContentAlignmentProperty.AddOwner<TextBox>();
 
         public static readonly StyledProperty<TextWrapping> TextWrappingProperty =
             TextBlock.TextWrappingProperty.AddOwner<TextBox>();

--- a/src/Avalonia.Themes.Default/TextBox.xaml
+++ b/src/Avalonia.Themes.Default/TextBox.xaml
@@ -12,10 +12,11 @@
                 Background="{TemplateBinding Background}"
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}">
-          <DockPanel Margin="{TemplateBinding Padding}">
+          <DockPanel Margin="{TemplateBinding Padding}"
+                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
 
             <TextBlock Name="floatingWatermark"
-                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                        Foreground="{DynamicResource ThemeAccentBrush}"
                        FontSize="{DynamicResource FontSizeSmall}"
                        Text="{TemplateBinding Watermark}"
@@ -38,13 +39,9 @@
                 <Panel>
                   <TextBlock Name="watermark"
                              Opacity="0.5"
-                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                              Text="{TemplateBinding Watermark}"
                              IsVisible="{TemplateBinding Text, Converter={x:Static StringConverters.IsNullOrEmpty}}"/>
                   <TextPresenter Name="PART_TextPresenter"
-                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                  Text="{TemplateBinding Text, Mode=TwoWay}"
                                  CaretIndex="{TemplateBinding CaretIndex}"
                                  SelectionStart="{TemplateBinding SelectionStart}"

--- a/src/Avalonia.Themes.Default/TextBox.xaml
+++ b/src/Avalonia.Themes.Default/TextBox.xaml
@@ -15,6 +15,7 @@
           <DockPanel Margin="{TemplateBinding Padding}">
 
             <TextBlock Name="floatingWatermark"
+                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                        Foreground="{DynamicResource ThemeAccentBrush}"
                        FontSize="{DynamicResource FontSizeSmall}"
                        Text="{TemplateBinding Watermark}"
@@ -37,9 +38,13 @@
                 <Panel>
                   <TextBlock Name="watermark"
                              Opacity="0.5"
+                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                              Text="{TemplateBinding Watermark}"
                              IsVisible="{TemplateBinding Text, Converter={x:Static StringConverters.IsNullOrEmpty}}"/>
                   <TextPresenter Name="PART_TextPresenter"
+                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                  Text="{TemplateBinding Text, Mode=TwoWay}"
                                  CaretIndex="{TemplateBinding CaretIndex}"
                                  SelectionStart="{TemplateBinding SelectionStart}"


### PR DESCRIPTION
## What does the pull request do?
Adds two properties
```
HorizontalAlignment HorizontalContentAlignment {get; set;}
VerticalAlignment VerticalContentAlignment {get; set;}
```
 to set vertical and horizontal alignment of Textbox's content (i.e. Text and Watermark). Both properties exist in WPF but were missing in Avalonia.

## What is the current behavior?
There is no such property but developers can achieve the same by overriding styles.


## What is the updated/expected behavior with this PR?
![image](https://user-images.githubusercontent.com/14368203/74554739-1ff0aa80-4f52-11ea-95d3-a2c5bcaed2bf.png)
```
<TextBox Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit." Width="200" />
<TextBox Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit." Width="400" Height="100"
		 HorizontalContentAlignment="Center" VerticalContentAlignment="Center"/>
<TextBox Watermark="ReadOnly" IsReadOnly="True" Text="This is read only"/>
<TextBox Width="200" Watermark="Watermark" />
<TextBox Width="200"
<TextBox HorizontalContentAlignment="Center" VerticalContentAlignment="Center"  Height="100" Width="200" Watermark="Watermark" />
<TextBox Width="200"  Height="100"
		 HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
		 Watermark="Floating Watermark"
		 UseFloatingWatermark="True"
		 Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit."/>
```
## Fixed issues
Fixes #2634
