### PR TITLE
[ Skia ] Draw caret on center in case of empty TextBox 

### DIFF
--- a/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
+++ b/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
@@ -140,20 +140,17 @@ namespace Avalonia.Skia
 
         public Rect HitTestTextPosition(int index)
         {
-            var lineWidth = (float)_bounds.Width;
-            var alignmentOffset = TransformX(0, lineWidth, _paint.TextAlign);
-
-            if (string.IsNullOrEmpty(Text) || index < 0)
+            if (string.IsNullOrEmpty(Text))
             {
+                var alignmentOffset = TransformX(0, 0, _paint.TextAlign);
                 return new Rect(alignmentOffset, 0, 0, _lineHeight);
             }
-
-            if (index >= Text.Length)
-            {
-                return new Rect(lineWidth + alignmentOffset, 0, 0, _lineHeight);
-            }
-
             var rects = GetRects();
+            if (index >= Text.Length || index < 0)
+            {
+                var r = rects.LastOrDefault();
+                return new Rect(r.X + r.Width, r.Y, 0, _lineHeight);
+            }
             return rects[index];
         }
 

--- a/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
+++ b/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
@@ -140,20 +140,20 @@ namespace Avalonia.Skia
 
         public Rect HitTestTextPosition(int index)
         {
+            var lineWidth = (float)_bounds.Width;
+            var alignmentOffset = TransformX(0, lineWidth, _paint.TextAlign);
+
+            if (string.IsNullOrEmpty(Text) || index < 0)
+            {
+                return new Rect(alignmentOffset, 0, 0, _lineHeight);
+            }
+
+            if (index >= Text.Length)
+            {
+                return new Rect(lineWidth + alignmentOffset, 0, 0, _lineHeight);
+            }
+
             var rects = GetRects();
-
-            if (rects.Count == 0)
-            {
-                var x = TransformX(0, 0, _paint.TextAlign);
-                return new Rect(x, 0, 0, _lineHeight);
-            }
-
-            if (index < 0 || index >= rects.Count)
-            {
-                var r = rects.LastOrDefault();
-                return new Rect(r.X + r.Width, r.Y, 0, _lineHeight);
-            }
-
             return rects[index];
         }
 

--- a/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
+++ b/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
@@ -142,21 +142,16 @@ namespace Avalonia.Skia
         {
             var rects = GetRects();
 
+            if (rects.Count == 0)
+            {
+                var x = TransformX(0, 0, _paint.TextAlign);
+                return new Rect(x, 0, 0, _lineHeight);
+            }
+
             if (index < 0 || index >= rects.Count)
             {
                 var r = rects.LastOrDefault();
                 return new Rect(r.X + r.Width, r.Y, 0, _lineHeight);
-            }
-
-            if (rects.Count == 0)
-            {
-                return new Rect(0, 0, 1, _lineHeight);
-            }
-
-            if (index == rects.Count)
-            {
-                var lr = rects[rects.Count - 1];
-                return new Rect(new Point(lr.X + lr.Width, lr.Y), rects[index - 1].Size);
             }
 
             return rects[index];


### PR DESCRIPTION
## What is the current behavior?

For `TextAlignment="Center"` caret is placed on the left side.

## What is the updated/expected behavior with this PR?

For `TextAlignment="Center"` caret is centered.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation



## Fixed issues
Fix for #3294 
