### PR TITLE
Add a single argument Parse function for FontFamily.

### DIFF
--- a/src/Avalonia.Visuals/Media/FontFamily.cs
+++ b/src/Avalonia.Visuals/Media/FontFamily.cs
@@ -137,12 +137,22 @@ namespace Avalonia.Media
         /// Parses a <see cref="T:Avalonia.Media.FontFamily"/> string.
         /// </summary>
         /// <param name="s">The <see cref="T:Avalonia.Media.FontFamily"/> string.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException">
+        /// Specified family is not supported.
+        /// </exception>
+        public static FontFamily Parse(string s) => Parse(s, null);
+
+        /// <summary>
+        /// Parses a <see cref="T:Avalonia.Media.FontFamily"/> string.
+        /// </summary>
+        /// <param name="s">The <see cref="T:Avalonia.Media.FontFamily"/> string.</param>
         /// <param name="baseUri">Specifies the base uri that is used to resolve font family assets.</param>
         /// <returns></returns>
         /// <exception cref="ArgumentException">
         /// Specified family is not supported.
         /// </exception>
-        public static FontFamily Parse(string s, Uri baseUri = null)
+        public static FontFamily Parse(string s, Uri baseUri)
         {
             if (string.IsNullOrEmpty(s))
             {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes problems with using DevTools to set font family properties.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
You can't set `FontFamily` from DevTools so you need to use the console.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
![font-family-dev-tools](https://user-images.githubusercontent.com/2588062/98484506-3e00e800-2210-11eb-9114-edc6bcb1fa9c.gif)


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Both DevTools and Xaml compiler rely on having such function signature available so I've simply added it.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->
I wonder if this change is breaking on ABI side (since when recompiling this should cause no problems).

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
