### PR TITLE
Parse most of the vector-like types during XAML compilation.

### DIFF
--- a/src/Avalonia.Base/Utilities/MathUtilities.cs
+++ b/src/Avalonia.Base/Utilities/MathUtilities.cs
@@ -5,7 +5,10 @@ namespace Avalonia.Utilities
     /// <summary>
     /// Provides math utilities not provided in System.Math.
     /// </summary>
-    public static class MathUtilities
+#if !BUILDTASK
+    public
+#endif
+    static class MathUtilities
     {
         // smallest such that 1.0+DoubleEpsilon != 1.0
         internal static readonly double DoubleEpsilon = 2.2204460492503131e-016;

--- a/src/Avalonia.Base/Utilities/StringTokenizer.cs
+++ b/src/Avalonia.Base/Utilities/StringTokenizer.cs
@@ -4,7 +4,10 @@ using static System.Char;
 
 namespace Avalonia.Utilities
 {
-    public struct StringTokenizer : IDisposable
+#if !BUILDTASK
+    public
+#endif
+    struct StringTokenizer : IDisposable
     {
         private const char DefaultSeparatorChar = ',';
 

--- a/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
+++ b/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
@@ -45,6 +45,12 @@
       <Compile Include="../Avalonia.Base/Utilities/IdentifierParser.cs">
         <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
       </Compile>
+      <Compile Include="../Avalonia.Base/Utilities/StringTokenizer.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>
+      <Compile Include="../Avalonia.Base/Utilities/MathUtilities.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>
       <Compile Include="..\Markup\Avalonia.Markup\Markup\Parsers\ArgumentListParser.cs">
         <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
       </Compile>
@@ -55,6 +61,24 @@
         <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
       </Compile>
       <Compile Include="../Avalonia.Base/Utilities/StyleClassParser.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>
+      <Compile Include="../Avalonia.Visuals/Thickness.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>
+      <Compile Include="../Avalonia.Visuals/Size.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>
+      <Compile Include="../Avalonia.Visuals/Vector.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>
+      <Compile Include="../Avalonia.Visuals/Point.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>
+      <Compile Include="../Avalonia.Visuals/Matrix.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>
+      <Compile Include="../Avalonia.Visuals/CornerRadius.cs">
         <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
       </Compile>
       <Compile Remove="../Markup/Avalonia.Markup.Xaml.Loader\xamlil.github\**\obj\**\*.cs" />

--- a/src/Avalonia.Visuals/CornerRadius.cs
+++ b/src/Avalonia.Visuals/CornerRadius.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Globalization;
+#if !BUILDTASK
 using Avalonia.Animation.Animators;
+#endif
 using Avalonia.Utilities;
 
 namespace Avalonia
@@ -8,11 +10,16 @@ namespace Avalonia
     /// <summary>
     /// Represents the radii of a rectangle's corners.
     /// </summary>
-    public readonly struct CornerRadius : IEquatable<CornerRadius>
+#if !BUILDTASK
+    public
+#endif
+    readonly struct CornerRadius : IEquatable<CornerRadius>
     {
         static CornerRadius()
         {
+#if !BUILDTASK
             Animation.Animation.RegisterAnimator<CornerRadiusAnimator>(prop => typeof(CornerRadius).IsAssignableFrom(prop.PropertyType));
+#endif
         }
 
         public CornerRadius(double uniformRadius)

--- a/src/Avalonia.Visuals/Matrix.cs
+++ b/src/Avalonia.Visuals/Matrix.cs
@@ -7,7 +7,10 @@ namespace Avalonia
     /// <summary>
     /// A 2x3 matrix.
     /// </summary>
-    public readonly struct Matrix : IEquatable<Matrix>
+#if !BUILDTASK
+    public
+#endif
+    readonly struct Matrix : IEquatable<Matrix>
     {
         private readonly double _m11;
         private readonly double _m12;

--- a/src/Avalonia.Visuals/Point.cs
+++ b/src/Avalonia.Visuals/Point.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Globalization;
+#if !BUILDTASK
 using Avalonia.Animation.Animators;
+#endif
 using Avalonia.Utilities;
 
 namespace Avalonia
@@ -8,11 +10,16 @@ namespace Avalonia
     /// <summary>
     /// Defines a point.
     /// </summary>
-    public readonly struct Point : IEquatable<Point>
+#if !BUILDTASK
+    public
+#endif
+    readonly struct Point : IEquatable<Point>
     {
         static Point()
         {
+#if !BUILDTASK
             Animation.Animation.RegisterAnimator<PointAnimator>(prop => typeof(Point).IsAssignableFrom(prop.PropertyType));
+#endif
         }
 
         /// <summary>

--- a/src/Avalonia.Visuals/Size.cs
+++ b/src/Avalonia.Visuals/Size.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Globalization;
+#if !BUILDTASK
 using Avalonia.Animation.Animators;
+#endif
 using Avalonia.Utilities;
 
 namespace Avalonia
@@ -8,11 +10,16 @@ namespace Avalonia
     /// <summary>
     /// Defines a size.
     /// </summary>
-    public readonly struct Size : IEquatable<Size>
+#if !BUILDTASK
+    public
+#endif
+    readonly struct Size : IEquatable<Size>
     {
         static Size()
         {
+#if !BUILDTASK
             Animation.Animation.RegisterAnimator<SizeAnimator>(prop => typeof(Size).IsAssignableFrom(prop.PropertyType));
+#endif
         }
 
         /// <summary>

--- a/src/Avalonia.Visuals/Thickness.cs
+++ b/src/Avalonia.Visuals/Thickness.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Globalization;
+#if !BUILDTASK
 using Avalonia.Animation.Animators;
+#endif
 using Avalonia.Utilities;
 
 namespace Avalonia
@@ -8,11 +10,16 @@ namespace Avalonia
     /// <summary>
     /// Describes the thickness of a frame around a rectangle.
     /// </summary>
-    public readonly struct Thickness : IEquatable<Thickness>
+#if !BUILDTASK
+    public
+#endif
+    readonly struct Thickness : IEquatable<Thickness>
     {
         static Thickness()
         {
+#if !BUILDTASK
             Animation.Animation.RegisterAnimator<ThicknessAnimator>(prop => typeof(Thickness).IsAssignableFrom(prop.PropertyType));
+#endif
         }
 
         /// <summary>

--- a/src/Avalonia.Visuals/Vector.cs
+++ b/src/Avalonia.Visuals/Vector.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Globalization;
+#if !BUILDTASK
 using Avalonia.Animation.Animators;
+#endif
 using Avalonia.Utilities;
 
 #nullable enable
@@ -10,11 +12,16 @@ namespace Avalonia
     /// <summary>
     /// Defines a vector.
     /// </summary>
-    public readonly struct Vector : IEquatable<Vector>
+#if !BUILDTASK
+    public
+#endif
+    readonly struct Vector : IEquatable<Vector>
     {
         static Vector()
         {
+#if !BUILDTASK
             Animation.Animation.RegisterAnimator<VectorAnimator>(prop => typeof(Vector).IsAssignableFrom(prop.PropertyType));
+#endif
         }
 
         /// <summary>

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AstNodes/AvaloniaXamlIlVectorLikeConstantAstNode.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AstNodes/AvaloniaXamlIlVectorLikeConstantAstNode.cs
@@ -1,0 +1,35 @@
+﻿using XamlX.Ast;
+using XamlX.Emit;
+using XamlX.IL;
+using XamlX.TypeSystem;
+
+namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.AstNodes
+{
+    class AvaloniaXamlIlVectorLikeConstantAstNode : XamlAstNode, IXamlAstValueNode, IXamlAstILEmitableNode
+    {
+        private readonly IXamlConstructor _constructor;
+        private readonly double[] _values;
+
+        public AvaloniaXamlIlVectorLikeConstantAstNode(IXamlLineInfo lineInfo, IXamlType type, IXamlConstructor constructor, double[] values) : base(lineInfo)
+        {
+            _constructor = constructor;
+            _values = values;
+            
+            Type = new XamlAstClrTypeReference(lineInfo, type, false);
+        }
+        
+        public IXamlAstTypeReference Type { get; }
+        
+        public XamlILNodeEmitResult Emit(XamlEmitContext<IXamlILEmitter, XamlILNodeEmitResult> context, IXamlILEmitter codeGen)
+        {
+            foreach (var value in _values)
+            {
+                codeGen.Ldc_R8(value);
+            }
+            
+            codeGen.Newobj(_constructor);
+            
+            return XamlILNodeEmitResult.Type(0, Type.GetClrType());
+        }
+    }
+}

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AstNodes/AvaloniaXamlIlVectorLikeConstantAstNode.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AstNodes/AvaloniaXamlIlVectorLikeConstantAstNode.cs
@@ -1,4 +1,6 @@
-﻿using XamlX.Ast;
+﻿using Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers;
+using XamlX;
+using XamlX.Ast;
 using XamlX.Emit;
 using XamlX.IL;
 using XamlX.TypeSystem;
@@ -10,8 +12,25 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.AstNodes
         private readonly IXamlConstructor _constructor;
         private readonly double[] _values;
 
-        public AvaloniaXamlIlVectorLikeConstantAstNode(IXamlLineInfo lineInfo, IXamlType type, IXamlConstructor constructor, double[] values) : base(lineInfo)
+        public AvaloniaXamlIlVectorLikeConstantAstNode(IXamlLineInfo lineInfo, AvaloniaXamlIlWellKnownTypes types, IXamlType type, IXamlConstructor constructor, double[] values) : base(lineInfo)
         {
+            var parameters = constructor.Parameters;
+
+            if (parameters.Count != values.Length)
+            {
+                throw new XamlTypeSystemException($"Constructor that takes {values.Length} parameters is expected, got {parameters.Count} instead.");
+            }
+
+            var elementType = types.XamlIlTypes.Double;
+
+            foreach (var parameter in parameters)
+            {
+                if (parameter != elementType)
+                {
+                    throw new XamlTypeSystemException($"Expected parameter of type {elementType}, got {parameter} instead.");
+                }
+            }
+            
             _constructor = constructor;
             _values = values;
             

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguage.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguage.cs
@@ -210,7 +210,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             {
                 var thickness = Thickness.Parse(text);
 
-                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types.Thickness, types.ThicknessFullConstructorName,
+                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.Thickness, types.ThicknessFullConstructor,
                     new[] { thickness.Left, thickness.Top, thickness.Right, thickness.Bottom });
                 
                 return true;
@@ -220,7 +220,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             {
                 var point = Point.Parse(text);
 
-                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types.Point, types.PointFullConstructorName,
+                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.Point, types.PointFullConstructor,
                     new[] { point.X, point.Y });
                 
                 return true;
@@ -230,7 +230,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             {
                 var vector = Vector.Parse(text);
 
-                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types.Vector, types.VectorFullConstructorName,
+                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.Vector, types.VectorFullConstructor,
                     new[] { vector.X, vector.Y });
                 
                 return true;
@@ -240,7 +240,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             {
                 var size = Size.Parse(text);
 
-                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types.Size, types.SizeFullConstructorName,
+                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.Size, types.SizeFullConstructor,
                     new[] { size.Width, size.Height });
                 
                 return true;
@@ -250,7 +250,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             {
                 var matrix = Matrix.Parse(text);
 
-                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types.Matrix, types.MatrixFullConstructorName,
+                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.Matrix, types.MatrixFullConstructor,
                     new[] { matrix.M11, matrix.M12, matrix.M21, matrix.M22, matrix.M31, matrix.M32 });
                 
                 return true;
@@ -260,7 +260,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             {
                 var cornerRadius = CornerRadius.Parse(text);
 
-                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types.CornerRadius, types.CornerRadiusFullConstructorName,
+                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.CornerRadius, types.CornerRadiusFullConstructor,
                     new[] { cornerRadius.TopLeft, cornerRadius.TopRight, cornerRadius.BottomRight, cornerRadius.BottomLeft });
                 
                 return true;

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguage.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguage.cs
@@ -205,6 +205,66 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                 result = new AvaloniaXamlIlFontFamilyAstNode(types, text, node);
                 return true;
             }
+            
+            if (type.Equals(types.Thickness))
+            {
+                var thickness = Thickness.Parse(text);
+
+                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types.Thickness, types.ThicknessFullConstructorName,
+                    new[] { thickness.Left, thickness.Top, thickness.Right, thickness.Bottom });
+                
+                return true;
+            }
+
+            if (type.Equals(types.Point))
+            {
+                var point = Point.Parse(text);
+
+                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types.Point, types.PointFullConstructorName,
+                    new[] { point.X, point.Y });
+                
+                return true;
+            }
+            
+            if (type.Equals(types.Vector))
+            {
+                var vector = Vector.Parse(text);
+
+                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types.Vector, types.VectorFullConstructorName,
+                    new[] { vector.X, vector.Y });
+                
+                return true;
+            }
+            
+            if (type.Equals(types.Size))
+            {
+                var size = Size.Parse(text);
+
+                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types.Size, types.SizeFullConstructorName,
+                    new[] { size.Width, size.Height });
+                
+                return true;
+            }
+            
+            if (type.Equals(types.Matrix))
+            {
+                var matrix = Matrix.Parse(text);
+
+                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types.Matrix, types.MatrixFullConstructorName,
+                    new[] { matrix.M11, matrix.M12, matrix.M21, matrix.M22, matrix.M31, matrix.M32 });
+                
+                return true;
+            }
+            
+            if (type.Equals(types.CornerRadius))
+            {
+                var cornerRadius = CornerRadius.Parse(text);
+
+                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types.CornerRadius, types.CornerRadiusFullConstructorName,
+                    new[] { cornerRadius.TopLeft, cornerRadius.TopRight, cornerRadius.BottomRight, cornerRadius.BottomLeft });
+                
+                return true;
+            }
 
             if (type.FullName == "Avalonia.AvaloniaProperty")
             {

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -54,17 +54,17 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType FontFamily { get; }
         public IXamlConstructor FontFamilyConstructorUriName { get; }
         public IXamlType Thickness { get; }
-        public IXamlConstructor ThicknessFullConstructorName { get; }
+        public IXamlConstructor ThicknessFullConstructor { get; }
         public IXamlType Point { get; }
-        public IXamlConstructor PointFullConstructorName { get; }
+        public IXamlConstructor PointFullConstructor { get; }
         public IXamlType Vector { get; }
-        public IXamlConstructor VectorFullConstructorName { get; }
+        public IXamlConstructor VectorFullConstructor { get; }
         public IXamlType Size { get; }
-        public IXamlConstructor SizeFullConstructorName { get; }
+        public IXamlConstructor SizeFullConstructor { get; }
         public IXamlType Matrix { get; }
-        public IXamlConstructor MatrixFullConstructorName { get; }
+        public IXamlConstructor MatrixFullConstructor { get; }
         public IXamlType CornerRadius { get; }
-        public IXamlConstructor CornerRadiusFullConstructorName { get; }
+        public IXamlConstructor CornerRadiusFullConstructor { get; }
 
         public AvaloniaXamlIlWellKnownTypes(TransformerConfiguration cfg)
         {
@@ -135,12 +135,12 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                 return (type, ctor);
             }
 
-            (Thickness, ThicknessFullConstructorName) = GetNumericTypeInfo("Avalonia.Thickness", XamlIlTypes.Double, 4);
-            (Point, PointFullConstructorName) = GetNumericTypeInfo("Avalonia.Point", XamlIlTypes.Double, 2);
-            (Vector, VectorFullConstructorName) = GetNumericTypeInfo("Avalonia.Vector", XamlIlTypes.Double, 2);
-            (Size, SizeFullConstructorName) = GetNumericTypeInfo("Avalonia.Size", XamlIlTypes.Double, 2);
-            (Matrix, MatrixFullConstructorName) = GetNumericTypeInfo("Avalonia.Matrix", XamlIlTypes.Double, 6);
-            (CornerRadius, CornerRadiusFullConstructorName) = GetNumericTypeInfo("Avalonia.CornerRadius", XamlIlTypes.Double, 4);
+            (Thickness, ThicknessFullConstructor) = GetNumericTypeInfo("Avalonia.Thickness", XamlIlTypes.Double, 4);
+            (Point, PointFullConstructor) = GetNumericTypeInfo("Avalonia.Point", XamlIlTypes.Double, 2);
+            (Vector, VectorFullConstructor) = GetNumericTypeInfo("Avalonia.Vector", XamlIlTypes.Double, 2);
+            (Size, SizeFullConstructor) = GetNumericTypeInfo("Avalonia.Size", XamlIlTypes.Double, 2);
+            (Matrix, MatrixFullConstructor) = GetNumericTypeInfo("Avalonia.Matrix", XamlIlTypes.Double, 6);
+            (CornerRadius, CornerRadiusFullConstructor) = GetNumericTypeInfo("Avalonia.CornerRadius", XamlIlTypes.Double, 4);
         }
     }
 

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using XamlX.Emit;
 using XamlX.IL;
 using XamlX.Transform;
@@ -52,7 +53,18 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType Uri { get; }
         public IXamlType FontFamily { get; }
         public IXamlConstructor FontFamilyConstructorUriName { get; }
-        
+        public IXamlType Thickness { get; }
+        public IXamlConstructor ThicknessFullConstructorName { get; }
+        public IXamlType Point { get; }
+        public IXamlConstructor PointFullConstructorName { get; }
+        public IXamlType Vector { get; }
+        public IXamlConstructor VectorFullConstructorName { get; }
+        public IXamlType Size { get; }
+        public IXamlConstructor SizeFullConstructorName { get; }
+        public IXamlType Matrix { get; }
+        public IXamlConstructor MatrixFullConstructorName { get; }
+        public IXamlType CornerRadius { get; }
+        public IXamlConstructor CornerRadiusFullConstructorName { get; }
 
         public AvaloniaXamlIlWellKnownTypes(TransformerConfiguration cfg)
         {
@@ -113,7 +125,22 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             Long = cfg.TypeSystem.GetType("System.Int64");
             Uri = cfg.TypeSystem.GetType("System.Uri");
             FontFamily = cfg.TypeSystem.GetType("Avalonia.Media.FontFamily");
-            FontFamilyConstructorUriName = FontFamily.FindConstructor(new List<IXamlType> { Uri, XamlIlTypes.String });
+            FontFamilyConstructorUriName = FontFamily.GetConstructor(new List<IXamlType> { Uri, XamlIlTypes.String });
+
+            (IXamlType, IXamlConstructor) GetNumericTypeInfo(string name, IXamlType componentType, int componentCount)
+            {
+                var type = cfg.TypeSystem.GetType(name);
+                var ctor = type.GetConstructor(Enumerable.Range(0, componentCount).Select(_ => componentType).ToList());
+
+                return (type, ctor);
+            }
+
+            (Thickness, ThicknessFullConstructorName) = GetNumericTypeInfo("Avalonia.Thickness", XamlIlTypes.Double, 4);
+            (Point, PointFullConstructorName) = GetNumericTypeInfo("Avalonia.Point", XamlIlTypes.Double, 2);
+            (Vector, VectorFullConstructorName) = GetNumericTypeInfo("Avalonia.Vector", XamlIlTypes.Double, 2);
+            (Size, SizeFullConstructorName) = GetNumericTypeInfo("Avalonia.Size", XamlIlTypes.Double, 2);
+            (Matrix, MatrixFullConstructorName) = GetNumericTypeInfo("Avalonia.Matrix", XamlIlTypes.Double, 6);
+            (CornerRadius, CornerRadiusFullConstructorName) = GetNumericTypeInfo("Avalonia.CornerRadius", XamlIlTypes.Double, 4);
         }
     }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Adds support for parsing common vector like types during XAML compilation time. Currently it supports:
- `Thickness`
- `Point`
- `Size`
- `Vector`
- `CornerRadius`
- `Matrix`

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
XAML compiler simply outputs `Parse` call which has runtime overhead and requires allocations.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
XAML compiler outputs direct constructor calls that create instances directly from already parsed data.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
