### PR TITLE
NthChild and NthLastChild selectors support 

### DIFF
--- a/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml
+++ b/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml
@@ -1,17 +1,28 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="ControlCatalog.Pages.ItemsRepeaterPage">
+  <UserControl.Styles>
+    <Style Selector="ItemsRepeater TextBlock.oddTemplate">
+      <Setter Property="Background" Value="Yellow" />
+      <Setter Property="Foreground" Value="Black" />
+    </Style>
+    <Style Selector="ItemsRepeater TextBlock.evenTemplate">
+      <Setter Property="Background" Value="Wheat" />
+      <Setter Property="Foreground" Value="Black" />
+    </Style>
+    <Style Selector="ItemsRepeater TextBlock:nth-child(5n+3)">
+      <Setter Property="Foreground" Value="Red" />
+    </Style>
+  </UserControl.Styles>
   <UserControl.Resources>
     <RecyclePool x:Key="RecyclePool" />
     <DataTemplate x:Key="odd">
-      <TextBlock Background="Yellow"
-                 Foreground="Black"
+      <TextBlock Classes="oddTemplate"
                  Height="{Binding Height}"
                  Text="{Binding Text}"/>
     </DataTemplate>
     <DataTemplate x:Key="even">
-      <TextBlock Background="Wheat"
-                 Foreground="Black"
+      <TextBlock Classes="evenTemplate"
                  Height="{Binding Height}"
                  Text="{Binding Text}"/>
     </DataTemplate>

--- a/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml
+++ b/samples/ControlCatalog/Pages/ItemsRepeaterPage.xaml
@@ -12,6 +12,11 @@
     </Style>
     <Style Selector="ItemsRepeater TextBlock:nth-child(5n+3)">
       <Setter Property="Foreground" Value="Red" />
+      <Setter Property="FontWeight" Value="Bold" />
+    </Style>
+    <Style Selector="ItemsRepeater TextBlock:nth-last-child(5n+4)">
+      <Setter Property="Foreground" Value="Blue" />
+      <Setter Property="FontWeight" Value="Bold" />
     </Style>
   </UserControl.Styles>
   <UserControl.Resources>

--- a/samples/ControlCatalog/Pages/ListBoxPage.xaml
+++ b/samples/ControlCatalog/Pages/ListBoxPage.xaml
@@ -2,9 +2,15 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="ControlCatalog.Pages.ListBoxPage">
   <DockPanel>
+    <DockPanel.Styles>
+      <Style Selector="ListBox ListBoxItem:nth-child(2n)">
+        <Setter Property="Foreground" Value="Blue" />
+      </Style>
+    </DockPanel.Styles>
     <StackPanel DockPanel.Dock="Top" Margin="4">
       <TextBlock Classes="h1">ListBox</TextBlock>
       <TextBlock Classes="h2">Hosts a collection of ListBoxItem.</TextBlock>
+      <TextBlock Classes="h2">Each 2nd item is highlighted</TextBlock>
     </StackPanel>
     <StackPanel DockPanel.Dock="Right" Margin="4">
       <CheckBox IsChecked="{Binding Multiple}">Multiple</CheckBox>

--- a/samples/ControlCatalog/Pages/ListBoxPage.xaml
+++ b/samples/ControlCatalog/Pages/ListBoxPage.xaml
@@ -3,8 +3,13 @@
              x:Class="ControlCatalog.Pages.ListBoxPage">
   <DockPanel>
     <DockPanel.Styles>
-      <Style Selector="ListBox ListBoxItem:nth-child(2n)">
+      <Style Selector="ListBox ListBoxItem:nth-child(5n+3)">
+        <Setter Property="Foreground" Value="Red" />
+        <Setter Property="FontWeight" Value="Bold" />
+      </Style>
+      <Style Selector="ListBox ListBoxItem:nth-last-child(5n+4)">
         <Setter Property="Foreground" Value="Blue" />
+        <Setter Property="FontWeight" Value="Bold" />
       </Style>
     </DockPanel.Styles>
     <StackPanel DockPanel.Dock="Top" Margin="4">

--- a/samples/ControlCatalog/Pages/ListBoxPage.xaml
+++ b/samples/ControlCatalog/Pages/ListBoxPage.xaml
@@ -15,7 +15,7 @@
     <StackPanel DockPanel.Dock="Top" Margin="4">
       <TextBlock Classes="h1">ListBox</TextBlock>
       <TextBlock Classes="h2">Hosts a collection of ListBoxItem.</TextBlock>
-      <TextBlock Classes="h2">Each 2nd item is highlighted</TextBlock>
+      <TextBlock Classes="h2">Each 5th item is highlighted with nth-child(5n+3) and nth-last-child(5n+4) rules.</TextBlock>
     </StackPanel>
     <StackPanel DockPanel.Dock="Right" Margin="4">
       <CheckBox IsChecked="{Binding Multiple}">Multiple</CheckBox>

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -13,6 +13,7 @@ using Avalonia.Controls.Utils;
 using Avalonia.Input;
 using Avalonia.LogicalTree;
 using Avalonia.Metadata;
+using Avalonia.Styling;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Controls
@@ -21,7 +22,7 @@ namespace Avalonia.Controls
     /// Displays a collection of items.
     /// </summary>
     [PseudoClasses(":empty", ":singleitem")]
-    public class ItemsControl : TemplatedControl, IItemsPresenterHost, ICollectionChangedListener
+    public class ItemsControl : TemplatedControl, IItemsPresenterHost, ICollectionChangedListener, IChildIndexProvider
     {
         /// <summary>
         /// The default value for the <see cref="ItemsPanel"/> property.
@@ -505,6 +506,22 @@ namespace Avalonia.Controls
             } while (c != null && c != from);
 
             return null;
+        }
+
+        (int Index, int? TotalCount) IChildIndexProvider.GetChildIndex(ILogical child)
+        {
+            if (Presenter is IChildIndexProvider innerProvider)
+            {
+                return innerProvider.GetChildIndex(child);
+            }
+
+            if (child is IControl control)
+            {
+                var index = ItemContainerGenerator.IndexFromContainer(control);
+                return (index, ItemCount);
+            }
+
+            return (-1, ItemCount);
         }
     }
 }

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -13,7 +13,6 @@ using Avalonia.Controls.Utils;
 using Avalonia.Input;
 using Avalonia.LogicalTree;
 using Avalonia.Metadata;
-using Avalonia.Styling;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Controls
@@ -146,8 +145,6 @@ namespace Avalonia.Controls
             get;
             protected set;
         }
-
-        int? IChildIndexProvider.TotalCount => (Presenter as IChildIndexProvider)?.TotalCount ?? ItemCount;
 
         event EventHandler<ChildIndexChangedEventArgs> IChildIndexProvider.ChildIndexChanged
         {
@@ -537,6 +534,18 @@ namespace Avalonia.Controls
         {
             return Presenter is IChildIndexProvider innerProvider
                 ? innerProvider.GetChildIndex(child) : -1;
+        }
+
+        bool IChildIndexProvider.TryGetTotalCount(out int count)
+        {
+            if (Presenter is IChildIndexProvider presenter
+                && presenter.TryGetTotalCount(out count))
+            {
+                return true;
+            }
+
+            count = ItemCount;
+            return true;
         }
     }
 }

--- a/src/Avalonia.Controls/Panel.cs
+++ b/src/Avalonia.Controls/Panel.cs
@@ -34,6 +34,8 @@ namespace Avalonia.Controls
             AffectsRender<Panel>(BackgroundProperty);
         }
 
+        private EventHandler<ChildIndexChangedEventArgs> _childIndexChanged;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Panel"/> class.
         /// </summary>
@@ -55,6 +57,14 @@ namespace Avalonia.Controls
         {
             get { return GetValue(BackgroundProperty); }
             set { SetValue(BackgroundProperty, value); }
+        }
+
+        int? IChildIndexProvider.TotalCount => Children.Count;
+
+        event EventHandler<ChildIndexChangedEventArgs> IChildIndexProvider.ChildIndexChanged
+        {
+            add => _childIndexChanged += value;
+            remove => _childIndexChanged -= value;
         }
 
         /// <summary>
@@ -141,6 +151,7 @@ namespace Avalonia.Controls
                     throw new NotSupportedException();
             }
 
+            _childIndexChanged?.Invoke(this, new ChildIndexChangedEventArgs());
             InvalidateMeasureOnChildrenChanged();
         }
 
@@ -165,15 +176,9 @@ namespace Avalonia.Controls
             panel?.InvalidateMeasure();
         }
 
-        (int Index, int? TotalCount) IChildIndexProvider.GetChildIndex(ILogical child)
+        int IChildIndexProvider.GetChildIndex(ILogical child)
         {
-            if (child is IControl control)
-            {
-                var index = Children.IndexOf(control);
-                return (index, Children.Count);
-            }
-
-            return (-1, Children.Count);
+            return child is IControl control ? Children.IndexOf(control) : -1;
         }
     }
 }

--- a/src/Avalonia.Controls/Panel.cs
+++ b/src/Avalonia.Controls/Panel.cs
@@ -2,8 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+
+using Avalonia.Controls.Presenters;
+using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Avalonia.Metadata;
+using Avalonia.Styling;
 
 namespace Avalonia.Controls
 {
@@ -14,7 +18,7 @@ namespace Avalonia.Controls
     /// Controls can be added to a <see cref="Panel"/> by adding them to its <see cref="Children"/>
     /// collection. All children are layed out to fill the panel.
     /// </remarks>
-    public class Panel : Control, IPanel
+    public class Panel : Control, IPanel, IChildIndexProvider
     {
         /// <summary>
         /// Defines the <see cref="Background"/> property.
@@ -159,6 +163,17 @@ namespace Avalonia.Controls
             var control = e.Sender as IControl;
             var panel = control?.VisualParent as TPanel;
             panel?.InvalidateMeasure();
+        }
+
+        (int Index, int? TotalCount) IChildIndexProvider.GetChildIndex(ILogical child)
+        {
+            if (child is IControl control)
+            {
+                var index = Children.IndexOf(control);
+                return (index, Children.Count);
+            }
+
+            return (-1, Children.Count);
         }
     }
 }

