### PR TITLE
Change GPU defaults

### DIFF
--- a/src/Avalonia.OpenGL/AngleOptions.cs
+++ b/src/Avalonia.OpenGL/AngleOptions.cs
@@ -10,9 +10,6 @@ namespace Avalonia.OpenGL
 			DirectX11
         }
 
-        public List<PlatformApi> AllowedPlatformApis = new List<PlatformApi>
-        {
-            PlatformApi.DirectX11
-        };
+        public List<PlatformApi> AllowedPlatformApis { get; set; } = null;
     }
 }

--- a/src/Avalonia.OpenGL/AngleOptions.cs
+++ b/src/Avalonia.OpenGL/AngleOptions.cs
@@ -7,7 +7,8 @@ namespace Avalonia.OpenGL
         public enum PlatformApi
         {
 			DirectX9,
-			DirectX11
+			DirectX11,
+            WGL
         }
 
         public IList<PlatformApi> AllowedPlatformApis { get; set; } = null;

--- a/src/Avalonia.OpenGL/AngleOptions.cs
+++ b/src/Avalonia.OpenGL/AngleOptions.cs
@@ -7,8 +7,7 @@ namespace Avalonia.OpenGL
         public enum PlatformApi
         {
 			DirectX9,
-			DirectX11,
-            WGL
+			DirectX11
         }
 
         public IList<PlatformApi> AllowedPlatformApis { get; set; } = null;

--- a/src/Avalonia.OpenGL/AngleOptions.cs
+++ b/src/Avalonia.OpenGL/AngleOptions.cs
@@ -10,6 +10,6 @@ namespace Avalonia.OpenGL
 			DirectX11
         }
 
-        public List<PlatformApi> AllowedPlatformApis { get; set; } = null;
+        public IList<PlatformApi> AllowedPlatformApis { get; set; } = null;
     }
 }

--- a/src/Avalonia.OpenGL/AngleOptions.cs
+++ b/src/Avalonia.OpenGL/AngleOptions.cs
@@ -12,7 +12,7 @@ namespace Avalonia.OpenGL
 
         public List<PlatformApi> AllowedPlatformApis = new List<PlatformApi>
         {
-            PlatformApi.DirectX9
+            PlatformApi.DirectX11
         };
     }
 }

--- a/src/Avalonia.OpenGL/EglConsts.cs
+++ b/src/Avalonia.OpenGL/EglConsts.cs
@@ -186,6 +186,9 @@ namespace Avalonia.OpenGL
         public const int EGL_PLATFORM_ANGLE_TYPE_DEFAULT_ANGLE = 0x3206;
         public const int EGL_PLATFORM_ANGLE_DEVICE_TYPE_HARDWARE_ANGLE = 0x320A;
         public const int EGL_PLATFORM_ANGLE_DEVICE_TYPE_NULL_ANGLE = 0x345E;
+
+        public const int EGL_PLATFORM_ANGLE_TYPE_OPENGL_ANGLE = 0x320D;
+        public const int EGL_PLATFORM_ANGLE_TYPE_OPENGLES_ANGLE = 0x320E;
         
         //EGL_ANGLE_platform_angle_d3d
         public const int EGL_PLATFORM_ANGLE_DEVICE_TYPE_ANGLE = 0x3209;

--- a/src/Avalonia.OpenGL/EglDisplay.cs
+++ b/src/Avalonia.OpenGL/EglDisplay.cs
@@ -36,7 +36,12 @@ namespace Avalonia.OpenGL
                         throw new OpenGlException("eglGetPlatformDisplayEXT is not supported by libegl.dll");
 
                     var allowedApis = AvaloniaLocator.Current.GetService<AngleOptions>()?.AllowedPlatformApis
