### PR TITLE
Fix DataGrid row height issue

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -3920,6 +3920,8 @@ namespace Avalonia.Controls
                     dataGridColumn: CurrentColumn,
                     dataGridRow: EditingRow,
                     dataGridCell: editingCell);
+
+                EditingRow.InvalidateDesiredHeight();
             }
 
             // We're done, so raise the CellEditEnded event

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -767,6 +767,11 @@ namespace Avalonia.Controls
             }
         }
 
+        internal void InvalidateDesiredHeight()
+        {
+            _cellsElement?.InvalidateDesiredHeight();
+        }
+
         internal void ResetGridLine()
         {
             _bottomGridLine = null;

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridCellsPresenter.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridCellsPresenter.cs
@@ -299,6 +299,11 @@ namespace Avalonia.Controls.Primitives
             DesiredHeight = 0;
         }
 
+        internal void InvalidateDesiredHeight()
+        {
+            DesiredHeight = 0;
+        }
+
         private bool ShouldDisplayCell(DataGridColumn column, double frozenLeftEdge, double scrollingLeftEdge)
         {
             if (!column.IsVisible)


### PR DESCRIPTION
## What does the pull request do?
Fixes #4207


## What is the current behavior?
If a row's height was changed when a cell is edited, the row doesn't return to the correct height afterward.


## What is the updated/expected behavior with this PR?
A row's height is now recalculated after a cell is edited.


## How was the solution implemented (if it's not obvious)?
The row height was being cached. The cached value is now reset after an edit is completed.


## Fixed issues
Fixes #4207 

