### PR TITLE
[OverlayPopupHost] remove render white rect override

### DIFF
--- a/src/Avalonia.Controls/Primitives/OverlayPopupHost.cs
+++ b/src/Avalonia.Controls/Primitives/OverlayPopupHost.cs
@@ -140,10 +140,5 @@ namespace Avalonia.Controls.Primitives
 
             return new OverlayPopupHost(overlayLayer);
         }
-
-        public override void Render(DrawingContext context)
-        {
-            context.FillRectangle(Brushes.White, new Rect(default, Bounds.Size));
-        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Removes redundant override, that blocks end users to create an overlay popup with a transparent backgrounds or transparent areas. Is there any valuable reason to do this?


## What is the current behavior?
Any overlay popup host fills white rectangle on render without even calling base.Render()


## What is the updated/expected behavior with this PR?
overlay popup host render works like all other controls render


## How was the solution implemented (if it's not obvious)?
Obvious AF :)
