### PR TITLE
Fix bringing items into view with ItemsRepeater

### DIFF
--- a/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml
+++ b/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml
@@ -16,12 +16,15 @@
       <Button Command="{Binding AddItem}">Add Item</Button>
       <Button Command="{Binding RandomizeHeights}">Randomize Heights</Button>
       <Button Command="{Binding ResetItems}">Reset items</Button>
+      <Button x:Name="scrollToLast">Scroll to Last</Button>
+      <Button x:Name="scrollToRandom">Scroll to Random</Button>
     </StackPanel>
     <Border BorderThickness="1" BorderBrush="{DynamicResource ThemeBorderMidBrush}" Margin="0 0 0 16">
       <ScrollViewer Name="scroller"
                     HorizontalScrollBarVisibility="Auto"
                     VerticalScrollBarVisibility="Auto">
-        <ItemsRepeater Name="repeater" Background="Transparent" Items="{Binding Items}">
+        <ItemsRepeater Name="repeater" Background="Transparent" Items="{Binding Items}"
+                       VerticalCacheLength="0" HorizontalCacheLength="0">
           <ItemsRepeater.ItemTemplate>
             <DataTemplate>
               <TextBlock Focusable="True" Height="{Binding Height}" Text="{Binding Text}"/>

--- a/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml
+++ b/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml
@@ -26,7 +26,10 @@
         <ItemsRepeater Name="repeater" Background="Transparent" Items="{Binding Items}">
           <ItemsRepeater.ItemTemplate>
             <DataTemplate>
-              <TextBlock Focusable="True" Height="{Binding Height}" Text="{Binding Text}"/>
+              <TextBlock Focusable="True"
+                         Background="{Binding Background}"
+                         Height="{Binding Height}"
+                         Text="{Binding Text}"/>
             </DataTemplate>
           </ItemsRepeater.ItemTemplate>
         </ItemsRepeater>

--- a/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml
+++ b/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml
@@ -23,8 +23,7 @@
       <ScrollViewer Name="scroller"
                     HorizontalScrollBarVisibility="Auto"
                     VerticalScrollBarVisibility="Auto">
-        <ItemsRepeater Name="repeater" Background="Transparent" Items="{Binding Items}"
-                       VerticalCacheLength="0" HorizontalCacheLength="0">
+        <ItemsRepeater Name="repeater" Background="Transparent" Items="{Binding Items}">
           <ItemsRepeater.ItemTemplate>
             <DataTemplate>
               <TextBlock Focusable="True" Height="{Binding Height}" Text="{Binding Text}"/>

