### PR TITLE
`StretchDirection` for `Viewbox`

### DIFF
--- a/samples/ControlCatalog/Pages/ViewboxPage.xaml
+++ b/samples/ControlCatalog/Pages/ViewboxPage.xaml
@@ -34,7 +34,7 @@
             <Border VerticalAlignment="Center" HorizontalAlignment="Center" Grid.Column="0" BorderThickness="1" BorderBrush="CornflowerBlue" Width="{Binding #WidthSlider.Value}" Height="{Binding #HeightSlider.Value}" >
               <Viewbox x:Name="Viewbox"
                 StretchDirection="{Binding #StretchDirectionSelector.SelectedItem}">
-                <Path Width="50" Stretch="Uniform" Fill="CornflowerBlue" Data="{StaticResource Acorn}"/>
+                <Ellipse Width="50" Height="50" Fill="CornflowerBlue" />
               </Viewbox>
             </Border>
           </Border>

--- a/samples/ControlCatalog/Pages/ViewboxPage.xaml
+++ b/samples/ControlCatalog/Pages/ViewboxPage.xaml
@@ -22,14 +22,38 @@
         </StreamGeometry>
     </UserControl.Resources>
 
-    <Grid RowDefinitions="Auto,*">
+    <Grid RowDefinitions="Auto,*,*">
         <StackPanel Orientation="Vertical" Spacing="4">
             <TextBlock Classes="h1">Viewbox</TextBlock>
             <TextBlock Classes="h2">A control used to scale single child.</TextBlock>
         </StackPanel>
+
+        <Grid Grid.Row="1" ColumnDefinitions="*,Auto" HorizontalAlignment="Center" Margin="0,10,0,0">
+
+          <Border HorizontalAlignment="Center" Grid.Column="0" BorderThickness="1" BorderBrush="Orange" Width="200" Height="200">
+            <Border VerticalAlignment="Center" HorizontalAlignment="Center" Grid.Column="0" BorderThickness="1" BorderBrush="CornflowerBlue" Width="{Binding #WidthSlider.Value}" Height="{Binding #HeightSlider.Value}" >
+              <Viewbox x:Name="Viewbox"
+                StretchDirection="{Binding #StretchDirectionSelector.SelectedItem}">
+                <Path Width="50" Stretch="Uniform" Fill="CornflowerBlue" Data="{StaticResource Acorn}"/>
+              </Viewbox>
+            </Border>
+          </Border>
+
+          <StackPanel HorizontalAlignment="Left" Orientation="Vertical" Grid.Column="1" Margin="8,0,0,0" Width="150">
+            <TextBlock Text="Width" />
+            <Slider Minimum="10" Maximum="200" Value="100" x:Name="WidthSlider" TickFrequency="25" TickPlacement="TopLeft" />
+            <TextBlock Text="Height" />
+            <Slider Minimum="10" Maximum="200" Value="100" x:Name="HeightSlider" TickFrequency="25" TickPlacement="TopLeft" />
+            <TextBlock Text="Stretch" />
+            <ComboBox x:Name="StretchSelector" HorizontalAlignment="Stretch" Margin="0,0,0,2" SelectionChanged="StretchSelector_OnSelectionChanged" />
+            <TextBlock Text="Stretch Direction" />
+            <ComboBox x:Name="StretchDirectionSelector" HorizontalAlignment="Stretch" />
+          </StackPanel>
+        </Grid>
+
         <Grid ColumnDefinitions="Auto,*,*"
               RowDefinitions="*,*,*,*"
-              Grid.Row="1" Margin="48"
+              Grid.Row="2" Margin="48"
               MaxWidth="400">
             <TextBlock Grid.Row="0" VerticalAlignment="Center">None</TextBlock>
             <TextBlock Grid.Row="1" VerticalAlignment="Center">Fill</TextBlock>

