### PR TITLE
Win32: Fix Title for Native OpenFolderDialog

### DIFF
--- a/src/Windows/Avalonia.Win32/SystemDialogImpl.cs
+++ b/src/Windows/Avalonia.Win32/SystemDialogImpl.cs
@@ -9,7 +9,6 @@ using Avalonia.Win32.Interop;
 
 namespace Avalonia.Win32
 {
-
     class SystemDialogImpl : ISystemDialogImpl
     {
         private const UnmanagedMethods.FOS DefaultDialogOptions = UnmanagedMethods.FOS.FOS_FORCEFILESYSTEM | UnmanagedMethods.FOS.FOS_NOVALIDATE |
@@ -113,6 +112,7 @@ namespace Avalonia.Win32
                 frm.GetOptions(out options);
                 options |= (uint)(UnmanagedMethods.FOS.FOS_PICKFOLDERS | DefaultDialogOptions);
                 frm.SetOptions(options);
+                frm.SetTitle(dialog.Title ?? "");
 
                 if (dialog.Directory != null)
                 {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

This PR fixes an issue where the title on the Win32 OpenFolderDialog wasn't being set properly.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

The title used is always the default value, "Select Folder".

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

The title used is now properly set from the provided options.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes #3037
Fixes #4465