### PR TITLE
Fix a memory leak in StreamNode.

### DIFF
--- a/src/Avalonia.Base/Data/Core/StreamNode.cs
+++ b/src/Avalonia.Base/Data/Core/StreamNode.cs
@@ -20,7 +20,7 @@ namespace Avalonia.Data.Core
 
         protected override void StartListeningCore(WeakReference<object> reference)
         {
-            GetPlugin(reference)?.Start(reference).Subscribe(ValueChanged);
+            _subscription = GetPlugin(reference)?.Start(reference).Subscribe(ValueChanged);
         }
 
         protected override void StopListeningCore()


### PR DESCRIPTION
`StreamNode` forgot to store a subscription, causing a memory leak. The subscription member variable was defined and used, but never assigned to. That is it.

I had to skip unit tests, because `Avalonia.LeakTests` (if that's a right place) requires Resharper with a plugin, which I don't have.

Probably fix for #5872.
