### PR TITLE
Fix DataGrid selection after sorting

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -910,6 +910,11 @@ namespace Avalonia.Controls
 
                     // Clear all row selections
                     ClearRowSelection(resetAnchorSlot: true);
+
+                    if (DataConnection.CollectionView != null)
+                    {
+                        DataConnection.CollectionView.MoveCurrentTo(null);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
## What does the pull request do?
This PR fixed the selection issue on DataGrid after sorting.


## What is the current behavior?
Bind the DataGrid SelectedItem to an Item. Select an Item from the DataGrid, then set the viewmodels SelectedItem to null.
After these, if you do sorting the selection comes back.


## What is the updated/expected behavior with this PR?
After the sorting, the selection will not come back.


## How was the solution implemented (if it's not obvious)?
In the `OnSelectedItemChanged` every time if the selected item was not null it was forwarded to the `CollectionView` which is good. But if the selected item was null there was no forwarding to the `CollectionView`. This PR updates the `CollectionView` if the selected item is null.


## Fixed issues
Fixes #5786
