### PR TITLE
Fix initial Window constraint again.

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -574,19 +574,36 @@ namespace Avalonia.Controls
         {
             var sizeToContent = SizeToContent;
             var clientSize = ClientSize;
-            var constraint = availableSize;
+            double constraintWidth;
+            double constraintHeight;
 
-            if ((sizeToContent & SizeToContent.Width) != 0)
+            if (sizeToContent.HasFlagCustom(SizeToContent.Width))
             {
-                constraint = constraint.WithWidth(double.PositiveInfinity);
+                constraintWidth = double.PositiveInfinity;
+            }
+            else if (!double.IsInfinity(availableSize.Width))
+            {
+                constraintWidth = availableSize.Width;
+            }
+            else
+            {
+                constraintWidth = clientSize.Width;
             }
 
-            if ((sizeToContent & SizeToContent.Height) != 0)
+            if (sizeToContent.HasFlagCustom(SizeToContent.Height))
             {
-                constraint = constraint.WithHeight(double.PositiveInfinity);
+                constraintHeight = double.PositiveInfinity;
+            }
+            else if (!double.IsInfinity(availableSize.Height))
+            {
+                constraintHeight = availableSize.Height;
+            }
+            else
+            {
+                constraintHeight = clientSize.Height;
             }
 
-            var result = base.MeasureOverride(constraint);
+            var result = base.MeasureOverride(new Size(constraintWidth, constraintHeight));
 
             if ((sizeToContent & SizeToContent.Width) == 0)
             {

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -375,6 +375,31 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
+        [Fact]
+        public void Child_Should_Be_Measured_With_ClientSize_If_No_Width_Height_And_SizeToContent_Is_Manual()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var child = new ChildControl();
+                var target = new Window
+                {
+                    SizeToContent = SizeToContent.Manual,
+                    Content = child
+                };
+
+                var windowImpl = Mock.Get<IWindowImpl>(target.PlatformImpl);
+
+                windowImpl.Setup(x => x.Show()).Callback(() =>
+                {
+                    windowImpl.Object.Resized?.Invoke(new Size(123, 234));
+                });
+
+                target.Show();
+
+                Assert.Equal(new Size(123, 234), child.MeasureSize);
+            }
+        }
+
         private IWindowImpl CreateImpl(Mock<IRenderer> renderer)
         {
             return Mock.Of<IWindowImpl>(x =>


### PR DESCRIPTION
## What does the pull request do?

Another fix for window layout. #3570 adjusted the initial constraint for a window and fixed the associated issue there, but it also introduced #3707.

This adds some extra logic for that case: when using manual sizing but initial `Width`/`Height` are not set, we need to use `ClientSize` as the initial constraint.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #3707