### PR TITLE
Fix native menus not being setup properly

### DIFF
--- a/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
+++ b/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
@@ -39,8 +39,7 @@ namespace Avalonia.Native
         public void SetNativeMenu(NativeMenu menu)
         {
             _menu = menu == null ? new NativeMenu() : menu;
-            _resetQueued = true; // we've reset the menu to something new, so make sure that a reset is queued
-            DoLayoutReset();
+            DoLayoutReset(true);
         }
 
         internal void UpdateIfNeeded()
@@ -74,9 +73,9 @@ namespace Avalonia.Native
             return result;
         }
 
-        private void DoLayoutReset()
+        private void DoLayoutReset(bool forceUpdate = false)
         {
-            if (_resetQueued)
+            if (_resetQueued || forceUpdate)
             {
                 _resetQueued = false;
 
@@ -109,7 +108,7 @@ namespace Avalonia.Native
             if (_resetQueued)
                 return;
             _resetQueued = true;
-            Dispatcher.UIThread.Post(DoLayoutReset, DispatcherPriority.Background);
+            Dispatcher.UIThread.Post(() => DoLayoutReset(), DispatcherPriority.Background);
         }
 
         private void SetMenu(NativeMenu menu)

--- a/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
+++ b/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Native
     class AvaloniaNativeMenuExporter : ITopLevelNativeMenuExporter
     {
         private IAvaloniaNativeFactory _factory;
-        private bool _resetQueued;
+        private bool _resetQueued = true; // so initial layout resets trigger a menu reset properly
         private bool _exported = false;
         private IAvnWindow _nativeWindow;
         private NativeMenu _menu;
@@ -39,7 +39,7 @@ namespace Avalonia.Native
         public void SetNativeMenu(NativeMenu menu)
         {
             _menu = menu == null ? new NativeMenu() : menu;
-
+            _resetQueued = true; // we've reset the menu to something new, so make sure that a reset is queued
             DoLayoutReset();
         }
 

--- a/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
+++ b/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Native
     class AvaloniaNativeMenuExporter : ITopLevelNativeMenuExporter
     {
         private IAvaloniaNativeFactory _factory;
-        private bool _resetQueued = true; // so initial layout resets trigger a menu reset properly
+        private bool _resetQueued = true;
         private bool _exported = false;
         private IAvnWindow _nativeWindow;
         private NativeMenu _menu;


### PR DESCRIPTION
## What does the pull request do?

Fixes the `_resetQueued` var in `AvaloniaNativeMenuExporter` -- that class didn't queue up a reset all the times it should.

## What is the current behavior?

Native menus don't load properly in the control catalog/elsewhere if setup in `MainWindow.xaml`.


## What is the updated/expected behavior with this PR?

Native menus now load again!

## How was the solution implemented (if it's not obvious)?

I changed two places for `_resetQueued`:

1. Initialize it to `true` on object construction so that the constructor calls to `DoLayoutReset();` actually do a reset/create the menus as needed
2. Set it to `true` in `SetNativeMenu(NativeMenu menu)` so that when an external object updates the menu, the new menu will be used when the layout is reset.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Fixed issues

Fixes #4395
