### PR TITLE
Change tap events to use PointerEventArgs rather than RoutedEventArgs

### DIFF
--- a/src/Avalonia.Input/Gestures.cs
+++ b/src/Avalonia.Input/Gestures.cs
@@ -5,17 +5,17 @@ namespace Avalonia.Input
 {
     public static class Gestures
     {
-        public static readonly RoutedEvent<RoutedEventArgs> TappedEvent = RoutedEvent.Register<RoutedEventArgs>(
+        public static readonly RoutedEvent<PointerEventArgs> TappedEvent = RoutedEvent.Register<PointerEventArgs>(
             "Tapped",
             RoutingStrategies.Bubble,
             typeof(Gestures));
 
-        public static readonly RoutedEvent<RoutedEventArgs> DoubleTappedEvent = RoutedEvent.Register<RoutedEventArgs>(
+        public static readonly RoutedEvent<PointerEventArgs> DoubleTappedEvent = RoutedEvent.Register<PointerEventArgs>(
             "DoubleTapped",
             RoutingStrategies.Bubble,
             typeof(Gestures));
 
-        public static readonly RoutedEvent<RoutedEventArgs> RightTappedEvent = RoutedEvent.Register<RoutedEventArgs>(
+        public static readonly RoutedEvent<PointerEventArgs> RightTappedEvent = RoutedEvent.Register<PointerEventArgs>(
             "RightTapped",
             RoutingStrategies.Bubble,
             typeof(Gestures));
@@ -80,7 +80,8 @@ namespace Avalonia.Input
                 {
                     if (s_lastPress.TryGetTarget(out var target) && target == e.Source)
                     {
-                        e.Source.RaiseEvent(new RoutedEventArgs(DoubleTappedEvent));
+                        e.Source.RaiseEvent(new PointerEventArgs(DoubleTappedEvent, e.Source, e.Pointer, e.RootVisual,
+                            e.RootVisualPosition, e.Timestamp, e.Properties, e.KeyModifiers));
                     }
                 }
             }
@@ -95,7 +96,8 @@ namespace Avalonia.Input
                 if (s_lastPress.TryGetTarget(out var target) && target == e.Source)
                 {
                     var et = e.InitialPressMouseButton != MouseButton.Right ? TappedEvent : RightTappedEvent;
-                    e.Source.RaiseEvent(new RoutedEventArgs(et));
+                    e.Source.RaiseEvent(new PointerEventArgs(et, e.Source, e.Pointer, e.RootVisual,
+                        e.RootVisualPosition, e.Timestamp, e.Properties, e.KeyModifiers));
                 }
             }
         }

--- a/src/Avalonia.Input/InputElement.cs
+++ b/src/Avalonia.Input/InputElement.cs
@@ -149,12 +149,12 @@ namespace Avalonia.Input
         /// <summary>
         /// Defines the <see cref="Tapped"/> event.
         /// </summary>
-        public static readonly RoutedEvent<RoutedEventArgs> TappedEvent = Gestures.TappedEvent;
+        public static readonly RoutedEvent<PointerEventArgs> TappedEvent = Gestures.TappedEvent;
 
         /// <summary>
         /// Defines the <see cref="DoubleTapped"/> event.
         /// </summary>
-        public static readonly RoutedEvent<RoutedEventArgs> DoubleTappedEvent = Gestures.DoubleTappedEvent;
+        public static readonly RoutedEvent<PointerEventArgs> DoubleTappedEvent = Gestures.DoubleTappedEvent;
 
         private bool _isEffectivelyEnabled = true;
         private bool _isFocused;

--- a/src/Avalonia.Input/PointerEventArgs.cs
+++ b/src/Avalonia.Input/PointerEventArgs.cs
@@ -7,9 +7,7 @@ namespace Avalonia.Input
 {
     public class PointerEventArgs : RoutedEventArgs
     {
-        private readonly IVisual _rootVisual;
-        private readonly Point _rootVisualPosition;
-        private readonly PointerPointProperties _properties;
+        public PointerPointProperties _properties;
 
         public PointerEventArgs(RoutedEvent routedEvent,
             IInteractive source,
@@ -21,8 +19,8 @@ namespace Avalonia.Input
            : base(routedEvent)
         {
             Source = source;
-            _rootVisual = rootVisual;
-            _rootVisualPosition = rootVisualPosition;
+            RootVisual = rootVisual;
+            RootVisualPosition = rootVisualPosition;
             _properties = properties;
             Pointer = pointer;
             Timestamp = timestamp;
@@ -51,6 +49,8 @@ namespace Avalonia.Input
 
         public IPointer Pointer { get; }
         public ulong Timestamp { get; }
+        public IVisual RootVisual { get; }
+        public Point RootVisualPosition { get; }
 
         private IPointerDevice _device;
 
@@ -78,11 +78,11 @@ namespace Avalonia.Input
 
         public Point GetPosition(IVisual relativeTo)
         {
-            if (_rootVisual == null)
+            if (RootVisual == null)
                 return default;
             if (relativeTo == null)
-                return _rootVisualPosition;
-            return _rootVisualPosition * _rootVisual.TransformToVisual(relativeTo) ?? default;
+                return RootVisualPosition;
+            return RootVisualPosition * RootVisual.TransformToVisual(relativeTo) ?? default;
         }
 
         [Obsolete("Use GetCurrentPoint")]
@@ -99,7 +99,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Returns the current pointer point properties
         /// </summary>
-        protected PointerPointProperties Properties => _properties;
+        public PointerPointProperties Properties => _properties;
     }
     
     public enum MouseButton


### PR DESCRIPTION
## What does the pull request do?
Addresses issues #3756 and #3240 by passing a PointerEventArgs rather than RoutedEventArgs, allowing coordinate information to be preserved.


## What is the current behavior?
Coordinate information is lost when a new RoutedEventArgs is sent, because the RoutedEventArgs class does not have the capability to store this information.


## What is the updated/expected behavior with this PR?
A new PointerEventArgs instance is created and passed, allowing users to cast to PointerEventArgs and get the exact coordinates of their click.


## How was the solution implemented (if it's not obvious)?


## Checklist


## Breaking changes


## Fixed issues
Fixes #3756
Fixes #3240 
