### PR TITLE
Fix skip convert ISolidColorBrush to Color when animation

### DIFF
--- a/src/Avalonia.Visuals/Animation/Animators/SolidColorBrushAnimator.cs
+++ b/src/Avalonia.Visuals/Animation/Animators/SolidColorBrushAnimator.cs
@@ -51,17 +51,14 @@ namespace Avalonia.Animation.Animators
                 if (_colorAnimator == null)
                     InitializeColorAnimator();
 
-                SolidColorBrush finalTarget;
-
                 // If it's ISCB, change it back to SCB.
-                if (targetVal.GetType() == typeof(ImmutableSolidColorBrush))
+                if (targetVal is ImmutableSolidColorBrush immutableSolidColorBrush)
                 {
-                    var col = (ImmutableSolidColorBrush)targetVal;
-                    targetVal = new SolidColorBrush(col.Color);
+                    targetVal = new SolidColorBrush(immutableSolidColorBrush.Color);
                     control.SetValue(Property, targetVal);
                 }
 
-                finalTarget = targetVal as SolidColorBrush;
+                var finalTarget = targetVal as SolidColorBrush;
 
                 return _colorAnimator.Apply(animation, finalTarget, clock ?? control.Clock, match, onComplete);
             }

--- a/src/Avalonia.Visuals/Animation/Animators/SolidColorBrushAnimator.cs
+++ b/src/Avalonia.Visuals/Animation/Animators/SolidColorBrushAnimator.cs
@@ -10,9 +10,9 @@ namespace Avalonia.Animation.Animators
     /// </summary>
     public class SolidColorBrushAnimator : Animator<SolidColorBrush>
     {
-        ColorAnimator _colorAnimator;
+        private ColorAnimator _colorAnimator;
 
-        void InitializeColorAnimator()
+        private void InitializeColorAnimator()
         {
             _colorAnimator = new ColorAnimator();
 
@@ -38,28 +38,29 @@ namespace Avalonia.Animation.Animators
                 }
             }
 
+            SolidColorBrush finalTarget;
             var targetVal = control.GetValue(Property);
-            // Add SCB if the target prop is empty.
             if (targetVal is null)
             {
-                targetVal = new SolidColorBrush(Colors.Transparent);
-                control.SetValue(Property, targetVal);
+                finalTarget = new SolidColorBrush(Colors.Transparent);
+                control.SetValue(Property, finalTarget);
             }
-
-            if (!(targetVal is ISolidColorBrush))
+            else if (targetVal is ImmutableSolidColorBrush immutableSolidColorBrush)
+            {
+                finalTarget = new SolidColorBrush(immutableSolidColorBrush.Color);
+                control.SetValue(Property, finalTarget);
+            }
+            else if (!(targetVal is ISolidColorBrush))
+            {
                 return Disposable.Empty;
+            }
+            else
+            {
+                finalTarget = targetVal as SolidColorBrush;
+            }
 
             if (_colorAnimator == null)
                 InitializeColorAnimator();
-
-            // If it's ISCB, change it back to SCB.
-            if (targetVal is ImmutableSolidColorBrush immutableSolidColorBrush)
-            {
-                targetVal = new SolidColorBrush(immutableSolidColorBrush.Color);
-                control.SetValue(Property, targetVal);
-            }
-
-            var finalTarget = targetVal as SolidColorBrush;
 
             return _colorAnimator.Apply(animation, finalTarget, clock ?? control.Clock, match, onComplete);
         }

--- a/src/Avalonia.Visuals/Animation/Animators/SolidColorBrushAnimator.cs
+++ b/src/Avalonia.Visuals/Animation/Animators/SolidColorBrushAnimator.cs
@@ -29,13 +29,13 @@ namespace Avalonia.Animation.Animators
         {
             foreach (var keyframe in this)
             {
-                if (keyframe.Value as ISolidColorBrush == null)
+                if (!(keyframe.Value is ISolidColorBrush))
                     return Disposable.Empty;
 
                 // Preprocess keyframe values to Color if the xaml parser converts them to ISCB.
-                if (keyframe.Value.GetType() == typeof(ImmutableSolidColorBrush))
+                if (keyframe.Value is ISolidColorBrush colorBrush)
                 {
-                    keyframe.Value = ((ImmutableSolidColorBrush)keyframe.Value).Color;
+                    keyframe.Value = colorBrush.Color;
                 }
             }
 

--- a/src/Avalonia.Visuals/Animation/Animators/SolidColorBrushAnimator.cs
+++ b/src/Avalonia.Visuals/Animation/Animators/SolidColorBrushAnimator.cs
@@ -50,13 +50,13 @@ namespace Avalonia.Animation.Animators
                 finalTarget = new SolidColorBrush(immutableSolidColorBrush.Color);
                 control.SetValue(Property, finalTarget);
             }
