### PR TITLE
Tooltip position recalculation

### DIFF
--- a/samples/ControlCatalog/Pages/SliderPage.xaml
+++ b/samples/ControlCatalog/Pages/SliderPage.xaml
@@ -22,6 +22,20 @@
                 IsSnapToTickEnabled="True"
                 Ticks="0,20,25,40,75,100"
                 Width="300" />
+        <Slider Name="SliderWithTooltip"
+                Value="0"
+                Minimum="0"
+                Maximum="100"
+                Width="300">
+          <Slider.Styles>
+            <Style Selector="Slider /template/ Thumb">
+              <Setter Property="ToolTip.Tip" Value="{Binding $parent[Slider].Value, Mode=OneWay, StringFormat='Value \{0:f\}'}" />
+              <Setter Property="ToolTip.Placement" Value="Top" />
+              <Setter Property="ToolTip.VerticalOffset" Value="-10" />
+              <Setter Property="ToolTip.HorizontalOffset" Value="-30" />
+            </Style>
+          </Slider.Styles>
+        </Slider>
         <Slider Value="0"
                 Minimum="0"
                 Maximum="100"

--- a/samples/ControlCatalog/Pages/ToolTipPage.xaml
+++ b/samples/ControlCatalog/Pages/ToolTipPage.xaml
@@ -6,7 +6,7 @@
         <TextBlock Classes="h1">ToolTip</TextBlock>
         <TextBlock Classes="h2">A control which pops up a hint when a control is hovered</TextBlock>
 
-        <Grid RowDefinitions="Auto,Auto"
+        <Grid RowDefinitions="Auto,Auto,Auto"
               ColumnDefinitions="Auto,Auto"
               Margin="0,16,0,0"
               HorizontalAlignment="Center">
@@ -37,6 +37,31 @@
                     </StackPanel>
                 </ToolTip.Tip>
                 <TextBlock>ToolTip bottom placement</TextBlock>
+            </Border>
+            <Border Grid.Row="2"
+                    Grid.ColumnSpan="2"
+                    Background="{DynamicResource SystemAccentColor}"
+                    Margin="5"
+                    Padding="50"
+                    ToolTip.Tip="Hello"
+                    ToolTip.Placement="Top">
+              <Border.Styles>
+                <Style Selector="Border">
+                  <Style.Animations>
+                    <Animation Duration="0:0:2" IterationCount="Infinite">
+                      <KeyFrame KeyTime="0:0:0">
+                        <Setter Property="ToolTip.HorizontalOffset" Value="0" />
+                        <Setter Property="ToolTip.VerticalOffset" Value="-50" />
+                      </KeyFrame>
+                      <KeyFrame KeyTime="0:0:2" >
+                        <Setter Property="ToolTip.HorizontalOffset" Value="100" />
+                        <Setter Property="ToolTip.VerticalOffset" Value="50" />
+                      </KeyFrame>
+                    </Animation>
+                  </Style.Animations>
+                </Style>
+              </Border.Styles>
+              <TextBlock>Moving offset</TextBlock>
             </Border>
         </Grid>
     </StackPanel>

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -28,12 +28,14 @@ namespace Avalonia.Controls
             {
                 control.PointerEnter -= ControlPointerEnter;
                 control.PointerLeave -= ControlPointerLeave;
+                control.PropertyChanged -= Control_PropertyChanged;
             }
 
             if (e.NewValue != null)
             {
                 control.PointerEnter += ControlPointerEnter;
                 control.PointerLeave += ControlPointerLeave;
+                control.PropertyChanged += Control_PropertyChanged;
             }
 
             if (ToolTip.GetIsOpen(control) && e.NewValue != e.OldValue && !(e.NewValue is ToolTip))
@@ -95,6 +97,17 @@ namespace Avalonia.Controls
         {
             var control = (Control)sender;
             Close(control);
+        }
+
+        private void Control_PropertyChanged(object sender, AvaloniaPropertyChangedEventArgs e)
+        {
+            var control = (Control)sender;
+
+            if (e.Property == Visual.TransformedBoundsProperty)
+            {
+                var toolTip = control.GetValue(ToolTip.ToolTipProperty);
+                toolTip?.RecalculatePosition(control);
+            }
         }
 
         private void StartShowTimer(int showDelay, Control control)

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -28,14 +28,12 @@ namespace Avalonia.Controls
             {
                 control.PointerEnter -= ControlPointerEnter;
                 control.PointerLeave -= ControlPointerLeave;
-                control.PropertyChanged -= Control_PropertyChanged;
             }
 
             if (e.NewValue != null)
             {
                 control.PointerEnter += ControlPointerEnter;
                 control.PointerLeave += ControlPointerLeave;
-                control.PropertyChanged += Control_PropertyChanged;
             }
 
             if (ToolTip.GetIsOpen(control) && e.NewValue != e.OldValue && !(e.NewValue is ToolTip))
@@ -53,10 +51,12 @@ namespace Avalonia.Controls
             if (e.OldValue is false && e.NewValue is true)
             {
                 control.DetachedFromVisualTree += ControlDetaching;
+                control.EffectiveViewportChanged += ControlEffectiveViewportChanged;
             }
             else if(e.OldValue is true && e.NewValue is false)
             {
                 control.DetachedFromVisualTree -= ControlDetaching;
+                control.EffectiveViewportChanged -= ControlEffectiveViewportChanged;
             }
         }
         
@@ -64,6 +64,7 @@ namespace Avalonia.Controls
         {
             var control = (Control)sender;
             control.DetachedFromVisualTree -= ControlDetaching;
+            control.EffectiveViewportChanged -= ControlEffectiveViewportChanged;
             Close(control);
         }
 
@@ -99,15 +100,11 @@ namespace Avalonia.Controls
             Close(control);
         }
 
-        private void Control_PropertyChanged(object sender, AvaloniaPropertyChangedEventArgs e)
+        private void ControlEffectiveViewportChanged(object sender, Layout.EffectiveViewportChangedEventArgs e)
         {
             var control = (Control)sender;
-
-            if (e.Property == Visual.BoundsProperty)
-            {
-                var toolTip = control.GetValue(ToolTip.ToolTipProperty);
-                toolTip?.RecalculatePosition(control);
-            }
+            var toolTip = control.GetValue(ToolTip.ToolTipProperty);
+            toolTip?.RecalculatePosition(control);
         }
 
         private void StartShowTimer(int showDelay, Control control)

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -103,7 +103,7 @@ namespace Avalonia.Controls
         {
             var control = (Control)sender;
 
-            if (e.Property == Visual.TransformedBoundsProperty)
+            if (e.Property == Visual.BoundsProperty)
             {
                 var toolTip = control.GetValue(ToolTip.ToolTipProperty);
                 toolTip?.RecalculatePosition(control);


### PR DESCRIPTION
## What does the pull request do?

ToolTip now listens for target bounds changing:
![slider](https://user-images.githubusercontent.com/3163374/103474728-ada8d480-4d74-11eb-988c-e4262066b403.gif)

ToolTip position now is recalculated on positioning props changed:
![moving-offset](https://user-images.githubusercontent.com/3163374/103474729-ada8d480-4d74-11eb-9942-c581a7fac95e.gif)


## Breaking changes
None


## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/5086
