### PR TITLE
Fix window sizing AGAIN

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -570,8 +570,8 @@ namespace Avalonia.Controls
         protected override Size MeasureOverride(Size availableSize)
         {
             var sizeToContent = SizeToContent;
-            var constraint = availableSize;
             var clientSize = ClientSize;
+            var constraint = clientSize;
 
             if (sizeToContent.HasFlagCustom(SizeToContent.Width))
             {

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -352,7 +352,8 @@ namespace Avalonia.Controls.UnitTests
 
                 target.Show();
 
-                Assert.Equal(new Size(100, 50), child.MeasureSize);
+                Assert.Equal(1, child.MeasureSizes.Count);
+                Assert.Equal(new Size(100, 50), child.MeasureSizes[0]);
             }
         }
 
@@ -373,7 +374,8 @@ namespace Avalonia.Controls.UnitTests
 
                 target.Show();
 
-                Assert.Equal(new Size(550, 450), child.MeasureSize);
+                Assert.Equal(1, child.MeasureSizes.Count);
+                Assert.Equal(new Size(550, 450), child.MeasureSizes[0]);
             }
         }
 
@@ -393,7 +395,8 @@ namespace Avalonia.Controls.UnitTests
 
                 target.Show();
 
-                Assert.Equal(Size.Infinity, child.MeasureSize);
+                Assert.Equal(1, child.MeasureSizes.Count);
+                Assert.Equal(Size.Infinity, child.MeasureSizes[0]);
             }
         }
 
@@ -549,11 +552,11 @@ namespace Avalonia.Controls.UnitTests
 
         private class ChildControl : Control
         {
-            public Size MeasureSize { get; private set; }
+            public List<Size> MeasureSizes { get; } = new List<Size>();
 
             protected override Size MeasureOverride(Size availableSize)
             {
-                MeasureSize = availableSize;
+                MeasureSizes.Add(availableSize);
                 return base.MeasureOverride(availableSize);
             }
         }


### PR DESCRIPTION
## What does the pull request do?

Fix window sizing AGAIN. The test `Child_Should_Be_Measured_With_ClientSize_If_SizeToContent_Is_Manual_And_No_Width_Height_Specified` was causing a double measure and so it didn't notice that the first pass was passing infinity as the constraint, and so should have been failing.

Fix the test, and the fail condition in `Window.MeasureOverride`.

## Checklist

- [x] Added unit tests (if possible)?
