### PR TITLE
Fix EntryPointNotFound on Windows 8 due to missing version check

### DIFF
--- a/src/Windows/Avalonia.Direct2D1/HwndRenderTarget.cs
+++ b/src/Windows/Avalonia.Direct2D1/HwndRenderTarget.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Platform;
+﻿using System;
+using Avalonia.Platform;
 using Avalonia.Win32.Interop;
 using SharpDX;
 using SharpDX.DXGI;
@@ -21,10 +22,7 @@ namespace Avalonia.Direct2D1
 
         protected override Size2F GetWindowDpi()
         {
-			var osVersion = System.Environment.OSVersion.Version;
-            if (UnmanagedMethods.ShCoreAvailable &&
-                (osVersion.Major > 6 || 
-                 osVersion.Major == 6 && osVersion.Minor >= 3))
+            if (UnmanagedMethods.ShCoreAvailable && Environment.OSVersion.Version > PlatformConstants.Windows8)
             {
                 uint dpix, dpiy;
 

--- a/src/Windows/Avalonia.Direct2D1/HwndRenderTarget.cs
+++ b/src/Windows/Avalonia.Direct2D1/HwndRenderTarget.cs
@@ -21,7 +21,10 @@ namespace Avalonia.Direct2D1
 
         protected override Size2F GetWindowDpi()
         {
-            if (UnmanagedMethods.ShCoreAvailable)
+			var osVersion = System.Environment.OSVersion.Version;
+            if (UnmanagedMethods.ShCoreAvailable &&
+                (osVersion.Major > 6 || 
+                 osVersion.Major == 6 && osVersion.Minor >= 3))
             {
                 uint dpix, dpiy;
 

--- a/src/Windows/Avalonia.Direct2D1/PlatformConstants.cs
+++ b/src/Windows/Avalonia.Direct2D1/PlatformConstants.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Avalonia.Direct2D1
+{
+    static class PlatformConstants
+    {
+        public static readonly Version Windows8 = new Version(6, 2);
+    }
+}

--- a/src/Windows/Avalonia.Win32/FramebufferManager.cs
+++ b/src/Windows/Avalonia.Win32/FramebufferManager.cs
@@ -87,9 +87,7 @@ namespace Avalonia.Win32
 
         private Vector GetCurrentDpi()
         {
-            if (UnmanagedMethods.ShCoreAvailable &&
-                (Win32Platform.WindowsVersion.Major > 6 || 
-                 Win32Platform.WindowsVersion.Major == 6 && Win32Platform.WindowsVersion.Minor >= 3))
+            if (UnmanagedMethods.ShCoreAvailable && Win32Platform.WindowsVersion > PlatformConstants.Windows8)
             {
                 var monitor =
                     UnmanagedMethods.MonitorFromWindow(_hwnd, UnmanagedMethods.MONITOR.MONITOR_DEFAULTTONEAREST);

--- a/src/Windows/Avalonia.Win32/FramebufferManager.cs
+++ b/src/Windows/Avalonia.Win32/FramebufferManager.cs
@@ -87,7 +87,9 @@ namespace Avalonia.Win32
 
         private Vector GetCurrentDpi()
         {
-            if (UnmanagedMethods.ShCoreAvailable)
+            if (UnmanagedMethods.ShCoreAvailable &&
+                (Win32Platform.WindowsVersion.Major > 6 || 
+                 Win32Platform.WindowsVersion.Major == 6 && Win32Platform.WindowsVersion.Minor >= 3))
             {
                 var monitor =
                     UnmanagedMethods.MonitorFromWindow(_hwnd, UnmanagedMethods.MONITOR.MONITOR_DEFAULTTONEAREST);

--- a/src/Windows/Avalonia.Win32/PlatformConstants.cs
+++ b/src/Windows/Avalonia.Win32/PlatformConstants.cs
@@ -1,8 +1,12 @@
+using System;
+
 namespace Avalonia.Win32
 {
     static class PlatformConstants
     {
         public const string WindowHandleType = "HWND";
         public const string CursorHandleType = "HCURSOR";
+
+        public static readonly Version Windows8 = new Version(6, 2);
     }
 }

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -731,8 +731,9 @@ namespace Avalonia.Win32
                 RegisterTouchWindow(_hwnd, 0);
             }
 
-            if (ShCoreAvailable)
-            {
+            if (ShCoreAvailable && (Win32Platform.WindowsVersion.Major > 6 || 
+                                    Win32Platform.WindowsVersion.Major == 6 && Win32Platform.WindowsVersion.Minor >= 3))
+			{
                 var monitor = MonitorFromWindow(
                     _hwnd,
                     MONITOR.MONITOR_DEFAULTTONEAREST);

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -731,8 +731,7 @@ namespace Avalonia.Win32
                 RegisterTouchWindow(_hwnd, 0);
             }
 
-            if (ShCoreAvailable && (Win32Platform.WindowsVersion.Major > 6 || 
-                                    Win32Platform.WindowsVersion.Major == 6 && Win32Platform.WindowsVersion.Minor >= 3))
+            if (ShCoreAvailable && Win32Platform.WindowsVersion > PlatformConstants.Windows8)
 			{
                 var monitor = MonitorFromWindow(
                     _hwnd,


### PR DESCRIPTION
## What does the pull request do?
This PR adds proper Windows OS version checks before p/invoke calls to `GetDpiForMonitor` (`shcore.dll`), which is only available on Windows 8.1 and later ([reference](https://docs.microsoft.com/en-us/windows/win32/api/shellscalingapi/nf-shellscalingapi-getdpiformonitor#requirements)). 
Avalonia previously checked whether `shcore.dll` is available on the system every time before calling that procedure. However, this doesn't cover the case that a system has an older `shcore.dll` in place without the required `GetDpiForMonitor` entry point (this affects all Windows 8 machines).

## What is the current behavior?
When a new Avalonia window is being created on Windows 8, the application crashes due to an `EntryPointNotFoundException` while attempting to retrieve DPI information: https://github.com/AvaloniaUI/Avalonia/blob/6bf37a90801c43f4a0add39c06f13f5fcdbc6757/src/Windows/Avalonia.Win32/WindowImpl.cs#L740
Besides this one, there are two more code snippets affected; check the file diff for details.

## What is the updated/expected behavior with this PR?
A version check has been added to skip this call on machines running Windows 8 (not 8.1!); same behavior as on Windows 7.

## Fixed issues
Fixes #5357