### PR TITLE
Port CornerRadiusFilterConverter from WinUI

### DIFF
--- a/src/Avalonia.Controls/Converters/CornerRadiusFilterConverter.cs
+++ b/src/Avalonia.Controls/Converters/CornerRadiusFilterConverter.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Controls.Converters
         /// <summary>
         /// Gets or sets the type of the filter applied to the <see cref="CornerRadiusFilterConverter"/>.
         /// </summary>
-        public CornerRadiusFilterKind Filter { get; set; }
+        public CornerRadiusFilterKinds Filter { get; set; }
 
         /// <summary>
         /// Gets or sets the scale multiplier applied to the <see cref="CornerRadiusFilterConverter"/>.
@@ -29,48 +29,16 @@ namespace Avalonia.Controls.Converters
                 return value;
             }
 
-            if (Filter == CornerRadiusFilterKind.TopLeftValue
-                || Filter == CornerRadiusFilterKind.BottomRightValue)
-            {
-                var doubleValue = GetDoubleValue(radius, Filter);
-                return double.IsNaN(Scale) ? doubleValue : doubleValue * Scale;
-            }
-            else
-            {
-                var cornerRadius = GetCornerRadiusValue(radius, Filter);
-                return double.IsNaN(Scale) ? cornerRadius : new CornerRadius(
-                    cornerRadius.TopLeft * Scale,
-                    cornerRadius.TopRight * Scale,
-                    cornerRadius.BottomRight * Scale,
-                    cornerRadius.BottomLeft * Scale);
-            }
+            return new CornerRadius(
+                Filter.HasAllFlags(CornerRadiusFilterKinds.TopLeft) ? radius.TopLeft * Scale : 0,
+                Filter.HasAllFlags(CornerRadiusFilterKinds.TopRight) ? radius.TopRight * Scale : 0,
+                Filter.HasAllFlags(CornerRadiusFilterKinds.BottomRight) ? radius.BottomRight * Scale : 0,
+                Filter.HasAllFlags(CornerRadiusFilterKinds.BottomLeft) ? radius.BottomLeft * Scale : 0);
         }
 
         public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
-        }
-
-        private CornerRadius GetCornerRadiusValue(CornerRadius radius, CornerRadiusFilterKind filterKind)
-        {
-            return filterKind switch
-            {
-                CornerRadiusFilterKind.Top => new CornerRadius(radius.TopLeft, radius.TopRight, 0, 0),
-                CornerRadiusFilterKind.Right => new CornerRadius(0, radius.TopRight, radius.BottomRight, 0),
-                CornerRadiusFilterKind.Bottom => new CornerRadius(0, 0, radius.BottomRight, radius.BottomLeft),
-                CornerRadiusFilterKind.Left => new CornerRadius(radius.TopLeft, 0, 0, radius.BottomLeft),
-                _ => radius,
-            };
-        }
-
-        private double GetDoubleValue(CornerRadius radius, CornerRadiusFilterKind filterKind)
-        {
-            return filterKind switch
-            {
-                CornerRadiusFilterKind.TopLeftValue => radius.TopLeft,
-                CornerRadiusFilterKind.BottomRightValue => radius.BottomRight,
-                _ => 0,
-            };
         }
     }
 }

--- a/src/Avalonia.Controls/Converters/CornerRadiusFilterConverter.cs
+++ b/src/Avalonia.Controls/Converters/CornerRadiusFilterConverter.cs
@@ -1,0 +1,76 @@
+﻿#nullable enable
+using System;
+using System.Globalization;
+
+using Avalonia.Data.Converters;
+
+namespace Avalonia.Controls.Converters
+{
+    /// <summary>
+    /// Converts an existing CornerRadius struct to a new CornerRadius struct,
+    /// with filters applied to extract only the specified fields, leaving the others set to 0.
+    /// </summary>
+    public class CornerRadiusFilterConverter : IValueConverter
+    {
+        /// <summary>
+        /// Gets or sets the type of the filter applied to the <see cref="CornerRadiusFilterConverter"/>.
+        /// </summary>
+        public CornerRadiusFilterKind Filter { get; set; }
+
+        /// <summary>
+        /// Gets or sets the scale multiplier applied to the <see cref="CornerRadiusFilterConverter"/>.
+        /// </summary>
+        public double Scale { get; set; } = 1;
+
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (!(value is CornerRadius radius))
+            {
+                return value;
+            }
+
+            if (Filter == CornerRadiusFilterKind.TopLeftValue
+                || Filter == CornerRadiusFilterKind.BottomRightValue)
+            {
+                var doubleValue = GetDoubleValue(radius, Filter);
+                return double.IsNaN(Scale) ? doubleValue : doubleValue * Scale;
+            }
+            else
+            {
+                var cornerRadius = GetCornerRadiusValue(radius, Filter);
+                return double.IsNaN(Scale) ? cornerRadius : new CornerRadius(
+                    cornerRadius.TopLeft * Scale,
+                    cornerRadius.TopRight * Scale,
+                    cornerRadius.BottomRight * Scale,
+                    cornerRadius.BottomLeft * Scale);
+            }
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        private CornerRadius GetCornerRadiusValue(CornerRadius radius, CornerRadiusFilterKind filterKind)
+        {
+            return filterKind switch
+            {
+                CornerRadiusFilterKind.Top => new CornerRadius(radius.TopLeft, radius.TopRight, 0, 0),
+                CornerRadiusFilterKind.Right => new CornerRadius(0, radius.TopRight, radius.BottomRight, 0),
+                CornerRadiusFilterKind.Bottom => new CornerRadius(0, 0, radius.BottomRight, radius.BottomLeft),
+                CornerRadiusFilterKind.Left => new CornerRadius(radius.TopLeft, 0, 0, radius.BottomLeft),
+                _ => radius,
+            };
+        }
+
+        private double GetDoubleValue(CornerRadius radius, CornerRadiusFilterKind filterKind)
+        {
+            return filterKind switch
+            {
+                CornerRadiusFilterKind.TopLeftValue => radius.TopLeft,
+                CornerRadiusFilterKind.BottomRightValue => radius.BottomRight,
+                _ => 0,
+            };
+        }
+    }
+}

