### PR TITLE
Fix ScrollContentPresenter not Arranging in certain conditions.

### DIFF
--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -257,15 +257,7 @@ namespace Avalonia.Controls.Presenters
                 return base.ArrangeOverride(finalSize);
             }
 
-            try
-            {
-                _arranging = true;
-                return ArrangeWithAnchoring(finalSize);
-            }
-            finally
-            {
-                _arranging = false;
-            }
+            return ArrangeWithAnchoring(finalSize);
         }
 
         private Size ArrangeWithAnchoring(Size finalSize)
@@ -316,7 +308,17 @@ namespace Avalonia.Controls.Presenters
                 }
 
                 Extent = newExtent;
-                Offset = newOffset;
+
+                try
+                {
+                    _arranging = true;
+                    Offset = newOffset;
+                }
+                finally
+                {
+                    _arranging = false;    
+                }
+                
                 ArrangeOverrideImpl(size, -Offset);
             }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
It fixes a bug where scrollcontentpresenters content is not arranged.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
In textbox and tabcontrol content doesnt get arrange when switching tabs for example... meaning the previous scrolloffset is kept even though the content may not need scrolling.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Arrange correctly.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
