### PR TITLE
Fixes/Fluent fix CheckBox Foreground, Background, BorderBrush properties

### DIFF
--- a/src/Avalonia.Themes.Fluent/CheckBox.xaml
+++ b/src/Avalonia.Themes.Fluent/CheckBox.xaml
@@ -1,12 +1,11 @@
 <Styles xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <Design.PreviewWith>
     <Border Padding="20">
-      <CheckBox IsThreeState="True" IsChecked="True" />
+      <CheckBox IsThreeState="True" IsChecked="True" Content="Content" Foreground="Gold" />
     </Border>
   </Design.PreviewWith>
   <Style Selector="CheckBox">
     <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundUnchecked}" />
-    <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundUnchecked}" />
     <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUnchecked}" />
     <Setter Property="Padding" Value="8,0,0,0" />
     <Setter Property="HorizontalAlignment" Value="Left" />
@@ -55,8 +54,8 @@
   </Style>
 
   <!-- Unchecked Normal State -->
-  <Style Selector="CheckBox /template/ ContentPresenter#ContentPresenter">
-    <Setter Property="TextBlock.Foreground" Value="{DynamicResource CheckBoxForegroundUnchecked}" />
+  <Style Selector="CheckBox">
+    <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundUnchecked}" />
   </Style>
 
   <Style Selector="CheckBox /template/ Border#PART_Border">
@@ -133,8 +132,8 @@
 
 
   <!-- Checked Normal State -->
-  <Style Selector="CheckBox:checked /template/ ContentPresenter#ContentPresenter">
-    <Setter Property="TextBlock.Foreground" Value="{DynamicResource CheckBoxForegroundChecked}" />
+  <Style Selector="CheckBox:checked">
+    <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundChecked}" />
   </Style>
 
   <Style Selector="CheckBox:checked /template/ Border#PART_Border">
@@ -213,8 +212,8 @@
 
 
   <!-- Indeterminate Normal State -->
-  <Style Selector="CheckBox:indeterminate /template/ ContentPresenter#ContentPresenter">
-    <Setter Property="TextBlock.Foreground" Value="{DynamicResource CheckBoxForegroundIndeterminate}" />
+  <Style Selector="CheckBox:indeterminate">
+    <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundIndeterminate}" />
   </Style>
 
   <Style Selector="CheckBox:indeterminate /template/ Border#PART_Border">

--- a/src/Avalonia.Themes.Fluent/CheckBox.xaml
+++ b/src/Avalonia.Themes.Fluent/CheckBox.xaml
@@ -5,8 +5,6 @@
     </Border>
   </Design.PreviewWith>
   <Style Selector="CheckBox">
-    <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundUnchecked}" />
-    <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUnchecked}" />
     <Setter Property="Padding" Value="8,0,0,0" />
     <Setter Property="HorizontalAlignment" Value="Left" />
     <Setter Property="VerticalAlignment" Value="Center" />
@@ -20,10 +18,12 @@
     <Setter Property="Template">
       <ControlTemplate>
         <Grid x:Name="RootGrid" ColumnDefinitions="20,*">
-          <Border x:Name="PART_Border" Background="{TemplateBinding Background}"
-                       BorderBrush="{TemplateBinding BorderBrush}"
-                       BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{DynamicResource ControlCornerRadius}" />
+          <Border x:Name="PART_Border"
+                  Grid.ColumnSpan="2"
+                  Background="{TemplateBinding Background}"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}"
+                  CornerRadius="{DynamicResource ControlCornerRadius}" />
 
           <Grid VerticalAlignment="Top" Height="32">
             <Border x:Name="NormalRectangle"
@@ -58,7 +58,7 @@
     <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundUnchecked}" />
   </Style>
 
-  <Style Selector="CheckBox /template/ Border#PART_Border">
+  <Style Selector="CheckBox">
     <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundUnchecked}" />
     <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUnchecked}" />
   </Style>
@@ -136,7 +136,7 @@
     <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundChecked}" />
   </Style>
 
-  <Style Selector="CheckBox:checked /template/ Border#PART_Border">
+  <Style Selector="CheckBox:checked">
     <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundChecked}" />
     <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushChecked}" />
   </Style>
@@ -216,7 +216,7 @@
     <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundIndeterminate}" />
   </Style>
 
-  <Style Selector="CheckBox:indeterminate /template/ Border#PART_Border">
+  <Style Selector="CheckBox:indeterminate">
     <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundIndeterminate}" />
     <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushIndeterminate}" />
   </Style>


### PR DESCRIPTION
## What is the current behavior?
CheckBox ignores Foreground, Background, BorderBrush properties.
![image](https://user-images.githubusercontent.com/3163374/94653273-4ee14400-02c9-11eb-9b6e-64fa9cee4c5e.png)

## What is the updated/expected behavior with this PR?
It is possible to set Foreground, Background, BorderBrush properties. 
![image](https://user-images.githubusercontent.com/3163374/94653253-46890900-02c9-11eb-9fae-92cd9e8e5b13.png)

NOTE: we still need to override these properties on pointerover, pressed and disabled states, but it is expected and we have same behavior in other controls.