### PR TITLE
Try to handle selection being changed in CollectionChanged handler.

### DIFF
--- a/src/Avalonia.Controls/Selection/SelectionModel.cs
+++ b/src/Avalonia.Controls/Selection/SelectionModel.cs
@@ -436,6 +436,29 @@ namespace Avalonia.Controls.Selection
             }
         }
 
+        private protected override bool IsValidCollectionChange(NotifyCollectionChangedEventArgs e)
+        {
+            if (!base.IsValidCollectionChange(e))
+            {
+                return false;
+            }
+
+            if (ItemsView is object && e.Action == NotifyCollectionChangedAction.Add)
+            {
+                if (e.NewStartingIndex <= _selectedIndex)
+                {
+                    return _selectedIndex + e.NewItems.Count < ItemsView.Count;
+                }
+
+                if (e.NewStartingIndex <= _anchorIndex)
+                {
+                    return _anchorIndex + e.NewItems.Count < ItemsView.Count;
+                }
+            }
+
+            return true;
+        }
+
         protected override void OnSourceCollectionChangeFinished()
         {
             if (_operation is object)

--- a/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Multiple.cs
@@ -1230,6 +1230,38 @@ namespace Avalonia.Controls.UnitTests.Selection
                 Assert.Equal(1, resetRaised);
                 Assert.Equal(1, selectedIndexRaised);
             }
+
+            [Fact]
+            public void Handles_Selection_Made_In_CollectionChanged()
+            {
+                // Tests the following scenario:
+                //
+                // - Items changes from empty to having 2 items
+                // - ViewModel auto-selects range 0..1 in CollectionChanged
+                // - SelectionModel receives CollectionChanged
+                // - And so adjusts the selected item from 0..1 to 2..4, which is past the end of
+                //   the items.
+                //
+                // There's not much we can do about this situation because the order in which
+                // CollectionChanged handlers are called can't be known (the problem also exists with
+                // WPF). The best we can do is not select an invalid index.
+                var target = CreateTarget(createData: false);
+                var data = new AvaloniaList<string>();
+
+                data.CollectionChanged += (s, e) =>
+                {
+                    target.SelectRange(0, 1);
+                };
+
+                target.Source = data;
+                data.AddRange(new[] { "foo", "bar" });
+
+                Assert.Equal(0, target.SelectedIndex);
+                Assert.Equal(new[] { 0, 1 }, target.SelectedIndexes);
+                Assert.Equal("foo", target.SelectedItem);
+                Assert.Equal(new[] { "foo", "bar" }, target.SelectedItems);
+                Assert.Equal(0, target.AnchorIndex);
+            }
         }
 
         public class BatchUpdate

--- a/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Single.cs
+++ b/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Single.cs
@@ -1052,6 +1052,37 @@ namespace Avalonia.Controls.UnitTests.Selection
                 Assert.Equal(1, resetRaised);
                 Assert.Equal(1, selectedIndexRaised);
             }
+
+            [Fact]
+            public void Handles_Selection_Made_In_CollectionChanged()
+            {
+                // Tests the following scenario:
+                //
+                // - Items changes from empty to having 1 item
+                // - ViewModel auto-selects item 0 in CollectionChanged
+                // - SelectionModel receives CollectionChanged
+                // - And so adjusts the selected item from 0 to 1, which is past the end of the items.
+                //
+                // There's not much we can do about this situation because the order in which
+                // CollectionChanged handlers are called can't be known (the problem also exists with
+                // WPF). The best we can do is not select an invalid index.
+                var target = CreateTarget(createData: false);
+                var data = new AvaloniaList<string>();
+
+                data.CollectionChanged += (s, e) =>
+                {
+                    target.Select(0);
+                };
+
+                target.Source = data;
+                data.Add("foo");
+
+                Assert.Equal(0, target.SelectedIndex);
+                Assert.Equal(new[] { 0 }, target.SelectedIndexes);
+                Assert.Equal("foo", target.SelectedItem);
+                Assert.Equal(new[] { "foo" }, target.SelectedItems);
+                Assert.Equal(0, target.AnchorIndex);
+            }
         }
 
         public class BatchUpdate


### PR DESCRIPTION
## What does the pull request do?

There is a situation where the selected indexes in a `SelectionModel` can end up being set to an invalid index. A common example is of how this happens is:

- The items collection is empty
- An item is added
- The view model auto-selects item 0 in a `CollectionChanged` handler
- `SelectionModel` receives `CollectionChanged`
- And so adjusts the selected item from 0 to 1, which is past the end of the items

This is also a problem which can occur in WPF (see https://stackoverflow.com/questions/25672111/automatically-select-item-added-to-an-observablecollection for one example of a user encountering the problem) and with the current design of `INotifyCollectionChanged` in .NET there's not much that can be done (yeah INCC gets my vote for the worst API in .NET).

Although there's not much we can do in this situation, previously when encountering it the invalid index would cause an `IndexOutOfRangeException`; we can fix that. This PR tries to detect such a situation and bail in shifting the selected indexes. This means:

`+` In the example above, the correct index will be selected
`-` In other situations an existing selection may not get shifted when an item is inserted and the selection is modified in a view model's `CollectionChanged`

I think this is better than throwing.