--- a/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml.cs
@@ -84,6 +84,7 @@ namespace ControlCatalog.Pages
 
         private void ScrollTo(int index)
         {
+            System.Diagnostics.Debug.WriteLine("Scroll to " + index);
             var layoutManager = ((Window)this.GetVisualRoot()).LayoutManager;
             var element = _repeater.GetOrCreateElement(index);
             layoutManager.ExecuteLayoutPass();

--- a/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml.cs
@@ -5,23 +5,32 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
+using Avalonia.VisualTree;
 using ControlCatalog.ViewModels;
 
 namespace ControlCatalog.Pages
 {
     public class ItemsRepeaterPage : UserControl
     {
+        private readonly ItemsRepeaterPageViewModel _viewModel;
         private ItemsRepeater _repeater;
         private ScrollViewer _scroller;
+        private Button _scrollToLast;
+        private Button _scrollToRandom;
+        private Random _random = new Random(0);
 
         public ItemsRepeaterPage()
         {
             this.InitializeComponent();
             _repeater = this.FindControl<ItemsRepeater>("repeater");
             _scroller = this.FindControl<ScrollViewer>("scroller");
+            _scrollToLast = this.FindControl<Button>("scrollToLast");
+            _scrollToRandom = this.FindControl<Button>("scrollToRandom");
             _repeater.PointerPressed += RepeaterClick;
             _repeater.KeyDown += RepeaterOnKeyDown;
-            DataContext = new ItemsRepeaterPageViewModel();
+            _scrollToLast.Click += scrollToLast_Click;
+            _scrollToRandom.Click += scrollToRandom_Click;
+            DataContext = _viewModel = new ItemsRepeaterPageViewModel();
         }
 
         private void InitializeComponent()
@@ -73,18 +82,36 @@ namespace ControlCatalog.Pages
             }
         }
 
+        private void ScrollTo(int index)
+        {
+            var layoutManager = ((Window)this.GetVisualRoot()).LayoutManager;
+            var element = _repeater.GetOrCreateElement(index);
+            layoutManager.ExecuteLayoutPass();
+            element.BringIntoView();
+        }
+
         private void RepeaterClick(object sender, PointerPressedEventArgs e)
         {
             var item = (e.Source as TextBlock)?.DataContext as ItemsRepeaterPageViewModel.Item;
-            ((ItemsRepeaterPageViewModel)DataContext).SelectedItem = item;
+            _viewModel.SelectedItem = item;
         }
 
         private void RepeaterOnKeyDown(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.F5)
             {
-                ((ItemsRepeaterPageViewModel)DataContext).ResetItems();
+                _viewModel.ResetItems();
             }
+        }
+
+        private void scrollToLast_Click(object sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            ScrollTo(_viewModel.Items.Count - 1);
+        }
+
+        private void scrollToRandom_Click(object sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            ScrollTo(_random.Next(_viewModel.Items.Count - 1));
         }
     }
 }

--- a/samples/ControlCatalog/ViewModels/ItemsRepeaterPageViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/ItemsRepeaterPageViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Avalonia.Media;
 using ReactiveUI;
 
 namespace ControlCatalog.ViewModels
@@ -27,7 +28,7 @@ namespace ControlCatalog.ViewModels
         public void AddItem()
         {
             var index = SelectedItem != null ? Items.IndexOf(SelectedItem) : -1;
-            Items.Insert(index + 1, new Item { Text = $"New Item {_newItemIndex++}" });
+            Items.Insert(index + 1, new Item(index + 1) { Text = $"New Item {_newItemIndex++}" });
         }
 
         public void RandomizeHeights()
@@ -52,7 +53,7 @@ namespace ControlCatalog.ViewModels
             _newGenerationIndex++;
 
             return new ObservableCollection<Item>(
-                Enumerable.Range(1, 100000).Select(i => new Item
+                Enumerable.Range(1, 100000).Select(i => new Item(i)
                 {
                     Text = $"Item {i.ToString()} {suffix}"
                 }));
@@ -61,6 +62,12 @@ namespace ControlCatalog.ViewModels
         public class Item : ReactiveObject
         {
             private double _height = double.NaN;
+            private int _index;
+
+            public Item(int index)
+            {
+                _index = index;
+            }
 
             public string Text { get; set; }
             
@@ -69,6 +76,8 @@ namespace ControlCatalog.ViewModels
                 get => _height;
                 set => this.RaiseAndSetIfChanged(ref _height, value);
             }
+
+            public IBrush Background => ((_index % 2) == 0) ? Brushes.Yellow : Brushes.Wheat;
         }
     }
 }

--- a/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
+++ b/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
@@ -80,6 +80,7 @@ namespace Avalonia.Controls
         static ItemsRepeater()
         {
             ClipToBoundsProperty.OverrideDefaultValue<ItemsRepeater>(true);
+            RequestBringIntoViewEvent.AddClassHandler<ItemsRepeater>((x, e) => x.OnRequestBringIntoView(e));
         }
 
         /// <summary>
@@ -741,6 +742,11 @@ namespace Avalonia.Controls
             {
                 _processingItemsSourceChange = null;
             }
+        }
+
+        private void OnRequestBringIntoView(RequestBringIntoViewEventArgs e)
+        {
+            _viewportManager.OnBringIntoViewRequested(e);
         }
 
         private void InvalidateMeasureForLayout(object sender, EventArgs e) => InvalidateMeasure();

