### PR TITLE
Fix Invalid DrawImage calls from Image class

### DIFF
--- a/src/Avalonia.Controls/Image.cs
+++ b/src/Avalonia.Controls/Image.cs
@@ -69,7 +69,7 @@ namespace Avalonia.Controls
         {
             var source = Source;
 
-            if (source != null && Bounds.Size != Size.Empty)
+            if (source != null && Bounds.Width > 0 && Bounds.Height > 0)
             {
                 Rect viewPort = new Rect(Bounds.Size);
                 Size sourceSize = source.Size;

--- a/src/Avalonia.Controls/Image.cs
+++ b/src/Avalonia.Controls/Image.cs
@@ -69,10 +69,11 @@ namespace Avalonia.Controls
         {
             var source = Source;
 
-            if (source != null)
+            if (source != null && Bounds.Size != Size.Empty)
             {
                 Rect viewPort = new Rect(Bounds.Size);
                 Size sourceSize = source.Size;
+
                 Vector scale = Stretch.CalculateScaling(Bounds.Size, sourceSize, StretchDirection);
                 Size scaledSize = sourceSize * scale;
                 Rect destRect = viewPort

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests.cs
@@ -935,6 +935,9 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
                     }
                 };
 
+                tree.Measure(Size.Infinity);
+                tree.Arrange(new Rect(new Size(100, 100)));
+
                 var scene = new Scene(tree);
                 var sceneBuilder = new SceneBuilder();
                 sceneBuilder.UpdateAll(scene);

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests.cs
@@ -920,13 +920,18 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
             {
-                var bitmap = RefCountable.Create(Mock.Of<IBitmapImpl>());
+                var bitmap = RefCountable.Create(Mock.Of<IBitmapImpl>(
+                    x => x.PixelSize == new PixelSize(100, 100) &&
+                    x.Dpi == new Vector(96, 96)));
+
                 Image img;
                 var tree = new TestRoot
                 {
                     Child = img = new Image
                     {
-                        Source = new Bitmap(bitmap)
+                        Source = new Bitmap(bitmap),
+                        Width = 100,
+                        Height = 100
                     }
                 };
 

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests.cs
@@ -360,7 +360,7 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
 
                 var result = initial.CloneScene();
                 sceneBuilder.Update(result, border);
-                
+
                 var borderNode = (VisualNode)result.Root.Children[0];
                 Assert.Same(border, borderNode.Visual);
 
@@ -880,15 +880,23 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
             {
-                var bitmap = RefCountable.Create(Mock.Of<IBitmapImpl>());
+                var bitmap = RefCountable.Create(Mock.Of<IBitmapImpl>(
+                    x => x.PixelSize == new PixelSize(100, 100) &&
+                    x.Dpi == new Vector(96, 96)));
+
                 Image img;
                 var tree = new TestRoot
                 {
                     Child = img = new Image
                     {
-                        Source = new Bitmap(bitmap)
+                        Source = new Bitmap(bitmap),
+                        Height = 100,
+                        Width = 100
                     }
                 };
+
+                tree.Measure(Size.Infinity);
+                tree.Arrange(new Rect(new Size(100, 100)));
 
                 Assert.Equal(2, bitmap.RefCount);
                 IRef<IDrawOperation> operation;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
fixes the issue discovered and described here:
https://github.com/AvaloniaUI/Avalonia/pull/3900#issuecomment-625531927

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
if an image has a source and its size is 0,0 (perfectly possible as user resizes some parts of the ui)

then it tries to calculate the scaling of the image to draw bitmap which ends up being 0 and it then  divides by zero here https://github.com/AvaloniaUI/Avalonia/blob/repro-invalid-draw-calls/src/Avalonia.Controls/Image.cs#L82

the result is `double.NaN` and it passes this to the DrawingContext.

This can cause random flickers and other inconsistencies when using the skia backend.

## What is the updated/expected behavior with this PR?
we wont attempt to draw an image if the size is 0.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
