### PR TITLE
Fix KeyNotFound exception in Animatable

### DIFF
--- a/src/Avalonia.Animation/Animatable.cs
+++ b/src/Avalonia.Animation/Animatable.cs
@@ -93,16 +93,16 @@ namespace Avalonia.Animation
                 var oldTransitions = change.OldValue.GetValueOrDefault<Transitions>();
                 var newTransitions = change.NewValue.GetValueOrDefault<Transitions>();
 
-                if (oldTransitions is object)
-                {
-                    oldTransitions.CollectionChanged -= TransitionsCollectionChanged;
-                    RemoveTransitions(oldTransitions);
-                }
-
                 if (newTransitions is object)
                 {
                     newTransitions.CollectionChanged += TransitionsCollectionChanged;
                     AddTransitions(newTransitions);
+                }
+
+                if (oldTransitions is object)
+                {
+                    oldTransitions.CollectionChanged -= TransitionsCollectionChanged;
+                    RemoveTransitions(oldTransitions);
                 }
             }
             else if (_transitionsEnabled &&
@@ -111,8 +111,10 @@ namespace Avalonia.Animation
                      !change.Property.IsDirect &&
                      change.Priority > BindingPriority.Animation)
             {
-                foreach (var transition in Transitions)
+                for (var i = Transitions.Count -1; i >= 0; --i)
                 {
+                    var transition = Transitions[i];
+
                     if (transition.Property == change.Property)
                     {
                         var state = _transitionState[transition];


### PR DESCRIPTION
## What does the pull request do?

When transitions are replaced, add the new transitions before removing the old transitions, so that when the old transition being disposed causes the value to change, there is a corresponding entry in `_transitionStates`.

Also search the `Transitions` collection from last to first to find a matching transition, so that later added transitions have priority.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #4059
