### PR TITLE
Fix TextBox.SelectedText = "" not clearing text

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -283,7 +283,14 @@ namespace Avalonia.Controls
                 }
 
                 _undoRedoHelper.Snapshot();
-                HandleTextInput(value);
+                if (value != "")
+                {
+                    HandleTextInput(value);
+                }
+                else
+                {
+                    DeleteSelection();
+                } 
                 _undoRedoHelper.Snapshot();
             }
         }

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -277,19 +277,14 @@ namespace Avalonia.Controls
             get { return GetSelection(); }
             set
             {
-                if (value == null)
-                {
-                    return;
-                }
-
                 _undoRedoHelper.Snapshot();
-                if (value != "")
+                if (string.IsNullOrEmpty(value))
                 {
-                    HandleTextInput(value);
+                    DeleteSelection();
                 }
                 else
                 {
-                    DeleteSelection();
+                    HandleTextInput(value);
                 } 
                 _undoRedoHelper.Snapshot();
             }

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -426,6 +426,24 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void SelectedText_CanClearText()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var target = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "0123"
+                };
+                target.SelectionStart = 1;
+                target.SelectionEnd = 3;
+                target.SelectedText = "";
+
+                Assert.True(target.Text == "03");
+            }
+        }
+
+        [Fact]
         public void CoerceCaretIndex_Doesnt_Cause_Exception_with_malformed_line_ending()
         {
             using (UnitTestApplication.Start(Services))

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -444,6 +444,24 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void SelectedText_NullClearsText()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var target = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "0123"
+                };
+                target.SelectionStart = 1;
+                target.SelectionEnd = 3;
+                target.SelectedText = null;
+
+                Assert.True(target.Text == "03");
+            }
+        }
+
+        [Fact]
         public void CoerceCaretIndex_Doesnt_Cause_Exception_with_malformed_line_ending()
         {
             using (UnitTestApplication.Start(Services))


### PR DESCRIPTION
## What does the pull request do?

If you ran `TextBox.SelectedText = "";`, the text wouldn't be cleared. This PR fixes that bug.

## What is the current behavior?

`myFavoriteTextBox.SelectedText = "";` does not clear the selected text.

## What is the updated/expected behavior with this PR?

`myFavoriteTextBox.SelectedText = "";` now clears the selected text by calling `DeleteSelection()`.

## Checklist

- [x] Added unit tests (if possible)?