### PR TITLE
LinuxFramebuffer: DrmOutput: Use the drmModeAddFB2 as main call and drmModeAddFB as fallback

### DIFF
--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/Drm.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/Drm.cs
@@ -267,6 +267,8 @@ namespace Avalonia.LinuxFramebuffer.Output
         [DllImport(libgbm, SetLastError = true)]
         public static extern uint gbm_bo_get_stride(IntPtr bo);
 
+        [DllImport(libgbm, SetLastError = true)]
+        public static extern uint gbm_bo_get_format(IntPtr bo);
 
         [StructLayout(LayoutKind.Explicit)]
         public struct GbmBoHandle

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/Drm.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/Drm.cs
@@ -176,7 +176,13 @@ namespace Avalonia.LinuxFramebuffer.Output
         [DllImport(libdrm, SetLastError = true)]
         public static extern int drmModeAddFB(int fd, uint width, uint height, byte depth,
             byte bpp, uint pitch, uint bo_handle,
-            out uint buf_id); 
+            out uint buf_id);
+
+        [DllImport(libdrm, SetLastError = true)]
+        public static extern int drmModeAddFB2(int fd, uint width, uint height,
+            uint pixel_format, uint[] bo_handles, uint[] pitches,
+            uint[] offsets, out uint buf_id, uint flags);
+
         [DllImport(libdrm, SetLastError = true)]
         public static extern int drmModeSetCrtc(int fd, uint crtcId, uint bufferId,
             uint x, uint y, uint *connectors, int count,
@@ -278,7 +284,7 @@ namespace Avalonia.LinuxFramebuffer.Output
         }
         
         [DllImport(libgbm, SetLastError = true)]
-        public static extern ulong gbm_bo_get_handle(IntPtr bo);
+        public static extern GbmBoHandle gbm_bo_get_handle(IntPtr bo);
 
         public static  class GbmColorFormats
         {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

I am working on a Toradex Apalis iMX6 that has a Vivante GPU and drivers for support KMS/DRM. Using the current mode, which uses the legacy call `drmModeAddFB` I get the following issue:

```
System.ComponentModel.Win32Exception (0xFFFFFFFE): drmModeAddFb failed
   at Avalonia.LinuxFramebuffer.Output.DrmOutput.GetFbIdForBo(IntPtr bo)
   at Avalonia.LinuxFramebuffer.Output.DrmOutput.Init(DrmCard card, DrmResources resources, DrmConnector connector, DrmModeInfo modeInfo)
   at Avalonia.LinuxFramebuffer.Output.DrmOutput..ctor(String path)
   at LinuxFramebufferPlatformExtensions.StartLinuxDrm[T](T builder, String[] args, String card, Double scaling)
   at TorizonAvaloniaSample.Program.Main(String[] args)
```

Taking a look at the `kmscube` implementation I saw that they use the `libdrm` call `drmModeAddFB2` together with `libgbm` `gbm_bo_get_format` for set the correct pixel format.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
