### PR TITLE
Add Popup.ShouldUseOverlayLayer property

### DIFF
--- a/src/Avalonia.Controls/Primitives/OverlayPopupHost.cs
+++ b/src/Avalonia.Controls/Primitives/OverlayPopupHost.cs
@@ -194,10 +194,16 @@ namespace Avalonia.Controls.Primitives
         // TODO12: mark PrivateAPI or internal.
         [Unstable("PopupHost is considered an internal API. Use Popup or any Popup-based controls (Flyout, Tooltip) instead.")]
         public static IPopupHost CreatePopupHost(Visual target, IAvaloniaDependencyResolver? dependencyResolver)
+            => CreatePopupHost(target, dependencyResolver, false);
+
+        internal static IPopupHost CreatePopupHost(Visual target, IAvaloniaDependencyResolver? dependencyResolver, bool shouldUseOverlayLayer)
         {
-            if (TopLevel.GetTopLevel(target) is { } topLevel && topLevel.PlatformImpl?.CreatePopup() is { } popupImpl)
+            if (!shouldUseOverlayLayer)
             {
-                return new PopupRoot(topLevel, popupImpl, dependencyResolver);
+                if (TopLevel.GetTopLevel(target) is { } topLevel && topLevel.PlatformImpl?.CreatePopup() is { } popupImpl)
+                {
+                    return new PopupRoot(topLevel, popupImpl, dependencyResolver);
+                }
             }
 
             if (OverlayLayer.GetOverlayLayer(target) is { } overlayLayer)

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -1260,6 +1260,38 @@ namespace Avalonia.Controls.UnitTests.Primitives
             return result;
         }
 
+        [Fact]
+        public void Popup_Open_With_Correct_IsUsingOverlayLayer_And_Disabled_OverlayLayer()
+        {
+            using (CreateServices())
+            {
+                var target = new Popup();
+                target.IsOpen = true;
+                target.ShouldUseOverlayLayer = false;
+
+                var window = PreparedWindow(target);
+                window.Show();
+
+                Assert.Equal(UsePopupHost, target.IsUsingOverlayLayer);
+            }
+        }
+
+        [Fact]
+        public void Popup_Open_With_Correct_IsUsingOverlayLayer_And_Enabled_OverlayLayer()
+        {
+            using (CreateServices())
+            {
+                var target = new Popup();
+                target.IsOpen = true;
+                target.ShouldUseOverlayLayer = true;
+
+                var window = PreparedWindow(target);
+                window.Show();
+
+                Assert.Equal(true, target.IsUsingOverlayLayer);
+            }
+        }
+
         private IDisposable CreateServices()
         {
             return UnitTestApplication.Start(TestServices.StyledWindow.With(


### PR DESCRIPTION
## What does the pull request do?
Ports [ShouldConstrainToRootBounds](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.primitives.popup.shouldconstraintorootbounds?view=winrt-19041) and readonly [IsConstrainedToRootBounds](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.primitives.popup.isconstrainedtorootbounds?view=winrt-19041#Windows_UI_Xaml_Controls_Primitives_Popup_IsConstrainedToRootBounds) from UWP.

> **ShouldConstrainToRootBounds**
In a UWP app on desktop, when this property is true, the popup is shown within the main XAML window handle (HWND). When this property is false, the popup is shown in its own top level HWND. In this case, the popup might be positioned to extend beyond the main app window.
When a popup with ShouldConstrainToRootBounds = false is first shown, it’s placed in its own window and shown in that context. 

## Differences from UWP implementaion:

- ShouldConstrainToRootBounds can be changed in any time, but new value is used only after popup was reopened. In UWP only first value set before popup opening works.
- To avoid breaking change, ShouldConstrainToRootBounds is "false" by default, while in UWP it's "true".

## How was the solution implemented (if it's not obvious)?
This property gives popup a hint, should it use PopupHost or Overlay layer.


## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
None (default value is not same as in UWP though)