### PR TITLE
Enable multitouch on X11,Windows by default

### DIFF
--- a/src/Avalonia.X11/X11Platform.cs
+++ b/src/Avalonia.X11/X11Platform.cs
@@ -190,7 +190,7 @@ namespace Avalonia
             "llvmpipe"
         };
         public string WmClass { get; set; } = Assembly.GetEntryAssembly()?.GetName()?.Name ?? "AvaloniaApplication";
-        public bool? EnableMultiTouch { get; set; }
+        public bool? EnableMultiTouch { get; set; } = true;
     }
     public static class AvaloniaX11PlatformExtensions
     {

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -40,8 +40,8 @@ namespace Avalonia
         public bool UseDeferredRendering { get; set; } = true;
         
         public bool? AllowEglInitialization { get; set; }
-        
-        public bool? EnableMultitouch { get; set; }
+
+        public bool? EnableMultitouch { get; set; } = true;
         public bool OverlayPopups { get; set; }
         public bool UseWgl { get; set; }
         public IList<GlVersion> WglProfiles { get; set; } = new List<GlVersion>


### PR DESCRIPTION
Seems like the only thing which blocked us from enabling multi-touch by default is DataGrid but now it is fixed by @maxkatz6 so prb we can change the default.