### PR TITLE
Compiled bindings: relaxed conditions for data context type inference

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlDataContextTypeTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlDataContextTypeTransformer.cs
@@ -24,7 +24,6 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             {
                 AvaloniaXamlIlDataContextTypeMetadataNode inferredDataContextTypeNode = null;
                 AvaloniaXamlIlDataContextTypeMetadataNode directiveDataContextTypeNode = null;
-                bool isDataTemplate = on.Type.GetClrType().Equals(context.GetAvaloniaTypes().DataTemplate);
 
                 for (int i = 0; i < on.Children.Count; ++i)
                 {
@@ -57,7 +56,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                         {
                             inferredDataContextTypeNode = ParseDataContext(context, on, obj);
                         }
-                        else if(isDataTemplate
+                        else if(context.GetAvaloniaTypes().DataTemplate.IsAssignableFrom(on.Type.GetClrType())
                             && pa.Property.Name == "DataType"
                             && pa.Values[0] is XamlTypeExtensionNode dataTypeNode)
                         {
@@ -70,7 +69,8 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                 // do more specialized inference
                 if (directiveDataContextTypeNode is null)
                 {
-                    if (isDataTemplate && inferredDataContextTypeNode is null)
+                    if (context.GetAvaloniaTypes().IDataTemplate.IsAssignableFrom(on.Type.GetClrType())
+                        && inferredDataContextTypeNode is null)
                     {
                         // Infer data type from collection binding on a control that displays items.
                         var parentObject = context.ParentNodes().OfType<XamlAstConstructableObjectNode>().FirstOrDefault();

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -41,6 +41,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType ResolveByNameExtension { get; }
 
         public IXamlType DataTemplate { get; }
+        public IXamlType IDataTemplate { get; }
         public IXamlType IItemsPresenterHost { get; }
         public IXamlType ItemsRepeater { get; }
         public IXamlType ReflectionBindingExtension { get; }
@@ -98,6 +99,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             CompiledBindingExtension = cfg.TypeSystem.GetType("Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindingExtension");
             ResolveByNameExtension = cfg.TypeSystem.GetType("Avalonia.Markup.Xaml.MarkupExtensions.ResolveByNameExtension");
             DataTemplate = cfg.TypeSystem.GetType("Avalonia.Markup.Xaml.Templates.DataTemplate");
+            IDataTemplate = cfg.TypeSystem.GetType("Avalonia.Controls.Templates.IDataTemplate");
             IItemsPresenterHost = cfg.TypeSystem.GetType("Avalonia.Controls.Presenters.IItemsPresenterHost");
             ItemsRepeater = cfg.TypeSystem.GetType("Avalonia.Controls.ItemsRepeater");
             ReflectionBindingExtension = cfg.TypeSystem.GetType("Avalonia.Markup.Xaml.MarkupExtensions.ReflectionBindingExtension");


### PR DESCRIPTION
## What does the pull request do?

Relaxes conditions for data templates, i.e. a data template would only be considered if the type was *exactly* `DataTemplate`.

## What is the current behavior?

Only `DataTemplate` instances are considered as data templates in data context type inference. For example, `TreeDataTemplate` doesn't work (this isn't the only bug actually, I'll try to fix the other one as well).

## What is the updated/expected behavior with this PR?

All valid data template types are checked in data context type inference.

## How was the solution implemented (if it's not obvious)?

For a given node type `type`:

1. `DataTemplate.DataType` property condition:
    - before: `type == typeof(DataTemplate)`
    - now: `typeof(DataTemplate).IsAssignableFrom(type)`
2. Items control data template inference condition:
    - before: `type == typeof(DataTemplate)`
    - now: `typeof(IDataTemplate).IsAssignableFrom(type)`

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation