### PR TITLE
Adding more ToString() overloads to improve DevTools

### DIFF
--- a/src/Avalonia.Controls/RowDefinitions.cs
+++ b/src/Avalonia.Controls/RowDefinitions.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using Avalonia.Collections;
 
 namespace Avalonia.Controls
 {
@@ -23,6 +22,11 @@ namespace Avalonia.Controls
             : this()
         {
             AddRange(GridLength.ParseLengths(s).Select(x => new RowDefinition(x)));
+        }
+
+        public override string ToString()
+        {
+            return string.Join(",", this.Select(x => x.Height));
         }
 
         /// <summary>

--- a/src/Avalonia.Visuals/Media/BoxShadow.cs
+++ b/src/Avalonia.Visuals/Media/BoxShadow.cs
@@ -93,25 +93,25 @@ namespace Avalonia.Media
 
             if (OffsetX != 0.0)
             {
-                sb.Append($" {OffsetX}");
+                sb.AppendFormat(" {0}", OffsetX.ToString());
             }
 
             if (OffsetY != 0.0)
             {
-                sb.Append($" {OffsetY}");
+                sb.AppendFormat(" {0}", OffsetY.ToString());
             }
             
             if (Blur != 0.0)
             {
-                sb.Append($" {Blur}");
+                sb.AppendFormat(" {0}", Blur.ToString());
             }
 
             if (Spread != 0.0)
             {
-                sb.Append($" {Spread}");
+                sb.AppendFormat(" {0}", Spread.ToString());
             }
 
-            sb.Append($" {Color.ToString()}");
+            sb.AppendFormat(" {0}", Color.ToString());
 
             return sb.ToString();
         }

--- a/src/Avalonia.Visuals/Media/BoxShadow.cs
+++ b/src/Avalonia.Visuals/Media/BoxShadow.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Text;
 using Avalonia.Animation.Animators;
 using Avalonia.Utilities;
 
@@ -75,6 +76,46 @@ namespace Avalonia.Media
                 return rv;
             }
         }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+
+            if (IsEmpty)
+            {
+                return "none";
+            }
+
+            if (IsInset)
+            {
+                sb.Append("inset");
+            }
+
+            if (OffsetX != 0.0)
+            {
+                sb.Append($" {OffsetX}");
+            }
+
+            if (OffsetY != 0.0)
+            {
+                sb.Append($" {OffsetY}");
+            }
+            
+            if (Blur != 0.0)
+            {
+                sb.Append($" {Blur}");
+            }
+
+            if (Spread != 0.0)
+            {
+                sb.Append($" {Spread}");
+            }
+
+            sb.Append($" {Color.ToString()}");
+
+            return sb.ToString();
+        }
+
         public static unsafe BoxShadow Parse(string s)
         {
             if(s == null)

--- a/src/Avalonia.Visuals/Media/BoxShadows.cs
+++ b/src/Avalonia.Visuals/Media/BoxShadows.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
+using System.Text;
 using Avalonia.Animation.Animators;
 
 namespace Avalonia.Media
@@ -41,6 +41,24 @@ namespace Avalonia.Media
                     return _first;
                 return _list[c - 1];
             }
+        }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+
+            if (Count == 0)
+            {
+                return "none";
+            }
+
+            foreach (var boxShadow in this)
+            {
+                sb.Append(boxShadow + " ");
+            }
+
+            return sb.ToString();
+
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Avalonia.Visuals/Media/BoxShadows.cs
+++ b/src/Avalonia.Visuals/Media/BoxShadows.cs
@@ -54,7 +54,7 @@ namespace Avalonia.Media
 
             foreach (var boxShadow in this)
             {
-                sb.Append(boxShadow + " ");
+                sb.Append($"{boxShadow} ");
             }
 
             return sb.ToString();

--- a/src/Avalonia.Visuals/Media/BoxShadows.cs
+++ b/src/Avalonia.Visuals/Media/BoxShadows.cs
@@ -54,7 +54,7 @@ namespace Avalonia.Media
 
             foreach (var boxShadow in this)
             {
-                sb.Append($"{boxShadow} ");
+                sb.AppendFormat("{0} ", boxShadow.ToString());
             }
 
             return sb.ToString();


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Adding `ToString()` overlods for `BoxShadows`, `BoxShadow` and `ColumnDefinitions` so the display correctly in DevTools.

![image](https://user-images.githubusercontent.com/4670166/124284367-38646380-db4d-11eb-8708-68698a41d3a7.png)
![image](https://user-images.githubusercontent.com/4670166/124284376-39959080-db4d-11eb-9a0c-54909acb27c7.png)


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
