### PR TITLE
Fix large/small scroll in ScrollViewer.

### DIFF
--- a/Avalonia.sln
+++ b/Avalonia.sln
@@ -204,16 +204,16 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Dialogs", "src\Ava
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.FreeDesktop", "src\Avalonia.FreeDesktop\Avalonia.FreeDesktop.csproj", "{4D36CEC8-53F2-40A5-9A37-79AAE356E2DA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalonia.Controls.DataGrid.UnitTests", "tests\Avalonia.Controls.DataGrid.UnitTests\Avalonia.Controls.DataGrid.UnitTests.csproj", "{351337F5-D66F-461B-A957-4EF60BDB4BA6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Controls.DataGrid.UnitTests", "tests\Avalonia.Controls.DataGrid.UnitTests\Avalonia.Controls.DataGrid.UnitTests.csproj", "{351337F5-D66F-461B-A957-4EF60BDB4BA6}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Shared\RenderHelpers\RenderHelpers.projitems*{3c4c0cb4-0c0f-4450-a37b-148c84ff905f}*SharedItemsImports = 13
-		src\Shared\RenderHelpers\RenderHelpers.projitems*{3e908f67-5543-4879-a1dc-08eace79b3cd}*SharedItemsImports = 4
+		src\Shared\RenderHelpers\RenderHelpers.projitems*{3e908f67-5543-4879-a1dc-08eace79b3cd}*SharedItemsImports = 5
 		src\Shared\PlatformSupport\PlatformSupport.projitems*{4488ad85-1495-4809-9aa4-ddfe0a48527e}*SharedItemsImports = 4
 		src\Shared\PlatformSupport\PlatformSupport.projitems*{7b92af71-6287-4693-9dcb-bd5b6e927e23}*SharedItemsImports = 4
-		src\Shared\RenderHelpers\RenderHelpers.projitems*{7d2d3083-71dd-4cc9-8907-39a0d86fb322}*SharedItemsImports = 4
-		tests\Avalonia.RenderTests\Avalonia.RenderTests.projitems*{dabfd304-d6a4-4752-8123-c2ccf7ac7831}*SharedItemsImports = 4
+		src\Shared\RenderHelpers\RenderHelpers.projitems*{7d2d3083-71dd-4cc9-8907-39a0d86fb322}*SharedItemsImports = 5
+		src\Shared\PlatformSupport\PlatformSupport.projitems*{88060192-33d5-4932-b0f9-8bd2763e857d}*SharedItemsImports = 5
 		src\Shared\PlatformSupport\PlatformSupport.projitems*{e4d9629c-f168-4224-3f51-a5e482ffbc42}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Avalonia.Controls/Presenters/ItemVirtualizer.cs
+++ b/src/Avalonia.Controls/Presenters/ItemVirtualizer.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Utils;
 using Avalonia.Input;
 using Avalonia.Layout;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.Presenters
 {
@@ -99,9 +100,14 @@ namespace Avalonia.Controls.Presenters
         {
             get
             {
-                return Vertical ?
-                    new Size(Owner.Panel.DesiredSize.Width, ExtentValue) :
-                    new Size(ExtentValue, Owner.Panel.DesiredSize.Height);
+                if (IsLogicalScrollEnabled)
+                {
+                    return Vertical ?
+                        new Size(Owner.Panel.DesiredSize.Width, ExtentValue) :
+                        new Size(ExtentValue, Owner.Panel.DesiredSize.Height);
+                }
+
+                return default;
             }
         }
 
@@ -112,9 +118,14 @@ namespace Avalonia.Controls.Presenters
         {
             get
             {
-                return Vertical ? 
-                    new Size(Owner.Panel.Bounds.Width, ViewportValue) :
-                    new Size(ViewportValue, Owner.Panel.Bounds.Height);
+                if (IsLogicalScrollEnabled)
+                {
+                    return Vertical ?
+                        new Size(Owner.Panel.Bounds.Width, ViewportValue) :
+                        new Size(ViewportValue, Owner.Panel.Bounds.Height);
+                }
+
+                return default;
             }
         }
 
@@ -125,11 +136,21 @@ namespace Avalonia.Controls.Presenters
         {
             get
             {
-                return Vertical ? new Vector(_crossAxisOffset, OffsetValue) : new Vector(OffsetValue, _crossAxisOffset);
+                if (IsLogicalScrollEnabled)
+                {
+                    return Vertical ? new Vector(_crossAxisOffset, OffsetValue) : new Vector(OffsetValue, _crossAxisOffset);
+                }
+
+                return default;
             }
 
             set
             {
+                if (!IsLogicalScrollEnabled)
+                {
+                    throw new NotSupportedException("Logical scrolling disabled.");
+                }
+
                 var oldCrossAxisOffset = _crossAxisOffset;
 
                 if (Vertical)
@@ -164,10 +185,10 @@ namespace Avalonia.Controls.Presenters
             }
 
             var virtualizingPanel = owner.Panel as IVirtualizingPanel;
-            var scrollable = (ILogicalScrollable)owner;
+            var scrollContentPresenter = owner.Parent as IScrollable;
             ItemVirtualizer result = null;
 
-            if (virtualizingPanel != null && scrollable.InvalidateScroll != null)
+            if (virtualizingPanel != null && scrollContentPresenter is object)
             {
                 switch (owner.VirtualizationMode)
                 {
@@ -277,6 +298,6 @@ namespace Avalonia.Controls.Presenters
         /// <summary>
         /// Invalidates the current scroll.
         /// </summary>
-        protected void InvalidateScroll() => ((ILogicalScrollable)Owner).InvalidateScroll?.Invoke();
+        protected void InvalidateScroll() => ((ILogicalScrollable)Owner).RaiseScrollInvalidated(EventArgs.Empty);
     }
 }

--- a/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
@@ -21,7 +21,7 @@ namespace Avalonia.Controls.Presenters
 
         private bool _canHorizontallyScroll;
         private bool _canVerticallyScroll;
-        EventHandler _scrollInvalidated;
+        private EventHandler _scrollInvalidated;
 
         /// <summary>
         /// Initializes static members of the <see cref="ItemsPresenter"/> class.

--- a/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
@@ -103,7 +103,7 @@ namespace Avalonia.Controls.Presenters
         }
 
         /// <inheritdoc/>
-        Size ILogicalScrollable.ScrollSize => new Size(16, 1);
+        Size ILogicalScrollable.ScrollSize => new Size(ScrollViewer.DefaultSmallChange, 1);
 
         /// <inheritdoc/>
         Size ILogicalScrollable.PageScrollSize => Virtualizer?.Viewport ?? new Size(16, 16);

--- a/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
@@ -21,6 +21,7 @@ namespace Avalonia.Controls.Presenters
 
         private bool _canHorizontallyScroll;
         private bool _canVerticallyScroll;
+        EventHandler _scrollInvalidated;
 
         /// <summary>
         /// Initializes static members of the <see cref="ItemsPresenter"/> class.
@@ -95,13 +96,17 @@ namespace Avalonia.Controls.Presenters
         Size IScrollable.Viewport => Virtualizer?.Viewport ?? Bounds.Size;
 
         /// <inheritdoc/>
-        Action ILogicalScrollable.InvalidateScroll { get; set; }
+        event EventHandler ILogicalScrollable.ScrollInvalidated
+        {
+            add => _scrollInvalidated += value;
+            remove => _scrollInvalidated -= value;
+        }
 
         /// <inheritdoc/>
-        Size ILogicalScrollable.ScrollSize => new Size(1, 1);
+        Size ILogicalScrollable.ScrollSize => new Size(16, 1);
 
         /// <inheritdoc/>
-        Size ILogicalScrollable.PageScrollSize => new Size(0, 1);
+        Size ILogicalScrollable.PageScrollSize => Virtualizer?.Viewport ?? new Size(16, 16);
 
         internal ItemVirtualizer Virtualizer { get; private set; }
 
@@ -115,6 +120,12 @@ namespace Avalonia.Controls.Presenters
         IControl ILogicalScrollable.GetControlInDirection(NavigationDirection direction, IControl from)
         {
             return Virtualizer?.GetControlInDirection(direction, from);
+        }
+
+        /// <inheritdoc/>
+        void ILogicalScrollable.RaiseScrollInvalidated(EventArgs e)
+        {
+            _scrollInvalidated?.Invoke(this, e);
         }
 
         public override void ScrollIntoView(object item)
@@ -138,7 +149,7 @@ namespace Avalonia.Controls.Presenters
         {
             Virtualizer?.Dispose();
             Virtualizer = ItemVirtualizer.Create(this);
-            ((ILogicalScrollable)this).InvalidateScroll?.Invoke();
+            _scrollInvalidated?.Invoke(this, EventArgs.Empty);
 
             KeyboardNavigation.SetTabNavigation(
                 (InputElement)Panel,
@@ -162,7 +173,7 @@ namespace Avalonia.Controls.Presenters
         {
             Virtualizer?.Dispose();
             Virtualizer = ItemVirtualizer.Create(this);
-            ((ILogicalScrollable)this).InvalidateScroll?.Invoke();
+            _scrollInvalidated?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Runtime.InteropServices.ComTypes;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using Avalonia.LogicalTree;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.Presenters
@@ -349,7 +351,7 @@ namespace Avalonia.Controls.Presenters
 
             if (scrollable != null)
             {
-                scrollable.InvalidateScroll = () => UpdateFromScrollable(scrollable);
+                scrollable.ScrollInvalidated += ScrollInvalidated;
 
                 if (scrollable.IsLogicalScrollEnabled)
                 {
@@ -360,10 +362,15 @@ namespace Avalonia.Controls.Presenters
                             .Subscribe(x => scrollable.CanVerticallyScroll = x),
                         this.GetObservable(OffsetProperty)
                             .Skip(1).Subscribe(x => scrollable.Offset = x),
-                        Disposable.Create(() => scrollable.InvalidateScroll = null));
+                        Disposable.Create(() => scrollable.ScrollInvalidated -= ScrollInvalidated));
                     UpdateFromScrollable(scrollable);
                 }
             }
+        }
+
+        private void ScrollInvalidated(object sender, EventArgs e)
+        {
+            UpdateFromScrollable((ILogicalScrollable)sender);
         }
 
         private void UpdateFromScrollable(ILogicalScrollable scrollable)

--- a/src/Avalonia.Controls/Primitives/ILogicalScrollable.cs
+++ b/src/Avalonia.Controls/Primitives/ILogicalScrollable.cs
@@ -32,22 +32,6 @@ namespace Avalonia.Controls.Primitives
         bool IsLogicalScrollEnabled { get; }
 
         /// <summary>
-        /// Gets or sets the scroll invalidation method.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// This method notifies the attached <see cref="ScrollViewer"/> of a change in 
-        /// the <see cref="IScrollable.Extent"/>, <see cref="IScrollable.Offset"/> or 
-        /// <see cref="IScrollable.Viewport"/> properties.
-        /// </para>
-        /// <para>
-        /// This property is set by the parent <see cref="ScrollViewer"/> when the 
-        /// <see cref="ILogicalScrollable"/> is placed inside it.
-        /// </para>
-        /// </remarks>
-        Action InvalidateScroll { get; set; }
-
-        /// <summary>
         /// Gets the size to scroll by, in logical units.
         /// </summary>
         Size ScrollSize { get; }
@@ -56,6 +40,15 @@ namespace Avalonia.Controls.Primitives
         /// Gets the size to page by, in logical units.
         /// </summary>
         Size PageScrollSize { get; }
+
+        /// <summary>
+        /// Raised when the scroll is invalidated.
+        /// </summary>
+        /// <remarks>
+        /// This event notifies an attached <see cref="ScrollViewer"/> of a change in 
+        /// one of the scroll properties.
+        /// </remarks>
+        event EventHandler ScrollInvalidated;
 
         /// <summary>
         /// Attempts to bring a portion of the target visual into view by scrolling the content.
@@ -72,5 +65,11 @@ namespace Avalonia.Controls.Primitives
         /// <param name="from">The control from which movement begins.</param>
         /// <returns>The control.</returns>
         IControl GetControlInDirection(NavigationDirection direction, IControl from);
+
+        /// <summary>
+        /// Raises the <see cref="ScrollInvalidated"/> event.
+        /// </summary>
+        /// <param name="e">The event args.</param>
+        void RaiseScrollInvalidated(EventArgs e);
     }
 }

--- a/src/Avalonia.Controls/ScrollViewer.cs
+++ b/src/Avalonia.Controls/ScrollViewer.cs
@@ -10,8 +10,6 @@ namespace Avalonia.Controls
     /// </summary>
     public class ScrollViewer : ContentControl, IScrollable, IScrollAnchorProvider
     {
-        private static readonly Size s_defaultSmallChange = new Size(16, 16);
-
         /// <summary>
         /// Defines the <see cref="CanHorizontallyScroll"/> property.
         /// </summary>
@@ -167,13 +165,15 @@ namespace Avalonia.Controls
                 nameof(VerticalScrollBarVisibility),
                 ScrollBarVisibility.Auto);
 
+        internal const double DefaultSmallChange = 16;
+
         private IDisposable _childSubscription;
         private ILogicalScrollable _logicalScrollable;
         private Size _extent;
         private Vector _offset;
         private Size _viewport;
         private Size _largeChange;
-        private Size _smallChange = s_defaultSmallChange;
+        private Size _smallChange = new Size(DefaultSmallChange, DefaultSmallChange);
 
         /// <summary>
         /// Initializes static members of the <see cref="ScrollViewer"/> class.
@@ -543,7 +543,7 @@ namespace Avalonia.Controls
             }
             else
             {
-                SetAndRaise(SmallChangeProperty, ref _smallChange, s_defaultSmallChange);
+                SetAndRaise(SmallChangeProperty, ref _smallChange, new Size(DefaultSmallChange, DefaultSmallChange));
                 SetAndRaise(LargeChangeProperty, ref _largeChange, Viewport);
             }
         }

