### PR TITLE
Replaced flag checking expressions by Enum.HasValue

### DIFF
--- a/src/Avalonia.Base/Utilities/TypeUtilities.cs
+++ b/src/Avalonia.Base/Utilities/TypeUtilities.cs
@@ -372,8 +372,8 @@ namespace Avalonia.Utilities
             const string implicitName = "op_Implicit";
             const string explicitName = "op_Explicit";
 
-            bool allowImplicit = (operatorType & OperatorType.Implicit) != 0;
-            bool allowExplicit = (operatorType & OperatorType.Explicit) != 0;
+            bool allowImplicit = operatorType.HasFlag(OperatorType.Implicit);
+            bool allowExplicit = operatorType.HasFlag(OperatorType.Explicit);
 
             foreach (MethodInfo method in fromType.GetMethods())
             {

--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
@@ -2595,7 +2595,7 @@ namespace Avalonia.Collections
         /// <returns>Whether the specified flag is set</returns>
         private bool CheckFlag(CollectionViewFlags flags)
         {
-            return (_flags & flags) != 0;
+            return _flags.HasFlags(flags);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -189,7 +189,7 @@ namespace Avalonia.Controls
                 return;
 
             if (e.Key == Key.F4 ||
-                ((e.Key == Key.Down || e.Key == Key.Up) && ((e.KeyModifiers & KeyModifiers.Alt) != 0)))
+                ((e.Key == Key.Down || e.Key == Key.Up) && e.KeyModifiers.HasFlag(KeyModifiers.Alt)))
             {
                 IsDropDownOpen = !IsDropDownOpen;
                 e.Handled = true;

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -637,7 +637,7 @@ namespace Avalonia.Controls
         /// </summary>
         internal bool MeasureOverrideInProgress
         {
-            get { return (CheckFlagsAnd(Flags.MeasureOverrideInProgress)); }
+            get { return CheckFlags(Flags.MeasureOverrideInProgress); }
             set { SetFlags(value, Flags.MeasureOverrideInProgress); }
         }
 
@@ -646,7 +646,7 @@ namespace Avalonia.Controls
         /// </summary>
         internal bool ArrangeOverrideInProgress
         {
-            get { return (CheckFlagsAnd(Flags.ArrangeOverrideInProgress)); }
+            get { return CheckFlags(Flags.ArrangeOverrideInProgress); }
             set { SetFlags(value, Flags.ArrangeOverrideInProgress); }
         }
 
@@ -2350,25 +2350,12 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// CheckFlagsAnd returns <c>true</c> if all the flags in the
+        /// CheckFlags returns <c>true</c> if all the flags in the
         /// given bitmask are set on the object.
         /// </summary>
-        private bool CheckFlagsAnd(Flags flags)
+        private bool CheckFlags(Flags flags)
         {
-            return ((_flags & flags) == flags);
-        }
-
-        /// <summary>
-        /// CheckFlagsOr returns <c>true</c> if at least one flag in the
-        /// given bitmask is set.
-        /// </summary>
-        /// <remarks>
-        /// If no bits are set in the given bitmask, the method returns
-        /// <c>true</c>.
-        /// </remarks>
-        private bool CheckFlagsOr(Flags flags)
-        {
-            return (flags == 0 || (_flags & flags) != 0);
+            return _flags.HasFlag(flags);
         }
 
         private static void OnShowGridLinesPropertyChanged(AvaloniaObject d, AvaloniaPropertyChangedEventArgs e)
@@ -2535,7 +2522,7 @@ namespace Avalonia.Controls
         /// </summary>
         private bool CellsStructureDirty
         {
-            get { return (!CheckFlagsAnd(Flags.ValidCellsStructure)); }
+            get { return !CheckFlags(Flags.ValidCellsStructure); }
             set { SetFlags(!value, Flags.ValidCellsStructure); }
         }
 
@@ -2544,7 +2531,7 @@ namespace Avalonia.Controls
         /// </summary>
         private bool ListenToNotifications
         {
-            get { return (CheckFlagsAnd(Flags.ListenToNotifications)); }
+            get { return CheckFlags(Flags.ListenToNotifications); }
             set { SetFlags(value, Flags.ListenToNotifications); }
         }
 
@@ -2553,7 +2540,7 @@ namespace Avalonia.Controls
         /// </summary>
         private bool SizeToContentU
         {
-            get { return (CheckFlagsAnd(Flags.SizeToContentU)); }
+            get { return CheckFlags(Flags.SizeToContentU); }
             set { SetFlags(value, Flags.SizeToContentU); }
         }
 
@@ -2562,7 +2549,7 @@ namespace Avalonia.Controls
         /// </summary>
         private bool SizeToContentV
         {
-            get { return (CheckFlagsAnd(Flags.SizeToContentV)); }
+            get { return CheckFlags(Flags.SizeToContentV); }
             set { SetFlags(value, Flags.SizeToContentV); }
         }
 
@@ -2571,7 +2558,7 @@ namespace Avalonia.Controls
         /// </summary>
         private bool HasStarCellsU
         {
-            get { return (CheckFlagsAnd(Flags.HasStarCellsU)); }
+            get { return CheckFlags(Flags.HasStarCellsU); }
             set { SetFlags(value, Flags.HasStarCellsU); }
         }
 
@@ -2580,7 +2567,7 @@ namespace Avalonia.Controls
         /// </summary>
         private bool HasStarCellsV
         {
-            get { return (CheckFlagsAnd(Flags.HasStarCellsV)); }
+            get { return CheckFlags(Flags.HasStarCellsV); }
             set { SetFlags(value, Flags.HasStarCellsV); }
         }
 
@@ -2589,7 +2576,7 @@ namespace Avalonia.Controls
         /// </summary>
         private bool HasGroup3CellsInAutoRows
         {
-            get { return (CheckFlagsAnd(Flags.HasGroup3CellsInAutoRows)); }
+            get { return CheckFlags(Flags.HasGroup3CellsInAutoRows); }
             set { SetFlags(value, Flags.HasGroup3CellsInAutoRows); }
         }
 
@@ -2803,10 +2790,10 @@ namespace Avalonia.Controls
             internal LayoutTimeSizeType SizeTypeU;
             internal LayoutTimeSizeType SizeTypeV;
             internal int Next;
-            internal bool IsStarU { get { return ((SizeTypeU & LayoutTimeSizeType.Star) != 0); } }
-            internal bool IsAutoU { get { return ((SizeTypeU & LayoutTimeSizeType.Auto) != 0); } }
-            internal bool IsStarV { get { return ((SizeTypeV & LayoutTimeSizeType.Star) != 0); } }
-            internal bool IsAutoV { get { return ((SizeTypeV & LayoutTimeSizeType.Auto) != 0); } }
+            internal bool IsStarU => SizeTypeU.HasFlag(LayoutTimeSizeType.Star);
+            internal bool IsAutoU => SizeTypeU.HasFlag(LayoutTimeSizeType.Auto);
+            internal bool IsStarV => SizeTypeV.HasFlag(LayoutTimeSizeType.Star);
+            internal bool IsAutoV => SizeTypeV.HasFlag(LayoutTimeSizeType.Auto);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -135,8 +135,8 @@ namespace Avalonia.Controls
                 e.Handled = UpdateSelectionFromEventSource(
                     e.Source,
                     true,
-                    (e.KeyModifiers & KeyModifiers.Shift) != 0,
-                    (e.KeyModifiers & KeyModifiers.Control) != 0);
+                    e.KeyModifiers.HasFlag(KeyModifiers.Shift),
+                    e.KeyModifiers.HasFlag(KeyModifiers.Control));
             }
         }
 
