### PR TITLE
Enable InputElement, Interactive, Visual and AvaloniaObject nullablity

### DIFF
--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -7,6 +7,8 @@ using Avalonia.Logging;
 using Avalonia.PropertyStore;
 using Avalonia.Threading;
 
+#nullable enable
+
 namespace Avalonia
 {
     /// <summary>
@@ -17,12 +19,12 @@ namespace Avalonia
     /// </remarks>
     public class AvaloniaObject : IAvaloniaObject, IAvaloniaObjectDebug, INotifyPropertyChanged, IValueSink
     {
-        private IAvaloniaObject _inheritanceParent;
-        private List<IDisposable> _directBindings;
-        private PropertyChangedEventHandler _inpcChanged;
-        private EventHandler<AvaloniaPropertyChangedEventArgs> _propertyChanged;
-        private List<IAvaloniaObject> _inheritanceChildren;
-        private ValueStore _values;
+        private IAvaloniaObject? _inheritanceParent;
+        private List<IDisposable>? _directBindings;
+        private PropertyChangedEventHandler? _inpcChanged;
+        private EventHandler<AvaloniaPropertyChangedEventArgs>? _propertyChanged;
+        private List<IAvaloniaObject>? _inheritanceChildren;
+        private ValueStore? _values;
         private bool _batchUpdate;
 
         /// <summary>
@@ -36,7 +38,7 @@ namespace Avalonia
         /// <summary>
         /// Raised when a <see cref="AvaloniaProperty"/> value changes on this object.
         /// </summary>
-        public event EventHandler<AvaloniaPropertyChangedEventArgs> PropertyChanged
+        public event EventHandler<AvaloniaPropertyChangedEventArgs>? PropertyChanged
         {
             add { _propertyChanged += value; }
             remove { _propertyChanged -= value; }
@@ -58,7 +60,7 @@ namespace Avalonia
         /// <value>
         /// The inheritance parent.
         /// </value>
-        protected IAvaloniaObject InheritanceParent
+        protected IAvaloniaObject? InheritanceParent
         {
             get
             {
@@ -289,7 +291,8 @@ namespace Avalonia
         /// <returns>True if the property is animating, otherwise false.</returns>
         public bool IsAnimating(AvaloniaProperty property)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
+            property = property ?? throw new ArgumentNullException(nameof(property));
+
             VerifyAccess();
 
             return _values?.IsAnimating(property) ?? false;
@@ -306,7 +309,8 @@ namespace Avalonia
         /// </remarks>
         public bool IsSet(AvaloniaProperty property)
         {
-            Contract.Requires<ArgumentNullException>(property != null);
+            property = property ?? throw new ArgumentNullException(nameof(property));
+
             VerifyAccess();
 
             return _values?.IsSet(property) ?? false;
@@ -320,7 +324,7 @@ namespace Avalonia
         /// <param name="priority">The priority of the value.</param>
         public void SetValue(
             AvaloniaProperty property,
-            object value,
+            object? value,
             BindingPriority priority = BindingPriority.LocalValue)
         {
             property = property ?? throw new ArgumentNullException(nameof(property));
@@ -338,7 +342,7 @@ namespace Avalonia
         /// <returns>
         /// An <see cref="IDisposable"/> if setting the property can be undone, otherwise null.
         /// </returns>
-        public IDisposable SetValue<T>(
+        public IDisposable? SetValue<T>(
             StyledPropertyBase<T> property,
             T value,
             BindingPriority priority = BindingPriority.LocalValue)
@@ -497,7 +501,7 @@ namespace Avalonia
         }
 
         /// <inheritdoc/>
-        Delegate[] IAvaloniaObjectDebug.GetPropertyChangedSubscribers()
+        Delegate[]? IAvaloniaObjectDebug.GetPropertyChangedSubscribers()
         {
             return _propertyChanged?.GetInvocationList();
         }
@@ -723,7 +727,8 @@ namespace Avalonia
             {
                 var values = o._values;
 
-                if (values?.TryGetValue(property, maxPriority, out value) == true)
+                if (values != null
+                    && values.TryGetValue(property, maxPriority, out value) == true)
                 {
                     return value;
                 }
@@ -873,7 +878,7 @@ namespace Avalonia
                 }
                 else
                 {
-                    LogBindingError(property, value.Error);
+                    LogBindingError(property, value.Error!);
                 }
             }
         }
@@ -907,14 +912,14 @@ namespace Avalonia
             {
                 _owner = owner;
                 _property = property;
-                _owner._directBindings.Add(this);
+                _owner._directBindings!.Add(this);
                 _subscription = source.Subscribe(this);
             }
 
             public void Dispose()
             {
                 _subscription.Dispose();
-                _owner._directBindings.Remove(this);
+                _owner._directBindings!.Remove(this);
             }
 
             public void OnCompleted() => Dispose();

--- a/src/Avalonia.Base/Diagnostics/IAvaloniaObjectDebug.cs
+++ b/src/Avalonia.Base/Diagnostics/IAvaloniaObjectDebug.cs
@@ -1,5 +1,7 @@
 using System;
 
+#nullable enable
+
 namespace Avalonia.Diagnostics
 {
     /// <summary>
@@ -14,6 +16,6 @@ namespace Avalonia.Diagnostics
         /// <returns>
         /// The subscribers or null if no subscribers.
         /// </returns>
-        Delegate[] GetPropertyChangedSubscribers();
+        Delegate[]? GetPropertyChangedSubscribers();
     }
 }

--- a/src/Avalonia.Base/IAvaloniaObject.cs
+++ b/src/Avalonia.Base/IAvaloniaObject.cs
@@ -1,6 +1,8 @@
 using System;
 using Avalonia.Data;
 
+#nullable enable
+
 namespace Avalonia
 {
     /// <summary>
@@ -11,7 +13,7 @@ namespace Avalonia
         /// <summary>
         /// Raised when a <see cref="AvaloniaProperty"/> value changes on this object.
         /// </summary>
-        event EventHandler<AvaloniaPropertyChangedEventArgs> PropertyChanged;
+        event EventHandler<AvaloniaPropertyChangedEventArgs>? PropertyChanged;
 
         /// <summary>
         /// Clears an <see cref="AvaloniaProperty"/>'s local value.
@@ -75,7 +77,10 @@ namespace Avalonia
         /// <param name="property">The property.</param>
         /// <param name="value">The value.</param>
         /// <param name="priority">The priority of the value.</param>
-        IDisposable SetValue<T>(
+        /// <returns>
+        /// An <see cref="IDisposable"/> if setting the property can be undone, otherwise null.
+        /// </returns>
+        IDisposable? SetValue<T>(
             StyledPropertyBase<T> property,
             T value,
             BindingPriority priority = BindingPriority.LocalValue);

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -201,7 +201,7 @@ namespace Avalonia.Controls
         {
             base.OnLostFocus(e);
 
-            if (_focusAdorner != null)
+            if (_focusAdorner?.Parent != null)
             {
                 var adornerLayer = (IPanel)_focusAdorner.Parent;
                 adornerLayer.Children.Remove(_focusAdorner);

--- a/src/Avalonia.Controls/IControl.cs
+++ b/src/Avalonia.Controls/IControl.cs
@@ -3,6 +3,8 @@ using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.VisualTree;
 
+#nullable enable
+
 namespace Avalonia.Controls
 {
     /// <summary>
@@ -15,6 +17,6 @@ namespace Avalonia.Controls
         INamed,
         IStyledElement
     {
-        new IControl Parent { get; }
+        new IControl? Parent { get; }
     }
 }

--- a/src/Avalonia.Input/IInputElement.cs
+++ b/src/Avalonia.Input/IInputElement.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 
+#nullable enable
+
 namespace Avalonia.Input
 {
     /// <summary>

--- a/src/Avalonia.Input/InputElement.cs
+++ b/src/Avalonia.Input/InputElement.cs
@@ -9,6 +9,8 @@ using Avalonia.Input.TextInput;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 
+#nullable enable
+
 namespace Avalonia.Input
 {
     /// <summary>

--- a/src/Avalonia.Input/KeyboardDevice.cs
+++ b/src/Avalonia.Input/KeyboardDevice.cs
@@ -60,7 +60,7 @@ namespace Avalonia.Input
                     ie.IsKeyboardFocusWithin = false;
                 }
 
-                el = (IInputElement)el.VisualParent;
+                el = (IInputElement?)el.VisualParent;
             }
         }
         
@@ -212,7 +212,7 @@ namespace Avalonia.Input
                             Source = element,
                         };
 
-                        IVisual currentHandler = element;
+                        IVisual? currentHandler = element;
                         while (currentHandler != null && !ev.Handled && keyInput.Type == RawKeyEventType.KeyDown)
                         {
                             var bindings = (currentHandler as IInputElement)?.KeyBindings;

--- a/src/Avalonia.Input/MouseDevice.cs
+++ b/src/Avalonia.Input/MouseDevice.cs
@@ -377,7 +377,7 @@ namespace Avalonia.Input
                 e.Source = element;
                 e.Handled = false;
                 element.RaiseEvent(e);
-                element = (IInputElement)element.VisualParent;
+                element = (IInputElement?)element.VisualParent;
             }
             
             root.PointerOverElement = null;
@@ -444,7 +444,7 @@ namespace Avalonia.Input
                     branch = el;
                     break;
                 }
-                el = (IInputElement)el.VisualParent;
+                el = (IInputElement?)el.VisualParent;
             }
 
             el = root.PointerOverElement;
@@ -460,7 +460,7 @@ namespace Avalonia.Input
                 e.Source = el;
                 e.Handled = false;
                 el.RaiseEvent(e);
-                el = (IInputElement)el.VisualParent;
+                el = (IInputElement?)el.VisualParent;
             }            
 
             el = root.PointerOverElement = element;
@@ -471,7 +471,7 @@ namespace Avalonia.Input
                 e.Source = el;
                 e.Handled = false;
                 el.RaiseEvent(e);
-                el = (IInputElement)el.VisualParent;
+                el = (IInputElement?)el.VisualParent;
             }
         }
 

--- a/src/Avalonia.Interactivity/IInteractive.cs
+++ b/src/Avalonia.Interactivity/IInteractive.cs
@@ -1,5 +1,7 @@
 using System;
 
+#nullable enable
+
 namespace Avalonia.Interactivity
 {
     /// <summary>

--- a/src/Avalonia.Interactivity/Interactive.cs
+++ b/src/Avalonia.Interactivity/Interactive.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using Avalonia.Layout;
 using Avalonia.VisualTree;
 
+#nullable enable
+
 namespace Avalonia.Interactivity
 {
     /// <summary>

--- a/src/Avalonia.Layout/Layoutable.cs
+++ b/src/Avalonia.Layout/Layoutable.cs
@@ -782,7 +782,7 @@ namespace Avalonia.Layout
         }
 
         /// <inheritdoc/>
-        protected sealed override void OnVisualParentChanged(IVisual oldParent, IVisual newParent)
+        protected sealed override void OnVisualParentChanged(IVisual? oldParent, IVisual? newParent)
         {
             LayoutHelper.InvalidateSelfAndChildrenMeasure(this);
 

--- a/src/Avalonia.Styling/Controls/ISetInheritanceParent.cs
+++ b/src/Avalonia.Styling/Controls/ISetInheritanceParent.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace Avalonia.Controls
 {
     /// <summary>
@@ -14,6 +16,6 @@ namespace Avalonia.Controls
         /// Sets the control's inheritance parent.
         /// </summary>
         /// <param name="parent">The parent.</param>
-        void SetParent(IAvaloniaObject parent);
+        void SetParent(IAvaloniaObject? parent);
     }
 }

--- a/src/Avalonia.Styling/Controls/ISetLogicalParent.cs
+++ b/src/Avalonia.Styling/Controls/ISetLogicalParent.cs
@@ -1,5 +1,7 @@
 using Avalonia.LogicalTree;
 
+#nullable enable
+
 namespace Avalonia.Controls
 {
     /// <summary>
@@ -14,6 +16,6 @@ namespace Avalonia.Controls
         /// Sets the control's parent.
         /// </summary>
         /// <param name="parent">The parent.</param>
-        void SetParent(ILogical parent);
+        void SetParent(ILogical? parent);
     }
 }

--- a/src/Avalonia.Styling/IDataContextProvider.cs
+++ b/src/Avalonia.Styling/IDataContextProvider.cs
@@ -1,4 +1,6 @@
-﻿namespace Avalonia
+﻿#nullable enable
+
+namespace Avalonia
 {
     /// <summary>
     /// Defines an element with a data context that can be used for binding.
@@ -8,6 +10,6 @@
         /// <summary>
         /// Gets or sets the element's data context.
         /// </summary>
-        object DataContext { get; set; }
+        object? DataContext { get; set; }
     }
 }

