### PR TITLE
[WIP] Feature/Fluent ButtonSpinner + NumericUpDown

### DIFF
--- a/samples/ControlCatalog/Pages/NumericUpDownPage.xaml
+++ b/samples/ControlCatalog/Pages/NumericUpDownPage.xaml
@@ -50,22 +50,22 @@
         <TextBlock Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Margin="2">Text:</TextBlock>
         <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding #upDown.Text}" VerticalAlignment="Center" Margin="2" />
       </Grid>
-      <Grid Grid.Row="0" Grid.Column="2" Margin="10,2,2,2" RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="Auto, 120">
+      <Grid Grid.Row="0" Grid.Column="2" Margin="10,2,2,2" RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="Auto, Auto">
         <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="10,2,2,2">Minimum:</TextBlock>
         <NumericUpDown Grid.Row="0" Grid.Column="1" Value="{Binding #upDown.Minimum}"
-                       CultureInfo="{Binding #upDown.CultureInfo}" VerticalAlignment="Center" Margin="2" Width="70" HorizontalAlignment="Center"/>
+                       CultureInfo="{Binding #upDown.CultureInfo}" VerticalAlignment="Center" Margin="2" HorizontalAlignment="Center"/>
 
         <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Margin="10,2,2,2">Maximum:</TextBlock>
         <NumericUpDown Grid.Row="1" Grid.Column="1" Value="{Binding #upDown.Maximum}"
-                       CultureInfo="{Binding #upDown.CultureInfo}" VerticalAlignment="Center" Margin="2" Width="70" HorizontalAlignment="Center"/>
+                       CultureInfo="{Binding #upDown.CultureInfo}" VerticalAlignment="Center" Margin="2" HorizontalAlignment="Center"/>
 
         <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="10,2,2,2">Increment:</TextBlock>
         <NumericUpDown Grid.Row="2" Grid.Column="1" Value="{Binding #upDown.Increment}" VerticalAlignment="Center"
-                       Margin="2" Width="70" HorizontalAlignment="Center"/>
+                       Margin="2" HorizontalAlignment="Center"/>
 
         <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="10,2,2,2">Value:</TextBlock>
         <NumericUpDown Grid.Row="3" Grid.Column="1" Value="{Binding #upDown.Value}" VerticalAlignment="Center"
-                       Margin="2" Width="70" HorizontalAlignment="Center"/>
+                       Margin="2" HorizontalAlignment="Center"/>
 
       </Grid>
     </Grid>
@@ -73,7 +73,7 @@
     <StackPanel Margin="2,10,2,2" Orientation="Horizontal" Spacing="10">
       <TextBlock FontSize="14" FontWeight="Bold" VerticalAlignment="Center">Usage of NumericUpDown:</TextBlock>
       <NumericUpDown Name="upDown" Minimum="0" Maximum="10" Increment="0.5"
-                     CultureInfo="en-US" VerticalAlignment="Center" Width="100"
+                     CultureInfo="en-US" VerticalAlignment="Center"
                      Watermark="Enter text" FormatString="{Binding SelectedFormat.Value}"/>
     </StackPanel>
 

