### PR TITLE
WIP: Display memory usage in DevTools.

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/MainViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/MainViewModel.cs
@@ -13,6 +13,7 @@ namespace Avalonia.Diagnostics.ViewModels
         private readonly TreePageViewModel _logicalTree;
         private readonly TreePageViewModel _visualTree;
         private readonly EventsPageViewModel _events;
+        private readonly PerformanceViewModel _perf;
         private readonly IDisposable _pointerOverSubscription;
         private ViewModelBase _content;
         private int _selectedTab;
@@ -26,6 +27,7 @@ namespace Avalonia.Diagnostics.ViewModels
             _logicalTree = new TreePageViewModel(this, LogicalTreeNode.Create(root));
             _visualTree = new TreePageViewModel(this, VisualTreeNode.Create(root));
             _events = new EventsPageViewModel(root);
+            _perf = new PerformanceViewModel();
 
             UpdateFocusedControl();
             KeyboardDevice.Instance.PropertyChanged += KeyboardPropertyChanged;
@@ -84,19 +86,14 @@ namespace Avalonia.Diagnostics.ViewModels
             set
             {
                 _selectedTab = value;
-
-                switch (value)
+                Content = value switch
                 {
-                    case 0:
-                        Content = _logicalTree;
-                        break;
-                    case 1:
-                        Content = _visualTree;
-                        break;
-                    case 2:
-                        Content = _events;
-                        break;
-                }
+                    0 => _logicalTree,
+                    1 => _visualTree,
+                    2 => _events,
+                    3 => _perf,
+                    _ => null,
+                };
 
                 RaisePropertyChanged();
             }

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/MainViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/MainViewModel.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using Avalonia.Controls;
 using Avalonia.Diagnostics.Models;
 using Avalonia.Input;
+using Avalonia.Platform;
 using Avalonia.Threading;
 
 namespace Avalonia.Diagnostics.ViewModels
@@ -27,7 +28,7 @@ namespace Avalonia.Diagnostics.ViewModels
             _logicalTree = new TreePageViewModel(this, LogicalTreeNode.Create(root));
             _visualTree = new TreePageViewModel(this, VisualTreeNode.Create(root));
             _events = new EventsPageViewModel(root);
-            _perf = new PerformanceViewModel();
+            _perf = new PerformanceViewModel(AvaloniaLocator.Current.GetService<IGraphicsMemoryDiagnostics>());
 
             UpdateFocusedControl();
             KeyboardDevice.Instance.PropertyChanged += KeyboardPropertyChanged;

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/PerformanceViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/PerformanceViewModel.cs
@@ -33,6 +33,11 @@ namespace Avalonia.Diagnostics.ViewModels
             get => _gpuMemory is object ? PrettyPrint(_gpuMemory.Value, 1) : "N/A";
         }
 
+        public string DarkMatter
+        {
+            get => PrettyPrint(_totalMemory - _managedMemory - (_gpuMemory ?? 0));
+        }
+
         public void Update()
         {
             using (var p = Process.GetCurrentProcess())
@@ -46,6 +51,7 @@ namespace Avalonia.Diagnostics.ViewModels
             RaisePropertyChanged(nameof(TotalMemory));
             RaisePropertyChanged(nameof(ManagedMemory));
             RaisePropertyChanged(nameof(GraphicsMemory));
+            RaisePropertyChanged(nameof(DarkMatter));
         }
 
         public static string PrettyPrint(long value, int decimalPlaces = 0)

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/PerformanceViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/PerformanceViewModel.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace Avalonia.Diagnostics.ViewModels
+{
+    internal class PerformanceViewModel : ViewModelBase
+    {
+        private long _totalMemory;
+        private long _managedMemory;
+        
+        public string TotalMemory
+        {
+            get => PrettyPrint(_totalMemory, 1);
+        }
+
+        public string ManagedMemory
+        {
+            get => PrettyPrint(_managedMemory, 1);
+        }
+
+        public void Update()
+        {
+            using (var p = Process.GetCurrentProcess())
+            {
+                p.Refresh();
+                _totalMemory = p.PrivateMemorySize64;
+                _managedMemory = GC.GetTotalMemory(true);
+            }
+
+            RaisePropertyChanged(nameof(TotalMemory));
+            RaisePropertyChanged(nameof(ManagedMemory));
+        }
+
+        public static string PrettyPrint(long value, int decimalPlaces = 0)
+        {
+            const long OneKb = 1024;
+            const long OneMb = OneKb * 1024;
+            const long OneGb = OneMb * 1024;
+            const long OneTb = OneGb * 1024;
+            var asTb = Math.Round((double)value / OneTb, decimalPlaces);
+            var asGb = Math.Round((double)value / OneGb, decimalPlaces);
+            var asMb = Math.Round((double)value / OneMb, decimalPlaces);
+            var asKb = Math.Round((double)value / OneKb, decimalPlaces);
+            string chosenValue = asTb > 1 ? string.Format("{0}TB", asTb)
+                : asGb > 1 ? string.Format("{0}GB", asGb)
+                : asMb > 1 ? string.Format("{0}MB", asMb)
+                : asKb > 1 ? string.Format("{0}KB", asKb)
+                : string.Format("{0}B", Math.Round((double)value, decimalPlaces));
+            return $"{chosenValue} ({value:N0} bytes)";
+        }
+    }
+}

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/MainView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/MainView.xaml
@@ -31,6 +31,7 @@
       <TabStripItem Content="Logical Tree"/>
       <TabStripItem Content="Visual Tree"/>
       <TabStripItem Content="Events"/>
