### PR TITLE
fix X11 XDestroyWindow crash

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -760,11 +760,7 @@ namespace Avalonia.X11
 
         public void Dispose()
         {
-            if (_handle != IntPtr.Zero)
-            {
-                XDestroyWindow(_x11.Display, _handle);
-                Cleanup();
-            }
+            Cleanup();            
         }
 
         void Cleanup()
@@ -787,8 +783,7 @@ namespace Avalonia.X11
             }
             
             if (_useRenderWindow && _renderHandle != IntPtr.Zero)
-            {
-                XDestroyWindow(_x11.Display, _renderHandle);
+            {                
                 _renderHandle = IntPtr.Zero;
             }
         }


### PR DESCRIPTION
## What does the pull request do?

Fix XDestroyWindow crash.

## What is the current behavior?

On Linux platform trying to create a dialog it crashes when closed or hovering a tooltip does the same when tooltip should disappers when another XWindow window is running, for example Silk.NET window.

## What is the updated/expected behavior with this PR?

Crash no more.

## How was the solution implemented (if it's not obvious)?

- [XDestroyWindow](https://github.com/SearchAThing-forks/Avalonia/commit/2ede354bbc7268f39c733342212a7730e976a7e0#diff-93a6a9ab3e9cf32b7e2b095c008a8851L765) not required on Dispose because it already call Cleanup that do the same.
- [XDestroyWindow](https://github.com/SearchAThing-forks/Avalonia/commit/2ede354bbc7268f39c733342212a7730e976a7e0#diff-93a6a9ab3e9cf32b7e2b095c008a8851L791) not required because here renderHandle window [its created as a child](https://github.com/SearchAThing-forks/Avalonia/blob/2ede354bbc7268f39c733342212a7730e976a7e0/src/Avalonia.X11/X11Window.cs#L134) and already included in destroy process by the parent.

A repro to check the behavior available here:

```sh
git clone https://github.com/devel0/repros.git
cd repros
git checkout b558e96ae21a5196222b9126eca8eda0457a6828
cd avalonia/xdestroywindow-crash
dotnet run
```

follow win appears:

<img width="400" src="https://user-images.githubusercontent.com/13405008/87942088-5cde4180-ca9c-11ea-828b-bc865e4504db.png"/>

clicking on `open modal dialog` and hovering `button with tooltip` doesn't crash, but if you first `open silk net win` you'll go the behavior.

It's useful to use follow tool to see x events:

```sh
xtrace -n dotnet run
```

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes

## Fixed issues

should related to #3536 