### PR TITLE
OSX: dont raise events when window isnt shown.

### DIFF
--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -251,6 +251,11 @@ namespace Avalonia.Native
 
         public bool RawTextInputEvent(uint timeStamp, string text)
         {
+            if (_inputRoot is null)
+            {
+                return false;
+            }
+            
             Dispatcher.UIThread.RunJobs(DispatcherPriority.Input + 1);
 
             var args = new RawTextInputEventArgs(_keyboard, timeStamp, _inputRoot, text);
@@ -262,6 +267,11 @@ namespace Avalonia.Native
 
         public bool RawKeyEvent(AvnRawKeyEventType type, uint timeStamp, AvnInputModifiers modifiers, uint key)
         {
+            if (_inputRoot is null)
+            {
+                return false;
+            }
+            
             Dispatcher.UIThread.RunJobs(DispatcherPriority.Input + 1);
 
             var args = new RawKeyEventArgs(_keyboard, timeStamp, _inputRoot, (RawKeyEventType)type, (Key)key, (RawInputModifiers)modifiers);
@@ -278,6 +288,11 @@ namespace Avalonia.Native
 
         public void RawMouseEvent(AvnRawMouseEventType type, uint timeStamp, AvnInputModifiers modifiers, AvnPoint point, AvnVector delta)
         {
+            if (_inputRoot is null)
+            {
+                return;
+            }
+            
             Dispatcher.UIThread.RunJobs(DispatcherPriority.Input + 1);
 
             switch (type)

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -251,10 +251,8 @@ namespace Avalonia.Native
 
         public bool RawTextInputEvent(uint timeStamp, string text)
         {
-            if (_inputRoot is null)
-            {
+            if (_inputRoot is null) 
                 return false;
-            }
             
             Dispatcher.UIThread.RunJobs(DispatcherPriority.Input + 1);
 
@@ -267,10 +265,8 @@ namespace Avalonia.Native
 
         public bool RawKeyEvent(AvnRawKeyEventType type, uint timeStamp, AvnInputModifiers modifiers, uint key)
         {
-            if (_inputRoot is null)
-            {
+            if (_inputRoot is null) 
                 return false;
-            }
             
             Dispatcher.UIThread.RunJobs(DispatcherPriority.Input + 1);
 
@@ -288,10 +284,8 @@ namespace Avalonia.Native
 
         public void RawMouseEvent(AvnRawMouseEventType type, uint timeStamp, AvnInputModifiers modifiers, AvnPoint point, AvnVector delta)
         {
-            if (_inputRoot is null)
-            {
+            if (_inputRoot is null) 
                 return;
-            }
             
             Dispatcher.UIThread.RunJobs(DispatcherPriority.Input + 1);
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Found on OSX events can be raised before a secondard window or popup is shown and this can cause a crash if mouse events are raised.

Protecting against this condition.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
