### PR TITLE
OSX - window state - keep field in sync.

### DIFF
--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -757,6 +757,7 @@ private:
                 }
                 
                 _lastWindowState = state;
+                _actualWindowState = state;
                 WindowEvents->WindowStateChanged(state);
             }
         }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Right now on OSX if you enter fullscreen mode, then exit fullscreen mode, it will immediately re-enter FS mode.

You will then never be able to get out of fs mode.

Was introduced by https://github.com/AvaloniaUI/Avalonia/pull/6083

That PR forgot to keep its variable up to date when OS changes the window state.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
