### PR TITLE
Set MenuItem icon presenter size from style

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/MenuItem.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/MenuItem.xaml
@@ -75,8 +75,6 @@
               </Grid.ColumnDefinitions>
               <ContentPresenter Name="PART_IconPresenter"
                                 Content="{TemplateBinding Icon}"
-                                Width="16"
-                                Height="16"
                                 Margin="{DynamicResource MenuIconPresenterMargin}"
                                 HorizontalAlignment="Center"
                                 VerticalAlignment="Center" />
@@ -199,6 +197,8 @@
   </Style>
 
   <Style Selector="MenuItem /template/ ContentPresenter#PART_IconPresenter">
+    <Setter Property="Width" Value="16" />
+    <Setter Property="Height" Value="16" />
     <Setter Property="IsVisible" Value="False" />
   </Style>
   <Style Selector="MenuItem:icon /template/ ContentPresenter#PART_IconPresenter">


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Sets MenuItem icon presenter size from style

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
MenuItem icon presenter size is set directly on presenter so it's not possible to change size from styles

![ControlCatalog NetCore_IfzKAy6Avb](https://user-images.githubusercontent.com/2297442/132902487-c40a83b4-08c8-45b6-931e-86331cdf455a.png)

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Change MenuItem icon presenter size from style

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Moved Width/Height set property value to a style

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
