### PR TITLE
Fix NextDrawAs in the DeferredRenderer

### DIFF
--- a/src/Avalonia.Visuals/Rendering/SceneGraph/DeferredDrawingContextImpl.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/DeferredDrawingContextImpl.cs
@@ -364,7 +364,7 @@ namespace Avalonia.Rendering.SceneGraph
             public int DrawOperationIndex { get; }
         }
 
-        private void Add(IDrawOperation node)
+        private void Add<T>(T node) where T : class, IDrawOperation
         {
             using (var refCounted = RefCountable.Create(node))
             {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes one inefficiency in the `DeferredRenderer`.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
`NextDrawAs<T>` generally never works since we invoke it as `NextDrawAs<RectangleNode>` and we store `IRef<IDrawOperation>`. Adding type parameter makes us store properly typed `IRef<RectangleNode`.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
