### PR TITLE
Fix MicroCom.targets doesn't work with paths with spaces

### DIFF
--- a/build/MicroCom.targets
+++ b/build/MicroCom.targets
@@ -15,7 +15,8 @@
           Inputs="@(AvnComIdl);$(MSBuildThisFileDirectory)../src/tools/MicroComGenerator/**/*.cs"
           Outputs="%(AvnComIdl.OutputFile)">
     <Message Importance="high" Text="Generating file %(AvnComIdl.OutputFile) from @(AvnComIdl)" />
-    <Exec Command="dotnet $(MSBuildThisFileDirectory)../src/tools/MicroComGenerator/bin/$(Configuration)/netcoreapp3.1/MicroComGenerator.dll -i @(AvnComIdl) --cs %(AvnComIdl.OutputFile)" LogStandardErrorAsError="true" />
+    <Exec Command="dotnet &quot;$(MSBuildThisFileDirectory)../src/tools/MicroComGenerator/bin/$(Configuration)/netcoreapp3.1/MicroComGenerator.dll&quot; -i @(AvnComIdl) --cs %(AvnComIdl.OutputFile)" 
+          LogStandardErrorAsError="true" />
     <ItemGroup>
       <!-- Remove and re-add generated file, this is needed for the clean build -->
       <Compile Remove="%(AvnComIdl.OutputFile)"/>


### PR DESCRIPTION
## What does the pull request do?
Checked the solution suggested in the issue description, it worked for me. The solution is widely used for such problems so i think we are ok with that


## What is the current behavior?
ControlCatalog.NetCore would not work if you have spaces in the path.


## What is the updated/expected behavior with this PR?
ControlCatalog.NetCore would work if you have spaces in the path.

## Fixed issues
closes #6302 
