### PR TITLE
A few small native menu fixes.

### DIFF
--- a/samples/ControlCatalog/DecoratedWindow.xaml
+++ b/samples/ControlCatalog/DecoratedWindow.xaml
@@ -6,25 +6,21 @@
         <NativeMenu.Menu>
     <NativeMenu>
       <NativeMenuItem Header="Decorated">
-        <NativeMenuItem.Menu>
-          <NativeMenu>
-            <NativeMenuItem Header="Open"/>
-            <NativeMenuItem Header="Recent">
-              <NativeMenuItem.Menu>
-                <NativeMenu/>
-              </NativeMenuItem.Menu>
-            </NativeMenuItem>
-            <NativeMenuItem Header="Quit Avalonia" Gesture="CMD+Q"/>
-          </NativeMenu>
-        </NativeMenuItem.Menu>
+        <NativeMenu>
+          <NativeMenuItem Header="Open"/>
+          <NativeMenuItem Header="Recent">
+            <NativeMenuItem.Menu>
+              <NativeMenu/>
+            </NativeMenuItem.Menu>
+          </NativeMenuItem>
+          <NativeMenuItem Header="Quit Avalonia" Gesture="CMD+Q"/>
+        </NativeMenu>
       </NativeMenuItem>
       <NativeMenuItem Header="Edit">
-        <NativeMenuItem.Menu>
-          <NativeMenu>
-            <NativeMenuItem Header="Copy"/>
-            <NativeMenuItem Header="Paste"/>
-          </NativeMenu>
-        </NativeMenuItem.Menu>
+        <NativeMenu>
+          <NativeMenuItem Header="Copy"/>
+          <NativeMenuItem Header="Paste"/>
+        </NativeMenu>
       </NativeMenuItem>
     </NativeMenu>
   </NativeMenu.Menu>

--- a/samples/ControlCatalog/MainWindow.xaml
+++ b/samples/ControlCatalog/MainWindow.xaml
@@ -16,47 +16,39 @@
   <NativeMenu.Menu>
     <NativeMenu>
       <NativeMenuItem Header="File">
-        <NativeMenuItem.Menu>
-          <NativeMenu>
-            <NativeMenuItem Icon="/Assets/test_icon.ico" Header="Open" Clicked="OnOpenClicked" Gesture="Ctrl+O"/>
-            <NativeMenuItemSeperator/>
-            <NativeMenuItem Icon="/Assets/github_icon.png" Header="Recent">
-              <NativeMenuItem.Menu>
-                <NativeMenu/>
-              </NativeMenuItem.Menu>
-            </NativeMenuItem>
-            <NativeMenuItemSeperator/>
-            <NativeMenuItem Header="{x:Static local:MainWindow.MenuQuitHeader}"
-                            Gesture="{x:Static local:MainWindow.MenuQuitGesture}"
-                            Clicked="OnCloseClicked" />
-          </NativeMenu>
-        </NativeMenuItem.Menu>
+        <NativeMenu>
+          <NativeMenuItem Icon="/Assets/test_icon.ico" Header="Open" Clicked="OnOpenClicked" Gesture="Ctrl+O"/>
+          <NativeMenuItemSeperator/>
+          <NativeMenuItem Icon="/Assets/github_icon.png" Header="Recent">
+            <NativeMenu/>
+          </NativeMenuItem>
+          <NativeMenuItemSeperator/>
+          <NativeMenuItem Header="{x:Static local:MainWindow.MenuQuitHeader}"
+                          Gesture="{x:Static local:MainWindow.MenuQuitGesture}"
+                          Clicked="OnCloseClicked" />
+        </NativeMenu>
       </NativeMenuItem>
       <NativeMenuItem Header="Edit">
-        <NativeMenuItem.Menu>
-          <NativeMenu>
-            <NativeMenuItem Header="Copy"/>
-            <NativeMenuItem Header="Paste"/>
-          </NativeMenu>
-        </NativeMenuItem.Menu>
+        <NativeMenu>
+          <NativeMenuItem Header="Copy"/>
+          <NativeMenuItem Header="Paste"/>
+        </NativeMenu>
       </NativeMenuItem>
       <NativeMenuItem Header="Options">
