### PR TITLE
Mark TabOnceActiveElement as nullable value.

### DIFF
--- a/src/Avalonia.Input/KeyboardNavigation.cs
+++ b/src/Avalonia.Input/KeyboardNavigation.cs
@@ -25,11 +25,10 @@ namespace Avalonia.Input
         /// attached property set to <see cref="KeyboardNavigationMode.Once"/>, this property
         /// defines to which child the focus should move.
         /// </remarks>
-        public static readonly AttachedProperty<IInputElement> TabOnceActiveElementProperty =
-            AvaloniaProperty.RegisterAttached<InputElement, IInputElement>(
+        public static readonly AttachedProperty<IInputElement?> TabOnceActiveElementProperty =
+            AvaloniaProperty.RegisterAttached<InputElement, IInputElement?>(
                 "TabOnceActiveElement",
                 typeof(KeyboardNavigation));
-
 
         /// <summary>
         /// Defines the IsTabStop attached property.
@@ -68,7 +67,7 @@ namespace Avalonia.Input
         /// </summary>
         /// <param name="element">The container.</param>
         /// <returns>The active element for the container.</returns>
-        public static IInputElement GetTabOnceActiveElement(InputElement element)
+        public static IInputElement? GetTabOnceActiveElement(InputElement element)
         {
             return element.GetValue(TabOnceActiveElementProperty);
         }
@@ -78,7 +77,7 @@ namespace Avalonia.Input
         /// </summary>
         /// <param name="element">The container.</param>
         /// <param name="value">The active element for the container.</param>
-        public static void SetTabOnceActiveElement(InputElement element, IInputElement value)
+        public static void SetTabOnceActiveElement(InputElement element, IInputElement? value)
         {
             element.SetValue(TabOnceActiveElementProperty, value);
         }


### PR DESCRIPTION
## What does the pull request do?

In the recent change to [add nullability annotations to Avalonia.Input](https://github.com/AvaloniaUI/Avalonia/pull/4284), the `KeyboardDevice.TabOnceActiveElement` attached property was marked as non-nullable when it should be nullable.