### PR TITLE
Fixed popup positioning issue

### DIFF
--- a/src/Avalonia.Base/Data/BindingValue.cs
+++ b/src/Avalonia.Base/Data/BindingValue.cs
@@ -108,12 +108,12 @@ namespace Avalonia.Data
         /// Gets a value indicating whether the binding value represents either a binding or data
         /// validation error.
         /// </summary>
-        public bool HasError => Type.HasFlagCustom(BindingValueType.HasError);
+        public bool HasError => Type.HasAllFlags(BindingValueType.HasError);
 
         /// <summary>
         /// Gets a value indicating whether the binding value has a value.
         /// </summary>
-        public bool HasValue => Type.HasFlagCustom(BindingValueType.HasValue);
+        public bool HasValue => Type.HasAllFlags(BindingValueType.HasValue);
 
         /// <summary>
         /// Gets the type of the binding value.

--- a/src/Avalonia.Base/EnumExtensions.cs
+++ b/src/Avalonia.Base/EnumExtensions.cs
@@ -9,7 +9,7 @@ namespace Avalonia
     public static class EnumExtensions
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool HasFlagCustom<T>(this T value, T flag) where T : unmanaged, Enum
+        public static unsafe bool HasAllFlags<T>(this T value, T flag) where T : unmanaged, Enum
         {
             if (sizeof(T) == 1)
             {
@@ -34,6 +34,37 @@ namespace Avalonia
                 var longValue = Unsafe.As<T, long>(ref value);
                 var longFlag = Unsafe.As<T, long>(ref flag);
                 return (longValue & longFlag) == longFlag;
+            }
+            else
+                throw new NotSupportedException("Enum with size of " + Unsafe.SizeOf<T>() + " are not supported");
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe bool HasAnyFlag<T>(this T value, T flag) where T : unmanaged, Enum
+        {
+            if (sizeof(T) == 1)
+            {
+                var byteValue = Unsafe.As<T, byte>(ref value);
+                var byteFlag = Unsafe.As<T, byte>(ref flag);
+                return (byteValue & byteFlag) != 0;
+            }
+            else if (sizeof(T) == 2)
+            {
+                var shortValue = Unsafe.As<T, short>(ref value);
+                var shortFlag = Unsafe.As<T, short>(ref flag);
+                return (shortValue & shortFlag) != 0;
+            }
+            else if (sizeof(T) == 4)
+            {
+                var intValue = Unsafe.As<T, int>(ref value);
+                var intFlag = Unsafe.As<T, int>(ref flag);
+                return (intValue & intFlag) != 0;
+            }
+            else if (sizeof(T) == 8)
+            {
+                var longValue = Unsafe.As<T, long>(ref value);
+                var longFlag = Unsafe.As<T, long>(ref flag);
+                return (longValue & longFlag) != 0;
             }
             else
                 throw new NotSupportedException("Enum with size of " + Unsafe.SizeOf<T>() + " are not supported");

--- a/src/Avalonia.Base/EnumExtensions.cs
+++ b/src/Avalonia.Base/EnumExtensions.cs
@@ -9,62 +9,67 @@ namespace Avalonia
     public static class EnumExtensions
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool HasAllFlags<T>(this T value, T flag) where T : unmanaged, Enum
+        [Obsolete("This method is obsolete. Use HasAllFlags instead.")]
+        public static bool HasFlagCustom<T>(this T value, T flag) where T : unmanaged, Enum
+            => value.HasAllFlags(flag);
+            
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe bool HasAllFlags<T>(this T value, T flags) where T : unmanaged, Enum
         {
             if (sizeof(T) == 1)
             {
                 var byteValue = Unsafe.As<T, byte>(ref value);
-                var byteFlag = Unsafe.As<T, byte>(ref flag);
-                return (byteValue & byteFlag) == byteFlag;
+                var byteFlags = Unsafe.As<T, byte>(ref flags);
+                return (byteValue & byteFlags) == byteFlags;
             }
             else if (sizeof(T) == 2)
             {
                 var shortValue = Unsafe.As<T, short>(ref value);
-                var shortFlag = Unsafe.As<T, short>(ref flag);
-                return (shortValue & shortFlag) == shortFlag;
+                var shortFlags = Unsafe.As<T, short>(ref flags);
+                return (shortValue & shortFlags) == shortFlags;
             }
             else if (sizeof(T) == 4)
             {
                 var intValue = Unsafe.As<T, int>(ref value);
-                var intFlag = Unsafe.As<T, int>(ref flag);
-                return (intValue & intFlag) == intFlag;
+                var intFlags = Unsafe.As<T, int>(ref flags);
+                return (intValue & intFlags) == intFlags;
             }
             else if (sizeof(T) == 8)
             {
                 var longValue = Unsafe.As<T, long>(ref value);
-                var longFlag = Unsafe.As<T, long>(ref flag);
-                return (longValue & longFlag) == longFlag;
+                var longFlags = Unsafe.As<T, long>(ref flags);
+                return (longValue & longFlags) == longFlags;
             }
             else
                 throw new NotSupportedException("Enum with size of " + Unsafe.SizeOf<T>() + " are not supported");
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool HasAnyFlag<T>(this T value, T flag) where T : unmanaged, Enum
+        public static unsafe bool HasAnyFlag<T>(this T value, T flags) where T : unmanaged, Enum
         {
             if (sizeof(T) == 1)
             {
                 var byteValue = Unsafe.As<T, byte>(ref value);
-                var byteFlag = Unsafe.As<T, byte>(ref flag);
-                return (byteValue & byteFlag) != 0;
+                var byteFlags = Unsafe.As<T, byte>(ref flags);
+                return (byteValue & byteFlags) != 0;
             }
             else if (sizeof(T) == 2)
             {
                 var shortValue = Unsafe.As<T, short>(ref value);
-                var shortFlag = Unsafe.As<T, short>(ref flag);
-                return (shortValue & shortFlag) != 0;
+                var shortFlags = Unsafe.As<T, short>(ref flags);
+                return (shortValue & shortFlags) != 0;
             }
             else if (sizeof(T) == 4)
             {
                 var intValue = Unsafe.As<T, int>(ref value);
-                var intFlag = Unsafe.As<T, int>(ref flag);
-                return (intValue & intFlag) != 0;
+                var intFlags = Unsafe.As<T, int>(ref flags);
+                return (intValue & intFlags) != 0;
             }
             else if (sizeof(T) == 8)
             {
                 var longValue = Unsafe.As<T, long>(ref value);
-                var longFlag = Unsafe.As<T, long>(ref flag);
-                return (longValue & longFlag) != 0;
+                var longFlags = Unsafe.As<T, long>(ref flags);
+                return (longValue & longFlags) != 0;
             }
             else
                 throw new NotSupportedException("Enum with size of " + Unsafe.SizeOf<T>() + " are not supported");

--- a/src/Avalonia.Base/Utilities/TypeUtilities.cs
+++ b/src/Avalonia.Base/Utilities/TypeUtilities.cs
@@ -372,8 +372,8 @@ namespace Avalonia.Utilities
             const string implicitName = "op_Implicit";
             const string explicitName = "op_Explicit";
 
-            bool allowImplicit = operatorType.HasFlagCustom(OperatorType.Implicit);
-            bool allowExplicit = operatorType.HasFlagCustom(OperatorType.Explicit);
+            bool allowImplicit = operatorType.HasAllFlags(OperatorType.Implicit);
+            bool allowExplicit = operatorType.HasAllFlags(OperatorType.Explicit);
 
             foreach (MethodInfo method in fromType.GetMethods())
             {

--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
@@ -2595,7 +2595,7 @@ namespace Avalonia.Collections
         /// <returns>Whether the specified flag is set</returns>
         private bool CheckFlag(CollectionViewFlags flags)
         {
-            return _flags.HasFlagCustom(flags);
+            return _flags.HasAllFlags(flags);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -206,7 +206,7 @@ namespace Avalonia.Controls
                 return;
 
             if (e.Key == Key.F4 ||
-                ((e.Key == Key.Down || e.Key == Key.Up) && e.KeyModifiers.HasFlagCustom(KeyModifiers.Alt)))
+                ((e.Key == Key.Down || e.Key == Key.Up) && e.KeyModifiers.HasAllFlags(KeyModifiers.Alt)))
             {
                 IsDropDownOpen = !IsDropDownOpen;
                 e.Handled = true;

--- a/src/Avalonia.Controls/Converters/PlatformKeyGestureConverter.cs
+++ b/src/Avalonia.Controls/Converters/PlatformKeyGestureConverter.cs
@@ -72,24 +72,24 @@ namespace Avalonia.Controls.Converters
                 }
             }
 
-            if (gesture.KeyModifiers.HasFlagCustom(KeyModifiers.Control))
+            if (gesture.KeyModifiers.HasAllFlags(KeyModifiers.Control))
             {
                 s.Append("Ctrl");
             }
 
-            if (gesture.KeyModifiers.HasFlagCustom(KeyModifiers.Shift))
+            if (gesture.KeyModifiers.HasAllFlags(KeyModifiers.Shift))
             {
                 Plus(s);
                 s.Append("Shift");
             }
 
-            if (gesture.KeyModifiers.HasFlagCustom(KeyModifiers.Alt))
+            if (gesture.KeyModifiers.HasAllFlags(KeyModifiers.Alt))
             {
                 Plus(s);
                 s.Append("Alt");
             }
 
-            if (gesture.KeyModifiers.HasFlagCustom(KeyModifiers.Meta))
+            if (gesture.KeyModifiers.HasAllFlags(KeyModifiers.Meta))
             {
                 Plus(s);
                 s.Append(meta);
@@ -105,22 +105,22 @@ namespace Avalonia.Controls.Converters
         {
             var s = new StringBuilder();
 
-            if (gesture.KeyModifiers.HasFlagCustom(KeyModifiers.Control))
+            if (gesture.KeyModifiers.HasAllFlags(KeyModifiers.Control))
             {
                 s.Append('⌃');
             }
 
-            if (gesture.KeyModifiers.HasFlagCustom(KeyModifiers.Alt))
+            if (gesture.KeyModifiers.HasAllFlags(KeyModifiers.Alt))
             {
                 s.Append('⌥');
             }
 
-            if (gesture.KeyModifiers.HasFlagCustom(KeyModifiers.Shift))
+            if (gesture.KeyModifiers.HasAllFlags(KeyModifiers.Shift))
             {
                 s.Append('⇧');
             }
 
-            if (gesture.KeyModifiers.HasFlagCustom(KeyModifiers.Meta))
+            if (gesture.KeyModifiers.HasAllFlags(KeyModifiers.Meta))
             {
                 s.Append('⌘');
             }

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -2355,7 +2355,7 @@ namespace Avalonia.Controls
         /// </summary>
         private bool CheckFlags(Flags flags)
         {
-            return _flags.HasFlagCustom(flags);
+            return _flags.HasAllFlags(flags);
         }
 
         private static void OnShowGridLinesPropertyChanged(AvaloniaObject d, AvaloniaPropertyChangedEventArgs e)
@@ -2790,10 +2790,10 @@ namespace Avalonia.Controls
             internal LayoutTimeSizeType SizeTypeU;
             internal LayoutTimeSizeType SizeTypeV;
             internal int Next;
-            internal bool IsStarU => SizeTypeU.HasFlagCustom(LayoutTimeSizeType.Star);
-            internal bool IsAutoU => SizeTypeU.HasFlagCustom(LayoutTimeSizeType.Auto);
-            internal bool IsStarV => SizeTypeV.HasFlagCustom(LayoutTimeSizeType.Star);
-            internal bool IsAutoV => SizeTypeV.HasFlagCustom(LayoutTimeSizeType.Auto);
+            internal bool IsStarU => SizeTypeU.HasAllFlags(LayoutTimeSizeType.Star);
+            internal bool IsAutoU => SizeTypeU.HasAllFlags(LayoutTimeSizeType.Auto);
+            internal bool IsStarV => SizeTypeV.HasAllFlags(LayoutTimeSizeType.Star);
+            internal bool IsAutoV => SizeTypeV.HasAllFlags(LayoutTimeSizeType.Auto);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -135,8 +135,8 @@ namespace Avalonia.Controls
                 e.Handled = UpdateSelectionFromEventSource(
                     e.Source,
                     true,
-                    e.KeyModifiers.HasFlagCustom(KeyModifiers.Shift),
-                    e.KeyModifiers.HasFlagCustom(KeyModifiers.Control));
+                    e.KeyModifiers.HasAllFlags(KeyModifiers.Shift),
+                    e.KeyModifiers.HasAllFlags(KeyModifiers.Control));
             }
         }
 
@@ -154,8 +154,8 @@ namespace Avalonia.Controls
                     e.Handled = UpdateSelectionFromEventSource(
                         e.Source,
                         true,
-                        e.KeyModifiers.HasFlagCustom(KeyModifiers.Shift),
-                        e.KeyModifiers.HasFlagCustom(KeyModifiers.Control),
+                        e.KeyModifiers.HasAllFlags(KeyModifiers.Shift),
+                        e.KeyModifiers.HasAllFlags(KeyModifiers.Control),
                         point.Properties.IsRightButtonPressed);
                 }
             }

--- a/src/Avalonia.Controls/Platform/InProcessDragSource.cs
+++ b/src/Avalonia.Controls/Platform/InProcessDragSource.cs
@@ -73,20 +73,20 @@ namespace Avalonia.Platform
         {
             if (effect == DragDropEffects.Copy || effect == DragDropEffects.Move || effect == DragDropEffects.Link || effect == DragDropEffects.None)
                 return effect; // No need to check for the modifiers.
-            if (effect.HasFlagCustom(DragDropEffects.Link) && modifiers.HasFlagCustom(RawInputModifiers.Alt))
+            if (effect.HasAllFlags(DragDropEffects.Link) && modifiers.HasAllFlags(RawInputModifiers.Alt))
                 return DragDropEffects.Link;
-            if (effect.HasFlagCustom(DragDropEffects.Copy) && modifiers.HasFlagCustom(RawInputModifiers.Control))
+            if (effect.HasAllFlags(DragDropEffects.Copy) && modifiers.HasAllFlags(RawInputModifiers.Control))
                 return DragDropEffects.Copy;
             return DragDropEffects.Move;
         }
 
         private StandardCursorType GetCursorForDropEffect(DragDropEffects effects)
         {
-            if (effects.HasFlagCustom(DragDropEffects.Copy))
+            if (effects.HasAllFlags(DragDropEffects.Copy))
                 return StandardCursorType.DragCopy;
-            if (effects.HasFlagCustom(DragDropEffects.Move))
+            if (effects.HasAllFlags(DragDropEffects.Move))
                 return StandardCursorType.DragMove;
-            if (effects.HasFlagCustom(DragDropEffects.Link))
+            if (effects.HasAllFlags(DragDropEffects.Link))
                 return StandardCursorType.DragLink;
             return StandardCursorType.No;
         }
@@ -161,7 +161,7 @@ namespace Avalonia.Platform
             
             void CheckDraggingAccepted(RawInputModifiers changedMouseButton)
             {
-                if (_initialInputModifiers.Value.HasFlagCustom(changedMouseButton))
+                if (_initialInputModifiers.Value.HasAllFlags(changedMouseButton))
                 {
                     var result = RaiseEventAndUpdateCursor(RawDragEventType.Drop, e.Root, e.Position, e.InputModifiers);
                     UpdateCursor(null, DragDropEffects.None);

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
@@ -253,8 +253,8 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
     {
         public static void ValidateEdge(this PopupAnchor edge)
         {
-            if (edge.HasFlagCustom(PopupAnchor.Left) && edge.HasFlagCustom(PopupAnchor.Right) ||
-                edge.HasFlagCustom(PopupAnchor.Top) && edge.HasFlagCustom(PopupAnchor.Bottom))
+            if (edge.HasAllFlags(PopupAnchor.Left) && edge.HasAllFlags(PopupAnchor.Right) ||
+                edge.HasAllFlags(PopupAnchor.Top) && edge.HasAllFlags(PopupAnchor.Bottom))
                 throw new ArgumentException("Opposite edges specified");
         }
 
@@ -265,10 +265,10 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
 
         public static PopupAnchor Flip(this PopupAnchor edge)
         {
-            if (edge.HasFlagCustom(PopupAnchor.HorizontalMask))
+            if (edge.HasAnyFlag(PopupAnchor.HorizontalMask))
                 edge ^= PopupAnchor.HorizontalMask;
 
-            if (edge.HasFlagCustom(PopupAnchor.VerticalMask))
+            if (edge.HasAnyFlag(PopupAnchor.VerticalMask))
                 edge ^= PopupAnchor.VerticalMask;
 
             return edge;
@@ -276,14 +276,14 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
 
         public static PopupAnchor FlipX(this PopupAnchor edge)
         {
-            if (edge.HasFlagCustom(PopupAnchor.HorizontalMask))
+            if (edge.HasAnyFlag(PopupAnchor.HorizontalMask))
                 edge ^= PopupAnchor.HorizontalMask;
             return edge;
         }
         
         public static PopupAnchor FlipY(this PopupAnchor edge)
         {
-            if (edge.HasFlagCustom(PopupAnchor.VerticalMask))
+            if (edge.HasAnyFlag(PopupAnchor.VerticalMask))
                 edge ^= PopupAnchor.VerticalMask;
             return edge;
         }

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
@@ -253,8 +253,8 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
     {
         public static void ValidateEdge(this PopupAnchor edge)
         {
-            if (edge.HasAllFlags(PopupAnchor.Left) && edge.HasAllFlags(PopupAnchor.Right) ||
-                edge.HasAllFlags(PopupAnchor.Top) && edge.HasAllFlags(PopupAnchor.Bottom))
+            if (edge.HasAllFlags(PopupAnchor.Left | PopupAnchor.Right) ||
+                edge.HasAllFlags(PopupAnchor.Top | PopupAnchor.Bottom))
                 throw new ArgumentException("Opposite edges specified");
         }
 

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositioner.cs
@@ -42,16 +42,16 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
         private static Point GetAnchorPoint(Rect anchorRect, PopupAnchor edge)
         {
             double x, y;
-            if (edge.HasFlagCustom(PopupAnchor.Left))
+            if (edge.HasAllFlags(PopupAnchor.Left))
                 x = anchorRect.X;
-            else if (edge.HasFlagCustom(PopupAnchor.Right))
+            else if (edge.HasAllFlags(PopupAnchor.Right))
                 x = anchorRect.Right;
             else
                 x = anchorRect.X + anchorRect.Width / 2;
             
-            if (edge.HasFlagCustom(PopupAnchor.Top))
+            if (edge.HasAllFlags(PopupAnchor.Top))
                 y = anchorRect.Y;
-            else if (edge.HasFlagCustom(PopupAnchor.Bottom))
+            else if (edge.HasAllFlags(PopupAnchor.Bottom))
                 y = anchorRect.Bottom;
             else
                 y = anchorRect.Y + anchorRect.Height / 2;
@@ -61,16 +61,16 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
         private static Point Gravitate(Point anchorPoint, Size size, PopupGravity gravity)
         {
             double x, y;
-            if (gravity.HasFlagCustom(PopupGravity.Left))
+            if (gravity.HasAllFlags(PopupGravity.Left))
                 x = -size.Width;
-            else if (gravity.HasFlagCustom(PopupGravity.Right))
+            else if (gravity.HasAllFlags(PopupGravity.Right))
                 x = 0;
             else
                 x = -size.Width / 2;
             
-            if (gravity.HasFlagCustom(PopupGravity.Top))
+            if (gravity.HasAllFlags(PopupGravity.Top))
                 y = -size.Height;
-            else if (gravity.HasFlagCustom(PopupGravity.Bottom))
+            else if (gravity.HasAllFlags(PopupGravity.Bottom))
                 y = 0;
             else
                 y = -size.Height / 2;
@@ -125,10 +125,10 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
 
             bool FitsInBounds(Rect rc, PopupAnchor edge = PopupAnchor.AllMask)
             {
-                if (edge.HasFlagCustom(PopupAnchor.Left) && rc.X < bounds.X ||
-                    edge.HasFlagCustom(PopupAnchor.Top) && rc.Y < bounds.Y ||
-                    edge.HasFlagCustom(PopupAnchor.Right) && rc.Right > bounds.Right ||
-                    edge.HasFlagCustom(PopupAnchor.Bottom) && rc.Bottom > bounds.Bottom)
+                if (edge.HasAllFlags(PopupAnchor.Left) && rc.X < bounds.X ||
+                    edge.HasAllFlags(PopupAnchor.Top) && rc.Y < bounds.Y ||
+                    edge.HasAllFlags(PopupAnchor.Right) && rc.Right > bounds.Right ||
+                    edge.HasAllFlags(PopupAnchor.Bottom) && rc.Bottom > bounds.Bottom)
                 {
                     return false;
                 }
@@ -147,7 +147,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             // If flipping geometry and anchor is allowed and helps, use the flipped one,
             // otherwise leave it as is
             if (!FitsInBounds(geo, PopupAnchor.HorizontalMask)
-                && constraintAdjustment.HasFlagCustom(PopupPositionerConstraintAdjustment.FlipX))
+                && constraintAdjustment.HasAllFlags(PopupPositionerConstraintAdjustment.FlipX))
             {
                 var flipped = GetUnconstrained(anchor.FlipX(), gravity.FlipX());
                 if (FitsInBounds(flipped, PopupAnchor.HorizontalMask))
@@ -155,7 +155,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             }
 
             // If sliding is allowed, try moving the rect into the bounds
-            if (constraintAdjustment.HasFlagCustom(PopupPositionerConstraintAdjustment.SlideX))
+            if (constraintAdjustment.HasAllFlags(PopupPositionerConstraintAdjustment.SlideX))
             {
                 geo = geo.WithX(Math.Max(geo.X, bounds.X));
                 if (geo.Right > bounds.Right)
@@ -163,7 +163,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             }
             
             // Resize the rect horizontally if allowed.
-            if (constraintAdjustment.HasFlagCustom(PopupPositionerConstraintAdjustment.ResizeX))
+            if (constraintAdjustment.HasAllFlags(PopupPositionerConstraintAdjustment.ResizeX))
             {
                 var unconstrainedRect = geo;
 
@@ -186,7 +186,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             // If flipping geometry and anchor is allowed and helps, use the flipped one,
             // otherwise leave it as is
             if (!FitsInBounds(geo, PopupAnchor.VerticalMask)
-                && constraintAdjustment.HasFlagCustom(PopupPositionerConstraintAdjustment.FlipY))
+                && constraintAdjustment.HasAllFlags(PopupPositionerConstraintAdjustment.FlipY))
             {
                 var flipped = GetUnconstrained(anchor.FlipY(), gravity.FlipY());
                 if (FitsInBounds(flipped, PopupAnchor.VerticalMask))
@@ -194,7 +194,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             }
 
             // If sliding is allowed, try moving the rect into the bounds
-            if (constraintAdjustment.HasFlagCustom(PopupPositionerConstraintAdjustment.SlideY))
+            if (constraintAdjustment.HasAllFlags(PopupPositionerConstraintAdjustment.SlideY))
             {
                 geo = geo.WithY(Math.Max(geo.Y, bounds.Y));
                 if (geo.Bottom > bounds.Bottom)
@@ -202,7 +202,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             }
 
             // Resize the rect vertically if allowed.
-            if (constraintAdjustment.HasFlagCustom(PopupPositionerConstraintAdjustment.ResizeY))
+            if (constraintAdjustment.HasAllFlags(PopupPositionerConstraintAdjustment.ResizeY))
             {
                 var unconstrainedRect = geo;
 

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -321,7 +321,7 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Gets a value indicating whether <see cref="SelectionMode.AlwaysSelected"/> is set.
         /// </summary>
-        protected bool AlwaysSelected => SelectionMode.HasFlagCustom(SelectionMode.AlwaysSelected);
+        protected bool AlwaysSelected => SelectionMode.HasAllFlags(SelectionMode.AlwaysSelected);
 
         /// <inheritdoc/>
         public override void BeginInit()
@@ -501,7 +501,7 @@ namespace Avalonia.Controls.Primitives
 
                 if (ItemCount > 0 &&
                     Match(keymap.SelectAll) &&
-                    SelectionMode.HasFlagCustom(SelectionMode.Multiple))
+                    SelectionMode.HasAllFlags(SelectionMode.Multiple))
                 {
                     Selection.SelectAll();
                     e.Handled = true;
@@ -530,7 +530,7 @@ namespace Avalonia.Controls.Primitives
             else if (change.Property == SelectionModeProperty && _selection is object)
             {
                 var newValue = change.NewValue.GetValueOrDefault<SelectionMode>();
-                _selection.SingleSelect = !newValue.HasFlagCustom(SelectionMode.Multiple);
+                _selection.SingleSelect = !newValue.HasAllFlags(SelectionMode.Multiple);
             }
         }
 
@@ -591,8 +591,8 @@ namespace Avalonia.Controls.Primitives
             }
 
             var mode = SelectionMode;
-            var multi = mode.HasFlagCustom(SelectionMode.Multiple);
-            var toggle = toggleModifier || mode.HasFlagCustom(SelectionMode.Toggle);
+            var multi = mode.HasAllFlags(SelectionMode.Multiple);
+            var toggle = toggleModifier || mode.HasAllFlags(SelectionMode.Toggle);
             var range = multi && rangeModifier;
 
             if (!select)
@@ -869,7 +869,7 @@ namespace Avalonia.Controls.Primitives
         {
             return new InternalSelectionModel
             {
-                SingleSelect = !SelectionMode.HasFlagCustom(SelectionMode.Multiple),
+                SingleSelect = !SelectionMode.HasAllFlags(SelectionMode.Multiple),
             };
         }
 

--- a/src/Avalonia.Controls/Repeater/RepeaterLayoutContext.cs
+++ b/src/Avalonia.Controls/Repeater/RepeaterLayoutContext.cs
@@ -53,8 +53,8 @@ namespace Avalonia.Controls
         {
             return _owner.GetElementImpl(
                 index,
-                options.HasFlagCustom(ElementRealizationOptions.ForceCreate),
-                options.HasFlagCustom(ElementRealizationOptions.SuppressAutoRecycle));
+                options.HasAllFlags(ElementRealizationOptions.ForceCreate),
+                options.HasAllFlags(ElementRealizationOptions.SuppressAutoRecycle));
         }
 
         protected override object GetItemAtCore(int index) => _owner.ItemsSourceView.GetAt(index);

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -600,7 +600,7 @@ namespace Avalonia.Controls
             var keymap = AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>();
 
             bool Match(List<KeyGesture> gestures) => gestures.Any(g => g.Matches(e));
-            bool DetectSelection() => e.KeyModifiers.HasFlagCustom(keymap.SelectionModifiers);
+            bool DetectSelection() => e.KeyModifiers.HasAllFlags(keymap.SelectionModifiers);
 
             if (Match(keymap.SelectAll))
             {
@@ -718,7 +718,7 @@ namespace Avalonia.Controls
             }
             else
             {
-                bool hasWholeWordModifiers = modifiers.HasFlagCustom(keymap.WholeWordTextActionModifiers);
+                bool hasWholeWordModifiers = modifiers.HasAllFlags(keymap.WholeWordTextActionModifiers);
                 switch (e.Key)
                 {
                     case Key.Left:

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -412,7 +412,7 @@ namespace Avalonia.Controls
                 e.Handled = UpdateSelectionFromEventSource(
                     e.Source,
                     true,
-                    e.KeyModifiers.HasFlagCustom(KeyModifiers.Shift));
+                    e.KeyModifiers.HasAllFlags(KeyModifiers.Shift));
             }
         }
 
@@ -521,8 +521,8 @@ namespace Avalonia.Controls
                     e.Handled = UpdateSelectionFromEventSource(
                         e.Source,
                         true,
-                        e.KeyModifiers.HasFlagCustom(KeyModifiers.Shift),
-                        e.KeyModifiers.HasFlagCustom(KeyModifiers.Control),
+                        e.KeyModifiers.HasAllFlags(KeyModifiers.Shift),
+                        e.KeyModifiers.HasAllFlags(KeyModifiers.Control),
                         point.Properties.IsRightButtonPressed);
                 }
             }
@@ -558,8 +558,8 @@ namespace Avalonia.Controls
             }
 
             var mode = SelectionMode;
-            var toggle = toggleModifier || mode.HasFlagCustom(SelectionMode.Toggle);
-            var multi = mode.HasFlagCustom(SelectionMode.Multiple);
+            var toggle = toggleModifier || mode.HasAllFlags(SelectionMode.Toggle);
+            var multi = mode.HasAllFlags(SelectionMode.Multiple);
             var range = multi && rangeModifier && selectedContainer != null;
 
             if (rightButton)

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -859,19 +859,19 @@ namespace Avalonia.Controls
             var constraint = clientSize;
             var maxAutoSize = PlatformImpl?.MaxAutoSizeHint ?? Size.Infinity;
 
-            if (sizeToContent.HasFlagCustom(SizeToContent.Width))
+            if (sizeToContent.HasAllFlags(SizeToContent.Width))
             {
                 constraint = constraint.WithWidth(maxAutoSize.Width);
             }
 
-            if (sizeToContent.HasFlagCustom(SizeToContent.Height))
+            if (sizeToContent.HasAllFlags(SizeToContent.Height))
             {
                 constraint = constraint.WithHeight(maxAutoSize.Height);
             }
 
             var result = base.MeasureOverride(constraint);
 
-            if (!sizeToContent.HasFlagCustom(SizeToContent.Width))
+            if (!sizeToContent.HasAllFlags(SizeToContent.Width))
             {
                 if (!double.IsInfinity(availableSize.Width))
                 {
@@ -883,7 +883,7 @@ namespace Avalonia.Controls
                 }
             }
 
-            if (!sizeToContent.HasFlagCustom(SizeToContent.Height))
+            if (!sizeToContent.HasAllFlags(SizeToContent.Height))
             {
                 if (!double.IsInfinity(availableSize.Height))
                 {

--- a/src/Avalonia.FreeDesktop/DBusIme/Fcitx/FcitxX11TextInputMethod.cs
+++ b/src/Avalonia.FreeDesktop/DBusIme/Fcitx/FcitxX11TextInputMethod.cs
@@ -76,13 +76,13 @@ namespace Avalonia.FreeDesktop.DBusIme.Fcitx
         protected override async Task<bool> HandleKeyCore(RawKeyEventArgs args, int keyVal, int keyCode)
         {
             FcitxKeyState state = default;
-            if (args.Modifiers.HasFlagCustom(RawInputModifiers.Control))
+            if (args.Modifiers.HasAllFlags(RawInputModifiers.Control))
                 state |= FcitxKeyState.FcitxKeyState_Ctrl;
-            if (args.Modifiers.HasFlagCustom(RawInputModifiers.Alt))
+            if (args.Modifiers.HasAllFlags(RawInputModifiers.Alt))
                 state |= FcitxKeyState.FcitxKeyState_Alt;
-            if (args.Modifiers.HasFlagCustom(RawInputModifiers.Shift))
+            if (args.Modifiers.HasAllFlags(RawInputModifiers.Shift))
                 state |= FcitxKeyState.FcitxKeyState_Shift;
-            if (args.Modifiers.HasFlagCustom(RawInputModifiers.Meta))
+            if (args.Modifiers.HasAllFlags(RawInputModifiers.Meta))
                 state |= FcitxKeyState.FcitxKeyState_Super;
 
             var type = args.Type == RawKeyEventType.KeyDown ?
@@ -126,13 +126,13 @@ namespace Avalonia.FreeDesktop.DBusIme.Fcitx
         {
             var state = (FcitxKeyState)ev.state;
             KeyModifiers mods = default;
-            if (state.HasFlagCustom(FcitxKeyState.FcitxKeyState_Ctrl))
+            if (state.HasAllFlags(FcitxKeyState.FcitxKeyState_Ctrl))
                 mods |= KeyModifiers.Control;
-            if (state.HasFlagCustom(FcitxKeyState.FcitxKeyState_Alt))
+            if (state.HasAllFlags(FcitxKeyState.FcitxKeyState_Alt))
                 mods |= KeyModifiers.Alt;
-            if (state.HasFlagCustom(FcitxKeyState.FcitxKeyState_Shift))
+            if (state.HasAllFlags(FcitxKeyState.FcitxKeyState_Shift))
                 mods |= KeyModifiers.Shift;
-            if (state.HasFlagCustom(FcitxKeyState.FcitxKeyState_Super))
+            if (state.HasAllFlags(FcitxKeyState.FcitxKeyState_Super))
                 mods |= KeyModifiers.Meta;
             FireForward(new X11InputMethodForwardedKey
             {

--- a/src/Avalonia.FreeDesktop/DBusIme/IBus/IBusX11TextInputMethod.cs
+++ b/src/Avalonia.FreeDesktop/DBusIme/IBus/IBusX11TextInputMethod.cs
@@ -33,18 +33,18 @@ namespace Avalonia.FreeDesktop.DBusIme.IBus
         {
             var state = (IBusModifierMask)k.state;
             KeyModifiers mods = default;
-            if (state.HasFlagCustom(IBusModifierMask.ControlMask))
+            if (state.HasAllFlags(IBusModifierMask.ControlMask))
                 mods |= KeyModifiers.Control;
-            if (state.HasFlagCustom(IBusModifierMask.Mod1Mask))
+            if (state.HasAllFlags(IBusModifierMask.Mod1Mask))
                 mods |= KeyModifiers.Alt;
-            if (state.HasFlagCustom(IBusModifierMask.ShiftMask))
+            if (state.HasAllFlags(IBusModifierMask.ShiftMask))
                 mods |= KeyModifiers.Shift;
-            if (state.HasFlagCustom(IBusModifierMask.Mod4Mask))
+            if (state.HasAllFlags(IBusModifierMask.Mod4Mask))
                 mods |= KeyModifiers.Meta;
             FireForward(new X11InputMethodForwardedKey
             {
                 KeyVal = (int)k.keyval,
-                Type = state.HasFlagCustom(IBusModifierMask.ReleaseMask) ? RawKeyEventType.KeyUp : RawKeyEventType.KeyDown,
+                Type = state.HasAllFlags(IBusModifierMask.ReleaseMask) ? RawKeyEventType.KeyUp : RawKeyEventType.KeyDown,
                 Modifiers = mods
             });
         }
@@ -82,13 +82,13 @@ namespace Avalonia.FreeDesktop.DBusIme.IBus
         protected override Task<bool> HandleKeyCore(RawKeyEventArgs args, int keyVal, int keyCode)
         {
             IBusModifierMask state = default;
-            if (args.Modifiers.HasFlagCustom(RawInputModifiers.Control))
+            if (args.Modifiers.HasAllFlags(RawInputModifiers.Control))
                 state |= IBusModifierMask.ControlMask;
-            if (args.Modifiers.HasFlagCustom(RawInputModifiers.Alt))
+            if (args.Modifiers.HasAllFlags(RawInputModifiers.Alt))
                 state |= IBusModifierMask.Mod1Mask;
-            if (args.Modifiers.HasFlagCustom(RawInputModifiers.Shift))
+            if (args.Modifiers.HasAllFlags(RawInputModifiers.Shift))
                 state |= IBusModifierMask.ShiftMask;
-            if (args.Modifiers.HasFlagCustom(RawInputModifiers.Meta))
+            if (args.Modifiers.HasAllFlags(RawInputModifiers.Meta))
                 state |= IBusModifierMask.Mod4Mask;
 
             if (args.Type == RawKeyEventType.KeyUp)

--- a/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
+++ b/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
@@ -223,13 +223,13 @@ namespace Avalonia.FreeDesktop
                             return null;
                         var lst = new List<string>();
                         var mod = item.Gesture;
-                        if (mod.KeyModifiers.HasFlagCustom(KeyModifiers.Control))
+                        if (mod.KeyModifiers.HasAllFlags(KeyModifiers.Control))
                             lst.Add("Control");
-                        if (mod.KeyModifiers.HasFlagCustom(KeyModifiers.Alt))
+                        if (mod.KeyModifiers.HasAllFlags(KeyModifiers.Alt))
                             lst.Add("Alt");
-                        if (mod.KeyModifiers.HasFlagCustom(KeyModifiers.Shift))
+                        if (mod.KeyModifiers.HasAllFlags(KeyModifiers.Shift))
                             lst.Add("Shift");
-                        if (mod.KeyModifiers.HasFlagCustom(KeyModifiers.Meta))
+                        if (mod.KeyModifiers.HasAllFlags(KeyModifiers.Meta))
                             lst.Add("Super");
                         lst.Add(item.Gesture.Key.ToString());
                         return new[] { lst.ToArray() };

--- a/src/Avalonia.Headless.Vnc/HeadlessVncFramebufferSource.cs
+++ b/src/Avalonia.Headless.Vnc/HeadlessVncFramebufferSource.cs
@@ -33,11 +33,11 @@ namespace Avalonia.Headless.Vnc
                 {
                     Window?.MouseMove(pt);
                     foreach (var btn in CheckedButtons)
-                        if (_previousButtons.HasFlagCustom(btn) && !buttons.HasFlagCustom(btn))
+                        if (_previousButtons.HasAllFlags(btn) && !buttons.HasAllFlags(btn))
                             Window?.MouseUp(pt, TranslateButton(btn), modifiers);
                     
                     foreach (var btn in CheckedButtons)
-                        if (!_previousButtons.HasFlagCustom(btn) && buttons.HasFlagCustom(btn))
+                        if (!_previousButtons.HasAllFlags(btn) && buttons.HasAllFlags(btn))
                             Window?.MouseDown(pt, TranslateButton(btn), modifiers);
                     _previousButtons = buttons;
                 }, DispatcherPriority.Input);

--- a/src/Avalonia.Input/AccessKeyHandler.cs
+++ b/src/Avalonia.Input/AccessKeyHandler.cs
@@ -177,7 +177,7 @@ namespace Avalonia.Input
         {
             bool menuIsOpen = MainMenu?.IsOpen == true;
 
-            if (e.KeyModifiers.HasFlagCustom(KeyModifiers.Alt) || menuIsOpen)
+            if (e.KeyModifiers.HasAllFlags(KeyModifiers.Alt) || menuIsOpen)
             {
                 // If any other key is pressed with the Alt key held down, or the main menu is open,
                 // find all controls who have registered that access key.

--- a/src/Avalonia.Input/KeyGesture.cs
+++ b/src/Avalonia.Input/KeyGesture.cs
@@ -115,24 +115,24 @@ namespace Avalonia.Input
                 }
             }
 
-            if (KeyModifiers.HasFlagCustom(KeyModifiers.Control))
+            if (KeyModifiers.HasAllFlags(KeyModifiers.Control))
             {
                 s.Append("Ctrl");
             }
 
-            if (KeyModifiers.HasFlagCustom(KeyModifiers.Shift))
+            if (KeyModifiers.HasAllFlags(KeyModifiers.Shift))
             {
                 Plus(s);
                 s.Append("Shift");
             }
 
-            if (KeyModifiers.HasFlagCustom(KeyModifiers.Alt))
+            if (KeyModifiers.HasAllFlags(KeyModifiers.Alt))
             {
                 Plus(s);
                 s.Append("Alt");
             }
 
-            if (KeyModifiers.HasFlagCustom(KeyModifiers.Meta))
+            if (KeyModifiers.HasAllFlags(KeyModifiers.Meta))
             {
                 Plus(s);
                 s.Append("Cmd");

--- a/src/Avalonia.Input/PointerPoint.cs
+++ b/src/Avalonia.Input/PointerPoint.cs
@@ -31,11 +31,11 @@ namespace Avalonia.Input
         {
             PointerUpdateKind = kind;
 
-            IsLeftButtonPressed = modifiers.HasFlagCustom(RawInputModifiers.LeftMouseButton);
-            IsMiddleButtonPressed = modifiers.HasFlagCustom(RawInputModifiers.MiddleMouseButton);
-            IsRightButtonPressed = modifiers.HasFlagCustom(RawInputModifiers.RightMouseButton);
-            IsXButton1Pressed = modifiers.HasFlagCustom(RawInputModifiers.XButton1MouseButton);
-            IsXButton2Pressed = modifiers.HasFlagCustom(RawInputModifiers.XButton2MouseButton);
+            IsLeftButtonPressed = modifiers.HasAllFlags(RawInputModifiers.LeftMouseButton);
+            IsMiddleButtonPressed = modifiers.HasAllFlags(RawInputModifiers.MiddleMouseButton);
+            IsRightButtonPressed = modifiers.HasAllFlags(RawInputModifiers.RightMouseButton);
+            IsXButton1Pressed = modifiers.HasAllFlags(RawInputModifiers.XButton1MouseButton);
+            IsXButton2Pressed = modifiers.HasAllFlags(RawInputModifiers.XButton2MouseButton);
 
             // The underlying input source might be reporting the previous state,
             // so make sure that we reflect the current state

--- a/src/Avalonia.Interactivity/EventRoute.cs
+++ b/src/Avalonia.Interactivity/EventRoute.cs
@@ -88,14 +88,14 @@ namespace Avalonia.Interactivity
             }
             else
             {
-                if (_event.RoutingStrategies.HasFlagCustom(RoutingStrategies.Tunnel))
+                if (_event.RoutingStrategies.HasAllFlags(RoutingStrategies.Tunnel))
                 {
                     e.Route = RoutingStrategies.Tunnel;
                     RaiseEventImpl(e);
                     _event.InvokeRouteFinished(e);
                 }
 
-                if (_event.RoutingStrategies.HasFlagCustom(RoutingStrategies.Bubble))
+                if (_event.RoutingStrategies.HasAllFlags(RoutingStrategies.Bubble))
                 {
                     e.Route = RoutingStrategies.Bubble;
                     RaiseEventImpl(e);
@@ -159,7 +159,7 @@ namespace Avalonia.Interactivity
 
                 // Raise the event handler.
                 if (entry.Handler is object &&
-                    entry.Routes.HasFlagCustom(e.Route) &&
+                    entry.Routes.HasAllFlags(e.Route) &&
                     (!e.Handled || entry.HandledEventsToo))
                 {
                     if (entry.Adapter is object)

--- a/src/Avalonia.Interactivity/Interactive.cs
+++ b/src/Avalonia.Interactivity/Interactive.cs
@@ -155,8 +155,8 @@ namespace Avalonia.Interactivity
             var result = new EventRoute(e);
             var hasClassHandlers = e.HasRaisedSubscriptions;
 
-            if (e.RoutingStrategies.HasFlagCustom(RoutingStrategies.Bubble) ||
-                e.RoutingStrategies.HasFlagCustom(RoutingStrategies.Tunnel))
+            if (e.RoutingStrategies.HasAllFlags(RoutingStrategies.Bubble) ||
+                e.RoutingStrategies.HasAllFlags(RoutingStrategies.Tunnel))
             {
                 IInteractive? element = this;
 

--- a/src/Avalonia.X11/X11Window.Ime.cs
+++ b/src/Avalonia.X11/X11Window.Ime.cs
@@ -96,14 +96,14 @@ namespace Avalonia.X11
 
         void HandleKeyEvent(ref XEvent ev)
         {
-            var index = ev.KeyEvent.state.HasFlagCustom(XModifierMask.ShiftMask);
+            var index = ev.KeyEvent.state.HasAllFlags(XModifierMask.ShiftMask);
 
             // We need the latin key, since it's mainly used for hotkeys, we use a different API for text anyway
             var key = (X11Key)XKeycodeToKeysym(_x11.Display, ev.KeyEvent.keycode, index ? 1 : 0).ToInt32();
                 
             // Manually switch the Shift index for the keypad,
             // there should be a proper way to do this
-            if (ev.KeyEvent.state.HasFlagCustom(XModifierMask.Mod2Mask)
+            if (ev.KeyEvent.state.HasAllFlags(XModifierMask.Mod2Mask)
                 && key > X11Key.Num_Lock && key <= X11Key.KP_9)
                 key = (X11Key)XKeycodeToKeysym(_x11.Display, ev.KeyEvent.keycode, index ? 0 : 1).ToInt32();
             

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -639,23 +639,23 @@ namespace Avalonia.X11
         RawInputModifiers TranslateModifiers(XModifierMask state)
         {
             var rv = default(RawInputModifiers);
-            if (state.HasFlagCustom(XModifierMask.Button1Mask))
+            if (state.HasAllFlags(XModifierMask.Button1Mask))
                 rv |= RawInputModifiers.LeftMouseButton;
-            if (state.HasFlagCustom(XModifierMask.Button2Mask))
+            if (state.HasAllFlags(XModifierMask.Button2Mask))
                 rv |= RawInputModifiers.RightMouseButton;
-            if (state.HasFlagCustom(XModifierMask.Button3Mask))
+            if (state.HasAllFlags(XModifierMask.Button3Mask))
                 rv |= RawInputModifiers.MiddleMouseButton;
-            if (state.HasFlagCustom(XModifierMask.Button4Mask))
+            if (state.HasAllFlags(XModifierMask.Button4Mask))
                 rv |= RawInputModifiers.XButton1MouseButton;
-            if (state.HasFlagCustom(XModifierMask.Button5Mask))
+            if (state.HasAllFlags(XModifierMask.Button5Mask))
                 rv |= RawInputModifiers.XButton2MouseButton;
-            if (state.HasFlagCustom(XModifierMask.ShiftMask))
+            if (state.HasAllFlags(XModifierMask.ShiftMask))
                 rv |= RawInputModifiers.Shift;
-            if (state.HasFlagCustom(XModifierMask.ControlMask))
+            if (state.HasAllFlags(XModifierMask.ControlMask))
                 rv |= RawInputModifiers.Control;
-            if (state.HasFlagCustom(XModifierMask.Mod1Mask))
+            if (state.HasAllFlags(XModifierMask.Mod1Mask))
                 rv |= RawInputModifiers.Alt;
-            if (state.HasFlagCustom(XModifierMask.Mod4Mask))
+            if (state.HasAllFlags(XModifierMask.Mod4Mask))
                 rv |= RawInputModifiers.Meta;
             return rv;
         }

--- a/src/Avalonia.X11/XI2Manager.cs
+++ b/src/Avalonia.X11/XI2Manager.cs
@@ -342,13 +342,13 @@ namespace Avalonia.X11
             Type = ev->evtype;
             Timestamp = (ulong)ev->time.ToInt64();
             var state = (XModifierMask)ev->mods.Effective;
-            if (state.HasFlagCustom(XModifierMask.ShiftMask))
+            if (state.HasAllFlags(XModifierMask.ShiftMask))
                 Modifiers |= RawInputModifiers.Shift;
-            if (state.HasFlagCustom(XModifierMask.ControlMask))
+            if (state.HasAllFlags(XModifierMask.ControlMask))
                 Modifiers |= RawInputModifiers.Control;
-            if (state.HasFlagCustom(XModifierMask.Mod1Mask))
+            if (state.HasAllFlags(XModifierMask.Mod1Mask))
                 Modifiers |= RawInputModifiers.Alt;
-            if (state.HasFlagCustom(XModifierMask.Mod4Mask))
+            if (state.HasAllFlags(XModifierMask.Mod4Mask))
                 Modifiers |= RawInputModifiers.Meta;
 
             Modifiers |= ParseButtonState(ev->buttons.MaskLen, ev->buttons.Mask);
@@ -364,7 +364,7 @@ namespace Avalonia.X11
             if (Type == XiEventType.XI_ButtonPress || Type == XiEventType.XI_ButtonRelease)
                 Button = ev->detail;
             Detail = ev->detail;
-            Emulated = ev->flags.HasFlagCustom(XiDeviceEventFlags.XIPointerEmulated);
+            Emulated = ev->flags.HasAllFlags(XiDeviceEventFlags.XIPointerEmulated);
         }
     }
     

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
@@ -54,7 +54,7 @@ namespace Avalonia.LinuxFramebuffer.Output
         }
 
         public PixelSize Resolution => new PixelSize(Mode.hdisplay, Mode.vdisplay);
-        public bool IsPreferred => Mode.type.HasFlagCustom(DrmModeType.DRM_MODE_TYPE_PREFERRED);
+        public bool IsPreferred => Mode.type.HasAllFlags(DrmModeType.DRM_MODE_TYPE_PREFERRED);
 
         public string Name { get; }
     }

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
@@ -147,13 +147,13 @@ namespace Avalonia.Win32.Interop.Wpf
         {
             var state = Keyboard.Modifiers;
             var rv = default(RawInputModifiers);
-            if (state.HasFlagCustom(ModifierKeys.Windows))
+            if (state.HasAllFlags(ModifierKeys.Windows))
                 rv |= RawInputModifiers.Meta;
-            if (state.HasFlagCustom(ModifierKeys.Alt))
+            if (state.HasAllFlags(ModifierKeys.Alt))
                 rv |= RawInputModifiers.Alt;
-            if (state.HasFlagCustom(ModifierKeys.Control))
+            if (state.HasAllFlags(ModifierKeys.Control))
                 rv |= RawInputModifiers.Control;
-            if (state.HasFlagCustom(ModifierKeys.Shift))
+            if (state.HasAllFlags(ModifierKeys.Shift))
                 rv |= RawInputModifiers.Shift;
             if (e != null)
             {

--- a/src/Windows/Avalonia.Win32/DataObject.cs
+++ b/src/Windows/Avalonia.Win32/DataObject.cs
@@ -181,7 +181,7 @@ namespace Avalonia.Win32
                 ole.GetData(ref format, out medium);
                 return;
             }
-            if(!format.tymed.HasFlagCustom(TYMED.TYMED_HGLOBAL))
+            if(!format.tymed.HasAllFlags(TYMED.TYMED_HGLOBAL))
                 Marshal.ThrowExceptionForHR(DV_E_TYMED);
 
             if (format.dwAspect != DVASPECT.DVASPECT_CONTENT)
@@ -205,7 +205,7 @@ namespace Avalonia.Win32
                 return;
             }
 
-            if (medium.tymed != TYMED.TYMED_HGLOBAL || !format.tymed.HasFlagCustom(TYMED.TYMED_HGLOBAL))
+            if (medium.tymed != TYMED.TYMED_HGLOBAL || !format.tymed.HasAllFlags(TYMED.TYMED_HGLOBAL))
                 Marshal.ThrowExceptionForHR(DV_E_TYMED);
 
             if (format.dwAspect != DVASPECT.DVASPECT_CONTENT)
@@ -228,7 +228,7 @@ namespace Avalonia.Win32
                 return ole.QueryGetData(ref format);
             if (format.dwAspect != DVASPECT.DVASPECT_CONTENT)
                 return DV_E_DVASPECT;
-            if (!format.tymed.HasFlagCustom(TYMED.TYMED_HGLOBAL))
+            if (!format.tymed.HasAllFlags(TYMED.TYMED_HGLOBAL))
                 return DV_E_TYMED;
 
             string dataFormat = ClipboardFormats.GetFormat(format.cfFormat);

--- a/src/Windows/Avalonia.Win32/OleDropTarget.cs
+++ b/src/Windows/Avalonia.Win32/OleDropTarget.cs
@@ -24,11 +24,11 @@ namespace Avalonia.Win32
         public static DropEffect ConvertDropEffect(DragDropEffects operation)
         {
             DropEffect result = DropEffect.None;
-            if (operation.HasFlagCustom(DragDropEffects.Copy))
+            if (operation.HasAllFlags(DragDropEffects.Copy))
                 result |= DropEffect.Copy;
-            if (operation.HasFlagCustom(DragDropEffects.Move))
+            if (operation.HasAllFlags(DragDropEffects.Move))
                 result |= DropEffect.Move;
-            if (operation.HasFlagCustom(DragDropEffects.Link))
+            if (operation.HasAllFlags(DragDropEffects.Link))
                 result |= DropEffect.Link;
             return result;
         }
@@ -36,11 +36,11 @@ namespace Avalonia.Win32
         public static DragDropEffects ConvertDropEffect(DropEffect effect)
         {
             DragDropEffects result = DragDropEffects.None;
-            if (effect.HasFlagCustom(DropEffect.Copy))
+            if (effect.HasAllFlags(DropEffect.Copy))
                 result |= DragDropEffects.Copy;
-            if (effect.HasFlagCustom(DropEffect.Move))
+            if (effect.HasAllFlags(DropEffect.Move))
                 result |= DragDropEffects.Move;
-            if (effect.HasFlagCustom(DropEffect.Link))
+            if (effect.HasAllFlags(DropEffect.Link))
                 result |= DragDropEffects.Link;
             return result;
         }
@@ -50,17 +50,17 @@ namespace Avalonia.Win32
             var modifiers = RawInputModifiers.None;
             var state = (UnmanagedMethods.ModifierKeys)grfKeyState;
 
-            if (state.HasFlagCustom(UnmanagedMethods.ModifierKeys.MK_LBUTTON))
+            if (state.HasAllFlags(UnmanagedMethods.ModifierKeys.MK_LBUTTON))
                 modifiers |= RawInputModifiers.LeftMouseButton;
-            if (state.HasFlagCustom(UnmanagedMethods.ModifierKeys.MK_MBUTTON))
+            if (state.HasAllFlags(UnmanagedMethods.ModifierKeys.MK_MBUTTON))
                 modifiers |= RawInputModifiers.MiddleMouseButton;
-            if (state.HasFlagCustom(UnmanagedMethods.ModifierKeys.MK_RBUTTON))
+            if (state.HasAllFlags(UnmanagedMethods.ModifierKeys.MK_RBUTTON))
                 modifiers |= RawInputModifiers.RightMouseButton;
-            if (state.HasFlagCustom(UnmanagedMethods.ModifierKeys.MK_SHIFT))
+            if (state.HasAllFlags(UnmanagedMethods.ModifierKeys.MK_SHIFT))
                 modifiers |= RawInputModifiers.Shift;
-            if (state.HasFlagCustom(UnmanagedMethods.ModifierKeys.MK_CONTROL))
+            if (state.HasAllFlags(UnmanagedMethods.ModifierKeys.MK_CONTROL))
                 modifiers |= RawInputModifiers.Control;
-            if (state.HasFlagCustom(UnmanagedMethods.ModifierKeys.MK_ALT))
+            if (state.HasAllFlags(UnmanagedMethods.ModifierKeys.MK_ALT))
                 modifiers |= RawInputModifiers.Alt;
             return modifiers;
         }

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -310,9 +310,9 @@ namespace Avalonia.Win32
                             {
                                 Input?.Invoke(new RawTouchEventArgs(_touchDevice, touchInput.Time,
                                     _owner,
-                                    touchInput.Flags.HasFlagCustom(TouchInputFlags.TOUCHEVENTF_UP) ?
+                                    touchInput.Flags.HasAllFlags(TouchInputFlags.TOUCHEVENTF_UP) ?
                                         RawPointerEventType.TouchEnd :
-                                        touchInput.Flags.HasFlagCustom(TouchInputFlags.TOUCHEVENTF_DOWN) ?
+                                        touchInput.Flags.HasAllFlags(TouchInputFlags.TOUCHEVENTF_DOWN) ?
                                             RawPointerEventType.TouchBegin :
                                             RawPointerEventType.TouchUpdate,
                                     PointToClient(new PixelPoint(touchInput.X / 100, touchInput.Y / 100)),
@@ -521,27 +521,27 @@ namespace Avalonia.Win32
             var keys = (ModifierKeys)ToInt32(wParam);
             var modifiers = WindowsKeyboardDevice.Instance.Modifiers;
 
-            if (keys.HasFlagCustom(ModifierKeys.MK_LBUTTON))
+            if (keys.HasAllFlags(ModifierKeys.MK_LBUTTON))
             {
                 modifiers |= RawInputModifiers.LeftMouseButton;
             }
 
-            if (keys.HasFlagCustom(ModifierKeys.MK_RBUTTON))
+            if (keys.HasAllFlags(ModifierKeys.MK_RBUTTON))
             {
                 modifiers |= RawInputModifiers.RightMouseButton;
             }
 
-            if (keys.HasFlagCustom(ModifierKeys.MK_MBUTTON))
+            if (keys.HasAllFlags(ModifierKeys.MK_MBUTTON))
             {
                 modifiers |= RawInputModifiers.MiddleMouseButton;
             }
 
-            if (keys.HasFlagCustom(ModifierKeys.MK_XBUTTON1))
+            if (keys.HasAllFlags(ModifierKeys.MK_XBUTTON1))
             {
                 modifiers |= RawInputModifiers.XButton1MouseButton;
             }
 
-            if (keys.HasFlagCustom(ModifierKeys.MK_XBUTTON2))
+            if (keys.HasAllFlags(ModifierKeys.MK_XBUTTON2))
             {
                 modifiers |= RawInputModifiers.XButton2MouseButton;
             }

--- a/src/Windows/Avalonia.Win32/WindowImpl.CustomCaptionProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.CustomCaptionProc.cs
@@ -23,13 +23,13 @@ namespace Avalonia.Win32
             AdjustWindowRectEx(ref rcFrame, (uint)(WindowStyles.WS_OVERLAPPEDWINDOW & ~WindowStyles.WS_CAPTION), false, 0);
 
             var borderThickness = new RECT();
-            if (GetStyle().HasFlagCustom(WindowStyles.WS_THICKFRAME))
+            if (GetStyle().HasAllFlags(WindowStyles.WS_THICKFRAME))
             {
                 AdjustWindowRectEx(ref borderThickness, (uint)(GetStyle()), false, 0);
                 borderThickness.left *= -1;
                 borderThickness.top *= -1;
             }
-            else if (GetStyle().HasFlagCustom(WindowStyles.WS_BORDER))
+            else if (GetStyle().HasAllFlags(WindowStyles.WS_BORDER))
             {
                 borderThickness = new RECT { bottom = 1, left = 1, right = 1, top = 1 };
             }

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -838,7 +838,7 @@ namespace Avalonia.Win32
             borderCaptionThickness.left *= -1;
             borderCaptionThickness.top *= -1;
 
-            bool wantsTitleBar = _extendChromeHints.HasFlagCustom(ExtendClientAreaChromeHints.SystemChrome) || _extendTitleBarHint == -1;
+            bool wantsTitleBar = _extendChromeHints.HasAllFlags(ExtendClientAreaChromeHints.SystemChrome) || _extendTitleBarHint == -1;
 
             if (!wantsTitleBar)
             {
@@ -855,7 +855,7 @@ namespace Avalonia.Win32
                 borderCaptionThickness.top = (int)(_extendTitleBarHint * RenderScaling);                
             }
 
-            margins.cyTopHeight = _extendChromeHints.HasFlagCustom(ExtendClientAreaChromeHints.SystemChrome) && !_extendChromeHints.HasFlagCustom(ExtendClientAreaChromeHints.PreferSystemChrome) ? borderCaptionThickness.top : 1;
+            margins.cyTopHeight = _extendChromeHints.HasAllFlags(ExtendClientAreaChromeHints.SystemChrome) && !_extendChromeHints.HasAllFlags(ExtendClientAreaChromeHints.PreferSystemChrome) ? borderCaptionThickness.top : 1;
 
             if (WindowState == WindowState.Maximized)
             {
@@ -908,8 +908,8 @@ namespace Avalonia.Win32
                 _extendedMargins = new Thickness();
             }
 
-            if(!_isClientAreaExtended || (_extendChromeHints.HasFlagCustom(ExtendClientAreaChromeHints.SystemChrome) &&
-                !_extendChromeHints.HasFlagCustom(ExtendClientAreaChromeHints.PreferSystemChrome)))
+            if(!_isClientAreaExtended || (_extendChromeHints.HasAllFlags(ExtendClientAreaChromeHints.SystemChrome) &&
+                !_extendChromeHints.HasAllFlags(ExtendClientAreaChromeHints.PreferSystemChrome)))
             {
                 EnableCloseButton(_hwnd);
             }
@@ -1253,7 +1253,7 @@ namespace Avalonia.Win32
         public Action<bool> ExtendClientAreaToDecorationsChanged { get; set; }
         
         /// <inheritdoc/>
-        public bool NeedsManagedDecorations => _isClientAreaExtended && _extendChromeHints.HasFlagCustom(ExtendClientAreaChromeHints.PreferSystemChrome);
+        public bool NeedsManagedDecorations => _isClientAreaExtended && _extendChromeHints.HasAllFlags(ExtendClientAreaChromeHints.PreferSystemChrome);
 
         /// <inheritdoc/>
         public Thickness ExtendedMargins => _extendedMargins;


### PR DESCRIPTION
Fixes popup positioning issue caused by #5462. `HasFlag` and `HasFlagCustom` don't check that all specified bits are set which isn't how masked values work. Thefeore, I renamed `HasFlagCustom` to `HasAllFlags` and added `HasAnyFlag` which returns `true` if any of the specified bits is set.