### PR TITLE
Fix nullable annotations in Avalonia.Input

### DIFF
--- a/src/Avalonia.Input/KeyGesture.cs
+++ b/src/Avalonia.Input/KeyGesture.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Avalonia.Input
@@ -29,7 +27,7 @@ namespace Avalonia.Input
             KeyModifiers = modifiers;
         }
 
-        public bool Equals(KeyGesture other)
+        public bool Equals(KeyGesture? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
@@ -37,12 +35,12 @@ namespace Avalonia.Input
             return Key == other.Key && KeyModifiers == other.KeyModifiers;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
 
-            return obj is KeyGesture && Equals((KeyGesture)obj);
+            return obj is KeyGesture gesture && Equals(gesture);
         }
 
         public override int GetHashCode()
@@ -53,12 +51,12 @@ namespace Avalonia.Input
             }
         }
 
-        public static bool operator ==(KeyGesture left, KeyGesture right)
+        public static bool operator ==(KeyGesture? left, KeyGesture? right)
         {
             return Equals(left, right);
         }
 
-        public static bool operator !=(KeyGesture left, KeyGesture right)
+        public static bool operator !=(KeyGesture? left, KeyGesture? right)
         {
             return !Equals(left, right);
         }

--- a/src/Avalonia.Input/PointerEventArgs.cs
+++ b/src/Avalonia.Input/PointerEventArgs.cs
@@ -86,14 +86,14 @@ namespace Avalonia.Input
         }
 
         [Obsolete("Use GetCurrentPoint")]
-        public PointerPoint GetPointerPoint(IVisual relativeTo) => GetCurrentPoint(relativeTo);
+        public PointerPoint GetPointerPoint(IVisual? relativeTo) => GetCurrentPoint(relativeTo);
         
         /// <summary>
         /// Returns the PointerPoint associated with the current event
         /// </summary>
         /// <param name="relativeTo">The visual which coordinate system to use. Pass null for toplevel coordinate system</param>
         /// <returns></returns>
-        public PointerPoint GetCurrentPoint(IVisual relativeTo)
+        public PointerPoint GetCurrentPoint(IVisual? relativeTo)
             => new PointerPoint(Pointer, GetPosition(relativeTo), _properties);
 
         /// <summary>


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes missing nullable annotations in `Avalonia.Input` that cause warnings on user side. Like you can't even compare `KeyGesture` instances with `null` since it requires non-nullable everywhere.