### PR TITLE
Close submenu when pointer leaves.

### DIFF
--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -333,6 +333,10 @@ namespace Avalonia.Controls.Platform
                 {
                     item.Parent.SelectedItem = null;
                 }
+                else if (!item.IsPointerOverSubMenu)
+                {
+                    item.IsSubMenuOpen = false;
+                }
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

When a scroller is present on a menu and the user scrolls, a submenu would not get closed, resulting in an "orphaned" submenu popup:

![iHoMLxbYjf](https://user-images.githubusercontent.com/1775141/85380209-f1589100-b53c-11ea-9eef-2c9eff45be36.gif)

This PR fixes that:

![9oGgKd4yTF](https://user-images.githubusercontent.com/1775141/85380236-fcabbc80-b53c-11ea-9770-b543c5ff2e61.gif)

This is another one of those PRs where the unit test was a lot harder than the fix, so no unit test for now...