### PR TITLE
Make sure that Path does not stay subscribed to Data indefinitely.

### DIFF
--- a/src/Avalonia.Controls/Shapes/Path.cs
+++ b/src/Avalonia.Controls/Shapes/Path.cs
@@ -1,5 +1,4 @@
 using System;
-using Avalonia.Data;
 using Avalonia.Media;
 
 namespace Avalonia.Controls.Shapes
@@ -8,6 +7,8 @@ namespace Avalonia.Controls.Shapes
     {
         public static readonly StyledProperty<Geometry> DataProperty =
             AvaloniaProperty.Register<Path, Geometry>(nameof(Data));
+
+        private EventHandler _geometryChangedHandler;
 
         static Path()
         {
@@ -21,21 +22,48 @@ namespace Avalonia.Controls.Shapes
             set { SetValue(DataProperty, value); }
         }
 
+        private EventHandler GeometryChangedHandler => _geometryChangedHandler ??= GeometryChanged;
+
         protected override Geometry CreateDefiningGeometry() => Data;
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+
+            if (Data is object)
+            {
+                Data.Changed += GeometryChangedHandler;
+            }
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+
+            if (Data is object)
+            {
+                Data.Changed -= GeometryChangedHandler;
+            }
+        }
 
         private void DataChanged(AvaloniaPropertyChangedEventArgs e)
         {
+            if (VisualRoot is null)
+            {
+                return;
+            }
+
             var oldGeometry = (Geometry)e.OldValue;
             var newGeometry = (Geometry)e.NewValue;
 
             if (oldGeometry is object)
             {
-                oldGeometry.Changed -= GeometryChanged;
+                oldGeometry.Changed -= GeometryChangedHandler;
             }
 
             if (newGeometry is object)
             {
-                newGeometry.Changed += GeometryChanged;
+                newGeometry.Changed += GeometryChangedHandler;
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/Shapes/PathTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Shapes/PathTests.cs
@@ -23,12 +23,16 @@ namespace Avalonia.Controls.UnitTests.Shapes
             var geometry = new EllipseGeometry { Rect = new Rect(0, 0, 10, 10) };
             var target = new Path { Data = geometry };
 
+            var root = new TestRoot(target);
+
             target.Measure(Size.Infinity);
             Assert.True(target.IsMeasureValid);
 
             geometry.Rect = new Rect(0, 0, 20, 20);
 
             Assert.False(target.IsMeasureValid);
+
+            root.Child = null;
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes a memory leak that was caused by `Path` control.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`Path` control will subscribe to `Data.Changed` event and in majority of cases it will never unsubscribe.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
`Path` only subscribes to `Data.Changed` when it is attached to the visual tree.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
This change changes `Subscribes_To_Geometry_Changes` test since before it implied that we will subscribe to all changes to the geometry which is no longer the case.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->