### PR TITLE
Fix issues related to RoutedViewHost and AutoDataTemplateBindingHook

### DIFF
--- a/build/ReactiveUI.props
+++ b/build/ReactiveUI.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="10.3.6" />
+    <PackageReference Include="ReactiveUI" Version="11.5.17" />
   </ItemGroup>
 </Project>

--- a/src/Avalonia.ReactiveUI/AutoDataTemplateBindingHook.cs
+++ b/src/Avalonia.ReactiveUI/AutoDataTemplateBindingHook.cs
@@ -48,6 +48,10 @@ namespace Avalonia.ReactiveUI
             if (itemsControl.ItemTemplate != null)
                 return true;
 
+            if (itemsControl.DataTemplates != null &&
+                itemsControl.DataTemplates.Count > 0)
+                return true;
+
             itemsControl.ItemTemplate = DefaultItemTemplate;
             return true;
         }

--- a/src/Avalonia.ReactiveUI/RoutedViewHost.cs
+++ b/src/Avalonia.ReactiveUI/RoutedViewHost.cs
@@ -66,6 +66,7 @@ namespace Avalonia.ReactiveUI
             this.WhenActivated(disposables =>
             {
                 this.WhenAnyObservable(x => x.Router.CurrentViewModel)
+                    .StartWith(default(object))
                     .DistinctUntilChanged()
                     .Subscribe(NavigateToViewModel)
                     .DisposeWith(disposables);
@@ -92,6 +93,13 @@ namespace Avalonia.ReactiveUI
         /// <param name="viewModel">ViewModel to which the user navigates.</param>
         private void NavigateToViewModel(object viewModel)
         {
+            if (Router == null)
+            {
+                this.Log().Warn("Router property is null. Falling back to default content.");
+                Content = DefaultContent;
+                return;
+            }
+
             if (viewModel == null)
             {
                 this.Log().Info("ViewModel is null. Falling back to default content.");

--- a/src/Avalonia.ReactiveUI/RoutedViewHost.cs
+++ b/src/Avalonia.ReactiveUI/RoutedViewHost.cs
@@ -65,9 +65,15 @@ namespace Avalonia.ReactiveUI
         {
             this.WhenActivated(disposables =>
             {
-                this.WhenAnyObservable(x => x.Router.CurrentViewModel)
-                    .StartWith(default(object))
-                    .DistinctUntilChanged()
+                var routerRemoved = this
+                    .WhenAnyValue(x => x.Router)
+                    .Where(router => router == null)
+                    .Cast<object>();
+
+                this.WhenAnyValue(x => x.Router)
+                    .Where(router => router != null)
+                    .SelectMany(router => router.CurrentViewModel)
+                    .Merge(routerRemoved)
                     .Subscribe(NavigateToViewModel)
                     .DisposeWith(disposables);
             });

--- a/src/Avalonia.ReactiveUI/RoutedViewHost.cs
+++ b/src/Avalonia.ReactiveUI/RoutedViewHost.cs
@@ -124,8 +124,8 @@ namespace Avalonia.ReactiveUI
     
             this.Log().Info($"Ready to show {viewInstance} with autowired {viewModel}.");
             viewInstance.ViewModel = viewModel;
-            if (viewInstance is IStyledElement styled)
-                styled.DataContext = viewModel;
+            if (viewInstance is IDataContextProvider provider)
+                provider.DataContext = viewModel;
             Content = viewInstance;
         }
     }

--- a/tests/Avalonia.ReactiveUI.UnitTests/AutoDataTemplateBindingHookTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AutoDataTemplateBindingHookTest.cs
@@ -61,15 +61,7 @@ namespace Avalonia.ReactiveUI.UnitTests
         }
 
         [Fact]
-        public void Should_Not_Override_Data_Template_Binding_When_Item_Template_Is_Set()
-        {
-            var view = new ExampleView(control => control.ItemTemplate = GetItemTemplate());
-            Assert.NotNull(view.List.ItemTemplate);
-            Assert.IsType<FuncDataTemplate<TextBlock>>(view.List.ItemTemplate);
-        }
-
-        [Fact]
-        public void Should_Use_View_Model_View_Host_As_Data_Template()
+        public void Should_Use_ViewModelViewHost_As_Data_Template_By_Default()
         {
             var view = new ExampleView();
             view.ViewModel.Items.Add(new NestedViewModel());
@@ -79,6 +71,33 @@ namespace Avalonia.ReactiveUI.UnitTests
             container.UpdateChild();
 
             Assert.IsType<ViewModelViewHost>(container.Child);
+        }
+
+        [Fact]
+        public void ViewModelViewHost_Should_Resolve_And_Embedd_Appropriate_View_Model()
+        {
+            var view = new ExampleView();
+            view.ViewModel.Items.Add(new NestedViewModel());
+
+            var child = view.List.Presenter.Panel.Children[0];
+            var container = (ContentPresenter) child;
+            container.UpdateChild();
+
+            var host = (ViewModelViewHost) container.Child;
+            Assert.IsType<NestedViewModel>(host.ViewModel);
+            Assert.IsType<NestedViewModel>(host.DataContext);
+
+            host.DataContext = "changed context";
+            Assert.IsType<string>(host.ViewModel);
+            Assert.IsType<string>(host.DataContext);
+        }
+
+        [Fact]
+        public void Should_Not_Override_Data_Template_Binding_When_Item_Template_Is_Set()
+        {
+            var view = new ExampleView(control => control.ItemTemplate = GetItemTemplate());
+            Assert.NotNull(view.List.ItemTemplate);
+            Assert.IsType<FuncDataTemplate<TextBlock>>(view.List.ItemTemplate);
         }
 
         [Fact]
@@ -105,25 +124,6 @@ namespace Avalonia.ReactiveUI.UnitTests
             container.UpdateChild();
 
             Assert.IsType<TextBlock>(container.Child);
-        }
-
-        [Fact]
-        public void Should_Resolve_And_Embedd_Appropriate_View_Model()
-        {
-            var view = new ExampleView();
-            view.ViewModel.Items.Add(new NestedViewModel());
-
-            var child = view.List.Presenter.Panel.Children[0];
-            var container = (ContentPresenter) child;
-            container.UpdateChild();
-
-            var host = (ViewModelViewHost) container.Child;
-            Assert.IsType<NestedViewModel>(host.ViewModel);
-            Assert.IsType<NestedViewModel>(host.DataContext);
-
-            host.DataContext = "changed context";
-            Assert.IsType<string>(host.ViewModel);
-            Assert.IsType<string>(host.DataContext);
         }
 
         private static FuncDataTemplate GetItemTemplate()

--- a/tests/Avalonia.ReactiveUI.UnitTests/AutoDataTemplateBindingHookTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/AutoDataTemplateBindingHookTest.cs
@@ -33,31 +33,13 @@ namespace Avalonia.ReactiveUI.UnitTests
                 Template = GetTemplate()
             };
 
