### PR TITLE
support cast in binding + some related small fixes for compiled binding

### DIFF
--- a/src/Avalonia.Base/Data/Core/TypeCastNode.cs
+++ b/src/Avalonia.Base/Data/Core/TypeCastNode.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Avalonia.Data.Core
+{
+    public class TypeCastNode : ExpressionNode
+    {
+        public override string Description => $"as {TargetType.FullName}";
+
+        public Type TargetType { get; }
+
+        public TypeCastNode(Type type)
+        {
+            TargetType = type;
+        }
+
+        protected virtual object Cast(object value)
+        {
+            return TargetType.IsInstanceOfType(value) ? value : null;
+        }
+
+        protected override void StartListeningCore(WeakReference<object> reference)
+        {
+            if (reference.TryGetTarget(out object target))
+            {
+                target = Cast(target);
+                reference = target == null ? NullReference : new WeakReference<object>(target);
+            }
+
+            base.StartListeningCore(reference);
+        }
+    }
+}

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
@@ -198,24 +198,21 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                     case BindingExpressionGrammar.AncestorNode ancestor:
                         if (ancestor.Namespace is null && ancestor.TypeName is null)
                         {
-                            if (ancestor.Namespace is null && ancestor.TypeName is null)
+                            var styledElementType = context.GetAvaloniaTypes().StyledElement;
+                            var ancestorType = context
+                                .ParentNodes()
+                                .OfType<XamlAstConstructableObjectNode>()
+                                .Where(x => styledElementType.IsAssignableFrom(x.Type.GetClrType()))
+                                .Skip(1)
+                                .ElementAtOrDefault(ancestor.Level)
+                                ?.Type.GetClrType();
+
+                            if (ancestorType is null)
                             {
-                                var styledElementType = context.GetAvaloniaTypes().StyledElement;
-                                var ancestorType = context
-                                    .ParentNodes()
-                                    .OfType<XamlAstConstructableObjectNode>()
-                                    .Where(x => styledElementType.IsAssignableFrom(x.Type.GetClrType()))
-                                    .Skip(1)
-                                    .ElementAtOrDefault(ancestor.Level)
-                                    ?.Type.GetClrType();
-
-                                if (ancestorType is null)
-                                {
-                                    throw new XamlX.XamlParseException("Unable to resolve implicit ancestor type based on XAML tree.", lineInfo);
-                                }
-
-                                nodes.Add(new FindAncestorPathElementNode(ancestorType, ancestor.Level));
+                                throw new XamlX.XamlParseException("Unable to resolve implicit ancestor type based on XAML tree.", lineInfo);
                             }
+
+                            nodes.Add(new FindAncestorPathElementNode(ancestorType, ancestor.Level));
                         }
                         else
                         {
@@ -622,10 +619,10 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             private readonly IXamlAstValueNode _rawSource;
 
             public RawSourcePathElementNode(IXamlAstValueNode rawSource)
-                :base(rawSource)
+                : base(rawSource)
             {
                 _rawSource = rawSource;
-                
+
             }
 
             public IXamlType Type => _rawSource.Type.GetClrType();

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
@@ -198,20 +198,24 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                     case BindingExpressionGrammar.AncestorNode ancestor:
                         if (ancestor.Namespace is null && ancestor.TypeName is null)
                         {
-                            var styledElementType = context.GetAvaloniaTypes().StyledElement;
-                            var ancestorType = context
-                                .ParentNodes()
-                                .OfType<XamlAstConstructableObjectNode>()
-                                .Where(x => styledElementType.IsAssignableFrom(x.Type.GetClrType()))
-                                .ElementAtOrDefault(ancestor.Level)
-                                ?.Type.GetClrType();
-
-                            if (ancestorType is null)
+                            if (ancestor.Namespace is null && ancestor.TypeName is null)
                             {
-                                throw new XamlX.XamlParseException("Unable to resolve implicit ancestor type based on XAML tree.", lineInfo);
-                            }
+                                var styledElementType = context.GetAvaloniaTypes().StyledElement;
+                                var ancestorType = context
+                                    .ParentNodes()
+                                    .OfType<XamlAstConstructableObjectNode>()
+                                    .Where(x => styledElementType.IsAssignableFrom(x.Type.GetClrType()))
+                                    .Skip(1)
+                                    .ElementAtOrDefault(ancestor.Level)
+                                    ?.Type.GetClrType();
 
-                            nodes.Add(new FindAncestorPathElementNode(ancestorType, ancestor.Level));
+                                if (ancestorType is null)
+                                {
+                                    throw new XamlX.XamlParseException("Unable to resolve implicit ancestor type based on XAML tree.", lineInfo);
+                                }
+
+                                nodes.Add(new FindAncestorPathElementNode(ancestorType, ancestor.Level));
+                            }
                         }
                         else
                         {

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
@@ -436,7 +436,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             {
                 codeGen.Ldtype(Type)
                     .Ldc_I4(_level)
-                    .EmitCall(context.GetAvaloniaTypes().CompiledBindingPathBuilder.FindMethod(m => m.Name == "FindAncestor"));
+                    .EmitCall(context.GetAvaloniaTypes().CompiledBindingPathBuilder.FindMethod(m => m.Name == "Ancestor"));
             }
         }
 

