### PR TITLE
Fix progressbar MinWidth\MinHeight defaults for both themes

### DIFF
--- a/src/Avalonia.Themes.Default/ProgressBar.xaml
+++ b/src/Avalonia.Themes.Default/ProgressBar.xaml
@@ -35,12 +35,12 @@
     <Setter Property="VerticalAlignment" Value="Bottom"/>
   </Style>
   <Style Selector="ProgressBar:horizontal">
-    <Setter Property="MinWidth" Value="200"/>
-    <Setter Property="MinHeight" Value="16"/>
+    <Setter Property="Width" Value="200"/>
+    <Setter Property="Height" Value="16"/>
   </Style>
   <Style Selector="ProgressBar:vertical">
-    <Setter Property="MinWidth" Value="16"/>
-    <Setter Property="MinHeight" Value="200"/>
+    <Setter Property="Width" Value="16"/>
+    <Setter Property="Height" Value="200"/>
   </Style>
   <Style Selector="ProgressBar:vertical /template/ LayoutTransformControl#PART_LayoutTransformControl">
     <Setter Property="LayoutTransform">

--- a/src/Avalonia.Themes.Fluent/Accents/FluentControlResourcesDark.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/FluentControlResourcesDark.xaml
@@ -282,7 +282,6 @@
 
     <!-- Resources for ProgressBar.xaml -->
     <x:Double x:Key="ProgressBarIndicatorPauseOpacity">0.6</x:Double>
-    <x:Double x:Key="ProgressBarThemeMinHeight">4</x:Double>
     <Thickness x:Key="ProgressBarBorderThemeThickness">0</Thickness>
     <SolidColorBrush x:Key="ProgressBarBackgroundThemeBrush" Color="#59FFFFFF" />
     <SolidColorBrush x:Key="ProgressBarBorderThemeBrush" Color="Transparent" />

--- a/src/Avalonia.Themes.Fluent/Accents/FluentControlResourcesLight.xaml
+++ b/src/Avalonia.Themes.Fluent/Accents/FluentControlResourcesLight.xaml
@@ -250,7 +250,6 @@
     <SolidColorBrush x:Key="ListBoxItemSelectedPointerOverBackgroundThemeBrush" Color="#FF5F37BE" />
     <!-- Resources for ProgressBar.xaml -->
     <x:Double x:Key="ProgressBarIndicatorPauseOpacity">0.6</x:Double>
-    <x:Double x:Key="ProgressBarThemeMinHeight">4</x:Double>
     <Thickness x:Key="ProgressBarBorderThemeThickness">0</Thickness>
     <SolidColorBrush x:Key="ProgressBarBackgroundThemeBrush" Color="#30000000" />
     <SolidColorBrush x:Key="ProgressBarBorderThemeBrush" Color="Transparent" />

--- a/src/Avalonia.Themes.Fluent/Controls/ProgressBar.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ProgressBar.xaml
@@ -13,7 +13,6 @@
     <Setter Property="BorderThickness" Value="{DynamicResource ProgressBarBorderThemeThickness}" />
     <Setter Property="BorderBrush" Value="{DynamicResource SystemControlHighlightTransparentBrush}" />
     <Setter Property="Maximum" Value="100" />
-    <Setter Property="MinHeight" Value="{DynamicResource ProgressBarThemeMinHeight}" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="Template">
       <ControlTemplate>
@@ -40,12 +39,12 @@
     <Setter Property="VerticalAlignment" Value="Bottom" />
   </Style>
   <Style Selector="ProgressBar:horizontal">
-    <Setter Property="MinWidth" Value="200" />
-    <Setter Property="MinHeight" Value="4" />
+    <Setter Property="Width" Value="200" />
+    <Setter Property="Height" Value="4" />
   </Style>
   <Style Selector="ProgressBar:vertical">
-    <Setter Property="MinWidth" Value="4" />
-    <Setter Property="MinHeight" Value="200" />
+    <Setter Property="Height" Value="200" />
+    <Setter Property="Width" Value="4" />
   </Style>
   <Style Selector="ProgressBar:vertical /template/ LayoutTransformControl#PART_LayoutTransformControl">
     <Setter Property="LayoutTransform">


### PR DESCRIPTION
## What does the pull request do?

## What is the current behavior?
Currently, Avalonia set MinHeight\MinWindth for user, which I think not really nice. If user will set Height\Width below the value set in control style it would not work
![image](https://user-images.githubusercontent.com/53405089/102820332-c06af300-43dd-11eb-9362-1c62f8a55ee0.png)
Here as you can see three progressbar's with different height values but it doesn't affect UI in any way. It would work only if you set MinHeight to 0. For WPF everything works without an explicit set of MinWidth\MinHeight.
## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
Just removed all explicit MinWidth\MinHeight set and changed them to Height\Width set

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Fixed issues
https://github.com/AvaloniaUI/Avalonia/issues/3194

