### PR TITLE
ComboBox: Let Data and Stretch be overridden

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/ComboBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ComboBox.xaml
@@ -112,9 +112,7 @@
                 <Panel Height="12"
                        Width="12" />
                 <Path x:Name="DropDownGlyph"
-                      Stretch="Uniform"
-                      VerticalAlignment="Center"
-                      Data="M1939 486L2029 576L1024 1581L19 576L109 486L1024 1401L1939 486Z" />
+                      VerticalAlignment="Center" />
               </Panel>
             </Viewbox>
             <Popup Name="PART_Popup"
@@ -160,6 +158,8 @@
 
   <Style Selector="ComboBox /template/ Path#DropDownGlyph">
     <Setter Property="Fill" Value="{DynamicResource ComboBoxDropDownGlyphForeground}" />
+    <Setter Property="Data" Value="M1939 486L2029 576L1024 1581L19 576L109 486L1024 1401L1939 486Z" />
+    <Setter Property="Stretch" Value="Uniform" />
   </Style>
 
   <!--  PointerOver State  -->


### PR DESCRIPTION
## What does the pull request do?
Moves `DropDownGlyph` `Data` and `Stretch` properties to a separate style entry so they can be overridden. They're currently hard coded in the original template making them impossible to override without re-templating. Ideally we need a separate priority for local values/dynamic/static resources inside templates so this isn't necessary - I know this works in WinUI, can't remember about WPF though.

## What is the updated/expected behavior with this PR?
You can now override the default glyph


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #6096 
