### PR TITLE
TextBox: Fix a few keys being hit causing undo to fail

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -602,6 +602,7 @@ namespace Avalonia.Controls
                         break;
 
                     case Key.Back:
+                        _undoRedoHelper.Snapshot();
                         if (hasWholeWordModifiers && SelectionStart == SelectionEnd)
                         {
                             SetSelectionForControlBackspace();
@@ -625,11 +626,13 @@ namespace Avalonia.Controls
                             CaretIndex -= removedCharacters;
                             SelectionStart = SelectionEnd = CaretIndex;
                         }
+                        _undoRedoHelper.Snapshot();
 
                         handled = true;
                         break;
 
                     case Key.Delete:
+                        _undoRedoHelper.Snapshot();
                         if (hasWholeWordModifiers && SelectionStart == SelectionEnd)
                         {
                             SetSelectionForControlDelete();
@@ -651,6 +654,7 @@ namespace Avalonia.Controls
                             SetTextInternal(text.Substring(0, caretIndex) +
                                             text.Substring(caretIndex + removedCharacters));
                         }
+                        _undoRedoHelper.Snapshot();
 
                         handled = true;
                         break;
@@ -658,7 +662,9 @@ namespace Avalonia.Controls
                     case Key.Enter:
                         if (AcceptsReturn)
                         {
+                            _undoRedoHelper.Snapshot();
                             HandleTextInput(NewLine);
+                            _undoRedoHelper.Snapshot();
                             handled = true;
                         }
 
@@ -667,7 +673,9 @@ namespace Avalonia.Controls
                     case Key.Tab:
                         if (AcceptsTab)
                         {
+                            _undoRedoHelper.Snapshot();
                             HandleTextInput("\t");
+                            _undoRedoHelper.Snapshot();
                             handled = true;
                         }
                         else

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -473,8 +473,10 @@ namespace Avalonia.Controls
             {
                 if (!IsPasswordBox)
                 {
+                    _undoRedoHelper.Snapshot();
                     Copy();
                     DeleteSelection();
+                    _undoRedoHelper.Snapshot();
                 }
 
                 handled = true;

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -554,6 +554,28 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
+
+        [Fact]
+        public void Cut_Allows_Undo()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var target = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "0123"
+                };
+                target.SelectionStart = 1;
+                target.SelectionEnd = 3;
+
+                RaiseKeyEvent(target, Key.X, KeyModifiers.Control); // cut
+                Assert.True(target.Text == "03");
+
+                RaiseKeyEvent(target, Key.Z, KeyModifiers.Control); // undo
+                Assert.True(target.Text == "0123");
+            }
+        }
+
         private static TestServices FocusServices => TestServices.MockThreadingInterface.With(
             focusManager: new FocusManager(),
             keyboardDevice: () => new KeyboardDevice(),

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -556,25 +556,29 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
-
-        [Fact]
-        public void Cut_Allows_Undo()
+        [Theory]
+        [InlineData(Key.X, KeyModifiers.Control)]
+        [InlineData(Key.Back, KeyModifiers.None)]
+        [InlineData(Key.Delete, KeyModifiers.None)]
+        [InlineData(Key.Tab, KeyModifiers.None)]
+        [InlineData(Key.Enter, KeyModifiers.None)]
+        public void Keys_Allow_Undo(Key key, KeyModifiers modifiers)
         {
             using (UnitTestApplication.Start(Services))
             {
                 var target = new TextBox
                 {
                     Template = CreateTemplate(),
-                    Text = "0123"
+                    Text = "0123",
+                    AcceptsReturn = true,
+                    AcceptsTab = true
                 };
                 target.SelectionStart = 1;
                 target.SelectionEnd = 3;
                 AvaloniaLocator.CurrentMutable
                     .Bind<Input.Platform.IClipboard>().ToSingleton<ClipboardStub>();
 
-                RaiseKeyEvent(target, Key.X, KeyModifiers.Control); // cut
-                Assert.True(target.Text == "03");
-
+                RaiseKeyEvent(target, key, modifiers);
                 RaiseKeyEvent(target, Key.Z, KeyModifiers.Control); // undo
                 Assert.True(target.Text == "0123");
             }

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Reactive.Linq;
+using System.Threading.Tasks;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.UnitTests;
@@ -567,6 +569,8 @@ namespace Avalonia.Controls.UnitTests
                 };
                 target.SelectionStart = 1;
                 target.SelectionEnd = 3;
+                AvaloniaLocator.CurrentMutable
+                    .Bind<Input.Platform.IClipboard>().ToSingleton<ClipboardStub>();
 
                 RaiseKeyEvent(target, Key.X, KeyModifiers.Control); // cut
                 Assert.True(target.Text == "03");
@@ -637,6 +641,15 @@ namespace Avalonia.Controls.UnitTests
                 get { return _bar; }
                 set { _bar = value; RaisePropertyChanged(); }
             }
+        }
+
+        private class ClipboardStub : IClipboard // in order to get tests working that use the clipboard
+        {
+            public Task<string> GetTextAsync() => Task.FromResult("");
+
+            public Task SetTextAsync(string text) => Task.CompletedTask;
+
+            public Task ClearAsync() => Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Adds several calls to `_undoRedoHelper.Snapshot();` in `TextBox` so that undo/redo works a little bit more as expected.

## What is the current behavior?

When the following keys are pressed, an `Undo` no longer does what you'd expect (by undoing the operation): `Ctrl+X`, `Back`, `Delete`, `Tab`, `Enter`.  

## What is the updated/expected behavior with this PR?

Each of these operations can now be followed by an `Undo` operation to undo whatever you just did.

## How was the solution implemented (if it's not obvious)?

Should be straight forward. I had to add a copy of `ClipboardStub` to `TextBoxTests` so that the `Cut` test succeeded -- otherwise, its call to `Copy` would throw an exception since there was no clipboard.

## Checklist

- [x] Added unit tests (if possible)?

## Breaking changes

No changes to the API.

## Notes

I'm not sure that backspace and delete should _always_ cause an undo/redo snapshot. That seems a little extreme -- feels like undo/redo should be triggered for a set of backspace/delete hits, as it were. The other keys, though, I feel more confident about. Let me know what you think and I'll adjust the PR accordingly.