### PR TITLE
Default DataGrid SelectedIndex & SelectedItem binding mode to TwoWay

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -535,7 +535,8 @@ namespace Avalonia.Controls
             AvaloniaProperty.RegisterDirect<DataGrid, int>(
                 nameof(SelectedIndex),
                 o => o.SelectedIndex,
-                (o, v) => o.SelectedIndex = v);
+                (o, v) => o.SelectedIndex = v,
+                defaultBindingMode: BindingMode.TwoWay);
 
         /// <summary>
         /// Gets or sets the index of the current selection.
@@ -553,7 +554,8 @@ namespace Avalonia.Controls
             AvaloniaProperty.RegisterDirect<DataGrid, object>(
                 nameof(SelectedItem),
                 o => o.SelectedItem,
-                (o, v) => o.SelectedItem = v);
+                (o, v) => o.SelectedItem = v,
+                defaultBindingMode: BindingMode.TwoWay);
 
         /// <summary>
         /// Gets or sets the data item corresponding to the selected row.


### PR DESCRIPTION
## What does the pull request do?

Default `BindingMode` of `SelectedIndex` & `SelectedItem` to `TwoWay` by default to remove surprise when coming from WPF.

In WPF, `SelectedIndex` and `SelectedItem` default to `TwoWay`: https://referencesource.microsoft.com/#PresentationFramework/src/Framework/System/windows/Controls/Primitives/Selector.cs,329 (this was found by walking up the inheritance chain from `DataGrid`)

In Avalonia, `SelectingItemsControl` (e.g. for `ListBox`) defaults these to `TwoWay`. https://github.com/AvaloniaUI/Avalonia/blob/59d51d6a56d1a6b62051e656be331b7cea39f668/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs#L51-L67

Yet DataGrid does not default to `TwoWay`, thus making the binding of `SelectedIndex` and `SelectedItem` not work as expected. https://github.com/AvaloniaUI/Avalonia/blob/59d51d6a56d1a6b62051e656be331b7cea39f668/src/Avalonia.Controls.DataGrid/DataGrid.cs#L534-L556

## What is the current behavior?

Binding mode is not TwoWay by default.


## What is the updated/expected behavior with this PR?

Binding mode is TwoWay by default.


## How was the solution implemented (if it's not obvious)?

Fairly obvious how this was done.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes

I suppose this would be a breaking change, but it's more in line with WPF and how Avalonia's ListBox, etc. work.

