### PR TITLE
Update macOS build instructions dylib copy instructions

### DIFF
--- a/Documentation/build.md
+++ b/Documentation/build.md
@@ -60,23 +60,10 @@ git submodule update --init --recursive
 
 ### Build native libraries (macOS only)
 
-On macOS it is necessary to build and manually install the respective native libraries using [Xcode](https://developer.apple.com/xcode/).  The steps to get this working correctly are:
-- (for revisions after 2 Nov 2020) Run `./build.sh GenerateCppHeaders` to generate `avalonia-native.h` from `avn.idl`
-- Navigate to the Avalonia/native/Avalonia.Native/src/OSX folder and open the `Avalonia.Native.OSX.xcodeproj` project
-- Build the library via the Product->Build menu.  This will generate binaries in your local path under ~/Library/Developer/Xcode/DerivedData/Avalonia.Native.OSX-*guid* where "guid" is uniquely generated every time you build.
-- Manually install the native library by copying it from the build artifacts folder into the shared dynamic library path:
+On macOS it is necessary to build and manually install the respective native libraries using [Xcode](https://developer.apple.com/xcode/). Execute the build script in the root project with the `CompileNative` task. It will build the headers, build the libraries, and place them in the appropriate place to allow .NET to find them at compilation and run time.
 
-```
-cd ~/Library/Developer/Xcode/DerivedData/Avalonia.Native.OSX-[guid]/Build/Products/Debug
-cp libAvalonia.Native.OSX.dylib /usr/local/lib/libAvalonia.Native.OSX.dylib
-```
-
-For compilation we also need this library on the build path. From the Avalonia root project directory:
-
-```
-mkdir -p build/Products/Release
-cp /usr/local/lib/libAvalonia.Native.OSX.dylib build/Products/Release
-
+```bash
+./build.sh CompileNative
 ```
 
 ###  Build and Run Avalonia

--- a/Documentation/build.md
+++ b/Documentation/build.md
@@ -68,7 +68,15 @@ On macOS it is necessary to build and manually install the respective native lib
 
 ```
 cd ~/Library/Developer/Xcode/DerivedData/Avalonia.Native.OSX-[guid]/Build/Products/Debug
-cp libAvalonia.Native.OSX.dylib /usr/local/lib/libAvaloniaNative.dylib
+cp libAvalonia.Native.OSX.dylib /usr/local/lib/libAvalonia.Native.OSX.dylib
+```
+
+For compilation we also need this library on the build path. From the Avalonia root project directory:
+
+```
+mkdir -p build/Products/Release
+cp /usr/local/lib/libAvalonia.Native.OSX.dylib build/Products/Release
+
 ```
 
 ###  Build and Run Avalonia


### PR DESCRIPTION
## What does the pull request do?
- Updates the macOS build instructions so it allows a successful from scratch build


## What is the current behavior?
- Build instructions use the wrong library name in the /usr/local/lib 
- Build instructions doesn't have a new additional step of copying down to build/Products/Release that is required now


## What is the updated/expected behavior with this PR?
- Users reading the build instructions on macOS can build it with greater ease

## How was the solution implemented (if it's not obvious)?
N/A


## Checklist

- [ N/A ] Added unit tests (if possible)?
- [ N/A ] Added XML documentation to any related classes?
- [ N/A ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
N/A


## Fixed issues
N/A
