### PR TITLE
Fix clicking TextBox border moving to end and mouse cursor being wrong when on border

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -701,7 +701,8 @@ namespace Avalonia.Controls
         {
             var text = Text;
 
-            if (text != null && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            var clickInfo = e.GetCurrentPoint(this);
+            if (text != null && clickInfo.Properties.IsLeftButtonPressed && !(clickInfo.Pointer?.Captured is Border))
             {
                 var point = e.GetPosition(_presenter);
                 var index = CaretIndex = _presenter.GetCaretIndex(point);

--- a/src/Avalonia.Themes.Default/TextBox.xaml
+++ b/src/Avalonia.Themes.Default/TextBox.xaml
@@ -69,7 +69,7 @@
   <Style Selector="TextBox:error /template/ Border#border">
     <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}"/>
   </Style>
-  <Style Selector="TextBox">
+  <Style Selector="TextBox /template/ DockPanel">
     <Setter Property="Cursor" Value="IBeam" />
   </Style>
     <Style Selector="TextBox:disabled /template/ Border#border">


### PR DESCRIPTION


## What does the pull request do?
Fixes #3675 with a twofold fix:

1. Cursor doesn't show IBeam when not in `DockPanel` (aka doesn't show when over the `Border`)
2. If you do click the border, `OnPointerPressed` ignores the click.


## What is the current behavior?

See #3675. Mouse cursor is IBeam when over the border, and clicking the `TextBox` doesn't move the caret as expected.

## What is the updated/expected behavior with this PR?

You can test this out on the `TextBox` sample page with the first `Lorem ipsum` text input.

## How was the solution implemented (if it's not obvious)?

Nothing too scary here.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes

No API changes.

## Fixed issues

Fixes #3675.
