### PR TITLE
Fixed more usages of deprecated APIs

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCell.cs
@@ -164,7 +164,7 @@ namespace Avalonia.Controls
             if (OwningGrid != null)
             {
                 OwningGrid.OnCellPointerPressed(new DataGridCellPointerPressedEventArgs(this, OwningRow, OwningColumn, e));
-                if (e.MouseButton == MouseButton.Left)
+                if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
                 {
                     if (!e.Handled)
                     //if (!e.Handled && OwningGrid.IsTabStop)

--- a/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
@@ -457,7 +457,7 @@ namespace Avalonia.Controls
 
         private void DataGridColumnHeader_PointerPressed(object sender, PointerPressedEventArgs e)
         {
-            if (OwningColumn == null || e.Handled || !IsEnabled || e.MouseButton != MouseButton.Left)
+            if (OwningColumn == null || e.Handled || !IsEnabled || e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
                 return;
             }

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -786,7 +786,7 @@ namespace Avalonia.Controls
 
         private void DataGridRow_PointerPressed(PointerPressedEventArgs e)
         {
-            if(e.MouseButton != MouseButton.Left)
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
                 return;
             }

--- a/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
@@ -277,7 +277,7 @@ namespace Avalonia.Controls
         //TODO TabStop
         private void DataGridRowGroupHeader_PointerPressed(PointerPressedEventArgs e)
         {
-            if (OwningGrid != null && e.MouseButton == MouseButton.Left)
+            if (OwningGrid != null && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
                 if (OwningGrid.IsDoubleClickRecordsClickOnCall(this) && !e.Handled)
                 {

--- a/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
@@ -164,7 +164,7 @@ namespace Avalonia.Controls.Primitives
         //TODO TabStop
         private void DataGridRowHeader_PointerPressed(object sender, PointerPressedEventArgs e)
         {
-            if(e.MouseButton != MouseButton.Left)
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
                 return;
             }

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -278,7 +278,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerPressed(e);
 
-            if (e.MouseButton == MouseButton.Left)
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
                 IsPressed = true;
                 e.Handled = true;

--- a/src/Avalonia.Controls/Calendar/CalendarButton.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarButton.cs
@@ -149,7 +149,8 @@ namespace Avalonia.Controls.Primitives
         protected override void OnPointerPressed(PointerPressedEventArgs e)
         {
             base.OnPointerPressed(e);
-            if (e.MouseButton == MouseButton.Left)
+
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
                 CalendarLeftMouseButtonDown?.Invoke(this, e);
         }
 

--- a/src/Avalonia.Controls/Calendar/CalendarDayButton.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarDayButton.cs
@@ -206,7 +206,7 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnPointerPressed(e);
 
-            if (e.MouseButton == MouseButton.Left)
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
                 CalendarDayButtonMouseDown?.Invoke(this, e);
         }
 

--- a/src/Avalonia.Controls/Calendar/DatePicker.cs
+++ b/src/Avalonia.Controls/Calendar/DatePicker.cs
@@ -839,7 +839,7 @@ namespace Avalonia.Controls
         }
         private void Calendar_PointerPressed(object sender, PointerPressedEventArgs e)
         {
-            if (e.MouseButton == MouseButton.Left)
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
                 e.Handled = true;
             }

--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -5,6 +5,7 @@ using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using Avalonia.Rendering;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 
 #nullable enable
 
@@ -338,8 +339,9 @@ namespace Avalonia.Controls.Platform
         protected internal virtual void PointerPressed(object sender, PointerPressedEventArgs e)
         {
             var item = GetMenuItem(e.Source as IControl);
+            var visual = (IVisual)sender;
 
-            if (e.MouseButton == MouseButton.Left && item?.HasSubMenu == true)
+            if (e.GetCurrentPoint(visual).Properties.IsLeftButtonPressed && item?.HasSubMenu == true)
             {
                 if (item.IsSubMenuOpen)
                 {

--- a/src/Avalonia.Controls/RepeatButton.cs
+++ b/src/Avalonia.Controls/RepeatButton.cs
@@ -88,7 +88,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerPressed(e);
 
-            if (e.MouseButton == MouseButton.Left)
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
                 StartTimer();
             }

--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -240,7 +240,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerPressed(e);
 
-            if (e.MouseButton == MouseButton.Left && e.Pointer.Type == PointerType.Mouse)
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed && e.Pointer.Type == PointerType.Mouse)
             {
                 e.Handled = UpdateSelectionFromEventSource(e.Source);
             }

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -290,7 +290,7 @@ namespace Avalonia.Controls
                 e.Handled = UpdateSelectionFromEventSource(
                     e.Source,
                     true,
-                    (e.InputModifiers & InputModifiers.Shift) != 0);
+                    (e.KeyModifiers & KeyModifiers.Shift) != 0);
             }
         }
 

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -675,7 +675,9 @@ namespace Avalonia.Controls
 
                 if (o != n)
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     RaisePropertyChanged(HasSystemDecorationsProperty, o, n);
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
             }
         }