--- a/src/Avalonia.Controls/Panel.cs
+++ b/src/Avalonia.Controls/Panel.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-
-using Avalonia.Controls.Presenters;
 using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Avalonia.Metadata;
@@ -58,8 +56,6 @@ namespace Avalonia.Controls
             get { return GetValue(BackgroundProperty); }
             set { SetValue(BackgroundProperty, value); }
         }
-
-        int? IChildIndexProvider.TotalCount => Children.Count;
 
         event EventHandler<ChildIndexChangedEventArgs> IChildIndexProvider.ChildIndexChanged
         {
@@ -179,6 +175,12 @@ namespace Avalonia.Controls
         int IChildIndexProvider.GetChildIndex(ILogical child)
         {
             return child is IControl control ? Children.IndexOf(control) : -1;
+        }
+
+        public bool TryGetTotalCount(out int count)
+        {
+            count = Children.Count;
+            return true;
         }
     }
 }

--- a/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
@@ -5,6 +5,7 @@ using Avalonia.Collections;
 using Avalonia.Controls.Generators;
 using Avalonia.Controls.Templates;
 using Avalonia.Controls.Utils;
+using Avalonia.LogicalTree;
 using Avalonia.Styling;
 
 namespace Avalonia.Controls.Presenters
@@ -12,7 +13,7 @@ namespace Avalonia.Controls.Presenters
     /// <summary>
     /// Base class for controls that present items inside an <see cref="ItemsControl"/>.
     /// </summary>
-    public abstract class ItemsPresenterBase : Control, IItemsPresenter, ITemplatedControl
+    public abstract class ItemsPresenterBase : Control, IItemsPresenter, ITemplatedControl, IChildIndexProvider
     {
         /// <summary>
         /// Defines the <see cref="Items"/> property.
@@ -247,6 +248,28 @@ namespace Avalonia.Controls.Presenters
         private void TemplatedParentChanged(AvaloniaPropertyChangedEventArgs e)
         {
             (e.NewValue as IItemsPresenterHost)?.RegisterItemsPresenter(this);
+        }
+
+        (int Index, int? TotalCount) IChildIndexProvider.GetChildIndex(ILogical child)
+        {
+            int? totalCount = null;
+            if (Items.TryGetCountFast(out var count))
+            {
+                totalCount = count;
+            }
+
+            if (child is IControl control)
+            {
+
+                if (ItemContainerGenerator is { } generator)
+                {
+                    var index = ItemContainerGenerator.IndexFromContainer(control);
+                    
+                    return (index, totalCount);
+                }
+            }
+
+            return (-1, totalCount);
         }
     }
 }

--- a/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Specialized;
-using System.Linq;
 
 using Avalonia.Collections;
 using Avalonia.Controls.Generators;
@@ -133,7 +132,7 @@ namespace Avalonia.Controls.Presenters
 
         protected bool IsHosted => TemplatedParent is IItemsPresenterHost;
 
-        int? IChildIndexProvider.TotalCount => Items.TryGetCountFast(out var count) ? count : null;
+        int? IChildIndexProvider.TotalCount => Items.TryGetCountFast(out var count) ? count : (int?)null;
 
         event EventHandler<ChildIndexChangedEventArgs> IChildIndexProvider.ChildIndexChanged
         {
@@ -161,6 +160,8 @@ namespace Avalonia.Controls.Presenters
             if (Panel != null)
             {
                 ItemsChanged(e);
+
+                _childIndexChanged?.Invoke(this, new ChildIndexChangedEventArgs());
             }
         }
 
@@ -192,7 +193,7 @@ namespace Avalonia.Controls.Presenters
         {
             for (var i = 0; i < e.Containers.Count; i++)
             {
-                _childIndexChanged?.Invoke(sender, new ChildIndexChangedEventArgs(e.Containers[i].ContainerControl));
+                _childIndexChanged?.Invoke(this, new ChildIndexChangedEventArgs(e.Containers[i].ContainerControl));
             }
         }
 

--- a/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenterBase.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Specialized;
-
 using Avalonia.Collections;
 using Avalonia.Controls.Generators;
 using Avalonia.Controls.Templates;
@@ -131,8 +130,6 @@ namespace Avalonia.Controls.Presenters
         }
 
         protected bool IsHosted => TemplatedParent is IItemsPresenterHost;
-
-        int? IChildIndexProvider.TotalCount => Items.TryGetCountFast(out var count) ? count : (int?)null;
 
         event EventHandler<ChildIndexChangedEventArgs> IChildIndexProvider.ChildIndexChanged
         {
@@ -284,6 +281,11 @@ namespace Avalonia.Controls.Presenters
             }
 
             return -1;
+        }
+
+        bool IChildIndexProvider.TryGetTotalCount(out int count)
+        {
+            return Items.TryGetCountFast(out count);
         }
     }
 }

--- a/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
+++ b/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
@@ -6,13 +6,11 @@
 using System;
 using System.Collections;
 using System.Collections.Specialized;
-
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Logging;
 using Avalonia.LogicalTree;
-using Avalonia.Styling;
 using Avalonia.Utilities;
 using Avalonia.VisualTree;
 
@@ -167,8 +165,6 @@ namespace Avalonia.Controls
             }
         }
 
-        int? IChildIndexProvider.TotalCount => ItemsSourceView.Count;
-
         event EventHandler<ChildIndexChangedEventArgs> IChildIndexProvider.ChildIndexChanged
         {
             add => _childIndexChanged += value;
@@ -180,6 +176,12 @@ namespace Avalonia.Controls
             return child is IControl control
                 ? GetElementIndex(control)
                 : -1;
+        }
+
+        bool IChildIndexProvider.TryGetTotalCount(out int count)
+        {
+            count = ItemsSourceView.Count;
+            return true;
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Utils/IEnumerableUtils.cs
+++ b/src/Avalonia.Controls/Utils/IEnumerableUtils.cs
@@ -12,22 +12,35 @@ namespace Avalonia.Controls.Utils
             return items.IndexOf(item) != -1;
         }
 
