### PR TITLE
Bind ScrollViewer scrollbar visibility properties in ComboBox templates.

### DIFF
--- a/src/Avalonia.Themes.Default/ComboBox.xaml
+++ b/src/Avalonia.Themes.Default/ComboBox.xaml
@@ -26,6 +26,7 @@
     <Setter Property="Padding" Value="4" />
     <Setter Property="MinHeight" Value="20" />
     <Setter Property="PlaceholderForeground" Value="{DynamicResource ThemeForegroundBrush}" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
     <Setter Property="Template">
       <ControlTemplate>
         <Border Name="border"
@@ -69,7 +70,8 @@
                    IsLightDismissEnabled="True">
               <Border BorderBrush="{DynamicResource ThemeBorderMidBrush}"
                       BorderThickness="1">
-                <ScrollViewer>
+                <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
                   <ItemsPresenter Name="PART_ItemsPresenter"
                                   Items="{TemplateBinding Items}"
                                   ItemsPanel="{TemplateBinding ItemsPanel}"

--- a/src/Avalonia.Themes.Fluent/ComboBox.xaml
+++ b/src/Avalonia.Themes.Fluent/ComboBox.xaml
@@ -133,7 +133,8 @@
                     Padding="{DynamicResource ComboBoxDropdownBorderPadding}"
                     HorizontalAlignment="Stretch"
                     CornerRadius="{DynamicResource OverlayCornerRadius}">
-              <ScrollViewer>
+              <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                            VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
                 <ItemsPresenter Name="PART_ItemsPresenter"
                                 Items="{TemplateBinding Items}"
                                 Margin="{DynamicResource ComboBoxDropdownContentMargin}"


### PR DESCRIPTION
## What does the pull request do?

As described in #4768, if the `ComboBox` popup width is limited, the displayed `ComboBoxItem`s get cut off. This is because the `ScrollViewer` in the `Popup` has its `HorizontalScrollBarVisibility` property set to `Hidden` instead of `Disabled` and so is giving infinite width to the `ComboBoxItem`s.

To fix this, bind the `ScrollViewer` scrollbar visibility properties to the templated parent and disable the horizontal scrollbar on the default theme (this was already being done in fluent theme).

## Fixed issues

Fixes #4768.
