### PR TITLE
Fix DataGrid column sorting with inherited interface property

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Utils/ReflectionHelper.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/ReflectionHelper.cs
@@ -340,10 +340,30 @@ namespace Avalonia.Controls.Utils
         internal static PropertyInfo GetPropertyOrIndexer(this Type type, string propertyPath, out object[] index)
         {
             index = null;
+            // Return the default value of GetProperty if the first character is not an indexer token.
             if (string.IsNullOrEmpty(propertyPath) || propertyPath[0] != LeftIndexerToken)
             {
-                // Return the default value of GetProperty if the first character is not an indexer token.
-                return type.GetProperty(propertyPath);
+                var property = type.GetProperty(propertyPath);
+                if (property != null)
+                {
+                    return property;
+                }
+
+                // GetProperty does not return inherited interface properties,
+                // so we need to enumerate them manually.
+                if (type.IsInterface)
+                {
+                    foreach (var typeInterface in type.GetInterfaces())
+                    {
+                        property = type.GetProperty(propertyPath);
+                        if (property != null)
+                        {
+                            return property;
+                        }
+                    }
+                }
+
+                return null;
             }
 
             if (propertyPath.Length < 2 || propertyPath[propertyPath.Length - 1] != RightIndexerToken)


### PR DESCRIPTION
## What does the pull request do?
Currently if user has column bind to property from inherited interface data is shown, but sorting does not work.
This simple PR fixes it.

## How was the solution implemented (if it's not obvious)?
https://stackoverflow.com/a/26766221
