### PR TITLE
Optimize shape rendering (pen creation mostly).

### DIFF
--- a/src/Avalonia.Controls/Shapes/Shape.cs
+++ b/src/Avalonia.Controls/Shapes/Shape.cs
@@ -1,6 +1,7 @@
 using System;
 using Avalonia.Collections;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 
 #nullable enable
 
@@ -199,8 +200,29 @@ namespace Avalonia.Controls.Shapes
 
             if (geometry != null)
             {
-                var pen = new Pen(Stroke, StrokeThickness, new DashStyle(StrokeDashArray, StrokeDashOffset),
-                     StrokeLineCap, StrokeJoin);
+                var stroke = Stroke;
+
+                ImmutablePen? pen = null;
+
+                if (stroke != null)
+                {
+                    var strokeDashArray = StrokeDashArray;
+
+                    ImmutableDashStyle? dashStyle = null;
+
+                    if (strokeDashArray != null && strokeDashArray.Count > 0)
+                    {
+                        dashStyle = new ImmutableDashStyle(strokeDashArray, StrokeDashOffset);
+                    }
+
+                    pen = new ImmutablePen(
+                        stroke.ToImmutable(),
+                        StrokeThickness,
+                        dashStyle,
+                        StrokeLineCap,
+                        StrokeJoin);
+                }
+
                 context.DrawGeometry(Fill, pen, geometry);
             }
         }

