### PR TITLE
Add missing XButtons 1 and 2 to MouseButton

### DIFF
--- a/src/Avalonia.Input/PointerEventArgs.cs
+++ b/src/Avalonia.Input/PointerEventArgs.cs
@@ -107,7 +107,9 @@ namespace Avalonia.Input
         None,
         Left,
         Right,
-        Middle
+        Middle,
+        XButton1,
+        XButton2
     }
 
     public class PointerPressedEventArgs : PointerEventArgs

--- a/src/Avalonia.Input/PointerPoint.cs
+++ b/src/Avalonia.Input/PointerPoint.cs
@@ -90,6 +90,10 @@ namespace Avalonia.Input
                 return MouseButton.Middle;
             if (kind == PointerUpdateKind.RightButtonPressed || kind == PointerUpdateKind.RightButtonReleased)
                 return MouseButton.Right;
+            if (kind == PointerUpdateKind.XButton1Pressed || kind == PointerUpdateKind.XButton1Released)
+                return MouseButton.XButton1;
+            if (kind == PointerUpdateKind.XButton2Pressed || kind == PointerUpdateKind.XButton2Released)
+                return MouseButton.XButton2;
             return MouseButton.None;
         }
     }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Mouse buttons 4 and 5 were added in #3033, but were not added to the `MouseButton` enum. This PR adds them.

## What is the current behavior?
`GetMouseButton`  returns `MouseButton.None` for the `PointerUpdateKind` values of XButton1 and XButton2, instead of `MouseButton.XButton1` and `MouseButton.XButton2`, respectively.

## What is the updated/expected behavior with this PR?
Using `GetMouseButton` will now work as expected.

## How was the solution implemented (if it's not obvious)?
Implemented the nits in [this comment](https://github.com/AvaloniaUI/Avalonia/issues/5679#issuecomment-801449548) by @kekekeks.

## Fixed issues
Fixes #5679