### PR TITLE
Fix: dont crash when closing window on OSX.

### DIFF
--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -162,9 +162,12 @@ namespace Avalonia.Native
 
             void IAvnWindowBaseEvents.Resized(AvnSize size)
             {
-                var s = new Size(size.Width, size.Height);
-                _parent._savedLogicalSize = s;
-                _parent.Resized?.Invoke(s);
+                if (_parent._native != null)
+                {
+                    var s = new Size(size.Width, size.Height);
+                    _parent._savedLogicalSize = s;
+                    _parent.Resized?.Invoke(s);
+                }
             }
 
             void IAvnWindowBaseEvents.PositionChanged(AvnPoint position)
@@ -317,7 +320,7 @@ namespace Avalonia.Native
             _native.SetTopMost(value);
         }
 
-        public double Scaling => _native.GetScaling();
+        public double Scaling => _native?.GetScaling() ?? 1;
 
         public Action Deactivated { get; set; }
         public Action Activated { get; set; }


### PR DESCRIPTION
## What does the pull request do?
Fixes issue reported #3544

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
osx close triggers resize event, causing avalonia to access Scaling property, this causes NRE because _native is set to null in Dispose.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Null check so that OSX calling back after avalonia considers window closed wont matter.

Fixed #3544 
