### PR TITLE
FontFamily and TimeSpan intrinsics

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AstNodes/AvaloniaXamlIlFontFamilyAstNode.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AstNodes/AvaloniaXamlIlFontFamilyAstNode.cs
@@ -35,9 +35,5 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.AstNodes
                 .Newobj(_types.FontFamilyConstructorUriName);
             return XamlILNodeEmitResult.Type(0, _types.FontFamily);
         }
-
-        
-
-        
     }
 }

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AstNodes/AvaloniaXamlIlFontFamilyAstNode.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AstNodes/AvaloniaXamlIlFontFamilyAstNode.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers;
+using XamlX.Ast;
+using XamlX.Emit;
+using XamlX.IL;
+using XamlX.TypeSystem;
+
+namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.AstNodes
+{
+    class AvaloniaXamlIlFontFamilyAstNode: XamlAstNode, IXamlAstValueNode, IXamlAstILEmitableNode
+    {
+        private readonly AvaloniaXamlIlWellKnownTypes _types;
+        private readonly string _text;
+
+        public IXamlAstTypeReference Type { get; }
+        
+        public AvaloniaXamlIlFontFamilyAstNode(AvaloniaXamlIlWellKnownTypes types,
+            string text,
+            IXamlLineInfo lineInfo) : base(lineInfo)
+        {
+            _types = types;
+            _text = text;
+            Type = new XamlAstClrTypeReference(lineInfo, types.FontFamily, false);
+        }
+        
+        public XamlILNodeEmitResult Emit(XamlEmitContext<IXamlILEmitter, XamlILNodeEmitResult> context, IXamlILEmitter codeGen)
+        {
+            codeGen
+                .Ldloc(context.ContextLocal)
+                .Castclass(context.Configuration.TypeMappings.UriContextProvider)
+                .EmitCall(context.Configuration.TypeMappings.UriContextProvider.FindMethod(
+                    "get_BaseUri", _types.Uri, false))
+                .Ldstr(_text)
+                .Newobj(_types.FontFamilyConstructorUriName);
+            return XamlILNodeEmitResult.Type(0, _types.FontFamily);
+        }
+
+        
+
+        
+    }
+}

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using XamlX.Emit;
 using XamlX.IL;
 using XamlX.Transform;
@@ -47,6 +48,11 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType ReflectionBindingExtension { get; }
 
         public IXamlType RelativeSource { get; }
+        public IXamlType Long { get; }
+        public IXamlType Uri { get; }
+        public IXamlType FontFamily { get; }
+        public IXamlConstructor FontFamilyConstructorUriName { get; }
+        
 
         public AvaloniaXamlIlWellKnownTypes(TransformerConfiguration cfg)
         {
@@ -104,6 +110,10 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             ItemsRepeater = cfg.TypeSystem.GetType("Avalonia.Controls.ItemsRepeater");
             ReflectionBindingExtension = cfg.TypeSystem.GetType("Avalonia.Markup.Xaml.MarkupExtensions.ReflectionBindingExtension");
             RelativeSource = cfg.TypeSystem.GetType("Avalonia.Data.RelativeSource");
+            Long = cfg.TypeSystem.GetType("System.Int64");
+            Uri = cfg.TypeSystem.GetType("System.Uri");
+            FontFamily = cfg.TypeSystem.GetType("Avalonia.Media.FontFamily");
+            FontFamilyConstructorUriName = FontFamily.FindConstructor(new List<IXamlType> { Uri, XamlIlTypes.String });
         }
     }
 


### PR DESCRIPTION
Following from https://github.com/kekekeks/XamlX/pull/39

@workgroupengineering 

The compiled method that builds the object tree uses a so-called "runtime XAML context" - an object that holds various info about the current XAML file and the current node, you can see its decompiled code [here](https://gist.github.com/kekekeks/20dbbb279d57036d2cc0cf967636e839). It is used for various things, but what's important for us here, is that it implements IServiceProvider and IUriContext. That instance is actually passed as IServiceProvider to markup extensions and type converters. So to get the current URI we need to emit something that decompiles into `(IUriContext)context).BaseUri`.

The context local can be accessed fromXamlEmitContext::ContextLocal.

So, what this PR does:

1) implements `AvaloniaXamlIlFontFamilyAstNode` that emits `new FontFamily(((IUriContext)context).BaseUri, "FONT NAME FROM XAML");`
2) changes AvaloniaXamlLanguage::CustomValueConverter to return said node as a converted value for FontFamily

I've also included a better TimeSpan conversion code as we've discussed that with @MarchingCube recently.