### PR TITLE
fix splitview by making it use contentpresenter, templates

### DIFF
--- a/src/Avalonia.Controls/ApiCompatBaseline.txt
+++ b/src/Avalonia.Controls/ApiCompatBaseline.txt
@@ -8,6 +8,12 @@ MembersMustExist : Member 'public void Avalonia.Controls.ListBox.Selection.set(A
 TypesMustExist : Type 'Avalonia.Controls.SelectionModel' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'Avalonia.Controls.SelectionModelChildrenRequestedEventArgs' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'Avalonia.Controls.SelectionModelSelectionChangedEventArgs' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public Avalonia.StyledProperty<Avalonia.Controls.IControl> Avalonia.StyledProperty<Avalonia.Controls.IControl> Avalonia.Controls.SplitView.ContentProperty' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public Avalonia.StyledProperty<Avalonia.Controls.IControl> Avalonia.StyledProperty<Avalonia.Controls.IControl> Avalonia.Controls.SplitView.PaneProperty' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public Avalonia.Controls.IControl Avalonia.Controls.SplitView.Content.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public void Avalonia.Controls.SplitView.Content.set(Avalonia.Controls.IControl)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public Avalonia.Controls.IControl Avalonia.Controls.SplitView.Pane.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public void Avalonia.Controls.SplitView.Pane.set(Avalonia.Controls.IControl)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'public Avalonia.DirectProperty<Avalonia.Controls.TreeView, Avalonia.Controls.ISelectionModel> Avalonia.DirectProperty<Avalonia.Controls.TreeView, Avalonia.Controls.ISelectionModel> Avalonia.Controls.TreeView.SelectionProperty' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'public Avalonia.Interactivity.RoutedEvent<Avalonia.Controls.SelectionChangedEventArgs> Avalonia.Interactivity.RoutedEvent<Avalonia.Controls.SelectionChangedEventArgs> Avalonia.Controls.TreeView.SelectionChangedEvent' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'public Avalonia.Controls.ISelectionModel Avalonia.Controls.TreeView.Selection.get()' does not exist in the implementation but it does exist in the contract.
@@ -17,4 +23,4 @@ InterfacesShouldHaveSameMembers : Interface member 'public System.String[] Avalo
 MembersMustExist : Member 'public Avalonia.DirectProperty<Avalonia.Controls.Primitives.SelectingItemsControl, Avalonia.Controls.ISelectionModel> Avalonia.DirectProperty<Avalonia.Controls.Primitives.SelectingItemsControl, Avalonia.Controls.ISelectionModel> Avalonia.Controls.Primitives.SelectingItemsControl.SelectionProperty' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'protected Avalonia.Controls.ISelectionModel Avalonia.Controls.Primitives.SelectingItemsControl.Selection.get()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'protected void Avalonia.Controls.Primitives.SelectingItemsControl.Selection.set(Avalonia.Controls.ISelectionModel)' does not exist in the implementation but it does exist in the contract.
-Total Issues: 18
+Total Issues: 24

