### PR TITLE
Passing dependencies to Application via constructor.

### DIFF
--- a/src/Avalonia.Controls/AppBuilderBase.cs
+++ b/src/Avalonia.Controls/AppBuilderBase.cs
@@ -88,6 +88,23 @@ namespace Avalonia.Controls
             };
         }
 
+        /// <summary>
+        /// Begin configuring an <see cref="Application"/>.
+        /// </summary>
+        /// <param name="appFactory">Factory function for <typeparamref name="TApp"/>.</param>
+        /// <typeparam name="TApp">The subclass of <see cref="Application"/> to configure.</typeparam>
+        /// <remarks><paramref name="appFactory"/> is useful for passing of dependencies to <typeparamref name="TApp"/>.</remarks>
+        /// <returns>An <typeparamref name="TAppBuilder"/> instance.</returns>
+        public static TAppBuilder Configure<TApp>(Func<TApp> appFactory)
+            where TApp : Application
+        {
+            return new TAppBuilder()
+            {
+                ApplicationType = typeof(TApp),
+                _appFactory = appFactory
+            };
+        }
+
         protected TAppBuilder Self => (TAppBuilder)this;
 
         public TAppBuilder AfterSetup(Action<TAppBuilder> callback)

--- a/tests/Avalonia.Controls.UnitTests/AppBuilderTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/AppBuilderTests.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls.UnitTests;
+﻿using System;
+using Avalonia.Controls.UnitTests;
 using Avalonia.Platform;
 using Xunit;
 
@@ -16,6 +17,22 @@ namespace Avalonia.Controls.UnitTests
     {
         class App : Application
         {
+        }
+
+        public class AppWithDependencies : Application
+        {
+            public AppWithDependencies()
+            {
+                throw new NotSupportedException();
+            }
+
+            public AppWithDependencies(object dependencyA, object dependencyB)
+            {
+                DependencyA = dependencyA;
+                DependencyB = dependencyB;
+            }
+            public object DependencyA { get; }
+            public object DependencyB { get; }
         }
 
         public class DefaultModule
@@ -53,7 +70,30 @@ namespace Avalonia.Controls.UnitTests
                 IsLoaded = true;
             }
         }
-        
+
+        [Fact]
+        public void UseAppFactory()
+        {
+            using (AvaloniaLocator.EnterScope())
+            {
+                ResetModuleLoadStates();
+
+                Func<AppWithDependencies> appFactory = () => new AppWithDependencies(dependencyA: new object(), dependencyB: new object());
+
+                var builder = AppBuilder.Configure<AppWithDependencies>(appFactory)
+                    .UseWindowingSubsystem(() => { })
+                    .UseRenderingSubsystem(() => { })
+                    .UseAvaloniaModules()
+                    .SetupWithoutStarting();
+
+                AppWithDependencies app = (AppWithDependencies)builder.Instance;
+                Assert.NotNull(app.DependencyA);
+                Assert.NotNull(app.DependencyB);
+
+                Assert.True(DefaultModule.IsLoaded);
+            }
+        }
+
         [Fact]
         public void LoadsDefaultModule()
         {

--- a/tests/Avalonia.Controls.UnitTests/AppBuilderTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/AppBuilderTests.cs
@@ -21,17 +21,14 @@ namespace Avalonia.Controls.UnitTests
 
         public class AppWithDependencies : Application
         {
-            public AppWithDependencies()
-            {
-                throw new NotSupportedException();
-            }
-
             public AppWithDependencies(object dependencyA, object dependencyB)
             {
                 DependencyA = dependencyA;
                 DependencyB = dependencyB;
             }
+
             public object DependencyA { get; }
+
             public object DependencyB { get; }
         }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Attempts to allow passing dependencies to applications without using `static` fields.

**This is a draft PR for the sake of starting discussion about this topic.**

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

`TApp` is always created using parameter-less constructor.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

User can specify her own `TApp` factory function so that `TApp` can receive all dependencies through a constructor.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

I think it should not break any existing code.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

None.