### PR TITLE
Don't call SetFocus on Windows with ShowActivated == false.

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -958,7 +958,7 @@ namespace Avalonia.Win32
                 MaximizeWithoutCoveringTaskbar();
             }
 
-            if (!Design.IsDesignMode)
+            if (!Design.IsDesignMode && activate)
             {
                 SetFocus(_hwnd);
             }


### PR DESCRIPTION
## What does the pull request do?

On win32, don't call `SetFocus` on `Windows` with `ShowActivated == false`.

This was causing the window to get activated.