### PR TITLE
Return desired size as is without recreating it

### DIFF
--- a/src/Avalonia.Layout/UniformGridLayout.cs
+++ b/src/Avalonia.Layout/UniformGridLayout.cs
@@ -447,7 +447,7 @@ namespace Avalonia.Layout
             // and only use the layout when to clear it when it's done.
             gridState.EnsureFirstElementOwnership(context);
 
-            return new Size(desiredSize.Width, desiredSize.Height);
+            return desiredSize;
         }
 
         protected internal override Size ArrangeOverride(VirtualizingLayoutContext context, Size finalSize)


### PR DESCRIPTION
The desired size is already computed and not modified in any way, so there's no need to deconstruct it to components and create again.