### PR TITLE
Fix - Missing Shadow - OSX and Window Position

### DIFF
--- a/native/Avalonia.Native/src/OSX/window.h
+++ b/native/Avalonia.Native/src/OSX/window.h
@@ -34,7 +34,6 @@ class WindowBaseImpl;
 -(double) getScaling;
 -(double) getExtendedTitleBarHeight;
 -(void) setIsExtended:(bool)value;
--(void) updateShadow;
 @end
 
 struct INSWindowHolder

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -25,6 +25,7 @@ public:
     ComPtr<IAvnGlContext> _glContext;
     NSObject<IRenderTarget>* renderTarget;
     AvnPoint lastPositionSet;
+    CGSize _lastRequestedSize;
     NSString* _lastTitle;
     IAvnMenu* _mainMenu;
     
@@ -193,9 +194,18 @@ public:
         {
             if(ret == nullptr)
                 return E_POINTER;
-            auto frame = [View frame];
-            ret->Width = frame.size.width;
-            ret->Height = frame.size.height;
+            
+            if(_shown)
+            {
+                auto frame = [View frame];
+                ret->Width = frame.size.width;
+                ret->Height = frame.size.height;
+            }
+            else
+            {
+                ret->Width = _lastRequestedSize.width;
+                ret->Height = _lastRequestedSize.height;
+            }
             return S_OK;
         }
     }
@@ -255,6 +265,9 @@ public:
             {
                 y = maxSize.height;
             }
+            
+            _lastRequestedSize.width = x;
+            _lastRequestedSize.height = y;
             
             [Window setContentSize:NSSize{x, y}];
             
@@ -530,7 +543,7 @@ private:
         _decorations = SystemDecorationsFull;
         _transitioningWindowState = false;
         _inSetWindowState = false;
-        _lastWindowState = Normal;
+        _lastWindowState = (AvnWindowState)-1;
         WindowEvents = events;
         [Window setCanBecomeKeyAndMain];
         [Window disableCursorRects];

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -50,7 +50,6 @@ public:
         [Window setBackingType:NSBackingStoreBuffered];
         
         [Window setOpaque:false];
-        [Window setContentView: StandardContainer];
     }
     
     virtual HRESULT ObtainNSWindowHandle(void** ret) override
@@ -112,6 +111,9 @@ public:
         {
             SetPosition(lastPositionSet);
             UpdateStyle();
+            
+            [Window setContentView: StandardContainer];
+            
             if(ShouldTakeFocusOnShow() && activate)
             {
                 [Window makeKeyAndOrderFront:Window];

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -537,7 +537,7 @@ private:
         _decorations = SystemDecorationsFull;
         _transitioningWindowState = false;
         _inSetWindowState = false;
-        _lastWindowState = (AvnWindowState)-1;
+        _lastWindowState = Normal;
         WindowEvents = events;
         [Window setCanBecomeKeyAndMain];
         [Window disableCursorRects];

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -25,7 +25,6 @@ public:
     ComPtr<IAvnGlContext> _glContext;
     NSObject<IRenderTarget>* renderTarget;
     AvnPoint lastPositionSet;
-    CGSize _lastRequestedSize;
     NSString* _lastTitle;
     IAvnMenu* _mainMenu;
     
@@ -201,11 +200,7 @@ public:
                 ret->Width = frame.size.width;
                 ret->Height = frame.size.height;
             }
-            else
-            {
-                ret->Width = _lastRequestedSize.width;
-                ret->Height = _lastRequestedSize.height;
-            }
+            
             return S_OK;
         }
     }
@@ -266,8 +261,10 @@ public:
                 y = maxSize.height;
             }
             
-            _lastRequestedSize.width = x;
-            _lastRequestedSize.height = y;
+            if(!_shown)
+            {
+                BaseEvents->Resized(AvnSize{x,y});
+            }
             
             [Window setContentSize:NSSize{x, y}];
             

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -194,12 +194,9 @@ public:
             if(ret == nullptr)
                 return E_POINTER;
             
-            if(_shown)
-            {
-                auto frame = [View frame];
-                ret->Width = frame.size.width;
-                ret->Height = frame.size.height;
-            }
+            auto frame = [View frame];
+            ret->Width = frame.size.width;
+            ret->Height = frame.size.height;
             
             return S_OK;
         }

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -125,10 +125,6 @@ public:
             
             _shown = true;
             
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [Window updateShadow];
-            });
-            
             return S_OK;
         }
     }