-                                      ?? new [] {AngleOptions.PlatformApi.DirectX11, AngleOptions.PlatformApi.DirectX9};
+                                      ?? new []
+                                      {
+                                          AngleOptions.PlatformApi.WGL,
+                                          AngleOptions.PlatformApi.DirectX11, 
+                                          AngleOptions.PlatformApi.DirectX9
+                                      };
 
                     foreach (var platformApi in allowedApis)
                     {
@@ -45,6 +50,8 @@ namespace Avalonia.OpenGL
                             dapi = EGL_PLATFORM_ANGLE_TYPE_D3D9_ANGLE;
                         else if (platformApi == AngleOptions.PlatformApi.DirectX11)
                             dapi = EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE;
+                        else if (platformApi == AngleOptions.PlatformApi.WGL)
+                            dapi = EGL_PLATFORM_ANGLE_TYPE_ANGLE;
                         else
                             continue;
 

--- a/src/Avalonia.OpenGL/EglDisplay.cs
+++ b/src/Avalonia.OpenGL/EglDisplay.cs
@@ -36,7 +36,7 @@ namespace Avalonia.OpenGL
                         throw new OpenGlException("eglGetPlatformDisplayEXT is not supported by libegl.dll");
 
                     var allowedApis = AvaloniaLocator.Current.GetService<AngleOptions>()?.AllowedPlatformApis
-                                      ?? new List<AngleOptions.PlatformApi> {AngleOptions.PlatformApi.DirectX11};
+                                      ?? new [] {AngleOptions.PlatformApi.DirectX11};
 
                     foreach (var platformApi in allowedApis)
                     {

--- a/src/Avalonia.OpenGL/EglDisplay.cs
+++ b/src/Avalonia.OpenGL/EglDisplay.cs
@@ -36,7 +36,7 @@ namespace Avalonia.OpenGL
                         throw new OpenGlException("eglGetPlatformDisplayEXT is not supported by libegl.dll");
 
                     var allowedApis = AvaloniaLocator.Current.GetService<AngleOptions>()?.AllowedPlatformApis
-                                      ?? new [] {AngleOptions.PlatformApi.DirectX11};
+                                      ?? new [] {AngleOptions.PlatformApi.DirectX11, AngleOptions.PlatformApi.DirectX9};
 
                     foreach (var platformApi in allowedApis)
                     {

--- a/src/Avalonia.OpenGL/EglDisplay.cs
+++ b/src/Avalonia.OpenGL/EglDisplay.cs
@@ -38,7 +38,6 @@ namespace Avalonia.OpenGL
                     var allowedApis = AvaloniaLocator.Current.GetService<AngleOptions>()?.AllowedPlatformApis
                                       ?? new []
                                       {
-                                          AngleOptions.PlatformApi.WGL,
                                           AngleOptions.PlatformApi.DirectX11, 
                                           AngleOptions.PlatformApi.DirectX9
                                       };
@@ -50,8 +49,6 @@ namespace Avalonia.OpenGL
                             dapi = EGL_PLATFORM_ANGLE_TYPE_D3D9_ANGLE;
                         else if (platformApi == AngleOptions.PlatformApi.DirectX11)
                             dapi = EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE;
-                        else if (platformApi == AngleOptions.PlatformApi.WGL)
-                            dapi = EGL_PLATFORM_ANGLE_TYPE_OPENGL_ANGLE;
                         else
                             continue;
 

--- a/src/Avalonia.OpenGL/EglDisplay.cs
+++ b/src/Avalonia.OpenGL/EglDisplay.cs
@@ -36,7 +36,7 @@ namespace Avalonia.OpenGL
                         throw new OpenGlException("eglGetPlatformDisplayEXT is not supported by libegl.dll");
 
                     var allowedApis = AvaloniaLocator.Current.GetService<AngleOptions>()?.AllowedPlatformApis
-                                      ?? new List<AngleOptions.PlatformApi> {AngleOptions.PlatformApi.DirectX9};
+                                      ?? new List<AngleOptions.PlatformApi> {AngleOptions.PlatformApi.DirectX11};
 
                     foreach (var platformApi in allowedApis)
                     {

--- a/src/Avalonia.OpenGL/EglDisplay.cs
+++ b/src/Avalonia.OpenGL/EglDisplay.cs
@@ -51,7 +51,7 @@ namespace Avalonia.OpenGL
                         else if (platformApi == AngleOptions.PlatformApi.DirectX11)
                             dapi = EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE;
                         else if (platformApi == AngleOptions.PlatformApi.WGL)
-                            dapi = EGL_PLATFORM_ANGLE_TYPE_ANGLE;
+                            dapi = EGL_PLATFORM_ANGLE_TYPE_OPENGL_ANGLE;
                         else
                             continue;
 

--- a/src/Skia/Avalonia.Skia/SkiaOptions.cs
+++ b/src/Skia/Avalonia.Skia/SkiaOptions.cs
@@ -15,6 +15,8 @@ namespace Avalonia
 
         /// <summary>
         /// The maximum number of bytes for video memory to store textures and resources.
+        /// This is set by default to the recommended value for Avalonia.
+        /// Setting this to null will give you the default Skia value.
         /// </summary>
         public long? MaxGpuResourceSizeBytes { get; set; } = 1024 * 600 * 4 * 12; // ~28mb 12x 1024 x 600 textures. 
     }

--- a/src/Skia/Avalonia.Skia/SkiaOptions.cs
+++ b/src/Skia/Avalonia.Skia/SkiaOptions.cs
@@ -15,9 +15,11 @@ namespace Avalonia
 
         /// <summary>
         /// The maximum number of bytes for video memory to store textures and resources.
+        /// </summary>
+        /// <remarks>
         /// This is set by default to the recommended value for Avalonia.
         /// Setting this to null will give you the default Skia value.
-        /// </summary>
+        /// </remarks>
         public long? MaxGpuResourceSizeBytes { get; set; } = 1024 * 600 * 4 * 12; // ~28mb 12x 1024 x 600 textures. 
     }
 }

--- a/src/Skia/Avalonia.Skia/SkiaOptions.cs
+++ b/src/Skia/Avalonia.Skia/SkiaOptions.cs
@@ -16,6 +16,6 @@ namespace Avalonia
         /// <summary>
         /// The maximum number of bytes for video memory to store textures and resources.
         /// </summary>
-        public long? MaxGpuResourceSizeBytes { get; set; }
+        public long? MaxGpuResourceSizeBytes { get; set; } = 1024 * 600 * 4 * 12; // ~28mb 12x 1024 x 600 textures. 
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Various users have been reporting memory leaks in issues such as https://github.com/AvaloniaUI/Avalonia/issues/3983. We've been unable to find any conclusive evidence of such leaks, instead I suspect that this is just Skia's default behavior: memory usage (private bytes) goes up during resize but comes back down and the working set stays relatively stable.

This is going to need some more investigation moving forwards, but in the meantime, in order to get 0.10 with GPU rendering enabled by default we're just going to tweak the GPU settings a little to improve memory use in general.

This PR:

- Sets options to use D3D11 by default in Angle instead of D3D9. D3D11 has _far_ better memory usage than D3D9 and the spikes seen when resizing are also smaller. We did have problems in the past with crashing when defaulting to D3D11, lets see if we see that again and if so either revert this or implement a blacklist [like chrome](https://chromium.googlesource.com/chromium/src/gpu/+/4291fe1553cf142655456b2d8af0f7bb9469c499/config/gpu_driver_bug_list_json.cc)
- Set default Skia cache size to be 28MiB instead of 100MiB. This default was taken from [Flutter](https://github.com/flutter/engine/pull/17798)

## Fixed issues

Closes #3983 for the moment. If anyone has a repro of a memory leak that doesn't settle down, please open a new issue!