### PR TITLE
Simple fluent theme selector

### DIFF
--- a/samples/RenderDemo/App.xaml
+++ b/samples/RenderDemo/App.xaml
@@ -3,7 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     x:Class="RenderDemo.App">
     <Application.Styles>
-        <StyleInclude Source="avares://Avalonia.Themes.Fluent/FluentLight.xaml"/>
+        <FluentTheme/>
         <StyleInclude Source="avares://RenderDemo/SideBar.xaml"/>
     </Application.Styles>
 </Application>

--- a/samples/Sandbox/App.axaml
+++ b/samples/Sandbox/App.axaml
@@ -3,6 +3,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     x:Class="Sandbox.App">
     <Application.Styles>
-        <FluentTheme Scheme="Dark"/>
+        <FluentTheme Mode="Dark"/>
     </Application.Styles>
 </Application>

--- a/samples/Sandbox/App.axaml
+++ b/samples/Sandbox/App.axaml
@@ -3,6 +3,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     x:Class="Sandbox.App">
     <Application.Styles>
-        <StyleInclude Source="avares://Avalonia.Themes.Fluent/FluentDark.xaml"/>
+        <FluentTheme Scheme="Dark"/>
     </Application.Styles>
 </Application>

--- a/src/Avalonia.Themes.Fluent/ApiCompatBaseline.txt
+++ b/src/Avalonia.Themes.Fluent/ApiCompatBaseline.txt
@@ -1,3 +1,4 @@
 Compat issues with assembly Avalonia.Themes.Fluent:
-TypesMustExist : Type 'Avalonia.Themes.Fluent.FluentTheme' does not exist in the implementation but it does exist in the contract.
-Total Issues: 1
+CannotRemoveBaseTypeOrInterface : Type 'Avalonia.Themes.Fluent.FluentTheme' does not inherit from base type 'Avalonia.Styling.Styles' in the implementation but it does in the contract.
+MembersMustExist : Member 'public void Avalonia.Themes.Fluent.FluentTheme..ctor()' does not exist in the implementation but it does exist in the contract.
+Total Issues: 2