--- a/src/Avalonia.Themes.Default/ScrollViewer.xaml
+++ b/src/Avalonia.Themes.Default/ScrollViewer.xaml
@@ -22,6 +22,8 @@
         </ScrollContentPresenter>
         <ScrollBar Name="horizontalScrollBar"
                    Orientation="Horizontal"
+                   LargeChange="{Binding LargeChange.Width, RelativeSource={RelativeSource TemplatedParent}}"
+                   SmallChange="{Binding SmallChange.Width, RelativeSource={RelativeSource TemplatedParent}}"
                    Maximum="{TemplateBinding HorizontalScrollBarMaximum}"
                    Value="{TemplateBinding HorizontalScrollBarValue, Mode=TwoWay}"
                    ViewportSize="{TemplateBinding HorizontalScrollBarViewportSize}"
@@ -30,6 +32,8 @@
                    Focusable="False"/>
         <ScrollBar Name="verticalScrollBar"
                    Orientation="Vertical"
+                   LargeChange="{Binding LargeChange.Height, RelativeSource={RelativeSource TemplatedParent}}"
+                   SmallChange="{Binding SmallChange.Height, RelativeSource={RelativeSource TemplatedParent}}"
                    Maximum="{TemplateBinding VerticalScrollBarMaximum}"
                    Value="{TemplateBinding VerticalScrollBarValue, Mode=TwoWay}"
                    ViewportSize="{TemplateBinding VerticalScrollBarViewportSize}"

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ScrollContentPresenterTests_ILogicalScrollable.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ScrollContentPresenterTests_ILogicalScrollable.cs
@@ -101,7 +101,7 @@ namespace Avalonia.Controls.UnitTests
 
             target.UpdateChild();
 