--- a/src/Avalonia.Dialogs/ManagedFileChooserViewModel.cs
+++ b/src/Avalonia.Dialogs/ManagedFileChooserViewModel.cs
@@ -136,7 +136,7 @@ namespace Avalonia.Dialogs
                         : dialog is OpenFolderDialog ? "Select directory"
                         : throw new ArgumentException(nameof(dialog)));
 
-            var directory = dialog.InitialDirectory;
+            var directory = dialog.Directory;
 
             if (directory == null || !Directory.Exists(directory))
             {

--- a/src/Avalonia.Input/DragEventArgs.cs
+++ b/src/Avalonia.Input/DragEventArgs.cs
@@ -52,8 +52,10 @@ namespace Avalonia.Input
             Data = data;
             _target = target;
             _targetLocation = targetLocation;
-            Modifiers = (InputModifiers)keyModifiers;
             KeyModifiers = keyModifiers;
+#pragma warning disable CS0618 // Type or member is obsolete
+            Modifiers = (InputModifiers)keyModifiers;
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
     }

--- a/src/Avalonia.Input/FocusManager.cs
+++ b/src/Avalonia.Input/FocusManager.cs
@@ -186,8 +186,9 @@ namespace Avalonia.Input
         private static void OnPreviewPointerPressed(object sender, RoutedEventArgs e)
         {
             var ev = (PointerPressedEventArgs)e;
+            var visual = (IVisual)sender;
 
-            if (sender == e.Source && ev.MouseButton == MouseButton.Left)
+            if (sender == e.Source && ev.GetCurrentPoint(visual).Properties.IsLeftButtonPressed)
             {
                 IVisual element = ev.Pointer?.Captured ?? e.Source as IInputElement;
 

--- a/src/Avalonia.Input/Gestures.cs
+++ b/src/Avalonia.Input/Gestures.cs
@@ -1,5 +1,6 @@
 using System;
 using Avalonia.Interactivity;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Input
 {
@@ -71,12 +72,13 @@ namespace Avalonia.Input
             if (ev.Route == RoutingStrategies.Bubble)
             {
                 var e = (PointerPressedEventArgs)ev;
+                var visual = (IVisual)ev.Source;
 
                 if (e.ClickCount <= 1)
                 {
                     s_lastPress = new WeakReference<IInteractive>(e.Source);
                 }
-                else if (s_lastPress != null && e.ClickCount == 2 && e.MouseButton == MouseButton.Left)
+                else if (s_lastPress != null && e.ClickCount == 2 && e.GetCurrentPoint(visual).Properties.IsLeftButtonPressed)
                 {
                     if (s_lastPress.TryGetTarget(out var target) && target == e.Source)
                     {

--- a/src/Avalonia.Input/PointerEventArgs.cs
+++ b/src/Avalonia.Input/PointerEventArgs.cs
@@ -128,10 +128,10 @@ namespace Avalonia.Input
             _obsoleteClickCount = obsoleteClickCount;
         }
 
-        [Obsolete("Use DoubleTapped or DoubleRightTapped event instead")]
+        [Obsolete("Use DoubleTapped event or Gestures.DoubleRightTapped attached event")]
         public int ClickCount => _obsoleteClickCount;
 
-        [Obsolete("Use PointerUpdateKind")]
+        [Obsolete("Use PointerPressedEventArgs.GetCurrentPoint(this).Properties")]
         public MouseButton MouseButton => Properties.PointerUpdateKind.GetMouseButton();
     }
 
@@ -153,7 +153,7 @@ namespace Avalonia.Input
         /// </summary>
         public MouseButton InitialPressMouseButton { get; }
 
-        [Obsolete("Either use GetCurrentPoint(this).Properties.PointerUpdateKind or InitialPressMouseButton, see https://github.com/AvaloniaUI/Avalonia/wiki/Pointer-events-in-0.9 for more details", true)]
+        [Obsolete("Use InitialPressMouseButton")]
         public MouseButton MouseButton => InitialPressMouseButton;
     }
 

--- a/src/Avalonia.Input/Raw/RawDragEvent.cs
+++ b/src/Avalonia.Input/Raw/RawDragEvent.cs
@@ -20,8 +20,10 @@ namespace Avalonia.Input.Raw
             Location = location;
             Data = data;
             Effects = effects;
-            Modifiers = (InputModifiers)modifiers;
             KeyModifiers = KeyModifiersUtils.ConvertToKey(modifiers);
+#pragma warning disable CS0618 // Type or member is obsolete
+            Modifiers = (InputModifiers)modifiers;
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/src/Avalonia.Native/SystemDialogs.cs
+++ b/src/Avalonia.Native/SystemDialogs.cs
@@ -28,7 +28,7 @@ namespace Avalonia.Native
                 _native.OpenFileDialog(nativeParent,
                                         events, ofd.AllowMultiple,
                                         ofd.Title ?? "",
-                                        ofd.InitialDirectory ?? "",
+                                        ofd.Directory ?? "",
                                         ofd.InitialFileName ?? "",
                                         string.Join(";", dialog.Filters.SelectMany(f => f.Extensions)));
             }
@@ -37,7 +37,7 @@ namespace Avalonia.Native
                 _native.SaveFileDialog(nativeParent,
                                         events,
                                         dialog.Title ?? "",
-                                        dialog.InitialDirectory ?? "",
+                                        dialog.Directory ?? "",
                                         dialog.InitialFileName ?? "",
                                         string.Join(";", dialog.Filters.SelectMany(f => f.Extensions)));
             }
@@ -51,7 +51,7 @@ namespace Avalonia.Native
 
             var nativeParent = GetNativeWindow(parent);
 
-            _native.SelectFolderDialog(nativeParent, events, dialog.Title ?? "", dialog.InitialDirectory ?? "");
+            _native.SelectFolderDialog(nativeParent, events, dialog.Title ?? "", dialog.Directory ?? "");
 
             return events.Task.ContinueWith(t => { events.Dispose(); return t.Result.FirstOrDefault(); });
         }