-        <NativeMenuItem.Menu>
-          <NativeMenu>
-           <NativeMenuItem Header="Check Me (None)" 
-                            Command="{Binding ToggleMenuItemCheckedCommand}"
-                            ToggleType="None"
-                            IsChecked="{Binding IsMenuItemChecked}"  />
-            <NativeMenuItem Header="Check Me (CheckBox)" 
-                            Command="{Binding ToggleMenuItemCheckedCommand}"
-                            ToggleType="CheckBox"
-                            IsChecked="{Binding IsMenuItemChecked}"  />
-            <NativeMenuItem Header="Check Me (Radio)" 
-                            Command="{Binding ToggleMenuItemCheckedCommand}"
-                            ToggleType="Radio"
-                            IsChecked="{Binding IsMenuItemChecked}"  />
-          </NativeMenu>
-        </NativeMenuItem.Menu>
+        <NativeMenu>
+          <NativeMenuItem Header="Check Me (None)" 
+                          Command="{Binding ToggleMenuItemCheckedCommand}"
+                          ToggleType="None"
+                          IsChecked="{Binding IsMenuItemChecked}"  />
+          <NativeMenuItem Header="Check Me (CheckBox)" 
+                          Command="{Binding ToggleMenuItemCheckedCommand}"
+                          ToggleType="CheckBox"
+                          IsChecked="{Binding IsMenuItemChecked}"  />
+          <NativeMenuItem Header="Check Me (Radio)" 
+                          Command="{Binding ToggleMenuItemCheckedCommand}"
+                          ToggleType="Radio"
+                          IsChecked="{Binding IsMenuItemChecked}"  />
+        </NativeMenu>
       </NativeMenuItem>
     </NativeMenu>
   </NativeMenu.Menu>

--- a/src/Avalonia.Controls/NativeMenuBar.cs
+++ b/src/Avalonia.Controls/NativeMenuBar.cs
@@ -1,7 +1,6 @@
 using System;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
-using Avalonia.Styling;
 
 namespace Avalonia.Controls
 {
@@ -16,7 +15,7 @@ namespace Avalonia.Controls
             EnableMenuItemClickForwardingProperty.Changed.Subscribe(args =>
             {
                 var item = (MenuItem)args.Sender;
-                if (args.NewValue.Equals(true))
+                if (args.NewValue.GetValueOrDefault<bool>())
                     item.Click += OnMenuItemClick;
                 else
                     item.Click -= OnMenuItemClick;

--- a/src/Avalonia.Controls/NativeMenuItem.cs
+++ b/src/Avalonia.Controls/NativeMenuItem.cs
@@ -151,7 +151,7 @@ namespace Avalonia.Controls
             IsEnabled = _command?.CanExecute(null) ?? true;
         }
 
-        public bool HasClickHandlers => Clicked != null;
+        public bool HasClickHandlers => Click != null;
 
         public ICommand Command
         {
@@ -182,11 +182,21 @@ namespace Avalonia.Controls
             set { SetValue(CommandParameterProperty, value); }
         }
 
-        public event EventHandler Clicked;
+        /// <summary>
+        /// Occurs when a <see cref="NativeMenuItem"/> is clicked.
+        /// </summary>
+        public event EventHandler Click;
+
+        [Obsolete("Use Click event.")]
+        public event EventHandler Clicked
+        {
+            add => Click += value;
+            remove => Click -= value;
+        }
 
         void INativeMenuItemExporterEventsImplBridge.RaiseClicked()
         {
-            Clicked?.Invoke(this, new EventArgs());
+            Click?.Invoke(this, new EventArgs());
 
             if (Command?.CanExecute(CommandParameter) == true)
             {

--- a/src/Avalonia.Controls/NativeMenuItem.cs
+++ b/src/Avalonia.Controls/NativeMenuItem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Windows.Input;
 using Avalonia.Input;
 using Avalonia.Media.Imaging;
+using Avalonia.Metadata;
 using Avalonia.Utilities;
 
 namespace Avalonia.Controls
@@ -62,6 +63,7 @@ namespace Avalonia.Controls
         public static readonly DirectProperty<NativeMenuItem, NativeMenu> MenuProperty =
             AvaloniaProperty.RegisterDirect<NativeMenuItem, NativeMenu>(nameof(Menu), o => o.Menu, (o, v) => o.Menu = v);
 
+        [Content]
         public NativeMenu Menu
         {
             get => _menu;

--- a/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
+++ b/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
@@ -60,7 +60,7 @@ namespace Avalonia.Native
                 Header = "About Avalonia",
             };
 
-            aboutItem.Clicked += async (sender, e) =>
+            aboutItem.Click += async (sender, e) =>
             {
                 var dialog = new AboutAvaloniaDialog();
 


### PR DESCRIPTION
## What does the pull request do?

- `NativeMenuBar` click forwarding was broken by #4648 - fix it by fixing the `BindingValue` comparison in `NativeMenuBar.cs`. We should probably add `IComparable<T>` to `BindingValue<T>` so that this would have worked as-is but that's a separate PR
- The "clicked" event in `MenuItem` and `Button` etc. is named `Click` but was called `Clicked` in `NativeMenu`. Renamed `NativeMenuItem.Clicked` -> `Click`, keeping the existing `Clicked` event as an obsolete member.
- Mark `NativeMenuItem.Menu` as the content property - means that submenus don't need the extra `<NativeMenuItem.Menu>` element in markup.
