### PR TITLE
feature: Disable ReactiveUI Platform Registrations

### DIFF
--- a/build/ReactiveUI.props
+++ b/build/ReactiveUI.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="12.1.1" />
+    <PackageReference Include="ReactiveUI" Version="13.2.10" />
   </ItemGroup>
 </Project>

--- a/src/Avalonia.ReactiveUI/AppBuilderExtensions.cs
+++ b/src/Avalonia.ReactiveUI/AppBuilderExtensions.cs
@@ -18,7 +18,6 @@ namespace Avalonia.ReactiveUI
             return builder.AfterPlatformServicesSetup(_ =>
             {
                 PlatformRegistrationManager.SetRegistrationNamespaces(RegistrationNamespace.Avalonia);
-                Locator.CurrentMutable.InitializeReactiveUI();
                 RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
                 Locator.CurrentMutable.RegisterConstant(new AvaloniaActivationForViewFetcher(), typeof(IActivationForViewFetcher));
                 Locator.CurrentMutable.RegisterConstant(new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));

--- a/src/Avalonia.ReactiveUI/AppBuilderExtensions.cs
+++ b/src/Avalonia.ReactiveUI/AppBuilderExtensions.cs
@@ -9,19 +9,22 @@ namespace Avalonia.ReactiveUI
     {
         /// <summary>
         /// Initializes ReactiveUI framework to use with Avalonia. Registers Avalonia 
-        /// scheduler and Avalonia activation for view fetcher. Always remember to
-        /// call this method if you are using ReactiveUI in your application.
+        /// scheduler, an activation for view fetcher, a template binding hook. Remember
+        /// to call this method if you are using ReactiveUI in your application.
         /// </summary>
         public static TAppBuilder UseReactiveUI<TAppBuilder>(this TAppBuilder builder)
-            where TAppBuilder : AppBuilderBase<TAppBuilder>, new()
-        {
-            return builder.AfterPlatformServicesSetup(_ =>
+            where TAppBuilder : AppBuilderBase<TAppBuilder>, new() =>
+            builder.AfterPlatformServicesSetup(_ => Locator.RegisterResolverCallbackChanged(() =>
             {
+                if (Locator.CurrentMutable is null)
+                {
+                    return;
+                }
+
                 PlatformRegistrationManager.SetRegistrationNamespaces(RegistrationNamespace.Avalonia);
                 RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
                 Locator.CurrentMutable.RegisterConstant(new AvaloniaActivationForViewFetcher(), typeof(IActivationForViewFetcher));
                 Locator.CurrentMutable.RegisterConstant(new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));
-            });
-        }
+            }));
     }
 }

--- a/src/Avalonia.ReactiveUI/AppBuilderExtensions.cs
+++ b/src/Avalonia.ReactiveUI/AppBuilderExtensions.cs
@@ -17,6 +17,8 @@ namespace Avalonia.ReactiveUI
         {
             return builder.AfterPlatformServicesSetup(_ =>
             {
+                PlatformRegistrationManager.SetRegistrationNamespaces(RegistrationNamespace.Avalonia);
+                Locator.CurrentMutable.InitializeReactiveUI();
                 RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
                 Locator.CurrentMutable.RegisterConstant(new AvaloniaActivationForViewFetcher(), typeof(IActivationForViewFetcher));
                 Locator.CurrentMutable.RegisterConstant(new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));


### PR DESCRIPTION
### What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

This PR removes irrelevant platform namespaces from ReactiveUI's `PlatformRegistrationManager`. Now, Avalonia.ReactiveUI will no longer try to load `ReactiveUI.WinForms`, `ReactiveUI.XamForms`, `ReactiveUI.Wpf` etc. implicitly. This behavior confused people with the "Break on all exceptions" option enabled in Microsoft Visual Studio (that option is enabled there by default).

Also, we now wrap Avalonia.ReactiveUI registrations in a `Locator.RegisterResolverCallbackChanged` in order to ensure Avalonia.ReactiveUI-specific services get re-registered into `Locator` when the underlying container implementation changes, e.g. a user installs `Splat.DryIoc` and calls `Locator.SetLocator(new DryIocDependencyResolver())`. This also eliminates a wide class of errors reported by people who override the default Splat.Locator and do not have the required dependencies wired up automatically.