### PR TITLE
ensure managed titlebar is attached in window when template is applied.

### DIFF
--- a/src/Avalonia.Controls/Chrome/CaptionButtons.cs
+++ b/src/Avalonia.Controls/Chrome/CaptionButtons.cs
@@ -38,12 +38,10 @@ namespace Avalonia.Controls.Chrome
         {
             if (_disposables != null)
             {
-                var layer = ChromeOverlayLayer.GetOverlayLayer(_hostWindow);
-
-                layer?.Children.Remove(this);
-
                 _disposables.Dispose();
                 _disposables = null;
+
+                _hostWindow = null;
             }
         }
 

--- a/src/Avalonia.Controls/Chrome/TitleBar.cs
+++ b/src/Avalonia.Controls/Chrome/TitleBar.cs
@@ -29,12 +29,12 @@ namespace Avalonia.Controls.Chrome
         {
             if (_disposables == null)
             {
-                var layer = ChromeOverlayLayer.GetOverlayLayer(_hostWindow);
-
-                layer?.Children.Add(this);
-
                 if (_hostWindow != null)
                 {
+                    var layer = ChromeOverlayLayer.GetOverlayLayer(_hostWindow);
+
+                    layer?.Children.Add(this);
+                    
                     _disposables = new CompositeDisposable
                     {
                         _hostWindow.GetObservable(Window.WindowDecorationMarginProperty)

--- a/src/Avalonia.Controls/Chrome/TitleBar.cs
+++ b/src/Avalonia.Controls/Chrome/TitleBar.cs
@@ -14,11 +14,6 @@ namespace Avalonia.Controls.Chrome
         private CompositeDisposable? _disposables;
         private CaptionButtons? _captionButtons;
 
-        public TitleBar()
-        {
-
-        }
-
         private void UpdateSize(Window window)
         {
             if (window != null)
@@ -51,20 +46,28 @@ namespace Avalonia.Controls.Chrome
 
             if (VisualRoot is Window window)
             {
+                _captionButtons?.Attach(window);   
+                
+                UpdateSize(window);
+            }
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+
+            if (VisualRoot is Window window)
+            {
                 _disposables = new CompositeDisposable
                 {
                     window.GetObservable(Window.WindowDecorationMarginProperty)
                         .Subscribe(x => UpdateSize(window)),
-
                     window.GetObservable(Window.ExtendClientAreaTitleBarHeightHintProperty)
                         .Subscribe(x => UpdateSize(window)),
-
                     window.GetObservable(Window.OffScreenMarginProperty)
                         .Subscribe(x => UpdateSize(window)),
-                    
                     window.GetObservable(Window.ExtendClientAreaChromeHintsProperty)
                         .Subscribe(x => UpdateSize(window)),
-
                     window.GetObservable(Window.WindowStateProperty)
                         .Subscribe(x =>
                         {
@@ -73,15 +76,17 @@ namespace Avalonia.Controls.Chrome
                             PseudoClasses.Set(":maximized", x == WindowState.Maximized);
                             PseudoClasses.Set(":fullscreen", x == WindowState.FullScreen);
                         }),
-                    
                     window.GetObservable(Window.IsExtendedIntoWindowDecorationsProperty)
                         .Subscribe(x => UpdateSize(window))
                 };
-
-                _captionButtons.Attach(window);   
-                
-                UpdateSize(window);
             }
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+
+            _disposables?.Dispose();
         }
     }
 }

--- a/src/Avalonia.Controls/Chrome/TitleBar.cs
+++ b/src/Avalonia.Controls/Chrome/TitleBar.cs
@@ -42,6 +42,8 @@ namespace Avalonia.Controls.Chrome
         {
             base.OnApplyTemplate(e);
 
+            _captionButtons?.Detach();
+            
             _captionButtons = e.NameScope.Get<CaptionButtons>("PART_CaptionButtons");
 
             if (VisualRoot is Window window)
@@ -87,6 +89,9 @@ namespace Avalonia.Controls.Chrome
             base.OnDetachedFromVisualTree(e);
 
             _disposables?.Dispose();
+            
+            _captionButtons?.Detach();
+            _captionButtons = null;
         }
     }
 }

