### PR TITLE
build.sh: add downloaded dotnet to PATH

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -67,6 +67,8 @@ else
     fi
 fi
 
+export PATH=$DOTNET_DIRECTORY:$PATH
+
 echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
 
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" -- ${BUILD_ARGUMENTS[@]}


### PR DESCRIPTION
The nukebuild program is not run with the downloaded sdk in PATH so it may not find appropriate SDKs.