### PR TITLE
[WIP] Fix detach from logical tree

### DIFF
--- a/src/Avalonia.Styling/StyledElement.cs
+++ b/src/Avalonia.Styling/StyledElement.cs
@@ -674,8 +674,9 @@ namespace Avalonia
                 OnDetachedFromLogicalTree(e);
                 DetachedFromLogicalTree?.Invoke(this, e);
 
-                var logicalChildren = LogicalChildren;
-                var logicalChildrenCount = logicalChildren.Count;
+                // Copy children into temp array, because list of children can be updated during detach.
+                var logicalChildren = LogicalChildren.ToArray();
+                var logicalChildrenCount = logicalChildren.Length;
 
                 for (var i = 0; i < logicalChildrenCount; i++)
                 {


### PR DESCRIPTION
## What does the pull request do?
LogicalChildren can be updated in DetachStyles (ControlCatalog.Content set to null and removed from the tree...), so we can't iterate over it in OnDetachedFromLogicalTreeCore without copying it before. Otherwise it is possible to receive IndexOutOfRangeException (see https://github.com/AvaloniaUI/Avalonia/issues/4706#issuecomment-695839701). Although it is possible to run OnDetachedFromLogicalTreeCore twice with this PR, it shouldn't be a problem.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Fixed issues
https://github.com/AvaloniaUI/Avalonia/issues/4706
