### PR TITLE
More control benchmarks and ScrollBar constructor optimization

### DIFF
--- a/src/Avalonia.Controls/Primitives/ScrollBar.cs
+++ b/src/Avalonia.Controls/Primitives/ScrollBar.cs
@@ -55,16 +55,6 @@ namespace Avalonia.Controls.Primitives
         {
             Thumb.DragDeltaEvent.AddClassHandler<ScrollBar>((x, e) => x.OnThumbDragDelta(e), RoutingStrategies.Bubble);
             Thumb.DragCompletedEvent.AddClassHandler<ScrollBar>((x, e) => x.OnThumbDragComplete(e), RoutingStrategies.Bubble);
-
-            static void AffectsIsVisible(AvaloniaProperty property)
-            {
-                property.Changed.AddClassHandler<ScrollBar>((x, e) => x.CalculateIsVisible());
-            }
-
-            AffectsIsVisible(MinimumProperty);
-            AffectsIsVisible(MaximumProperty);
-            AffectsIsVisible(ViewportSizeProperty);
-            AffectsIsVisible(VisibilityProperty);
         }
 
         /// <summary>
@@ -106,9 +96,9 @@ namespace Avalonia.Controls.Primitives
         public event EventHandler<ScrollEventArgs> Scroll;
 
         /// <summary>
-        /// Calculates whether the scrollbar should be visible.
+        /// Calculates and updates whether the scrollbar should be visible.
         /// </summary>
-        private void CalculateIsVisible()
+        private void UpdateIsVisible()
         {
             var isVisible = Visibility switch
             {
@@ -147,6 +137,16 @@ namespace Avalonia.Controls.Primitives
             if (property == OrientationProperty)
             {
                 UpdatePseudoClasses(newValue.GetValueOrDefault<Orientation>());
+            }
+            else
+            {
+                if (property == MinimumProperty ||
+                    property == MaximumProperty || 
+                    property == ViewportSizeProperty ||
+                    property == VisibilityProperty)
+                {
+                    UpdateIsVisible();
+                }
             }
         }
 

--- a/tests/Avalonia.Benchmarks/Layout/ControlsBenchmark.cs
+++ b/tests/Avalonia.Benchmarks/Layout/ControlsBenchmark.cs
@@ -7,12 +7,12 @@ using BenchmarkDotNet.Attributes;
 namespace Avalonia.Benchmarks.Layout
 {
     [MemoryDiagnoser]
-    public class CalendarBenchmark : IDisposable
+    public class ControlsBenchmark : IDisposable
     {
         private readonly IDisposable _app;
         private readonly TestRoot _root;
 
-        public CalendarBenchmark()
+        public ControlsBenchmark()
         {
             _app = UnitTestApplication.Start(
                 TestServices.StyledWindow.With(
@@ -34,6 +34,28 @@ namespace Avalonia.Benchmarks.Layout
             var calendar = new Calendar();
 
             _root.Child = calendar;
+
+            _root.LayoutManager.ExecuteLayoutPass();
+        }
+
+        [Benchmark]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void CreateButton()
+        {
+            var button = new Button();
+
+            _root.Child = button;
+
+            _root.LayoutManager.ExecuteLayoutPass();
+        }
+
+        [Benchmark]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void CreateTextBox()
+        {
+            var textBox = new TextBox();
+
+            _root.Child = textBox;
 
             _root.LayoutManager.ExecuteLayoutPass();
         }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Wanted to add more benchmarks for common controls so we can get better overview about the state of performance.

And while doing that I've noticed that `ScrollBar` is calculating visibility in a sub-optimal way (observables, bindings, LINQ - root of all the evil).

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
|        Method |     Mean |     Error |    StdDev |   Gen 0 |   Gen 1 |  Gen 2 | Allocated |
|-------------- |---------:|----------:|----------:|--------:|--------:|-------:|----------:|
| CreateTextBox | 1.010 ms | 0.0078 ms | 0.0069 ms | 39.0625 | 19.5313 | 1.9531 | 160.16 KB |

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
|        Method |     Mean |    Error |   StdDev |   Gen 0 |   Gen 1 |  Gen 2 | Allocated |
|-------------- |---------:|---------:|---------:|--------:|--------:|-------:|----------:|
| CreateTextBox | 949.9 us | 2.510 us | 2.225 us | 37.1094 | 17.5781 | 1.9531 | 152.58 KB |

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Use already existing `OnPropertyChanged<T>` method to check for changes. Got like 5% perf and memory improvement for free.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation