### PR TITLE
Fixes/tooltip stuck on screen

### DIFF
--- a/src/Avalonia.Controls/ToolTip.cs
+++ b/src/Avalonia.Controls/ToolTip.cs
@@ -66,6 +66,7 @@ namespace Avalonia.Controls
         static ToolTip()
         {
             TipProperty.Changed.Subscribe(ToolTipService.Instance.TipChanged);
+            IsOpenProperty.Changed.Subscribe(ToolTipService.Instance.TipOpenChanged);
             IsOpenProperty.Changed.Subscribe(IsOpenChanged);
         }
 

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -29,7 +29,6 @@ namespace Avalonia.Controls
                 control.PointerEnter -= ControlPointerEnter;
                 control.PointerLeave -= ControlPointerLeave;
                 control.DetachedFromVisualTree -= ControlDetaching;
-                Close(control);
             }
 
             if (e.NewValue != null)

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -28,20 +28,33 @@ namespace Avalonia.Controls
             {
                 control.PointerEnter -= ControlPointerEnter;
                 control.PointerLeave -= ControlPointerLeave;
-                control.DetachedFromVisualTree -= ControlDetaching;
             }
 
             if (e.NewValue != null)
             {
                 control.PointerEnter += ControlPointerEnter;
                 control.PointerLeave += ControlPointerLeave;
+            }
+        }
+
+        internal void TipOpenChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            var control = (Control)e.Sender;
+
+            if (e.OldValue is false && e.NewValue is true)
+            {
                 control.DetachedFromVisualTree += ControlDetaching;
+            }
+            else if(e.OldValue is true && e.NewValue is false)
+            {
+                control.DetachedFromVisualTree -= ControlDetaching;
             }
         }
         
         private void ControlDetaching(object sender, VisualTreeAttachmentEventArgs e)
         {
             var control = (Control)sender;
+            control.DetachedFromVisualTree -= ControlDetaching;
             Close(control);
         }
 

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -29,6 +29,7 @@ namespace Avalonia.Controls
                 control.PointerEnter -= ControlPointerEnter;
                 control.PointerLeave -= ControlPointerLeave;
                 control.DetachedFromVisualTree -= ControlDetaching;
+                Close(control);
             }
 
             if (e.NewValue != null)

--- a/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
@@ -64,6 +64,40 @@ namespace Avalonia.Controls.UnitTests
                 Assert.False(ToolTip.GetIsOpen(target));
             }
         }
+        
+        [Fact]
+        public void Should_Close_When_Tip_Is_Changed()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var window = new Window();
+
+                var panel = new Panel();
+                
+                var target = new Decorator()
+                {
+                    [ToolTip.TipProperty] = "Tip",
+                    [ToolTip.ShowDelayProperty] = 0
+                };
+                
+                panel.Children.Add(target);
+
+                window.Content = panel;
+
+                window.ApplyTemplate();
+                window.Presenter.ApplyTemplate();
+
+                Assert.True((target as IVisual).IsAttachedToVisualTree);                               
+
+                _mouseHelper.Enter(target);
+
+                Assert.True(ToolTip.GetIsOpen(target));
+                
+                ToolTip.SetTip(target, "");
+                
+                Assert.False(ToolTip.GetIsOpen(target));
+            }
+        }
 
         [Fact]
         public void Should_Open_On_Pointer_Enter()


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Tooltips can get stuck on the screen. This https://github.com/AvaloniaUI/Avalonia/pull/4296 was supposed to resolve the issue

however when the user reproduced the issue using an mvvm style application, the datacontext will be removed from the control before detached from visual tree.

This causes TipChanged to be called. and the DetachedFromVisualTree handler unsubscribed.



## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
in some cases tooltips can be stuck on the screen.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
