### PR TITLE
Make non-virtualized items be materialized only once.

### DIFF
--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -155,6 +155,11 @@ namespace Avalonia.Controls.Presenters
             }
         }
 
+        protected override void PanelCreated(IPanel panel)
+        {
+            ItemsChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+        }
+
         /// <summary>
         /// Moves to the selected page, animating if a <see cref="PageTransition"/> is set.
         /// </summary>

--- a/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
@@ -229,8 +229,6 @@ namespace Avalonia.Controls.Presenters
             }
 
             PanelCreated(Panel);
-
-            ItemsChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
 
         /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests.cs
@@ -61,6 +61,25 @@ namespace Avalonia.Controls.UnitTests.Presenters
         }
 
         [Fact]
+        public void Should_Create_Containers_Only_Once()
+        {
+            var parent = new TestItemsControl();
+            var target = new ItemsPresenter
+            {
+                Items = new[] { "foo", "bar" },
+                [StyledElement.TemplatedParentProperty] = parent,
+            };
+            var raised = 0;
+
+            parent.ItemContainerGenerator.Materialized += (s, e) => ++raised;
+
+            target.ApplyTemplate();
+
+            Assert.Equal(2, target.Panel.Children.Count);
+            Assert.Equal(2, raised);
+        }
+
+        [Fact]
         public void ItemContainerGenerator_Should_Be_Picked_Up_From_TemplatedControl()
         {
             var parent = new TestItemsControl();


### PR DESCRIPTION
## What does the pull request do?

When virtualization was turned off in an `ItemsControl`, items were virtualized twice. on control creation. Fix that.

## Checklist

- [x] Added unit tests (if possible)?

Attn: @pr8x 