### PR TITLE
Check if TextBox.Text is null in AutoCompleteBox

### DIFF
--- a/src/Avalonia.Controls/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox.cs
@@ -2005,7 +2005,7 @@ namespace Avalonia.Controls
             // The TextBox.TextChanged event was not firing immediately and
             // was causing an immediate update, even with wrapping. If there is
             // a selection currently, no update should happen.
-            if (IsTextCompletionEnabled && TextBox != null && TextBoxSelectionLength > 0 && TextBoxSelectionStart != TextBox.Text.Length)
+            if (IsTextCompletionEnabled && TextBox != null && TextBoxSelectionLength > 0 && TextBoxSelectionStart != (TextBox.Text?.Length ?? 0))
             {
                 return;
             }
@@ -2303,7 +2303,7 @@ namespace Avalonia.Controls
             {
                 if (IsTextCompletionEnabled && TextBox != null && userInitiated)
                 {
-                    int currentLength = TextBox.Text.Length;
+                    int currentLength = TextBox.Text?.Length ?? 0;
                     int selectionStart = TextBoxSelectionStart;
                     if (selectionStart == text.Length && selectionStart > _textSelectionStart)
                     {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes NullReferenceException in AutoCompleteBox

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

```
2021-08-05 21:49:26 [1] CRITICAL	Program:Main (89)	System.NullReferenceException: Object reference not set to an instance of an object.
   at Avalonia.Controls.AutoCompleteBox.UpdateTextCompletion(Boolean userInitiated) in /_/src/Avalonia.Controls/AutoCompleteBox.cs:line 2306
   at Avalonia.Controls.AutoCompleteBox.PopulateComplete() in /_/src/Avalonia.Controls/AutoCompleteBox.cs:line 2282
   at Avalonia.Controls.AutoCompleteBox.PopulateDropDown(Object sender, EventArgs e) in /_/src/Avalonia.Controls/AutoCompleteBox.cs:line 1786
   at Avalonia.Controls.AutoCompleteBox.TextUpdated(String newText, Boolean userInitiated) in /_/src/Avalonia.Controls/AutoCompleteBox.cs:line 2036
   at Avalonia.Controls.AutoCompleteBox.<OnTextBoxTextChanged>b__187_0() in /_/src/Avalonia.Controls/AutoCompleteBox.cs:line 1926
   at Avalonia.Threading.JobRunner.RunJobs(Nullable`1 priority) in /_/src/Avalonia.Base/Threading/JobRunner.cs:line 37
```

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
No NullReferenceException is thrown.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Added null checks when accessing TextBox.Text property.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