-            public ExampleView()
+            public ExampleView(Action<ItemsControl> adjustItemsControl = null)
             {
+                adjustItemsControl?.Invoke(List);
                 List.ApplyTemplate();
                 List.Presenter.ApplyTemplate();
+                
                 Content = List;
-
-                ViewModel = new ExampleViewModel();
-                this.OneWayBind(ViewModel, x => x.Items, x => x.List.Items);
-            }
-        }
-
-        public class ExampleViewWithItemTemplate : ReactiveUserControl<ExampleViewModel>
-        {
-            public ItemsControl List { get; } = new ItemsControl
-            {
-                Template = GetTemplate()
-            };
-
-            public ExampleViewWithItemTemplate()
-            {
-                List.ApplyTemplate();
-                List.Presenter.ApplyTemplate();
-                List.ItemTemplate = GetItemTemplate();
-                Content = List;
-
                 ViewModel = new ExampleViewModel();
                 this.OneWayBind(ViewModel, x => x.Items, x => x.List.Items);
             }
@@ -81,7 +63,7 @@ namespace Avalonia.ReactiveUI.UnitTests
         [Fact]
         public void Should_Not_Override_Data_Template_Binding_When_Item_Template_Is_Set()
         {
-            var view = new ExampleViewWithItemTemplate();
+            var view = new ExampleView(control => control.ItemTemplate = GetItemTemplate());
             Assert.NotNull(view.List.ItemTemplate);
             Assert.IsType<FuncDataTemplate<TextBlock>>(view.List.ItemTemplate);
         }
@@ -102,7 +84,20 @@ namespace Avalonia.ReactiveUI.UnitTests
         [Fact]
         public void Should_Not_Use_View_Model_View_Host_When_Item_Template_Is_Set()
         {
-            var view = new ExampleViewWithItemTemplate();
+            var view = new ExampleView(control => control.ItemTemplate = GetItemTemplate());
+            view.ViewModel.Items.Add(new NestedViewModel());
+
+            var child = view.List.Presenter.Panel.Children[0];
+            var container = (ContentPresenter) child;
+            container.UpdateChild();
+
+            Assert.IsType<TextBlock>(container.Child);
+        }
+        
+        [Fact]
+        public void Should_Not_Use_View_Model_View_Host_When_Data_Templates_Are_Not_Empty()
+        {
+            var view = new ExampleView(control => control.DataTemplates.Add(GetItemTemplate()));
             view.ViewModel.Items.Add(new NestedViewModel());
 
             var child = view.List.Presenter.Panel.Children[0];
@@ -116,7 +111,6 @@ namespace Avalonia.ReactiveUI.UnitTests
         public void Should_Resolve_And_Embedd_Appropriate_View_Model()
         {
             var view = new ExampleView();
-            var root = new TestRoot { Child = view };
             view.ViewModel.Items.Add(new NestedViewModel());
 
             var child = view.List.Presenter.Panel.Children[0];
@@ -139,17 +133,14 @@ namespace Avalonia.ReactiveUI.UnitTests
 
         private static FuncControlTemplate GetTemplate()
         {
-            return new FuncControlTemplate<ItemsControl>((parent, scope) =>
+            return new FuncControlTemplate<ItemsControl>((parent, scope) => new Border
             {
-                return new Border
+                Background = new Media.SolidColorBrush(0xffffffff),
+                Child = new ItemsPresenter
                 {
-                    Background = new Media.SolidColorBrush(0xffffffff),
-                    Child = new ItemsPresenter
-                    {
-                        Name = "PART_ItemsPresenter",
-                        [~ItemsPresenter.ItemsProperty] = parent[~ItemsControl.ItemsProperty],
-                    }.RegisterInNameScope(scope)
-                };
+                    Name = "PART_ItemsPresenter",
+                    [~ItemsPresenter.ItemsProperty] = parent[~ItemsControl.ItemsProperty],
+                }.RegisterInNameScope(scope)
             });
         }
     }

--- a/tests/Avalonia.ReactiveUI.UnitTests/RoutedViewHostTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/RoutedViewHostTest.cs
@@ -62,50 +62,42 @@ namespace Avalonia.ReactiveUI.UnitTests
                 PageTransition = null
             };
 
-            var root = new TestRoot 
-            { 
-                Child = host 
+            var root = new TestRoot
+            {
+                Child = host
             };
             
             Assert.NotNull(host.Content);
-            Assert.Equal(typeof(TextBlock), host.Content.GetType());
+            Assert.IsType<TextBlock>(host.Content);
             Assert.Equal(defaultContent, host.Content);
 
             var first = new FirstRoutableViewModel();
-            screen.Router.Navigate
-                .Execute(first)
-                .Subscribe();
+            screen.Router.Navigate.Execute(first).Subscribe();
 
             Assert.NotNull(host.Content);
-            Assert.Equal(typeof(FirstRoutableView), host.Content.GetType());
+            Assert.IsType<FirstRoutableView>(host.Content);
             Assert.Equal(first, ((FirstRoutableView)host.Content).DataContext);
             Assert.Equal(first, ((FirstRoutableView)host.Content).ViewModel);
 
             var second = new SecondRoutableViewModel();
-            screen.Router.Navigate
-                .Execute(second)
-                .Subscribe();
+            screen.Router.Navigate.Execute(second).Subscribe();
 
             Assert.NotNull(host.Content);
-            Assert.Equal(typeof(SecondRoutableView), host.Content.GetType());
+            Assert.IsType<SecondRoutableView>(host.Content);
             Assert.Equal(second, ((SecondRoutableView)host.Content).DataContext);
             Assert.Equal(second, ((SecondRoutableView)host.Content).ViewModel);
 
-            screen.Router.NavigateBack
-                .Execute(Unit.Default)
-                .Subscribe();
+            screen.Router.NavigateBack.Execute(Unit.Default).Subscribe();
 
             Assert.NotNull(host.Content);
-            Assert.Equal(typeof(FirstRoutableView), host.Content.GetType());
+            Assert.IsType<FirstRoutableView>(host.Content);
             Assert.Equal(first, ((FirstRoutableView)host.Content).DataContext);
             Assert.Equal(first, ((FirstRoutableView)host.Content).ViewModel);
 
-            screen.Router.NavigateBack
-                .Execute(Unit.Default)
-                .Subscribe();
+            screen.Router.NavigateBack.Execute(Unit.Default).Subscribe();
 
             Assert.NotNull(host.Content);
-            Assert.Equal(typeof(TextBlock), host.Content.GetType());
+            Assert.IsType<TextBlock>(host.Content);
             Assert.Equal(defaultContent, host.Content);
         }
 
@@ -121,9 +113,9 @@ namespace Avalonia.ReactiveUI.UnitTests
                 Router = null
             };
 