--- a/src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs
+++ b/src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs
@@ -112,7 +112,7 @@ namespace Avalonia.X11.NativeDialogs
                 () => ShowDialog(dialog.Title, platformImpl,
                     dialog is OpenFileDialog ? GtkFileChooserAction.Open : GtkFileChooserAction.Save,
                     (dialog as OpenFileDialog)?.AllowMultiple ?? false,
-                    Path.Combine(string.IsNullOrEmpty(dialog.InitialDirectory) ? "" : dialog.InitialDirectory,
+                    Path.Combine(string.IsNullOrEmpty(dialog.Directory) ? "" : dialog.Directory,
                         string.IsNullOrEmpty(dialog.InitialFileName) ? "" : dialog.InitialFileName), dialog.Filters));
         }
 
@@ -125,7 +125,7 @@ namespace Avalonia.X11.NativeDialogs
             return await await RunOnGlibThread(async () =>
             {
                 var res = await ShowDialog(dialog.Title, platformImpl,
-                    GtkFileChooserAction.SelectFolder, false, dialog.InitialDirectory, null);
+                    GtkFileChooserAction.SelectFolder, false, dialog.Directory, null);
                 return res?.FirstOrDefault();
             });
         }

--- a/src/Windows/Avalonia.Win32/SystemDialogImpl.cs
+++ b/src/Windows/Avalonia.Win32/SystemDialogImpl.cs
@@ -56,11 +56,11 @@ namespace Avalonia.Win32
                 frm.SetFileTypes((uint)filters.Count, filters.ToArray());
                 frm.SetFileTypeIndex(0);
 
