### PR TITLE
Prevent duplicate properties in DevTools.

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ControlDetailsViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ControlDetailsViewModel.cs
@@ -81,7 +81,7 @@ namespace Avalonia.Diagnostics.ViewModels
             if (o is AvaloniaObject ao)
             {
                 return AvaloniaPropertyRegistry.Instance.GetRegistered(ao)
-                    .Concat(AvaloniaPropertyRegistry.Instance.GetRegisteredAttached(ao.GetType()))
+                    .Union(AvaloniaPropertyRegistry.Instance.GetRegisteredAttached(ao.GetType()))
                     .Select(x => new AvaloniaPropertyViewModel(ao, x));
             }
             else


### PR DESCRIPTION
## What does the pull request do?

DevTools was displaying duplicate properties at times:

![image](https://user-images.githubusercontent.com/1775141/91530137-e4746700-e90a-11ea-87ba-935c21444be0.png)

Properties can be registered on a control as both normal properties and attached properties, so we need to de-duplicate them.
