### PR TITLE
Fix property type for `Viewbox.Stretch.`

### DIFF
--- a/samples/ControlCatalog/Pages/ViewboxPage.xaml
+++ b/samples/ControlCatalog/Pages/ViewboxPage.xaml
@@ -12,8 +12,9 @@
 
           <Border HorizontalAlignment="Center" Grid.Column="0" BorderThickness="1" BorderBrush="Orange" Width="200" Height="200">
             <Border VerticalAlignment="Center" HorizontalAlignment="Center" Grid.Column="0" BorderThickness="1" BorderBrush="CornflowerBlue" Width="{Binding #WidthSlider.Value}" Height="{Binding #HeightSlider.Value}" >
-              <Viewbox x:Name="Viewbox"
-                StretchDirection="{Binding #StretchDirectionSelector.SelectedItem}">
+              <Viewbox
+                  Stretch="{Binding #StretchSelector.SelectedItem}"
+                  StretchDirection="{Binding #StretchDirectionSelector.SelectedItem}">
                 <Ellipse Width="50" Height="50" Fill="CornflowerBlue" />
               </Viewbox>
             </Border>
@@ -25,7 +26,7 @@
             <TextBlock Text="Height" />
             <Slider Minimum="10" Maximum="200" Value="100" x:Name="HeightSlider" TickFrequency="25" TickPlacement="TopLeft" />
             <TextBlock Text="Stretch" />
-            <ComboBox x:Name="StretchSelector" HorizontalAlignment="Stretch" Margin="0,0,0,2" SelectionChanged="StretchSelector_OnSelectionChanged" />
+            <ComboBox x:Name="StretchSelector" HorizontalAlignment="Stretch" Margin="0,0,0,2" />
             <TextBlock Text="Stretch Direction" />
             <ComboBox x:Name="StretchDirectionSelector" HorizontalAlignment="Stretch" />
           </StackPanel>

--- a/samples/ControlCatalog/Pages/ViewboxPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/ViewboxPage.xaml.cs
@@ -6,23 +6,18 @@ namespace ControlCatalog.Pages
 {
     public class ViewboxPage : UserControl
     {
-        private readonly Viewbox _viewbox;
-        private readonly ComboBox _stretchSelector;
-
         public ViewboxPage()
         {
             InitializeComponent();
 
-            _viewbox = this.FindControl<Viewbox>("Viewbox");
+            var stretchSelector = this.FindControl<ComboBox>("StretchSelector");
 
-            _stretchSelector = this.FindControl<ComboBox>("StretchSelector");
-
-            _stretchSelector.Items = new[]
+            stretchSelector.Items = new[]
             {
                 Stretch.Uniform, Stretch.UniformToFill, Stretch.Fill, Stretch.None
             };
 
-            _stretchSelector.SelectedIndex = 0;
+            stretchSelector.SelectedIndex = 0;
 
             var stretchDirectionSelector = this.FindControl<ComboBox>("StretchDirectionSelector");
 
@@ -37,11 +32,6 @@ namespace ControlCatalog.Pages
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-        }
-
-        private void StretchSelector_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            _viewbox.Stretch = (Stretch) _stretchSelector.SelectedItem!;
         }
     }
 }

--- a/src/Avalonia.Controls/Viewbox.cs
+++ b/src/Avalonia.Controls/Viewbox.cs
@@ -12,7 +12,8 @@ namespace Avalonia.Controls
         /// Defines the <see cref="Stretch"/> property.
         /// </summary>
         public static readonly AvaloniaProperty<Stretch> StretchProperty =
-            AvaloniaProperty.Register<Image, Stretch>(nameof(Stretch), Stretch.Uniform);
+            AvaloniaProperty.RegisterDirect<Viewbox, Stretch>(nameof(Stretch),
+                v => v.Stretch, (c, v) => c.Stretch = v, Stretch.Uniform);
 
         /// <summary>
         /// Defines the <see cref="StretchDirection"/> property.


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
By reverting part of my change to `Stretch`  in https://github.com/AvaloniaUI/Avalonia/pull/5917 I've managed to mix property types.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Bindings don't work for `Stretch`.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Bindings work for `Stretch`.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
