### PR TITLE
Prevent exceptions when removing styles.

### DIFF
--- a/src/Avalonia.Styling/Controls/ResourceNodeExtensions.cs
+++ b/src/Avalonia.Styling/Controls/ResourceNodeExtensions.cs
@@ -147,13 +147,16 @@ namespace Avalonia.Controls
             {
                 if (_target.Owner is object)
                 {
-                    observer.OnNext(Convert(_target.Owner?.FindResource(_key)));
+                    observer.OnNext(Convert(_target.Owner.FindResource(_key)));
                 }
             }
 
             private void PublishNext()
             {
-                PublishNext(Convert(_target.Owner?.FindResource(_key)));
+                if (_target.Owner is object)
+                {
+                    PublishNext(Convert(_target.Owner.FindResource(_key)));
+                }
             }
 
             private void OwnerChanged(object sender, EventArgs e)


### PR DESCRIPTION
## What does the pull request do?

When a `DynamicResource` appeared in a style, and that style was removed from the application then a bunch of useless exceptions were thrown, as described in https://github.com/AvaloniaUI/Avalonia/issues/4655#issuecomment-724130576.

This happened because in `FloatingResourceObservable` if `_target.Owner` was null, the resource observable produced a `null` which may not be valid for the target property, resulting in an exception . Although the exception is caught, it slows things down.

Because the target of this observable is a style that's now detached from the tree we can just not raise a change here as any lookups we do are going to be pointless.

This is one of those changes where a unit test is a lot harder than the fix itself, so no unit tests unfortunately.

## Fixed issues

Probably doesn't fix, but should improve #4655.