### PR TITLE
Parse Color and GridLength during compilation

### DIFF
--- a/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
+++ b/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0</TargetFrameworks>
-        <TargetFrameworks Condition="$(Configuration) == 'Debug'">netstandard2.0;netcoreapp2.0</TargetFrameworks>
+        <TargetFrameworks Condition="$(Configuration) == 'Debug'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
         <OutputType>exe</OutputType>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
@@ -79,6 +79,15 @@
         <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
       </Compile>
       <Compile Include="../Avalonia.Visuals/CornerRadius.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>
+      <Compile Include="../Avalonia.Visuals/Media/Color.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>
+      <Compile Include="../Avalonia.Visuals/Media/KnownColors.cs">
+        <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
+      </Compile>
+      <Compile Include="../Avalonia.Controls/GridLength.cs">
         <Link>Markup/%(RecursiveDir)%(FileName)%(Extension)</Link>
       </Compile>
       <Compile Remove="../Markup/Avalonia.Markup.Xaml.Loader\xamlil.github\**\obj\**\*.cs" />

--- a/src/Avalonia.Build.Tasks/SpanCompat.cs
+++ b/src/Avalonia.Build.Tasks/SpanCompat.cs
@@ -1,3 +1,4 @@
+#if !NETCOREAPP3_1
 namespace System
 {
     // This is a hack to enable our span code to work inside MSBuild task without referencing System.Memory
@@ -63,6 +64,8 @@ namespace System
         }
 
         public override string ToString() => _length == 0 ? string.Empty : _s.Substring(_start, _length);
+
+        public static implicit operator ReadOnlySpan<T>(char[] arr) => new ReadOnlySpan<T>(new string(arr));
     }
 
     static class SpanCompatExtensions
@@ -71,3 +74,4 @@ namespace System
     }
 
 }
+#endif

--- a/src/Avalonia.Controls/GridLength.cs
+++ b/src/Avalonia.Controls/GridLength.cs
@@ -8,7 +8,10 @@ namespace Avalonia.Controls
     /// <summary>
     /// Defines the valid units for a <see cref="GridLength"/>.
     /// </summary>
