### PR TITLE
[X11] Fixed potential freezes/segfaults on window close

### DIFF
--- a/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/DeferredRenderer.cs
@@ -35,6 +35,8 @@ namespace Avalonia.Rendering
         private IRef<IDrawOperation> _currentDraw;
         private readonly IDeferredRendererLock _lock;
         private readonly object _sceneLock = new object();
+        private readonly object _startStopLock = new object();
+        private readonly object _renderLoopIsRenderingLock = new object();
         private readonly Action _updateSceneIfNeededDelegate;
 
         /// <summary>
@@ -139,6 +141,8 @@ namespace Avalonia.Rendering
             }
 
             Stop();
+            // Wait for any in-progress rendering to complete
+            lock(_renderLoopIsRenderingLock){}
             DisposeRenderTarget();
         }
 
@@ -233,20 +237,26 @@ namespace Avalonia.Rendering
         /// <inheritdoc/>
         public void Start()
         {
-            if (!_running && _renderLoop != null)
+            lock (_startStopLock)
             {
-                _renderLoop.Add(this);
-                _running = true;
+                if (!_running && _renderLoop != null)
+                {
+                    _renderLoop.Add(this);
+                    _running = true;
+                }
             }
         }
 
         /// <inheritdoc/>
         public void Stop()
         {
-            if (_running && _renderLoop != null)
+            lock (_startStopLock)
             {
-                _renderLoop.Remove(this);
-                _running = false;
+                if (_running && _renderLoop != null)
+                {
+                    _renderLoop.Remove(this);
+                    _running = false;
+                }
             }
         }
 
@@ -255,7 +265,16 @@ namespace Avalonia.Rendering
 
         void IRenderLoopTask.Update(TimeSpan time) => UpdateScene();
 
-        void IRenderLoopTask.Render() => Render(false);
+        void IRenderLoopTask.Render()
+        {
+            lock (_renderLoopIsRenderingLock)
+            {
+                lock(_startStopLock)
+                    if(!_running)
+                        return;
+                Render(false);
+            }
+        }
 
         /// <inheritdoc/>
         Size IVisualBrushRenderer.GetRenderTargetSize(IVisualBrush brush)

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -805,13 +805,14 @@ namespace Avalonia.X11
             
             if (_handle != IntPtr.Zero)
             {
-                XDestroyWindow(_x11.Display, _handle);
                 _platform.Windows.Remove(_handle);
                 _platform.XI2?.OnWindowDestroyed(_handle);
+                var handle = _handle;
                 _handle = IntPtr.Zero;
                 Closed?.Invoke();
                 _mouse.Dispose();
                 _touch.Dispose();
+                XDestroyWindow(_x11.Display, handle);
             }
             
             if (_useRenderWindow && _renderHandle != IntPtr.Zero)


### PR DESCRIPTION
Some OpenGL drivers act erracticaly when the target window is gone before they finish rendering

Fixes https://github.com/AvaloniaUI/Avalonia/issues/6589