### PR TITLE
[ TimePicker ] Reset column indexes in a Grid to avoid exception

### DIFF
--- a/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Controls
         /// Defines the <see cref="MinuteIncrement"/> property
         /// </summary>
         public static readonly DirectProperty<TimePicker, int> MinuteIncrementProperty =
-            AvaloniaProperty.RegisterDirect<TimePicker, int>(nameof(MinuteIncrement), 
+            AvaloniaProperty.RegisterDirect<TimePicker, int>(nameof(MinuteIncrement),
                 x => x.MinuteIncrement, (x, v) => x.MinuteIncrement = v);
 
         /// <summary>
@@ -34,17 +34,17 @@ namespace Avalonia.Controls
         /// Defines the <see cref="ClockIdentifier"/> property
         /// </summary>
         public static readonly DirectProperty<TimePicker, string> ClockIdentifierProperty =
-           AvaloniaProperty.RegisterDirect<TimePicker, string>(nameof(ClockIdentifier), 
+           AvaloniaProperty.RegisterDirect<TimePicker, string>(nameof(ClockIdentifier),
                x => x.ClockIdentifier, (x, v) => x.ClockIdentifier = v);
 
         /// <summary>
         /// Defines the <see cref="SelectedTime"/> property
         /// </summary>
         public static readonly DirectProperty<TimePicker, TimeSpan?> SelectedTimeProperty =
-            AvaloniaProperty.RegisterDirect<TimePicker, TimeSpan?>(nameof(SelectedTime), 
+            AvaloniaProperty.RegisterDirect<TimePicker, TimeSpan?>(nameof(SelectedTime),
                 x => x.SelectedTime, (x, v) => x.SelectedTime = v);
 
-        //Template Items
+        // Template Items
         private TimePickerPresenter _presenter;
         private Button _flyoutButton;
         private Border _firstPickerHost;
@@ -52,7 +52,7 @@ namespace Avalonia.Controls
         private Border _thirdPickerHost;
         private TextBlock _hourText;
         private TextBlock _minuteText;
-        public TextBlock _periodText;
+        private TextBlock _periodText;
         private Rectangle _firstSplitter;
         private Rectangle _secondSplitter;
         private Grid _contentGrid;
@@ -145,7 +145,7 @@ namespace Avalonia.Controls
             if (_flyoutButton != null)
                 _flyoutButton.Click -= OnFlyoutButtonClicked;
 
-            if(_presenter != null)
+            if (_presenter != null)
             {
                 _presenter.Confirmed -= OnConfirmed;
                 _presenter.Dismissed -= OnDismissPicker;
@@ -170,7 +170,6 @@ namespace Avalonia.Controls
             _popup = e.NameScope.Find<Popup>("Popup");
             _presenter = e.NameScope.Find<TimePickerPresenter>("PickerPresenter");
 
-
             if (_flyoutButton != null)
                 _flyoutButton.Click += OnFlyoutButtonClicked;
 
@@ -185,7 +184,6 @@ namespace Avalonia.Controls
                 _presenter[!TimePickerPresenter.MinuteIncrementProperty] = this[!MinuteIncrementProperty];
                 _presenter[!TimePickerPresenter.ClockIdentifierProperty] = this[!ClockIdentifierProperty];
             }
-
         }
 
         private void SetGrid()
@@ -195,30 +193,19 @@ namespace Avalonia.Controls
 
             bool use24HourClock = ClockIdentifier == "24HourClock";
 
-            if (!use24HourClock)
-            {
-                _contentGrid.ColumnDefinitions = new ColumnDefinitions("*,Auto,*,Auto,*");
-                _thirdPickerHost.IsVisible = true;
-                _secondSplitter.IsVisible = true;
+            var columnsD = use24HourClock ? "*, Auto, *" : "*, Auto, *, Auto, *";
+            _contentGrid.ColumnDefinitions = new ColumnDefinitions(columnsD);
 
-                Grid.SetColumn(_firstPickerHost, 0);
-                Grid.SetColumn(_secondPickerHost, 2);
-                Grid.SetColumn(_thirdPickerHost, 4);
+            _thirdPickerHost.IsVisible = !use24HourClock;
+            _secondSplitter.IsVisible = !use24HourClock;
 
-                Grid.SetColumn(_firstSplitter, 1);
-                Grid.SetColumn(_secondSplitter, 3);
-            }
-            else
-            {
-                _contentGrid.ColumnDefinitions = new ColumnDefinitions("*,Auto,*");
-                _thirdPickerHost.IsVisible = false;
-                _secondSplitter.IsVisible = false;
+            Grid.SetColumn(_firstPickerHost, 0);
+            Grid.SetColumn(_secondPickerHost, 2);
 
-                Grid.SetColumn(_firstPickerHost, 0);
-                Grid.SetColumn(_secondPickerHost, 2);
+            Grid.SetColumn(_thirdPickerHost, use24HourClock ? 0 : 4);
 
-                Grid.SetColumn(_firstSplitter, 1);
-            }
+            Grid.SetColumn(_firstSplitter, 1);
+            Grid.SetColumn(_secondSplitter, use24HourClock ? 0 : 3);
         }
 
         private void SetSelectedTimeText()
@@ -237,14 +224,13 @@ namespace Avalonia.Controls
                     hr = hr > 12 ? hr - 12 : hr == 0 ? 12 : hr;
                     newTime = new TimeSpan(hr, newTime.Minutes, 0);
                 }
-                _hourText.Text = newTime.ToString("%h");
 
