### PR TITLE
Split DRM output instance from the DRM platform EGL interface

### DIFF
--- a/src/Avalonia.OpenGL/Egl/EglPlatformOpenGlInterface.cs
+++ b/src/Avalonia.OpenGL/Egl/EglPlatformOpenGlInterface.cs
@@ -6,11 +6,14 @@ namespace Avalonia.OpenGL.Egl
 {
     public class EglPlatformOpenGlInterface : IPlatformOpenGlInterface
     {
-        public EglDisplay Display { get; private set; }
+        public EglDisplay Display { get; }
+        
         public bool CanCreateContexts => true;
+        
         public bool CanShareContexts => Display.SupportsSharing;
         
         public EglContext PrimaryEglContext { get; }
+        
         public IGlContext PrimaryContext => PrimaryEglContext;
         
         public EglPlatformOpenGlInterface(EglDisplay display)

--- a/src/Linux/Avalonia.LinuxFramebuffer/FramebufferToplevelImpl.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/FramebufferToplevelImpl.cs
@@ -14,8 +14,6 @@ namespace Avalonia.LinuxFramebuffer
     {
         private readonly IOutputBackend _outputBackend;
         private readonly IInputBackend _inputBackend;
-
-        private bool _renderQueued;
         public IInputRoot InputRoot { get; private set; }
 
         public FramebufferToplevelImpl(IOutputBackend outputBackend, IInputBackend inputBackend)

--- a/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
@@ -44,7 +44,6 @@ namespace Avalonia.LinuxFramebuffer
                 .Bind<IRenderLoop>().ToConstant(new RenderLoop())
                 .Bind<PlatformHotkeyConfiguration>().ToSingleton<PlatformHotkeyConfiguration>();
         }
-
        
         internal static LinuxFramebufferLifetime Initialize<T>(T builder, IOutputBackend outputBackend) where T : AppBuilderBase<T>, new()
         {
@@ -52,19 +51,9 @@ namespace Avalonia.LinuxFramebuffer
             
             builder
                 .UseSkia()
-                .UseWindowingSubsystem(platform.Initialize, OutputPlatformName(outputBackend));
+                .UseWindowingSubsystem(platform.Initialize, outputBackend.Name);
             
             return new LinuxFramebufferLifetime(outputBackend);
-        }
-
-        private static string OutputPlatformName(IOutputBackend outputBackend)
-        {
-            var name = outputBackend.GetType().Name.ToLowerInvariant();
-            
-            if (name.EndsWith("output"))
-                name = name.Substring(0, name.Length - "output".Length);
-            
-            return name;
         }
     }
 
@@ -154,4 +143,3 @@ public static class LinuxFramebufferPlatformExtensions
         return lifetime.ExitCode;
     }
 }
-

--- a/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Threading;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Embedding;
@@ -13,49 +14,61 @@ using Avalonia.LinuxFramebuffer.Output;
 using Avalonia.OpenGL;
 using Avalonia.Platform;
 using Avalonia.Rendering;
