### PR TITLE
Fix ContextMenu Open

### DIFF
--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -246,7 +246,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Opens the menu.
         /// </summary>
-        public override void Open() => throw new NotSupportedException();
+        public override void Open() => Open(null);
 
         /// <summary>
         /// Opens a context menu on the specified control.

--- a/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
@@ -45,6 +45,55 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Open_Should_Use_Default_Control()
+        {
+            using (Application())
+            {
+                var sut = new ContextMenu();
+                var target = new Panel
+                {
+                    ContextMenu = sut
+                };
+
+                var window = new Window { Content = target };
+                window.ApplyTemplate();
+                window.Presenter.ApplyTemplate();
+
+                bool opened = false;
+
+                sut.MenuOpened += (sender, args) =>
+                {
+                    opened = true;
+                };
+
+                sut.Open();
+
+                Assert.True(opened);
+            }
+        }
+
+        [Fact]
+        public void Open_Should_Raise_Exception_If_AlreadyDetached()
+        {
+            using (Application())
+            {
+                var sut = new ContextMenu();
+                var target = new Panel
+                {
+                    ContextMenu = sut
+                };
+
+                var window = new Window { Content = target };
+                window.ApplyTemplate();
+                window.Presenter.ApplyTemplate();
+
+                target.ContextMenu = null;
+
+               Assert.ThrowsAny<Exception>(()=> sut.Open());
+            }
+        }
+
+        [Fact]
         public void Closing_Raises_Single_Closed_Event()
         {
             using (Application())


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes common scenario (before 0.10.0-rc1 everything was fine) for `ContextMenu.Open()`

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Currently `ContextMenu.Open()` throws `NotSuppordedException` and that's not correct when `ContextMenu `is already attached to at least one control (also `ContextMenu.Open(null)` is working fine at the same time)

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
 `ContextMenu.Open()` work fine when `ContextMenu `is attached

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
 `ContextMenu.Open()` call  `ContextMenu.Open(null)`

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #5187