--- a/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
+++ b/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
@@ -10,6 +10,7 @@ using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Layout;
+using Avalonia.Logging;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Controls
@@ -306,6 +307,7 @@ namespace Avalonia.Controls
                             virtInfo.AutoRecycleCandidate &&
                             !virtInfo.KeepAlive)
                         {
+                            Logger.TryGet(LogEventLevel.Verbose)?.Log("Repeater", this, "AutoClear - {Index}", virtInfo.Index);
                             ClearElementImpl(element);
                         }
                     }

--- a/src/Avalonia.Controls/Repeater/RepeaterLayoutContext.cs
+++ b/src/Avalonia.Controls/Repeater/RepeaterLayoutContext.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Avalonia.Layout;
+using Avalonia.Logging;
 
 namespace Avalonia.Controls
 {
@@ -58,7 +59,11 @@ namespace Avalonia.Controls
 
         protected override object GetItemAtCore(int index) => _owner.ItemsSourceView.GetAt(index);
 
-        protected override void RecycleElementCore(ILayoutable element) => _owner.ClearElementImpl((IControl)element);
+        protected override void RecycleElementCore(ILayoutable element)
+        {
+            Logger.TryGet(LogEventLevel.Verbose)?.Log("Repeater", this, "RepeaterLayout - RecycleElement: {Index}", _owner.GetElementIndex((IControl)element));
+            _owner.ClearElementImpl((IControl)element);
+        }
 
         protected override Rect RealizationRectCore() => _owner.RealizationWindow;
     }

--- a/src/Avalonia.Controls/Repeater/ViewManager.cs
+++ b/src/Avalonia.Controls/Repeater/ViewManager.cs
@@ -11,6 +11,7 @@ using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.Logging;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Controls
@@ -60,11 +61,13 @@ namespace Avalonia.Controls
             if (suppressAutoRecycle)
             {
                 virtInfo.AutoRecycleCandidate = false;
+                Logger.TryGet(LogEventLevel.Verbose)?.Log("Repeater", this, "GetElement: {Index} Not AutoRecycleCandidate:", virtInfo.Index);
             }
             else
             {
                 virtInfo.AutoRecycleCandidate = true;
                 virtInfo.KeepAlive = true;
+                Logger.TryGet(LogEventLevel.Verbose)?.Log("Repeater", this, "GetElement: {Index} AutoRecycleCandidate:", virtInfo.Index);
             }
 
             return element;

--- a/src/Avalonia.Controls/Repeater/ViewportManager.cs
+++ b/src/Avalonia.Controls/Repeater/ViewportManager.cs
@@ -530,7 +530,7 @@ namespace Avalonia.Controls
             // partially remedey this by triggering also on Bounds changes, but this won't work so 
             // well for nested ItemsRepeaters.
             //
-            // UWP uses the EffectiveBoundsChanged event (which I think was implemented specially
+            // UWP uses the EffectiveViewportChanged event (which I think was implemented specially
             // for this case): we need to implement that in Avalonia.
             return control.GetObservable(Visual.TransformedBoundsProperty)
                 .Merge(control.GetObservable(Visual.BoundsProperty).Select(_ => control.TransformedBounds))

--- a/src/Avalonia.Controls/Repeater/ViewportManager.cs
+++ b/src/Avalonia.Controls/Repeater/ViewportManager.cs
@@ -459,6 +459,7 @@ namespace Avalonia.Controls
         private void UpdateViewport(Rect viewport)
         {
             var currentVisibleWindow = viewport;
+            var oldVisibleWindow = _visibleWindow;
 
             if (-currentVisibleWindow.X <= ItemsRepeater.ClearedElementsArrangePosition.X &&
                 -currentVisibleWindow.Y <= ItemsRepeater.ClearedElementsArrangePosition.Y)
@@ -471,7 +472,10 @@ namespace Avalonia.Controls
                 _visibleWindow = currentVisibleWindow;
             }
 
