### PR TITLE
Set initial size when showing Window as dialog.

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -500,6 +500,19 @@ namespace Avalonia.Controls
 
             EnsureInitialized();
             IsVisible = true;
+
+            var initialSize = new Size(
+                double.IsNaN(Width) ? ClientSize.Width : Width,
+                double.IsNaN(Height) ? ClientSize.Height : Height);
+
+            if (initialSize != ClientSize)
+            {
+                using (BeginAutoSizing())
+                {
+                    PlatformImpl?.Resize(initialSize);
+                }
+            }
+
             LayoutManager.ExecuteInitialLayoutPass(this);
 
             var result = new TaskCompletionSource<TResult>();

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -336,210 +336,227 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
-        [Fact]
-        public void Child_Should_Be_Measured_With_Width_And_Height_If_SizeToContent_Is_Manual()
+        public class SizingTests
         {
-            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            [Fact]
+            public void Child_Should_Be_Measured_With_Width_And_Height_If_SizeToContent_Is_Manual()
             {
-                var child = new ChildControl();
-                var target = new Window 
-                { 
-                    Width = 100,
-                    Height = 50,
-                    SizeToContent = SizeToContent.Manual,
-                    Content = child 
-                };
+                using (UnitTestApplication.Start(TestServices.StyledWindow))
+                {
+                    var child = new ChildControl();
+                    var target = new Window
+                    {
+                        Width = 100,
+                        Height = 50,
+                        SizeToContent = SizeToContent.Manual,
+                        Content = child
+                    };
 
-                target.Show();
+                    Show(target);
 
-                Assert.Equal(1, child.MeasureSizes.Count);
-                Assert.Equal(new Size(100, 50), child.MeasureSizes[0]);
+                    Assert.Equal(1, child.MeasureSizes.Count);
+                    Assert.Equal(new Size(100, 50), child.MeasureSizes[0]);
+                }
+            }
+
+            [Fact]
+            public void Child_Should_Be_Measured_With_ClientSize_If_SizeToContent_Is_Manual_And_No_Width_Height_Specified()
+            {
+                using (UnitTestApplication.Start(TestServices.StyledWindow))
+                {
+                    var windowImpl = MockWindowingPlatform.CreateWindowMock();
+                    windowImpl.Setup(x => x.ClientSize).Returns(new Size(550, 450));
+
+                    var child = new ChildControl();
+                    var target = new Window(windowImpl.Object)
+                    {
+                        SizeToContent = SizeToContent.Manual,
+                        Content = child
+                    };
+
+                    Show(target);
+
+                    Assert.Equal(1, child.MeasureSizes.Count);
+                    Assert.Equal(new Size(550, 450), child.MeasureSizes[0]);
+                }
+            }
+
+            [Fact]
+            public void Child_Should_Be_Measured_With_Infinity_If_SizeToContent_Is_WidthAndHeight()
+            {
+                using (UnitTestApplication.Start(TestServices.StyledWindow))
+                {
+                    var child = new ChildControl();
+                    var target = new Window
+                    {
+                        Width = 100,
+                        Height = 50,
+                        SizeToContent = SizeToContent.WidthAndHeight,
+                        Content = child
+                    };
+
+                    Show(target);
+
+                    Assert.Equal(1, child.MeasureSizes.Count);
+                    Assert.Equal(Size.Infinity, child.MeasureSizes[0]);
+                }
+            }
+
+            [Fact]
+            public void Should_Not_Have_Offset_On_Bounds_When_Content_Larger_Than_Max_Window_Size()
+            {
+                // Issue #3784.
+                using (UnitTestApplication.Start(TestServices.StyledWindow))
+                {
+                    var windowImpl = MockWindowingPlatform.CreateWindowMock();
+                    var clientSize = new Size(200, 200);
+                    var maxClientSize = new Size(480, 480);
+
+                    windowImpl.Setup(x => x.Resize(It.IsAny<Size>())).Callback<Size>(size =>
+                    {
+                        clientSize = size.Constrain(maxClientSize);
+                        windowImpl.Object.Resized?.Invoke(clientSize);
+                    });
+
+                    windowImpl.Setup(x => x.ClientSize).Returns(() => clientSize);
+
+                    var child = new Canvas
+                    {
+                        Width = 400,
+                        Height = 800,
+                    };
+                    var target = new Window(windowImpl.Object)
+                    {
+                        SizeToContent = SizeToContent.WidthAndHeight,
+                        Content = child
+                    };
+
+                    Show(target);
+
+                    Assert.Equal(new Size(400, 480), target.Bounds.Size);
+
+                    // Issue #3784 causes this to be (0, 160) which makes no sense as Window has no
+                    // parent control to be offset against.
+                    Assert.Equal(new Point(0, 0), target.Bounds.Position);
+                }
+            }
+
+            [Fact]
+            public void Width_Height_Should_Not_Be_NaN_After_Show_With_SizeToContent_WidthAndHeight()
+            {
+                using (UnitTestApplication.Start(TestServices.StyledWindow))
+                {
+                    var child = new Canvas
+                    {
+                        Width = 400,
+                        Height = 800,
+                    };
+
+                    var target = new Window()
+                    {
+                        SizeToContent = SizeToContent.WidthAndHeight,
+                        Content = child
+                    };
+
+                    Show(target);
+
+                    Assert.Equal(400, target.Width);
+                    Assert.Equal(800, target.Height);
+                }
+            }
+
+            [Fact]
+            public void SizeToContent_Should_Not_Be_Lost_On_Show()
+            {
+                using (UnitTestApplication.Start(TestServices.StyledWindow))
+                {
+                    var child = new Canvas
+                    {
+                        Width = 400,
+                        Height = 800,
+                    };
+
+                    var target = new Window()
+                    {
+                        SizeToContent = SizeToContent.WidthAndHeight,
+                        Content = child
+                    };
+
+                    Show(target);
+
+                    Assert.Equal(SizeToContent.WidthAndHeight, target.SizeToContent);
+                }
+            }
+
+            [Fact]
+            public void Width_Height_Should_Be_Updated_When_SizeToContent_Is_WidthAndHeight()
+            {
+                using (UnitTestApplication.Start(TestServices.StyledWindow))
+                {
+                    var child = new Canvas
+                    {
+                        Width = 400,
+                        Height = 800,
+                    };
+
+                    var target = new Window()
+                    {
+                        SizeToContent = SizeToContent.WidthAndHeight,
+                        Content = child
+                    };
+
+                    Show(target);
+
+                    Assert.Equal(400, target.Width);
+                    Assert.Equal(800, target.Height);
+
+                    child.Width = 410;
+                    target.LayoutManager.ExecuteLayoutPass();
+
+                    Assert.Equal(410, target.Width);
+                    Assert.Equal(800, target.Height);
+                    Assert.Equal(SizeToContent.WidthAndHeight, target.SizeToContent);
+                }
+            }
+
+            [Fact]
+            public void Setting_Width_Should_Resize_WindowImpl()
+            {
+                // Issue #3796
+                using (UnitTestApplication.Start(TestServices.StyledWindow))
+                {
+                    var target = new Window()
+                    {
+                        Width = 400,
+                        Height = 800,
+                    };
+
+                    Show(target);
+
+                    Assert.Equal(400, target.Width);
+                    Assert.Equal(800, target.Height);
+
+                    target.Width = 410;
+                    target.LayoutManager.ExecuteLayoutPass();
+
+                    var windowImpl = Mock.Get(target.PlatformImpl);
+                    windowImpl.Verify(x => x.Resize(new Size(410, 800)));
+                    Assert.Equal(410, target.Width);
+                }
+            }
+
+            protected virtual void Show(Window window)
+            {
+                window.Show();
             }
         }
 
