### PR TITLE
Fix typo & add missing attribute related to RelativePanel

### DIFF
--- a/src/Avalonia.Controls/RelativePanel.AttachedProperties.cs
+++ b/src/Avalonia.Controls/RelativePanel.AttachedProperties.cs
@@ -33,7 +33,7 @@ namespace Avalonia.Controls
             AlignVerticalCenterWithProperty.Changed.AddClassHandler<Layoutable>(OnAlignPropertiesChanged);
             BelowProperty.Changed.AddClassHandler<Layoutable>(OnAlignPropertiesChanged);
             LeftOfProperty.Changed.AddClassHandler<Layoutable>(OnAlignPropertiesChanged);
-            LeftOfProperty.Changed.AddClassHandler<Layoutable>(OnAlignPropertiesChanged);
+            RightOfProperty.Changed.AddClassHandler<Layoutable>(OnAlignPropertiesChanged);
         }
 
         /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/RelativePanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/RelativePanelTests.cs
@@ -31,6 +31,7 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new Rect(20, 0, 20, 20), target.Children[1].Bounds);
         }
 
+        [Fact]
         public void Lays_Out_1_Child_Below_the_other()
         {
             var rect1 = new Rectangle { Height = 20, Width = 20 };


### PR DESCRIPTION
## What does the pull request do?
Fix typo

## What is the current behavior?
The `LeftOfProperty` property is used twice, the `RightOf` one is missing.

## What is the updated/expected behavior with this PR?
The `RightOf` property is added.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
