### PR TITLE
Replaced LogToDebug with LogToTrace.

### DIFF
--- a/samples/BindingDemo/App.xaml.cs
+++ b/samples/BindingDemo/App.xaml.cs
@@ -26,6 +26,6 @@ namespace BindingDemo
           => AppBuilder.Configure<App>()
                 .UsePlatformDetect()
                 .UseReactiveUI()
-                .LogToDebug();
+                .LogToTrace();
     }
 }

--- a/samples/ControlCatalog.Desktop/Program.cs
+++ b/samples/ControlCatalog.Desktop/Program.cs
@@ -18,7 +18,7 @@ namespace ControlCatalog
         /// </summary>
         public static AppBuilder BuildAvaloniaApp()
             => AppBuilder.Configure<App>()
-                .LogToDebug()
+                .LogToTrace()
                 .UsePlatformDetect()
                 .UseReactiveUI();
 

--- a/samples/ControlCatalog.NetCore/Program.cs
+++ b/samples/ControlCatalog.NetCore/Program.cs
@@ -121,7 +121,7 @@ namespace ControlCatalog.NetCore
                 .UseSkia()
                 .UseReactiveUI()
                 .UseManagedSystemDialogs()
-                .LogToDebug();
+                .LogToTrace();
 
         static void SilenceConsole()
         {

--- a/samples/RenderDemo/App.xaml.cs
+++ b/samples/RenderDemo/App.xaml.cs
@@ -33,6 +33,6 @@ namespace RenderDemo
                })
                 .UsePlatformDetect()
                 .UseReactiveUI()
-                .LogToDebug();
+                .LogToTrace();
     }
 }

--- a/samples/Sandbox/Program.cs
+++ b/samples/Sandbox/Program.cs
@@ -10,7 +10,7 @@ namespace Sandbox
             AppBuilder.Configure<App>()
                 .UsePlatformDetect()
                 .UseReactiveUI()
-                .LogToDebug()
+                .LogToTrace()
                 .StartWithClassicDesktopLifetime(args);
         }
     }

--- a/samples/VirtualizationDemo/Program.cs
+++ b/samples/VirtualizationDemo/Program.cs
@@ -9,7 +9,7 @@ namespace VirtualizationDemo
             => AppBuilder.Configure<App>()
                 .UsePlatformDetect()
                 .UseReactiveUI()
-                .LogToDebug();
+                .LogToTrace();
 
         public static int Main(string[] args)
             => BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);

--- a/src/Avalonia.Base/ApiCompatBaseline.txt
+++ b/src/Avalonia.Base/ApiCompatBaseline.txt
@@ -1,3 +1,4 @@
 Compat issues with assembly Avalonia.Base:
 CannotAddAbstractMembers : Member 'protected System.IObservable<Avalonia.AvaloniaPropertyChangedEventArgs> Avalonia.AvaloniaProperty.GetChanged()' is abstract in the implementation but is missing in the contract.
-Total Issues: 1
+TypesMustExist : Type 'Avalonia.Logging.DebugLogSink' does not exist in the implementation but it does exist in the contract.
+Total Issues: 2

