### PR TITLE
Transitions for solid color brushes.

### DIFF
--- a/samples/RenderDemo/Pages/TransitionsPage.xaml
+++ b/samples/RenderDemo/Pages/TransitionsPage.xaml
@@ -145,7 +145,7 @@
       <Style Selector="Border.Rect10">
         <Setter Property="Transitions">
           <Transitions>
-            <ISolidColorBrushTransition Property="Background" Duration="0:0:0.5" />
+            <BrushTransition Property="Background" Duration="0:0:0.5" />
           </Transitions>
         </Setter>
         <Setter Property="Background" Value="Red" />
@@ -153,6 +153,26 @@
 
       <Style Selector="Border.Rect10:pointerover">
         <Setter Property="Background" Value="Orange" />
+      </Style>
+
+      <Style Selector="Border.Rect11">
+        <Setter Property="Transitions">
+          <Transitions>
+            <BrushTransition Property="Background" Duration="0:0:0.5" />
+          </Transitions>
+        </Setter>
+        <Setter Property="Background" Value="Red" />
+      </Style>
+
+      <Style Selector="Border.Rect11:pointerover">
+        <Setter Property="Background" >
+          <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+            <LinearGradientBrush.GradientStops>
+              <GradientStop Offset="0" Color="Red"/>
+              <GradientStop Offset="1" Color="Blue"/>
+            </LinearGradientBrush.GradientStops>
+          </LinearGradientBrush>
+        </Setter>
       </Style>
     </Styles>
   </UserControl.Styles>
@@ -181,6 +201,7 @@
         <Border Classes="Test Shadow" CornerRadius="0 30 60 0" Child="{x:Null}" />
 
         <Border Classes="Test Rect10" />
+        <Border Classes="Test Rect11" />
       </WrapPanel>
     </StackPanel>
   </Grid>

--- a/samples/RenderDemo/Pages/TransitionsPage.xaml
+++ b/samples/RenderDemo/Pages/TransitionsPage.xaml
@@ -141,6 +141,19 @@
       <Style Selector="Border.Shadow:pointerover">
         <Setter Property="BoxShadow" Value="inset 30 30 20 30 Green, 20 40 20 10 Red"/>
       </Style>
+
+      <Style Selector="Border.Rect10">
+        <Setter Property="Transitions">
+          <Transitions>
+            <ISolidColorBrushTransition Property="Background" Duration="0:0:0.5" />
+          </Transitions>
+        </Setter>
+        <Setter Property="Background" Value="Red" />
+      </Style>
+
+      <Style Selector="Border.Rect10:pointerover">
+        <Setter Property="Background" Value="Orange" />
+      </Style>
     </Styles>
   </UserControl.Styles>
 
@@ -166,6 +179,8 @@
 
         <Border Classes="Test Shadow" CornerRadius="10" Child="{x:Null}" />
         <Border Classes="Test Shadow" CornerRadius="0 30 60 0" Child="{x:Null}" />
+
+        <Border Classes="Test Rect10" />
       </WrapPanel>
     </StackPanel>
   </Grid>

--- a/src/Avalonia.Visuals/Animation/Transitions/BrushTransition.cs
+++ b/src/Avalonia.Visuals/Animation/Transitions/BrushTransition.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Avalonia.Animation.Animators;
+using Avalonia.Media;
+
+namespace Avalonia.Animation
+{
+    /// <summary>
+    /// Transition class that handles <see cref="AvaloniaProperty"/> with <see cref="IBrush"/> type.
+    /// Only values of <see cref="ISolidColorBrush"/> will correctly transition.
+    /// </summary>
+    public class ISolidColorBrushTransition : Transition<IBrush>
+    {
+        private static readonly ISolidColorBrushAnimator s_animator = new ISolidColorBrushAnimator();
+
+        public override IObservable<IBrush> DoTransition(IObservable<double> progress, IBrush oldValue, IBrush newValue)
+        {
+            var oldSolidBrush = AsImmutable(oldValue);
+            var newSolidBrush = AsImmutable(newValue);
+
+            return new AnimatorTransitionObservable<ISolidColorBrush, ISolidColorBrushAnimator>(
+                s_animator, progress, Easing, oldSolidBrush, newSolidBrush);
+        }
+
+        private static ISolidColorBrush AsImmutable(IBrush brush)
+        {
+            return (ISolidColorBrush)(brush as ISolidColorBrush)?.ToImmutable();
+        }
+    }
+}