--- a/src/Avalonia.Controls/Primitives/ChromeOverlayLayer.cs
+++ b/src/Avalonia.Controls/Primitives/ChromeOverlayLayer.cs
@@ -24,6 +24,11 @@ namespace Avalonia.Controls.Primitives
             return null;
         }
 
+        public void Add(Control c)
+        {
+            base.Children.Add(c);
+        }
+
         public bool HitTest(Point point) => Children.HitTestCustom(point);
     }
 }

--- a/src/Avalonia.Controls/Primitives/ChromeOverlayLayer.cs
+++ b/src/Avalonia.Controls/Primitives/ChromeOverlayLayer.cs
@@ -8,7 +8,7 @@ namespace Avalonia.Controls.Primitives
 {
     public class ChromeOverlayLayer : Panel, ICustomSimpleHitTest
     {
-        public static ChromeOverlayLayer? GetOverlayLayer(IVisual visual)
+        public static Panel? GetOverlayLayer(IVisual visual)
         {
             foreach (var v in visual.GetVisualAncestors())
                 if (v is VisualLayerManager vlm)

--- a/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
+++ b/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
@@ -11,8 +11,17 @@ namespace Avalonia.Controls.Primitives
 
         private ILogicalRoot _logicalRoot;
         private readonly List<Control> _layers = new List<Control>();
-        
 
+        public static readonly StyledProperty<Panel> ChromeOverlayLayerProperty =
+            AvaloniaProperty.Register<VisualLayerManager, Panel>(nameof(ChromeOverlayLayer));
+
+        public VisualLayerManager()
+        {
+            var chromeOverlayLayer = new ChromeOverlayLayer();
+            AddLayer(chromeOverlayLayer, ChromeZIndex);
+            ChromeOverlayLayer = chromeOverlayLayer;
+        }
+        
         public bool IsPopup { get; set; }
         
         public AdornerLayer AdornerLayer
@@ -26,15 +35,10 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
-        public ChromeOverlayLayer ChromeOverlayLayer
+        public Panel ChromeOverlayLayer
         {
-            get
-            {
-                var rv = FindLayer<ChromeOverlayLayer>();
-                if (rv == null)
-                    AddLayer(rv = new ChromeOverlayLayer(), ChromeZIndex);
-                return rv;
-            }
+            get => GetValue(ChromeOverlayLayerProperty);
+            private set => SetValue(ChromeOverlayLayerProperty, value);
         }
 
         public OverlayLayer OverlayLayer

--- a/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
+++ b/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
@@ -15,9 +15,9 @@ namespace Avalonia.Controls.Primitives
 
         public static readonly StyledProperty<ChromeOverlayLayer> ChromeOverlayLayerProperty =
             AvaloniaProperty.Register<VisualLayerManager, ChromeOverlayLayer>(nameof(ChromeOverlayLayer));
-        
+
         public bool IsPopup { get; set; }
-        
+
         public AdornerLayer AdornerLayer
         {
             get
@@ -28,7 +28,7 @@ namespace Avalonia.Controls.Primitives
                 return rv;
             }
         }
-        
+
         public ChromeOverlayLayer ChromeOverlayLayer
         {
             get
@@ -56,7 +56,7 @@ namespace Avalonia.Controls.Primitives
                 if (IsPopup)
                     return null;
                 var rv = FindLayer<OverlayLayer>();
-                if(rv == null)
+                if (rv == null)
                     AddLayer(rv = new OverlayLayer(), OverlayZIndex);
                 return rv;
             }
@@ -77,7 +77,8 @@ namespace Avalonia.Controls.Primitives
             layer.ZIndex = zindex;
             VisualChildren.Add(layer);
             if (((ILogical)this).IsAttachedToLogicalTree)
-                ((ILogical)layer).NotifyAttachedToLogicalTree(new LogicalTreeAttachmentEventArgs(_logicalRoot, layer, this));
+                ((ILogical)layer).NotifyAttachedToLogicalTree(
+                    new LogicalTreeAttachmentEventArgs(_logicalRoot, layer, this));
             InvalidateArrange();
         }
 

--- a/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
+++ b/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Avalonia.LogicalTree;
+using Avalonia.Metadata;
 
 namespace Avalonia.Controls.Primitives
 {
@@ -12,15 +13,8 @@ namespace Avalonia.Controls.Primitives
         private ILogicalRoot _logicalRoot;
         private readonly List<Control> _layers = new List<Control>();
 
-        public static readonly StyledProperty<Panel> ChromeOverlayLayerProperty =
-            AvaloniaProperty.Register<VisualLayerManager, Panel>(nameof(ChromeOverlayLayer));
-
-        public VisualLayerManager()
-        {
-            var chromeOverlayLayer = new ChromeOverlayLayer();
-            AddLayer(chromeOverlayLayer, ChromeZIndex);
-            ChromeOverlayLayer = chromeOverlayLayer;
-        }
+        public static readonly StyledProperty<ChromeOverlayLayer> ChromeOverlayLayerProperty =
+            AvaloniaProperty.Register<VisualLayerManager, ChromeOverlayLayer>(nameof(ChromeOverlayLayer));
         
         public bool IsPopup { get; set; }
         
@@ -34,11 +28,25 @@ namespace Avalonia.Controls.Primitives
                 return rv;
             }
         }
