### PR TITLE
Win32: Fix handling of subsequent keypress after Alt/F10

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -808,6 +808,31 @@ namespace Avalonia.Win32.Interop
             MNC_SELECT = 3
         }
 
+        public enum SysCommands
+        {
+            SC_SIZE = 0xF000,
+            SC_MOVE = 0xF010,
+            SC_MINIMIZE = 0xF020,
+            SC_MAXIMIZE = 0xF030,
+            SC_NEXTWINDOW = 0xF040,
+            SC_PREVWINDOW = 0xF050,
+            SC_CLOSE = 0xF060,
+            SC_VSCROLL = 0xF070,
+            SC_HSCROLL = 0xF080,
+            SC_MOUSEMENU = 0xF090,
+            SC_KEYMENU = 0xF100,
+            SC_ARRANGE = 0xF110,
+            SC_RESTORE = 0xF120,
+            SC_TASKLIST = 0xF130,
+            SC_SCREENSAVE = 0xF140,
+            SC_HOTKEY = 0xF150,
+            SC_DEFAULT = 0xF160,
+            SC_MONITORPOWER = 0xF170,
+            SC_CONTEXTHELP = 0xF180,
+            SC_SEPARATOR = 0xF00F,
+            SCF_ISSECURE = 0x00000001,
+        }
+
         [StructLayout(LayoutKind.Sequential)]
         public struct RGBQUAD
         {

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -123,6 +123,12 @@ namespace Avalonia.Win32
                         break;
                     }
 
+                case WindowsMessage.WM_SYSCOMMAND:
+                    // Disable system handling of Alt/F10 menu keys.
+                    if ((SysCommands)wParam == SysCommands.SC_KEYMENU && HighWord(ToInt32(lParam)) <= 0)
+                        return IntPtr.Zero;
+                    break;
+
                 case WindowsMessage.WM_MENUCHAR:
                     {
                         // mute the system beep


### PR DESCRIPTION
## What does the pull request do?

As described in #6592 win32 was swallowing the subsequent keypress after the Alt/F10 key was pressed. Because we handle opening menus ourselves without the help of the OS, we need to disable the default win32 menu key handling in order to get this keypress.

See https://stackoverflow.com/questions/9627379/how-to-disable-normal-behaviour-of-alt-key/9627980#9627980 for the solution.

## Fixed issues

Fixes #6592.
