### PR TITLE
Revert GridSplitter size for default theme

### DIFF
--- a/src/Avalonia.Themes.Default/GridSplitter.xaml
+++ b/src/Avalonia.Themes.Default/GridSplitter.xaml
@@ -2,8 +2,8 @@
 
   <Style Selector="GridSplitter">
     <Setter Property="Focusable" Value="True" />
-    <Setter Property="MinWidth" Value="6" />
-    <Setter Property="MinHeight" Value="6" />
+    <Setter Property="MinWidth" Value="1" />
+    <Setter Property="MinHeight" Value="1" />
     <Setter Property="Background" Value="{DynamicResource ThemeControlMidBrush}" />
     <Setter Property="PreviewContent">
       <Template>


### PR DESCRIPTION
## What does the pull request do?
Change minimum size for `Default` (`Simple`) theme to 1

## What is the current behavior?
Minimum size is 6 pixels, which breaks old apps

## Fixed issues
Fixes #4412 
