### PR TITLE
Make ItemContainerInfo.Index setter public.

### DIFF
--- a/src/Avalonia.Controls/Generators/ItemContainerInfo.cs
+++ b/src/Avalonia.Controls/Generators/ItemContainerInfo.cs
@@ -37,6 +37,6 @@ namespace Avalonia.Controls.Generators
         /// <summary>
         /// Gets the index of the item in the <see cref="ItemsControl.Items"/> collection.
         /// </summary>
-        public int Index { get; internal set; }
+        public int Index { get; set; }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

It's possible to implement custom item container generators by implementing the `IItemContainerGenerator` interface, however if you do so it's not possible to correctly react to collection changes because the `ItemContainerInfo.Index` property setter is `internal`. This needs to be make public to allow people to implement custom `IItemContainerGenerator`s.