### PR TITLE
Properly applies Binding.StringFormat in DataGrid

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridBoundColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridBoundColumn.cs
@@ -55,7 +55,7 @@ namespace Avalonia.Controls
                                 binding.Mode = BindingMode.TwoWay;
                             } 
 
-                            if (binding.Converter == null)
+                            if (binding.Converter == null && string.IsNullOrEmpty(binding.StringFormat))
                             {
                                 binding.Converter = DataGridValueConverter.Instance;
                             }


### PR DESCRIPTION
## What does the pull request do?
Fixes #3792 by allowing the binding system to properly apply a `StringFormatValueConverter`


## What is the current behavior?
Data within `DataGrids` is not being properly formatted when a `Binding.StringFormat` is provided


## What is the updated/expected behavior with this PR?
`DataGridCells` use the `Binding.StringFormat` to generate the text they display


## How was the solution implemented (if it's not obvious)?
Prevents using the default `DataGridValueConverter` when a `Binding.StringFormat` has been set.


## Fixed issues
Fixes #3792
