### PR TITLE
Prevent DeferredRenderer crash when a VisualBrush is used as OpacityMask

### DIFF
--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -279,13 +279,13 @@ namespace Avalonia.Rendering
         /// <inheritdoc/>
         Size IVisualBrushRenderer.GetRenderTargetSize(IVisualBrush brush)
         {
-            return (_currentDraw.Item as BrushDrawOperation)?.ChildScenes?[brush.Visual]?.Size ?? Size.Empty;
+            return (_currentDraw?.Item as BrushDrawOperation)?.ChildScenes?[brush.Visual]?.Size ?? Size.Empty;
         }
 
         /// <inheritdoc/>
         void IVisualBrushRenderer.RenderVisualBrush(IDrawingContextImpl context, IVisualBrush brush)
         {
-            var childScene = (_currentDraw.Item as BrushDrawOperation)?.ChildScenes?[brush.Visual];
+            var childScene = (_currentDraw?.Item as BrushDrawOperation)?.ChildScenes?[brush.Visual];
 
             if (childScene != null)
             {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
The PR makes sure the DeferredRenderer isn't crashing when a VisualBrush is used as an OpacityMask.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The application crashes.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
The renderer doesn't crash anymore but the OpacityMask isn't working in combination with the DeferredRenderer.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
The renderer expected a current node to be present when the visual of the brush was rendered. This isn't the case when a VisualBrush is used as an OpacityMask because the brush isn't part of the child scene. We prevent a crash by introducing a null check.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes: #2889