### PR TITLE
Fixes/fluent menuitem style adjustments

### DIFF
--- a/samples/ControlCatalog/Pages/MenuPage.xaml
+++ b/samples/ControlCatalog/Pages/MenuPage.xaml
@@ -20,7 +20,9 @@
                         <Separator/>
                         <MenuItem Header="Menu with _Submenu">
                             <MenuItem Header="Submenu _1"/>
-                            <MenuItem Header="Submenu _2"/>
+                            <MenuItem Header="Submenu _2 with Submenu">
+                                <MenuItem Header="Submenu Level 2" />
+                            </MenuItem>
                         </MenuItem>
                         <MenuItem Header="Menu Item with _Icon" InputGesture="Ctrl+Shift+B">
                             <MenuItem.Icon>
@@ -50,6 +52,33 @@
                             <Setter Property="CommandParameter" Value="{Binding CommandParameter}"/>
                         </Style>
                     </Menu.Styles>
+                </Menu>
+            </StackPanel>
+        
+
+            <StackPanel>
+                <TextBlock Classes="h3" Margin="4 8">Mixed</TextBlock>
+                <Menu>
+                    <MenuItem Header="_File">
+                        <MenuItem Header="_New" CommandParameter="{Binding}" InputGesture="Ctrl+N"/>
+                        <Separator/>
+                        <MenuItem Header="_Open..." InputGesture="Ctrl+O"/>
+                        <Separator/>
+                        <MenuItem Header="Execu_te Script..." />
+                        <Separator/>
+                        <MenuItem Header="_Recent" Items="{Binding RecentItems}">
+                            <MenuItem.Styles>
+                                <Style Selector="MenuItem">
+                                    <Setter Property="Header" Value="{Binding Header}"/>
+                                </Style>
+                            </MenuItem.Styles>
+                        </MenuItem>
+                        <Separator/>
+                        <MenuItem Header="E_xit" InputGesture="Alt+F4"/>
+                    </MenuItem>
+                    <MenuItem Header="_Help">
+                        <MenuItem Header="_About"/>
+                    </MenuItem>
                 </Menu>
             </StackPanel>
         </StackPanel>

--- a/samples/ControlCatalog/ViewModels/MenuPageViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/MenuPageViewModel.cs
@@ -17,6 +17,23 @@ namespace ControlCatalog.ViewModels
             SaveCommand = ReactiveCommand.Create(Save, Observable.Return(false));
             OpenRecentCommand = ReactiveCommand.Create<string>(OpenRecent);
 
+            var recentItems = new[]
+            {
+                new MenuItemViewModel
+                {
+                    Header = "File1.txt",
+                    Command = OpenRecentCommand,
+                    CommandParameter = @"c:\foo\File1.txt"
+                },
+                new MenuItemViewModel
+                {
+                    Header = "File2.txt",
+                    Command = OpenRecentCommand,
+                    CommandParameter = @"c:\foo\File2.txt"
+                },
+            };
+
+            RecentItems = recentItems;
             MenuItems = new[]
             {
                 new MenuItemViewModel
@@ -24,27 +41,13 @@ namespace ControlCatalog.ViewModels
                     Header = "_File",
                     Items = new[]
                     {
-                        new MenuItemViewModel { Header = "_Open...", Command = OpenCommand },
+                        new MenuItemViewModel { Header = "O_pen...", Command = OpenCommand },
                         new MenuItemViewModel { Header = "Save", Command = SaveCommand },
                         new MenuItemViewModel { Header = "-" },
                         new MenuItemViewModel
                         {
                             Header = "Recent",
-                            Items = new[]
-                            {
-                                new MenuItemViewModel
-                                {
-                                    Header = "File1.txt",
-                                    Command = OpenRecentCommand,
-                                    CommandParameter = @"c:\foo\File1.txt"
-                                },
-                                new MenuItemViewModel
-                                {
-                                    Header = "File2.txt",
-                                    Command = OpenRecentCommand,
-                                    CommandParameter = @"c:\foo\File2.txt"
-                                },
-                            }
+                            Items = recentItems
                         },
                     }
                 },
@@ -61,6 +64,7 @@ namespace ControlCatalog.ViewModels
         }
 
         public IReadOnlyList<MenuItemViewModel> MenuItems { get; set; }
+        public IReadOnlyList<MenuItemViewModel> RecentItems { get; set; }
         public ReactiveCommand<Unit, Unit> OpenCommand { get; }
         public ReactiveCommand<Unit, Unit> SaveCommand { get; }
         public ReactiveCommand<string, Unit> OpenRecentCommand { get; }

