### PR TITLE
Add CTRL+Click to clear DataGridColumn sort

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
@@ -67,7 +67,7 @@ namespace Avalonia.Controls
 
         static DataGridColumnHeader()
         {
-            AreSeparatorsVisibleProperty.Changed.AddClassHandler<DataGridColumnHeader>((x,e) => x.OnAreSeparatorsVisibleChanged(e));
+            AreSeparatorsVisibleProperty.Changed.AddClassHandler<DataGridColumnHeader>((x, e) => x.OnAreSeparatorsVisibleChanged(e));
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Avalonia.Controls
         {
             get;
             set;
-        } 
+        }
         internal DataGrid OwningGrid => OwningColumn?.OwningGrid;
 
         internal int ColumnIndex
@@ -116,19 +116,19 @@ namespace Avalonia.Controls
                 }
                 return OwningColumn.Index;
             }
-        } 
+        }
 
         internal ListSortDirection? CurrentSortingState
         {
             get;
             private set;
-        } 
+        }
 
         private bool IsMouseOver
         {
             get;
             set;
-        } 
+        }
 
         private bool IsPressed
         {
@@ -158,14 +158,14 @@ namespace Avalonia.Controls
                 && OwningGrid.DataConnection.AllowSort)
             {
                 var sort = OwningColumn.GetSortDescription();
-                if(sort != null)
+                if (sort != null)
                 {
                     CurrentSortingState = sort.Descending ? ListSortDirection.Descending : ListSortDirection.Ascending;
                 }
             }
-            PseudoClasses.Set(":sortascending", 
+            PseudoClasses.Set(":sortascending",
                 CurrentSortingState.HasValue && CurrentSortingState.Value == ListSortDirection.Ascending);
-            PseudoClasses.Set(":sortdescending", 
+            PseudoClasses.Set(":sortdescending",
                 CurrentSortingState.HasValue && CurrentSortingState.Value == ListSortDirection.Descending);
         }
 
@@ -195,7 +195,7 @@ namespace Avalonia.Controls
             // completed a click without dragging, so we're sorting
             InvokeProcessSort(keyModifiers);
             handled = true;
-        } 
+        }
 
         internal void InvokeProcessSort(KeyModifiers keyModifiers)
         {
@@ -208,7 +208,7 @@ namespace Avalonia.Controls
             {
                 Avalonia.Threading.Dispatcher.UIThread.Post(() => ProcessSort(keyModifiers));
             }
-        } 
+        }
 
         //TODO GroupSorting
         internal void ProcessSort(KeyModifiers keyModifiers)
@@ -246,45 +246,49 @@ namespace Avalonia.Controls
                         owningGrid.DataConnection.SortDescriptions.Clear();
                     }
 
-                    if (sort != null)
+                    // if ctrl is held down, we only clear the sort directions
+                    if (!ctrl)
                     {
-                        newSort = sort.SwitchSortDirection();
-
-                        // changing direction should not affect sort order, so we replace this column's
-                        // sort description instead of just adding it to the end of the collection
-                        int oldIndex = owningGrid.DataConnection.SortDescriptions.IndexOf(sort);
-                        if (oldIndex >= 0)
+                        if (sort != null)
                         {
-                            owningGrid.DataConnection.SortDescriptions.Remove(sort);
-                            owningGrid.DataConnection.SortDescriptions.Insert(oldIndex, newSort);
+                            newSort = sort.SwitchSortDirection();
+
+                            // changing direction should not affect sort order, so we replace this column's
+                            // sort description instead of just adding it to the end of the collection
+                            int oldIndex = owningGrid.DataConnection.SortDescriptions.IndexOf(sort);
+                            if (oldIndex >= 0)
+                            {
+                                owningGrid.DataConnection.SortDescriptions.Remove(sort);
+                                owningGrid.DataConnection.SortDescriptions.Insert(oldIndex, newSort);
+                            }
+                            else
+                            {
+                                owningGrid.DataConnection.SortDescriptions.Add(newSort);
+                            }
                         }
                         else
                         {
+                            string propertyName = OwningColumn.GetSortPropertyName();
+                            // no-opt if we couldn't find a property to sort on
+                            if (string.IsNullOrEmpty(propertyName))
+                            {
+                                return;
+                            }
+
+                            newSort = DataGridSortDescription.FromPath(propertyName, culture: collectionView.Culture);
                             owningGrid.DataConnection.SortDescriptions.Add(newSort);
                         }
                     }
