### PR TITLE
EmbedXaml: remove <None> items generated for XAML files by default

### DIFF
--- a/build/EmbedXaml.props
+++ b/build/EmbedXaml.props
@@ -4,6 +4,7 @@
      <Compile Update="**\*.xaml.cs">
       <DependentUpon>%(Filename)</DependentUpon>
     </Compile>
+    <None Remove="**\*.xaml"/>
     <AvaloniaResource Include="**\*.xaml">
       <SubType>Designer</SubType>
     </AvaloniaResource>


### PR DESCRIPTION
Currently, some XAML files look like this (duplicated as `AvaloniaResource` and `None`) when the project `RenderDemo` is opened in Rider:
![image](https://user-images.githubusercontent.com/92793/100535379-03a4cc80-324b-11eb-8949-f885c6e2a570.png)

Rider shows the actual situation as seen by MSBuild.

After debugging a bit, I've found that these items are generated by [`Microsoft.Net.SDK.DefaultItems.props`](https://github.com/dotnet/sdk/blob/19751ff8c3f58300df2e8eb2b5a174bcdf779661/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props#L37), and I don't believe they're actually supposed to be here.

Interestingly enough, a similar change has already been done in the WPF MSBuild SDK; see [`Microsoft.NET.Sdk.WindowsDesktop.props`](https://github.com/dotnet/wpf/blob/1f710fd49d8b87a515253a997075dbeeb6ca0c7c/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props#L32-L33) (though I haven't been looking too much into it and the underlying reason why Visual Studio "would prefer" for these items to be removed).

Generally, I think it's a good idea to exclude items from `<None>` if we're adding them by mask as another item kind in the same file.