### PR TITLE
Fixes/issue 6442

### DIFF
--- a/src/Avalonia.Base/Threading/AvaloniaSynchronizationContext.cs
+++ b/src/Avalonia.Base/Threading/AvaloniaSynchronizationContext.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Runtime.ConstrainedExecution;
 using System.Threading;
 
 namespace Avalonia.Threading
@@ -39,9 +37,10 @@ namespace Avalonia.Threading
             if (Dispatcher.UIThread.CheckAccess())
                 d(state);
             else
-                Dispatcher.UIThread.InvokeAsync(() => d(state), DispatcherPriority.Send).Wait();
+            {
+                Dispatcher.UIThread.Post(() => d(state), DispatcherPriority.Send);
+            }
+                
         }
-
-
     }
 }

--- a/src/Avalonia.Base/Threading/AvaloniaSynchronizationContext.cs
+++ b/src/Avalonia.Base/Threading/AvaloniaSynchronizationContext.cs
@@ -38,7 +38,16 @@ namespace Avalonia.Threading
                 d(state);
             else
             {
-                Dispatcher.UIThread.Post(() => d(state), DispatcherPriority.Send);
+                try
+                {
+                    Dispatcher.UIThread.InvokeAsync(() => d(state), DispatcherPriority.Send).Wait();
+                }
+                catch (System.AggregateException aex)
+                {
+
+                    throw aex.InnerExceptions[0];
+                }
+                
             }
                 
         }

--- a/tests/Avalonia.Base.UnitTests/Threading/AvaloniaSynchronizationContextTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Threading/AvaloniaSynchronizationContextTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Threading;
+using Avalonia.Platform;
+using Avalonia.Threading;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Threading
+{
+    public class AvaloniaSynchronizationContextTests
+    {
+        class ThreadingInterface : IPlatformThreadingInterface
+        {
+            readonly int threadId;
+
+            public ThreadingInterface()
+            {
+                threadId = Thread.CurrentThread.ManagedThreadId;
+            }
+
+            public bool CurrentThreadIsLoopThread => threadId == Thread.CurrentThread.ManagedThreadId;
+
+            public event Action<DispatcherPriority?> Signaled;
+
+            public void RunLoop(CancellationToken cancellationToken)
+            {
+
+            }
+
+            public void Signal(DispatcherPriority priority) => 
+                Signaled?.Invoke(priority);
+
+            public IDisposable StartTimer(DispatcherPriority priority, TimeSpan interval, Action tick) => 
+                System.Reactive.Disposables.Disposable.Empty;
+        }
+
+        [Fact]
+        public async void Unwrap_Exception_When_Call_Send_Not_In_Current_Context()
+        {
+            using (UnitTestApplication.Start(new TestServices(threadingInterface: new ThreadingInterface())))
+            {
+                AvaloniaSynchronizationContext.InstallIfNeeded();
+                var ctx = SynchronizationContext.Current;
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+                _ = await Assert.ThrowsAsync<ArgumentException>(async () =>
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+                    {
+                          ctx.Send(state => throw new ArgumentException("hello"), null);
+                    });
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
BugFix

this PR is alternative at PR #6464

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When call AvaloniaSynchronizationContext.Send in not UI Thread and invoked delegate throw a exception , the exception is wrapp in AggregateException .

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
When call AvaloniaSynchronizationContext.Send in not UI Thread and invoked delegate throw a exception , the exception is not wrap in the AggregateException.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #6442 