--- a/src/Avalonia.Visuals/Animation/Transitions/BrushTransition.cs
+++ b/src/Avalonia.Visuals/Animation/Transitions/BrushTransition.cs
@@ -22,19 +22,11 @@ namespace Avalonia.Animation
 
             if (oldSolidColorBrush != null && newSolidColorBrush != null)
             {
-                EnsureImmutable(ref oldSolidColorBrush);
-                EnsureImmutable(ref newSolidColorBrush);
-
                 return new AnimatorTransitionObservable<ISolidColorBrush, ISolidColorBrushAnimator>(
                     s_animator, progress, Easing, oldSolidColorBrush, newSolidColorBrush);
             }
 
             return new IncompatibleTransitionObservable(progress, Easing, oldValue, newValue);
-        }
-
-        private static void EnsureImmutable(ref ISolidColorBrush brush)
-        {
-            brush = (ISolidColorBrush)brush.ToImmutable();
         }
 
         private static ISolidColorBrush? TryGetSolidColorBrush(IBrush? brush)
@@ -54,7 +46,7 @@ namespace Avalonia.Animation
 
             public IncompatibleTransitionObservable(IObservable<double> progress, Easing easing, IBrush? from, IBrush? to) : base(progress, easing)
             {
-                _from = @from;
+                _from = from;
                 _to = to;
             }
 

--- a/src/Avalonia.Visuals/Animation/Transitions/BrushTransition.cs
+++ b/src/Avalonia.Visuals/Animation/Transitions/BrushTransition.cs
@@ -1,29 +1,67 @@
 ﻿using System;
 using Avalonia.Animation.Animators;
+using Avalonia.Animation.Easings;
 using Avalonia.Media;
+
+#nullable enable
 
 namespace Avalonia.Animation
 {
     /// <summary>
     /// Transition class that handles <see cref="AvaloniaProperty"/> with <see cref="IBrush"/> type.
-    /// Only values of <see cref="ISolidColorBrush"/> will correctly transition.
+    /// Only values of <see cref="ISolidColorBrush"/> will transition correctly at the moment.
     /// </summary>
-    public class ISolidColorBrushTransition : Transition<IBrush>
+    public class BrushTransition : Transition<IBrush?>
     {
         private static readonly ISolidColorBrushAnimator s_animator = new ISolidColorBrushAnimator();
 
-        public override IObservable<IBrush> DoTransition(IObservable<double> progress, IBrush oldValue, IBrush newValue)
+        public override IObservable<IBrush?> DoTransition(IObservable<double> progress, IBrush? oldValue, IBrush? newValue)
         {
-            var oldSolidBrush = AsImmutable(oldValue);
-            var newSolidBrush = AsImmutable(newValue);
+            var oldSolidColorBrush = TryGetSolidColorBrush(oldValue);
+            var newSolidColorBrush = TryGetSolidColorBrush(newValue);
 
-            return new AnimatorTransitionObservable<ISolidColorBrush, ISolidColorBrushAnimator>(
-                s_animator, progress, Easing, oldSolidBrush, newSolidBrush);
+            if (oldSolidColorBrush != null && newSolidColorBrush != null)
+            {
+                EnsureImmutable(ref oldSolidColorBrush);
+                EnsureImmutable(ref newSolidColorBrush);
+
+                return new AnimatorTransitionObservable<ISolidColorBrush, ISolidColorBrushAnimator>(
+                    s_animator, progress, Easing, oldSolidColorBrush, newSolidColorBrush);
+            }
+
+            return new IncompatibleTransitionObservable(progress, Easing, oldValue, newValue);
         }
 
-        private static ISolidColorBrush AsImmutable(IBrush brush)
+        private static void EnsureImmutable(ref ISolidColorBrush brush)
         {
-            return (ISolidColorBrush)(brush as ISolidColorBrush)?.ToImmutable();
+            brush = (ISolidColorBrush)brush.ToImmutable();
+        }
+
+        private static ISolidColorBrush? TryGetSolidColorBrush(IBrush? brush)
+        {
+            if (brush is null)
+            {
+                return Brushes.Transparent;
+            }
+
+            return brush as ISolidColorBrush;
+        }
+
+        private class IncompatibleTransitionObservable : TransitionObservableBase<IBrush?>
+        {
+            private readonly IBrush? _from;
+            private readonly IBrush? _to;
+
+            public IncompatibleTransitionObservable(IObservable<double> progress, Easing easing, IBrush? from, IBrush? to) : base(progress, easing)
+            {
+                _from = @from;
+                _to = to;
+            }
+
+            protected override IBrush? ProduceValue(double progress)
+            {
+                return progress < 0.5 ? _from : _to;
+            }
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Adds a transition for `ISolidColorBrush` based brushes.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
No transitions between brushes.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
For solid color brushes - one can transition between colors.


https://user-images.githubusercontent.com/2588062/121200027-b2b60680-c873-11eb-9088-25f7c2c4d9ec.mp4



## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
