### PR TITLE
Checkmark support for dbus exporter

### DIFF
--- a/samples/ControlCatalog/MainWindow.xaml
+++ b/samples/ControlCatalog/MainWindow.xaml
@@ -41,6 +41,7 @@
           <NativeMenu>
             <NativeMenuItem Header="Check Me Out" 
                             Command="{Binding ToggleMenuItemCheckedCommand}"
+                            ToggleType="CheckBox"
                             IsChecked="{Binding IsMenuItemChecked}"  />
           </NativeMenu>
         </NativeMenuItem.Menu>

--- a/src/Avalonia.Controls/NativeMenuItem.cs
+++ b/src/Avalonia.Controls/NativeMenuItem.cs
@@ -12,6 +12,7 @@ namespace Avalonia.Controls
         private bool _isEnabled = true;
         private ICommand _command;
         private bool _isChecked = false;
+        private NativeMenuItemToggleType _toggleType;
 
         private NativeMenu _menu;
 
@@ -99,6 +100,18 @@ namespace Avalonia.Controls
             get => _isChecked;
             set => SetAndRaise(IsCheckedProperty, ref _isChecked, value);
         }
+        
+        public static readonly DirectProperty<NativeMenuItem, NativeMenuItemToggleType> ToggleTypeProperty =
+            AvaloniaProperty.RegisterDirect<NativeMenuItem, NativeMenuItemToggleType>(
+                nameof(ToggleType),
+                o => o.ToggleType,
+                (o, v) => o.ToggleType = v);
+
+        public NativeMenuItemToggleType ToggleType
+        {
+            get => _toggleType;
+            set => SetAndRaise(ToggleTypeProperty, ref _toggleType, value);
+        }
 
         public static readonly DirectProperty<NativeMenuItem, ICommand> CommandProperty =
             Button.CommandProperty.AddOwner<NativeMenuItem>(
@@ -168,5 +181,12 @@ namespace Avalonia.Controls
                 Command.Execute(CommandParameter);
             }
         }
+    }
+    
+    public enum NativeMenuItemToggleType
+    {
+        None,
+        CheckBox,
+        Radio
     }
 }

--- a/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
+++ b/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
@@ -184,7 +184,7 @@ namespace Avalonia.FreeDesktop
 
             private static string[] AllProperties = new[]
             {
-                "type", "label", "enabled", "visible", "shortcut", "toggle-type", "children-display"
+                "type", "label", "enabled", "visible", "shortcut", "toggle-type", "children-display", "toggle-state"
             };
             
             object GetProperty((NativeMenuItemBase item, NativeMenu menu) i, string name)
@@ -232,6 +232,25 @@ namespace Avalonia.FreeDesktop
                             lst.Add("Super");
                         lst.Add(item.Gesture.Key.ToString());
                         return new[] { lst.ToArray() };
+                    }
+
+                    if (name == "toggle-type")
+                    {
+                        if (item.ToggleType == NativeMenuItemToggleType.CheckBox)
+                            return "checkmark";
+                        if (item.ToggleType == NativeMenuItemToggleType.Radio)
+                            return "radio";
+                        // Someone has forgot to set the style
+                        if (item.IsChecked)
+                            return "checkmark";
+                    }
+
+                    if (name == "toggle-state")
+                    {
+                        if (item.IsChecked)
+                            return 1;
+                        if (item.ToggleType != NativeMenuItemToggleType.None)
+                            return 0;
                     }
 
                     if (name == "children-display")


### PR DESCRIPTION
![dbus](https://user-images.githubusercontent.com/1067584/80502138-ef2ce880-8978-11ea-8e0c-7e33740364a8.gif)

Note: we need to decide the naming for IsChecked and ToggleType (enum: None/CheckBox/Radio). ToggleType name was borrowed from dbusmenu spec (`toggle-type`) where checked state is communicated via `toggle-state` property.

So either IsChecked should be renamed to IsToggled or ToggleType has to be renamed to something else.