-        public static int Count(this IEnumerable items)
+        public static bool TryGetCountFast(this IEnumerable items, out int count)
         {
             if (items != null)
             {
                 if (items is ICollection collection)
                 {
-                    return collection.Count;
+                    count = collection.Count;
+                    return true;
                 }
                 else if (items is IReadOnlyCollection<object> readOnly)
                 {
-                    return readOnly.Count;
+                    count = readOnly.Count;
+                    return true;
                 }
-                else
-                {
-                    return Enumerable.Count(items.Cast<object>());
-                }
+            }
+
+            count = 0;
+            return false;
+        }
+
+        public static int Count(this IEnumerable items)
+        {
+            if (TryGetCountFast(items, out var count))
+            {
+                return count;
+            }
+            else if (items != null)
+            {
+                return Enumerable.Count(items.Cast<object>());
             }
             else
             {

--- a/src/Avalonia.Styling/LogicalTree/ChildIndexChangedEventArgs.cs
+++ b/src/Avalonia.Styling/LogicalTree/ChildIndexChangedEventArgs.cs
@@ -1,0 +1,23 @@
+﻿#nullable enable
+using System;
+
+namespace Avalonia.LogicalTree
+{
+    public class ChildIndexChangedEventArgs : EventArgs
+    {
+        public ChildIndexChangedEventArgs()
+        {
+        }
+
+        public ChildIndexChangedEventArgs(ILogical child)
+        {
+            Child = child;
+        }
+
+        /// <summary>
+        /// Logical child which index was changed.
+        /// If null, all children should be reset.
+        /// </summary>
+        public ILogical? Child { get; }
+    }
+}

--- a/src/Avalonia.Styling/LogicalTree/ChildIndexChangedEventArgs.cs
+++ b/src/Avalonia.Styling/LogicalTree/ChildIndexChangedEventArgs.cs
@@ -3,6 +3,9 @@ using System;
 
 namespace Avalonia.LogicalTree
 {
+    /// <summary>
+    /// Event args for <see cref="IChildIndexProvider.ChildIndexChanged"/> event.
+    /// </summary>
     public class ChildIndexChangedEventArgs : EventArgs
     {
         public ChildIndexChangedEventArgs()

--- a/src/Avalonia.Styling/LogicalTree/IChildIndexProvider.cs
+++ b/src/Avalonia.Styling/LogicalTree/IChildIndexProvider.cs
@@ -1,0 +1,14 @@
+﻿#nullable enable
+using System;
+
+namespace Avalonia.LogicalTree
+{
+    public interface IChildIndexProvider
+    {
+        int GetChildIndex(ILogical child);
+
+        int? TotalCount { get; }
+
+        event EventHandler<ChildIndexChangedEventArgs>? ChildIndexChanged;
+    }
+}

--- a/src/Avalonia.Styling/LogicalTree/IChildIndexProvider.cs
+++ b/src/Avalonia.Styling/LogicalTree/IChildIndexProvider.cs
@@ -3,12 +3,30 @@ using System;
 
 namespace Avalonia.LogicalTree
 {
+    /// <summary>
+    /// Child's index and total count information provider used by list-controls (ListBox, StackPanel, etc.)
+    /// </summary>
+    /// <remarks>
+    /// Used by nth-child and nth-last-child selectors. 
+    /// </remarks>
     public interface IChildIndexProvider
     {
+        /// <summary>
+        /// Gets child's actual index in order of the original source.
+        /// </summary>
+        /// <param name="child">Logical child.</param>
+        /// <returns>Index or -1 if child was not found.</returns>
         int GetChildIndex(ILogical child);
 
+        /// <summary>
+        /// Total children count or null if source is infinite.
+        /// Some Avalonia features might not work if <see cref="TotalCount"/> is null, for instance: nth-last-child selector.
+        /// </summary>
         int? TotalCount { get; }
 
+        /// <summary>
+        /// Notifies subscriber when child's index or total count was changed.
+        /// </summary>
         event EventHandler<ChildIndexChangedEventArgs>? ChildIndexChanged;
     }
 }

--- a/src/Avalonia.Styling/LogicalTree/IChildIndexProvider.cs
+++ b/src/Avalonia.Styling/LogicalTree/IChildIndexProvider.cs
@@ -20,9 +20,9 @@ namespace Avalonia.LogicalTree
 
         /// <summary>
         /// Total children count or null if source is infinite.
-        /// Some Avalonia features might not work if <see cref="TotalCount"/> is null, for instance: nth-last-child selector.
+        /// Some Avalonia features might not work if <see cref="TryGetTotalCount"/> returns false, for instance: nth-last-child selector.
         /// </summary>
-        int? TotalCount { get; }
+        bool TryGetTotalCount(out int count);
 
         /// <summary>
         /// Notifies subscriber when child's index or total count was changed.

--- a/src/Avalonia.Styling/Styling/Activators/NthChildActivator.cs
+++ b/src/Avalonia.Styling/Styling/Activators/NthChildActivator.cs
@@ -1,0 +1,56 @@
+﻿#nullable enable
+using System;
+
+using Avalonia.LogicalTree;
+
+namespace Avalonia.Styling.Activators
+{
+    /// <summary>
+    /// An <see cref="IStyleActivator"/> which is active when control's index was changed.
+    /// </summary>
+    internal sealed class NthChildActivator : StyleActivatorBase
+    {
+        private readonly ILogical _control;
+        private readonly IChildIndexProvider _provider;
+        private readonly int _step;
+        private readonly int _offset;
+        private readonly bool _reversed;
+        private EventHandler<ChildIndexChangedEventArgs>? _childIndexChangedHandler;
+
+        public NthChildActivator(
+            ILogical control,
+            IChildIndexProvider provider,
+            int step, int offset, bool reversed)
+        {
+            _control = control;
+            _provider = provider;
+            _step = step;
+            _offset = offset;
+            _reversed = reversed;
+        }
+
+        private EventHandler<ChildIndexChangedEventArgs> ChildIndexChangedHandler => _childIndexChangedHandler ??= ChildIndexChanged;
+
+        protected override void Initialize()
+        {
+            PublishNext(IsMatching());
+            _provider.ChildIndexChanged += ChildIndexChangedHandler;
+        }
+
+        protected override void Deinitialize()
+        {
+            _provider.ChildIndexChanged -= ChildIndexChangedHandler;
+        }
+
+        private void ChildIndexChanged(object sender, ChildIndexChangedEventArgs e)
+        {
+            if (e.Child is null
+                || e.Child == _control)
+            {
+                PublishNext(IsMatching());
+            }
+        }
+
+        private bool IsMatching() => NthChildSelector.Evaluate(_control, _provider, _step, _offset, _reversed).IsMatch;
+    }
+}

--- a/src/Avalonia.Styling/Styling/Activators/NthChildActivator.cs
+++ b/src/Avalonia.Styling/Styling/Activators/NthChildActivator.cs
@@ -44,7 +44,12 @@ namespace Avalonia.Styling.Activators
 
         private void ChildIndexChanged(object sender, ChildIndexChangedEventArgs e)
         {
-            if (e.Child is null
+            // Run matching again if:
+            // 1. Selector is reversed, so other item insertion/deletion might affect total count without changing subscribed item index.
+            // 2. e.Child is null, when all children indeces were changed.
+            // 3. Subscribed child index was changed.
+            if (_reversed
+                || e.Child is null                
                 || e.Child == _control)
             {
                 PublishNext(IsMatching());

--- a/src/Avalonia.Styling/Styling/Activators/NthChildActivator.cs
+++ b/src/Avalonia.Styling/Styling/Activators/NthChildActivator.cs
@@ -1,6 +1,4 @@
 ﻿#nullable enable
-using System;
-
 using Avalonia.LogicalTree;
 
 namespace Avalonia.Styling.Activators
@@ -15,7 +13,6 @@ namespace Avalonia.Styling.Activators
         private readonly int _step;
         private readonly int _offset;
         private readonly bool _reversed;
-        private EventHandler<ChildIndexChangedEventArgs>? _childIndexChangedHandler;
 
         public NthChildActivator(
             ILogical control,
@@ -29,17 +26,15 @@ namespace Avalonia.Styling.Activators
             _reversed = reversed;
         }
 
-        private EventHandler<ChildIndexChangedEventArgs> ChildIndexChangedHandler => _childIndexChangedHandler ??= ChildIndexChanged;
-
         protected override void Initialize()
         {
             PublishNext(IsMatching());
-            _provider.ChildIndexChanged += ChildIndexChangedHandler;
+            _provider.ChildIndexChanged += ChildIndexChanged;
         }
 
         protected override void Deinitialize()
         {
-            _provider.ChildIndexChanged -= ChildIndexChangedHandler;
+            _provider.ChildIndexChanged -= ChildIndexChanged;
         }
 
         private void ChildIndexChanged(object sender, ChildIndexChangedEventArgs e)

--- a/src/Avalonia.Styling/Styling/NthChildSelector.cs
+++ b/src/Avalonia.Styling/Styling/NthChildSelector.cs
@@ -1,0 +1,134 @@
+﻿#nullable enable
+using System;
+using System.Text;
+
+using Avalonia.LogicalTree;
+
+namespace Avalonia.Styling
+{
+    public interface IChildIndexProvider
+    {
+        (int Index, int? TotalCount) GetChildIndex(ILogical child);
+    }
+
+    public class NthLastChildSelector : NthChildSelector
+    {
+        public NthLastChildSelector(Selector? previous, int step, int offset) : base(previous, step, offset, true)
+        {
+        }
+    }
+
+    public class NthChildSelector : Selector
+    {
+        private const string NthChildSelectorName = "nth-child";
+        private const string NthLastChildSelectorName = "nth-last-child";
+        private readonly Selector? _previous;
+        private readonly bool _reversed;
+
+        internal protected NthChildSelector(Selector? previous, int step, int offset, bool reversed)
+        {
+            _previous = previous;
+            Step = step;
+            Offset = offset;
+            _reversed = reversed;
+        }
+
+        public NthChildSelector(Selector? previous, int step, int offset)
+            : this(previous, step, offset, false)
+        {
+
+        }
+
+        public override bool InTemplate => _previous?.InTemplate ?? false;
+
+        public override bool IsCombinator => false;
+
+        public override Type? TargetType => _previous?.TargetType;
+
+        public int Step { get; }
+        public int Offset { get; }
+
+        protected override SelectorMatch Evaluate(IStyleable control, bool subscribe)
+        {
+            var logical = (ILogical)control;
+            var controlParent = logical.LogicalParent;
+
+            if (controlParent is IChildIndexProvider childIndexProvider)
+            {
+                var (index, totalCount) = childIndexProvider.GetChildIndex(logical);
+                if (index < 0)
+                {
+                    return SelectorMatch.NeverThisInstance;
+                }
+
+                if (_reversed)
+                {
+                    if (totalCount is int totalCountValue)
+                    {
+                        index = totalCountValue - index;
+                    }
+                    else
+                    {
+                        return SelectorMatch.NeverThisInstance;
+                    }
+                }
+                else
+                {
+                    // nth child index is 1-based
+                    index += 1;
+                }
+                
+
+                var n = Math.Sign(Step);
+
+                var diff = index - Offset;
+                var match = diff == 0 || (Math.Sign(diff) == n && diff % Step == 0);
+
+                return match ? SelectorMatch.AlwaysThisInstance : SelectorMatch.NeverThisInstance;
+            }
+            else
+            {
+                return SelectorMatch.NeverThisInstance;
+            }
+
+        }
+
+        protected override Selector? MovePrevious() => _previous;
+
+        public override string ToString()
+        {
+            var expectedCapacity = NthLastChildSelectorName.Length + 8;
+            var stringBuilder = new StringBuilder(_previous?.ToString(), expectedCapacity);
+            
+            stringBuilder.Append(':');
+            stringBuilder.Append(_reversed ? NthLastChildSelectorName : NthChildSelectorName);
+            stringBuilder.Append('(');
+
+            var hasStep = false;
+            if (Step != 0)
+            {
+                hasStep = true;
+                stringBuilder.Append(Step);
+                stringBuilder.Append('n');
+            }
+
+            if (Offset > 0)
+            {
+                if (hasStep)
+                {
+                    stringBuilder.Append('+');
+                }
+                stringBuilder.Append(Offset);
+            }
+            else if (Offset < 0)
+            {
+                stringBuilder.Append('-');
+                stringBuilder.Append(-Offset);
+            }
+
+            stringBuilder.Append(')');
+
+            return stringBuilder.ToString();
+        }
+    }
+}

--- a/src/Avalonia.Styling/Styling/NthChildSelector.cs
+++ b/src/Avalonia.Styling/Styling/NthChildSelector.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 using System;
 using System.Text;
-
 using Avalonia.LogicalTree;
 using Avalonia.Styling.Activators;
 
@@ -51,7 +50,11 @@ namespace Avalonia.Styling
 
         protected override SelectorMatch Evaluate(IStyleable control, bool subscribe)
         {
-            var logical = (ILogical)control;
+            if (!(control is ILogical logical))
+            {
+                return SelectorMatch.NeverThisType;
+            }
+
             var controlParent = logical.LogicalParent;
 
             if (controlParent is IChildIndexProvider childIndexProvider)
@@ -78,7 +81,7 @@ namespace Avalonia.Styling
 
             if (reversed)
             {
-                if (childIndexProvider.TotalCount is int totalCountValue)
+                if (childIndexProvider.TryGetTotalCount(out var totalCountValue))
                 {
                     index = totalCountValue - index;
                 }

--- a/src/Avalonia.Styling/Styling/NthChildSelector.cs
+++ b/src/Avalonia.Styling/Styling/NthChildSelector.cs
@@ -7,6 +7,12 @@ using Avalonia.Styling.Activators;
 
 namespace Avalonia.Styling
 {
+    /// <summary>
+    /// The :nth-child() pseudo-class matches elements based on their position in a group of siblings.
+    /// </summary>
+    /// <remarks>
+    /// Element indices are 1-based.
+    /// </remarks>
     public class NthChildSelector : Selector
     {
         private const string NthChildSelectorName = "nth-child";
@@ -22,6 +28,12 @@ namespace Avalonia.Styling
             _reversed = reversed;
         }
 
+        /// <summary>
+        /// Creates an instance of <see cref="NthChildSelector"/>
+        /// </summary>
+        /// <param name="previous">Previous selector.</param>
+        /// <param name="step">Position step.</param>
+        /// <param name="offset">Initial index offset.</param>
         public NthChildSelector(Selector? previous, int step, int offset)
             : this(previous, step, offset, false)
         {

--- a/src/Avalonia.Styling/Styling/NthLastChildSelector.cs
+++ b/src/Avalonia.Styling/Styling/NthLastChildSelector.cs
@@ -1,0 +1,11 @@
+﻿#nullable enable
+
+namespace Avalonia.Styling
+{
+    public class NthLastChildSelector : NthChildSelector
+    {
+        public NthLastChildSelector(Selector? previous, int step, int offset) : base(previous, step, offset, true)
+        {
+        }
+    }
+}

--- a/src/Avalonia.Styling/Styling/NthLastChildSelector.cs
+++ b/src/Avalonia.Styling/Styling/NthLastChildSelector.cs
@@ -2,8 +2,20 @@
 
 namespace Avalonia.Styling
 {
+    /// <summary>
+    /// The :nth-child() pseudo-class matches elements based on their position among a group of siblings, counting from the end.
+    /// </summary>
+    /// <remarks>
+    /// Element indices are 1-based.
+    /// </remarks>
     public class NthLastChildSelector : NthChildSelector
     {
+        /// <summary>
+        /// Creates an instance of <see cref="NthLastChildSelector"/>
+        /// </summary>
+        /// <param name="previous">Previous selector.</param>
+        /// <param name="step">Position step.</param>
+        /// <param name="offset">Initial index offset, counting from the end.</param>
         public NthLastChildSelector(Selector? previous, int step, int offset) : base(previous, step, offset, true)
         {
         }

--- a/src/Avalonia.Styling/Styling/Selectors.cs
+++ b/src/Avalonia.Styling/Styling/Selectors.cs
@@ -123,6 +123,16 @@ namespace Avalonia.Styling
             return new NotSelector(previous, argument);
         }
 
+        public static Selector NthChild(this Selector previous, int step, int offset)
+        {
+            return new NthChildSelector(previous, step, offset);
+        }
+
+        public static Selector NthLastChild(this Selector previous, int step, int offset)
+        {
+            return new NthLastChildSelector(previous, step, offset);
+        }
+
         /// <summary>
         /// Returns a selector which matches a type.
         /// </summary>

--- a/src/Avalonia.Styling/Styling/Selectors.cs
+++ b/src/Avalonia.Styling/Styling/Selectors.cs
@@ -123,11 +123,17 @@ namespace Avalonia.Styling
             return new NotSelector(previous, argument);
         }
 
+        /// <inheritdoc cref="NthChildSelector"/>
+        /// <inheritdoc cref="NthChildSelector(Selector?, int, int)"/>
+        /// <returns>The selector.</returns>
         public static Selector NthChild(this Selector previous, int step, int offset)
         {
             return new NthChildSelector(previous, step, offset);
         }
 
+        /// <inheritdoc cref="NthLastChildSelector"/>
+        /// <inheritdoc cref="NthLastChildSelector(Selector?, int, int)"/>
+        /// <returns>The selector.</returns>
         public static Selector NthLastChild(this Selector previous, int step, int offset)
         {
             return new NthLastChildSelector(previous, step, offset);

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlSelectorTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlSelectorTransformer.cs
@@ -97,6 +97,12 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                         case SelectorGrammar.NotSyntax not:
                             result = new XamlIlNotSelector(result, Create(not.Argument, typeResolver));
                             break;
+                        case SelectorGrammar.NthChildSyntax nth:
+                            result = new XamlIlNthChildSelector(result, nth.Step, nth.Offset, XamlIlNthChildSelector.SelectorType.NthChild);
+                            break;
+                        case SelectorGrammar.NthLastChildSyntax nth:
+                            result = new XamlIlNthChildSelector(result, nth.Step, nth.Offset, XamlIlNthChildSelector.SelectorType.NthLastChild);
+                            break;
                         case SelectorGrammar.CommaSyntax comma:
                             if (results == null) 
                                 results = new XamlIlOrSelectorNode(node, selectorType);
@@ -270,6 +276,35 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             context.Emit(Argument, codeGen, Type.GetClrType());
             EmitCall(context, codeGen,
                 m => m.Name == "Not" && m.Parameters.Count == 2 && m.Parameters[1].Equals(Type.GetClrType()));
+        }
+    }
+
+    class XamlIlNthChildSelector : XamlIlSelectorNode
+    {
+        private readonly int _step;
+        private readonly int _offset;
+        private readonly SelectorType _type;
+
+        public enum SelectorType
+        {
+            NthChild,
+            NthLastChild
+        }
+
+        public XamlIlNthChildSelector(XamlIlSelectorNode previous, int step, int offset, SelectorType type) : base(previous)
+        {
+            _step = step;
+            _offset = offset;
+            _type = type;
+        }
+
+        public override IXamlType TargetType => Previous?.TargetType;
+        protected override void DoEmit(XamlEmitContext<IXamlILEmitter, XamlILNodeEmitResult> context, IXamlILEmitter codeGen)
+        {
+            codeGen.Ldc_I4(_step);
+            codeGen.Ldc_I4(_offset);
+            EmitCall(context, codeGen,
+                m => m.Name == _type.ToString() && m.Parameters.Count == 3);
         }
     }
 

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/SelectorParser.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/SelectorParser.cs
@@ -104,6 +104,12 @@ namespace Avalonia.Markup.Parsers
                     case SelectorGrammar.NotSyntax not:
                         result = result.Not(x => Create(not.Argument));
                         break;
+                    case SelectorGrammar.NthChildSyntax nth:
+                        result = result.NthChild(nth.Step, nth.Offset);
+                        break;
+                    case SelectorGrammar.NthLastChildSyntax nth:
+                        result = result.NthLastChild(nth.Step, nth.Offset);
+                        break;
                     case SelectorGrammar.CommaSyntax comma:
                         if (results == null)
                         {

--- a/tests/Avalonia.Markup.UnitTests/Parsers/SelectorGrammarTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/SelectorGrammarTests.cs
@@ -237,6 +237,96 @@ namespace Avalonia.Markup.UnitTests.Parsers
         }
 
         [Fact]
+        public void OfType_NthChild()
+        {
+            var result = SelectorGrammar.Parse("Button:nth-child(2n+1)");
+
+            Assert.Equal(
+                new SelectorGrammar.ISyntax[]
+                {
+                    new SelectorGrammar.OfTypeSyntax { TypeName = "Button" },
+                    new SelectorGrammar.NthChildSyntax()
+                    {
+                        Step = 2,
+                        Offset = 1
+                    }
+                },
+                result);
+        }
+
+        [Fact]
+        public void OfType_NthChild_Without_Offset()
+        {
+            var result = SelectorGrammar.Parse("Button:nth-child(2147483647n)");
+
+            Assert.Equal(
+                new SelectorGrammar.ISyntax[]
+                {
+                    new SelectorGrammar.OfTypeSyntax { TypeName = "Button" },
+                    new SelectorGrammar.NthChildSyntax()
+                    {
+                        Step = int.MaxValue,
+                        Offset = 0
+                    }
+                },
+                result);
+        }
+
+        [Fact]
+        public void OfType_NthLastChild()
+        {
+            var result = SelectorGrammar.Parse("Button:nth-last-child(2n+1)");
+
+            Assert.Equal(
+                new SelectorGrammar.ISyntax[]
+                {
+                    new SelectorGrammar.OfTypeSyntax { TypeName = "Button" },
+                    new SelectorGrammar.NthLastChildSyntax()
+                    {
+                        Step = 2,
+                        Offset = 1
+                    }
+                },
+                result);
+        }
+
+        [Fact]
+        public void OfType_NthChild_Odd()
+        {
+            var result = SelectorGrammar.Parse("Button:nth-child(odd)");
+
+            Assert.Equal(
+                new SelectorGrammar.ISyntax[]
+                {
+                    new SelectorGrammar.OfTypeSyntax { TypeName = "Button" },
+                    new SelectorGrammar.NthChildSyntax()
+                    {
+                        Step = 2,
+                        Offset = 1
+                    }
+                },
+                result);
+        }
+
+        [Fact]
+        public void OfType_NthChild_Even()
+        {
+            var result = SelectorGrammar.Parse("Button:nth-child(even)");
+
+            Assert.Equal(
+                new SelectorGrammar.ISyntax[]
+                {
+                    new SelectorGrammar.OfTypeSyntax { TypeName = "Button" },
+                    new SelectorGrammar.NthChildSyntax()
+                    {
+                        Step = 2,
+                        Offset = 0
+                    }
+                },
+                result);
+        }
+
+        [Fact]
         public void Is_Descendent_Not_OfType_Class()
         {
             var result = SelectorGrammar.Parse(":is(Control) :not(Button.foo)");

--- a/tests/Avalonia.Markup.UnitTests/Parsers/SelectorGrammarTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/SelectorGrammarTests.cs
@@ -236,6 +236,75 @@ namespace Avalonia.Markup.UnitTests.Parsers
                 result);
         }
 
+        [Theory]
+        [InlineData(":nth-child(xn+2)")]
+        [InlineData(":nth-child(2n+b)")]
+        [InlineData(":nth-child(2n+)")]
+        [InlineData(":nth-child(2na)")]
+        [InlineData(":nth-child(2x+1)")]
+        public void NthChild_Invalid_Inputs(string input)
+        {
+            Assert.Throws<ExpressionParseException>(() => SelectorGrammar.Parse(input));
+        }
+
+        [Theory]
+        [InlineData(":nth-child(+1)", 0, 1)]
+        [InlineData(":nth-child(1)", 0, 1)]
+        [InlineData(":nth-child(-1)", 0, -1)]
+        [InlineData(":nth-child(2n+1)", 2, 1)]
+        [InlineData(":nth-child(n)", 1, 0)]
+        [InlineData(":nth-child(+n)", 1, 0)]
+        [InlineData(":nth-child(-n)", -1, 0)]
+        [InlineData(":nth-child(-2n)", -2, 0)]
+        [InlineData(":nth-child(n+5)", 1, 5)]
+        [InlineData(":nth-child(n-5)", 1, -5)]
+        [InlineData(":nth-child( 2n + 1 )", 2, 1)]
+        [InlineData(":nth-child( 2n - 1 )", 2, -1)]
+        public void NthChild_Variations(string input, int step, int offset)
+        {
+            var result = SelectorGrammar.Parse(input);
+
+            Assert.Equal(
+                new SelectorGrammar.ISyntax[]
+                {
+                    new SelectorGrammar.NthChildSyntax()
+                    {
+                        Step = step,
+                        Offset = offset
+                    }
+                },
+                result);
+        }
+
+        [Theory]
+        [InlineData(":nth-last-child(+1)", 0, 1)]
+        [InlineData(":nth-last-child(1)", 0, 1)]
+        [InlineData(":nth-last-child(-1)", 0, -1)]
+        [InlineData(":nth-last-child(2n+1)", 2, 1)]
+        [InlineData(":nth-last-child(n)", 1, 0)]
+        [InlineData(":nth-last-child(+n)", 1, 0)]
+        [InlineData(":nth-last-child(-n)", -1, 0)]
+        [InlineData(":nth-last-child(-2n)", -2, 0)]
+        [InlineData(":nth-last-child(n+5)", 1, 5)]
+        [InlineData(":nth-last-child(n-5)", 1, -5)]
+        [InlineData(":nth-last-child( 2n + 1 )", 2, 1)]
+        [InlineData(":nth-last-child( 2n - 1 )", 2, -1)]
+        public void NthLastChild_Variations(string input, int step, int offset)
+        {
+            var result = SelectorGrammar.Parse(input);
+
+            Assert.Equal(
+                new SelectorGrammar.ISyntax[]
+                {
+                    new SelectorGrammar.NthLastChildSyntax()
+                    {
+                        Step = step,
+                        Offset = offset
+                    }
+                },
+                result);
+        }
+
         [Fact]
         public void OfType_NthChild()
         {

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
@@ -268,6 +268,65 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
         }
 
         [Fact]
+        public void Style_Can_Use_NthChild_Selector()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+             xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <Window.Styles>
+        <Style Selector='Border.foo:nth-child(2n+1)'>
+            <Setter Property='Background' Value='Red'/>
+        </Style>
+    </Window.Styles>
+    <StackPanel>
+        <Border x:Name='b1' Classes='foo'/>
+        <Border x:Name='b2' />
+    </StackPanel>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var b1 = window.FindControl<Border>("b1");
+                var b2 = window.FindControl<Border>("b2");
+
+                Assert.Equal(Colors.Red, ((ISolidColorBrush)b1.Background).Color);
+                Assert.Null(b2.Background);
+            }
+        }
+
+        [Fact]
+        public void Style_Can_Use_NthChild_Selector_After_Reoder()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+             xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <Window.Styles>
+        <Style Selector='Border:nth-child(2n+1)'>
+            <Setter Property='Background' Value='Red'/>
+        </Style>
+    </Window.Styles>
+    <StackPanel x:Name='parent'>
+        <Border x:Name='b1' />
+        <Border x:Name='b2' />
+    </StackPanel>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+
+                var parent = window.FindControl<StackPanel>("parent");
+                var b1 = window.FindControl<Border>("b1");
+                var b2 = window.FindControl<Border>("b2");
+
+                parent.Children.Remove(b1);
+                parent.Children.Add(b1);
+
+                Assert.Null(b1.Background);
+                Assert.Equal(Colors.Red, ((ISolidColorBrush)b2.Background).Color);
+            }
+        }
+
+        [Fact]
         public void Style_Can_Use_Or_Selector_1()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
@@ -1,10 +1,8 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Xml;
 using Avalonia.Controls;
-using Avalonia.Markup.Data;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Markup.Xaml.Templates;
 using Avalonia.Media;

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -336,6 +337,45 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
             }
         }
 
+        [Fact]
+        public void Style_Can_Use_NthLastChild_Selector_After_Reoder()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+             xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <Window.Styles>
+        <Style Selector='Border:nth-last-child(2n)'>
+            <Setter Property='Background' Value='Red'/>
+        </Style>
+    </Window.Styles>
+    <StackPanel x:Name='parent'>
+        <Border x:Name='b1' />
+        <Border x:Name='b2' />
+    </StackPanel>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+
+                var parent = window.FindControl<StackPanel>("parent");
+                var b1 = window.FindControl<Border>("b1");
+                var b2 = window.FindControl<Border>("b2");
+
+                Assert.Equal(Brushes.Red, b1.Background);
+                Assert.Null(b2.Background);
+
+                parent.Children.Remove(b1);
+
+                Assert.Null(b1.Background);
+                Assert.Null(b2.Background);
+
+                parent.Children.Add(b1);
+
+                Assert.Null(b1.Background);
+                Assert.Equal(Brushes.Red, b2.Background);
+            }
+        }
+
 
         [Fact]
         public void Style_Can_Use_NthChild_Selector_With_ListBox()
@@ -364,25 +404,18 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
                 window.Show();
 
-                var items = list.Presenter.Panel.Children.Cast<ListBoxItem>();
-                ListBoxItem At(int index) => items.ElementAt(index);
+                IEnumerable<IBrush> GetColors() => list.Presenter.Panel.Children.Cast<ListBoxItem>().Select(t => t.Background);
 
-                Assert.Equal(Brushes.Transparent, At(0).Background);
-                Assert.Equal(Brushes.Green, At(1).Background);
-                Assert.Equal(Brushes.Transparent, At(2).Background);
+                Assert.Equal(new[] { Brushes.Transparent, Brushes.Green, Brushes.Transparent }, GetColors());
 
                 collection.Remove(Brushes.Green);
 
-                Assert.Equal(Brushes.Transparent, At(0).Background);
-                Assert.Equal(Brushes.Blue, At(1).Background);
+                Assert.Equal(new[] { Brushes.Transparent, Brushes.Blue }, GetColors());
 
                 collection.Add(Brushes.Violet);
                 collection.Add(Brushes.Black);
 
-                Assert.Equal(Brushes.Transparent, At(0).Background);
-                Assert.Equal(Brushes.Blue, At(1).Background);
-                Assert.Equal(Brushes.Transparent, At(2).Background);
-                Assert.Equal(Brushes.Black, At(3).Background);
+                Assert.Equal(new[] { Brushes.Transparent, Brushes.Blue, Brushes.Transparent, Brushes.Black }, GetColors());
             }
         }
 
