### PR TITLE
Enable light dismiss overlay for popups

### DIFF
--- a/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
+++ b/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
@@ -67,8 +67,6 @@ namespace Avalonia.Controls.Primitives
         {
             get
             {
-                if (IsPopup)
-                    return null;
                 var rv = FindLayer<LightDismissOverlayLayer>();
                 if (rv == null)
                 {


### PR DESCRIPTION
Enable light dismiss for popups. 
Fixed problem: a ComboBox inside of a Popup doesn't get dismissed if parent Popup got clicked on