### PR TITLE
OSX - fix potential deadlock with user code

### DIFF
--- a/native/Avalonia.Native/src/OSX/platformthreading.mm
+++ b/native/Avalonia.Native/src/OSX/platformthreading.mm
@@ -157,11 +157,14 @@ NSArray<NSString*>* _modes;
 
 -(void) perform
 {
+    ComPtr<IAvnSignaledCallback> cb;
     @synchronized (self) {
         _signaled  = false;
-        if(_parent != NULL && _parent->SignaledCallback != NULL)
-            _parent->SignaledCallback->Signaled(0, false);
+        if(_parent != NULL)
+            cb = _parent->SignaledCallback;
     }
+    if(cb != nullptr)
+        cb->Signaled(0, false);
 }
 
 -(void) setParent:(PlatformThreadingInterface *)parent


### PR DESCRIPTION
The following code reliably triggers a deadlock on OSX
```cs
var tmr = new DispatcherTimer(TimeSpan.FromMilliseconds(100), DispatcherPriority.Background,
(_, __) =>
{
  Dispatcher.UIThread.Post(() =>
  {
    Task.Run(() =>
      Dispatcher.UIThread.Post(() => Console.WriteLine("Test"))
    .Wait();
  });
});
tmr.Start();
```
A similar pattern is quite common within ReactiveUI framework and there were reports about deadlocks when trying to change property value from property change notification.

This pattern is violating "don't wait for things on UI thread" principle, but we should still avoid the deadlock, especially with RxUI actively utilizing it.