### PR TITLE
trick to make OSX invalidate the shadow.

### DIFF
--- a/native/Avalonia.Native/src/OSX/window.h
+++ b/native/Avalonia.Native/src/OSX/window.h
@@ -34,6 +34,7 @@ class WindowBaseImpl;
 -(double) getScaling;
 -(double) getExtendedTitleBarHeight;
 -(void) setIsExtended:(bool)value;
+-(void) updateShadow;
 @end
 
 struct INSWindowHolder

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -1844,8 +1844,8 @@ NSArray* AllLoopModes = [NSArray arrayWithObjects: NSDefaultRunLoopMode, NSEvent
 
 - (void)updateShadow
 {
-    // Because of [invalidateShadow] of NSWindow is not working,
-    // We should do the trick as following to force the NSWindow re-renders its shadow.
+    // Common problem in Cocoa where [invalidateShadow] does work,
+    // This hack forces Cocoa to invalidate the shadow.
     
     NSRect frame = [self frame];
     NSRect updatedFrame = NSMakeRect(frame.origin.x, frame.origin.y, frame.size.width + 1.0, frame.size.height + 1.0);

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -124,7 +124,11 @@ public:
             [Window setTitle:_lastTitle];
             
             _shown = true;
-        
+            
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [Window updateShadow];
+            });
+            
             return S_OK;
         }
     }
@@ -1836,6 +1840,19 @@ NSArray* AllLoopModes = [NSArray arrayWithObjects: NSDefaultRunLoopMode, NSEvent
     bool _isExtended;
     AvnMenu* _menu;
     double _lastScaling;
+}
+
+- (void)updateShadow
+{
+    // Because of [invalidateShadow] of NSWindow is not working,
+    // We should do the trick as following to force the NSWindow re-renders its shadow.
+    
+    NSRect frame = [self frame];
+    NSRect updatedFrame = NSMakeRect(frame.origin.x, frame.origin.y, frame.size.width + 1.0, frame.size.height + 1.0);
+    [self setFrame:updatedFrame display:YES];
+    [self setFrame:frame display:YES];
+    
+    [self invalidateShadow];
 }
 
 -(void) setIsExtended:(bool)value;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
On OSX often when mainwindow or dialog opens, the shadow is missing, making it difficult to see the window edge.

Turns out this is a common problem in cocoa apis and other projects are using this workaround.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
![image](https://user-images.githubusercontent.com/4672627/118794339-650c3680-b891-11eb-826e-2e47ceed173d.png)


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
![image](https://user-images.githubusercontent.com/4672627/118794196-3d1cd300-b891-11eb-872b-8559c208f7ec.png)


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Avaloniaui.net with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
