### PR TITLE
[WIP] Allow cross origin requests to previewer host

### DIFF
--- a/src/Avalonia.DesignerSupport/Remote/HtmlTransport/SimpleWebSocketHttpServer.cs
+++ b/src/Avalonia.DesignerSupport/Remote/HtmlTransport/SimpleWebSocketHttpServer.cs
@@ -146,7 +146,7 @@ namespace Avalonia.DesignerSupport.Remote.HtmlTransport
 
         public async Task RespondAsync(int code, byte[] data, string contentType)
         {
-            var headers = Encoding.UTF8.GetBytes($"HTTP/1.1 {code} {(HttpStatusCode)code}\r\nConnection: close\r\nContent-Type: {contentType}\r\nContent-Length: {data.Length}\r\n\r\n");
+            var headers = Encoding.UTF8.GetBytes($"HTTP/1.1 {code} {(HttpStatusCode)code}\r\nConnection: close\r\nContent-Type: {contentType}\r\nContent-Length: {data.Length}\r\nAccess-Control-Allow-Origin: *\r\n\r\n");
             await _stream.WriteAsync(headers, 0, headers.Length);
             await _stream.WriteAsync(data, 0, data.Length);
             _stream.Dispose();


### PR DESCRIPTION
## What does the pull request do?
This PR allows hosting of designer window inside other hosts. This enables vscode extension to use designer without altering existing html. 

Only other way would be to prerender this html page (so there is no requirement to include styles or scripts), and then extension could load it via regular http request and paste pre-rendered html (as CORS does not apply to websocket requests).

## What is the current behavior?
Currently CORS is disabled. Vscode extension model does not allow opening webpage, only loading from string. So to load it exension needs to set html like `<iframe stc="$DESIGNER_HOST"/>`. This iframe is hosted inside vscode window with url like `vs-code://some-random-uuid`. Because designer is hosted at `http://localhost:port` electron does not allow loading this request, as it is cross-origin.

## What is the updated/expected behavior with this PR?
Server sends `cross-origin-allow: *` which allows loading designer in any context. We do not care too much about other websites hijacking designer website.

## How was the solution implemented (if it's not obvious)?
Add  `cross-origin-allow: *` header to headers field

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Fixed issues
This is required for vscode designer, there's no .