### PR TITLE
Avoid crashing at "open file" dialog (Fix #5541)

### DIFF
--- a/src/Avalonia.Dialogs/ManagedFileChooserSources.cs
+++ b/src/Avalonia.Dialogs/ManagedFileChooserSources.cs
@@ -71,6 +71,10 @@ namespace Avalonia.Dialogs
                        {
                            return null;
                        }
+                       catch (DirectoryNotFoundException _)
+                       {
+                           return null;
+                       }
 
                        return new ManagedFileChooserNavigationItem
                        {

--- a/src/Avalonia.Dialogs/ManagedFileChooserSources.cs
+++ b/src/Avalonia.Dialogs/ManagedFileChooserSources.cs
@@ -67,11 +67,7 @@ namespace Avalonia.Dialogs
                        {
                            Directory.GetFiles(x.VolumePath);
                        }
-                       catch (UnauthorizedAccessException _)
-                       {
-                           return null;
-                       }
-                       catch (DirectoryNotFoundException _)
+                       catch (Exception _)
                        {
                            return null;
                        }


### PR DESCRIPTION
## What does the pull request do?
Avoid crashing at "open file" dialog 

## What is the current behavior?
Crash if the directory doesn't exist 


## What is the updated/expected behavior with this PR?
Won't crash if the directory doesn't exist 


## How was the solution implemented (if it's not obvious)?
catch DirectoryNotFoundException


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
N/A

## Fixed issues
Fixes #5541 
