### PR TITLE
Fix TransformToVisual not dealing with non-invertible transforms.

### DIFF
--- a/src/Avalonia.Visuals/Matrix.cs
+++ b/src/Avalonia.Visuals/Matrix.cs
@@ -282,16 +282,16 @@ namespace Avalonia
         }
 
         /// <summary>
-        /// Inverts the Matrix.
+        /// Attempts to invert the Matrix.
         /// </summary>
-        /// <returns>The inverted matrix.</returns>
-        public Matrix Invert()
+        /// <returns>The inverted matrix or <see langword="null"/> when matrix is not invertible.</returns>
+        public Matrix? TryInvert()
         {
             double d = GetDeterminant();
 
             if (MathUtilities.IsZero(d))
             {
-                throw new InvalidOperationException("Transform is not invertible.");
+                return null;
             }
 
             return new Matrix(
@@ -301,6 +301,23 @@ namespace Avalonia
                 _m11 / d,
                 ((_m21 * _m32) - (_m22 * _m31)) / d,
                 ((_m12 * _m31) - (_m11 * _m32)) / d);
+        }
+
+        /// <summary>
+        /// Inverts the Matrix.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Matrix is not invertible.</exception>
+        /// <returns>The inverted matrix.</returns>
+        public Matrix Invert()
+        {
+            Matrix? inverted = TryInvert();
+
+            if (!inverted.HasValue)
+            {
+                throw new InvalidOperationException("Transform is not invertible.");
+            }
+
+            return inverted.Value;
         }
 
         /// <summary>

--- a/src/Avalonia.Visuals/Matrix.cs
+++ b/src/Avalonia.Visuals/Matrix.cs
@@ -285,22 +285,26 @@ namespace Avalonia
         /// Attempts to invert the Matrix.
         /// </summary>
         /// <returns>The inverted matrix or <see langword="null"/> when matrix is not invertible.</returns>
-        public Matrix? TryInvert()
+        public bool TryInvert(out Matrix inverted)
         {
             double d = GetDeterminant();
 
             if (MathUtilities.IsZero(d))
             {
-                return null;
+                inverted = default;
+                
+                return false;
             }
 
-            return new Matrix(
+            inverted = new Matrix(
                 _m22 / d,
                 -_m12 / d,
                 -_m21 / d,
                 _m11 / d,
                 ((_m21 * _m32) - (_m22 * _m31)) / d,
                 ((_m12 * _m31) - (_m11 * _m32)) / d);
+
+            return true;
         }
 
         /// <summary>
@@ -310,14 +314,12 @@ namespace Avalonia
         /// <returns>The inverted matrix.</returns>
         public Matrix Invert()
         {
-            Matrix? inverted = TryInvert();
-
-            if (!inverted.HasValue)
+            if (!TryInvert(out Matrix inverted))
             {
                 throw new InvalidOperationException("Transform is not invertible.");
             }
 
-            return inverted.Value;
+            return inverted;
         }
 
         /// <summary>

--- a/src/Avalonia.Visuals/VisualExtensions.cs
+++ b/src/Avalonia.Visuals/VisualExtensions.cs
@@ -51,14 +51,12 @@ namespace Avalonia
                 var thisOffset = GetOffsetFrom(common, from);
                 var thatOffset = GetOffsetFrom(common, to);
 
-                var thatOffsetInverted = thatOffset.TryInvert();
-
-                if (!thatOffsetInverted.HasValue)
+                if (!thatOffset.TryInvert(out var thatOffsetInverted))
                 {
                     return null;
                 }
-                
-                return thatOffsetInverted.Value * thisOffset;
+
+                return thatOffsetInverted * thisOffset;
             }
 
             return null;

--- a/src/Avalonia.Visuals/VisualExtensions.cs
+++ b/src/Avalonia.Visuals/VisualExtensions.cs
@@ -50,7 +50,15 @@ namespace Avalonia
             {
                 var thisOffset = GetOffsetFrom(common, from);
                 var thatOffset = GetOffsetFrom(common, to);
-                return -thatOffset * thisOffset;
+
+                var thatOffsetInverted = thatOffset.TryInvert();
+
+                if (!thatOffsetInverted.HasValue)
+                {
+                    return null;
+                }
+                
+                return thatOffsetInverted.Value * thisOffset;
             }
 
             return null;

--- a/tests/Avalonia.Visuals.UnitTests/VisualTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/VisualTests.cs
@@ -236,6 +236,25 @@ namespace Avalonia.Visuals.UnitTests
         }
 
         [Fact]
+        public void TransformToVisual_With_NonInvertible_RenderTransform_Should_Work()
+        {
+            var child = new Decorator
+            {
+                Width = 100,
+                Height = 100,
+                RenderTransform = new ScaleTransform() { ScaleX = 0, ScaleY = 0 }
+            };
+            var root = new TestRoot() { Child = child, Width = 400, Height = 400 };
+
+            root.Measure(Size.Infinity);
+            root.Arrange(new Rect(new Point(), root.DesiredSize));
+
+            var tr = root.TransformToVisual(child);
+
+            Assert.Null(tr);
+        }
+
+        [Fact]
         public void Should_Not_Log_Binding_Error_When_Not_Attached_To_Logical_Tree()
         {
             var target = new Decorator { DataContext = "foo" };


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes random crashes that can occur when controls use invalid render transforms. `Viewbox` is one of such cases since having 0x0 size element inside will create a singular render transform matrix. And while 0x0 scale in the `Viewbox` is odd it seems that WPF does the same so it makes no sense to diverge too far.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`TransformToVisual` crashes when `to` visual has a non-invertible render transform.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
`TransformToVisual` returns `null` when `to` visual has non-invertible transform. WPF is doing the same as well.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->



