### PR TITLE
fix osx window state logic.

### DIFF
--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -513,6 +513,7 @@ private:
     bool _fullScreenActive;
     SystemDecorations _decorations;
     AvnWindowState _lastWindowState;
+    AvnWindowState _actualWindowState;
     bool _inSetWindowState;
     NSRect _preZoomSize;
     bool _transitioningWindowState;
@@ -539,6 +540,7 @@ private:
         _transitioningWindowState = false;
         _inSetWindowState = false;
         _lastWindowState = Normal;
+        _actualWindowState = Normal;
         WindowEvents = events;
         [Window setCanBecomeKeyAndMain];
         [Window disableCursorRects];
@@ -633,7 +635,7 @@ private:
     
     void WindowStateChanged () override
     {
-        if(!_inSetWindowState && !_transitioningWindowState)
+        if(_shown && !_inSetWindowState && !_transitioningWindowState)
         {
             AvnWindowState state;
             GetWindowState(&state);
@@ -963,14 +965,14 @@ private:
     {
         @autoreleasepool
         {
-            if(_lastWindowState == state)
+            if(_actualWindowState == state)
             {
                 return S_OK;
             }
             
             _inSetWindowState = true;
             
-            auto currentState = _lastWindowState;
+            auto currentState = _actualWindowState;
             _lastWindowState = state;
             
             if(currentState == Normal)
@@ -1049,7 +1051,10 @@ private:
                         }
                         break;
                 }
+                
+                _actualWindowState = _lastWindowState;
             }
+            
             
             _inSetWindowState = false;
             


### PR DESCRIPTION
## What does the pull request do?
When you set WindowState from XAML, (before window is actually shown) OSX ignores the value...

I think introduced by.  https://github.com/AvaloniaUI/Avalonia/commit/5a3602ffd52ed2e802fa2d6d04664bedb9c51c62

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
