### PR TITLE
Fix KeyFrame's KeyTime conversion to Cue

### DIFF
--- a/src/Avalonia.Animation/Animation.cs
+++ b/src/Avalonia.Animation/Animation.cs
@@ -251,7 +251,7 @@ namespace Avalonia.Animation
 
                     if (keyframe.TimingMode == KeyFrameTimingMode.TimeSpan)
                     {
-                        cue = new Cue(keyframe.KeyTime.Ticks / Duration.Ticks);
+                        cue = new Cue(keyframe.KeyTime.TotalSeconds / Duration.TotalSeconds);
                     }
 
                     var newKF = new AnimatorKeyFrame(handler, cue);

--- a/tests/Avalonia.Animation.UnitTests/AnimationIterationTests.cs
+++ b/tests/Avalonia.Animation.UnitTests/AnimationIterationTests.cs
@@ -15,6 +15,55 @@ namespace Avalonia.Animation.UnitTests
     public class AnimationIterationTests
     {
         [Fact]
+        public void Check_KeyTime_Correctly_Converted_To_Cue()
+        {
+            var keyframe1 = new KeyFrame()
+            {
+                Setters =
+                {
+                    new Setter(Border.WidthProperty, 100d),
+                },
+                KeyTime = TimeSpan.FromSeconds(0.5)
+            };
+
+            var keyframe2 = new KeyFrame()
+            {
+                Setters =
+                {
+                    new Setter(Border.WidthProperty, 0d),
+                },
+                KeyTime = TimeSpan.FromSeconds(0)
+            };
+
+            var animation = new Animation()
+            {
+                Duration = TimeSpan.FromSeconds(1),
+                Children =
+                {
+                    keyframe2,
+                    keyframe1
+                }
+            };
+
+            var border = new Border()
+            {
+                Height = 100d,
+                Width = 100d
+            };
+
+            var clock = new TestClock();
+            var animationRun = animation.RunAsync(border, clock);
+
+            clock.Step(TimeSpan.Zero); 
+            Assert.Equal(border.Width, 0d);
+
+            clock.Step(TimeSpan.FromSeconds(1)); 
+            Assert.Equal(border.Width, 100d);
+ 
+        }
+
+
+        [Fact]
         public void Check_Initial_Inter_and_Trailing_Delay_Values()
         {
             var keyframe1 = new KeyFrame()


### PR DESCRIPTION
Fixing a rookie mistake :facepalm: 

Basically I determined that `KeyFrames` were not being converted properly into `Cue` due to `TimeSpan.Tick` being an integer instead of floating-point. `Cue` objects expects a percent of the `KeyFrame`'s desired starting time over `Animation`'s `Duration`. This caused problems with the animations subsystem because it had duplicate entries due to duplication in `Cue` values in `KeyFrames`. Also added a unit test to prevent the bug from resurfacing again :) 

Fixes #3653 