-    public enum GridUnitType
+#if !BUILDTASK
+    public
+#endif
+    enum GridUnitType
     {
         /// <summary>
         /// The row or column is auto-sized to fit its content.
@@ -29,7 +32,10 @@ namespace Avalonia.Controls
     /// <summary>
     /// Holds the width or height of a <see cref="Grid"/>'s column and row definitions.
     /// </summary>
-    public struct GridLength : IEquatable<GridLength>
+#if !BUILDTASK
+    public
+#endif
+    struct GridLength : IEquatable<GridLength>
     {
         private readonly GridUnitType _type;
 

--- a/src/Avalonia.Visuals/Media/Color.cs
+++ b/src/Avalonia.Visuals/Media/Color.cs
@@ -1,17 +1,24 @@
 using System;
 using System.Globalization;
+#if !BUILDTASK
 using Avalonia.Animation.Animators;
+#endif
 
 namespace Avalonia.Media
 {
     /// <summary>
     /// An ARGB color.
     /// </summary>
-    public readonly struct Color : IEquatable<Color>
+#if !BUILDTASK
+    public
+#endif
+    readonly struct Color : IEquatable<Color>
     {
         static Color()
         {
+#if !BUILDTASK
             Animation.Animation.RegisterAnimator<ColorAnimator>(prop => typeof(Color).IsAssignableFrom(prop.PropertyType));
+#endif
         }
 
         /// <summary>
@@ -223,7 +230,12 @@ namespace Avalonia.Media
             if (input.Length == 3 || input.Length == 4)
             {
                 var extendedLength = 2 * input.Length;
+                
+#if !BUILDTASK
                 Span<char> extended = stackalloc char[extendedLength];
+#else
+                char[] extended = new char[extendedLength];
+#endif
 
                 for (int i = 0; i < input.Length; i++)
                 {

--- a/src/Avalonia.Visuals/Media/KnownColors.cs
+++ b/src/Avalonia.Visuals/Media/KnownColors.cs
@@ -8,7 +8,9 @@ namespace Avalonia.Media
     {
         private static readonly IReadOnlyDictionary<string, KnownColor> _knownColorNames;
         private static readonly IReadOnlyDictionary<uint, string> _knownColors;
+#if !BUILDTASK
         private static readonly Dictionary<KnownColor, ISolidColorBrush> _knownBrushes;
+#endif
 
         static KnownColors()
         {
@@ -32,14 +34,19 @@ namespace Avalonia.Media
 
             _knownColorNames = knownColorNames;
             _knownColors = knownColors;
+            
+#if !BUILDTASK
             _knownBrushes = new Dictionary<KnownColor, ISolidColorBrush>();
+#endif
         }
 
+#if !BUILDTASK
         public static ISolidColorBrush GetKnownBrush(string s)
         {
             var color = GetKnownColor(s);
             return color != KnownColor.None ? color.ToBrush() : null;
         }
+#endif
 
         public static KnownColor GetKnownColor(string s)
         {
@@ -61,6 +68,7 @@ namespace Avalonia.Media
             return Color.FromUInt32((uint)color);
         }
 
+#if !BUILDTASK
         public static ISolidColorBrush ToBrush(this KnownColor color)
         {
             lock (_knownBrushes)
@@ -74,6 +82,7 @@ namespace Avalonia.Media
                 return brush;
             }
         }
+#endif
     }
 
     internal enum KnownColor : uint

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AstNodes/AvaloniaXamlIlGridLengthAstNode.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AstNodes/AvaloniaXamlIlGridLengthAstNode.cs
@@ -1,0 +1,34 @@
+﻿using Avalonia.Controls;
+using Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers;
+using XamlX.Ast;
+using XamlX.Emit;
+using XamlX.IL;
+
+namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.AstNodes
+{
+    class AvaloniaXamlIlGridLengthAstNode : XamlAstNode, IXamlAstValueNode, IXamlAstILEmitableNode
+    {
+        private readonly AvaloniaXamlIlWellKnownTypes _types;
+        private readonly GridLength _gridLength;
+
+        public AvaloniaXamlIlGridLengthAstNode(IXamlLineInfo lineInfo, AvaloniaXamlIlWellKnownTypes types, GridLength gridLength) : base(lineInfo)
+        {
+            _types = types;
+            _gridLength = gridLength;
+
+            Type = new XamlAstClrTypeReference(lineInfo, types.GridLength, false);
+        }
+        
+        public IXamlAstTypeReference Type { get; }
+        
+        public XamlILNodeEmitResult Emit(XamlEmitContext<IXamlILEmitter, XamlILNodeEmitResult> context, IXamlILEmitter codeGen)
+        {
+            codeGen
+                .Ldc_R8(_gridLength.Value)
+                .Ldc_I4((int)_gridLength.GridUnitType)
+                .Newobj(_types.GridLengthConstructorValueType);
+            
+            return XamlILNodeEmitResult.Type(0, Type.GetClrType());
+        }
+    }
+}

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguage.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguage.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Avalonia.Controls;
 using Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.AstNodes;
 using Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers;
+using Avalonia.Media;
 using XamlX;
 using XamlX.Ast;
 using XamlX.Emit;
@@ -205,65 +207,138 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                 result = new AvaloniaXamlIlFontFamilyAstNode(types, text, node);
                 return true;
             }
-            
+
             if (type.Equals(types.Thickness))
             {
-                var thickness = Thickness.Parse(text);
-
-                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.Thickness, types.ThicknessFullConstructor,
-                    new[] { thickness.Left, thickness.Top, thickness.Right, thickness.Bottom });
+                try
+                {
+                    var thickness = Thickness.Parse(text);
+            
+                    result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.Thickness, types.ThicknessFullConstructor,
+                        new[] { thickness.Left, thickness.Top, thickness.Right, thickness.Bottom });
                 
-                return true;
+                    return true;
+                }
+                catch
+                {
+                    throw new XamlX.XamlLoadException($"Unable to parse \"{text}\" as a thickness", node);
+                }
             }
 
             if (type.Equals(types.Point))
             {
-                var point = Point.Parse(text);
-
-                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.Point, types.PointFullConstructor,
-                    new[] { point.X, point.Y });
+                try
+                {
+                    var point = Point.Parse(text);
+            
+                    result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.Point, types.PointFullConstructor,
+                        new[] { point.X, point.Y });
                 
-                return true;
+                    return true;
+                }
+                catch
+                {
+                    throw new XamlX.XamlLoadException($"Unable to parse \"{text}\" as a point", node);
+                }
             }
             
             if (type.Equals(types.Vector))
             {
-                var vector = Vector.Parse(text);
-
-                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.Vector, types.VectorFullConstructor,
-                    new[] { vector.X, vector.Y });
+                try
+                {
+                    var vector = Vector.Parse(text);
+            
+                    result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.Vector, types.VectorFullConstructor,
+                        new[] { vector.X, vector.Y });
                 
-                return true;
+                    return true;
+                }
+                catch
+                {
+                    throw new XamlX.XamlLoadException($"Unable to parse \"{text}\" as a vector", node);
+                }
             }
             
             if (type.Equals(types.Size))
             {
-                var size = Size.Parse(text);
-
-                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.Size, types.SizeFullConstructor,
-                    new[] { size.Width, size.Height });
+                try
+                {
+                    var size = Size.Parse(text);
                 
-                return true;
+                    result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.Size, types.SizeFullConstructor,
+                        new[] { size.Width, size.Height });
+                
+                    return true;
+                }
+                catch
+                {
+                    throw new XamlX.XamlLoadException($"Unable to parse \"{text}\" as a size", node);
+                }
             }
             
             if (type.Equals(types.Matrix))
             {
-                var matrix = Matrix.Parse(text);
-
-                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.Matrix, types.MatrixFullConstructor,
-                    new[] { matrix.M11, matrix.M12, matrix.M21, matrix.M22, matrix.M31, matrix.M32 });
+                try
+                {
+                    var matrix = Matrix.Parse(text);
+                    
+                    result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.Matrix, types.MatrixFullConstructor,
+                        new[] { matrix.M11, matrix.M12, matrix.M21, matrix.M22, matrix.M31, matrix.M32 });
                 
