### PR TITLE
Don't constrain header's ContentPresenter on TreeViewItem

### DIFF
--- a/src/Avalonia.Themes.Default/TreeViewItem.xaml
+++ b/src/Avalonia.Themes.Default/TreeViewItem.xaml
@@ -17,8 +17,7 @@
                             BorderThickness="{TemplateBinding BorderThickness}"
                             TemplatedControl.IsTemplateFocusTarget="True">
                         <Grid Name="PART_Header"
-                              ColumnDefinitions="16, Auto"
-                              HorizontalAlignment="Left"
+                              ColumnDefinitions="16, *"
                               Margin="{TemplateBinding Level, Mode=OneWay, Converter={StaticResource LeftMarginConverter}}" >
                             <ToggleButton Name="expander"
                                           Focusable="False"


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This enables the user to use the maximum available space in a `TreeViewItem`'s header section. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The header's `ContentPresenter` is forced to size to the left, limiting the options of the user.
