### PR TITLE
Attach CloseOnClickChanged event handler for NotificationCard.

### DIFF
--- a/src/Avalonia.Controls/ApiCompatBaseline.txt
+++ b/src/Avalonia.Controls/ApiCompatBaseline.txt
@@ -1,6 +1,7 @@
 Compat issues with assembly Avalonia.Controls:
 MembersMustExist : Member 'public void Avalonia.Controls.Embedding.Offscreen.OffscreenTopLevelImplBase.SetCursor(Avalonia.Platform.IPlatformHandle)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public Avalonia.AvaloniaProperty Avalonia.AvaloniaProperty Avalonia.Controls.Notifications.NotificationCard.CloseOnClickProperty' does not exist in the implementation but it does exist in the contract.
 InterfacesShouldHaveSameMembers : Interface member 'public void Avalonia.Platform.ITopLevelImpl.SetCursor(Avalonia.Platform.ICursorImpl)' is present in the implementation but not in the contract.
 InterfacesShouldHaveSameMembers : Interface member 'public void Avalonia.Platform.ITopLevelImpl.SetCursor(Avalonia.Platform.IPlatformHandle)' is present in the contract but not in the implementation.
 MembersMustExist : Member 'public void Avalonia.Platform.ITopLevelImpl.SetCursor(Avalonia.Platform.IPlatformHandle)' does not exist in the implementation but it does exist in the contract.
-Total Issues: 4
+Total Issues: 5

--- a/src/Avalonia.Controls/Notifications/NotificationCard.cs
+++ b/src/Avalonia.Controls/Notifications/NotificationCard.cs
@@ -16,6 +16,11 @@ namespace Avalonia.Controls.Notifications
         private bool _isClosed;
         private bool _isClosing;
 
+        static NotificationCard()
+        {
+            CloseOnClickProperty.Changed.AddClassHandler<Button>(OnCloseOnClickPropertyChanged);
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationCard"/> class.
         /// </summary>
@@ -105,22 +110,26 @@ namespace Avalonia.Controls.Notifications
 
         public static bool GetCloseOnClick(Button obj)
         {
+            Contract.Requires<ArgumentNullException>(obj != null);
             return (bool)obj.GetValue(CloseOnClickProperty);
         }
 
         public static void SetCloseOnClick(Button obj, bool value)
         {
+            Contract.Requires<ArgumentNullException>(obj != null);
             obj.SetValue(CloseOnClickProperty, value);
         }
 
         /// <summary>
         /// Defines the CloseOnClick property.
         /// </summary>
-        public static readonly AvaloniaProperty CloseOnClickProperty =
-          AvaloniaProperty.RegisterAttached<Button, bool>("CloseOnClick", typeof(NotificationCard)/*, validate: CloseOnClickChanged*/);
+        public static readonly AttachedProperty<bool> CloseOnClickProperty =
+          AvaloniaProperty.RegisterAttached<NotificationCard, Button, bool>("CloseOnClick", defaultValue: false);
 
-        private static bool CloseOnClickChanged(Button button, bool value)
+        private static void OnCloseOnClickPropertyChanged(AvaloniaObject d, AvaloniaPropertyChangedEventArgs e)
         {
+            var button = (Button)d;
+            var value = (bool)e.NewValue;
             if (value)
             {
                 button.Click += Button_Click;
@@ -129,8 +138,6 @@ namespace Avalonia.Controls.Notifications
             {
                 button.Click -= Button_Click;
             }
-
-            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
## What does the pull request do?
This fixed issue #5411.

## What is the current behavior?
This re-attached the event handler for CloseOnClick done a button inside a NotificationCard.

## What is the updated/expected behavior with this PR?
When clicking a button inside a NotificationCard and CloseOnClick is set to true then the NotificationCard should close when button is clicked.


## How was the solution implemented (if it's not obvious)?
This re-attaches an already implemented event handler that was disabled probably because of some refactoring.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