--- a/src/Avalonia.Themes.Fluent/Menu.xaml
+++ b/src/Avalonia.Themes.Fluent/Menu.xaml
@@ -10,7 +10,7 @@
     </Border>
   </Design.PreviewWith>
 
-  <Style.Resources>    
+  <Style.Resources>
     <x:Double x:Key="MenuBarHeight">32</x:Double>
     <Thickness x:Key="MenuBarItemPadding">12,0,12,0</Thickness>
   </Style.Resources>

--- a/src/Avalonia.Themes.Fluent/Menu.xaml
+++ b/src/Avalonia.Themes.Fluent/Menu.xaml
@@ -10,11 +10,13 @@
     </Border>
   </Design.PreviewWith>
 
-  <Style.Resources>
-    <x:Double x:Key="MenuHeight">32</x:Double>
+  <Style.Resources>    
+    <x:Double x:Key="MenuBarHeight">32</x:Double>
+    <Thickness x:Key="MenuBarItemPadding">12,0,12,0</Thickness>
   </Style.Resources>
+
   <Setter Property="Background" Value="Transparent" />
-  <Setter Property="Height" Value="{StaticResource MenuHeight}" />
+  <Setter Property="Height" Value="{StaticResource MenuBarHeight}" />
   <Setter Property="Template">
     <ControlTemplate>
       <Border Background="{TemplateBinding Background}"

--- a/src/Avalonia.Themes.Fluent/MenuItem.xaml
+++ b/src/Avalonia.Themes.Fluent/MenuItem.xaml
@@ -40,6 +40,7 @@
 
   <Styles.Resources>
     <conv:PlatformKeyGestureConverter x:Key="KeyGestureConverter" />
+    <x:Double x:Key="MenuFlyoutSubItemPopupHorizontalOffset">-4</x:Double>
     <Thickness x:Key="MenuFlyoutScrollerMargin">0,4,0,4</Thickness>
     <Thickness x:Key="MenuIconPresenterMargin">0,0,12,0</Thickness>
     <Thickness x:Key="MenuInputGestureTextMargin">24,0,0,0</Thickness>    
@@ -54,83 +55,85 @@
     <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Border Name="PART_LayoutRoot"
-                Padding="{TemplateBinding Padding}"
-                Background="{TemplateBinding Background}"
-                BorderBrush="{TemplateBinding BorderBrush}"
-                BorderThickness="{TemplateBinding BorderThickness}">
-          <Grid>
-            <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="Auto"
-                                SharedSizeGroup="MenuItemIcon"  />
-              <ColumnDefinition Width="*" />
-              <ColumnDefinition Width="Auto"
-                                SharedSizeGroup="MenuItemIGT" />
-              <ColumnDefinition Width="Auto"
-                                SharedSizeGroup="MenuItemChevron" />
-            </Grid.ColumnDefinitions>
-            <ContentPresenter Name="PART_IconPresenter"
-                              Content="{TemplateBinding Icon}"
-                              Width="16"
-                              Height="16"
-                              Margin="{DynamicResource MenuIconPresenterMargin}"
-                              HorizontalAlignment="Center"
-                              VerticalAlignment="Center"/>
+        <Panel>
+          <Border Name="PART_LayoutRoot"
+                  Padding="{TemplateBinding Padding}"
+                  Background="{TemplateBinding Background}"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}">
+            <Grid>
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"
+                                  SharedSizeGroup="MenuItemIcon" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto"
+                                  SharedSizeGroup="MenuItemIGT" />
+                <ColumnDefinition Width="Auto"
+                                  SharedSizeGroup="MenuItemChevron" />
+              </Grid.ColumnDefinitions>
+              <ContentPresenter Name="PART_IconPresenter"
+                                Content="{TemplateBinding Icon}"
+                                Width="16"
+                                Height="16"
+                                Margin="{DynamicResource MenuIconPresenterMargin}"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center" />
 
