### PR TITLE
Button state update when CommandParameter changed

### DIFF
--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -89,6 +89,7 @@ namespace Avalonia.Controls
         {
             FocusableProperty.OverrideDefaultValue(typeof(Button), true);
             CommandProperty.Changed.Subscribe(CommandChanged);
+            CommandParameterProperty.Changed.Subscribe(CommandParameterChanged);
             IsDefaultProperty.Changed.Subscribe(IsDefaultChanged);
             IsCancelProperty.Changed.Subscribe(IsCancelChanged);
         }
@@ -376,6 +377,18 @@ namespace Avalonia.Controls
                     }
                 }
 
+                button.CanExecuteChanged(button, EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Called when the <see cref="CommandParameter"/> property changes.
+        /// </summary>
+        /// <param name="e">The event args.</param>
+        private static void CommandParameterChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            if (e.Sender is Button button)
+            {
                 button.CanExecuteChanged(button, EventArgs.Empty);
             }
         }


### PR DESCRIPTION
## What does the pull request do?
Updates `Button.IsEnabled` after change `Button.CommandParameter`

## What is the current behavior?
`Button.CommandParameter` changes doesn't affect `IsEnabled`

## How was the solution implemented (if it's not obvious)?
Porting `MenuItem` code to `Button`