### PR TITLE
Allow user to set GPU VMem limit.

### DIFF
--- a/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
+++ b/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
@@ -18,13 +18,17 @@ namespace Avalonia.Skia
 
         private GRContext GrContext { get; }
 
-        public PlatformRenderInterface(ICustomSkiaGpu customSkiaGpu)
+        public PlatformRenderInterface(ICustomSkiaGpu customSkiaGpu, long maxResourceBytes)
         {
             if (customSkiaGpu != null)
             {
                 _customSkiaGpu = customSkiaGpu;
 
                 GrContext = _customSkiaGpu.GrContext;
+
+                GrContext.GetResourceCacheLimits(out var maxResources, out _);
+
+                GrContext.SetResourceCacheLimits(maxResources, maxResourceBytes);
 
                 return;
             }
@@ -39,6 +43,10 @@ namespace Avalonia.Skia
                     : GRGlInterface.AssembleGlesInterface((_, proc) => display.GlInterface.GetProcAddress(proc)))
                 {
                     GrContext = GRContext.Create(GRBackend.OpenGL, iface);
+
+                    GrContext.GetResourceCacheLimits(out var maxResources, out _);
+
+                    GrContext.SetResourceCacheLimits(maxResources, maxResourceBytes);
                 }
                 display.ClearContext();
             }

--- a/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
+++ b/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
@@ -18,7 +18,7 @@ namespace Avalonia.Skia
 
         private GRContext GrContext { get; }
 
-        public PlatformRenderInterface(ICustomSkiaGpu customSkiaGpu, long maxResourceBytes)
+        public PlatformRenderInterface(ICustomSkiaGpu customSkiaGpu, long maxResourceBytes = 100000000)
         {
             if (customSkiaGpu != null)
             {

--- a/src/Skia/Avalonia.Skia/SkiaOptions.cs
+++ b/src/Skia/Avalonia.Skia/SkiaOptions.cs
@@ -8,9 +8,18 @@ namespace Avalonia
     /// </summary>
     public class SkiaOptions
     {
+        public SkiaOptions()
+        {
+            MaxGpuResourceSizeBytes = 512000000;
+        }
         /// <summary>
         /// Custom gpu factory to use. Can be used to customize behavior of Skia renderer.
         /// </summary>
         public Func<ICustomSkiaGpu> CustomGpuFactory { get; set; }
+
+        /// <summary>
+        /// The maximum number of bytes for video memory to store textures and resources.
+        /// </summary>
+        public long MaxGpuResourceSizeBytes { get; set; }
     }
 }

--- a/src/Skia/Avalonia.Skia/SkiaPlatform.cs
+++ b/src/Skia/Avalonia.Skia/SkiaPlatform.cs
@@ -18,7 +18,7 @@ namespace Avalonia.Skia
         public static void Initialize(SkiaOptions options)
         {
             var customGpu = options.CustomGpuFactory?.Invoke();
-            var renderInterface = new PlatformRenderInterface(customGpu);
+            var renderInterface = new PlatformRenderInterface(customGpu, options.MaxGpuResourceSizeBytes);
 
             AvaloniaLocator.CurrentMutable
                 .Bind<IPlatformRenderInterface>().ToConstant(renderInterface)


### PR DESCRIPTION
## What does the pull request do?
It allows the user to configure the resource memory available for skia when using gpu.

## What is the current behavior?
scrolling with even just a few images is extremely poor performance. Skia by default only allows 100mb for resources.. so a few small jpegs and that is used up. Then after that bitmaps have to be software rendered.

## What is the updated/expected behavior with this PR?
allow the user to increase the memory upper limit, and keep all the bitmaps in video memory.


## Fixed issues
#3043
