### PR TITLE
Fix AutoCompleteBox Text Initialization Bug

### DIFF
--- a/src/Avalonia.Controls/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox.cs
@@ -10,6 +10,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
+using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Collections;
@@ -1100,6 +1101,7 @@ namespace Avalonia.Controls
                 {
                     _textBoxSubscriptions =
                         _textBox.GetObservable(TextBox.TextProperty)
+                                .Skip(1)
                                 .Subscribe(_ => OnTextBoxTextChanged());
 
                     if (Text != null)


### PR DESCRIPTION
## What does the pull request do?
Fixes a mistake made when porting the control that would cause setting `AutoCompleteBox.Text` before the template is loaded to open the search `DropDown`


## What is the current behavior?
`AutoComplete.OnTextBoxTextChanged()` gets called twice during the `TextBox` setter when `Text` has been set


## What is the updated/expected behavior with this PR?
`AutoComplete.OnTextBoxTextChanged()` only gets called on changes, not for its inital value.


## How was the solution implemented (if it's not obvious)?
The additon of `.Skip(1)` makes the `TextBox.TextProperty` observable behave the same the `TextChanged` event used in the original source code.

