### PR TITLE
Add "Star" static to GridLength

### DIFF
--- a/src/Avalonia.Controls/GridLength.cs
+++ b/src/Avalonia.Controls/GridLength.cs
@@ -78,6 +78,12 @@ namespace Avalonia.Controls
         public static GridLength Auto => new GridLength(0, GridUnitType.Auto);
 
         /// <summary>
+        /// Gets an instance of <see cref="GridLength"/> that indicates that a row or column should
+        /// fill its content.
+        /// </summary>
+        public static GridLength Star => new GridLength(1, GridUnitType.Star);
+
+        /// <summary>
         /// Gets the unit of the <see cref="GridLength"/>.
         /// </summary>
         public GridUnitType GridUnitType => _type;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Add "Star" static property to `GridLength` to remain consistent with `GridLength.Auto`.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
