### PR TITLE
Don't display vertical grid lines by default.

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Default.xaml
@@ -201,7 +201,6 @@
     <Setter Property="HorizontalScrollBarVisibility" Value="Auto" />
     <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
     <Setter Property="SelectionMode" Value="Extended" />
-    <Setter Property="GridLinesVisibility" Value="Vertical" />
     <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource ThemeBorderHighColor}" />
     <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource ThemeBorderHighColor}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLowColor}"/>


### PR DESCRIPTION
## What does the pull request do?

Don't display vertical grid lines by default in default theme. This has historically been the setting applied to this property by the default theme, however grid lines were previously broken so they didn't appear.

The grid lines are rather ugly and DevTools uses the default theme, making DevTools extension ugly. The fluent theme doesn't set this property, so it's more consistent like this too.
