### PR TITLE
Add DesignStyle property

### DIFF
--- a/src/Avalonia.Controls/Design.cs
+++ b/src/Avalonia.Controls/Design.cs
@@ -60,15 +60,15 @@ namespace Avalonia.Controls
             return target.GetValue(PreviewWithProperty);
         }
 
-        public static readonly AttachedProperty<Style> DesignStyleProperty = AvaloniaProperty
-            .RegisterAttached<Control, Style>("DesignStyle", typeof(Design));
+        public static readonly AttachedProperty<IStyle> DesignStyleProperty = AvaloniaProperty
+            .RegisterAttached<Control, IStyle>("DesignStyle", typeof(Design));
 
-        public static void SetDesignStyle(Control control, Style value)
+        public static void SetDesignStyle(Control control, IStyle value)
         {
             control.SetValue(DesignStyleProperty, value);
         }
 
-        public static Style GetDesignStyle(Control control)
+        public static IStyle GetDesignStyle(Control control)
         {
             return control.GetValue(DesignStyleProperty);
         }

--- a/src/Avalonia.Controls/Design.cs
+++ b/src/Avalonia.Controls/Design.cs
@@ -60,6 +60,19 @@ namespace Avalonia.Controls
             return target.GetValue(PreviewWithProperty);
         }
 
+        public static readonly AttachedProperty<Style> DesignStyleProperty = AvaloniaProperty
+            .RegisterAttached<Control, Style>("DesignStyle", typeof(Design));
+
+        public static void SetDesignStyle(Control control, Style value)
+        {
+            control.SetValue(DesignStyleProperty, value);
+        }
+
+        public static Style GetDesignStyle(Control control)
+        {
+            return control.GetValue(DesignStyleProperty);
+        }
+
         public static void ApplyDesignModeProperties(Control target, Control source)
         {
             if (source.IsSet(WidthProperty))
@@ -68,6 +81,8 @@ namespace Avalonia.Controls
                 target.Height = source.GetValue(HeightProperty);
             if (source.IsSet(DataContextProperty))
                 target.DataContext = source.GetValue(DataContextProperty);
+            if (source.IsSet(DesignStyleProperty))
+                target.Styles.Add(source.GetValue(DesignStyleProperty));
         }
     }
 }


### PR DESCRIPTION

## What does the pull request do?
Adds a DesignStyle property which can be used to set a style at design time. This is similar to functionality in WPF (see https://stackoverflow.com/questions/9076419/design-time-only-background-color-in-wpf). Useful when authoring controls that are styled at runtime but you want to apply a style at design time to make working in the XAML editor clearer.

Example usage:
  <Design.DesignStyle>
    <Style Selector="TabControl.sidebar">
      <Setter Property="Background" Value="Red" />
    </Style>
  </Design.DesignStyle>

## What is the updated/expected behavior with this PR?
Applies the specified style at design time, but not at runtime.
