### PR TITLE
Stop ItemsSourceView using a cached size.

### DIFF
--- a/src/Avalonia.Controls/Repeater/ItemsSourceView.cs
+++ b/src/Avalonia.Controls/Repeater/ItemsSourceView.cs
@@ -25,7 +25,6 @@ namespace Avalonia.Controls
     {
         private readonly IList _inner;
         private INotifyCollectionChanged _notifyCollectionChanged;
-        private int _cachedSize = -1;
 
         /// <summary>
         /// Initializes a new instance of the ItemsSourceView class for the specified data source.
@@ -54,18 +53,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets the number of items in the collection.
         /// </summary>
-        public int Count
-        {
-            get
-            {
-                if (_cachedSize == -1)
-                {
-                    _cachedSize = _inner.Count;
-                }
-
-                return _cachedSize;
-            }
-        }
+        public int Count => _inner.Count;
 
         /// <summary>
         /// Gets a value that indicates whether the items source can provide a unique key for each item.
@@ -126,7 +114,6 @@ namespace Avalonia.Controls
 
         protected void OnItemsSourceChanged(NotifyCollectionChangedEventArgs args)
         {
-            _cachedSize = _inner.Count;
             CollectionChanged?.Invoke(this, args);
         }
 


### PR DESCRIPTION
## What does the pull request do?

`ItemsSourceView` was ported from WinUI - it's purpose is to wrap an `IEnumerable` in order to provide a standardized view of interactions between a collection and an `ItemsRepeater` (to handle cases like #54).

`ItemsSourceView` caches the count of the inner collection. This can mean that `Count` is out-of-date with regards to the inner collection if it's accessed in a collection changed handler before `OnItemsSourceChanged` is fired.

It's never been clear to me why ItemsSourceView caches the size; I suspect it's due to the performance characteristics of WinRT and so I think it can be safely removed in Avalonia.

## Fixed issues

Fixes #4409
