### PR TITLE
Fix ContextMenu positioning when a popup is right-clicked

### DIFF
--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -269,7 +269,7 @@ namespace Avalonia.Controls
             }
 
             control ??= _attachedControls![0];
-            Open(control, control);
+            Open(control, PlacementTarget ?? control);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -269,53 +269,7 @@ namespace Avalonia.Controls
             }
 
             control ??= _attachedControls![0];
-
-            if (IsOpen)
-            {
-                return;
-            }
-
-            if (_popup == null)
-            {
-                _popup = new Popup
-                {
-                    HorizontalOffset = HorizontalOffset,
-                    VerticalOffset = VerticalOffset,
-                    PlacementAnchor = PlacementAnchor,
-                    PlacementConstraintAdjustment = PlacementConstraintAdjustment,
-                    PlacementGravity = PlacementGravity,
-                    PlacementMode = PlacementMode,
-                    PlacementRect = PlacementRect,
-                    PlacementTarget = PlacementTarget ?? control,
-                    IsLightDismissEnabled = true,
-                    OverlayDismissEventPassThrough = true,
-                    WindowManagerAddShadowHint = WindowManagerAddShadowHint,
-                };
-
-                _popup.Opened += PopupOpened;
-                _popup.Closed += PopupClosed;
-            }
-
-            if (_popup.Parent != control)
-            {
-                ((ISetLogicalParent)_popup).SetParent(null);
-                ((ISetLogicalParent)_popup).SetParent(control);
-            }
-
-            if (PlacementTarget is null && _popup.PlacementTarget != control)
-            {
-                _popup.PlacementTarget = control;
-            }
-
-            _popup.Child = this;
-            IsOpen = true;
-            _popup.IsOpen = true;
-
-            RaiseEvent(new RoutedEventArgs
-            {
-                RoutedEvent = MenuOpenedEvent,
-                Source = this,
-            });
+            Open(control, control);
         }
 
         /// <summary>
@@ -348,6 +302,51 @@ namespace Avalonia.Controls
         protected override IItemContainerGenerator CreateItemContainerGenerator()
         {
             return new MenuItemContainerGenerator(this);
+        }
+
+        private void Open(Control control, Control placementTarget)
+        {
+            if (IsOpen)
+            {
+                return;
+            }
+
+            if (_popup == null)
+            {
+                _popup = new Popup
+                {
+                    HorizontalOffset = HorizontalOffset,
+                    VerticalOffset = VerticalOffset,
+                    PlacementAnchor = PlacementAnchor,
+                    PlacementConstraintAdjustment = PlacementConstraintAdjustment,
+                    PlacementGravity = PlacementGravity,
+                    PlacementMode = PlacementMode,
+                    PlacementRect = PlacementRect,
+                    IsLightDismissEnabled = true,
+                    OverlayDismissEventPassThrough = true,
+                    WindowManagerAddShadowHint = WindowManagerAddShadowHint,
+                };
+
+                _popup.Opened += PopupOpened;
+                _popup.Closed += PopupClosed;
+            }
+
+            if (_popup.Parent != control)
+            {
+                ((ISetLogicalParent)_popup).SetParent(null);
+                ((ISetLogicalParent)_popup).SetParent(control);
+            }
+
+            _popup.PlacementTarget = placementTarget;
+            _popup.Child = this;
+            IsOpen = true;
+            _popup.IsOpen = true;
+
+            RaiseEvent(new RoutedEventArgs
+            {
+                RoutedEvent = MenuOpenedEvent,
+                Source = this,
+            });
         }
 
         private void PopupOpened(object sender, EventArgs e)
@@ -403,7 +402,7 @@ namespace Avalonia.Controls
                 if (contextMenu.CancelOpening())
                     return;
 
-                contextMenu.Open(control);
+                contextMenu.Open(control, e.Source as Control ?? control);
                 e.Handled = true;
             }
         }


### PR DESCRIPTION
## What does the pull request do?

As described in #5101 when opening a context menu on a popup contained within a control, we open the popup at -1,-1 due to the placement target being in a different window to which the click occured on.

Moved the implementation of `ContextMenu.Open` into a private method that accepts a control and a placement target. When calling `Open` due to a right-click in `ControlPointerReleased`, call this method with the clicked control as the placement target.

## Fixed issues

Fixes #5101
