### PR TITLE
Used EqualityComparer<T>.Default to check values for equality

### DIFF
--- a/src/Avalonia.Visuals/Media/FormattedText.cs
+++ b/src/Avalonia.Visuals/Media/FormattedText.cs
@@ -200,7 +200,7 @@ namespace Avalonia.Media
 
         private void Set<T>(ref T field, T value)
         {
-            if (field != null && field.Equals(value))
+            if (EqualityComparer<T>.Default.Equals(field, value))
             {
                 return;
             }


### PR DESCRIPTION
The current implementation uses `object.Equals(object)` to check that the current value equals to a new one which makes a box in case of a value type and involves type checks, but using `EqualityComparer<T>.Default` not only removes boxing, but also can allows the call to be deverirtualized.