-
-        public Panel ChromeOverlayLayer
+        
+        public ChromeOverlayLayer ChromeOverlayLayer
         {
-            get => GetValue(ChromeOverlayLayerProperty);
-            private set => SetValue(ChromeOverlayLayerProperty, value);
+            get
+            {
+                var current = GetValue(ChromeOverlayLayerProperty);
+
+                if (current is null)
+                {
+                    var chromeOverlayLayer = new ChromeOverlayLayer();
+                    AddLayer(chromeOverlayLayer, ChromeZIndex);
+
+                    SetValue(ChromeOverlayLayerProperty, chromeOverlayLayer);
+
+                    current = chromeOverlayLayer;
+                }
+
+                return current;
+            }
         }
 
         public OverlayLayer OverlayLayer

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls.Chrome;
 using Avalonia.Controls.Platform;
+using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -75,6 +76,7 @@ namespace Avalonia.Controls
         private bool _isExtendedIntoWindowDecorations;
         private Thickness _windowDecorationMargin;
         private Thickness _offScreenMargin;
+        private bool _templateApplied;
 
         /// <summary>
         /// Defines the <see cref="SizeToContent"/> property.
@@ -553,7 +555,7 @@ namespace Avalonia.Controls
             WindowDecorationMargin = PlatformImpl.ExtendedMargins;
             OffScreenMargin = PlatformImpl.OffScreenMargin;
 
-            if (PlatformImpl.NeedsManagedDecorations)
+            if (PlatformImpl.NeedsManagedDecorations && _templateApplied)
             {
                 if (_managedTitleBar == null)
                 {
@@ -566,6 +568,15 @@ namespace Avalonia.Controls
                 _managedTitleBar?.Detach();
                 _managedTitleBar = null;
             }
+        }
+
+        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+        {
+            base.OnApplyTemplate(e);
+
+            _templateApplied = true;
+            
+            ExtendClientAreaToDecorationsChanged(PlatformImpl.IsClientAreaExtendedToDecorations);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -71,12 +71,10 @@ namespace Avalonia.Controls
     /// </summary>
     public class Window : WindowBase, IStyleable, IFocusScope, ILayoutRoot
     {
-        private readonly List<(Window child, bool isDialog)> _children = new List<(Window, bool)>();        
-        private TitleBar _managedTitleBar;
+        private readonly List<(Window child, bool isDialog)> _children = new List<(Window, bool)>();
         private bool _isExtendedIntoWindowDecorations;
         private Thickness _windowDecorationMargin;
         private Thickness _offScreenMargin;
-        private bool _templateApplied;
 
         /// <summary>
         /// Defines the <see cref="SizeToContent"/> property.
@@ -554,29 +552,6 @@ namespace Avalonia.Controls
             IsExtendedIntoWindowDecorations = isExtended;
             WindowDecorationMargin = PlatformImpl.ExtendedMargins;
             OffScreenMargin = PlatformImpl.OffScreenMargin;
-
-            if (PlatformImpl.NeedsManagedDecorations && _templateApplied)
-            {
-                if (_managedTitleBar == null)
-                {
-                    _managedTitleBar = new TitleBar(this);
-                    _managedTitleBar.Attach();
-                }                
-            }
-            else
-            {
-                _managedTitleBar?.Detach();
-                _managedTitleBar = null;
-            }
-        }
-
-        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
-        {
-            base.OnApplyTemplate(e);
-
-            _templateApplied = true;
-            
-            ExtendClientAreaToDecorationsChanged(PlatformImpl.IsClientAreaExtendedToDecorations);
         }
 
         /// <summary>

--- a/src/Avalonia.Themes.Default/Window.xaml
+++ b/src/Avalonia.Themes.Default/Window.xaml
@@ -1,23 +1,22 @@
 <Style xmlns="https://github.com/avaloniaui" Selector="Window">
-  <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}"/>
-  <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
-  <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}"/>
+  <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>  
+  <Setter Property="TransparencyBackgroundFallback" Value="{DynamicResource SystemControlBackgroundAltHighBrush}" />
+  <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+  <Setter Property="FontSize" Value="{DynamicResource ContentControlFontSize}"/>  
+  <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
   <Setter Property="Template">
     <ControlTemplate>
       <Panel>
