### PR TITLE
More reliable pixendensitydetection under Xorg/Randr

### DIFF
--- a/src/Avalonia.X11/X11Atoms.cs
+++ b/src/Avalonia.X11/X11Atoms.cs
@@ -114,6 +114,8 @@ namespace Avalonia.X11
         public readonly IntPtr XA_WM_CLASS = (IntPtr)67;
         public readonly IntPtr XA_WM_TRANSIENT_FOR = (IntPtr)68;
 
+        public readonly IntPtr RR_PROPERTY_RANDR_EDID = (IntPtr)82;
+
         public readonly IntPtr WM_PROTOCOLS;
         public readonly IntPtr WM_DELETE_WINDOW;
         public readonly IntPtr WM_TAKE_FOCUS;

--- a/src/Avalonia.X11/X11Structs.cs
+++ b/src/Avalonia.X11/X11Structs.cs
@@ -1870,7 +1870,7 @@ namespace Avalonia.X11 {
 		public const string XNFontSet = "fontSet";
 	}
 	
-    struct XRRMonitorInfo {
+    unsafe struct XRRMonitorInfo {
         public IntPtr Name;
         public int Primary;
         public int Automatic;
@@ -1881,6 +1881,6 @@ namespace Avalonia.X11 {
         public int Height;
         public int MWidth;
         public int MHeight;
-        public IntPtr Outputs;
+        public IntPtr* Outputs;
     } 
 }

--- a/src/Avalonia.X11/XLib.cs
+++ b/src/Avalonia.X11/XLib.cs
@@ -502,10 +502,10 @@ namespace Avalonia.X11
             XRRGetMonitors(IntPtr dpy, IntPtr window, bool get_active, out int nmonitors);
 
         [DllImport(libX11Randr)]
-        public static extern IntPtr* XRRListOutputProperties(IntPtr dpy, long output, out int count);
+        public static extern IntPtr* XRRListOutputProperties(IntPtr dpy, IntPtr output, out int count);
 
         [DllImport(libX11Randr)]
-        public static extern int XRRGetOutputProperty(IntPtr dpy, long output, IntPtr atom, long offset, long length, bool _delete, bool pending, IntPtr req_type, out int actual_type, out int actual_format, out int nitems, out long bytes_after, out IntPtr prop);
+        public static extern int XRRGetOutputProperty(IntPtr dpy, IntPtr output, IntPtr atom, int offset, int length, bool _delete, bool pending, IntPtr req_type, out IntPtr actual_type, out int actual_format, out int nitems, out long bytes_after, out IntPtr prop);
             
         [DllImport(libX11Randr)]
         public static extern void XRRSelectInput(IntPtr dpy, IntPtr window, RandrEventMask mask);

--- a/src/Avalonia.X11/XLib.cs
+++ b/src/Avalonia.X11/XLib.cs
@@ -500,6 +500,13 @@ namespace Avalonia.X11
         [DllImport(libX11Randr)]
         public static extern XRRMonitorInfo*
             XRRGetMonitors(IntPtr dpy, IntPtr window, bool get_active, out int nmonitors);
+
+        [DllImport(libX11Randr)]
+        public static extern IntPtr* XRRListOutputProperties(IntPtr dpy, long output, out int count);
+
+        [DllImport(libX11Randr)]
+        public static extern int XRRGetOutputProperty(IntPtr dpy, long output, IntPtr atom, long offset, long length, bool _delete, bool pending, IntPtr req_type, out int actual_type, out int actual_format, out int nitems, out long bytes_after, out IntPtr prop);
+            
         [DllImport(libX11Randr)]
         public static extern void XRRSelectInput(IntPtr dpy, IntPtr window, RandrEventMask mask);
 


### PR DESCRIPTION
## What does the pull request do?
Physical monitor dimensions are parsed from the monitors EDID instead of requesting them from Randr.
Automatic pixeldensity detection locks to specific scalingfactors (100%, 125%,150%,175%,200%) and falls back to 100% if internal values are way off (scalingfactor higher than 300%) or no EDID is found.

## What is the current behavior?
Xrandr reports unreliable physical monitor dimensions with hacky/invalid EDIDs, e.g. no physical dimension for specific modes.
This can lead to scalingfactors of 1000% and higher.

## What is the updated/expected behavior with this PR?
- Detect the pixeldensity more reliable and don't overscale.
- Select a scalingfactor from a list of predefined scalingfactors similar to Windows (100%,125%,150%,175%.200%).

## How was the solution implemented (if it's not obvious)?
- Get the EDID via `XRRListOutputProperties` and `XRRGetOutputProperty`. [Code Reference from Chromium](https://github.com/chromium/chromium/blob/55f44515cd0b9e7739b434d1c62f4b7e321cd530/ui/base/x/x11_display_util.cc#L165-L203)
- Parse width and height (in cm) from the `Basic Display Parameters`, as these values should be more likely to be correct than the modespecific dimension.[Wikipedia Reference](https://en.wikipedia.org/wiki/Extended_Display_Identification_Data)

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
Fixes #5124