### PR TITLE
Update native control visibility when ancestor visibility changes

### DIFF
--- a/src/Avalonia.Controls/NativeControlHost.cs
+++ b/src/Avalonia.Controls/NativeControlHost.cs
@@ -16,30 +16,16 @@ namespace Avalonia.Controls
         private bool _queuedForDestruction;
         private bool _queuedForMoveResize;
         private readonly List<Visual> _propertyChangedSubscriptions = new List<Visual>();
-        private readonly EventHandler<AvaloniaPropertyChangedEventArgs> _propertyChangedHandler;
-        static NativeControlHost()
-        {
-            IsVisibleProperty.Changed.AddClassHandler<NativeControlHost>(OnVisibleChanged);
-        }
-
-        public NativeControlHost()
-        {
-            _propertyChangedHandler = PropertyChangedHandler;
-        }
-
-        private static void OnVisibleChanged(NativeControlHost host, AvaloniaPropertyChangedEventArgs arg2)
-            => host.UpdateHost();
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             _currentRoot = e.Root as TopLevel;
             var visual = (IVisual)this;
-            while (visual != _currentRoot)
+            while (visual != null)
             {
-
                 if (visual is Visual v)
                 {
-                    v.PropertyChanged += _propertyChangedHandler;
+                    v.PropertyChanged += PropertyChangedHandler;
                     _propertyChangedSubscriptions.Add(v);
                 }
 
@@ -51,7 +37,7 @@ namespace Avalonia.Controls
 
         private void PropertyChangedHandler(object sender, AvaloniaPropertyChangedEventArgs e)
         {
-            if (e.IsEffectiveValueChange && e.Property == BoundsProperty)
+            if (e.IsEffectiveValueChange && (e.Property == BoundsProperty || e.Property == IsVisibleProperty))
                 EnqueueForMoveResize();
         }
 
@@ -61,7 +47,7 @@ namespace Avalonia.Controls
             if (_propertyChangedSubscriptions != null)
             {
                 foreach (var v in _propertyChangedSubscriptions)
-                    v.PropertyChanged -= _propertyChangedHandler;
+                    v.PropertyChanged -= PropertyChangedHandler;
                 _propertyChangedSubscriptions.Clear();
             }
             UpdateHost();


### PR DESCRIPTION
When the visibility of an ancestor of the `NativeControlHost` changes the control was not updated.

## What does the pull request do?
Listen to ancestors visibility property changes and update `NativeControlHost`.


## What is the current behavior?
The control does not get notifications and remains outdated.


## What is the updated/expected behavior with this PR?
The `NativeControlHost` depends on the ancestors visibility, so it has to listen for changes on its hierarchy.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
