### PR TITLE
Fix GridSplitter not resizing correctly

### DIFF
--- a/src/Avalonia.Base/Utilities/MathUtilities.cs
+++ b/src/Avalonia.Base/Utilities/MathUtilities.cs
@@ -31,6 +31,21 @@ namespace Avalonia.Utilities
         }
 
         /// <summary>
+        /// AreClose - Returns whether or not two doubles are "close".  That is, whether or
+        /// not they are within epsilon of each other.
+        /// </summary>
+        /// <param name="value1"> The first double to compare. </param>
+        /// <param name="value2"> The second double to compare. </param>
+        /// <param name="eps"> The fixed epsilon value used to compare.</param>
+        public static bool AreClose(double value1, double value2, double eps)
+        {
+            //in case they are Infinities (then epsilon check does not work)
+            if (value1 == value2) return true;
+            double delta = value1 - value2;
+            return (-eps < delta) && (eps > delta);
+        }
+
+        /// <summary>
         /// AreClose - Returns whether or not two floats are "close".  That is, whether or 
         /// not they are within epsilon of each other.
         /// </summary> 

--- a/src/Avalonia.Controls/GridSplitter.cs
+++ b/src/Avalonia.Controls/GridSplitter.cs
@@ -632,11 +632,11 @@ namespace Avalonia.Controls
                 double actualLength2 = GetActualLength(definition2);
 
                 // When splitting, Check to see if the total pixels spanned by the definitions 
