### PR TITLE
Add Not value converter to BoolConverters

### DIFF
--- a/src/Avalonia.Base/Data/Converters/BoolConverters.cs
+++ b/src/Avalonia.Base/Data/Converters/BoolConverters.cs
@@ -18,5 +18,11 @@ namespace Avalonia.Data.Converters
         /// </summary>
         public static readonly IMultiValueConverter Or =
             new FuncMultiValueConverter<bool, bool>(x => x.Any(y => y));
+
+        /// <summary>
+        /// A value converter that returns true when input is false and false when input is true.
+        /// </summary>
+        public static readonly IValueConverter Not =
+            new FuncValueConverter<bool, bool>(x => !x);
     }
 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Add `Not` value converter to `BoolConverters`

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`Not` value converter is missing from `BoolConverters`

It is useful when using `<Binding/>` element directly.
```XAML
 <Binding Path="IsVisible" Converter="{x:Static BoolConverters.Not}"/>
```

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
`Not` value converter is available from `BoolConverters`

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Using FuncValueConverter

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
