### PR TITLE
Prevent `ScrollSlotIntoView` from crashing on start

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridRows.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRows.cs
@@ -425,7 +425,7 @@ namespace Avalonia.Controls
                 UpdateDisplayedRows(DisplayData.FirstScrollingSlot, CellsHeight);
             }
 
-            if (DisplayData.FirstScrollingSlot < slot && DisplayData.LastScrollingSlot > slot)
+            if (DisplayData.FirstScrollingSlot < slot && (DisplayData.LastScrollingSlot > slot || DisplayData.LastScrollingSlot == -1))
             {
                 // The row is already displayed in its entirety
                 return true;


### PR DESCRIPTION
## What does the pull request do?

I didn't dig deep into `DataGrid` code - it's huge and complicated but I have feeling like this check is the right one.

There was an exception cause `LastScrollingSlot` is equal to `-1` so there is no way to get height from `GetExactSlotElementHeight` method

Again, maybe the right move would be investigate deeper why `ScrollSlotIntoView` is called when `LastScrollingSlot` and `FirstScrollingSlot` are defaults but I believe it requires a much more time and knowledge about `DataGrid` in particular and event priority in `Avalonia` in general than I'm currently willing to spend on.

Nevertheless I think this small fix worth it since it seems like doesn't break anything and allows using of `ScrollSlotIntoView` method without unexpected exceptions.

## What is the current behavior?

`ArgumentOutOfRangeException` exception is thrown 


## What is the updated/expected behavior with this PR?

No `ArgumentOutOfRangeException` exception is thrown


## How was the solution implemented (if it's not obvious)?


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues

Fixes: #6127 
