### PR TITLE
Read bitmap data from clipboard (HBITMAP) Unknown_Format_2

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -891,6 +891,9 @@ namespace Avalonia.Win32.Interop
             uint uStartScan, uint cScanLines,
            IntPtr lpvBits, [In] ref BITMAPINFO lpbmi, uint fuColorUse);
 
+        [DllImport("gdi32.dll")]
+        public static extern long GetBitmapBits([In] IntPtr hbmp, [In] int cbBuffer, [Out] byte[] lpvBits);
+
         [DllImport("user32.dll")]
         public static extern bool ReleaseDC(IntPtr hWnd, IntPtr hDC);
 

--- a/src/Windows/Avalonia.Win32/OleDataObject.cs
+++ b/src/Windows/Avalonia.Win32/OleDataObject.cs
@@ -44,7 +44,7 @@ namespace Avalonia.Win32
 
         public object Get(string dataFormat)
         {
-            if (dataFormat == ClipboardFormats.GetFormat(2)) // check for CF_BITMAP
+            if (dataFormat == ClipboardFormats.GetFormat(StandardClipboardFormats.CF_BITMAP))
             {
                 return GetImage();
             }
@@ -54,8 +54,8 @@ namespace Avalonia.Win32
 
         private object GetImage()
         {
-            // read bitmapInfo CF_DIB format
-            var bitmapInfoData = GetDataFromOleHGLOBAL(ClipboardFormats.GetFormat(8), DVASPECT.DVASPECT_CONTENT) as byte[];
+            // read bitmapInfo
+            var bitmapInfoData = GetDataFromOleHGLOBAL(ClipboardFormats.GetFormat(StandardClipboardFormats.CF_DIB), DVASPECT.DVASPECT_CONTENT) as byte[];
 
             if (bitmapInfoData == null)
             {
@@ -66,7 +66,7 @@ namespace Avalonia.Win32
 
             // get bitmap handle HBITMAP
             var formatEtc = new FORMATETC();
-            formatEtc.cfFormat = 2; // CF_BITMAP
+            formatEtc.cfFormat = StandardClipboardFormats.CF_BITMAP;
             formatEtc.dwAspect = DVASPECT.DVASPECT_CONTENT;
             formatEtc.lindex = -1;
             formatEtc.tymed = TYMED.TYMED_GDI;

--- a/src/Windows/Avalonia.Win32/OleDataObject.cs
+++ b/src/Windows/Avalonia.Win32/OleDataObject.cs
@@ -44,7 +44,7 @@ namespace Avalonia.Win32
 
         public object Get(string dataFormat)
         {
-            if (dataFormat == "Unknown_Format_2")
+            if (dataFormat == ClipboardFormats.GetFormat(2)) // check for CF_BITMAP
             {
                 return GetImage();
             }
@@ -54,8 +54,8 @@ namespace Avalonia.Win32
 
         private object GetImage()
         {
-            // read bitmapInfo
-            var bitmapInfoData = GetDataFromOleHGLOBAL("Unknown_Format_8", DVASPECT.DVASPECT_CONTENT) as byte[];
+            // read bitmapInfo CF_DIB format
+            var bitmapInfoData = GetDataFromOleHGLOBAL(ClipboardFormats.GetFormat(8), DVASPECT.DVASPECT_CONTENT) as byte[];
 
             if (bitmapInfoData == null)
             {
@@ -66,7 +66,7 @@ namespace Avalonia.Win32
 
             // get bitmap handle HBITMAP
             var formatEtc = new FORMATETC();
-            formatEtc.cfFormat = 2; // Unknown_Format_2
+            formatEtc.cfFormat = 2; // CF_BITMAP
             formatEtc.dwAspect = DVASPECT.DVASPECT_CONTENT;
             formatEtc.lindex = -1;
             formatEtc.tymed = TYMED.TYMED_GDI;

--- a/src/Windows/Avalonia.Win32/StandardClipboardFormats.cs
+++ b/src/Windows/Avalonia.Win32/StandardClipboardFormats.cs
@@ -1,0 +1,162 @@
+﻿namespace Avalonia.Win32
+{
+    internal static class StandardClipboardFormats
+    {
+        /// <summary>
+        /// A handle to a bitmap (HBITMAP).
+        /// </summary>
+        public static short CF_BITMAP = 2;
+
+        /// <summary>
+        /// A memory object containing a BITMAPINFO structure followed by the bitmap bits.
+        /// </summary>
+        public static short CF_DIB = 8;
+
+        /// <summary>
+        /// A memory object containing a BITMAPV5HEADER structure followed by the bitmap color space information and the bitmap bits.
+        /// </summary>
+        public static short CF_DIBV5 = 17;
+
+        /// <summary>
+        /// Software Arts' Data Interchange Format.
+        /// </summary>
+        public static short CF_DIF = 5;
+
+        /// <summary>
+        /// Bitmap display format associated with a private format.
+        /// The hMem parameter must be a handle to data that can be displayed in bitmap format in lieu of the privately formatted data.
+        /// </summary>
+        public static short CF_DSPBITMAP = 0x0082;
+
+        /// <summary>
+        /// Enhanced metafile display format associated with a private format.
+        /// The hMem parameter must be a handle to data that can be displayed in enhanced metafile format in lieu of the privately formatted data.
+        /// </summary>
+        public static short CF_DSPENHMETAFILE = 0x008E;
+
+        /// <summary>
+        /// Metafile-picture display format associated with a private format.
+        /// The hMem parameter must be a handle to data that can be displayed in metafile-picture format in lieu of the privately formatted data.
+        /// </summary>
+        public static short CF_DSPMETAFILEPICT = 0x0083;
+
+        /// <summary>
+        /// Text display format associated with a private format.
+        /// The hMem parameter must be a handle to data that can be displayed in text format in lieu of the privately formatted data.
+        /// </summary>
+        public static short CF_DSPTEXT = 0x0081;
+
+        /// <summary>
+        /// A handle to an enhanced metafile (HENHMETAFILE).
+        /// </summary>
+        public static short CF_ENHMETAFILE = 14;
+
+        /// <summary>
+        /// Start of a range of integer values for application-defined GDI object clipboard formats. The end of the range is CF_GDIOBJLAST.
+        /// Handles associated with clipboard formats in this range are not automatically deleted using the GlobalFree function when the clipboard is emptied.
+        /// Also, when using values in this range, the hMem parameter is not a handle to a GDI object, but is a handle allocated by the GlobalAlloc function with the GMEM_MOVEABLE flag.
+        /// </summary>
+        public static short CF_GDIOBJFIRST = 0x0300;
+
+        /// <summary>
+        /// <see cref="CF_GDIOBJFIRST"/>
+        /// </summary>
+        public static short CF_GDIOBJLAST = 0x03FF;
+
+        /// <summary>
+        /// A handle to type HDROP that identifies a list of files.
+        /// An application can retrieve information about the files by passing the handle to the DragQueryFile function.
+        /// </summary>
+        public static short CF_HDROP = 15;
+
+        /// <summary>
+        /// The data is a handle (HGLOBAL) to the locale identifier (LCID) associated with text in the clipboard.
+        /// When you close the clipboard, if it contains CF_TEXT data but no CF_LOCALE data, the system automatically
+        /// sets the CF_LOCALE format to the current input language. You can use the CF_LOCALE format to associate
+        /// a different locale with the clipboard text.
+        /// An application that pastes text from the clipboard can retrieve this format to determine which character set was
+        /// used to generate the text.
+        /// Note that the clipboard does not support plain text in multiple character sets.
+        /// To achieve this, use a formatted text data type such as RTF instead.
+        /// The system uses the code page associated with CF_LOCALE to implicitly convert from CF_TEXT to CF_UNICODETEXT.
+        /// Therefore, the correct code page table is used for the conversion.
+        /// </summary>
+        public static short CF_LOCALE = 16;
+
+        /// <summary>
+        /// Handle to a metafile picture format as defined by the METAFILEPICT structure.
+        /// When passing a CF_METAFILEPICT handle by means of DDE, the application responsible for deleting hMem should
+        /// also free the metafile referred to by the CF_METAFILEPICT handle.
+        /// </summary>
+        public static short CF_METAFILEPICT = 3;
+
+        /// <summary>
+        /// Text format containing characters in the OEM character set.
+        /// Each line ends with a carriage return/linefeed (CR-LF) combination. A null character signals the end of the data.
+        /// </summary>
+        public static short CF_OEMTEXT = 7;
+
+        /// <summary>
+        /// Owner-display format. The clipboard owner must display and update the clipboard viewer window,
+        /// and receive the WM_ASKCBFORMATNAME, WM_HSCROLLCLIPBOARD, WM_PAINTCLIPBOARD, WM_SIZECLIPBOARD, and WM_VSCROLLCLIPBOARD messages.
+        /// The hMem parameter must be NULL.
+        /// </summary>
+        public static short CF_OWNERDISPLAY = 0x0080;
+
+        /// <summary>
+        /// Handle to a color palette. Whenever an application places data in the clipboard that depends on or assumes a color palette, it should place the palette on the clipboard as well.
+        /// If the clipboard contains data in the CF_PALETTE (logical color palette) format, the application should use the SelectPalette and RealizePalette functions to realize (compare) any other data in the clipboard against that logical palette.
+        /// When displaying clipboard data, the clipboard always uses as its current palette any object on the clipboard that is in the CF_PALETTE format.
+        /// </summary>
+        public static short CF_PALETTE = 9;
+
+        /// <summary>
+        /// Data for the pen extensions to the Microsoft Windows for Pen Computing.
+        /// </summary>
+        public static short CF_PENDATA = 10;
+
+        /// <summary>
+        /// Start of a range of integer values for private clipboard formats.
+        /// The range ends with CF_PRIVATELAST. Handles associated with private clipboard formats are not freed automatically; the clipboard owner must free such handles,
+        /// typically in response to the WM_DESTROYCLIPBOARD message.
+        /// </summary>
+        public static short CF_PRIVATEFIRST = 0x0200;
+
+        /// <summary>
+        /// <see cref="CF_PRIVATEFIRST"/>
+        /// </summary>
+        public static short CF_PRIVATELAST = 0x02FF;
+
+        /// <summary>
+        /// Represents audio data more complex than can be represented in a CF_WAVE standard wave format.
+        /// </summary>
+        public static short CF_RIFF = 11;
+
+        /// <summary>
+        /// Microsoft Symbolic Link (SYLK) format.
+        /// </summary>
+        public static short CF_SYLK = 4;
+
+        /// <summary>
+        /// Text format. Each line ends with a carriage return/linefeed (CR-LF) combination.
+        /// A null character signals the end of the data. Use this format for ANSI text.
+        /// </summary>
+        public static short CF_TEXT = 1;
+
+        /// <summary>
+        /// Tagged-image file format.
+        /// </summary>
+        public static short CF_TIFF = 6;
+
+        /// <summary>
+        /// Unicode text format. Each line ends with a carriage return/linefeed (CR-LF) combination.
+        /// A null character signals the end of the data.
+        /// </summary>
+        public static short CF_UNICODETEXT = 13;
+
+        /// <summary>
+        /// Represents audio data in one of the standard wave formats, such as 11 kHz or 22 kHz PCM.
+        /// </summary>
+        public static short CF_WAVE = 12;
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
When an image is on the clipboard, such as from paint.net, the await clipboard.GetFormatsAsync(); method returns three formats:
Unknown_Format_8 - A memory object containing a BITMAPINFO structure followed by the bitmap bits.
Unknown_Format_17 - A memory object containing a BITMAPV5HEADER structure followed by the bitmap color space information and the bitmap bits.
Unknown_Format_2 - A handle to a bitmap (HBITMAP).
[https://docs.microsoft.com/](https://docs.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats)
The current implementation reads data for structures Unknown_Format_8 and Unknown_Format_17 but **Unknown_Format_2** HBITMAP is a handle that is located in a different area of memory and it is impossible to get it in the current implementation.

## What is the current behavior?
`var imagePixelsData = await clipboard.GetDataAsync("Unknown_Format_2") as byte[]; `
throw exception


## What is the updated/expected behavior with this PR?
`var imagePixelsData = await clipboard.GetDataAsync("Unknown_Format_2") as byte[]; `
return raw image bytes


## How was the solution implemented (if it's not obvious)?
Implemented correct reading of HBITMAP and through the call UnmanagedMethods.GetBitmapBits reading bytes of the image

You can use the method for check
`private async Task ReadClipboardImageAsync()
        {
            var clipboard = Application.Current.Clipboard;

            var formats = await clipboard.GetFormatsAsync();
            if (formats.Contains("Unknown_Format_8") && formats.Contains("Unknown_Format_2"))
            {
                var imagePixelsData = await clipboard.GetDataAsync("Unknown_Format_2") as byte[];

                var bitmapInfoData = await clipboard.GetDataAsync("Unknown_Format_8") as byte[];
                var header = ReadImageHeader(bitmapInfoData);

                var pixels = new SKColor[header.biWidth * header.biHeight];
                var pixelIndex = 0;

                var pos = 0;
                for (var y = 0; y < header.biHeight; y++)
                {
                    for (var x = 0; x < header.biWidth; x++)
                    {
                        var b = imagePixelsData[pos++];
                        var g = imagePixelsData[pos++];
                        var r = imagePixelsData[pos++];
                        if (header.biBitCount == 32)
                        {
                            var a = imagePixelsData[pos++];
                            pixels[pixelIndex++] = new SKColor(r, g, b, a);
                            continue;
                        }
                        pixels[pixelIndex++] = new SKColor(r, g, b);
                    }
                }

                var bitmap = new SKBitmap(new SKImageInfo(header.biWidth, header.biHeight));
                bitmap.Pixels = pixels;

                using var writeStream = File.Open("C:\\Projects\\Sample.png", FileMode.OpenOrCreate, FileAccess.Write);
                bitmap.Encode(SKEncodedImageFormat.Png, 100).SaveTo(writeStream);
            }
        }`

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
I think no

## Obsoletions / Deprecations
no

## Fixed issues
Partial #3588
