### PR TITLE
fix nuget package build

### DIFF
--- a/build/SharedVersion.props
+++ b/build/SharedVersion.props
@@ -20,6 +20,6 @@
   </PropertyGroup>
 
   <ItemGroup Label="PackageIcon">
-    <None Include="$(SolutionDir)/build/Assets/Icon.png" Pack="true" PackagePath=""/>
+    <None Include="$(MSBuildThisFileDirectory)/Assets/Icon.png" Pack="true" PackagePath=""/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

fixes nuget build for:
- nuke CreateNugetPackages
- dotnet pack
## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
currently create nuget packages is failing:
`C:\Program Files\dotnet\sdk\3.1.402\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(198,5): error : Could not find a part of the path 'D:\Assets'. [D:\Development\GitHub\Avalonia\packages\Avalonia\Avalonia.csproj]`

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
