### PR TITLE
Fixes control validation message when data type does not match control input.

### DIFF
--- a/src/Avalonia.Controls/DataValidationErrors.cs
+++ b/src/Avalonia.Controls/DataValidationErrors.cs
@@ -130,10 +130,12 @@ namespace Avalonia.Controls
 
         private static object GetExceptionData(Exception exception)
         {
-            if (exception is DataValidationException dataValidationException)
-                return dataValidationException.ErrorData;
-
-            return exception;
+            return exception switch
+            {
+                DataValidationException dataValidationException => dataValidationException.ErrorData,
+                InvalidCastException invalidCastException => invalidCastException.Message,
+                _ => exception
+            };
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
When a control is bound to a data type, if the control input cannot be cast to said data type, the user is presented with an unfriendly validation message. This PR aims to solve that by checking to see if a given exception is of a certain type and extracting the user friendly message to be displayed.

## What is the current behavior?
Currently, the control displays the exception type full name along with the exception message.
![image](https://user-images.githubusercontent.com/21192520/103817782-42564f80-505f-11eb-8376-1b13539279ea.png)


## What is the updated/expected behavior with this PR?
Only the exception message is displayed.
![image](https://user-images.githubusercontent.com/21192520/103817721-23f05400-505f-11eb-9f62-de7e855151a1.png)


## How was the solution implemented (if it's not obvious)?
When unpacking the exceptions, the current implementation takes the whole exception object for all exceptions other than data validation exceptions. The solution is to add logic to handle `InvalidCastException`'s that will extract the user friendly message rather than dumping the whole exception object.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation


## Fixed issues
Fixes #4559