--- a/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
+++ b/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
@@ -23,6 +23,7 @@
         <Compile Include="MarkupExtensions\CompiledBindings\ObservableStreamPlugin.cs" />
         <Compile Include="MarkupExtensions\CompiledBindings\PropertyInfoAccessorFactory.cs" />
         <Compile Include="MarkupExtensions\CompiledBindings\PropertyInfoAccessorPlugin.cs" />
+        <Compile Include="MarkupExtensions\CompiledBindings\StrongTypeCastNode.cs" />
         <Compile Include="MarkupExtensions\CompiledBindings\TaskStreamPlugin.cs" />
         <Compile Include="MarkupExtensions\DynamicResourceExtension.cs" />
         <Compile Include="MarkupExtensions\ResolveByNameExtension.cs" />

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindingExtension.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindingExtension.cs
@@ -26,6 +26,8 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
             {
                 Path = Path,
                 Converter = Converter,
+                ConverterParameter = ConverterParameter,
+                TargetNullValue = TargetNullValue,
                 FallbackValue = FallbackValue,
                 Mode = Mode,
                 Priority = Priority,

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindings/CompiledBindingPath.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindings/CompiledBindingPath.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Data.Core;
 using Avalonia.Data.Core.Plugins;
@@ -53,6 +54,9 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
                     case IStronglyTypedStreamElement stream:
                         node = new StreamNode(stream.CreatePlugin());
                         break;
+                    case ITypeCastElement typeCast:
+                        node = new StrongTypeCastNode(typeCast.Type, typeCast.Cast);
+                        break;
                     default:
                         throw new InvalidOperationException($"Unknown binding path element type {element.GetType().FullName}");
                 }
@@ -66,6 +70,9 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
         internal SourceMode SourceMode => _elements.Count > 0 && _elements[0] is IControlSourceBindingPathElement ? SourceMode.Control : SourceMode.Data;
 
         internal object RawSource { get; }
+
+        public override string ToString()
+            => string.Concat(_elements.Select(e => e.ToString()));
     }
 
     public class CompiledBindingPathBuilder
@@ -126,6 +133,12 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
             return this;
         }
 
+        public CompiledBindingPathBuilder TypeCast<T>()
+        {
+            _elements.Add(new TypeCastPathElement<T>());
+            return this;
+        }
+
         public CompiledBindingPathBuilder SetRawSource(object rawSource)
         {
             _rawSource = rawSource;
@@ -157,11 +170,21 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
         public IPropertyInfo Property { get; }
 
         public Func<WeakReference<object>, IPropertyInfo, IPropertyAccessor> AccessorFactory { get; }
+
+        public override string ToString()
+            => $".{Property.Name}";
     }
 
     internal interface IStronglyTypedStreamElement : ICompiledBindingPathElement
     {
         IStreamPlugin CreatePlugin();
+    }
+
+    internal interface ITypeCastElement : ICompiledBindingPathElement
+    {
+        Type Type { get; }
+
+        Func<object, object> Cast { get; }
     }
 
     internal class TaskStreamPathElement<T> : IStronglyTypedStreamElement
