### PR TITLE
Fix devtools selection highlight requiring direct hover over the control

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml
@@ -20,6 +20,7 @@
       <TreeView.Styles>
         <Style Selector="TreeViewItem">
           <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
+          <Setter Property="Background" Value="Transparent" />
         </Style>
       </TreeView.Styles>
     </TreeView>

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Generators;
@@ -6,6 +7,7 @@ using Avalonia.Diagnostics.ViewModels;
 using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Diagnostics.Views
 {
@@ -100,12 +102,19 @@ namespace Avalonia.Diagnostics.Views
         private void TreeViewItemTemplateApplied(object sender, TemplateAppliedEventArgs e)
         {
             var item = (TreeViewItem)sender;
-            var headerPresenter = item.HeaderPresenter;
-            headerPresenter.ApplyTemplate();
 
-            var header = headerPresenter.Child;
-            header.PointerEnter += AddAdorner;
-            header.PointerLeave += RemoveAdorner;
+            // This depends on the default tree item template.
+            // We want to handle events in the item header but exclude events coming from children.
+            var header = item.FindDescendantOfType<Border>();
+
+            Debug.Assert(header != null);
+
+            if (header != null)
+            {
+                header.PointerEnter += AddAdorner;
+                header.PointerLeave += RemoveAdorner;
+            }
+
             item.TemplateApplied -= TreeViewItemTemplateApplied;
         }
     }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes fairly annoying issue that requires hovering over the element name to see the bounds adorner.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
One has to zig zag through dev tools tree view to actually follow control bounds.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Entire element area applies bounds adorner.

https://user-images.githubusercontent.com/2588062/118834630-a36e1980-b8c2-11eb-9e2e-3037fdeb369b.mp4


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
It depends on the default tree view item template to find a control that represents the header but excludes children.
We want to exclude children since pointer enter/leave events bubble and cause all sort of problems for the current implementation.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
