### PR TITLE
Revert "Collection pooling for DeferredRenderer"

### DIFF
--- a/src/Avalonia.Visuals/Rendering/SceneGraph/Scene.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/Scene.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Rendering.SceneGraph
     /// </summary>
     public class Scene : IDisposable
     {
-        private readonly Dictionary<IVisual, IVisualNode> _index;
+        private Dictionary<IVisual, IVisualNode> _index;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Scene"/> class.
@@ -83,7 +83,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <returns>The cloned scene.</returns>
         public Scene CloneScene()
         {
-            var index = new Dictionary<IVisual, IVisualNode>(_index.Count);
+            var index = new Dictionary<IVisual, IVisualNode>();
             var root = Clone((VisualNode)Root, null, index);
 
             var result = new Scene(root, index, Layers.Clone(), Generation + 1)
@@ -162,18 +162,9 @@ namespace Avalonia.Rendering.SceneGraph
 
             index.Add(result.Visual, result);
 
-            int childCount = source.Children.Count;
-
-            if (childCount > 0)
+            foreach (var child in source.Children)
             {
-                Span<IVisualNode> children = result.AddChildrenSpan(childCount);
-
-                for (var i = 0; i < childCount; i++)
-                {
-                    var child = source.Children[i];
-
-                    children[i] = Clone((VisualNode)child, result, index);
-                }
+                result.AddChild(Clone((VisualNode)child, result, index));
             }
 
             return result;

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneLayers.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneLayers.cs
@@ -11,28 +11,16 @@ namespace Avalonia.Rendering.SceneGraph
     public class SceneLayers : IEnumerable<SceneLayer>
     {
         private readonly IVisual _root;
-        private readonly List<SceneLayer> _inner;
-        private readonly Dictionary<IVisual, SceneLayer> _index;
+        private readonly List<SceneLayer> _inner = new List<SceneLayer>();
+        private readonly Dictionary<IVisual, SceneLayer> _index = new Dictionary<IVisual, SceneLayer>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SceneLayers"/> class.
         /// </summary>
         /// <param name="root">The scene's root visual.</param>
-        public SceneLayers(IVisual root) : this(root, 0)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SceneLayers"/> class.
-        /// </summary>
-        /// <param name="root">The scene's root visual.</param>
-        /// <param name="capacity">Initial layer capacity.</param>
-        public SceneLayers(IVisual root, int capacity)
+        public SceneLayers(IVisual root)
         {
             _root = root;
-
-            _inner = new List<SceneLayer>(capacity);
-            _index = new Dictionary<IVisual, SceneLayer>(capacity);
         }
 
         /// <summary>
@@ -96,7 +84,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <returns>The cloned layers.</returns>
         public SceneLayers Clone()
         {
-            var result = new SceneLayers(_root, Count);
+            var result = new SceneLayers(_root);
 
             foreach (var src in _inner)
             {


### PR DESCRIPTION
Reverts AvaloniaUI/Avalonia#3775

`PooledList` causes severe perf problems when you have a huge scene. I will rework this PR later to not use it and retain other benefits.