--- a/samples/ControlCatalog/Pages/ViewboxPage.xaml
+++ b/samples/ControlCatalog/Pages/ViewboxPage.xaml
@@ -1,26 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="ControlCatalog.Pages.ViewboxPage">
-    <UserControl.Resources>
-        <StreamGeometry x:Key="Acorn">
-            F1 M 16.6309,18.6563C 17.1309,
-            8.15625 29.8809,14.1563 29.8809,
-            14.1563C 30.8809,11.1563 34.1308,
-            11.4063 34.1308,11.4063C 33.5,12
-            34.6309,13.1563 34.6309,13.1563C
-            32.1309,13.1562 31.1309,14.9062
-            31.1309,14.9062C 41.1309,23.9062
-            32.6309,27.9063 32.6309,27.9062C
-            24.6309,24.9063 21.1309,22.1562
-            16.6309,18.6563 Z M 16.6309,19.9063C
-            21.6309,24.1563 25.1309,26.1562
-            31.6309,28.6562C 31.6309,28.6562
-            26.3809,39.1562 18.3809,36.1563C
-            18.3809,36.1563 18,38 16.3809,36.9063C
-            15,36 16.3809,34.9063 16.3809,34.9063C
-            16.3809,34.9063 10.1309,30.9062 16.6309,19.9063 Z
-        </StreamGeometry>
-    </UserControl.Resources>
 
     <Grid RowDefinitions="Auto,*,*">
         <StackPanel Orientation="Vertical" Spacing="4">
@@ -51,40 +31,5 @@
           </StackPanel>
         </Grid>
 
-        <Grid ColumnDefinitions="Auto,*,*"
-              RowDefinitions="*,*,*,*"
-              Grid.Row="2" Margin="48"
-              MaxWidth="400">
-            <TextBlock Grid.Row="0" VerticalAlignment="Center">None</TextBlock>
-            <TextBlock Grid.Row="1" VerticalAlignment="Center">Fill</TextBlock>
-            <TextBlock Grid.Row="2" VerticalAlignment="Center">Uniform</TextBlock>
-            <TextBlock Grid.Row="3" VerticalAlignment="Center">UniformToFill</TextBlock>
-
-            <Viewbox Grid.Row="0" Grid.Column="1" Stretch="None">
-                <TextBlock>Hello World!</TextBlock>
-            </Viewbox>
-            <Viewbox Grid.Row="1" Grid.Column="1" Stretch="Fill">
-                <TextBlock>Hello World!</TextBlock>
-            </Viewbox>
-            <Viewbox Grid.Row="2" Grid.Column="1" Stretch="Uniform">
-                <TextBlock>Hello World!</TextBlock>
-            </Viewbox>
-            <Viewbox Grid.Row="3" Grid.Column="1" Stretch="UniformToFill">
-                <TextBlock>Hello World!</TextBlock>
-            </Viewbox>
-
-            <Viewbox Grid.Row="0" Grid.Column="2" Stretch="None">
-                <Path Fill="Blue" Data="{StaticResource Acorn}"/>
-            </Viewbox>
-            <Viewbox Grid.Row="1" Grid.Column="2" Stretch="Fill">
-                <Path Fill="Blue" Data="{StaticResource Acorn}"/>
-            </Viewbox>
-            <Viewbox Grid.Row="2" Grid.Column="2" Stretch="Uniform">
-                <Path Fill="Blue" Data="{StaticResource Acorn}"/>
-            </Viewbox>
-            <Viewbox Grid.Row="3" Grid.Column="2" Stretch="UniformToFill">
-                <Path Fill="Blue" Data="{StaticResource Acorn}"/>
-            </Viewbox>
-        </Grid>
     </Grid>
 </UserControl>

--- a/samples/ControlCatalog/Pages/ViewboxPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/ViewboxPage.xaml.cs
@@ -1,18 +1,47 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using Avalonia.Media;
 
 namespace ControlCatalog.Pages
 {
     public class ViewboxPage : UserControl
     {
+        private readonly Viewbox _viewbox;
+        private readonly ComboBox _stretchSelector;
+
         public ViewboxPage()
         {
-            this.InitializeComponent();
+            InitializeComponent();
+
+            _viewbox = this.FindControl<Viewbox>("Viewbox");
+
+            _stretchSelector = this.FindControl<ComboBox>("StretchSelector");
+
+            _stretchSelector.Items = new[]
+            {
+                Stretch.Uniform, Stretch.UniformToFill, Stretch.Fill, Stretch.None
+            };
+
+            _stretchSelector.SelectedIndex = 0;
+
+            var stretchDirectionSelector = this.FindControl<ComboBox>("StretchDirectionSelector");
+
+            stretchDirectionSelector.Items = new[]
+            {
+                StretchDirection.Both, StretchDirection.DownOnly, StretchDirection.UpOnly
+            };
+
+            stretchDirectionSelector.SelectedIndex = 0;
         }
 
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
+        }
+
+        private void StretchSelector_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            _viewbox.Stretch = (Stretch) _stretchSelector.SelectedItem!;
         }
     }
 }

