### PR TITLE
Don't focus children of disabled controls when tabbing between controls.

### DIFF
--- a/src/Avalonia.Input/Navigation/TabNavigation.cs
+++ b/src/Avalonia.Input/Navigation/TabNavigation.cs
@@ -234,7 +234,7 @@ namespace Avalonia.Input.Navigation
             // Return the first visible element.
             var uiElement = e as InputElement;
 
-            if (uiElement is null || uiElement.IsVisible)
+            if (uiElement is null || IsVisibleAndEnabled(uiElement))
             {
                 if (e is IVisual elementAsVisual)
                 {
@@ -245,7 +245,7 @@ namespace Avalonia.Input.Navigation
                     {
                         if (children[i] is InputElement ie)
                         {
-                            if (ie.IsVisible)
+                            if (IsVisibleAndEnabled(ie))
                                 return ie;
                             else
                             {
@@ -270,7 +270,7 @@ namespace Avalonia.Input.Navigation
             // Return the last visible element.
             var uiElement = e as InputElement;
 
-            if (uiElement == null || uiElement.IsVisible)
+            if (uiElement == null || IsVisibleAndEnabled(uiElement))
             {
                 var elementAsVisual = e as IVisual;
 
@@ -283,7 +283,7 @@ namespace Avalonia.Input.Navigation
                     {
                         if (children[i] is InputElement ie)
                         {
-                            if (ie.IsVisible)
+                            if (IsVisibleAndEnabled(ie))
                                 return ie;
                             else
                             {
@@ -600,7 +600,7 @@ namespace Avalonia.Input.Navigation
                     var vchild = children[i];
                     if (vchild == elementAsVisual)
                         break;
-                    if (vchild.IsVisible == true && vchild is IInputElement ie)
+                    if (vchild is IInputElement ie && IsVisibleAndEnabled(ie))
                         prev = ie;
                 }
                 return prev;
@@ -668,5 +668,6 @@ namespace Avalonia.Input.Navigation
         }
 
         private static bool IsTabStopOrGroup(IInputElement e) => IsTabStop(e) || IsGroup(e);
+        private static bool IsVisibleAndEnabled(IInputElement e) => e.IsVisible && e.IsEnabled;
     }
 }

--- a/tests/Avalonia.Input.UnitTests/KeyboardNavigationTests_Tab.cs
+++ b/tests/Avalonia.Input.UnitTests/KeyboardNavigationTests_Tab.cs
@@ -1225,5 +1225,32 @@ namespace Avalonia.Input.UnitTests
                 "Button2", "Button3", "Button5", "Button1", "Button6", "Button4"
             }, result);
         }
+
+        [Fact]
+        public void Cannot_Focus_Child_Of_Disabled_Control()
+        {
+            Button start;
+            Button expected;
+
+            var top = new StackPanel
+            {
+                [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Cycle,
+                Children =
+                {
+                    (start = new Button { Name = "Button1" }),
+                    new Border
+                    {
+                        IsEnabled = false,
+                        Child = new Button { Name = "Button2" },
+                    },
+                    (expected = new Button { Name = "Button3" }),
+                }
+            };
+
+            var current = (IInputElement)start;
+            var result = KeyboardNavigationHandler.GetNext(current, NavigationDirection.Next);
+
+            Assert.Same(expected, result);
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

#5996 ported WPF's tab navigation code but also introduced #6439 where descendants of disabled controls now incorrectly receive focus.

This happened because WPF and Avalonia's `IsEnabled` properties are slightly different: In WPF if reflects both the enabled state of the actual control and the effectively enabled state which comes from ancestor controls. In Avalonia that effectively enabled state is exposed on a different property: `IsEffectivelyEnabled`. When I ported the tab navigation code from WPF, I didn't take that into account.

WPF's visibility property however doesn't reflect the state of a control's owners and so tab navigation for invisible controls works correctly. Take advantage of this fact by changing any checks for `IsVisible` to also check `IsEnabled`.

(This is despite @danwalmsley's claim in https://github.com/AvaloniaUI/Avalonia/issues/6439#issuecomment-901486752 that invisible controls now get focus when tabbing. I couldn't repro this so I think that it does work correctly for invisible controls)

## Fixed issues

Fixes #6439 