-            Assert.NotNull(scrollable.InvalidateScroll);
+            Assert.True(scrollable.HasScrollInvalidatedSubscriber);
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace Avalonia.Controls.UnitTests
             target.Content = null;
             target.UpdateChild();
 
-            Assert.Null(scrollable.InvalidateScroll);
+            Assert.False(scrollable.HasScrollInvalidatedSubscriber);
         }
 
         [Fact]
@@ -217,7 +217,7 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Rect(0, 0, 100, 100), scrollable.Bounds);
 
             scrollable.IsLogicalScrollEnabled = false;
-            scrollable.InvalidateScroll();
+            scrollable.RaiseScrollInvalidated(EventArgs.Empty);
             target.Measure(new Size(100, 100));
             target.Arrange(new Rect(0, 0, 100, 100));
 
@@ -227,7 +227,7 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Rect(0, 0, 150, 150), scrollable.Bounds);
 
             scrollable.IsLogicalScrollEnabled = true;
-            scrollable.InvalidateScroll();
+            scrollable.RaiseScrollInvalidated(EventArgs.Empty);
             target.Measure(new Size(100, 100));
             target.Arrange(new Rect(0, 0, 100, 100));
 
@@ -318,12 +318,20 @@ namespace Avalonia.Controls.UnitTests
             private Size _extent;
             private Vector _offset;
             private Size _viewport;
+            private EventHandler _scrollInvalidated;
 
             public bool CanHorizontallyScroll { get; set; }
             public bool CanVerticallyScroll { get; set; }
             public bool IsLogicalScrollEnabled { get; set; } = true;
             public Size AvailableSize { get; private set; }
-            public Action InvalidateScroll { get; set; }
+
+            public bool HasScrollInvalidatedSubscriber => _scrollInvalidated != null;
+            
+            public event EventHandler ScrollInvalidated
+            {
+                add => _scrollInvalidated += value;
+                remove => _scrollInvalidated -= value;
+            }
 
             public Size Extent
             {
@@ -331,7 +339,7 @@ namespace Avalonia.Controls.UnitTests
                 set
                 {
                     _extent = value;
-                    InvalidateScroll?.Invoke();
+                    _scrollInvalidated?.Invoke(this, EventArgs.Empty);
                 }
             }
 
@@ -341,7 +349,7 @@ namespace Avalonia.Controls.UnitTests
                 set
                 {
                     _offset = value;
-                    InvalidateScroll?.Invoke();
+                    _scrollInvalidated?.Invoke(this, EventArgs.Empty);
                 }
             }
 
@@ -351,7 +359,7 @@ namespace Avalonia.Controls.UnitTests
                 set
                 {
                     _viewport = value;
-                    InvalidateScroll?.Invoke();
+                    _scrollInvalidated?.Invoke(this, EventArgs.Empty);
                 }
             }
 
