### PR TITLE
Fix pointer interaction with reversed direction slider.

### DIFF
--- a/src/Avalonia.Controls/Slider.cs
+++ b/src/Avalonia.Controls/Slider.cs
@@ -341,7 +341,9 @@ namespace Avalonia.Controls
 
             var pointNum = orient ? x.Position.X : x.Position.Y;
             var logicalPos = MathUtilities.Clamp(pointNum / pointDen, 0.0d, 1.0d);
-            var invert = orient ? 0 : 1;
+            var invert = orient ? 
+                IsDirectionReversed ? 1 : 0 :
+                IsDirectionReversed ? 0 : 1;
             var calcVal = Math.Abs(invert - logicalPos);
             var range = Maximum - Minimum;
             var finalValue = calcVal * range + Minimum;


### PR DESCRIPTION
## What does the pull request do?

Previously dragging a slider with `IsDirectionRevered = true` resulted in the slider moving the wrong way. You can see this in control catalog even. Fix the drag logic so that the slider moves in the correct direction.
