### PR TITLE
Reduce deferred renderer enumerator allocations

### DIFF
--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -356,7 +356,8 @@ namespace Avalonia.Rendering
                     node.BeginRender(context, isLayerRoot);
 
                     var drawOperations = node.DrawOperations;
-                    for (int i = 0; i < drawOperations.Count; i++)
+                    var drawOperationsCount = drawOperations.Count;
+                    for (int i = 0; i < drawOperationsCount; i++)
                     {
                         var operation = drawOperations[i];
                         _currentDraw = operation;
@@ -365,7 +366,8 @@ namespace Avalonia.Rendering
                     }
 
                     var children = node.Children;
-                    for (int i = 0; i < children.Count; i++)
+                    var childrenCount = children.Count;
+                    for (int i = 0; i < childrenCount; i++)
                     {
                         var child = children[i];
                         Render(context, (VisualNode)child, layer, clipBounds);

--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -355,15 +355,19 @@ namespace Avalonia.Rendering
 
                     node.BeginRender(context, isLayerRoot);
 
-                    foreach (var operation in node.DrawOperations)
+                    var drawOperations = node.DrawOperations;
+                    for (int i = 0; i < drawOperations.Count; i++)
                     {
+                        var operation = drawOperations[i];
                         _currentDraw = operation;
                         operation.Item.Render(context);
                         _currentDraw = null;
                     }
 
-                    foreach (var child in node.Children)
+                    var children = node.Children;
+                    for (int i = 0; i < children.Count; i++)
                     {
+                        var child = children[i];
                         Render(context, (VisualNode)child, layer, clipBounds);
                     }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
In profiling updating of text TextBoxes I noticed a large number of enumerator allocs in the renderer.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The vs .NET Object Allocation Tracking tool reports 174131 enumerator allocations on updating the binding on 400 TextBoxes. This is a huge number that I do not fully understand, I wonder if the tool could be causing some of it by slowing the process down and causing the renderer to run more often.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
5078 allocations are reported

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
