### PR TITLE
Setting adorner bounds on init

### DIFF
--- a/src/Avalonia.Controls/Primitives/AdornerLayer.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerLayer.cs
@@ -151,6 +151,7 @@ namespace Avalonia.Controls.Primitives
                     adorner.SetValue(s_adornedElementInfoProperty, info);
                 }
 
+                info.Bounds = adorned.TransformedBounds;
                 info.Subscription = adorned.GetObservable(TransformedBoundsProperty).Subscribe(x =>
                 {
                     info.Bounds = x;


### PR DESCRIPTION
While an adorner subscribes for `TransformedBounds` changes an initial value isn't set. This PR fixes the issue by setting bounds before subscription.