### PR TITLE
fixes(Win32.Interop): field 'Direct2DImageSurface._oldDpi' is never a…

### DIFF
--- a/src/Windows/Avalonia.Win32.Interop/Wpf/Direct2DImageSurface.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/Direct2DImageSurface.cs
@@ -150,6 +150,7 @@ namespace Avalonia.Win32.Interop.Wpf
             if (_image == null || _oldDpi.X != dpi.X || _oldDpi.Y != dpi.Y)
             {
                 _image = new D3DImage(dpi.X, dpi.Y);
+                _oldDpi = dpi;
             }
             _impl.ImageSource = _image;
             


### PR DESCRIPTION
Fixes field 'Direct2DImageSurface._oldDpi' is never a…ssigned to, and will always have its default value

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
