### PR TITLE
Fix existing and add missing osx-specific key shortcuts

### DIFF
--- a/src/Avalonia.Native/AvaloniaNativePlatform.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatform.cs
@@ -109,10 +109,16 @@ namespace Avalonia.Native
                 .Bind<IRenderLoop>().ToConstant(new RenderLoop())
                 .Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(60))
                 .Bind<ISystemDialogImpl>().ToConstant(new SystemDialogs(_factory.CreateSystemDialogs()))
-                .Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration(KeyModifiers.Meta))
+                .Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration(KeyModifiers.Meta, wholeWordTextActionModifiers: KeyModifiers.Alt))
                 .Bind<IMountedVolumeInfoProvider>().ToConstant(new MacOSMountedVolumeInfoProvider())
                 .Bind<IPlatformDragSource>().ToConstant(new AvaloniaNativeDragSource(_factory));
 
+            var hotkeys = AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>();
+            hotkeys.MoveCursorToTheStartOfLine.Add(new KeyGesture(Key.Left, hotkeys.CommandModifiers));
+            hotkeys.MoveCursorToTheStartOfLineWithSelection.Add(new KeyGesture(Key.Left, hotkeys.CommandModifiers | hotkeys.SelectionModifiers));
+            hotkeys.MoveCursorToTheEndOfLine.Add(new KeyGesture(Key.Right, hotkeys.CommandModifiers));
+            hotkeys.MoveCursorToTheEndOfLineWithSelection.Add(new KeyGesture(Key.Right, hotkeys.CommandModifiers | hotkeys.SelectionModifiers));
+            
             if (_options.UseGpu)
             {
                 try


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
#6195 reported some macOS text editing key shortcuts being incorrect.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
* <kbd>Cmd</kbd> + <kbd>left</kbd>/<kbd>right</kbd> arrow: 
  * cursor moves one character left/right
* <kbd>Option</kbd> + <kbd>left</kbd>/<kbd>right</kbd> arrow:
  * cursor moves one character left/right

These shortcuts' corresponding <kbd>shift</kbd> selection variants were similarly incorrect.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
* <kbd>Cmd</kbd> + <kbd>left</kbd>/<kbd>right</kbd> arrow: 
  * cursor moves to the start/end of the line
* <kbd>Option</kbd> + <kbd>left</kbd>/<kbd>right</kbd> arrow:
  * cursor moves to the start/end of the previous/next word 

These shortcuts' corresponding <kbd>shift</kbd> selection variants now correctly expand selection behavior in a similar way.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Instead of adding platform checks inside PlatformHotkeyConfiguration, I simply added the missing KeyGestures to existing properties during initialization of AvaloniaNativePlatform, while the incorrect ones were an easy argument to constructor fix.

I couldn't find any tests related to currently existing key shortcuts, so I didn't add any for these new macOS-specific ones.

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #6195 
