### PR TITLE
Fixed #3664

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridSelectedItemsCollection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridSelectedItemsCollection.cs
@@ -335,7 +335,7 @@ namespace Avalonia.Controls
             _oldSelectedItemsCache = new List<object>(_selectedItemsCache);
 
             return
-                new SelectionChangedEventArgs(DataGrid.SelectionChangedEvent, removedSelectedItems, addedSelectedItems)
+                new SelectionChangedEventArgs(DataGrid.SelectionChangedEvent, addedSelectedItems, removedSelectedItems)
                 {
                     Source = OwningGrid
                 };


### PR DESCRIPTION
## What does the pull request do?
Fixes incorrect order of parameters for `DataGrid.SelectionChangedEventArgs` event

## What is the current behavior?
Added and removed items are passed in incorrect order to `SelectionChangedEventArgs`

## What is the updated/expected behavior with this PR?
Added and removed items are passed in correct order to `SelectionChangedEventArgs`

## Fixed issues
Fixes #3664 