### PR TITLE
Fixed invalid cast issue if source isn't visual and nullability warnings

### DIFF
--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -356,17 +356,13 @@ namespace Avalonia.Controls.Primitives
         /// <returns>The container or null if the event did not originate in a container.</returns>
         protected IControl? GetContainerFromEventSource(IInteractive eventSource)
         {
-            var parent = (IVisual)eventSource;
-
-            while (parent != null)
+            for (var current = eventSource as IVisual; current != null; current = current.VisualParent)
             {
-                if (parent is IControl control && control.LogicalParent == this
-                                               && ItemContainerGenerator?.IndexFromContainer(control) != -1)
+                if (current is IControl control && control.LogicalParent == this &&
+                    ItemContainerGenerator?.IndexFromContainer(control) != -1)
                 {
                     return control;
                 }
-
-                parent = parent.VisualParent;
             }
 
             return null;

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -354,7 +354,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         /// <param name="eventSource">The control that raised the event.</param>
         /// <returns>The container or null if the event did not originate in a container.</returns>
-        protected IControl? GetContainerFromEventSource(IInteractive eventSource)
+        protected IControl? GetContainerFromEventSource(IInteractive? eventSource)
         {
             for (var current = eventSource as IVisual; current != null; current = current.VisualParent)
             {
@@ -666,7 +666,7 @@ namespace Avalonia.Controls.Primitives
         /// false.
         /// </returns>
         protected bool UpdateSelectionFromEventSource(
-            IInteractive eventSource,
+            IInteractive? eventSource,
             bool select = true,
             bool rangeModifier = false,
             bool toggleModifier = false,


### PR DESCRIPTION
## What does the pull request do?

The PR fixes nullability of an parameter and a warning caused by it. The `eventSource` parameter of `UpdateSelectionFromEventSource` wasn't nullable while `GetContainerFromEventSource` accepts a nullable value. Plus there's a possible invalid cast exception in case when `eventSource` isn't a visual.


## What is the current behavior?

The current behavior is a few compiler warnings in Avalonia and the user code calling `UpdateSelectionFromEventSource`. Plus a potential invalid cast.

## What is the updated/expected behavior with this PR?

In case when an `eventSource` isn't a visual and not a `null`, the `GetContainerFromEventSource` returns a `null` value since it's unable to traverse visual tree upward. Less compiler warnings.