-using Avalonia.Threading;
 
 namespace Avalonia.LinuxFramebuffer
 {
-    class LinuxFramebufferPlatform
+    internal class LinuxFramebufferPlatform
     {
-        IOutputBackend _fb;
+        private static readonly KeyboardDevice KeyboardDevice = new KeyboardDevice();
+        private static readonly MouseDevice MouseDevice = new MouseDevice();
+        private static readonly InternalPlatformThreadingInterface Threading = new InternalPlatformThreadingInterface();
+
         private static readonly Stopwatch St = Stopwatch.StartNew();
+        
         internal static uint Timestamp => (uint)St.ElapsedTicks;
-        public static InternalPlatformThreadingInterface Threading;
-        LinuxFramebufferPlatform(IOutputBackend backend)
+
+        private LinuxFramebufferPlatform()
         {
-            _fb = backend;
         }
 
-
-        void Initialize()
+        private void Initialize()
         {
-            Threading = new InternalPlatformThreadingInterface();
-            if (_fb is IGlOutputBackend gl)
-                AvaloniaLocator.CurrentMutable.Bind<IPlatformOpenGlInterface>().ToConstant(gl.PlatformOpenGlInterface);
             AvaloniaLocator.CurrentMutable
                 .Bind<IPlatformThreadingInterface>().ToConstant(Threading)
                 .Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(60))
                 .Bind<IRenderLoop>().ToConstant(new RenderLoop())
                 .Bind<ICursorFactory>().ToTransient<CursorFactoryStub>()
-                .Bind<IKeyboardDevice>().ToConstant(new KeyboardDevice())
+                .Bind<IKeyboardDevice>().ToConstant(KeyboardDevice)
+                .Bind<IMouseDevice>().ToConstant(MouseDevice)
                 .Bind<IPlatformSettings>().ToSingleton<PlatformSettings>()
                 .Bind<IRenderLoop>().ToConstant(new RenderLoop())
                 .Bind<PlatformHotkeyConfiguration>().ToSingleton<PlatformHotkeyConfiguration>();
-
         }
 
        
         internal static LinuxFramebufferLifetime Initialize<T>(T builder, IOutputBackend outputBackend) where T : AppBuilderBase<T>, new()
         {
-            var platform = new LinuxFramebufferPlatform(outputBackend);
-            builder.UseSkia().UseWindowingSubsystem(platform.Initialize, "fbdev");
-            return new LinuxFramebufferLifetime(platform._fb);
+            var platform = new LinuxFramebufferPlatform();
+            
+            builder
+                .UseSkia()
+                .UseWindowingSubsystem(platform.Initialize, OutputPlatformName(outputBackend));
+            
+            return new LinuxFramebufferLifetime(outputBackend);
+        }
+
+        private static string OutputPlatformName(IOutputBackend outputBackend)
+        {
+            var name = outputBackend.GetType().Name.ToLowerInvariant();
+            
+            if (name.EndsWith("output"))
+                name = name.Substring(0, name.Length - "output".Length);
+            
+            return name;
         }
     }
 
-    class LinuxFramebufferLifetime : IControlledApplicationLifetime, ISingleViewApplicationLifetime
+    internal class LinuxFramebufferLifetime : IControlledApplicationLifetime, ISingleViewApplicationLifetime
     {
         private readonly IOutputBackend _fb;
         private TopLevel _topLevel;
@@ -66,10 +79,10 @@ namespace Avalonia.LinuxFramebuffer
         {
             _fb = fb;
         }
-        
+
         public Control MainView
         {
-            get => (Control)_topLevel?.Content;
+            get => (Control) _topLevel?.Content;
             set
             {
                 if (_topLevel == null)
@@ -91,14 +104,16 @@ namespace Avalonia.LinuxFramebuffer
         }
 
         public int ExitCode { get; private set; }
-        public event EventHandler<ControlledApplicationLifetimeStartupEventArgs> Startup;
-        public event EventHandler<ControlledApplicationLifetimeExitEventArgs> Exit;
 
+        public event EventHandler<ControlledApplicationLifetimeStartupEventArgs> Startup;
+
+        public event EventHandler<ControlledApplicationLifetimeExitEventArgs> Exit;
+        
         public void Start(string[] args)
         {
             Startup?.Invoke(this, new ControlledApplicationLifetimeStartupEventArgs(args));
         }
-        
+
         public void Shutdown(int exitCode)
         {
             ExitCode = exitCode;
@@ -106,6 +121,9 @@ namespace Avalonia.LinuxFramebuffer
             Exit?.Invoke(this, e);
             ExitCode = e.ApplicationExitCode;
             _cts.Cancel();
+
+            if (_fb is IDisposable disposable)
+                disposable.Dispose();
         }
     }
 }