-                if (dialog.InitialDirectory != null)
+                if (dialog.Directory != null)
                 {
                     UnmanagedMethods.IShellItem directoryShellItem;
                     Guid riid = UnmanagedMethods.ShellIds.IShellItem;
-                    if (UnmanagedMethods.SHCreateItemFromParsingName(dialog.InitialDirectory, IntPtr.Zero, ref riid, out directoryShellItem) == (uint)UnmanagedMethods.HRESULT.S_OK)
+                    if (UnmanagedMethods.SHCreateItemFromParsingName(dialog.Directory, IntPtr.Zero, ref riid, out directoryShellItem) == (uint)UnmanagedMethods.HRESULT.S_OK)
                     {
                         frm.SetFolder(directoryShellItem);
                         frm.SetDefaultFolder(directoryShellItem);
@@ -114,21 +114,21 @@ namespace Avalonia.Win32
                 options |= (uint)(UnmanagedMethods.FOS.FOS_PICKFOLDERS | DefaultDialogOptions);
                 frm.SetOptions(options);
 
-                if (dialog.InitialDirectory != null)
+                if (dialog.Directory != null)
                 {
                     UnmanagedMethods.IShellItem directoryShellItem;
                     Guid riid = UnmanagedMethods.ShellIds.IShellItem;
-                    if (UnmanagedMethods.SHCreateItemFromParsingName(dialog.InitialDirectory, IntPtr.Zero, ref riid, out directoryShellItem) == (uint)UnmanagedMethods.HRESULT.S_OK)
+                    if (UnmanagedMethods.SHCreateItemFromParsingName(dialog.Directory, IntPtr.Zero, ref riid, out directoryShellItem) == (uint)UnmanagedMethods.HRESULT.S_OK)
                     {
                         frm.SetFolder(directoryShellItem);
                     }
                 }
 
-                if (dialog.DefaultDirectory != null)
+                if (dialog.Directory != null)
                 {
                     UnmanagedMethods.IShellItem directoryShellItem;
                     Guid riid = UnmanagedMethods.ShellIds.IShellItem;
-                    if (UnmanagedMethods.SHCreateItemFromParsingName(dialog.DefaultDirectory, IntPtr.Zero, ref riid, out directoryShellItem) == (uint)UnmanagedMethods.HRESULT.S_OK)
+                    if (UnmanagedMethods.SHCreateItemFromParsingName(dialog.Directory, IntPtr.Zero, ref riid, out directoryShellItem) == (uint)UnmanagedMethods.HRESULT.S_OK)
                     {
                         frm.SetDefaultFolder(directoryShellItem);
                     }

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_Multiple.cs
@@ -669,7 +669,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
             target.ApplyTemplate();
             target.Presenter.ApplyTemplate();
-            _helper.Click((Interactive)target.Presenter.Panel.Children[2], modifiers: InputModifiers.Shift);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[2], modifiers: KeyModifiers.Shift);
 
             var panel = target.Presenter.Panel;
 
@@ -713,17 +713,17 @@ namespace Avalonia.Controls.UnitTests.Primitives
             VerifyAdded("Bar");
 
             receivedArgs = null;
-            _helper.Click((Interactive)target.Presenter.Panel.Children[2], modifiers: InputModifiers.Control);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[2], modifiers: KeyModifiers.Control);
 
             VerifyAdded("Baz");
 
             receivedArgs = null;
-            _helper.Click((Interactive)target.Presenter.Panel.Children[3], modifiers: InputModifiers.Control);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[3], modifiers: KeyModifiers.Control);
 
             VerifyAdded("Qux");
 
             receivedArgs = null;
