### PR TITLE
Include inner exception when throwing from BindingEntry

### DIFF
--- a/src/Avalonia.Base/PropertyStore/BindingEntry.cs
+++ b/src/Avalonia.Base/PropertyStore/BindingEntry.cs
@@ -79,7 +79,7 @@ namespace Avalonia.PropertyStore
 
         public void OnError(Exception error)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException("BindingEntry.OnError is not implemented", error);
         }
 
         public void OnNext(BindingValue<T> value)


### PR DESCRIPTION
## What does the pull request do?
For some reason in the logs of my app I see NotImplementedException from BindingEntry class.
But it's kind of hard to understand a reason without knowing exception that caused call to OnError.
This PR makes this method a bit more useful at least for debugging.  