### PR TITLE
Optional tooltip DataValidationError template

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -163,6 +163,10 @@
   <Style Selector="DataGridCell:invalid /template/ Rectangle#InvalidVisualElement">
     <Setter Property="IsVisible" Value="True" />
   </Style>
+  <Style Selector="DataGridCell > TextBox DataValidationErrors">
+    <Setter Property="Template" Value="{DynamicResource TooltipDataValidationContentTemplate}" />
+    <Setter Property="ErrorTemplate" Value="{DynamicResource TooltipDataValidationErrorTemplate}" />
+  </Style>
 
   <Style Selector="DataGridColumnHeader">
     <Setter Property="Foreground" Value="{DynamicResource DataGridColumnHeaderForegroundBrush}" />

--- a/src/Avalonia.Themes.Fluent/Controls/DataValidationErrors.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/DataValidationErrors.xaml
@@ -1,44 +1,102 @@
-<Style xmlns="https://github.com/avaloniaui" 
-       Selector="DataValidationErrors"
-       xmlns:sys="clr-namespace:System;assembly=netstandard">
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:sys="using:System">
   <Design.PreviewWith>
-    <Border Padding="20"> 
-      <TextBox Text="Sample">
-        <DataValidationErrors.Error>
-          <sys:Exception/> 
-        </DataValidationErrors.Error>
-      </TextBox>
+    <Border Padding="20">
+      <StackPanel Spacing="20">
+        <TextBox Text="Sample">
+          <DataValidationErrors.Error>
+            <sys:Exception />
+          </DataValidationErrors.Error>
+        </TextBox>
+        <TextBox Text="Sample">
+          <TextBox.Styles>
+            <Style Selector="DataValidationErrors">
+              <Setter Property="Template" Value="{DynamicResource TooltipDataValidationContentTemplate}" />
+              <Setter Property="ErrorTemplate" Value="{DynamicResource TooltipDataValidationErrorTemplate}" />
+            </Style>
+          </TextBox.Styles>
+          <DataValidationErrors.Error>
+            <sys:Exception />
+          </DataValidationErrors.Error>
+        </TextBox>
+      </StackPanel>
     </Border>
   </Design.PreviewWith>
