### PR TITLE
Reduce memory pressure when using bindings

### DIFF
--- a/src/Avalonia.Base/Data/BindingOperations.cs
+++ b/src/Avalonia.Base/Data/BindingOperations.cs
@@ -45,7 +45,7 @@ namespace Avalonia.Data
                 case BindingMode.OneWay:
                     return target.Bind(property, binding.Observable ?? binding.Subject, binding.Priority);
                 case BindingMode.TwoWay:
-                    return new CompositeDisposable(
+                    return new TwoWayBindingDisposable(
                         target.Bind(property, binding.Subject, binding.Priority),
                         target.GetObservable(property).Subscribe(binding.Subject));
                 case BindingMode.OneTime:
@@ -86,6 +86,32 @@ namespace Avalonia.Data
 
                 default:
                     throw new ArgumentException("Invalid binding mode.");
+            }
+        }
+
+        private sealed class TwoWayBindingDisposable : IDisposable
+        {
+            private readonly IDisposable _first;
+            private readonly IDisposable _second;
+            private bool _isDisposed;
+
+            public TwoWayBindingDisposable(IDisposable first, IDisposable second)
+            {
+                _first = first;
+                _second = second;
+            }
+
+            public void Dispose()
+            {
+                if (_isDisposed)
+                {
+                    return;
+                }
+
+                _first.Dispose();
+                _second.Dispose();
+
+                _isDisposed = true;
             }
         }
     }

--- a/src/Avalonia.Base/Reactive/AvaloniaPropertyObservable.cs
+++ b/src/Avalonia.Base/Reactive/AvaloniaPropertyObservable.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Avalonia.Reactive
 {
@@ -55,9 +56,9 @@ namespace Avalonia.Reactive
                     newValue = (T)e.Sender.GetValue(e.Property);
                 }
 
-                if (!Equals(newValue, _value))
+                if (!EqualityComparer<T>.Default.Equals(newValue, _value))
                 {
-                    _value = (T)newValue;
+                    _value = newValue;
                     PublishNext(_value);
                 }
             }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
I've noticed that `BindingOperations.Apply`  was causing several array allocations, it was caused by two copies of our disposables. Plus extra allocations in `CompositeDisposable` itself.
Also fixed boxing in observable for avalonia properties. (Not noticeable in bindings really since we use `object` variant anyway atm, might change with typed bindings usage).

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Binding two-way properties causes several not needed allocations.
|                          Method |       Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------- |-----------:|----------:|----------:|-------:|------:|------:|----------:|
|       TwoWayBinding_Via_Binding |   5.026 us | 0.0230 us | 0.0204 us | 0.6561 |     - |     - |   2.68 KB |
| UpdateTwoWayBinding_Via_Binding | 151.190 us | 0.9779 us | 0.8166 us | 8.0566 |     - |     - |  33.88 KB |


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
|                          Method |       Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------- |-----------:|----------:|----------:|-------:|------:|------:|----------:|
|       TwoWayBinding_Via_Binding |   4.757 us | 0.0249 us | 0.0233 us | 0.6104 |     - |     - |   2.52 KB |
| UpdateTwoWayBinding_Via_Binding | 148.445 us | 0.8685 us | 0.8124 us | 8.0566 |     - |     - |  33.72 KB |

We also lost like 1KB of allocations in Calendar benchmark (but it is a drop in the bucket of 223 KB allocated in there anyway).

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
