### PR TITLE
Fix Expander HeaderTemplate for Simple Theme

### DIFF
--- a/src/Avalonia.Themes.Default/Expander.xaml
+++ b/src/Avalonia.Themes.Default/Expander.xaml
@@ -101,6 +101,7 @@
                               Grid.Column="1" 
                               Background="Transparent" 
                               Content="{TemplateBinding Content}" 
+                              ContentTemplate="{Binding $parent[Expander].HeaderTemplate}"
                               VerticalAlignment="Center" 
                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"


### PR DESCRIPTION
## What is the current behavior?
If you will set HeaderTemplate for Expander with Simple theme it would be ignored.

## What is the updated/expected behavior with this PR?
It works.

## Fixed issues
closes #4398