### PR TITLE
Enhance matrix to 3x3 (to include perspective information)

### DIFF
--- a/src/Avalonia.Visuals/Matrix.cs
+++ b/src/Avalonia.Visuals/Matrix.cs
@@ -1,12 +1,21 @@
 using System;
 using System.Globalization;
+using System.Linq;
 using Avalonia.Utilities;
 
 namespace Avalonia
 {
     /// <summary>
-    /// A 2x3 matrix.
+    /// A 3x3 matrix.
     /// </summary>
+    /// <remakrs>Matrix layout:
+    ///         | 1st col | 2nd col | 3r col |
+    /// 1st row | scaleX  | skrewY  | persX  |
+    /// 2nd row | skrewX  | scaleY  | persY  |
+    /// 3rd row | transX  | transY  | persZ  |
+    /// 
+    /// Note: Skia.SkMatrix uses a transposed layout (where for example skrewX/skrewY and perspp0/tranX are swapped).
+    /// </remakrs>
 #if !BUILDTASK
     public
 #endif
@@ -14,40 +23,77 @@ namespace Avalonia
     {
         private readonly double _m11;
         private readonly double _m12;
+        private readonly double _m13;
         private readonly double _m21;
         private readonly double _m22;
+        private readonly double _m23;
         private readonly double _m31;
         private readonly double _m32;
+        private readonly double _m33;
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Matrix"/> struct (equivalent to a 2x3 Matrix without perspective).
+        /// </summary>
+        /// <param name="scaleX">The first element of the first row.</param>
+        /// <param name="skrewY">The second element of the first row.</param>
+        /// <param name="skrewX">The first element of the second row.</param>
+        /// <param name="scaleY">The second element of the second row.</param>
+        /// <param name="offsetX">The first element of the third row.</param>
+        /// <param name="offsetY">The second element of the third row.</param>
+        public Matrix(
+            double scaleX,
+            double skrewY,
+            double skrewX,
+            double scaleY,
+            double offsetX,
+            double offsetY) : this( scaleX, skrewY, 0, skrewX, scaleY, 0, offsetX, offsetY, 1)
+        {
+        }
+
+
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Matrix"/> struct.
         /// </summary>
-        /// <param name="m11">The first element of the first row.</param>
-        /// <param name="m12">The second element of the first row.</param>
-        /// <param name="m21">The first element of the second row.</param>
-        /// <param name="m22">The second element of the second row.</param>
+        /// <param name="scaleX">The first element of the first row.</param>
+        /// <param name="skrewY">The second element of the first row.</param>
+        /// <param name="persX">The third element of the first row.</param>
+        /// <param name="skrewX">The first element of the second row.</param>
+        /// <param name="scaleY">The second element of the second row.</param>
+        /// <param name="persY">The third element of the second row.</param>
         /// <param name="offsetX">The first element of the third row.</param>
         /// <param name="offsetY">The second element of the third row.</param>
+        /// <param name="persZ">The third element of the third row.</param>
         public Matrix(
-            double m11,
-            double m12,
-            double m21,
-            double m22,
+            double scaleX,
+            double skrewY,
+            double persX,
+            double skrewX,
+            double scaleY,
+            double persY, 
             double offsetX,
-            double offsetY)
+            double offsetY,
+            double persZ)
         {
-            _m11 = m11;
-            _m12 = m12;
-            _m21 = m21;
-            _m22 = m22;
+            _m11 = scaleX;
+            _m12 = skrewY;
+            _m13 = persX;
+            _m21 = skrewX;
+            _m22 = scaleY;
+            _m23 = persY;
             _m31 = offsetX;
             _m32 = offsetY;
+            _m33 = persZ;
         }
 
         /// <summary>
         /// Returns the multiplicative identity matrix.
         /// </summary>
-        public static Matrix Identity { get; } = new Matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0);
+        public static Matrix Identity { get; } = new Matrix(
+            1.0, 0.0, 0.0,
+            0.0, 1.0, 0.0,
+            0.0, 0.0, 1.0);
 
         /// <summary>
         /// Returns whether the matrix is the identity matrix.
@@ -60,34 +106,49 @@ namespace Avalonia
         public bool HasInverse => !MathUtilities.IsZero(GetDeterminant());
 
         /// <summary>
-        /// The first element of the first row
+        /// The first element of the first row (scaleX).
         /// </summary>
         public double M11 => _m11;
 
         /// <summary>
-        /// The second element of the first row
+        /// The second element of the first row (skrewY).
         /// </summary>
         public double M12 => _m12;
 
         /// <summary>
-        /// The first element of the second row
+        /// The third element of the first row (persX: input x-axis perspective factor).
+        /// </summary>
+        public double M13 => _m13;
+
+        /// <summary>
+        /// The first element of the second row (skrewX).
         /// </summary>
         public double M21 => _m21;
 
         /// <summary>
-        /// The second element of the second row
+        /// The second element of the second row (scaleY).
         /// </summary>
         public double M22 => _m22;
 
         /// <summary>
-        /// The first element of the third row
+        /// The third element of the second row (persY: input y-axis perspective factor).
+        /// </summary>
+        public double M23 => _m23;
+
+        /// <summary>
+        /// The first element of the third row (offsetX/translateX).
         /// </summary>
         public double M31 => _m31;
 
         /// <summary>
-        /// The second element of the third row
+        /// The second element of the third row (offsetY/translateY).
         /// </summary>
         public double M32 => _m32;
+
+        /// <summary>
+        /// The third element of the third row (persZ: perspective scale factor).
+        /// </summary>
+        public double M33 => _m33;
 
         /// <summary>
         /// Multiplies two matrices together and returns the resulting matrix.
@@ -103,7 +164,7 @@ namespace Avalonia
                 (value1.M21 * value2.M11) + (value1.M22 * value2.M21),
                 (value1.M21 * value2.M12) + (value1.M22 * value2.M22),
                 (value1._m31 * value2.M11) + (value1._m32 * value2.M21) + value2._m31,
-                (value1._m31 * value2.M12) + (value1._m32 * value2.M22) + value2._m32);
+                (value1._m31 * value2.M12) + (value1._m32 * value2.M22) + value2._m32); //TODO: include perspective
         }
 
         /// <summary>
@@ -171,7 +232,7 @@ namespace Avalonia
         /// <returns>A scaling matrix.</returns>
         public static Matrix CreateScale(double xScale, double yScale)
         {
-            return CreateScale(new Vector(xScale, yScale));
+            return new Matrix(xScale, 0, 0, yScale, 0, 0);
         }
 
         /// <summary>
@@ -181,7 +242,7 @@ namespace Avalonia
         /// <returns>A scaling matrix.</returns>
         public static Matrix CreateScale(Vector scales)
         {
-            return new Matrix(scales.X, 0, 0, scales.Y, 0, 0);
+            return CreateScale(scales.X, scales.Y);
         }
 
         /// <summary>
@@ -219,13 +280,14 @@ namespace Avalonia
         /// Calculates the determinant for this matrix.
         /// </summary>
         /// <returns>The determinant.</returns>
-        /// <remarks>
-        /// The determinant is calculated by expanding the matrix with a third column whose
-        /// values are (0,0,1).
-        /// </remarks>
         public double GetDeterminant()
         {
-            return (_m11 * _m22) - (_m12 * _m21);
+            //return (_m11 * _m22) - (_m12 * _m21); //TODO: ensure new implementation yields the same result as before, when pers is 0,0,1
+
+            // implemented using "Laplace expansion":
+            return _m11 * (_m22 * _m33 - _m23 * _m32)
+                 - _m12 * (_m21 * _m33 - _m23 * _m31)
+                 + _m13 * (_m21 * _m32 - _m22 * _m31);
         }
 
         /// <summary>
@@ -238,10 +300,13 @@ namespace Avalonia
             // ReSharper disable CompareOfFloatsByEqualityOperator
             return _m11 == other.M11 &&
                    _m12 == other.M12 &&
+                   _m13 == other.M13 &&
                    _m21 == other.M21 &&
                    _m22 == other.M22 &&
+                   _m23 == other.M23 &&
                    _m31 == other.M31 &&
-                   _m32 == other.M32;
+                   _m32 == other.M32 &&
+                   _m33 == other.M33;
             // ReSharper restore CompareOfFloatsByEqualityOperator
         }
 
@@ -258,9 +323,18 @@ namespace Avalonia
         /// <returns>The hash code.</returns>
         public override int GetHashCode()
         {
-            return M11.GetHashCode() + M12.GetHashCode() +
-                   M21.GetHashCode() + M22.GetHashCode() +
-                   M31.GetHashCode() + M32.GetHashCode();
+            return (_m11, _m12, _m13, _m21, _m22, _m23, _m31, _m32, _m33).GetHashCode();
+        }
+
+        /// <summary>
+        ///  Determines if the current matrix contains perspective (non-affine) transforms (true) or only (affine) transforms that could be mapped into an 2x3 matrix (false).
+        /// </summary>
+        private bool ContainsPerspective()
+        {
+
+            // ReSharper disable CompareOfFloatsByEqualityOperator
+            return _m31 != 0 || _m32 != 0 || _m33 != 1;
+            // ReSharper restore CompareOfFloatsByEqualityOperator
         }
 
         /// <summary>
@@ -270,15 +344,25 @@ namespace Avalonia
         public override string ToString()
         {
             CultureInfo ci = CultureInfo.CurrentCulture;
+
+            string msg;
+            double[] values;
+
+            if (ContainsPerspective())
+            {
+                msg = "{{ {{M11:{0} M12:{1} M13:{2}}} {{M21:{3} M22:{4} M23:{5}}} {{M31:{6} M32:{7} M33:{8}}} }}";
+                values = new[] { M11, M12, M13, M21, M22, M23, M31, M32, M33 };
+            }
+            else
+            {
+                msg = "{{ {{M11:{0} M12:{1}}} {{M21:{2} M22:{3}}} {{M31:{4} M32:{5}}} }}";
+                values = new[] { M11, M12, M21, M22, M31, M32 };
+            }
+
             return string.Format(
                 ci,
-                "{{ {{M11:{0} M12:{1}}} {{M21:{2} M22:{3}}} {{M31:{4} M32:{5}}} }}",
-                M11.ToString(ci),
-                M12.ToString(ci),
-                M21.ToString(ci),
-                M22.ToString(ci),
-                M31.ToString(ci),
-                M32.ToString(ci));
+                msg,
+                values.Select((v) => v.ToString(ci)).ToArray());
         }
 
         /// <summary>
