### PR TITLE
Fix bound TabStrip/Carousel selection

### DIFF
--- a/.ncrunch/Sandbox.v3.ncrunchproject
+++ b/.ncrunch/Sandbox.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/src/Avalonia.Controls/Selection/SelectionModel.cs
+++ b/src/Avalonia.Controls/Selection/SelectionModel.cs
@@ -242,12 +242,7 @@ namespace Avalonia.Controls.Selection
         {
             using var update = BatchUpdate();
             var o = update.Operation;
-            var range = CoerceRange(start, end);
-
-            if (range.Begin == -1)
-            {
-                return;
-            }
+            var range = new IndexRange(start, end);
 
             if (RangesEnabled)
             {

--- a/src/Avalonia.Controls/Selection/SelectionModel.cs
+++ b/src/Avalonia.Controls/Selection/SelectionModel.cs
@@ -242,7 +242,7 @@ namespace Avalonia.Controls.Selection
         {
             using var update = BatchUpdate();
             var o = update.Operation;
-            var range = new IndexRange(start, end);
+            var range = new IndexRange(Math.Max(0, start), end);
 
             if (RangesEnabled)
             {

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -1813,6 +1813,88 @@ namespace Avalonia.Controls.UnitTests.Primitives
             Assert.Equal(1, raised);
         }
 
+        [Fact]
+        public void Handles_Removing_Last_Item_In_Two_Controls_With_Bound_SelectedIndex()
+        {
+            var items = new ObservableCollection<string> { "foo" };
+
+            // Simulates problem with TabStrip and Carousel with bound SelectedIndex.
+            var tabStrip = new TestSelector 
+            { 
+                Items = items, 
+                SelectionMode = SelectionMode.AlwaysSelected,
+            };
+
+            var carousel = new TestSelector
+            {
+                Items = items,
+                [!Carousel.SelectedIndexProperty] = tabStrip[!TabStrip.SelectedIndexProperty],
+            };
+
+            var tabStripRaised = 0;
+            var carouselRaised = 0;
+
+            tabStrip.SelectionChanged += (s, e) =>
+            {
+                Assert.Equal(new[] { "foo" }, e.RemovedItems);
+                Assert.Empty(e.AddedItems);
+                ++tabStripRaised;
+            };
+
+            carousel.SelectionChanged += (s, e) =>
+            {
+                Assert.Equal(new[] { "foo" }, e.RemovedItems);
+                Assert.Empty(e.AddedItems);
+                ++carouselRaised;
+            };
+
+            items.RemoveAt(0);
+
+            Assert.Equal(1, tabStripRaised);
+            Assert.Equal(1, carouselRaised);
+        }
+
+        [Fact]
+        public void Handles_Removing_Last_Item_In_Controls_With_Bound_SelectedItem()
+        {
+            var items = new ObservableCollection<string> { "foo" };
+
+            // Simulates problem with TabStrip and Carousel with bound SelectedItem.
+            var tabStrip = new TestSelector
+            {
+                Items = items,
+                SelectionMode = SelectionMode.AlwaysSelected,
+            };
+
+            var carousel = new TestSelector
+            {
+                Items = items,
+                [!Carousel.SelectedItemProperty] = tabStrip[!TabStrip.SelectedItemProperty],
+            };
+
+            var tabStripRaised = 0;
+            var carouselRaised = 0;
+
+            tabStrip.SelectionChanged += (s, e) =>
+            {
+                Assert.Equal(new[] { "foo" }, e.RemovedItems);
+                Assert.Empty(e.AddedItems);
+                ++tabStripRaised;
+            };
+
+            carousel.SelectionChanged += (s, e) =>
+            {
+                Assert.Equal(new[] { "foo" }, e.RemovedItems);
+                Assert.Empty(e.AddedItems);
+                ++carouselRaised;
+            };
+
+            items.RemoveAt(0);
+
+            Assert.Equal(1, tabStripRaised);
+            Assert.Equal(1, carouselRaised);
+        }
+
         private static void Prepare(SelectingItemsControl target)
         {
             var root = new TestRoot


### PR DESCRIPTION
## What does the pull request do?

When a `TabStrip` and `Carousel` were bound by their `SelectedIndex`/`SelectedItem`, removing the last item resulted in an `ArgumentOutOfRangeException`.

This happened because of the interaction between the order of `CollectionChanged` handlers getting called and `SelectedIndex`/`SelectedItems` bound values being updated. This resulted in:

- Last item is removed
- `TabStrip`'s selection model receives the `CollectionChanged` event
- `TabStrip` `SelectedIndex` gets set to -1
- The binding sets `SelectedIndex` on the `Carousel` to -1
- The `Carousel`'s selection model starts a new operation, and saves the current `SelectedIndex` to the `Operation` - but this `SelectedIndex` is still 0
- The selection model clears the selection but 0 is out of range for selected values, so the selection doesn't get cleared
- The operation is committed with an invalid `SelectedIndex`

The solution here is to not coerce the upper index when deselecting a range. This causes the invalid selected index to be cleared, and has no downsides as deselecting an invalid index in the general case is a no-op.

## Checklist

- [x] Added unit tests (if possible)?
