### PR TITLE
Some small selection fixes

### DIFF
--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -491,8 +491,7 @@ namespace Avalonia.Controls.Primitives
 
                 if (ItemCount > 0 &&
                     Match(keymap.SelectAll) &&
-                    (((SelectionMode & SelectionMode.Multiple) != 0) ||
-                      (SelectionMode & SelectionMode.Toggle) != 0))
+                    SelectionMode.HasFlag(SelectionMode.Multiple))
                 {
                     Selection.SelectAll();
                     e.Handled = true;

--- a/src/Avalonia.Controls/Selection/InternalSelectionModel.cs
+++ b/src/Avalonia.Controls/Selection/InternalSelectionModel.cs
@@ -63,6 +63,11 @@ namespace Avalonia.Controls.Selection
 
         private protected override void SetSource(IEnumerable? value)
         {
+            if (Source == value)
+            {
+                return;
+            }
+
             object?[]? oldSelection = null;
 
             if (Source is object && value is object)

--- a/src/Avalonia.Layout/FlowLayoutAlgorithm.cs
+++ b/src/Avalonia.Layout/FlowLayoutAlgorithm.cs
@@ -211,7 +211,7 @@ namespace Avalonia.Layout
                             anchorPosition = new Point(anchorBounds.X, anchorBounds.Y);
                         }
                     }
-                    else
+                    else if (anchorIndex >= 0)
                     {
                         // It is possible to end up in a situation during a collection change where GetAnchorForTargetElement returns an index
                         // which is not in the realized range. Eg. insert one item at index 0 for a grid layout. 


### PR DESCRIPTION
## What does the pull request do?

A few more small selection fixes:

- Short-circuit `InternalSelectionModel.Source` setter when value hasn't changed
- Don't try to SelectAll with `Toggle` selection mode - toggle doesn't mean multiple selection
- Don't try to realize index -1 in `ItemsRepeater`
