### PR TITLE
upgrade osx vm image, to output arm64 apple m1 compatible avalonia.na…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,8 @@ jobs:
   - task: Xcode@5
     inputs:
       actions: 'build'
-      scheme: 'macosx11.0'
+      scheme: ''
+      sdk: 'macosx11.0'
       configuration: 'Release'
       xcWorkspacePath: '**/*.xcodeproj/project.xcworkspace'
       xcodeVersion: '12' # Options: 8, 9, default, specifyPath

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ jobs:
     inputs:
       actions: 'build'
       scheme: ''
-      sdk: 'macosx10.14'
+      sdk: 'macosx10.15'
       configuration: 'Release'
       xcWorkspacePath: '**/*.xcodeproj/project.xcworkspace'
       xcodeVersion: '12' # Options: 8, 9, default, specifyPath

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,18 +46,11 @@ jobs:
     inputs:
       script: |
         cd src/tools/MicroComGenerator; dotnet run -i ../../Avalonia.Native/avn.idl --cpp ../../../native/Avalonia.Native/inc/avalonia-native.h
- 
-  - task: CmdLine@2
-    displayName: 'List SDKs'
-    inputs:
-      script: |
-        xcodebuild -showsdks
 
-  - task: Xcode@5
   - task: Xcode@5
     inputs:
       actions: 'build'
-      scheme: ''
+      scheme: 'macosx11.0'
       configuration: 'Release'
       xcWorkspacePath: '**/*.xcodeproj/project.xcworkspace'
       xcodeVersion: '12' # Options: 8, 9, default, specifyPath

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
   variables:
     SolutionDir: '$(Build.SourcesDirectory)'
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   - task: UseDotNet@2
     displayName: 'Use .NET Core SDK 3.1.401'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
       sdk: 'macosx10.14'
       configuration: 'Release'
       xcWorkspacePath: '**/*.xcodeproj/project.xcworkspace'
-      xcodeVersion: '10' # Options: 8, 9, default, specifyPath
+      xcodeVersion: '12' # Options: 8, 9, default, specifyPath
       args: '-derivedDataPath ./'
 
   - task: CmdLine@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,14 @@ jobs:
     inputs:
       script: |
         cd src/tools/MicroComGenerator; dotnet run -i ../../Avalonia.Native/avn.idl --cpp ../../../native/Avalonia.Native/inc/avalonia-native.h
+ 
+  - task: CmdLine@2
+    displayName: 'List SDKs'
+    inputs:
+      script: |
+        xcodebuild -showsdks
 
+  - task: Xcode@5
   - task: Xcode@5
     inputs:
       actions: 'build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,6 @@ jobs:
     inputs:
       actions: 'build'
       scheme: ''
-      sdk: 'macosx10.15'
       configuration: 'Release'
       xcWorkspacePath: '**/*.xcodeproj/project.xcworkspace'
       xcodeVersion: '12' # Options: 8, 9, default, specifyPath


### PR DESCRIPTION
…tive dylib.

Simply use Xcode 12.2 on Azure Pipelines, which will generate an ARM64 compatible dylib.

Much more is required before we are able to run natively on M1 chips.

```
libAvalonia.Native.OSX.dylib: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit dynamically linked shared library x86_64] [arm64:Mach-O 64-bit dynamically linked shared library arm64]
libAvalonia.Native.OSX.dylib (for architecture x86_64):	Mach-O 64-bit dynamically linked shared library x86_64
libAvalonia.Native.OSX.dylib (for architecture arm64):	Mach-O 64-bit dynamically linked shared library arm64

```

changes to v11 sdk
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
