### PR TITLE
Revert "Enable light dismiss overlay for popups"

### DIFF
--- a/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
+++ b/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
@@ -67,6 +67,8 @@ namespace Avalonia.Controls.Primitives
         {
             get
             {
+                if (IsPopup)
+                    return null;
                 var rv = FindLayer<LightDismissOverlayLayer>();
                 if (rv == null)
                 {


### PR DESCRIPTION
Reverts AvaloniaUI/Avalonia#4898 which breaks menus and context menus (sub-items don't open properly anymore).