### PR TITLE
FlyoutBase create presenter before calling Opening event

### DIFF
--- a/src/Avalonia.Controls/Flyouts/FlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/FlyoutBase.cs
@@ -215,11 +215,6 @@ namespace Avalonia.Controls.Primitives
                 }
             }
 
-            if (CancelOpening())
-            {
-                return false;
-            }
-
             if (Popup.Parent != null && Popup.Parent != placementTarget)
             {
                 ((ISetLogicalParent)Popup).SetParent(null);
@@ -234,6 +229,11 @@ namespace Avalonia.Controls.Primitives
             if (Popup.Child == null)
             {
                 Popup.Child = CreatePresenter();
+            }
+
+            if (CancelOpening())
+            {
+                return false;
             }
 
             PositionPopup(showAtPointer);


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
In the changes made in 0.10.7 in FlyoutBase, the Opening event was moved to earlier in the ShowCore method, thus CreatePresenter() hasn't been called and will be null on the first attempt to open, throwing a NRE if you try to reference it. This differs from WinUI where the presenter is created and available when the Opening event fires. This PR moves the check for CancelOpening() and calling the Opening event to after CreatePresenter to revert to original behavior. Cancelling the flyout opening will still create the presenter now, but I don't think that's a huge problem.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