@@ -1842,19 +1838,6 @@ NSArray* AllLoopModes = [NSArray arrayWithObjects: NSDefaultRunLoopMode, NSEvent
     double _lastScaling;
 }
 
-- (void)updateShadow
-{
-    // Common problem in Cocoa where [invalidateShadow] does work,
-    // This hack forces Cocoa to invalidate the shadow.
-    
-    NSRect frame = [self frame];
-    NSRect updatedFrame = NSMakeRect(frame.origin.x, frame.origin.y, frame.size.width + 1.0, frame.size.height + 1.0);
-    [self setFrame:updatedFrame display:YES];
-    [self setFrame:frame display:YES];
-    
-    [self invalidateShadow];
-}
-
 -(void) setIsExtended:(bool)value;
 {
     _isExtended = value;
@@ -2013,7 +1996,6 @@ NSArray* AllLoopModes = [NSArray arrayWithObjects: NSDefaultRunLoopMode, NSEvent
     _lastScaling = [self backingScaleFactor];
     [self setOpaque:NO];
     [self setBackgroundColor: [NSColor clearColor]];
-    [self invalidateShadow];
     _isExtended = false;
     return self;
 }

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -668,10 +668,11 @@ namespace Avalonia.Controls
                 
                 Owner = parent;
                 parent?.AddChild(this, false);
-
-                PlatformImpl?.Show(ShowActivated);
-                Renderer?.Start();
+                
                 SetWindowStartupLocation(Owner?.PlatformImpl);
+                
+                PlatformImpl?.Show(ShowActivated);
+                Renderer?.Start();                
             }
             OnOpened(EventArgs.Empty);
         }
@@ -739,6 +740,9 @@ namespace Avalonia.Controls
                 PlatformImpl?.SetParent(owner.PlatformImpl);
                 Owner = owner;
                 owner.AddChild(this, true);
+                
+                SetWindowStartupLocation(owner.PlatformImpl);
+                
                 PlatformImpl?.Show(ShowActivated);
 
                 Renderer?.Start();
@@ -755,8 +759,6 @@ namespace Avalonia.Controls
 
                 OnOpened(EventArgs.Empty);
             }
-
-            SetWindowStartupLocation(owner.PlatformImpl);
 
             return result.Task;
         }

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -656,7 +656,6 @@ namespace Avalonia.Controls
                     if (PlatformImpl != null)
                     {
                         PlatformImpl.Resize(initialSize);
-                        ClientSize = PlatformImpl.ClientSize;
                     }
                 }
             }

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -653,10 +653,7 @@ namespace Avalonia.Controls
             {
                 using (BeginAutoSizing())
                 {
-                    if (PlatformImpl != null)
-                    {
-                        PlatformImpl.Resize(initialSize);
-                    }
+                    PlatformImpl?.Resize(initialSize);
                 }
             }
 

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -653,7 +653,11 @@ namespace Avalonia.Controls
             {
                 using (BeginAutoSizing())
                 {
-                    PlatformImpl?.Resize(initialSize);
+                    if (PlatformImpl != null)
+                    {
+                        PlatformImpl.Resize(initialSize);
+                        ClientSize = PlatformImpl.ClientSize;
+                    }
                 }
             }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

This fixes what happens when Show or ShowDialog is called.

1) on osx, the contentview is set after the Window has been resized and before it is actually shown.
this means that OSX is now happy and correctly draws the border / shadow.

2) I noticed now that windows were showing very quickly with the above fix, that when you show a dialog or window, with CenterScreen or CenterOwner, the window would initially show up at a position and then jump to the correct position.

this must have been introduced by #1714 but not noticable on other platforms and prob had been hidden on osx due to first issue.

So I made sure the window position was set before telling the platform to show the window (in showcore and showdialog)
makes sense, you need to set the window position to set it.

3) this broke the window centerscreen functionality on OSX... why?

On Win32 when the window is not shown yet, when we tell the backend to resize the window, we get a Resized event and that event causes clientsize to get updated. The window centering code then uses ClientSize to calculate the position of the window in the center of the screen.

On OSX however... when the window is not shown,... no resized event comes and ClientSize remained 0,0 and this means the centering on osx was not working. I fixed this by making the OSX backend raise the resized event when Resize is called and the window hasnt been shown yet.

Both Windows and OSX now behave correctly. Someone will need to test Linux.



## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