@@ -181,6 +204,9 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
     internal class SelfPathElement : ICompiledBindingPathElement, IControlSourceBindingPathElement
     {
         public static readonly SelfPathElement Instance = new SelfPathElement();
+
+        public override string ToString()
+            => "$self";
     }
 
     internal class AncestorPathElement : ICompiledBindingPathElement, IControlSourceBindingPathElement
@@ -193,6 +219,9 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
 
         public Type AncestorType { get; }
         public int Level { get; }
+
+        public override string ToString()
+           => $"$parent[{AncestorType?.Name},{Level}]";
     }
 
     internal class VisualAncestorPathElement : ICompiledBindingPathElement, IControlSourceBindingPathElement
@@ -217,6 +246,9 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
 
         public INameScope NameScope { get; }
         public string Name { get; }
+
+        public override string ToString()
+            => $"#{Name}";
     }
 
     internal class ArrayElementPathElement : ICompiledBindingPathElement
@@ -229,5 +261,24 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
 
         public int[] Indices { get; }
         public Type ElementType { get; }
+        public override string ToString()
+            => $"[{string.Join(",", Indices)}]";
+    }
+
+    internal class TypeCastPathElement<T> : ITypeCastElement
+    {
+        private static object TryCast(object obj)
+        {
+            if (obj is T result)
+                return result;
+            return null;
+        }
+
+        public Type Type => typeof(T);
+
+        public Func<object, object> Cast => TryCast;
+
+        public override string ToString()
+            => $"({Type.FullName})";
     }
 }

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindings/StrongTypeCastNode.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindings/StrongTypeCastNode.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Avalonia.Data.Core;
+
+namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
+{
+    public class StrongTypeCastNode : TypeCastNode
+    {
+        private Func<object, object> _cast;
+
+        public StrongTypeCastNode(Type type, Func<object, object> cast) : base(type)
+        {
+            _cast = cast;
+        }
+
+        protected override object Cast(object value)
+            => _cast(value);
+    }
+}

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/BindingExpressionGrammar.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/BindingExpressionGrammar.cs
@@ -170,6 +170,12 @@ namespace Avalonia.Markup.Parsers
         {
             var (ns, owner) = ParseTypeName(ref r);
 
+            if(!r.End && r.TakeIf(')'))
+            {
+                nodes.Add(new TypeCastNode() { Namespace = ns, TypeName = owner });
+                return State.AfterMember;
+            }
+
             if (r.End || !r.TakeIf('.'))
             {
                 throw new ExpressionParseException(r.Position, "Invalid attached property name.");
@@ -220,6 +226,11 @@ namespace Avalonia.Markup.Parsers
                 }
 
                 result = ParseBeforeMember(ref r, nodes);
+
+                if(r.Peek == '[')
+                {
+                    result = ParseIndexer(ref r, nodes);
+                }
             }
 
             nodes.Add(new TypeCastNode { Namespace = ns, TypeName = typeName });

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/BindingExpressionGrammar.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/BindingExpressionGrammar.cs
@@ -183,6 +183,11 @@ namespace Avalonia.Markup.Parsers
 
             var name = r.ParseIdentifier();
 
+            if (name.Length == 0)
+            {
+                throw new ExpressionParseException(r.Position, "Attached Property name expected after '.'.");
+            }
+
             if (r.End || !r.TakeIf(')'))
             {
                 throw new ExpressionParseException(r.Position, "Expected ')'.");

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/ExpressionParser.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/ExpressionParser.cs
@@ -59,6 +59,9 @@ namespace Avalonia.Markup.Parsers
                     case BindingExpressionGrammar.NameNode elementName:
                         nextNode = new ElementNameNode(_nameScope, elementName.Name);
                         break;
+                    case BindingExpressionGrammar.TypeCastNode typeCast:
+                        nextNode = ParseTypeCastNode(typeCast);
+                        break;
                 }
                 if (rootNode is null)
                 {
@@ -90,6 +93,22 @@ namespace Avalonia.Markup.Parsers
             }
 
             return new FindAncestorNode(ancestorType, ancestorLevel);
+        }
+
+        private TypeCastNode ParseTypeCastNode(BindingExpressionGrammar.TypeCastNode node)
+        {
+            Type castType = null;
+            if (!(node.Namespace is null) && !(node.TypeName is null))
+            {
+                if (_typeResolver == null)
+                {
+                    throw new InvalidOperationException("Cannot parse a binding path with a typed Cast without a type resolver. Maybe you can use a LINQ Expression binding path instead?");
+                }
+
+                castType = _typeResolver(node.Namespace, node.TypeName);
+            }
+
+            return new TypeCastNode(castType);
         }
 
         private AvaloniaPropertyAccessorNode ParseAttachedProperty(BindingExpressionGrammar.AttachedPropertyNameNode node)

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_AttachedProperty.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_AttachedProperty.cs
@@ -129,7 +129,7 @@ namespace Avalonia.Markup.UnitTests.Parsers
         {
             var data = new Class1();
 
-            Assert.Throws<ExpressionParseException>(() => ExpressionObserverBuilder.Build(data, "(Owner)", typeResolver: _typeResolver));
+            Assert.Throws<ExpressionParseException>(() => ExpressionObserverBuilder.Build(data, "(Owner.)", typeResolver: _typeResolver));
         }
 
         [Fact]

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/BindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/BindingExtensionTests.cs
@@ -94,7 +94,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
         xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
         >
-    <ContentControl Content='{Binding $parent.DataContext(local:TestDataContext).StringProperty}' Name='contentControl' />
+    <ContentControl Content='{Binding $parent.((local:TestDataContext)DataContext).StringProperty}' Name='contentControl' />
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
                 var contentControl = window.FindControl<ContentControl>("contentControl");
@@ -120,7 +120,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
         xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
         >
-    <ContentControl Content='{Binding $parent.DataContext(local:TestDataContext)}' Name='contentControl' />
+    <ContentControl Content='{Binding $parent.((local:TestDataContext)DataContext)}' Name='contentControl' />
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
                 var contentControl = window.FindControl<ContentControl>("contentControl");

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/BindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/BindingExtensionTests.cs
@@ -84,6 +84,54 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             }
         }
 
+        [Fact]
+        public void SupportCastToTypeInExpression()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
+        >
+    <ContentControl Content='{Binding $parent.DataContext(local:TestDataContext).StringProperty}' Name='contentControl' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var contentControl = window.FindControl<ContentControl>("contentControl");
+
+                var dataContext = new TestDataContext
+                {
+                    StringProperty = "foobar"
+                };
+
+                window.DataContext = dataContext;
+
+                Assert.Equal(dataContext.StringProperty, contentControl.Content);
+            }
+        }
+
+        [Fact]
+        public void SupportCastToTypeInExpression_DifferentTypeEvaluatesToNull()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
+        >
+    <ContentControl Content='{Binding $parent.DataContext(local:TestDataContext)}' Name='contentControl' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var contentControl = window.FindControl<ContentControl>("contentControl");
+
+                var dataContext = "foo";
+
+                window.DataContext = dataContext;
+
+                Assert.Equal(null, contentControl.Content);
+            }
+        }
         private class FooBar
         {
             public object Foo { get; } = null;

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -760,6 +760,36 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         }
 
         [Fact]
