### PR TITLE
Fix OpenBrowser on Linux

### DIFF
--- a/src/Avalonia.Dialogs/AboutAvaloniaDialog.xaml.cs
+++ b/src/Avalonia.Dialogs/AboutAvaloniaDialog.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
@@ -42,7 +43,8 @@ namespace Avalonia.Dialogs
 
         private static void ShellExec(string cmd, bool waitForExit = true)
         {
-            var escapedArgs = cmd.Replace("\"", "\\\"");
+            var escapedArgs = Regex.Replace(cmd, "(?=[`~!#&*()|;'<>])", "\\")
+                .Replace("\"", "\\\\\\\"");
 
             using (var process = Process.Start(
                 new ProcessStartInfo


### PR DESCRIPTION
## What does the pull request do?

I wrote the code `AboutAvaloniaDialog.OpenBrowser` to open url in Linux.
However, I found an error that some characters were not escaped and did not work.

For example `https://mydomain?a=&b=!#tag`

## What is the current behavior?

Only the `"` character is escaped in the ShellExec function.
And the correct way to escape the `"` character is `\\\"`

```csharp
private static void ShellExec(string cmd, bool waitForExit = true)
{
    var escapedArgs = cmd.Replace("\"", "\\\"");

    using (var process = Process.Start(
        new ProcessStartInfo
...
```


## What is the updated/expected behavior with this PR?

Check if the url displayed in the browser is the same as the url passed to the function

```csharp
AboutAvaloniaDialog.OpenBrowser("https://...?test=`~!#&*()|;'<>\"");
```

## How was the solution implemented (if it's not obvious)?

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

Fix AboutAvaloniaDialog.OpenBrowser on Linux

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
