### PR TITLE
Unwrap BindingNotification in MultiBinding.

### DIFF
--- a/src/Markup/Avalonia.Markup/Data/MultiBinding.cs
+++ b/src/Markup/Avalonia.Markup/Data/MultiBinding.cs
@@ -107,6 +107,14 @@ namespace Avalonia.Data
 
         private object ConvertValue(IList<object> values, Type targetType, IMultiValueConverter converter)
         {
+            for (var i = 0; i < values.Count; ++i)
+            {
+                if (values[i] is BindingNotification notification)
+                {
+                    values[i] = notification.Value;
+                }
+            }
+
             var culture = CultureInfo.CurrentCulture;
             var converted = converter.Convert(values, targetType, ConverterParameter, culture);
 

--- a/tests/Avalonia.Markup.UnitTests/Data/MultiBindingTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/MultiBindingTests.cs
@@ -113,6 +113,50 @@ namespace Avalonia.Markup.UnitTests.Data
             Assert.Equal("(null)", target.Text);
         }
 
+        [Fact]
+        public void Should_Pass_UnsetValue_To_Converter_For_Broken_Binding()
+        {
+            var source = new { A = 1, B = 2, C = 3 };
+            var target = new TextBlock { DataContext = source };
+
+            var binding = new MultiBinding
+            {
+                Converter = new ConcatConverter(),
+                Bindings = new[]
+                {
+                    new Binding { Path = "A" },
+                    new Binding { Path = "B" },
+                    new Binding { Path = "Missing" },
+                },
+            };
+
+            target.Bind(TextBlock.TextProperty, binding);
+
+            Assert.Equal("1,2,(unset)", target.Text);
+        }
+
+        [Fact]
+        public void Should_Pass_FallbackValue_To_Converter_For_Broken_Binding()
+        {
+            var source = new { A = 1, B = 2, C = 3 };
+            var target = new TextBlock { DataContext = source };
+
+            var binding = new MultiBinding
+            {
+                Converter = new ConcatConverter(),
+                Bindings = new[]
+                {
+                    new Binding { Path = "A" },
+                    new Binding { Path = "B" },
+                    new Binding { Path = "Missing", FallbackValue = "Fallback" },
+                },
+            };
+
+            target.Bind(TextBlock.TextProperty, binding);
+
+            Assert.Equal("1,2,Fallback", target.Text);
+        }
+
         private class ConcatConverter : IMultiValueConverter
         {
             public object Convert(IList<object> values, Type targetType, object parameter, CultureInfo culture)


### PR DESCRIPTION
## What does the pull request do?

If a `Binding` in a `MultiBinding` produced an error then a `BindingNotification` would be passed to the converter, this may be unexpected. In WPF, an `UnsetValue` is passed to the converter, so do this in Avalonia too.

## Checklist

- [x] Added unit tests (if possible)?