-            _helper.Click((Interactive)target.Presenter.Panel.Children[1], modifiers: InputModifiers.Control);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[1], modifiers: KeyModifiers.Control);
 
             VerifyRemoved("Bar");
         }
@@ -741,14 +741,14 @@ namespace Avalonia.Controls.UnitTests.Primitives
             target.ApplyTemplate();
             target.Presenter.ApplyTemplate();
             _helper.Click((Interactive)target.Presenter.Panel.Children[1]);
-            _helper.Click((Interactive)target.Presenter.Panel.Children[2], modifiers: InputModifiers.Control);
-            _helper.Click((Interactive)target.Presenter.Panel.Children[3], modifiers: InputModifiers.Control);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[2], modifiers: KeyModifiers.Control);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[3], modifiers: KeyModifiers.Control);
 
             Assert.Equal(1, target.SelectedIndex);
             Assert.Equal("Bar", target.SelectedItem);
             Assert.Equal(new[] { "Bar", "Baz", "Qux" }, target.SelectedItems);
 
-            _helper.Click((Interactive)target.Presenter.Panel.Children[1], modifiers: InputModifiers.Control);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[1], modifiers: KeyModifiers.Control);
 
             Assert.Equal(2, target.SelectedIndex);
             Assert.Equal("Baz", target.SelectedItem);
@@ -768,12 +768,12 @@ namespace Avalonia.Controls.UnitTests.Primitives
             target.ApplyTemplate();
             target.Presenter.ApplyTemplate();
             _helper.Click((Interactive)target.Presenter.Panel.Children[1]);
-            _helper.Click((Interactive)target.Presenter.Panel.Children[2], modifiers: InputModifiers.Control);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[2], modifiers: KeyModifiers.Control);
 
             Assert.Equal(1, target.SelectedIndex);
             Assert.Equal("Bar", target.SelectedItem);
 
-            _helper.Click((Interactive)target.Presenter.Panel.Children[2], modifiers: InputModifiers.Control);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[2], modifiers: KeyModifiers.Control);
 
             Assert.Equal(1, target.SelectedIndex);
             Assert.Equal("Bar", target.SelectedItem);
@@ -792,7 +792,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             target.ApplyTemplate();
             target.Presenter.ApplyTemplate();
             _helper.Click((Interactive)target.Presenter.Panel.Children[3]);
-            _helper.Click((Interactive)target.Presenter.Panel.Children[4], modifiers: InputModifiers.Control);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[4], modifiers: KeyModifiers.Control);
 
             var panel = target.Presenter.Panel;
 
@@ -813,7 +813,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             target.ApplyTemplate();
             target.Presenter.ApplyTemplate();
             _helper.Click((Interactive)target.Presenter.Panel.Children[3]);
-            _helper.Click((Interactive)target.Presenter.Panel.Children[5], modifiers: InputModifiers.Shift);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[5], modifiers: KeyModifiers.Shift);
 
             var panel = target.Presenter.Panel;
 
@@ -834,7 +834,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             target.ApplyTemplate();
             target.Presenter.ApplyTemplate();
             _helper.Click((Interactive)target.Presenter.Panel.Children[0]);
-            _helper.Click((Interactive)target.Presenter.Panel.Children[5], modifiers: InputModifiers.Shift);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[5], modifiers: KeyModifiers.Shift);
 
             var panel = target.Presenter.Panel;
 