-            var root = new TestRoot 
-            { 
-                Child = host 
+            var root = new TestRoot
+            {
+                Child = host
             };
 
             Assert.NotNull(host.Content);
@@ -138,9 +130,17 @@ namespace Avalonia.ReactiveUI.UnitTests
             screen.Router.Navigate.Execute(first).Subscribe();
 
             Assert.NotNull(host.Content);
-            Assert.Equal(typeof(FirstRoutableView), host.Content.GetType());
-            Assert.Equal(first, ((FirstRoutableView)host.Content).DataContext);
-            Assert.Equal(first, ((FirstRoutableView)host.Content).ViewModel);
+            Assert.IsType<FirstRoutableView>(host.Content);
+
+            host.Router = null;
+            
+            Assert.NotNull(host.Content);
+            Assert.Equal(defaultContent, host.Content);
+
+            host.Router = screen.Router;
+            
+            Assert.NotNull(host.Content);
+            Assert.IsType<FirstRoutableView>(host.Content);
         }
     }
 }

--- a/tests/Avalonia.ReactiveUI.UnitTests/RoutedViewHostTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/RoutedViewHostTest.cs
@@ -108,5 +108,39 @@ namespace Avalonia.ReactiveUI.UnitTests
             Assert.Equal(typeof(TextBlock), host.Content.GetType());
             Assert.Equal(defaultContent, host.Content);
         }