-    
-  <Setter Property="Template">
-    <ControlTemplate>
-      <DockPanel LastChildFill="True">
-        <ContentControl Margin="0 4 0 0"
-          DockPanel.Dock="Bottom"
-          ContentTemplate="{TemplateBinding ErrorTemplate}"
-          DataContext="{TemplateBinding Owner}"
-          Content="{Binding (DataValidationErrors.Errors)}"
-          IsVisible="{Binding (DataValidationErrors.HasErrors)}" />
-        <ContentPresenter
-          Name="PART_ContentPresenter"
-          Background="{TemplateBinding Background}"
-          BorderThickness="{TemplateBinding BorderThickness}"
-          ContentTemplate="{TemplateBinding ContentTemplate}"
-          Content="{TemplateBinding Content}"
-          Padding="{TemplateBinding Padding}" />
-      </DockPanel>
-    </ControlTemplate>
-  </Setter>
-  <Setter Property="ErrorTemplate">
-    <DataTemplate>
-      <ItemsControl Items="{Binding}">
-        <ItemsControl.ItemTemplate>
-          <DataTemplate>
-            <TextBlock Text="{Binding }" Foreground="{DynamicResource SystemControlErrorTextForegroundBrush}" TextWrapping="Wrap" />
-          </DataTemplate>
-        </ItemsControl.ItemTemplate>
-      </ItemsControl>
-    </DataTemplate>
-  </Setter>
-</Style>
+
+  <Style Selector="DataValidationErrors">
+    <Style.Resources>
+      <DataTemplate x:Key="InlineDataValidationErrorTemplate">
+        <ItemsControl Items="{Binding}">
+          <ItemsControl.ItemTemplate>
+            <DataTemplate>
+              <TextBlock Foreground="{DynamicResource SystemControlErrorTextForegroundBrush}"
+                         Text="{Binding}"
+                         TextWrapping="Wrap" />
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
+      </DataTemplate>
+      <ControlTemplate x:Key="InlineDataValidationContentTemplate" TargetType="DataValidationErrors">
+        <DockPanel LastChildFill="True">
+          <ContentControl x:Name="InlineDataValidationContentControl"
+                          Margin="0,4,0,0"
+                          Content="{Binding (DataValidationErrors.Errors)}"
+                          ContentTemplate="{TemplateBinding ErrorTemplate}"
+                          DataContext="{TemplateBinding Owner}"
+                          DockPanel.Dock="Bottom"
+                          IsVisible="{Binding (DataValidationErrors.HasErrors)}" />
+          <ContentPresenter Name="PART_ContentPresenter"
+                            Padding="{TemplateBinding Padding}"
+                            Background="{TemplateBinding Background}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}" />
+        </DockPanel>
+      </ControlTemplate>
+
+      <DataTemplate x:Key="TooltipDataValidationErrorTemplate">
+        <Panel Name="PART_InlineErrorTemplatePanel" Background="Transparent">
+          <Panel.Styles>
+            <Style Selector="Panel#PART_InlineErrorTemplatePanel">
+              <Setter Property="Margin" Value="8,0,4,0" />
+            </Style>
+            <Style Selector="Panel#PART_InlineErrorTemplatePanel ToolTip">
+              <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+            </Style>
+            <Style Selector="Panel#PART_InlineErrorTemplatePanel ToolTip TextBlock">
+              <Setter Property="TextWrapping" Value="Wrap" />
+            </Style>
+          </Panel.Styles>
+          <ToolTip.Tip>
+            <ItemsControl Items="{Binding}" />
+          </ToolTip.Tip>
+          <Path Width="14"
+                Height="14"
+                Data="M14,7 A7,7 0 0,0 0,7 M0,7 A7,7 0 1,0 14,7 M7,3l0,5 M7,9l0,2"
+                Stroke="{DynamicResource SystemControlErrorTextForegroundBrush}"
+                StrokeThickness="2" />
+        </Panel>
+      </DataTemplate>
+      <ControlTemplate x:Key="TooltipDataValidationContentTemplate" TargetType="DataValidationErrors">
+        <DockPanel LastChildFill="True">
+          <ContentControl Content="{Binding (DataValidationErrors.Errors)}"
+                          ContentTemplate="{TemplateBinding ErrorTemplate}"
+                          DataContext="{TemplateBinding Owner}"
+                          DockPanel.Dock="Right"
+                          IsVisible="{Binding (DataValidationErrors.HasErrors)}" />
+          <ContentPresenter Name="PART_ContentPresenter"
+                            Padding="{TemplateBinding Padding}"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}" />
+        </DockPanel>
+      </ControlTemplate>
+    </Style.Resources>
+
+    <Setter Property="Template" Value="{StaticResource InlineDataValidationContentTemplate}" />
+    <Setter Property="ErrorTemplate" Value="{StaticResource InlineDataValidationErrorTemplate}" />
+  </Style>
+</Styles>

--- a/src/Avalonia.Themes.Fluent/Controls/DataValidationErrors.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/DataValidationErrors.xaml
@@ -59,7 +59,7 @@
         <Panel Name="PART_InlineErrorTemplatePanel" Background="Transparent">
           <Panel.Styles>
             <Style Selector="Panel#PART_InlineErrorTemplatePanel">
-              <Setter Property="Margin" Value="8,0,4,0" />
+              <Setter Property="Margin" Value="8,0" />
             </Style>
             <Style Selector="Panel#PART_InlineErrorTemplatePanel ToolTip">
               <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}" />


### PR DESCRIPTION
## What does the pull request do?
Previously this PR, https://github.com/AvaloniaUI/Avalonia/pull/4964, changed data validation error default style.
But in some specific cases inline error is not usable, so it will be really useful to keep tooltip validation out-of-box, available optionally.
Also we have DataGrid validation bug exactly for the same reason.

## What is the current behavior?
![image](https://user-images.githubusercontent.com/3163374/116804630-3a2e8e00-aaee-11eb-8c4b-c170ae8e1de7.png)

## What is the updated/expected behavior with this PR?
![image](https://user-images.githubusercontent.com/3163374/116804620-2420cd80-aaee-11eb-95d6-c8a5fc1a977b.png)
![image](https://user-images.githubusercontent.com/3163374/116804597-fcca0080-aaed-11eb-83d8-406c1c9b1562.png)


## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/5403