--- a/src/Avalonia.Styling/IStyledElement.cs
+++ b/src/Avalonia.Styling/IStyledElement.cs
@@ -4,6 +4,8 @@ using Avalonia.Controls;
 using Avalonia.LogicalTree;
 using Avalonia.Styling;
 
+#nullable enable
+
 namespace Avalonia
 {
     public interface IStyledElement :
@@ -17,7 +19,7 @@ namespace Avalonia
         /// <summary>
         /// Occurs when the control has finished initialization.
         /// </summary>
-        event EventHandler Initialized;
+        event EventHandler? Initialized;
 
         /// <summary>
         /// Gets a value that indicates whether the element has finished initialization.
@@ -32,6 +34,6 @@ namespace Avalonia
         /// <summary>
         /// Gets the control's logical parent.
         /// </summary>
-        IStyledElement Parent { get; }
+        IStyledElement? Parent { get; }
     }
 }

--- a/src/Avalonia.Styling/StyledElement.cs
+++ b/src/Avalonia.Styling/StyledElement.cs
@@ -465,7 +465,7 @@ namespace Avalonia
         /// Sets the styled element's inheritance parent.
         /// </summary>
         /// <param name="parent">The parent.</param>
-        void ISetInheritanceParent.SetParent(IAvaloniaObject parent)
+        void ISetInheritanceParent.SetParent(IAvaloniaObject? parent)
         {
             InheritanceParent = parent;
         }

