### PR TITLE
Ensure that TryParse won't throw.

### DIFF
--- a/src/Avalonia.Visuals/Media/Color.cs
+++ b/src/Avalonia.Visuals/Media/Color.cs
@@ -89,6 +89,11 @@ namespace Avalonia.Media
         /// <returns>The <see cref="Color"/>.</returns>
         public static Color Parse(string s)
         {
+            if (s is null)
+            {
+                throw new ArgumentNullException(nameof(s));
+            }
+
             if (TryParse(s, out Color color))
             {
                 return color;
@@ -120,14 +125,16 @@ namespace Avalonia.Media
         /// <returns>The status of the operation.</returns>
         public static bool TryParse(string s, out Color color)
         {
+            color = default;
+
             if (s == null)
             {
-                throw new ArgumentNullException(nameof(s));
+                return false;
             }
 
             if (s.Length == 0)
             {
-                throw new FormatException();
+                return false;
             }
 
             if (s[0] == '#' && TryParseInternal(s.AsSpan(), out color))
@@ -143,8 +150,6 @@ namespace Avalonia.Media
 
                 return true;
             }
-
-            color = default;
 
             return false;
         }

--- a/src/Avalonia.Visuals/Media/Color.cs
+++ b/src/Avalonia.Visuals/Media/Color.cs
@@ -127,7 +127,7 @@ namespace Avalonia.Media
         {
             color = default;
 
-            if (s == null)
+            if (s is null)
             {
                 return false;
             }

--- a/tests/Avalonia.Visuals.UnitTests/Media/ColorTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/ColorTests.cs
@@ -179,5 +179,25 @@ namespace Avalonia.Visuals.UnitTests.Media
         {
             Assert.False(Color.TryParse("#ff808g80", out _));
         }
+
+        [Fact]
+        public void Parse_Throws_ArgumentNullException_For_Null_Input()
+        {
+            Assert.Throws<ArgumentNullException>(() => Color.Parse((string)null));
+        }
+
+        [Fact]
+        public void Parse_Throws_FormatException_For_Invalid_Input()
+        {
+            Assert.Throws<FormatException>(() => Color.Parse(string.Empty));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void TryParse_Returns_False_For_Invalid_Input(string input)
+        {
+            Assert.False(Color.TryParse(input, out _));
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
As described in #4279 `TryParse` could actually throw thus breaking `TryX` contract.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`Color.TryParse` can throw.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
`Color.TryParse` does not throw.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
Fixes #4279