-            TryInvalidateMeasure();
+            if (_visibleWindow != oldVisibleWindow)
+            {
+                TryInvalidateMeasure();
+            }
         }
 
         private static void ValidateCacheLength(double cacheLength)

--- a/src/Avalonia.Controls/Repeater/ViewportManager.cs
+++ b/src/Avalonia.Controls/Repeater/ViewportManager.cs
@@ -306,8 +306,11 @@ namespace Avalonia.Controls
 
         public void OnMakeAnchor(IControl anchor, bool isAnchorOutsideRealizedRange)
         {
-            _makeAnchorElement = anchor;
-            _isAnchorOutsideRealizedRange = isAnchorOutsideRealizedRange;
+            if (_makeAnchorElement != anchor)
+            {
+                _makeAnchorElement = anchor;
+                _isAnchorOutsideRealizedRange = isAnchorOutsideRealizedRange;
+            }
         }
 
         public void OnBringIntoViewRequested(RequestBringIntoViewEventArgs args)
@@ -334,13 +337,12 @@ namespace Avalonia.Controls
                     ////}
                 }
 
-                // Register to rendering event to go back to how things were before where any child can be the anchor.
-                _isBringIntoViewInProgress = true;
-                ////if (!m_renderingToken)
-                ////{
-                ////    winrt::Windows::UI::Xaml::Media::CompositionTarget compositionTarget{ nullptr };
-                ////    m_renderingToken = compositionTarget.Rendering(winrt::auto_revoke, { this, &ViewportManagerWithPlatformFeatures::OnCompositionTargetRendering });
-                ////}
+                // Register action to go back to how things were before where any child can be the anchor.
+                if (!_isBringIntoViewInProgress)
+                {
+                    _isBringIntoViewInProgress = true;
+                    Dispatcher.UIThread.Post(OnCompositionTargetRendering);
+                }
             }
         }
 
@@ -360,6 +362,26 @@ namespace Avalonia.Controls
             }
 
             return targetChild;
+        }
+
+        private void OnCompositionTargetRendering()
+        {
+            _isBringIntoViewInProgress = false;
+            _makeAnchorElement = null;
+
+            // Now that the item has been brought into view, we can let the anchor provider pick a new anchor.
+            ////foreach (var child in _owner.Children)
+            ////{
+            ////    if (!child.CanBeScrollAnchor)
+            ////    {
+            ////        var info = ItemsRepeater.GetVirtualizationInfo(child);
+
+            ////        if (info.IsRealized && info.IsHeldByLayout)
+            ////        {
+            ////            child.CanBeScrollAnchor = true;
+            ////        }
+            ////    }
+            ////}
         }
 
         public void ResetScrollers()

--- a/src/Avalonia.Controls/Repeater/ViewportManager.cs
+++ b/src/Avalonia.Controls/Repeater/ViewportManager.cs
@@ -346,10 +346,14 @@ namespace Avalonia.Controls
                 }
 
                 // Register action to go back to how things were before where any child can be the anchor.
+                // Register action to go back to how things were before where any child can be the anchor. Here,
+                // WinUI uses CompositionTarget.Rendering but we don't currently have that, so post an action to
+                // run *after* rendering has completed (priority needs to be lower than Render as Transformed
+                // bounds must have been set in order for OnEffectiveViewportChanged to trigger).
                 if (!_isBringIntoViewInProgress)
                 {
                     _isBringIntoViewInProgress = true;
-                    Dispatcher.UIThread.Post(OnCompositionTargetRendering);
+                    Dispatcher.UIThread.Post(OnCompositionTargetRendering, DispatcherPriority.Loaded);
                 }
             }
         }

--- a/src/Avalonia.Controls/Repeater/ViewportManager.cs
+++ b/src/Avalonia.Controls/Repeater/ViewportManager.cs
@@ -383,19 +383,10 @@ namespace Avalonia.Controls
             _isBringIntoViewInProgress = false;
             _makeAnchorElement = null;
 
