### PR TITLE
Fix invalid navigation direction for Tab.

### DIFF
--- a/src/Avalonia.Input/NavigationDirection.cs
+++ b/src/Avalonia.Input/NavigationDirection.cs
@@ -102,7 +102,7 @@ namespace Avalonia.Input
             switch (key)
             {
                 case Key.Tab:
-                    return (modifiers & KeyModifiers.Shift) != 0 ?
+                    return (modifiers & KeyModifiers.Shift) == 0 ?
                         NavigationDirection.Next : NavigationDirection.Previous;
                 case Key.Up:
                     return NavigationDirection.Up;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes broken `ToNavigationDirection`.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`ToNavigationDirection` returns previous for TAB and next for SHIFT+TAB.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
TAB is next and SHIFT+TAB is previous

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
This part of the codebase is largely directly untested as it is used by other controls. Tests for controls are not picking this up.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
