### PR TITLE
Use SKFontManager for typeface matching and handle null typeface because of Android

### DIFF
--- a/src/Skia/Avalonia.Skia/FontManagerImpl.cs
+++ b/src/Skia/Avalonia.Skia/FontManagerImpl.cs
@@ -109,20 +109,23 @@ namespace Avalonia.Skia
             if (typeface.FontFamily.Key == null)
             {
                 var defaultName = SKTypeface.Default.FamilyName;
+                var fontStyle = new SKFontStyle((SKFontStyleWeight)typeface.Weight, SKFontStyleWidth.Normal, (SKFontStyleSlant)typeface.Style);
 
                 foreach (var familyName in typeface.FontFamily.FamilyNames)
                 {
-                    skTypeface = SKTypeface.FromFamilyName(familyName, (SKFontStyleWeight)typeface.Weight,
-                        SKFontStyleWidth.Normal, (SKFontStyleSlant)typeface.Style);
+                    skTypeface = _skFontManager.MatchFamily(familyName, fontStyle);
 
-                    if (!skTypeface.FamilyName.Equals(familyName, StringComparison.Ordinal) &&
-                        defaultName.Equals(skTypeface.FamilyName, StringComparison.Ordinal))
+                    if (skTypeface is null
+                        || (!skTypeface.FamilyName.Equals(familyName, StringComparison.Ordinal)
+                            && defaultName.Equals(skTypeface.FamilyName, StringComparison.Ordinal)))
                     {
                         continue;
                     }
 
                     break;
                 }
+
+                skTypeface ??= _skFontManager.MatchTypeface(SKTypeface.Default, fontStyle);
             }
             else
             {


### PR DESCRIPTION
## What does the pull request do?

Context: https://github.com/mono/SkiaSharp/issues/1058#issuecomment-564482266

This feels a bit hacky, because maybe the fallback can still return `null`, but not sure, I tested it on Android and it works.

## What is the current behavior?

As discussed in mono/SkiaSharp#1058, the behavior for `SKTypeface.FromFamilyName` is not consistent. Also on Android the `skTypeface` is `null` and it causes an NRE, so for now fallback to default.

## What is the updated/expected behavior with this PR?

Typeface matching should be more consistent and not fail on Android.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation