### PR TITLE
Apply delay when closing submenu due to pointer leave.

### DIFF
--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -355,7 +355,13 @@ namespace Avalonia.Controls.Platform
                 }
                 else if (!item.IsPointerOverSubMenu)
                 {
-                    item.IsSubMenuOpen = false;
+                    DelayRun(() =>
+                    {
+                        if (!item.IsPointerOverSubMenu)
+                        {
+                            item.IsSubMenuOpen = false;
+                        }
+                    }, MenuShowDelay);
                 }
             }
         }


### PR DESCRIPTION
## What does the pull request do?

Sometimes a submenu was being closed when the pointer was moved into it as described in #4729 and #5320. This was caused by the pointer-over state being removed on the parent menu item before the pointer over state was added to the submenu item.

Fix this by applying a delay to closing submenus, which is behavior consistent with how menus should work anyway.

## Fixed issues

Fixes #4729
Fixes #5320
