### PR TITLE
Fluent AutoCompleteBox

### DIFF
--- a/src/Avalonia.Themes.Fluent/Accents/BaseDark.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/BaseDark.xaml
@@ -139,6 +139,7 @@
     <SolidColorBrush x:Key="SystemControlErrorTextForegroundBrush" Color="{StaticResource SystemErrorTextColor}" />
     <SolidColorBrush x:Key="SystemControlTransientBorderBrush" Color="#000000" Opacity="0.36" />
     <!--<AcrylicBrush x:Key="SystemControlTransientBackgroundBrush" BackgroundSource="HostBackdrop" TintColor="{StaticResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{StaticResource SystemChromeMediumLowColor}" />-->
+    <SolidColorBrush x:Key="SystemControlTransientBackgroundBrush" Color="{StaticResource SystemChromeMediumLowColor}" />
     <StaticResource x:Key="SystemControlDescriptionTextForegroundBrush" ResourceKey="SystemControlPageTextBaseMediumBrush" />
     <x:Boolean x:Key="IsApplicationFocusVisualKindReveal">False</x:Boolean>
 

--- a/src/Avalonia.Themes.Fluent/Accents/BaseDark.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/BaseDark.xaml
@@ -159,8 +159,8 @@
     <x:Double x:Key="AppBarThemeMinimalHeight">24</x:Double>
     <x:Double x:Key="AppBarThemeCompactHeight">40</x:Double>
     <x:Double x:Key="AppBarExpandButtonCircleDiameter">3</x:Double>
-    <x:Double x:Key="AutoSuggestListMaxHeight">374</x:Double>
-    <x:Double x:Key="AutoSuggestListBorderOpacity">0</x:Double>
+    <x:Double x:Key="AutoCompleteListMaxHeight">374</x:Double>
+    <x:Double x:Key="AutoCompleteListBorderOpacity">0</x:Double>
     <Thickness x:Key="CheckBoxBorderThemeThickness">2</Thickness>
     <Thickness x:Key="CheckBoxCheckedStrokeThickness">0</Thickness>
     <x:Double x:Key="ComboBoxArrowThemeFontSize">21</x:Double>
@@ -258,10 +258,10 @@
     <Thickness x:Key="AppBarTopBorderThemeThickness">0,0,0,0</Thickness>
     <Thickness x:Key="AppBarTopThemePadding">0,0,0,0</Thickness>
     <Thickness x:Key="AppBarExpandButtonCircleInnerPadding">3,0,3,0</Thickness>
-    <Thickness x:Key="AutoSuggestListBorderThemeThickness">1</Thickness>
-    <Thickness x:Key="AutoSuggestListMargin">0,2,0,2</Thickness>
-    <Thickness x:Key="AutoSuggestListPadding">-1,0,-1,0</Thickness>
-    <Thickness x:Key="AutoSuggestListViewItemMargin">12,11,0,13</Thickness>
+    <Thickness x:Key="AutoCompleteListBorderThemeThickness">1</Thickness>
+    <Thickness x:Key="AutoCompleteListMargin">0,2,0,2</Thickness>
+    <Thickness x:Key="AutoCompleteListPadding">-1,0,-1,0</Thickness>
+    <Thickness x:Key="AutoCompleteListViewItemMargin">12,11,0,13</Thickness>
     <Thickness x:Key="ButtonBorderThemeThickness">2</Thickness>
     <Thickness x:Key="CalendarDatePickerBorderThemeThickness">2</Thickness>
     <Thickness x:Key="ComboBoxBorderThemeThickness">2</Thickness>

--- a/src/Avalonia.Themes.Fluent/Accents/BaseDark.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/BaseDark.xaml
@@ -160,7 +160,6 @@
     <x:Double x:Key="AppBarThemeMinimalHeight">24</x:Double>
     <x:Double x:Key="AppBarThemeCompactHeight">40</x:Double>
     <x:Double x:Key="AppBarExpandButtonCircleDiameter">3</x:Double>
