### PR TITLE
Enable clipping for canceled text layout

### DIFF
--- a/src/Avalonia.Visuals/Media/TextFormatting/TextLayout.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextLayout.cs
@@ -233,15 +233,15 @@ namespace Avalonia.Media.TextFormatting
 
                         var textLine = TextFormatter.Current.FormatLine(textSource, 0, MaxWidth, _paragraphProperties);
 
+                        UpdateBounds(textLine, ref left, ref right, ref bottom);
+
+                        textLines.Add(textLine);
+
                         if (!double.IsPositiveInfinity(MaxHeight) && bottom + textLine.LineMetrics.Size.Height > MaxHeight)
                         {
                             currentPosition = _text.Length;
                             break;
                         }
-
-                        UpdateBounds(textLine, ref left, ref right, ref bottom);
-
-                        textLines.Add(textLine);
 
                         if (_paragraphProperties.TextTrimming != TextTrimming.None)
                         {
@@ -254,22 +254,15 @@ namespace Avalonia.Media.TextFormatting
 
                         currentPosition += textLine.Text.Length;
                     }
+                }
 
-                    if (lineBreaker.Current.Required && currentPosition == _text.Length)
-                    {
-                        var emptyTextLine = CreateEmptyTextLine(currentPosition);
+                if (lineBreaker.Current.Required && currentPosition == _text.Length)
+                {
+                    var emptyTextLine = CreateEmptyTextLine(currentPosition);
 
-                        if (!double.IsPositiveInfinity(MaxHeight) && bottom + emptyTextLine.LineMetrics.Size.Height > MaxHeight)
-                        {
-                            break;
-                        }
+                    UpdateBounds(emptyTextLine, ref left, ref right, ref bottom);
 
-                        UpdateBounds(emptyTextLine, ref left, ref right, ref bottom);
-
-                        textLines.Add(emptyTextLine);
-
-                        break;
-                    }
+                    textLines.Add(emptyTextLine);
                 }
 
                 Bounds = new Rect(left, 0, right, bottom);

--- a/tests/Avalonia.Skia.UnitTests/TextLayoutTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/TextLayoutTests.cs
@@ -29,10 +29,10 @@ namespace Avalonia.Skia.UnitTests
 
                 var layout = new TextLayout(
                     s_multiLineText,
-                    Typeface.Default, 
+                    Typeface.Default,
                     12.0f,
                     Brushes.Black.ToImmutable(),
-                    textStyleOverrides : spans);
+                    textStyleOverrides: spans);
 
                 var textLine = layout.TextLines[0];
 
@@ -72,16 +72,16 @@ namespace Avalonia.Skia.UnitTests
                         12.0f,
                         Brushes.Black.ToImmutable(),
                         textWrapping: TextWrapping.Wrap,
-                        maxWidth : 25);
+                        maxWidth: 25);
 
                     var actual = new TextLayout(
                         s_multiLineText,
                         Typeface.Default,
                         12.0f,
                         Brushes.Black.ToImmutable(),
-                        textWrapping : TextWrapping.Wrap,
-                        maxWidth : 25,
-                        textStyleOverrides : spans);
+                        textWrapping: TextWrapping.Wrap,
+                        maxWidth: 25,
+                        textStyleOverrides: spans);
 
                     Assert.Equal(expected.TextLines.Count, actual.TextLines.Count);
 
@@ -115,7 +115,7 @@ namespace Avalonia.Skia.UnitTests
                     Typeface.Default,
                     12.0f,
                     Brushes.Black.ToImmutable(),
-                    textStyleOverrides : spans);
+                    textStyleOverrides: spans);
 
                 var textLine = layout.TextLines[0];
 
@@ -153,7 +153,7 @@ namespace Avalonia.Skia.UnitTests
                     Typeface.Default,
                     12.0f,
                     Brushes.Black.ToImmutable(),
-                    textStyleOverrides : spans);
+                    textStyleOverrides: spans);
 
                 var textLine = layout.TextLines[0];
 
@@ -190,7 +190,7 @@ namespace Avalonia.Skia.UnitTests
                     Typeface.Default,
                     12.0f,
                     Brushes.Black.ToImmutable(),
-                    textStyleOverrides : spans);
+                    textStyleOverrides: spans);
 
                 var textLine = layout.TextLines[0];
 
@@ -301,8 +301,8 @@ namespace Avalonia.Skia.UnitTests
                     Typeface.Default,
                     12.0f,
                     Brushes.Black.ToImmutable(),
-                    textWrapping : TextWrapping.Wrap,
-                    maxWidth : 180,
+                    textWrapping: TextWrapping.Wrap,
+                    maxWidth: 180,
                     textStyleOverrides: spans);
 
                 Assert.Equal(
@@ -332,8 +332,8 @@ namespace Avalonia.Skia.UnitTests
                     Typeface.Default,
                     12.0f,
                     Brushes.Black.ToImmutable(),
-                    maxWidth : 200, 
-                    maxHeight : 125,
+                    maxWidth: 200,
+                    maxHeight: 125,
                     textStyleOverrides: spans);
 
                 Assert.Equal(foreground, layout.TextLines[0].TextRuns[1].Style.Foreground);
@@ -430,7 +430,7 @@ namespace Avalonia.Skia.UnitTests
 
                 Assert.Equal(5, ((ShapedTextRun)layout.TextLines[0].TextRuns[0]).GlyphRun.GlyphClusters[5]);
 
-                if(expectedLength == 7)
+                if (expectedLength == 7)
                 {
                     Assert.Equal(5, ((ShapedTextRun)layout.TextLines[0].TextRuns[0]).GlyphRun.GlyphClusters[6]);
                 }
@@ -480,12 +480,38 @@ namespace Avalonia.Skia.UnitTests
             }
         }
 
