### PR TITLE
Use more specific .NET core versions.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,16 +35,16 @@ jobs:
     vmImage: 'macOS-10.14'
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 3.1.x'
+    displayName: 'Use .NET Core SDK 3.1.101'
     inputs:
       packageType: sdk
-      version: 3.1.x
+      version: 3.1.101
 
   - task: UseDotNet@2
-    displayName: 'Use .NET Core Runtime 3.1.x'
+    displayName: 'Use .NET Core Runtime 3.1.1'
     inputs:
       packageType: runtime
-      version: 3.1.x
+      version: 3.1.1
 
   - task: CmdLine@2
     displayName: 'Install Mono 5.18'


### PR DESCRIPTION
## What does the pull request do?

Install a more specific .NET core version to fix problem with CI failing on OSX: it was installing 3.1.200 of the SDK while we specify 3.1.101 in `global.json`
