### PR TITLE
Fixes/unable to bind where application provides datacontext

### DIFF
--- a/src/Markup/Avalonia.Markup/Data/BindingBase.cs
+++ b/src/Markup/Avalonia.Markup/Data/BindingBase.cs
@@ -137,9 +137,9 @@ namespace Avalonia.Data
         {
             Contract.Requires<ArgumentNullException>(target != null);
 
-            if (!(target is IStyledElement))
+            if (!(target is IDataContextProvider))
             {
-                target = anchor as IStyledElement;
+                target = anchor as IDataContextProvider;
 
                 if (target == null)
                 {

--- a/tests/Avalonia.Controls.UnitTests/ApplicationTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ApplicationTests.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Reactive.Subjects;
 using Avalonia.Data;
-using Avalonia.Threading;
 using Avalonia.UnitTests;
 using Xunit;
 

--- a/tests/Avalonia.Controls.UnitTests/ApplicationTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ApplicationTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reactive.Subjects;
+using Avalonia.Data;
 using Avalonia.Threading;
 using Avalonia.UnitTests;
 using Xunit;
@@ -30,6 +32,21 @@ namespace Avalonia.Controls.UnitTests
                 resources["foo"] = "bar";
 
                 Assert.True(raised);
+            }
+        }
+
+        [Fact]
+        public void Can_Bind_To_DataContext()
+        {
+            using (UnitTestApplication.Start())
+            {
+                var application = Application.Current;
+
+                application.DataContext = "Test";
+
+                application.Bind(Application.NameProperty, new Binding("."));
+
+                Assert.Equal("Test", Application.Current.Name);
             }
         }
     }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
When we merged the CompiledBindings pr it was still assuming IStyledElement was the interface for DataContext property.

It had previously been changed to use IDataContextProvider but was missed.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
crashes if `Binding` is used with `Application` class.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
now works as expected.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
