### PR TITLE
Implement ScrollViewer.ScrollChanged

### DIFF
--- a/src/Avalonia.Controls/ScrollChangedEventArgs.cs
+++ b/src/Avalonia.Controls/ScrollChangedEventArgs.cs
@@ -1,0 +1,45 @@
+﻿using Avalonia.Interactivity;
+
+namespace Avalonia.Controls
+{
+    /// <summary>
+    /// Describes a change in scrolling state.
+    /// </summary>
+    public class ScrollChangedEventArgs : RoutedEventArgs
+    {
+        public ScrollChangedEventArgs(
+            Vector extentDelta,
+            Vector offsetDelta,
+            Vector viewportDelta)
+            : this(ScrollViewer.ScrollChangedEvent, extentDelta, offsetDelta, viewportDelta)
+        {
+        }
+
+        public ScrollChangedEventArgs(
+            RoutedEvent routedEvent,
+            Vector extentDelta,
+            Vector offsetDelta,
+            Vector viewportDelta)
+            : base(routedEvent)
+        {
+            ExtentDelta = extentDelta;
+            OffsetDelta = offsetDelta;
+            ViewportDelta = viewportDelta;
+        }
+
+        /// <summary>
+        /// Gets the change to the value of <see cref="ScrollViewer.Extent"/>.
+        /// </summary>
+        public Vector ExtentDelta { get; }
+
+        /// <summary>
+        /// Gets the change to the value of <see cref="ScrollViewer.Offset"/>.
+        /// </summary>
+        public Vector OffsetDelta { get; }
+
+        /// <summary>
+        /// Gets the change to the value of <see cref="ScrollViewer.Viewport"/>.
+        /// </summary>
+        public Vector ViewportDelta { get; }
+    }
+}

--- a/tests/Avalonia.Controls.UnitTests/ScrollViewerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ScrollViewerTests.cs
@@ -4,7 +4,6 @@ using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Layout;
-using Avalonia.LogicalTree;
 using Moq;
 using Xunit;
 
@@ -145,6 +144,78 @@ namespace Avalonia.Controls.UnitTests
             ((ContentPresenter)target.Presenter).UpdateChild();
 
             Assert.Equal(new Size(45, 67), target.LargeChange);
+        }
+
+        [Fact]
+        public void Changing_Extent_Should_Raise_ScrollChanged()
+        {
+            var target = new ScrollViewer();
+            var raised = 0;
+
+            target.SetValue(ScrollViewer.ExtentProperty, new Size(100, 100));
+            target.SetValue(ScrollViewer.ViewportProperty, new Size(50, 50));
+            target.Offset = new Vector(10, 10);
+
+            target.ScrollChanged += (s, e) =>
+            {
+                Assert.Equal(new Vector(11, 12), e.ExtentDelta);
+                Assert.Equal(default, e.OffsetDelta);
+                Assert.Equal(default, e.ViewportDelta);
+                ++raised;
+            };
+
+            target.SetValue(ScrollViewer.ExtentProperty, new Size(111, 112));
+
+            Assert.Equal(1, raised);
+
+        }
+
+        [Fact]
+        public void Changing_Offset_Should_Raise_ScrollChanged()
+        {
+            var target = new ScrollViewer();
+            var raised = 0;
+
+            target.SetValue(ScrollViewer.ExtentProperty, new Size(100, 100));
+            target.SetValue(ScrollViewer.ViewportProperty, new Size(50, 50));
+            target.Offset = new Vector(10, 10);
+
+            target.ScrollChanged += (s, e) =>
+            {
+                Assert.Equal(default, e.ExtentDelta);
+                Assert.Equal(new Vector(12, 14), e.OffsetDelta);
+                Assert.Equal(default, e.ViewportDelta);
+                ++raised;
+            };
+
+            target.Offset = new Vector(22, 24);
+
+            Assert.Equal(1, raised);
+
+        }
+
+        [Fact]
+        public void Changing_Viewport_Should_Raise_ScrollChanged()
+        {
+            var target = new ScrollViewer();
+            var raised = 0;
+
+            target.SetValue(ScrollViewer.ExtentProperty, new Size(100, 100));
+            target.SetValue(ScrollViewer.ViewportProperty, new Size(50, 50));
+            target.Offset = new Vector(10, 10);
+
+            target.ScrollChanged += (s, e) =>
+            {
+                Assert.Equal(default, e.ExtentDelta);
+                Assert.Equal(default, e.OffsetDelta);
+                Assert.Equal(new Vector(6, 8), e.ViewportDelta);
+                ++raised;
+            };
+
+            target.SetValue(ScrollViewer.ViewportProperty, new Size(56, 58));
+
+            Assert.Equal(1, raised);
+
         }
 
         private Control CreateTemplate(ScrollViewer control, INameScope scope)


### PR DESCRIPTION
## What does the pull request do?

Implements the `ScrollViewer.ScrollChanged` event. The API for `ScrollChangedEventArgs` is different to WPF's here, because:

- Avalonia's `ScrollViewer` exposes `Extent`, `Offset` and `Viewport` as `Size`/`Vector` structs whereas WPF exposes separate `double` values for the X and Y components for each of these
- The current values are not included in the event args: then can easily be read from the `sender`
- UWP doesn't expose these values at all

## Considerations

UWP doesn't expose `ScrollChanged`, instead it has `ViewChanging`/`ViewChanged` events because the UWP `ScrollViewer` supports zoom as well. To complicate things, WinUI then removes the `ViewChanging` event.

The event args in UWP don't expose any information about the change, whereas the WPF event args expose information about the change, together with the current value of the properties. I decided to go for a middle route and just expose information about the change.

## Checklist

- [x] Added unit tests (if possible)?

## NOTE

~~Depends on #3725, after merging that PR, change target of this PR to master.~~ done