### PR TITLE
[OSX] prevent osx from inserting View and Help menu options.

### DIFF
--- a/native/Avalonia.Native/src/OSX/app.mm
+++ b/native/Avalonia.Native/src/OSX/app.mm
@@ -15,6 +15,10 @@ NSApplicationActivationPolicy AvnDesiredActivationPolicy = NSApplicationActivati
         }
         
         [[NSApplication sharedApplication] setActivationPolicy: AvnDesiredActivationPolicy];
+        
+        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"NSFullScreenMenuItemEverywhere"];
+        
+        [[NSApplication sharedApplication] setHelpMenu: [[NSMenu new] initWithTitle:@""]];
     }
 }
 

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -425,6 +425,7 @@ private:
         WindowEvents = events;
         [Window setCanBecomeKeyAndMain];
         [Window disableCursorRects];
+        [Window setTabbingMode:NSWindowTabbingModeDisallowed];
     }
     
     virtual HRESULT Show () override


### PR DESCRIPTION
## What does the pull request do?
Stops OSX from inserting menu items that are not applicable to avalonia apps.

## What is the current behavior?
if user has a native menu item headered "View" or "Help"

OSX adds items like "Show Tabbed View" and "Enter FullScreen Mode" and "Search".

## What is the updated/expected behavior with this PR?
These alien menu items wont be inserted.

https://stackoverflow.com/questions/40508783/remove-show-hide-tab-bar-menu-item
https://stackoverflow.com/questions/52154977/how-to-get-rid-of-enter-full-screen-menu-item