### PR TITLE
Vortice port in progress

### DIFF
--- a/Avalonia.sln
+++ b/Avalonia.sln
@@ -148,6 +148,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Props", "Props", "{F3AC8BC1
 		build\System.Drawing.Common.props = build\System.Drawing.Common.props
 		build\System.Memory.props = build\System.Memory.props
 		build\UnitTests.NetFX.props = build\UnitTests.NetFX.props
+		build\Vortice.Windows.props = build\Vortice.Windows.props
 		build\XUnit.props = build\XUnit.props
 	EndProjectSection
 EndProject

--- a/build/SharpDX.props
+++ b/build/SharpDX.props
@@ -1,9 +1,13 @@
-﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
+  <PropertyGroup>
+    <SharpDXVersion>4.0.1</SharpDXVersion>
+  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SharpDX" Version="4.0.1" />
-    <PackageReference Include="SharpDX.Direct2D1" Version="4.0.1" />
-    <PackageReference Include="SharpDX.Direct3D11" Version="4.0.1" />
-    <PackageReference Include="SharpDX.DXGI" Version="4.0.1" />
-    <PackageReference Include="SharpDX.Direct3D9" Version="4.0.1" Condition="'$(UseDirect3D9)' == 'true'" />
+    <PackageReference Include="SharpDX" Version="$(SharpDXVersion)" />
+    <PackageReference Include="SharpDX.Direct2D1" Version="$(SharpDXVersion)" />
+    <PackageReference Include="SharpDX.Direct3D11" Version="$(SharpDXVersion)" />
+    <PackageReference Include="SharpDX.DXGI" Version="$(SharpDXVersion)" />
+    <PackageReference Include="SharpDX.Mathematics" Version="$(SharpDXVersion)" />
+    <PackageReference Include="SharpDX.D3DCompiler" Version="$(SharpDXVersion)" Condition="'$(UseD3DCompiler)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/build/Vortice.Windows.props
+++ b/build/Vortice.Windows.props
@@ -1,0 +1,11 @@
+﻿<Project>
+  <PropertyGroup>
+    <VorticeVersion>1.9.69</VorticeVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Vortice.Direct2D1" Version="$(VorticeVersion)" />
+    <PackageReference Include="Vortice.Direct3D11" Version="$(VorticeVersion)" />
+    <PackageReference Include="Vortice.Direct3D9" Version="$(VorticeVersion)" Condition="'$(UseDirect3D9)' == 'true'" />
+    <PackageReference Include="Vortice.D3DCompiler" Version="$(VorticeVersion)" Condition="'$(UseD3DCompiler)' == 'true'" />
+  </ItemGroup>
+</Project>

--- a/global.json
+++ b/global.json
@@ -1,10 +1,7 @@
 {
-	"sdk": {
-		"version": "3.1.401"
-	},
     "msbuild-sdks": {
-        "Microsoft.Build.Traversal": "1.0.43",
-        "MSBuild.Sdk.Extras": "2.0.54",
+        "Microsoft.Build.Traversal": "3.0.3",
+        "MSBuild.Sdk.Extras": "3.0.23",
         "AggregatePackage.NuGet.Sdk" : "0.1.12"
     }
 }

--- a/samples/interop/Direct3DInteropSample/Direct3DInteropSample.csproj
+++ b/samples/interop/Direct3DInteropSample/Direct3DInteropSample.csproj
@@ -2,10 +2,9 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net461</TargetFramework>
+        <UseD3DCompiler>true</UseD3DCompiler>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="SharpDX.Mathematics" Version="4.0.1" />
-        <PackageReference Include="SharpDX.D3DCompiler" Version="4.0.1" />
         <Compile Update="**\*.paml.cs">
             <DependentUpon>%(Filename)</DependentUpon>
         </Compile>
@@ -28,4 +27,5 @@
     </ItemGroup>
     <Import Project="..\..\..\build\Rx.props" />
     <Import Project="..\..\..\build\ReferenceCoreLibraries.props" />
+    <Import Project="..\..\..\build\SharpDX.props" />
 </Project>

--- a/samples/interop/NativeEmbedSample/EmbedSample.cs
+++ b/samples/interop/NativeEmbedSample/EmbedSample.cs
@@ -9,7 +9,6 @@ using Avalonia.Threading;
 using MonoMac.AppKit;
 using MonoMac.Foundation;
 using MonoMac.WebKit;
-using Encoding = SharpDX.Text.Encoding;
 
 namespace NativeEmbedSample
 {

--- a/src/Avalonia.Desktop/AppBuilderDesktopExtensions.cs
+++ b/src/Avalonia.Desktop/AppBuilderDesktopExtensions.cs
@@ -48,6 +48,6 @@ namespace Avalonia
 
         static void LoadSkia<TAppBuilder>(TAppBuilder builder)
             where TAppBuilder : AppBuilderBase<TAppBuilder>, new()
-             => builder.UseSkia();
+             => builder.UseDirect2D1();
     }
 }

--- a/src/Avalonia.Desktop/Avalonia.Desktop.csproj
+++ b/src/Avalonia.Desktop/Avalonia.Desktop.csproj
@@ -10,6 +10,7 @@
       <ProjectReference Include="../../src/Avalonia.Native/Avalonia.Native.csproj" />
       <ProjectReference Include="../../packages/Avalonia/Avalonia.csproj" />
       <ProjectReference Include="../Avalonia.X11/Avalonia.X11.csproj" />
+      <ProjectReference Include="..\Windows\Avalonia.Direct2D1\Avalonia.Direct2D1.csproj" />
   </ItemGroup>
   
   <Import Project="..\..\build\ApiDiff.props" />  

--- a/src/Avalonia.Visuals/Media/Typeface.cs
+++ b/src/Avalonia.Visuals/Media/Typeface.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Diagnostics;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 
 namespace Avalonia.Media
@@ -7,7 +7,6 @@ namespace Avalonia.Media
     /// <summary>
     /// Represents a typeface.
     /// </summary>
-    [DebuggerDisplay("Name = {FontFamily.Name}, Weight = {Weight}, Style = {Style}")]
     public readonly struct Typeface : IEquatable<Typeface>
     {
         /// <summary>
@@ -97,6 +96,21 @@ namespace Avalonia.Media
                 hashCode = (hashCode * 397) ^ (int)Weight;
                 return hashCode;
             }
+        }
+
+        public override string ToString()
+        {
+            if (FontFamily == FontFamily.Default && Weight == FontWeight.Normal && Style == FontStyle.Normal)
+                return "<Default>";
+
+            var parts = new List<string>(3) { $"Name = {FontFamily}" };
+
+            if (Weight != FontWeight.Normal)
+                parts.Add($"Weight = {Weight}");
+            if (Style != FontStyle.Normal)
+                parts.Add($"Style = {Style}");
+
+            return string.Join(", ", parts);
         }
     }
 }

--- a/src/Windows/Avalonia.Direct2D1/Avalonia.Direct2D1.csproj
+++ b/src/Windows/Avalonia.Direct2D1/Avalonia.Direct2D1.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />
   </ItemGroup>
   <Import Project="..\..\..\build\Rx.props" />
-  <Import Project="..\..\..\build\SharpDX.props" />
+  <Import Project="..\..\..\build\Vortice.Windows.props" />
   <Import Project="..\..\..\build\HarfBuzzSharp.props" />
   <Import Project="..\..\Shared\RenderHelpers\RenderHelpers.projitems" Label="Shared" />
   <Import Project="..\..\..\build\JetBrains.Annotations.props" />

--- a/src/Windows/Avalonia.Direct2D1/ExternalRenderTarget.cs
+++ b/src/Windows/Avalonia.Direct2D1/ExternalRenderTarget.cs
@@ -2,7 +2,7 @@
 using Avalonia.Direct2D1.Media.Imaging;
 using Avalonia.Platform;
 using Avalonia.Rendering;
