### PR TITLE
Fixed Avalonia version in About dialog

### DIFF
--- a/src/Avalonia.Dialogs/AboutAvaloniaDialog.xaml
+++ b/src/Avalonia.Dialogs/AboutAvaloniaDialog.xaml
@@ -79,8 +79,8 @@
         <DrawingPresenter Drawing="{DynamicResource AvaloniaLogo}" />
       </Border>
       <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Margin="10,-10,0,0">
-        <TextBlock Text="Avalonia 0.9" FontSize="40" Foreground="White" />
-        <TextBlock Text="Development Build" Margin="0,-10,0,0" FontSize="15" Foreground="White" />
+        <TextBlock Text="{Binding Version, StringFormat=Avalonia {0}}" FontSize="40" Foreground="White" />
+        <TextBlock Text="Development Build" IsVisible="{Binding IsDevelopmentBuild}" Margin="0,-10,0,0" FontSize="15" Foreground="White" />
       </StackPanel>
     </StackPanel>
     <StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Center" Spacing="20" Margin="10 60 10 0">

--- a/src/Avalonia.Dialogs/AboutAvaloniaDialog.xaml.cs
+++ b/src/Avalonia.Dialogs/AboutAvaloniaDialog.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Avalonia.Controls;
@@ -7,12 +8,18 @@ namespace Avalonia.Dialogs
 {
     public class AboutAvaloniaDialog : Window
     {
+        private static readonly Version s_version = typeof(AboutAvaloniaDialog).Assembly.GetName().Version;
+
+        public static string Version { get; } = s_version.ToString(2);
+
+        public static bool IsDevelopmentBuild { get; } = s_version.Revision == 999;
+
         public AboutAvaloniaDialog()
         {
             AvaloniaXamlLoader.Load(this);
             DataContext = this;
         }
- 
+
         public static void OpenBrowser(string url)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))


### PR DESCRIPTION
## Changes

- Fixed Avalonia version in About dialog (was 0.9, changed to use assembly version major and minor).
- Hide "Development Build" text if it's a release build (patch/revision != 999).