### PR TITLE
Reduce the element of surprise in XAML compiler

### DIFF
--- a/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
+++ b/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
@@ -46,7 +46,9 @@ namespace Avalonia.Build.Tasks
             string output, bool verifyIl, MessageImportance logImportance, string strongNameKey, bool patchCom,
             bool skipXamlCompilation)
         {
-            var typeSystem = new CecilTypeSystem(references.Concat(new[] { input }), input);
+            var typeSystem = new CecilTypeSystem(references
+                .Where(r => !r.ToLowerInvariant().EndsWith("avalonia.build.tasks.dll"))
+                .Concat(new[] { input }), input);
             
             var asm = typeSystem.TargetAssemblyDefinition;
 

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/Avalonia.Markup.Xaml.Loader.csproj
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/Avalonia.Markup.Xaml.Loader.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageId>Avalonia.Markup.Xaml.Loader</PackageId>
+    <DefineConstants>$(DefineConstants);XAMLX_INTERNAL</DefineConstants>
   </PropertyGroup>
   <Import Project="IncludeXamlIlSre.props" />
   <ItemGroup>

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -374,7 +374,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
     </Window.DataTemplates>
     <ContentControl Name='target' Content='{CompiledBinding}' />
 </Window>";
-                Assert.Throws<XamlTransformException>(() => AvaloniaRuntimeXamlLoader.Load(xaml));
+                ThrowsXamlTransformException(() => AvaloniaRuntimeXamlLoader.Load(xaml));
             }
         }
 
@@ -392,7 +392,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         <TextBlock Text='{CompiledBinding StringProperty}' Name='textBlock' />
     </ContentControl>
 </Window>";
-                Assert.Throws<XamlTransformException>(() => AvaloniaRuntimeXamlLoader.Load(xaml));
+                ThrowsXamlTransformException(() => AvaloniaRuntimeXamlLoader.Load(xaml));
             }
         }
 
@@ -449,7 +449,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         </ItemsControl.DataTemplates>
     </ItemsControl>
 </Window>";
-                Assert.Throws<XamlTransformException>(() => AvaloniaRuntimeXamlLoader.Load(xaml));
+                ThrowsXamlTransformException(() => AvaloniaRuntimeXamlLoader.Load(xaml));
             }
         }
 
@@ -599,7 +599,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         x:CompileBindings='true'>
     <TextBlock Text='{Binding InvalidPath}' Name='textBlock' />
 </Window>";
-                Assert.Throws<XamlX.XamlParseException>(() => AvaloniaRuntimeXamlLoader.Load(xaml));
+                ThrowsXamlParseException(() => AvaloniaRuntimeXamlLoader.Load(xaml));
             }
         }
 
@@ -657,7 +657,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         x:DataType='local:TestDataContext'
         x:CompileBindings='notabool'>
 </Window>";
-                Assert.Throws<XamlX.XamlParseException>(() => AvaloniaRuntimeXamlLoader.Load(xaml));
+                ThrowsXamlParseException(() => AvaloniaRuntimeXamlLoader.Load(xaml));
             }
         }
 
@@ -818,8 +818,25 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 Assert.Equal(null, contentControl.Content);
             }
         }
-    }
 
+        void Throws(string type, Action cb)
+        {
+            try
+            {
+                cb();
+            }
+            catch (Exception e) when (e.GetType().Name == type)
+            {
+                return;
+            }
+
+            throw new Exception("Expected " + type);
+        }
+
+        void ThrowsXamlParseException(Action cb) => Throws("XamlParseException", cb);
+        void ThrowsXamlTransformException(Action cb) => Throws("XamlTransformException", cb);
+    }
+    
     public interface INonIntegerIndexer
     {
         string this[string key] { get; set; }


### PR DESCRIPTION
1) hide what's supposed to be hidden from the runtime loader
2) explicitly exclude Avalonia.Build.Tasks.dll from the list of referenced assemblies since I couldn't make MSBuild to use the common sense