### PR TITLE
Fix ShowInTaskbar on Win32.

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -581,8 +581,15 @@ namespace Avalonia.Win32
 
         public void SetParent(IWindowImpl parent)
         {
-            _parent = (WindowImpl)parent;
-            SetWindowLongPtr(_hwnd, (int)WindowLongParam.GWL_HWNDPARENT, _parent?._hwnd ?? IntPtr.Zero);
+            var parentHwnd = ((WindowImpl)parent)?._hwnd ?? IntPtr.Zero;
+
+            if (parentHwnd == IntPtr.Zero && !_windowProperties.ShowInTaskbar)
+            {
+                parentHwnd = OffscreenParentWindow.Handle;
+                _hiddenWindowIsParent = true;
+            }
+
+            SetWindowLongPtr(_hwnd, (int)WindowLongParam.GWL_HWNDPARENT, parentHwnd);
         }
 
         public void SetEnabled(bool enable) => EnableWindow(_hwnd, enable);
@@ -1108,6 +1115,7 @@ namespace Avalonia.Win32
                         if (shown)
                             Hide();
 
+                        _hiddenWindowIsParent = false;
                         SetParent(null);
 
                         if (shown)

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -527,6 +527,7 @@ namespace Avalonia.Win32
             }
 
             _framebuffer.Dispose();
+            _hiddenWindow?.Dispose();
         }
 
         public void Invalidate(Rect rect)

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -572,8 +572,7 @@ namespace Avalonia.Win32
 
         public virtual void Show(bool activate)
         {
-            SetWindowLongPtr(_hwnd, (int)WindowLongParam.GWL_HWNDPARENT, _parent != null ? _parent._hwnd : IntPtr.Zero);
-
+            SetParent(_parent);
             ShowWindow(_showWindowState, activate);
         }
 

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -85,6 +85,7 @@ namespace Avalonia.Win32
         private ExtendClientAreaChromeHints _extendChromeHints = ExtendClientAreaChromeHints.Default;
         private bool _isCloseRequested;
         private bool _shown;
+        private WindowImpl _hiddenWindow;
 
         public WindowImpl()
         {
@@ -581,7 +582,7 @@ namespace Avalonia.Win32
         public void SetParent(IWindowImpl parent)
         {
             _parent = (WindowImpl)parent;
-            SetWindowLongPtr(_hwnd, (int)WindowLongParam.GWL_HWNDPARENT, _parent._hwnd);
+            SetWindowLongPtr(_hwnd, (int)WindowLongParam.GWL_HWNDPARENT, _parent?._hwnd ?? IntPtr.Zero);
         }
 
         public void SetEnabled(bool enable) => EnableWindow(_hwnd, enable);
@@ -753,6 +754,11 @@ namespace Avalonia.Win32
                     _scaling = dpix / 96.0;
                 }
             }
+        }
+
+        private WindowImpl GetOrCreateHiddenWindow()
+        {
+            return _hiddenWindow ??= new WindowImpl();
         }
 
         private void CreateDropTarget()
@@ -1094,16 +1100,35 @@ namespace Avalonia.Win32
                 if (newProperties.ShowInTaskbar)
                 {
                     exStyle |= WindowStyles.WS_EX_APPWINDOW;
+
+                    if (_hiddenWindow is object && _parent == _hiddenWindow)
+                    {
+                        // Can't enable the taskbar icon by clearing the parent window unless the window
+                        // is hidden. Hide the window and show it again with the same activation state
+                        // when we've finished. Interestingly it seems to work fine the other way.
+                        var shown = IsWindowVisible(_hwnd);
+                        var activated = GetActiveWindow() == _hwnd;
+
+                        if (shown)
+                            Hide();
+
+                        SetParent(null);
+
+                        if (shown)
+                            Show(activated);
+                    }
+
                 }
                 else
                 {
+                    // To hide a non-owned window's taskbar icon we need to parent it to a hidden window.
+                    if (_parent is null)
+                        SetParent(GetOrCreateHiddenWindow());
+
                     exStyle &= ~WindowStyles.WS_EX_APPWINDOW;
                 }
 
                 SetExtendedStyle(exStyle);
-
-                // TODO: To hide non-owned window from taskbar we need to parent it to a hidden window.
-                // Otherwise it will still show in the taskbar.
             }
 
             WindowStyles style;


### PR DESCRIPTION
## What does the pull request do?

`Window.ShowInTaskbar` wasn't working on win32. Originally when this feature was implemented it used the `WS_EX_TOOLWINDOW` style to hide the icon, but this has the unwanted side-effect of removing certain window decorations and so this style was removed in #3705.

To _correctly_ hide the taskbar icon on win32 we need to parent the window to a hidden window. In addition if the window is visible when when set `ShowInTaskBar = true` then we need to temporarily hide the window and show it again.

## Fixed issues

Fixes #5454 