### PR TITLE
Added ComboBox.PopupClosedOverride.

### DIFF
--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -234,6 +234,23 @@ namespace Avalonia.Controls
             base.OnTemplateApplied(e);
         }
 
+        /// <summary>
+        /// Called when the ComboBox popup is closed, with the <see cref="PopupClosedEventArgs"/>
+        /// that caused the popup to close.
+        /// </summary>
+        /// <param name="e">The event args.</param>
+        /// <remarks>
+        /// This method can be overridden to control whether the event that caused the popup to close
+        /// is swallowed or passed through.
+        /// </remarks>
+        protected virtual void PopupClosedOverride(PopupClosedEventArgs e)
+        {
+            if (e.CloseEvent is PointerEventArgs pointerEvent)
+            {
+                pointerEvent.Handled = true;
+            }
+        }
+
         internal void ItemFocused(ComboBoxItem dropDownItem)
         {
             if (IsDropDownOpen && dropDownItem.IsFocused && dropDownItem.IsArrangeValid)
@@ -247,10 +264,7 @@ namespace Avalonia.Controls
             _subscriptionsOnOpen?.Dispose();
             _subscriptionsOnOpen = null;
 
-            if (e.CloseEvent is PointerEventArgs pointerEvent)
-            {
-                pointerEvent.Handled = true;
-            }
+            PopupClosedOverride(e);
 
             if (CanFocus(this))
             {


### PR DESCRIPTION
## What does the pull request do?

Adds a virtual `ComboBox.PopupClosedOverride` method to control whether the event that caused the popup to close is swallowed or passed through.

For now just implemented on `ComboBox` - we may want to implement it in future on all controls that display popups if this is something that proves generally useful.

## Fixed issues

Fixes #3845.
