### PR TITLE
Fix LayoutContext.LayoutState

### DIFF
--- a/src/Avalonia.Layout/LayoutContext.cs
+++ b/src/Avalonia.Layout/LayoutContext.cs
@@ -14,7 +14,11 @@ namespace Avalonia.Layout
         /// <summary>
         /// Gets or sets an object that represents the state of a layout.
         /// </summary>
-        public object LayoutState { get; set; }
+        public object LayoutState 
+        {
+            get => LayoutStateCore;
+            set => LayoutStateCore = value;
+        }
 
         /// <summary>
         /// Implements the behavior of <see cref="LayoutState"/> in a derived or custom LayoutContext.


### PR DESCRIPTION
## What does the pull request do?

`LayoutState` should delegate to `LayoutStateCore` - see upstream implementation at https://github.com/microsoft/microsoft-ui-xaml/blob/c6c8d084231f8cc4ffa978305e9f2a0f93a9a39c/dev/Repeater/LayoutContext.cpp#L13-L18

Not sure why this hasn't caused us more noticeable problems in the past, but it is certainly wrong. Probably was causing incorrect size estimation in `StackLayout` at least.
