### PR TITLE
Don't handle tab navigation in DefaultMenuInteractionHandler.

### DIFF
--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -231,7 +231,7 @@ namespace Avalonia.Controls.Platform
                 {
                     var direction = e.Key.ToNavigationDirection();
 
-                    if (direction.HasValue)
+                    if (direction?.IsDirectional() == true)
                     {
                         if (item == null && _isContextMenu)
                         {

--- a/src/Avalonia.Input/NavigationDirection.cs
+++ b/src/Avalonia.Input/NavigationDirection.cs
@@ -83,7 +83,7 @@ namespace Avalonia.Input
         /// </returns>
         public static bool IsDirectional(this NavigationDirection direction)
         {
-            return direction > NavigationDirection.Previous ||
+            return direction > NavigationDirection.Previous &&
                 direction <= NavigationDirection.PageDown;
         }
 


### PR DESCRIPTION
## What does the pull request do?

Allow the default keyboard interaction handler to handle tab key presses in menus instead of `DefaultMenuInteractionHandler`, because the logic in `DefaultMenuInteractionHandler` was causing the focus to get stuck in the menu.

Also fix `NavigationDirection.IsDirectional` method whose logic contained a copy-pasta.

A meaningful unit test is hard to write here as it involves quite a few moving parts (the menu, menu items, menu interaction handler and window interaction handler), so didn't include one as again the fix is much simpler than the test.

Fixes #5002.
