### PR TITLE
Feature: Checkmark in native macOS menus

### DIFF
--- a/native/Avalonia.Native/inc/avalonia-native.h
+++ b/native/Avalonia.Native/inc/avalonia-native.h
@@ -404,6 +404,7 @@ AVNCOM(IAvnAppMenuItem, 19) : IUnknown
     virtual HRESULT SetTitle (void* utf8String) = 0;
     virtual HRESULT SetGesture (void* utf8String, AvnInputModifiers modifiers) = 0;
     virtual HRESULT SetAction (IAvnPredicateCallback* predicate, IAvnActionCallback* callback) = 0;
+    virtual HRESULT SetIsChecked (bool isChecked) = 0;
 };
 
 extern "C" IAvaloniaNativeFactory* CreateAvaloniaNative();

--- a/native/Avalonia.Native/src/OSX/menu.h
+++ b/native/Avalonia.Native/src/OSX/menu.h
@@ -46,6 +46,8 @@ public:
     
     virtual HRESULT SetAction (IAvnPredicateCallback* predicate, IAvnActionCallback* callback) override;
     
+    virtual HRESULT SetIsChecked (bool isChecked) override;
+    
     bool EvaluateItemEnabled();
     
     void RaiseOnClicked();

--- a/native/Avalonia.Native/src/OSX/menu.mm
+++ b/native/Avalonia.Native/src/OSX/menu.mm
@@ -110,6 +110,12 @@ HRESULT AvnAppMenuItem::SetAction (IAvnPredicateCallback* predicate, IAvnActionC
     return S_OK;
 }
 
+HRESULT AvnAppMenuItem::SetIsChecked (bool isChecked)
+{
+    [_native setState:(isChecked ? NSOnState : NSOffState)];
+    return S_OK;
+}
+
 bool AvnAppMenuItem::EvaluateItemEnabled()
 {
     if(_predicate != nullptr)

--- a/samples/ControlCatalog/MainWindow.xaml
+++ b/samples/ControlCatalog/MainWindow.xaml
@@ -36,6 +36,15 @@
           </NativeMenu>
         </NativeMenuItem.Menu>
       </NativeMenuItem>
+      <NativeMenuItem Header="Options">
+        <NativeMenuItem.Menu>
+          <NativeMenu>
+            <NativeMenuItem Header="Check Me Out" 
+                            Command="{Binding ToggleMenuItemCheckedCommand}"
+                            IsChecked="{Binding IsMenuItemChecked}"  />
+          </NativeMenu>
+        </NativeMenuItem.Menu>
+      </NativeMenuItem>
     </NativeMenu>
   </NativeMenu.Menu>
 

--- a/samples/ControlCatalog/ViewModels/MainWindowViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/MainWindowViewModel.cs
@@ -10,6 +10,8 @@ namespace ControlCatalog.ViewModels
     {
         private IManagedNotificationManager _notificationManager;
 
+        private bool _isMenuItemChecked = true;
+
         public MainWindowViewModel(IManagedNotificationManager notificationManager)
         {
             _notificationManager = notificationManager;
@@ -42,12 +44,23 @@ namespace ControlCatalog.ViewModels
             {
                 (App.Current.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime).Shutdown();
             });
+
+            ToggleMenuItemCheckedCommand = ReactiveCommand.Create(() => 
+            {
+                IsMenuItemChecked = !IsMenuItemChecked;
+            });
         }
 
         public IManagedNotificationManager NotificationManager
         {
             get { return _notificationManager; }
             set { this.RaiseAndSetIfChanged(ref _notificationManager, value); }
+        }
+
+        public bool IsMenuItemChecked
+        {
+            get { return _isMenuItemChecked; }
+            set { this.RaiseAndSetIfChanged(ref _isMenuItemChecked, value); }
         }
 
         public ReactiveCommand<Unit, Unit> ShowCustomManagedNotificationCommand { get; }
@@ -59,5 +72,7 @@ namespace ControlCatalog.ViewModels
         public ReactiveCommand<Unit, Unit> AboutCommand { get; }
 
         public ReactiveCommand<Unit, Unit> ExitCommand { get; }
+
+        public ReactiveCommand<Unit, Unit> ToggleMenuItemCheckedCommand { get; }
     }
 }

