### PR TITLE
Respect CancellationToken in InternalPlatformThreadingInterface.RunLoop.

### DIFF
--- a/src/Avalonia.Controls/Platform/InternalPlatformThreadingInterface.cs
+++ b/src/Avalonia.Controls/Platform/InternalPlatformThreadingInterface.cs
@@ -21,10 +21,12 @@ namespace Avalonia.Controls.Platform
 
         public void RunLoop(CancellationToken cancellationToken)
         {
-            while (true)
+            var handles = new[] { _signaled, cancellationToken.WaitHandle };
+
+            while (!cancellationToken.IsCancellationRequested)
             {
                 Signaled?.Invoke(null);
-                _signaled.WaitOne();
+                WaitHandle.WaitAny(handles);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

`InternalPlatformThreadingInterface.RunLoop` was ignoring the cancellation token. This PR makes it respect it.

This is needed in order to run secondary message pumps on the Framebuffer.

## Questions

[`HeadlessPlatformThreadingInterface`](https://github.com/AvaloniaUI/Avalonia/blob/7e6d59d6702e1c679c5cd77193bda8f8f3bd3812/src/Avalonia.Headless/HeadlessPlatformThreadingInterface.cs#L33) does a similar thing but:

- It has a timeout
- It creates a new array each time

I'm not sure if either of those things are necessary here?