--- a/src/Avalonia.Styling/StyledElement.cs
+++ b/src/Avalonia.Styling/StyledElement.cs
@@ -300,7 +300,7 @@ namespace Avalonia
         bool IStyleHost.IsStylesInitialized => _styles != null;
 
         /// <inheritdoc/>
-        IStyleHost? IStyleHost.StylingParent => (IStyleHost)InheritanceParent;
+        IStyleHost? IStyleHost.StylingParent => (IStyleHost?)InheritanceParent;
 
         /// <inheritdoc/>
         public virtual void BeginInit()

--- a/src/Avalonia.Styling/Styling/ISetterValue.cs
+++ b/src/Avalonia.Styling/Styling/ISetterValue.cs
@@ -1,4 +1,6 @@
-﻿namespace Avalonia.Styling
+﻿#nullable enable
+
+namespace Avalonia.Styling
 {
     /// <summary>
     /// Customizes the behavior of a class when added as a value to an <see cref="ISetter"/>.

--- a/src/Avalonia.Styling/Styling/PropertySetterInstance.cs
+++ b/src/Avalonia.Styling/Styling/PropertySetterInstance.cs
@@ -50,7 +50,7 @@ namespace Avalonia.Styling
                 }
                 else
                 {
-                    _subscription = _target.Bind(_directProperty, this);
+                    _subscription = _target.Bind(_directProperty!, this);
                 }
             }
             else
