### PR TITLE
Snap thumb on custom ticks and add Ticks property on slider

### DIFF
--- a/samples/ControlCatalog/Pages/SliderPage.xaml
+++ b/samples/ControlCatalog/Pages/SliderPage.xaml
@@ -6,11 +6,21 @@
     <TextBlock Classes="h2">A control that lets the user select from a range of values by moving a Thumb control along a Track.</TextBlock>
 
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 16 0 0" Spacing="16">
-      <Slider Value="0"
-              Minimum="0"
-              Maximum="100"
-              TickFrequency="10"
-              Width="300"/>
+      <StackPanel Orientation="Vertical"
+                  HorizontalAlignment="Center">
+        <Slider Value="0"
+                Minimum="0"
+                Maximum="100"
+                TickFrequency="10"
+                Width="300" />
+        <Slider Name="CustomTickedSlider"
+                Value="0"
+                Minimum="0"
+                Maximum="100"
+                TickPlacement="BottomRight"
+                IsSnapToTickEnabled="True"
+                Width="300" />
+      </StackPanel>
       <Slider Value="0"
               Minimum="0"
               Maximum="100"

--- a/samples/ControlCatalog/Pages/SliderPage.xaml
+++ b/samples/ControlCatalog/Pages/SliderPage.xaml
@@ -19,6 +19,7 @@
                 Maximum="100"
                 TickPlacement="BottomRight"
                 IsSnapToTickEnabled="True"
+                Ticks="0,20,25,40,75,100"
                 Width="300" />
       </StackPanel>
       <Slider Value="0"

--- a/samples/ControlCatalog/Pages/SliderPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/SliderPage.xaml.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
@@ -14,16 +13,6 @@ namespace ControlCatalog.Pages
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-
-            var slider = this.FindControl<Slider>("CustomTickedSlider");
-            slider.Ticks = new List<double>
-            {
-                0d,
-                5d,
-                20d,
-                50d,
-                100d
-            };
         }
     }
 }

--- a/samples/ControlCatalog/Pages/SliderPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/SliderPage.xaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
@@ -13,6 +14,16 @@ namespace ControlCatalog.Pages
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
+
+            var slider = this.FindControl<Slider>("CustomTickedSlider");
+            slider.Ticks = new List<double>
+            {
+                0d,
+                5d,
+                20d,
+                50d,
+                100d
+            };
         }
     }
 }

--- a/src/Avalonia.Controls/Slider.cs
+++ b/src/Avalonia.Controls/Slider.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using Avalonia.Collections;
 using Avalonia.Controls.Mixins;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
@@ -68,7 +68,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="TicksProperty"/> property.
         /// </summary>
-        public static readonly StyledProperty<List<double>> TicksProperty =
+        public static readonly StyledProperty<AvaloniaList<double>> TicksProperty =
             TickBar.TicksProperty.AddOwner<Slider>();
 
         // Slider required parts
@@ -105,7 +105,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the ticks to be drawn on the tick bar.
         /// </summary>
-        public List<double> Ticks
+        public AvaloniaList<double> Ticks
         {
             get => GetValue(TicksProperty);
             set => SetValue(TicksProperty, value);
@@ -263,7 +263,7 @@ namespace Avalonia.Controls
                 double next = Maximum;
 
                 // This property is rarely set so let's try to avoid the GetValue
-                List<double> ticks = Ticks;
+                var ticks = Ticks;
 
                 // If ticks collection is available, use it.
                 // Note that ticks may be unsorted.

--- a/src/Avalonia.Controls/Slider.cs
+++ b/src/Avalonia.Controls/Slider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Avalonia.Controls.Mixins;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
@@ -64,6 +65,12 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<TickPlacement> TickPlacementProperty =
             AvaloniaProperty.Register<TickBar, TickPlacement>(nameof(TickPlacement), 0d);
 
+        /// <summary>
+        /// Defines the <see cref="TicksProperty"/> property.
+        /// </summary>
+        public static readonly StyledProperty<List<double>> TicksProperty =
+            TickBar.TicksProperty.AddOwner<Slider>();
+
         // Slider required parts
         private bool _isDragging = false;
         private Track _track;
@@ -83,7 +90,8 @@ namespace Avalonia.Controls
             PressedMixin.Attach<Slider>();
             OrientationProperty.OverrideDefaultValue(typeof(Slider), Orientation.Horizontal);
             Thumb.DragStartedEvent.AddClassHandler<Slider>((x, e) => x.OnThumbDragStarted(e), RoutingStrategies.Bubble);
-            Thumb.DragCompletedEvent.AddClassHandler<Slider>((x, e) => x.OnThumbDragCompleted(e), RoutingStrategies.Bubble);
+            Thumb.DragCompletedEvent.AddClassHandler<Slider>((x, e) => x.OnThumbDragCompleted(e),
+                RoutingStrategies.Bubble);
         }
 
         /// <summary>
