### PR TITLE
Invalidate brush when Opacity changes.

### DIFF
--- a/src/Avalonia.Visuals/Media/Brush.cs
+++ b/src/Avalonia.Visuals/Media/Brush.cs
@@ -19,6 +19,11 @@ namespace Avalonia.Media
         /// <inheritdoc/>
         public event EventHandler Invalidated;
 
+        static Brush()
+        {
+            AffectsRender<Brush>(OpacityProperty);
+        }
+
         /// <summary>
         /// Gets or sets the opacity of the brush.
         /// </summary>

--- a/tests/Avalonia.Visuals.UnitTests/Media/BrushTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/BrushTests.cs
@@ -77,5 +77,17 @@ namespace Avalonia.Visuals.UnitTests.Media
         {
             Assert.Throws<FormatException>(() => Brush.Parse("#ff808g80"));
         }
+
+        [Fact]
+        public void Changing_Opacity_Raises_Invalidated()
+        {
+            var target = new SolidColorBrush();
+            var raised = false;
+
+            target.Invalidated += (s, e) => raised = true;
+            target.Opacity = 0.5;
+
+            Assert.True(raised);
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Invalidates `Brush` when `Opacity` changes.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #2755.