### PR TITLE
Fix vector scale commutativeness

### DIFF
--- a/src/Avalonia.Visuals/Vector.cs
+++ b/src/Avalonia.Visuals/Vector.cs
@@ -86,6 +86,15 @@ namespace Avalonia
         /// Scales a vector.
         /// </summary>
         /// <param name="vector">The vector.</param>
+        /// <param name="scale">The scaling factor.</param>
+        /// <returns>The scaled vector.</returns>
+        public static Vector operator *(double scale, Vector vector)
+            => Multiply(vector, scale);
+
+        /// <summary>
+        /// Scales a vector.
+        /// </summary>
+        /// <param name="vector">The vector.</param>
         /// <param name="scale">The divisor.</param>
         /// <returns>The scaled vector.</returns>
         public static Vector operator /(Vector vector, double scale)

--- a/tests/Avalonia.Visuals.UnitTests/VectorTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/VectorTests.cs
@@ -105,5 +105,15 @@ namespace Avalonia.Visuals.UnitTests
 
             Assert.Equal(expected, Vector.Multiply(vector, 2));
         }
+
+        [Fact]
+        public void Scale_Vector_Should_Be_Commutative()
+        {
+            var vector = new Vector(10, 2);
+
+            var expected = vector * 2;
+
+            Assert.Equal(expected, 2 * vector);
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes commutativenes for Vector scaling.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Build for ControlCatalog.Android is broken in AndroidFrameBuffer since commutativeness is not implemented in Vector class.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Unit Test implemented for Vector.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Additional overload for * operator added.

## Checklist

- [x ] Added unit tests (if possible)?
- [ x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #456
-->
Fixes #5757