--- a/src/Avalonia.Controls/Converters/MarginMultiplierConverter.cs
+++ b/src/Avalonia.Controls/Converters/MarginMultiplierConverter.cs
@@ -18,10 +18,24 @@ namespace Avalonia.Controls.Converters
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (!(value is int depth))
-                return new Thickness(0);
-
-            return new Thickness(Left ? Indent * depth : 0, Top ? Indent * depth : 0, Right ? Indent * depth : 0, Bottom ? Indent * depth : 0);
+            if (value is int scalarDepth)
+            {
+                return new Thickness(
+                    Left ? Indent * scalarDepth : 0,
+                    Top ? Indent * scalarDepth : 0,
+                    Right ? Indent * scalarDepth : 0,
+                    Bottom ? Indent * scalarDepth : 0);
+            }
+            else if (value is Thickness thinknessDepth)
+            {
+                return new Thickness(
+                    Left ? Indent * thinknessDepth.Left : 0,
+                    Top ? Indent * thinknessDepth.Top : 0,
+                    Right ? Indent * thinknessDepth.Right : 0,
+                    Bottom ? Indent * thinknessDepth.Bottom : 0);
+            }
+            return new Thickness(0);
+            
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/Avalonia.Themes.Fluent/ButtonSpinner.xaml
+++ b/src/Avalonia.Themes.Fluent/ButtonSpinner.xaml
@@ -1,104 +1,206 @@
-<Styles xmlns="https://github.com/avaloniaui">
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:sys="clr-namespace:System;assembly=netstandard"
+        xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls">
+  <Design.PreviewWith>
+    <Border Padding="20"
+            Background="Black">
+      <StackPanel Spacing="20">
+        <ButtonSpinner ButtonSpinnerLocation="Right"
+                       Content="Right disabled inline spinner"
+                       AllowSpin="False" />
+        <ButtonSpinner ButtonSpinnerLocation="Left"
+                       Content="Left spinner" />
+        <ButtonSpinner ButtonSpinnerLocation="Right"
+                       Classes="CompactInlineButtonSpinner"
+                       Content="Right compact spinner" />
+        <ButtonSpinner ButtonSpinnerLocation="Left"
+                       Classes="CompactInlineButtonSpinner"
+                       AllowSpin="False"
+                       Content="Left disabled compact spinner" />
+        <ButtonSpinner ShowButtonSpinner="False"
+                       Content="Hide spinner" />
+      </StackPanel>
+    </Border>
+  </Design.PreviewWith>
+
+  <Styles.Resources>
+    <converters:MarginMultiplierConverter x:Key="ButtonSpinner_OnlyLeftThinknessConverter"
+                                          Indent="1"
+                                          Left="True" />
+    <converters:MarginMultiplierConverter x:Key="ButtonSpinner_OnlyRightThinknessConverter"
+                                          Indent="1"
+                                          Right="True" />
+
+    <StreamGeometry x:Key="ButtonSpinnerIncreaseButtonIcon">M0,9 L10,0 20,9 19,10 10,2 1,10 z</StreamGeometry>
+    <StreamGeometry x:Key="ButtonSpinnerDecreaseButtonIcon">M0,1 L10,10 20,1 19,0 10,8 1,0 z</StreamGeometry>
+    <StreamGeometry x:Key="ButtonSpinnerIncreaseDecreaseButtonIcon">M0,9 L10,0 20,9 19,10 10,2 1,10 z M0,16 L10,25 20,16 19,15 10,23 1,15 z</StreamGeometry>
+  </Styles.Resources>
+
+  <!--  RepeatButton.ButtonSpinnerRepeatButton  -->
+  <Style Selector="RepeatButton.ButtonSpinnerRepeatButton">
+    <Setter Property="MinWidth" Value="34" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+  </Style>
+
+  <Style Selector="RepeatButton.ButtonSpinnerRepeatButton /template/ ContentPresenter">
+    <Setter Property="BorderBrush" Value="{TemplateBinding BorderBrush}" />
+  </Style>
+  <Style Selector="RepeatButton.ButtonSpinnerRepeatButton:disabled">
+    <Setter Property="BorderBrush" Value="{TemplateBinding BorderBrush}" />
+  </Style>
+
+  <!--  ButtonSpinner  -->
   <Style Selector="ButtonSpinner">
-    <Setter Property="Background" Value="Transparent"/>
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}"/>
-    <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
-    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-    <Setter Property="VerticalContentAlignment" Value="Center"/>
-  </Style>
-  <Style Selector="ButtonSpinner /template/ RepeatButton">
-    <Setter Property="Background" Value="Transparent"/>
-    <Setter Property="BorderBrush" Value="Transparent"/>
-  </Style>
-  <Style Selector="ButtonSpinner /template/ RepeatButton:pointerover">
-    <Setter Property="Background" Value="{DynamicResource ThemeControlMidBrush}"/>
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}"/>
-  </Style>
-  <Style Selector="ButtonSpinner /template/ RepeatButton#PART_IncreaseButton">
-    <Setter Property="Content">
-      <Template>
-        <Path Fill="{DynamicResource ThemeForegroundBrush}"
-              Width="8"
-              Height="4"
-              Stretch="Uniform"
-              HorizontalAlignment="Center"
-              VerticalAlignment="Center"
-              Data="M0,5 L4.5,.5 9,5 6,5 4.5,3.5 3,5 z"/>
-      </Template>
-    </Setter>
-  </Style>
-  <Style Selector="ButtonSpinner /template/ RepeatButton#PART_DecreaseButton">
-    <Setter Property="Content">
-      <Template>
-        <Path Fill="{DynamicResource ThemeForegroundBrush}"
-              Width="8"
-              Height="4"
-              Stretch="Uniform"
-              HorizontalAlignment="Center"
-              VerticalAlignment="Center"
-              Data="M0,0 L3,0 4.5,1.5 6,0 9,0 4.5,4.5 z"/>
-      </Template>
-    </Setter>
-  </Style>
-  <Style Selector="ButtonSpinner:right">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="Padding" Value="10, 0" />
+    <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
+    <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
+    <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Border Name="border"
-                Background="{TemplateBinding Background}"
+        <Border Background="{TemplateBinding Background}"
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}"
-                Margin="{TemplateBinding Padding}"
-                HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                VerticalAlignment="{TemplateBinding VerticalAlignment}">
-          <Grid ColumnDefinitions="*,Auto">
-            <ContentPresenter Name="PART_ContentPresenter" Grid.Column="0"
+                CornerRadius="{DynamicResource ControlCornerRadius}">
+          <Grid ColumnDefinitions="Auto,*,Auto">
+            <ContentPresenter Name="PART_ContentPresenter"
+                              Grid.Column="1"
                               ContentTemplate="{TemplateBinding ContentTemplate}"
                               Content="{TemplateBinding Content}"
                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                              Padding="{TemplateBinding Padding}"/>
