### PR TITLE
Fix: Thumb should handle pointer capture loss

### DIFF
--- a/src/Avalonia.Controls/Primitives/Thumb.cs
+++ b/src/Avalonia.Controls/Primitives/Thumb.cs
@@ -56,6 +56,26 @@ namespace Avalonia.Controls.Primitives
         {
         }
 
+        protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+        {
+            if (_lastPoint.HasValue)
+            {
+                var ev = new VectorEventArgs
+                {
+                    RoutedEvent = DragCompletedEvent,
+                    Vector = _lastPoint.Value,
+                };
+
+                _lastPoint = null;
+
+                RaiseEvent(ev);
+            }
+
+            PseudoClasses.Remove(":pressed");
+
+            base.OnPointerCaptureLost(e);
+        }
+
         protected override void OnPointerMoved(PointerEventArgs e)
         {
             if (_lastPoint.HasValue)


### PR DESCRIPTION
## What does the pull request do?

Adds pointer capture loss handling to the Thumb control.

## What is the current behavior?

Thumb control does not stop dragging when it loses pointer capture, causing unwanted behavior of scrollbars and other controls based on it.

## What is the updated/expected behavior with this PR?

Thumb control should stop dragging when pointer capture is lost.

## Fixed issues

Fixes #6243