### PR TITLE
Fix RemoteDemo crash

### DIFF
--- a/samples/ControlCatalog/MainView.xaml.cs
+++ b/samples/ControlCatalog/MainView.xaml.cs
@@ -60,8 +60,8 @@ namespace ControlCatalog
             var decorations = this.Find<ComboBox>("Decorations");
             decorations.SelectionChanged += (sender, e) =>
             {
-                Window window = (Window)VisualRoot;
-                window.SystemDecorations = (SystemDecorations)decorations.SelectedIndex;
+                if (VisualRoot is Window window)
+                    window.SystemDecorations = (SystemDecorations)decorations.SelectedIndex;
             };
         }
 
@@ -69,7 +69,8 @@ namespace ControlCatalog
         {
             base.OnAttachedToVisualTree(e);
             var decorations = this.Find<ComboBox>("Decorations");
-            decorations.SelectedIndex = (int)((Window)VisualRoot).SystemDecorations;
+            if (VisualRoot is Window window)
+                decorations.SelectedIndex = (int)window.SystemDecorations;
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Fixes a crash caused by window decorations not being available when using remote rendering. This prevented the `RemoteDemo` project from starting.

## What is the current behavior?
```
Unhandled exception. System.InvalidCastException: Unable to cast object of type 'Avalonia.Controls.Embedding.EmbeddableControlRoot' to type 'Avalonia.Controls.Window'.
   at ControlCatalog.MainView.OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e) in /home/marcus/RiderProjects/Avalonia/samples/ControlCatalog/MainView.xaml.cs:line 72
   at Avalonia.Visual.OnAttachedToVisualTreeCore(VisualTreeAttachmentEventArgs e) in /home/marcus/RiderProjects/Avalonia/src/Avalonia.Visuals/Visual.cs:line 396
   at Avalonia.Input.InputElement.OnAttachedToVisualTreeCore(VisualTreeAttachmentEventArgs e) in /home/marcus/RiderProjects/Avalonia/src/Avalonia.Input/InputElement.cs:line 420
   at Avalonia.Controls.Control.OnAttachedToVisualTreeCore(VisualTreeAttachmentEventArgs e) in /home/marcus/RiderProjects/Avalonia/src/Avalonia.Controls/Control.cs:line 142
   at Avalonia.Visual.SetVisualParent(Visual value) in /home/marcus/RiderProjects/Avalonia/src/Avalonia.Visuals/Visual.cs:line 600
   at Avalonia.Visual.VisualChildrenChanged(Object sender, NotifyCollectionChangedEventArgs e) in /home/marcus/RiderProjects/Avalonia/src/Avalonia.Visuals/Visual.cs:line 620
   at Avalonia.Collections.AvaloniaList`1.NotifyAdd(T item, Int32 index) in /home/marcus/RiderProjects/Avalonia/src/Avalonia.Base/Collections/AvaloniaList.cs:line 596
   at Avalonia.Collections.AvaloniaList`1.Add(T item) in /home/marcus/RiderProjects/Avalonia/src/Avalonia.Base/Collections/AvaloniaList.cs:line 187
   at Avalonia.Controls.Presenters.ContentPresenter.UpdateChild() in /home/marcus/RiderProjects/Avalonia/src/Avalonia.Controls/Presenters/ContentPresenter.cs:line 259
   at Avalonia.Controls.Presenters.ContentPresenter.ContentChanged(AvaloniaPropertyChangedEventArgs e) in /home/marcus/RiderProjects/Avalonia/src/Avalonia.Controls/Presenters/ContentPresenter.cs:line 407
```

## What is the updated/expected behavior with this PR?
`RemoteDemo` does not crash anymore. :smile: 