### PR TITLE
Fix autoscroll to selected item in listbox #4855

### DIFF
--- a/src/Avalonia.Controls/Presenters/ItemVirtualizerSimple.cs
+++ b/src/Avalonia.Controls/Presenters/ItemVirtualizerSimple.cs
@@ -512,6 +512,14 @@ namespace Avalonia.Controls.Presenters
             var generator = Owner.ItemContainerGenerator;
             var newOffset = -1.0;
 
+            if (!panel.IsMeasureValid && panel.PreviousMeasure.HasValue)
+            {
+                //before any kind of scrolling we need to make sure panel measure is valid
+                //or we risk get panel into not valid state
+                //we make a preemptive quick measure so scrolling is valid
+                panel.Measure(panel.PreviousMeasure.Value);
+            }
+
             if (index >= 0 && index < ItemCount)
             {
                 if (index <= FirstIndex)

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
@@ -407,6 +407,53 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(1, raised);
         }
 
+        [Fact]
+        public void Adding_And_Selecting_Item_With_AutoScrollToSelectedItem_Should_NotHide_FirstItem()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var items = new AvaloniaList<string>();
+
+                var wnd = new Window() { Width = 100, Height = 100, IsVisible = true };
+
+                var target = new ListBox()
+                {
+                    VerticalAlignment = Layout.VerticalAlignment.Top,
+                    AutoScrollToSelectedItem = true,
+                    Width = 50,
+                    VirtualizationMode = ItemVirtualizationMode.Simple,
+                    ItemTemplate = new FuncDataTemplate<object>((c, _) => new Border() { Height = 10 }),
+                    Items = items,
+                };
+                wnd.Content = target;
+
+                var lm = wnd.LayoutManager;
+
+                lm.ExecuteInitialLayoutPass();
+
+                var panel = target.Presenter.Panel;
+
+                items.Add("Item 1");
+                target.Selection.Select(0);
+                lm.ExecuteLayoutPass();
+
+                Assert.Equal(1, panel.Children.Count);
+
+                items.Add("Item 2");
+                target.Selection.Select(1);
+                lm.ExecuteLayoutPass();
+
+                Assert.Equal(2, panel.Children.Count);
+
+                //make sure we have enough space to show all items
+                Assert.True(panel.Bounds.Height >= panel.Children.Sum(c => c.Bounds.Height));
+
+                //make sure we show items and they completelly visible, not only partially
+                Assert.True(panel.Children[0].Bounds.Top >= 0 && panel.Children[0].Bounds.Bottom <= panel.Bounds.Height, "first item is not completelly visible!");
+                Assert.True(panel.Children[1].Bounds.Top >= 0 && panel.Children[1].Bounds.Bottom <= panel.Bounds.Height, "second item is not completelly visible!");
+            }
+        }
+
         private FuncControlTemplate ListBoxTemplate()
         {
             return new FuncControlTemplate<ListBox>((parent, scope) =>


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes auto selection of listbox

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
if item is added and selected immediatelly (in specific conditions #4855) first item of the listbox is hidden

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
listbox will not scroll to hide first item if there is enough space

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Before we attempt to scroll we force update layout of the virtualizing panel (only if needed), so we have valid state of the child items in the panel

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->
Nope

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #4855 