### PR TITLE
- Add ReadPixels OpenGL function

### DIFF
--- a/src/Avalonia.OpenGL/GlInterface.cs
+++ b/src/Avalonia.OpenGL/GlInterface.cs
@@ -368,6 +368,10 @@ namespace Avalonia.OpenGL
         public delegate void GlDeleteShader(int shader);
         [GlEntryPoint("glDeleteShader")]
         public GlDeleteShader DeleteShader { get; }
+        
+        public delegate void GlReadPixels(int x, int y, int width, int height, int format, int type, IntPtr data);
+        [GlEntryPoint("glReadPixels")]
+        public GlReadPixels ReadPixels { get; }
         // ReSharper restore UnassignedGetOnlyAutoProperty
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Add missing [glReadPixels ](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glReadPixels.xhtml) function

## What is the updated/expected behavior with this PR?
Function is not used in Avalonia source code. It's needed for my custom render target implementation.
