### PR TITLE
Fix TextAlignment for TextBlock when HorizontalAlignment is used.

### DIFF
--- a/src/Avalonia.Visuals/Media/TextFormatting/TextLayout.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextLayout.cs
@@ -305,9 +305,11 @@ namespace Avalonia.Media.TextFormatting
         /// <param name="height">The current height.</param>
         private static void UpdateBounds(TextLine textLine, ref double width, ref double height)
         {
-            if (width < textLine.Width)
+            var lineWidth = textLine.Width + textLine.Start * 2;
+            
+            if (width < lineWidth)
             {
-                width = textLine.Width;
+                width = lineWidth;
             }
 
             height += textLine.Height;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes a rendering issue with the TextBlock that occurs when the TextBox is aligned by its parent.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Previously each TextLine's Start offset wasn't taken into account when the TextLayout's Size was calculated.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
We now calculate the TextLayout's size properly.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