-            <ContentPresenter Name="PART_HeaderPresenter"
-                              Content="{TemplateBinding Header}"
-                              VerticalAlignment="Center"
-                              HorizontalAlignment="Stretch"
-                              TextBlock.Foreground="{TemplateBinding Foreground}"
-                              Grid.Column="1">
-              <ContentPresenter.DataTemplates>
-                <DataTemplate DataType="sys:String">
-                  <AccessText Text="{Binding}" />
-                </DataTemplate>
-              </ContentPresenter.DataTemplates>
-            </ContentPresenter>
-            <TextBlock x:Name="PART_InputGestureText"
-                       Grid.Column="2"
-                       Classes="CaptionTextBlockStyle"
-                       Margin="{DynamicResource MenuInputGestureTextMargin}"
-                       Text="{TemplateBinding InputGesture,
-                                              Converter={StaticResource KeyGestureConverter}}"
-                       HorizontalAlignment="Right"
-                       VerticalAlignment="Center" />
-            <Path Name="PART_ChevronPath"
-                  Stretch="Uniform"
-                  Width="8"
-                  Height="16"
-                  Data="{StaticResource MenuItemChevronPathData}"
-                  Margin="{DynamicResource MenuFlyoutItemChevronMargin}"
-                  VerticalAlignment="Center"
-                  Grid.Column="3" />
-            <Popup Name="PART_Popup"
-                   WindowManagerAddShadowHint="True"
-                   PlacementMode="Right"
-                   StaysOpen="True"
-                   IsOpen="{TemplateBinding IsSubMenuOpen,
-                                            Mode=TwoWay}">
-              <Border Background="{DynamicResource MenuFlyoutPresenterBackground}"
-                      BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
-                      BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThemeThickness}"
-                      Padding="{DynamicResource MenuFlyoutPresenterThemePadding}"
-                      MaxWidth="{DynamicResource FlyoutThemeMaxWidth}"
-                      MinHeight="{DynamicResource MenuFlyoutThemeMinHeight}"
-                      HorizontalAlignment="Stretch"
-                      CornerRadius="{DynamicResource OverlayCornerRadius}">
-                <ScrollViewer>
-                  <ItemsPresenter Name="PART_ItemsPresenter"
-                                  Items="{TemplateBinding Items}"
-                                  ItemsPanel="{TemplateBinding ItemsPanel}"
-                                  ItemTemplate="{TemplateBinding ItemTemplate}"
-                                  Margin="{DynamicResource MenuFlyoutScrollerMargin}"
-                                  Grid.IsSharedSizeScope="True" />
-                </ScrollViewer>
-              </Border>
-            </Popup>
-          </Grid>
-        </Border>
+              <ContentPresenter Name="PART_HeaderPresenter"
+                                Content="{TemplateBinding Header}"
+                                VerticalAlignment="Center"
+                                HorizontalAlignment="Stretch"
+                                TextBlock.Foreground="{TemplateBinding Foreground}"
+                                Grid.Column="1">
+                <ContentPresenter.DataTemplates>
+                  <DataTemplate DataType="sys:String">
+                    <AccessText Text="{Binding}" />
+                  </DataTemplate>
+                </ContentPresenter.DataTemplates>
+              </ContentPresenter>
+              <TextBlock x:Name="PART_InputGestureText"
+                         Grid.Column="2"
+                         Classes="CaptionTextBlockStyle"
+                         Margin="{DynamicResource MenuInputGestureTextMargin}"
+                         Text="{TemplateBinding InputGesture, Converter={StaticResource KeyGestureConverter}}"
+                         HorizontalAlignment="Right"
+                         VerticalAlignment="Center" />
+              <Path Name="PART_ChevronPath"
+                    Stretch="Uniform"
+                    Width="8"
+                    Height="16"
+                    Data="{StaticResource MenuItemChevronPathData}"
+                    Margin="{DynamicResource MenuFlyoutItemChevronMargin}"
+                    VerticalAlignment="Center"
+                    Grid.Column="3" />
+            </Grid>
+          </Border>
+          <Popup Name="PART_Popup"
+                 WindowManagerAddShadowHint="True"
+                 PlacementMode="Right"
+                 HorizontalOffset="{StaticResource MenuFlyoutSubItemPopupHorizontalOffset}"
+                 StaysOpen="True"
+                 IsOpen="{TemplateBinding IsSubMenuOpen,
+                                          Mode=TwoWay}">
+            <Border Background="{DynamicResource MenuFlyoutPresenterBackground}"
+                    BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
+                    BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThemeThickness}"
+                    Padding="{DynamicResource MenuFlyoutPresenterThemePadding}"
+                    MaxWidth="{DynamicResource FlyoutThemeMaxWidth}"
+                    MinHeight="{DynamicResource MenuFlyoutThemeMinHeight}"
+                    HorizontalAlignment="Stretch"
+                    CornerRadius="{DynamicResource OverlayCornerRadius}">
+              <ScrollViewer>
+                <ItemsPresenter Name="PART_ItemsPresenter"
+                                Items="{TemplateBinding Items}"
+                                ItemsPanel="{TemplateBinding ItemsPanel}"
+                                ItemTemplate="{TemplateBinding ItemTemplate}"
+                                Margin="{DynamicResource MenuFlyoutScrollerMargin}"
+                                Grid.IsSharedSizeScope="True" />
+              </ScrollViewer>
+            </Border>
+          </Popup>
+        </Panel>
       </ControlTemplate>
     </Setter>
   </Style>

