### PR TITLE
Fix validation of not found members

### DIFF
--- a/src/Avalonia.Base/Data/Core/PropertyAccessorNode.cs
+++ b/src/Avalonia.Base/Data/Core/PropertyAccessorNode.cs
@@ -73,7 +73,10 @@ namespace Avalonia.Data.Core
                 }
             }
 
-            Debug.Assert(accessor != null);
+            if (accessor is null)
+            {
+                throw new AvaloniaInternalException("Data validators must return non-null accessor.");
+            }
 
             _accessor = accessor;
             accessor.Subscribe(ValueChanged);

--- a/src/Avalonia.Base/Data/Core/PropertyAccessorNode.cs
+++ b/src/Avalonia.Base/Data/Core/PropertyAccessorNode.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using Avalonia.Data.Core.Plugins;
 
 namespace Avalonia.Data.Core
@@ -49,6 +50,18 @@ namespace Avalonia.Data.Core
 
             var accessor = plugin?.Start(reference, PropertyName);
 
+            // We need to handle accessor fallback before handling validation. Validators do not support null accessors.
+            if (accessor == null)
+            {
+                reference.TryGetTarget(out object instance);
+
+                var message = $"Could not find a matching property accessor for '{PropertyName}' on '{instance}'";
+
+                var exception = new MissingMemberException(message);
+
+                accessor = new PropertyError(new BindingNotification(exception, BindingErrorType.Error));
+            }
+
             if (_enableValidation && Next == null)
             {
                 foreach (var validator in ExpressionObserver.DataValidators)
@@ -60,16 +73,7 @@ namespace Avalonia.Data.Core
                 }
             }
 
-            if (accessor == null)
-            {
-                reference.TryGetTarget(out object instance);
-
-                var message = $"Could not find a matching property accessor for '{PropertyName}' on '{instance}'";
-
-                var exception = new MissingMemberException(message);
-
-                accessor = new PropertyError(new BindingNotification(exception, BindingErrorType.Error));
-            }
+            Debug.Assert(accessor != null);
 
             _accessor = accessor;
             accessor.Subscribe(ValueChanged);

--- a/tests/Avalonia.Base.UnitTests/Data/Core/ExpressionObserverTests_Property.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/ExpressionObserverTests_Property.cs
@@ -578,6 +578,28 @@ namespace Avalonia.Base.UnitTests.Data.Core
             Assert.True(true);
         }
 
+        [Fact]
+        public void Should_Not_Throw_Exception_When_Enabling_Data_Validation_On_Missing_Member()
+        {
+            var source = new Class1();
+            var target = new PropertyAccessorNode("NotFound", true);
+
+            target.Target = new WeakReference<object>(source);
+
+            var result = new List<object>();
+
+            target.Subscribe(x => result.Add(x));
+
+            Assert.Equal(
+                new object[]
+                {
+                    new BindingNotification(
+                        new MissingMemberException("Could not find a matching property accessor for 'NotFound' on 'Avalonia.Base.UnitTests.Data.Core.ExpressionObserverTests_Property+Class1'"),
+                        BindingErrorType.Error),
+                },
+                result);
+        }
+
         private interface INext
         {
             int PropertyChangedSubscriptionCount { get; }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
After property accessor reorder new bug has been introduced - validation accessors cannot deal with null inner accessors leading to crashes.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
We get strange exceptions caused by internal implementation throwing (usually NRE).

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Restored previous behavior - validation accessors will receive fallback accessor.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
I guess we can make this code clearer by adding nullable annotations to mark which parts can handle null and which cannot.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation


## Fixed issues
Fixes #4143