@@ -878,12 +878,12 @@ namespace Avalonia.Controls.UnitTests.Primitives
             VerifyAdded("Bar");
 
             receivedArgs = null;
-            _helper.Click((Interactive)target.Presenter.Panel.Children[3], modifiers: InputModifiers.Shift);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[3], modifiers: KeyModifiers.Shift);
 
             VerifyAdded("Baz" ,"Qux");
 
             receivedArgs = null;
-            _helper.Click((Interactive)target.Presenter.Panel.Children[2], modifiers: InputModifiers.Shift);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[2], modifiers: KeyModifiers.Shift);
 
             VerifyRemoved("Qux");
         }
@@ -904,15 +904,15 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
             Assert.Equal(new[] { "Foo" }, target.SelectedItems);
 
-            _helper.Click((Interactive)target.Presenter.Panel.Children[4], modifiers: InputModifiers.Control);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[4], modifiers: KeyModifiers.Control);
 
             Assert.Equal(new[] { "Foo", "Bar" }, target.SelectedItems);
 
-            _helper.Click((Interactive)target.Presenter.Panel.Children[3], modifiers: InputModifiers.Control);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[3], modifiers: KeyModifiers.Control);
 
             Assert.Equal(new[] { "Foo", "Bar", "Foo" }, target.SelectedItems);
 
-            _helper.Click((Interactive)target.Presenter.Panel.Children[1], modifiers: InputModifiers.Control);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[1], modifiers: KeyModifiers.Control);
 
             Assert.Equal(new[] { "Foo", "Bar", "Foo", "Bar" }, target.SelectedItems);
         }
@@ -1174,7 +1174,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             target.ApplyTemplate();
             target.Presenter.ApplyTemplate();
             _helper.Click((Interactive)target.Presenter.Panel.Children[0]);
-            _helper.Click((Interactive)target.Presenter.Panel.Children[1], modifiers: InputModifiers.Shift);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[1], modifiers: KeyModifiers.Shift);
 
             Assert.Equal(2, target.SelectedItems.Count);
 
@@ -1224,7 +1224,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             target.Presenter.ApplyTemplate();
 
             _helper.Click((Interactive)target.Presenter.Panel.Children[0]);
-            _helper.Click((Interactive)target.Presenter.Panel.Children[2], MouseButton.Right, modifiers: InputModifiers.Shift);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[2], MouseButton.Right, modifiers: KeyModifiers.Shift);
 
             Assert.Equal(1, target.SelectedItems.Count);
         }
@@ -1244,7 +1244,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             target.Presenter.ApplyTemplate();
 
             _helper.Click((Interactive)target.Presenter.Panel.Children[0]);
-            _helper.Click((Interactive)target.Presenter.Panel.Children[2], MouseButton.Right, modifiers: InputModifiers.Control);
+            _helper.Click((Interactive)target.Presenter.Panel.Children[2], MouseButton.Right, modifiers: KeyModifiers.Control);
 
             Assert.Equal(1, target.SelectedItems.Count);
         }

--- a/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
@@ -167,7 +167,7 @@ namespace Avalonia.Controls.UnitTests
 
             Assert.True(container.IsSelected);
 
-            _mouse.Click(container, modifiers: InputModifiers.Control);
+            _mouse.Click(container, modifiers: KeyModifiers.Control);
 
             Assert.Null(target.SelectedItem);
             Assert.False(container.IsSelected);
@@ -202,7 +202,7 @@ namespace Avalonia.Controls.UnitTests
 
             Assert.True(container1.IsSelected);
 
-            _mouse.Click(container2, modifiers: InputModifiers.Control);
+            _mouse.Click(container2, modifiers: KeyModifiers.Control);
             
             Assert.Equal(item2, target.SelectedItem);
             Assert.False(container1.IsSelected);
@@ -234,15 +234,15 @@ namespace Avalonia.Controls.UnitTests
             var item1Container = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(item1);
             var item2Container = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(item2);
 