--- a/src/Avalonia.Controls/Converters/CornerRadiusFilterKind.cs
+++ b/src/Avalonia.Controls/Converters/CornerRadiusFilterKind.cs
@@ -1,0 +1,37 @@
+﻿namespace Avalonia.Controls.Converters
+{
+    /// <summary>
+    /// Defines constants that specify the filter type for a <see cref="CornerRadiusFilterConverter"/> instance.
+    /// </summary>
+    public enum CornerRadiusFilterKind
+    {
+        /// <summary>
+        /// No filter applied.
+        /// </summary>
+        None,
+        /// <summary>
+        /// Filters TopLeft and TopRight values, sets BottomLeft and BottomRight to 0.
+        /// </summary>
+        Top,
+        /// <summary>
+        /// Filters TopRight and BottomRight values, sets TopLeft and BottomLeft to 0.
+        /// </summary>
+        Right,
+        /// <summary>
+        /// Filters BottomLeft and BottomRight values, sets TopLeft and TopRight to 0.
+        /// </summary>
+        Bottom,
+        /// <summary>
+        /// Filters TopLeft and BottomLeft values, sets TopRight and BottomRight to 0.
+        /// </summary>
+        Left,
+        /// <summary>
+        /// Gets the double value of TopLeft corner.
+        /// </summary>
+        TopLeftValue,
+        /// <summary>
+        /// Gets the double value of BottomRight corner.
+        /// </summary>
+        BottomRightValue
+    }
+}

--- a/src/Avalonia.Controls/Converters/CornerRadiusFilterKind.cs
+++ b/src/Avalonia.Controls/Converters/CornerRadiusFilterKind.cs
@@ -1,37 +1,32 @@
-﻿namespace Avalonia.Controls.Converters
+﻿using System;
+
+namespace Avalonia.Controls.Converters
 {
     /// <summary>
     /// Defines constants that specify the filter type for a <see cref="CornerRadiusFilterConverter"/> instance.
     /// </summary>
-    public enum CornerRadiusFilterKind
+    [Flags]
+    public enum CornerRadiusFilterKinds
     {
         /// <summary>
         /// No filter applied.
         /// </summary>
         None,
         /// <summary>
-        /// Filters TopLeft and TopRight values, sets BottomLeft and BottomRight to 0.
+        /// Filters TopLeft value.
         /// </summary>
-        Top,
+        TopLeft = 1,
         /// <summary>
-        /// Filters TopRight and BottomRight values, sets TopLeft and BottomLeft to 0.
+        /// Filters TopRight value.
         /// </summary>
-        Right,
+        TopRight = 2,
         /// <summary>
-        /// Filters BottomLeft and BottomRight values, sets TopLeft and TopRight to 0.
+        /// Filters BottomLeft value.
         /// </summary>
-        Bottom,
+        BottomLeft = 4,
         /// <summary>
-        /// Filters TopLeft and BottomLeft values, sets TopRight and BottomRight to 0.
+        /// Filters BottomRight value.
         /// </summary>
-        Left,
-        /// <summary>
-        /// Gets the double value of TopLeft corner.
-        /// </summary>
-        TopLeftValue,
-        /// <summary>
-        /// Gets the double value of BottomRight corner.
-        /// </summary>
-        BottomRightValue
+        BottomRight = 8
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Ports [CornerRadiusFilterConverter](https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.controls.primitives.cornerradiusfilterconverter?view=winui-3.0) from WinUI.
Useful when developer needs to reuse same resource or template binding, but with filtering specific corners.
Unblocks https://github.com/AvaloniaUI/Avalonia/pull/5573
Partially solves inconvenience discussed previously here https://github.com/AvaloniaUI/Avalonia/discussions/5594
Note: Better solution would be new XamlX syntax sugar to allow modifying CornerRadius/Thickness structs in style setters and xaml attributes (something like new "with" keyword from C#), but simple converter will solve this issue in short term.