@@ -114,11 +132,18 @@ public static class LinuxFramebufferPlatformExtensions
 {
     public static int StartLinuxFbDev<T>(this T builder, string[] args, string fbdev = null, double scaling = 1)
         where T : AppBuilderBase<T>, new() =>
-        StartLinuxDirect(builder, args, new FbdevOutput(fbdev) {Scaling = scaling});
+        StartLinuxDirect(builder, args, new FbdevOutput(fbdev) { Scaling = scaling });
 
     public static int StartLinuxDrm<T>(this T builder, string[] args, string card = null, double scaling = 1)
-        where T : AppBuilderBase<T>, new() => StartLinuxDirect(builder, args, new DrmOutput(card) {Scaling = scaling});
-    
+        where T : AppBuilderBase<T>, new()
+    {
+        var drmOutput = new DrmPlatform(card, scaling);
+        
+        AvaloniaLocator.CurrentMutable.Bind<IPlatformOpenGlInterface>().ToConstant(drmOutput.EglPlatformInterface);
+        
+        return StartLinuxDirect(builder, args, drmOutput.CreateOutput());
+    }
+
     public static int StartLinuxDirect<T>(this T builder, string[] args, IOutputBackend backend)
         where T : AppBuilderBase<T>, new()
     {

--- a/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
@@ -127,9 +127,6 @@ public static class LinuxFramebufferPlatformExtensions
         where T : AppBuilderBase<T>, new()
     {
         var drmOutput = new DrmPlatform(card, scaling);
-        
-        AvaloniaLocator.CurrentMutable.Bind<IPlatformOpenGlInterface>().ToConstant(drmOutput.EglPlatformInterface);
-        
         return StartLinuxDirect(builder, args, drmOutput.CreateOutput());
     }
 

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/Drm.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/Drm.cs
@@ -211,7 +211,9 @@ namespace Avalonia.LinuxFramebuffer.Output
         [DllImport(libgbm, SetLastError = true)]
         public static extern IntPtr gbm_create_device(int fd);
         
-        
+        [DllImport(libgbm, SetLastError = true)]
+        public static extern void gbm_device_destroy(IntPtr IntPtr);
+
         [Flags]
         public enum GbmBoFlags {
             /**
@@ -244,6 +246,10 @@ namespace Avalonia.LinuxFramebuffer.Output
 
         [DllImport(libgbm, SetLastError = true)]
         public static extern IntPtr gbm_surface_create(IntPtr device, int width, int height, uint format, GbmBoFlags flags);
+        
+        [DllImport(libgbm, SetLastError = true)]
+        public static extern IntPtr gbm_surface_destroy(IntPtr gbmSurface);
+        
         [DllImport(libgbm, SetLastError = true)]
         public static extern IntPtr gbm_surface_lock_front_buffer(IntPtr surface);
         [DllImport(libgbm, SetLastError = true)]
@@ -257,6 +263,9 @@ namespace Avalonia.LinuxFramebuffer.Output
         [DllImport(libgbm, SetLastError = true)]
         public static extern IntPtr gbm_bo_set_user_data(IntPtr bo, IntPtr userData,
             GbmBoUserDataDestroyCallbackDelegate onFree);
+        
+        [DllImport(libgbm, SetLastError = true)]
+        public static extern void gbm_bo_destroy(IntPtr bo);
 
         [DllImport(libgbm, SetLastError = true)]
         public static extern uint gbm_bo_get_width(IntPtr bo);

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
@@ -140,8 +140,10 @@ namespace Avalonia.LinuxFramebuffer.Output
         }
     }
     
-    public unsafe class DrmCard : IDisposable
+    public class DrmCard : IDisposable
     {
+        private bool _disposed;
+        
         public DrmCard(string path = null)
         {
             Path = path ?? "/dev/dri/card0";
@@ -153,10 +155,7 @@ namespace Avalonia.LinuxFramebuffer.Output
             GbmDevice = new GbmDevice(this);
         }
 
-        ~DrmCard()
-        {
-            ReleaseUnmanagedResources();
-        }
+        ~DrmCard() => Dispose(false);
 
         public int Fd { get; private set; }
 
@@ -168,11 +167,26 @@ namespace Avalonia.LinuxFramebuffer.Output
 
         public void Dispose()
         {
-            GbmDevice.Dispose();
-            ReleaseUnmanagedResources();
+            Dispose(true);
             GC.SuppressFinalize(this);
         }
-        
+
+        private void Dispose(bool disposing)
+        { 
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                GbmDevice.Dispose();
+            }
+
+            ReleaseUnmanagedResources();
+            _disposed = true;
+        }
+
         private void ReleaseUnmanagedResources()
         {
             if (Fd != -1)

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
@@ -139,6 +139,7 @@ namespace Avalonia.LinuxFramebuffer.Output
     
     public unsafe class DrmCard : IDisposable
     {
+        private IntPtr _gbmDevice;
         public int Fd { get; private set; }
         public DrmCard(string path = null)
         {
@@ -149,8 +150,24 @@ namespace Avalonia.LinuxFramebuffer.Output
         }
 
         public DrmResources GetResources() => new DrmResources(Fd);
+
+        /// <summary>
+        /// Pointer to the Graphics Buffer Management (GBM) Device for the DrmCard.  
+        /// </summary>
+        internal IntPtr GbmDevice
+        {
+            get
+            {
+                if (_gbmDevice == IntPtr.Zero)
+                    _gbmDevice = gbm_create_device(Fd);
+
+                return _gbmDevice;
+            }
+        }
+
         public void Dispose()
         {
+            gbm_device_destroy(_gbmDevice);
             close(Fd);
             Fd = -1;
         }

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
@@ -16,6 +16,9 @@ namespace Avalonia.LinuxFramebuffer.Output
         };
 
         public DrmModeConnection Connection { get; }
+
+        public bool IsConnected => Connection == DrmModeConnection.DRM_MODE_CONNECTED;
+        
         public uint Id { get; }
         public string Name { get; }
         public Size SizeMm { get; }

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
@@ -41,12 +41,12 @@ namespace Avalonia.LinuxFramebuffer.Output
         /// <inheritdoc />
         public string Name => "drm";
 
-        void FbDestroyCallback(IntPtr bo, IntPtr userData)
+        private void FbDestroyCallback(IntPtr bo, IntPtr userData)
         {
             drmModeRmFB(_card.Fd, userData.ToInt32());
         }
 
-        uint GetFbIdForBo(IntPtr bo)
+        private uint GetFbIdForBo(IntPtr bo)
         {
             if (bo == IntPtr.Zero)
                 throw new ArgumentException("bo is 0");
@@ -85,7 +85,7 @@ namespace Avalonia.LinuxFramebuffer.Output
         }
         
         
-        void Init(DrmResources resources, DrmConnector connector, DrmModeInfo modeInfo)
+        private void Init(DrmResources resources, DrmConnector connector, DrmModeInfo modeInfo)
         {
             FbDestroyDelegate = FbDestroyCallback;
             
@@ -111,7 +111,7 @@ namespace Avalonia.LinuxFramebuffer.Output
 
             _crtcId = GetCrtc();
 
-            _gbmTargetSurface = gbm_surface_create(_card.GbmDevice, modeInfo.Resolution.Width, modeInfo.Resolution.Height,
+            _gbmTargetSurface = _card.GbmDevice.CreateSurface(modeInfo.Resolution.Width, modeInfo.Resolution.Height,
                 GbmColorFormats.GBM_FORMAT_XRGB8888, GbmBoFlags.GBM_BO_USE_SCANOUT | GbmBoFlags.GBM_BO_USE_RENDERING);
             
             if(_gbmTargetSurface == null)
@@ -155,7 +155,7 @@ namespace Avalonia.LinuxFramebuffer.Output
             return new RenderTarget(this);
         }
 
-        class RenderTarget : IGlPlatformSurfaceRenderTarget
+        private class RenderTarget : IGlPlatformSurfaceRenderTarget
         {
             private readonly DrmOutput _parent;
 
@@ -168,7 +168,7 @@ namespace Avalonia.LinuxFramebuffer.Output
                 // We are wrapping GBM buffer chain associated with CRTC, and don't free it on a whim
             }
 
-            class RenderSession : IGlPlatformSurfaceRenderingSession
+            private class RenderSession : IGlPlatformSurfaceRenderingSession
             {
                 private readonly DrmOutput _parent;
                 private readonly IDisposable _clearContext;

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
@@ -13,13 +13,8 @@ namespace Avalonia.LinuxFramebuffer.Output
 {
     public unsafe class DrmOutput : IOutputBackend, IGlPlatformSurface, IDisposable
     {
-        private DrmCard _card;
-        
-        public PixelSize PixelSize => _mode.Resolution;
-        
-        public double Scaling { get; set; }
-
-        public IPlatformOpenGlInterface PlatformOpenGlInterface => _drmPlatform.EglPlatformInterface;
+        private readonly DrmPlatform _drmPlatform;
+        private readonly DrmCard _card;
 
         private GbmBoUserDataDestroyCallbackDelegate FbDestroyDelegate;
         private drmModeModeInfo _mode;
@@ -28,13 +23,23 @@ namespace Avalonia.LinuxFramebuffer.Output
         private IntPtr _currentBo;
         private IntPtr _gbmTargetSurface;
         private uint _crtcId;
-        private DrmPlatform _drmPlatform;
 
         internal DrmOutput(DrmPlatform drmPlatform, DrmResources resources, DrmConnector connector, DrmModeInfo modeInfo)
         {
             _drmPlatform = drmPlatform;
-            Init(drmPlatform.Card, resources, connector, modeInfo);
+            _card = drmPlatform.Card;
+            
+            Init(resources, connector, modeInfo);
         }
+        
+        /// <inheritdoc />
+        public PixelSize PixelSize => _mode.Resolution;
+        
+        /// <inheritdoc />
+        public double Scaling { get; set; }
+        
+        /// <inheritdoc />
+        public string Name => "drm";
 
         void FbDestroyCallback(IntPtr bo, IntPtr userData)
         {
@@ -80,10 +85,10 @@ namespace Avalonia.LinuxFramebuffer.Output
         }
         
         
-        void Init(DrmCard card, DrmResources resources, DrmConnector connector, DrmModeInfo modeInfo)
+        void Init(DrmResources resources, DrmConnector connector, DrmModeInfo modeInfo)
         {
             FbDestroyDelegate = FbDestroyCallback;
-            _card = card;
+            
             uint GetCrtc()
             {
                 if (resources.Encoders.TryGetValue(connector.EncoderId, out var encoder))
@@ -244,6 +249,4 @@ namespace Avalonia.LinuxFramebuffer.Output
             _card?.Dispose();
         }
     }
-
-
 }

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmPlatform.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmPlatform.cs
@@ -17,20 +17,20 @@ namespace Avalonia.LinuxFramebuffer.Output
     /// </remarks>
     internal class DrmPlatform
     {
-        public DrmPlatform(string path = null, double scaling = 1.0)
-            : this(new DrmCard(path), scaling)
+        public DrmPlatform(string path = null, double defaultScaling = 1.0)
+            : this(new DrmCard(path), defaultScaling)
         {
         }
 
-        public DrmPlatform(DrmCard card, double scaling = 1.0)
+        public DrmPlatform(DrmCard card, double defaultScaling = 1.0)
         {
-            Scaling = scaling;
+            DefaultScaling = defaultScaling;
             Card = card;
             EglPlatformInterface = new EglPlatformOpenGlInterface(new EglDisplay(new EglInterface(eglGetProcAddress),
                 false, 0x31D7, Card.GbmDevice.Handle, null));
         }
 
-        public double Scaling { get; set; }
+        public double DefaultScaling { get; set; }
 
         public DrmCard Card { get; }
 
@@ -52,12 +52,38 @@ namespace Avalonia.LinuxFramebuffer.Output
             if (mode == null)
                 throw new InvalidOperationException("Unable to find a usable DRM mode");
 
-            return CreateOutput(resources, connector, mode);
+            return CreateOutput(connector, mode, resources);
         }
 
-        public DrmOutput CreateOutput(DrmResources resources, DrmConnector connector, DrmModeInfo mode)
+        /// <summary>
+        /// Create a DRM display output instance.
+        /// </summary>
+        /// <param name="connector">The DRM connector the display output is to use.</param>
+        /// <param name="mode">The display mode to use.</param>
+        /// <param name="resources">All DRM resources for the card.</param>
+        /// <returns>A <see cref="DrmOutput"/> instance for the provided configuration.</returns>
+        public DrmOutput CreateOutput(DrmConnector connector, DrmModeInfo mode, DrmResources resources)
         {
-            return new DrmOutput(this, resources, connector, mode) { Scaling = Scaling };
+            return new DrmOutput(this, resources, connector, mode)
+            {
+                Scaling = DefaultScaling
+            };
+        }
+
+        /// <summary>
+        /// Create a DRM display output instance.
+        /// </summary>
+        /// <param name="connector">The DRM connector the display output is to use.</param>
+        /// <param name="mode">The display mode to use.</param>
+        /// <param name="resources">All DRM resources for the card.</param>
+        /// <param name="scaling">The sale to use for this DRM display output.</param>
+        /// <returns>A <see cref="DrmOutput"/> instance for the provided configuration.</returns>
+        public DrmOutput CreateOutput(DrmConnector connector, DrmModeInfo mode, DrmResources resources, double scaling)
+        {
+            return new DrmOutput(this, resources, connector, mode)
+            {
+                Scaling = scaling
+            };
         }
 
         [DllImport("libEGL.so.1")]

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmPlatform.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmPlatform.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Avalonia.OpenGL;
+using Avalonia.OpenGL.Egl;
+using Avalonia.OpenGL.Surfaces;
+using Avalonia.Platform.Interop;
+
+namespace Avalonia.LinuxFramebuffer.Output
+{
+    /// <summary>
+    ///     Provides the base handle to the DRM output and its associated EGL interface.
+    /// </summary>
+    /// <remarks>
+    ///     Shared resource creates a separation of the <see cref="IPlatformOpenGlInterface" /> instance, and
+    ///     the <see cref="DrmOutput" /> instances, which provide the <see cref="IGlPlatformSurface" /> for each DRM connector.
+    /// </remarks>
+    internal class DrmPlatform
+    {
+        public DrmPlatform(string path = null, double scaling = 1.0)
+            : this(new DrmCard(path), scaling)
+        {
+        }
+
+        public DrmPlatform(DrmCard card, double scaling = 1.0)
+        {
+            Scaling = scaling;
+            Card = card;
+            EglPlatformInterface = new EglPlatformOpenGlInterface(new EglDisplay(new EglInterface(eglGetProcAddress),
+                false, 0x31D7, Card.GbmDevice, null));
+        }
+
+        public double Scaling { get; set; }
+
+        public DrmCard Card { get; }
+
+        internal EglPlatformOpenGlInterface EglPlatformInterface { get; }
+
+        public DrmOutput CreateOutput()
+        {
+            var resources = Card.GetResources();
+
+            var connector =
+                resources.Connectors.LastOrDefault(x => x.Connection == DrmModeConnection.DRM_MODE_CONNECTED);
+            if (connector == null)
+                throw new InvalidOperationException("Unable to find connected DRM connector");
+
+            var mode = connector.Modes.OrderByDescending(x => x.IsPreferred)
+                .ThenByDescending(x => x.Resolution.Width * x.Resolution.Height)
+                .FirstOrDefault();
+
+            if (mode == null)
+                throw new InvalidOperationException("Unable to find a usable DRM mode");
+
+            return CreateOutput(resources, connector, mode);
+        }
+
+        public DrmOutput CreateOutput(DrmResources resources, DrmConnector connector, DrmModeInfo mode)
+        {
+            return new DrmOutput(this, resources, connector, mode) { Scaling = Scaling };
+        }
+
+        [DllImport("libEGL.so.1")]
+        private static extern IntPtr eglGetProcAddress(Utf8Buffer proc);
+    }
+}

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmPlatform.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmPlatform.cs
@@ -15,7 +15,7 @@ namespace Avalonia.LinuxFramebuffer.Output
     ///     Shared resource creates a separation of the <see cref="IPlatformOpenGlInterface" /> instance, and
     ///     the <see cref="DrmOutput" /> instances, which provide the <see cref="IGlPlatformSurface" /> for each DRM connector.
     /// </remarks>
-    internal class DrmPlatform
+    public class DrmPlatform
     {
         public DrmPlatform(string path = null, double defaultScaling = 1.0)
             : this(new DrmCard(path), defaultScaling)

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmPlatform.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmPlatform.cs
@@ -28,6 +28,9 @@ namespace Avalonia.LinuxFramebuffer.Output
             Card = card;
             EglPlatformInterface = new EglPlatformOpenGlInterface(new EglDisplay(new EglInterface(eglGetProcAddress),
                 false, 0x31D7, Card.GbmDevice.Handle, null));
+            
+            // Register the platform OpenGL interface.
+            AvaloniaLocator.CurrentMutable.Bind<IPlatformOpenGlInterface>().ToConstant(EglPlatformInterface);
         }
 
         public double DefaultScaling { get; set; }
@@ -40,8 +43,7 @@ namespace Avalonia.LinuxFramebuffer.Output
         {
             var resources = Card.GetResources();
 
-            var connector =
-                resources.Connectors.LastOrDefault(x => x.Connection == DrmModeConnection.DRM_MODE_CONNECTED);
+            var connector = resources.Connectors.FirstOrDefault(x => x.IsConnected);
             if (connector == null)
                 throw new InvalidOperationException("Unable to find connected DRM connector");
 

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmPlatform.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmPlatform.cs
@@ -27,7 +27,7 @@ namespace Avalonia.LinuxFramebuffer.Output
             Scaling = scaling;
             Card = card;
             EglPlatformInterface = new EglPlatformOpenGlInterface(new EglDisplay(new EglInterface(eglGetProcAddress),
-                false, 0x31D7, Card.GbmDevice, null));
+                false, 0x31D7, Card.GbmDevice.Handle, null));
         }
 
         public double Scaling { get; set; }

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/FbdevOutput.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/FbdevOutput.cs
@@ -14,7 +14,6 @@ namespace Avalonia.LinuxFramebuffer
         private fb_var_screeninfo _varInfo;
         private IntPtr _mappedLength;
         private IntPtr _mappedAddress;
-        public double Scaling { get; set; }
 
         public FbdevOutput(string fileName = null)
         {
@@ -33,6 +32,12 @@ namespace Avalonia.LinuxFramebuffer
                 throw;
             }
         }
+        
+        /// <inheritdoc />
+        public double Scaling { get; set; }
+        
+        /// <inheritdoc />
+        public string Name => "fbdev";
 
         void Init()
         {

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/GbmDevice.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/GbmDevice.cs
@@ -1,0 +1,45 @@
+using System;
+using System.ComponentModel;
+
+namespace Avalonia.LinuxFramebuffer.Output
+{
+    public sealed class GbmDevice : IDisposable
+    {
+        private IntPtr _gbmDevice;
+
+        public GbmDevice(DrmCard drmCard)
+        {
+            _gbmDevice = LibDrm.gbm_create_device(drmCard.Fd);
+            
+            if (_gbmDevice == IntPtr.Zero)
+                throw new Win32Exception("Could not create GBM Device for DRM card " + drmCard.Path);
+        }
+
+        ~GbmDevice()
+        {
+            ReleaseUnmanagedResources();
+        }
+
+        public IntPtr Handle => _gbmDevice;
+
+        public void Dispose()
+        {
+            ReleaseUnmanagedResources();
+            GC.SuppressFinalize(this);
+        }
+
+        internal IntPtr CreateSurface(int width, int height, uint format, LibDrm.GbmBoFlags flags)
+        {
+            return LibDrm.gbm_surface_create(_gbmDevice, width, height, format, flags);
+        }
+
+        private void ReleaseUnmanagedResources()
+        {
+            if (_gbmDevice != IntPtr.Zero)
+            {
+                LibDrm.gbm_device_destroy(_gbmDevice);
+                _gbmDevice = IntPtr.Zero;
+            }
+        }
+    }
+}

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/GbmDevice.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/GbmDevice.cs
@@ -7,6 +7,8 @@ namespace Avalonia.LinuxFramebuffer.Output
     {
         private IntPtr _gbmDevice;
 
+        private bool _disposed;
+
         public GbmDevice(DrmCard drmCard)
         {
             _gbmDevice = LibDrm.gbm_create_device(drmCard.Fd);
@@ -15,22 +17,31 @@ namespace Avalonia.LinuxFramebuffer.Output
                 throw new Win32Exception("Could not create GBM Device for DRM card " + drmCard.Path);
         }
 
-        ~GbmDevice()
-        {
-            ReleaseUnmanagedResources();
-        }
+        ~GbmDevice() => Dispose(false);
 
         public IntPtr Handle => _gbmDevice;
 
         public void Dispose()
         {
-            ReleaseUnmanagedResources();
+            Dispose(true);
             GC.SuppressFinalize(this);
         }
 
         internal IntPtr CreateSurface(int width, int height, uint format, LibDrm.GbmBoFlags flags)
         {
             return LibDrm.gbm_surface_create(_gbmDevice, width, height, format, flags);
+        }
+        
+        private void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            
+            ReleaseUnmanagedResources();
+
+            _disposed = true;
         }
 
         private void ReleaseUnmanagedResources()

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/IGlOutputBackend.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/IGlOutputBackend.cs
@@ -1,9 +1,0 @@
-using Avalonia.OpenGL;
-
-namespace Avalonia.LinuxFramebuffer.Output
-{
-    public interface IGlOutputBackend : IOutputBackend
-    {
-        public IPlatformOpenGlInterface PlatformOpenGlInterface { get; }
-    }
-}

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/IOutputBackend.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/IOutputBackend.cs
@@ -2,7 +2,19 @@ namespace Avalonia.LinuxFramebuffer.Output
 {
     public interface IOutputBackend
     {
+        /// <summary>
+        /// Gets the size of the output display in device pixels.
+        /// </summary>
         PixelSize PixelSize { get; }
+        
+        /// <summary>
+        /// Gets or sets the scaling of the output display.
+        /// </summary>
         double Scaling { get; set; }
+        
+        /// <summary>
+        /// Gets the interface name for the display output implementation.
+        /// </summary>
+        string Name { get; }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Step towards dual screen displays is to split the platform EGL interface from the DrmOutput instances which are used for surfaces for each display

## What is the current behavior?
DrmOutput is the platform OpenGl provider, and single surface instance.

## What is the updated/expected behavior with this PR?
Now able to create multiple DrmOutput instances for multiple connectors.

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
No breaking changes. ControlCatalog.NetCore still runs with the `--drm` command line args, and no changes required.