@@ -289,7 +373,7 @@ namespace Avalonia
         {
             double d = GetDeterminant();
 
-            if (MathUtilities.IsZero(d))
+            if (MathUtilities.IsZero(d)) //TODO: decide if special handling is required for perspective
             {
                 inverted = default;
                 
@@ -325,20 +409,30 @@ namespace Avalonia
         /// <summary>
         /// Parses a <see cref="Matrix"/> string.
         /// </summary>
-        /// <param name="s">Six comma-delimited double values (m11, m12, m21, m22, offsetX, offsetY) that describe the new <see cref="Matrix"/></param>
+        /// <param name="s">Six or nine comma-delimited double values (m11, m12, m21, m22, offsetX, offsetY[, persX, persY, persZ]) that describe the new <see cref="Matrix"/></param>
         /// <returns>The <see cref="Matrix"/>.</returns>
         public static Matrix Parse(string s)
         {
+            // initialize to satisfy compiler - only used when retrieved from string.
+            double v8 = 0;
+            double v9 = 0;
+
             using (var tokenizer = new StringTokenizer(s, CultureInfo.InvariantCulture, exceptionMessage: "Invalid Matrix."))
             {
-                return new Matrix(
-                    tokenizer.ReadDouble(),
-                    tokenizer.ReadDouble(),
-                    tokenizer.ReadDouble(),
-                    tokenizer.ReadDouble(),
-                    tokenizer.ReadDouble(),
-                    tokenizer.ReadDouble()
-                );
+                var v1 = tokenizer.ReadDouble();
+                var v2 = tokenizer.ReadDouble();
+                var v3 = tokenizer.ReadDouble();
+                var v4 = tokenizer.ReadDouble();
+                var v5 = tokenizer.ReadDouble();
+                var v6 = tokenizer.ReadDouble();
+                var pers = tokenizer.TryReadDouble(out var v7);
+                pers = pers && tokenizer.TryReadDouble(out v8);
+                pers = pers && tokenizer.TryReadDouble(out v9);
+
+                if (pers) 
+                    return new Matrix(v1, v2, v7, v3, v4, v8, v5, v6, v9);
+                else
+                    return new Matrix(v1, v2, v3, v4, v5, v6);
             }
         }
 
@@ -347,14 +441,14 @@ namespace Avalonia
         /// </summary>
         /// <param name="matrix">Matrix to decompose.</param>
         /// <param name="decomposed">Decomposed matrix.</param>
-        /// <returns>The status of the operation.</returns>
+        /// <returns>The status of the operation.</returns>        
         public static bool TryDecomposeTransform(Matrix matrix, out Decomposed decomposed)
         {
             decomposed = default;
 
             var determinant = matrix.GetDeterminant();
             
-            if (MathUtilities.IsZero(determinant))
+            if (MathUtilities.IsZero(determinant) || matrix.ContainsPerspective())
             {
                 return false;
             }

--- a/src/Avalonia.Visuals/Matrix.cs
+++ b/src/Avalonia.Visuals/Matrix.cs
@@ -14,7 +14,7 @@ namespace Avalonia
     /// 2nd row | skrewX  | scaleY  | persY  |
     /// 3rd row | transX  | transY  | persZ  |
     /// 
-    /// Note: Skia.SkMatrix uses a transposed layout (where for example skrewX/skrewY and perspp0/tranX are swapped).
+    /// Note: Skia.SkMatrix uses a transposed layout (where for example skrewX/skrewY and persX/transX are swapped).
     /// </remakrs>
 #if !BUILDTASK
     public
@@ -333,7 +333,7 @@ namespace Avalonia
         {
 
             // ReSharper disable CompareOfFloatsByEqualityOperator
-            return _m31 != 0 || _m32 != 0 || _m33 != 1;
+            return _m13 != 0 || _m23 != 0 || _m33 != 1;
             // ReSharper restore CompareOfFloatsByEqualityOperator
         }
 

--- a/src/Skia/Avalonia.Skia/SkiaSharpExtensions.cs
+++ b/src/Skia/Avalonia.Skia/SkiaSharpExtensions.cs
@@ -103,9 +103,9 @@ namespace Avalonia.Skia
                 SkewY = (float)m.M12,
                 ScaleY = (float)m.M22,
                 TransY = (float)m.M32,
-                Persp0 = 0,
-                Persp1 = 0,
-                Persp2 = 1
+                Persp0 = (float)m.M13,
+                Persp1 = (float)m.M23,
+                Persp2 = (float)m.M33
             };
 
             return sm;


### PR DESCRIPTION
## What does the pull request do?
Add support for perspective transforms (to allow building 3D rotation effects).


## What is the current behavior?
Avalonia uses a 2x3 matrix to describe transformations. SkiaSharp uses a 3x3 matrix offering support for perspective transforms but in `SkiaSharpExtensions`, these additional fields are always initialized with no perspective (0,0,1).


## What is the updated/expected behavior with this PR?
In the end, there should be an easy to use `PerspectiveTransform` (similar to `RotateTransform`, `ScaleTransform` and `SkrewTransform`).


## How was the solution implemented (if it's not obvious)?
1. enhance Matrix
2. support new matrix fields in `SkiaSharpExtensions` (, `Avalonia.Direct2D1.PrimitiveExtensions` and others?)
3. provide animate-able `PerspectiveTramsform`


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
