### PR TITLE
Adjusted TextBox right-click behavior

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -683,13 +683,12 @@ namespace Avalonia.Controls
 
         protected override void OnPointerPressed(PointerPressedEventArgs e)
         {
-            var point = e.GetPosition(_presenter);
-            var index = _presenter.GetCaretIndex(point);
             var text = Text;
 
             if (text != null && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
-                CaretIndex = index;
+                var point = e.GetPosition(_presenter);
+                var index = CaretIndex = _presenter.GetCaretIndex(point);
                 switch (e.ClickCount)
                 {
                     case 1:

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -684,11 +684,12 @@ namespace Avalonia.Controls
         protected override void OnPointerPressed(PointerPressedEventArgs e)
         {
             var point = e.GetPosition(_presenter);
-            var index = CaretIndex = _presenter.GetCaretIndex(point);
+            var index = _presenter.GetCaretIndex(point);
             var text = Text;
 
-            if (text != null && e.MouseButton == MouseButton.Left)
+            if (text != null && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
+                CaretIndex = index;
                 switch (e.ClickCount)
                 {
                     case 1:
@@ -714,7 +715,8 @@ namespace Avalonia.Controls
 
         protected override void OnPointerMoved(PointerEventArgs e)
         {
-            if (_presenter != null && e.Pointer.Captured == _presenter)
+            // selection should not change during pointer move if the user right clicks
+            if (_presenter != null && e.Pointer.Captured == _presenter && !e.GetCurrentPoint(this).Properties.IsRightButtonPressed)
             {
                 var point = e.GetPosition(_presenter);
 
@@ -727,6 +729,22 @@ namespace Avalonia.Controls
         {
             if (_presenter != null && e.Pointer.Captured == _presenter)
             {
+                if (e.InitialPressMouseButton == MouseButton.Right)
+                {
+                    var point = e.GetPosition(_presenter);
+                    var caretIndex = _presenter.GetCaretIndex(point);
+
+                    // see if mouse clicked inside current selection
+                    // if it did not, we change the selection to where the user clicked
+                    var firstSelection = Math.Min(SelectionStart, SelectionEnd);
+                    var lastSelection = Math.Max(SelectionStart, SelectionEnd);
+                    var didClickInSelection = SelectionStart != SelectionEnd && 
+                        caretIndex >= firstSelection && caretIndex <= lastSelection;
+                    if (!didClickInSelection)
+                    {
+                        CaretIndex = SelectionEnd = SelectionStart = caretIndex;
+                    }
+                }
                 e.Pointer.Capture(null);
             }
         }

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -715,7 +715,7 @@ namespace Avalonia.Controls
         protected override void OnPointerMoved(PointerEventArgs e)
         {
             // selection should not change during pointer move if the user right clicks
-            if (_presenter != null && e.Pointer.Captured == _presenter && !e.GetCurrentPoint(this).Properties.IsRightButtonPressed)
+            if (_presenter != null && e.Pointer.Captured == _presenter && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
                 var point = e.GetPosition(_presenter);
 


### PR DESCRIPTION
## What does the pull request do?

WPF does not allow dragging to change selection for right clicks. Furthermore, it only changes the selection on mouse up of right click, not mouse down, and only if the user clicked outside the current selection.

This commit adjusts TextBox selection behavior to work like WPF with one exception: in WPF, if you right click and then move your mouse outside the `TextBox`, it will not change the caret location. This PR does not fix that one edge case.

## What is the current behavior?

Right clicking and dragging in a `TextBox` works like a left click in terms of changing selection.


## What is the updated/expected behavior with this PR?

`TextBox` now:

* Doesn't change selection on mouse down unless it's a left click
* Right click and drag no longer allows selection change
* Right click no longer changes selection if you click inside the current selection
* If you right click outside the selection, on mouse up, the caret location will be changed as necessary

## How was the solution implemented (if it's not obvious)?

Nothing really spectacular here. I also removed an obsolete use in `TextBox.OnPointerPressed` of `MouseButton`.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes

I guess this changes selection behavior, so that's sort of a breaking change...no breaking API changes, though.

## Fixed issues

None
