### PR TITLE
Removed unused call to IsSelectedWithPartialAt in SelectionModel

### DIFF
--- a/src/Avalonia.Controls/SelectionModel.cs
+++ b/src/Avalonia.Controls/SelectionModel.cs
@@ -189,8 +189,6 @@ namespace Avalonia.Controls
             }
             set
             {
-                var isSelected = IsSelectedWithPartialAt(value);
-
                 if (!IsSelectedAt(value) || SelectedItems.Count > 1)
                 {
                     using var operation = new Operation(this);


### PR DESCRIPTION
## What does the pull request do?

There was an used call to `IsSelectedWithPartialAt` in `SelectionModel.SelectedIndex.set` which @pr8x reported was causing an exception in `TreeView` occasionally. Removed it.