@@ -415,25 +448,19 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
                 window.Show();
 
-                var items = list.Children;
-                TextBlock At(int index) => (TextBlock)list.GetOrCreateElement(index);
+                IEnumerable<IBrush> GetColors() => Enumerable.Range(0, list.ItemsSourceView.Count)
+                    .Select(t => (list.GetOrCreateElement(t) as TextBlock)!.Foreground);
 
-                Assert.Equal(Brushes.Transparent, At(0).Foreground);
-                Assert.Equal(Brushes.Green, At(1).Foreground);
-                Assert.Equal(Brushes.Transparent, At(2).Foreground);
+                Assert.Equal(new[] { Brushes.Transparent, Brushes.Green, Brushes.Transparent }, GetColors());
 
                 collection.Remove(Brushes.Green);
 
-                Assert.Equal(Brushes.Transparent, At(0).Foreground);
-                Assert.Equal(Brushes.Blue, At(1).Foreground);
+                Assert.Equal(new[] { Brushes.Transparent, Brushes.Blue }, GetColors());
 
                 collection.Add(Brushes.Violet);
                 collection.Add(Brushes.Black);
 
-                Assert.Equal(Brushes.Transparent, At(0).Foreground);
-                Assert.Equal(Brushes.Blue, At(1).Foreground);
-                Assert.Equal(Brushes.Transparent, At(2).Foreground);
-                Assert.Equal(Brushes.Black, At(3).Foreground);
+                Assert.Equal(new[] { Brushes.Transparent, Brushes.Blue, Brushes.Transparent, Brushes.Black }, GetColors());
             }
         }
 

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_NthChild.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_NthChild.cs
@@ -1,4 +1,7 @@
+using System.Threading.Tasks;
+
 using Avalonia.Controls;
