### PR TITLE
Makes TextBox.UndoRedoState struct readonly

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -145,7 +145,7 @@ namespace Avalonia.Controls
                 (o, v) => o.UndoLimit = v,
                 unsetValue: -1);
 
-        struct UndoRedoState : IEquatable<UndoRedoState>
+        readonly struct UndoRedoState : IEquatable<UndoRedoState>
         {
             public string Text { get; }
             public int CaretPosition { get; }


### PR DESCRIPTION
## What does the pull request do?
Explicitly states TextBox.UndoRedoState struct as readonly


## What is the current behavior?
TextBox.UndoRedoState struct is readonly but not marked as such


## What is the updated/expected behavior with this PR?
Generated (IL, native) code using TextBox.UndoRedoState struct can be further optimised.
