### PR TITLE
Invalidate Path on geometry change.

### DIFF
--- a/src/Avalonia.Controls/Shapes/Path.cs
+++ b/src/Avalonia.Controls/Shapes/Path.cs
@@ -1,3 +1,5 @@
+using System;
+using Avalonia.Data;
 using Avalonia.Media;
 
 namespace Avalonia.Controls.Shapes
@@ -10,6 +12,7 @@ namespace Avalonia.Controls.Shapes
         static Path()
         {
             AffectsGeometry<Path>(DataProperty);
+            DataProperty.Changed.AddClassHandler<Path>((o, e) => o.DataChanged(e));
         }
 
         public Geometry Data
@@ -19,5 +22,26 @@ namespace Avalonia.Controls.Shapes
         }
 
         protected override Geometry CreateDefiningGeometry() => Data;
+
+        private void DataChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            var oldGeometry = (Geometry)e.OldValue;
+            var newGeometry = (Geometry)e.NewValue;
+
+            if (oldGeometry is object)
+            {
+                oldGeometry.Changed -= GeometryChanged;
+            }
+
+            if (newGeometry is object)
+            {
+                newGeometry.Changed += GeometryChanged;
+            }
+        }
+
+        private void GeometryChanged(object sender, EventArgs e)
+        {
+            InvalidateGeometry();
+        }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/Shapes/PathTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Shapes/PathTests.cs
@@ -1,4 +1,6 @@
 ﻿using Avalonia.Controls.Shapes;
+using Avalonia.Media;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Shapes
@@ -11,6 +13,22 @@ namespace Avalonia.Controls.UnitTests.Shapes
             var target = new Path();
 
             target.Measure(Size.Infinity);
+        }
+
+        [Fact]
+        public void Subscribes_To_Geometry_Changes()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var geometry = new EllipseGeometry { Rect = new Rect(0, 0, 10, 10) };
+            var target = new Path { Data = geometry };
+
+            target.Measure(Size.Infinity);
+            Assert.True(target.IsMeasureValid);
+
+            geometry.Rect = new Rect(0, 0, 20, 20);
+
+            Assert.False(target.IsMeasureValid);
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

As described in #2680, `Path` was not listening for changes to the geometry stored in its `Data` property and thus was not getting invalidated when the geometry changes. This PR adds a listener in `Path` to the `Geometry.Changed` event and invalidates the path when it is fired.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #2680