### PR TITLE
Update TextPresenter.cs

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -301,8 +301,6 @@ namespace Avalonia.Controls.Presenters
                 context.FillRectangle(background, new Rect(Bounds.Size));
             }
 
-            FormattedText.Constraint = Bounds.Size;
-
             context.DrawText(Foreground, new Point(), FormattedText);
         }
 
@@ -315,10 +313,6 @@ namespace Avalonia.Controls.Presenters
             {
                 var start = Math.Min(selectionStart, selectionEnd);
                 var length = Math.Max(selectionStart, selectionEnd) - start;
-
-                // issue #600: set constraint before any FormattedText manipulation
-                //             see base.Render(...) implementation
-                FormattedText.Constraint = _constraint;
 
                 var rects = FormattedText.HitTestTextRange(start, length);
 
@@ -497,6 +491,14 @@ namespace Avalonia.Controls.Presenters
                     Constraint = availableSize,
                 }.Bounds.Size;
             }
+        }
+        
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            if (FormattedText != null)
+                FormattedText.Constraint = finalSize;
+
+            return base.ArrangeOverride(finalSize);
         }
 
         private int CoerceCaretIndex(int value)


### PR DESCRIPTION
## What does the pull request do?
Try to fix invalid selection in TextBox with right and center aligned text.


## What is the current behavior?

- Invalid selection rect due to wrong FormattedText constraint
- Rare invalid selection when TextBox call TextPresenter.GetCaretIndex before TextPresenter.Render

## What is the updated/expected behavior with this PR?
Valid selection rect (maybe)


## How was the solution implemented (if it's not obvious)?
Set FormattedText constraint on Arrange pass.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
