### PR TITLE
Fix for render cycle crash when RenderTransform contains invalid values.

### DIFF
--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Avalonia.Logging;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Threading;
@@ -179,6 +180,13 @@ namespace Avalonia.Rendering.SceneGraph
                     var origin = visual.RenderTransformOrigin.ToPixels(new Size(visual.Bounds.Width, visual.Bounds.Height));
                     var offset = Matrix.CreateTranslation(origin);
                     renderTransform = (-offset) * visual.RenderTransform.Value * (offset);
+
+                    var det = renderTransform.GetDeterminant();
+                    if (double.IsNaN(det) || double.IsInfinity(det))
+                    {
+                        Logger.TryGet(LogEventLevel.Error)?.Log(LogArea.Visual, renderTransform, "Render transform matrix contains NaN or Infinities.");
+                        return;
+                    }
                 }
 
                 m = renderTransform * m;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This "fixes" the issue when the rendering subsystem gets a matrix from RenderTransform that contains `double.NaN` or infinities and crashes the whole scene.
 
## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

It checks `RenderTransform`'s matrix determinant and when it's either a `NaN` or infinite then it logs the anomaly and returns.

## Fixed issues
Also fixes #3653 but #3836 addresses the root cause.
Also could fix https://github.com/zkSNACKs/WalletWasabi/issues/3500 but it needs to be tested.
