### PR TITLE
Don't display warning when WinUICompositorConnection succeeds.

### DIFF
--- a/src/Windows/Avalonia.Win32/WinRT/Composition/WinUICompositorConnection.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/Composition/WinUICompositorConnection.cs
@@ -144,6 +144,7 @@ namespace Avalonia.Win32.WinRT.Composition
                 try
                 {
                     TryCreateAndRegisterCore(angle);
+                    return;
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
## What does the pull request do?

We're always displaying a warning on startup that says:

```
[WinUIComposition] Unable to initialize WinUI compositor: Windows 10 Build 17134 is required. Your machine has Windows 10 Build 19043 installed.
```

This happens even on machines where Windows 10 is later than build 17134. This was due to a missing `return` after `TryCreateAndRegister`, meaning it fell through to the error state.
