### PR TITLE
Add WS_CLIPCHILDREN to PopupImpl.

### DIFF
--- a/src/Windows/Avalonia.Win32/PopupImpl.cs
+++ b/src/Windows/Avalonia.Win32/PopupImpl.cs
@@ -69,7 +69,8 @@ namespace Avalonia.Win32
         {
             UnmanagedMethods.WindowStyles style =
                 UnmanagedMethods.WindowStyles.WS_POPUP |
-                UnmanagedMethods.WindowStyles.WS_CLIPSIBLINGS;
+                UnmanagedMethods.WindowStyles.WS_CLIPSIBLINGS |
+                UnmanagedMethods.WindowStyles.WS_CLIPCHILDREN;
 
             UnmanagedMethods.WindowStyles exStyle =
                 UnmanagedMethods.WindowStyles.WS_EX_TOOLWINDOW |


### PR DESCRIPTION
## What does the pull request do?

#4105 originally added this change, but was closed because [the embedding PR was supposed to add it](https://github.com/AvaloniaUI/Avalonia/pull/4105#issuecomment-642959771) - however when that [PR was merged](https://github.com/AvaloniaUI/Avalonia/pull/3866) it only added the style to `WindowImpl`.

Needed for embedding chromium, see https://github.com/AvaloniaUI/Avalonia/issues/3281#issuecomment-557615525