### PR TITLE
Fix auto-sizing on secondary monitors on win32.

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -652,8 +652,8 @@ namespace Avalonia.Controls
 
                 PlatformImpl?.Show();
                 Renderer?.Start();
+                SetWindowStartupLocation(Owner?.PlatformImpl);
             }
-            SetWindowStartupLocation(Owner?.PlatformImpl);
             OnOpened(EventArgs.Empty);
         }
 

--- a/src/Avalonia.Controls/WindowBase.cs
+++ b/src/Avalonia.Controls/WindowBase.cs
@@ -39,6 +39,7 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<bool> TopmostProperty =
             AvaloniaProperty.Register<WindowBase, bool>(nameof(Topmost));
 
+        private int _autoSizing;
         private bool _hasExecutedInitialLayoutPass;
         private bool _isActive;
         private bool _ignoreVisibilityChange;
@@ -97,11 +98,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Whether an auto-size operation is in progress.
         /// </summary>
-        protected bool AutoSizing
-        {
-            get;
-            private set;
-        }
+        protected bool AutoSizing => _autoSizing > 0;
 
         /// <summary>
         /// Gets or sets the owner of the window.
@@ -186,8 +183,8 @@ namespace Avalonia.Controls
         /// </remarks>
         protected IDisposable BeginAutoSizing()
         {
-            AutoSizing = true;
-            return Disposable.Create(() => AutoSizing = false);
+            ++_autoSizing;
+            return Disposable.Create(() => --_autoSizing);
         }
 
         /// <summary>


### PR DESCRIPTION
## What does the pull request do?

Fixes autosizing windows shown on secondary monitors on win32:

- Allow nested calls to `BeginAutoSizing` - previously it was called twice when showing a window on a secondary monitor and when the second `using` block exited it cleared the autosizing state despite the outer block not completing
- Call `SetWindowStartupLocation` within the auto-sizing block. Moving to a secondary monitor causes a resize message.

## Fixed issues

Fixes #4477 