### PR TITLE
Fix: NullReferenceException when using TwoWay binding with indexer to null DataContext

### DIFF
--- a/src/Avalonia.Base/Data/Core/SettableNode.cs
+++ b/src/Avalonia.Base/Data/Core/SettableNode.cs
@@ -15,7 +15,8 @@ namespace Avalonia.Data.Core
 
         private bool ShouldNotSet(object value)
         {
-            if (PropertyType == null)
+            var propertyType = PropertyType;
+            if (propertyType == null)
             {
                 return false;
             }
@@ -37,7 +38,7 @@ namespace Avalonia.Data.Core
                 return false;
             }
 
-            if (PropertyType.IsValueType)
+            if (propertyType.IsValueType)
             {
                 return lastValue.Equals(value);
             }

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/Nodes/StringIndexerNode.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/Nodes/StringIndexerNode.cs
@@ -129,7 +129,10 @@ namespace Avalonia.Markup.Parsers.Nodes
         {
             get
             {
-                Target.TryGetTarget(out object target);
+                if (!Target.TryGetTarget(out object target))
+                {
+                    return null;
+                }
 
                 return GetIndexer(target.GetType().GetTypeInfo())?.PropertyType;
             }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Binding.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Binding.cs
@@ -4,6 +4,8 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Logging;
 using Avalonia.Platform;
@@ -795,6 +797,24 @@ namespace Avalonia.Base.UnitTests
             target.Bind(Class1.DoubleValueProperty, new Binding("[0]", BindingMode.TwoWay) { Source = source });
 
             Assert.False(source.SetterCalled);
+        }
+
+        [Fact]
+        public void TwoWay_Binding_Should_Not_Fail_With_Null_DataContext()
+        {
+            var target = new TextBlock();
+            target.DataContext = null;
+
+            target.Bind(TextBlock.TextProperty, new Binding("Missing", BindingMode.TwoWay));
+        }
+
+        [Fact]
+        public void TwoWay_Binding_Should_Not_Fail_With_Null_DataContext_Indexer()
+        {
+            var target = new TextBlock();
+            target.DataContext = null;
+
+            target.Bind(TextBlock.TextProperty, new Binding("[0]", BindingMode.TwoWay));
         }
 
         [Fact]


### PR DESCRIPTION
## What is the current behavior?
NullReferenceException

## What is the updated/expected behavior with this PR?
Binding doesn't try to write value back, when DataContext is null.

## How was the solution implemented (if it's not obvious)?
PropertyType now returns null when Target is null.
After "null" type is handled in ShouldNotSet method and returns signal that write back is not allowed.

## Checklist

- [X] Added unit tests (if possible)?

## Fixed issues
Fixes #5194
