### PR TITLE
Fix AvaloniaList's ICollection.CopyTo implementation

### DIFF
--- a/.ncrunch/Avalonia.Controls.UnitTests.net47.v3.ncrunchproject
+++ b/.ncrunch/Avalonia.Controls.UnitTests.net47.v3.ncrunchproject
@@ -3,5 +3,6 @@
     <HiddenComponentWarnings>
       <Value>MissingOrIgnoredProjectReference</Value>
     </HiddenComponentWarnings>
+        <FixtureName>Avalonia.Controls.UnitTests.TimePickerTests</FixtureName>
   </Settings>
 </ProjectConfiguration>

--- a/tests/Avalonia.Base.UnitTests/Collections/AvaloniaListTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Collections/AvaloniaListTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -333,6 +334,28 @@ namespace Avalonia.Base.UnitTests.Collections
             target.Clear();
 
             Assert.True(raised);
+        }
+
+        [Fact]
+        public void Can_CopyTo_Array_Of_Same_Type()
+        {
+            var target = new AvaloniaList<string> { "foo", "bar", "baz" };
+            var result = new string[3];
+
+            target.CopyTo(result, 0);
+
+            Assert.Equal(target, result);
+        }
+
+        [Fact]
+        public void Can_CopyTo_Array_Of_Base_Type()
+        {
+            var target = new AvaloniaList<string> { "foo", "bar", "baz" };
+            var result = new object[3];
+
+            ((IList)target).CopyTo(result, 0);
+
+            Assert.Equal(target, result);
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

The `CopyTo` implementation in `AvaloniaList` did not handle copying to arrays of a base type. Copy the [`ICollection.CopyTo`](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Private.CoreLib/src/System/Collections/ObjectModel/Collection.cs#L169-L238) implementation from the BCL.

## Checklist

- [x] Added unit tests (if possible)?
