### PR TITLE
Use MathUtilities to implement Size/Vector NearlyEquals.

### DIFF
--- a/src/Avalonia.Visuals/Size.cs
+++ b/src/Avalonia.Visuals/Size.cs
@@ -189,7 +189,7 @@ namespace Avalonia
         }
 
         /// <summary>
-        /// Returns a boolean indicating whether the size is equal to the other given size.
+        /// Returns a boolean indicating whether the size is equal to the other given size (bitwise).
         /// </summary>
         /// <param name="other">The other size to test equality against.</param>
         /// <returns>True if this size is equal to other; False otherwise.</returns>
@@ -199,6 +199,16 @@ namespace Avalonia
             return _width == other._width &&
                    _height == other._height;
             // ReSharper enable CompareOfFloatsByEqualityOperator
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the size is equal to the other given size (numerically).
+        /// </summary>
+        /// <param name="other">The other size to test equality against.</param>
+        /// <returns>True if this size is equal to other; False otherwise.</returns>
+        public bool NearlyEquals(Size other)
+        {
+            return MathUtilities.AreClose(_width, other._width) && MathUtilities.AreClose(_height, other._height);
         }
 
         /// <summary>

--- a/src/Avalonia.Visuals/Size.cs
+++ b/src/Avalonia.Visuals/Size.cs
@@ -208,7 +208,8 @@ namespace Avalonia
         /// <returns>True if this size is equal to other; False otherwise.</returns>
         public bool NearlyEquals(Size other)
         {
-            return MathUtilities.AreClose(_width, other._width) && MathUtilities.AreClose(_height, other._height);
+            return MathUtilities.AreClose(_width, other._width) && 
+                   MathUtilities.AreClose(_height, other._height);
         }
 
         /// <summary>

--- a/src/Avalonia.Visuals/Vector.cs
+++ b/src/Avalonia.Visuals/Vector.cs
@@ -155,7 +155,8 @@ namespace Avalonia
         /// <returns>True if vectors are nearly equal.</returns>
         public bool NearlyEquals(Vector other)
         {
-            return MathUtilities.AreClose(_x, other._x) && MathUtilities.AreClose(_y, other._y);
+            return MathUtilities.AreClose(_x, other._x) && 
+                   MathUtilities.AreClose(_y, other._y);
         }
 
         public override bool Equals(object obj) => obj is Vector other && Equals(other);

--- a/src/Avalonia.Visuals/Vector.cs
+++ b/src/Avalonia.Visuals/Vector.cs
@@ -2,7 +2,8 @@ using System;
 using System.Globalization;
 using Avalonia.Animation.Animators;
 using Avalonia.Utilities;
-using JetBrains.Annotations;
+
+#nullable enable
 
 namespace Avalonia
 {
@@ -17,20 +18,20 @@ namespace Avalonia
         }
 
         /// <summary>
-        /// The X vector.
+        /// The X component.
         /// </summary>
         private readonly double _x;
 
         /// <summary>
-        /// The Y vector.
+        /// The Y component.
         /// </summary>
         private readonly double _y;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector"/> structure.
         /// </summary>
-        /// <param name="x">The X vector.</param>
-        /// <param name="y">The Y vector.</param>
+        /// <param name="x">The X component.</param>
+        /// <param name="y">The Y component.</param>
         public Vector(double x, double y)
         {
             _x = x;
@@ -38,12 +39,12 @@ namespace Avalonia
         }
 
         /// <summary>
-        /// Gets the X vector.
+        /// Gets the X component.
         /// </summary>
         public double X => _x;
 
         /// <summary>
-        /// Gets the Y vector.
+        /// Gets the Y component.
         /// </summary>
         public double Y => _y;
 
@@ -57,18 +58,18 @@ namespace Avalonia
         }
 
         /// <summary>
-        /// Calculates the dot product of two vectors
+        /// Calculates the dot product of two vectors.
         /// </summary>
-        /// <param name="a">First vector</param>
-        /// <param name="b">Second vector</param>
-        /// <returns>The dot product</returns>
+        /// <param name="a">First vector.</param>
+        /// <param name="b">Second vector.</param>
+        /// <returns>The dot product.</returns>
         public static double operator *(Vector a, Vector b)
             => Dot(a, b);
 
         /// <summary>
         /// Scales a vector.
         /// </summary>
