### PR TITLE
Fix leak in PropertySetterBindingInstance.

### DIFF
--- a/src/Avalonia.Styling/Styling/PropertySetterBindingInstance.cs
+++ b/src/Avalonia.Styling/Styling/PropertySetterBindingInstance.cs
@@ -24,6 +24,7 @@ namespace Avalonia.Styling
         private BindingValue<T> _value;
         private IDisposable? _subscription;
         private IDisposable? _subscriptionTwoWay;
+        private IDisposable? _innerSubscription;
         private bool _isActive;
 
         public PropertySetterBindingInstance(
@@ -121,6 +122,9 @@ namespace Avalonia.Styling
                 sub.Dispose();
             }
 
+            _innerSubscription?.Dispose();
+            _innerSubscription = null;
+
             base.Dispose();
         }
 
@@ -144,13 +148,13 @@ namespace Avalonia.Styling
 
         protected override void Subscribed()
         {
-            _subscription = _binding.Observable.Subscribe(_inner);
+            _innerSubscription = _binding.Observable.Subscribe(_inner);
         }
 
         protected override void Unsubscribed()
         {
-            _subscription?.Dispose();
-            _subscription = null;
+            _innerSubscription?.Dispose();
+            _innerSubscription = null;
         }
 
         private void PublishNext()


### PR DESCRIPTION
## What does the pull request do?

`PropertySetterBindingInstance_subscription` was being used twice: for the subscription from the `PropertySetterBindingInstance` to the control (line 69) and from the subscription to the source binding to the `PropertySetterBindingInstance` (line 151).

I'm afraid that I didn't do a unit test for this: creating the unit test was 100x more difficult than just fixing the problem - sorry :(