### PR TITLE
force osx shadow invalidation on programatic resize.

### DIFF
--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -265,6 +265,11 @@ public:
             
             [Window setContentSize:NSSize{x, y}];
             
+            
+            // Forces the shadow to invalidate on resize.
+            [Window setContentView: nullptr];
+            [Window setContentView: StandardContainer];
+            
             return S_OK;
         }
     }

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -263,12 +263,8 @@ public:
                 BaseEvents->Resized(AvnSize{x,y});
             }
             
+            [StandardContainer setFrameSize:NSSize{x,y}];
             [Window setContentSize:NSSize{x, y}];
-            
-            
-            // Forces the shadow to invalidate on resize.
-            [Window setContentView: nullptr];
-            [Window setContentView: StandardContainer];
             
             return S_OK;
         }
@@ -2250,6 +2246,7 @@ protected:
         {
             if (Window != nullptr)
             {
+                [StandardContainer setFrameSize:NSSize{x,y}];
                 [Window setContentSize:NSSize{x, y}];
             
                 [Window setFrameTopLeftPoint:ToNSPoint(ConvertPointY(lastPositionSet))];


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes the incorrect shadow calculation on OSX

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Shadow sometimes does not show correctly

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Works

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Set the size of the Content Container *before* we set the size of the window frame.

This makes cocoa do the correct calculation.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
