### PR TITLE
Fix ICustomHitTest

### DIFF
--- a/src/Avalonia.Visuals/Rendering/ICustomSimpleHitTest.cs
+++ b/src/Avalonia.Visuals/Rendering/ICustomSimpleHitTest.cs
@@ -11,6 +11,7 @@ namespace Avalonia.Rendering
     /// </summary>
     public interface ICustomSimpleHitTest
     {
+        /// <param name="point">The point to hit test in global coordinate space.</param>
         bool HitTest(Point point);
     }
 

--- a/src/Avalonia.Visuals/Rendering/ICustomSimpleHitTest.cs
+++ b/src/Avalonia.Visuals/Rendering/ICustomSimpleHitTest.cs
@@ -17,10 +17,6 @@ namespace Avalonia.Rendering
     /// <summary>
     /// Allows customization of hit-testing for all renderers.
     /// </summary>
-    /// <remarks>
-    /// Note that this interface can only used to make a portion of a control non-hittable, it
-    /// cannot expand the hittable area of a control.
-    /// </remarks>
     public interface ICustomHitTest : ICustomSimpleHitTest
     {
     }

--- a/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
@@ -225,7 +225,7 @@ namespace Avalonia.Rendering
 
             if (filter?.Invoke(visual) != false)
             {
-                bool containsPoint = false;
+                bool containsPoint;
 
                 if (visual is ICustomSimpleHitTest custom)
                 {

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/Scene.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/Scene.cs
@@ -256,7 +256,8 @@ namespace Avalonia.Rendering.SceneGraph
 
                     if (childCount == 0 || wasVisited)
                     {
-                        if ((wasVisited || FilterAndClip(node, ref clip)) && (node.Visual is ICustomSimpleHitTest custom ? custom.HitTest(_point) : node.HitTest(_point)))
+                        if ((wasVisited || FilterAndClip(node, ref clip)) &&
+                            (node.Visual is ICustomSimpleHitTest custom ? custom.HitTest(_point) : node.HitTest(_point)))
                         {
                             _current = node.Visual;
 
@@ -311,8 +312,7 @@ namespace Avalonia.Rendering.SceneGraph
 
                     if (!clipped && node.Visual is ICustomHitTest custom)
                     {
-                        var controlPoint = _sceneRoot.Visual.TranslatePoint(_point, node.Visual);
-                        clipped = !custom.HitTest(controlPoint.Value);
+                        clipped = !custom.HitTest(_point);
                     }
 
                     return !clipped;

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/Scene.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/Scene.cs
@@ -256,7 +256,7 @@ namespace Avalonia.Rendering.SceneGraph
 
                     if (childCount == 0 || wasVisited)
                     {
-                        if ((wasVisited || FilterAndClip(node, ref clip)) && node.HitTest(_point))
+                        if ((wasVisited || FilterAndClip(node, ref clip)) && (node.Visual is ICustomSimpleHitTest custom ? custom.HitTest(_point) : node.HitTest(_point)))
                         {
                             _current = node.Visual;
 

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/CustomHitTestBorder.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/CustomHitTestBorder.cs
@@ -1,0 +1,17 @@
+﻿using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Rendering;
+
+namespace Avalonia.Visuals.UnitTests.Rendering
+{
+    internal class CustomHitTestBorder : Border, ICustomHitTest
+    {
+        public bool HitTest(Point point)
+        {
+            // Move hit testing window halfway to the left
+            return Bounds
+                .WithX(Bounds.X - Bounds.Width / 2)  
+                .Contains(point);
+        }
+    }
+}

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/DeferredRendererTests_HitTesting.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/DeferredRendererTests_HitTesting.cs
@@ -1,6 +1,9 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Platform;
@@ -9,8 +12,6 @@ using Avalonia.UnitTests;
 using Avalonia.VisualTree;
 using Moq;
 using Xunit;
-using System;
-using Avalonia.Controls.Shapes;
 
 namespace Avalonia.Visuals.UnitTests.Rendering
 {
@@ -497,6 +498,42 @@ namespace Avalonia.Visuals.UnitTests.Rendering
                 Assert.Equal(new IVisual[] { canvas, border }, result);
 
                 result = root.Renderer.HitTest(new Point(110, 110), root, null);
+                Assert.Empty(result);
+            }
+        }
+
+        [Fact]
+        public void HitTest_Should_Accommodate_ICustomHitTest()
+        {
+            using (TestApplication())
+            {
+                Border border;
+
+                var root = new TestRoot
+                {
+                    Width = 300,
+                    Height = 200,
+                    Child = border = new CustomHitTestBorder
+                    {
+                        Width = 100,
+                        Height = 100,
+                        Background = Brushes.Red,
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        VerticalAlignment = VerticalAlignment.Center
+                    }
+                }; 
+
+                root.Renderer = new DeferredRenderer(root, null);
+                root.Measure(Size.Infinity);
+                root.Arrange(new Rect(root.DesiredSize));
+
+                var result = root.Renderer.HitTest(new Point(75, 100), root, null);
+                Assert.Equal(new[] { border }, result);
+
+                result = root.Renderer.HitTest(new Point(125, 100), root, null);
+                Assert.Equal(new[] { border }, result);
+
+                result = root.Renderer.HitTest(new Point(175, 100), root, null);
                 Assert.Empty(result);
             }
         }

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/ImmediateRendererTests_HitTesting.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/ImmediateRendererTests_HitTesting.cs
@@ -413,6 +413,43 @@ namespace Avalonia.Visuals.UnitTests.Rendering
             }
         }
 
+        [Fact]
+        public void HitTest_Should_Accommodate_ICustomHitTest()
+        {
+            using (TestApplication())
+            {
+                Border border;
+
+                var root = new TestRoot
+                {
+                    Width = 300,
+                    Height = 200,
+                    Child = border = new CustomHitTestBorder
+                    {
+                        Width = 100,
+                        Height = 100,
+                        Background = Brushes.Red,
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        VerticalAlignment = VerticalAlignment.Center
+                    }
+                };
+
+                root.Renderer = new ImmediateRenderer(root);
+                root.Measure(Size.Infinity);
+                root.Arrange(new Rect(root.DesiredSize));
+                root.Renderer.Paint(new Rect(root.ClientSize));
+
+                var result = root.Renderer.HitTest(new Point(75, 100), root, null).First();
+                Assert.Equal(border, result);
+
+                result = root.Renderer.HitTest(new Point(125, 100), root, null).First();
+                Assert.Equal(border, result);
+
+                result = root.Renderer.HitTest(new Point(175, 100), root, null).First();
+                Assert.Equal(root, result);
+            }
+        }
+
         private IDisposable TestApplication()
         {
             return UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
ICustomHitTest wasn't being handled correctly when using deferred renderer. Immediate renderer functions as intended.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Deferred renderer passes incorrectly translated points for clipping, and for actual hit testing doesn't test at all.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
A repro is provided in #5879. Deferred renderer now passes non-translated points and does actual hit testing. On an slightly less related note, upon inspection it's possible to expand the hit window using this interface, so I've removed an old comment which claimed it was not possible. This is intended behavior.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->
People using deferred renderer will now have non-translated points passed to `HitTest`.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #5879
