### PR TITLE
fix: Don't Try to Emit x:FieldModifier or x:ClassModifier

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/IgnoredDirectivesTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/IgnoredDirectivesTransformer.cs
@@ -15,7 +15,10 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                 {
                     if (d.Namespace == XamlNamespaces.Xaml2006)
                     {
-                        if (d.Name == "Precompile" || d.Name == "Class")
+                        if (d.Name == "Precompile" ||
+                            d.Name == "Class" ||
+                            d.Name == "FieldModifier" ||
+                            d.Name == "ClassModifier")
                             no.Children.Remove(d);
                     }
                 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/IgnoredDirectivesTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/IgnoredDirectivesTests.cs
@@ -1,0 +1,31 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Markup.Xaml.UnitTests.Xaml
+{
+    public class IgnoredDirectivesTests : XamlTestBase
+    {
+        [Fact]
+        public void Ignored_Directives_Should_Compile()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                const string xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:sys='clr-namespace:System;assembly=netstandard'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <TextBlock x:Name='target' x:FieldModifier='Public' Text='Foo'/>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var target = window.FindControl<TextBlock>("target");
+
+                window.ApplyTemplate();
+                target.ApplyTemplate();
+
+                Assert.Equal("Foo", target.Text);
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

This PR adds support for `x:FieldModifier` directives so they can be used in our typed `x:Name` reference source generator.
Related PR: https://github.com/AvaloniaUI/Avalonia.NameGenerator/pull/20

#### What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Currently, if we try to compile XAML markup with `x:FieldModifier` directives inside that markup file, we get the following compile-time error: `Avalonia.NameGenerator.Sandbox.Views.SignUpView.xaml(11,10,11,10): Avalonia error XAMLIL: Unable to find emitter for node type: XamlX.Ast.XamlAstXmlDirective (line 11 position 10) Line 11, position 10.` The build error seems to be coming from the Xaml compiler that decides to compile this directive (the reason for this is that no one has told the compiler to ignore that directive).

https://github.com/AvaloniaUI/Avalonia.NameGenerator/pull/20

#### What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Now, XAML markup with `x:FieldModifier` directives produces valid XAML, and `x:FieldModifier` directives are ignored.

#### How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

The `IgnoredDirectivesTransformer` was extended to strip out `FieldModifier`s from the AST.

#### Checklist

- [x] Added unit tests (if possible)?

#### Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

This PR will unblock the PR https://github.com/AvaloniaUI/Avalonia.NameGenerator/pull/20 that fixes https://github.com/AvaloniaUI/Avalonia.NameGenerator/issues/19