### PR TITLE
Relax .NET SDK version for CLI commands

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
 	"sdk": {
+		"rollForward": "latestFeature",
 		"version": "3.1.401"
 	},
     "msbuild-sdks": {


### PR DESCRIPTION
The latest .NET 3.1 version as of 2021-08-29 is `3.1.412`, and this is the version requested since commit 21fc8620f (Try using 3.1.401, 2020-09-01). Consequently, the current `dotnet` tool runs successfully on 0.10.0 -- however, it does not run on 0.9.12, nor indeed any other revision before that commit.

The [default behavior][docs] when `global.json` specifies an SDK version but no roll-forward policy is to use the `latestPatch` policy. That's true for both .NET Core 2 and .NET Core 3 but only the latter exposes the roll-forward policy for customization.

The .NET SDK version scheme is not semver, so in version `3.1.101` that e.g. the `0.9.12` tag uses, `101` is not a "patch" according to the roll-forward policy. Rather, it is a combined feature and patch, the first digit being the feature. If we restate the .NET version number according to semver's rules it behaves like `3.1.1.01` and the default roll-forward policy behaves like `3.1.1.x`. It should then be fairly clear why, for revisions before the commit mentioned above, the `dotnet` tool rejects SDK version `3.1.412`.

Despite the .NET version numbering scheme, for Linux Microsoft distributes the SDK at the minor version level [1], not the feature level, so installing a patch level compatible SDK is prohibitively difficult [2].

This has 2 important implications:

1. The requested .NET version is not exact. If that was the intention, `rollForward` must explicitly specify `disable`.
2. It is at best difficult, at worst impossible, for the same Linux system to build both the `stable/0.10.0` and `stable/0.9` branches, or in more general terms to build any older revision with a different feature level requirement.

This PR relaxes the roll-forward policy from patch level to feature level, allowing future feature level releases to build this revision in the name of practicality. The patch applies cleanly to `master` and `stable/0.10.x`, and is easily adapted to `stable/0.9`.

I understand the motivation for a strict version but the current configuration is not very pragmatic, and I suspect not completely deliberate. It is probable that some configuration is missing but unclear which exact configuration that would be. I don't use or care about Avalonia and I only ended up in #4082 incidentally, after failing to run `dotnet` on an older revision for completely unrelated and largely uninteresting reasons. Here is one fix; take it or leave it, but at least understand that 1) the build instructions are inconsistent with the behaviour, and 2) the behaviour is very restrictive.

[1] So `3.1`, not `3.1.4`.
[2] The installer will also uninstall other "irrelevant" versions. I don't know if that judgment is based on patch level or feature level, but if that is also on feature level, Avalonia basically cannot co-exist with other .NET 3.1 projects.

[docs]: https://docs.microsoft.com/en-us/dotnet/core/tools/global-json?tabs=netcore3x
