### PR TITLE
Use IsNullOrEmpty instead of IsNullOrWhiteSpace for :empty pseudoclass

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1290,7 +1290,7 @@ namespace Avalonia.Controls
 
         private void UpdatePseudoclasses()
         {
-            PseudoClasses.Set(":empty", string.IsNullOrWhiteSpace(Text));
+            PseudoClasses.Set(":empty", string.IsNullOrEmpty(Text));
         }
 
         private bool IsPasswordBox => PasswordChar != default(char);


### PR DESCRIPTION
## What is the current behavior?
TextBox with spaces has ":empty" pseudoclass.

## What is the updated/expected behavior with this PR?
TextBox with spaces has not ":empty" pseudoclass.

## Breaking changes
Technically - yes. But I don't think it will affect anybody, since previous behavior was unexpected.

## Fixed issues
Fixes #6134