--- a/src/Avalonia.Visuals/Media/Immutable/ImmutableDashStyle.cs
+++ b/src/Avalonia.Visuals/Media/Immutable/ImmutableDashStyle.cs
@@ -10,6 +10,8 @@ namespace Avalonia.Media.Immutable
     /// </summary>
     public class ImmutableDashStyle : IDashStyle, IEquatable<IDashStyle>
     {
+        private readonly double[] _dashes;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableDashStyle"/> class.
         /// </summary>
@@ -17,12 +19,12 @@ namespace Avalonia.Media.Immutable
         /// <param name="offset">The dash sequence offset.</param>
         public ImmutableDashStyle(IEnumerable<double> dashes, double offset)
         {
-            Dashes = (IReadOnlyList<double>)dashes?.ToList() ?? Array.Empty<double>();
+            _dashes = dashes?.ToArray() ?? Array.Empty<double>();
             Offset = offset;
         }
 
         /// <inheritdoc/>
-        public IReadOnlyList<double> Dashes { get; }
+        public IReadOnlyList<double> Dashes => _dashes;
 
         /// <inheritdoc/>
         public double Offset { get; }
@@ -56,9 +58,9 @@ namespace Avalonia.Media.Immutable
             var hashCode = 717868523;
             hashCode = hashCode * -1521134295 + Offset.GetHashCode();
 
-            if (Dashes != null)
+            if (_dashes != null)
             {
-                foreach (var i in Dashes)
+                foreach (var i in _dashes)
                 {
                     hashCode = hashCode * -1521134295 + i.GetHashCode();
                 }
@@ -69,7 +71,7 @@ namespace Avalonia.Media.Immutable
 
         private static bool SequenceEqual(IReadOnlyList<double> left, IReadOnlyList<double> right)
         {
-            if (left == right)
+            if (ReferenceEquals(left, right))
             {
                 return true;
             }

--- a/src/Avalonia.Visuals/Media/Immutable/ImmutablePen.cs
+++ b/src/Avalonia.Visuals/Media/Immutable/ImmutablePen.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Media.Immutable
             ImmutableDashStyle dashStyle = null,
             PenLineCap lineCap = PenLineCap.Flat,
             PenLineJoin lineJoin = PenLineJoin.Miter,
-            double miterLimit = 10.0) : this(new SolidColorBrush(color), thickness, dashStyle, lineCap, lineJoin, miterLimit)
+            double miterLimit = 10.0) : this(new ImmutableSolidColorBrush(color), thickness, dashStyle, lineCap, lineJoin, miterLimit)
         {
         }
 

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -249,6 +249,8 @@ namespace Avalonia.Rendering.SceneGraph
                     {
                         var visualChildren = (IList<IVisual>) visual.VisualChildren;
 
+                        node.TryPreallocateChildren(visualChildren.Count);
+
                         if (visualChildren.Count == 1)
                         {
                             var childNode = GetOrCreateChildNode(scene, visualChildren[0], node);

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
@@ -358,6 +358,11 @@ namespace Avalonia.Rendering.SceneGraph
 
         internal void TryPreallocateChildren(int count)
         {
+            if (count == 0)
+            {
+                return;
+            }
+
             EnsureChildrenCreated(count);
         }
 

--- a/tests/Avalonia.Benchmarks/NullDrawingContextImpl.cs
+++ b/tests/Avalonia.Benchmarks/NullDrawingContextImpl.cs
@@ -1,0 +1,103 @@
+﻿using Avalonia.Media;
+using Avalonia.Platform;
+using Avalonia.Rendering.SceneGraph;
+using Avalonia.Utilities;
+using Avalonia.Visuals.Media.Imaging;
+
+namespace Avalonia.Benchmarks
+{
+    internal class NullDrawingContextImpl : IDrawingContextImpl
+    {
+        public void Dispose()
+        {
+        }
+
+        public Matrix Transform { get; set; }
+
+        public void Clear(Color color)
+        {
+        }
+
+        public void DrawBitmap(IRef<IBitmapImpl> source, double opacity, Rect sourceRect, Rect destRect,
+            BitmapInterpolationMode bitmapInterpolationMode = BitmapInterpolationMode.Default)
+        {
+        }
+
+        public void DrawBitmap(IRef<IBitmapImpl> source, IBrush opacityMask, Rect opacityMaskRect, Rect destRect)
+        {
+        }
+
+        public void DrawLine(IPen pen, Point p1, Point p2)
+        {
+        }
+
+        public void DrawGeometry(IBrush brush, IPen pen, IGeometryImpl geometry)
+        {
+        }
+
+        public void DrawRectangle(IBrush brush, IPen pen, RoundedRect rect, BoxShadows boxShadows = default)
+        {
+        }
+
+        public void DrawText(IBrush foreground, Point origin, IFormattedTextImpl text)
+        {
+        }
+
+        public void DrawGlyphRun(IBrush foreground, GlyphRun glyphRun)
+        {
+        }
+
+        public IDrawingContextLayerImpl CreateLayer(Size size)
+        {
+            return null;
+        }
+
+        public void PushClip(Rect clip)
+        {
+        }
+
+        public void PushClip(RoundedRect clip)
+        {
+        }
+
+        public void PopClip()
+        {
+        }
+
+        public void PushOpacity(double opacity)
+        {
+        }
+
+        public void PopOpacity()
+        {
+        }
+
+        public void PushOpacityMask(IBrush mask, Rect bounds)
+        {
+        }
+
+        public void PopOpacityMask()
+        {
+        }
+
+        public void PushGeometryClip(IGeometryImpl clip)
+        {
+        }
+
+        public void PopGeometryClip()
+        {
+        }
+
+        public void PushBitmapBlendMode(BitmapBlendingMode blendingMode)
+        {
+        }
+
+        public void PopBitmapBlendMode()
+        {
+        }
+
+        public void Custom(ICustomDrawOperation custom)
+        {
+        }
+    }
+}

--- a/tests/Avalonia.Benchmarks/NullRenderingPlatform.cs
+++ b/tests/Avalonia.Benchmarks/NullRenderingPlatform.cs
@@ -18,12 +18,12 @@ namespace Avalonia.Benchmarks
 
         public IGeometryImpl CreateEllipseGeometry(Rect rect)
         {
-            throw new NotImplementedException();
+            return new MockStreamGeometryImpl();
         }
 
         public IGeometryImpl CreateLineGeometry(Point p1, Point p2)
         {
-            throw new NotImplementedException();
+            return new MockStreamGeometryImpl();
         }
 
         public IGeometryImpl CreateRectangleGeometry(Rect rect)

--- a/tests/Avalonia.Benchmarks/Rendering/ShapeRendering.cs
+++ b/tests/Avalonia.Benchmarks/Rendering/ShapeRendering.cs
@@ -1,0 +1,53 @@
+﻿using Avalonia.Controls.Shapes;
+using Avalonia.Media;
+using Avalonia.Platform;
+using BenchmarkDotNet.Attributes;
+
+namespace Avalonia.Benchmarks.Rendering
+{
+    [MemoryDiagnoser]
+    public class ShapeRendering
+    {
+        private readonly DrawingContext _drawingContext;
+        private readonly Line _lineFill;
+        private readonly Line _lineFillAndStroke;
+        private readonly Line _lineNoBrushes;
+        private readonly Line _lineStroke;
+
+        public ShapeRendering()
+        {
+            _lineNoBrushes = new Line();
+            _lineStroke = new Line { Stroke = new SolidColorBrush() };
+            _lineFill = new Line { Fill = new SolidColorBrush() };
+            _lineFillAndStroke = new Line { Stroke = new SolidColorBrush(), Fill = new SolidColorBrush() };
+
+            _drawingContext = new DrawingContext(new NullDrawingContextImpl(), true);
+
+            AvaloniaLocator.CurrentMutable.Bind<IPlatformRenderInterface>().ToConstant(new NullRenderingPlatform());
+        }
+
+        [Benchmark]
+        public void Render_Line_NoBrushes()
+        {
+            _lineNoBrushes.Render(_drawingContext);
+        }
+
+        [Benchmark]
+        public void Render_Line_WithStroke()
+        {
+            _lineStroke.Render(_drawingContext);
+        }
+
+        [Benchmark]
+        public void Render_Line_WithFill()
+        {
+            _lineFill.Render(_drawingContext);
+        }
+
+        [Benchmark]
+        public void Render_Line_WithFillAndStroke()
+        {
+            _lineFillAndStroke.Render(_drawingContext);
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
An optimization for core `Shape` rendering that minimizes perf and memory impact.
Best case (no brushes) improved cpu perf x200 and removed all allocations.
Worst case we are looking at cpu perf x38 and 98% memory reduction.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
|                        Method |      Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------------------ |----------:|----------:|----------:|-------:|-------:|------:|----------:|
|         Render_Line_NoBrushes |  9.246 us | 0.0540 us | 0.0506 us | 0.7019 | 0.0153 |     - |   3.01 KB |
|        Render_Line_WithStroke | 14.182 us | 0.0617 us | 0.0577 us | 0.7782 | 0.0305 |     - |   3.32 KB |
|          Render_Line_WithFill |  9.320 us | 0.0447 us | 0.0373 us | 0.7019 | 0.0153 |     - |   3.01 KB |
| Render_Line_WithFillAndStroke | 13.953 us | 0.0374 us | 0.0312 us | 0.7782 | 0.0305 |     - |   3.32 KB |

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
|                        Method |      Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------ |----------:|---------:|---------:|-------:|------:|------:|----------:|
|         Render_Line_NoBrushes |  45.30 ns | 0.092 ns | 0.086 ns |      - |     - |     - |         - |
|        Render_Line_WithStroke | 339.26 ns | 1.937 ns | 1.812 ns | 0.0210 |     - |     - |      88 B |
|          Render_Line_WithFill |  87.35 ns | 0.374 ns | 0.332 ns |      - |     - |     - |         - |
| Render_Line_WithFillAndStroke | 352.55 ns | 2.207 ns | 2.065 ns | 0.0210 |     - |     - |      88 B |

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Best optimization is to just avoid doing any work, so when `Stroke` is not set we can just ignore it.
Also majority of rendered shapes are not using dashes so there is no point in allocating dash style for everything.

Biggest change is using immutable pen and dash styles. Mutable variants have an absurd overhead due to change tracking.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