-            else if (!(targetVal is ISolidColorBrush))
+            else if (targetVal is ISolidColorBrush)
             {
-                return Disposable.Empty;
+                finalTarget = targetVal as SolidColorBrush;
             }
             else
             {
-                finalTarget = targetVal as SolidColorBrush;
+                return Disposable.Empty;
             }
 
             if (_colorAnimator == null)

--- a/src/Avalonia.Visuals/Animation/Animators/SolidColorBrushAnimator.cs
+++ b/src/Avalonia.Visuals/Animation/Animators/SolidColorBrushAnimator.cs
@@ -46,25 +46,22 @@ namespace Avalonia.Animation.Animators
                 control.SetValue(Property, targetVal);
             }
 
-            // Continue if target prop is not empty & is a SolidColorBrush derivative. 
-            if (typeof(ISolidColorBrush).IsAssignableFrom(targetVal.GetType()))
+            if (!(targetVal is ISolidColorBrush))
+                return Disposable.Empty;
+
+            if (_colorAnimator == null)
+                InitializeColorAnimator();
+
+            // If it's ISCB, change it back to SCB.
+            if (targetVal is ImmutableSolidColorBrush immutableSolidColorBrush)
             {
-                if (_colorAnimator == null)
-                    InitializeColorAnimator();
-
-                // If it's ISCB, change it back to SCB.
-                if (targetVal is ImmutableSolidColorBrush immutableSolidColorBrush)
-                {
-                    targetVal = new SolidColorBrush(immutableSolidColorBrush.Color);
-                    control.SetValue(Property, targetVal);
-                }
-
-                var finalTarget = targetVal as SolidColorBrush;
-
-                return _colorAnimator.Apply(animation, finalTarget, clock ?? control.Clock, match, onComplete);
+                targetVal = new SolidColorBrush(immutableSolidColorBrush.Color);
+                control.SetValue(Property, targetVal);
             }
 
-            return Disposable.Empty;
+            var finalTarget = targetVal as SolidColorBrush;
+
+            return _colorAnimator.Apply(animation, finalTarget, clock ?? control.Clock, match, onComplete);
         }
 
         public override SolidColorBrush Interpolate(double p, SolidColorBrush o, SolidColorBrush n) => null;

--- a/src/Avalonia.Visuals/Animation/Animators/SolidColorBrushAnimator.cs
+++ b/src/Avalonia.Visuals/Animation/Animators/SolidColorBrushAnimator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reactive.Disposables;
-using Avalonia.Logging;
 using Avalonia.Media;
 using Avalonia.Media.Immutable;
 
@@ -39,11 +38,13 @@ namespace Avalonia.Animation.Animators
                 }
             }
 
-            // Add SCB if the target prop is empty.
-            if (control.GetValue(Property) == null)
-                control.SetValue(Property, new SolidColorBrush(Colors.Transparent));
-
             var targetVal = control.GetValue(Property);
+            // Add SCB if the target prop is empty.
+            if (targetVal is null)
+            {
+                targetVal = new SolidColorBrush(Colors.Transparent);
+                control.SetValue(Property, targetVal);
+            }
 
             // Continue if target prop is not empty & is a SolidColorBrush derivative. 
             if (typeof(ISolidColorBrush).IsAssignableFrom(targetVal.GetType()))

--- a/src/Avalonia.Visuals/Animation/Animators/SolidColorBrushAnimator.cs
+++ b/src/Avalonia.Visuals/Animation/Animators/SolidColorBrushAnimator.cs
@@ -26,15 +26,16 @@ namespace Avalonia.Animation.Animators
 
         public override IDisposable Apply(Animation animation, Animatable control, IClock clock, IObservable<bool> match, Action onComplete)
         {
+            // Preprocess keyframe values to Color if the xaml parser converts them to ISCB.
             foreach (var keyframe in this)
             {
-                if (!(keyframe.Value is ISolidColorBrush))
-                    return Disposable.Empty;
-
-                // Preprocess keyframe values to Color if the xaml parser converts them to ISCB.
                 if (keyframe.Value is ISolidColorBrush colorBrush)
                 {
                     keyframe.Value = colorBrush.Color;
+                }
+                else
+                {
+                    return Disposable.Empty;
                 }
             }
 


### PR DESCRIPTION
## What does the pull request do?
Fix skip convert I`SolidColorBrush` to `Color` when animation


## What is the current behavior?
In animation only `ImmutableSolidColorBrush` converted to `Color`


## What is the updated/expected behavior with this PR?
It is considered that the brush may differ from the immutable. The code has also been updated to more readable


## How was the solution implemented (if it's not obvious)?
You can for example here change the value to `#ff123456`
https://github.com/AvaloniaUI/Avalonia/blob/7f2d92043fecd18403523323969594aa4e5633e6/samples/RenderDemo/Pages/AnimationsPage.xaml#L113-L115


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation


## Fixed issues

Fixes #3244
Fixes #3709 