### PR TITLE
Reuse empty value store arrays.

### DIFF
--- a/src/Avalonia.Base/Utilities/AvaloniaPropertyValueStore.cs
+++ b/src/Avalonia.Base/Utilities/AvaloniaPropertyValueStore.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+#nullable enable
 
 namespace Avalonia.Utilities
 {
@@ -9,12 +12,14 @@ namespace Avalonia.Utilities
     /// <typeparam name="TValue">Stored value type.</typeparam>
     internal sealed class AvaloniaPropertyValueStore<TValue>
     {
+        // The last item in the list is always int.MaxValue.
+        private static readonly Entry[] s_emptyEntries = { new Entry { PropertyId = int.MaxValue, Value = default! } };
+        
         private Entry[] _entries;
 
         public AvaloniaPropertyValueStore()
         {
-            // The last item in the list is always int.MaxValue
-            _entries = new[] { new Entry { PropertyId = int.MaxValue, Value = default } };
+            _entries = s_emptyEntries;
         }
 
         private (int, bool) TryFindEntry(int propertyId)
@@ -86,7 +91,7 @@ namespace Avalonia.Utilities
             return (0, false);
         }
 
-        public bool TryGetValue(AvaloniaProperty property, out TValue value)
+        public bool TryGetValue(AvaloniaProperty property, [MaybeNull] out TValue value)
         {
             (int index, bool found) = TryFindEntry(property.Id);
             if (!found)
@@ -132,7 +137,18 @@ namespace Avalonia.Utilities
 
             if (found)
             {
-                Entry[] entries = new Entry[_entries.Length - 1];
+                var newLength = _entries.Length - 1;
+                
+                // Special case - one element left means that value store is empty so we can just reuse our "empty" array.
+                if (newLength == 1)
+                {
+                    _entries = s_emptyEntries;
+                    
+                    return;
+                }
+                
+                var entries = new Entry[newLength];
+
                 int ix = 0;
 
                 for (int i = 0; i < _entries.Length; ++i)

--- a/tests/Avalonia.Benchmarks/Layout/ControlsBenchmark.cs
+++ b/tests/Avalonia.Benchmarks/Layout/ControlsBenchmark.cs
@@ -17,7 +17,8 @@ namespace Avalonia.Benchmarks.Layout
             _app = UnitTestApplication.Start(
                 TestServices.StyledWindow.With(
                     renderInterface: new NullRenderingPlatform(),
-                    threadingInterface: new NullThreadingPlatform()));
+                    threadingInterface: new NullThreadingPlatform(),
+                    standardCursorFactory: new NullCursorFactory()));
 
             _root = new TestRoot(true, null)
             {

--- a/tests/Avalonia.Benchmarks/NullCursorFactory.cs
+++ b/tests/Avalonia.Benchmarks/NullCursorFactory.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Avalonia.Input;
+using Avalonia.Platform;
+
+namespace Avalonia.Benchmarks
+{
+    internal class NullCursorFactory : IStandardCursorFactory
+    {
+        public IPlatformHandle GetCursor(StandardCursorType cursorType)
+        {
+            return new PlatformHandle(IntPtr.Zero, "null");
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Removes one extra (tiny) allocation from each `AvaloniaObject` instance by simply reusing empty array.
No big gains but this change is pretty much free (and removes like 10k array allocations from ControlCatalog startup).

Also I've noticed that we were still using Moq cursor factory in benchmarks which is kinda slow since it uses reflection.

## Benchmarks

Before
|         Method |        Mean |     Error |    StdDev |    Gen 0 |    Gen 1 |   Gen 2 |  Allocated |
|--------------- |------------:|----------:|----------:|---------:|---------:|--------:|-----------:|
| CreateCalendar | 22,691.6 us | 159.25 us | 141.17 us | 718.7500 | 343.7500 | 31.2500 | 4240.21 KB |
|   CreateButton |    177.1 us |   0.81 us |   0.64 us |   9.7656 |   0.9766 |       - |   40.28 KB |
|  CreateTextBox |  1,268.1 us |   6.48 us |   6.07 us |  52.7344 |  27.3438 |  3.9063 |  213.33 KB |

After
         Method |        Mean |     Error |   StdDev |    Gen 0 |    Gen 1 |  Gen 2 |  Allocated |
|--------------- |------------:|----------:|---------:|---------:|---------:|-------:|-----------:|
| CreateCalendar | 22,431.0 us | 120.56 us | 94.12 us | 687.5000 | 312.5000 |      - | 4220.51 KB |
|   CreateButton |    178.0 us |   1.29 us |  1.21 us |   9.7656 |   0.9766 |      - |    40.2 KB |
|  CreateTextBox |  1,267.6 us |  12.46 us | 11.66 us |  52.7344 |  27.3438 | 3.9063 |  212.29 KB |