--- a/src/Avalonia.Themes.Fluent/MenuItem.xaml
+++ b/src/Avalonia.Themes.Fluent/MenuItem.xaml
@@ -183,10 +183,10 @@
   </Style>
 
   <Style Selector="MenuItem">
-    <!-- Narrow padding should be used for mouse input, when non-narrow one should be used for touch input in future. -->
+    <!--  Narrow padding should be used for mouse input, when non-narrow one should be used for touch input in future.  -->
     <Setter Property="Padding" Value="{DynamicResource MenuFlyoutItemThemePaddingNarrow}" />
   </Style>
-  
+
   <Style Selector="MenuItem /template/ ContentPresenter#PART_IconPresenter">
     <Setter Property="IsVisible" Value="False" />
   </Style>
@@ -212,14 +212,15 @@
     <Setter Property="Fill" Value="{DynamicResource MenuFlyoutSubItemChevronPointerOver}" />
   </Style>
 
-  <Style Selector="MenuItem:pressed /template/ Border#PART_LayoutRoot">
+  <!--  Listen for PART_LayoutRoot:pressed instead of MenuItem:pressed, so it will not be triggered when menu subitem is pressed  -->
+  <Style Selector="MenuItem:pressed /template/ Border#PART_LayoutRoot:pointerover">
     <Setter Property="Background" Value="{DynamicResource MenuFlyoutItemBackgroundPressed}" />
     <Setter Property="BorderBrush" Value="{DynamicResource MenuFlyoutItemBorderBrushPressed}" />
   </Style>
-  <Style Selector="MenuItem:pressed /template/ TextBlock#PART_InputGestureText">
+  <Style Selector="MenuItem:pressed /template/ Border#PART_LayoutRoot:pointerover TextBlock#PART_InputGestureText">
     <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForegroundPressed}" />
   </Style>
-  <Style Selector="MenuItem:pressed /template/ Path#PART_ChevronPath">
+  <Style Selector="MenuItem:pressed /template/ Border#PART_LayoutRoot:pointerover Path#PART_ChevronPath">
     <Setter Property="Fill" Value="{DynamicResource MenuFlyoutSubItemChevronPressed}" />
   </Style>
 

--- a/src/Avalonia.Themes.Fluent/MenuItem.xaml
+++ b/src/Avalonia.Themes.Fluent/MenuItem.xaml
@@ -25,11 +25,12 @@
         </MenuItem>
         <MenuItem Header="Edit">
           <MenuItem Header="Go To">
-            <MenuItem Header="Go To Line"/>
+            <MenuItem Header="Go To Line" />
           </MenuItem>
         </MenuItem>
         <MenuItem Header="View">
-          <MenuItem Header="Designer" InputGesture="Shift+F7" />
+          <MenuItem Header="Designer"
+                    InputGesture="Shift+F7" />
         </MenuItem>
         <MenuItem Header="Project">
           <MenuItem Header="Add class" />
@@ -43,7 +44,7 @@
     <x:Double x:Key="MenuFlyoutSubItemPopupHorizontalOffset">-4</x:Double>
     <Thickness x:Key="MenuFlyoutScrollerMargin">0,4,0,4</Thickness>
     <Thickness x:Key="MenuIconPresenterMargin">0,0,12,0</Thickness>
-    <Thickness x:Key="MenuInputGestureTextMargin">24,0,0,0</Thickness>    
+    <Thickness x:Key="MenuInputGestureTextMargin">24,0,0,0</Thickness>
     <StreamGeometry x:Key="MenuItemChevronPathData">M 1,0 10,10 l -9,10 -1,-1 L 8,10 -0,1 Z</StreamGeometry>
   </Styles.Resources>
 
@@ -113,8 +114,7 @@
                  PlacementMode="Right"
                  HorizontalOffset="{StaticResource MenuFlyoutSubItemPopupHorizontalOffset}"
                  StaysOpen="True"
