### PR TITLE
Fixes Context Menu crashing when opened on a second control and the first no longer in visual tree.

### DIFF
--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -279,6 +279,11 @@ namespace Avalonia.Controls
                 ((ISetLogicalParent)_popup).SetParent(control);
             }
 
+            if (PlacementTarget is null && _popup.PlacementTarget != control)
+            {
+                _popup.PlacementTarget = control;
+            }
+
             _popup.Child = this;
             IsOpen = true;
             _popup.IsOpen = true;

--- a/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Avalonia.Input;
+using Avalonia.LogicalTree;
 using Avalonia.Markup.Xaml;
 using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Platform;
@@ -130,6 +131,44 @@ namespace Avalonia.Controls.UnitTests
                 Assert.True(sut.IsOpen);
                 popupImpl.Verify(x => x.Hide(), Times.Once);
                 popupImpl.Verify(x => x.Show(), Times.Exactly(2));
+            }
+        }
+        
+        [Fact]
+        public void Context_Menu_Can_Be_Shared_Between_Controls_Even_After_A_Control_Is_Removed_From_Visual_Tree()
+        {
+            using (Application())
+            {
+                var sut = new ContextMenu();
+                var target1 = new Panel
+                {
+                    ContextMenu = sut
+                };
+
+                var target2 = new Panel
+                {
+                    ContextMenu = sut
+                };
+
+                var sp = new StackPanel { Children = { target1, target2 } };
+                var window = new Window { Content = sp };
+                
+                window.ApplyTemplate();
+                window.Presenter.ApplyTemplate();
+
+                _mouse.Click(target1, MouseButton.Right);
+
+                Assert.True(sut.IsOpen);
+
+                _mouse.Click(target2, MouseButton.Left);
+                
+                Assert.False(sut.IsOpen);
+                
+                sp.Children.Remove(target1);
+                
+                _mouse.Click(target2, MouseButton.Right);
+                
+                Assert.True(sut.IsOpen);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Allows a single context menu to be used on multiple controls.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The first time a context menu opens it captures the logical parent of the context menu, and captures it in the popups `PlacementTarget` property.

If that original parent control later is removed from visual tree, i.e. user changes tab or page or something... then this `PlacementTarget` will now have a `VisualRoot == null`.

This will then crash the second time the context menu is opened.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
We no set the placement target every time the popup is opened and the parent control has changed.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
