### PR TITLE
Fix native dialogs throwing InvalidCastException

### DIFF
--- a/src/Avalonia.Dialogs/ManagedFileChooser.xaml
+++ b/src/Avalonia.Dialogs/ManagedFileChooser.xaml
@@ -58,7 +58,7 @@
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
                 <StackPanel.Styles>
                     <Style Selector="Button">
-                        <Setter Property="Margin">4</Setter>
+                        <Setter Property="Margin" Value="4"/>
                     </Style>
                 </StackPanel.Styles>
                 <Button Command="{Binding Ok}">OK</Button>


### PR DESCRIPTION
## What does the pull request do?

Managed file dialogs are currently throwing an `InvalidCastException` due to this XAML:

`<Setter Property="Margin">4</Setter>`

It complains that it cannot convert a string to a `Thickness`. (It seems like that should work, but let's just roll with the error for now I guess...)

You can fix this by doing:

`<Setter Property="Margin" Value="4"/>`

## What is the current behavior?

Managed file dialogs don't work at all and crash the program. You can repro this in the sample.

## What is the updated/expected behavior with this PR?

Managed file dialogs no longer crash!

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes

None