### PR TITLE
macOS: Fix title not showing up in SelectFolderDialog, OpenFileDialog and SaveFileDialog

### DIFF
--- a/native/Avalonia.Native/src/OSX/SystemDialogs.mm
+++ b/native/Avalonia.Native/src/OSX/SystemDialogs.mm
@@ -20,7 +20,7 @@ public:
             
             if(title != nullptr)
             {
-				panel.message = [NSString stringWithUTF8String:title];
+			    panel.message = [NSString stringWithUTF8String:title];
                 panel.title = [NSString stringWithUTF8String:title];
             }
             
@@ -95,7 +95,7 @@ public:
             
             if(title != nullptr)
             {
-				panel.message = [NSString stringWithUTF8String:title];
+			    panel.message = [NSString stringWithUTF8String:title];
                 panel.title = [NSString stringWithUTF8String:title];
             }
             
@@ -184,7 +184,7 @@ public:
             
             if(title != nullptr)
             {
-				panel.message = [NSString stringWithUTF8String:title];
+			    panel.message = [NSString stringWithUTF8String:title];
                 panel.title = [NSString stringWithUTF8String:title];
             }
             

--- a/native/Avalonia.Native/src/OSX/SystemDialogs.mm
+++ b/native/Avalonia.Native/src/OSX/SystemDialogs.mm
@@ -20,7 +20,7 @@ public:
             
             if(title != nullptr)
             {
-			    panel.message = [NSString stringWithUTF8String:title];
+                panel.message = [NSString stringWithUTF8String:title];
                 panel.title = [NSString stringWithUTF8String:title];
             }
             
@@ -95,7 +95,7 @@ public:
             
             if(title != nullptr)
             {
-			    panel.message = [NSString stringWithUTF8String:title];
+                panel.message = [NSString stringWithUTF8String:title];
                 panel.title = [NSString stringWithUTF8String:title];
             }
             
@@ -184,7 +184,7 @@ public:
             
             if(title != nullptr)
             {
-			    panel.message = [NSString stringWithUTF8String:title];
+                panel.message = [NSString stringWithUTF8String:title];
                 panel.title = [NSString stringWithUTF8String:title];
             }
             

--- a/native/Avalonia.Native/src/OSX/SystemDialogs.mm
+++ b/native/Avalonia.Native/src/OSX/SystemDialogs.mm
@@ -20,6 +20,7 @@ public:
             
             if(title != nullptr)
             {
+				panel.message = [NSString stringWithUTF8String:title];
                 panel.title = [NSString stringWithUTF8String:title];
             }
             
@@ -94,6 +95,7 @@ public:
             
             if(title != nullptr)
             {
+				panel.message = [NSString stringWithUTF8String:title];
                 panel.title = [NSString stringWithUTF8String:title];
             }
             
@@ -182,6 +184,7 @@ public:
             
             if(title != nullptr)
             {
+				panel.message = [NSString stringWithUTF8String:title];
                 panel.title = [NSString stringWithUTF8String:title];
             }
             


### PR DESCRIPTION
## What does the pull request do?
This pull request makes it so that the `title` of `SelectFolderDialogs`, `OpenFileDialogs` and `SaveFileDialogs` shows up (for example, above the `Save As` text in the case of `SaveFileDialogs`).

![image](https://user-images.githubusercontent.com/25257376/80154223-aeb32080-85ae-11ea-945b-24962e3f9dda.png)


## What is the current behavior?
Currently, the title does not show up in either `SelectFolderDialogs`, `OpenFileDialogs` or `SaveFileDialogs`.

![image](https://user-images.githubusercontent.com/25257376/80154246-bc68a600-85ae-11ea-9439-78914db68d37.png)


## What is the updated/expected behavior with this PR?
The title is showing up as expected.


## How was the solution implemented (if it's not obvious)?
This was accomplished by setting the `title` in the `message` property in addition to the `title` property of `NSOpenPanel` and `NSSavePanel`.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
None.


## Fixed issues
Fixes first part of #3809 .