-    <x:Double x:Key="AutoCompleteListMaxHeight">374</x:Double>
     <x:Double x:Key="AutoCompleteListBorderOpacity">0</x:Double>
     <Thickness x:Key="CheckBoxBorderThemeThickness">2</Thickness>
     <Thickness x:Key="CheckBoxCheckedStrokeThickness">0</Thickness>

--- a/src/Avalonia.Themes.Fluent/Accents/BaseLight.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/BaseLight.xaml
@@ -158,8 +158,8 @@
     <x:Double x:Key="AppBarThemeMinimalHeight">24</x:Double>
     <x:Double x:Key="AppBarThemeCompactHeight">40</x:Double>
     <x:Double x:Key="AppBarExpandButtonCircleDiameter">3</x:Double>
-    <x:Double x:Key="AutoSuggestListMaxHeight">374</x:Double>
-    <x:Double x:Key="AutoSuggestListBorderOpacity">0</x:Double>
+    <x:Double x:Key="AutoCompleteListMaxHeight">374</x:Double>
+    <x:Double x:Key="AutoCompleteListBorderOpacity">0</x:Double>
     <Thickness x:Key="CheckBoxBorderThemeThickness">2</Thickness>
     <Thickness x:Key="CheckBoxCheckedStrokeThickness">0</Thickness>
     <x:Double x:Key="ComboBoxArrowThemeFontSize">21</x:Double>
@@ -257,10 +257,10 @@
     <Thickness x:Key="AppBarTopBorderThemeThickness">0,0,0,0</Thickness>
     <Thickness x:Key="AppBarTopThemePadding">0,0,0,0</Thickness>
     <Thickness x:Key="AppBarExpandButtonCircleInnerPadding">3,0,3,0</Thickness>
-    <Thickness x:Key="AutoSuggestListBorderThemeThickness">1</Thickness>
-    <Thickness x:Key="AutoSuggestListMargin">0,2,0,2</Thickness>
-    <Thickness x:Key="AutoSuggestListPadding">-1,0,-1,0</Thickness>
-    <Thickness x:Key="AutoSuggestListViewItemMargin">12,11,0,13</Thickness>
+    <Thickness x:Key="AutoCompleteListBorderThemeThickness">1</Thickness>
+    <Thickness x:Key="AutoCompleteListMargin">0,2,0,2</Thickness>
+    <Thickness x:Key="AutoCompleteListPadding">-1,0,-1,0</Thickness>
+    <Thickness x:Key="AutoCompleteListViewItemMargin">12,11,0,13</Thickness>
     <Thickness x:Key="ButtonBorderThemeThickness">2</Thickness>
     <Thickness x:Key="CalendarDatePickerBorderThemeThickness">2</Thickness>
     <Thickness x:Key="ComboBoxBorderThemeThickness">2</Thickness>

--- a/src/Avalonia.Themes.Fluent/Accents/BaseLight.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/BaseLight.xaml
@@ -159,7 +159,6 @@
     <x:Double x:Key="AppBarThemeMinimalHeight">24</x:Double>
     <x:Double x:Key="AppBarThemeCompactHeight">40</x:Double>
     <x:Double x:Key="AppBarExpandButtonCircleDiameter">3</x:Double>
-    <x:Double x:Key="AutoCompleteListMaxHeight">374</x:Double>
     <x:Double x:Key="AutoCompleteListBorderOpacity">0</x:Double>
     <Thickness x:Key="CheckBoxBorderThemeThickness">2</Thickness>
     <Thickness x:Key="CheckBoxCheckedStrokeThickness">0</Thickness>

--- a/src/Avalonia.Themes.Fluent/Accents/BaseLight.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/BaseLight.xaml
@@ -139,6 +139,7 @@
     <SolidColorBrush x:Key="SystemControlErrorTextForegroundBrush" Color="{StaticResource SystemErrorTextColor}" />
     <SolidColorBrush x:Key="SystemControlTransientBorderBrush" Color="#000000" Opacity="0.14" />
     <!--<AcrylicBrush x:Key="SystemControlTransientBackgroundBrush" BackgroundSource="HostBackdrop" TintColor="{StaticResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{StaticResource SystemChromeMediumLowColor}" />-->