-        /// <param name="vector">The vector</param>
+        /// <param name="vector">The vector.</param>
         /// <param name="scale">The scaling factor.</param>
         /// <returns>The scaled vector.</returns>
         public static Vector operator *(Vector vector, double scale)
@@ -77,7 +78,7 @@ namespace Avalonia
         /// <summary>
         /// Scales a vector.
         /// </summary>
-        /// <param name="vector">The vector</param>
+        /// <param name="vector">The vector.</param>
         /// <param name="scale">The divisor.</param>
         /// <returns>The scaled vector.</returns>
         public static Vector operator /(Vector vector, double scale)
@@ -100,12 +101,12 @@ namespace Avalonia
         }
 
         /// <summary>
-        /// Length of the vector
+        /// Length of the vector.
         /// </summary>
         public double Length => Math.Sqrt(SquaredLength);
 
         /// <summary>
-        /// Squared Length of the vector
+        /// Squared Length of the vector.
         /// </summary>
         public double SquaredLength => _x * _x + _y * _y;
 
@@ -187,9 +188,9 @@ namespace Avalonia
         }
 
         /// <summary>
-        /// Returns a new vector with the specified X coordinate.
+        /// Returns a new vector with the specified X component.
         /// </summary>
-        /// <param name="x">The X coordinate.</param>
+        /// <param name="x">The X component.</param>
         /// <returns>The new vector.</returns>
         public Vector WithX(double x)
         {
@@ -197,9 +198,9 @@ namespace Avalonia
         }
 
         /// <summary>
-        /// Returns a new vector with the specified Y coordinate.
+        /// Returns a new vector with the specified Y component.
         /// </summary>
-        /// <param name="y">The Y coordinate.</param>
+        /// <param name="y">The Y component.</param>
         /// <returns>The new vector.</returns>
         public Vector WithY(double y)
         {
@@ -309,25 +310,25 @@ namespace Avalonia
             => new Vector(-vector._x, -vector._y);
 
         /// <summary>
-        /// Returnes the vector (0.0, 0.0)
+        /// Returns the vector (0.0, 0.0).
         /// </summary>
         public static Vector Zero
             => new Vector(0, 0);
 
         /// <summary>
-        /// Returnes the vector (1.0, 1.0)
+        /// Returns the vector (1.0, 1.0).
         /// </summary>
         public static Vector One
             => new Vector(1, 1);
 
         /// <summary>
-        /// Returnes the vector (1.0, 0.0)
+        /// Returns the vector (1.0, 0.0).
         /// </summary>
         public static Vector UnitX
             => new Vector(1, 0);
 
         /// <summary>
-        /// Returnes the vector (0.0, 1.0)
+        /// Returns the vector (0.0, 1.0).
         /// </summary>
         public static Vector UnitY
             => new Vector(0, 1);

--- a/src/Avalonia.Visuals/Vector.cs
+++ b/src/Avalonia.Visuals/Vector.cs
@@ -154,9 +154,7 @@ namespace Avalonia
         /// <returns>True if vectors are nearly equal.</returns>
         public bool NearlyEquals(Vector other)
         {
-            const float tolerance = float.Epsilon;
-
-            return Math.Abs(_x - other._x) < tolerance && Math.Abs(_y - other._y) < tolerance;
+            return MathUtilities.AreClose(_x, other._x) && MathUtilities.AreClose(_y, other._y);
         }
 
         public override bool Equals(object obj) => obj is Vector other && Equals(other);


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
One more followup after our great floating point epsilon wars. `Vector.NearlyEquals` can be implemented using `MathUtilities`, and `Size` was lacking similar function. Also fixed some of the doc comments.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`Vector.NearlyEquals` gives different results than comparing components with `MathUtilities.AreClose`.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Hopefully unified numerical precision handling :)

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
I guess our `Vector` and `Size` classes could use a few unit tests (up for grabs perhaps? :) )

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

cc: @rstm-sf 