### PR TITLE
Fix flaky DatePickerTests.

### DIFF
--- a/tests/Avalonia.Controls.UnitTests/DatePickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DatePickerTests.cs
@@ -203,7 +203,9 @@ namespace Avalonia.Controls.UnitTests
         }
 
         private static TestServices Services => TestServices.MockThreadingInterface.With(
-            standardCursorFactory: Mock.Of<IStandardCursorFactory>());
+            fontManagerImpl: new MockFontManagerImpl(),
+            standardCursorFactory: Mock.Of<IStandardCursorFactory>(),
+            textShaperImpl: new MockTextShaperImpl());
 
         private IControlTemplate CreateTemplate()
         {

--- a/tests/Avalonia.Controls.UnitTests/TimePickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TimePickerTests.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Controls.UnitTests
 {
     public class TimePickerTests
     {
-        [Fact(Skip = "FIX ME ASAP")]
+        [Fact]
         public void SelectedTimeChanged_Should_Fire_When_SelectedTime_Set()
         {
             using (UnitTestApplication.Start(Services))
@@ -98,9 +98,10 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
-
         private static TestServices Services => TestServices.MockThreadingInterface.With(
-            standardCursorFactory: Mock.Of<IStandardCursorFactory>());
+            fontManagerImpl: new MockFontManagerImpl(),
+            standardCursorFactory: Mock.Of<IStandardCursorFactory>(),
+            textShaperImpl: new MockTextShaperImpl());
 
         private IControlTemplate CreateTemplate()
         {


### PR DESCRIPTION
## What does the pull request do?

`DatePickerTests` are proving to be flaky, especially on mac. Register the services that are reported missing when they fail.
