### PR TITLE
Use newer image in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 <br />
 [![NuGet](https://img.shields.io/nuget/v/Avalonia.svg)](https://www.nuget.org/packages/Avalonia) [![downloads](https://img.shields.io/nuget/dt/avalonia)](https://www.nuget.org/packages/Avalonia) [![MyGet](https://img.shields.io/myget/avalonia-ci/vpre/Avalonia.svg?label=myget)](https://www.myget.org/gallery/avalonia-ci) ![Size](https://img.shields.io/github/repo-size/avaloniaui/avalonia.svg) 
 
-<img alt="Avalonia" src="https://user-images.githubusercontent.com/6759207/84897744-cab6d800-b0ae-11ea-8214-e5174d71f5c8.png" width="500"/>
+<img alt="Avalonia" src="https://user-images.githubusercontent.com/6759207/84897744-cab6d800-b0ae-11ea-8214-e5174d71f5c8.png" width="400"/>
 
 ## 📖 About AvaloniaUI 
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 <br />
 [![NuGet](https://img.shields.io/nuget/v/Avalonia.svg)](https://www.nuget.org/packages/Avalonia) [![downloads](https://img.shields.io/nuget/dt/avalonia)](https://www.nuget.org/packages/Avalonia) [![MyGet](https://img.shields.io/myget/avalonia-ci/vpre/Avalonia.svg?label=myget)](https://www.myget.org/gallery/avalonia-ci) ![Size](https://img.shields.io/github/repo-size/avaloniaui/avalonia.svg) 
 
-<img src="https://user-images.githubusercontent.com/6759207/84750966-ac74ad80-afc4-11ea-97a4-067d99c15a7d.png" width="500"/>
+<img alt="Avalonia" src="https://user-images.githubusercontent.com/6759207/84894772-03a07e00-b0aa-11ea-9fd8-2fcbbde65930.png" width="500"/>
 
 ## 📖 About AvaloniaUI 
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 <br />
 [![NuGet](https://img.shields.io/nuget/v/Avalonia.svg)](https://www.nuget.org/packages/Avalonia) [![downloads](https://img.shields.io/nuget/dt/avalonia)](https://www.nuget.org/packages/Avalonia) [![MyGet](https://img.shields.io/myget/avalonia-ci/vpre/Avalonia.svg?label=myget)](https://www.myget.org/gallery/avalonia-ci) ![Size](https://img.shields.io/github/repo-size/avaloniaui/avalonia.svg) 
 
-<img alt="Avalonia" src="https://user-images.githubusercontent.com/6759207/84894772-03a07e00-b0aa-11ea-9fd8-2fcbbde65930.png" width="500"/>
+<img alt="Avalonia" src="https://user-images.githubusercontent.com/6759207/84897744-cab6d800-b0ae-11ea-8214-e5174d71f5c8.png" width="500"/>
 
 ## 📖 About AvaloniaUI 
 


### PR DESCRIPTION
### What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Updates Avalonia image in `README.md` with a modification of our [OpenGraph]() image, shown in https://github.com/AvaloniaUI/Avalonia/issues/2914

### What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

<img src="https://user-images.githubusercontent.com/6759207/84895206-abb64700-b0aa-11ea-9ea9-d6cb345f098d.png" width="200" />

### What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

<img src="https://user-images.githubusercontent.com/6759207/84895372-e4562080-b0aa-11ea-9336-bf7bdb1a3719.png" width="200" />

### Update

Now this PR uses the following image, as requested.

<img src="https://user-images.githubusercontent.com/6759207/84898659-48c7ae80-b0b0-11ea-99cb-33c064de6261.png" width="200" />