### PR TITLE
Parse cursor type during xaml compilation

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguage.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguage.cs
@@ -341,6 +341,18 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                 }
             }
 
+            if (type.Equals(types.Cursor))
+            {
+                if (TypeSystemHelpers.TryGetEnumValueNode(types.StandardCursorType, text, node, out var enumConstantNode))
+                {
+                    var cursorTypeRef = new XamlAstClrTypeReference(node, types.Cursor, false);
+
+                    result = new XamlAstNewClrObjectNode(node, cursorTypeRef, types.CursorTypeConstructor, new List<IXamlAstValueNode> { enumConstantNode });
+                    
+                    return true;
+                }
+            }
+
             if (type.FullName == "Avalonia.AvaloniaProperty")
             {
                 var scope = context.ParentNodes().OfType<AvaloniaXamlIlTargetTypeMetadataNode>().FirstOrDefault();

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -69,6 +69,9 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType GridLength { get; }
         public IXamlConstructor GridLengthConstructorValueType { get; }
         public IXamlType Color { get; }
+        public IXamlType StandardCursorType { get; }
+        public IXamlType Cursor { get; }
+        public IXamlConstructor CursorTypeConstructor { get; }
 
         public AvaloniaXamlIlWellKnownTypes(TransformerConfiguration cfg)
         {
@@ -150,6 +153,9 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             GridLength = cfg.TypeSystem.GetType("Avalonia.Controls.GridLength");
             GridLengthConstructorValueType = GridLength.GetConstructor(new List<IXamlType> { XamlIlTypes.Double, cfg.TypeSystem.GetType("Avalonia.Controls.GridUnitType") });
             Color = cfg.TypeSystem.GetType("Avalonia.Media.Color");
+            StandardCursorType = cfg.TypeSystem.GetType("Avalonia.Input.StandardCursorType");
+            Cursor = cfg.TypeSystem.GetType("Avalonia.Input.Cursor");
+            CursorTypeConstructor = Cursor.GetConstructor(new List<IXamlType> { StandardCursorType });
         }
     }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
XAML compiler will try to parse cursor type and use enum based constructor instead of parsing.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
I guess not having a dedicated AST node in this case is fine, reduces boilerplate a bit.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation
