### PR TITLE
AutoCompleteBox: Only handle the Enter key when the DropDown is open

### DIFF
--- a/src/Avalonia.Controls/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox.cs
@@ -1405,8 +1405,11 @@ namespace Avalonia.Controls
                     break;
 
                 case Key.Enter:
-                    OnAdapterSelectionComplete(this, new RoutedEventArgs());
-                    e.Handled = true;
+                    if (IsDropDownOpen)
+                    {
+                        OnAdapterSelectionComplete(this, new RoutedEventArgs());
+                        e.Handled = true;
+                    }
                     break;
 
                 default:


### PR DESCRIPTION
## What does the pull request do?
Fixes #5106


## What is the current behavior?
When pressing the [Enter] key while the AutoCompleteBox is focused, the default button's command is not invoked


## What is the updated/expected behavior with this PR?
The Enter key is only handled when the dropdown is open (so that the user can select one of the suggestions)


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
none


## Fixed issues
Fixes #5106
