### PR TITLE
Fluent non-transparent notification background

### DIFF
--- a/src/Avalonia.Themes.Fluent/Accents/FluentControlResourcesDark.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/FluentControlResourcesDark.xaml
@@ -439,7 +439,7 @@
     <StaticResource x:Key="CalendarViewNavigationButtonBorderBrush" ResourceKey="SystemControlTransparentBrush" />
     
     <!--Resources for NotificationCard.xaml -->
-    <SolidColorBrush x:Key="NotificationCardBackgroundBrush" Color="#444444" Opacity="0.75"/>
+    <SolidColorBrush x:Key="NotificationCardBackgroundBrush" Color="#444444" />
     <SolidColorBrush x:Key="NotificationCardProgressBackgroundBrush" Color="#9A9A9A" />
     <SolidColorBrush x:Key="NotificationCardInformationBackgroundBrush" Color="#007ACC" Opacity="0.75"/>
     <SolidColorBrush x:Key="NotificationCardSuccessBackgroundBrush" Color="#1F9E45" Opacity="0.75"/>


### PR DESCRIPTION
## What is the current behavior?
![image](https://user-images.githubusercontent.com/3163374/95302346-d5f56580-084f-11eb-940d-8fe48c89b324.png)

## What is the updated/expected behavior with this PR?
Notification isn't transparent.