### PR TITLE
Fix owned windows and dialogs not having a parent.

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -580,7 +580,9 @@ namespace Avalonia.Win32
 
         public void SetParent(IWindowImpl parent)
         {
-            var parentHwnd = ((WindowImpl)parent)?._hwnd ?? IntPtr.Zero;
+            _parent = (WindowImpl)parent;
+            
+            var parentHwnd = _parent?._hwnd ?? IntPtr.Zero;
 
             if (parentHwnd == IntPtr.Zero && !_windowProperties.ShowInTaskbar)
             {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes problems introduced by https://github.com/AvaloniaUI/Avalonia/pull/5715.

## What is the current behavior?
Owned windows and dialogs are not parented correctly on win32. Causing said windows to hide behind the main window and generally have weird behavior when windows get minimized


## What is the updated/expected behavior with this PR?
Back to normal.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
