### PR TITLE
[X11] Don't trigger Resized event on ConfigureEvent for popups

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -442,7 +442,7 @@ namespace Avalonia.X11
                             updatedSizeViaScaling = UpdateScaling();
                         }
 
-                        if (changedSize && !updatedSizeViaScaling)
+                        if (changedSize && !updatedSizeViaScaling && !_popup)
                             Resized?.Invoke(ClientSize);
 
                         Dispatcher.UIThread.RunJobs(DispatcherPriority.Layout);


### PR DESCRIPTION
Sometimes there is a race that disables auto-sizing
1) Resize(100, 100)
2) Resize(200,200)
3) ConfigureEvent(100, 100), Resized is triggered, WindowBase treats it as a user-triggered resize, everything gets broken

Since we are controlling popup size exclusively via override_redirect flag, we can skip triggering Resized event from ConfigureEvent.