### PR TITLE
Fix ApiDiff.props for Turkish locale.

### DIFF
--- a/build/ApiDiff.props
+++ b/build/ApiDiff.props
@@ -7,6 +7,6 @@
     <ItemGroup>
       <PackageDownload Include="$(NugetPackageName)" Version="[$(ApiContractPackageVersion)]" />
       <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20372.2" PrivateAssets="All" />
-    <ResolvedMatchingContract Include="$(NuGetPackageRoot)\$(NugetPackageName.ToLower())\$(ApiContractPackageVersion)\lib\$(TargetFramework)\$(AssemblyName).dll" />
+      <ResolvedMatchingContract Include="$(NuGetPackageRoot)\$(NugetPackageName.ToLowerInvariant())\$(ApiContractPackageVersion)\lib\$(TargetFramework)\$(AssemblyName).dll" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes builds on machines with Turkish locale.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Avalonia.ReactiveUI project gives an error because a wrong file path is queried. (Note the `ı` character.)

```
...\avalonia.reactiveuı\0.10.0-preview3\lib\netstandard2.0\Avalonia.ReactiveUI.dll' did not exist.
```