--- a/src/Avalonia.Themes.Fluent/FluentTheme.cs
+++ b/src/Avalonia.Themes.Fluent/FluentTheme.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Styling;
+
+#nullable enable
+
+namespace Avalonia.Themes.Fluent
+{
+    public enum FluentColorScheme
+    {
+        Light,
+        Dark,
+    }
+
+    /// <summary>
+    /// Includes the fluent theme in an application.
+    /// </summary>
+    public class FluentTheme : IStyle, IResourceProvider
+    {
+        private readonly Uri _baseUri;
+        private IStyle[]? _loaded;
+        private bool _isLoading;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FluentTheme"/> class.
+        /// </summary>
+        /// <param name="baseUri">The base URL for the XAML context.</param>
+        public FluentTheme(Uri baseUri)
+        {
+            _baseUri = baseUri;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FluentTheme"/> class.
+        /// </summary>
+        /// <param name="serviceProvider">The XAML service provider.</param>
+        public FluentTheme(IServiceProvider serviceProvider)
+        {
+            _baseUri = ((IUriContext)serviceProvider.GetService(typeof(IUriContext))).BaseUri;
+        }
+
+        /// <summary>
+        /// Gets or sets the color scheme to use (light, dark).
+        /// </summary>
+        public FluentColorScheme Scheme { get; set; }
+
+        public IResourceHost? Owner => (Loaded as IResourceProvider)?.Owner;
+
+        /// <summary>
+        /// Gets the loaded style.
+        /// </summary>
+        public IStyle Loaded
+        {
+            get
+            {
+                if (_loaded == null)
+                {
+                    _isLoading = true;
+                    var loaded = (IStyle)AvaloniaXamlLoader.Load(GetUri(), _baseUri);
+                    _loaded = new[] { loaded };
+                    _isLoading = false;
+                }
+
+                return _loaded?[0]!;
+            }
+        }
+
+        bool IResourceNode.HasResources => (Loaded as IResourceProvider)?.HasResources ?? false;
+
+        IReadOnlyList<IStyle> IStyle.Children => _loaded ?? Array.Empty<IStyle>();
+
+        public event EventHandler OwnerChanged
+        {
+            add
+            {
+                if (Loaded is IResourceProvider rp)
+                {
+                    rp.OwnerChanged += value;
+                }
+            }
+            remove
+            {
+                if (Loaded is IResourceProvider rp)
+                {
+                    rp.OwnerChanged -= value;
+                }
+            }
+        }
+
+        public SelectorMatchResult TryAttach(IStyleable target, IStyleHost? host) => Loaded.TryAttach(target, host);
+
+        public bool TryGetResource(object key, out object? value)
+        {
+            if (!_isLoading && Loaded is IResourceProvider p)
+            {
+                return p.TryGetResource(key, out value);
+            }
+
+            value = null;
+            return false;
+        }
+
+        void IResourceProvider.AddOwner(IResourceHost owner) => (Loaded as IResourceProvider)?.AddOwner(owner);
+        void IResourceProvider.RemoveOwner(IResourceHost owner) => (Loaded as IResourceProvider)?.RemoveOwner(owner);
+
+        private Uri GetUri() => Scheme switch
+        {
+            FluentColorScheme.Dark => new Uri("avares://Avalonia.Themes.Fluent/FluentDark.xaml", UriKind.Absolute),
+            _ => new Uri("avares://Avalonia.Themes.Fluent/FluentLight.xaml", UriKind.Absolute),
+        };
+    }
+}

--- a/src/Avalonia.Themes.Fluent/FluentTheme.cs
+++ b/src/Avalonia.Themes.Fluent/FluentTheme.cs
@@ -8,7 +8,7 @@ using Avalonia.Styling;
 
 namespace Avalonia.Themes.Fluent
 {
-    public enum FluentColorScheme
+    public enum FluentThemeMode
     {
         Light,
         Dark,
@@ -42,9 +42,9 @@ namespace Avalonia.Themes.Fluent
         }
 
         /// <summary>
-        /// Gets or sets the color scheme to use (light, dark).
+        /// Gets or sets the mode of the fluent theme (light, dark).
         /// </summary>
-        public FluentColorScheme Scheme { get; set; }
+        public FluentThemeMode Mode { get; set; }
 
         public IResourceHost? Owner => (Loaded as IResourceProvider)?.Owner;
 
@@ -105,9 +105,9 @@ namespace Avalonia.Themes.Fluent
         void IResourceProvider.AddOwner(IResourceHost owner) => (Loaded as IResourceProvider)?.AddOwner(owner);
         void IResourceProvider.RemoveOwner(IResourceHost owner) => (Loaded as IResourceProvider)?.RemoveOwner(owner);
 
-        private Uri GetUri() => Scheme switch
+        private Uri GetUri() => Mode switch
         {
-            FluentColorScheme.Dark => new Uri("avares://Avalonia.Themes.Fluent/FluentDark.xaml", UriKind.Absolute),
+            FluentThemeMode.Dark => new Uri("avares://Avalonia.Themes.Fluent/FluentDark.xaml", UriKind.Absolute),
             _ => new Uri("avares://Avalonia.Themes.Fluent/FluentLight.xaml", UriKind.Absolute),
         };
     }

--- a/src/Avalonia.Themes.Fluent/Properties/AssemblyInfo.cs
+++ b/src/Avalonia.Themes.Fluent/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Avalonia.Metadata;
+
+[assembly: XmlnsDefinition("https://github.com/avaloniaui", "Avalonia.Themes.Fluent")]


### PR DESCRIPTION
## What does the pull request do?

Allows the fluent theme to be included in an application with a simple:

```
<Application.Styles>
    <FluentTheme/>
</Application.Styles>
```

or 

```
<Application.Styles>
    <FluentTheme Mode="Dark"/>
</Application.Styles>
```

Where `Mode` can be set to `Light` (default) or `Dark`.

This has two advantages:

- Including fluent theme doesn't require remembering a URL
- Will allow us to modify the XAML resources without breaking people
