### PR TITLE
Fixing FluentTheme Expanded header foreground issue

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/Expander.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/Expander.xaml
@@ -26,6 +26,9 @@
       </ControlTemplate>
     </Setter>
   </Style>
+  <Style Selector="Expander[IsExpanded=true] /template/ ToggleButton#PART_toggle /template/ ContentPresenter#PART_ContentPresenter">
+    <Setter Property="TextBlock.Foreground" Value="{DynamicResource ToggleButtonForeground}"/>
+  </Style>
   <Style Selector="Expander[ExpandDirection=Up]">
     <Setter Property="Template">
       <ControlTemplate>


### PR DESCRIPTION
My first attempt at contributing!


Tested with 0.10.0 with both Light and Dark themes.

## What does the pull request do?
This commit adds a style selector to ensure that the Expanded control keeps its foreground when expanded. Fixes #5349 



## What is the current behavior?
The expander header foreground will change to white, which in the light theme make it become unreadable. 

## What is the updated/expected behavior with this PR?
The foreground will not change when the expander is expanded. 


## How was the solution implemented (if it's not obvious)?
N/A


## Breaking changes
None


## Fixed issues
Fixes #5349 