+
 using Xunit;
 
 namespace Avalonia.Styling.UnitTests
@@ -21,7 +24,7 @@ namespace Avalonia.Styling.UnitTests
         }
 
         [Fact]
-        public void Nth_Child_Match_Control_In_Panel()
+        public async Task Nth_Child_Match_Control_In_Panel()
         {
             Border b1, b2, b3, b4;
             var panel = new StackPanel();
@@ -35,14 +38,14 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthChild(2, 0);
 
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b3).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b4).Result);
+            Assert.False(await target.Match(b1).Activator!.Take(1));
+            Assert.True(await target.Match(b2).Activator!.Take(1));
+            Assert.False(await target.Match(b3).Activator!.Take(1));
+            Assert.True(await target.Match(b4).Activator!.Take(1));
         }
 
         [Fact]
-        public void Nth_Child_Match_Control_In_Panel_With_Offset()
+        public async Task Nth_Child_Match_Control_In_Panel_With_Offset()
         {
             Border b1, b2, b3, b4;
             var panel = new StackPanel();
@@ -56,14 +59,14 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthChild(2, 1);
 
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b1).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b2).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b3).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+            Assert.True(await target.Match(b1).Activator!.Take(1));
+            Assert.False(await target.Match(b2).Activator!.Take(1));
+            Assert.True(await target.Match(b3).Activator!.Take(1));
+            Assert.False(await target.Match(b4).Activator!.Take(1));
         }
 
         [Fact]
