### PR TITLE
Use TextBox text alignment and wrapping in watermark

### DIFF
--- a/src/Avalonia.Themes.Default/TextBox.xaml
+++ b/src/Avalonia.Themes.Default/TextBox.xaml
@@ -40,6 +40,8 @@
                   <TextBlock Name="watermark"
                              Opacity="0.5"
                              Text="{TemplateBinding Watermark}"
+                             TextAlignment="{TemplateBinding TextAlignment}"
+                             TextWrapping="{TemplateBinding TextWrapping}"
                              IsVisible="{TemplateBinding Text, Converter={x:Static StringConverters.IsNullOrEmpty}}"/>
                   <TextPresenter Name="PART_TextPresenter"
                                  Text="{TemplateBinding Text, Mode=TwoWay}"

--- a/src/Avalonia.Themes.Fluent/TextBox.xaml
+++ b/src/Avalonia.Themes.Fluent/TextBox.xaml
@@ -72,6 +72,8 @@
                     <TextBlock Name="watermark"
                                Opacity="0.5"
                                Text="{TemplateBinding Watermark}"
+                               TextAlignment="{TemplateBinding TextAlignment}"
+                               TextWrapping="{TemplateBinding TextWrapping}"
                                IsVisible="{TemplateBinding Text, Converter={x:Static StringConverters.IsNullOrEmpty}}"/>
                     <!-- TODO eliminate this margin... text layout issue? -->
                     <TextPresenter Name="PART_TextPresenter"


### PR DESCRIPTION
## What does the pull request do?
Use `TextBox` text alignment and wrapping in watermark. This is the same as WinUI: https://github.com/microsoft/microsoft-ui-xaml/blob/507826eccc8bba066c466c84c1947d5bae5835f5/dev/CommonStyles/TextBox_themeresources.xaml#L332-L333


## What is the current behavior?
`TextBox` watermark doesn't use same alignment and wrapping as text.


## What is the updated/expected behavior with this PR?
`TextBox` watermark uses same alignment and wrapping as text.


## How was the solution implemented (if it's not obvious)?
Updated `TextBox` template in both default and fluent themes to bind `TextAlignment` and `TextWrapping` to the watermark `TextBlock`.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