-                // is the same asbefore starting resize. If not cancel the drag
+                // is the same as before starting resize. If not cancel the drag.
                 if (_resizeData.SplitBehavior == SplitBehavior.Split &&
                     !MathUtilities.AreClose(
                         actualLength1 + actualLength2,
-                        _resizeData.OriginalDefinition1ActualLength + _resizeData.OriginalDefinition2ActualLength))
+                        _resizeData.OriginalDefinition1ActualLength + _resizeData.OriginalDefinition2ActualLength, LayoutHelper.LayoutEpsilon))
                 {
                     CancelResize();
 

--- a/src/Avalonia.Controls/GridSplitter.cs
+++ b/src/Avalonia.Controls/GridSplitter.cs
@@ -609,10 +609,20 @@ namespace Avalonia.Controls
         private void MoveSplitter(double horizontalChange, double verticalChange)
         {
             Debug.Assert(_resizeData != null, "_resizeData should not be null when calling MoveSplitter");
-
-            // Calculate the offset to adjust the splitter.
-            var delta = _resizeData.ResizeDirection == GridResizeDirection.Columns ? horizontalChange : verticalChange;
-
+            
+            // Calculate the offset to adjust the splitter.  If layout rounding is enabled, we
+            // need to round to an integer physical pixel value to avoid round-ups of children that
+            // expand the bounds of the Grid.  In practice this only happens in high dpi because
+            // horizontal/vertical offsets here are never fractional (they correspond to mouse movement
+            // across logical pixels).  Rounding error only creeps in when converting to a physical
+            // display with something other than the logical 96 dpi.
+            double delta = _resizeData.ResizeDirection == GridResizeDirection.Columns ? horizontalChange : verticalChange;
+            
+            if (UseLayoutRounding)
+            {
+                delta = LayoutHelper.RoundLayoutValue(delta, LayoutHelper.GetLayoutScale(this));
+            }
+            
             DefinitionBase definition1 = _resizeData.Definition1;
             DefinitionBase definition2 = _resizeData.Definition2;
 

--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -378,7 +378,7 @@ namespace Avalonia.Controls.Presenters
             var useLayoutRounding = UseLayoutRounding;
             var availableSize = finalSize;
             var sizeForChild = availableSize;
-            var scale = GetLayoutScale();
+            var scale = LayoutHelper.GetLayoutScale(this);
             var originX = offset.X;
             var originY = offset.Y;
 
@@ -460,18 +460,6 @@ namespace Avalonia.Controls.Presenters
         private void UpdatePseudoClasses()
         {
             PseudoClasses.Set(":empty", Content is null);
-        }
-
-        private double GetLayoutScale()
-        {
-            var result = (VisualRoot as ILayoutRoot)?.LayoutScaling ?? 1.0;
-
-            if (result == 0 || double.IsNaN(result) || double.IsInfinity(result))
-            {
-                throw new Exception($"Invalid LayoutScaling returned from {VisualRoot.GetType()}");
-            }
-
-            return result;
         }
 
         private void TemplatedParentChanged(AvaloniaPropertyChangedEventArgs e)

--- a/src/Avalonia.Layout/LayoutHelper.cs
+++ b/src/Avalonia.Layout/LayoutHelper.cs
@@ -83,6 +83,25 @@ namespace Avalonia.Layout
         }
 
         /// <summary>
+        /// Obtains layout scale of the given control.
+        /// </summary>
+        /// <param name="control">The control.</param>
+        /// <exception cref="Exception">Thrown when control has no root or returned layout scaling is invalid.</exception>
+        public static double GetLayoutScale(ILayoutable control)
+        {
+            var visualRoot = control.VisualRoot;
+            
+            var result = (visualRoot as ILayoutRoot)?.LayoutScaling ?? 1.0;
+
+            if (result == 0 || double.IsNaN(result) || double.IsInfinity(result))
+            {
+                throw new Exception($"Invalid LayoutScaling returned from {visualRoot.GetType()}");
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// Rounds a size to integer values for layout purposes, compensating for high DPI screen
         /// coordinates.
         /// </summary>

--- a/src/Avalonia.Layout/LayoutHelper.cs
+++ b/src/Avalonia.Layout/LayoutHelper.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Layout
         /// Epsilon value used for certain layout calculations.
         /// Based on the value in WPF LayoutDoubleUtil.
         /// </summary>
-        public const double LayoutEpsilon = 0.00000153;
+        public static double LayoutEpsilon { get; } = 0.00000153;
 
         /// <summary>
         /// Calculates a control's size based on its <see cref="ILayoutable.Width"/>,

--- a/src/Avalonia.Layout/LayoutHelper.cs
+++ b/src/Avalonia.Layout/LayoutHelper.cs
@@ -10,6 +10,12 @@ namespace Avalonia.Layout
     public static class LayoutHelper
     {
         /// <summary>
+        /// Epsilon value used for certain layout calculations.
+        /// Based on the value in WPF LayoutDoubleUtil.
+        /// </summary>
+        public const double LayoutEpsilon = 0.00000153;
+
+        /// <summary>
         /// Calculates a control's size based on its <see cref="ILayoutable.Width"/>,
         /// <see cref="ILayoutable.Height"/>, <see cref="ILayoutable.MinWidth"/>,
         /// <see cref="ILayoutable.MaxWidth"/>, <see cref="ILayoutable.MinHeight"/> and

--- a/src/Avalonia.Layout/Layoutable.cs
+++ b/src/Avalonia.Layout/Layoutable.cs
@@ -590,7 +590,7 @@ namespace Avalonia.Layout
 
                 if (UseLayoutRounding)
                 {
-                    var scale = GetLayoutScale();
+                    var scale = LayoutHelper.GetLayoutScale(this);
                     width = LayoutHelper.RoundLayoutValue(width, scale);
                     height = LayoutHelper.RoundLayoutValue(height, scale);
                 }
@@ -652,7 +652,7 @@ namespace Avalonia.Layout
                 var horizontalAlignment = HorizontalAlignment;
                 var verticalAlignment = VerticalAlignment;
                 var size = availableSizeMinusMargins;
-                var scale = GetLayoutScale();
+                var scale = LayoutHelper.GetLayoutScale(this);
                 var useLayoutRounding = UseLayoutRounding;
 
                 if (horizontalAlignment != HorizontalAlignment.Stretch)
@@ -832,18 +832,6 @@ namespace Avalonia.Layout
         private static Size NonNegative(Size size)
         {
             return new Size(Math.Max(size.Width, 0), Math.Max(size.Height, 0));
-        }
-
-        private double GetLayoutScale()
-        {
-            var result =  (VisualRoot as ILayoutRoot)?.LayoutScaling ?? 1.0;
-
-            if (result == 0 || double.IsNaN(result) || double.IsInfinity(result))
-            {
-                throw new Exception($"Invalid LayoutScaling returned from {VisualRoot.GetType()}");
-            }
-
-            return result;
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
When porting `GridSplitter` I've omitted DPI correction for some reason. This PR brings it back.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
As described in #5759 - splitter does not work correctly in higher DPI.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Splitter works better in high DPI. One more fix is needed before it will function correctly.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

Ported https://github.com/dotnet/wpf/blob/main/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridSplitter.cs#L872-L895

@rstm-sf It seems that WPF uses a random number as an epsilon for layout calculations. I wonder if we can come up with something better or we should just allow for using custom epsilons with checks.

https://github.com/dotnet/wpf/blob/826e2df1774c8beaf71d757d776a20b714b6dd5e/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs#L6440-L6456

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->


## Fixed issues
Fixes #5759
