### PR TITLE
Fix Issue3825

### DIFF
--- a/src/Avalonia.Visuals/Media/GlyphRun.cs
+++ b/src/Avalonia.Visuals/Media/GlyphRun.cs
@@ -555,7 +555,7 @@ namespace Avalonia.Media
                 }
             }
 
-            return new Rect(0, 0, width, height);
+            return new Rect(0, GlyphTypeface.Ascent * Scale, width, height);
         }
 
         private void Set<T>(ref T field, T value)
@@ -595,8 +595,6 @@ namespace Avalonia.Media
             _glyphRunImpl = platformRenderInterface.CreateGlyphRun(this, out var width);
 
             var height = (GlyphTypeface.Descent - GlyphTypeface.Ascent + GlyphTypeface.LineGap) * Scale;
-
-            _bounds = new Rect(0, 0, width, height);
         }
 
         void IDisposable.Dispose()

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/GlyphRunNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/GlyphRunNode.cs
@@ -25,7 +25,7 @@ namespace Avalonia.Rendering.SceneGraph
             GlyphRun glyphRun,
             Point baselineOrigin,
             IDictionary<IVisual, Scene> childScenes = null)
-            : base(glyphRun.Bounds, transform)
+            : base(glyphRun.Bounds.Translate(baselineOrigin), transform)
         {
             Transform = transform;
             Foreground = foreground?.ToImmutable();


### PR DESCRIPTION
## What does the pull request do?
Addresses #3825 by fixing the code that determines the `Bounds` of a `GlyphRunNode` so that they take into account the position of the text, rather than assuming it is positioned at `0,-ascent`

## What is the current behavior?
`GlyphRunNodes` are mis-positioned, resulting in incorrect dirty rectangles when the text of a textbox changes to something with multiple lines but the same total height and width as previously, resulting in incorrect rendering of the result.

## What is the updated/expected behavior with this PR?
Text should always render correctly.

## How was the solution implemented (if it's not obvious)?
It should be fairly obvious, but the `_bounds` property is not assigned in `GlyphRun.Initialise` because it wasn't being used and was redundant with `CalculateBounds` as called by the `Bounds` property. The `Bounds` for a `GlyphRun` are now relative to the baseline origin 

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes


## Fixed issues
Fixes #3825


I can add tests on request with some guidance.