### PR TITLE
Fix DataGrid wheel scroll calculation

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -67,7 +67,7 @@ namespace Avalonia.Controls
         private const double DATAGRID_minimumColumnHeaderHeight = 4;
         internal const double DATAGRID_maximumStarColumnWidth = 10000;
         internal const double DATAGRID_minimumStarColumnWidth = 0.001;
-        private const double DATAGRID_mouseWheelDelta = 72.0;
+        private const double DATAGRID_mouseWheelDelta = 50.0;
         private const double DATAGRID_maxHeadersThickness = 32768;
 
         private const double DATAGRID_defaultRowHeight = 22;
@@ -2217,20 +2217,23 @@ namespace Avalonia.Controls
             if (IsEnabled && !e.Handled && DisplayData.NumDisplayedScrollingElements > 0)
             {
                 double scrollHeight = 0;
-                if (e.Delta.Y > 0)
+                var delta = DATAGRID_mouseWheelDelta * e.Delta.Y;
+                var deltaAbs = Math.Abs(delta);
+
+                if (delta > 0)
                 {
-                    scrollHeight = Math.Max(-_verticalOffset, -DATAGRID_mouseWheelDelta);
+                    scrollHeight = Math.Max(-_verticalOffset, -deltaAbs);
                 }
-                else if (e.Delta.Y < 0)
+                else if (delta < 0)
                 {
                     if (_vScrollBar != null && VerticalScrollBarVisibility == ScrollBarVisibility.Visible)
                     {
-                        scrollHeight = Math.Min(Math.Max(0, _vScrollBar.Maximum - _verticalOffset), DATAGRID_mouseWheelDelta);
+                        scrollHeight = Math.Min(Math.Max(0, _vScrollBar.Maximum - _verticalOffset), deltaAbs);
                     }
                     else
                     {
                         double maximum = EdgedRowsHeightCalculated - CellsHeight;
-                        scrollHeight = Math.Min(Math.Max(0, maximum - _verticalOffset), DATAGRID_mouseWheelDelta);
+                        scrollHeight = Math.Min(Math.Max(0, maximum - _verticalOffset), deltaAbs);
                     }
                 }
                 if (scrollHeight != 0)


### PR DESCRIPTION
## What does the pull request do?
DataGrid ignores value of args.Delta when scrolling with wheel/trackpad.
On mouse wheel Delta usually is 1 or -1, while on trackpad its value is way smaller and could be less than 0.001. Because of this when user scroll data grid with trackpad it scrolls with insane speed on the smallest deltas.
In this PR I did two changes:
1. Changed base scroll height from 75 to 50. It makes it a bit slower, but matches scroll height from ScrollContentPresenter. Compared with UWP - it's even slower there.
2. Included actual Delta value in scroll step calculation.

## What is the current behavior?
It's not possible to precisely scroll, instead it scrolls almost whole page at once:
![bugged](https://user-images.githubusercontent.com/3163374/127752811-944c2958-7ba0-4644-ab51-ab2eea39f5e7.gif)


## What is the updated/expected behavior with this PR?
It's possible to precisely scroll, even by couple of rows at once:
![fixed](https://user-images.githubusercontent.com/3163374/127752813-ab72b93b-67e5-4678-9b90-dbda6de539fb.gif)