-            <Grid Grid.Column="1" RowDefinitions="*,*" IsVisible="{TemplateBinding ShowButtonSpinner}">
-              <RepeatButton Grid.Row="0" Name="PART_IncreaseButton"/>
-              <RepeatButton Grid.Row="1" Name="PART_DecreaseButton"/>
-            </Grid>
+                              Padding="{TemplateBinding Padding}" />
+
+            <StackPanel Name="PART_SpinnerPanel"
+                        Orientation="Horizontal"
+                        IsVisible="{TemplateBinding ShowButtonSpinner}">
+              <RepeatButton Name="PART_IncreaseButton"
+                            Classes="ButtonSpinnerRepeatButton"
+                            VerticalContentAlignment="Center"
+                            Foreground="{TemplateBinding Foreground}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            Background="{TemplateBinding Background}"
+                            FontSize="{TemplateBinding FontSize}">
+                <Path Fill="{TemplateBinding Foreground}"
+                      Width="16"
+                      Height="8"
+                      Stretch="Uniform"
+                      HorizontalAlignment="Center"
+                      VerticalAlignment="Center"
+                      Data="{StaticResource ButtonSpinnerIncreaseButtonIcon}" />
+              </RepeatButton>
+
+              <RepeatButton Name="PART_DecreaseButton"
+                            Classes="ButtonSpinnerRepeatButton"
+                            Foreground="{TemplateBinding Foreground}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            Background="{TemplateBinding Background}"
+                            VerticalContentAlignment="Center"
+                            FontSize="{TemplateBinding FontSize}">
+                <Path Fill="{TemplateBinding Foreground}"
+                      Width="16"
+                      Height="8"
+                      Stretch="Uniform"
+                      HorizontalAlignment="Center"
+                      VerticalAlignment="Center"
+                      Data="{StaticResource ButtonSpinnerDecreaseButtonIcon}" />
+              </RepeatButton>
+              <Border Name="PART_UpDownIconBorder"
+                      MinWidth="34">
+                <Path Name="PART_UpDownPathIcon"
+                      Fill="{TemplateBinding Foreground}"
+                      Height="12"
+                      Stretch="Uniform"
+                      HorizontalAlignment="Center"
+                      VerticalAlignment="Center"
+                      Data="{StaticResource ButtonSpinnerIncreaseDecreaseButtonIcon}" />
+              </Border>
+
+              <Popup x:Name="UpDownPopup"
+                     Grid.Row="1"
+                     Grid.Column="1"
+                     VerticalOffset="-20"
+                     HorizontalOffset="-28"
+                     PlacementMode="Right"
+                     PlacementTarget="{TemplateBinding}"
+                     HorizontalAlignment="Left">
+
+                <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                        BorderBrush="{DynamicResource ToolTipBorderBrush}"
+                        BorderThickness="{DynamicResource ToolTipBorderThemeThickness}"
+                        CornerRadius="{DynamicResource OverlayCornerRadius}">
+                  <Grid x:Name="PopupContentRoot"
+                        RowDefinitions="*,*">
+                    <RepeatButton x:Name="PopupUpSpinButton"
+                                  Classes="ButtonSpinnerRepeatButton">
+                      <Path Fill="{TemplateBinding Foreground}"
+                            Width="16"
+                            Height="8"
+                            Stretch="Uniform"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Data="{StaticResource ButtonSpinnerDecreaseButtonIcon}" />
+                    </RepeatButton>
+
+                    <RepeatButton x:Name="PopupDownSpinButton"
+                                  Grid.Row="1"
+                                  Classes="ButtonSpinnerRepeatButton"
+                                  Content="&#xE70D;" />
+                  </Grid>
+                </Border>
+              </Popup>
+            </StackPanel>
           </Grid>
         </Border>
       </ControlTemplate>
     </Setter>
   </Style>
