### PR TITLE
Fix tooltip memory leak

### DIFF
--- a/src/Avalonia.Controls/ToolTip.cs
+++ b/src/Avalonia.Controls/ToolTip.cs
@@ -246,7 +246,7 @@ namespace Avalonia.Controls
             if (_popup != null)
             {
                 _popup.SetChild(null);
-                _popup.Hide();
+                _popup.Dispose();
                 _popup = null;
             }
         }


### PR DESCRIPTION
## What does the pull request do?
Fix memory leak caused by tooltips not disposing the popup window when the tooltip is closed.



## What is the current behavior?
Each time a tooltip is opened and closed, the application leaks a PopupImpl instance and all the tooltip UI controls and bound view models.


## What is the updated/expected behavior with this PR?
The popup window resources are freed when the tooltip closes.

To prove the fix run the ControlCatalog app in Visual Studio debugger. On the tooltip tab open and close the tooltip several times. Take a memory snapshot in Visual Studio and filter for PopupImpl there should be none. Previously there would be one for each time the tooltip opened and closed.
 

## How was the solution implemented (if it's not obvious)?
Called Dispose instead of Hide to close the tooltip popup window.


## Checklist
No unit tests


## Breaking changes
None


## Fixed issues
Fixes #2822

