### PR TITLE
Fix TextBox invalidation

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -74,16 +74,15 @@ namespace Avalonia.Controls.Presenters
 
         static TextPresenter()
         {
-            AffectsRender<TextPresenter>(PasswordCharProperty,
-                SelectionBrushProperty, SelectionForegroundBrushProperty,
-                SelectionStartProperty, SelectionEndProperty);
+            AffectsRender<TextPresenter>(SelectionBrushProperty);
 
-            Observable.Merge(
-                TextProperty.Changed,
-                SelectionStartProperty.Changed,
-                SelectionEndProperty.Changed,
-                PasswordCharProperty.Changed
-            ).AddClassHandler<TextPresenter>((x,_) => x.InvalidateFormattedText());
+            Observable.Merge(TextProperty.Changed, TextBlock.ForegroundProperty.Changed,
+                TextAlignmentProperty.Changed, TextWrappingProperty.Changed,
+                TextBlock.FontSizeProperty.Changed, TextBlock.FontStyleProperty.Changed, 
+                TextBlock.FontWeightProperty.Changed, TextBlock.FontFamilyProperty.Changed,
+                SelectionStartProperty.Changed, SelectionEndProperty.Changed,
+                SelectionForegroundBrushProperty.Changed
+            ).AddClassHandler<TextPresenter>((x, _) => x.InvalidateFormattedText());
 
             CaretIndexProperty.Changed.AddClassHandler<TextPresenter>((x, e) => x.CaretIndexChanged((int)e.NewValue));
         }
@@ -184,7 +183,7 @@ namespace Avalonia.Controls.Presenters
         {
             get
             {
-                return _formattedText ?? (_formattedText = CreateFormattedText(Bounds.Size, Text));
+                return _formattedText ?? (_formattedText = CreateFormattedText());
             }
         }
 
@@ -219,7 +218,7 @@ namespace Avalonia.Controls.Presenters
             get => GetValue(SelectionForegroundBrushProperty);
             set => SetValue(SelectionForegroundBrushProperty, value);
         }
-        
+
         public IBrush CaretBrush
         {
             get => GetValue(CaretBrushProperty);
@@ -284,13 +283,9 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         protected void InvalidateFormattedText()
         {
-            if (_formattedText != null)
-            {
-                _constraint = _formattedText.Constraint;
-                _formattedText = null;
-            }
+            _formattedText = null;
 
-            InvalidateVisual();
+            InvalidateMeasure();
         }
 
         /// <summary>
@@ -307,6 +302,7 @@ namespace Avalonia.Controls.Presenters
             }
 
             FormattedText.Constraint = Bounds.Size;
+
             context.DrawText(Foreground, new Point(), FormattedText);
         }
 
@@ -424,20 +420,20 @@ namespace Avalonia.Controls.Presenters
         /// <summary>
         /// Creates the <see cref="FormattedText"/> used to render the text.
         /// </summary>
-        /// <param name="constraint">The constraint of the text.</param>
-        /// <param name="text">The text to generated the <see cref="FormattedText"/> for.</param>
         /// <returns>A <see cref="FormattedText"/> object.</returns>
-        protected virtual FormattedText CreateFormattedText(Size constraint, string text)
+        protected virtual FormattedText CreateFormattedText()
         {
             FormattedText result = null;
 
+            var text = Text;
+
             if (PasswordChar != default(char))
             {
-                result = CreateFormattedTextInternal(constraint, new string(PasswordChar, text?.Length ?? 0));
+                result = CreateFormattedTextInternal(_constraint, new string(PasswordChar, text?.Length ?? 0));
             }
             else
             {
-                result = CreateFormattedTextInternal(constraint, text);
+                result = CreateFormattedTextInternal(_constraint, text);
             }
 
             var selectionStart = SelectionStart;
@@ -467,12 +463,14 @@ namespace Avalonia.Controls.Presenters
             {
                 if (TextWrapping == TextWrapping.Wrap)
                 {
-                    FormattedText.Constraint = new Size(availableSize.Width, double.PositiveInfinity);
+                    _constraint = new Size(availableSize.Width, double.PositiveInfinity);
                 }
                 else
                 {
-                    FormattedText.Constraint = Size.Infinity;
+                    _constraint = Size.Infinity;
                 }
+
+                _formattedText = null;
 
                 return FormattedText.Bounds.Size;
             }

--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -81,7 +81,7 @@ namespace Avalonia.Controls.Presenters
                 TextBlock.FontSizeProperty.Changed, TextBlock.FontStyleProperty.Changed, 
                 TextBlock.FontWeightProperty.Changed, TextBlock.FontFamilyProperty.Changed,
                 SelectionStartProperty.Changed, SelectionEndProperty.Changed,
-                SelectionForegroundBrushProperty.Changed
+                SelectionForegroundBrushProperty.Changed, PasswordCharProperty.Changed
             ).AddClassHandler<TextPresenter>((x, _) => x.InvalidateFormattedText());
 
             CaretIndexProperty.Changed.AddClassHandler<TextPresenter>((x, e) => x.CaretIndexChanged((int)e.NewValue));

--- a/src/Avalonia.Visuals/Media/FormattedText.cs
+++ b/src/Avalonia.Visuals/Media/FormattedText.cs
@@ -200,7 +200,13 @@ namespace Avalonia.Media
 
         private void Set<T>(ref T field, T value)
         {
+            if (field != null && field.Equals(value))
+            {
+                return;
+            }
+
             field = value;
+
             _platformImpl = null;
         }
     }

--- a/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
+++ b/src/Skia/Avalonia.Skia/FormattedTextImpl.cs
@@ -149,7 +149,17 @@ namespace Avalonia.Skia
             if (index >= Text.Length || index < 0)
             {
                 var r = rects.LastOrDefault();
-                return new Rect(r.X + r.Width, r.Y, 0, _lineHeight);
+
+                var c = Text[Text.Length - 1];
+
+                switch (c)
+                {
+                    case '\n':
+                    case '\r':
+                        return new Rect(r.X, r.Y, 0, _lineHeight);
+                    default:
+                        return new Rect(r.X + r.Width, r.Y, 0, _lineHeight);
+                }
             }
             return rects[index];
         }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Text rendering related properties now properly invalidate the formatted text.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
TextBox isn't properly invalidated when certain properties change.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
TextBox properly measures and renders when text-related properties change.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Call InvalidateMeasure when text properties change.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
