### PR TITLE
Fix padding inconsistency

### DIFF
--- a/src/Avalonia.Themes.Default/TabControl.xaml
+++ b/src/Avalonia.Themes.Default/TabControl.xaml
@@ -57,6 +57,6 @@
         <Setter Property="Orientation" Value="Vertical"/>
     </Style>
     <Style Selector="TabControl[TabStripPlacement=Right]">
-        <Setter Property="Padding" Value="0 0 0 4"/>
+        <Setter Property="Padding" Value="0 0 4 0"/>
     </Style>
 </Styles>


### PR DESCRIPTION
## What does the pull request do?
Small fix for what I believe is a typo that causes a slight inconsistency in the default template of the tab control.

## What is the current behavior?
The padding is always added to the side the headers are at, except when the headers are right the padding is at the bottom.

## What is the updated/expected behavior with this PR?
The padding is now consistent for all sides.


