### PR TITLE
Fix light dismiss overlay intercepting titlebar hit tests for OSX.

### DIFF
--- a/src/Avalonia.Native/WindowImpl.cs
+++ b/src/Avalonia.Native/WindowImpl.cs
@@ -114,7 +114,7 @@ namespace Avalonia.Native
                 {
                     var visual = (_inputRoot as Window).Renderer.HitTestFirst(e.Position, _inputRoot as Window, x =>
                             {
-                                if (x is IInputElement ie && !ie.IsHitTestVisible)
+                                if (x is IInputElement ie && (!ie.IsHitTestVisible || !ie.IsVisible))
                                 {
                                     return false;
                                 }


### PR DESCRIPTION
## What does the pull request do?
Just matches current OSX behaviour with Windows behaviour by making the very same thing as in 
https://github.com/AvaloniaUI/Avalonia/pull/6016
but for OSX.

## Fixed issues
closes #6221
