### PR TITLE
TextBox - dont lose textselection when context menu opens

### DIFF
--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -280,9 +280,8 @@ namespace Avalonia.Controls
             }
 
             _popup.Child = this;
-            _popup.IsOpen = true;
-
             IsOpen = true;
+            _popup.IsOpen = true;
 
             RaiseEvent(new RoutedEventArgs
             {

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -410,10 +410,15 @@ namespace Avalonia.Controls
         protected override void OnLostFocus(RoutedEventArgs e)
         {
             base.OnLostFocus(e);
-            SelectionStart = 0;
-            SelectionEnd = 0;
+
+            if (ContextMenu == null || !ContextMenu.IsOpen)
+            {
+                SelectionStart = 0;
+                SelectionEnd = 0;
+                RevealPassword = false;
+            }
+            
             _presenter?.HideCaret();
-            RevealPassword = false;
         }
 
         protected override void OnTextInput(TextInputEventArgs e)

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -18,6 +18,46 @@ namespace Avalonia.Controls.UnitTests
     public class TextBoxTests
     {
         [Fact]
+        public void Opening_Context_Menu_Does_not_Loose_Selection()
+        {
+            using (UnitTestApplication.Start(FocusServices))
+            {
+                var target1 = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "1234",
+                    ContextMenu = new TestContextMenu()
+                };
+
+                var target2 = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "5678"
+                };
+                
+                var sp = new StackPanel();
+                sp.Children.Add(target1);
+                sp.Children.Add(target2);
+
+                target1.ApplyTemplate();
+                target2.ApplyTemplate();
+                
+                var root = new TestRoot() { Child = sp };
+
+                target1.SelectionStart = 0;
+                target1.SelectionEnd = 3;
+                
+                target1.Focus();
+                Assert.False(target2.IsFocused);
+                Assert.True(target1.IsFocused);
+
+                target2.Focus();
+                
+                Assert.Equal("123", target1.SelectedText);
+            }
+        }
+        
+        [Fact]
         public void DefaultBindingMode_Should_Be_TwoWay()
         {
             Assert.Equal(
@@ -693,6 +733,14 @@ namespace Avalonia.Controls.UnitTests
             public Task<string[]> GetFormatsAsync() => Task.FromResult(Array.Empty<string>());
 
             public Task<object> GetDataAsync(string format) => Task.FromResult((object)null);
+        }
+        
+        private class TestContextMenu : ContextMenu
+        {
+            public TestContextMenu()
+            {
+                IsOpen = true;
+            }
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -18,7 +18,7 @@ namespace Avalonia.Controls.UnitTests
     public class TextBoxTests
     {
         [Fact]
-        public void Opening_Context_Menu_Does_not_Loose_Selection()
+        public void Opening_Context_Menu_Does_not_Lose_Selection()
         {
             using (UnitTestApplication.Start(FocusServices))
             {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
When implementing copy and paste context menu items for textbox its not possible because text selection gets lost.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Dont lose the selection.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
