### PR TITLE
Fix #5699: filter BuildAvaloniaApp by signature

### DIFF
--- a/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
+++ b/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
@@ -169,7 +169,7 @@ namespace Avalonia.DesignerSupport.Remote
             if (entryPoint == null)
                 throw Die($"Assembly {args.AppPath} doesn't have an entry point");
             var builderMethod = entryPoint.DeclaringType.GetMethod(BuilderMethodName,
-                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, null, Array.Empty<Type>(), null);
             if (builderMethod == null)
                 throw Die($"{entryPoint.DeclaringType.FullName} doesn't have a method named {BuilderMethodName}");
             Design.IsDesignMode = true;


### PR DESCRIPTION
## What does the pull request do?
This adds a method filter when the designer process searches for a `BuildAvaloniaApp` method.


## What is the current behavior?
Current behavior is described in #5699.

## What is the updated/expected behavior with this PR?
The designer process should ignore `BuildAvaloniaApp` variants with wrong signatures.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
None.

## Fixed issues
Fixes #5699.
