### PR TITLE
Remove disposable allocations from routed event AddHandler in the common case.

### DIFF
--- a/src/Avalonia.Controls/Calendar/DatePicker.cs
+++ b/src/Avalonia.Controls/Calendar/DatePicker.cs
@@ -476,7 +476,7 @@ namespace Avalonia.Controls
             {
                 _dropDownButton.Click += DropDownButton_Click;
                 _buttonPointerPressedSubscription =
-                    _dropDownButton.AddHandler(PointerPressedEvent, DropDownButton_PointerPressed, handledEventsToo: true);
+                    _dropDownButton.AddDisposableHandler(PointerPressedEvent, DropDownButton_PointerPressed, handledEventsToo: true);
             }
 
             if (_textBox != null)

--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -9,6 +9,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Avalonia.VisualTree;
@@ -265,7 +266,7 @@ namespace Avalonia.Controls
             var toplevel = this.GetVisualRoot() as TopLevel;
             if (toplevel != null)
             {
-                _subscriptionsOnOpen = toplevel.AddHandler(PointerWheelChangedEvent, (s, ev) =>
+                _subscriptionsOnOpen = toplevel.AddDisposableHandler(PointerWheelChangedEvent, (s, ev) =>
                 {
                     //eat wheel scroll event outside dropdown popup while it's open
                     if (IsDropDownOpen && (ev.Source as IVisual).GetVisualRoot() == toplevel)

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -279,7 +279,7 @@ namespace Avalonia.Controls.Primitives
                 }
             }
 
-            DeferCleanup(topLevel.AddHandler(PointerPressedEvent, PointerPressedOutside, RoutingStrategies.Tunnel));
+            DeferCleanup(topLevel.AddDisposableHandler(PointerPressedEvent, PointerPressedOutside, RoutingStrategies.Tunnel));
 
             DeferCleanup(InputManager.Instance?.Process.Subscribe(ListenForNonClientClick));
 

--- a/src/Avalonia.Diagnostics/Diagnostics/DevTools.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/DevTools.cs
@@ -22,7 +22,7 @@ namespace Avalonia.Diagnostics
                 }
             }
 
