### PR TITLE
Fix opening submenu popup for menus without subitems

### DIFF
--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -303,7 +303,8 @@ namespace Avalonia.Controls.Platform
                 {
                     item.Parent.SelectedItem.Close();
                     SelectItemAndAncestors(item);
-                    Open(item, false);
+                    if (item.HasSubMenu)
+                        Open(item, false);
                 }
                 else
                 {


### PR DESCRIPTION
## What does the pull request do?
See title


## What is the current behavior?
See GIF in #6613



## What is the updated/expected behavior with this PR?
Sub menu popup gets closed and no submenu popup shows up for menu items without subitems.


## How was the solution implemented (if it's not obvious)?
Its obvious

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #6613
