### PR TITLE
Avoid allocating extra delegates when initializing and deinitializing StyleClassActivator

### DIFF
--- a/src/Avalonia.Styling/Styling/Activators/StyleClassActivator.cs
+++ b/src/Avalonia.Styling/Styling/Activators/StyleClassActivator.cs
@@ -14,12 +14,16 @@ namespace Avalonia.Styling.Activators
     {
         private readonly IList<string> _match;
         private readonly IAvaloniaReadOnlyList<string> _classes;
+        private NotifyCollectionChangedEventHandler? _classesChangedHandler;
 
         public StyleClassActivator(IAvaloniaReadOnlyList<string> classes, IList<string> match)
         {
             _classes = classes;
             _match = match;
         }
+
+        private NotifyCollectionChangedEventHandler ClassesChangedHandler =>
+            _classesChangedHandler ??= ClassesChanged;
 
         public static bool AreClassesMatching(IReadOnlyList<string> classes, IList<string> toMatch)
         {
@@ -51,16 +55,15 @@ namespace Avalonia.Styling.Activators
             return remainingMatches == 0;
         }
 
-
         protected override void Initialize()
         {
             PublishNext(IsMatching());
-            _classes.CollectionChanged += ClassesChanged;
+            _classes.CollectionChanged += ClassesChangedHandler;
         }
 
         protected override void Deinitialize()
         {
-            _classes.CollectionChanged -= ClassesChanged;
+            _classes.CollectionChanged -= ClassesChangedHandler;
         }
 
         private void ClassesChanged(object sender, NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
When poking around CalendarBenchmark I've noticed that we create quite a few `NotifyCollectionChangedEventHandler` instances. A lot of them were coming from `StyleClassActivator.Deinitialize` since it would allocate a new delegate to simply remove it from the event. Idea for this PR was to just filter out some noise from the memory benchmarks and brings tiny perf/memory improvements.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Every time we `Initialize` or `Deinitialize` we allocate new `NotifyCollectionChangedEventHandler`.

|         Method |     Mean |     Error |    StdDev |    Gen 0 |    Gen 1 | Gen 2 | Allocated |
|--------------- |---------:|----------:|----------:|---------:|---------:|------:|----------:|
| CreateCalendar | 19.66 ms | 0.3142 ms | 0.2785 ms | 593.7500 | 250.0000 |     - |    3.6 MB |

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
We only allocate `NotifyCollectionChangedEventHandler` when needed and we keep the instance of the handler. One problem we might consider is that we will keep the handler alive despite not having subscribers which will increase memory usage, although I am not sure if this happens often enough.

Memory difference is from the lack of extra handler allocation. Performance is the same within the margin of error.

|         Method |     Mean |     Error |    StdDev |    Gen 0 |    Gen 1 | Gen 2 | Allocated |
|--------------- |---------:|----------:|----------:|---------:|---------:|------:|----------:|
| CreateCalendar | 19.41 ms | 0.1203 ms | 0.1067 ms | 593.7500 | 250.0000 |     - |   3.58 MB |