-            ClickContainer(item1Container, InputModifiers.Control);
+            ClickContainer(item1Container, KeyModifiers.Control);
             Assert.True(item1Container.IsSelected);
 
-            ClickContainer(item2Container, InputModifiers.Control);
+            ClickContainer(item2Container, KeyModifiers.Control);
             Assert.True(item2Container.IsSelected);
 
             Assert.Equal(new[] {item1, item2}, target.Selection.SelectedItems.OfType<Node>());
 
-            ClickContainer(item1Container, InputModifiers.Control);
+            ClickContainer(item1Container, KeyModifiers.Control);
             Assert.False(item1Container.IsSelected);
 
             Assert.DoesNotContain(item1, target.Selection.SelectedItems.OfType<Node>());
@@ -273,11 +273,11 @@ namespace Avalonia.Controls.UnitTests
             var fromContainer = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(from);
             var toContainer = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(to);
 
-            ClickContainer(fromContainer, InputModifiers.None);
+            ClickContainer(fromContainer, KeyModifiers.None);
 
             Assert.True(fromContainer.IsSelected);
 
-            ClickContainer(toContainer, InputModifiers.Shift);
+            ClickContainer(toContainer, KeyModifiers.Shift);
             AssertChildrenSelected(target, rootNode);
         }
 
@@ -306,11 +306,11 @@ namespace Avalonia.Controls.UnitTests
             var fromContainer = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(from);
             var toContainer = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(to);
 
-            ClickContainer(fromContainer, InputModifiers.None);
+            ClickContainer(fromContainer, KeyModifiers.None);
 
             Assert.True(fromContainer.IsSelected);
 
-            ClickContainer(toContainer, InputModifiers.Shift);
+            ClickContainer(toContainer, KeyModifiers.Shift);
             AssertChildrenSelected(target, rootNode);
         }
 
@@ -339,12 +339,12 @@ namespace Avalonia.Controls.UnitTests
             var fromContainer = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(from);
             var toContainer = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(to);
 
-            ClickContainer(fromContainer, InputModifiers.None);
+            ClickContainer(fromContainer, KeyModifiers.None);
 
-            ClickContainer(toContainer, InputModifiers.Shift);
+            ClickContainer(toContainer, KeyModifiers.Shift);
             AssertChildrenSelected(target, rootNode);
 
-            ClickContainer(fromContainer, InputModifiers.None);
+            ClickContainer(fromContainer, KeyModifiers.None);
 
             Assert.True(fromContainer.IsSelected);
 
@@ -660,8 +660,8 @@ namespace Avalonia.Controls.UnitTests
                 var fromContainer = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(from);
                 var toContainer = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(to);
 
-                ClickContainer(fromContainer, InputModifiers.None);
-                ClickContainer(toContainer, InputModifiers.Shift);
+                ClickContainer(fromContainer, KeyModifiers.None);
+                ClickContainer(toContainer, KeyModifiers.Shift);
 
                 var keymap = AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>();
                 var selectAllGesture = keymap.SelectAll.First();
@@ -706,8 +706,8 @@ namespace Avalonia.Controls.UnitTests
                 var fromContainer = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(from);
                 var toContainer = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(to);
 
-                ClickContainer(fromContainer, InputModifiers.None);
-                ClickContainer(toContainer, InputModifiers.Shift);
+                ClickContainer(fromContainer, KeyModifiers.None);
+                ClickContainer(toContainer, KeyModifiers.Shift);
 
                 var keymap = AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>();
                 var selectAllGesture = keymap.SelectAll.First();
@@ -778,8 +778,8 @@ namespace Avalonia.Controls.UnitTests
             var toContainer = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(to);
             var thenContainer = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(then);
 
-            ClickContainer(fromContainer, InputModifiers.None);
-            ClickContainer(toContainer, InputModifiers.Shift);
+            ClickContainer(fromContainer, KeyModifiers.None);
+            ClickContainer(toContainer, KeyModifiers.Shift);
 
             Assert.Equal(2, target.Selection.SelectedItems.Count);
 