@@ -100,7 +100,7 @@ namespace Avalonia.Styling
                 }
                 else
                 {
-                    _target.ClearValue(_directProperty);
+                    _target.ClearValue(_directProperty!);
                 }
             }
 

--- a/src/Avalonia.Styling/Styling/PropertySetterLazyInstance.cs
+++ b/src/Avalonia.Styling/Styling/PropertySetterLazyInstance.cs
@@ -53,7 +53,7 @@ namespace Avalonia.Styling
             }
             else
             {
-                _subscription = _target.Bind(_directProperty, this);
+                _subscription = _target.Bind(_directProperty!, this);
             }
         }
 
@@ -91,7 +91,7 @@ namespace Avalonia.Styling
                 }
                 else
                 {
-                    _target.ClearValue(_directProperty);
+                    _target.ClearValue(_directProperty!);
                 }
             }
 

--- a/src/Avalonia.Visuals/Visual.cs
+++ b/src/Avalonia.Visuals/Visual.cs
@@ -11,6 +11,8 @@ using Avalonia.Rendering;
 using Avalonia.Utilities;
 using Avalonia.VisualTree;
 
+#nullable enable
+
 namespace Avalonia
 {
     /// <summary>
@@ -45,8 +47,8 @@ namespace Avalonia
         /// <summary>
         /// Defines the <see cref="Clip"/> property.
         /// </summary>
-        public static readonly StyledProperty<Geometry> ClipProperty =
-            AvaloniaProperty.Register<Visual, Geometry>(nameof(Clip));
+        public static readonly StyledProperty<Geometry?> ClipProperty =
+            AvaloniaProperty.Register<Visual, Geometry?>(nameof(Clip));
 
         /// <summary>
         /// Defines the <see cref="IsVisibleProperty"/> property.
@@ -63,14 +65,14 @@ namespace Avalonia
         /// <summary>
         /// Defines the <see cref="OpacityMask"/> property.
         /// </summary>
-        public static readonly StyledProperty<IBrush> OpacityMaskProperty =
-            AvaloniaProperty.Register<Visual, IBrush>(nameof(OpacityMask));
+        public static readonly StyledProperty<IBrush?> OpacityMaskProperty =
+            AvaloniaProperty.Register<Visual, IBrush?>(nameof(OpacityMask));
 
         /// <summary>
         /// Defines the <see cref="RenderTransform"/> property.
         /// </summary>
-        public static readonly StyledProperty<ITransform> RenderTransformProperty =
-            AvaloniaProperty.Register<Visual, ITransform>(nameof(RenderTransform));
+        public static readonly StyledProperty<ITransform?> RenderTransformProperty =
+            AvaloniaProperty.Register<Visual, ITransform?>(nameof(RenderTransform));
 
         /// <summary>
         /// Defines the <see cref="RenderTransformOrigin"/> property.
@@ -81,8 +83,8 @@ namespace Avalonia
         /// <summary>
         /// Defines the <see cref="IVisual.VisualParent"/> property.
         /// </summary>
-        public static readonly DirectProperty<Visual, IVisual> VisualParentProperty =
-            AvaloniaProperty.RegisterDirect<Visual, IVisual>("VisualParent", o => o._visualParent);
+        public static readonly DirectProperty<Visual, IVisual?> VisualParentProperty =
+            AvaloniaProperty.RegisterDirect<Visual, IVisual?>(nameof(IVisual.VisualParent), o => o._visualParent);
 
         /// <summary>
         /// Defines the <see cref="ZIndex"/> property.
@@ -92,8 +94,8 @@ namespace Avalonia
 
         private Rect _bounds;
         private TransformedBounds? _transformedBounds;
-        private IRenderRoot _visualRoot;
-        private IVisual _visualParent;
+        private IRenderRoot? _visualRoot;
+        private IVisual? _visualParent;
 
         /// <summary>
         /// Initializes static members of the <see cref="Visual"/> class.
@@ -128,12 +130,12 @@ namespace Avalonia
         /// <summary>
         /// Raised when the control is attached to a rooted visual tree.
         /// </summary>
-        public event EventHandler<VisualTreeAttachmentEventArgs> AttachedToVisualTree;
+        public event EventHandler<VisualTreeAttachmentEventArgs>? AttachedToVisualTree;
 
         /// <summary>
         /// Raised when the control is detached from a rooted visual tree.
         /// </summary>
-        public event EventHandler<VisualTreeAttachmentEventArgs> DetachedFromVisualTree;
+        public event EventHandler<VisualTreeAttachmentEventArgs>? DetachedFromVisualTree;
 
         /// <summary>
         /// Gets the bounds of the control relative to its parent.
@@ -161,7 +163,7 @@ namespace Avalonia
         /// <summary>
         /// Gets or sets the geometry clip for this visual.
         /// </summary>
-        public Geometry Clip
+        public Geometry? Clip
         {
             get { return GetValue(ClipProperty); }
             set { SetValue(ClipProperty, value); }
@@ -174,7 +176,7 @@ namespace Avalonia
         {
             get
             {
-                IVisual node = this;
+                IVisual? node = this;
 
                 while (node != null)
                 {
@@ -211,7 +213,7 @@ namespace Avalonia
         /// <summary>
         /// Gets or sets the opacity mask of the control.
         /// </summary>
-        public IBrush OpacityMask
+        public IBrush? OpacityMask
         {
             get { return GetValue(OpacityMaskProperty); }
             set { SetValue(OpacityMaskProperty, value); }
@@ -220,7 +222,7 @@ namespace Avalonia
         /// <summary>
         /// Gets or sets the render transform of the control.
         /// </summary>
-        public ITransform RenderTransform
+        public ITransform? RenderTransform
         {
             get { return GetValue(RenderTransformProperty); }
             set { SetValue(RenderTransformProperty, value); }
@@ -261,7 +263,7 @@ namespace Avalonia
         /// <summary>
         /// Gets the root of the visual tree, if the control is attached to a visual tree.
         /// </summary>
-        protected IRenderRoot VisualRoot => _visualRoot ?? (this as IRenderRoot);
+        protected IRenderRoot? VisualRoot => _visualRoot ?? (this as IRenderRoot);
 
         /// <summary>
         /// Gets a value indicating whether this control is attached to a visual root.
@@ -276,12 +278,12 @@ namespace Avalonia
         /// <summary>
         /// Gets the control's parent visual.
         /// </summary>
-        IVisual IVisual.VisualParent => _visualParent;
+        IVisual? IVisual.VisualParent => _visualParent;
 
         /// <summary>
         /// Gets the root of the visual tree, if the control is attached to a visual tree.
         /// </summary>
-        IRenderRoot IVisual.VisualRoot => VisualRoot;
+        IRenderRoot? IVisual.VisualRoot => VisualRoot;
         
         TransformedBounds? IVisual.TransformedBounds
         {
@@ -476,12 +478,12 @@ namespace Avalonia
         /// </summary>
         /// <param name="oldParent">The old visual parent.</param>
         /// <param name="newParent">The new visual parent.</param>
-        protected virtual void OnVisualParentChanged(IVisual oldParent, IVisual newParent)
+        protected virtual void OnVisualParentChanged(IVisual? oldParent, IVisual? newParent)
         {
             RaisePropertyChanged(
                 VisualParentProperty,
-                new Optional<IVisual>(oldParent),
-                new BindingValue<IVisual>(newParent),
+                new Optional<IVisual?>(oldParent),
+                new BindingValue<IVisual?>(newParent),
                 BindingPriority.LocalValue);
         }
 
@@ -582,7 +584,7 @@ namespace Avalonia
         /// Sets the visual parent of the Visual.
         /// </summary>
         /// <param name="value">The visual parent.</param>
-        private void SetVisualParent(Visual value)
+        private void SetVisualParent(Visual? value)
         {
             if (_visualParent == value)
             {
@@ -634,7 +636,7 @@ namespace Avalonia
             }
         }
         
-        private static void SetVisualParent(IList children, Visual parent)
+        private static void SetVisualParent(IList children, Visual? parent)
         {
             var count = children.Count;
 

--- a/src/Avalonia.Visuals/VisualTree/IVisual.cs
+++ b/src/Avalonia.Visuals/VisualTree/IVisual.cs
@@ -3,6 +3,8 @@ using Avalonia.Collections;
 using Avalonia.Media;
 using Avalonia.Rendering;
 
+#nullable enable
+
 namespace Avalonia.VisualTree
 {
     /// <summary>
@@ -21,12 +23,12 @@ namespace Avalonia.VisualTree
         /// <summary>
         /// Raised when the control is attached to a rooted visual tree.
         /// </summary>
-        event EventHandler<VisualTreeAttachmentEventArgs> AttachedToVisualTree;
+        event EventHandler<VisualTreeAttachmentEventArgs>? AttachedToVisualTree;
 
         /// <summary>
         /// Raised when the control is detached from a rooted visual tree.
         /// </summary>
-        event EventHandler<VisualTreeAttachmentEventArgs> DetachedFromVisualTree;
+        event EventHandler<VisualTreeAttachmentEventArgs>? DetachedFromVisualTree;
 
         /// <summary>
         /// Gets the bounds of the control relative to its parent.
@@ -46,7 +48,7 @@ namespace Avalonia.VisualTree
         /// <summary>
         /// Gets or sets the geometry clip for this visual.
         /// </summary>
-        Geometry Clip { get; set; }
+        Geometry? Clip { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether this control is attached to a visual root.
@@ -71,12 +73,12 @@ namespace Avalonia.VisualTree
         /// <summary>
         /// Gets or sets the opacity mask for the control.
         /// </summary>
-        IBrush OpacityMask { get; set; }
+        IBrush? OpacityMask { get; set; }
 
         /// <summary>
         /// Gets or sets the render transform of the control.
         /// </summary>
-        ITransform RenderTransform { get; set; }
+        ITransform? RenderTransform { get; set; }
 
         /// <summary>
         /// Gets or sets the render transform origin of the control.
@@ -91,12 +93,12 @@ namespace Avalonia.VisualTree
         /// <summary>
         /// Gets the control's parent visual.
         /// </summary>
-        IVisual VisualParent { get; }
+        IVisual? VisualParent { get; }
 
         /// <summary>
         /// Gets the root of the visual tree, if the control is attached to a visual tree.
         /// </summary>
-        IRenderRoot VisualRoot { get; }
+        IRenderRoot? VisualRoot { get; }
 
         /// <summary>
         /// Gets or sets the Z index of the node.


### PR DESCRIPTION
## What does the pull request do?
Enable AvaloniaObject nullablity

## What is the current behavior?
Rider with enable nullability (+errors as warning) is insane:
![image](https://user-images.githubusercontent.com/3163374/118917130-2e203a00-b8fe-11eb-9b30-a63393d80efc.png)
![image](https://user-images.githubusercontent.com/3163374/118917486-ff569380-b8fe-11eb-8115-b19e2e8c13b7.png)
