### PR TITLE
Removing MinWidth default values for CheckBox and RadioButton

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/CheckBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/CheckBox.xaml
@@ -11,7 +11,6 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Center" />    
     <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
-    <Setter Property="MinWidth" Value="120" />
     <Setter Property="MinHeight" Value="32" />
     <!--<Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
     <Setter Property="FocusVisualMargin" Value="-7,-3,-7,-3" />-->

--- a/src/Avalonia.Themes.Fluent/Controls/RadioButton.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/RadioButton.xaml
@@ -19,7 +19,6 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Center" />    
     <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
-    <Setter Property="MinWidth" Value="120" />
     <Setter Property="Template">
       <ControlTemplate TargetType="RadioButton">
         <Border Name="RootBorder"


### PR DESCRIPTION
Removed the MinWidth default values (120) for CheckBox and RadioButton to resolve #5355

## What does the pull request do?
Removes the MinWidth default for both CheckBox and RadioButton


## What is the current behavior?
The controls default to a MinWidth of 120.

## What is the updated/expected behavior with this PR?
The controls should now be sensible width by default. 


## Fixed issues
Fixes #5355