-  <Style Selector="ButtonSpinner:left">
-    <Setter Property="Template">
-      <ControlTemplate>
-        <Border Name="border"
-                Background="{TemplateBinding Background}"
-                BorderBrush="{TemplateBinding BorderBrush}"
-                BorderThickness="{TemplateBinding BorderThickness}"
-                Margin="{TemplateBinding Padding}"
-                HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                VerticalAlignment="{TemplateBinding VerticalAlignment}">
-          <Grid ColumnDefinitions="Auto,*">
-            <Grid Grid.Column="0" RowDefinitions="*,*" IsVisible="{TemplateBinding ShowButtonSpinner}">
-              <RepeatButton Grid.Row="0" Name="PART_IncreaseButton"/>
-              <RepeatButton Grid.Row="1" Name="PART_DecreaseButton"/>
-            </Grid>
-            <ContentPresenter Name="PART_ContentPresenter" Grid.Column="1"
-                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                              Content="{TemplateBinding Content}"
-                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                              Padding="{TemplateBinding Padding}"/>
-          </Grid>
-        </Border>
-      </ControlTemplate>
-    </Setter>
+
+  <!--  ButtonSpinnerLocation=Right  -->
+  <Style Selector="ButtonSpinner:right /template/ StackPanel#PART_SpinnerPanel">
+    <Setter Property="Grid.Column" Value="2" />
   </Style>
-  <Style Selector="ButtonSpinner:pointerover /template/ Border#border">
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}"/>
+  <Style Selector="ButtonSpinner:right /template/ RepeatButton.ButtonSpinnerRepeatButton">
+    <Setter Property="BorderThickness" Value="{Binding $parent[ButtonSpinner].BorderThickness, Converter={StaticResource ButtonSpinner_OnlyLeftThinknessConverter}}" />
   </Style>
-  <Style Selector="ButtonSpinner:focus /template/ Border#border">
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighBrush}"/>
+
+  <!--  ButtonSpinnerLocation=Left  -->
+  <Style Selector="ButtonSpinner:left /template/ StackPanel#PART_SpinnerPanel">
+    <Setter Property="Grid.Column" Value="0" />
   </Style>
-  <Style Selector="ButtonSpinner:error /template/ Border#border">
-    <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}"/>
+  <Style Selector="ButtonSpinner:left /template/ RepeatButton.ButtonSpinnerRepeatButton">
+    <Setter Property="BorderThickness" Value="{Binding $parent[ButtonSpinner].BorderThickness, Converter={StaticResource ButtonSpinner_OnlyRightThinknessConverter}}" />
   </Style>
+
+  <!--  Inline (default)  -->
+  <Style Selector="ButtonSpinner:not(.CompactInlineButtonSpinner) /template/ Border#PART_UpDownIconBorder">
+    <Setter Property="IsVisible" Value="False" />
+  </Style>
+
+  <!--  CompactInline  -->
+  <Style Selector="ButtonSpinner.CompactInlineButtonSpinner /template/ RepeatButton.ButtonSpinnerRepeatButton">
+    <Setter Property="IsVisible" Value="False" />
+  </Style>
+
+  <Style Selector="ButtonSpinner.CompactInlineButtonSpinner[AllowSpin=false] /template/ Path#PART_UpDownPathIcon">
+    <Setter Property="Opacity" Value="0.5" />
+  </Style>
+
+  <Style Selector="ButtonSpinner.CompactInlineButtonSpinner:pointerover /template/ Popup#UpDownPopup">
+    <Setter Property="IsOpen" Value="True" />
+  </Style>
+
+  <!--  Error state  -->
+  <Style Selector="ButtonSpinner:error">
+    <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}" />
+  </Style>
+
 </Styles>

