### PR TITLE
Parent Windows get chance to cancel closing before any children close.

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -502,10 +502,10 @@ namespace Avalonia.Controls
             if (!ShouldCancelClose())
             {
                 CloseInternal();
-                return true;
+                return false;
             }
             
-            return false;
+            return true;
         }
 
         private void CloseInternal()

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -4,10 +4,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
-using Avalonia.Controls.Chrome;
 using Avalonia.Controls.Platform;
-using Avalonia.Controls.Primitives;
-using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
@@ -531,7 +528,7 @@ namespace Avalonia.Controls
         private bool ShouldCancelClose()
         {
             bool canClose = true;
-            
+
             foreach (var (child, _) in _children.ToList())
             {
                 if (child.ShouldCancelClose())

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -499,7 +499,7 @@ namespace Avalonia.Controls
         /// </summary>
         protected virtual bool HandleClosing()
         {
-            if (ShouldCancelClose())
+            if (!ShouldCancelClose())
             {
                 CloseInternal();
                 return true;

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -525,13 +525,18 @@ namespace Avalonia.Controls
             PlatformImpl?.Dispose();
         }
 
-        private bool ShouldCancelClose()
+        private bool ShouldCancelClose(CancelEventArgs args = null)
         {
+            if (args is null)
+            {
+                args = new CancelEventArgs();
+            }
+            
             bool canClose = true;
 
             foreach (var (child, _) in _children.ToList())
             {
-                if (child.ShouldCancelClose())
+                if (child.ShouldCancelClose(args))
                 {
                     canClose = false;
                 }
@@ -539,7 +544,6 @@ namespace Avalonia.Controls
 
             if (canClose)
             {
-                var args = new CancelEventArgs();
                 OnClosing(args);
 
                 return args.Cancel;

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Avalonia.Layout;
 using Avalonia.Platform;
 using Avalonia.Rendering;
 using Avalonia.UnitTests;
@@ -135,6 +134,107 @@ namespace Avalonia.Controls.UnitTests
                 window.Close();
 
                 Assert.Equal(1, count);
+            }
+        }
+        
+        [Fact]
+        public void Child_windows_should_be_closed_before_parent()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var window = new Window();
+                var child = new Window();
+
+                int count = 0;
+                int windowClosing = 0;
+                int childClosing = 0;
+                int windowClosed = 0;
+                int childClosed = 0;
+
+                window.Closing += (sender, e) =>
+                {
+                    count++;
+                    windowClosing = count;
+                };
+                
+                child.Closing += (sender, e) =>
+                {
+                    count++;
+                    childClosing = count;
+                };
+                
+                window.Closed += (sender, e) =>
+                {
+                    count++;
+                    windowClosed = count;
+                };
+                
+                child.Closed += (sender, e) =>
+                {
+                    count++;
+                    childClosed = count;
+                };
+
+                window.Show();
+                child.Show(window);
+                
+                window.Close();
+
+                Assert.Equal(2, windowClosing);
+                Assert.Equal(1, childClosing);
+                Assert.Equal(4, windowClosed);
+                Assert.Equal(3, childClosed);
+            }
+        }
+        
+        [Fact]
+        public void Child_windows_must_not_close_before_parent_has_chance_to_Cancel()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var window = new Window();
+                var child = new Window();
+
+                int count = 0;
+                int windowClosing = 0;
+                int childClosing = 0;
+                int windowClosed = 0;
+                int childClosed = 0;
+
+                window.Closing += (sender, e) =>
+                {
+                    count++;
+                    windowClosing = count;
+                    e.Cancel = true;
+                };
+                
+                child.Closing += (sender, e) =>
+                {
+                    count++;
+                    childClosing = count;
+                };
+                
+                window.Closed += (sender, e) =>
+                {
+                    count++;
+                    windowClosed = count;
+                };
+                
+                child.Closed += (sender, e) =>
+                {
+                    count++;
+                    childClosed = count;
+                };
+
+                window.Show();
+                child.Show(window);
+                
+                window.Close();
+
+                Assert.Equal(2, windowClosing);
+                Assert.Equal(1, childClosing);
+                Assert.Equal(0, windowClosed);
+                Assert.Equal(0, childClosed);
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -137,8 +137,10 @@ namespace Avalonia.Controls.UnitTests
             }
         }
         