-using SharpDX;
+using SharpGen.Runtime;
 
 namespace Avalonia.Direct2D1
 {
@@ -25,13 +25,13 @@ namespace Avalonia.Direct2D1
         {
             var target =  _externalRenderTargetProvider.GetOrCreateRenderTarget();
             _externalRenderTargetProvider.BeforeDrawing();
-            return new DrawingContextImpl(visualBrushRenderer, null, target, null, () =>
+            return new DrawingContextImpl(visualBrushRenderer, null, target, finishedCallback: () =>
             {
                 try
                 {
                     _externalRenderTargetProvider.AfterDrawing();
                 }
-                catch (SharpDXException ex) when ((uint) ex.HResult == 0x8899000C) // D2DERR_RECREATE_TARGET
+                catch (SharpGenException ex) when ((uint) ex.HResult == 0x8899000C) // D2DERR_RECREATE_TARGET
                 {
                     _externalRenderTargetProvider.DestroyRenderTarget();
                 }

--- a/src/Windows/Avalonia.Direct2D1/FramebufferShimRenderTarget.cs
+++ b/src/Windows/Avalonia.Direct2D1/FramebufferShimRenderTarget.cs
@@ -4,7 +4,7 @@ using Avalonia.Direct2D1.Media;
 using Avalonia.Platform;
 using Avalonia.Rendering;
 using Avalonia.Win32.Interop;
-using SharpDX.WIC;
+using Vortice.WIC;
 using PixelFormat = Avalonia.Platform.PixelFormat;
 
 namespace Avalonia.Direct2D1
@@ -49,7 +49,7 @@ namespace Avalonia.Direct2D1
             {
                 return base.CreateDrawingContext(visualBrushRenderer, () =>
                 {
-                    using (var l = WicImpl.Lock(BitmapLockFlags.Read))
+                    using (var l = WicImpl.Lock(BitmapLockFlags.LockRead))
                     {
                         for (var y = 0; y < _target.Size.Height; y++)
                         {

--- a/src/Windows/Avalonia.Direct2D1/HwndRenderTarget.cs
+++ b/src/Windows/Avalonia.Direct2D1/HwndRenderTarget.cs
@@ -1,7 +1,8 @@
 ﻿using Avalonia.Platform;
 using Avalonia.Win32.Interop;
-using SharpDX;
-using SharpDX.DXGI;
+using Vortice;
+using Vortice.DXGI;
+using Vortice.Mathematics;
 
 namespace Avalonia.Direct2D1
 {
@@ -14,12 +15,12 @@ namespace Avalonia.Direct2D1
             _window = window;
         }
 
-        protected override SwapChain1 CreateSwapChain(Factory2 dxgiFactory, SwapChainDescription1 swapChainDesc)
+        protected override IDXGISwapChain1 CreateSwapChain(IDXGIFactory2 dxgiFactory, SwapChainDescription1 swapChainDesc)
         {
-            return new SwapChain1(dxgiFactory, Direct2D1Platform.DxgiDevice, _window.Handle, ref swapChainDesc);
+            return dxgiFactory.CreateSwapChainForHwnd(Direct2D1Platform.DxgiDevice, _window.Handle, swapChainDesc);
         }
 
-        protected override Size2F GetWindowDpi()
+        protected override SizeF GetWindowDpi()
         {
             if (UnmanagedMethods.ShCoreAvailable)
             {
@@ -35,18 +36,18 @@ namespace Avalonia.Direct2D1
                         out dpix,
                         out dpiy) == 0)
                 {
-                    return new Size2F(dpix, dpiy);
+                    return new SizeF(dpix, dpiy);
                 }
             }
 
-            return new Size2F(96, 96);
+            return new SizeF(96, 96);
         }
 
-        protected override Size2 GetWindowSize()
+        protected override Vortice.Mathematics.Size GetWindowSize()
         {
             UnmanagedMethods.RECT rc;
             UnmanagedMethods.GetClientRect(_window.Handle, out rc);
-            return new Size2(rc.right - rc.left, rc.bottom - rc.top);
+            return new(rc.right - rc.left, rc.bottom - rc.top);
         }
     }
 }

--- a/src/Windows/Avalonia.Direct2D1/IExternalDirect2DRenderTargetSurface.cs
+++ b/src/Windows/Avalonia.Direct2D1/IExternalDirect2DRenderTargetSurface.cs
@@ -2,7 +2,7 @@
 {
     public interface IExternalDirect2DRenderTargetSurface
     {
-        SharpDX.Direct2D1.RenderTarget GetOrCreateRenderTarget();
+        Vortice.Direct2D1.ID2D1RenderTarget GetOrCreateRenderTarget();
         void DestroyRenderTarget();
         void BeforeDrawing();
         void AfterDrawing();

--- a/src/Windows/Avalonia.Direct2D1/Media/AvaloniaTextRenderer.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/AvaloniaTextRenderer.cs
@@ -1,36 +1,39 @@
-using SharpDX;
-using SharpDX.Direct2D1;
-using SharpDX.DirectWrite;
-using SharpDX.Mathematics.Interop;
+using System;
+using System.Numerics;
+using SharpGen.Runtime;
+using Vortice.DCommon;
+using Vortice.Direct2D1;
+using Vortice.DirectWrite;
+using Vortice.Mathematics;
 
 namespace Avalonia.Direct2D1.Media
 {
-    internal class AvaloniaTextRenderer : TextRendererBase
+    internal sealed class AvaloniaTextRenderer : CallbackBase, IDWriteTextRenderer
     {
         private readonly DrawingContextImpl _context;
 
-        private readonly SharpDX.Direct2D1.RenderTarget _renderTarget;
+        private readonly Vortice.Direct2D1.ID2D1RenderTarget _renderTarget;
 
-        private readonly Brush _foreground;
+        private readonly ID2D1Brush _foreground;
 
         public AvaloniaTextRenderer(
             DrawingContextImpl context,
-            SharpDX.Direct2D1.RenderTarget target,
-            Brush foreground)
+            Vortice.Direct2D1.ID2D1RenderTarget target,
+            ID2D1Brush foreground)
         {
             _context = context;
             _renderTarget = target;
             _foreground = foreground;
         }
 
-        public override Result DrawGlyphRun(
-            object clientDrawingContext,
+        public void DrawGlyphRun(
+            IntPtr clientDrawingContext,
             float baselineOriginX,
             float baselineOriginY,
             MeasuringMode measuringMode,
             GlyphRun glyphRun,
-            GlyphRunDescription glyphRunDescription,
-            ComObject clientDrawingEffect)
+            ref GlyphRunDescription glyphRunDescription,
+            IUnknown clientDrawingEffect)
         {
             var wrapper = clientDrawingEffect as BrushWrapper;
 
@@ -40,7 +43,7 @@ namespace Avalonia.Direct2D1.Media
                 _context.CreateBrush(wrapper.Brush, new Size()).PlatformBrush;
 
             _renderTarget.DrawGlyphRun(
-                new RawVector2 { X = baselineOriginX, Y = baselineOriginY },
+                new PointF { X = baselineOriginX, Y = baselineOriginY },
                 glyphRun,
                 brush,
                 measuringMode);
@@ -49,18 +52,39 @@ namespace Avalonia.Direct2D1.Media
             {
                 brush.Dispose();
             }
-
-            return Result.Ok;
         }
 
-        public override RawMatrix3x2 GetCurrentTransform(object clientDrawingContext)
+        public void DrawUnderline(IntPtr clientDrawingContext, float baselineOriginX, float baselineOriginY, ref Underline underline,
+                                  IUnknown clientDrawingEffect)
+        {
+            throw new SharpGenException(Result.NotImplemented);
+        }
+
+        public void DrawStrikethrough(IntPtr clientDrawingContext, float baselineOriginX, float baselineOriginY,
+                                      ref Strikethrough strikethrough, IUnknown clientDrawingEffect)
+        {
+            throw new SharpGenException(Result.NotImplemented);
+        }
+
+        public void DrawInlineObject(IntPtr clientDrawingContext, float originX, float originY, IDWriteInlineObject inlineObject,
+                                     RawBool isSideways, RawBool isRightToLeft, IUnknown clientDrawingEffect)
+        {
+            throw new SharpGenException(Result.NotImplemented);
+        }
+
+        public Matrix3x2 GetCurrentTransform(IntPtr clientDrawingContext)
         {
             return _renderTarget.Transform;
         }
 
-        public override float GetPixelsPerDip(object clientDrawingContext)
+        public float GetPixelsPerDip(IntPtr clientDrawingContext)
         {
-            return _renderTarget.DotsPerInch.Width / 96;
+            return _renderTarget.Dpi.X / 96;
+        }
+
+        public RawBool IsPixelSnappingDisabled(IntPtr clientDrawingContext)
+        {
+            return false;
         }
     }
 }

--- a/src/Windows/Avalonia.Direct2D1/Media/BrushImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/BrushImpl.cs
@@ -4,7 +4,7 @@ namespace Avalonia.Direct2D1.Media
 {
     public abstract class BrushImpl : IDisposable
     {
-        public SharpDX.Direct2D1.Brush PlatformBrush { get; set; }
+        public Vortice.Direct2D1.ID2D1Brush PlatformBrush { get; set; }
 
         public virtual void Dispose()
         {

--- a/src/Windows/Avalonia.Direct2D1/Media/BrushWrapper.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/BrushWrapper.cs
@@ -1,5 +1,5 @@
 using Avalonia.Media;
-using SharpDX;
+using SharpGen.Runtime;
 
 namespace Avalonia.Direct2D1.Media
 {

--- a/src/Windows/Avalonia.Direct2D1/Media/DWriteResourceFontFileStream.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/DWriteResourceFontFileStream.cs
@@ -1,13 +1,14 @@
 using System;
-using SharpDX;
-using SharpDX.DirectWrite;
+using SharpGen.Runtime;
+using Vortice;
+using Vortice.DirectWrite;
 
 namespace Avalonia.Direct2D1.Media
 {
     /// <summary>
     /// This FontFileStream implementation is reading data from a <see cref="DataStream"/>.
     /// </summary>
-    public class DWriteResourceFontFileStream : CallbackBase, FontFileStream
+    public class DWriteResourceFontFileStream : CallbackBase, IDWriteFontFileStream
     {
         private readonly DataStream _stream;
 
@@ -28,16 +29,16 @@ namespace Avalonia.Direct2D1.Media
         /// <param name="fragmentSize">The size of the file fragment, in bytes.</param>
         /// <param name="fragmentContext">When this method returns, contains the address of</param>
         /// <remarks>
-        /// Note that ReadFileFragment implementations must check whether the requested font file fragment is within the file bounds. Otherwise, an error should be returned from ReadFileFragment.   {{DirectWrite}} may invoke <see cref="SharpDX.DirectWrite.FontFileStream"/> methods on the same object from multiple threads simultaneously. Therefore, ReadFileFragment implementations that rely on internal mutable state must serialize access to such state across multiple threads. For example, an implementation that uses separate Seek and Read operations to read a file fragment must place the code block containing Seek and Read calls under a lock or a critical section.
+        /// Note that ReadFileFragment implementations must check whether the requested font file fragment is within the file bounds. Otherwise, an error should be returned from ReadFileFragment.   {{DirectWrite}} may invoke <see cref="Vortice.DirectWrite.FontFileStream"/> methods on the same object from multiple threads simultaneously. Therefore, ReadFileFragment implementations that rely on internal mutable state must serialize access to such state across multiple threads. For example, an implementation that uses separate Seek and Read operations to read a file fragment must place the code block containing Seek and Read calls under a lock or a critical section.
         /// </remarks>
         /// <unmanaged>HRESULT IDWriteFontFileStream::ReadFileFragment([Out, Buffer] const void** fragmentStart,[None] __int64 fileOffset,[None] __int64 fragmentSize,[Out] void** fragmentContext)</unmanaged>
-        void FontFileStream.ReadFileFragment(out IntPtr fragmentStart, long fileOffset, long fragmentSize, out IntPtr fragmentContext)
+        public void ReadFileFragment(out IntPtr fragmentStart, ulong fileOffset, ulong fragmentSize, out IntPtr fragmentContext)
         {
             lock (this)
             {
                 fragmentContext = IntPtr.Zero;
 
-                _stream.Position = fileOffset;
+                _stream.Position = (long) fileOffset;
 
                 fragmentStart = _stream.PositionPointer;
             }
@@ -48,7 +49,7 @@ namespace Avalonia.Direct2D1.Media
         /// </summary>
         /// <param name="fragmentContext">A reference to the client-defined context of a font fragment returned from {{ReadFileFragment}}.</param>
         /// <unmanaged>void IDWriteFontFileStream::ReleaseFileFragment([None] void* fragmentContext)</unmanaged>
-        void FontFileStream.ReleaseFileFragment(IntPtr fragmentContext)
+        public void ReleaseFileFragment(IntPtr fragmentContext)
         {
             // Nothing to release. No context are used
         }
@@ -61,9 +62,12 @@ namespace Avalonia.Direct2D1.Media
         /// Implementing GetFileSize() for asynchronously loaded font files may require downloading the complete file contents. Therefore, this method should be used only for operations that either require a complete font file to be loaded (for example, copying a font file) or that need to make decisions based on the value of the file size (for example, validation against a persisted file size).
         /// </remarks>
         /// <unmanaged>HRESULT IDWriteFontFileStream::GetFileSize([Out] __int64* fileSize)</unmanaged>
-        long FontFileStream.GetFileSize()
+        public ulong GetFileSize()
         {
-            return _stream.Length;
+            lock (this)
+            {
+                return (ulong) _stream.Length;
+            }
         }
 
         /// <summary>
@@ -76,7 +80,8 @@ namespace Avalonia.Direct2D1.Media
         /// The "last modified time" is used by DirectWrite font selection algorithms to determine whether one font resource is more up to date than another one.
         /// </remarks>
         /// <unmanaged>HRESULT IDWriteFontFileStream::GetLastWriteTime([Out] __int64* lastWriteTime)</unmanaged>
-        long FontFileStream.GetLastWriteTime()
+
+        public ulong GetLastWriteTime()
         {
             return 0;
         }

--- a/src/Windows/Avalonia.Direct2D1/Media/DWriteResourceFontLoader.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/DWriteResourceFontLoader.cs
@@ -1,16 +1,16 @@
 using System.Collections.Generic;
 using Avalonia.Platform;
-using SharpDX;
-using SharpDX.DirectWrite;
+using SharpGen.Runtime;
+using Vortice;
+using Vortice.DirectWrite;
 
 namespace Avalonia.Direct2D1.Media
 {
     using System;
 
-    internal class DWriteResourceFontLoader : CallbackBase, FontCollectionLoader, FontFileLoader
+    internal class DWriteResourceFontLoader : CallbackBase, IDWriteFontCollectionLoader, IDWriteFontFileLoader
     {
-        private readonly List<DWriteResourceFontFileStream> _fontStreams = new List<DWriteResourceFontFileStream>();
-        private readonly List<DWriteResourceFontFileEnumerator> _enumerators = new List<DWriteResourceFontFileEnumerator>();
+        private readonly List<DataStream> _fontStreams = new List<DataStream>();
         private readonly DataStream _keyStream;
 
         /// <summary>
@@ -18,7 +18,7 @@ namespace Avalonia.Direct2D1.Media
         /// </summary>
         /// <param name="factory">The factory.</param>
         /// <param name="fontAssets"></param>
-        public DWriteResourceFontLoader(Factory factory, IEnumerable<Uri> fontAssets)
+        public DWriteResourceFontLoader(IDWriteFactory factory, IEnumerable<Uri> fontAssets)
         {
             var factory1 = factory;
 
@@ -34,7 +34,7 @@ namespace Avalonia.Direct2D1.Media
 
                 dataStream.Position = 0;
 
-                _fontStreams.Add(new DWriteResourceFontFileStream(dataStream));
+                _fontStreams.Add(dataStream);
             }
 
             // Build a Key storage that stores the index of the font
@@ -62,19 +62,15 @@ namespace Avalonia.Direct2D1.Media
         /// <summary>
         /// Creates a font file enumerator object that encapsulates a collection of font files. The font system calls back to this interface to create a font collection.
         /// </summary>
-        /// <param name="factory">Pointer to the <see cref="SharpDX.DirectWrite.Factory"/> object that was used to create the current font collection.</param>
+        /// <param name="factory">Pointer to the <see cref="Vortice.DirectWrite.Factory"/> object that was used to create the current font collection.</param>
         /// <param name="collectionKey">A font collection key that uniquely identifies the collection of font files within the scope of the font collection loader being used. The buffer allocated for this key must be at least  the size, in bytes, specified by collectionKeySize.</param>
         /// <returns>
         /// a reference to the newly created font file enumerator.
         /// </returns>
         /// <unmanaged>HRESULT IDWriteFontCollectionLoader::CreateEnumeratorFromKey([None] IDWriteFactory* factory,[In, Buffer] const void* collectionKey,[None] int collectionKeySize,[Out] IDWriteFontFileEnumerator** fontFileEnumerator)</unmanaged>
-        FontFileEnumerator FontCollectionLoader.CreateEnumeratorFromKey(Factory factory, DataPointer collectionKey)
+        public IDWriteFontFileEnumerator CreateEnumeratorFromKey(IDWriteFactory factory, IntPtr collectionKey, int collectionKeySize)
         {
-            var enumerator = new DWriteResourceFontFileEnumerator(factory, this, collectionKey);
-
-            _enumerators.Add(enumerator);
-
-            return enumerator;
+            return new DWriteResourceFontFileEnumerator(factory, this, collectionKey, collectionKeySize);
         }
 
         /// <summary>
@@ -82,17 +78,18 @@ namespace Avalonia.Direct2D1.Media
         /// </summary>
         /// <param name="fontFileReferenceKey">A reference to a font file reference key that uniquely identifies the font file resource within the scope of the font loader being used. The buffer allocated for this key must at least be the size, in bytes, specified by  fontFileReferenceKeySize.</param>
         /// <returns>
-        /// a reference to the newly created <see cref="SharpDX.DirectWrite.FontFileStream"/> object.
+        /// a reference to the newly created <see cref="Vortice.DirectWrite.FontFileStream"/> object.
         /// </returns>
         /// <remarks>
         /// The resource is closed when the last reference to fontFileStream is released.
         /// </remarks>
         /// <unmanaged>HRESULT IDWriteFontFileLoader::CreateStreamFromKey([In, Buffer] const void* fontFileReferenceKey,[None] int fontFileReferenceKeySize,[Out] IDWriteFontFileStream** fontFileStream)</unmanaged>
-        FontFileStream FontFileLoader.CreateStreamFromKey(DataPointer fontFileReferenceKey)
+        public IDWriteFontFileStream CreateStreamFromKey(IntPtr fontFileReferenceKey, int fontFileReferenceKeySize)
         {
-            var index = SharpDX.Utilities.Read<int>(fontFileReferenceKey.Pointer);
+            int index = 0;
+            MemoryHelpers.Read(fontFileReferenceKey, ref index);
 
-            return _fontStreams[index];
+            return new DWriteResourceFontFileStream(_fontStreams[index]);
         }
     }
 }

--- a/src/Windows/Avalonia.Direct2D1/Media/Direct2D1FontCollectionCache.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Direct2D1FontCollectionCache.cs
@@ -1,28 +1,33 @@
 using System.Collections.Concurrent;
 using Avalonia.Media;
 using Avalonia.Media.Fonts;
-using SharpDX.DirectWrite;
-using FontFamily = Avalonia.Media.FontFamily;
-using FontStyle = SharpDX.DirectWrite.FontStyle;
-using FontWeight = SharpDX.DirectWrite.FontWeight;
+using JetBrains.Annotations;
+using Vortice.DirectWrite;
+using FontStyle = Vortice.DirectWrite.FontStyle;
+using FontWeight = Vortice.DirectWrite.FontWeight;
 
 namespace Avalonia.Direct2D1.Media
 {
     internal static class Direct2D1FontCollectionCache
     {
-        private static readonly ConcurrentDictionary<FontFamilyKey, FontCollection> s_cachedCollections;
-        internal static readonly FontCollection InstalledFontCollection;
+        private static readonly ConcurrentDictionary<FontFamilyKey, IDWriteFontCollection> s_cachedCollections;
+        internal static readonly IDWriteFontCollection InstalledFontCollection;
 
         static Direct2D1FontCollectionCache()
         {
-            s_cachedCollections = new ConcurrentDictionary<FontFamilyKey, FontCollection>();
+            s_cachedCollections = new ConcurrentDictionary<FontFamilyKey, IDWriteFontCollection>();
 
             InstalledFontCollection = Direct2D1Platform.DirectWriteFactory.GetSystemFontCollection(false);
         }
 
-        public static Font GetFont(Typeface typeface)
+        public static IDWriteFont GetFont(Typeface typeface) =>
+            GetFontFamily(typeface.FontFamily)?.GetFirstMatchingFont(
+                (FontWeight)typeface.Weight, FontStretch.Normal, (FontStyle)typeface.Style
+            ) ?? throw new AvaloniaInternalException($"Failed to find DirectWrite font matching typeface [{typeface}]");
+
+        [CanBeNull]
+        private static IDWriteFontFamily GetFontFamily(FontFamily fontFamily)
         {
-            var fontFamily = typeface.FontFamily;
             var fontCollection = GetOrAddFontCollection(fontFamily);
             int index;
 
@@ -30,33 +35,29 @@ namespace Avalonia.Direct2D1.Media
             {
                 if (fontCollection.FindFamilyName(name, out index))
                 {
-                    return fontCollection.GetFontFamily(index).GetFirstMatchingFont(
-                        (FontWeight)typeface.Weight,
-                        FontStretch.Normal,
-                        (FontStyle)typeface.Style);
+                    return fontCollection.GetFontFamily(index);
                 }
             }
 
-            InstalledFontCollection.FindFamilyName("Segoe UI", out index);
-
-            return InstalledFontCollection.GetFontFamily(index).GetFirstMatchingFont(
-                (FontWeight)typeface.Weight,
-                FontStretch.Normal,
-                (FontStyle)typeface.Style);
+            return InstalledFontCollection.FindFamilyName("Segoe UI", out index)
+                       ? InstalledFontCollection.GetFontFamily(index)
+                       : null;
         }
 
-        private static FontCollection GetOrAddFontCollection(FontFamily fontFamily)
+        private static IDWriteFontCollection GetOrAddFontCollection(FontFamily fontFamily)
         {
             return fontFamily.Key == null ? InstalledFontCollection : s_cachedCollections.GetOrAdd(fontFamily.Key, CreateFontCollection);
         }
 
-        private static FontCollection CreateFontCollection(FontFamilyKey key)
+        private static IDWriteFontCollection CreateFontCollection(FontFamilyKey key)
         {
             var assets = FontFamilyLoader.LoadFontAssets(key);
 
             var fontLoader = new DWriteResourceFontLoader(Direct2D1Platform.DirectWriteFactory, assets);
 
-            return new FontCollection(Direct2D1Platform.DirectWriteFactory, fontLoader, fontLoader.Key);
+            return Direct2D1Platform.DirectWriteFactory.CreateCustomFontCollection(
+                fontLoader, fontLoader.Key.BasePointer, checked((int)fontLoader.Key.Length)
+            );
         }
     }
 }

--- a/src/Windows/Avalonia.Direct2D1/Media/DrawingContextImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/DrawingContextImpl.cs
@@ -6,9 +6,10 @@ using Avalonia.Rendering;
 using Avalonia.Rendering.SceneGraph;
 using Avalonia.Utilities;
 using Avalonia.Visuals.Media.Imaging;
-using SharpDX;
-using SharpDX.Direct2D1;
-using SharpDX.Mathematics.Interop;
+using SharpGen.Runtime;
+using Vortice;
+using Vortice.DCommon;
+using Vortice.Direct2D1;
 using BitmapInterpolationMode = Avalonia.Visuals.Media.Imaging.BitmapInterpolationMode;
 
 namespace Avalonia.Direct2D1.Media
@@ -20,10 +21,10 @@ namespace Avalonia.Direct2D1.Media
     {
         private readonly IVisualBrushRenderer _visualBrushRenderer;
         private readonly ILayerFactory _layerFactory;
-        private readonly SharpDX.Direct2D1.RenderTarget _renderTarget;
-        private readonly DeviceContext _deviceContext;
+        private readonly ID2D1RenderTarget _renderTarget;
+        private readonly ID2D1DeviceContext _deviceContext;
         private readonly bool _ownsDeviceContext;
-        private readonly SharpDX.DXGI.SwapChain1 _swapChain;
+        private readonly Vortice.DXGI.IDXGISwapChain1 _swapChain;
         private readonly Action _finishedCallback;
 
         /// <summary>
@@ -40,8 +41,8 @@ namespace Avalonia.Direct2D1.Media
         public DrawingContextImpl(
             IVisualBrushRenderer visualBrushRenderer,
             ILayerFactory layerFactory,
-            SharpDX.Direct2D1.RenderTarget renderTarget,
-            SharpDX.DXGI.SwapChain1 swapChain = null,
+            Vortice.Direct2D1.ID2D1RenderTarget renderTarget,
+            Vortice.DXGI.IDXGISwapChain1 swapChain = null,
             Action finishedCallback = null)
         {
             _visualBrushRenderer = visualBrushRenderer;
@@ -50,14 +51,14 @@ namespace Avalonia.Direct2D1.Media
             _swapChain = swapChain;
             _finishedCallback = finishedCallback;
 
-            if (_renderTarget is DeviceContext deviceContext)
+            if (_renderTarget is ID2D1DeviceContext deviceContext)
             {
                 _deviceContext = deviceContext;
                 _ownsDeviceContext = false;
             }
             else
             {
-                _deviceContext = _renderTarget.QueryInterface<DeviceContext>();
+                _deviceContext = _renderTarget.QueryInterface<ID2D1DeviceContext>();
                 _ownsDeviceContext = true;
             }
 
@@ -93,10 +94,10 @@ namespace Avalonia.Direct2D1.Media
             {
                 _deviceContext.EndDraw();
 
-                _swapChain?.Present(1, SharpDX.DXGI.PresentFlags.None);
+                _swapChain?.Present(1, Vortice.DXGI.PresentFlags.None);
                 _finishedCallback?.Invoke();
             }
-            catch (SharpDXException ex) when ((uint)ex.HResult == 0x8899000C) // D2DERR_RECREATE_TARGET
+            catch (SharpGenException ex) when ((uint)ex.HResult == 0x8899000C) // D2DERR_RECREATE_TARGET
             {
                 throw new RenderTargetCorruptedException(ex);
             }
@@ -191,9 +192,9 @@ namespace Avalonia.Direct2D1.Media
         public void DrawBitmap(IRef<IBitmapImpl> source, IBrush opacityMask, Rect opacityMaskRect, Rect destRect)
         {
             using (var d2dSource = ((BitmapImpl)source.Item).GetDirect2DBitmap(_deviceContext))
-            using (var sourceBrush = new BitmapBrush(_deviceContext, d2dSource.Value))
+            using (var sourceBrush = _deviceContext.CreateBitmapBrush(d2dSource.Value, null, null))
             using (var d2dOpacityMask = CreateBrush(opacityMask, opacityMaskRect.Size))
-            using (var geometry = new SharpDX.Direct2D1.RectangleGeometry(Direct2D1Platform.Direct2D1Factory, destRect.ToDirect2D()))
+            using (var geometry = Direct2D1Platform.Direct2D1Factory.CreateRectangleGeometry(destRect.ToDirect2D()))
             {
                 if (d2dOpacityMask.PlatformBrush != null)
                 {
@@ -250,7 +251,7 @@ namespace Avalonia.Direct2D1.Media
                     if (d2dBrush.PlatformBrush != null)
                     {
                         var impl = (GeometryImpl)geometry;
-                        _deviceContext.FillGeometry(impl.Geometry, d2dBrush.PlatformBrush);
+                        _deviceContext.FillGeometry(impl.Geometry, d2dBrush.PlatformBrush, null);
                     }
                 }
             }
@@ -288,18 +289,18 @@ namespace Avalonia.Direct2D1.Media
                     {
                         if (isRounded)
                         {
-                            _deviceContext.FillRoundedRectangle(
-                                new RoundedRectangle
-                                {
-                                    Rect = new RawRectangleF(
-                                        (float)rect.X,
-                                        (float)rect.Y,
-                                        (float)rect.Right,
-                                        (float)rect.Bottom),
-                                    RadiusX = (float)radiusX,
-                                    RadiusY = (float)radiusY
-                                },
-                                b.PlatformBrush);
+                            RoundedRectangle roundedRectangle = new()
+                            {
+                                Rect = new RawRectF(
+                                    (float)rect.X,
+                                    (float)rect.Y,
+                                    (float)rect.Right,
+                                    (float)rect.Bottom),
+                                RadiusX = (float)radiusX,
+                                RadiusY = (float)radiusY
+                            };
+
+                            _deviceContext.FillRoundedRectangle(ref roundedRectangle, b.PlatformBrush);
                         }
                         else
                         {
@@ -354,7 +355,7 @@ namespace Avalonia.Direct2D1.Media
                 {
                     if (brush.PlatformBrush != null)
                     {
-                        impl.TextLayout.Draw(renderer, (float)origin.X, (float)origin.Y);
+                        impl.TextLayout.Draw(IntPtr.Zero, renderer, (float)origin.X, (float)origin.Y);
                     }
                 }
             }
@@ -385,7 +386,7 @@ namespace Avalonia.Direct2D1.Media
             else
             {
                 var platform = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
-                var dpi = new Vector(_deviceContext.DotsPerInch.Width, _deviceContext.DotsPerInch.Height);
+                var dpi = new Vector(_deviceContext.Dpi.X, _deviceContext.Dpi.Y);
                 var pixelSize = PixelSize.FromSizeWithDpi(size, dpi);
                 return (IDrawingContextLayerImpl)platform.CreateRenderTargetBitmap(pixelSize, dpi);
             }
@@ -412,8 +413,8 @@ namespace Avalonia.Direct2D1.Media
             _deviceContext.PopAxisAlignedClip();
         }
 
-        readonly Stack<Layer> _layers = new Stack<Layer>();
-        private readonly Stack<Layer> _layerPool = new Stack<Layer>();
+        readonly Stack<ID2D1Layer> _layers = new Stack<ID2D1Layer>();
+        private readonly Stack<ID2D1Layer> _layerPool = new Stack<ID2D1Layer>();
         /// <summary>
         /// Pushes an opacity value.
         /// </summary>
@@ -430,7 +431,7 @@ namespace Avalonia.Direct2D1.Media
                     Opacity = (float)opacity,
                 };
 
-                var layer = _layerPool.Count != 0 ? _layerPool.Pop() : new Layer(_deviceContext);
+                var layer = _layerPool.Count != 0 ? _layerPool.Pop() : _deviceContext.CreateLayer(null);
                 _deviceContext.PushLayer(ref parameters, layer);
 
                 _layers.Push(layer);
@@ -505,13 +506,15 @@ namespace Avalonia.Direct2D1.Media
                         // We need to ensure the size we're requesting is an integer pixel size, otherwise
                         // D2D alters the DPI of the render target, which messes stuff up. PixelSize.FromSize
                         // will do the rounding for us.
-                        var dpi = new Vector(_deviceContext.DotsPerInch.Width, _deviceContext.DotsPerInch.Height);
+                        var dpi = new Vector(_deviceContext.Dpi.X, _deviceContext.Dpi.Y);
                         var pixelSize = PixelSize.FromSizeWithDpi(intermediateSize, dpi);
 
-                        using (var intermediate = new BitmapRenderTarget(
-                            _deviceContext,
-                            CompatibleRenderTargetOptions.None,
-                            pixelSize.ToSizeWithDpi(dpi).ToSharpDX()))
+                        using (var intermediate = _deviceContext.CreateCompatibleRenderTarget(
+                            pixelSize.ToSizeWithDpi(dpi).ToSharpDX(),
+                            null,
+                            null,
+                            CompatibleRenderTargetOptions.None
+                            ))
                         {
                             using (var ctx = new RenderTarget(intermediate).CreateDrawingContext(_visualBrushRenderer))
                             {
@@ -545,7 +548,7 @@ namespace Avalonia.Direct2D1.Media
                 Opacity = 1,
                 GeometricMask = ((GeometryImpl)clip).Geometry
             };
-            var layer = _layerPool.Count != 0 ? _layerPool.Pop() : new Layer(_deviceContext);
+            var layer = _layerPool.Count != 0 ? _layerPool.Pop() : _deviceContext.CreateLayer();
             _deviceContext.PushLayer(ref parameters, layer);
 
             _layers.Push(layer);
@@ -576,7 +579,7 @@ namespace Avalonia.Direct2D1.Media
                 Opacity = 1,
                 OpacityBrush = CreateBrush(mask, bounds.Size).PlatformBrush
             };
-            var layer = _layerPool.Count != 0 ? _layerPool.Pop() : new Layer(_deviceContext);
+            var layer = _layerPool.Count != 0 ? _layerPool.Pop() : _deviceContext.CreateLayer();
             _deviceContext.PushLayer(ref parameters, layer);
 
             _layers.Push(layer);

--- a/src/Windows/Avalonia.Direct2D1/Media/EllipseGeometryImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/EllipseGeometryImpl.cs
@@ -1,4 +1,4 @@
-using SharpDX.Direct2D1;
+using Vortice.Direct2D1;
 
 namespace Avalonia.Direct2D1.Media
 {
@@ -15,10 +15,10 @@ namespace Avalonia.Direct2D1.Media
         {
         }
 
-        private static Geometry CreateGeometry(Rect rect)
+        private static ID2D1Geometry CreateGeometry(Rect rect)
         {
             var ellipse = new Ellipse(rect.Center.ToSharpDX(), (float)rect.Width / 2, (float)rect.Height / 2);
-            return new EllipseGeometry(Direct2D1Platform.Direct2D1Factory, ellipse);
+            return Direct2D1Platform.Direct2D1Factory.CreateEllipseGeometry(ellipse);
         }
     }
 }

--- a/src/Windows/Avalonia.Direct2D1/Media/FontManagerImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/FontManagerImpl.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using Avalonia.Media;
 using Avalonia.Platform;
-using SharpDX.DirectWrite;
+using Vortice.DirectWrite;
 using FontFamily = Avalonia.Media.FontFamily;
 using FontStyle = Avalonia.Media.FontStyle;
 using FontWeight = Avalonia.Media.FontWeight;
@@ -40,8 +40,8 @@ namespace Avalonia.Direct2D1.Media
             for (var i = 0; i < familyCount; i++)
             {
                 var font = Direct2D1FontCollectionCache.InstalledFontCollection.GetFontFamily(i)
-                    .GetMatchingFonts((SharpDX.DirectWrite.FontWeight)fontWeight, FontStretch.Normal,
-                        (SharpDX.DirectWrite.FontStyle)fontStyle).GetFont(0);
+                    .GetMatchingFonts((Vortice.DirectWrite.FontWeight)fontWeight, FontStretch.Normal,
+                        (Vortice.DirectWrite.FontStyle)fontStyle).GetFont(0);
 
                 if (!font.HasCharacter(codepoint))
                 {

--- a/src/Windows/Avalonia.Direct2D1/Media/GlyphRunImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/GlyphRunImpl.cs
@@ -4,12 +4,12 @@ namespace Avalonia.Direct2D1.Media
 {
     internal class GlyphRunImpl : IGlyphRunImpl
     {
-        public GlyphRunImpl(SharpDX.DirectWrite.GlyphRun glyphRun)
+        public GlyphRunImpl(Vortice.DirectWrite.GlyphRun glyphRun)
         {
             GlyphRun = glyphRun;
         }
 
-        public SharpDX.DirectWrite.GlyphRun GlyphRun { get; }
+        public Vortice.DirectWrite.GlyphRun GlyphRun { get; }
 
         public void Dispose()
         {

--- a/src/Windows/Avalonia.Direct2D1/Media/Imaging/BitmapImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Imaging/BitmapImpl.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 using Avalonia.Platform;
-using D2DBitmap = SharpDX.Direct2D1.Bitmap;
+using Vortice.Direct2D1;
 
 namespace Avalonia.Direct2D1.Media
 {
@@ -11,7 +11,7 @@ namespace Avalonia.Direct2D1.Media
         public abstract PixelSize PixelSize { get; }
         public int Version { get; protected set; } = 1;
 
-        public abstract OptionalDispose<D2DBitmap> GetDirect2DBitmap(SharpDX.Direct2D1.RenderTarget target);
+        public abstract OptionalDispose<ID2D1Bitmap> GetDirect2DBitmap(ID2D1RenderTarget target);
 
         public void Save(string fileName)
         {

--- a/src/Windows/Avalonia.Direct2D1/Media/Imaging/D2DBitmapImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Imaging/D2DBitmapImpl.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
-using SharpDX.WIC;
-using Bitmap = SharpDX.Direct2D1.Bitmap;
+using Vortice.WIC;
+using Bitmap = Vortice.Direct2D1.ID2D1Bitmap;
 
 namespace Avalonia.Direct2D1.Media
 {
@@ -19,7 +19,7 @@ namespace Avalonia.Direct2D1.Media
         /// <param name="d2DBitmap">The GPU bitmap.</param>
         /// <remarks>
         /// This bitmap must be either from the same render target,
-        /// or if the render target is a <see cref="SharpDX.Direct2D1.DeviceContext"/>,
+        /// or if the render target is a <see cref="Vortice.Direct2D1.DeviceContext"/>,
         /// the device associated with this context, to be renderable.
         /// </remarks>
         public D2DBitmapImpl(Bitmap d2DBitmap)
@@ -28,7 +28,7 @@ namespace Avalonia.Direct2D1.Media
         }
 
         public override Vector Dpi => new Vector(96, 96);
-        public override PixelSize PixelSize => _direct2DBitmap.PixelSize.ToAvalonia();
+        public override PixelSize PixelSize => ((Vortice.Mathematics.Size)_direct2DBitmap.PixelSize).ToAvalonia();
 
         public override void Dispose()
         {
@@ -36,18 +36,18 @@ namespace Avalonia.Direct2D1.Media
             _direct2DBitmap.Dispose();
         }
 
-        public override OptionalDispose<Bitmap> GetDirect2DBitmap(SharpDX.Direct2D1.RenderTarget target)
+        public override OptionalDispose<Bitmap> GetDirect2DBitmap(Vortice.Direct2D1.ID2D1RenderTarget target)
         {
             return new OptionalDispose<Bitmap>(_direct2DBitmap, false);
         }
 
         public override void Save(Stream stream)
         {
-            using (var encoder = new PngBitmapEncoder(Direct2D1Platform.ImagingFactory, stream))
-            using (var frame = new BitmapFrameEncode(encoder))
-            using (var bitmapSource = _direct2DBitmap.QueryInterface<BitmapSource>())
+            using (var encoder = Direct2D1Platform.ImagingFactory.CreateEncoder(ContainerFormat.Png, stream))
+            using (var frame = encoder.CreateNewFrame(null))
+            using (var bitmapSource = _direct2DBitmap.QueryInterface<IWICBitmapSource>())
             {
-                frame.Initialize();
+                frame.Initialize(null);
                 frame.WriteSource(bitmapSource);
                 frame.Commit();
                 encoder.Commit();

--- a/src/Windows/Avalonia.Direct2D1/Media/Imaging/D2DRenderTargetBitmapImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Imaging/D2DRenderTargetBitmapImpl.cs
@@ -3,30 +3,33 @@ using System.IO;
 using Avalonia.Platform;
 using Avalonia.Rendering;
 using Avalonia.Utilities;
-using SharpDX;
-using SharpDX.Direct2D1;
-using D2DBitmap = SharpDX.Direct2D1.Bitmap;
+using Vortice;
+using Vortice.Direct2D1;
+using Vortice.Mathematics;
+using D2DBitmap = Vortice.Direct2D1.ID2D1Bitmap;
 
 namespace Avalonia.Direct2D1.Media.Imaging
 {
     public class D2DRenderTargetBitmapImpl : D2DBitmapImpl, IDrawingContextLayerImpl, ILayerFactory
     {
-        private readonly BitmapRenderTarget _renderTarget;
+        private readonly ID2D1BitmapRenderTarget _renderTarget;
 
-        public D2DRenderTargetBitmapImpl(BitmapRenderTarget renderTarget)
+        public D2DRenderTargetBitmapImpl(ID2D1BitmapRenderTarget renderTarget)
             : base(renderTarget.Bitmap)
         {
             _renderTarget = renderTarget;
         }
 
         public static D2DRenderTargetBitmapImpl CreateCompatible(
-            SharpDX.Direct2D1.RenderTarget renderTarget,
+            Vortice.Direct2D1.ID2D1RenderTarget renderTarget,
             Size size)
         {
-            var bitmapRenderTarget = new BitmapRenderTarget(
-                renderTarget,
-                CompatibleRenderTargetOptions.None,
-                new Size2F((float)size.Width, (float)size.Height));
+            var bitmapRenderTarget = renderTarget.CreateCompatibleRenderTarget(
+                new SizeF((float)size.Width, (float)size.Height),
+                null,
+                null,
+                CompatibleRenderTargetOptions.None
+                );
             return new D2DRenderTargetBitmapImpl(bitmapRenderTarget);
         }
 
@@ -49,7 +52,7 @@ namespace Avalonia.Direct2D1.Media.Imaging
             _renderTarget.Dispose();
         }
 
-        public override OptionalDispose<D2DBitmap> GetDirect2DBitmap(SharpDX.Direct2D1.RenderTarget target)
+        public override OptionalDispose<D2DBitmap> GetDirect2DBitmap(Vortice.Direct2D1.ID2D1RenderTarget target)
         {
             return new OptionalDispose<D2DBitmap>(_renderTarget.Bitmap, false);
         }

--- a/src/Windows/Avalonia.Direct2D1/Media/Imaging/WicBitmapImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Imaging/WicBitmapImpl.cs
@@ -1,10 +1,11 @@
 using System;
 using System.IO;
+using Avalonia.Media.Imaging;
 using Avalonia.Win32.Interop;
-using SharpDX.WIC;
+using Vortice.WIC;
 using APixelFormat = Avalonia.Platform.PixelFormat;
 using AlphaFormat = Avalonia.Platform.AlphaFormat;
-using D2DBitmap = SharpDX.Direct2D1.Bitmap;
+using D2DBitmap = Vortice.Direct2D1.ID2D1Bitmap;
 
 namespace Avalonia.Direct2D1.Media
 {
@@ -13,7 +14,7 @@ namespace Avalonia.Direct2D1.Media
     /// </summary>
     public class WicBitmapImpl : BitmapImpl
     {
-        private readonly BitmapDecoder _decoder;
+        private readonly IWICBitmapDecoder _decoder;
 
         private static BitmapInterpolationMode ConvertInterpolationMode(Avalonia.Visuals.Media.Imaging.BitmapInterpolationMode interpolationMode)
         {
@@ -41,15 +42,14 @@ namespace Avalonia.Direct2D1.Media
         /// <param name="fileName">The filename of the bitmap to load.</param>
         public WicBitmapImpl(string fileName)
         {
-            using (var decoder = new BitmapDecoder(Direct2D1Platform.ImagingFactory, fileName, DecodeOptions.CacheOnDemand))
-            using (var frame = decoder.GetFrame(0))
-            {
-                WicImpl = new Bitmap(Direct2D1Platform.ImagingFactory, frame, BitmapCreateCacheOption.CacheOnDemand);
-                Dpi = new Vector(96, 96);
-            }
+            using var decoder = Direct2D1Platform.ImagingFactory.CreateDecoderFromFileName(fileName, metadataOptions: DecodeOptions.CacheOnDemand);
+            using var frame = decoder.GetFrame(0);
+
+            WicImpl = Direct2D1Platform.ImagingFactory.CreateBitmapFromSource(frame, BitmapCreateCacheOption.CacheOnDemand);
+            Dpi = new Vector(96, 96);
         }
 
-        private WicBitmapImpl(Bitmap bmp)
+        private WicBitmapImpl(IWICBitmap bmp)
         {
             WicImpl = bmp;
             Dpi = new Vector(96, 96);
@@ -62,10 +62,10 @@ namespace Avalonia.Direct2D1.Media
         public WicBitmapImpl(Stream stream)
         {
             // https://stackoverflow.com/questions/48982749/decoding-image-from-stream-using-wic/48982889#48982889
-            _decoder = new BitmapDecoder(Direct2D1Platform.ImagingFactory, stream, DecodeOptions.CacheOnLoad);
+            _decoder = Direct2D1Platform.ImagingFactory.CreateDecoderFromStream(stream, DecodeOptions.CacheOnLoad);
 
             using var frame = _decoder.GetFrame(0);
-            WicImpl = new Bitmap(Direct2D1Platform.ImagingFactory, frame, BitmapCreateCacheOption.CacheOnLoad);
+            WicImpl = Direct2D1Platform.ImagingFactory.CreateBitmapFromSource(frame, BitmapCreateCacheOption.CacheOnLoad);
             Dpi = new Vector(96, 96);
         }
 
@@ -89,8 +89,7 @@ namespace Avalonia.Direct2D1.Media
             }
 
             PixelFormat = pixelFormat;
-            WicImpl = new Bitmap(
-                Direct2D1Platform.ImagingFactory,
+            WicImpl = Direct2D1Platform.ImagingFactory.CreateBitmap(
                 size.Width,
                 size.Height,
                 pixelFormat.Value.ToWic(alphaFormat.Value),
@@ -101,12 +100,12 @@ namespace Avalonia.Direct2D1.Media
 
         public WicBitmapImpl(APixelFormat format, AlphaFormat alphaFormat, IntPtr data, PixelSize size, Vector dpi, int stride)
         {
-            WicImpl = new Bitmap(Direct2D1Platform.ImagingFactory, size.Width, size.Height, format.ToWic(alphaFormat), BitmapCreateCacheOption.CacheOnDemand);
+            WicImpl = Direct2D1Platform.ImagingFactory.CreateBitmap(size.Width, size.Height, format.ToWic(alphaFormat), BitmapCreateCacheOption.CacheOnDemand);
             WicImpl.SetResolution(dpi.X, dpi.Y);
             PixelFormat = format;
             Dpi = dpi;
 
-            using (var l = WicImpl.Lock(BitmapLockFlags.Write))
+            using (var l = WicImpl.Lock(BitmapLockFlags.LockWrite))
             {
                 for (var row = 0; row < size.Height; row++)
                 {
@@ -120,7 +119,7 @@ namespace Avalonia.Direct2D1.Media
 
         public WicBitmapImpl(Stream stream, int decodeSize, bool horizontal, Avalonia.Visuals.Media.Imaging.BitmapInterpolationMode interpolationMode)
         {
-            _decoder = new BitmapDecoder(Direct2D1Platform.ImagingFactory, stream, DecodeOptions.CacheOnLoad);
+            _decoder = Direct2D1Platform.ImagingFactory.CreateDecoderFromStream(stream, DecodeOptions.CacheOnLoad);
 
             using var frame = _decoder.GetFrame(0);
 
@@ -140,16 +139,16 @@ namespace Avalonia.Direct2D1.Media
 
             if (frame.Size.Width != desired.Width || frame.Size.Height != desired.Height)
             {
-                using (var scaler = new BitmapScaler(Direct2D1Platform.ImagingFactory))
+                using (var scaler = Direct2D1Platform.ImagingFactory.CreateBitmapScaler())
                 {
                     scaler.Initialize(frame, desired.Width, desired.Height, ConvertInterpolationMode(interpolationMode));
 
-                    WicImpl = new Bitmap(Direct2D1Platform.ImagingFactory, scaler, BitmapCreateCacheOption.CacheOnLoad);                    
+                    WicImpl = Direct2D1Platform.ImagingFactory.CreateBitmapFromSource(scaler, BitmapCreateCacheOption.CacheOnLoad);                    
                 }
             }
             else
             {
-                WicImpl = new Bitmap(Direct2D1Platform.ImagingFactory, frame, BitmapCreateCacheOption.CacheOnLoad);
+                WicImpl = Direct2D1Platform.ImagingFactory.CreateBitmapFromSource(frame, BitmapCreateCacheOption.CacheOnLoad);
             }
 
             Dpi = new Vector(96, 96);
@@ -170,26 +169,26 @@ namespace Avalonia.Direct2D1.Media
         /// <summary>
         /// Gets the WIC implementation of the bitmap.
         /// </summary>
-        public Bitmap WicImpl { get; }
+        public IWICBitmap WicImpl { get; }
 
         /// <summary>
         /// Gets a Direct2D bitmap to use on the specified render target.
         /// </summary>
         /// <param name="renderTarget">The render target.</param>
         /// <returns>The Direct2D bitmap.</returns>
-        public override OptionalDispose<D2DBitmap> GetDirect2DBitmap(SharpDX.Direct2D1.RenderTarget renderTarget)
+        public override OptionalDispose<D2DBitmap> GetDirect2DBitmap(Vortice.Direct2D1.ID2D1RenderTarget renderTarget)
         {
-            using var converter = new FormatConverter(Direct2D1Platform.ImagingFactory);
-            converter.Initialize(WicImpl, SharpDX.WIC.PixelFormat.Format32bppPBGRA);
-            return new OptionalDispose<D2DBitmap>(D2DBitmap.FromWicBitmap(renderTarget, converter), true);
+            using var converter = Direct2D1Platform.ImagingFactory.CreateFormatConverter();
+            converter.Initialize(WicImpl, Vortice.WIC.PixelFormat.Format32bppPBGRA, BitmapDitherType.None, null, 0.0, BitmapPaletteType.Custom);
+            return new OptionalDispose<D2DBitmap>(renderTarget.CreateBitmapFromWicBitmap(converter, null), true);
         }
 
         public override void Save(Stream stream)
         {
-            using (var encoder = new PngBitmapEncoder(Direct2D1Platform.ImagingFactory, stream))
-            using (var frame = new BitmapFrameEncode(encoder))
+            using (var encoder = Direct2D1Platform.ImagingFactory.CreateEncoder(ContainerFormat.Png, stream))
+            using (var frame = encoder.CreateNewFrame(null))
             {
-                frame.Initialize();
+                frame.Initialize(null);
                 frame.WriteSource(WicImpl);
                 frame.Commit();
                 encoder.Commit();

--- a/src/Windows/Avalonia.Direct2D1/Media/Imaging/WicRenderTargetBitmapImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Imaging/WicRenderTargetBitmapImpl.cs
@@ -1,13 +1,13 @@
 using System;
 using Avalonia.Platform;
 using Avalonia.Rendering;
-using SharpDX.Direct2D1;
+using Vortice.Direct2D1;
 
 namespace Avalonia.Direct2D1.Media
 {
     public class WicRenderTargetBitmapImpl : WicBitmapImpl, IDrawingContextLayerImpl
     {
-        private readonly WicRenderTarget _renderTarget;
+        private readonly ID2D1RenderTarget _renderTarget;
 
         public WicRenderTargetBitmapImpl(
             PixelSize size,
@@ -21,8 +21,7 @@ namespace Avalonia.Direct2D1.Media
                 DpiY = (float)dpi.Y,
             };
 
-            _renderTarget = new WicRenderTarget(
-                Direct2D1Platform.Direct2D1Factory,
+            _renderTarget = Direct2D1Platform.Direct2D1Factory.CreateWicBitmapRenderTarget(
                 WicImpl,
                 props);
         }

--- a/src/Windows/Avalonia.Direct2D1/Media/Imaging/WriteableWicBitmapImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Imaging/WriteableWicBitmapImpl.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Avalonia.Platform;
-using SharpDX.WIC;
+using Vortice.WIC;
 using PixelFormat = Avalonia.Platform.PixelFormat;
 
 namespace Avalonia.Direct2D1.Media.Imaging
@@ -15,10 +15,10 @@ namespace Avalonia.Direct2D1.Media.Imaging
         class LockedBitmap : ILockedFramebuffer
         {
             private readonly WriteableWicBitmapImpl _parent;
-            private readonly BitmapLock _lock;
+            private readonly IWICBitmapLock _lock;
             private readonly PixelFormat _format;
 
-            public LockedBitmap(WriteableWicBitmapImpl parent, BitmapLock l, PixelFormat format)
+            public LockedBitmap(WriteableWicBitmapImpl parent, IWICBitmapLock l, PixelFormat format)
             {
                 _parent = parent;
                 _lock = l;
@@ -41,6 +41,6 @@ namespace Avalonia.Direct2D1.Media.Imaging
         }
 
         public ILockedFramebuffer Lock() =>
-            new LockedBitmap(this, WicImpl.Lock(BitmapLockFlags.Write), PixelFormat.Value);
+            new LockedBitmap(this, WicImpl.Lock(BitmapLockFlags.LockWrite), PixelFormat.Value);
     }
 }

--- a/src/Windows/Avalonia.Direct2D1/Media/LineGeometryImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/LineGeometryImpl.cs
@@ -1,4 +1,4 @@
-using SharpDX.Direct2D1;
+using Vortice.Direct2D1;
 
 namespace Avalonia.Direct2D1.Media
 {
@@ -12,7 +12,7 @@ namespace Avalonia.Direct2D1.Media
         /// </summary>
         public LineGeometryImpl(Point p1, Point p2)
         {
-            using (var sink = ((PathGeometry)Geometry).Open())
+            using (var sink = ((ID2D1PathGeometry)Geometry).Open())
             {
                 sink.BeginFigure(p1.ToSharpDX(), FigureBegin.Hollow);
                 sink.AddLine(p2.ToSharpDX());

--- a/src/Windows/Avalonia.Direct2D1/Media/LinearGradientBrushImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/LinearGradientBrushImpl.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Avalonia.Media;
+using Vortice.Direct2D1;
 
 namespace Avalonia.Direct2D1.Media
 {
@@ -7,7 +8,7 @@ namespace Avalonia.Direct2D1.Media
     {
         public LinearGradientBrushImpl(
             ILinearGradientBrush brush,
-            SharpDX.Direct2D1.RenderTarget target,
+            Vortice.Direct2D1.ID2D1RenderTarget target,
             Size destinationSize)
         {
             if (brush.GradientStops.Count == 0)
@@ -15,7 +16,7 @@ namespace Avalonia.Direct2D1.Media
                 return;
             }
 
-            var gradientStops = brush.GradientStops.Select(s => new SharpDX.Direct2D1.GradientStop
+            var gradientStops = brush.GradientStops.Select(s => new Vortice.Direct2D1.GradientStop
             {
                 Color = s.Color.ToDirect2D(),
                 Position = (float)s.Offset
@@ -24,19 +25,18 @@ namespace Avalonia.Direct2D1.Media
             var startPoint = brush.StartPoint.ToPixels(destinationSize);
             var endPoint = brush.EndPoint.ToPixels(destinationSize);
 
-            using (var stops = new SharpDX.Direct2D1.GradientStopCollection(
-                target,
+            using (var stops = target.CreateGradientStopCollection(
                 gradientStops,
+                Gamma.StandardRgb,
                 brush.SpreadMethod.ToDirect2D()))
             {
-                PlatformBrush = new SharpDX.Direct2D1.LinearGradientBrush(
-                    target,
-                    new SharpDX.Direct2D1.LinearGradientBrushProperties
+                PlatformBrush = target.CreateLinearGradientBrush(
+                    new Vortice.Direct2D1.LinearGradientBrushProperties
                     {
                         StartPoint = startPoint.ToSharpDX(),
                         EndPoint = endPoint.ToSharpDX()
                     },
-                    new SharpDX.Direct2D1.BrushProperties
+                    new Vortice.Direct2D1.BrushProperties
                     {
                         Opacity = (float)brush.Opacity,
                         Transform = PrimitiveExtensions.Matrix3x2Identity,

--- a/src/Windows/Avalonia.Direct2D1/Media/RadialGradientBrushImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/RadialGradientBrushImpl.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Avalonia.Media;
+using Vortice.Direct2D1;
 
 namespace Avalonia.Direct2D1.Media
 {
@@ -7,7 +8,7 @@ namespace Avalonia.Direct2D1.Media
     {
         public RadialGradientBrushImpl(
             IRadialGradientBrush brush,
-            SharpDX.Direct2D1.RenderTarget target,
+            Vortice.Direct2D1.ID2D1RenderTarget target,
             Size destinationSize)
         {
             if (brush.GradientStops.Count == 0)
@@ -15,7 +16,7 @@ namespace Avalonia.Direct2D1.Media
                 return;
             }
 
-            var gradientStops = brush.GradientStops.Select(s => new SharpDX.Direct2D1.GradientStop
+            var gradientStops = brush.GradientStops.Select(s => new Vortice.Direct2D1.GradientStop
             {
                 Color = s.Color.ToDirect2D(),
                 Position = (float)s.Offset
@@ -28,21 +29,20 @@ namespace Avalonia.Direct2D1.Media
             var radiusX = brush.Radius * destinationSize.Width;
             var radiusY = brush.Radius * destinationSize.Height;
 
-            using (var stops = new SharpDX.Direct2D1.GradientStopCollection(
-                target,
+            using (var stops = target.CreateGradientStopCollection(
                 gradientStops,
+                Gamma.StandardRgb,
                 brush.SpreadMethod.ToDirect2D()))
             {
-                PlatformBrush = new SharpDX.Direct2D1.RadialGradientBrush(
-                    target,
-                    new SharpDX.Direct2D1.RadialGradientBrushProperties
+                PlatformBrush = target.CreateRadialGradientBrush(
+                    new Vortice.Direct2D1.RadialGradientBrushProperties
                     {
                         Center = centerPoint.ToSharpDX(),
                         GradientOriginOffset = gradientOrigin.ToSharpDX(),
                         RadiusX = (float)radiusX,
                         RadiusY = (float)radiusY
                     },
-                    new SharpDX.Direct2D1.BrushProperties
+                    new Vortice.Direct2D1.BrushProperties
                     {
                         Opacity = (float)brush.Opacity,
                         Transform = PrimitiveExtensions.Matrix3x2Identity,

--- a/src/Windows/Avalonia.Direct2D1/Media/RectangleGeometryImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/RectangleGeometryImpl.cs
@@ -1,4 +1,4 @@
-using SharpDX.Direct2D1;
+using Vortice.Direct2D1;
 
 namespace Avalonia.Direct2D1.Media
 {
@@ -15,9 +15,9 @@ namespace Avalonia.Direct2D1.Media
         {
         }
 
-        private static Geometry CreateGeometry(Rect rect)
+        private static ID2D1Geometry CreateGeometry(Rect rect)
         {
-            return new RectangleGeometry(Direct2D1Platform.Direct2D1Factory, rect.ToDirect2D());
+            return Direct2D1Platform.Direct2D1Factory.CreateRectangleGeometry(rect.ToDirect2D());
         }
     }
 }

--- a/src/Windows/Avalonia.Direct2D1/Media/SolidColorBrushImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/SolidColorBrushImpl.cs
@@ -1,15 +1,15 @@
 using Avalonia.Media;
+using Color = Vortice.Mathematics.Color;
 
 namespace Avalonia.Direct2D1.Media
 {
     public class SolidColorBrushImpl : BrushImpl
     {
-        public SolidColorBrushImpl(ISolidColorBrush brush, SharpDX.Direct2D1.RenderTarget target)
+        public SolidColorBrushImpl(ISolidColorBrush brush, Vortice.Direct2D1.ID2D1RenderTarget target)
         {
-            PlatformBrush = new SharpDX.Direct2D1.SolidColorBrush(
-                target,
-                brush?.Color.ToDirect2D() ?? new SharpDX.Mathematics.Interop.RawColor4(),
-                new SharpDX.Direct2D1.BrushProperties
+            PlatformBrush = target.CreateSolidColorBrush(
+                brush?.Color.ToDirect2D() ?? new Color(),
+                new Vortice.Direct2D1.BrushProperties
                 {
                     Opacity = brush != null ? (float)brush.Opacity : 1.0f,
                     Transform = target.Transform
@@ -21,12 +21,11 @@ namespace Avalonia.Direct2D1.Media
         /// Direct2D has no ConicGradient implementation so fall back to a solid colour brush based on 
         /// the first gradient stop.
         /// </summary>
-        public SolidColorBrushImpl(IConicGradientBrush brush, SharpDX.Direct2D1.DeviceContext target)
+        public SolidColorBrushImpl(IConicGradientBrush brush, Vortice.Direct2D1.ID2D1DeviceContext target)
         {
-            PlatformBrush = new SharpDX.Direct2D1.SolidColorBrush(
-                target,
-                brush?.GradientStops[0].Color.ToDirect2D() ?? new SharpDX.Mathematics.Interop.RawColor4(),
-                new SharpDX.Direct2D1.BrushProperties
+            PlatformBrush = target.CreateSolidColorBrush(
+                brush?.GradientStops[0].Color.ToDirect2D() ?? new Color(),
+                new Vortice.Direct2D1.BrushProperties
                 {
                     Opacity = brush != null ? (float)brush.Opacity : 1.0f,
                     Transform = target.Transform

--- a/src/Windows/Avalonia.Direct2D1/Media/StreamGeometryContextImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/StreamGeometryContextImpl.cs
@@ -2,17 +2,17 @@ using System;
 using Avalonia.Logging;
 using Avalonia.Media;
 using Avalonia.Platform;
-using SharpDX.Direct2D1;
-using D2D = SharpDX.Direct2D1;
-using SweepDirection = SharpDX.Direct2D1.SweepDirection;
+using Vortice.Direct2D1;
+using D2D = Vortice.Direct2D1;
+using SweepDirection = Vortice.Direct2D1.SweepDirection;
 
 namespace Avalonia.Direct2D1.Media
 {
     public class StreamGeometryContextImpl : IStreamGeometryContextImpl
     {
-        private readonly GeometrySink _sink;
+        private readonly ID2D1GeometrySink _sink;
 
-        public StreamGeometryContextImpl(GeometrySink sink)
+        public StreamGeometryContextImpl(ID2D1GeometrySink sink)
         {
             _sink = sink;
         }

--- a/src/Windows/Avalonia.Direct2D1/Media/StreamGeometryImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/StreamGeometryImpl.cs
@@ -1,5 +1,5 @@
 using Avalonia.Platform;
-using SharpDX.Direct2D1;
+using Vortice.Direct2D1;
 
 namespace Avalonia.Direct2D1.Media
 {
@@ -20,7 +20,7 @@ namespace Avalonia.Direct2D1.Media
         /// Initializes a new instance of the <see cref="StreamGeometryImpl"/> class.
         /// </summary>
         /// <param name="geometry">An existing Direct2D <see cref="PathGeometry"/>.</param>
-        public StreamGeometryImpl(PathGeometry geometry)
+        public StreamGeometryImpl(ID2D1PathGeometry geometry)
             : base(geometry)
         {
         }
@@ -28,10 +28,10 @@ namespace Avalonia.Direct2D1.Media
         /// <inheritdoc/>
         public IStreamGeometryImpl Clone()
         {
-            var result = new PathGeometry(Direct2D1Platform.Direct2D1Factory);
+            var result = Direct2D1Platform.Direct2D1Factory.CreatePathGeometry();
             using (var sink = result.Open())
             {
-                ((PathGeometry)Geometry).Stream(sink);
+                ((ID2D1PathGeometry)Geometry).Stream(sink);
                 sink.Close();
             }
 
@@ -41,12 +41,12 @@ namespace Avalonia.Direct2D1.Media
         /// <inheritdoc/>
         public IStreamGeometryContextImpl Open()
         {
-            return new StreamGeometryContextImpl(((PathGeometry)Geometry).Open());
+            return new StreamGeometryContextImpl(((ID2D1PathGeometry)Geometry).Open());
         }
 
-        private static Geometry CreateGeometry()
+        private static ID2D1Geometry CreateGeometry()
         {
-            return new PathGeometry(Direct2D1Platform.Direct2D1Factory);
+            return Direct2D1Platform.Direct2D1Factory.CreatePathGeometry();
         }
     }
 }

--- a/src/Windows/Avalonia.Direct2D1/Media/TransformedGeometryImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/TransformedGeometryImpl.cs
@@ -1,5 +1,5 @@
 using Avalonia.Platform;
-using SharpDX.Direct2D1;
+using Vortice.Direct2D1;
 
 namespace Avalonia.Direct2D1.Media
 {
@@ -10,7 +10,7 @@ namespace Avalonia.Direct2D1.Media
         /// </summary>
         /// <param name="source">The source geometry.</param>
         /// <param name="geometry">An existing Direct2D <see cref="TransformedGeometry"/>.</param>
-        public TransformedGeometryImpl(TransformedGeometry geometry, GeometryImpl source)
+        public TransformedGeometryImpl(ID2D1TransformedGeometry geometry, GeometryImpl source)
             : base(geometry)
         {
             SourceGeometry = source;
@@ -19,8 +19,8 @@ namespace Avalonia.Direct2D1.Media
         public IGeometryImpl SourceGeometry { get; }
 
         /// <inheritdoc/>
-        public Matrix Transform => ((TransformedGeometry)Geometry).Transform.ToAvalonia();
+        public Matrix Transform => ((ID2D1TransformedGeometry)Geometry).Transform.ToAvalonia();
 
-        protected override Geometry GetSourceGeometry() => ((TransformedGeometry)Geometry).SourceGeometry;
+        protected override ID2D1Geometry GetSourceGeometry() => ((ID2D1TransformedGeometry)Geometry).SourceGeometry;
     }
 }

--- a/src/Windows/Avalonia.Direct2D1/PrimitiveExtensions.cs
+++ b/src/Windows/Avalonia.Direct2D1/PrimitiveExtensions.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Linq;
+using System.Numerics;
 using Avalonia.Platform;
-using SharpDX;
-using SharpDX.Direct2D1;
-using SharpDX.Mathematics.Interop;
-using DWrite = SharpDX.DirectWrite;
+using Vortice;
+using Vortice.Direct2D1;
+using Vortice.Mathematics;
+using DWrite = Vortice.DirectWrite;
 
 namespace Avalonia.Direct2D1
 {
@@ -15,17 +16,17 @@ namespace Avalonia.Direct2D1
         /// </summary>
         public const float ZeroTolerance = 1e-6f; // Value a 8x higher than 1.19209290E-07F
 
-        public static readonly RawRectangleF RectangleInfinite;
+        public static readonly RawRectF RectangleInfinite;
 
         /// <summary>
         /// Gets the identity matrix.
         /// </summary>
         /// <value>The identity matrix.</value>
-        public readonly static RawMatrix3x2 Matrix3x2Identity = new RawMatrix3x2 { M11 = 1, M12 = 0, M21 = 0, M22 = 1, M31 = 0, M32 = 0 };
+        public readonly static Matrix3x2 Matrix3x2Identity = new Matrix3x2 { M11 = 1, M12 = 0, M21 = 0, M22 = 1, M31 = 0, M32 = 0 };
 
         static PrimitiveExtensions()
         {
-            RectangleInfinite = new RawRectangleF
+            RectangleInfinite = new RawRectF
             {
                 Left = float.NegativeInfinity,
                 Top = float.NegativeInfinity,
@@ -34,28 +35,28 @@ namespace Avalonia.Direct2D1
             };
         }
 
-        public static Rect ToAvalonia(this RawRectangleF r)
+        public static Rect ToAvalonia(this RawRectF r)
         {
             return new Rect(new Point(r.Left, r.Top), new Point(r.Right, r.Bottom));
         }
 
-        public static PixelSize ToAvalonia(this Size2 p) => new PixelSize(p.Width, p.Height);
+        public static PixelSize ToAvalonia(this Vortice.Mathematics.Size p) => new PixelSize(p.Width, p.Height);
 
-        public static Vector ToAvaloniaVector(this Size2F p) => new Vector(p.Width, p.Height);
+        public static Vector ToAvaloniaVector(this SizeF p) => new Vector(p.Width, p.Height);
 
-        public static RawRectangleF ToSharpDX(this Rect r)
+        public static RawRectF ToSharpDX(this Rect r)
         {
-            return new RawRectangleF((float)r.X, (float)r.Y, (float)r.Right, (float)r.Bottom);
+            return new RawRectF((float)r.X, (float)r.Y, (float)r.Right, (float)r.Bottom);
         }
 
-        public static RawVector2 ToSharpDX(this Point p)
+        public static PointF ToSharpDX(this Point p)
         {
-            return new RawVector2 { X = (float)p.X, Y = (float)p.Y };
+            return new PointF { X = (float)p.X, Y = (float)p.Y };
         }
 
-        public static Size2F ToSharpDX(this Size p)
+        public static SizeF ToSharpDX(this Size p)
         {
-            return new Size2F((float)p.Width, (float)p.Height);
+            return new SizeF((float)p.Width, (float)p.Height);
         }
 
         public static ExtendMode ToDirect2D(this Avalonia.Media.GradientSpreadMethod spreadMethod)
@@ -68,7 +69,7 @@ namespace Avalonia.Direct2D1
                 return ExtendMode.Wrap;
         }
 
-        public static SharpDX.Direct2D1.LineJoin ToDirect2D(this Avalonia.Media.PenLineJoin lineJoin)
+        public static Vortice.Direct2D1.LineJoin ToDirect2D(this Avalonia.Media.PenLineJoin lineJoin)
         {
             if (lineJoin == Avalonia.Media.PenLineJoin.Round)
                 return LineJoin.Round;
@@ -78,7 +79,7 @@ namespace Avalonia.Direct2D1
                 return LineJoin.Bevel;
         }
         
-        public static SharpDX.Direct2D1.CapStyle ToDirect2D(this Avalonia.Media.PenLineCap lineCap)
+        public static Vortice.Direct2D1.CapStyle ToDirect2D(this Avalonia.Media.PenLineCap lineCap)
         {
             if (lineCap == Avalonia.Media.PenLineCap.Flat)
                 return CapStyle.Flat;
@@ -95,11 +96,11 @@ namespace Avalonia.Direct2D1
             bool isPremul = alphaFormat == AlphaFormat.Premul;
 
             if (format == Platform.PixelFormat.Rgb565)
-                return SharpDX.WIC.PixelFormat.Format16bppBGR565;
+                return Vortice.WIC.PixelFormat.Format16bppBGR565;
             if (format == Platform.PixelFormat.Bgra8888)
-                return isPremul ? SharpDX.WIC.PixelFormat.Format32bppPBGRA : SharpDX.WIC.PixelFormat.Format32bppBGRA;
+                return isPremul ? Vortice.WIC.PixelFormat.Format32bppPBGRA : Vortice.WIC.PixelFormat.Format32bppBGRA;
             if (format == Platform.PixelFormat.Rgba8888)
-                return isPremul ? SharpDX.WIC.PixelFormat.Format32bppPRGBA : SharpDX.WIC.PixelFormat.Format32bppRGBA;
+                return isPremul ? Vortice.WIC.PixelFormat.Format32bppPRGBA : Vortice.WIC.PixelFormat.Format32bppRGBA;
             throw new ArgumentException("Unknown pixel format");
         }
 
@@ -109,7 +110,7 @@ namespace Avalonia.Direct2D1
         /// <param name="pen">The pen to convert.</param>
         /// <param name="renderTarget">The render target.</param>
         /// <returns>The Direct2D brush.</returns>
-        public static StrokeStyle ToDirect2DStrokeStyle(this Avalonia.Media.IPen pen, SharpDX.Direct2D1.RenderTarget renderTarget)
+        public static ID2D1StrokeStyle ToDirect2DStrokeStyle(this Avalonia.Media.IPen pen, Vortice.Direct2D1.ID2D1RenderTarget renderTarget)
         {
             return pen.ToDirect2DStrokeStyle(Direct2D1Platform.Direct2D1Factory);
         }
@@ -120,7 +121,7 @@ namespace Avalonia.Direct2D1
         /// <param name="pen">The pen to convert.</param>
         /// <param name="factory">The factory associated with this resource.</param>
         /// <returns>The Direct2D brush.</returns>
-        public static StrokeStyle ToDirect2DStrokeStyle(this Avalonia.Media.IPen pen, Factory factory)
+        public static ID2D1StrokeStyle ToDirect2DStrokeStyle(this Avalonia.Media.IPen pen, ID2D1Factory factory)
         {
             var d2dLineCap = pen.LineCap.ToDirect2D();
 
@@ -143,7 +144,7 @@ namespace Avalonia.Direct2D1
 
             dashes = dashes ?? Array.Empty<float>();
 
-            return new StrokeStyle(factory, properties, dashes);
+            return factory.CreateStrokeStyle(properties, dashes);
         }
 
         /// <summary>
@@ -151,9 +152,9 @@ namespace Avalonia.Direct2D1
         /// </summary>
         /// <param name="color">The color to convert.</param>
         /// <returns>The Direct2D color.</returns>
-        public static RawColor4 ToDirect2D(this Avalonia.Media.Color color)
+        public static Color4 ToDirect2D(this Avalonia.Media.Color color)
         {
-            return new RawColor4(
+            return new Color4(
                 (float)(color.R / 255.0),
                 (float)(color.G / 255.0),
                 (float)(color.B / 255.0),
@@ -165,9 +166,9 @@ namespace Avalonia.Direct2D1
         /// </summary>
         /// <param name="matrix">The <see cref="Matrix"/>.</param>
         /// <returns>The <see cref="RawMatrix3x2"/>.</returns>
-        public static RawMatrix3x2 ToDirect2D(this Matrix matrix)
+        public static Matrix3x2 ToDirect2D(this Matrix matrix)
         {
-            return new RawMatrix3x2
+            return new Matrix3x2
             {
                 M11 = (float)matrix.M11,
                 M12 = (float)matrix.M12,
@@ -183,7 +184,7 @@ namespace Avalonia.Direct2D1
         /// </summary>
         /// <param name="matrix">The matrix</param>
         /// <returns>a <see cref="Avalonia.Matrix"/>.</returns>
-        public static Matrix ToAvalonia(this RawMatrix3x2 matrix)
+        public static Matrix ToAvalonia(this Matrix3x2 matrix)
         {
             return new Matrix(
                 matrix.M11,
@@ -195,13 +196,13 @@ namespace Avalonia.Direct2D1
         }
 
         /// <summary>
-        /// Converts a Avalonia <see cref="Rect"/> to a Direct2D <see cref="RawRectangleF"/>
+        /// Converts a Avalonia <see cref="Rect"/> to a Direct2D <see cref="RawRectF"/>
         /// </summary>
         /// <param name="rect">The <see cref="Rect"/>.</param>
-        /// <returns>The <see cref="RawRectangleF"/>.</returns>
-        public static RawRectangleF ToDirect2D(this Rect rect)
+        /// <returns>The <see cref="RawRectF"/>.</returns>
+        public static RawRectF ToDirect2D(this Rect rect)
         {
-            return new RawRectangleF(
+            return new RawRectF(
                 (float)rect.X,
                 (float)rect.Y,
                 (float)rect.Right,

--- a/src/Windows/Avalonia.Direct2D1/RenderTarget.cs
+++ b/src/Windows/Avalonia.Direct2D1/RenderTarget.cs
@@ -10,13 +10,13 @@ namespace Avalonia.Direct2D1
         /// <summary>
         /// The render target.
         /// </summary>
-        private readonly SharpDX.Direct2D1.RenderTarget _renderTarget;
+        private readonly Vortice.Direct2D1.ID2D1RenderTarget _renderTarget;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RenderTarget"/> class.
         /// </summary>
         /// <param name="renderTarget">The render target.</param>
-        public RenderTarget(SharpDX.Direct2D1.RenderTarget renderTarget)
+        public RenderTarget(Vortice.Direct2D1.ID2D1RenderTarget renderTarget)
         {
             _renderTarget = renderTarget;
         }

--- a/src/Windows/Avalonia.Direct2D1/SwapChainRenderTarget.cs
+++ b/src/Windows/Avalonia.Direct2D1/SwapChainRenderTarget.cs
@@ -1,19 +1,21 @@
-﻿using Avalonia.Direct2D1.Media;
+﻿using System.Numerics;
+using Avalonia.Direct2D1.Media;
 using Avalonia.Direct2D1.Media.Imaging;
 using Avalonia.Platform;
 using Avalonia.Rendering;
-using SharpDX;
-using SharpDX.Direct2D1;
-using SharpDX.DXGI;
+using Vortice;
+using Vortice.Direct2D1;
+using Vortice.DXGI;
+using Vortice.Mathematics;
 
 namespace Avalonia.Direct2D1
 {   
     public abstract class SwapChainRenderTarget : IRenderTarget, ILayerFactory
     {
-        private Size2 _savedSize;
-        private Size2F _savedDpi;
-        private DeviceContext _deviceContext;
-        private SwapChain1 _swapChain;
+        private Vortice.Mathematics.Size _savedSize;
+        private Vector2 _savedDpi;
+        private ID2D1DeviceContext _deviceContext;
+        private IDXGISwapChain1 _swapChain;
 
         /// <summary>
         /// Creates a drawing context for a rendering session.
@@ -79,30 +81,35 @@ namespace Avalonia.Direct2D1
                 SwapEffect = SwapEffect.Discard,
             };
 
-            using (var dxgiAdapter = Direct2D1Platform.DxgiDevice.Adapter)
-            using (var dxgiFactory = dxgiAdapter.GetParent<SharpDX.DXGI.Factory2>())
+            Direct2D1Platform.DxgiDevice.GetAdapter(out var dxgiAdapter).CheckError();
+            try
             {
+                using var dxgiFactory = dxgiAdapter.GetParent<Vortice.DXGI.IDXGIFactory2>();
                 _swapChain = CreateSwapChain(dxgiFactory, swapChainDescription);
+            }
+            finally
+            {
+                dxgiAdapter.Dispose();
             }
         }
 
         private void CreateDeviceContext()
         {
-            _deviceContext = new DeviceContext(Direct2D1Platform.Direct2D1Device, DeviceContextOptions.None) { DotsPerInch = _savedDpi };
+            _deviceContext = Direct2D1Platform.Direct2D1Device.CreateDeviceContext(DeviceContextOptions.None);
+            _deviceContext.Dpi = _savedDpi;
 
             if (_swapChain == null)
             {
                 CreateSwapChain();
             }
 
-            using (var dxgiBackBuffer = _swapChain.GetBackBuffer<Surface>(0))
-            using (var d2dBackBuffer = new Bitmap1(
-                _deviceContext,
+            using (var dxgiBackBuffer = _swapChain.GetBuffer<IDXGISurface>(0))
+            using (var d2dBackBuffer = _deviceContext.CreateBitmapFromDxgiSurface(
                 dxgiBackBuffer,
                 new BitmapProperties1(
-                    new SharpDX.Direct2D1.PixelFormat
+                    new Vortice.DCommon.PixelFormat
                     {
-                        AlphaMode = SharpDX.Direct2D1.AlphaMode.Premultiplied,
+                        AlphaMode = Vortice.DCommon.AlphaMode.Premultiplied,
                         Format = Format.B8G8R8A8_UNorm
                     },
                     _savedSize.Width,
@@ -113,10 +120,10 @@ namespace Avalonia.Direct2D1
             }
         }
 
-        protected abstract SwapChain1 CreateSwapChain(SharpDX.DXGI.Factory2 dxgiFactory, SwapChainDescription1 swapChainDesc);
+        protected abstract IDXGISwapChain1 CreateSwapChain(Vortice.DXGI.IDXGIFactory2 dxgiFactory, SwapChainDescription1 swapChainDesc);
 
-        protected abstract Size2F GetWindowDpi();
+        protected abstract SizeF GetWindowDpi();
 
-        protected abstract Size2 GetWindowSize();
+        protected abstract Vortice.Mathematics.Size GetWindowSize();
     }
 }

--- a/src/Windows/Avalonia.Direct2D1/Utils/DebugUtils.cs
+++ b/src/Windows/Avalonia.Direct2D1/Utils/DebugUtils.cs
@@ -4,7 +4,7 @@ namespace Avalonia.Direct2D1.Utils
 {
     internal static class DebugUtils
     {
-        public static void Save(SharpDX.Direct2D1.BitmapRenderTarget bitmap, string filename)
+        public static void Save(Vortice.Direct2D1.ID2D1BitmapRenderTarget bitmap, string filename)
         {
             var rtb = new D2DRenderTargetBitmapImpl(bitmap);
             rtb.Save(filename);

--- a/src/Windows/Avalonia.Win32.Interop/Avalonia.Win32.Interop.csproj
+++ b/src/Windows/Avalonia.Win32.Interop/Avalonia.Win32.Interop.csproj
@@ -16,5 +16,5 @@
     <Compile Include="..\Avalonia.Win32\Interop\UnmanagedMethods.cs" Link="UnmanagedMethods.cs" />
   </ItemGroup>
 
-  <Import Project="..\..\..\build\SharpDX.props" />
+  <Import Project="..\..\..\build\Vortice.Windows.props" />
 </Project>

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/Direct2DImageSurface.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/Direct2DImageSurface.cs
@@ -3,18 +3,17 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
 using Avalonia.Direct2D1;
-using SharpDX.Direct2D1;
-using SharpDX.Direct3D11;
-using SharpDX.Direct3D9;
-using SharpDX.DXGI;
-using AlphaMode = SharpDX.Direct2D1.AlphaMode;
-using Device = SharpDX.Direct3D11.Device;
-using Format = SharpDX.DXGI.Format;
-using Query = SharpDX.Direct3D11.Query;
-using QueryType = SharpDX.Direct3D11.QueryType;
-using RenderTarget = SharpDX.Direct2D1.RenderTarget;
-using Surface = SharpDX.DXGI.Surface;
-using Usage = SharpDX.Direct3D9.Usage;
+using Vortice.Direct2D1;
+using Vortice.Direct3D11;
+using Vortice.Direct3D9;
+using Vortice.DXGI;
+using AlphaMode = Vortice.DCommon.AlphaMode;
+using Device = Vortice.Direct3D11.ID3D11Device;
+using Format = Vortice.DXGI.Format;
+using Query = Vortice.Direct3D11.ID3D11Query;
+using QueryType = Vortice.Direct3D11.QueryType;
+using RenderTarget = Vortice.Direct2D1.ID2D1RenderTarget;
+using Surface = Vortice.DXGI.IDXGISurface;
 
 namespace Avalonia.Win32.Interop.Wpf
 {
@@ -23,9 +22,9 @@ namespace Avalonia.Win32.Interop.Wpf
         class SwapBuffer: IDisposable
         {
             private readonly Query _event;
-            private readonly SharpDX.Direct3D11.Resource _resource;
-            private readonly SharpDX.Direct3D11.Resource _sharedResource;
-            public SharpDX.Direct3D9.Surface Texture { get; }
+            private readonly Vortice.Direct3D11.ID3D11Resource _resource;
+            private readonly Vortice.Direct3D11.ID3D11Resource _sharedResource;
+            public Vortice.Direct3D9.IDirect3DSurface9 Texture { get; }
             public RenderTarget Target { get;}
             public IntSize Size { get; }
 
@@ -33,53 +32,55 @@ namespace Avalonia.Win32.Interop.Wpf
             {
                 int width = (int) size.Width;
                 int height = (int) size.Height;
-                _event = new Query(s_dxDevice, new QueryDescription {Type = QueryType.Event});
-                using (var texture = new Texture2D(s_dxDevice, new Texture2DDescription
+                _event = s_dxDevice.CreateQuery(new QueryDescription {QueryType = QueryType.Event});
+                using (var texture = s_dxDevice.CreateTexture2D(new Texture2DDescription
                 {
                     Width = width,
                     Height = height,
                     ArraySize = 1,
                     MipLevels = 1,
                     Format = Format.B8G8R8A8_UNorm,
-                    Usage = ResourceUsage.Default,
+                    Usage = Vortice.Direct3D11.Usage.Default,
                     SampleDescription = new SampleDescription(2, 0),
                     BindFlags = BindFlags.RenderTarget,
                 }))
                 using (var surface = texture.QueryInterface<Surface>())
                 
                 {
-                    _resource = texture.QueryInterface<SharpDX.Direct3D11.Resource>();
-                    
-                    Target = new RenderTarget(Direct2D1Platform.Direct2D1Factory, surface,
+                    _resource = texture.QueryInterface<Vortice.Direct3D11.ID3D11Resource>();
+
+                    Target = Direct2D1Platform.Direct2D1Factory.CreateDxgiSurfaceRenderTarget(
+                        surface,
                         new RenderTargetProperties
                         {
-                            DpiX = (float) dpi.X,
-                            DpiY = (float) dpi.Y,
+                            DpiX = (float)dpi.X,
+                            DpiY = (float)dpi.Y,
                             MinLevel = FeatureLevel.Level_10,
-                            PixelFormat = new PixelFormat(Format.B8G8R8A8_UNorm, AlphaMode.Premultiplied),
-
+                            PixelFormat = new Vortice.DCommon.PixelFormat(Format.B8G8R8A8_UNorm, AlphaMode.Premultiplied),
                         });
                 }
-                using (var texture = new Texture2D(s_dxDevice, new Texture2DDescription
+                using (var texture = s_dxDevice.CreateTexture2D(new Texture2DDescription
                 {
                     Width = width,
                     Height = height,
                     ArraySize = 1,
                     MipLevels = 1,
                     Format = Format.B8G8R8A8_UNorm,
-                    Usage = ResourceUsage.Default,
+                    Usage = Vortice.Direct3D11.Usage.Default,
                     SampleDescription = new SampleDescription(1, 0),
                     BindFlags = BindFlags.RenderTarget|BindFlags.ShaderResource,
                     OptionFlags = ResourceOptionFlags.Shared,
                 }))
-                using (var resource = texture.QueryInterface<SharpDX.DXGI.Resource>())
+                using (var resource = texture.QueryInterface<Vortice.DXGI.IDXGIResource>())
                 {
-                    _sharedResource = texture.QueryInterface<SharpDX.Direct3D11.Resource>();
+                    _sharedResource = texture.QueryInterface<Vortice.Direct3D11.ID3D11Resource>();
                     var handle = resource.SharedHandle;
-                    using (var texture9 = new Texture(s_d3DDevice, texture.Description.Width,
-                        texture.Description.Height, 1,
-                        Usage.RenderTarget, SharpDX.Direct3D9.Format.A8R8G8B8, Pool.Default, ref handle))
-                        Texture = texture9.GetSurfaceLevel(0);
+                    using var texture9 = s_d3DDevice.CreateTexture(
+                        texture.Description.Width, texture.Description.Height, 1,
+                        Vortice.Direct3D9.Usage.RenderTarget, Vortice.Direct3D9.Format.A8R8G8B8, Pool.Default,
+                        ref handle
+                    );
+                    Texture = texture9.GetSurfaceLevel(0);
                 }
                 Size = size;
             }
@@ -98,7 +99,9 @@ namespace Avalonia.Win32.Interop.Wpf
                 s_dxDevice.ImmediateContext.ResolveSubresource(_resource, 0, _sharedResource, 0, Format.B8G8R8A8_UNorm);
                 s_dxDevice.ImmediateContext.Flush();
                 s_dxDevice.ImmediateContext.End(_event);
-                s_dxDevice.ImmediateContext.GetData(_event).Dispose();
+                while (!s_dxDevice.ImmediateContext.IsDataAvailable(_event))
+                {
+                }
             }
         }
 
@@ -106,8 +109,8 @@ namespace Avalonia.Win32.Interop.Wpf
         private SwapBuffer _backBuffer;
         private readonly WpfTopLevelImpl _impl;
         private static Device s_dxDevice;
-        private static Direct3DEx s_d3DContext;
-        private static DeviceEx s_d3DDevice;
+        private static IDirect3D9Ex s_d3DContext;
+        private static IDirect3DDevice9Ex s_d3DDevice;
         private Vector _oldDpi;
 
 
@@ -117,18 +120,18 @@ namespace Avalonia.Win32.Interop.Wpf
         {
             if(s_d3DDevice != null)
                 return;
-            s_d3DContext = new Direct3DEx();
+            D3D9.Create9Ex(out s_d3DContext).CheckError();
 
-            SharpDX.Direct3D9.PresentParameters presentparams = new SharpDX.Direct3D9.PresentParameters
+            Vortice.Direct3D9.PresentParameters presentparams = new()
             {
                 Windowed = true,
-                SwapEffect = SharpDX.Direct3D9.SwapEffect.Discard,
+                SwapEffect = Vortice.Direct3D9.SwapEffect.Discard,
                 DeviceWindowHandle = GetDesktopWindow(),
                 PresentationInterval = PresentInterval.Default
             };
-            s_dxDevice = s_dxDevice ?? AvaloniaLocator.Current.GetService<SharpDX.DXGI.Device>()
-                             .QueryInterface<SharpDX.Direct3D11.Device>();
-            s_d3DDevice = new DeviceEx(s_d3DContext, 0, DeviceType.Hardware, IntPtr.Zero, CreateFlags.HardwareVertexProcessing | CreateFlags.Multithreaded | CreateFlags.FpuPreserve, presentparams);
+            s_dxDevice ??= AvaloniaLocator.Current.GetService<Vortice.DXGI.IDXGIDevice>()
+                                          .QueryInterface<Vortice.Direct3D11.ID3D11Device>();
+            s_d3DDevice = s_d3DContext.CreateDeviceEx(0, DeviceType.Hardware, IntPtr.Zero, CreateFlags.HardwareVertexProcessing | CreateFlags.Multithreaded | CreateFlags.FpuPreserve, presentparams);
 
         }
 

--- a/tests/Avalonia.Direct2D1.UnitTests/Media/FontManagerImplTests.cs
+++ b/tests/Avalonia.Direct2D1.UnitTests/Media/FontManagerImplTests.cs
@@ -25,9 +25,9 @@ namespace Avalonia.Direct2D1.UnitTests.Media
 
                 Assert.Equal("Arial", font.FontFamily.FamilyNames.GetString(0));
 
-                Assert.Equal(SharpDX.DirectWrite.FontWeight.Normal, font.Weight);
+                Assert.Equal(Vortice.DirectWrite.FontWeight.Normal, font.Weight);
 
-                Assert.Equal(SharpDX.DirectWrite.FontStyle.Normal, font.Style);
+                Assert.Equal(Vortice.DirectWrite.FontStyle.Normal, font.Style);
             }
         }
 
@@ -47,9 +47,9 @@ namespace Avalonia.Direct2D1.UnitTests.Media
 
                 Assert.Equal("Arial", font.FontFamily.FamilyNames.GetString(0));
 
-                Assert.Equal(SharpDX.DirectWrite.FontWeight.Bold, font.Weight);
+                Assert.Equal(Vortice.DirectWrite.FontWeight.Bold, font.Weight);
 
-                Assert.Equal(SharpDX.DirectWrite.FontStyle.Normal, font.Style);
+                Assert.Equal(Vortice.DirectWrite.FontStyle.Normal, font.Style);
             }
         }
 
@@ -71,9 +71,9 @@ namespace Avalonia.Direct2D1.UnitTests.Media
 
                 Assert.Equal(defaultName, font.FontFamily.FamilyNames.GetString(0));
 
-                Assert.Equal(SharpDX.DirectWrite.FontWeight.Normal, font.Weight);
+                Assert.Equal(Vortice.DirectWrite.FontWeight.Normal, font.Weight);
 
-                Assert.Equal(SharpDX.DirectWrite.FontStyle.Normal, font.Style);
+                Assert.Equal(Vortice.DirectWrite.FontStyle.Normal, font.Style);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
Replace deprecated SharpDX with Vortice, updated continuation of SharpDX project. The bindings are a bit closer to native, no "magic constructors", interface names are unchanged, migrated to SharpGen 2.0 branch.

## What is the current behavior?
Avalonia has a dependency on an old version of SharpDX.

## What is the updated/expected behavior with this PR?
Avalonia uses latest version of Vortice.

## How was the solution implemented (if it's not obvious)?
Manually. :)

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
SharpDX is no longer a dependency, Vortice is.

# WORK IN PROGRESS (doesn't even compile at the moment)
1. I would like to know if Avalonia maintainers are interested in migrating from SharpDX to Vortice. This bit is the reason I'm submitting the PR this early.
2. Changes are required in Vortice. E.g. amerkoleci/Vortice.Windows#134, amerkoleci/Vortice.Windows#135 and some other parts related to DWrite interface callbacks.

Note, that Vortice is now strongly-named (as is SharpGen), as required by Avalonia policy.