### PR TITLE
Handle requesting children of unrealized TreeView containers.

### DIFF
--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -395,7 +395,7 @@ namespace Avalonia.Controls
         private void OnSelectionModelChildrenRequested(object sender, SelectionModelChildrenRequestedEventArgs e)
         {
             var container = ItemContainerGenerator.Index.ContainerFromItem(e.Source) as ItemsControl;
-            e.Children = container.GetObservable(ItemsProperty);
+            e.Children = container?.GetObservable(ItemsProperty);
         }
 
         private TreeViewItem GetContainerInDirection(


### PR DESCRIPTION
## What does the pull request do?

As reported in #3910, `TreeView` was crashing when doing a multiple selection. This is because `SelectionModel` can request children of unrealized containers. Make sure we handle that.

## Fixed issues

Fixes #3910 