### PR TITLE
Always clear selection on SelectionNode Source change

### DIFF
--- a/src/Avalonia.Controls/SelectionNode.cs
+++ b/src/Avalonia.Controls/SelectionNode.cs
@@ -82,9 +82,9 @@ namespace Avalonia.Controls
             {
                 if (_source != value)
                 {
+                    ClearSelection();
                     if (_source != null)
                     {
-                        ClearSelection();
                         ClearChildNodes();
                         UnhookCollectionChangedHandler();
                     }

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Avalonia.Collections;
@@ -323,6 +324,26 @@ namespace Avalonia.Controls.UnitTests
             ApplyTemplate(target);
 
             Assert.NotEqual(dataContext, tabItem.Content);
+        }
+
+        [Fact]
+        public void Can_Have_Empty_Tab_Control()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <TabControl Name='tabs' Items='{Binding Tabs}'/>
+</Window>";
+                var loader = new Markup.Xaml.AvaloniaXamlLoader();
+                var window = (Window)loader.Load(xaml);
+                var tabControl = window.FindControl<TabControl>("tabs");
+
+                tabControl.DataContext = new { Tabs = new List<string>() };
+                window.ApplyTemplate();
+            }
         }
 
         private IControlTemplate TabControlTemplate()

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -6,6 +6,7 @@ using Avalonia.Collections;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
+using Avalonia.Controls.Utils;
 using Avalonia.LogicalTree;
 using Avalonia.Styling;
 using Avalonia.UnitTests;
@@ -343,6 +344,8 @@ namespace Avalonia.Controls.UnitTests
 
                 tabControl.DataContext = new { Tabs = new List<string>() };
                 window.ApplyTemplate();
+
+                Assert.Equal(0, tabControl.Items.Count());
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

Always clear selection on `SelectionNode.Source` change. This fixes #3919 which was caused by `SelectionNode.PopulateSelectedItemsFromSelectedIndices()` using an invalid selection in `ItemsSourceView!.GetAt(i)`.

In the [code SelectionNode is based on](https://github.com/microsoft/microsoft-ui-xaml/blob/ee03bace144e3a37650df0536955f5f658dd2aad/dev/Repeater/SelectionNode.cpp#L32), the selection is always cleared whenever the source changes.

## What is the current behavior?

Binding a `TabControl`'s `Items` property to an empty `List` would crash the app due to [this line](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/SelectionNode.cs#L911) using an invalid index. Basically, the code is currently assuming that there is always a selected tab (`SelectionMode` = `AlwaysSelected`). The comment for `AlwaysSelected` says that it means "An item will always be selected as long as there are items to select.", which implies that an empty source _should_ be OK, so the failing `TabControl` state is a legitimate thing for a user to do.

## What is the updated/expected behavior with this PR?

You can now bind to an empty list for `TabControl`.

## How was the solution implemented (if it's not obvious)?

Should be fairly straightforward.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Fixed issues

Fixes #3919

## Notes

There's probably an easier/better way to write the unit test, I'm guessing, but using the XAML for the unit test makes it fairly easy to understand what's being tested.