-                 IsOpen="{TemplateBinding IsSubMenuOpen,
-                                          Mode=TwoWay}">
+                 IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}">
             <Border Background="{DynamicResource MenuFlyoutPresenterBackground}"
                     BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
                     BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThemeThickness}"
@@ -160,8 +160,7 @@
             <Popup Name="PART_Popup"
                    WindowManagerAddShadowHint="False"
                    MinWidth="{Binding Bounds.Width, RelativeSource={RelativeSource TemplatedParent}}"
-                   IsOpen="{TemplateBinding IsSubMenuOpen,
-                                            Mode=TwoWay}"
+                   IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}"
                    StaysOpen="True">
               <Border Background="{DynamicResource MenuFlyoutPresenterBackground}"
                       BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
@@ -191,7 +190,7 @@
     <!--  Narrow padding should be used for mouse input, when non-narrow one should be used for touch input in future.  -->
     <Setter Property="Padding" Value="{StaticResource MenuFlyoutItemThemePaddingNarrow}" />
   </Style>
-  
+
   <Style Selector="Menu > MenuItem">
     <!--  Custom padding for Menu > MenuItem  -->
     <Setter Property="Padding" Value="{StaticResource MenuBarItemPadding}" />
@@ -222,7 +221,7 @@
     <Setter Property="Fill" Value="{DynamicResource MenuFlyoutSubItemChevronPointerOver}" />
   </Style>
 
-  <!--  Listen for PART_LayoutRoot:pressed instead of MenuItem:pressed, so it will not be triggered when menu subitem is pressed  -->
+  <!--  Listen for PART_LayoutRoot:pointerover, so it will not be triggered when subitem is pressed  -->
   <Style Selector="MenuItem:pressed /template/ Border#PART_LayoutRoot:pointerover">
     <Setter Property="Background" Value="{DynamicResource MenuFlyoutItemBackgroundPressed}" />
     <Setter Property="BorderBrush" Value="{DynamicResource MenuFlyoutItemBorderBrushPressed}" />

--- a/src/Avalonia.Themes.Fluent/MenuItem.xaml
+++ b/src/Avalonia.Themes.Fluent/MenuItem.xaml
@@ -148,6 +148,8 @@
           <Panel>
             <ContentPresenter Name="PART_HeaderPresenter"
                               Content="{TemplateBinding Header}"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Stretch"
                               Margin="{TemplateBinding Padding}">
               <ContentPresenter.DataTemplates>
                 <DataTemplate DataType="sys:String">
@@ -187,7 +189,12 @@
 
   <Style Selector="MenuItem">
     <!--  Narrow padding should be used for mouse input, when non-narrow one should be used for touch input in future.  -->
-    <Setter Property="Padding" Value="{DynamicResource MenuFlyoutItemThemePaddingNarrow}" />
+    <Setter Property="Padding" Value="{StaticResource MenuFlyoutItemThemePaddingNarrow}" />
+  </Style>
+  
+  <Style Selector="Menu > MenuItem">
+    <!--  Custom padding for Menu > MenuItem  -->
+    <Setter Property="Padding" Value="{StaticResource MenuBarItemPadding}" />
   </Style>
 
   <Style Selector="MenuItem /template/ ContentPresenter#PART_IconPresenter">


### PR DESCRIPTION
## What does the pull request do?
Some adjustments to make Menu+MenuItem looks better.

## What is the current behavior?
![image](https://user-images.githubusercontent.com/3163374/88122043-816a1480-cb95-11ea-9da9-fffe868aae0d.png)

## What is the updated/expected behavior with this PR?
![image](https://user-images.githubusercontent.com/3163374/88122050-83cc6e80-cb95-11ea-881a-b55a0a73841c.png)

## How was the solution implemented (if it's not obvious)?
- Popup moved from nested MenuItem's grid children to root MenuItem's container (new Panel), so absolute horizontal offset could be correctly calculated
- Added MenuFlyoutSubItemPopupHorizontalOffset to allow to change relative horizontal offset (doesn't exist in WinUI)
- Changed "Menu > MenuItem" alignment and added MenuBarItemPadding to it (doesn't exist in WinUI)
- Renamed "MenuHeight" to "MenuBarHeight" (doesn't exist in WinUI)
- Fixed case, when ":pressed" state was triggering when child from sub menu was pressed.

## Breaking changes
MenuHeight renamed to MenuBarHeight, but this should be fine, because previous name was added in last preview version.