### PR TITLE
Handle initial selection in SelectedItems.

### DIFF
--- a/samples/ControlCatalog/Pages/ListBoxPage.xaml
+++ b/samples/ControlCatalog/Pages/ListBoxPage.xaml
@@ -11,8 +11,7 @@
               Spacing="16">
       <StackPanel Orientation="Vertical" Spacing="8">
         <ListBox Items="{Binding Items}"
-                 SelectedItem="{Binding SelectedItem}"
-                 SelectedItems="{Binding SelectedItems}"
+                 Selection="{Binding Selection}"
                  AutoScrollToSelectedItem="True"
                  SelectionMode="{Binding SelectionMode}"
                  Width="250"

--- a/samples/ControlCatalog/Pages/ListBoxPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/ListBoxPage.xaml.cs
@@ -1,10 +1,6 @@
-using System;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Reactive;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
-using ReactiveUI;
+using ControlCatalog.ViewModels;
 
 namespace ControlCatalog.Pages
 {
@@ -13,72 +9,12 @@ namespace ControlCatalog.Pages
         public ListBoxPage()
         {
             InitializeComponent();
-            DataContext = new PageViewModel();
+            DataContext = new ListBoxPageViewModel();
         }
 
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-        }
-
-        private class PageViewModel : ReactiveObject
-        {
-            private int _counter;
-            private SelectionMode _selectionMode;
-
-            public PageViewModel()
-            {
-                Items = new ObservableCollection<string>(Enumerable.Range(1, 10000).Select(i => GenerateItem()));
-                SelectedItems = new ObservableCollection<string>();
-
-                AddItemCommand = ReactiveCommand.Create(() => Items.Add(GenerateItem()));
-
-                RemoveItemCommand = ReactiveCommand.Create(() =>
-                {
-                    while (SelectedItems.Count > 0)
-                    {
-                        Items.Remove(SelectedItems[0]);
-                    }
-                });
-
-                SelectRandomItemCommand = ReactiveCommand.Create(() =>
-                {
-                    var random = new Random();
-
-                    SelectedItem = Items[random.Next(Items.Count - 1)];
-                });
-            }
-
-            public ObservableCollection<string> Items { get; }
-
-            private string _selectedItem;
-
-            public string SelectedItem
-            {
-                get { return _selectedItem; }
-                set { this.RaiseAndSetIfChanged(ref _selectedItem, value); }
-            }
-
-
-            public ObservableCollection<string> SelectedItems { get; }
-
-            public ReactiveCommand<Unit, Unit> AddItemCommand { get; }
-
-            public ReactiveCommand<Unit, Unit> RemoveItemCommand { get; }
-
-            public ReactiveCommand<Unit, Unit> SelectRandomItemCommand { get; }
-
-            public SelectionMode SelectionMode
-            {
-                get => _selectionMode;
-                set
-                {
-                    SelectedItems.Clear();
-                    this.RaiseAndSetIfChanged(ref _selectionMode, value);
-                }
-            }
-
-            private string GenerateItem() => $"Item {_counter++.ToString()}";
         }
     }
 }

--- a/samples/ControlCatalog/ViewModels/ListBoxPageViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/ListBoxPageViewModel.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reactive;
+using Avalonia.Controls;
+using ReactiveUI;
+
+namespace ControlCatalog.ViewModels
+{
+    public class ListBoxPageViewModel : ReactiveObject
+    {
+        private int _counter;
+        private SelectionMode _selectionMode;
+
+        public ListBoxPageViewModel()
+        {
+            Items = new ObservableCollection<string>(Enumerable.Range(1, 10000).Select(i => GenerateItem()));
+            Selection = new SelectionModel();
+            Selection.Select(1);
+
+            AddItemCommand = ReactiveCommand.Create(() => Items.Add(GenerateItem()));
+
+            RemoveItemCommand = ReactiveCommand.Create(() =>
+            {
+                while (Selection.SelectedItems.Count > 0)
+                {
+                    Items.Remove((string)Selection.SelectedItems.First());
+                }
+            });
+
+            SelectRandomItemCommand = ReactiveCommand.Create(() =>
+            {
+                var random = new Random();
+
+                using (Selection.Update())
+                {
+                    Selection.ClearSelection();
+                    Selection.Select(random.Next(Items.Count - 1));
+                }
+            });
+        }
+
+        public ObservableCollection<string> Items { get; }
+
+        public SelectionModel Selection { get; }
+
+        public ReactiveCommand<Unit, Unit> AddItemCommand { get; }
+
+        public ReactiveCommand<Unit, Unit> RemoveItemCommand { get; }
+
+        public ReactiveCommand<Unit, Unit> SelectRandomItemCommand { get; }
+
+        public SelectionMode SelectionMode
+        {
+            get => _selectionMode;
+            set
+            {
+                Selection.ClearSelection();
+                this.RaiseAndSetIfChanged(ref _selectionMode, value);
+            }
+        }
+
+        private string GenerateItem() => $"Item {_counter++.ToString()}";
+    }
+}

--- a/tests/Avalonia.Controls.UnitTests/Utils/SelectedItemsSyncTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Utils/SelectedItemsSyncTests.cs
@@ -208,6 +208,20 @@ namespace Avalonia.Controls.UnitTests.Utils
                 target.SetItems(new[] { "foo", "bar", "baz" }));
         }
 
+        [Fact]
+        public void Selected_Items_Can_Be_Set_Before_SelectionModel_Source()
+        {
+            var model = new SelectionModel();
+            var target = new SelectedItemsSync(model);
+            var items = new AvaloniaList<string> { "foo", "bar", "baz" };
+            var selectedItems = new AvaloniaList<string> { "bar" };
+
+            target.SetItems(selectedItems);
+            model.Source = items;
+
+            Assert.Equal(new IndexPath(1), model.SelectedIndex);
+        }
+
         private static SelectedItemsSync CreateTarget(
             IEnumerable<string> items = null)
         {


### PR DESCRIPTION
## What does the pull request do?

As described in #4272, an initial selection in `SelectedItems` wasn't being respected. Make `SelectedItemsSync` handle this correctly by detecting a null `Source` in the `SelectionModel` and updating the selection when `Source` is finally set.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #4272 