### PR TITLE
Fixes 4781  - listbox selecteditem not in item ignored

### DIFF
--- a/src/Avalonia.Controls/Selection/SelectionModel.cs
+++ b/src/Avalonia.Controls/Selection/SelectionModel.cs
@@ -98,7 +98,12 @@ namespace Avalonia.Controls.Selection
             {
                 if (ItemsView is object)
                 {
-                    SelectedIndex = ItemsView.IndexOf(value!);
+                    var index = ItemsView.IndexOf(value!);
+
+                    if (index >= 0)
+                    {
+                        SelectedIndex = index;
+                    }
                 }
                 else
                 {

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -385,7 +385,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
-        public void Setting_SelectedItem_To_Not_Present_Item_Should_Clear_Selection()
+        public void Setting_SelectedItem_To_Not_Present_Item_Should_Be_Ignored()
         {
             var items = new[]
             {
@@ -407,8 +407,8 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
             target.SelectedItem = new Item();
 
-            Assert.Null(target.SelectedItem);
-            Assert.Equal(-1, target.SelectedIndex);
+            Assert.Equal(items[1], target.SelectedItem);
+            Assert.Equal(1, target.SelectedIndex);
         }
 
         [Fact]


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Changes the behavior of ListBox so that setting the `SelectedItem` to an object not inside its `Items` list is ignored. This matches the behavior of WPF.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
We clear the selection if this situation occurs.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
We ignore the new value.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #4781