-                return true;
+                    return true;
+                }
+                catch
+                {
+                    throw new XamlX.XamlLoadException($"Unable to parse \"{text}\" as a matrix", node);
+                }
             }
             
             if (type.Equals(types.CornerRadius))
             {
-                var cornerRadius = CornerRadius.Parse(text);
-
-                result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.CornerRadius, types.CornerRadiusFullConstructor,
-                    new[] { cornerRadius.TopLeft, cornerRadius.TopRight, cornerRadius.BottomRight, cornerRadius.BottomLeft });
+                try
+                {
+                    var cornerRadius = CornerRadius.Parse(text);
+            
+                    result = new AvaloniaXamlIlVectorLikeConstantAstNode(node, types, types.CornerRadius, types.CornerRadiusFullConstructor,
+                        new[] { cornerRadius.TopLeft, cornerRadius.TopRight, cornerRadius.BottomRight, cornerRadius.BottomLeft });
                 
+                    return true;
+                }
+                catch
+                {
+                    throw new XamlX.XamlLoadException($"Unable to parse \"{text}\" as a corner radius", node);
+                }
+            }
+            
+            if (type.Equals(types.Color))
+            {
+                if (!Color.TryParse(text, out Color color))
+                {
+                    throw new XamlX.XamlLoadException($"Unable to parse \"{text}\" as a color", node);
+                }
+
+                result = new XamlStaticOrTargetedReturnMethodCallNode(node,
+                    type.GetMethod(
+                        new FindMethodMethodSignature("FromUInt32", type, types.UInt) { IsStatic = true }),
+                    new[] { new XamlConstantNode(node, types.UInt, color.ToUint32()) });
+
                 return true;
+            }
+
+            if (type.Equals(types.GridLength))
+            {
+                try
+                {
+                    var gridLength = GridLength.Parse(text);
+                
+                    result = new AvaloniaXamlIlGridLengthAstNode(node, types, gridLength);
+                    
+                    return true;
+                }
+                catch
+                {
+                    throw new XamlX.XamlLoadException($"Unable to parse \"{text}\" as a grid length", node);
+                }
             }
 
             if (type.FullName == "Avalonia.AvaloniaProperty")

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -49,6 +49,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType ReflectionBindingExtension { get; }
 
         public IXamlType RelativeSource { get; }
+        public IXamlType UInt { get; }
         public IXamlType Long { get; }
         public IXamlType Uri { get; }
         public IXamlType FontFamily { get; }
@@ -65,6 +66,9 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlConstructor MatrixFullConstructor { get; }
         public IXamlType CornerRadius { get; }
         public IXamlConstructor CornerRadiusFullConstructor { get; }
+        public IXamlType GridLength { get; }
+        public IXamlConstructor GridLengthConstructorValueType { get; }
+        public IXamlType Color { get; }
 
         public AvaloniaXamlIlWellKnownTypes(TransformerConfiguration cfg)
         {
@@ -122,6 +126,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             ItemsRepeater = cfg.TypeSystem.GetType("Avalonia.Controls.ItemsRepeater");
             ReflectionBindingExtension = cfg.TypeSystem.GetType("Avalonia.Markup.Xaml.MarkupExtensions.ReflectionBindingExtension");
             RelativeSource = cfg.TypeSystem.GetType("Avalonia.Data.RelativeSource");
+            UInt = cfg.TypeSystem.GetType("System.UInt32");
             Long = cfg.TypeSystem.GetType("System.Int64");
             Uri = cfg.TypeSystem.GetType("System.Uri");
             FontFamily = cfg.TypeSystem.GetType("Avalonia.Media.FontFamily");
@@ -141,6 +146,10 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             (Size, SizeFullConstructor) = GetNumericTypeInfo("Avalonia.Size", XamlIlTypes.Double, 2);
             (Matrix, MatrixFullConstructor) = GetNumericTypeInfo("Avalonia.Matrix", XamlIlTypes.Double, 6);
             (CornerRadius, CornerRadiusFullConstructor) = GetNumericTypeInfo("Avalonia.CornerRadius", XamlIlTypes.Double, 4);
+
+            GridLength = cfg.TypeSystem.GetType("Avalonia.Controls.GridLength");
+            GridLengthConstructorValueType = GridLength.GetConstructor(new List<IXamlType> { XamlIlTypes.Double, cfg.TypeSystem.GetType("Avalonia.Controls.GridUnitType") });
+            Color = cfg.TypeSystem.GetType("Avalonia.Media.Color");
         }
     }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Follow up PR for https://github.com/AvaloniaUI/Avalonia/pull/5053. This adds parsing for two other common types:
- `Color`
- `GridLength`

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Runtime parsing and runtime error validation.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Compile time verification and much cheaper construction during runtime.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Many structs do not have `TryParse` so exception handling had to be used. Perhaps we should open an `up-to-grabs` ticket for implementing `TryParse` variants and utilizing it. But wrapping everything allows for having clear errors in XAML already.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
