### PR TITLE
Added EffectiveViewportChanged event.

### DIFF
--- a/src/Avalonia.Controls/Repeater/ViewportManager.cs
+++ b/src/Avalonia.Controls/Repeater/ViewportManager.cs
@@ -533,27 +533,6 @@ namespace Avalonia.Controls
             }
         }
 
-        private IDisposable SubscribeToEffectiveViewportChanged(IControl control)
-        {
-            // HACK: This is a bit of a hack. We need the effective viewport of the ItemsRepeater -
-            // we can get this from TransformedBounds, but this property is updated after layout has
-            // run, which is too late. Instead, for now lets just hook into an internal event on
-            // ScrollContentPresenter to find out what the offset and viewport will be after arrange
-            // and use those values. Note that this doesn't handle nested ScrollViewers at all, but
-            // it's enough to get scrolling to non-uniformly sized items working for now.
-            //
-            // UWP uses the EffectiveViewportChanged event (which I think was implemented specially
-            // for this case): we need to implement that in Avalonia, but the semantics of it aren't
-            // clear to me. Hopefully the source for this event will be released with WinUI 3.
-            if (control.VisualParent is Layoutable layoutable)
-            {
-                layoutable.EffectiveViewportChanged += OnEffectiveViewportChanged;
-                return Disposable.Create(() => layoutable.EffectiveViewportChanged -= OnEffectiveViewportChanged);
-            }
-
-            return Disposable.Empty;
-        }
-
         private class ScrollerInfo
         {
             public ScrollerInfo(ScrollViewer scroller)

--- a/src/Avalonia.Layout/EffectiveViewportChangedEventArgs.cs
+++ b/src/Avalonia.Layout/EffectiveViewportChangedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Avalonia.Layout
+{
+    /// <summary>
+    /// Provides data for the <see cref="Layoutable.EffectiveViewportChanged"/> event.
+    /// </summary>
+    public class EffectiveViewportChangedEventArgs : EventArgs
+    {
+        public EffectiveViewportChangedEventArgs(Rect effectiveViewport)
+        {
+            EffectiveViewport = effectiveViewport;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Rect"/> representing the effective viewport.
+        /// </summary>
+        /// <remarks>
+        /// The viewport is expressed in coordinates relative to the control that the event is
+        /// raised on.
+        /// </remarks>
+        public Rect EffectiveViewport { get; }
+    }
+}

--- a/src/Avalonia.Layout/ILayoutManager.cs
+++ b/src/Avalonia.Layout/ILayoutManager.cs
@@ -54,5 +54,17 @@ namespace Avalonia.Layout
         /// </remarks>
         [Obsolete("Call ExecuteInitialLayoutPass without parameter")]
         void ExecuteInitialLayoutPass(ILayoutRoot root);
+
+        /// <summary>
+        /// Registers a control as wanting to receive effective viewport notifications.
+        /// </summary>
+        /// <param name="control">The control.</param>
+        void RegisterEffectiveViewportListener(ILayoutable control);
+
+        /// <summary>
+        /// Registers a control as no longer wanting to receive effective viewport notifications.
+        /// </summary>
+        /// <param name="control">The control.</param>
+        void UnregisterEffectiveViewportListener(ILayoutable control);
     }
 }

--- a/src/Avalonia.Layout/ILayoutable.cs
+++ b/src/Avalonia.Layout/ILayoutable.cs
@@ -111,5 +111,12 @@ namespace Avalonia.Layout
         /// </summary>
         /// <param name="control">The child control.</param>
         void ChildDesiredSizeChanged(ILayoutable control);
+
+        /// <summary>
+        /// Used by the <see cref="LayoutManager"/> to notify the control that its effective
+        /// viewport is changed.
+        /// </summary>
+        /// <param name="e">The viewport information.</param>
+        void EffectiveViewportChanged(EffectiveViewportChangedEventArgs e);
     }
 }

