### PR TITLE
dont use datatemplate in datavalidationerrors.

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/DataValidationErrors.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/DataValidationErrors.xaml
@@ -27,14 +27,12 @@
   <Style Selector="DataValidationErrors">
     <Style.Resources>
       <DataTemplate x:Key="InlineDataValidationErrorTemplate">
-        <ItemsControl Items="{Binding}">
-          <ItemsControl.DataTemplates>
-            <DataTemplate>
-              <TextBlock Foreground="{DynamicResource SystemControlErrorTextForegroundBrush}"
-                         Text="{Binding}"
-                         TextWrapping="Wrap" />
-            </DataTemplate>
-          </ItemsControl.DataTemplates>
+        <ItemsControl Items="{Binding}" TextBlock.Foreground="{DynamicResource SystemControlErrorTextForegroundBrush}">
+          <ItemsControl.Styles>
+            <Style Selector="TextBlock">
+              <Setter Property="TextWrapping" Value="Wrap" />
+            </Style>
+          </ItemsControl.Styles>
         </ItemsControl>
       </DataTemplate>
       <ControlTemplate x:Key="InlineDataValidationContentTemplate" TargetType="DataValidationErrors">

--- a/src/Avalonia.Themes.Fluent/Controls/DataValidationErrors.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/DataValidationErrors.xaml
@@ -28,13 +28,13 @@
     <Style.Resources>
       <DataTemplate x:Key="InlineDataValidationErrorTemplate">
         <ItemsControl Items="{Binding}">
-          <ItemsControl.ItemTemplate>
+          <ItemsControl.DataTemplates>
             <DataTemplate>
               <TextBlock Foreground="{DynamicResource SystemControlErrorTextForegroundBrush}"
                          Text="{Binding}"
                          TextWrapping="Wrap" />
             </DataTemplate>
-          </ItemsControl.ItemTemplate>
+          </ItemsControl.DataTemplates>
         </ItemsControl>
       </DataTemplate>
       <ControlTemplate x:Key="InlineDataValidationContentTemplate" TargetType="DataValidationErrors">


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
remove use of datatemplates in DataValidationErrors.



## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
users cannot provide their own template easily.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
User can supply a template simply like:

```
<Application.DataTemplates>
    <local:ViewLocator/>
    <DataTemplate DataType="models:ErrorDescriptor" x:DataType="models:ErrorDescriptor">
      <TextBlock Text="Error here"/>
    </DataTemplate>
```

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