@@ -374,6 +382,11 @@ namespace Avalonia.Controls.UnitTests
             public bool BringIntoView(IControl target, Rect targetRect)
             {
                 throw new NotImplementedException();
+            }
+
+            public void RaiseScrollInvalidated(EventArgs e)
+            {
+                _scrollInvalidated?.Invoke(this, e);
             }
 
             protected override Size MeasureOverride(Size availableSize)


### PR DESCRIPTION
## What does the pull request do?

Fixes scrolling in a `ScrollViewer` when clicking on the scrollbar buttons or on the track.

## What is the current behavior?

The `ScrollViewer` always scrolls by one pixel when clicking the scrollbar buttons or the track.

## What is the updated/expected behavior with this PR?

For non-logical scrolling:

- Use 16 for small scroll size (value taken from WPF)
- Use viewport size for large scroll

For logical scrolling, use the `ScrollSize`/`PageScrollSize` defined on `ILogicalScrollable`. Note that this required a small breaking change to `ILogicalScrollable`.

## Checklist

- [x] Added unit tests (if possible)?

## Breaking changes

Required a small breaking change to `ILogicalScrollable`: 

- `InvalidateScroll` property has become an event: `ScrollInvalidated`
- A `RaiseScrollInvalidated` method has been added to raise `ScrollInvalidated`

## Fixed issues

Fixes #3245 