-        [Fact]
-        public void Child_windows_should_be_closed_before_parent_OSCloseButton()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Child_windows_should_be_closed_before_parent(bool programaticClose)
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
@@ -178,9 +180,16 @@ namespace Avalonia.Controls.UnitTests
                 window.Show();
                 child.Show(window);
 
-                var cancel = window.PlatformImpl.Closing();
-                
-                Assert.Equal(false, cancel);
+                if (programaticClose)
+                {
+                    window.Close();
+                }
+                else
+                {
+                    var cancel = window.PlatformImpl.Closing();
+
+                    Assert.Equal(false, cancel);
+                }
 
                 Assert.Equal(2, windowClosing);
                 Assert.Equal(1, childClosing);
@@ -189,8 +198,10 @@ namespace Avalonia.Controls.UnitTests
             }
         }
         
-        [Fact]
-        public void Child_windows_must_not_close_before_parent_has_chance_to_Cancel_OSCloseButton()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Child_windows_must_not_close_before_parent_has_chance_to_Cancel_OSCloseButton(bool programaticClose)
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
@@ -231,110 +242,16 @@ namespace Avalonia.Controls.UnitTests
                 window.Show();
                 child.Show(window);
                 
-                var cancel = window.PlatformImpl.Closing();
-                
-                Assert.Equal(true, cancel);
-
-                Assert.Equal(2, windowClosing);
-                Assert.Equal(1, childClosing);
-                Assert.Equal(0, windowClosed);
-                Assert.Equal(0, childClosed);
-            }
-        }
-        
-        [Fact]
-        public void Child_windows_should_be_closed_before_parent_Programatically()
-        {
-            using (UnitTestApplication.Start(TestServices.StyledWindow))
-            {
-                var window = new Window();
-                var child = new Window();
-
-                int count = 0;
-                int windowClosing = 0;
-                int childClosing = 0;
-                int windowClosed = 0;
-                int childClosed = 0;
-
-                window.Closing += (sender, e) =>
+                if (programaticClose)
                 {
-                    count++;
-                    windowClosing = count;
-                };
-                
-                child.Closing += (sender, e) =>
+                    window.Close();
+                }
+                else
                 {
-                    count++;
-                    childClosing = count;
-                };
-                
-                window.Closed += (sender, e) =>
-                {
-                    count++;
-                    windowClosed = count;
-                };
-                
-                child.Closed += (sender, e) =>
-                {
-                    count++;
-                    childClosed = count;
-                };
+                    var cancel = window.PlatformImpl.Closing();
 
-                window.Show();
-                child.Show(window);
-                
-                window.Close();
-
-                Assert.Equal(2, windowClosing);
-                Assert.Equal(1, childClosing);
-                Assert.Equal(4, windowClosed);
-                Assert.Equal(3, childClosed);
-            }
-        }
-        
-        [Fact]
-        public void Child_windows_must_not_close_before_parent_has_chance_to_Cancel_Programatically()
-        {
-            using (UnitTestApplication.Start(TestServices.StyledWindow))
-            {
-                var window = new Window();
-                var child = new Window();
-
-                int count = 0;
-                int windowClosing = 0;
-                int childClosing = 0;
-                int windowClosed = 0;
-                int childClosed = 0;
-
-                window.Closing += (sender, e) =>
-                {
-                    count++;
-                    windowClosing = count;
-                    e.Cancel = true;
-                };
-                
-                child.Closing += (sender, e) =>
-                {
-                    count++;
-                    childClosing = count;
-                };
-                
-                window.Closed += (sender, e) =>
-                {
-                    count++;
-                    windowClosed = count;
-                };
-                
-                child.Closed += (sender, e) =>
-                {
-                    count++;
-                    childClosed = count;
-                };
-
-                window.Show();
-                child.Show(window);
-                
-                window.Close();
+                    Assert.Equal(true, cancel);
+                }
 
                 Assert.Equal(2, windowClosing);
                 Assert.Equal(1, childClosing);

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -138,7 +138,112 @@ namespace Avalonia.Controls.UnitTests
         }
         
         [Fact]
