### PR TITLE
Restore pre-BoxShadow rect deflation behavior

### DIFF
--- a/src/Avalonia.Controls/Utils/BorderRenderHelper.cs
+++ b/src/Avalonia.Controls/Utils/BorderRenderHelper.cs
@@ -118,12 +118,11 @@ namespace Avalonia.Controls.Utils
                     pen = new Pen(borderBrush, borderThickness);
                 }
 
-                var rrect = new RoundedRect(new Rect(_size), _cornerRadius.TopLeft, _cornerRadius.TopRight,
-                    _cornerRadius.BottomRight, _cornerRadius.BottomLeft);
+                var rect = new Rect(_size);
                 if (Math.Abs(borderThickness) > double.Epsilon)
-                {
-                    rrect = rrect.Deflate(borderThickness * 0.5, borderThickness * 0.5);
-                }
+                    rect.Deflate(borderThickness * 0.5);
+                var rrect = new RoundedRect(rect, _cornerRadius.TopLeft, _cornerRadius.TopRight,
+                    _cornerRadius.BottomRight, _cornerRadius.BottomLeft);
 
                 context.PlatformImpl.DrawRectangle(background, pen, rrect, boxShadows);
             }


### PR DESCRIPTION
Should probably fix https://github.com/AvaloniaUI/Avalonia/issues/3985