### PR TITLE
Implement measure pass in AdornerLayer.

### DIFF
--- a/src/Avalonia.Controls/Primitives/AdornerLayer.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerLayer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Resources;
 using Avalonia.Media;
 using Avalonia.Rendering;
 using Avalonia.Utilities;
@@ -45,10 +46,27 @@ namespace Avalonia.Controls.Primitives
                 ?.AdornerLayer;
         }
 
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            foreach (var child in Children)
+            {
+                var info = child.GetValue(s_adornedElementInfoProperty);
+
+                if (info != null && info.Bounds.HasValue)
+                {
+                    child.Measure(info.Bounds.Value.Bounds.Size);
+                }
+                else
+                {
+                    child.Measure(availableSize);
+                }
+            }
+
+            return default;
+        }
+
         protected override Size ArrangeOverride(Size finalSize)
         {
-            var parent = Parent;
-
             foreach (var child in Children)
             {
                 var info = child.GetValue(s_adornedElementInfoProperty);


### PR DESCRIPTION
## What does the pull request do?

Previously the `AdornerLayer` was falling back to the base class implementation of `MeasureOverride`, in `Canvas`. This meant that at times, adorner controls were being measured with a larger constraint than the final size given to them. `Grid` doesn't like it when this happens which causes problems with various controls.

Add a measure pass to `AdornerLayer` which passes the adorned control's bounds as the constraint (which is the value that the arrange pass will use).

cc: @YohDeadfall 