### PR TITLE
Apply global clip to adorner element.

### DIFF
--- a/src/Avalonia.Controls/Primitives/AdornerLayer.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerLayer.cs
@@ -3,6 +3,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using Avalonia.Media;
 using Avalonia.Rendering;
+using Avalonia.Utilities;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.Primitives
@@ -78,15 +79,20 @@ namespace Avalonia.Controls.Primitives
 
         private void UpdateClip(IControl control, TransformedBounds bounds)
         {
-            var clip = control.Clip as RectangleGeometry;
-
-            if (clip == null)
+            if (!(control.Clip is RectangleGeometry clip))
             {
-                clip = new RectangleGeometry { Transform = new MatrixTransform() };
+                clip = new RectangleGeometry();
                 control.Clip = clip;
             }
 
-            clip.Rect = bounds.Bounds;
+            var clipBounds = bounds.Bounds;
+
+            if (bounds.Transform.HasInverse)
+            {
+                clipBounds = bounds.Clip.TransformToAABB(bounds.Transform.Invert());
+            }
+
+            clip.Rect = clipBounds;
         }
 
         private void ChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
## What does the pull request do?

Previously, the adorner clip was not taking into account the clip inherited from ancestor controls, resulting in #3984.

Fix this by applying the clip from `TransformedBounds.Clip` by translating it to local coordinates first. Note that this doesn't work well for controls with a render transform applied, but at least it fixes the issue in the common case.

## Notes

I didn't add any unit tests: a render test here would have been ideal, but I ended up heading down a long trail of shaving yaks to get that working. We need to refactor our render tests so they can render templated controls.

To correctly handle transformed controls, we need either:

- To have a way of applying a clip in global coordinates to a control
- To implement combining geometries

Both of those are bigger issues, so not addressed here.

## Fixed issues

Fixes #3984