### PR TITLE
Fix DynamicResource lookup in Application.

### DIFF
--- a/src/Avalonia.Styling/ApiCompatBaseline.txt
+++ b/src/Avalonia.Styling/ApiCompatBaseline.txt
@@ -1,0 +1,3 @@
+Compat issues with assembly Avalonia.Styling:
+MembersMustExist : Member 'public System.IObservable<System.Object> Avalonia.Controls.ResourceNodeExtensions.GetResourceObservable(Avalonia.IStyledElement, System.Object, System.Func<System.Object, System.Object>)' does not exist in the implementation but it does exist in the contract.
+Total Issues: 1

--- a/src/Avalonia.Styling/Controls/ResourceNodeExtensions.cs
+++ b/src/Avalonia.Styling/Controls/ResourceNodeExtensions.cs
@@ -60,7 +60,7 @@ namespace Avalonia.Controls
         }
 
         public static IObservable<object?> GetResourceObservable(
-            this IStyledElement control,
+            this IResourceHost control,
             object key,
             Func<object?, object?>? converter = null)
         {
@@ -83,11 +83,11 @@ namespace Avalonia.Controls
 
         private class ResourceObservable : LightweightObservableBase<object?>
         {
-            private readonly IStyledElement _target;
+            private readonly IResourceHost _target;
             private readonly object _key;
             private readonly Func<object?, object?>? _converter;
 
-            public ResourceObservable(IStyledElement target, object key, Func<object?, object?>? converter)
+            public ResourceObservable(IResourceHost target, object key, Func<object?, object?>? converter)
             {
                 _target = target;
                 _key = key;

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/DynamicResourceExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/DynamicResourceExtensionTests.cs
@@ -345,6 +345,23 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             Assert.Equal(0xff506070, brush.Color.ToUint32());
         }
 
+        [Fact]
+        public void DynamicResource_Can_Be_Assigned_To_Resource_Property_In_Application()
+        {
+            var xaml = @"
+<Application xmlns='https://github.com/avaloniaui'
+             xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <Application.Resources>
+        <Color x:Key='color'>#ff506070</Color>
+        <SolidColorBrush x:Key='brush' Color='{DynamicResource color}'/>
+    </Application.Resources>
+</Application>";
+
+            var application = (Application)AvaloniaRuntimeXamlLoader.Load(xaml);
+            var brush = (SolidColorBrush)application.Resources["brush"];
+
+            Assert.Equal(0xff506070, brush.Color.ToUint32());
+        }
 
         [Fact]
         public void DynamicResource_Can_Be_Assigned_To_ItemTemplate_Property()


### PR DESCRIPTION
## What does the pull request do?

Dynamic resources in `Application.Resources` were not being correctly resolved, e.g.:

```
<ResourceDictionary>
  <Color x:Key="ResistorColor">#FFeee1c3</Color>
  <SolidColorBrush x:Key="ResistorBrush" Color="{DynamicResource ResistorColor}"/>
</ResourceDictionary>
```

`ResistorBrush` was not getting its color assigned.

This was because `DynamicResourceExtension` was looking for a `IStyledElement` as its anchor but `Application` doesn't implement that. Instead of looking for an `IStyledElement` as an anchor, look for an `IResourceHost` because `Application` does this interface and it has everything we need.

## Checklist

- [x] Added unit tests (if possible)?

## Breaking changes

`ResourceNodeExtensions.GetResourceObservable()` now takes an `IResourceHost` instead of an `IStyledElement`, but this API was added in the 0.10-preview timeline so not strictly a breaking change.