+        [InlineData("0123456789\r0123456789", 2)]
+        [InlineData("0123456789", 1)]
+        [Theory]
+        public void Should_Include_Last_Line_When_Constraint_Is_Surpassed(string text, int numberOfLines)
+        {
+            using (Start())
+            {
+                var glyphTypeface = Typeface.Default.GlyphTypeface;
+
+                var emHeight = glyphTypeface.DesignEmHeight;
+
+                var lineHeight = (glyphTypeface.Descent - glyphTypeface.Ascent) * (12.0 / emHeight);
+
+                var layout = new TextLayout(
+                    text,
+                    Typeface.Default,
+                    12,
+                    Brushes.Black.ToImmutable(),
+                    maxHeight: lineHeight * numberOfLines - lineHeight * 0.5);
+
+                Assert.Equal(numberOfLines, layout.TextLines.Count);
+
+                Assert.Equal(numberOfLines * lineHeight, layout.Bounds.Height);
+            }
+        }
+
         public static IDisposable Start()
         {
             var disposable = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface
-                .With(renderInterface: new PlatformRenderInterface(null), 
+                .With(renderInterface: new PlatformRenderInterface(null),
                     textShaperImpl: new TextShaperImpl(),
-                    fontManagerImpl : new CustomFontManagerImpl()));
+                    fontManagerImpl: new CustomFontManagerImpl()));
 
             return disposable;
         }

--- a/tests/Avalonia.Skia.UnitTests/TextLayoutTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/TextLayoutTests.cs
@@ -29,10 +29,10 @@ namespace Avalonia.Skia.UnitTests
 
                 var layout = new TextLayout(
                     s_multiLineText,
-                    Typeface.Default,
+                    Typeface.Default, 
                     12.0f,
                     Brushes.Black.ToImmutable(),
-                    textStyleOverrides: spans);
+                    textStyleOverrides : spans);
 
                 var textLine = layout.TextLines[0];
 
@@ -72,16 +72,16 @@ namespace Avalonia.Skia.UnitTests
                         12.0f,
                         Brushes.Black.ToImmutable(),
                         textWrapping: TextWrapping.Wrap,
-                        maxWidth: 25);
+                        maxWidth : 25);
 
                     var actual = new TextLayout(
                         s_multiLineText,
                         Typeface.Default,
                         12.0f,
                         Brushes.Black.ToImmutable(),
-                        textWrapping: TextWrapping.Wrap,
-                        maxWidth: 25,
-                        textStyleOverrides: spans);
+                        textWrapping : TextWrapping.Wrap,
+                        maxWidth : 25,
+                        textStyleOverrides : spans);
 
                     Assert.Equal(expected.TextLines.Count, actual.TextLines.Count);
 
@@ -115,7 +115,7 @@ namespace Avalonia.Skia.UnitTests
                     Typeface.Default,
                     12.0f,
                     Brushes.Black.ToImmutable(),
-                    textStyleOverrides: spans);
+                    textStyleOverrides : spans);
 
                 var textLine = layout.TextLines[0];
 
@@ -153,7 +153,7 @@ namespace Avalonia.Skia.UnitTests
                     Typeface.Default,
                     12.0f,
                     Brushes.Black.ToImmutable(),
-                    textStyleOverrides: spans);
+                    textStyleOverrides : spans);
 
                 var textLine = layout.TextLines[0];
 
@@ -190,7 +190,7 @@ namespace Avalonia.Skia.UnitTests
                     Typeface.Default,
                     12.0f,
                     Brushes.Black.ToImmutable(),
-                    textStyleOverrides: spans);
+                    textStyleOverrides : spans);
 
                 var textLine = layout.TextLines[0];
 
@@ -301,8 +301,8 @@ namespace Avalonia.Skia.UnitTests
                     Typeface.Default,
                     12.0f,
                     Brushes.Black.ToImmutable(),
-                    textWrapping: TextWrapping.Wrap,
-                    maxWidth: 180,
+                    textWrapping : TextWrapping.Wrap,
+                    maxWidth : 180,
                     textStyleOverrides: spans);
 
                 Assert.Equal(
@@ -332,8 +332,8 @@ namespace Avalonia.Skia.UnitTests
                     Typeface.Default,
                     12.0f,
                     Brushes.Black.ToImmutable(),
-                    maxWidth: 200,
-                    maxHeight: 125,
+                    maxWidth : 200, 
+                    maxHeight : 125,
                     textStyleOverrides: spans);
 
                 Assert.Equal(foreground, layout.TextLines[0].TextRuns[1].Style.Foreground);
@@ -430,7 +430,7 @@ namespace Avalonia.Skia.UnitTests
 
                 Assert.Equal(5, ((ShapedTextRun)layout.TextLines[0].TextRuns[0]).GlyphRun.GlyphClusters[5]);
 
-                if (expectedLength == 7)
+                if(expectedLength == 7)
                 {
                     Assert.Equal(5, ((ShapedTextRun)layout.TextLines[0].TextRuns[0]).GlyphRun.GlyphClusters[6]);
                 }
@@ -509,9 +509,9 @@ namespace Avalonia.Skia.UnitTests
         public static IDisposable Start()
         {
             var disposable = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface
-                .With(renderInterface: new PlatformRenderInterface(null),
+                .With(renderInterface: new PlatformRenderInterface(null), 
                     textShaperImpl: new TextShaperImpl(),
-                    fontManagerImpl: new CustomFontManagerImpl()));
+                    fontManagerImpl : new CustomFontManagerImpl()));
 
             return disposable;
         }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR adds the last processed line to the text layout when the text bounds surpass the constraint.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
If the text layout is canceled the current line isn't added to the text layout.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
