### PR TITLE
Allow moving items in ItemsRepeater

### DIFF
--- a/src/Avalonia.Layout/ElementManager.cs
+++ b/src/Avalonia.Layout/ElementManager.cs
@@ -325,7 +325,10 @@ namespace Avalonia.Layout
                         break;
 
                     case NotifyCollectionChangedAction.Move:
-                        throw new NotImplementedException();
+                        int size = args.OldItems != null ? args.OldItems.Count : 1;
+                        OnItemsRemoved(args.OldStartingIndex, size);
+                        OnItemsAdded(args.NewStartingIndex, size);
+                        break;
                 }
             }
         }


### PR DESCRIPTION
## What does the pull request do?
Adds the code from upstream in WinUI to handle `INotifyCollectionChanged` move actions for the `ItemsRepeater`, which currently throws a `NotImplementedException` if using a `StackLayout` or `UniformGridLayout`

Tested manually. No test included as I didn't see any for the ItemsRepeater and I think this is simple enough one isn't required.
