### PR TITLE
Hid maximize box on Windows for CanResize="false"

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1007,10 +1007,12 @@ namespace Avalonia.Win32
                 if (newProperties.IsResizable)
                 {
                     style |= WindowStyles.WS_SIZEFRAME;
+                    style |= WindowStyles.WS_MAXIMIZEBOX;
                 }
                 else
                 {
                     style &= ~WindowStyles.WS_SIZEFRAME;
+                    style &= ~WindowStyles.WS_MAXIMIZEBOX;
                 }
 
                 SetStyle(style);


### PR DESCRIPTION
## What does the pull request do?

This PR makes the maximize box behavior on Windows the same as on MacOS.

## What is the current behavior?

At the moment `Window.CanResize="false"` disables maximize box on MacOS, but [it's still active on Windows](https://github.com/AvaloniaUI/Avalonia/issues/437#issuecomment-493003671).

## What is the updated/expected behavior with this PR?

Now the maximize box behaves the same under both MacOS and Windows: it's inactive for `Window.CanResize="false"` and active for `Window.CanResize="true"`.

## Related issues

#437