--- a/src/Avalonia.Controls/SplitView.cs
+++ b/src/Avalonia.Controls/SplitView.cs
@@ -9,6 +9,8 @@ using Avalonia.Platform;
 using Avalonia.VisualTree;
 using System;
 using System.Reactive.Disposables;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Templates;
 
 namespace Avalonia.Controls
 {
@@ -78,7 +80,7 @@ namespace Avalonia.Controls
     [PseudoClasses(":compactoverlay", ":compactinline", ":overlay", ":inline")]
     [PseudoClasses(":left", ":right")]
     [PseudoClasses(":lightdismiss")]
-    public class SplitView : TemplatedControl
+    public class SplitView : ContentControl
     {
         /*
             Pseudo classes & combos
@@ -86,12 +88,6 @@ namespace Avalonia.Controls
             :compactoverlay :compactinline :overlay :inline
             :left :right
         */
-
-        /// <summary>
-        /// Defines the <see cref="Content"/> property
-        /// </summary>
-        public static readonly StyledProperty<IControl> ContentProperty =
-            AvaloniaProperty.Register<SplitView, IControl>(nameof(Content));
 
         /// <summary>
         /// Defines the <see cref="CompactPaneLength"/> property
@@ -133,8 +129,14 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="Pane"/> property
         /// </summary>
-        public static readonly StyledProperty<IControl> PaneProperty =
-            AvaloniaProperty.Register<SplitView, IControl>(nameof(Pane));
+        public static readonly StyledProperty<object?> PaneProperty =
+            AvaloniaProperty.Register<SplitView, object?>(nameof(Pane));
+
+        /// <summary>
+        /// Defines the <see cref="HeaderTemplate"/> property.
+        /// </summary>
+        public static readonly StyledProperty<IDataTemplate?> PaneTemplateProperty =
+            AvaloniaProperty.Register<HeaderedContentControl, IDataTemplate?>(nameof(PaneTemplate));
 
         /// <summary>
         /// Defines the <see cref="UseLightDismissOverlayMode"/> property
@@ -166,16 +168,7 @@ namespace Avalonia.Controls
             CompactPaneLengthProperty.Changed.AddClassHandler<SplitView>((x, v) => x.OnCompactPaneLengthChanged(v));
             PanePlacementProperty.Changed.AddClassHandler<SplitView>((x, v) => x.OnPanePlacementChanged(v));
             DisplayModeProperty.Changed.AddClassHandler<SplitView>((x, v) => x.OnDisplayModeChanged(v));
-        }
-
-        /// <summary>
-        /// Gets or sets the content of the SplitView
-        /// </summary>
-        [Content]
-        public IControl Content
-        {
-            get => GetValue(ContentProperty);
-            set => SetValue(ContentProperty, value);
+            
         }
 
         /// <summary>
@@ -265,10 +258,19 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets or sets the Pane for the SplitView
         /// </summary>
-        public IControl Pane
+        public object Pane
         {
             get => GetValue(PaneProperty);
             set => SetValue(PaneProperty, value);
+        }
+        
+        /// <summary>
+        /// Gets or sets the data template used to display the header content of the control.
+        /// </summary>
+        public IDataTemplate? PaneTemplate
+        {
+            get => GetValue(PaneTemplateProperty);
+            set => SetValue(PaneTemplateProperty, value);
         }
 
         /// <summary>
@@ -311,6 +313,18 @@ namespace Avalonia.Controls
         /// Fired when the pane is opening
         /// </summary>
         public event EventHandler<EventArgs> PaneOpening;
+
+        protected override bool RegisterContentPresenter(IContentPresenter presenter)
+        {
+            var result = base.RegisterContentPresenter(presenter);
+
+            if (presenter.Name == "PART_PanePresenter")
+            {
+                return true;
+            }
+            
+            return result;
+        }
 
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {

--- a/src/Avalonia.Dialogs/ApiCompatBaseline.txt
+++ b/src/Avalonia.Dialogs/ApiCompatBaseline.txt
@@ -1,0 +1,1 @@
+Total Issues: 0

--- a/src/Avalonia.Themes.Default/SplitView.xaml
+++ b/src/Avalonia.Themes.Default/SplitView.xaml
@@ -32,12 +32,12 @@
                  ClipToBounds="True"
                  HorizontalAlignment="Left"
                  ZIndex="100">
-            <Border Child="{TemplateBinding Pane}"/>
+            <ContentPresenter x:Name="PART_PanePresenter" Content="{TemplateBinding Pane}" ContentTemplate="{TemplateBinding PaneTemplate}" />
             <Rectangle Name="HCPaneBorder" Fill="{DynamicResource SystemControlForegroundTransparentBrush}" Width="1" HorizontalAlignment="Right"  />
           </Panel>
 
           <Panel Name="ContentRoot">
-            <Border Child="{TemplateBinding Content}" />
+            <ContentPresenter x:Name="PART_ContentPresenter" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" />
             <Rectangle Name="LightDismissLayer"/>
           </Panel>
 
@@ -106,14 +106,14 @@
                  ClipToBounds="True"
                  HorizontalAlignment="Right"
                  ZIndex="100">
-            <Border Child="{TemplateBinding Pane}"/>
+            <ContentPresenter x:Name="PART_PanePresenter" Content="{TemplateBinding Pane}" ContentTemplate="{TemplateBinding PaneTemplate}"/>
             <Rectangle Name="HCPaneBorder"
                        Fill="{DynamicResource SystemControlForegroundTransparentBrush}"
                        Width="1" HorizontalAlignment="Left"  />
           </Panel>
 
           <Panel Name="ContentRoot">
-            <Border Child="{TemplateBinding Content}" />
+            <ContentPresenter x:Name="PART_ContentPresenter" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" />
             <Rectangle Name="LightDismissLayer"/>
           </Panel>
 

--- a/src/Avalonia.Themes.Fluent/SplitView.xaml
+++ b/src/Avalonia.Themes.Fluent/SplitView.xaml
@@ -32,12 +32,12 @@
                  ClipToBounds="True"
                  HorizontalAlignment="Left"
                  ZIndex="100">
-            <Border Child="{TemplateBinding Pane}"/>
+            <ContentPresenter x:Name="PART_PanePresenter" Content="{TemplateBinding Pane}" ContentTemplate="{TemplateBinding PaneTemplate}" />
             <Rectangle Name="HCPaneBorder" Fill="{DynamicResource SystemControlForegroundTransparentBrush}" Width="1" HorizontalAlignment="Right"  />
           </Panel>
 
           <Panel Name="ContentRoot">
-            <Border Child="{TemplateBinding Content}" />
+            <ContentPresenter x:Name="PART_ContentPresenter" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" />
             <Rectangle Name="LightDismissLayer"/>
           </Panel>
 
@@ -106,14 +106,14 @@
                  ClipToBounds="True"
                  HorizontalAlignment="Right"
                  ZIndex="100">
-            <Border Child="{TemplateBinding Pane}"/>
+            <ContentPresenter x:Name="PART_PanePresenter" Content="{TemplateBinding Pane}" ContentTemplate="{TemplateBinding PaneTemplate}"/>
             <Rectangle Name="HCPaneBorder"
                        Fill="{DynamicResource SystemControlForegroundTransparentBrush}"
                        Width="1" HorizontalAlignment="Left"  />
           </Panel>
 
           <Panel Name="ContentRoot">
-            <Border Child="{TemplateBinding Content}" />
+            <ContentPresenter x:Name="PART_ContentPresenter" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" />
             <Rectangle Name="LightDismissLayer"/>
           </Panel>
 


### PR DESCRIPTION
…s children be logical children.

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
It makes SplitView correctly a content control and registers content presenters.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Has no logical children

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Has logical children and compatible with Templating.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