-        public void Child_windows_should_be_closed_before_parent()
+        public void Child_windows_should_be_closed_before_parent_OSCloseButton()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var window = new Window();
+                var child = new Window();
+
+                int count = 0;
+                int windowClosing = 0;
+                int childClosing = 0;
+                int windowClosed = 0;
+                int childClosed = 0;
+
+                window.Closing += (sender, e) =>
+                {
+                    count++;
+                    windowClosing = count;
+                };
+                
+                child.Closing += (sender, e) =>
+                {
+                    count++;
+                    childClosing = count;
+                };
+                
+                window.Closed += (sender, e) =>
+                {
+                    count++;
+                    windowClosed = count;
+                };
+                
+                child.Closed += (sender, e) =>
+                {
+                    count++;
+                    childClosed = count;
+                };
+
+                window.Show();
+                child.Show(window);
+
+                var cancel = window.PlatformImpl.Closing();
+                
+                Assert.Equal(false, cancel);
+
+                Assert.Equal(2, windowClosing);
+                Assert.Equal(1, childClosing);
+                Assert.Equal(4, windowClosed);
+                Assert.Equal(3, childClosed);
+            }
+        }
+        
+        [Fact]
+        public void Child_windows_must_not_close_before_parent_has_chance_to_Cancel_OSCloseButton()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var window = new Window();
+                var child = new Window();
+
+                int count = 0;
+                int windowClosing = 0;
+                int childClosing = 0;
+                int windowClosed = 0;
+                int childClosed = 0;
+
+                window.Closing += (sender, e) =>
+                {
+                    count++;
+                    windowClosing = count;
+                    e.Cancel = true;
+                };
+                
+                child.Closing += (sender, e) =>
+                {
+                    count++;
+                    childClosing = count;
+                };
+                
+                window.Closed += (sender, e) =>
+                {
+                    count++;
+                    windowClosed = count;
+                };
+                
+                child.Closed += (sender, e) =>
+                {
+                    count++;
+                    childClosed = count;
+                };
+
+                window.Show();
+                child.Show(window);
+                
+                var cancel = window.PlatformImpl.Closing();
+                
+                Assert.Equal(true, cancel);
+
+                Assert.Equal(2, windowClosing);
+                Assert.Equal(1, childClosing);
+                Assert.Equal(0, windowClosed);
+                Assert.Equal(0, childClosed);
+            }
+        }
+        
+        [Fact]
+        public void Child_windows_should_be_closed_before_parent_Programatically()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
@@ -188,7 +293,7 @@ namespace Avalonia.Controls.UnitTests
         }
         
         [Fact]
-        public void Child_windows_must_not_close_before_parent_has_chance_to_Cancel()
+        public void Child_windows_must_not_close_before_parent_has_chance_to_Cancel_Programatically()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Allows apps that use child windows to be able to easily prevent the app from closing.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
If you have child windows open, each child window gets asked if it wants to cancel closing, and if it doesnt, it immediately closes. Child windows are asked before the main window.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Each child window is enumerated with closing event giving the chance to cancel. then the mainwindow is asked if it wants to cancel via closing event.

Only after this has happened are any windows closed or not as the case may be.

This matches the order that WPF does things (the only difference that we enumerate child windows and wpf doesnt)

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
