### PR TITLE
Remove local value for MaxHeight on CaptionButtons

### DIFF
--- a/src/Avalonia.Themes.Default/TitleBar.xaml
+++ b/src/Avalonia.Themes.Default/TitleBar.xaml
@@ -15,7 +15,7 @@
           <Panel x:Name="PART_MouseTracker" Height="1" VerticalAlignment="Top" />
           <Panel x:Name="PART_Container">
             <Border x:Name="PART_Background" Background="{TemplateBinding Background}" />
-            <CaptionButtons x:Name="PART_CaptionButtons" VerticalAlignment="Top" HorizontalAlignment="Right" Foreground="{TemplateBinding Foreground}" MaxHeight="30" />
+            <CaptionButtons x:Name="PART_CaptionButtons" VerticalAlignment="Top" HorizontalAlignment="Right" Foreground="{TemplateBinding Foreground}" />
           </Panel>
         </Panel>
       </ControlTemplate>

--- a/src/Avalonia.Themes.Fluent/TitleBar.xaml
+++ b/src/Avalonia.Themes.Fluent/TitleBar.xaml
@@ -15,7 +15,7 @@
           <Panel x:Name="PART_MouseTracker" Height="1" VerticalAlignment="Top" />
           <Panel x:Name="PART_Container">
             <Border x:Name="PART_Background" Background="{TemplateBinding Background}" />
-            <CaptionButtons x:Name="PART_CaptionButtons" VerticalAlignment="Top" HorizontalAlignment="Right" Foreground="{TemplateBinding Foreground}" MaxHeight="30" />
+            <CaptionButtons x:Name="PART_CaptionButtons" VerticalAlignment="Top" HorizontalAlignment="Right" Foreground="{TemplateBinding Foreground}" />
           </Panel>
         </Panel>
       </ControlTemplate>


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Removes wrong `MaxHeight` that was hardcoded in `TitleBar` despite having entry in style of `CaptionButtons` as well.