### PR TITLE
Use TypeConverters in TypeUtilities.TryConvert

### DIFF
--- a/src/Avalonia.Base/Utilities/TypeUtilities.cs
+++ b/src/Avalonia.Base/Utilities/TypeUtilities.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -183,6 +184,14 @@ namespace Avalonia.Utilities
                         return false;
                     }
                 }
+            }
+
+            var typeConverter = TypeDescriptor.GetConverter(to);
+
+            if (typeConverter.CanConvertFrom(from) == true)
+            {
+                result = typeConverter.ConvertFrom(null, culture, value);
+                return true;
             }
 
             var cast = FindTypeConversionOperatorMethod(from, to, OperatorType.Implicit | OperatorType.Explicit);

--- a/tests/Avalonia.Base.UnitTests/Data/DefaultValueConverterTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/DefaultValueConverterTests.cs
@@ -51,6 +51,18 @@ namespace Avalonia.Base.UnitTests.Data.Converters
         }
 
         [Fact]
+        public void Can_Convert_String_To_TimeSpan()
+        {
+            var result = DefaultValueConverter.Instance.Convert(
+                "00:00:10",
+                typeof(TimeSpan),
+                null,
+                CultureInfo.InvariantCulture);
+
+            Assert.Equal(TimeSpan.FromSeconds(10), result);
+        }
+
+        [Fact]
         public void Can_Convert_Int_To_Enum()
         {
             var result = DefaultValueConverter.Instance.Convert(


### PR DESCRIPTION
## What does the pull request do?

`TypeUtilities.TryConvert` says:

```
/// <summary>
/// Try to convert a value to a type by any means possible.
/// </summary>
```

However it doesn't try to use `TypeConverter`s, resulting in #3584. Make it look for a `TypeConverter` and try to use it.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #3584