@@ -813,7 +813,7 @@ namespace Avalonia.Controls.UnitTests
             var toContainer = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(to);
 
             _mouse.Click(fromContainer);
-            _mouse.Click(toContainer, MouseButton.Right, modifiers: InputModifiers.Shift);
+            _mouse.Click(toContainer, MouseButton.Right, modifiers: KeyModifiers.Shift);
 
             Assert.Equal(1, target.Selection.SelectedItems.Count);
         }
@@ -843,7 +843,7 @@ namespace Avalonia.Controls.UnitTests
             var toContainer = (TreeViewItem)target.ItemContainerGenerator.Index.ContainerFromItem(to);
 
             _mouse.Click(fromContainer);
-            _mouse.Click(toContainer, MouseButton.Right, modifiers: InputModifiers.Control);
+            _mouse.Click(toContainer, MouseButton.Right, modifiers: KeyModifiers.Control);
 
             Assert.Equal(1, target.Selection.SelectedItems.Count);
         }
@@ -963,7 +963,7 @@ namespace Avalonia.Controls.UnitTests
                 ApplyTemplates(target);
 
                 _mouse.Click(GetItem(target, 0));
-                _mouse.Click(GetItem(target, 1), modifiers: InputModifiers.Shift);
+                _mouse.Click(GetItem(target, 1), modifiers: KeyModifiers.Shift);
             }
         }
 
@@ -1170,7 +1170,7 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
-        void ClickContainer(IControl container, InputModifiers modifiers)
+        void ClickContainer(IControl container, KeyModifiers modifiers)
         {
             _mouse.Click(container, modifiers: modifiers);
         }

--- a/tests/Avalonia.Controls.UnitTests/Utils/HotKeyManagerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Utils/HotKeyManagerTests.cs
@@ -21,8 +21,8 @@ namespace Avalonia.Controls.UnitTests.Utils
                     .Bind<IWindowingPlatform>().ToConstant(new WindowingPlatformMock())
                     .Bind<IStyler>().ToConstant(styler.Object);
 
-                var gesture1 = new KeyGesture(Key.A, InputModifiers.Control);
-                var gesture2 = new KeyGesture(Key.B, InputModifiers.Control);
+                var gesture1 = new KeyGesture(Key.A, KeyModifiers.Control);
+                var gesture2 = new KeyGesture(Key.B, KeyModifiers.Control);
 
                 var tl = new Window();
                 var button = new Button();

--- a/tests/Avalonia.Input.UnitTests/MouseDeviceTests.cs
+++ b/tests/Avalonia.Input.UnitTests/MouseDeviceTests.cs
@@ -14,6 +14,7 @@ namespace Avalonia.Input.UnitTests
 {
     public class MouseDeviceTests
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         [Fact]
         public void Capture_Is_Transferred_To_Parent_When_Control_Removed()
         {
@@ -31,6 +32,7 @@ namespace Avalonia.Input.UnitTests
 
             Assert.Same(root, target.Captured);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         [Fact]
         public void MouseMove_Should_Update_IsPointerOver()
@@ -207,7 +209,9 @@ namespace Avalonia.Input.UnitTests
 
                 SendMouseMove(inputManager, root, new Point(11, 11));
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 var result = root.MouseDevice.GetPosition(root.Child);
+#pragma warning restore CS0618 // Type or member is obsolete
                 Assert.Equal(new Point(1, 11), result);
             }
         }


### PR DESCRIPTION
## What does the pull request do?

- Use `e.GetCurrentPoint(this).Properties` instead of `e.MouseButton` in pointer events
- Use `KeyModifiers` instead of `InputModifiers`
- Use `Directory` instead of `InitialDirectory` in file dialogs
- Improve `PointerEventArgs` deprecation messages
- Disable warnings when implementing deprecated API members
- Disable warnings for tests of deprecated APIs