### PR TITLE
SelectedDate and SelectedTime => TwoWay by default

### DIFF
--- a/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Templates;
+using Avalonia.Data;
 using Avalonia.Interactivity;
 using System;
 using System.Collections.Generic;
@@ -88,7 +89,8 @@ namespace Avalonia.Controls
         /// </summary>
         public static readonly DirectProperty<DatePicker, DateTimeOffset?> SelectedDateProperty =
             AvaloniaProperty.RegisterDirect<DatePicker, DateTimeOffset?>(nameof(SelectedDate), 
-                x => x.SelectedDate, (x, v) => x.SelectedDate = v);
+                x => x.SelectedDate, (x, v) => x.SelectedDate = v,
+                defaultBindingMode: BindingMode.TwoWay);
 
         // Template Items
         private Button _flyoutButton;

--- a/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Templates;
+using Avalonia.Data;
 using System;
 using System.Globalization;
 
@@ -44,7 +45,8 @@ namespace Avalonia.Controls
         /// </summary>
         public static readonly DirectProperty<TimePicker, TimeSpan?> SelectedTimeProperty =
             AvaloniaProperty.RegisterDirect<TimePicker, TimeSpan?>(nameof(SelectedTime),
-                x => x.SelectedTime, (x, v) => x.SelectedTime = v);
+                x => x.SelectedTime, (x, v) => x.SelectedTime = v,
+                defaultBindingMode: BindingMode.TwoWay);
 
         // Template Items
         private TimePickerPresenter _presenter;


### PR DESCRIPTION
Makes `DatePicker.SelectedDate` and `TimePicker.SelectedTime` use `TwoWay` binding by default. Fixes #3407. For the record, WPF's `DatePicker.SelectedDate` is `TwoWay` by default: https://referencesource.microsoft.com/#PresentationFramework/src/Framework/System/Windows/Controls/DatePicker.cs,412

## What does the pull request do?

See above.

## What is the current behavior?
These properties don't use `TwoWay` bindings by default.


## What is the updated/expected behavior with this PR?

`TwoWay` binding now!

## How was the solution implemented (if it's not obvious)?

It's obvious.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

Technically, this might be considered a breaking change in case this isn't expected by the end user.

## Fixed issues

Fixes #3407 
