### PR TITLE
Avoid boxing nullable values in BindingValue.

### DIFF
--- a/src/Avalonia.Base/Data/BindingValue.cs
+++ b/src/Avalonia.Base/Data/BindingValue.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Avalonia.Utilities;
 
@@ -358,6 +359,7 @@ namespace Avalonia.Data
                 e);
         }
 
+        [Conditional("DEBUG")]
         private static void ValidateValue([AllowNull] T value)
         {
             if (value is UnsetValueType)


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Deals with `Nullable<T>` problems when used as a binding value.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Due to https://github.com/dotnet/runtime/issues/50915 we are boxing `TransformedBounds?` when it is passed to binding code.
This happens quite frequently since each visual has a property using this struct, plus we update it a lot when resizing.

![image](https://user-images.githubusercontent.com/2588062/119343762-2d3d2e80-bc97-11eb-962c-75b983fb7fff.png)

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
![image](https://user-images.githubusercontent.com/2588062/119343546-e5b6a280-bc96-11eb-8080-ed02da05d748.png)

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
