### PR TITLE
Make animation value override local value

### DIFF
--- a/src/Avalonia.Base/ValueStore.cs
+++ b/src/Avalonia.Base/ValueStore.cs
@@ -232,6 +232,7 @@ namespace Avalonia
                 else
                 {
                     var priorityValue = new PriorityValue<T>(_owner, property, this, l);
+                    priorityValue.SetValue(value, priority);
                     _values.SetValue(property, priorityValue);
                 }
             }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_SetValue.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_SetValue.cs
@@ -241,6 +241,17 @@ namespace Avalonia.Base.UnitTests
         }
 
         [Fact]
+        public void SetValue_Animation_Overrides_LocalValue()
+        {
+            Class1 target = new Class1();
+
+            target.SetValue(Class1.FooProperty, "one", BindingPriority.LocalValue);
+            Assert.Equal("one", target.GetValue(Class1.FooProperty));
+            target.SetValue(Class1.FooProperty, "two", BindingPriority.Animation);
+            Assert.Equal("two", target.GetValue(Class1.FooProperty));
+        }
+
+        [Fact]
         public void Setting_UnsetValue_Reverts_To_Default_Value()
         {
             Class1 target = new Class1();


### PR DESCRIPTION
## What does the pull request do?

In #3255 we updated the value store, but this was missed: setting an animation value should override a local value. This might be the cause of #3466 (if you could test @ahopper?) but whatever, it's definitely wrong.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Might be the cause of #3466?