-            // Now that the item has been brought into view, we can let the anchor provider pick a new anchor.
-            ////foreach (var child in _owner.Children)
-            ////{
-            ////    if (!child.CanBeScrollAnchor)
-            ////    {
-            ////        var info = ItemsRepeater.GetVirtualizationInfo(child);
-
-            ////        if (info.IsRealized && info.IsHeldByLayout)
-            ////        {
-            ////            child.CanBeScrollAnchor = true;
-            ////        }
-            ////    }
-            ////}
+            // HACK: Invalidate measure now that the anchor has been removed so that a layout can be
+            // done with a proper realization rect. This is a hack not present upstream to try to fix
+            // https://github.com/microsoft/microsoft-ui-xaml/issues/1422
+            TryInvalidateMeasure();
         }
 
         public void ResetScrollers()

--- a/src/Avalonia.Controls/Repeater/ViewportManager.cs
+++ b/src/Avalonia.Controls/Repeater/ViewportManager.cs
@@ -35,8 +35,8 @@ namespace Avalonia.Controls
         // actually happened. This can happen in cases where no scrollviewer
         // in the parent chain can scroll in the shift direction.
         private Point _unshiftableShift;
-        private double _maximumHorizontalCacheLength = 0.0;
-        private double _maximumVerticalCacheLength = 0.0;
+        private double _maximumHorizontalCacheLength = 2.0;
+        private double _maximumVerticalCacheLength = 2.0;
         private double _horizontalCacheBufferPerSide;
         private double _verticalCacheBufferPerSide;
         private bool _isBringIntoViewInProgress;

--- a/src/Avalonia.Layout/AttachedLayout.cs
+++ b/src/Avalonia.Layout/AttachedLayout.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Layout
     /// </summary>
     public abstract class AttachedLayout : AvaloniaObject
     {
-        internal string LayoutId { get; set; }
+        public string LayoutId { get; set; }
 
         /// <summary>
         /// Occurs when the measurement state (layout) has been invalidated.

--- a/src/Avalonia.Layout/ElementManager.cs
+++ b/src/Avalonia.Layout/ElementManager.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using Avalonia.Layout.Utils;
+using Avalonia.Logging;
 
 namespace Avalonia.Layout
 {
@@ -78,6 +79,7 @@ namespace Avalonia.Layout
                 {
                     // Sentinel. Create the element now since we need it.
                     int dataIndex = GetDataIndexFromRealizedRangeIndex(realizedIndex);
+                    Logger.TryGet(LogEventLevel.Verbose)?.Log("Repeater", this, "Creating element for sentinal with data index {Index}", dataIndex);
                     element = _context.GetOrCreateElementAt(
                         dataIndex,
                         ElementRealizationOptions.ForceCreate | ElementRealizationOptions.SuppressAutoRecycle);
@@ -232,6 +234,8 @@ namespace Avalonia.Layout
                 {
                     Insert(0, dataIndex, element);
                 }
+
+                Logger.TryGet(LogEventLevel.Verbose)?.Log("Repeater", this, "{LayoutId}: Created element for index {index}", layoutId, dataIndex);
             }
         }
 

--- a/src/Avalonia.Layout/FlowLayoutAlgorithm.cs
+++ b/src/Avalonia.Layout/FlowLayoutAlgorithm.cs
@@ -394,20 +394,17 @@ namespace Avalonia.Layout
                 // If we did not reach the top or bottom of the extent, we realized one 
                 // extra item before we knew we were outside the realization window. Do not
                 // account for that element in the indicies inside the realization window.
-                if (count > 0)
+                if (direction == GenerateDirection.Forward)
                 {
-                    if (direction == GenerateDirection.Forward)
-                    {
-                        int dataCount = _context.ItemCount;
-                        _lastRealizedDataIndexInsideRealizationWindow = previousIndex == dataCount - 1 ? dataCount - 1 : previousIndex - 1;
-                        _lastRealizedDataIndexInsideRealizationWindow = Math.Max(0, _lastRealizedDataIndexInsideRealizationWindow);
-                    }
-                    else
-                    {
-                        int dataCount = _context.ItemCount;
-                        _firstRealizedDataIndexInsideRealizationWindow = previousIndex == 0 ? 0 : previousIndex + 1;
-                        _firstRealizedDataIndexInsideRealizationWindow = Math.Min(dataCount - 1, _firstRealizedDataIndexInsideRealizationWindow);
-                    }
+                    int dataCount = _context.ItemCount;
+                    _lastRealizedDataIndexInsideRealizationWindow = previousIndex == dataCount - 1 ? dataCount - 1 : previousIndex - 1;
+                    _lastRealizedDataIndexInsideRealizationWindow = Math.Max(0, _lastRealizedDataIndexInsideRealizationWindow);
+                }
+                else
+                {
+                    int dataCount = _context.ItemCount;
+                    _firstRealizedDataIndexInsideRealizationWindow = previousIndex == 0 ? 0 : previousIndex + 1;
+                    _firstRealizedDataIndexInsideRealizationWindow = Math.Min(dataCount - 1, _firstRealizedDataIndexInsideRealizationWindow);
                 }
 
                 _elementManager.DiscardElementsOutsideWindow(direction == GenerateDirection.Forward, currentIndex);

--- a/src/Avalonia.Layout/StackLayout.cs
+++ b/src/Avalonia.Layout/StackLayout.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Specialized;
 using Avalonia.Data;
+using Avalonia.Logging;
 
 namespace Avalonia.Layout
 {
@@ -107,8 +108,15 @@ namespace Avalonia.Layout
                             _orientation.MajorStart(extent) + 
                             (remainingItems * averageElementSize));
                 }
