### PR TITLE
Devtools misc fixes

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/TreeNode.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/TreeNode.cs
@@ -23,6 +23,8 @@ namespace Avalonia.Diagnostics.ViewModels
 
             if (visual is IControl control)
             {
+                ElementName = control.Name;
+
                 var removed = Observable.FromEventPattern<LogicalTreeAttachmentEventArgs>(
                     x => control.DetachedFromLogicalTree += x,
                     x => control.DetachedFromLogicalTree -= x);
@@ -59,6 +61,11 @@ namespace Avalonia.Diagnostics.ViewModels
         {
             get { return _classes; }
             private set { RaiseAndSetIfChanged(ref _classes, value); }
+        }
+
+        public string ElementName
+        {
+            get;
         }
 
         public IVisual Visual

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/ControlDetailsView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/ControlDetailsView.xaml
@@ -26,6 +26,12 @@
         <DataGridTextColumn Header="Type" Binding="{Binding Type}" />
         <DataGridTextColumn Header="Priority" Binding="{Binding Priority}" IsReadOnly="True" />
       </DataGrid.Columns>
+
+      <DataGrid.Styles>
+        <Style Selector="DataGridRow TextBox">
+          <Setter Property="SelectionBrush" Value="LightBlue"/>
+        </Style>
+      </DataGrid.Styles>
     </DataGrid>
 
   </Grid>

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:Avalonia.Diagnostics.ViewModels"
              x:Class="Avalonia.Diagnostics.Views.TreePageView">
-  <Grid ColumnDefinitions="0.5*,4,*">    
+  <Grid ColumnDefinitions="0.8*,4,*">    
     <TreeView Name="tree"
               BorderThickness="0"
               Items="{Binding Nodes}"

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:Avalonia.Diagnostics.ViewModels"
              x:Class="Avalonia.Diagnostics.Views.TreePageView">
-  <Grid ColumnDefinitions="*,4,3*">    
+  <Grid ColumnDefinitions="0.5*,4,*">    
     <TreeView Name="tree"
               BorderThickness="0"
               Items="{Binding Nodes}"
@@ -13,6 +13,7 @@
           <StackPanel Orientation="Horizontal" Spacing="8">
             <TextBlock Text="{Binding Type}"/>
             <TextBlock Text="{Binding Classes}"/>
+            <TextBlock Foreground="Gray" Text="{Binding ElementName}"/>
           </StackPanel>
         </TreeDataTemplate>
       </TreeView.DataTemplates>


### PR DESCRIPTION
- Display Name of controls in the hierarchy
- Fix selection brush inside DataGrid
- Increase default panel width and fix annoying bug that prevents resizing the panel sometimes (not sure where this is coming from)

Maybe we should adjust the default theme for DataGrid to include this selection brush fix? Which color should we use in that case?

![image](https://user-images.githubusercontent.com/4670166/97425199-0fcb0080-1912-11eb-83bf-314f6697562b.png)
