### PR TITLE
Change HorizontalScrollBarVisibility default

### DIFF
--- a/src/Avalonia.Controls/ScrollViewer.cs
+++ b/src/Avalonia.Controls/ScrollViewer.cs
@@ -120,7 +120,7 @@ namespace Avalonia.Controls
         public static readonly AttachedProperty<ScrollBarVisibility> HorizontalScrollBarVisibilityProperty =
             AvaloniaProperty.RegisterAttached<ScrollViewer, Control, ScrollBarVisibility>(
                 nameof(HorizontalScrollBarVisibility),
-                ScrollBarVisibility.Hidden);
+                ScrollBarVisibility.Disabled);
 
         /// <summary>
         /// Defines the VerticalScrollBarMaximum property.

--- a/tests/Avalonia.Controls.UnitTests/ScrollViewerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ScrollViewerTests.cs
@@ -37,7 +37,7 @@ namespace Avalonia.Controls.UnitTests
             target.HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
             target.HorizontalScrollBarVisibility = ScrollBarVisibility.Auto;
 
-            Assert.Equal(new[] { true, false, true }, values);
+            Assert.Equal(new[] { false, true }, values);
         }
 
         [Fact]

--- a/tests/Avalonia.Layout.UnitTests/LayoutableTests_EffectiveViewportChanged.cs
+++ b/tests/Avalonia.Layout.UnitTests/LayoutableTests_EffectiveViewportChanged.cs
@@ -162,7 +162,7 @@ namespace Avalonia.Layout.UnitTests
             {
                 var root = CreateRoot();
                 var target = new Canvas { Width = 200, Height = 200 };
-                var scroller = new ScrollViewer { Width = 100, Height = 100, Content = target, Template = ScrollViewerTemplate() };
+                var scroller = new ScrollViewer { Width = 100, Height = 100, Content = target, Template = ScrollViewerTemplate(), HorizontalScrollBarVisibility = ScrollBarVisibility.Hidden };
                 var raised = 0;
 
                 target.EffectiveViewportChanged += (s, e) =>
@@ -185,7 +185,7 @@ namespace Avalonia.Layout.UnitTests
             {
                 var root = CreateRoot();
                 var target = new Canvas { Width = 200, Height = 200 };
-                var scroller = new ScrollViewer { Width = 100, Height = 100, Content = target, Template = ScrollViewerTemplate() };
+                var scroller = new ScrollViewer { Width = 100, Height = 100, Content = target, Template = ScrollViewerTemplate(), HorizontalScrollBarVisibility = ScrollBarVisibility.Hidden };
                 var raised = 0;
 
                 root.Child = scroller;


### PR DESCRIPTION
It was previously discussed to have "Disabled" as default.
It matches UWP's default: https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.scrollviewer.horizontalscrollbarvisibility?view=winrt-19041#property-value
Although I just checked and found that WPF's default is actually "Hidden": https://docs.microsoft.com/en-us/dotnet/api/system.windows.controls.scrollviewer.horizontalscrollbarvisibility?view=net-5.0#property-value

## Breaking changes
Previous default was "Hidden".
Current default is "Disabled".

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/5020