### PR TITLE
Fix IsChecked property differing from :checked pseudoclass

### DIFF
--- a/src/Avalonia.Controls/Primitives/ToggleButton.cs
+++ b/src/Avalonia.Controls/Primitives/ToggleButton.cs
@@ -94,7 +94,7 @@ namespace Avalonia.Controls.Primitives
             set 
             { 
                 SetAndRaise(IsCheckedProperty, ref _isChecked, value);
-                UpdatePseudoClasses(value);
+                UpdatePseudoClasses(IsChecked);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
Fixes a bug where `IsChecked` could be true on a button without the `:checked` pseudoclass, so it would appear unchecked on the UI.

## What is the current behavior?
`SetAndRaise` does not always change the property value, but `UpdatePseudoClasses` would always be called with the new value, regardless of whether or not it was actually applied.

## What is the updated/expected behavior with this PR?
`IsChecked` should now always remain in sync with the `:checked` and `:unchecked` pseudoclasses.


## How was the solution implemented (if it's not obvious)?
Call `UpdatePseudoClasses` with the actual value of `IsChecked`, not the (possibly incorrect) new value.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes

## Fixed issues
