### PR TITLE
Improve LogicalExtensions a bit.

### DIFF
--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -392,7 +392,7 @@ namespace Avalonia.Controls.Platform
             {
                 var control = e.Source as ILogical;
 
-                if (!Menu.IsLogicalParentOf(control))
+                if (!Menu.IsLogicalAncestorOf(control))
                 {
                     Menu.Close();
                 }

--- a/src/Avalonia.Dialogs/ManagedFileChooser.xaml.cs
+++ b/src/Avalonia.Dialogs/ManagedFileChooser.xaml.cs
@@ -34,7 +34,7 @@ namespace Avalonia.Dialogs
                 return;
             }
 
-            var isQuickLink = _quickLinksRoot.IsLogicalParentOf(e.Source as Control);
+            var isQuickLink = _quickLinksRoot.IsLogicalAncestorOf(e.Source as Control);
             if (e.ClickCount == 2 || isQuickLink)
             {
                 if (model.ItemType == ManagedFileChooserItemType.File)

--- a/src/Avalonia.Styling/LogicalTree/LogicalExtensions.cs
+++ b/src/Avalonia.Styling/LogicalTree/LogicalExtensions.cs
@@ -3,8 +3,16 @@ using System.Collections.Generic;
 
 namespace Avalonia.LogicalTree
 {
+    /// <summary>
+    /// Provides extension methods for working with the logical tree.
+    /// </summary>
     public static class LogicalExtensions
     {
+        /// <summary>
+        /// Enumerates the ancestors of an <see cref="ILogical"/> in the logical tree.
+        /// </summary>
+        /// <param name="logical">The logical.</param>
+        /// <returns>The logical's ancestors.</returns>
         public static IEnumerable<ILogical> GetLogicalAncestors(this ILogical logical)
         {
             Contract.Requires<ArgumentNullException>(logical != null);
@@ -18,6 +26,11 @@ namespace Avalonia.LogicalTree
             }
         }
 
+        /// <summary>
+        /// Enumerates an <see cref="ILogical"/> and its ancestors in the logical tree.
+        /// </summary>
+        /// <param name="logical">The logical.</param>
+        /// <returns>The logical and its ancestors.</returns>
         public static IEnumerable<ILogical> GetSelfAndLogicalAncestors(this ILogical logical)
         {
             yield return logical;
@@ -57,11 +70,21 @@ namespace Avalonia.LogicalTree
             return null;
         }
 
+        /// <summary>
+        /// Enumerates the children of an <see cref="ILogical"/> in the logical tree.
+        /// </summary>
+        /// <param name="logical">The logical.</param>
+        /// <returns>The logical children.</returns>
         public static IEnumerable<ILogical> GetLogicalChildren(this ILogical logical)
         {
             return logical.LogicalChildren;
         }
 
+        /// <summary>
+        /// Enumerates the descendants of an <see cref="ILogical"/> in the logical tree.
+        /// </summary>
+        /// <param name="logical">The logical.</param>
+        /// <returns>The logical's ancestors.</returns>
         public static IEnumerable<ILogical> GetLogicalDescendants(this ILogical logical)
         {
             foreach (ILogical child in logical.LogicalChildren)
@@ -75,6 +98,11 @@ namespace Avalonia.LogicalTree
             }
         }
 
+        /// <summary>
+        /// Enumerates an <see cref="ILogical"/> and its descendants in the logical tree.
+        /// </summary>
+        /// <param name="logical">The logical.</param>
+        /// <returns>The logical and its ancestors.</returns>
         public static IEnumerable<ILogical> GetSelfAndLogicalDescendants(this ILogical logical)
         {
             yield return logical;
@@ -107,16 +135,34 @@ namespace Avalonia.LogicalTree
             return FindDescendantOfTypeCore<T>(logical);
         }
 
+        /// <summary>
+        /// Gets the logical parent of an <see cref="ILogical"/>.
+        /// </summary>
+        /// <param name="logical">The logical.</param>
+        /// <returns>The parent, or null if the logical is unparented.</returns>
         public static ILogical GetLogicalParent(this ILogical logical)
         {
             return logical.LogicalParent;
         }
 
+        /// <summary>
+        /// Gets the logical parent of an <see cref="ILogical"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the logical parent.</typeparam>
+        /// <param name="logical">The logical.</param>
+        /// <returns>
+        /// The parent, or null if the logical is unparented or its parent is not of type <typeparamref name="T"/>.
+        /// </returns>
         public static T GetLogicalParent<T>(this ILogical logical) where T : class
         {
             return logical.LogicalParent as T;
         }
 
+        /// <summary>
+        /// Enumerates the siblings of an <see cref="ILogical"/> in the logical tree.
+        /// </summary>
+        /// <param name="logical">The logical.</param>
+        /// <returns>The logical siblings.</returns>
         public static IEnumerable<ILogical> GetLogicalSiblings(this ILogical logical)
         {
             ILogical parent = logical.LogicalParent;
@@ -130,6 +176,15 @@ namespace Avalonia.LogicalTree
             }
         }
 
+        /// <summary>
+        /// Tests whether an <see cref="ILogical"/> is an ancestor of another logical.
+        /// </summary>
+        /// <param name="logical">The logical.</param>
+        /// <param name="target">The potential descendant.</param>
+        /// <returns>
+        /// True if <paramref name="logical"/> is an ancestor of <paramref name="target"/>;
+        /// otherwise false.
+        /// </returns>
         public static bool IsLogicalAncestorOf(this ILogical logical, ILogical target)
         {
             ILogical current = target?.LogicalParent;

--- a/src/Avalonia.Visuals/VisualTree/VisualExtensions.cs
+++ b/src/Avalonia.Visuals/VisualTree/VisualExtensions.cs
@@ -377,7 +377,7 @@ namespace Avalonia.VisualTree
         /// </returns>
         public static bool IsVisualAncestorOf(this IVisual visual, IVisual target)
         {
-            IVisual current = target;
+            IVisual current = target?.VisualParent;
 
             while (current != null)
             {

--- a/src/Avalonia.Visuals/VisualTree/VisualExtensions.cs
+++ b/src/Avalonia.Visuals/VisualTree/VisualExtensions.cs
@@ -377,7 +377,19 @@ namespace Avalonia.VisualTree
         /// </returns>
         public static bool IsVisualAncestorOf(this IVisual visual, IVisual target)
         {
-            return target.GetVisualAncestors().Any(x => x == visual);
+            IVisual current = target;
+
+            while (current != null)
+            {
+                if (current == visual)
+                {
+                    return true;
+                }
+
+                current = current.VisualParent;
+            }
+
+            return false;
         }
 
         public static IEnumerable<IVisual> SortByZIndex(this IEnumerable<IVisual> elements)


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Cleanup `LogicalExtensions` to have similar features as `VisualExtensions`.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Removed some LINQ usage and added two direct functions to grab first ancestor and descendant of a given type.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

`IsLogicalParentOf` -> `IsLogicalAncestorOf`. Previous name is not correct, should I add deprecated function with the old name though?