### PR TITLE
Correctly sync SelectedItems on collection reset.

### DIFF
--- a/tests/Avalonia.Controls.UnitTests/Selection/InternalSelectionModelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Selection/InternalSelectionModelTests.cs
@@ -97,6 +97,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             target.WritableSelectedItems.Clear();
 
             Assert.Empty(target.SelectedIndexes);
+            Assert.Empty(target.WritableSelectedItems);
         }
 
         [Fact]
@@ -123,6 +124,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             target.WritableSelectedItems = null;
 
             Assert.Empty(target.SelectedIndexes);
+            Assert.Empty(target.WritableSelectedItems);
         }
 
         [Fact]
@@ -182,6 +184,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             target.Source = items;
 
             Assert.Equal(1, target.SelectedIndex);
+            Assert.Equal(new[] { "bar" }, target.WritableSelectedItems);
         }
 
         [Fact]
@@ -203,6 +206,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             items.Reset(new[] { "baz", "foo", "bar" });
 
             Assert.Equal(2, target.SelectedIndex);
+            Assert.Equal(new[] { "bar" }, target.WritableSelectedItems);
         }
 
         [Fact]
@@ -227,6 +231,7 @@ namespace Avalonia.Controls.UnitTests.Selection
 
             Assert.Equal(-1, target.SelectedIndex);
             Assert.Equal(null, target.SelectedItem);
+            Assert.Empty(target.WritableSelectedItems);
 
             Assert.Contains(nameof(target.SelectedIndex), changed);
             Assert.Contains(nameof(target.SelectedItem), changed);
@@ -246,6 +251,7 @@ namespace Avalonia.Controls.UnitTests.Selection
 
             Assert.Equal("foo", target.SelectedItem);
             Assert.Equal(1, target.SelectedIndex);
+            Assert.Equal(new[] { "foo" }, target.WritableSelectedItems);
         }
 
         [Fact]
@@ -257,6 +263,7 @@ namespace Avalonia.Controls.UnitTests.Selection
             target.Source = new[] { "baz", "foo", "bar" };
 
             Assert.Equal(2, target.SelectedIndex);
+            Assert.Equal(new[] { "bar" }, target.WritableSelectedItems);
         }
 
         private static InternalSelectionModel CreateTarget(


### PR DESCRIPTION
## What does the pull request do?

When `InternalSelectionModel`  gets a `Reset` event it tries to restore the selection from `WritableSelectedItems`, however this was causing items to be added twice to `WriteableSelectedItems`:

- Collection is reset
- Selection is cleared
- `InternalSelectionModel` restores selection on reset from `WritableSelectedItems`
- Which changes the selection
- Which adds the selection back to `WritableSelectedItems`, causing the selected item to appear twice in the collection

To fix it:

- Set a flag when receiving a reset event to make sure nothing is written back to `WritableSelectedItems`
- On reset, remove items from `WritableSelectedItems` that aren't present in the source list

I'd somehow left out checks for `WriteableSelectedItems` in the unit tests for `Reset` events, so added those check in.

cc: @pr8x 