### PR TITLE
Override default value instead of setting local value in LightDismissOverlayLayer

### DIFF
--- a/src/Avalonia.Controls/Primitives/LightDismissOverlayLayer.cs
+++ b/src/Avalonia.Controls/Primitives/LightDismissOverlayLayer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
+using Avalonia.Media;
 using Avalonia.Rendering;
 using Avalonia.Styling;
 using Avalonia.VisualTree;
@@ -16,6 +17,11 @@ namespace Avalonia.Controls.Primitives
     public class LightDismissOverlayLayer : Border, ICustomHitTest
     {
         public IInputElement? InputPassThroughElement { get; set; }
+
+        static LightDismissOverlayLayer()
+        {
+            BackgroundProperty.OverrideDefaultValue<LightDismissOverlayLayer>(Brushes.Transparent);
+        }
 
         /// <summary>
         /// Returns the light dismiss overlay for a specified visual.

--- a/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
+++ b/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
@@ -74,7 +74,6 @@ namespace Avalonia.Controls.Primitives
                 {
                     rv = new LightDismissOverlayLayer
                     {
-                        Background = Brushes.Transparent,
                         IsVisible = false
                     };
 


### PR DESCRIPTION
## What does the pull request do?
Override default value instead of setting local value in LightDismissOverlayLayer.
It's possible now to use Styles to change light dissmiss background color:
```xaml
<Style Selector="LightDismissOverlayLayer">
  <Setter Property="Background" Value="Black" />
  <Setter Property="Opacity" Value="0.1" />
</Style>
```

## What is the current behavior?
Background value is set with Local priority

## What is the updated/expected behavior with this PR?
Default value was changed to Transparent as expected for this control. 