### PR TITLE
Fix Treeview SelectedItem is set to null before update selection

### DIFF
--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -215,8 +215,7 @@ namespace Avalonia.Controls
 
         private void SelectSingleItem(object item)
         {
-            SelectedItems.Clear();
-            SelectedItems.Add(item);
+            SelectedItems = new AvaloniaList<object>(item);
         }
 
         /// <summary>


### PR DESCRIPTION
## What does the pull request do?
When SelectedItem changes it will update the binding only once with the new selected item.


## What is the current behavior?
Currently when a user binds to SelectedItem and selection changed, the binding will be raised twice. Once for being null and another time with the actual new selected item.

## Fixed issues
Fixes #3576
