### PR TITLE
Use ItemCount to determine PseudoClass in ItemsControl for better consistency

### DIFF
--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -346,6 +346,8 @@ namespace Avalonia.Controls
                 Presenter.Items = newValue;
             }
 
+            UpdatePseudoClasses();
+
             SubscribeToItems(newValue);
         }
 
@@ -372,9 +374,7 @@ namespace Avalonia.Controls
 
             Presenter?.ItemsChanged(e);
 
-            var collection = sender as ICollection;
-            PseudoClasses.Set(":empty", collection == null || collection.Count == 0);
-            PseudoClasses.Set(":singleitem", collection != null && collection.Count == 1);
+            UpdatePseudoClasses();
         }
 
         /// <summary>
@@ -431,9 +431,6 @@ namespace Avalonia.Controls
         /// <param name="items">The items collection.</param>
         private void SubscribeToItems(IEnumerable items)
         {
-            PseudoClasses.Set(":empty", items == null || items.Count() == 0);
-            PseudoClasses.Set(":singleitem", items != null && items.Count() == 1);
-
             if (items is INotifyCollectionChanged incc)
             {
                 CollectionChangedEventManager.Instance.AddListener(incc, this);
@@ -467,6 +464,12 @@ namespace Avalonia.Controls
             {
                 ItemCount = Items.Count();
             }
+        }
+
+        private void UpdatePseudoClasses()
+        {
+            PseudoClasses.Set(":empty", ItemCount == 0);
+            PseudoClasses.Set(":singleitem", ItemCount == 1);
         }
 
         protected static IInputElement GetNextControl(

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -70,7 +70,7 @@ namespace Avalonia.Controls
         /// </summary>
         public ItemsControl()
         {
-            PseudoClasses.Add(":empty");
+            UpdatePseudoClasses(0);
             SubscribeToItems(_items);
         }
 
@@ -323,6 +323,16 @@ namespace Avalonia.Controls
             base.OnKeyDown(e);
         }
 
+        protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == ItemCountProperty)
+            {
+                UpdatePseudoClasses(change.NewValue.GetValueOrDefault<int>());
+            }
+        }
+
         /// <summary>
         /// Called when the <see cref="Items"/> property changes.
         /// </summary>
@@ -345,8 +355,6 @@ namespace Avalonia.Controls
             {
                 Presenter.Items = newValue;
             }
-
-            UpdatePseudoClasses();
 
             SubscribeToItems(newValue);
         }
@@ -373,8 +381,6 @@ namespace Avalonia.Controls
             }
 
             Presenter?.ItemsChanged(e);
-
-            UpdatePseudoClasses();
         }
 
         /// <summary>
@@ -466,10 +472,10 @@ namespace Avalonia.Controls
             }
         }
 