@@ -154,8 +154,8 @@ namespace Avalonia.Controls
                     e.Handled = UpdateSelectionFromEventSource(
                         e.Source,
                         true,
-                        (e.KeyModifiers & KeyModifiers.Shift) != 0,
-                        (e.KeyModifiers & KeyModifiers.Control) != 0,
+                        e.KeyModifiers.HasFlag(KeyModifiers.Shift),
+                        e.KeyModifiers.HasFlag(KeyModifiers.Control),
                         point.Properties.IsRightButtonPressed);
                 }
             }

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
@@ -253,9 +253,8 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
     {
         public static void ValidateEdge(this PopupAnchor edge)
         {
-            if (((edge & PopupAnchor.Left) != 0 && (edge & PopupAnchor.Right) != 0)
-                ||
-                ((edge & PopupAnchor.Top) != 0 && (edge & PopupAnchor.Bottom) != 0))
+            if (edge.HasFlag(PopupAnchor.Left) && edge.HasFlag(PopupAnchor.Right) ||
+                edge.HasFlag(PopupAnchor.Top) && edge.HasFlag(PopupAnchor.Bottom))
                 throw new ArgumentException("Opposite edges specified");
         }
 
@@ -266,25 +265,25 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
 
         public static PopupAnchor Flip(this PopupAnchor edge)
         {
-            var hmask = PopupAnchor.Left | PopupAnchor.Right;
-            var vmask = PopupAnchor.Top | PopupAnchor.Bottom;
-            if ((edge & hmask) != 0)
-                edge ^= hmask;
-            if ((edge & vmask) != 0)
-                edge ^= vmask;
+            if (edge.HasFlag(PopupAnchor.HorizontalMask))
+                edge ^= PopupAnchor.HorizontalMask;
+
+            if (edge.HasFlag(PopupAnchor.VerticalMask))
+                edge ^= PopupAnchor.VerticalMask;
+
             return edge;
         }
 
         public static PopupAnchor FlipX(this PopupAnchor edge)
         {
-            if ((edge & PopupAnchor.HorizontalMask) != 0)
+            if (edge.HasFlag(PopupAnchor.HorizontalMask))
                 edge ^= PopupAnchor.HorizontalMask;
             return edge;
         }
         
         public static PopupAnchor FlipY(this PopupAnchor edge)
         {
-            if ((edge & PopupAnchor.VerticalMask) != 0)
+            if (edge.HasFlag(PopupAnchor.VerticalMask))
                 edge ^= PopupAnchor.VerticalMask;
             return edge;
         }

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositioner.cs
@@ -42,16 +42,16 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
         private static Point GetAnchorPoint(Rect anchorRect, PopupAnchor edge)
         {
             double x, y;
-            if ((edge & PopupAnchor.Left) != 0)
+            if (edge.HasFlag(PopupAnchor.Left))
                 x = anchorRect.X;
-            else if ((edge & PopupAnchor.Right) != 0)
+            else if (edge.HasFlag(PopupAnchor.Right))
                 x = anchorRect.Right;
             else
                 x = anchorRect.X + anchorRect.Width / 2;
             
-            if ((edge & PopupAnchor.Top) != 0)
+            if (edge.HasFlag(PopupAnchor.Top))
                 y = anchorRect.Y;
-            else if ((edge & PopupAnchor.Bottom) != 0)
+            else if (edge.HasFlag(PopupAnchor.Bottom))
                 y = anchorRect.Bottom;
             else
                 y = anchorRect.Y + anchorRect.Height / 2;
@@ -61,16 +61,16 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
         private static Point Gravitate(Point anchorPoint, Size size, PopupGravity gravity)
         {
             double x, y;
-            if ((gravity & PopupGravity.Left) != 0)
+            if (gravity.HasFlag(PopupGravity.Left))
                 x = -size.Width;
-            else if ((gravity & PopupGravity.Right) != 0)
+            else if (gravity.HasFlag(PopupGravity.Right))
                 x = 0;
             else
                 x = -size.Width / 2;
             
-            if ((gravity & PopupGravity.Top) != 0)
+            if (gravity.HasFlag(PopupGravity.Top))
                 y = -size.Height;
-            else if ((gravity & PopupGravity.Bottom) != 0)
+            else if (gravity.HasFlag(PopupGravity.Bottom))
                 y = 0;
             else
                 y = -size.Height / 2;
@@ -125,21 +125,13 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
 
             bool FitsInBounds(Rect rc, PopupAnchor edge = PopupAnchor.AllMask)
             {
-                if ((edge & PopupAnchor.Left) != 0
-                    && rc.X < bounds.X)
+                if (edge.HasFlag(PopupAnchor.Left) && rc.X < bounds.X ||
+                    edge.HasFlag(PopupAnchor.Top) && rc.Y < bounds.Y ||
+                    edge.HasFlag(PopupAnchor.Right) && rc.Right > bounds.Right ||
+                    edge.HasFlag(PopupAnchor.Bottom) && rc.Bottom > bounds.Bottom)
+                {
                     return false;
-
-                if ((edge & PopupAnchor.Top) != 0
-                    && rc.Y < bounds.Y)
-                    return false;
-
-                if ((edge & PopupAnchor.Right) != 0
-                    && rc.Right > bounds.Right)
-                    return false;
-
-                if ((edge & PopupAnchor.Bottom) != 0
-                    && rc.Bottom > bounds.Bottom)
-                    return false;
+                }
 
                 return true;
             }
@@ -155,7 +147,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             // If flipping geometry and anchor is allowed and helps, use the flipped one,
             // otherwise leave it as is
             if (!FitsInBounds(geo, PopupAnchor.HorizontalMask)
-                && (constraintAdjustment & PopupPositionerConstraintAdjustment.FlipX) != 0)
+                && constraintAdjustment.HasFlag(PopupPositionerConstraintAdjustment.FlipX))
             {
                 var flipped = GetUnconstrained(anchor.FlipX(), gravity.FlipX());
                 if (FitsInBounds(flipped, PopupAnchor.HorizontalMask))
@@ -163,7 +155,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             }
 
             // If sliding is allowed, try moving the rect into the bounds
-            if ((constraintAdjustment & PopupPositionerConstraintAdjustment.SlideX) != 0)
+            if (constraintAdjustment.HasFlag(PopupPositionerConstraintAdjustment.SlideX))
             {
                 geo = geo.WithX(Math.Max(geo.X, bounds.X));
                 if (geo.Right > bounds.Right)
@@ -171,7 +163,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             }
             
             // Resize the rect horizontally if allowed.
-            if ((constraintAdjustment & PopupPositionerConstraintAdjustment.ResizeX) != 0)
+            if (constraintAdjustment.HasFlag(PopupPositionerConstraintAdjustment.ResizeX))
             {
                 var unconstrainedRect = geo;
 
@@ -194,7 +186,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             // If flipping geometry and anchor is allowed and helps, use the flipped one,
             // otherwise leave it as is
             if (!FitsInBounds(geo, PopupAnchor.VerticalMask)
-                && (constraintAdjustment & PopupPositionerConstraintAdjustment.FlipY) != 0)
+                && constraintAdjustment.HasFlag(PopupPositionerConstraintAdjustment.FlipY))
             {
                 var flipped = GetUnconstrained(anchor.FlipY(), gravity.FlipY());
                 if (FitsInBounds(flipped, PopupAnchor.VerticalMask))
@@ -202,7 +194,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             }
 
             // If sliding is allowed, try moving the rect into the bounds
-            if ((constraintAdjustment & PopupPositionerConstraintAdjustment.SlideY) != 0)
+            if (constraintAdjustment.HasFlag(PopupPositionerConstraintAdjustment.SlideY))
             {
                 geo = geo.WithY(Math.Max(geo.Y, bounds.Y));
                 if (geo.Bottom > bounds.Bottom)
@@ -210,7 +202,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             }
 
             // Resize the rect vertically if allowed.
-            if ((constraintAdjustment & PopupPositionerConstraintAdjustment.ResizeY) != 0)
+            if (constraintAdjustment.HasFlag(PopupPositionerConstraintAdjustment.ResizeY))
             {
                 var unconstrainedRect = geo;
 

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -321,7 +321,7 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Gets a value indicating whether <see cref="SelectionMode.AlwaysSelected"/> is set.
         /// </summary>
-        protected bool AlwaysSelected => (SelectionMode & SelectionMode.AlwaysSelected) != 0;
+        protected bool AlwaysSelected => SelectionMode.HasFlag(SelectionMode.AlwaysSelected);
 
         /// <inheritdoc/>
         public override void BeginInit()
@@ -581,8 +581,8 @@ namespace Avalonia.Controls.Primitives
             }
 
             var mode = SelectionMode;
-            var multi = (mode & SelectionMode.Multiple) != 0;
-            var toggle = (toggleModifier || (mode & SelectionMode.Toggle) != 0);
+            var multi = mode.HasFlag(SelectionMode.Multiple);
+            var toggle = toggleModifier || mode.HasFlag(SelectionMode.Toggle);
             var range = multi && rangeModifier;
 
             if (!select)

--- a/src/Avalonia.Controls/Repeater/RepeaterLayoutContext.cs
+++ b/src/Avalonia.Controls/Repeater/RepeaterLayoutContext.cs
@@ -53,8 +53,8 @@ namespace Avalonia.Controls
         {
             return _owner.GetElementImpl(
                 index,
-                (options & ElementRealizationOptions.ForceCreate) != 0,
-                (options & ElementRealizationOptions.SuppressAutoRecycle) != 0);
+                options.HasFlag(ElementRealizationOptions.ForceCreate),
+                options.HasFlag(ElementRealizationOptions.SuppressAutoRecycle));
         }
 
         protected override object GetItemAtCore(int index) => _owner.ItemsSourceView.GetAt(index);

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -411,7 +411,7 @@ namespace Avalonia.Controls
                 e.Handled = UpdateSelectionFromEventSource(
                     e.Source,
                     true,
-                    (e.KeyModifiers & KeyModifiers.Shift) != 0);
+                    e.KeyModifiers.HasFlag(KeyModifiers.Shift));
             }
         }
 