-        public void Nth_Child_Match_Control_In_Panel_With_Negative_Offset()
+        public async Task Nth_Child_Match_Control_In_Panel_With_Negative_Offset()
         {
             Border b1, b2, b3, b4;
             var panel = new StackPanel();
@@ -77,14 +80,14 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthChild(4, -1);
 
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b2).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b3).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+            Assert.False(await target.Match(b1).Activator!.Take(1));
+            Assert.False(await target.Match(b2).Activator!.Take(1));
+            Assert.True(await target.Match(b3).Activator!.Take(1));
+            Assert.False(await target.Match(b4).Activator!.Take(1));
         }
 
         [Fact]
-        public void Nth_Child_Match_Control_In_Panel_With_Singular_Step()
+        public async Task Nth_Child_Match_Control_In_Panel_With_Singular_Step()
         {
             Border b1, b2, b3, b4;
             var panel = new StackPanel();
@@ -98,14 +101,14 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthChild(1, 2);
 
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b3).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b4).Result);
+            Assert.False(await target.Match(b1).Activator!.Take(1));
+            Assert.True(await target.Match(b2).Activator!.Take(1));
+            Assert.True(await target.Match(b3).Activator!.Take(1));
+            Assert.True(await target.Match(b4).Activator!.Take(1));
         }
 
         [Fact]
-        public void Nth_Child_Match_Control_In_Panel_With_Singular_Step_With_Negative_Offset()
+        public async Task Nth_Child_Match_Control_In_Panel_With_Singular_Step_With_Negative_Offset()
         {
             Border b1, b2, b3, b4;
             var panel = new StackPanel();
@@ -119,14 +122,14 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthChild(1, -1);
 
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b1).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b3).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b4).Result);
+            Assert.True(await target.Match(b1).Activator!.Take(1));
+            Assert.True(await target.Match(b2).Activator!.Take(1));
+            Assert.True(await target.Match(b3).Activator!.Take(1));
+            Assert.True(await target.Match(b4).Activator!.Take(1));
         }
 
         [Fact]
-        public void Nth_Child_Match_Control_In_Panel_With_Zero_Step_With_Offset()
+        public async Task Nth_Child_Match_Control_In_Panel_With_Zero_Step_With_Offset()
         {
             Border b1, b2, b3, b4;
             var panel = new StackPanel();
@@ -140,14 +143,14 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthChild(0, 2);
 
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b3).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+            Assert.False(await target.Match(b1).Activator!.Take(1));
+            Assert.True(await target.Match(b2).Activator!.Take(1));
+            Assert.False(await target.Match(b3).Activator!.Take(1));
+            Assert.False(await target.Match(b4).Activator!.Take(1));
         }
 
         [Fact]
-        public void Nth_Child_Doesnt_Match_Control_In_Panel_With_Zero_Step_With_Negative_Offset()
+        public async Task Nth_Child_Doesnt_Match_Control_In_Panel_With_Zero_Step_With_Negative_Offset()
         {
             Border b1, b2, b3, b4;
             var panel = new StackPanel();
@@ -161,14 +164,14 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthChild(0, -2);
 
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b2).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b3).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+            Assert.False(await target.Match(b1).Activator!.Take(1));
+            Assert.False(await target.Match(b2).Activator!.Take(1));
+            Assert.False(await target.Match(b3).Activator!.Take(1));
+            Assert.False(await target.Match(b4).Activator!.Take(1));
         }
 
         [Fact]
-        public void Nth_Child_Match_Control_In_Panel_With_Previous_Selector()
+        public async Task Nth_Child_Match_Control_In_Panel_With_Previous_Selector()
         {
             Border b1, b2;
             Button b3, b4;
@@ -184,14 +187,16 @@ namespace Avalonia.Styling.UnitTests
             var previous = default(Selector).OfType<Border>();
             var target = previous.NthChild(2, 0);
 
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
+            Assert.False(await target.Match(b1).Activator!.Take(1));
+            Assert.True(await target.Match(b2).Activator!.Take(1));
+            Assert.Null(target.Match(b3).Activator);
             Assert.Equal(SelectorMatchResult.NeverThisType, target.Match(b3).Result);
+            Assert.Null(target.Match(b4).Activator);
             Assert.Equal(SelectorMatchResult.NeverThisType, target.Match(b4).Result);
         }
 
         [Fact]
-        public void Nth_Child_Doesnt_Match_Control_Out_Of_Panel_Parent()
+        public async Task Nth_Child_Doesnt_Match_Control_Out_Of_Panel_Parent()
         {
             Border b1;
             var contentControl = new ContentControl();
@@ -199,7 +204,7 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthChild(1, 0);
 
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
+            Assert.False(await target.Match(b1).Activator!.Take(1));
         }
 
         [Fact]

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_NthChild.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_NthChild.cs
@@ -1,0 +1,217 @@
+using Avalonia.Controls;
+using Xunit;
+
+namespace Avalonia.Styling.UnitTests
+{
+    public class SelectorTests_NthChild
+    {
+        [Theory]
+        [InlineData(2, 0, ":nth-child(2n)")]
+        [InlineData(2, 1, ":nth-child(2n+1)")]
+        [InlineData(1, 0, ":nth-child(1n)")]
+        [InlineData(4, -1, ":nth-child(4n-1)")]
+        [InlineData(0, 1, ":nth-child(1)")]
+        [InlineData(0, -1, ":nth-child(-1)")]
+        [InlineData(int.MaxValue, int.MinValue + 1, ":nth-child(2147483647n-2147483647)")]
+        public void Not_Selector_Should_Have_Correct_String_Representation(int step, int offset, string expected)
+        {
+            var target = default(Selector).NthChild(step, offset);
+
+            Assert.Equal(expected, target.ToString());
+        }
+
+        [Fact]
+        public void Nth_Child_Match_Control_In_Panel()
+        {
+            Border b1, b2, b3, b4;
+            var panel = new StackPanel();
+            panel.Children.AddRange(new[]
+            {
+                b1 = new Border(),
+                b2 = new Border(),
+                b3 = new Border(),
+                b4 = new Border()
+            });
+
+            var target = default(Selector).NthChild(2, 0);
+
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b3).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b4).Result);
+        }
+
+        [Fact]
+        public void Nth_Child_Match_Control_In_Panel_With_Offset()
+        {
+            Border b1, b2, b3, b4;
+            var panel = new StackPanel();
+            panel.Children.AddRange(new[]
+            {
+                b1 = new Border(),
+                b2 = new Border(),
+                b3 = new Border(),
+                b4 = new Border()
+            });
+
+            var target = default(Selector).NthChild(2, 1);
+
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b1).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b2).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b3).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+        }
+
+        [Fact]
+        public void Nth_Child_Match_Control_In_Panel_With_Negative_Offset()
+        {
+            Border b1, b2, b3, b4;
+            var panel = new StackPanel();
+            panel.Children.AddRange(new[]
+            {
+                b1 = new Border(),
+                b2 = new Border(),
+                b3 = new Border(),
+                b4 = new Border()
+            });
+
+            var target = default(Selector).NthChild(4, -1);
+
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b2).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b3).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+        }
+
+        [Fact]
+        public void Nth_Child_Match_Control_In_Panel_With_Singular_Step()
+        {
+            Border b1, b2, b3, b4;
+            var panel = new StackPanel();
+            panel.Children.AddRange(new[]
+            {
+                b1 = new Border(),
+                b2 = new Border(),
+                b3 = new Border(),
+                b4 = new Border()
+            });
+
+            var target = default(Selector).NthChild(1, 2);
+
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b3).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b4).Result);
+        }
+
+        [Fact]
+        public void Nth_Child_Match_Control_In_Panel_With_Singular_Step_With_Negative_Offset()
+        {
+            Border b1, b2, b3, b4;
+            var panel = new StackPanel();
+            panel.Children.AddRange(new[]
+            {
+                b1 = new Border(),
+                b2 = new Border(),
+                b3 = new Border(),
+                b4 = new Border()
+            });
+
+            var target = default(Selector).NthChild(1, -1);
+
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b1).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b3).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b4).Result);
+        }
+
+        [Fact]
+        public void Nth_Child_Match_Control_In_Panel_With_Zero_Step_With_Offset()
+        {
+            Border b1, b2, b3, b4;
+            var panel = new StackPanel();
+            panel.Children.AddRange(new[]
+            {
+                b1 = new Border(),
+                b2 = new Border(),
+                b3 = new Border(),
+                b4 = new Border()
+            });
+
+            var target = default(Selector).NthChild(0, 2);
+
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b3).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+        }
+
+        [Fact]
+        public void Nth_Child_Doesnt_Match_Control_In_Panel_With_Zero_Step_With_Negative_Offset()
+        {
+            Border b1, b2, b3, b4;
+            var panel = new StackPanel();
+            panel.Children.AddRange(new[]
+            {
+                b1 = new Border(),
+                b2 = new Border(),
+                b3 = new Border(),
+                b4 = new Border()
+            });
+
+            var target = default(Selector).NthChild(0, -2);
+
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b2).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b3).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+        }
+
+        [Fact]
+        public void Nth_Child_Match_Control_In_Panel_With_Previous_Selector()
+        {
+            Border b1, b2;
+            Button b3, b4;
+            var panel = new StackPanel();
+            panel.Children.AddRange(new Control[]
+            {
+                b1 = new Border(),
+                b2 = new Border(),
+                b3 = new Button(),
+                b4 = new Button()
+            });
+
+            var previous = default(Selector).OfType<Border>();
+            var target = previous.NthChild(2, 0);
+
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisType, target.Match(b3).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisType, target.Match(b4).Result);
+        }
+
+        [Fact]
+        public void Nth_Child_Doesnt_Match_Control_Out_Of_Panel_Parent()
+        {
+            Border b1;
+            var contentControl = new ContentControl();
+            contentControl.Content = b1 = new Border();
+
+            var target = default(Selector).NthChild(1, 0);
+
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
+        }
+
+        [Fact]
+        public void Returns_Correct_TargetType()
+        {
+            var target = new NthChildSelector(default(Selector).OfType<Control1>(), 1, 0);
+
+            Assert.Equal(typeof(Control1), target.TargetType);
+        }
+
+        public class Control1 : Control
+        {
+        }
+    }
+}

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_NthChild.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_NthChild.cs
@@ -196,7 +196,7 @@ namespace Avalonia.Styling.UnitTests
         }
 
         [Fact]