--- a/src/Avalonia.Base/Logging/TraceLogSink.cs
+++ b/src/Avalonia.Base/Logging/TraceLogSink.cs
@@ -6,12 +6,12 @@ using Avalonia.Utilities;
 
 namespace Avalonia.Logging
 {
-    public class DebugLogSink : ILogSink
+    public class TraceLogSink : ILogSink
     {
         private readonly LogEventLevel _level;
         private readonly IList<string> _areas;
 
-        public DebugLogSink(
+        public TraceLogSink(
             LogEventLevel minimumLevel,
             IList<string> areas = null)
         {
@@ -28,7 +28,7 @@ namespace Avalonia.Logging
         {
             if (IsEnabled(level, area))
             {
-                Debug.WriteLine(Format<object, object, object>(area, messageTemplate, source));
+                Trace.WriteLine(Format<object, object, object>(area, messageTemplate, source));
             }
         }
 
@@ -36,7 +36,7 @@ namespace Avalonia.Logging
         {
             if (IsEnabled(level, area))
             {
-                Debug.WriteLine(Format<T0, object, object>(area, messageTemplate, source, propertyValue0));
+                Trace.WriteLine(Format<T0, object, object>(area, messageTemplate, source, propertyValue0));
             }
         }
 
@@ -44,7 +44,7 @@ namespace Avalonia.Logging
         {
             if (IsEnabled(level, area))
             {
-                Debug.WriteLine(Format<T0, T1, object>(area, messageTemplate, source, propertyValue0, propertyValue1));
+                Trace.WriteLine(Format<T0, T1, object>(area, messageTemplate, source, propertyValue0, propertyValue1));
             }
         }
 
@@ -52,7 +52,7 @@ namespace Avalonia.Logging
         {
             if (IsEnabled(level, area))
             {
-                Debug.WriteLine(Format(area, messageTemplate, source, propertyValue0, propertyValue1, propertyValue2));
+                Trace.WriteLine(Format(area, messageTemplate, source, propertyValue0, propertyValue1, propertyValue2));
             }
         }
 
@@ -60,7 +60,7 @@ namespace Avalonia.Logging
         {
             if (IsEnabled(level, area))
             {
-                Debug.WriteLine(Format(area, messageTemplate, source, propertyValues));
+                Trace.WriteLine(Format(area, messageTemplate, source, propertyValues));
             }
         }
 

--- a/src/Avalonia.Controls/LoggingExtensions.cs
+++ b/src/Avalonia.Controls/LoggingExtensions.cs
@@ -1,25 +1,36 @@
-﻿using Avalonia.Controls;
+﻿using System;
+using Avalonia.Controls;
 using Avalonia.Logging;
 
 namespace Avalonia
 {
     public static class LoggingExtensions
     {
-        /// <summary>
-        /// Logs Avalonia events to the <see cref="System.Diagnostics.Debug"/> sink.
-        /// </summary>
-        /// <typeparam name="T">The application class type.</typeparam>
-        /// <param name="builder">The app builder instance.</param>
-        /// <param name="level">The minimum level to log.</param>
-        /// <param name="areas">The areas to log. Valid values are listed in <see cref="LogArea"/>.</param>
-        /// <returns>The app builder instance.</returns>
+        [Obsolete("Use LogToTrace")]
         public static T LogToDebug<T>(
             this T builder,
             LogEventLevel level = LogEventLevel.Warning,
             params string[] areas)
                 where T : AppBuilderBase<T>, new()
         {
-            Logger.Sink = new DebugLogSink(level, areas);
+            return LogToTrace(builder, level, areas);
+        }
+
+        /// <summary>
+        /// Logs Avalonia events to the <see cref="System.Diagnostics.Trace"/> sink.
+        /// </summary>
+        /// <typeparam name="T">The application class type.</typeparam>
+        /// <param name="builder">The app builder instance.</param>
+        /// <param name="level">The minimum level to log.</param>
+        /// <param name="areas">The areas to log. Valid values are listed in <see cref="LogArea"/>.</param>
+        /// <returns>The app builder instance.</returns>
+        public static T LogToTrace<T>(
+            this T builder,
+            LogEventLevel level = LogEventLevel.Warning,
+            params string[] areas)
+                where T : AppBuilderBase<T>, new()
+        {
+            Logger.Sink = new TraceLogSink(level, areas);
             return builder;
         }
     }


### PR DESCRIPTION
## What does the pull request do?

Fixes logging.

Calls to `System.Diagnostics.Debug` are removed in release builds meaning nothing was getting logged. Deprecated the `LogToDebug` AppBuilder method in favor of `LogToTrace`.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes

Renamed `DebugLogSink` -> `TraceLogSink` but this class was only added in the 0.10 previews so not technically a breaking change.

## Fixed issues

Fixes #4901
