### PR TITLE
Add redirects for Q/A and discussions in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve Avalonia
 title: ''
 labels: bug
 assignees: ''
-
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,8 +24,9 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. Windows, Mac, Linux (State distribution)]
- - Version [e.g. 0.10.0-rc1 or 0.9.12]
+
+- OS: [e.g. Windows, Mac, Linux (State distribution)]
+- Version [e.g. 0.10.0-rc1 or 0.9.12]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Questions, Discussions, Ideas
     url: https://github.com/AvaloniaUI/Avalonia/discussions/new

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions, Discussions, Ideas
+    url: https://github.com/AvaloniaUI/Avalonia/discussions/new
+    about: Please ask and answer questions here.
+  - name: Avalonia Community Support on Gitter
+    url: https://gitter.im/AvaloniaUI/Avalonia
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: ''
 labels: enhancement
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**


### PR DESCRIPTION
## What does the pull request do?
Add redirects for Q/A and discussions in issue templates


## What is the current behavior?
People have trouble when they want to ask a question


## What is the updated/expected behavior with this PR?
Add redirects for Q/A and discussions on Discussions or Gitter
