### PR TITLE
Fix hardcoded thumb min length

### DIFF
--- a/src/Avalonia.Controls/Primitives/Track.cs
+++ b/src/Avalonia.Controls/Primitives/Track.cs
@@ -353,6 +353,15 @@ namespace Avalonia.Controls.Primitives
             var trackLength = isVertical ? arrangeSize.Height : arrangeSize.Width;
             double thumbMinLength = 10;
 
+            StyledProperty<double> minLengthProperty = isVertical ? MinHeightProperty : MinWidthProperty;
+
+            var thumb = Thumb;
+
+            if (thumb != null && thumb.IsSet(minLengthProperty))
+            {
+                thumbMinLength = thumb.GetValue(minLengthProperty);
+            }
+
             thumbLength = trackLength * viewportSize / extent;
             CoerceLength(ref thumbLength, trackLength);
             thumbLength = Math.Max(thumbMinLength, thumbLength);


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Our `Track` code was using hardcoded 10px thumb min length which lead to overlaps in fluent theme.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Small thumbs overlap scrollbar buttons.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Small thumbs do not overlap scrollbar buttons.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
After a chat with @grokys  we figured that we can check if `Thumb` has `MinHeight/MinWidth` set and use that if present instead.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
