### PR TITLE
prevent so with ResourceInclude and StyleInclude.

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ResourceInclude.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ResourceInclude.cs
@@ -51,7 +51,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
 
         bool IResourceNode.TryGetResource(object key, out object? value)
         {
-            if(!_isLoading)
+            if (!_isLoading)
             {
                 return Loaded.TryGetResource(key, out value);                
             }

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ResourceInclude.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ResourceInclude.cs
@@ -13,6 +13,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
     {
         private Uri? _baseUri;
         private IResourceDictionary? _loaded;
+        private bool _isLoading;
 
         /// <summary>
         /// Gets the loaded resource dictionary.
@@ -21,8 +22,9 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
         {
             get
             {
-                if (_loaded == null)
+                if (!_isLoading)
                 {
+                    _isLoading = true;
                     var loader = new AvaloniaXamlLoader();
                     _loaded = (IResourceDictionary)loader.Load(Source, _baseUri);
                 }

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ResourceInclude.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ResourceInclude.cs
@@ -12,8 +12,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
     public class ResourceInclude : IResourceProvider
     {
         private Uri? _baseUri;
-        private IResourceDictionary? _loaded;
-        private bool _isLoading;
+        private IResourceDictionary? _loaded;        
 
         /// <summary>
         /// Gets the loaded resource dictionary.
@@ -22,9 +21,8 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
         {
             get
             {
-                if (!_isLoading)
-                {
-                    _isLoading = true;
+                if (_loaded is null)
+                {                    
                     var loader = new AvaloniaXamlLoader();
                     _loaded = (IResourceDictionary)loader.Load(Source, _baseUri);
                 }

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ResourceInclude.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ResourceInclude.cs
@@ -22,7 +22,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
         {
             get
             {
-                if (_loaded is null)
+                if (_loaded == null)
                 {
                     _isLoading = true;
                     var loader = new AvaloniaXamlLoader();

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ResourceInclude.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/ResourceInclude.cs
@@ -12,7 +12,8 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
     public class ResourceInclude : IResourceProvider
     {
         private Uri? _baseUri;
-        private IResourceDictionary? _loaded;        
+        private IResourceDictionary? _loaded;
+        private bool _isLoading;
 
         /// <summary>
         /// Gets the loaded resource dictionary.
@@ -22,9 +23,11 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
             get
             {
                 if (_loaded is null)
-                {                    
+                {
+                    _isLoading = true;
                     var loader = new AvaloniaXamlLoader();
                     _loaded = (IResourceDictionary)loader.Load(Source, _baseUri);
+                    _isLoading = false;
                 }
 
                 return _loaded;
@@ -48,7 +51,13 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
 
         bool IResourceNode.TryGetResource(object key, out object? value)
         {
-            return Loaded.TryGetResource(key, out value);
+            if(!_isLoading)
+            {
+                return Loaded.TryGetResource(key, out value);                
+            }
+
+            value = null;
+            return false;
         }
 
         void IResourceProvider.AddOwner(IResourceHost owner) => Loaded.AddOwner(owner);

--- a/src/Markup/Avalonia.Markup.Xaml/Styling/StyleInclude.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Styling/StyleInclude.cs
@@ -13,8 +13,7 @@ namespace Avalonia.Markup.Xaml.Styling
     public class StyleInclude : IStyle, IResourceProvider
     {
         private readonly Uri _baseUri;
-        private IStyle[]? _loaded;
-        private bool _isLoading;
+        private IStyle[]? _loaded;        
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StyleInclude"/> class.
@@ -48,10 +47,8 @@ namespace Avalonia.Markup.Xaml.Styling
         {
             get
             {
-                if (!_isLoading)
+                if (_loaded is null)
                 {
-                    _isLoading = true;
-
                     var loader = new AvaloniaXamlLoader();
                     var loaded = (IStyle)loader.Load(Source, _baseUri);
                     _loaded = new[] { loaded };

--- a/src/Markup/Avalonia.Markup.Xaml/Styling/StyleInclude.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Styling/StyleInclude.cs
@@ -13,7 +13,8 @@ namespace Avalonia.Markup.Xaml.Styling
     public class StyleInclude : IStyle, IResourceProvider
     {
         private readonly Uri _baseUri;
-        private IStyle[]? _loaded;        
+        private IStyle[]? _loaded;
+        private bool _isLoading;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StyleInclude"/> class.
@@ -49,9 +50,11 @@ namespace Avalonia.Markup.Xaml.Styling
             {
                 if (_loaded is null)
                 {
+                    _isLoading = true;
                     var loader = new AvaloniaXamlLoader();
                     var loaded = (IStyle)loader.Load(Source, _baseUri);
                     _loaded = new[] { loaded };
+                    _isLoading = false;
                 }
 
                 return _loaded?[0]!;
@@ -84,7 +87,7 @@ namespace Avalonia.Markup.Xaml.Styling
 
         public bool TryGetResource(object key, out object? value)
         {
-            if (Loaded is IResourceProvider p)
+            if (!_isLoading && Loaded is IResourceProvider p)
             {
                 return p.TryGetResource(key, out value);
             }

--- a/src/Markup/Avalonia.Markup.Xaml/Styling/StyleInclude.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Styling/StyleInclude.cs
@@ -14,6 +14,7 @@ namespace Avalonia.Markup.Xaml.Styling
     {
         private readonly Uri _baseUri;
         private IStyle[]? _loaded;
+        private bool _isLoading;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StyleInclude"/> class.
@@ -47,8 +48,10 @@ namespace Avalonia.Markup.Xaml.Styling
         {
             get
             {
-                if (_loaded == null)
+                if (!_isLoading)
                 {
+                    _isLoading = true;
+
                     var loader = new AvaloniaXamlLoader();
                     var loaded = (IStyle)loader.Load(Source, _baseUri);
                     _loaded = new[] { loaded };

--- a/src/Markup/Avalonia.Markup.Xaml/Styling/StyleInclude.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Styling/StyleInclude.cs
@@ -48,7 +48,7 @@ namespace Avalonia.Markup.Xaml.Styling
         {
             get
             {
-                if (_loaded is null)
+                if (_loaded == null)
                 {
                     _isLoading = true;
                     var loader = new AvaloniaXamlLoader();

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/ResourceIncludeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/ResourceIncludeTests.cs
@@ -44,6 +44,36 @@ namespace Avalonia.Markup.Xaml.UnitTests.MakrupExtensions
                 }
             }
 
+            [Fact]
+            public void Missing_ResourceKey_In_ResourceInclude_Does_Not_Cause_StackOverflow()
+            {
+                var styleXaml = @"
+<ResourceDictionary xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <StaticResource x:Key='brush' ResourceKey='missing' />
+</ResourceDictionary>";
+
+                using (StartWithResources(("test:style.xaml", styleXaml)))
+                {
+                    var xaml = @"
+<Application xmlns='https://github.com/avaloniaui'
+             xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source='test:style.xaml'/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>";
+
+                    var loader = new AvaloniaXamlLoader();
+                    var app = Application.Current;
+
+                    loader.Load(xaml, null, app);
+                }
+            }
+
             private IDisposable StartWithResources(params (string, string)[] assets)
             {
                 var assetLoader = new MockAssetLoader(assets);

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/ResourceIncludeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/ResourceIncludeTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.UnitTests;
@@ -70,7 +71,14 @@ namespace Avalonia.Markup.Xaml.UnitTests.MakrupExtensions
                     var loader = new AvaloniaXamlLoader();
                     var app = Application.Current;
 
-                    loader.Load(xaml, null, app);
+                    try
+                    {
+                        loader.Load(xaml, null, app);
+                    }
+                    catch (KeyNotFoundException)
+                    {
+
+                    }
                 }
             }
 

--- a/tests/Avalonia.Markup.Xaml.UnitTests/StyleIncludeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/StyleIncludeTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Avalonia.UnitTests;
 using Xunit;
 
@@ -30,7 +31,14 @@ namespace Avalonia.Markup.Xaml.UnitTests
                 var loader = new AvaloniaXamlLoader();
                 var app = Application.Current;
 
-                loader.Load(xaml, null, app);
+                try
+                {
+                    loader.Load(xaml, null, app);
+                }
+                catch (KeyNotFoundException)
+                {
+
+                }
             }
         }
 

--- a/tests/Avalonia.Markup.Xaml.UnitTests/StyleIncludeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/StyleIncludeTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Markup.Xaml.UnitTests
+{
+    public class StyleIncludeTests : XamlTestBase
+    {
+        [Fact]
+        public void Missing_ResourceKey_In_StyleInclude_Does_Not_Cause_StackOverflow()
+        {
+            var styleXaml = @"
+<Style xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <Style.Resources>
+        <StaticResource x:Key='brush' ResourceKey='missing' />
+    </Style.Resources>
+</Style>";
+
+            using (StartWithResources(("test:style.xaml", styleXaml)))
+            {
+                var xaml = @"
+<Application xmlns='https://github.com/avaloniaui'
+             xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <Application.Styles>
+        <StyleInclude Source='test:style.xaml'/>
+    </Application.Styles>
+</Application>";
+
+                var loader = new AvaloniaXamlLoader();
+                var app = Application.Current;
+
+                loader.Load(xaml, null, app);
+            }
+        }
+
+        private IDisposable StartWithResources(params (string, string)[] assets)
+        {
+            var assetLoader = new MockAssetLoader(assets);
+            var services = new TestServices(assetLoader: assetLoader);
+            return UnitTestApplication.Start(services);
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Currently if you reference a resource from BaseDark or Light that doesnt exist.. you get a Stackoverfow.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
This prevents trying to recursively load the resource over and over again.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist
Id like to add a unit test, but it seems to be dependent on pre-compiled xaml...

so I couldnt get my test to do the same with identical xaml.

If we require a unit test, I would require some assistance.

issue is easily reproed...
https://github.com/AvaloniaUI/Avalonia/tree/fixes/stack-overflow-resources

just run control catalog here...

baseDark.xaml is cut down to trigger the bug with a single resource.

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