--- a/src/Avalonia.Controls/Image.cs
+++ b/src/Avalonia.Controls/Image.cs
@@ -31,8 +31,8 @@ namespace Avalonia.Controls
 
         static Image()
         {
-            AffectsRender<Image>(SourceProperty, StretchProperty);
-            AffectsMeasure<Image>(SourceProperty, StretchProperty);
+            AffectsRender<Image>(SourceProperty, StretchProperty, StretchDirectionProperty);
+            AffectsMeasure<Image>(SourceProperty, StretchProperty, StretchDirectionProperty);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Viewbox.cs
+++ b/src/Avalonia.Controls/Viewbox.cs
@@ -1,40 +1,50 @@
-﻿using System;
-using Avalonia.Media;
+﻿using Avalonia.Media;
 
 namespace Avalonia.Controls
 {
     /// <summary>
-    /// Viewbox is used to scale single child.
+    /// Viewbox is used to scale single child to fit in the available space.
     /// </summary>
     /// <seealso cref="Avalonia.Controls.Decorator" />
     public class Viewbox : Decorator
     {
         /// <summary>
-        /// The stretch property
+        /// Defines the <see cref="Stretch"/> property.
         /// </summary>
         public static readonly AvaloniaProperty<Stretch> StretchProperty =
-                AvaloniaProperty.RegisterDirect<Viewbox, Stretch>(nameof(Stretch),
-                    v => v.Stretch, (c, v) => c.Stretch = v, Stretch.Uniform);
+            AvaloniaProperty.Register<Image, Stretch>(nameof(Stretch), Stretch.Uniform);
+
+        /// <summary>
+        /// Defines the <see cref="StretchDirection"/> property.
+        /// </summary>
+        public static readonly StyledProperty<StretchDirection> StretchDirectionProperty =
+            AvaloniaProperty.Register<Viewbox, StretchDirection>(nameof(StretchDirection), StretchDirection.Both);
 
         private Stretch _stretch = Stretch.Uniform;
+
+        static Viewbox()
+        {
+            ClipToBoundsProperty.OverrideDefaultValue<Viewbox>(true);
+            AffectsMeasure<Viewbox>(StretchProperty, StretchDirectionProperty);
+        }
 
         /// <summary>
         /// Gets or sets the stretch mode, 
         /// which determines how child fits into the available space.
         /// </summary>
-        /// <value>
-        /// The stretch.
-        /// </value>
         public Stretch Stretch
         {
             get => _stretch;
             set => SetAndRaise(StretchProperty, ref _stretch, value);
         }
 
-        static Viewbox()
+        /// <summary>
+        /// Gets or sets a value controlling in what direction contents will be stretched.
+        /// </summary>
+        public StretchDirection StretchDirection
         {
-            ClipToBoundsProperty.OverrideDefaultValue<Viewbox>(true);
-            AffectsMeasure<Viewbox>(StretchProperty);
+            get => GetValue(StretchDirectionProperty);
+            set => SetValue(StretchDirectionProperty, value);
         }
 
         protected override Size MeasureOverride(Size availableSize)
@@ -47,9 +57,9 @@ namespace Avalonia.Controls
 
                 var childSize = child.DesiredSize;
 
-                var scale = GetScale(availableSize, childSize, Stretch);
+                var size = Stretch.CalculateSize(availableSize, childSize, StretchDirection);
 
-                return (childSize * scale).Constrain(availableSize);
+                return size.Constrain(availableSize);
             }
 
             return new Size();
@@ -62,7 +72,9 @@ namespace Avalonia.Controls
             if (child != null)
             {
                 var childSize = child.DesiredSize;
-                var scale = GetScale(finalSize, childSize, Stretch);
+                var scale = Stretch.CalculateScaling(finalSize, childSize, StretchDirection);
+
+                // TODO: Viewbox should have another decorator as a child so we won't affect other render transforms.
                 var scaleTransform = child.RenderTransform as ScaleTransform;
 
                 if (scaleTransform == null)
@@ -80,45 +92,6 @@ namespace Avalonia.Controls
             }
 
             return new Size();
-        }
-
-        private static Vector GetScale(Size availableSize, Size childSize, Stretch stretch)
-        {
-            double scaleX = 1.0;
-            double scaleY = 1.0;
-
-            bool validWidth = !double.IsPositiveInfinity(availableSize.Width);
-            bool validHeight = !double.IsPositiveInfinity(availableSize.Height);
-
-            if (stretch != Stretch.None && (validWidth || validHeight))
-            {
-                scaleX = childSize.Width <= 0.0 ? 0.0 : availableSize.Width / childSize.Width;
-                scaleY = childSize.Height <= 0.0 ? 0.0 : availableSize.Height / childSize.Height;
-
-                if (!validWidth)
-                {
-                    scaleX = scaleY;
-                }
-                else if (!validHeight)
-                {
-                    scaleY = scaleX;
-                }
-                else
-                {
-                    switch (stretch)
-                    {
-                        case Stretch.Uniform:
-                            scaleX = scaleY = Math.Min(scaleX, scaleY);
-                            break;
-
-                        case Stretch.UniformToFill:
-                            scaleX = scaleY = Math.Max(scaleX, scaleY);
-                            break;
-                    }
-                }
-            }
-
-            return new Vector(scaleX, scaleY);
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/ViewboxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ViewboxTests.cs
@@ -114,5 +114,61 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(2.0, scaleTransform.ScaleX);
             Assert.Equal(2.0, scaleTransform.ScaleY);
         }
+
+        [Theory]
+        [InlineData(50, 100, 50, 100, 50, 100, 1)]
+        [InlineData(50, 100, 150, 150, 50, 100, 1)]
+        [InlineData(50, 100, 25, 50, 25, 50, 0.5)]
+        public void Viewbox_Should_Return_Correct_SizeAndScale_StretchDirection_DownOnly(
+            double childWidth, double childHeight,
+            double viewboxWidth, double viewboxHeight,
+            double expectedWidth, double expectedHeight,
+            double expectedScale)
+        {
+            var target = new Viewbox
+            {
+                Child = new Control { Width = childWidth, Height = childHeight },
+                StretchDirection = StretchDirection.DownOnly
+            };
+
+            target.Measure(new Size(viewboxWidth, viewboxHeight));
+            target.Arrange(new Rect(default, target.DesiredSize));
+
+            Assert.Equal(new Size(expectedWidth, expectedHeight), target.DesiredSize);
+
+            var scaleTransform = target.Child.RenderTransform as ScaleTransform;
+
+            Assert.NotNull(scaleTransform);
+            Assert.Equal(expectedScale, scaleTransform.ScaleX);
+            Assert.Equal(expectedScale, scaleTransform.ScaleY);
+        }
+
+        [Theory]
+        [InlineData(50, 100, 50, 100, 50, 100, 1)]
+        [InlineData(50, 100, 25, 50, 25, 50, 1)]
+        [InlineData(50, 100, 150, 150, 75, 150, 1.5)]
+        public void Viewbox_Should_Return_Correct_SizeAndScale_StretchDirection_UpOnly(
+            double childWidth, double childHeight,
+            double viewboxWidth, double viewboxHeight,
+            double expectedWidth, double expectedHeight,
+            double expectedScale)
+        {
+            var target = new Viewbox
+            {
+                Child = new Control { Width = childWidth, Height = childHeight },
+                StretchDirection = StretchDirection.UpOnly
+            };
+
+            target.Measure(new Size(viewboxWidth, viewboxHeight));
+            target.Arrange(new Rect(default, target.DesiredSize));
+
+            Assert.Equal(new Size(expectedWidth, expectedHeight), target.DesiredSize);
+
+            var scaleTransform = target.Child.RenderTransform as ScaleTransform;
+
+            Assert.NotNull(scaleTransform);
+            Assert.Equal(expectedScale, scaleTransform.ScaleX);
+            Assert.Equal(expectedScale, scaleTransform.ScaleY);
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Implements `StretchDirection` as in WPF/WinUI https://docs.microsoft.com/en-us/dotnet/api/system.windows.controls.viewbox.stretchdirectionproperty?view=net-5.0

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`Viewbox` content is always scaled.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
One can control stretching behavior.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Current `Viewbox.Stretch` is a bit problematic since it is a direct property for some reason. For backport reasons I won't change it in the current PR but I will create a follow up one with a breaking change.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation