### PR TITLE
Fixed key gesture matching when this has an OEM key

### DIFF
--- a/src/Avalonia.Input/KeyGesture.cs
+++ b/src/Avalonia.Input/KeyGesture.cs
@@ -144,7 +144,10 @@ namespace Avalonia.Input
             return s.ToString();
         }
 
-        public bool Matches(KeyEventArgs keyEvent) => ResolveNumPadOperationKey(keyEvent.Key) == Key && keyEvent.KeyModifiers == KeyModifiers;
+        public bool Matches(KeyEventArgs keyEvent) =>
+            keyEvent != null &&
+            keyEvent.KeyModifiers == KeyModifiers &&
+            ResolveNumPadOperationKey(keyEvent.Key) == ResolveNumPadOperationKey(Key);
 
         // TODO: Move that to external key parser
         private static Key ParseKey(string key)


### PR DESCRIPTION
## What does the pull request do?

Fixes a key gesture matching bug when the current has an OEM key.

## What is the current behavior?

The current behavior is to return `false` due to conversion of comparand's key while the current has an OEM key. Therefore, matching works only for comparands which don't have OEM specific keys.

## What is the updated/expected behavior with this PR?

Both keys converted from OEM specific values and compared afterwards, so matching works for OEM and non-OEM keys.

/cc @MarchingCube