+    <SolidColorBrush x:Key="SystemControlTransientBackgroundBrush" Color="{StaticResource SystemChromeMediumLowColor}" />
     <StaticResource x:Key="SystemControlDescriptionTextForegroundBrush" ResourceKey="SystemControlPageTextBaseMediumBrush" />
     <x:Boolean x:Key="IsApplicationFocusVisualKindReveal">False</x:Boolean>
 

--- a/src/Avalonia.Themes.Fluent/Accents/FluentBaseDark.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/FluentBaseDark.xaml
@@ -135,6 +135,12 @@
     <StaticResource x:Key="ContentLinkForegroundColor" ResourceKey="SystemControlHyperlinkTextBrush" />
     <StaticResource x:Key="ContentLinkBackgroundColor" ResourceKey="SystemControlPageBackgroundChromeLowBrush" />
 
+    <!-- Resources for AutoCompleteBox.xaml -->
+    <StaticResource x:Key="AutoCompleteBoxLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+    <StaticResource x:Key="AutoCompleteBoxSuggestionsListBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
+    <StaticResource x:Key="AutoCompleteBoxSuggestionsListBorderBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />
+    <x:Double x:Key="AutoCompleteBoxIconFontSize">12</x:Double>
+
     <!-- BaseResources for CheckBox.xaml -->
     <StaticResource x:Key="CheckBoxForegroundUnchecked" ResourceKey="SystemControlForegroundBaseHighBrush" />
     <StaticResource x:Key="CheckBoxForegroundUncheckedPointerOver" ResourceKey="SystemControlForegroundBaseHighBrush" />

--- a/src/Avalonia.Themes.Fluent/Accents/FluentBaseLight.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/FluentBaseLight.xaml
@@ -136,6 +136,12 @@
     <StaticResource x:Key="ContentLinkForegroundColor" ResourceKey="SystemControlHyperlinkTextBrush" />
     <StaticResource x:Key="ContentLinkBackgroundColor" ResourceKey="SystemControlPageBackgroundChromeLowBrush" />
 
+    <!-- Resources for AutoCompleteBox.xaml -->
+    <StaticResource x:Key="AutoCompleteBoxLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+    <StaticResource x:Key="AutoCompleteBoxSuggestionsListBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
+    <StaticResource x:Key="AutoCompleteBoxSuggestionsListBorderBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />
+    <x:Double x:Key="AutoCompleteBoxIconFontSize">12</x:Double>
+
     <!-- BaseResources for CheckBox.xaml -->
     <StaticResource x:Key="CheckBoxForegroundUnchecked" ResourceKey="SystemControlForegroundBaseHighBrush" />
     <StaticResource x:Key="CheckBoxForegroundUncheckedPointerOver" ResourceKey="SystemControlForegroundBaseHighBrush" />

--- a/src/Avalonia.Themes.Fluent/Accents/FluentControlResourcesDark.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/FluentControlResourcesDark.xaml
@@ -83,8 +83,8 @@
     <StaticResource x:Key="TextControlPlaceholderForegroundFocused" ResourceKey="SystemControlForegroundBaseMediumLowBrush" />
 
     <!-- Resources for AutoCompleteBox.xaml -->
-    <StaticResource x:Key="AutoCompleteBoxSuggestionsListBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
-    <StaticResource x:Key="AutoCompleteBoxSuggestionsListBorderBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />
+    <StaticResource x:Key="AutoCompleteBoxSuggestionsListBackground" ResourceKey="SystemControlTransientBackgroundBrush" />
+    <StaticResource x:Key="AutoCompleteBoxSuggestionsListBorderBrush" ResourceKey="SystemControlTransientBorderBrush" />
     <StaticResource x:Key="AutoCompleteBoxLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
     <x:Double x:Key="AutoCompleteBoxIconFontSize">12</x:Double>
 