-            return root.AddHandler(
+            return root.AddDisposableHandler(
                 InputElement.KeyDownEvent,
                 PreviewKeyDown,
                 RoutingStrategies.Tunnel);

--- a/src/Avalonia.Interactivity/IInteractive.cs
+++ b/src/Avalonia.Interactivity/IInteractive.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Interactivity
         /// <param name="routes">The routing strategies to listen to.</param>
         /// <param name="handledEventsToo">Whether handled events should also be listened for.</param>
         /// <returns>A disposable that terminates the event subscription.</returns>
-        IDisposable AddHandler(
+        void AddHandler(
             RoutedEvent routedEvent,
             Delegate handler,
             RoutingStrategies routes = RoutingStrategies.Direct | RoutingStrategies.Bubble,
@@ -38,7 +38,7 @@ namespace Avalonia.Interactivity
         /// <param name="routes">The routing strategies to listen to.</param>
         /// <param name="handledEventsToo">Whether handled events should also be listened for.</param>
         /// <returns>A disposable that terminates the event subscription.</returns>
-        IDisposable AddHandler<TEventArgs>(
+        void AddHandler<TEventArgs>(
             RoutedEvent<TEventArgs> routedEvent,
             EventHandler<TEventArgs> handler,
             RoutingStrategies routes = RoutingStrategies.Direct | RoutingStrategies.Bubble,

--- a/src/Avalonia.Interactivity/Interactive.cs
+++ b/src/Avalonia.Interactivity/Interactive.cs
@@ -27,8 +27,7 @@ namespace Avalonia.Interactivity
         /// <param name="handler">The handler.</param>
         /// <param name="routes">The routing strategies to listen to.</param>
         /// <param name="handledEventsToo">Whether handled events should also be listened for.</param>
-        /// <returns>A disposable that terminates the event subscription.</returns>
-        public IDisposable AddHandler(
+        public void AddHandler(
             RoutedEvent routedEvent,
             Delegate handler,
             RoutingStrategies routes = RoutingStrategies.Direct | RoutingStrategies.Bubble,
@@ -38,7 +37,8 @@ namespace Avalonia.Interactivity
             handler = handler ?? throw new ArgumentNullException(nameof(handler));
 
             var subscription = new EventSubscription(handler, routes, handledEventsToo);
-            return AddEventSubscription(routedEvent, subscription);
+
+            AddEventSubscription(routedEvent, subscription);
         }
 
         /// <summary>
@@ -49,8 +49,7 @@ namespace Avalonia.Interactivity
         /// <param name="handler">The handler.</param>
         /// <param name="routes">The routing strategies to listen to.</param>
         /// <param name="handledEventsToo">Whether handled events should also be listened for.</param>
-        /// <returns>A disposable that terminates the event subscription.</returns>
-        public IDisposable AddHandler<TEventArgs>(
+        public void AddHandler<TEventArgs>(
             RoutedEvent<TEventArgs> routedEvent,
             EventHandler<TEventArgs> handler,
             RoutingStrategies routes = RoutingStrategies.Direct | RoutingStrategies.Bubble,
@@ -69,7 +68,7 @@ namespace Avalonia.Interactivity
 
             var subscription = new EventSubscription(handler, routes, handledEventsToo, (baseHandler, sender, args) => InvokeAdapter(baseHandler, sender, args));
 
-            return AddEventSubscription(routedEvent, subscription);
+            AddEventSubscription(routedEvent, subscription);
         }
 
         /// <summary>
@@ -188,7 +187,7 @@ namespace Avalonia.Interactivity
             return result;
         }
 
-        private IDisposable AddEventSubscription(RoutedEvent routedEvent, EventSubscription subscription)
+        private void AddEventSubscription(RoutedEvent routedEvent, EventSubscription subscription)
         {
             _eventHandlers ??= new Dictionary<RoutedEvent, List<EventSubscription>>();
 
@@ -199,8 +198,6 @@ namespace Avalonia.Interactivity
             }
 
             subscriptions.Add(subscription);
-
-            return new UnsubscribeDisposable(subscriptions, subscription);
         }
 
         private readonly struct EventSubscription
@@ -224,23 +221,6 @@ namespace Avalonia.Interactivity
             public RoutingStrategies Routes { get; }
 
             public bool HandledEventsToo { get; }
-        }
-
-        private sealed class UnsubscribeDisposable : IDisposable
-        {
-            private readonly List<EventSubscription> _subscriptions;
-            private readonly EventSubscription _subscription;
-
-            public UnsubscribeDisposable(List<EventSubscription> subscriptions, EventSubscription subscription)
-            {
-                _subscriptions = subscriptions;
-                _subscription = subscription;
-            }
-
-            public void Dispose()
-            {
-                _subscriptions.Remove(_subscription);
-            }
         }
     }
 }

--- a/src/Avalonia.Interactivity/InteractiveExtensions.cs
+++ b/src/Avalonia.Interactivity/InteractiveExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
 namespace Avalonia.Interactivity
@@ -11,6 +12,28 @@ namespace Avalonia.Interactivity
     /// </summary>
     public static class InteractiveExtensions
     {
+        /// <summary>
+        /// Adds a handler for the specified routed event and returns a disposable that can terminate the event subscription.
+        /// </summary>
+        /// <typeparam name="TEventArgs">The type of the event's args.</typeparam>
+        /// <param name="o">Target for adding given event handler.</param>
+        /// <param name="routedEvent">The routed event.</param>
+        /// <param name="handler">The handler.</param>
+        /// <param name="routes">The routing strategies to listen to.</param>
+        /// <param name="handledEventsToo">Whether handled events should also be listened for.</param>
+        /// <returns>A disposable that terminates the event subscription.</returns>
+        public static IDisposable AddDisposableHandler<TEventArgs>(this IInteractive o, RoutedEvent<TEventArgs> routedEvent,
+            EventHandler<TEventArgs> handler,
+            RoutingStrategies routes = RoutingStrategies.Direct | RoutingStrategies.Bubble,
+            bool handledEventsToo = false) where TEventArgs : RoutedEventArgs
+        {
+            o.AddHandler(routedEvent, handler, routes, handledEventsToo);
+
+            return Disposable.Create(
+                (instance: o, handler, routedEvent),
+                state => state.instance.RemoveHandler(state.routedEvent, state.handler));
+        }
+
         /// <summary>
         /// Gets an observable for a <see cref="RoutedEvent{TEventArgs}"/>.
         /// </summary>
@@ -31,7 +54,7 @@ namespace Avalonia.Interactivity
             o = o ?? throw new ArgumentNullException(nameof(o));
             routedEvent = routedEvent ?? throw new ArgumentNullException(nameof(routedEvent));
 
-            return Observable.Create<TEventArgs>(x => o.AddHandler(
+            return Observable.Create<TEventArgs>(x => o.AddDisposableHandler(
                 routedEvent, 
                 (_, e) => x.OnNext(e), 
                 routes,

--- a/tests/Avalonia.Benchmarks/NullGlyphRun.cs
+++ b/tests/Avalonia.Benchmarks/NullGlyphRun.cs
@@ -1,0 +1,11 @@
+﻿using Avalonia.Platform;
+
+namespace Avalonia.Benchmarks
+{
+    internal class NullGlyphRun : IGlyphRunImpl
+    {
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/Avalonia.Benchmarks/NullRenderingPlatform.cs
+++ b/tests/Avalonia.Benchmarks/NullRenderingPlatform.cs
@@ -72,7 +72,9 @@ namespace Avalonia.Benchmarks
 
         public IGlyphRunImpl CreateGlyphRun(GlyphRun glyphRun, out double width)
         {
-            throw new NotImplementedException();
+            width = default;
+
+            return new NullGlyphRun();
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
`AddHandler` was always returning `IDisposable` allowing for easy unsubscribe for the user. This PR changes this behavior to not do this by default and adds a separate function with this behavior.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Most of the `AddHandler` callers don't even use returned value (all event implementations in `AvaloniaObject` just discard returned `IDisposable`). There are only a few call sites that use this feature.

|         Method |     Mean |     Error |    StdDev |    Gen 0 |    Gen 1 |   Gen 2 | Allocated |
|--------------- |---------:|----------:|----------:|---------:|---------:|--------:|----------:|
| CreateCalendar | 19.29 ms | 0.1664 ms | 0.1557 ms | 625.0000 | 281.2500 | 31.2500 |   3.61 MB |

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Adds a separate `AddDisposableHandler` that can returns `IDisposable` that can be used to unsubscribe from the handler.

Perf gains in calendar case are tiny but we can clearly see that we collect less often now as `AddHandler` is not forced to allocate all the time. But we shouldn't prevent users from not being able have non-allocating `AddHandler` to support 1% niche use case.

|         Method |     Mean |     Error |    StdDev |    Gen 0 |    Gen 1 | Gen 2 | Allocated |
|--------------- |---------:|----------:|----------:|---------:|---------:|------:|----------:|
| CreateCalendar | 19.18 ms | 0.2813 ms | 0.2631 ms | 593.7500 | 250.0000 |     - |    3.6 MB |

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

Users that are utilizing `AddHandler` return value should use `AddDisposableHandler` instead.
