### PR TITLE
Added IComparer sorting to DataGridColumn

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridSortDescription.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridSortDescription.cs
@@ -265,6 +265,43 @@ namespace Avalonia.Collections
         {
             return new DataGridPathSortDescription(propertyPath, direction, comparer, null);
         }
+
+        public static DataGridSortDescription FromComparer(IComparer comparer, ListSortDirection direction = ListSortDirection.Ascending)
+        {
+            return new DataGridComparerSortDesctiption(comparer, direction);
+        }
+    }
+
+    public class DataGridComparerSortDesctiption : DataGridSortDescription
+    {
+        private readonly IComparer _innerComparer;
+        private readonly ListSortDirection _direction;
+        private readonly IComparer<object> _comparer;
+
+        public IComparer SourceComparer => _innerComparer;
+        public override IComparer<object> Comparer => _comparer;
+        public override ListSortDirection Direction => _direction;
+        public DataGridComparerSortDesctiption(IComparer comparer, ListSortDirection direction)
+        {
+            _innerComparer = comparer;
+            _direction = direction;
+            _comparer = Comparer<object>.Create((x, y) => Compare(x, y));
+        }
+
+        private int Compare(object x, object y)
+        {
+            int result = _innerComparer.Compare(x, y);
+
+            if (Direction == ListSortDirection.Descending)
+                return -result;
+            else
+                return result;
+        }
+        public override DataGridSortDescription SwitchSortDirection()
+        {
+            var newDirection = _direction == ListSortDirection.Ascending ? ListSortDirection.Descending : ListSortDirection.Ascending;
+            return new DataGridComparerSortDesctiption(_innerComparer, newDirection);
+        }
     }
 
     public class DataGridSortDescriptionCollection : AvaloniaList<DataGridSortDescription>

--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
@@ -1009,6 +1009,14 @@ namespace Avalonia.Controls
             get;
             set;
         }
+        /// <summary>
+        /// Holds a Comparer to use for sorting, if not using the default.
+        /// </summary>
+        public System.Collections.IComparer CustomSortComparer
+        {
+            get;
+            set;
+        }
 
         /// <summary>
         /// We get the sort description from the data source.  We don't worry whether we can modify sort -- perhaps the sort description
@@ -1020,6 +1028,14 @@ namespace Avalonia.Controls
                 && OwningGrid.DataConnection != null
                 && OwningGrid.DataConnection.SortDescriptions != null)
             {
+                if(CustomSortComparer != null)
+                {
+                    return
+                        OwningGrid.DataConnection.SortDescriptions
+                                  .OfType<DataGridComparerSortDesctiption>()
+                                  .FirstOrDefault(s => s.SourceComparer == CustomSortComparer);
+                }
+
                 string propertyName = GetSortPropertyName();
 
                 return OwningGrid.DataConnection.SortDescriptions.FirstOrDefault(s => s.HasPropertyPath && s.PropertyPath == propertyName);

--- a/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
@@ -274,6 +274,12 @@ namespace Avalonia.Controls
                                     owningGrid.DataConnection.SortDescriptions.Add(newSort);
                                 }
                             }
+                            else if (OwningColumn.CustomSortComparer != null)
+                            {
+                                newSort = DataGridSortDescription.FromComparer(OwningColumn.CustomSortComparer);
+
+                                owningGrid.DataConnection.SortDescriptions.Add(newSort);
+                            }
                             else
                             {
                                 string propertyName = OwningColumn.GetSortPropertyName();


### PR DESCRIPTION
## What does the pull request do?
Adds an `IComparer` property to `DataGridColumn` that can be used to customize the sort that is applied when a column header is clicked

## What is the updated/expected behavior with this PR?
When the `CustomSortComparer` property is set on a `DataGridColumn`, the comparer is used to sort the rows when the column header is clicked. This also allows for column sorting without the use of reflection.
