### PR TITLE
Fix light dismiss overlay intercepting titlebar hit tests.

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.CustomCaptionProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.CustomCaptionProc.cs
@@ -117,7 +117,7 @@ namespace Avalonia.Win32
                             {
                                 var visual = window.Renderer.HitTestFirst(position, _owner as Window, x =>
                                 {
-                                    if (x is IInputElement ie && !ie.IsHitTestVisible)
+                                    if (x is IInputElement ie && (!ie.IsHitTestVisible || !ie.IsVisible))
                                     {
                                         return false;
                                     }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes hit testing problem with extended titlebar.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
If for some reason `LightDismissOverlay` is created as one of the first layers it will intercept hit tests and prevent dragging window via the titlebar.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Extended titlebar window can be dragged all the time.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Renderer hit tests are a bit quirky and one actually has to check manually if visual is actually visible.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
