### PR TITLE
Fixes/tooltip must close when detached from visual tree

### DIFF
--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -28,13 +28,21 @@ namespace Avalonia.Controls
             {
                 control.PointerEnter -= ControlPointerEnter;
                 control.PointerLeave -= ControlPointerLeave;
+                control.DetachedFromVisualTree -= ControlDetaching;
             }
 
             if (e.NewValue != null)
             {
                 control.PointerEnter += ControlPointerEnter;
                 control.PointerLeave += ControlPointerLeave;
+                control.DetachedFromVisualTree += ControlDetaching;
             }
+        }
+        
+        private void ControlDetaching(object sender, VisualTreeAttachmentEventArgs e)
+        {
+            var control = (Control)sender;
+            Close(control);
         }
 
         /// <summary>

--- a/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
@@ -30,6 +30,40 @@ namespace Avalonia.Controls.UnitTests
 
             Assert.False(ToolTip.GetIsOpen(control));
         }
+        
+        [Fact]
+        public void Should_Close_When_Control_Detaches()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var window = new Window();
+
+                var panel = new Panel();
+                
+                var target = new Decorator()
+                {
+                    [ToolTip.TipProperty] = "Tip",
+                    [ToolTip.ShowDelayProperty] = 0
+                };
+                
+                panel.Children.Add(target);
+
+                window.Content = panel;
+
+                window.ApplyTemplate();
+                window.Presenter.ApplyTemplate();
+
+                Assert.True((target as IVisual).IsAttachedToVisualTree);                               
+
+                _mouseHelper.Enter(target);
+
+                Assert.True(ToolTip.GetIsOpen(target));
+                
+                panel.Children.Remove(target);
+                
+                Assert.False(ToolTip.GetIsOpen(target));
+            }
+        }
 
         [Fact]
         public void Should_Open_On_Pointer_Enter()


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes tooltips to prevent them from being stuck on screen.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Issues like: https://github.com/zkSNACKs/WalletWasabi/issues/3909 can occur.

The parent control gets detached from visualtree whilst tooltip is open. Tooltip looses stlyes but gets permanently stuck on screen.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Tooltip is closed when parent detaches from visual tree.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