-        [Fact]
-        public void Child_Should_Be_Measured_With_ClientSize_If_SizeToContent_Is_Manual_And_No_Width_Height_Specified()
+        public class DialogSizingTests : SizingTests
         {
-            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            protected override void Show(Window window)
             {
-                var windowImpl = MockWindowingPlatform.CreateWindowMock();
-                windowImpl.Setup(x => x.ClientSize).Returns(new Size(550, 450));
-
-                var child = new ChildControl();
-                var target = new Window(windowImpl.Object)
-                {
-                    SizeToContent = SizeToContent.Manual,
-                    Content = child
-                };
-
-                target.Show();
-
-                Assert.Equal(1, child.MeasureSizes.Count);
-                Assert.Equal(new Size(550, 450), child.MeasureSizes[0]);
-            }
-        }
-
-        [Fact]
-        public void Child_Should_Be_Measured_With_Infinity_If_SizeToContent_Is_WidthAndHeight()
-        {
-            using (UnitTestApplication.Start(TestServices.StyledWindow))
-            {
-                var child = new ChildControl();
-                var target = new Window
-                {
-                    Width = 100,
-                    Height = 50,
-                    SizeToContent = SizeToContent.WidthAndHeight,
-                    Content = child
-                };
-
-                target.Show();
-
-                Assert.Equal(1, child.MeasureSizes.Count);
-                Assert.Equal(Size.Infinity, child.MeasureSizes[0]);
-            }
-        }
-
-        [Fact]
-        public void Should_Not_Have_Offset_On_Bounds_When_Content_Larger_Than_Max_Window_Size()
-        {
-            // Issue #3784.
-            using (UnitTestApplication.Start(TestServices.StyledWindow))
-            {
-                var windowImpl = MockWindowingPlatform.CreateWindowMock();
-                var clientSize = new Size(200, 200);
-                var maxClientSize = new Size(480, 480);
-
-                windowImpl.Setup(x => x.Resize(It.IsAny<Size>())).Callback<Size>(size =>
-                {
-                    clientSize = size.Constrain(maxClientSize);
-                    windowImpl.Object.Resized?.Invoke(clientSize);
-                });
-
-                windowImpl.Setup(x => x.ClientSize).Returns(() => clientSize);
-
-                var child = new Canvas
-                {
-                    Width = 400,
-                    Height = 800,
-                };
-                var target = new Window(windowImpl.Object)
-                {
-                    SizeToContent = SizeToContent.WidthAndHeight,
-                    Content = child
-                };
-
-                target.Show();
-
-                Assert.Equal(new Size(400, 480), target.Bounds.Size);
-
-                // Issue #3784 causes this to be (0, 160) which makes no sense as Window has no
-                // parent control to be offset against.
-                Assert.Equal(new Point(0, 0), target.Bounds.Position);
-            }
-        }
-
-        [Fact]
-        public void Width_Height_Should_Not_Be_NaN_After_Show_With_SizeToContent_WidthAndHeight()
-        {
-            using (UnitTestApplication.Start(TestServices.StyledWindow))
-            {
-                var child = new Canvas
-                {
-                    Width = 400,
-                    Height = 800,
-                };
-
-                var target = new Window()
-                {
-                    SizeToContent = SizeToContent.WidthAndHeight,
-                    Content = child
-                };
-
-                target.Show();
-
-                Assert.Equal(400, target.Width);
-                Assert.Equal(800, target.Height);
-            }
-        }
-
-        [Fact]
-        public void SizeToContent_Should_Not_Be_Lost_On_Show()
-        {
-            using (UnitTestApplication.Start(TestServices.StyledWindow))
-            {
-                var child = new Canvas
-                {
-                    Width = 400,
-                    Height = 800,
-                };
-
-                var target = new Window()
-                {
-                    SizeToContent = SizeToContent.WidthAndHeight,
-                    Content = child
-                };
-
-                target.Show();
-
-                Assert.Equal(SizeToContent.WidthAndHeight, target.SizeToContent);
-            }
-        }
-
-        [Fact]
-        public void Width_Height_Should_Be_Updated_When_SizeToContent_Is_WidthAndHeight()
-        {
-            using (UnitTestApplication.Start(TestServices.StyledWindow))
-            {
-                var child = new Canvas
-                {
-                    Width = 400,
-                    Height = 800,
-                };
-
-                var target = new Window()
-                {
-                    SizeToContent = SizeToContent.WidthAndHeight,
-                    Content = child
-                };
-
-                target.Show();
-
-                Assert.Equal(400, target.Width);
-                Assert.Equal(800, target.Height);
-
-                child.Width = 410;
-                target.LayoutManager.ExecuteLayoutPass();
-
-                Assert.Equal(410, target.Width);
-                Assert.Equal(800, target.Height);
-                Assert.Equal(SizeToContent.WidthAndHeight, target.SizeToContent);
-            }
-        }
-
-        [Fact]
-        public void Setting_Width_Should_Resize_WindowImpl()
-        {
-            // Issue #3796
-            using (UnitTestApplication.Start(TestServices.StyledWindow))
-            {
-                var target = new Window()
-                {
-                    Width = 400,
-                    Height = 800,
-                };
-
-                target.Show();
-
-                Assert.Equal(400, target.Width);
-                Assert.Equal(800, target.Height);
-
-                target.Width = 410;
-                target.LayoutManager.ExecuteLayoutPass();
-
-                var windowImpl = Mock.Get(target.PlatformImpl);
-                windowImpl.Verify(x => x.Resize(new Size(410, 800)));
-                Assert.Equal(410, target.Width);
+                var owner = new Window();
+                window.ShowDialog(owner);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

#3787 fixed initial window sizing for `Window`s shown with `Show` but neglected to fix `ShowDialog`.

This PR refactors the initial window size unit tests to test both `Show` and `ShowDialog` and ports the fix from #3787 to fix the `ShowDialog` case.

Ideally this stuff should be refactored, but in the absence of decent unit tests for `Window`, it was easier just to fix it like this for now.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #3787 