### PR TITLE
Add PolyLineSegment path segment

### DIFF
--- a/src/Avalonia.Visuals/Media/PolyLineSegment.cs
+++ b/src/Avalonia.Visuals/Media/PolyLineSegment.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using Avalonia.Collections;
+
+namespace Avalonia.Media
+{
+    /// <summary>
+    /// Represents a set of line segments defined by a points collection with each Point specifying the end point of a line segment.
+    /// </summary>
+    public sealed class PolyLineSegment : PathSegment
+    {
+        /// <summary>
+        /// Defines the <see cref="Points"/> property.
+        /// </summary>
+        public static readonly StyledProperty<Points> PointsProperty
+            = AvaloniaProperty.Register<PolyLineSegment, Points>(nameof(Points));
+
+        /// <summary>
+        /// Gets or sets the points.
+        /// </summary>
+        /// <value>
+        /// The points.
+        /// </value>
+        public AvaloniaList<Point> Points
+        {
+            get => GetValue(PointsProperty);
+            set => SetValue(PointsProperty, value);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PolyLineSegment"/> class.
+        /// </summary>
+        public PolyLineSegment()
+        {
+            Points = new Points();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PolyLineSegment"/> class.
+        /// </summary>
+        /// <param name="points">The points.</param>
+        public PolyLineSegment(IEnumerable<Point> points) : this()
+        {
+            Points.AddRange(points);
+        }
+
+        protected internal override void ApplyTo(StreamGeometryContext ctx)
+        {
+            var points = Points;
+            if (points.Count > 0)
+            {
+                for (int i = 0; i < points.Count; i++)
+                {
+                    ctx.LineTo(points[i]);
+                }
+            }
+        }
+
+        public override string ToString()
+            => Points.Count >= 1 ? "L " + string.Join(" ", Points) : "";
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Adds PolyLineSegment path segment class.

https://docs.microsoft.com/en-us/dotnet/api/system.windows.media.polylinesegment?view=net-5.0

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
PolyLineSegment path segment class is missing.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
PolyLineSegment  is available.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #6056