+
+        [Fact]
+        public void RoutedViewHost_Should_Show_Default_Content_When_Router_Is_Null()
+        {
+            var screen = new ScreenViewModel();
+            var defaultContent = new TextBlock();
+            var host = new RoutedViewHost 
+            { 
+                DefaultContent = defaultContent,
+                PageTransition = null,
+                Router = null
+            };
+
+            var root = new TestRoot 
+            { 
+                Child = host 
+            };
+
+            Assert.NotNull(host.Content);
+            Assert.Equal(defaultContent, host.Content);
+
+            host.Router = screen.Router;
+
+            Assert.NotNull(host.Content);
+            Assert.Equal(defaultContent, host.Content);
+            
+            var first = new FirstRoutableViewModel();
+            screen.Router.Navigate.Execute(first).Subscribe();
+
+            Assert.NotNull(host.Content);
+            Assert.Equal(typeof(FirstRoutableView), host.Content.GetType());
+            Assert.Equal(first, ((FirstRoutableView)host.Content).DataContext);
+            Assert.Equal(first, ((FirstRoutableView)host.Content).ViewModel);
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

This PR addresses the two issues that were recently discovered during a discussion in Avalonia Telegram chat. The first issue is related to `RoutedViewHost` which doesn't show `DefaultContent` when `RoutedViewHost.Router` property is null. The second issue is related to `AutoDataTemplateBindingHook` which enforces `ViewModelViewHost` usage when `ItemsControl.DataTemplates` property is set. Also, this PR updates ReactiveUI to the latest available version.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

1. Currently, `RoutedViewHost` doesn't show default content when its `Router` property is set to `Null`, unset, or bound to a view model property which is set to `Null`. This results in no information shown on the screen at all, and confuses new users.
```xaml
<!-- This results into no content getting displayed. -->
<rxui:RoutedViewHost>
  <rxui:RoutedViewHost.DefaultContent>
    <TextBlock Text="Default content!" />
  </rxui:RoutedViewHost.DefaultContent>
</rxui:RoutedViewHost>
```

2. Currently, when `ItemsControl.DataTemplates` property is set, and someone decides to use [ReactiveUI code-behind bindings](https://www.reactiveui.net/docs/handbook/data-binding/), the `AutoDataTemplateBindingHook` is evaluated and `ItemsControl.DataTemplates` property is ignored, resulting in `ViewModelViewHost` controls getting displayed. However, according to [ReactiveUI documentation](https://www.reactiveui.net/docs/handbook/view-location/), that control shouldn't override the templates if they were set by a user.
3. ReactiveUI version is `10.3.6`

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

1. Now, `DefaultContent` is displayed when `RoutedViewHost.Router` property is `Null`.
2. The `ItemsControl.DataTemplates` property will no longer be overridden by a `ViewModelViewHost` if it contains some templates intentionally specified by a developer.
3. ReactiveUI version is `11.5.17`

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

Hopefully, this PR won't introduce any changes that would break existing apps. 