+      <TabStripItem Content="Performance"/>
     </TabStrip>
 
     <ContentControl Grid.Row="2"

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/PerformanceView.axaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/PerformanceView.axaml
@@ -4,7 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Avalonia.Diagnostics.Views.PerformanceView">
-    <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto">
+    <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto">
         <Grid.Styles>
             <Style Selector="TextBlock">
                 <Setter Property="Margin" Value="4"/>
@@ -14,5 +14,7 @@
         <TextBlock Grid.Column="1" Grid.Row="0" Text="{Binding TotalMemory}"/>
         <TextBlock Grid.Column="0" Grid.Row="1">Managed memory</TextBlock>
         <TextBlock Grid.Column="1" Grid.Row="1" Text="{Binding ManagedMemory}"/>
+        <TextBlock Grid.Column="0" Grid.Row="2">Graphics memory</TextBlock>
+        <TextBlock Grid.Column="1" Grid.Row="2" Text="{Binding GraphicsMemory}"/>
     </Grid>
 </UserControl>

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/PerformanceView.axaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/PerformanceView.axaml
@@ -1,0 +1,18 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Avalonia.Diagnostics.Views.PerformanceView">
+    <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto">
+        <Grid.Styles>
+            <Style Selector="TextBlock">
+                <Setter Property="Margin" Value="4"/>
+            </Style>
+        </Grid.Styles>
+        <TextBlock Grid.Column="0" Grid.Row="0">Total memory</TextBlock>
+        <TextBlock Grid.Column="1" Grid.Row="0" Text="{Binding TotalMemory}"/>
+        <TextBlock Grid.Column="0" Grid.Row="1">Managed memory</TextBlock>
+        <TextBlock Grid.Column="1" Grid.Row="1" Text="{Binding ManagedMemory}"/>
+    </Grid>
+</UserControl>

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/PerformanceView.axaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/PerformanceView.axaml
@@ -4,7 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Avalonia.Diagnostics.Views.PerformanceView">
-    <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto">
+    <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto">
         <Grid.Styles>
             <Style Selector="TextBlock">
                 <Setter Property="Margin" Value="4"/>
@@ -16,5 +16,7 @@
         <TextBlock Grid.Column="1" Grid.Row="1" Text="{Binding ManagedMemory}"/>
         <TextBlock Grid.Column="0" Grid.Row="2">Graphics memory</TextBlock>
         <TextBlock Grid.Column="1" Grid.Row="2" Text="{Binding GraphicsMemory}"/>
+        <TextBlock Grid.Column="0" Grid.Row="3">Dark matter</TextBlock>
+        <TextBlock Grid.Column="1" Grid.Row="3" Text="{Binding DarkMatter}"/>
     </Grid>
 </UserControl>

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/PerformanceView.axaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/PerformanceView.axaml.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Avalonia.Controls;
+using Avalonia.Diagnostics.ViewModels;
+using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+
+#nullable enable
+
+namespace Avalonia.Diagnostics.Views
+{
+    public class PerformanceView : UserControl
+    {
+        private DispatcherTimer _timer;
+
+        public PerformanceView()
+        {
+            this.InitializeComponent();
+
+            _timer = new DispatcherTimer();
+            _timer.Interval = TimeSpan.FromSeconds(1);
+            _timer.Tick += (s, e) => Update();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            Update();
+            _timer.Start();
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            _timer.Stop();
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+
+        private void Update()
+        {
+            var vm = (PerformanceViewModel?)DataContext;
+            vm?.Update();
+        }
+    }
+}

--- a/src/Avalonia.Visuals/Platform/IGraphicsMemoryDiagnostics.cs
+++ b/src/Avalonia.Visuals/Platform/IGraphicsMemoryDiagnostics.cs
@@ -1,0 +1,7 @@
+﻿namespace Avalonia.Platform
+{
+    public interface IGraphicsMemoryDiagnostics
+    {
+        public ulong GetResourceUsage();
+    }
+}

--- a/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
+++ b/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
@@ -31,8 +31,12 @@ namespace Avalonia.Skia
             }
 
             var gl = AvaloniaLocator.Current.GetService<IWindowingPlatformGlFeature>();
-            if (gl != null) 
-                _skiaGpu = new GlSkiaGpu(gl, maxResourceBytes);
+            if (gl != null)
+            {
+                var gpu = new GlSkiaGpu(gl, maxResourceBytes);
+                _skiaGpu = gpu;
+                AvaloniaLocator.CurrentMutable.BindToSelf<IGraphicsMemoryDiagnostics>(gpu);
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## What does the pull request do?

In an attempt to get to the bottom of #3983 I've added some memory diagnostics to DevTools:

![image](https://user-images.githubusercontent.com/1775141/92035522-1eac9100-ed6f-11ea-913c-e6675578558a.png)

- Total memory: The total memory of the application ([Process.PrivateMemorySize64](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.privatememorysize64?f1url=%3FappId%3DDev16IDEF1%26l%3DEN-US%26k%3Dk(System.Diagnostics.Process.PrivateMemorySize64);k(DevLang-csharp)%26rd%3Dtrue&view=netcore-3.1))
- Managed memory: The managed memory ([GC.GetTotalMemory(true)](https://docs.microsoft.com/en-us/dotnet/api/system.gc.gettotalmemory?f1url=%3FappId%3DDev16IDEF1%26l%3DEN-US%26k%3Dk(System.GC.GetTotalMemory);k(DevLang-csharp)%26rd%3Dtrue&view=netcore-3.1))
- Graphics memory: The Skia graphics memory ([GrContext.dumpMemoryStatistics](https://api.skia.org/classGrContext.html#a3543f1cf044b39fbbfae96cf92e2cb22))
- Dark matter: Unexplained memory usage (total memory minus managed and graphics memory)