### PR TITLE
Changed the DataGrid mouse wheel delta from 2 to 3 lines

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -65,7 +65,7 @@ namespace Avalonia.Controls
         private const double DATAGRID_minimumColumnHeaderHeight = 4;
         internal const double DATAGRID_maximumStarColumnWidth = 10000;
         internal const double DATAGRID_minimumStarColumnWidth = 0.001;
-        private const double DATAGRID_mouseWheelDelta = 48.0;
+        private const double DATAGRID_mouseWheelDelta = 72.0;
         private const double DATAGRID_maxHeadersThickness = 32768;
 
         private const double DATAGRID_defaultRowHeight = 22;


### PR DESCRIPTION
## What does the pull request do?
The current DataGrid scrolls 2 lines by default when the mouse wheel is scrolled. This changes that default to 3 lines to match the Windows default.

## What is the current behavior?
The mouse wheel scrolls 2 lines in the DataGrid. This ends up requiring 50% more scrolling than the Windows default.

## What is the updated/expected behavior with this PR?
The mouse wheel scrolls 3 lines in the DataGrid

## How was the solution implemented (if it's not obvious)?
Changed pixel amount from 48 to 72 pixels for the mouse wheel delta