--- a/src/Avalonia.Themes.Fluent/NumericUpDown.xaml
+++ b/src/Avalonia.Themes.Fluent/NumericUpDown.xaml
@@ -1,38 +1,62 @@
-<Styles xmlns="https://github.com/avaloniaui">
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:sys="clr-namespace:System;assembly=netstandard"
+        xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls">
+  <Design.PreviewWith>
+    <Border Padding="20"
+            Background="Black">
+      <StackPanel Spacing="20">
+        <NumericUpDown Minimum="0"
+                       Maximum="10"
+                       Increment="0.5"
+                       Width="150"
+                       Watermark="Enter text" />
+        <NumericUpDown Minimum="0"
+                       Maximum="10"
+                       Increment="0.5"
+                       Width="150"
+                       ButtonSpinnerLocation="Left"
+                       Watermark="Enter text" />
+      </StackPanel>
+    </Border>
+  </Design.PreviewWith>
+
   <Style Selector="NumericUpDown">
-    <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
-    <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}"/>
-    <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
-    <Setter Property="Padding" Value="4"/>
+    <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrush}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
+    <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
+    <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
+    <Setter Property="Padding" Value="8, 4, 4, 4" />
     <Setter Property="Template">
       <ControlTemplate>
         <ButtonSpinner Name="PART_Spinner"
                        Background="{TemplateBinding Background}"
                        BorderThickness="{TemplateBinding BorderThickness}"
                        BorderBrush="{TemplateBinding BorderBrush}"
+                       Padding="0"
                        HorizontalContentAlignment="Stretch"
                        VerticalContentAlignment="Stretch"
                        AllowSpin="{TemplateBinding AllowSpin}"
                        ShowButtonSpinner="{TemplateBinding ShowButtonSpinner}"
                        ButtonSpinnerLocation="{TemplateBinding ButtonSpinnerLocation}">
           <TextBox Name="PART_TextBox"
-                   BorderThickness="0"
-                   Background="{TemplateBinding Background}" 
-                   BorderBrush="{TemplateBinding BorderBrush}"
+                   Background="Transparent"
+                   BorderBrush="Transparent"
+                   Margin="-2"
                    Padding="{TemplateBinding Padding}"
                    Watermark="{TemplateBinding Watermark}"
                    DataValidationErrors.Errors="{TemplateBinding (DataValidationErrors.Errors)}"
                    IsReadOnly="{TemplateBinding IsReadOnly}"
                    Text="{TemplateBinding Text}"
                    AcceptsReturn="False"
-                   TextWrapping="NoWrap">
-          </TextBox>
+                   TextWrapping="NoWrap" />
         </ButtonSpinner>
       </ControlTemplate>
     </Setter>
   </Style>
-  <Style Selector="NumericUpDown /template/ TextBox#PART_TextBox">
-    <Setter Property="Margin" Value="4"/>
-    <Setter Property="MinWidth" Value="20"/>
-  </Style>
+
 </Styles>

--- a/src/Avalonia.Themes.Fluent/TextBox.xaml
+++ b/src/Avalonia.Themes.Fluent/TextBox.xaml
@@ -27,6 +27,7 @@
                             Grid.ColumnSpan="2"
                             TextBlock.FontWeight="Normal"
                             TextBlock.Foreground="{DynamicResource TextControlHeaderForeground}"
+                            IsVisible="False"
                             Margin="{DynamicResource TextBoxTopHeaderMargin}" />
           
           <Border Name="border"


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Button spinner (popup for compact view is not implemented yet in this PR):
![image](https://user-images.githubusercontent.com/3163374/84484242-8075c700-ac68-11ea-8ebd-fec2046a3a39.png)

NumericUpDown:
![image](https://user-images.githubusercontent.com/3163374/84484270-8c618900-ac68-11ea-84c9-f184282e5b77.png)


## How was the solution implemented (if it's not obvious)?
As reference I used NumberBox from WinUI. But problem is that NumberBox is solid control, when NumericUpDown uses ButtonSpinner. So it just looks similar from some point, but can't be same.

Still WIP.


## Breaking changes
Not yet. But we probably need to replace AllowSpin property with [SpinButtonPlacementMode](https://docs.microsoft.com/en-gb/uwp/api/microsoft.ui.xaml.controls.numberboxspinbuttonplacementmode?view=winui-2.3). Or just Compact and Inline values and leave AllowSpin for "Hide". But it also requires backport to default style.
@grokys @danwalmsley 