### PR TITLE
Don't activate window when extending client area.

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -900,7 +900,7 @@ namespace Avalonia.Win32
                 IntPtr.Zero,
                 rcWindow.left, rcWindow.top,
                 rcClient.Width, rcClient.Height,
-                SetWindowPosFlags.SWP_FRAMECHANGED);
+                SetWindowPosFlags.SWP_FRAMECHANGED | SetWindowPosFlags.SWP_NOACTIVATE);
 
             if (_isClientAreaExtended && WindowState != WindowState.FullScreen)
             {


### PR DESCRIPTION
## What does the pull request do?

Fixes the issue described in #5988: `Window.ShowActivated = false` doesn't work with `ExtendClientAreaToDecorationsHint = true`.

When a window with `ExtendClientAreaToDecorationsHint` is shown on win32, `WindowImpl.ExtendClientArea` is called which in turn calls the win32 `SetWindowPos` API. However `SetWindowPosFlags.SWP_NOACTIVATE` wasn't being passed to that function, causing the window to be activated regardless of the `ShowActivated` setting.

Pass `SetWindowPosFlags.SWP_NOACTIVATE` to `SetWindowPos` here whether `ShowActivated` is set or not: the window will be activated in the later `SetWindowPos` call if necessary.

## Fixed issues

Fixes #5988
