### PR TITLE
Mark glBlitFramebuffer optional to allow ES2.0 drm devices

### DIFF
--- a/src/Avalonia.OpenGL/GlInterface.cs
+++ b/src/Avalonia.OpenGL/GlInterface.cs
@@ -128,7 +128,7 @@ namespace Avalonia.OpenGL
             int dstY1,
             int mask,
             int filter);
-        [GlMinVersionEntryPoint("glBlitFramebuffer", 3, 0)]
+        [GlMinVersionEntryPoint("glBlitFramebuffer", 3, 0), GlOptionalEntryPoint]
         public GlBlitFramebuffer BlitFramebuffer { get; }
         
         public delegate void GlGenRenderbuffers(int count, int[] res);


### PR DESCRIPTION
## What does the pull request do?
Mark glBlitFramebuffer as GlOptionalEntryPoint in Avalonia.OpenGL.GlInterface. There are provisions in the code to allow Avalonia.OpenGL.GlInterface.BlitFramebuffer to be optional.


## What is the current behavior?
Trying to start Avalonia on DRM on an OpenGL ES 2.0 device cause it to crash because glBlitFramebuffer isn't available.


## What is the updated/expected behavior with this PR?
It starts on DRM with ES 2.0 (at least on an iMX8M Mini)
