### PR TITLE
fix: DataContext Inheritance in ReactiveUserControl<TViewModel>

### DIFF
--- a/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
+++ b/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
@@ -28,30 +28,8 @@ namespace Avalonia.ReactiveUI
             // This WhenActivated block calls ViewModel's WhenActivated
             // block if the ViewModel implements IActivatableViewModel.
             this.WhenActivated(disposables => { });
-
-            this.GetObservable(DataContextProperty).Subscribe(value =>
-            {
-                if (value is TViewModel viewModel)
-                {
-                    ViewModel = viewModel;
-                }
-                else
-                {
-                    ViewModel = null;
-                }
-            });
-
-            this.GetObservable(ViewModelProperty).Subscribe(value =>
-            {
-                if (value == null)
-                {
-                    DataContext = AvaloniaProperty.UnsetValue;
-                }
-                else
-                {
-                    DataContext = value;
-                }
-            });
+            this.GetObservable(DataContextProperty).Subscribe(OnDataContextChanged);
+            this.GetObservable(ViewModelProperty).Subscribe(OnViewModelChanged);
         }
 
         /// <summary>
@@ -67,6 +45,30 @@ namespace Avalonia.ReactiveUI
         {
             get => ViewModel;
             set => ViewModel = (TViewModel)value;
+        }
+
+        private void OnDataContextChanged(object value)
+        {
+            if (value is TViewModel viewModel)
+            {
+                ViewModel = viewModel;
+            }
+            else
+            {
+                ViewModel = null;
+            }
+        }
+
+        private void OnViewModelChanged(object value)
+        {
+            if (value == null)
+            {
+                ClearValue(DataContextProperty);
+            }
+            else if (DataContext != value)
+            {
+                DataContext = value;
+            }
         }
     }
 }

--- a/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
+++ b/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
@@ -28,7 +28,6 @@ namespace Avalonia.ReactiveUI
             // This WhenActivated block calls ViewModel's WhenActivated
             // block if the ViewModel implements IActivatableViewModel.
             this.WhenActivated(disposables => { });
-            this.GetObservable(DataContextProperty).Subscribe(OnDataContextChanged);
             this.GetObservable(ViewModelProperty).Subscribe(OnViewModelChanged);
         }
 
@@ -47,16 +46,9 @@ namespace Avalonia.ReactiveUI
             set => ViewModel = (TViewModel)value;
         }
 
-        private void OnDataContextChanged(object value)
+        protected override void OnDataContextChanged(EventArgs e)
         {
-            if (value is TViewModel viewModel)
-            {
-                ViewModel = viewModel;
-            }
-            else
-            {
-                ViewModel = null;
-            }
+            ViewModel = DataContext as TViewModel;
         }
 
         private void OnViewModelChanged(object value)

--- a/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
+++ b/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
@@ -29,10 +29,29 @@ namespace Avalonia.ReactiveUI
             // block if the ViewModel implements IActivatableViewModel.
             this.WhenActivated(disposables => { });
 
-            this.ObservableForProperty(x => x.ViewModel, false, true)
-                .Subscribe(args => DataContext = args.Value);
-            this.ObservableForProperty(x => x.DataContext, false, true)
-                .Subscribe(args => ViewModel = args.Value as TViewModel);
+            this.GetObservable(DataContextProperty).Subscribe(value =>
+            {
+                if (value is TViewModel viewModel)
+                {
+                    ViewModel = viewModel;
+                }
+                else
+                {
+                    ViewModel = null;
+                }
+            });
+
+            this.GetObservable(ViewModelProperty).Subscribe(value =>
+            {
+                if (value == null)
+                {
+                    DataContext = AvaloniaProperty.UnsetValue;
+                }
+                else
+                {
+                    DataContext = value;
+                }
+            });
         }
 
         /// <summary>

--- a/src/Avalonia.ReactiveUI/ReactiveWindow.cs
+++ b/src/Avalonia.ReactiveUI/ReactiveWindow.cs
@@ -28,30 +28,8 @@ namespace Avalonia.ReactiveUI
             // This WhenActivated block calls ViewModel's WhenActivated
             // block if the ViewModel implements IActivatableViewModel.
             this.WhenActivated(disposables => { });
-
-            this.GetObservable(DataContextProperty).Subscribe(value =>
-            {
-                if (value is TViewModel viewModel)
-                {
-                    ViewModel = viewModel;
-                }
-                else
-                {
-                    ViewModel = null;
-                }
-            });
-
-            this.GetObservable(ViewModelProperty).Subscribe(value =>
-            {
-                if (value == null)
-                {
-                    DataContext = AvaloniaProperty.UnsetValue;
-                }
-                else
-                {
-                    DataContext = value;
-                }
-            });
+            this.GetObservable(DataContextProperty).Subscribe(OnDataContextChanged);
+            this.GetObservable(ViewModelProperty).Subscribe(OnViewModelChanged);
         }
             
         /// <summary>