+                _hourText.Text = newTime.ToString("%h");
                 _minuteText.Text = newTime.ToString("mm");
                 PseudoClasses.Set(":hasnotime", false);
 
                 _periodText.Text = time.Value.Hours >= 12 ? CultureInfo.CurrentCulture.DateTimeFormat.PMDesignator :
                     CultureInfo.CurrentCulture.DateTimeFormat.AMDesignator;
-
             }
             else
             {
@@ -262,7 +248,7 @@ namespace Avalonia.Controls
             SelectedTimeChanged?.Invoke(this, new TimePickerSelectedValueChangedEventArgs(oldTime, newTime));
         }
 
-        private void OnFlyoutButtonClicked(object sender, Avalonia.Interactivity.RoutedEventArgs e)
+        private void OnFlyoutButtonClicked(object sender, Interactivity.RoutedEventArgs e)
         {
             _presenter.Time = SelectedTime ?? DateTime.Now.TimeOfDay;
 
@@ -270,7 +256,7 @@ namespace Avalonia.Controls
 
             var deltaY = _presenter.GetOffsetForPopup();
 
-            //The extra 5 px I think is related to default popup placement behavior
+            // The extra 5 px I think is related to default popup placement behavior
             _popup.Host.ConfigurePosition(_popup.PlacementTarget, PlacementMode.AnchorAndGravity, new Point(0, deltaY + 5),
                 Primitives.PopupPositioning.PopupAnchor.Bottom, Primitives.PopupPositioning.PopupGravity.Bottom,
                  Primitives.PopupPositioning.PopupPositionerConstraintAdjustment.SlideY);
@@ -287,6 +273,5 @@ namespace Avalonia.Controls
             _popup.Close();
             SelectedTime = _presenter.Time;
         }
-
     }
 }

--- a/src/Avalonia.Controls/DateTimePickers/TimePickerPresenter.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePickerPresenter.cs
@@ -39,7 +39,7 @@ namespace Avalonia.Controls
             KeyboardNavigation.SetTabNavigation(this, KeyboardNavigationMode.Cycle);
         }
 
-        //TemplateItems
+        // TemplateItems
         private Grid _pickerContainer;
         private Button _acceptButton;
         private Button _dismissButton;
@@ -55,8 +55,8 @@ namespace Avalonia.Controls
         private Button _minuteDownButton;
         private Button _periodDownButton;
 
-        //Backing Fields
-        private TimeSpan _Time;
+        // Backing Fields
+        private TimeSpan _time;
         private int _minuteIncrement = 1;
         private string _clockIdentifier = "12HourClock";
 
@@ -83,7 +83,7 @@ namespace Avalonia.Controls
             get => _clockIdentifier;
             set
             {
-                if (string.IsNullOrEmpty(value) || value == "" || !(value == "12HourClock" || value == "24HourClock"))
+                if (string.IsNullOrEmpty(value) || !(value == "12HourClock" || value == "24HourClock"))
                     throw new ArgumentException("Invalid ClockIdentifier");
                 SetAndRaise(ClockIdentifierProperty, ref _clockIdentifier, value);
                 InitPicker();
@@ -95,10 +95,10 @@ namespace Avalonia.Controls
         /// </summary>
         public TimeSpan Time
         {
-            get => _Time;
+            get => _time;
             set
             {
-                SetAndRaise(TimeProperty, ref _Time, value);
+                SetAndRaise(TimeProperty, ref _time, value);
                 InitPicker();
             }
         }
@@ -213,26 +213,24 @@ namespace Avalonia.Controls
 
         private void SetGrid()
         {
-            if (ClockIdentifier == "12HourClock")
-            {
-                _pickerContainer.ColumnDefinitions = new ColumnDefinitions("*,Auto,*,Auto,*");
-                _spacer2.IsVisible = true;
-                _periodHost.IsVisible = true;
-            }
-            else
-            {
-                _pickerContainer.ColumnDefinitions = new ColumnDefinitions("*,Auto,*");
-                _spacer2.IsVisible = false;
-                _periodHost.IsVisible = false;
-            }
+            bool use24HourClock = ClockIdentifier == "24HourClock";
+
+            var columnsD = use24HourClock ? "*, Auto, *" : "*, Auto, *, Auto, *";
+            _pickerContainer.ColumnDefinitions = new ColumnDefinitions(columnsD);
+
+            _spacer2.IsVisible = !use24HourClock;
+            _periodHost.IsVisible = !use24HourClock;
+
+            Grid.SetColumn(_spacer2, use24HourClock ? 0 : 3);
+            Grid.SetColumn(_periodHost, use24HourClock ? 0 : 4);
         }
 
-        private void OnDismissButtonClicked(object sender, Avalonia.Interactivity.RoutedEventArgs e)
+        private void OnDismissButtonClicked(object sender, RoutedEventArgs e)
         {
             OnDismiss();
         }
 
-        private void OnAcceptButtonClicked(object sender, Avalonia.Interactivity.RoutedEventArgs e)
+        private void OnAcceptButtonClicked(object sender, RoutedEventArgs e)
         {
             OnConfirmed();
         }


### PR DESCRIPTION
## What does the pull request do?
Similar to #4295 provides workaround to make sure cells are in expected range.

## What is the current behavior?
Set `ClockIdentifier` to `24HourClock` leads to the `System.ArgumentOutOfRangeException` exception.

## What is the updated/expected behavior with this PR?
Exception isn't thrown.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Fixed issues

Fixes: #4342