### PR TITLE
Fix DataGrid RowSize Bug #3687

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridCellsPresenter.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridCellsPresenter.cs
@@ -269,6 +269,9 @@ namespace Avalonia.Controls.Primitives
                 // Since we didn't know the final widths of the columns until we resized,
                 // we waited until now to measure each cell
                 double leftEdge = 0;
+                if (autoSizeHeight)
+                    DesiredHeight = 0;
+
                 foreach (DataGridColumn column in OwningGrid.ColumnsInternal.GetVisibleColumns())
                 {
                     DataGridCell cell = OwningRow.Cells[column.Index];


### PR DESCRIPTION
## What does the pull request do?
Fixes issue #3687 by setting DataGridCells.DesiredHeight to 0 before measuring the individual cells


## What is the current behavior?
See #3687 DataGrid rows can have the wrong height after being recycled


## What is the updated/expected behavior with this PR?
Row heights are now calculated correctly


## How was the solution implemented (if it's not obvious)?
The cached DesiredHeight needed to be reset during the measure pass of the DataGridCellsPresenter


## Fixed issues
Fixes #3687