@@ -67,6 +45,30 @@ namespace Avalonia.ReactiveUI
         {
             get => ViewModel;
             set => ViewModel = (TViewModel)value;
+        }
+
+        private void OnDataContextChanged(object value)
+        {
+            if (value is TViewModel viewModel)
+            {
+                ViewModel = viewModel;
+            }
+            else
+            {
+                ViewModel = null;
+            }
+        }
+
+        private void OnViewModelChanged(object value)
+        {
+            if (value == null)
+            {
+                ClearValue(DataContextProperty);
+            }
+            else if (DataContext != value)
+            {
+                DataContext = value;
+            }
         }
     }
 }

--- a/src/Avalonia.ReactiveUI/ReactiveWindow.cs
+++ b/src/Avalonia.ReactiveUI/ReactiveWindow.cs
@@ -29,10 +29,29 @@ namespace Avalonia.ReactiveUI
             // block if the ViewModel implements IActivatableViewModel.
             this.WhenActivated(disposables => { });
 
-            this.ObservableForProperty(x => x.ViewModel, false, true)
-                .Subscribe(args => DataContext = args.Value);
-            this.ObservableForProperty(x => x.DataContext, false, true)
-                .Subscribe(args => ViewModel = args.Value as TViewModel);
+            this.GetObservable(DataContextProperty).Subscribe(value =>
+            {
+                if (value is TViewModel viewModel)
+                {
+                    ViewModel = viewModel;
+                }
+                else
+                {
+                    ViewModel = null;
+                }
+            });
+
+            this.GetObservable(ViewModelProperty).Subscribe(value =>
+            {
+                if (value == null)
+                {
+                    DataContext = AvaloniaProperty.UnsetValue;
+                }
+                else
+                {
+                    DataContext = value;
+                }
+            });
         }
             
         /// <summary>

--- a/tests/Avalonia.ReactiveUI.UnitTests/ReactiveUserControlTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/ReactiveUserControlTest.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Disposables;
+using Avalonia.Controls;
 using Avalonia.UnitTests;
 using ReactiveUI;
 using Splat;
@@ -99,6 +100,76 @@ namespace Avalonia.ReactiveUI.UnitTests
             Assert.NotNull(view.ViewModel);
             Assert.NotNull(view.DataContext);
             Assert.False(view.ViewModel.IsActive);
+        }
+        
+        [Fact]
+        public void Should_Inherit_DataContext()
+        {
+            var vm1 = new ExampleViewModel();
+            var vm2 = new ExampleViewModel();
+            var view = new ExampleView();
+            var root = new TestRoot(view);
+            
+            Assert.Null(view.DataContext);
+            Assert.Null(view.ViewModel);
+            
+            root.DataContext = vm1;
+            
+            Assert.Same(vm1, view.DataContext);
+            Assert.Same(vm1, view.ViewModel);
+            
+            root.DataContext = null;
+            
+            Assert.Null(view.DataContext);
+            Assert.Null(view.ViewModel);
+            
+            root.DataContext = vm2;
+            
+            Assert.Same(vm2, view.DataContext);
+            Assert.Same(vm2, view.ViewModel);
+        }
+
+        [Fact]
+        public void Should_Not_Overlap_Change_Notifications()
+        {
+            var vm1 = new ExampleViewModel();
+            var vm2 = new ExampleViewModel();
+
+            var view1 = new ExampleView();
+            var view2 = new ExampleView();
+            
+            Assert.Null(view1.DataContext);
+            Assert.Null(view2.DataContext);
+            Assert.Null(view1.ViewModel);
+            Assert.Null(view2.ViewModel);
+
+            view1.DataContext = vm1;
+            
+            Assert.Same(vm1, view1.DataContext);
+            Assert.Same(vm1, view1.ViewModel);
+            Assert.Null(view2.DataContext);
+            Assert.Null(view2.ViewModel);
+
+            view2.DataContext = vm2;
+
+            Assert.Same(vm1, view1.DataContext);
+            Assert.Same(vm1, view1.ViewModel);
+            Assert.Same(vm2, view2.DataContext);
+            Assert.Same(vm2, view2.ViewModel);
+
+            view1.ViewModel = null;
+
+            Assert.Null(view1.DataContext);
+            Assert.Null(view1.ViewModel);
+            Assert.Same(vm2, view2.DataContext);
+            Assert.Same(vm2, view2.ViewModel);
+
+            view2.ViewModel = null;
+
+            Assert.Null(view1.DataContext);
+            Assert.Null(view2.DataContext);
+            Assert.Null(view1.ViewModel);
+            Assert.Null(view2.ViewModel);
         }
     }
 }


### PR DESCRIPTION
#### What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Fixes https://github.com/AvaloniaUI/Avalonia/issues/4962 The regression was introduced in https://github.com/AvaloniaUI/Avalonia/pull/4917

#### What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Currently, the `DataContext` is set to `null` when `ViewModel` changes, and this breaks `DataContext` inheritance.

#### What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Now, we are using `ClearValue` extension method in order to indicate that the `DataContext` is null.

cc @grokys 