### PR TITLE
Enable the previewer in Avalonia samples.

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
       <IsPackable>false</IsPackable>
+      <AvaloniaPreviewerNetCoreToolPath>$(MSBuildThisFileDirectory)..\src\tools\Avalonia.Designer.HostApp\bin\Debug\netcoreapp2.0\Avalonia.Designer.HostApp.dll</AvaloniaPreviewerNetCoreToolPath>
   </PropertyGroup>
   <Import Project="..\build\SharedVersion.props" />
 </Project>


### PR DESCRIPTION
## What does the pull request do?

The previewer has been broken for a while in the Avalonia samples. Enable it again by setting the required MSBuild property.

Fixes #3966 