--- a/src/Avalonia.Themes.Fluent/Accents/FluentControlResourcesDark.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/FluentControlResourcesDark.xaml
@@ -82,6 +82,12 @@
     <StaticResource x:Key="TextControlForegroundFocused" ResourceKey="SystemControlForegroundBaseHighBrush" />
     <StaticResource x:Key="TextControlPlaceholderForegroundFocused" ResourceKey="SystemControlForegroundBaseMediumLowBrush" />
 
+    <!-- Resources for AutoCompleteBox.xaml -->
+    <StaticResource x:Key="AutoCompleteBoxSuggestionsListBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
+    <StaticResource x:Key="AutoCompleteBoxSuggestionsListBorderBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />
+    <StaticResource x:Key="AutoCompleteBoxLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+    <x:Double x:Key="AutoCompleteBoxIconFontSize">12</x:Double>
+
     <!-- Resources for Checkbox.xaml -->
     <Thickness x:Key="CheckBoxBorderThemeThickness">1</Thickness>
     <Thickness x:Key="CheckBoxCheckedStrokeThickness">0</Thickness>

--- a/src/Avalonia.Themes.Fluent/Accents/FluentControlResourcesLight.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/FluentControlResourcesLight.xaml
@@ -82,6 +82,12 @@
     <StaticResource x:Key="TextControlForegroundFocused" ResourceKey="SystemControlForegroundBaseHighBrush" />
     <StaticResource x:Key="TextControlPlaceholderForegroundFocused" ResourceKey="SystemControlForegroundBaseMediumLowBrush" />
 
+    <!-- Resources for AutoCompleteBox.xaml -->
+    <StaticResource x:Key="AutoCompleteBoxSuggestionsListBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
+    <StaticResource x:Key="AutoCompleteBoxSuggestionsListBorderBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />
+    <StaticResource x:Key="AutoCompleteBoxLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+    <x:Double x:Key="AutoCompleteBoxIconFontSize">12</x:Double>
+
     <!-- Resources for CheckBox.xaml -->
     <x:Double x:Key="CheckBoxBorderThemeThickness">1</x:Double>
     <x:Double x:Key="CheckBoxCheckedStrokeThickness">0</x:Double>

--- a/src/Avalonia.Themes.Fluent/Accents/FluentControlResourcesLight.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/FluentControlResourcesLight.xaml
@@ -83,8 +83,8 @@
     <StaticResource x:Key="TextControlPlaceholderForegroundFocused" ResourceKey="SystemControlForegroundBaseMediumLowBrush" />
 
     <!-- Resources for AutoCompleteBox.xaml -->
-    <StaticResource x:Key="AutoCompleteBoxSuggestionsListBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
-    <StaticResource x:Key="AutoCompleteBoxSuggestionsListBorderBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />
+    <StaticResource x:Key="AutoCompleteBoxSuggestionsListBackground" ResourceKey="SystemControlTransientBackgroundBrush" />
+    <StaticResource x:Key="AutoCompleteBoxSuggestionsListBorderBrush" ResourceKey="SystemControlTransientBorderBrush" />
     <StaticResource x:Key="AutoCompleteBoxLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
     <x:Double x:Key="AutoCompleteBoxIconFontSize">12</x:Double>
 

--- a/src/Avalonia.Themes.Fluent/AutoCompleteBox.xaml
+++ b/src/Avalonia.Themes.Fluent/AutoCompleteBox.xaml
@@ -1,37 +1,64 @@
-<Styles xmlns="https://github.com/avaloniaui">
+<Styles xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <Design.PreviewWith>
+    <Border Padding="20">
+      <AutoCompleteBox Width="200">
+        <AutoCompleteBox.Items>
+          Alabama
+          Alaska
+          Arizona
+          Arkansas
+          California
+          Colorado
+          Connecticut
+          Delaware
+        </AutoCompleteBox.Items>
+      </AutoCompleteBox>
+    </Border>
+  </Design.PreviewWith>
+
   <Style Selector="AutoCompleteBox">
