### PR TITLE
Collection pooling for DeferredRenderer

### DIFF
--- a/src/Avalonia.Visuals/Rendering/SceneGraph/Scene.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/Scene.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Rendering.SceneGraph
     /// </summary>
     public class Scene : IDisposable
     {
-        private Dictionary<IVisual, IVisualNode> _index;
+        private readonly Dictionary<IVisual, IVisualNode> _index;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Scene"/> class.
@@ -83,7 +83,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <returns>The cloned scene.</returns>
         public Scene CloneScene()
         {
-            var index = new Dictionary<IVisual, IVisualNode>();
+            var index = new Dictionary<IVisual, IVisualNode>(_index.Count);
             var root = Clone((VisualNode)Root, null, index);
 
             var result = new Scene(root, index, Layers.Clone(), Generation + 1)
@@ -162,9 +162,18 @@ namespace Avalonia.Rendering.SceneGraph
 
             index.Add(result.Visual, result);
 
-            foreach (var child in source.Children)
+            int childCount = source.Children.Count;
+
+            if (childCount > 0)
             {
-                result.AddChild(Clone((VisualNode)child, result, index));
+                Span<IVisualNode> children = result.AddChildrenSpan(childCount);
+
+                for (var i = 0; i < childCount; i++)
+                {
+                    var child = source.Children[i];
+
+                    children[i] = Clone((VisualNode)child, result, index);
+                }
             }
 
             return result;

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneLayers.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneLayers.cs
@@ -11,16 +11,28 @@ namespace Avalonia.Rendering.SceneGraph
     public class SceneLayers : IEnumerable<SceneLayer>
     {
         private readonly IVisual _root;
-        private readonly List<SceneLayer> _inner = new List<SceneLayer>();
-        private readonly Dictionary<IVisual, SceneLayer> _index = new Dictionary<IVisual, SceneLayer>();
+        private readonly List<SceneLayer> _inner;
+        private readonly Dictionary<IVisual, SceneLayer> _index;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SceneLayers"/> class.
         /// </summary>
         /// <param name="root">The scene's root visual.</param>
-        public SceneLayers(IVisual root)
+        public SceneLayers(IVisual root) : this(root, 0)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SceneLayers"/> class.
+        /// </summary>
+        /// <param name="root">The scene's root visual.</param>
+        /// <param name="capacity">Initial layer capacity.</param>
+        public SceneLayers(IVisual root, int capacity)
         {
             _root = root;
+
+            _inner = new List<SceneLayer>(capacity);
+            _index = new Dictionary<IVisual, SceneLayer>(capacity);
         }
 
         /// <summary>
@@ -84,7 +96,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <returns>The cloned layers.</returns>
         public SceneLayers Clone()
         {
-            var result = new SceneLayers(_root);
+            var result = new SceneLayers(_root, Count);
 
             foreach (var src in _inner)
             {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`DeferredRenderer` clones the `Scene` a lot and currently this operation is not very cheap.

![image](https://user-images.githubusercontent.com/2588062/79053834-a7038b80-7c40-11ea-842b-1e631f35ffbe.png)


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Less memory allocations when having animated content on the screen (causing scene cloning).

Memory traffic over 20 seconds on `ProgressBar` page.

![image](https://user-images.githubusercontent.com/2588062/79053840-b387e400-7c40-11ea-8bb0-194acf10e15c.png)

Many of the outstanding allocations like `ConcurrentDictionary` or `object` are coming from SkiaSharp. Most of it is related to `SKPaint`.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Use `PooledList` that I've introduced before to store children and draw operations. In other cases where it may not be worth pooling - simply provide initial sizes so we can allocate once.

Also minor changes to drop a closure and enumerator boxing.

`ArrayPool<T>.Shared` has a limit of 8 arrays per bucket limiting how useful it is. On the other hand I don't want to introduce extra complexity since there are plans to redo the renderer anyway.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
