### PR TITLE
Load window/dialog startup location before render

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -449,13 +449,13 @@ namespace Avalonia.Controls
             }
 
             LayoutManager.ExecuteInitialLayoutPass(this);
+            SetWindowStartupLocation(Owner?.PlatformImpl);
 
             using (BeginAutoSizing())
             {
                 PlatformImpl?.Show();
                 Renderer?.Start();
             }
-            SetWindowStartupLocation(Owner?.PlatformImpl);
             OnOpened(EventArgs.Empty);
         }
 
@@ -514,6 +514,7 @@ namespace Avalonia.Controls
             }
 
             LayoutManager.ExecuteInitialLayoutPass(this);
+            SetWindowStartupLocation(owner.PlatformImpl);
 
             var result = new TaskCompletionSource<TResult>();
 
@@ -535,8 +536,6 @@ namespace Avalonia.Controls
 
                 OnOpened(EventArgs.Empty);
             }
-
-            SetWindowStartupLocation(owner.PlatformImpl);
 
             return result.Task;
         }

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -551,6 +551,28 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
+        [Fact]
+        public void Auto_Sizing_Is_Done_After_ExecuteInitialLayoutPass()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var child = new TextBlock()
+                {
+                    Text = "Welcome to Avalonia!"
+                };
+                var target = new Window
+                {
+                    Width = 200,
+                    SizeToContent = SizeToContent.Height,
+                    Content = child
+                };
+                target.IsVisible = true; // not measured unless visible
+                target.LayoutManager.ExecuteInitialLayoutPass(target);
+
+                Assert.Equal(child.DesiredSize.Height, target.DesiredSize.Height);
+            }
+        }
+
         public class DialogSizingTests : SizingTests
         {
             protected override void Show(Window window)


### PR DESCRIPTION
## What does the pull request do?

There was an issue filed in #2859 where dialogs would flash in the wrong location before showing up in the center of their owner. This PR fixes that by moving the setting of the `Position` variable to before render starts so that the position is "ready" by the time rendering starts.

I have a repro of the bug here: https://github.com/Deadpikle/AvaloniaBugs/tree/master/DialogStartupLocation

I also made the same change for `Window.Show()` to resolve a similar issue I was seeing in my app.

Note: I think I remember reading that X11 has async position setting or something. Will this do something negative to the way X11 is handled?

~~EDIT: I see the CLA down there. I don't expect any issues, but I've sent a message to my employer to make sure it's OK to sign just to make sure I dot my i's and cross my t's.~~ Update: CLA signed!

## What is the current behavior?

If you set a `Window` dialog to show in `CenterOwner`, the dialog will flash really quickly in the top left corner of the window before showing up in its proper position.

## What is the updated/expected behavior with this PR?

The dialog no longer flashes in the wrong position -- it shows up for the first time in the proper position in the center of its owner.

## How was the solution implemented (if it's not obvious)?

Nothing really special here. Just moved a line of code.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes

No breaking changes.

## Fixed issues

Closes #2859 
