### PR TITLE
Allow for controling delay of scrollbar hide/show.

### DIFF
--- a/src/Avalonia.Controls/Primitives/ScrollBar.cs
+++ b/src/Avalonia.Controls/Primitives/ScrollBar.cs
@@ -57,6 +57,18 @@ namespace Avalonia.Controls.Primitives
         public static readonly StyledProperty<bool> AllowAutoHideProperty =
             AvaloniaProperty.Register<ScrollBar, bool>(nameof(AllowAutoHide), true);
 
+        /// <summary>
+        /// Defines the <see cref="HideDelay"/> property.
+        /// </summary>
+        public static readonly StyledProperty<TimeSpan> HideDelayProperty =
+            AvaloniaProperty.Register<ScrollBar, TimeSpan>(nameof(HideDelay), TimeSpan.FromSeconds(2));
+
+        /// <summary>
+        /// Defines the <see cref="ShowDelay"/> property.
+        /// </summary>
+        public static readonly StyledProperty<TimeSpan> ShowDelayProperty =
+            AvaloniaProperty.Register<ScrollBar, TimeSpan>(nameof(ShowDelay), TimeSpan.FromSeconds(0.5));
+
         private Button _lineUpButton;
         private Button _lineDownButton;
         private Button _pageUpButton;
@@ -125,6 +137,24 @@ namespace Avalonia.Controls.Primitives
         {
             get => GetValue(AllowAutoHideProperty);
             set => SetValue(AllowAutoHideProperty, value);
+        }
+        
+        /// <summary>
+        /// Gets a value that determines how long will be the hide delay after user stops interacting with the scrollbar.
+        /// </summary>
+        public TimeSpan HideDelay
+        {
+            get => GetValue(HideDelayProperty);
+            set => SetValue(HideDelayProperty, value);
+        }
+        
+        /// <summary>
+        /// Gets a value that determines how long will be the show delay when user starts interacting with the scrollbar.
+        /// </summary>
+        public TimeSpan ShowDelay
+        {
+            get => GetValue(ShowDelayProperty);
+            set => SetValue(ShowDelayProperty, value);
         }
 
         public event EventHandler<ScrollEventArgs> Scroll;
@@ -296,12 +326,12 @@ namespace Avalonia.Controls.Primitives
 
         private void CollapseAfterDelay()
         {
-            InvokeAfterDelay(Collapse, TimeSpan.FromSeconds(2));
+            InvokeAfterDelay(Collapse, HideDelay);
         }
 
         private void ExpandAfterDelay()
         {
-            InvokeAfterDelay(Expand, TimeSpan.FromMilliseconds(400));
+            InvokeAfterDelay(Expand, ShowDelay);
         }
 
         private void Collapse()


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Exposes currently hardcoded delays used to control scrollbar hide/show (when autohide is enabled).

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Hardcoded 2 seconds to hide and 0.5 second to show.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Control authors can choose delay.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
I was considering to use a direct property but ultimately I've decided to use a styled one since it would allow for better control and most of the users might not change the default anyway.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
