### PR TITLE
osx obey minsize.

### DIFF
--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -27,6 +27,7 @@ public:
     AvnPoint lastPositionSet;
     NSString* _lastTitle;
     IAvnMenu* _mainMenu;
+    
     bool _shown;
     
     WindowBaseImpl(IAvnWindowBaseEvents* events, IAvnGlContext* gl)
@@ -230,6 +231,29 @@ public:
     {
         @autoreleasepool
         {
+            auto maxSize = [Window maxSize];
+            auto minSize = [Window minSize];
+            
+            if (x < minSize.width)
+            {
+                x = minSize.width;
+            }
+            
+            if (y < minSize.height)
+            {
+                y = minSize.height;
+            }
+            
+            if (x > maxSize.width)
+            {
+                x = maxSize.width;
+            }
+            
+            if (y > maxSize.height)
+            {
+                y = maxSize.height;
+            }
+            
             [Window setContentSize:NSSize{x, y}];
             
             return S_OK;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
OSX was not obeying min/max size contraints.

Avalonia assumes the backend enforces this... osx allows you to set the min and max size... but it isnt enforced for some reason.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
