### PR TITLE
Fix NREs that occur when rendering to 0x0 framebuffer

### DIFF
--- a/src/Shared/PlatformSupport/StandardRuntimePlatform.cs
+++ b/src/Shared/PlatformSupport/StandardRuntimePlatform.cs
@@ -86,11 +86,15 @@ namespace Avalonia.Shared.PlatformSupport
 #if DEBUG
                 if (Thread.CurrentThread.ManagedThreadId == GCThread?.ManagedThreadId)
                 {
-                    lock(_lock)
+                    lock (_lock)
+                    {
                         if (!IsDisposed)
+                        {
                             Console.Error.WriteLine("Native blob disposal from finalizer thread\nBacktrace: "
-                                                    + Environment.StackTrace
-                                                    + "\n\nBlob created by " + _backtrace);
+                                                 + Environment.StackTrace
+                                                 + "\n\nBlob created by " + _backtrace);
+                        }
+                    }
                 }
 #endif
                 DoDispose();

--- a/src/Windows/Avalonia.Win32/FramebufferManager.cs
+++ b/src/Windows/Avalonia.Win32/FramebufferManager.cs
@@ -17,16 +17,18 @@ namespace Avalonia.Win32
 
         public ILockedFramebuffer Lock()
         {
-            UnmanagedMethods.RECT rc;
-            UnmanagedMethods.GetClientRect(_hwnd, out rc);
-            var width = rc.right - rc.left;
-            var height = rc.bottom - rc.top;
-            if ((_fb == null || _fb.Size.Width != width || _fb.Size.Height != height) && width > 0 && height > 0)
+            UnmanagedMethods.GetClientRect(_hwnd, out var rc);
+
+            var width = Math.Max(1, rc.right - rc.left);
+            var height = Math.Max(1, rc.bottom - rc.top);
+
+            if ((_fb == null || _fb.Size.Width != width || _fb.Size.Height != height))
             {
                 _fb?.Deallocate();
                 _fb = null;
                 _fb = new WindowFramebuffer(_hwnd, new PixelSize(width, height));
             }
+
             return _fb;
         }
     }

--- a/src/Windows/Avalonia.Win32/FramebufferManager.cs
+++ b/src/Windows/Avalonia.Win32/FramebufferManager.cs
@@ -5,7 +5,7 @@ using Avalonia.Win32.Interop;
 
 namespace Avalonia.Win32
 {
-    class FramebufferManager : IFramebufferPlatformSurface
+    class FramebufferManager : IFramebufferPlatformSurface, IDisposable
     {
         private readonly IntPtr _hwnd;
         private WindowFramebuffer _fb;
@@ -30,6 +30,12 @@ namespace Avalonia.Win32
             }
 
             return _fb;
+        }
+
+        public void Dispose()
+        {
+            _fb?.Deallocate();
+            _fb = null;
         }
     }
 }

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -389,6 +389,8 @@ namespace Avalonia.Win32
                 UnregisterClass(_className, GetModuleHandle(null));
                 _className = null;
             }
+
+            _framebuffer.Dispose();
         }
 
         public void Invalidate(Rect rect)


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
As described in https://github.com/AvaloniaUI/Avalonia/issues/3755 - having a popup that will have zero sized content will throw NRE in Skia renderer (only when using software rasterization to a framebuffer).

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Also added a fix to properly dispose framebuffers when closing windows.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #3755
