### PR TITLE
Compiler intrinsic based type nullability check

### DIFF
--- a/src/Avalonia.Base/Data/Converters/FuncValueConverter.cs
+++ b/src/Avalonia.Base/Data/Converters/FuncValueConverter.cs
@@ -26,7 +26,7 @@ namespace Avalonia.Data.Converters
         /// <inheritdoc/>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is TIn || (value == null && TypeUtilities.AcceptsNull<TIn>()))
+            if (TypeUtilities.CanCast<TIn>(value))
             {
                 return _convert((TIn)value);
             }

--- a/src/Avalonia.Base/Data/Converters/FuncValueConverter.cs
+++ b/src/Avalonia.Base/Data/Converters/FuncValueConverter.cs
@@ -26,7 +26,7 @@ namespace Avalonia.Data.Converters
         /// <inheritdoc/>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is TIn || (value == null && TypeUtilities.AcceptsNull(typeof(TIn))))
+            if (value is TIn || (value == null && TypeUtilities.AcceptsNull<TIn>()))
             {
                 return _convert((TIn)value);
             }

--- a/src/Avalonia.Base/Utilities/TypeUtilities.cs
+++ b/src/Avalonia.Base/Utilities/TypeUtilities.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Avalonia.Utilities
 {
@@ -94,6 +95,17 @@ namespace Avalonia.Utilities
         }
 
         /// <summary>
+        /// Returns a value indicating whether null can be assigned to the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type</typeparam>
+        /// <returns>True if the type accepts null values; otherwise false.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool AcceptsNull<T>()
+        {
+            return default(T) is null;
+        }
+
+        /// <summary>
         /// Returns a value indicating whether value can be casted to the specified type.
         /// If value is null, checks if instances of that type can be null.
         /// </summary>
@@ -102,7 +114,7 @@ namespace Avalonia.Utilities
         /// <returns>True if the cast is possible, otherwise false.</returns>
         public static bool CanCast<T>(object value)
         {
-            return value is T || (value is null && AcceptsNull(typeof(T)));
+            return value is T || (value is null && AcceptsNull<T>());
         }
 
         /// <summary>


### PR DESCRIPTION
The change removes reflection usage from converters for nullability checks by using a compiler intrinsic. `AcceptsNull<T>()` marked as aggressively inlinable since the JIT doesn't do it automatically.