### PR TITLE
Datagrid :empty-rows and :empty-columns pseudoclasses

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -31,7 +31,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// Displays data in a customizable grid.
     /// </summary>
-    [PseudoClasses(":invalid")]
+    [PseudoClasses(":invalid", ":empty-rows", ":empty-columns")]
     public partial class DataGrid : TemplatedControl
     {
         private const string DATAGRID_elementRowsPresenterName = "PART_RowsPresenter";
@@ -711,6 +711,7 @@ namespace Avalonia.Controls
 
             DisplayData = new DataGridDisplayData(this);
             ColumnsInternal = CreateColumnsInstance();
+            ColumnsInternal.CollectionChanged += ColumnsInternal_CollectionChanged;
 
             RowHeightEstimate = DATAGRID_defaultRowHeight;
             RowDetailsHeightEstimate = 0;
@@ -727,6 +728,8 @@ namespace Avalonia.Controls
             CurrentCellCoordinates = new DataGridCellCoordinates(-1, -1);
 
             RowGroupHeaderHeightEstimate = DATAGRID_defaultRowHeight;
+
+            UpdatePseudoClasses();
         }
 
         private void SetValueNoCallback<T>(AvaloniaProperty<T> property, T value, BindingPriority priority = BindingPriority.LocalValue)
@@ -851,7 +854,25 @@ namespace Avalonia.Controls
                 // can be set when the DataGrid is not part of the visual tree
                 _measured = false;
                 InvalidateMeasure();
+
+                UpdatePseudoClasses();
             }
+        }
+
+        private void ColumnsInternal_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.Action == NotifyCollectionChangedAction.Add
+                || e.Action == NotifyCollectionChangedAction.Remove
+                || e.Action == NotifyCollectionChangedAction.Reset)
+            {
+                UpdatePseudoClasses();
+            }
+        }
+
+        internal void UpdatePseudoClasses()
+        {
+            PseudoClasses.Set(":empty-columns", !ColumnsInternal.GetVisibleColumns().Any());
+            PseudoClasses.Set(":empty-rows", !DataConnection.Any());
         }
 
         private void OnSelectedIndexChanged(AvaloniaPropertyChangedEventArgs e)
@@ -1348,7 +1369,6 @@ namespace Avalonia.Controls
         internal DataGridColumnCollection ColumnsInternal
         {
             get;
-            private set;
         }
 
         internal int AnchorSlot

--- a/src/Avalonia.Controls.DataGrid/DataGridDataConnection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridDataConnection.cs
@@ -77,24 +77,7 @@ namespace Avalonia.Controls
             private set;
         }
 
-        public int Count
-        {
-            get
-            {
-                IList list = List;
-                if (list != null)
-                {
-                    return list.Count;
-                }
-
-                if(DataSource is DataGridCollectionView cv)
-                {
-                    return cv.Count;
-                }
-
-                return DataSource?.Cast<object>().Count() ?? 0;
-            }
-        }
+        public int Count => GetCount(true);
 
         public bool DataIsPrimitive
         {
@@ -208,6 +191,24 @@ namespace Avalonia.Controls
                     return null;
                 }
             }
+        }
+
+        internal bool Any()
+        {
+            return GetCount(false) > 0;
+        }
+
+        /// <param name="allowSlow">When "allowSlow" is false, method will not use Linq.Count() method and will return 0 or 1 instead.</param>
+        private int GetCount(bool allowSlow)
+        {
+            return DataSource switch
+            {
+                ICollection collection => collection.Count,
+                DataGridCollectionView cv => cv.Count,
+                IEnumerable enumerable when allowSlow => enumerable.Cast<object>().Count(),
+                IEnumerable enumerable when !allowSlow => enumerable.Cast<object>().Any() ? 1 : 0,
+                _ => 0
+            };
         }
 
         /// <summary>
@@ -675,6 +676,8 @@ namespace Avalonia.Controls
                     }
                     break;
             }
+
+            _owner.UpdatePseudoClasses();
         }
 
         private void UpdateDataProperties()

--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -588,18 +588,11 @@
             <!--<DataGridColumnHeader Name="PART_TopRightCornerHeader"
                                   Grid.Column="2"
                                   Template="{StaticResource TopRightHeaderTemplate}" />-->
-            <!--<Rectangle Name="PART_ColumnHeadersAndRowsSeparator"
+            <Rectangle Name="PART_ColumnHeadersAndRowsSeparator"
                        Grid.ColumnSpan="3"
                        VerticalAlignment="Bottom"
-                       StrokeThickness="1"
                        Height="1"
-                       Fill="{DynamicResource DataGridGridLinesBrush}" />-->
-            <Border Name="PART_ColumnHeadersAndRowsSeparator"
-                    Grid.ColumnSpan="3"
-                    Height="2"
-                    VerticalAlignment="Bottom"
-                    BorderThickness="0,0,0,1"
-                    BorderBrush="{DynamicResource DataGridGridLinesBrush}" />
+                       Fill="{DynamicResource DataGridGridLinesBrush}" />
 
             <DataGridRowsPresenter Name="PART_RowsPresenter"
                                    Grid.Row="1"
@@ -641,5 +634,15 @@
         </Border>
       </ControlTemplate>
     </Setter>
+  </Style>
+
+  <Style Selector="DataGrid:empty-columns /template/ DataGridColumnHeader#PART_TopLeftCornerHeader">
+    <Setter Property="IsVisible" Value="False" />
+  </Style>
+  <Style Selector="DataGrid:empty-columns /template/ DataGridColumnHeadersPresenter#PART_ColumnHeadersPresenter">
+    <Setter Property="IsVisible" Value="False" />
+  </Style>
+  <Style Selector="DataGrid:empty-columns /template/ Rectangle#PART_ColumnHeadersAndRowsSeparator">
+    <Setter Property="IsVisible" Value="False" />
   </Style>
 </Styles>


### PR DESCRIPTION
## What is the current behavior?
1. There is no ":empty" equivalent in the DataGrid.
2. Currently DataGrid without columns shows separator:
![image](https://user-images.githubusercontent.com/3163374/94495948-0dfe0800-01c1-11eb-83ce-530376fdb7ab.png)

## What is the updated/expected behavior with this PR?
1. There are ":empty-rows" and ":empty-columns" in the DataGrid.
2. No separators are visible, when there are no visible columns,