### PR TITLE
Fix clearing focus.

### DIFF
--- a/src/Avalonia.Input/FocusManager.cs
+++ b/src/Avalonia.Input/FocusManager.cs
@@ -75,7 +75,9 @@ namespace Avalonia.Input
                 // If control is null, set focus to the topmost focus scope.
                 foreach (var scope in GetFocusScopeAncestors(Current).Reverse().ToList())
                 {
-                    if (_focusScopes.TryGetValue(scope, out var element) && element != null)
+                    if (scope != Scope &&
+                        _focusScopes.TryGetValue(scope, out var element) &&
+                        element != null)
                     {
                         Focus(element, method);
                         return;

--- a/tests/Avalonia.Input.UnitTests/InputElement_Focus.cs
+++ b/tests/Avalonia.Input.UnitTests/InputElement_Focus.cs
@@ -318,5 +318,24 @@ namespace Avalonia.Input.UnitTests
                 Assert.True(root2.IsKeyboardFocusWithin);
             }
         }
+
+        [Fact]
+        public void Can_Clear_Focus()
+        {
+            Button target;
+
+            using (UnitTestApplication.Start(TestServices.RealFocus))
+            {
+                var root = new TestRoot
+                {
+                    Child = target = new Button()
+                };
+
+                target.Focus();
+                FocusManager.Instance.Focus(null);
+
+                Assert.Null(FocusManager.Instance.Current);
+            }
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

As described in #4906, clearing focus did not work because the `FocusManager` sets focus to the top-level focus scope even when we're in that scope.

Fix it by making sure that the scope we're focusing isn't the current one.

## Checklist

- [x] Added unit tests (if possible)?

## Fixed issues

Fixes #4906 