+                else
+                {
+                    Logger.TryGet(LogEventLevel.Verbose)?.Log("Repeater", this, "{LayoutId}: Estimating extent with no realized elements",
+                        LayoutId);
+                }
             }
 
+            Logger.TryGet(LogEventLevel.Verbose)?.Log("Repeater", this, "{LayoutId}: Extent is ({Size}). Based on average {Average}",
+                LayoutId, extent.Size, averageElementSize);
             return extent;
         }
 

--- a/src/Avalonia.Layout/UniformGridLayout.cs
+++ b/src/Avalonia.Layout/UniformGridLayout.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Specialized;
 using Avalonia.Data;
+using Avalonia.Logging;
 
 namespace Avalonia.Layout
 {
@@ -379,8 +380,14 @@ namespace Avalonia.Layout
                         ref extent,
                         _orientation.MajorEnd(lastRealizedLayoutBounds) - _orientation.MajorStart(extent) + (remainingItems / itemsPerLine) * lineSize);
                 }
+                else
+                {
+                    Logger.TryGet(LogEventLevel.Verbose)?.Log("Repeater", this, "{LayoutId}: Estimating extent with no realized elements", LayoutId);
+                }
             }
 
+            Logger.TryGet(LogEventLevel.Verbose)?.Log("Repeater", this, "{LayoutId}: Extent is ({Size}). Based on lineSize {LineSize} and items per line {ItemsPerLine}",
+                LayoutId, extent.Size, lineSize, itemsPerLine);
             return extent;
         }
 


### PR DESCRIPTION
## What does the pull request do?

`ItemsRepeater` has problems with bringing items into view. This PR aims to fix them

- Update ControlCatalog to add a "scroll to last" and "scroll to random" button for testing
- Handle `RequestBringIntoView` event in `ItemsRepeater`
- Fix difference between default values for cache size between `ItemsRepeater` and `ViewportManager`
- Add a callback to reset anchor element (WinUI does this on `CompositionTarget.Rendering` event - we don't have that so just schedule it using `DispatcherTimer`)
- Remove an old hack that seems to no longer be necessary
- Fix calculation of effective viewport

Note that this PR only fixes the issues on the Avalonia side. There are still bugs remaining in `ItemsRepeater` itself such as https://github.com/microsoft/microsoft-ui-xaml/issues/1422