### PR TITLE
Fix copy pasta error in HeaderedContentControl

### DIFF
--- a/src/Avalonia.Controls/Primitives/HeaderedContentControl.cs
+++ b/src/Avalonia.Controls/Primitives/HeaderedContentControl.cs
@@ -1,7 +1,8 @@
-using Avalonia.Controls.Mixins;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Templates;
 using Avalonia.LogicalTree;
+
+#nullable enable
 
 namespace Avalonia.Controls.Primitives
 {
@@ -13,14 +14,14 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Defines the <see cref="Header"/> property.
         /// </summary>
-        public static readonly StyledProperty<object> HeaderProperty =
-            AvaloniaProperty.Register<HeaderedContentControl, object>(nameof(Header));
+        public static readonly StyledProperty<object?> HeaderProperty =
+            AvaloniaProperty.Register<HeaderedContentControl, object?>(nameof(Header));
 
         /// <summary>
         /// Defines the <see cref="HeaderTemplate"/> property.
         /// </summary>
-        public static readonly StyledProperty<IDataTemplate> HeaderTemplateProperty =
-            AvaloniaProperty.Register<HeaderedContentControl, IDataTemplate>(nameof(HeaderTemplate));
+        public static readonly StyledProperty<IDataTemplate?> HeaderTemplateProperty =
+            AvaloniaProperty.Register<HeaderedContentControl, IDataTemplate?>(nameof(HeaderTemplate));
 
         /// <summary>
         /// Initializes static members of the <see cref="ContentControl"/> class.
@@ -33,16 +34,16 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Gets or sets the header content.
         /// </summary>
-        public object Header
+        public object? Header
         {
-            get { return GetValue(HeaderProperty); }
-            set { SetValue(HeaderProperty, value); }
+            get => GetValue(HeaderProperty);
+            set => SetValue(HeaderProperty, value);
         }
 
         /// <summary>
         /// Gets the header presenter from the control's template.
         /// </summary>
-        public IContentPresenter HeaderPresenter
+        public IContentPresenter? HeaderPresenter
         {
             get;
             private set;
@@ -51,10 +52,10 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Gets or sets the data template used to display the header content of the control.
         /// </summary>
-        public IDataTemplate HeaderTemplate
+        public IDataTemplate? HeaderTemplate
         {
-            get { return GetValue(HeaderTemplateProperty); }
-            set { SetValue(HeaderTemplateProperty, value); }
+            get => GetValue(HeaderTemplateProperty);
+            set => SetValue(HeaderTemplateProperty, value);
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/Primitives/HeaderedContentControl.cs
+++ b/src/Avalonia.Controls/Primitives/HeaderedContentControl.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         static HeaderedContentControl()
         {
-            ContentProperty.Changed.AddClassHandler<HeaderedContentControl>((x, e) => x.HeaderChanged(e));
+            HeaderProperty.Changed.AddClassHandler<HeaderedContentControl>((x, e) => x.HeaderChanged(e));
         }
 
         /// <summary>


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
I've noticed that we have duplicate entries in logical tree for all `HeaderedContentControl` derived controls.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When you check an `Expander` in DevTools you will see content twice in the logical tree.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Content is present only once in the logical tree.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
First commit fixes the issue and second one cleans up this control code a bit.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
