### PR TITLE
!B Fixing materialize events being called twice when using ItemVirtualizerNone

### DIFF
--- a/src/Avalonia.Controls/Presenters/ItemVirtualizerNone.cs
+++ b/src/Avalonia.Controls/Presenters/ItemVirtualizerNone.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using Avalonia.Controls.Generators;
-using Avalonia.Controls.Utils;
 
 namespace Avalonia.Controls.Presenters
 {
@@ -16,10 +15,6 @@ namespace Avalonia.Controls.Presenters
         public ItemVirtualizerNone(ItemsPresenter owner)
             : base(owner)
         {
-            if (Items != null && owner.Panel != null)
-            {
-                AddContainers(0, Items);
-            }
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Turns out that (De)materialize events are called twice when loading items in `ItemsPresenter` that uses `ItemVirtualizerNone`. Tested locally, seems to work fine.
