### PR TITLE
Store args in ClassicDesktopStyleApplicationLifetime.

### DIFF
--- a/src/Avalonia.Controls/ApiCompatBaseline.txt
+++ b/src/Avalonia.Controls/ApiCompatBaseline.txt
@@ -12,7 +12,9 @@ MembersMustExist : Member 'public Avalonia.DirectProperty<Avalonia.Controls.Tree
 MembersMustExist : Member 'public Avalonia.Interactivity.RoutedEvent<Avalonia.Controls.SelectionChangedEventArgs> Avalonia.Interactivity.RoutedEvent<Avalonia.Controls.SelectionChangedEventArgs> Avalonia.Controls.TreeView.SelectionChangedEvent' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'public Avalonia.Controls.ISelectionModel Avalonia.Controls.TreeView.Selection.get()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'public void Avalonia.Controls.TreeView.Selection.set(Avalonia.Controls.ISelectionModel)' does not exist in the implementation but it does exist in the contract.
+InterfacesShouldHaveSameMembers : Interface member 'public System.String[] Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime.Args' is present in the implementation but not in the contract.
+InterfacesShouldHaveSameMembers : Interface member 'public System.String[] Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime.Args.get()' is present in the implementation but not in the contract.
 MembersMustExist : Member 'public Avalonia.DirectProperty<Avalonia.Controls.Primitives.SelectingItemsControl, Avalonia.Controls.ISelectionModel> Avalonia.DirectProperty<Avalonia.Controls.Primitives.SelectingItemsControl, Avalonia.Controls.ISelectionModel> Avalonia.Controls.Primitives.SelectingItemsControl.SelectionProperty' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'protected Avalonia.Controls.ISelectionModel Avalonia.Controls.Primitives.SelectingItemsControl.Selection.get()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'protected void Avalonia.Controls.Primitives.SelectingItemsControl.Selection.set(Avalonia.Controls.ISelectionModel)' does not exist in the implementation but it does exist in the contract.
-Total Issues: 16
+Total Issues: 18

--- a/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
@@ -47,6 +47,11 @@ namespace Avalonia.Controls.ApplicationLifetimes
         /// <inheritdoc/>
         public event EventHandler<ControlledApplicationLifetimeExitEventArgs> Exit;
 
+        /// <summary>
+        /// Gets the arguments passed to the AppBuilder Start method.
+        /// </summary>
+        public string[] Args { get; set; }
+        
         /// <inheritdoc/>
         public ShutdownMode ShutdownMode { get; set; }
         
@@ -68,9 +73,6 @@ namespace Avalonia.Controls.ApplicationLifetimes
             else if (ShutdownMode == ShutdownMode.OnMainWindowClose && window == MainWindow)
                 Shutdown();
         }
-        
-        
-
 
         public void Shutdown(int exitCode = 0)
         {
@@ -123,7 +125,11 @@ namespace Avalonia
             this T builder, string[] args, ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose)
             where T : AppBuilderBase<T>, new()
         {
-            var lifetime = new ClassicDesktopStyleApplicationLifetime() {ShutdownMode = shutdownMode};
+            var lifetime = new ClassicDesktopStyleApplicationLifetime()
+            {
+                Args = args,
+                ShutdownMode = shutdownMode
+            };
             builder.SetupWithLifetime(lifetime);
             return lifetime.Start(args);
         }

--- a/src/Avalonia.Controls/ApplicationLifetimes/IClassicDesktopStyleApplicationLifetime.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/IClassicDesktopStyleApplicationLifetime.cs
@@ -9,6 +9,13 @@ namespace Avalonia.Controls.ApplicationLifetimes
     public interface IClassicDesktopStyleApplicationLifetime : IControlledApplicationLifetime
     {
         /// <summary>
+        /// Gets the arguments passed to the
+        /// <see cref="ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime{T}(T, string[], ShutdownMode)"/>
+        /// method.
+        /// </summary>
+        string[] Args { get; }
+        
+        /// <summary>
         /// Gets or sets the <see cref="ShutdownMode"/>. This property indicates whether the application is shutdown explicitly or implicitly. 
         /// If <see cref="ShutdownMode"/> is set to OnExplicitShutdown the application is only closes if Shutdown is called.
         /// The default is OnLastWindowClose


### PR DESCRIPTION
## What does the pull request do?

The recommended way to show the main window with the classic desktop lifetime is using this pattern in `App.OnFrameworkInitializationCompleted`:

```csharp
if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
{
	desktopLifetime.MainWindow = new MainWindow();
}
```

However it's sometimes necessary to have access to the command-line args in order to decide what to do here (e.g. show a different window based on the args passed).

The current way to get the command-line args is to add a handler for `desktopLifetime.Startup`, but why does it have to be like this?

We're passing the args to the `StartWithClassicDesktopLifetime` method which creates the `ClassicDesktopStyleApplicationLifetime` object, so the args are available at this point. So I figured, why not simply add the args as a parameter to `IClassicDesktopStyleApplicationLifetime `?

There may well be a reason this wasn't already done - if so feel free to close and treat this PR as an explanation as to why things weren't done like this.
