### PR TITLE
Fix ContextMenu leak 

### DIFF
--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -21,6 +21,7 @@ namespace Avalonia.Controls
             new FuncTemplate<IPanel>(() => new StackPanel { Orientation = Orientation.Vertical });
         private Popup _popup;
         private bool _attachedToControl;
+        private IInputElement _previousFocus;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ContextMenu"/> class.
@@ -150,6 +151,7 @@ namespace Avalonia.Controls
 
         private void PopupOpened(object sender, EventArgs e)
         {
+            _previousFocus = FocusManager.Instance?.Current;
             Focus();
         }
 
@@ -170,6 +172,9 @@ namespace Avalonia.Controls
             {
                 ((ISetLogicalParent)_popup).SetParent(null);
             }
+
+            // HACK: Reset the focus when the popup is closed. We need to fix this so it's automatic.
+            FocusManager.Instance?.Focus(_previousFocus);
 
             RaiseEvent(new RoutedEventArgs
             {

--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -96,7 +96,7 @@ namespace Avalonia.Controls.Platform
                 root.Deactivated -= WindowDeactivated;
             }
 
-            _inputManagerSubscription!.Dispose();
+            _inputManagerSubscription?.Dispose();
 
             Menu = null;
             _root = null;

--- a/src/Avalonia.Controls/WindowBase.cs
+++ b/src/Avalonia.Controls/WindowBase.cs
@@ -255,7 +255,7 @@ namespace Avalonia.Controls
 
             if (scope != null)
             {
-                FocusManager.Instance.SetFocusScope(scope);
+                FocusManager.Instance?.SetFocusScope(scope);
             }
 
             IsActive = true;

--- a/src/Avalonia.Input/FocusManager.cs
+++ b/src/Avalonia.Input/FocusManager.cs
@@ -168,7 +168,7 @@ namespace Avalonia.Input
             {
                 var scope = control as IFocusScope;
 
-                if (scope != null)
+                if (scope != null && control.VisualRoot?.IsVisible == true)
                 {
                     yield return scope;
                 }

--- a/tests/Avalonia.LeakTests/ControlTests.cs
+++ b/tests/Avalonia.LeakTests/ControlTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Remoting.Contexts;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Diagnostics;
@@ -416,6 +417,37 @@ namespace Avalonia.LeakTests
 
                 dotMemory.Check(memory =>
                     Assert.Equal(0, memory.GetObjects(where => where.Type.Is<Canvas>()).ObjectsCount));
+            }
+        }
+
+        [Fact]
+        public void Context_MenuItems_Are_Freed()
+        {
+            using (Start())
+            {
+                void BuildAndShowContextMenu(Control control)
+                {
+                    var contextMenu = new ContextMenu
+                    {
+                        Items = new[]
+                        {
+                            new MenuItem { Header = "Foo" },
+                            new MenuItem { Header = "Foo" },
+                        }
+                    };
+
+                    contextMenu.Open(control);
+                    contextMenu.Close();
+                }
+
+                var window = new Window();
+                BuildAndShowContextMenu(window);
+                BuildAndShowContextMenu(window);
+
+                dotMemory.Check(memory =>
+                    Assert.Equal(0, memory.GetObjects(where => where.Type.Is<ContextMenu>()).ObjectsCount));
+                dotMemory.Check(memory =>
+                    Assert.Equal(0, memory.GetObjects(where => where.Type.Is<MenuItem>()).ObjectsCount));
             }
         }
 

--- a/tests/Avalonia.LeakTests/ControlTests.cs
+++ b/tests/Avalonia.LeakTests/ControlTests.cs
@@ -422,7 +422,43 @@ namespace Avalonia.LeakTests
         }
 
         [Fact]
-        public void Context_MenuItems_Are_Freed()
+        public void Attached_ContextMenu_Is_Freed()
+        {
+            using (Start())
+            {
+                void AttachShowAndDetachContextMenu(Control control)
+                {
+                    var contextMenu = new ContextMenu
+                    {
+                        Items = new[]
+                        {
+                            new MenuItem { Header = "Foo" },
+                            new MenuItem { Header = "Foo" },
+                        }
+                    };
+
+                    control.ContextMenu = contextMenu;
+                    contextMenu.Open(control);
+                    contextMenu.Close();
+                    control.ContextMenu = null;
+                }
+
+                var window = new Window();
+                window.Show();
+
+                Assert.Same(window, FocusManager.Instance.Current);
+
+                AttachShowAndDetachContextMenu(window);
+
+                dotMemory.Check(memory =>
+                    Assert.Equal(0, memory.GetObjects(where => where.Type.Is<ContextMenu>()).ObjectsCount));
+                dotMemory.Check(memory =>
+                    Assert.Equal(0, memory.GetObjects(where => where.Type.Is<MenuItem>()).ObjectsCount));
+            }
+        }
+
+        [Fact]
+        public void Standalone_ContextMenu_Is_Freed()
         {
             using (Start())
             {

--- a/tests/Avalonia.LeakTests/ControlTests.cs
+++ b/tests/Avalonia.LeakTests/ControlTests.cs
@@ -5,6 +5,7 @@ using System.Runtime.Remoting.Contexts;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Diagnostics;
+using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Platform;
@@ -441,6 +442,10 @@ namespace Avalonia.LeakTests
                 }
 
                 var window = new Window();
+                window.Show();
+
+                Assert.Same(window, FocusManager.Instance.Current);
+
                 BuildAndShowContextMenu(window);
                 BuildAndShowContextMenu(window);
 
@@ -453,7 +458,10 @@ namespace Avalonia.LeakTests
 
         private IDisposable Start()
         {
-            return UnitTestApplication.Start(TestServices.StyledWindow);
+            return UnitTestApplication.Start(TestServices.StyledWindow.With(
+                focusManager: new FocusManager(),
+                keyboardDevice: () => new KeyboardDevice(),
+                inputManager: new InputManager()));
         }
 
         private class Node

--- a/tests/Avalonia.UnitTests/MockWindowingPlatform.cs
+++ b/tests/Avalonia.UnitTests/MockWindowingPlatform.cs
@@ -21,6 +21,10 @@ namespace Avalonia.UnitTests
         {
             var win = Mock.Of<IWindowImpl>(x => x.Scaling == 1);
             var mock = Mock.Get(win);
+            mock.Setup(x => x.Show()).Callback(() =>
+            {
+                mock.Object.Activated?.Invoke();
+            });
             mock.Setup(x => x.CreatePopup()).Returns(() =>
             {
                 if (popupImpl != null)


### PR DESCRIPTION
## What does the pull request do?

`ContextMenu` was leaking in two places:

- When the menu is shown, a `Popup` is created and attached to the logical tree, however it was never detached
- When the menu is hidden, it remained focused in `FocusManager`/`KeyboardDevice`

## How was the solution implemented (if it's not obvious)?

- When a context menu that is not attached to a control (i.e. not assigned to `Control.ContextMenu`) is closed, detach it from the logical tree
- When a context menu that is attached to a control is detached from a control, detach it from the logical tree
- Add a hack to read the currently focused control when the menu is shown, and restore it when the menu closes. This should in theory be handled automatically by the focus scope code in `FocusManager` but it's not. Added a hack here instead of fixing the root cause because `FocusManager`/`KeyboardDevice` will soon be refactored and moved to be per-`TopLevel`

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #3738 