### PR TITLE
Implement indexed sort for visual children.

### DIFF
--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Threading;

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Threading;
@@ -258,14 +259,25 @@ namespace Avalonia.Rendering.SceneGraph
                         }
                         else if (visualChildren.Count > 1)
                         {
-                            var sortedChildren = new IVisual[visualChildren.Count];
-                            visualChildren.CopyTo(sortedChildren, 0);
+                            var count = visualChildren.Count;
+                            var sortedChildren = new (IVisual visual, int index)[count];
 
-                            Array.Sort(sortedChildren, ZIndexComparer.ComparisonInstance);
+                            for (var i = 0; i < count; i++)
+                            {
+                                sortedChildren[i] = (visualChildren[i], i);
+                            }
+
+                            // Regular Array.Sort is unstable, we need to provide indices as well to avoid reshuffling elements.
+                            Array.Sort(sortedChildren, (lhs, rhs) =>
+                            {
+                                var result = ZIndexComparer.Instance.Compare(lhs.visual, rhs.visual);
+
+                                return result == 0 ? lhs.index.CompareTo(rhs.index) : result;
+                            });
 
                             foreach (var child in sortedChildren)
                             {
-                                var childNode = GetOrCreateChildNode(scene, child, node);
+                                var childNode = GetOrCreateChildNode(scene, child.Item1, node);
                                 Update(context, scene, (VisualNode)childNode, clip, forceRecurse);
                             }
                         }

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/SceneBuilderTests.cs
@@ -246,6 +246,34 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
         }
 
         [Fact]
+        public void Should_Respect_Uniform_ZIndex()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                Panel panel;
+
+                var tree = new TestRoot
+                {
+                    Child = panel = new Panel()
+                };
+
+                for (var i = 0; i < 128; i++)
+                {
+                    panel.Children.Add(new Border());
+                }
+
+                var result = new Scene(tree);
+                var sceneBuilder = new SceneBuilder();
+                sceneBuilder.UpdateAll(result);
+
+                var panelNode = result.FindNode(tree.Child);
+                var expected = panel.Children.ToArray();
+                var actual = panelNode.Children.OfType<IVisualNode>().Select(x => x.Visual).ToArray();
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [Fact]
         public void ClipBounds_Should_Be_In_Global_Coordinates()
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes problems reported in https://github.com/AvaloniaUI/Avalonia/issues/6257. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
As in the ticket - items with the same `ZIndex` can render incorrectly.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Preserved both natural ordering and `ZIndex` ordering.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
`Array.Sort` is unstable (quicksort) which can reshuffle elements with the same value. In this scenario 18 elements with a value of 0 can be distributed differently. Number of children mattered due to sort implementation internals.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes #6257
