### PR TITLE
Attempt to fix X11 nvidia segfault

### DIFF
--- a/src/Avalonia.Visuals/Rendering/RenderLoop.cs
+++ b/src/Avalonia.Visuals/Rendering/RenderLoop.cs
@@ -90,7 +90,7 @@ namespace Avalonia.Rendering
                 }
             }
         }
-        
+
         private void TimerTick(TimeSpan time)
         {
             if (Interlocked.CompareExchange(ref _inTick, 1, 0) == 0)

--- a/src/Avalonia.Visuals/Rendering/RenderLoop.cs
+++ b/src/Avalonia.Visuals/Rendering/RenderLoop.cs
@@ -18,6 +18,7 @@ namespace Avalonia.Rendering
     {
         private readonly IDispatcher _dispatcher;
         private List<IRenderLoopTask> _items = new List<IRenderLoopTask>();
+        private List<IRenderLoopTask> _itemsCopy = new List<IRenderLoopTask>();
         private IRenderTimer _timer;
         private int _inTick;
         private int _inUpdate;
@@ -63,11 +64,14 @@ namespace Avalonia.Rendering
             Contract.Requires<ArgumentNullException>(i != null);
             Dispatcher.UIThread.VerifyAccess();
 
-            _items.Add(i);
-
-            if (_items.Count == 1)
+            lock (_items)
             {
-                Timer.Tick += TimerTick;
+                _items.Add(i);
+
+                if (_items.Count == 1)
+                {
+                    Timer.Tick += TimerTick;
+                }
             }
         }
 
@@ -76,15 +80,17 @@ namespace Avalonia.Rendering
         {
             Contract.Requires<ArgumentNullException>(i != null);
             Dispatcher.UIThread.VerifyAccess();
-
-            _items.Remove(i);
-
-            if (_items.Count == 0)
+            lock (_items)
             {
-                Timer.Tick -= TimerTick;
+                _items.Remove(i);
+
+                if (_items.Count == 0)
+                {
+                    Timer.Tick -= TimerTick;
+                }
             }
         }
-
+        
         private void TimerTick(TimeSpan time)
         {
             if (Interlocked.CompareExchange(ref _inTick, 1, 0) == 0)
@@ -129,10 +135,20 @@ namespace Avalonia.Rendering
                         }, DispatcherPriority.Render);
                     }
 
-                    for(int i = 0; i < _items.Count; i++)
+                    lock (_items)
                     {
-                        _items[i].Render();
+                        _itemsCopy.Clear();
+                        foreach (var i in _items)
+                            _itemsCopy.Add(i);
                     }
+
+                    for (int i = 0; i < _itemsCopy.Count; i++)
+                    {
+                        _itemsCopy[i].Render();
+                    }
+                    
+                    _itemsCopy.Clear();
+
                 }
                 catch (Exception ex)
                 {

--- a/src/Avalonia.Visuals/Rendering/SleepLoopRenderTimer.cs
+++ b/src/Avalonia.Visuals/Rendering/SleepLoopRenderTimer.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Avalonia.Rendering
+{
+    public class SleepLoopRenderTimer : IRenderTimer
+    {
+        public event Action<TimeSpan> Tick;
+
+        public SleepLoopRenderTimer(int fps)
+        {
+            var timeBetweenTicks = TimeSpan.FromSeconds(1d / fps);
+            new Thread(() =>
+            {
+                var st = Stopwatch.StartNew();
+                var now = st.Elapsed;
+                var lastTick = now;
+
+                while (true)
+                {
+                    var timeTillNextTick = lastTick + timeBetweenTicks - now;
+                    if (timeTillNextTick.TotalMilliseconds > 1)
+                        Thread.Sleep(timeTillNextTick);
+
+
+                    Tick?.Invoke(now);
+                    now = st.Elapsed;
+                }
+            }) { IsBackground = true }.Start();
+        }
+    }
+}

--- a/src/Avalonia.X11/X11Platform.cs
+++ b/src/Avalonia.X11/X11Platform.cs
@@ -47,7 +47,7 @@ namespace Avalonia.X11
             AvaloniaLocator.CurrentMutable.BindToSelf(this)
                 .Bind<IWindowingPlatform>().ToConstant(this)
                 .Bind<IPlatformThreadingInterface>().ToConstant(new X11PlatformThreading(this))
-                .Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(60))
+                .Bind<IRenderTimer>().ToConstant(new SleepLoopRenderTimer(60))
                 .Bind<IRenderLoop>().ToConstant(new RenderLoop())
                 .Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration(KeyModifiers.Control))
                 .Bind<IKeyboardDevice>().ToFunc(() => KeyboardDevice)


### PR DESCRIPTION
Apparently, nvidia driver doesn't like to be used with a stencil buffer when it was previously was called from multiple threads (not at the same time, just multiple different ones). I don't have an explanation for this phenomena, but using a single thread for the render timer seems to fix the crash.