### PR TITLE
Fix X11 dropping modifier keys

### DIFF
--- a/src/Avalonia.X11/XI2Manager.cs
+++ b/src/Avalonia.X11/XI2Manager.cs
@@ -351,7 +351,7 @@ namespace Avalonia.X11
             if (state.HasFlag(XModifierMask.Mod4Mask))
                 Modifiers |= RawInputModifiers.Meta;
 
-            Modifiers = ParseButtonState(ev->buttons.MaskLen, ev->buttons.Mask);
+            Modifiers |= ParseButtonState(ev->buttons.MaskLen, ev->buttons.Mask);
 
             Valuators = new Dictionary<int, double>();
             Position = new Point(ev->event_x, ev->event_y);


### PR DESCRIPTION

## What does the pull request do?
When the call to ParseButtonState was added to XI2Manager, it incorrectly overwrote the Modifiers variable - so the checks already done to populate Modifiers with Control/Alt/Shift key states were lost. This changes it to add the states from ParseButtonState to any key states already set in the variable.

## What is the current behavior?

Currently, key states for Control/Shift/etc. are calculated but then overwritten - so those key states are never set in the various events.

## What is the updated/expected behavior with this PR?
See repro code in issue #4988 - this change resolves that so the behaviour on X11 is consistent with other platforms.

## How was the solution implemented (if it's not obvious)?
N/A

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
N/A

## Fixed issues
Fixes #4988
