### PR TITLE
scale flyout transient area.

### DIFF
--- a/src/Avalonia.Controls/Flyouts/FlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/FlyoutBase.cs
@@ -252,7 +252,9 @@ namespace Avalonia.Controls.Primitives
                     if (Popup?.Host is PopupRoot root)
                     { 
                         // Get the popup root bounds and convert to screen coordinates
-                        var tmp = root.Bounds.Inflate(100);
+                        var topLevel = root.Parent as TopLevel;
+
+                        var tmp = root.Bounds.Inflate(topLevel.PointToClient(new PixelPoint(100, 100)).X);
                         var scPt = root.PointToScreen(tmp.TopLeft);
                         enlargedPopupRect = new Rect(scPt.X, scPt.Y, tmp.Width, tmp.Height);
                     }

--- a/src/Avalonia.Controls/Flyouts/FlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/FlyoutBase.cs
@@ -4,6 +4,7 @@ using Avalonia.Input;
 using Avalonia.Input.Raw;
 using Avalonia.Layout;
 using Avalonia.Logging;
+using Avalonia.Rendering;
 
 #nullable enable
 
@@ -252,7 +253,8 @@ namespace Avalonia.Controls.Primitives
                     if (Popup?.Host is PopupRoot root)
                     { 
                         // Get the popup root bounds and convert to screen coordinates
-                        var tmp = root.Bounds.Inflate(root.PointToClient(new PixelPoint(100, 100)).X);
+                        
+                        var tmp = root.Bounds.Inflate(100 * (root as IRenderRoot).RenderScaling);
                         var scPt = root.PointToScreen(tmp.TopLeft);
                         enlargedPopupRect = new Rect(scPt.X, scPt.Y, tmp.Width, tmp.Height);
                     }

--- a/src/Avalonia.Controls/Flyouts/FlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/FlyoutBase.cs
@@ -252,9 +252,7 @@ namespace Avalonia.Controls.Primitives
                     if (Popup?.Host is PopupRoot root)
                     { 
                         // Get the popup root bounds and convert to screen coordinates
-                        var topLevel = root.Parent as TopLevel;
-
-                        var tmp = root.Bounds.Inflate(topLevel.PointToClient(new PixelPoint(100, 100)).X);
+                        var tmp = root.Bounds.Inflate(root.PointToClient(new PixelPoint(100, 100)).X);
                         var scPt = root.PointToScreen(tmp.TopLeft);
                         enlargedPopupRect = new Rect(scPt.X, scPt.Y, tmp.Width, tmp.Height);
                     }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes the transient dismiss area logic for flyout.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Flyout with `ShowMode="TransientWithDismissOnPointerMoveAway"` set, calculates an inflated boundary around the flyout, where if the mouse moves outside this area, it should close.

However this boundary is often calculated incorrectly, not taking into account scaling.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

 - Changed the logic to use PixelSize, PixelPoint and PixelRect to make it obvious when screen coordinates and client coordinates are being used in the code.
 
 - Dismiss boundary is now calculated correctly and consistently on all platforms, taking into account the scaling.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
