### PR TITLE
Fix ScrollBar leak.

### DIFF
--- a/src/Avalonia.Controls/Primitives/ScrollBar.cs
+++ b/src/Avalonia.Controls/Primitives/ScrollBar.cs
@@ -141,7 +141,7 @@ namespace Avalonia.Controls.Primitives
                 _ => throw new InvalidOperationException("Invalid value for ScrollBar.Visibility.")
             };
 
-            SetValue(IsVisibleProperty, isVisible, BindingPriority.Style);
+            SetValue(IsVisibleProperty, isVisible);
         }
 
         protected override void OnKeyDown(KeyEventArgs e)


### PR DESCRIPTION
## What does the pull request do?

Each time `Scrollbar.UpdateIsVisible` was called, a new entry is added to the `IsVisible` priority store because we were setting it with `Style` priority. Fix it by setting it with local value priority, which _subtly_ changes its semantics but hopefully not so that anyone notices.

Seems that it was introduced by https://github.com/AvaloniaUI/Avalonia/pull/3676

~~@danwalmsley let's wait until 0.10.1 for this one as it might break someone. If it does we need a different approach.~~