### PR TITLE
fix issue #3113 compile avalonia.native.dylib with nuke

### DIFF
--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -138,9 +138,19 @@ partial class Build : NukeBuild
                 .SetWorkingDirectory(webappDir)
                 .SetCommand("dist"));
         });
-    
-    Target Compile => _ => _
+
+    Target CompileNative => _ => _
         .DependsOn(Clean)
+        .OnlyWhenStatic(() => EnvironmentInfo.IsOsx)
+        .Executes(() =>
+        {
+            var project = $"{RootDirectory}/native/Avalonia.Native/src/OSX/Avalonia.Native.OSX.xcodeproj/";
+            var args = $"-project {project} -configuration {Parameters.Configuration} CONFIGURATION_BUILD_DIR={RootDirectory}/Build/Products/Release";
+            ProcessTasks.StartProcess("xcodebuild", args).AssertZeroExitCode();
+        });
+
+    Target Compile => _ => _
+        .DependsOn(Clean, CompileNative)
         .DependsOn(CompileHtmlPreviewer)
         .Executes(async () =>
         {

--- a/src/Avalonia.Native/Avalonia.Native.csproj
+++ b/src/Avalonia.Native/Avalonia.Native.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <PackAvaloniaNative Condition="'$(PackAvaloniaNative)' == ''">$([MSBuild]::IsOSPlatform(OSX))</PackAvaloniaNative>
+    <IsPackable>$(PackAvaloniaNative)</IsPackable>
     <IsPackable Condition="'$([MSBuild]::IsOSPlatform(OSX))' == 'True'">true</IsPackable>
     <TargetFramework>netstandard2.0</TargetFramework>
     <CastXmlPath Condition="Exists('/usr/bin/castxml')">/usr/bin/castxml</CastXmlPath>
@@ -10,8 +11,9 @@
     <SharpGenGenerateConsumerBindMapping>false</SharpGenGenerateConsumerBindMapping>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(Configuration)' == 'Release' AND '$([MSBuild]::IsOSPlatform(OSX))' == 'true'">
+  <ItemGroup Condition="'$(PackAvaloniaNative)' == 'true'">
     <Content Include="../../Build/Products/Release/libAvalonia.Native.OSX.dylib">
+      <Link>libAvaloniaNative.dylib</Link>
       <PackagePath>runtimes/osx/native/libAvaloniaNative.dylib</PackagePath>
       <Pack>true</Pack>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Improves avalonia build on mac so one can just execute nuke build, same as on windows

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
One is not able to build run ControlCatalog on mac easy, need to perform some tricky actions like:
- build manually `libAvalonia.Native.OSX.dylib`
- rename it to `libAvaloniaNative.dylib`
- copy  `libAvaloniaNative.dylib` to ControlCatalog bin dir in order to run the app

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
We should be able to just execute `nuke Compile` and be able tun run ControlCatalog on mac

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
- added new build Task `CompileAvaloniaNative` so it compiles the native lib with xcode
- configured `Avalonia.Native.csproj` to copy libAvaloniaNative to output with proper name

## Breaking changes
nope

## Fixed issues
Fixes #3113 