### PR TITLE
Ensure windows set to fullscreen are shown.

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -853,7 +853,7 @@ namespace Avalonia.Win32
 
         private void ShowWindow(WindowState state)
         {
-            ShowWindowCommand command;
+            ShowWindowCommand? command;
 
             var newWindowProperties = _windowProperties;
 
@@ -875,8 +875,8 @@ namespace Avalonia.Win32
 
                 case WindowState.FullScreen:
                     newWindowProperties.IsFullScreen = true;
-                    UpdateWindowProperties(newWindowProperties);
-                    return;
+                    command = IsWindowVisible(_hwnd) ? (ShowWindowCommand?)null : ShowWindowCommand.Restore;
+                    break;
 
                 default:
                     throw new ArgumentException("Invalid WindowState.");
@@ -884,7 +884,10 @@ namespace Avalonia.Win32
 
             UpdateWindowProperties(newWindowProperties);
 
-            UnmanagedMethods.ShowWindow(_hwnd, command);
+            if (command.HasValue)
+            {
+                UnmanagedMethods.ShowWindow(_hwnd, command.Value);
+            }
 
             if (state == WindowState.Maximized)
             {


### PR DESCRIPTION
## What does the pull request do?

Previously, `UnmanagedMethods.ShowWindow` wasn't called when trying to show a window with `WindowState="FullScreen"`.

This is because win32 conflates showing a window and setting a window state, and setting all windows states except fullscreen require a call to `ShowWindow`, except fullscreen which does *not*. However it _does_ require a call to `ShowWindow` when we are actually showing the window ;)

## Fixed issues

Fixes #4640 