### PR TITLE
Correctly read EDID on X11.

### DIFF
--- a/src/Avalonia.X11/X11Atoms.cs
+++ b/src/Avalonia.X11/X11Atoms.cs
@@ -114,7 +114,7 @@ namespace Avalonia.X11
         public readonly IntPtr XA_WM_CLASS = (IntPtr)67;
         public readonly IntPtr XA_WM_TRANSIENT_FOR = (IntPtr)68;
 
-        public readonly IntPtr RR_PROPERTY_RANDR_EDID = (IntPtr)82;
+        public readonly IntPtr EDID;
 
         public readonly IntPtr WM_PROTOCOLS;
         public readonly IntPtr WM_DELETE_WINDOW;

--- a/src/Avalonia.X11/X11Screens.cs
+++ b/src/Avalonia.X11/X11Screens.cs
@@ -91,12 +91,12 @@ namespace Avalonia.X11
                 var hasEDID = false;
                 for(var pc = 0; pc < propertyCount; pc++)
                 {
-                    if(properties[pc] == _x11.Atoms.RR_PROPERTY_RANDR_EDID)
+                    if(properties[pc] == _x11.Atoms.EDID)
                         hasEDID = true;
                 }
                 if(!hasEDID)
                     return null;
-                XRRGetOutputProperty(_x11.Display, rrOutput, _x11.Atoms.RR_PROPERTY_RANDR_EDID, 0, EDIDStructureLength, false, false, _x11.Atoms.AnyPropertyType, out IntPtr actualType, out int actualFormat, out int bytesAfter, out _, out IntPtr prop);
+                XRRGetOutputProperty(_x11.Display, rrOutput, _x11.Atoms.EDID, 0, EDIDStructureLength, false, false, _x11.Atoms.AnyPropertyType, out IntPtr actualType, out int actualFormat, out int bytesAfter, out _, out IntPtr prop);
                 if(actualType != _x11.Atoms.XA_INTEGER)
                     return null;
                 if(actualFormat != 8) // Expecting an byte array


### PR DESCRIPTION
## What does the pull request do?

#5178 appears to have broken display scaling on Ubuntu at least for me:

![image](https://user-images.githubusercontent.com/1775141/105968361-4afedc00-6087-11eb-8bf2-24fc521676f9.png)

Seems that reading the EDID was broken. With input from @kekekeks managed to come up with this fix. 

Pinging @robinxan who wrote #5178 for a double-check.