@@ -520,8 +520,8 @@ namespace Avalonia.Controls
                     e.Handled = UpdateSelectionFromEventSource(
                         e.Source,
                         true,
-                        (e.KeyModifiers & KeyModifiers.Shift) != 0,
-                        (e.KeyModifiers & KeyModifiers.Control) != 0,
+                        e.KeyModifiers.HasFlag(KeyModifiers.Shift),
+                        e.KeyModifiers.HasFlag(KeyModifiers.Control),
                         point.Properties.IsRightButtonPressed);
                 }
             }
@@ -557,9 +557,9 @@ namespace Avalonia.Controls
             }
 
             var mode = SelectionMode;
-            var toggle = toggleModifier || (mode & SelectionMode.Toggle) != 0;
-            var multi = (mode & SelectionMode.Multiple) != 0;
-            var range = multi && selectedContainer != null && rangeModifier;
+            var toggle = toggleModifier || mode.HasFlag(SelectionMode.Toggle);
+            var multi = mode.HasFlag(SelectionMode.Multiple);
+            var range = multi && rangeModifier && selectedContainer != null;
 
             if (rightButton)
             {

--- a/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
+++ b/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
@@ -223,13 +223,13 @@ namespace Avalonia.FreeDesktop
                             return null;
                         var lst = new List<string>();
                         var mod = item.Gesture;
-                        if ((mod.KeyModifiers & KeyModifiers.Control) != 0)
+                        if (mod.KeyModifiers.HasFlag(KeyModifiers.Control))
                             lst.Add("Control");
-                        if ((mod.KeyModifiers & KeyModifiers.Alt) != 0)
+                        if (mod.KeyModifiers.HasFlag(KeyModifiers.Alt))
                             lst.Add("Alt");
-                        if ((mod.KeyModifiers & KeyModifiers.Shift) != 0)
+                        if (mod.KeyModifiers.HasFlag(KeyModifiers.Shift))
                             lst.Add("Shift");
-                        if ((mod.KeyModifiers & KeyModifiers.Meta) != 0)
+                        if (mod.KeyModifiers.HasFlag(KeyModifiers.Meta))
                             lst.Add("Super");
                         lst.Add(item.Gesture.Key.ToString());
                         return new[] { lst.ToArray() };

--- a/src/Avalonia.Input/AccessKeyHandler.cs
+++ b/src/Avalonia.Input/AccessKeyHandler.cs
@@ -177,7 +177,7 @@ namespace Avalonia.Input
         {
             bool menuIsOpen = MainMenu?.IsOpen == true;
 
-            if ((e.KeyModifiers & KeyModifiers.Alt) != 0 || menuIsOpen)
+            if (e.KeyModifiers.HasFlag(KeyModifiers.Alt) || menuIsOpen)
             {
                 // If any other key is pressed with the Alt key held down, or the main menu is open,
                 // find all controls who have registered that access key.


### PR DESCRIPTION
## What does the pull request do?

The PR replaces expression checking the value for a flag by invocation of `Enum.HasFlag` which isn't boxing since 2017 (dotnet/runtime#6080).

## What is the current behavior?

Currently there are a lot of hand written expressions checking for null which can be simplified.

## What is the updated/expected behavior with this PR?

No changes except more clean code.