### PR TITLE
fix datagrid virtualization in some situations

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.cs
@@ -22,6 +22,22 @@ namespace Avalonia.Controls.Primitives
         }
 
         private double _measureHeightOffset = 0;
+        private double _effectiveViewPortHeight = 0;
+
+        public DataGridRowsPresenter()
+        {
+            EffectiveViewportChanged += OnEffectiveViewportChanged;
+        }
+
+        private void OnEffectiveViewportChanged(object sender, Layout.EffectiveViewportChangedEventArgs e)
+        {
+            if (_effectiveViewPortHeight != e.EffectiveViewport.Height)
+            {
+                _effectiveViewPortHeight = e.EffectiveViewport.Height;
+                InvalidateMeasure();
+            }
+        }
+
         private double CalculateEstimatedAvailableHeight(Size availableSize)
         {
             if(!Double.IsPositiveInfinity(availableSize.Height))
@@ -108,6 +124,11 @@ namespace Avalonia.Controls.Primitives
         /// </returns>
         protected override Size MeasureOverride(Size availableSize)
         {
+            if (double.IsInfinity(availableSize.Height))
+            {
+                availableSize = availableSize.WithHeight(_effectiveViewPortHeight);
+            }
+
             if (availableSize.Height == 0 || OwningGrid == null)
             {
                 return base.MeasureOverride(availableSize);


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes Datagrid Virtuallization in case it's measured with Infinity (Parent Grid/Scroll etc. )

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Datagrid will wait for Effective value for the measure so it's not longer measuring with infinity (thus virtualization if completely off)

very easy repro of the current problem:

-  Start Control Catalog
- Go to DataGrid page -> it will take 3-10 seconds to show datagrids
- after changes in this pr DataGrid page in Control Catalog will open almost instantly

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Datagrid will measure with effective viewport instead infinity and work properly in situations where it has been measured with Infinity

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues

Fixes #3648
Fixes #2873