+        public void SupportCastToTypeInExpressionWithPropertyIndexer()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='using:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions'
+        x:DataType='local:TestDataContext'>
+    <ContentControl Content='{CompiledBinding ((local:TestData)ObjectsArrayProperty[0]).StringProperty}' Name='contentControl' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var contentControl = window.FindControl<ContentControl>("contentControl");
+
+                var data = new TestData()
+                {
+                    StringProperty = "Foo"
+                };
+                var dataContext = new TestDataContext
+                {
+                    ObjectsArrayProperty = new object[] { data }
+                };
+
+                window.DataContext = dataContext;
+
+                Assert.Equal(data.StringProperty, contentControl.Content);
+            }
+        }
+
+        [Fact]
         public void SupportCastToTypeInExpressionWithProperty_DifferentTypeEvaluatesToNull()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
@@ -818,6 +848,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
     }
 
+    public class TestData
+    {
+        public string StringProperty { get; set; }
+    }
+
     public class TestDataContext : IHasPropertyDerived
     {
         public string StringProperty { get; set; }
@@ -829,6 +864,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         public ObservableCollection<string> ObservableCollectionProperty { get; set; } = new ObservableCollection<string>();
 
         public string[] ArrayProperty { get; set; }
+
+        public object[] ObjectsArrayProperty { get; set; }
 
         public List<string> ListProperty { get; set; } = new List<string>();
 

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -638,6 +638,52 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         }
 
         [Fact]
+        public void SupportCastToTypeInExpression()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='using:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions'
+        x:DataType='local:TestDataContext'>
+    <ContentControl Content='{CompiledBinding $parent.DataContext(local:TestDataContext)}' Name='contentControl' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var contentControl = window.FindControl<ContentControl>("contentControl");
+
+                var dataContext = new TestDataContext();
+
+                window.DataContext = dataContext;
+
+                Assert.Equal(dataContext, contentControl.Content);
+            }
+        }
+
+        [Fact]
+        public void SupportCastToTypeInExpression_DifferentTypeEvaluatesToNull()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='using:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions'
+        x:DataType='local:TestDataContext'>
+    <ContentControl Content='{CompiledBinding $parent.DataContext(local:TestDataContext)}' Name='contentControl' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var contentControl = window.FindControl<ContentControl>("contentControl");
+
+                var dataContext = "foo";
+
+                window.DataContext = dataContext;
+
+                Assert.Equal(null, contentControl.Content);
+            }
+        }
+
+        [Fact]
         public void SupportCastToTypeInExpressionWithProperty()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -616,23 +616,105 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 Assert.Throws<XamlX.XamlParseException>(() => AvaloniaRuntimeXamlLoader.Load(xaml));
             }
         }
+
+        [Fact]
+        public void SupportCastToTypeInExpressionWithProperty()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='using:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions'
+        x:DataType='local:TestDataContext'>
+    <ContentControl Content='{CompiledBinding $parent.DataContext(local:TestDataContext).StringProperty}' Name='contentControl' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var contentControl = window.FindControl<ContentControl>("contentControl");
+
+                var dataContext = new TestDataContext
+                {
+                    StringProperty = "foobar"
+                };
+
+                window.DataContext = dataContext;
+
+                Assert.Equal(dataContext.StringProperty, contentControl.Content);
+            }
+        }
+
+        [Fact]
+        public void SupportCastToTypeInExpressionWithProperty1()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='using:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions'
+        x:DataType='local:TestDataContext'>
+    <ContentControl Content='{CompiledBinding $parent.DataContext(local:TestDataContext.StringProperty)}' Name='contentControl' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var contentControl = window.FindControl<ContentControl>("contentControl");
+
+                var dataContext = new TestDataContext
+                {
+                    StringProperty = "foobar"
+                };
+
+                window.DataContext = dataContext;
+
+                Assert.Equal(dataContext.StringProperty, contentControl.Content);
+            }
+        }
+
+        [Fact]
+        public void SupportCastToTypeInExpressionWithProperty_DifferentTypeEvaluatesToNull()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='using:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions'
+        x:DataType='local:TestDataContext'>
+    <ContentControl Content='{CompiledBinding $parent.DataContext(local:TestDataContext).StringProperty}' Name='contentControl' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var contentControl = window.FindControl<ContentControl>("contentControl");
+
+                var dataContext = new TestDataContext
+                {
+                    StringProperty = "foobar"
+                };
+
+                window.DataContext = dataContext;
+
+                Assert.Equal(dataContext.StringProperty, contentControl.Content);
+
+                window.DataContext = "foo";
+
+                Assert.Equal(null, contentControl.Content);
+            }
+        }
     }
 
     public interface INonIntegerIndexer
     {
-        string this[string key] {get; set;}
+        string this[string key] { get; set; }
     }
 
     public interface INonIntegerIndexerDerived : INonIntegerIndexer
