### PR TITLE
Set initial input focus using LinuxFrameBufferPlatform

### DIFF
--- a/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Threading;
 using Avalonia.Controls;
@@ -79,6 +79,11 @@ namespace Avalonia.LinuxFramebuffer
                     tl.Prepare();
                     _topLevel = tl;
                     _topLevel.Renderer.Start();
+
+                    if (_topLevel is IFocusScope scope)
+                    {
+                        FocusManager.Instance?.SetFocusScope(scope);
+                    }
                 }
 
                 _topLevel.Content = value;


### PR DESCRIPTION
## What does the pull request do?
When starting an application using Linux DRM, there is no initial focus UI element set. This is normally done with the activation of a Window, which doesnt exit in this instance.


## What is the current behavior?
Application starts without an initial focus until a touch input is received.


## What is the updated/expected behavior with this PR?
Allows for Tab based navigation to work when wiring in an input method for Tab navigation, without needing to touch the screen to set an initial focused elemetn.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

