### PR TITLE
Fix AutoCompleteBox NRE

### DIFF
--- a/src/Avalonia.Controls/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox.cs
@@ -2094,7 +2094,21 @@ namespace Avalonia.Controls
                 bool inResults = !(stringFiltering || objectFiltering);
                 if (!inResults)
                 {
-                    inResults = stringFiltering ? TextFilter(text, FormatValue(item)) : ItemFilter(text, item);
+                    if (stringFiltering)
+                    {
+                        inResults = TextFilter(text, FormatValue(item));
+                    }
+                    else
+                    {
+                        if (ItemFilter == null)
+                        {
+                            throw new Exception("ItemFilter property can not be unassigned when FilterMode has value AutoCompleteFilterMode.Custom");
+                        }
+                        else
+                        {
+                            inResults = ItemFilter(text, item);
+                        }
+                    }
                 }
 
                 if (view_count > view_index && inResults && _view[view_index] == item)

--- a/src/Avalonia.Controls/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox.cs
@@ -2102,7 +2102,7 @@ namespace Avalonia.Controls
                     {
                         if (ItemFilter == null)
                         {
-                            throw new Exception("ItemFilter property can not be unassigned when FilterMode has value AutoCompleteFilterMode.Custom");
+                            throw new Exception("ItemFilter property can not be null when FilterMode has value AutoCompleteFilterMode.Custom");
                         }
                         else
                         {

--- a/src/Avalonia.Controls/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox.cs
@@ -2100,7 +2100,7 @@ namespace Avalonia.Controls
                     }
                     else
                     {
-                        if (ItemFilter == null)
+                        if (ItemFilter is null)
                         {
                             throw new Exception("ItemFilter property can not be null when FilterMode has value AutoCompleteFilterMode.Custom");
                         }

--- a/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
@@ -106,6 +106,16 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Custom_FilterMode_Without_ItemFilter_Setting_Throws_Exception()
+        {
+            RunTest((control, textbox) =>
+            {
+                control.FilterMode = AutoCompleteFilterMode.Custom;
+                Assert.Throws<Exception>(() => { control.Text = "a"; });
+            });
+        }
+
+        [Fact]
         public void Text_Completion_Via_Text_Property()
         {
             RunTest((control, textbox) =>


### PR DESCRIPTION
## What is the current behavior?
Avalonia throws self-descriptive Exception


## What is the updated/expected behavior with this PR?
Avalonia throws unhandled NullReferenceException


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Fixed issues
closes #6526