--- a/src/Avalonia.Layout/LayoutManager.cs
+++ b/src/Avalonia.Layout/LayoutManager.cs
@@ -355,19 +355,26 @@ namespace Avalonia.Layout
 
         private void CalculateEffectiveViewport(IVisual target, IVisual control, ref Rect viewport)
         {
+            // Recurse until the top level control.
             if (control.VisualParent is object)
             {
                 CalculateEffectiveViewport(target, control.VisualParent, ref viewport);
             }
-
-            if (control.ClipToBounds || control.VisualParent is null)
-            {
-                viewport = control.Bounds;
-            }
             else
             {
-                viewport = viewport.Translate(-control.Bounds.Position);
+                viewport = new Rect(control.Bounds.Size);
             }
+
+            // Apply the control clip bounds if it's not the target control. We don't apply it to
+            // the target control because it may itself be clipped to bounds and if so the viewport
+            // we calculate would be of no use.
+            if (control != target && control.ClipToBounds)
+            {
+                viewport = control.Bounds.Intersect(viewport);
+            }
+
+            // Translate the viewport into this control's coordinate space.
+            viewport = viewport.Translate(-control.Bounds.Position);
 
             if (control != target && control.RenderTransform is object)
             {

--- a/src/Avalonia.Layout/LayoutManager.cs
+++ b/src/Avalonia.Layout/LayoutManager.cs
@@ -349,15 +349,15 @@ namespace Avalonia.Layout
         private Rect CalculateEffectiveViewport(IVisual control)
         {
             var viewport = new Rect(0, 0, double.PositiveInfinity, double.PositiveInfinity);
-            CalculateEffectiveViewport(control, ref viewport);
+            CalculateEffectiveViewport(control, control, ref viewport);
             return viewport;
         }
 
-        private void CalculateEffectiveViewport(IVisual control, ref Rect viewport)
+        private void CalculateEffectiveViewport(IVisual target, IVisual control, ref Rect viewport)
         {
             if (control.VisualParent is object)
             {
-                CalculateEffectiveViewport(control.VisualParent, ref viewport);
+                CalculateEffectiveViewport(target, control.VisualParent, ref viewport);
             }
 
             if (control.ClipToBounds || control.VisualParent is null)
@@ -367,6 +367,14 @@ namespace Avalonia.Layout
             else
             {
                 viewport = viewport.Translate(-control.Bounds.Position);
+            }
+
+            if (control != target && control.RenderTransform is object)
+            {
+                var origin = control.RenderTransformOrigin.ToPixels(control.Bounds.Size);
+                var offset = Matrix.CreateTranslation(origin);
+                var renderTransform = (-offset) * control.RenderTransform.Value.Invert() * (offset);
+                viewport = viewport.TransformToAABB(renderTransform);
             }
         }
 

--- a/src/Avalonia.Layout/LayoutManager.cs
+++ b/src/Avalonia.Layout/LayoutManager.cs
@@ -199,7 +199,9 @@ namespace Avalonia.Layout
         void ILayoutManager.RegisterEffectiveViewportListener(ILayoutable control)
         {
             _effectiveViewportChangedListeners ??= new List<EffectiveViewportChangedListener>();
-            _effectiveViewportChangedListeners.Add(new EffectiveViewportChangedListener(control));
+            _effectiveViewportChangedListeners.Add(new EffectiveViewportChangedListener(
+                control,
+                CalculateEffectiveViewport(control)));
         }
 
         void ILayoutManager.UnregisterEffectiveViewportListener(ILayoutable control)
@@ -331,8 +333,7 @@ namespace Avalonia.Layout
                 for (var i = 0; i < _effectiveViewportChangedListeners.Count; ++i)
                 {
                     var l = _effectiveViewportChangedListeners[i];
-                    var viewport = new Rect(0, 0, double.PositiveInfinity, double.PositiveInfinity);
-                    CalculateEffectiveViewport(l.Listener, ref viewport);
+                    var viewport = CalculateEffectiveViewport(l.Listener);
 
                     if (viewport != l.Viewport)
                     {
@@ -343,6 +344,13 @@ namespace Avalonia.Layout
             }
 
             return startCount != _toMeasure.Count + _toMeasure.Count;
+        }
+
+        private Rect CalculateEffectiveViewport(IVisual control)
+        {
+            var viewport = new Rect(0, 0, double.PositiveInfinity, double.PositiveInfinity);
+            CalculateEffectiveViewport(control, ref viewport);
+            return viewport;
         }
 
         private void CalculateEffectiveViewport(IVisual control, ref Rect viewport)
@@ -364,12 +372,6 @@ namespace Avalonia.Layout
 
         private readonly struct EffectiveViewportChangedListener
         {
-            public EffectiveViewportChangedListener(ILayoutable listener)
-            {
-                Listener = listener;
-                Viewport = new Rect(double.NaN, double.NaN, double.NaN, double.NaN);
-            }
-
             public EffectiveViewportChangedListener(ILayoutable listener, Rect viewport)
             {
                 Listener = listener;

--- a/src/Avalonia.Layout/LayoutManager.cs
+++ b/src/Avalonia.Layout/LayoutManager.cs
@@ -208,7 +208,7 @@ namespace Avalonia.Layout
         {
             if (_effectiveViewportChangedListeners is object)
             {
-                for (var i = 0; i < _effectiveViewportChangedListeners.Count; ++i)
+                for (var i = _effectiveViewportChangedListeners.Count - 1; i >= 0; --i)
                 {
                     if (_effectiveViewportChangedListeners[i].Listener == control)
                     {

--- a/tests/Avalonia.Layout.UnitTests/LayoutableTests_EffectiveViewportChanged.cs
+++ b/tests/Avalonia.Layout.UnitTests/LayoutableTests_EffectiveViewportChanged.cs
@@ -1,0 +1,333 @@
+﻿using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Layout.UnitTests
+{
+    public class LayoutableTests_EffectiveViewportChanged
+    {
+        [Fact]
+        public void EffectiveViewportChanged_Not_Raised_When_Control_Added_To_Tree()
+        {
+            var root = new TestRoot();
+            var canvas = new Canvas();
+            var raised = 0;
+
+            canvas.EffectiveViewportChanged += (s, e) =>
+            {
+                ++raised;
+            };
+
+            root.Child = canvas;
+
+            Assert.Equal(0, raised);
+        }
+
+        [Fact]
+        public void EffectiveViewportChanged_Raised_Before_LayoutUpdated()
+        {
+            var root = new TestRoot();
+            var canvas = new Canvas();
+            var raised = 0;
+            var layoutUpdatedRaised = 0;
+
+            canvas.LayoutUpdated += (s, e) =>
+            {
+                Assert.Equal(1, raised);
+                ++layoutUpdatedRaised;
+            };
+
+            canvas.EffectiveViewportChanged += (s, e) =>
+            {
+                ++raised;
+            };
+
+            root.Child = canvas;
+            root.LayoutManager.ExecuteInitialLayoutPass(root);
+
+            Assert.Equal(1, layoutUpdatedRaised);
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void Invalidating_In_Handler_Causes_Layout_To_Be_Rerun_Before_LayoutUpdated()
+        {
+            var root = new TestRoot();
+            var canvas = new TestCanvas();
+            var raised = 0;
+            var layoutUpdatedRaised = 0;
+
+            canvas.LayoutUpdated += (s, e) =>
+            {
+                Assert.Equal(2, canvas.MeasureCount);
+                Assert.Equal(2, canvas.ArrangeCount);
+                ++layoutUpdatedRaised;
+            };
+
+            canvas.EffectiveViewportChanged += (s, e) =>
+            {
+                canvas.InvalidateMeasure();
+                ++raised;
+            };
+
+            root.Child = canvas;
+            root.LayoutManager.ExecuteInitialLayoutPass(root);
+
+            Assert.Equal(1, raised);
+            Assert.Equal(1, layoutUpdatedRaised);
+        }
+
+        [Fact]
+        public void Viewport_Extends_Beyond_Centered_Control()
+        {
+            var root = new TestRoot
+            {
+                Width = 1200,
+                Height = 900,
+            };
+
+            var canvas = new Canvas
+            {
+                Width = 52,
+                Height = 52,
+            };
+            var raised = 0;
+
+            canvas.EffectiveViewportChanged += (s, e) =>
+            {
+                Assert.Equal(new Rect(-574, -424, 1200, 900), e.EffectiveViewport);
+                ++raised;
+            };
+
+            root.Child = canvas;
+            root.LayoutManager.ExecuteInitialLayoutPass(root);
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void Viewport_Extends_Beyond_Nested_Centered_Control()
+        {
+            var root = new TestRoot
+            {
+                Width = 1200,
+                Height = 900,
+            };
+
+            var canvas = new Canvas
+            {
+                Width = 52,
+                Height = 52,
+            };
+
+            var outer = new Border
+            {
+                Width = 100,
+                Height = 100,
+                Child = canvas,
+            };
+
+            var raised = 0;
+
+            canvas.EffectiveViewportChanged += (s, e) =>
+            {
+                Assert.Equal(new Rect(-574, -424, 1200, 900), e.EffectiveViewport);
+                ++raised;
+            };
+
+            root.Child = outer;
+            root.LayoutManager.ExecuteInitialLayoutPass(root);
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void ScrollViewer_Determines_EffectiveViewport()
+        {
+            var root = new TestRoot
+            {
+                Width = 1200,
+                Height = 900,
+            };
+
+            var canvas = new Canvas
+            {
+                Width = 200,
+                Height = 200,
+            };
+
+            var outer = new ScrollViewer
+            {
+                Width = 100,
+                Height = 100,
+                Content = canvas,
+                Template = ScrollViewerTemplate(),
+            };
+
+            var raised = 0;
+
+            canvas.EffectiveViewportChanged += (s, e) =>
+            {
+                Assert.Equal(new Rect(0, 0, 100, 100), e.EffectiveViewport);
+                ++raised;
+            };
+
+            root.Child = outer;
+            root.LayoutManager.ExecuteInitialLayoutPass(root);
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void Scrolled_ScrollViewer_Determines_EffectiveViewport()
+        {
+            var root = new TestRoot
+            {
+                Width = 1200,
+                Height = 900,
+            };
+
+            var canvas = new Canvas
+            {
+                Width = 200,
+                Height = 200,
+            };
+
+            var outer = new ScrollViewer
+            {
+                Width = 100,
+                Height = 100,
+                Content = canvas,
+                Template = ScrollViewerTemplate(),
+            };
+
+            var raised = 0;
+
+            root.Child = outer;
+            root.LayoutManager.ExecuteInitialLayoutPass(root);
+
+            canvas.EffectiveViewportChanged += (s, e) =>
+            {
+                Assert.Equal(new Rect(0, 10, 100, 100), e.EffectiveViewport);
+                ++raised;
+            };
+            
+            outer.Offset = new Vector(0, 10);
+            root.LayoutManager.ExecuteLayoutPass();
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void Moving_Parent_Updates_EffectiveViewport()
+        {
+            var root = new TestRoot
+            {
+                Width = 1200,
+                Height = 900,
+            };
+
+            var canvas = new Canvas
+            {
+                Width = 100,
+                Height = 100,
+            };
+
+            var outer = new Border
+            {
+                Width = 200,
+                Height = 200,
+                Child = canvas,
+            };
+
+            var raised = 0;
+
+            root.Child = outer;
+            root.LayoutManager.ExecuteInitialLayoutPass(root);
+
+            canvas.EffectiveViewportChanged += (s, e) =>
+            {
+                Assert.Equal(new Rect(-554, -400, 1200, 900), e.EffectiveViewport);
+                ++raised;
+            };
+
+            // Change the parent margin to move it.
+            outer.Margin = new Thickness(8, 0, 0, 0);
+            root.LayoutManager.ExecuteLayoutPass();
+
+            Assert.Equal(1, raised);
+        }
+
+        private IControlTemplate ScrollViewerTemplate()
+        {
+            return new FuncControlTemplate<ScrollViewer>((control, scope) => new Grid
+            {
+                ColumnDefinitions = new ColumnDefinitions
+                {
+                    new ColumnDefinition(1, GridUnitType.Star),
+                    new ColumnDefinition(GridLength.Auto),
+                },
+                RowDefinitions = new RowDefinitions
+                {
+                    new RowDefinition(1, GridUnitType.Star),
+                    new RowDefinition(GridLength.Auto),
+                },
+                Children =
+                {
+                    new ScrollContentPresenter
+                    {
+                        Name = "PART_ContentPresenter",
+                        [~ContentPresenter.ContentProperty] = control[~ContentControl.ContentProperty],
+                        [~~ScrollContentPresenter.ExtentProperty] = control[~~ScrollViewer.ExtentProperty],
+                        [~~ScrollContentPresenter.OffsetProperty] = control[~~ScrollViewer.OffsetProperty],
+                        [~~ScrollContentPresenter.ViewportProperty] = control[~~ScrollViewer.ViewportProperty],
+                        [~ScrollContentPresenter.CanHorizontallyScrollProperty] = control[~ScrollViewer.CanHorizontallyScrollProperty],
+                        [~ScrollContentPresenter.CanVerticallyScrollProperty] = control[~ScrollViewer.CanVerticallyScrollProperty],
+                    }.RegisterInNameScope(scope),
+                    new ScrollBar
+                    {
+                        Name = "horizontalScrollBar",
+                        Orientation = Orientation.Horizontal,
+                        [~RangeBase.MaximumProperty] = control[~ScrollViewer.HorizontalScrollBarMaximumProperty],
+                        [~~RangeBase.ValueProperty] = control[~~ScrollViewer.HorizontalScrollBarValueProperty],
+                        [~ScrollBar.ViewportSizeProperty] = control[~ScrollViewer.HorizontalScrollBarViewportSizeProperty],
+                        [~ScrollBar.VisibilityProperty] = control[~ScrollViewer.HorizontalScrollBarVisibilityProperty],
+                        [Grid.RowProperty] = 1,
+                    }.RegisterInNameScope(scope),
+                    new ScrollBar
+                    {
+                        Name = "verticalScrollBar",
+                        Orientation = Orientation.Vertical,
+                        [~RangeBase.MaximumProperty] = control[~ScrollViewer.VerticalScrollBarMaximumProperty],
+                        [~~RangeBase.ValueProperty] = control[~~ScrollViewer.VerticalScrollBarValueProperty],
+                        [~ScrollBar.ViewportSizeProperty] = control[~ScrollViewer.VerticalScrollBarViewportSizeProperty],
+                        [~ScrollBar.VisibilityProperty] = control[~ScrollViewer.VerticalScrollBarVisibilityProperty],
+                        [Grid.ColumnProperty] = 1,
+                    }.RegisterInNameScope(scope),
+                },
+            });
+        }
+
+
+        private class TestCanvas : Canvas
+        {
+            public int MeasureCount { get; private set; }
+            public int ArrangeCount { get; private set; }
+
+            protected override Size MeasureOverride(Size availableSize)
+            {
+                ++MeasureCount;
+                return base.MeasureOverride(availableSize);
+            }
+
+            protected override Size ArrangeOverride(Size finalSize)
+            {
+                ++ArrangeCount;
+                return base.ArrangeOverride(finalSize);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Implements the [`EffectiveViewportChanged`](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.frameworkelement.effectiveviewportchanged?view=winrt-19041) event from UWP and makes `ItemsRepeater` use it.

Previously `ItemsRepeater` relied on a hack which tried to simulate the `EffectiveViewportChanged` event, but it didn't work in all cases resulting in problems when using `ItemsRepeater` in some cases.

This PR adds a limited version of UWP's `EffectiveViewportChanged` in that it only implements the `EffectiveViewport` property on `EffectiveViewportChangedEventArgs` which is all that `ItemsRepeater` needs. The other properties can be added later if necessary.

Tested against UWP using the unit tests at https://github.com/grokys/EffectiveBoundsTestsUWP.

## Checklist

- [x] Added unit tests (if possible)?