-    <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}"/>
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}"/>
-    <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
-    <Setter Property="Padding" Value="4"/>
+    <Setter Property="VerticalAlignment" Value="Top" />
+    <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
+    <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
+    <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Panel>
+        <Grid Name="PART_LayoutRoot">
           <TextBox Name="PART_TextBox"
-                   Background="{TemplateBinding Background}" 
-                   BorderBrush="{TemplateBinding BorderBrush}" 
-                   BorderThickness="{TemplateBinding BorderThickness}"
-                   Padding="{TemplateBinding Padding}"
                    Watermark="{TemplateBinding Watermark}"
+                   Width="{TemplateBinding Width}"
+                   Foreground="{TemplateBinding Foreground}"
+                   Background="{TemplateBinding Background}"
+                   BorderBrush="{TemplateBinding BorderBrush}"
+                   BorderThickness="{TemplateBinding BorderThickness}"
+                   FontSize="{TemplateBinding FontSize}"
+                   FontFamily="{TemplateBinding FontFamily}"
+                   FontWeight="{TemplateBinding FontWeight}"
+                   Margin="0"
                    DataValidationErrors.Errors="{TemplateBinding (DataValidationErrors.Errors)}" />
           
           <Popup Name="PART_Popup"
                  MinWidth="{Binding Bounds.Width, RelativeSource={RelativeSource TemplatedParent}}"
                  MaxHeight="{TemplateBinding MaxDropDownHeight}"
-                 PlacementTarget="{TemplateBinding}"
-                 StaysOpen="False">
-            <Border BorderBrush="{DynamicResource ThemeBorderMidBrush}"
-                    BorderThickness="1">
+                 StaysOpen="False"
+                 PlacementTarget="{TemplateBinding}">
+            <Border Name="PART_SuggestionsContainer"
+                    Padding="{DynamicResource AutoCompleteListMargin}"
+                    BorderThickness="{DynamicResource AutoCompleteListBorderThemeThickness}"
+                    BorderBrush="{DynamicResource AutoCompleteBoxSuggestionsListBorderBrush}"
+                    Background="{DynamicResource AutoCompleteBoxSuggestionsListBackground}"
+                    CornerRadius="{DynamicResource OverlayCornerRadius}">
               <ListBox Name="PART_SelectingItemsControl"
                        BorderThickness="0"
-                       Background="{TemplateBinding Background}"
-                       Foreground="{TemplateBinding Foreground}"
                        ItemTemplate="{TemplateBinding ItemTemplate}"
-                       ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                       ScrollViewer.VerticalScrollBarVisibility="Auto" />
+                       MaxHeight="{DynamicResource AutoCompleteListMaxHeight}"
+                       Margin="{DynamicResource AutoCompleteListPadding}" />
             </Border>
           </Popup>
-        </Panel>
+        </Grid>
       </ControlTemplate>
     </Setter>
   </Style>

--- a/src/Avalonia.Themes.Fluent/AutoCompleteBox.xaml
+++ b/src/Avalonia.Themes.Fluent/AutoCompleteBox.xaml
@@ -56,7 +56,6 @@
                        BorderThickness="0"
                        Foreground="{DynamicResource AutoCompleteBoxSuggestionsListForeground}"
                        ItemTemplate="{TemplateBinding ItemTemplate}"
-                       MaxHeight="{DynamicResource AutoCompleteListMaxHeight}"
                        Margin="{DynamicResource AutoCompleteListPadding}" />
             </Border>
           </Popup>

--- a/src/Avalonia.Themes.Fluent/AutoCompleteBox.xaml
+++ b/src/Avalonia.Themes.Fluent/AutoCompleteBox.xaml
@@ -24,6 +24,7 @@
     <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
     <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
     <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
+    <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="Template">
       <ControlTemplate>
         <Grid Name="PART_LayoutRoot">

--- a/src/Avalonia.Themes.Fluent/AutoCompleteBox.xaml
+++ b/src/Avalonia.Themes.Fluent/AutoCompleteBox.xaml
@@ -37,6 +37,7 @@
                    FontSize="{TemplateBinding FontSize}"
                    FontFamily="{TemplateBinding FontFamily}"
                    FontWeight="{TemplateBinding FontWeight}"
