### PR TITLE
Fix a couple of tests that only fail in debug mode.

### DIFF
--- a/tests/Avalonia.Visuals.UnitTests/Media/PenTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Media/PenTests.cs
@@ -59,9 +59,9 @@ namespace Avalonia.Visuals.UnitTests.Media
         }
 
         [Fact]
-        public void Equality_Is_Implemented_Between_Immutable_And_Mmutable_Pens()
+        public void Equality_Is_Implemented_Between_Immutable_And_Mutable_Pens()
         {
-            var brush = new SolidColorBrush(Colors.Red);
+            var brush = new ImmutableSolidColorBrush(Colors.Red);
             var target1 = new ImmutablePen(
                 brush: brush,
                 thickness: 2,
@@ -83,7 +83,7 @@ namespace Avalonia.Visuals.UnitTests.Media
         [Fact]
         public void Equality_Is_Implemented_Between_Mutable_And_Immutable_DashStyles()
         {
-            var brush = new SolidColorBrush(Colors.Red);
+            var brush = new ImmutableSolidColorBrush(Colors.Red);
             var target1 = new ImmutablePen(
                 brush: brush,
                 thickness: 2,


### PR DESCRIPTION
## What does the pull request do?

#6039 added a call to `Debug.Assert` when an immutable pen was passed a mutable brush. Unfortunately two tests were doing just that, but they didn't fail on CI because the assert only takes place in debug builds.

Fix the two tests.
