### PR TITLE
Fix ItemsRepeater leak

### DIFF
--- a/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
+++ b/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
@@ -684,11 +684,11 @@ namespace Avalonia.Controls
 
                 WeakEventHandlerManager.Unsubscribe<EventArgs, ItemsRepeater>(
                     oldValue,
-                    nameof(newValue.MeasureInvalidated),
+                    nameof(AttachedLayout.MeasureInvalidated),
                     InvalidateMeasureForLayout);
                 WeakEventHandlerManager.Unsubscribe<EventArgs, ItemsRepeater>(
                     oldValue,
-                    nameof(newValue.ArrangeInvalidated),
+                    nameof(AttachedLayout.ArrangeInvalidated),
                     InvalidateArrangeForLayout);
 
                 // Walk through all the elements and make sure they are cleared
@@ -709,11 +709,11 @@ namespace Avalonia.Controls
 
                 WeakEventHandlerManager.Subscribe<AttachedLayout, EventArgs, ItemsRepeater>(
                     newValue,
-                    nameof(newValue.MeasureInvalidated),
+                    nameof(AttachedLayout.MeasureInvalidated),
                     InvalidateMeasureForLayout);
                 WeakEventHandlerManager.Subscribe<AttachedLayout, EventArgs, ItemsRepeater>(
                     newValue,
-                    nameof(newValue.ArrangeInvalidated),
+                    nameof(AttachedLayout.ArrangeInvalidated),
                     InvalidateArrangeForLayout);
             }
 

--- a/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
+++ b/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
@@ -7,10 +7,10 @@ using System;
 using System.Collections;
 using System.Collections.Specialized;
 using Avalonia.Controls.Templates;
-using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Logging;
+using Avalonia.Utilities;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Controls
@@ -681,8 +681,15 @@ namespace Avalonia.Controls
             if (oldValue != null)
             {
                 oldValue.UninitializeForContext(LayoutContext);
-                oldValue.MeasureInvalidated -= InvalidateMeasureForLayout;
-                oldValue.ArrangeInvalidated -= InvalidateArrangeForLayout;
+
+                WeakEventHandlerManager.Unsubscribe<EventArgs, ItemsRepeater>(
+                    oldValue,
+                    nameof(newValue.MeasureInvalidated),
+                    InvalidateMeasureForLayout);
+                WeakEventHandlerManager.Unsubscribe<EventArgs, ItemsRepeater>(
+                    oldValue,
+                    nameof(newValue.ArrangeInvalidated),
+                    InvalidateArrangeForLayout);
 
                 // Walk through all the elements and make sure they are cleared
                 foreach (var element in Children)
@@ -699,8 +706,15 @@ namespace Avalonia.Controls
             if (newValue != null)
             {
                 newValue.InitializeForContext(LayoutContext);
-                newValue.MeasureInvalidated += InvalidateMeasureForLayout;
-                newValue.ArrangeInvalidated += InvalidateArrangeForLayout;
+
+                WeakEventHandlerManager.Subscribe<AttachedLayout, EventArgs, ItemsRepeater>(
+                    newValue,
+                    nameof(newValue.MeasureInvalidated),
+                    InvalidateMeasureForLayout);
+                WeakEventHandlerManager.Subscribe<AttachedLayout, EventArgs, ItemsRepeater>(
+                    newValue,
+                    nameof(newValue.ArrangeInvalidated),
+                    InvalidateArrangeForLayout);
             }
 
             bool isVirtualizingLayout = newValue != null && newValue is VirtualizingLayout;

--- a/src/Avalonia.Layout/Layoutable.cs
+++ b/src/Avalonia.Layout/Layoutable.cs
@@ -758,8 +758,6 @@ namespace Avalonia.Layout
 
         protected override void OnDetachedFromVisualTreeCore(VisualTreeAttachmentEventArgs e)
         {
-            base.OnDetachedFromVisualTreeCore(e);
-
             if (e.Root is ILayoutRoot r)
             {
                 if (_layoutUpdated is object)
@@ -772,6 +770,8 @@ namespace Avalonia.Layout
                     r.LayoutManager.UnregisterEffectiveViewportListener(this);
                 }
             }
+
+            base.OnDetachedFromVisualTreeCore(e);
         }
 
         /// <summary>

--- a/tests/Avalonia.LeakTests/ControlTests.cs
+++ b/tests/Avalonia.LeakTests/ControlTests.cs
@@ -557,8 +557,6 @@ namespace Avalonia.LeakTests
         {
             using (Start())
             {
-                var geometry = new EllipseGeometry { Rect = new Rect(0, 0, 10, 10) };
-
                 Func<Window> run = () =>
                 {
                     var window = new Window
@@ -582,9 +580,6 @@ namespace Avalonia.LeakTests
 
                 dotMemory.Check(memory =>
                     Assert.Equal(0, memory.GetObjects(where => where.Type.Is<ItemsRepeater>()).ObjectsCount));
-
-                // We are keeping geometry alive to simulate a resource that outlives the control.
-                GC.KeepAlive(geometry);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

As described in #4599, `ItemsRepeater` instances were leaking. Fix this by:

- Cleaning up `EffectiveViewportChanged` subscriptions before calling `OnDetachedFromVisualTree` so that (un)subscribing to the `EffectiveViewportChanged`  event in `OnDetachedFromVisualTree` doesn't cause a leak
- Use weak event handlers for `AttachedLayout.MeasureInvalidated`/`ArrangeInvalidated`. Seems that C++/WinRT uses weak event handlers by default so we need to do the same here.

## Checklist

- [x ] Added unit tests (if possible)?

## Fixed issues

Fixes #4599