### PR TITLE
OSX: Fix showing window with no specified size.

### DIFF
--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -52,6 +52,7 @@ public:
         [Window setBackingType:NSBackingStoreBuffered];
         
         [Window setOpaque:false];
+        [Window setContentView: StandardContainer];
     }
     
     virtual HRESULT ObtainNSWindowHandle(void** ret) override
@@ -124,7 +125,6 @@ public:
             SetPosition(lastPositionSet);
             UpdateStyle();
             
-            [Window setContentView: StandardContainer];
             [Window setTitle:_lastTitle];
             
             if(ShouldTakeFocusOnShow() && activate)


### PR DESCRIPTION
## What does the pull request do?

A Window without a `Width`/`Height` specified was not getting shown on OSX since #6250 (1f8b90925771c64e54afa1a264938de0fd5e3c70). This can be seen by running the `Sandbox` sample; nothing gets shown.

Because #6250 changed the order of initialization around on `Show`, we need to set the content view in the constructor to fix this.