@@ -92,6 +100,15 @@ namespace Avalonia.Controls
         public Slider()
         {
             UpdatePseudoClasses(Orientation);
+        }
+
+        /// <summary>
+        /// Defines the ticks to be drawn on the tick bar.
+        /// </summary>
+        public List<double> Ticks
+        {
+            get => GetValue(TicksProperty);
+            set => SetValue(TicksProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/TickBar.cs
+++ b/src/Avalonia.Controls/TickBar.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using Avalonia.Controls.Primitives;
-using Avalonia.Data;
-using Avalonia.Data.Converters;
+using Avalonia.Collections;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Utilities;
@@ -135,15 +131,15 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="Ticks"/> property.
         /// </summary>
-        public static readonly StyledProperty<List<double>> TicksProperty =
-            AvaloniaProperty.Register<TickBar, List<double>>(nameof(Ticks));
+        public static readonly StyledProperty<AvaloniaList<double>> TicksProperty =
+            AvaloniaProperty.Register<TickBar, AvaloniaList<double>>(nameof(Ticks));
 
         /// <summary>
         /// The Ticks property contains collection of value of type Double which
         /// are the logical positions use to draw the ticks.
         /// The property value is a <see cref="DoubleCollection" />.
         /// </summary>
-        public List<double> Ticks
+        public AvaloniaList<double> Ticks
         {
             get { return GetValue(TicksProperty); }
             set { SetValue(TicksProperty, value); }

--- a/src/Avalonia.Themes.Default/Slider.xaml
+++ b/src/Avalonia.Themes.Default/Slider.xaml
@@ -87,7 +87,10 @@
         </ControlTemplate>
     </Setter>
   </Style>
-    <Style Selector="Slider:disabled /template/ Grid#grid">
-        <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}" />
-    </Style>
+  <Style Selector="Slider /template/ TickBar">
+    <Setter Property="Ticks" Value="{TemplateBinding Ticks}" />
+  </Style>
+  <Style Selector="Slider:disabled /template/ Grid#grid">
+    <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}" />
+  </Style>
 </Styles>

--- a/src/Avalonia.Themes.Fluent/Slider.xaml
+++ b/src/Avalonia.Themes.Fluent/Slider.xaml
@@ -182,6 +182,7 @@
 
   <Style Selector="Slider /template/ TickBar">
     <Setter Property="IsVisible" Value="False" />
+    <Setter Property="Ticks" Value="{TemplateBinding Ticks}" />
   </Style>
 
   <!-- TickBar Placement States -->


### PR DESCRIPTION
## What does the pull request do?
This pull requests ports the behavior of custom Ticks from the WPF Sliders to Avalonia Sliders. 


## What is the current behavior?
Currently when the TickBar has custom ticks set and the snap to tick is enabled, the thumb wont snap on them. Also in order to set Ticks on a Slider you must create a template and set the ticks on the TickBar, which is tedious.


## What is the updated/expected behavior with this PR?
A control has been created in the controls project where you can see the thumb snap to the custom created ticks, also ticks are set on the Slider in the code behind.


## How was the solution implemented (if it's not obvious)?
It's a port from WPF, the exact source of `SnapToTick` implementation is [here](https://referencesource.microsoft.com/#PresentationFramework/src/Framework/System/windows/Controls/Slider.cs,1099).


## Checklist

- [ ] Added unit tests (if possible)?
- [X] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
There are none.


## Fixed issues
Fixes #4192 
