### PR TITLE
Don't automatically handle Popup close click

### DIFF
--- a/src/Avalonia.Controls/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox.cs
@@ -1630,12 +1630,17 @@ namespace Avalonia.Controls
         /// </summary>
         /// <param name="sender">The source object.</param>
         /// <param name="e">The event data.</param>
-        private void DropDownPopup_Closed(object sender, EventArgs e)
+        private void DropDownPopup_Closed(object sender, PopupClosedEventArgs e)
         {
             // Force the drop down dependency property to be false.
             if (IsDropDownOpen)
             {
                 IsDropDownOpen = false;
+            }
+
+            if (e.CloseEvent is PointerEventArgs pointerEvent)
+            {
+                pointerEvent.Handled = true;
             }
 
             // Fire the DropDownClosed event

--- a/src/Avalonia.Controls/Calendar/DatePicker.cs
+++ b/src/Avalonia.Controls/Calendar/DatePicker.cs
@@ -895,12 +895,17 @@ namespace Avalonia.Controls
                 _ignoreButtonClick = false;
             }
         }
-        private void PopUp_Closed(object sender, EventArgs e)
+        private void PopUp_Closed(object sender, PopupClosedEventArgs e)
         {
             IsDropDownOpen = false;
 
             if(!_isPopupClosing)
             {
+                if (e.CloseEvent is PointerEventArgs pointerEvent)
+                {
+                    pointerEvent.Handled = true;
+                }
+
                 _isPopupClosing = true;
                 Threading.Dispatcher.UIThread.InvokeAsync(() => _isPopupClosing = false);
             }

--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -242,10 +242,15 @@ namespace Avalonia.Controls
             }
         }
 
-        private void PopupClosed(object sender, EventArgs e)
+        private void PopupClosed(object sender, PopupClosedEventArgs e)
         {
             _subscriptionsOnOpen?.Dispose();
             _subscriptionsOnOpen = null;
+
+            if (e.CloseEvent is PointerEventArgs pointerEvent)
+            {
+                pointerEvent.Handled = true;
+            }
 
             if (CanFocus(this))
             {

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -404,7 +404,6 @@ namespace Avalonia.Controls.Primitives
             if (!StaysOpen && !IsChildOrThis((IVisual)e.Source))
             {
                 Close();
-                e.Handled = true;
             }
         }
 

--- a/src/Avalonia.Controls/Primitives/PopupClosedEventArgs.cs
+++ b/src/Avalonia.Controls/Primitives/PopupClosedEventArgs.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Avalonia.Interactivity;
+
+#nullable enable
+
+namespace Avalonia.Controls.Primitives
+{
+    /// <summary>
+    /// Holds data for the <see cref="Popup.Closed"/> event.
+    /// </summary>
+    public class PopupClosedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PopupClosedEventArgs"/> class.
+        /// </summary>
+        /// <param name="closeEvent"></param>
+        public PopupClosedEventArgs(EventArgs? closeEvent)
+        {
+            CloseEvent = closeEvent;
+        }
+
+        /// <summary>
+        /// Gets the event that closed the popup, if any.
+        /// </summary>
+        /// <remarks>
+        /// If <see cref="Popup.StaysOpen"/> is false, then this property will hold details of the
+        /// interaction that caused the popup to close if the close was caused by e.g. a pointer press
+        /// outside the popup. It can be used to mark the event as handled if the event should not
+        /// be propagated.
+        /// </remarks>
+        public EventArgs? CloseEvent { get; }
+    }
+}

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -298,13 +298,6 @@ namespace Avalonia.Controls.UnitTests.Primitives
             }
         }
 
-        Window PreparedWindow(object content = null)
-        {
-            var w = new Window {Content = content};
-            w.ApplyTemplate();
-            return w;
-        }
-
         [Fact]
         public void DataContextBeginUpdate_Should_Not_Be_Called_For_Controls_That_Dont_Inherit()
         {
@@ -351,6 +344,35 @@ namespace Avalonia.Controls.UnitTests.Primitives
             }
         }
 
+        [Fact]
+        public void StaysOpen_False_Should_Not_Handle_Closing_Click()
+        {
+            using (CreateServices())
+            {
+                var window = PreparedWindow();
+                var target = new Popup() 
+                { 
+                    PlacementTarget = window ,
+                    StaysOpen = false,
+                };
+
+                target.Open();
+
+                var pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, true);
+                var e = new PointerPressedEventArgs(
+                    window,
+                    pointer,
+                    window,
+                    default,
+                    0,
+                    new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonPressed),
+                    KeyModifiers.None);
+                window.RaiseEvent(e);
+
+                Assert.False(e.Handled);
+            }
+        }
+
         private IDisposable CreateServices()
         {
             return UnitTestApplication.Start(TestServices.StyledWindow.With(windowingPlatform:
@@ -361,6 +383,13 @@ namespace Avalonia.Controls.UnitTests.Primitives
                             return null;
                         return MockWindowingPlatform.CreatePopupMock().Object;
                     })));
+        }
+
+        private Window PreparedWindow(object content = null)
+        {
+            var w = new Window { Content = content };
+            w.ApplyTemplate();
+            return w;
         }
 
         private static IControl PopupContentControlTemplate(PopupContentControl control, INameScope scope)

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -358,18 +358,39 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
                 target.Open();
 
-                var pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, true);
-                var e = new PointerPressedEventArgs(
-                    window,
-                    pointer,
-                    window,
-                    default,
-                    0,
-                    new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonPressed),
-                    KeyModifiers.None);
+                var e = CreatePointerPressedEventArgs(window);
                 window.RaiseEvent(e);
 
                 Assert.False(e.Handled);
+            }
+        }
+
+        [Fact]
+        public void Should_Pass_Closing_Click_To_Closed_Event()
+        {
+            using (CreateServices())
+            {
+                var window = PreparedWindow();
+                var target = new Popup()
+                {
+                    PlacementTarget = window,
+                    StaysOpen = false,
+                };
+
+                target.Open();
+
+                var press = CreatePointerPressedEventArgs(window);
+                var raised = 0;
+
+                target.Closed += (s, e) =>
+                {
+                    Assert.Same(press, e.CloseEvent);
+                    ++raised;
+                };
+
+                window.RaiseEvent(press);
+
+                Assert.Equal(1, raised);
             }
         }
 
@@ -383,6 +404,19 @@ namespace Avalonia.Controls.UnitTests.Primitives
                             return null;
                         return MockWindowingPlatform.CreatePopupMock().Object;
                     })));
+        }
+
+        private PointerPressedEventArgs CreatePointerPressedEventArgs(Window source)
+        {
+            var pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, true);
+            return new PointerPressedEventArgs(
+                source,
+                pointer,
+                source,
+                default,
+                0,
+                new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonPressed),
+                KeyModifiers.None);
         }
 
         private Window PreparedWindow(object content = null)


### PR DESCRIPTION
## What does the pull request do?

As described in #3760, clicking another control which a context menu is open doesn't cause a click on that control. This is because a `Popup` with `StaysOpen="False"` was handling the pointer event.

As described in the issue, `Popup` doesn't mark the click as handled in WPF, and instead controls that want to mark the click as handled need to implement their own closing logic.

That doesn't sound like a very usable solution to me, so I came up with another solution: pass the event that caused the popup to close (if any) to the `Popup.Close` event - in this way controls that want the close click swallowed can mark the event as handled, and those that don't can just do nothing.

This both makes our default behavior the same as WPF, and extends that API to prevent the need for controls to write their own popup close interaction logic.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #3760