### PR TITLE
Unittests showing how direct xaml set of color works but using string…

### DIFF
--- a/tests/Avalonia.Markup.Xaml.UnitTests/TypeConverter/AssignmentTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/TypeConverter/AssignmentTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+using Xunit;
+
+namespace Avalonia.Markup.Xaml.UnitTests.TypeConverter
+{
+    public class AssignmentTests : XamlTestBase
+    {
+        [Fact]
+        public void Brush_Property_Set_Using_Name()
+        {
+            var testClass = typeof(TestAvaloniaElement);
+            var parsed = AvaloniaRuntimeXamlLoader.Parse<TestAvaloniaElement>(
+                $"<{testClass.Name} xmlns='clr-namespace:{testClass.Namespace}' TestBrush='AliceBlue'/>", testClass.Assembly);
+
+            Assert.NotNull(parsed);
+            Assert.NotNull(parsed.TestBrush);
+            Assert.IsType(typeof(ImmutableSolidColorBrush), parsed.TestBrush);
+            Assert.Equal("AliceBlue", ((ImmutableSolidColorBrush)parsed.TestBrush).Color.ToString());
+            Assert.Equal(Color.Parse("AliceBlue"), ((ImmutableSolidColorBrush)parsed.TestBrush).Color);
+        }
+
+        [Fact]
+        public void Color_Property_Set_Using_Name()
+        {
+            var testClass = typeof(TestAvaloniaElement);
+            var parsed = AvaloniaRuntimeXamlLoader.Parse<TestAvaloniaElement>(
+                $"<{testClass.Name} xmlns='clr-namespace:{testClass.Namespace}' TestColor='AliceBlue'/>", testClass.Assembly);
+
+            Assert.NotNull(parsed);
+            Assert.NotNull(parsed.TestColor);
+            Assert.IsType(typeof(Color), parsed.TestColor);
+            Assert.Equal("AliceBlue", (parsed.TestColor).ToString());
+            Assert.Equal(Color.Parse("AliceBlue"), parsed.TestColor);
+        }
+
+        [Fact]
+        public void Color_Property_Set_Using_HexStr()
+        {
+            var testClass = typeof(TestAvaloniaElement);
+            var parsed = AvaloniaRuntimeXamlLoader.Parse<TestAvaloniaElement>(
+                $"<{testClass.Name} xmlns='clr-namespace:{testClass.Namespace}' TestColor='#44556677'/>", testClass.Assembly);
+
+            Assert.NotNull(parsed);
+            Assert.NotNull(parsed.TestColor);
+            Assert.IsType(typeof(Color), parsed.TestColor);
+            Assert.Equal(Color.FromArgb(0x44,0x55,0x66,0x77), parsed.TestColor);
+        }
+    }
+}

--- a/tests/Avalonia.Markup.Xaml.UnitTests/TypeConverter/TestAvaloniaElement.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/TypeConverter/TestAvaloniaElement.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Avalonia.Media;
+
+namespace Avalonia.Markup.Xaml.UnitTests.TypeConverter
+{
+    public class TestAvaloniaElement : AvaloniaObject
+    {
+        public static readonly StyledProperty<IBrush> TestBrushrProperty =
+            AvaloniaProperty.Register<TestAvaloniaElement, IBrush>(nameof(TestBrush), null);
+
+        public static readonly StyledProperty<Color> TestColorProperty =
+            AvaloniaProperty.Register<TestAvaloniaElement, Color>(nameof(TestColor), default(Color));
+
+        public IBrush TestBrush { get { return GetValue(TestBrushrProperty); } set { SetValue(TestBrushrProperty, value); } }
+
+        public Color TestColor { get { return GetValue(TestColorProperty); } set { SetValue(TestColorProperty, value); } }
+    }
+}

--- a/tests/Avalonia.Styling.UnitTests/StyleTests.cs
+++ b/tests/Avalonia.Styling.UnitTests/StyleTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Media;
 using Avalonia.UnitTests;
 using Moq;
 using Xunit;
@@ -10,6 +11,24 @@ namespace Avalonia.Styling.UnitTests
 {
     public class StyleTests
     {
+        [Fact]
+        public void Style_Should_Assign_Color_Value_From_Stringrepr()
+        {
+            Style style = new Style(x => x.OfType<Class1>())
+            {
+                Setters =
+                {
+                    new Setter(Class1.TestColorProperty, "#11223344"),
+                },
+            };
+
+            var target = new Class1();
+
+            style.TryAttach(target, null);
+
+            Assert.Equal(Color.Parse("#11223344"), target.TestColor);
+        }
+
         [Fact]
         public void Style_With_Only_Type_Selector_Should_Update_Value()
         {
@@ -457,6 +476,15 @@ namespace Avalonia.Styling.UnitTests
             {
                 get { return GetValue(FooProperty); }
                 set { SetValue(FooProperty, value); }
+            }
+
+            public static readonly StyledProperty<Color> TestColorProperty =
+                AvaloniaProperty.Register<Class1, Color>(nameof(TestColor), default(Color));
+
+            public Color TestColor
+            {
+                get { return GetValue(TestColorProperty); } 
+                set { SetValue(TestColorProperty, value); }
             }
 
             protected override Size MeasureOverride(Size availableSize)


### PR DESCRIPTION
… in style setter fails

## What does the pull request do?
Show problem of issue #4546


## What is the current behavior?
No test showing the problem

## What is the updated/expected behavior with this PR?
1/4 Test fails



## How was the solution implemented (if it's not obvious)?
TBD


## Checklist

[X]UNIT TESTS