### PR TITLE
Fix hosting ComboBox in ItemsRepeater

### DIFF
--- a/src/Avalonia.Controls/Repeater/ViewportManager.cs
+++ b/src/Avalonia.Controls/Repeater/ViewportManager.cs
@@ -340,6 +340,11 @@ namespace Avalonia.Controls
                 // Note that the element being brought into view could be a descendant.
                 var targetChild = GetImmediateChildOfRepeater((IControl)args.TargetObject);
 
+                if (targetChild is null)
+                {
+                    return;
+                }
+
                 // Make sure that only the target child can be the anchor during the bring into view operation.
                 foreach (var child in _owner.Children)
                 {
@@ -373,7 +378,7 @@ namespace Avalonia.Controls
 
             if (parent == null)
             {
-                throw new InvalidOperationException("OnBringIntoViewRequested called with args.target element not under the ItemsRepeater that recieved the call");
+                return null;
             }
 
             return targetChild;


### PR DESCRIPTION
## What does the pull request do?

As described in #4176 `ItemsRepeater` expects a `BringIntoView` request to come from a descendent control on the visual tree, but because we route events from popups to the parent control it can actually come from the popup visual tree.

It would probably make sense to filter these events (see #3209) but that's a bigger task that will require some consideration. For the moment, don't throw when a `BringIntoView` is received from non-descendent; instead do nothing.

## Fixed issues

Fixes #4176.
