### PR TITLE
Fix dev tools crashing on X11.

### DIFF
--- a/src/Avalonia.Base/Threading/DispatcherTimer.cs
+++ b/src/Avalonia.Base/Threading/DispatcherTimer.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Threading
         private readonly DispatcherPriority _priority;
 
         private TimeSpan _interval;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DispatcherTimer"/> class.
         /// </summary>
@@ -154,6 +154,8 @@ namespace Avalonia.Threading
             TimeSpan interval,
             DispatcherPriority priority = DispatcherPriority.Normal)
         {
+            interval = (interval != TimeSpan.Zero) ? interval : TimeSpan.FromTicks(1);
+            
             var timer = new DispatcherTimer(priority) { Interval = interval };
 
             timer.Tick += (s, e) =>
@@ -197,7 +199,7 @@ namespace Avalonia.Threading
             }
         }
 
-        
+
 
         /// <summary>
         /// Raises the <see cref="Tick"/> event on the dispatcher thread.

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -347,7 +347,7 @@ namespace Avalonia.Controls
 
                 if (container != null)
                 {
-                    DispatcherTimer.RunOnce(container.BringIntoView, TimeSpan.FromTicks(1));
+                    DispatcherTimer.RunOnce(container.BringIntoView, TimeSpan.Zero);
                 }
             }
         }

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -347,7 +347,7 @@ namespace Avalonia.Controls
 
                 if (container != null)
                 {
-                    DispatcherTimer.RunOnce(container.BringIntoView, TimeSpan.Zero);
+                    DispatcherTimer.RunOnce(container.BringIntoView, TimeSpan.FromTicks(1));
                 }
             }
         }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix the issue where devtools crashes on Linux.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Don't use TimeSpan.Zero when spawning DispatcherTimer.RunOnce. Hence i added the minimum time allowed on TimeSpan.
 