### PR TITLE
Feature: TextBox.SelectedText

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -275,6 +275,22 @@ namespace Avalonia.Controls
             }
         }
 
+        public string SelectedText
+        {
+            get { return GetSelection(); }
+            set
+            {
+                if (value == null)
+                {
+                    return;
+                }
+
+                _undoRedoHelper.Snapshot();
+                HandleTextInput(value);
+                _undoRedoHelper.Snapshot();
+            }
+        }
+
         /// <summary>
         /// Gets or sets the horizontal alignment of the content within the control.
         /// </summary>

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -385,6 +385,49 @@ namespace Avalonia.Controls.UnitTests
                 Assert.True(target.SelectionEnd <= "123".Length);
             }
         }
+
+        [Fact]
+        public void SelectedText_Changes_OnSelectionChange()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var target = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "0123456789"
+                };
+
+                Assert.True(target.SelectedText == "");
+
+                target.SelectionStart = 2;
+                target.SelectionEnd = 4;
+
+                Assert.True(target.SelectedText == "23");
+            }
+        }
+
+        [Fact]
+        public void SelectedText_EditsText()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var target = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "0123"
+                };
+
+                target.SelectedText = "AA";
+                Assert.True(target.Text == "AA0123");
+
+                target.SelectionStart = 1;
+                target.SelectionEnd = 3;
+                target.SelectedText = "BB";
+
+                Assert.True(target.Text == "ABB123");
+            }
+        }
+
         [Fact]
         public void CoerceCaretIndex_Doesnt_Cause_Exception_with_malformed_line_ending()
         {


### PR DESCRIPTION
## What does the pull request do?

Adds a `SelectedText` getter/setter to `TextBox` based on the description from WPF [here](https://docs.microsoft.com/en-us/dotnet/api/system.windows.controls.textbox.selectedtext?view=netframework-4.8).

## What is the current behavior?

`TextBox` does not currently have such a property.

## What is the updated/expected behavior with this PR?

You can now do things like:

```csharp
var textBox = new TextBox();
var text = textBox.SelectedText;
textBox.SelectedText = "Hello all!";
```

## How was the solution implemented (if it's not obvious)?

Fairly straight forward -- calls already-existing code for this functionality.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes

No breaking changes.

## Fixed issues

None.