+                   Padding="{TemplateBinding Padding}"
                    Margin="0"
                    DataValidationErrors.Errors="{TemplateBinding (DataValidationErrors.Errors)}" />
           
@@ -53,6 +54,7 @@
                     CornerRadius="{DynamicResource OverlayCornerRadius}">
               <ListBox Name="PART_SelectingItemsControl"
                        BorderThickness="0"
+                       Foreground="{DynamicResource AutoCompleteBoxSuggestionsListForeground}"
                        ItemTemplate="{TemplateBinding ItemTemplate}"
                        MaxHeight="{DynamicResource AutoCompleteListMaxHeight}"
                        Margin="{DynamicResource AutoCompleteListPadding}" />


### PR DESCRIPTION
## What does the pull request do?
Fluent style for AutoCompleteBox.
This branch depends on feature/fluent-listbox, so for simpler code review I targeted this PR to that branch.

### What is missed in this PR, but exist in WinUI styles:
1. Clear and Query buttons in inner TextBox. It requires changes in default styles also - https://github.com/AvaloniaUI/Avalonia/issues/4022 and https://github.com/AvaloniaUI/Avalonia/issues/4023, not sure if Avalonia need it, so better to discuss.
2. [AutoSuggestBox.TextBoxStyle](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.autosuggestbox.textboxstyle?view=winrt-19041) which allows to customize inner TextBox. As I understand, Avalonia doesn't need it, because developers can use selectors like "AutoCompleteBox /template/ TextBox /template/ Border" @grokys @danwalmsley. Also WinUI/UWP default style in TextBoxStyle adds Clear and Query buttons.
2. Control's properties, which is not supported by Avalonia: [IsTabStop](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.control.istabstop?view=winrt-19041), [UseSystemFocusVisuals](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.control.usesystemfocusvisuals?view=winrt-19041), [CornerRadius](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.control.cornerradius?view=winrt-19041), [FontStretch](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.control.fontstretch?view=winrt-19041), [DesiredCandidateWindowAlignment](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.textbox.desiredcandidatewindowalignment?view=winrt-19041), [Header](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.textbox.header?view=winrt-19041) and [Description](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.textbox.description?view=winrt-19041) (last three are TextBox properties).
3. Empty [VisualStateGroup Orientation](https://github.com/microsoft/microsoft-ui-xaml/blob/master/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml#L391) with Landscape and Portrait states. Probably it exists in WinUI style for customization, but I can't remember or find information about those states and when they can be set.
4. Border CornerRadius doesn't provide same result as WinUI, because Popup doesn't support transparent background. There is related issue https://github.com/AvaloniaUI/Avalonia/issues/631
5. [AutoSuggestBoxHelper.KeepInteriorCornersSquare](https://github.com/microsoft/microsoft-ui-xaml/blob/master/dev/AutoSuggestBox/AutoSuggestBoxHelper.cpp) which changes controls' CornerRadius to avoid empty corners between TextBox and Popup. In Avalonia it could be done with selector from AutoCompleteBox to Popup and inner TextBox Border, but it is not actual problem in Avalonia because of non-transparent Popup - there's no any empty corners now.
6. Avalonia has MaxDropDownHeight property in the control and WinUI has AutoCompleteListMaxHeight resource. In this PR both were available, but it can confuse developers, so I removed AutoCompleteListMaxHeight. 

### Breaking changes (only for Fluent style)
1. Background property sets TextBox.Background and ListBox.Background in default style, but in WinUI and Fluent style is sets only TextBox.Background. AutoCompleteBoxSuggestionsListBackground is used for ListBox.Background instead.
2. Foreground property sets TextBox.Foreground and ListBox.Foreground in default style, but in WinUI and Fluent style is sets only TextBox.Foreground. There's no any way to set ListBox.Foreground.

In my opinion it is useful, when developer can set two different backgrounds for Popup and TextBox. But it doesn't match old behavior and there is not way to set ListBox.Foreground (except Style with specific selector). How should it be updated?