### PR TITLE
Add ClipGeometry and OpacityMask properties to DrawingGroup

### DIFF
--- a/src/Avalonia.Visuals/Media/DrawingGroup.cs
+++ b/src/Avalonia.Visuals/Media/DrawingGroup.cs
@@ -12,6 +12,12 @@ namespace Avalonia.Media
         public static readonly StyledProperty<Transform> TransformProperty =
             AvaloniaProperty.Register<DrawingGroup, Transform>(nameof(Transform));
 
+        public static readonly StyledProperty<Geometry> ClipGeometryProperty =
+            AvaloniaProperty.Register<DrawingGroup, Geometry>(nameof(ClipGeometry));
+
+        public static readonly StyledProperty<IBrush> OpacityMaskProperty =
+            AvaloniaProperty.Register<DrawingGroup, IBrush>(nameof(OpacityMask));
+
         public double Opacity
         {
             get => GetValue(OpacityProperty);
@@ -24,6 +30,18 @@ namespace Avalonia.Media
             set => SetValue(TransformProperty, value);
         }
 
+        public Geometry ClipGeometry
+        {
+            get => GetValue(ClipGeometryProperty);
+            set => SetValue(ClipGeometryProperty, value);
+        }
+
+        public IBrush OpacityMask
+        {
+            get => GetValue(OpacityMaskProperty);
+            set => SetValue(OpacityMaskProperty, value);
+        }
+
         [Content]
         public AvaloniaList<Drawing> Children { get; } = new AvaloniaList<Drawing>();
 
@@ -31,6 +49,8 @@ namespace Avalonia.Media
         {
             using (context.PushPreTransform(Transform?.Value ?? Matrix.Identity))
             using (context.PushOpacity(Opacity))
+            using (ClipGeometry != null ? context.PushGeometryClip(ClipGeometry) : default(DrawingContext.PushedState))
+            using (OpacityMask != null ? context.PushOpacityMask(OpacityMask, GetBounds()) : default(DrawingContext.PushedState))
             {
                 foreach (var drawing in Children)
                 {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Adds ClipGeometry and OpacityMask properties to DrawingGroup

This properties exists in WPF
https://docs.microsoft.com/en-us/dotnet/api/system.windows.media.drawinggroup.clipgeometry?view=netcore-3.1
https://docs.microsoft.com/en-us/dotnet/api/system.windows.media.drawinggroup.opacitymask?view=netcore-3.1

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
DrawingGroup does not have ClipGeometry and OpacityMask properties

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
DrawingGroup has ClipGeometry and OpacityMask properties

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

The draw order for ClipGeometry and OpacityMask is based on ImmediateRenderer:
https://github.com/AvaloniaUI/Avalonia/blob/2b3f7e9e017ea62f82b92bb38c711c4c69c23ef1/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs#L290-L298

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #4865