### PR TITLE
Re-enable SharpGenTools.Sdk to patch calli but disable codegen

### DIFF
--- a/src/Avalonia.Native/Avalonia.Native.csproj
+++ b/src/Avalonia.Native/Avalonia.Native.csproj
@@ -7,7 +7,7 @@
     <CastXmlPath Condition="Exists('/usr/bin/castxml')">/usr/bin/castxml</CastXmlPath>
     <CastXmlPath Condition="Exists('/usr/local/bin/castxml')">/usr/local/bin/castxml</CastXmlPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <SharpGenGenerateConsumerBinding>false</SharpGenGenerateConsumerBinding>
+    <SharpGenGenerateConsumerBindMapping>false</SharpGenGenerateConsumerBindMapping>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release' AND '$([MSBuild]::IsOSPlatform(OSX))' == 'true'">

--- a/src/Avalonia.Native/Avalonia.Native.csproj
+++ b/src/Avalonia.Native/Avalonia.Native.csproj
@@ -7,6 +7,7 @@
     <CastXmlPath Condition="Exists('/usr/bin/castxml')">/usr/bin/castxml</CastXmlPath>
     <CastXmlPath Condition="Exists('/usr/local/bin/castxml')">/usr/local/bin/castxml</CastXmlPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <SharpGenGenerateConsumerBinding>false</SharpGenGenerateConsumerBinding>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release' AND '$([MSBuild]::IsOSPlatform(OSX))' == 'true'">

--- a/src/Avalonia.Native/Avalonia.Native.csproj
+++ b/src/Avalonia.Native/Avalonia.Native.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <SharpGenMapping Include="Mappings.xml" />
-    <!--<PackageReference Include="SharpGenTools.Sdk" Version="1.2.1" PrivateAssets="all" />-->
+    <!--<SharpGenMapping Include="Mappings.xml" />-->
+    <PackageReference Include="SharpGenTools.Sdk" Version="1.2.1" PrivateAssets="all" />
     <PackageReference Include="SharpGen.Runtime" Version="1.2.1" />
     <PackageReference Include="SharpGen.Runtime.COM" Version="1.2.0" />
     <ProjectReference Include="..\..\packages\Avalonia\Avalonia.csproj" />


### PR DESCRIPTION
When we disabled SharpGenTools.Sdk, we accidentally broke the calli patching. This change re-enables the calli patching and disables the code-gen steps by commenting out the mapping file.

This fixes the failures on startup on Mac.