-        <Panel IsHitTestVisible="False" Margin="{TemplateBinding OffScreenMargin}">
-          <Border Name="PART_TransparencyFallback" IsHitTestVisible="False" />
-        </Panel>
-        <Border Background="{TemplateBinding Background}">
-          <VisualLayerManager>
-            <ContentPresenter Name="PART_ContentPresenter"
-                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                              Content="{TemplateBinding Content}"
-                              Margin="{TemplateBinding Padding}"
-                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
-          </VisualLayerManager>
-        </Border>
+        <Border Name="PART_TransparencyFallback" IsHitTestVisible="False" />
+        <Border Background="{TemplateBinding Background}" IsHitTestVisible="False" />
+        <VisualLayerManager>
+          <ContentPresenter Name="PART_ContentPresenter"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            Content="{TemplateBinding Content}"
+                            Margin="{TemplateBinding Padding}"
+                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
+        </VisualLayerManager>
       </Panel>
     </ControlTemplate>
   </Setter>

--- a/src/Avalonia.Themes.Default/Window.xaml
+++ b/src/Avalonia.Themes.Default/Window.xaml
@@ -10,6 +10,9 @@
         <Border Name="PART_TransparencyFallback" IsHitTestVisible="False" />
         <Border Background="{TemplateBinding Background}" IsHitTestVisible="False" />
         <VisualLayerManager>
+          <VisualLayerManager.ChromeOverlayLayer>
+            <TitleBar />
+          </VisualLayerManager.ChromeOverlayLayer>
           <ContentPresenter Name="PART_ContentPresenter"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
                             Content="{TemplateBinding Content}"

--- a/src/Avalonia.Themes.Fluent/Window.xaml
+++ b/src/Avalonia.Themes.Fluent/Window.xaml
@@ -8,16 +8,15 @@
     <ControlTemplate>
       <Panel>
         <Border Name="PART_TransparencyFallback" IsHitTestVisible="False" />
-        <Border Background="{TemplateBinding Background}">
-          <VisualLayerManager>
-            <ContentPresenter Name="PART_ContentPresenter"
-                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                              Content="{TemplateBinding Content}"
-                              Margin="{TemplateBinding Padding}"
-                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
-          </VisualLayerManager>
-        </Border>
+        <Border Background="{TemplateBinding Background}" IsHitTestVisible="False" />
+        <VisualLayerManager>
+          <ContentPresenter Name="PART_ContentPresenter"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            Content="{TemplateBinding Content}"
+                            Margin="{TemplateBinding Padding}"
+                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
+        </VisualLayerManager>
       </Panel>
     </ControlTemplate>
   </Setter>

--- a/src/Avalonia.Themes.Fluent/Window.xaml
+++ b/src/Avalonia.Themes.Fluent/Window.xaml
@@ -10,6 +10,9 @@
         <Border Name="PART_TransparencyFallback" IsHitTestVisible="False" />
         <Border Background="{TemplateBinding Background}" IsHitTestVisible="False" />
         <VisualLayerManager>
+          <VisualLayerManager.ChromeOverlayLayer>
+            <TitleBar />
+          </VisualLayerManager.ChromeOverlayLayer>
           <ContentPresenter Name="PART_ContentPresenter"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
                             Content="{TemplateBinding Content}"


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Ensures that if ExtendedToTitleBarHint = true before windowtemplate is applied it will still install managed titlebar when requested.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
managed titlebar is missing unless this property is changed after window is shown.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