-        private void UpdatePseudoClasses()
+        private void UpdatePseudoClasses(int itemCount)
         {
-            PseudoClasses.Set(":empty", ItemCount == 0);
-            PseudoClasses.Set(":singleitem", ItemCount == 1);
+            PseudoClasses.Set(":empty", itemCount == 0);
+            PseudoClasses.Set(":singleitem", itemCount == 1);
         }
 
         protected static IInputElement GetNextControl(

--- a/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
@@ -394,6 +394,70 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Item_Count_Should_Be_Set_When_Items_Added()
+        {
+            var target = new ItemsControl()
+            {
+                Template = GetTemplate(),
+                Items = new[] { 1, 2, 3 },
+            };
+
+            Assert.Equal(3, target.ItemCount);
+        }
+
+        [Fact]
+        public void Item_Count_Should_Be_Set_When_Items_Changed()
+        {
+            var items = new ObservableCollection<int>() { 1, 2, 3 };
+
+            var target = new ItemsControl()
+            {
+                Template = GetTemplate(),
+                Items = items,
+            };
+
+            items.Add(4);
+
+            Assert.Equal(4, target.ItemCount);
+
+            items.Clear();
+
+            Assert.Equal(0, target.ItemCount);
+        }
+
+        [Fact]
+        public void Empty_Class_Should_Be_Set_When_Items_Collection_Cleared()
+        {
+            var items = new ObservableCollection<int>() { 1, 2, 3 };
+
+            var target = new ItemsControl()
+            {
+                Template = GetTemplate(),
+                Items = items,
+            };
+
+            items.Clear();
+
+            Assert.Contains(":empty", target.Classes);
+        }
+
+        [Fact]
+        public void Empty_Class_Should_Not_Be_Set_When_Items_Collection_Count_Increases()
+        {
+            var items = new ObservableCollection<int>() {};
+
+            var target = new ItemsControl()
+            {
+                Template = GetTemplate(),
+                Items = items,
+            };
+
+            items.Add(1);
+
+            Assert.DoesNotContain(":empty", target.Classes);
+        }
+
+        [Fact]
         public void Setting_Presenter_Explicitly_Should_Set_Item_Parent()
         {
             var target = new TestItemsControl();

--- a/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
@@ -380,6 +380,17 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Empty_Class_Should_Be_Set_When_Items_Not_Set()
+        {
+            var target = new ItemsControl()
+            {
+                Template = GetTemplate(),
+            };
+
+            Assert.Contains(":empty", target.Classes);
+        }
+
+        [Fact]
         public void Empty_Class_Should_Be_Set_When_Empty_Collection_Set()
         {
             var target = new ItemsControl()
@@ -444,7 +455,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Empty_Class_Should_Not_Be_Set_When_Items_Collection_Count_Increases()
         {
-            var items = new ObservableCollection<int>() {};
+            var items = new ObservableCollection<int>() { };
 
             var target = new ItemsControl()
             {
@@ -455,6 +466,54 @@ namespace Avalonia.Controls.UnitTests
             items.Add(1);
 
             Assert.DoesNotContain(":empty", target.Classes);
+        }
+
+        [Fact]
+        public void Single_Item_Class_Should_Be_Set_When_Items_Collection_Count_Increases_To_One()
+        {
+            var items = new ObservableCollection<int>() { };
+
+            var target = new ItemsControl()
+            {
+                Template = GetTemplate(),
+                Items = items,
+            };
+
+            items.Add(1);
+
+            Assert.Contains(":singleitem", target.Classes);
+        }
+
+        [Fact]
+        public void Empty_Class_Should_Not_Be_Set_When_Items_Collection_Cleared()
+        {
+            var items = new ObservableCollection<int>() { 1, 2, 3 };
+
+            var target = new ItemsControl()
+            {
+                Template = GetTemplate(),
+                Items = items,
+            };
+
+            items.Clear();
+
+            Assert.DoesNotContain(":singleitem", target.Classes);
+        }
+
+        [Fact]
+        public void Single_Item_Class_Should_Not_Be_Set_When_Items_Collection_Count_Increases_Beyond_One()
+        {
+            var items = new ObservableCollection<int>() { 1 };
+
+            var target = new ItemsControl()
+            {
+                Template = GetTemplate(),
+                Items = items,
+            };
+
+            items.Add(2);
+
+            Assert.DoesNotContain(":singleitem", target.Classes);
         }
 
         [Fact]


### PR DESCRIPTION
## What does the pull request do?
This PR is making `ItemsControl` more consistent in how it updates the `PseudoClasses`. An (intended) side effect of this is to allow the use of a collection that implements `INotifyCollectionChanged` and `IEnumerable`, but not `ICollection`.

In my particular use case (where this was a problem) it was fine to implement `ICollection` on the custom collection, but the inconsistency between interpreting `Items` as an `IEnumerable` when the collection is first built and not when it changes is probably not desirable.

This is related to #54, and while it was indicating that this might be a reasonable change, it may well be the case that it would be better to reject collections that do not implement `ICollection` outright.

## What is the current behavior?
Currently `ItemsControl` sets the `PseudoClasses` assuming that `Items` is an `ICollection` when the collection is modified. However, it allows it to be an `IEnumerable` when it first determines the `PseudoClasses`. Consequently, it supports well-behaved `IEnumerable` collections with the exception of setting the `:empty` psuedo-classes when a non-`ICollection` is used that notifies a change regardless of the number of items in the collection (which is otherwise determined through `IEnumerable`).

## What is the updated/expected behavior with this PR?
For consistency, the code should fall back to interrogating the `IEnumerable` directly if it cannot cast it as `ICollection`.

## How was the solution implemented (if it's not obvious)?
The code to set the `PseudoClasses` is put in one method, and depends on the `ItemCount` property, rather than re-computing it, which previous was performed in 2 different ways (one allowed `IEnumerable`, and one which did not).

Tests are added to check `ItemCount` and `:isempty` when a collection changes. I'm happy to add more tests (for e.g. `:singleitem`) if this suits. _If_ it is deemed appropriate that `IEnumerable` should be supported, then I'll be happy to add additional tests for them (none of these tests fail with the original code because the PR doesn't change the observable behaviour when using an `ICollection`).

## Checklist
- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation