### PR TITLE
fixes RemoteWidget error when width or height is equal to zero. Issue…

### DIFF
--- a/src/Avalonia.Controls/Remote/RemoteWidget.cs
+++ b/src/Avalonia.Controls/Remote/RemoteWidget.cs
@@ -70,7 +70,7 @@ namespace Avalonia.Controls.Remote
 
         public override void Render(DrawingContext context)
         {
-            if (_lastFrame != null)
+            if (_lastFrame != null && _lastFrame.Width != 0 && _lastFrame.Height != 0)
             {
                 var fmt = (PixelFormat) _lastFrame.Format;
                 if (_bitmap == null || _bitmap.PixelSize.Width != _lastFrame.Width ||


### PR DESCRIPTION
## What does the pull request do?
Fixes the [Issue #6068](https://github.com/AvaloniaUI/Avalonia/issues/6068) when RemoteWidget throws an exception and stops rendering any further frames when window's width or height is equal to zero.


## What is the current behavior?
RemoteWidget throws an exception when window's width or height is equal to zero and stops rendering any further frames.

![BlankRemoteWidgetWindow](https://user-images.githubusercontent.com/1831879/122048070-1fd01b80-cde1-11eb-8ebc-9d30a2f4e8c1.gif)

## What is the updated/expected behavior with this PR?
RemoteWidget continues rendering process when window's width or height is equal to zero


## Fixed issues
Fixes #6068 