-    {}
+    { }
 
     public interface IHasProperty
     {
-        string StringProperty {get; set; }
+        string StringProperty { get; set; }
     }
 
     public interface IHasPropertyDerived : IHasProperty
-    {}
+    { }
 
     public class TestDataContext : IHasPropertyDerived
     {

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -671,7 +671,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
         xmlns:local='using:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions'
         x:DataType='local:TestDataContext'>
-    <ContentControl Content='{CompiledBinding $parent.DataContext(local:TestDataContext)}' Name='contentControl' />
+    <ContentControl Content='{CompiledBinding $parent.((local:TestDataContext)DataContext)}' Name='contentControl' />
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
                 var contentControl = window.FindControl<ContentControl>("contentControl");
@@ -694,7 +694,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
         xmlns:local='using:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions'
         x:DataType='local:TestDataContext'>
-    <ContentControl Content='{CompiledBinding $parent.DataContext(local:TestDataContext)}' Name='contentControl' />
+    <ContentControl Content='{CompiledBinding $parent.((local:TestDataContext)DataContext)}' Name='contentControl' />
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
                 var contentControl = window.FindControl<ContentControl>("contentControl");
@@ -717,7 +717,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
         xmlns:local='using:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions'
         x:DataType='local:TestDataContext'>
-    <ContentControl Content='{CompiledBinding $parent.DataContext(local:TestDataContext).StringProperty}' Name='contentControl' />
+    <ContentControl Content='{CompiledBinding $parent.((local:TestDataContext)DataContext).StringProperty}' Name='contentControl' />
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
                 var contentControl = window.FindControl<ContentControl>("contentControl");
@@ -743,7 +743,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
         xmlns:local='using:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions'
         x:DataType='local:TestDataContext'>
-    <ContentControl Content='{CompiledBinding $parent.DataContext(local:TestDataContext.StringProperty)}' Name='contentControl' />
+    <ContentControl Content='{CompiledBinding $parent.DataContext(local:TestDataContext).StringProperty}' Name='contentControl' />
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
                 var contentControl = window.FindControl<ContentControl>("contentControl");
@@ -769,7 +769,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
         xmlns:local='using:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions'
         x:DataType='local:TestDataContext'>
-    <ContentControl Content='{CompiledBinding $parent.DataContext(local:TestDataContext).StringProperty}' Name='contentControl' />
+    <ContentControl Content='{CompiledBinding $parent.((local:TestDataContext)DataContext).StringProperty}' Name='contentControl' />
 </Window>";
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
                 var contentControl = window.FindControl<ContentControl>("contentControl");

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -602,6 +602,26 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         }
 
         [Fact]
+        public void SupportParentInPath()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
+        Title='foo'
+        x:DataType='local:TestDataContext'>
+    <ContentControl Content='{CompiledBinding $parent.Title}' Name='contentControl' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var contentControl = window.FindControl<ContentControl>("contentControl");
+
+                Assert.Equal("foo", contentControl.Content);
+            }
+        }
+
+        [Fact]
         public void ThrowsOnInvalidCompileBindingsDirective()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Add support for c# style cast in binding path, proposed syntax similar to WinUI:

> ` {Binding $parent.((local:TestDataContext)DataContext).StringProperty}`


Additional fixes:

- fixed issue with Compiled Binding to `$parent.Property` 

- fixed issue with Converter parameter missing from `CompiledBinding` 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

It's not possible to type cast in binding path

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Support cast in Binding path

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #5030 