### PR TITLE
Fix TextLine GetPrevious/NextCharacterHit

### DIFF
--- a/src/Avalonia.Visuals/Media/TextFormatting/TextLineImpl.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextLineImpl.cs
@@ -181,6 +181,17 @@ namespace Avalonia.Media.TextFormatting
                 return nextCharacterHit;
             }
 
+            if (characterHit.FirstCharacterIndex + characterHit.TrailingLength <= TextRange.Start + TextRange.Length)
+            {
+                return characterHit; // Can't move, we're after the last character
+            }
+
+            var runIndex = GetRunIndexAtCodepointIndex(TextRange.End);
+
+            var textRun = _textRuns[runIndex];
+
+            characterHit = textRun.GlyphRun.GetNextCaretCharacterHit(characterHit);
+
             return characterHit; // Can't move, we're after the last character
         }
 
@@ -190,6 +201,11 @@ namespace Avalonia.Media.TextFormatting
             if (TryFindPreviousCharacterHit(characterHit, out var previousCharacterHit))
             {
                 return previousCharacterHit;
+            }
+
+            if (characterHit.FirstCharacterIndex < TextRange.Start)
+            {
+                characterHit = new CharacterHit(TextRange.Start);
             }
 
             return characterHit; // Can't move, we're before the first character

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Media;
 using Avalonia.Media.TextFormatting;
@@ -10,6 +9,65 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 {
     public class TextLineTests
     {
+        private static readonly string s_multiLineText = "012345678\r\r0123456789";
+
+        [Fact]
+        public void Should_Get_First_CharacterHit()
+        {
+            using (Start())
+            {
+                var defaultProperties = new GenericTextRunProperties(Typeface.Default);
+
+                var textSource = new SingleBufferTextSource(s_multiLineText, defaultProperties);
+
+                var formatter = new TextFormatterImpl();
+
+                var currentIndex = 0;
+
+                while (currentIndex < s_multiLineText.Length)
+                {
+                    var textLine =
+                        formatter.FormatLine(textSource, currentIndex, double.PositiveInfinity,
+                            new GenericTextParagraphProperties(defaultProperties));
+
+                    var firstCharacterHit = textLine.GetPreviousCaretCharacterHit(new CharacterHit(int.MinValue));
+
+                    Assert.Equal(textLine.TextRange.Start, firstCharacterHit.FirstCharacterIndex);
+
+                    currentIndex += textLine.TextRange.Length;
+                }
+            }
+        }
+
+        [Fact]
+        public void Should_Get_Last_CharacterHit()
+        {
+            using (Start())
+            {
+                var defaultProperties = new GenericTextRunProperties(Typeface.Default);
+
+                var textSource = new SingleBufferTextSource(s_multiLineText, defaultProperties);
+
+                var formatter = new TextFormatterImpl();
+
+                var currentIndex = 0;
+
+                while (currentIndex < s_multiLineText.Length)
+                {
+                    var textLine =
+                        formatter.FormatLine(textSource, currentIndex, double.PositiveInfinity,
+                            new GenericTextParagraphProperties(defaultProperties));
+
+                    var lastCharacterHit = textLine.GetNextCaretCharacterHit(new CharacterHit(int.MaxValue));
+
+                    Assert.Equal(textLine.TextRange.Start + textLine.TextRange.Length,
+                        lastCharacterHit.FirstCharacterIndex + lastCharacterHit.TrailingLength);
+
+                    currentIndex += textLine.TextRange.Length;
+                }
+            }
+        }
+
         [InlineData("𐐷𐐷𐐷𐐷𐐷")]
         [InlineData("𐐷1234")]
         [Theory]


### PR DESCRIPTION
##  What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
It makes sure to always return a valid CharacterHit

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
If no CharacterHit can be found the current CharacterHit is returned

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
For NextCharacterHit the last possible CharacterHit is returned
For NextCharacterHit the first possible CharacterHit is returned

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