-                    else
-                    {
-                        string propertyName = OwningColumn.GetSortPropertyName();
-                        // no-opt if we couldn't find a property to sort on
-                        if (string.IsNullOrEmpty(propertyName))
-                        {
-                            return;
-                        }
-
-                        newSort = DataGridSortDescription.FromPath(propertyName, culture: collectionView.Culture);
-                        owningGrid.DataConnection.SortDescriptions.Add(newSort);
-                    }
                 }
             }
-        } 
+        }
 
         private bool CanReorderColumn(DataGridColumn column)
         {
-            return OwningGrid.CanUserReorderColumns 
+            return OwningGrid.CanUserReorderColumns
                 && !(column is DataGridFillerColumn)
                 && (column.CanUserReorderInternal.HasValue && column.CanUserReorderInternal.Value || !column.CanUserReorderInternal.HasValue);
-        } 
+        }
 
         /// <summary>
         /// Determines whether a column can be resized by dragging the border of its header.  If star sizing
@@ -302,7 +306,7 @@ namespace Avalonia.Controls
                 return false;
             }
             return column.ActualCanUserResize;
-        }  
+        }
 
         private static bool TrySetResizeColumn(DataGridColumn column)
         {
@@ -316,7 +320,7 @@ namespace Avalonia.Controls
                 return true;
             }
             return false;
-        } 
+        }
 
         //TODO DragDrop
 
@@ -371,7 +375,7 @@ namespace Avalonia.Controls
             {
                 if (_dragMode == DragMode.MouseDown)
                 {
-                   OnMouseLeftButtonUp_Click(args.KeyModifiers, ref handled);
+                    OnMouseLeftButtonUp_Click(args.KeyModifiers, ref handled);
                 }
                 else if (_dragMode == DragMode.Reorder)
                 {
@@ -449,7 +453,7 @@ namespace Avalonia.Controls
 
             OnMouseLeave();
             ApplyState();
-        } 
+        }
 
         private void DataGridColumnHeader_PointerPressed(object sender, PointerPressedEventArgs e)
         {
@@ -577,7 +581,7 @@ namespace Avalonia.Controls
             {
                 return OwningGrid.Columns.Count - 1;
             }
-        } 
+        }
 
         /// <summary>
         /// Returns true if the mouse is 
@@ -723,7 +727,7 @@ namespace Avalonia.Controls
                     Point targetPosition = new Point(0, 0);
                     if (targetColumn == null || targetColumn == OwningGrid.ColumnsInternal.FillerColumn || targetColumn.IsFrozen != OwningColumn.IsFrozen)
                     {
-                        targetColumn = 
+                        targetColumn =
                             OwningGrid.ColumnsInternal.GetLastColumn(
                                 isVisible: true,
                                 isFrozen: OwningColumn.IsFrozen,
@@ -741,7 +745,7 @@ namespace Avalonia.Controls
 
                 handled = true;
             }
-        } 
+        }
 
         private void OnMouseMove_Resize(ref bool handled, Point mousePositionHeaders)
         {
@@ -764,7 +768,7 @@ namespace Avalonia.Controls
 
                 handled = true;
             }
-        } 
+        }
 
         private void SetDragCursor(Point mousePosition)
         {


### PR DESCRIPTION
## What does the pull request do?
Adds CTRL+Click to clear DataGridColumn sort.


## What is the current behavior?
It is currently not possible for the end user to clear sort directions after he/she clicked/sorted a column. This behavior is identical to WPF.


## What is the updated/expected behavior with this PR?
User can clear the sort. This behavior is different to WPF but matching with for example DevExpress and other control libraries.


## How was the solution implemented (if it's not obvious)?
Execute existing sort code only when CTRL is not pressed. There is already a keyboard input check for SHIFT key so in the end I only added one IF condition for CTRL. There was also some code factoring done by VS.