-        public async Task Nth_Child_Doesnt_Match_Control_Out_Of_Panel_Parent()
+        public void Nth_Child_Doesnt_Match_Control_Out_Of_Panel_Parent()
         {
             Border b1;
             var contentControl = new ContentControl();
@@ -204,7 +204,7 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthChild(1, 0);
 
-            Assert.False(await target.Match(b1).Activator!.Take(1));
+            Assert.Equal(SelectorMatch.NeverThisInstance, target.Match(b1));
         }
 
         [Fact]

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_NthChild.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_NthChild.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Xunit;
@@ -203,6 +204,76 @@ namespace Avalonia.Styling.UnitTests
             var target = default(Selector).NthChild(1, 0);
 
             Assert.Equal(SelectorMatch.NeverThisInstance, target.Match(b1));
+        }
+
+
+        [Theory] // http://nthmaster.com/
+        [InlineData(+0, 8, false, false, false, false, false, false, false, true , false, false, false)]
+        [InlineData(+1, 6, false, false, false, false, false, true , true , true , true , true , true )]
+        [InlineData(-1, 9, true , true , true , true , true , true , true , true , true , false, false)]
+        public async Task Nth_Child_Master_Com_Test_Sigle_Selector(
+            int step, int offset, params bool[] items)
+        {
+            var panel = new StackPanel();
+            panel.Children.AddRange(items.Select(_ => new Border()));
+
+            var previous = default(Selector).OfType<Border>();
+            var target = previous.NthChild(step, offset);
+
+            var results = new bool[items.Length];
+            for (int index = 0; index < items.Length; index++)
+            {
+                var border = panel.Children[index];
+                results[index] = await target.Match(border).Activator!.Take(1);
+            }
+
+            Assert.Equal(items, results);
+        }
+
+        [Theory] // http://nthmaster.com/
+        [InlineData(+1, 4, -1, 8, false, false, false, true , true , true , true , true , false, false, false)]
+        [InlineData(+3, 1, +2, 0, false, false, false, true , false, false, false, false, false, true , false)]
+        public async Task Nth_Child_Master_Com_Test_Double_Selector(
+            int step1, int offset1, int step2, int offset2, params bool[] items)
+        {
+            var panel = new StackPanel();
+            panel.Children.AddRange(items.Select(_ => new Border()));
+
+            var previous = default(Selector).OfType<Border>();
+            var middle = previous.NthChild(step1, offset1);
+            var target = middle.NthChild(step2, offset2);
+
+            var results = new bool[items.Length];
+            for (int index = 0; index < items.Length; index++)
+            {
+                var border = panel.Children[index];
+                results[index] = await target.Match(border).Activator!.Take(1);
+            }
+
+            Assert.Equal(items, results);
+        }
+
+        [Theory] // http://nthmaster.com/
+        [InlineData(+1, 2, 2, 1, -1, 9, false, false, true , false, true , false, true , false, true , false, false)]
+        public async Task Nth_Child_Master_Com_Test_Triple_Selector(
+            int step1, int offset1, int step2, int offset2, int step3, int offset3, params bool[] items)
+        {
+            var panel = new StackPanel();
+            panel.Children.AddRange(items.Select(_ => new Border()));
+
+            var previous = default(Selector).OfType<Border>();
+            var middle1 = previous.NthChild(step1, offset1);
+            var middle2 = middle1.NthChild(step2, offset2);
+            var target = middle2.NthChild(step3, offset3);
+
+            var results = new bool[items.Length];
+            for (int index = 0; index < items.Length; index++)
+            {
+                var border = panel.Children[index];
+                results[index] = await target.Match(border).Activator!.Take(1);
+            }
+
+            Assert.Equal(items, results);
         }
 
         [Fact]

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_NthChild.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_NthChild.cs
@@ -1,7 +1,5 @@
 using System.Threading.Tasks;
-
 using Avalonia.Controls;
-
 using Xunit;
 
 namespace Avalonia.Styling.UnitTests

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_NthLastChild.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_NthLastChild.cs
@@ -1,0 +1,217 @@
+using Avalonia.Controls;
+using Xunit;
+
+namespace Avalonia.Styling.UnitTests
+{
+    public class SelectorTests_NthLastChild
+    {
+        [Theory]
+        [InlineData(2, 0, ":nth-last-child(2n)")]
+        [InlineData(2, 1, ":nth-last-child(2n+1)")]
+        [InlineData(1, 0, ":nth-last-child(1n)")]
+        [InlineData(4, -1, ":nth-last-child(4n-1)")]
+        [InlineData(0, 1, ":nth-last-child(1)")]
+        [InlineData(0, -1, ":nth-last-child(-1)")]
+        [InlineData(int.MaxValue, int.MinValue + 1, ":nth-last-child(2147483647n-2147483647)")]
+        public void Not_Selector_Should_Have_Correct_String_Representation(int step, int offset, string expected)
+        {
+            var target = default(Selector).NthLastChild(step, offset);
+
+            Assert.Equal(expected, target.ToString());
+        }
+
+        [Fact]
+        public void Nth_Child_Match_Control_In_Panel()
+        {
+            Border b1, b2, b3, b4;
+            var panel = new StackPanel();
+            panel.Children.AddRange(new[]
+            {
+                b1 = new Border(),
+                b2 = new Border(),
+                b3 = new Border(),
+                b4 = new Border()
+            });
+
+            var target = default(Selector).NthLastChild(2, 0);
+
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b1).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b2).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b3).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+        }
+
+        [Fact]
+        public void Nth_Child_Match_Control_In_Panel_With_Offset()
+        {
+            Border b1, b2, b3, b4;
+            var panel = new StackPanel();
+            panel.Children.AddRange(new[]
+            {
+                b1 = new Border(),
+                b2 = new Border(),
+                b3 = new Border(),
+                b4 = new Border()
+            });
+
+            var target = default(Selector).NthLastChild(2, 1);
+
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b3).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b4).Result);
+        }
+
+        [Fact]
+        public void Nth_Child_Match_Control_In_Panel_With_Negative_Offset()
+        {
+            Border b1, b2, b3, b4;
+            var panel = new StackPanel();
+            panel.Children.AddRange(new[]
+            {
+                b1 = new Border(),
+                b2 = new Border(),
+                b3 = new Border(),
+                b4 = new Border()
+            });
+
+            var target = default(Selector).NthLastChild(4, -1);
+
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b3).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+        }
+
+        [Fact]
+        public void Nth_Child_Match_Control_In_Panel_With_Singular_Step()
+        {
+            Border b1, b2, b3, b4;
+            var panel = new StackPanel();
+            panel.Children.AddRange(new[]
+            {
+                b1 = new Border(),
+                b2 = new Border(),
+                b3 = new Border(),
+                b4 = new Border()
+            });
+
+            var target = default(Selector).NthLastChild(1, 2);
+
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b1).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b3).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+        }
+
+        [Fact]
+        public void Nth_Child_Match_Control_In_Panel_With_Singular_Step_With_Negative_Offset()
+        {
+            Border b1, b2, b3, b4;
+            var panel = new StackPanel();
+            panel.Children.AddRange(new[]
+            {
+                b1 = new Border(),
+                b2 = new Border(),
+                b3 = new Border(),
+                b4 = new Border()
+            });
+
+            var target = default(Selector).NthLastChild(1, -2);
+
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b1).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b3).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b4).Result);
+        }
+
+        [Fact]
+        public void Nth_Child_Match_Control_In_Panel_With_Zero_Step_With_Offset()
+        {
+            Border b1, b2, b3, b4;
+            var panel = new StackPanel();
+            panel.Children.AddRange(new[]
+            {
+                b1 = new Border(),
+                b2 = new Border(),
+                b3 = new Border(),
+                b4 = new Border()
+            });
+
+            var target = default(Selector).NthLastChild(0, 2);
+
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b2).Result);
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b3).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+        }
+
+        [Fact]
+        public void Nth_Child_Doesnt_Match_Control_In_Panel_With_Zero_Step_With_Negative_Offset()
+        {
+            Border b1, b2, b3, b4;
+            var panel = new StackPanel();
+            panel.Children.AddRange(new[]
+            {
+                b1 = new Border(),
+                b2 = new Border(),
+                b3 = new Border(),
+                b4 = new Border()
+            });
+
+            var target = default(Selector).NthLastChild(0, -2);
+
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b2).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b3).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+        }
+
+        [Fact]
+        public void Nth_Child_Match_Control_In_Panel_With_Previous_Selector()
+        {
+            Border b1, b2;
+            Button b3, b4;
+            var panel = new StackPanel();
+            panel.Children.AddRange(new Control[]
+            {
+                b1 = new Border(),
+                b2 = new Border(),
+                b3 = new Button(),
+                b4 = new Button()
+            });
+
+            var previous = default(Selector).OfType<Border>();
+            var target = previous.NthLastChild(2, 0);
+
+            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b1).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b2).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisType, target.Match(b3).Result);
+            Assert.Equal(SelectorMatchResult.NeverThisType, target.Match(b4).Result);
+        }
+
+        [Fact]
+        public void Nth_Child_Doesnt_Match_Control_Out_Of_Panel_Parent()
+        {
+            Border b1;
+            var contentControl = new ContentControl();
+            contentControl.Content = b1 = new Border();
+
+            var target = default(Selector).NthLastChild(1, 0);
+
+            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
+        }
+
+        [Fact]
+        public void Returns_Correct_TargetType()
+        {
+            var target = new NthLastChildSelector(default(Selector).OfType<Control1>(), 1, 0);
+
+            Assert.Equal(typeof(Control1), target.TargetType);
+        }
+
+        public class Control1 : Control
+        {
+        }
+    }
+}

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_NthLastChild.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_NthLastChild.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 using Avalonia.Controls;
 using Xunit;
 
