### PR TITLE
Update TreeView index when not attached to logical tree.

### DIFF
--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -51,6 +51,7 @@ namespace Avalonia.Controls
             SelectableMixin.Attach<TreeViewItem>(IsSelectedProperty);
             FocusableProperty.OverrideDefaultValue<TreeViewItem>(true);
             ItemsPanelProperty.OverrideDefaultValue<TreeViewItem>(DefaultPanel);
+            ParentProperty.Changed.AddClassHandler<TreeViewItem>((o, e) => o.OnParentChanged(e));
             RequestBringIntoViewEvent.AddClassHandler<TreeViewItem>((x, e) => x.OnRequestBringIntoView(e));
         }
 
@@ -178,6 +179,17 @@ namespace Avalonia.Controls
             }
 
             return logical != null ? result : @default;
+        }
+
+        private void OnParentChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            if (!((ILogical)this).IsAttachedToLogicalTree && e.NewValue is null)
+            {
+                // If we're not attached to the logical tree, then OnDetachedFromLogicalTree isn't going to be
+                // called when the item is removed. This results in the item not being removed from the index,
+                // causing #3551. In this case, update the index when Parent is changed to null.
+                ItemContainerGenerator.UpdateIndex();
+            }
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
@@ -1002,6 +1002,35 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(1, child2Node.Presenter.Panel.Children.Count);
         }
 
+        [Fact]
+        public void Clearing_TreeView_Items_Clears_Index()
+        {
+            // Issue #3551
+            var tree = CreateTestTreeData();
+            var target = new TreeView
+            {
+                Template = CreateTreeViewTemplate(),
+                Items = tree,
+            };
+
+            var root = new TestRoot();
+            root.Child = target;
+
+            CreateNodeDataTemplate(target);
+            ApplyTemplates(target);
+
+            var rootNode = tree[0];
+            var container = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(rootNode);
+
+            Assert.NotNull(container);
+
+            root.Child = null;
+
+            tree.Clear();
+
+            Assert.Empty(target.ItemContainerGenerator.Index.Containers);
+        }
+
         private void ApplyTemplates(TreeView tree)
         {
             tree.ApplyTemplate();


### PR DESCRIPTION
## What does the pull request do?

#3551 describes a memory leak when a `TreeView`'s items are cleared when the `TreeView` isn't attached to the logical tree. This PR fixes that by listening for `Parent` changing to null and updating the index if we're not attached to the logical tree.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #3551 