### PR TITLE
Unwrap TargetInvocationExceptionin remote protocol.

### DIFF
--- a/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
+++ b/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
@@ -234,18 +234,10 @@ namespace Avalonia.DesignerSupport.Remote
                 }
                 catch (Exception e)
                 {
-                    var xmlException = e as XmlException;
-                    
                     s_transport.Send(new UpdateXamlResultMessage
                     {
                         Error = e.ToString(),
-                        Exception = new ExceptionDetails
-                        {
-                            ExceptionType = e.GetType().FullName,
-                            Message = e.Message.ToString(),
-                            LineNumber = xmlException?.LineNumber,
-                            LinePosition = xmlException?.LinePosition,
-                        }
+                        Exception = new ExceptionDetails(e),
                     });
                 }
             }

--- a/src/Avalonia.Remote.Protocol/DesignMessages.cs
+++ b/src/Avalonia.Remote.Protocol/DesignMessages.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Xml;
 
 namespace Avalonia.Remote.Protocol.Designer
 {
@@ -26,6 +29,27 @@ namespace Avalonia.Remote.Protocol.Designer
     
     public class ExceptionDetails
     {
+        public ExceptionDetails()
+        {
+        }
+
+        public ExceptionDetails(Exception e)
+        {
+            if (e is TargetInvocationException)
+            {
+                e = e.InnerException;
+            }
+
+            ExceptionType = e.GetType().Name;
+            Message = e.Message;
+
+            if (e is XmlException xml)
+            {
+                LineNumber = xml.LineNumber;
+                LinePosition = xml.LinePosition;
+            }
+        }
+
         public string ExceptionType { get; set; }
         public string Message { get; set; }
         public int? LineNumber { get; set; }


### PR DESCRIPTION
## What does the pull request do?

Unwraps `TargetInvocationException` in the remote protocol, to provide a better error message to the designer. Users were getting a bunch of these exceptions, and they're not useful - we need the inner exception.