@@ -21,7 +23,7 @@ namespace Avalonia.Styling.UnitTests
         }
 
         [Fact]
-        public void Nth_Child_Match_Control_In_Panel()
+        public async Task Nth_Child_Match_Control_In_Panel()
         {
             Border b1, b2, b3, b4;
             var panel = new StackPanel();
@@ -35,14 +37,14 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthLastChild(2, 0);
 
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b1).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b2).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b3).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+            Assert.True(await target.Match(b1).Activator!.Take(1));
+            Assert.False(await target.Match(b2).Activator!.Take(1));
+            Assert.True(await target.Match(b3).Activator!.Take(1));
+            Assert.False(await target.Match(b4).Activator!.Take(1));
         }
 
         [Fact]
-        public void Nth_Child_Match_Control_In_Panel_With_Offset()
+        public async Task Nth_Child_Match_Control_In_Panel_With_Offset()
         {
             Border b1, b2, b3, b4;
             var panel = new StackPanel();
@@ -56,14 +58,14 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthLastChild(2, 1);
 
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b3).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b4).Result);
+            Assert.False(await target.Match(b1).Activator!.Take(1));
+            Assert.True(await target.Match(b2).Activator!.Take(1));
+            Assert.False(await target.Match(b3).Activator!.Take(1));
+            Assert.True(await target.Match(b4).Activator!.Take(1));
         }
 
         [Fact]
-        public void Nth_Child_Match_Control_In_Panel_With_Negative_Offset()
+        public async Task Nth_Child_Match_Control_In_Panel_With_Negative_Offset()
         {
             Border b1, b2, b3, b4;
             var panel = new StackPanel();
@@ -77,14 +79,14 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthLastChild(4, -1);
 
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b3).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+            Assert.False(await target.Match(b1).Activator!.Take(1));
+            Assert.True(await target.Match(b2).Activator!.Take(1));
+            Assert.False(await target.Match(b3).Activator!.Take(1));
+            Assert.False(await target.Match(b4).Activator!.Take(1));
         }
 
         [Fact]
-        public void Nth_Child_Match_Control_In_Panel_With_Singular_Step()
+        public async Task Nth_Child_Match_Control_In_Panel_With_Singular_Step()
         {
             Border b1, b2, b3, b4;
             var panel = new StackPanel();
@@ -98,14 +100,14 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthLastChild(1, 2);
 
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b1).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b3).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+            Assert.True(await target.Match(b1).Activator!.Take(1));
+            Assert.True(await target.Match(b2).Activator!.Take(1));
+            Assert.True(await target.Match(b3).Activator!.Take(1));
+            Assert.False(await target.Match(b4).Activator!.Take(1));
         }
 
         [Fact]
-        public void Nth_Child_Match_Control_In_Panel_With_Singular_Step_With_Negative_Offset()
+        public async Task Nth_Child_Match_Control_In_Panel_With_Singular_Step_With_Negative_Offset()
         {
             Border b1, b2, b3, b4;
             var panel = new StackPanel();
@@ -119,14 +121,14 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthLastChild(1, -2);
 
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b1).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b2).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b3).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b4).Result);
+            Assert.True(await target.Match(b1).Activator!.Take(1));
+            Assert.True(await target.Match(b2).Activator!.Take(1));
+            Assert.True(await target.Match(b3).Activator!.Take(1));
+            Assert.True(await target.Match(b4).Activator!.Take(1));
         }
 
         [Fact]
-        public void Nth_Child_Match_Control_In_Panel_With_Zero_Step_With_Offset()
+        public async Task Nth_Child_Match_Control_In_Panel_With_Zero_Step_With_Offset()
         {
             Border b1, b2, b3, b4;
             var panel = new StackPanel();
@@ -140,14 +142,14 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthLastChild(0, 2);
 
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b2).Result);
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b3).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+            Assert.False(await target.Match(b1).Activator!.Take(1));
+            Assert.False(await target.Match(b2).Activator!.Take(1));
+            Assert.True(await target.Match(b3).Activator!.Take(1));
+            Assert.False(await target.Match(b4).Activator!.Take(1));
         }
 
         [Fact]
-        public void Nth_Child_Doesnt_Match_Control_In_Panel_With_Zero_Step_With_Negative_Offset()
+        public async Task Nth_Child_Doesnt_Match_Control_In_Panel_With_Zero_Step_With_Negative_Offset()
         {
             Border b1, b2, b3, b4;
             var panel = new StackPanel();
@@ -161,14 +163,14 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthLastChild(0, -2);
 
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b2).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b3).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b4).Result);
+            Assert.False(await target.Match(b1).Activator!.Take(1));
+            Assert.False(await target.Match(b2).Activator!.Take(1));
+            Assert.False(await target.Match(b3).Activator!.Take(1));
+            Assert.False(await target.Match(b4).Activator!.Take(1));
         }
 
         [Fact]
-        public void Nth_Child_Match_Control_In_Panel_With_Previous_Selector()
+        public async Task Nth_Child_Match_Control_In_Panel_With_Previous_Selector()
         {
             Border b1, b2;
             Button b3, b4;
@@ -184,14 +186,16 @@ namespace Avalonia.Styling.UnitTests
             var previous = default(Selector).OfType<Border>();
             var target = previous.NthLastChild(2, 0);
 
-            Assert.Equal(SelectorMatchResult.AlwaysThisInstance, target.Match(b1).Result);
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b2).Result);
+            Assert.True(await target.Match(b1).Activator!.Take(1));
+            Assert.False(await target.Match(b2).Activator!.Take(1));
+            Assert.Null(target.Match(b3).Activator);
             Assert.Equal(SelectorMatchResult.NeverThisType, target.Match(b3).Result);
+            Assert.Null(target.Match(b4).Activator);
             Assert.Equal(SelectorMatchResult.NeverThisType, target.Match(b4).Result);
         }
 
         [Fact]
-        public void Nth_Child_Doesnt_Match_Control_Out_Of_Panel_Parent()
+        public async Task Nth_Child_Doesnt_Match_Control_Out_Of_Panel_Parent()
         {
             Border b1;
             var contentControl = new ContentControl();
@@ -199,7 +203,7 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthLastChild(1, 0);
 
-            Assert.Equal(SelectorMatchResult.NeverThisInstance, target.Match(b1).Result);
+            Assert.False(await target.Match(b1).Activator!.Take(1));
         }
 
         [Fact]

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_NthLastChild.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_NthLastChild.cs
@@ -195,7 +195,7 @@ namespace Avalonia.Styling.UnitTests
         }
 
         [Fact]
-        public async Task Nth_Child_Doesnt_Match_Control_Out_Of_Panel_Parent()
+        public void Nth_Child_Doesnt_Match_Control_Out_Of_Panel_Parent()
         {
             Border b1;
             var contentControl = new ContentControl();
@@ -203,7 +203,7 @@ namespace Avalonia.Styling.UnitTests
 
             var target = default(Selector).NthLastChild(1, 0);
 
-            Assert.False(await target.Match(b1).Activator!.Take(1));
+            Assert.Equal(SelectorMatch.NeverThisInstance, target.Match(b1));
         }
 
         [Fact]

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_NthLastChild.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_NthLastChild.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-
 using Avalonia.Controls;
 using Xunit;
 

--- a/tests/Avalonia.Styling.UnitTests/StyleActivatorExtensions.cs
+++ b/tests/Avalonia.Styling.UnitTests/StyleActivatorExtensions.cs
@@ -20,13 +20,17 @@ namespace Avalonia.Styling.UnitTests
 
         public static IObservable<bool> ToObservable(this IStyleActivator activator)
         {
+            if (activator == null)
+            {
+                throw new ArgumentNullException(nameof(activator));
+            }
+
             return new ObservableAdapter(activator);
         }
 
         private class ObservableAdapter : LightweightObservableBase<bool>, IStyleActivatorSink
         {
             private readonly IStyleActivator _source;
-            private bool _value;
             
             public ObservableAdapter(IStyleActivator source) => _source = source;
             protected override void Initialize() => _source.Subscribe(this);
@@ -34,7 +38,6 @@ namespace Avalonia.Styling.UnitTests
 
             void IStyleActivatorSink.OnNext(bool value, int tag)
             {
-                _value = value;
                 PublishNext(value);
             }
         }


### PR DESCRIPTION
## What does the pull request do?
```xaml
<Style Selector="ListBox ListBoxItem:nth-child(2n)">
  <Setter Property="Foreground" Value="Blue" />
</Style>
```

![scroll2](https://user-images.githubusercontent.com/3163374/128624070-df209425-b346-46fd-a148-9ea7a311ed46.gif)


## How was the solution implemented (if it's not obvious)?
New selector and IChildIndexProvider interface to be able to read item position/total count.
Currently this implementation has two problems:
1. ~When item is removed (virtualization or manually from Panel) indexing is going broken. Selector activator should be created and IChildIndexProvider should be extended to observable.~ Fixed
2. IChildIndexProvider can't be used in the future for another selector like ```nth-of-type``` or ```nth-child(2n of .class)```. Filtered by type or class list will have different indexes comparing with original list.


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None so far

## Obsoletions / Deprecations
None

## Fixed issues
Closes https://github.com/AvaloniaUI/Avalonia/issues/6262
