### PR TITLE
Fixes/update tooltip content when already opened

### DIFF
--- a/src/Avalonia.Controls/ToolTip.cs
+++ b/src/Avalonia.Controls/ToolTip.cs
@@ -55,7 +55,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Stores the current <see cref="ToolTip"/> instance in the control.
         /// </summary>
-        private static readonly AttachedProperty<ToolTip> ToolTipProperty =
+        internal static readonly AttachedProperty<ToolTip> ToolTipProperty =
             AvaloniaProperty.RegisterAttached<ToolTip, Control, ToolTip>("ToolTip");
 
         private IPopupHost _popup;

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -35,6 +35,13 @@ namespace Avalonia.Controls
                 control.PointerEnter += ControlPointerEnter;
                 control.PointerLeave += ControlPointerLeave;
             }
+
+            if (e.NewValue != e.OldValue && ToolTip.GetIsOpen(control))
+            {
+                var tip = control.GetValue(ToolTip.ToolTipProperty);
+
+                tip.Content = e.NewValue;
+            }
         }
 
         internal void TipOpenChanged(AvaloniaPropertyChangedEventArgs e)

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -36,7 +36,7 @@ namespace Avalonia.Controls
                 control.PointerLeave += ControlPointerLeave;
             }
 
-            if (e.NewValue != e.OldValue && ToolTip.GetIsOpen(control))
+            if (ToolTip.GetIsOpen(control) && e.NewValue != e.OldValue && !(e.NewValue is ToolTip))
             {
                 var tip = control.GetValue(ToolTip.ToolTipProperty);
 

--- a/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
@@ -124,6 +124,35 @@ namespace Avalonia.Controls.UnitTests
                 Assert.True(ToolTip.GetIsOpen(target));
             }
         }
+        
+        [Fact]
+        public void Content_Should_Update_When_Tip_Property_Changes_And_Already_Open()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var window = new Window();
+
+                var target = new Decorator()
+                {
+                    [ToolTip.TipProperty] = "Tip",
+                    [ToolTip.ShowDelayProperty] = 0
+                };
+
+                window.Content = target;
+
+                window.ApplyTemplate();
+                window.Presenter.ApplyTemplate();
+
+                _mouseHelper.Enter(target);
+
+                Assert.True(ToolTip.GetIsOpen(target));
+                Assert.Equal("Tip", target.GetValue(ToolTip.ToolTipProperty).Content);
+                
+                
+                ToolTip.SetTip(target, "Tip1");
+                Assert.Equal("Tip1", target.GetValue(ToolTip.ToolTipProperty).Content);
+            }
+        }
 
         [Fact]
         public void Should_Open_On_Pointer_Enter_With_Delay()


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Ensures tooltips auto update the content if they are already opened and the tip property changes.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The tooltip wont update whilst opened.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Content changes automatically.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
