### PR TITLE
Use screen bounds Bottom instead of Height for constraining popups.

### DIFF
--- a/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositioner.cs
@@ -221,7 +221,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
 
                 if (!FitsInBounds(unconstrainedRect, PopupAnchor.Bottom))
                 {
-                    unconstrainedRect = unconstrainedRect.WithHeight(bounds.Height - unconstrainedRect.Y);
+                    unconstrainedRect = unconstrainedRect.WithHeight(bounds.Bottom - unconstrainedRect.Y);
                 }
 
                 if (IsValid(unconstrainedRect))


### PR DESCRIPTION
## What does the pull request do?

Use the screen bottom rather than the height when constraining popups.

Secondary screens on Windows can have a Y offset (i.e. `bounds.Y != 0`) if they're offset vertically from the primary screen, and when this was the case the popup wasn't getting properly constrained as the bottom is not equal to the height, resulting in #4726.

## Fixed issues

Fixes #4726