### PR TITLE
This method should correctly render also if the children is created d…

### DIFF
--- a/src/Avalonia.Controls/ControlExtensions.cs
+++ b/src/Avalonia.Controls/ControlExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Data;
 using Avalonia.LogicalTree;
@@ -64,6 +65,31 @@ namespace Avalonia.Controls
             }
 
             return nameScope.Find<T>(name);
+        }
+
+        /// <summary>
+        /// Finds the named child control in the scope of the specified control.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="control"></param>
+        /// <param name="name"></param>
+        /// <returns>List of controls, The control or null if not found</returns>
+        public static IList<T>? FindChildren<T>(this IControl control, string name) where T : class, IControl
+        {
+            Contract.Requires<ArgumentNullException>(control != null);
+            Contract.Requires<ArgumentNullException>(name != null);
+
+            List<T> result = new List<T>();
+
+            foreach (IControl item in control.LogicalChildren)
+            {
+                if (item.Name == name && item is T t)
+                {
+                    result.Add(t);
+                }
+            }
+
+            return result.Count == 0 ? null : result;
         }
 
         /// <summary>


### PR DESCRIPTION
…ynamically runtime.

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
I could not get the FindControl or Find method on an existing Control to work with other controls being generated at runtime.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
FindControl or Find method could not recognise existing children, that are created runtime.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Children should now be queryable from parent

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
I did have to include System.Collections.Generic in namespace

## Checklist

- [ ] Added unit tests (if possible)? No
- [x] Added XML documentation to any related classes? Yes
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
