### PR TITLE
Fixed memory leak in RemoteWidget

### DIFF
--- a/src/Avalonia.Controls/Remote/RemoteWidget.cs
+++ b/src/Avalonia.Controls/Remote/RemoteWidget.cs
@@ -75,7 +75,11 @@ namespace Avalonia.Controls.Remote
                 var fmt = (PixelFormat) _lastFrame.Format;
                 if (_bitmap == null || _bitmap.PixelSize.Width != _lastFrame.Width ||
                     _bitmap.PixelSize.Height != _lastFrame.Height)
-                    _bitmap = new WriteableBitmap(new PixelSize(_lastFrame.Width, _lastFrame.Height), new Vector(96, 96), fmt);
+                {
+                    _bitmap?.Dispose();
+                    _bitmap = new WriteableBitmap(new PixelSize(_lastFrame.Width, _lastFrame.Height),
+                        new Vector(96, 96), fmt);
+                }
                 using (var l = _bitmap.Lock())
                 {
                     var lineLen = (fmt == PixelFormat.Rgb565 ? 2 : 4) * _lastFrame.Width;


### PR DESCRIPTION
## What does the pull request do?
Fixed that bitmaps did not get disposed correctly causing a memory leak in RemoteWidget.

## What is the current behavior?
On window resize, new `WriteableBitmap`s are created, but the old one get never disposed. This causes unnecessary memory usage until the garbage collector kicks in.

## What is the updated/expected behavior with this PR?
One memory leak less.

## How was the solution implemented (if it's not obvious)?
Old bitmaps are disposed before creating new ones.