### PR TITLE
Avoid IAffectsRender subscribe attempts on values that can't implement it

### DIFF
--- a/src/Avalonia.Visuals/AvaloniaPropertyExtensions.cs
+++ b/src/Avalonia.Visuals/AvaloniaPropertyExtensions.cs
@@ -1,0 +1,27 @@
+﻿using Avalonia.Media;
+
+#nullable enable
+
+namespace Avalonia
+{
+    /// <summary>
+    /// Extensions for <see cref="AvaloniaProperty"/>.
+    /// </summary>
+    public static class AvaloniaPropertyExtensions
+    {
+        /// <summary>
+        /// Checks if values of given property can affect rendering (via <see cref="IAffectsRender"/>).
+        /// </summary>
+        /// <param name="property">Property to check.</param>
+        public static bool CanValueAffectRender(this AvaloniaProperty property)
+        {
+            var propertyType = property.PropertyType;
+
+            // Only case that we are sure that property value CAN'T affect render are sealed types that don't implement
+            // the interface.
+            var cannotAffectRender = propertyType.IsSealed && !typeof(IAffectsRender).IsAssignableFrom(propertyType);
+
+            return !cannotAffectRender;
+        }
+    }
+}

--- a/src/Avalonia.Visuals/Media/Brush.cs
+++ b/src/Avalonia.Visuals/Media/Brush.cs
@@ -69,14 +69,14 @@ namespace Avalonia.Media
         protected static void AffectsRender<T>(params AvaloniaProperty[] properties)
             where T : Brush
         {
-            void Invalidate(AvaloniaPropertyChangedEventArgs e)
+            static void Invalidate(AvaloniaPropertyChangedEventArgs e)
             {
                 (e.Sender as T)?.RaiseInvalidated(EventArgs.Empty);
             }
 
             foreach (var property in properties)
             {
-                property.Changed.Subscribe(Invalidate);
+                property.Changed.Subscribe(e => Invalidate(e));
             }
         }
 

--- a/src/Avalonia.Visuals/Visual.cs
+++ b/src/Avalonia.Visuals/Visual.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Specialized;
-using System.Linq;
 using Avalonia.Collections;
 using Avalonia.Data;
 using Avalonia.Logging;

--- a/src/Avalonia.Visuals/Visual.cs
+++ b/src/Avalonia.Visuals/Visual.cs
@@ -336,7 +336,15 @@ namespace Avalonia
         protected static void AffectsRender<T>(params AvaloniaProperty[] properties)
             where T : Visual
         {
-            void Invalidate(AvaloniaPropertyChangedEventArgs e)
+            static void Invalidate(AvaloniaPropertyChangedEventArgs e)
+            {
+                if (e.Sender is T sender)
+                {
+                    sender.InvalidateVisual();
+                }
+            }
+
+            static void InvalidateAndSubscribe(AvaloniaPropertyChangedEventArgs e)
             {
                 if (e.Sender is T sender)
                 {
@@ -347,7 +355,7 @@ namespace Avalonia
 
                     if (e.NewValue is IAffectsRender newValue)
                     {
-                        WeakEventHandlerManager.Subscribe<IAffectsRender, EventArgs, T>(newValue, nameof(newValue.Invalidated), sender.AffectsRenderInvalidated);                        
+                        WeakEventHandlerManager.Subscribe<IAffectsRender, EventArgs, T>(newValue, nameof(newValue.Invalidated), sender.AffectsRenderInvalidated);
                     }
 
                     sender.InvalidateVisual();
@@ -356,7 +364,14 @@ namespace Avalonia
 
             foreach (var property in properties)
             {
-                property.Changed.Subscribe(Invalidate);
+                if (property.CanValueAffectRender())
+                {
+                    property.Changed.Subscribe(e => InvalidateAndSubscribe(e));
+                }
+                else
+                {
+                    property.Changed.Subscribe(e => Invalidate(e));
+                }
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Adds extra heuristics to `AffectsRender` on `Visual` and `Pen` that use different handler when given property value cannot implement `IAffectsRender`. It allows to reduce amount of boxing allocations that we would otherwise cause.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
|         Method |     Mean |     Error |    StdDev |    Gen 0 |    Gen 1 |   Gen 2 | Allocated |
|--------------- |---------:|----------:|----------:|---------:|---------:|--------:|----------:|
| CreateCalendar | 22.61 ms | 0.2047 ms | 0.1814 ms | 750.0000 | 343.7500 | 62.5000 |   4.28 MB |

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
|         Method |     Mean |     Error |    StdDev |    Gen 0 |    Gen 1 |   Gen 2 | Allocated |
|--------------- |---------:|----------:|----------:|---------:|---------:|--------:|----------:|
| CreateCalendar | 21.54 ms | 0.1454 ms | 0.1360 ms | 718.7500 | 343.7500 | 31.2500 |   4.19 MB |

List of properties that are skipped:
```
Skipped Avalonia.Visual.Bounds of type Avalonia.Rect
Skipped Avalonia.Visual.ClipToBounds of type System.Boolean
Skipped Avalonia.Visual.IsVisible of type System.Boolean
Skipped Avalonia.Visual.Opacity of type System.Double
Skipped Avalonia.Controls.Border.BorderThickness of type Avalonia.Thickness
Skipped Avalonia.Controls.Border.CornerRadius of type Avalonia.CornerRadius
Skipped Avalonia.Controls.TextBlock.FontWeight of type Avalonia.Media.FontWeight
Skipped Avalonia.Controls.TextBlock.FontSize of type System.Double
Skipped Avalonia.Controls.TextBlock.FontStyle of type Avalonia.Media.FontStyle
Skipped Avalonia.Controls.Border.BorderThickness of type Avalonia.Thickness
Skipped Avalonia.Controls.Border.CornerRadius of type Avalonia.CornerRadius
Skipped Avalonia.Controls.Shapes.Shape.StrokeDashOffset of type System.Double
Skipped Avalonia.Controls.Shapes.Shape.StrokeThickness of type System.Double
Skipped Avalonia.Controls.Shapes.Shape.StrokeLineCap of type Avalonia.Media.PenLineCap
Skipped Avalonia.Controls.Shapes.Shape.StrokeJoin of type Avalonia.Media.PenLineJoin
```

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Heuristic is simple - if property type is sealed and it does not implement `IAffectsRender` - there is no point in trying to subscribe since it will never work anyway.

Also changed a few method groups to normal lambdas to reuse the same delegate across properties.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation