### PR TITLE
Fixes/textbox caret index lost on focus lost

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -407,7 +407,7 @@ namespace Avalonia.Controls
             _presenter?.ShowCaret();
         }
 
-        private void ClearSelection()
+        public void ClearSelection()
         {
             SelectionStart = SelectionEnd = CaretIndex;
         }

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -407,13 +407,18 @@ namespace Avalonia.Controls
             _presenter?.ShowCaret();
         }
 
+        private void ClearSelection()
+        {
+            SelectionStart = SelectionEnd = CaretIndex;
+        }
+
         protected override void OnLostFocus(RoutedEventArgs e)
         {
             base.OnLostFocus(e);
 
             if (ContextMenu == null || !ContextMenu.IsOpen)
             {
-                SelectionStart = SelectionEnd = CaretIndex;
+                ClearSelection();
                 RevealPassword = false;
             }
             
@@ -443,7 +448,7 @@ namespace Avalonia.Controls
                     text = Text ?? string.Empty;
                     SetTextInternal(text.Substring(0, caretIndex) + input + text.Substring(caretIndex));
                     CaretIndex += input.Length;
-                    SelectionStart = SelectionEnd = CaretIndex;
+                    ClearSelection();
                     _undoRedoHelper.DiscardRedo();
                 }
             }
@@ -661,7 +666,7 @@ namespace Avalonia.Controls
                             SetTextInternal(text.Substring(0, caretIndex - removedCharacters) +
                                             text.Substring(caretIndex));
                             CaretIndex -= removedCharacters;
-                            SelectionStart = SelectionEnd = CaretIndex;
+                            ClearSelection();
                         }
                         _undoRedoHelper.Snapshot();
 
@@ -734,7 +739,7 @@ namespace Avalonia.Controls
             }
             else if (movement)
             {
-                SelectionStart = SelectionEnd = CaretIndex;
+                ClearSelection();
             }
 
             if (handled || movement)
@@ -1041,7 +1046,8 @@ namespace Avalonia.Controls
                     var end = Math.Max(selectionStart, selectionEnd);
                     var text = Text;
                     SetTextInternal(text.Substring(0, start) + text.Substring(end));
-                    SelectionStart = SelectionEnd = CaretIndex = start;
+                    CaretIndex = start;
+                    ClearSelection();
                     return true;
                 }
                 else
@@ -1130,7 +1136,8 @@ namespace Avalonia.Controls
             set
             {
                 Text = value.Text;
-                SelectionStart = SelectionEnd = CaretIndex = value.CaretPosition;
+                CaretIndex = value.CaretPosition;
+                ClearSelection();
             }
         }
     }

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -369,6 +369,14 @@ namespace Avalonia.Controls
             get { return _newLine; }
             set { SetAndRaise(NewLineProperty, ref _newLine, value); }
         }
+        
+        /// <summary>
+        /// Clears the current selection, maintaining the <see cref="CaretIndex"/>
+        /// </summary>
+        public void ClearSelection()
+        {
+            SelectionStart = SelectionEnd = CaretIndex;
+        }
 
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
@@ -405,11 +413,6 @@ namespace Avalonia.Controls
             }
 
             _presenter?.ShowCaret();
-        }
-
-        public void ClearSelection()
-        {
-            SelectionStart = SelectionEnd = CaretIndex;
         }
 
         protected override void OnLostFocus(RoutedEventArgs e)

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -413,8 +413,7 @@ namespace Avalonia.Controls
 
             if (ContextMenu == null || !ContextMenu.IsOpen)
             {
-                SelectionStart = 0;
-                SelectionEnd = 0;
+                SelectionStart = SelectionEnd = CaretIndex;
                 RevealPassword = false;
             }
             

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -563,6 +563,41 @@ namespace Avalonia.Controls.UnitTests
         }
         
         [Fact]
+        public void TextBox_CaretIndex_Persists_When_Focus_Lost()
+        {
+            using (UnitTestApplication.Start(FocusServices))
+            {
+                var target1 = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "1234"
+                };
+                var target2 = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "5678"
+                };
+                var sp = new StackPanel();
+                sp.Children.Add(target1);
+                sp.Children.Add(target2);
+
+                target1.ApplyTemplate();
+                target2.ApplyTemplate();
+                
+                var root = new TestRoot { Child = sp };
+
+                target2.Focus();
+                target2.CaretIndex = 2;
+                Assert.False(target1.IsFocused);
+                Assert.True(target2.IsFocused);
+
+                target1.Focus();
+                
+                Assert.Equal(2, target2.CaretIndex);
+            }
+        }
+        
+        [Fact]
         public void TextBox_Reveal_Password_Reset_When_Lost_Focus()
         {
             using (UnitTestApplication.Start(FocusServices))


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
When a textbox has caret index and on windows alt-tab is pressed or another way textbox looses focus...
the caret index is reset to 0.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Hard coded reset to 0, but this is not correct way to reset selection.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
reset selection to caret index instead.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