--- a/src/Avalonia.Controls/NativeMenuItem.cs
+++ b/src/Avalonia.Controls/NativeMenuItem.cs
@@ -93,11 +93,10 @@ namespace Avalonia.Controls
             set => SetValue(GestureProperty, value);
         }
 
-        public static readonly DirectProperty<NativeMenuItem, bool> IsCheckedProperty =
-            AvaloniaProperty.RegisterDirect<NativeMenuItem, bool>(
+        public static readonly StyledProperty<bool> IsCheckedProperty =
+            AvaloniaProperty.Register<NativeMenuItem, bool>(
                 nameof(IsChecked),
-                o => o._isChecked,
-                (o, v) => o._isChecked = v,
+                defaultValue: false,
                 defaultBindingMode: Data.BindingMode.TwoWay);
 
         public bool IsChecked

--- a/src/Avalonia.Controls/NativeMenuItem.cs
+++ b/src/Avalonia.Controls/NativeMenuItem.cs
@@ -102,7 +102,7 @@ namespace Avalonia.Controls
         public bool IsChecked
         {
             get => GetValue(IsCheckedProperty);
-            set { SetAndRaise(IsCheckedProperty, ref _isChecked, value); }
+            set => SetAndRaise(IsCheckedProperty, ref _isChecked, value);
         }
 
         private ICommand _command;

--- a/src/Avalonia.Controls/NativeMenuItem.cs
+++ b/src/Avalonia.Controls/NativeMenuItem.cs
@@ -10,6 +10,7 @@ namespace Avalonia.Controls
         private string _header;
         private KeyGesture _gesture;
         private bool _enabled = true;
+        private bool _isChecked = false;
 
         private NativeMenu _menu;
 
@@ -90,6 +91,19 @@ namespace Avalonia.Controls
         {
             get => GetValue(GestureProperty);
             set => SetValue(GestureProperty, value);
+        }
+
+        public static readonly DirectProperty<NativeMenuItem, bool> IsCheckedProperty =
+            AvaloniaProperty.RegisterDirect<NativeMenuItem, bool>(
+                nameof(IsChecked),
+                o => o._isChecked,
+                (o, v) => o._isChecked = v,
+                defaultBindingMode: Data.BindingMode.TwoWay);
+
+        public bool IsChecked
+        {
+            get => GetValue(IsCheckedProperty);
+            set => SetValue(IsCheckedProperty, value);
         }
 
         private ICommand _command;

--- a/src/Avalonia.Controls/NativeMenuItem.cs
+++ b/src/Avalonia.Controls/NativeMenuItem.cs
@@ -103,7 +103,7 @@ namespace Avalonia.Controls
         public bool IsChecked
         {
             get => GetValue(IsCheckedProperty);
-            set => SetValue(IsCheckedProperty, value);
+            set { SetAndRaise(IsCheckedProperty, ref _isChecked, value); }
         }
 
         private ICommand _command;

--- a/src/Avalonia.Controls/NativeMenuItem.cs
+++ b/src/Avalonia.Controls/NativeMenuItem.cs
@@ -95,8 +95,7 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<bool> IsCheckedProperty =
             AvaloniaProperty.Register<NativeMenuItem, bool>(
                 nameof(IsChecked),
-                defaultValue: false,
-                defaultBindingMode: Data.BindingMode.TwoWay);
+                defaultValue: false);
 
         public bool IsChecked
         {

--- a/src/Avalonia.Controls/NativeMenuItem.cs
+++ b/src/Avalonia.Controls/NativeMenuItem.cs
@@ -10,7 +10,6 @@ namespace Avalonia.Controls
         private string _header;
         private KeyGesture _gesture;
         private bool _enabled = true;
-        private bool _isChecked = false;
 
         private NativeMenu _menu;
 
@@ -102,7 +101,7 @@ namespace Avalonia.Controls
         public bool IsChecked
         {
             get => GetValue(IsCheckedProperty);
-            set => SetAndRaise(IsCheckedProperty, ref _isChecked, value);
+            set => SetValue(IsCheckedProperty, value);
         }
 
         private ICommand _command;

--- a/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
+++ b/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
@@ -349,6 +349,9 @@ namespace Avalonia.Native
 
                         return false;
                     }), new MenuActionCallback(() => { item.RaiseClick(); }));
+
+                    menuItem.IsChecked = item.IsChecked;
+
                     menu.AddItem(menuItem);
 
                     if (item.Menu?.Items?.Count >= 0)
@@ -409,6 +412,8 @@ namespace Avalonia.Native
                         {
                             menuItem.Title = buffer.DangerousGetHandle();
                         }
+
+                        menuItem.IsChecked = item.IsChecked;
 
                         if (item.Gesture != null)
                         {

--- a/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
+++ b/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
@@ -240,8 +240,10 @@ namespace Avalonia.Native
 
         private void OnItemPropertyChanged(object sender, AvaloniaPropertyChangedEventArgs e)
         {
-            if (e.Sender is NativeMenuItem menuItem && _nativeMenuItemsMap.ContainsKey(menuItem)) {
-                if (e.Property.Name == "IsChecked") {
+            if (e.Sender is NativeMenuItem menuItem && _nativeMenuItemsMap.ContainsKey(menuItem))
+            {
+                if (e.Property.Name == "IsChecked")
+                {
                     _nativeMenuItemsMap[menuItem].IsChecked = menuItem.IsChecked;
                 }
             }
@@ -360,7 +362,8 @@ namespace Avalonia.Native
 
                     item.PropertyChanged += OnItemPropertyChanged;
 
-                    if (!_nativeMenuItemsMap.ContainsKey(item)) {
+                    if (!_nativeMenuItemsMap.ContainsKey(item))
+                    {
                         _nativeMenuItemsMap.Add(item, menuItem);
                     }
 
@@ -437,9 +440,12 @@ namespace Avalonia.Native
                             }
                         }
                     }
-                    if (!_nativeMenuItemsMap.ContainsKey(item)) {
+                    
+                    if (!_nativeMenuItemsMap.ContainsKey(item))
+                    {
                         _nativeMenuItemsMap.Add(item, menuItem);
                     }
+
                     menu.AddItem(menuItem);
                 }
                 else if(i is NativeMenuItemSeperator seperator)


### PR DESCRIPTION
## What does the pull request do?

Right now, native menus on macOS can't have the little checkmark (on/off state). This PR adds in that functionality as a bindable property to `NativeMenu`.

**This PR does not attempt to do anything for native menus on Linux.** Based on a cursory reading of `DBusMenuExporter` [here](https://github.com/AvaloniaUI/Avalonia/blob/e80ddf5c6591bff9e936fa3c8655e0daff9fd39b/src/Avalonia.FreeDesktop/DBusMenuExporter.cs#L159), it looks like it will be OK and just reset the menu if a property changes...? (Not optimal, but "should work".) Totally untested on my part.

## What is the updated/expected behavior with this PR?

You can now do things like this!

```xml
<NativeMenuItem Header="Check me!"
    Command="{Binding ToggleMenuItemCheckedCommand}"
    IsChecked="{BInding IsMenuItemChecked}" />
```

```csharp
private bool _isMenuItemChecked = true;

public ReactiveCommand<Unit, Unit> ToggleMenuItemCheckedCommand { get; }

ToggleMenuItemCheckedCommand = ReactiveCommand.Create(() => 
{
    IsMenuItemChecked = !IsMenuItemChecked;
});

public bool IsMenuItemChecked
{
    get { return _isMenuItemChecked; }
    set { this.RaiseAndSetIfChanged(ref _isMenuItemChecked, value); }
}
```


## How was the solution implemented (if it's not obvious)?

`AvaloniaNativeMenuExporter` now monitors for property changes in `NativeMenuItem`. In order to avoid laying out the entire menu again whenever something changes, we keep track of a map of `NativeMenuItem` to `IAvnAppMenuItem` so that we can do a quick lookup and UI change on just the item that changed.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes

No breaking changes to the API.

## Fixed issues

Fixes #3660 

## Note

I also have data binding to headers working [here](https://github.com/Deadpikle/Avalonia/commit/da2106a3c4820952ed497942e24e6a53357e1eca), but don't have an open PR for that yet so that this one can be handled first.

Another note: It looks like Linux could [support checkmarks](https://gjs-docs.gnome.org/dbusmenu04~0.4_api/dbusmenu.menuitem_toggle_check), but I'm not sure yet how to do Avalonia dev on Linux (and have no Linux dev experience 😅). Should I try to do this, or leave this for a separate PR / someone else?