### PR TITLE
Allow customizing the framebuffer FPS + Respect IRendererFactory

### DIFF
--- a/src/Linux/Avalonia.LinuxFramebuffer/FramebufferToplevelImpl.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/FramebufferToplevelImpl.cs
@@ -30,10 +30,9 @@ namespace Avalonia.LinuxFramebuffer
 
         public IRenderer CreateRenderer(IRenderRoot root)
         {
-            return new DeferredRenderer(root, AvaloniaLocator.Current.GetService<IRenderLoop>())
-            {
-                
-            };
+            var factory = AvaloniaLocator.Current.GetService<IRendererFactory>();
+            var renderLoop = AvaloniaLocator.Current.GetService<IRenderLoop>();
+            return factory?.Create(root, renderLoop) ?? new DeferredRenderer(root, renderLoop);
         }
 
         public void Dispose()
@@ -41,7 +40,7 @@ namespace Avalonia.LinuxFramebuffer
             throw new NotSupportedException();
         }
 
-        
+
         public void Invalidate(Rect rect)
         {
         }

--- a/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
@@ -37,15 +37,17 @@ namespace Avalonia.LinuxFramebuffer
             Threading = new InternalPlatformThreadingInterface();
             if (_fb is IGlOutputBackend gl)
                 AvaloniaLocator.CurrentMutable.Bind<IPlatformOpenGlInterface>().ToConstant(gl.PlatformOpenGlInterface);
+            
+            var opts = AvaloniaLocator.Current.GetService<LinuxFramebufferPlatformOptions>();
+            
             AvaloniaLocator.CurrentMutable
                 .Bind<IPlatformThreadingInterface>().ToConstant(Threading)
-                .Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(60))
+                .Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(opts?.Fps ?? 60))
                 .Bind<IRenderLoop>().ToConstant(new RenderLoop())
                 .Bind<ICursorFactory>().ToTransient<CursorFactoryStub>()
                 .Bind<IKeyboardDevice>().ToConstant(new KeyboardDevice())
                 .Bind<IPlatformSettings>().ToSingleton<PlatformSettings>()
                 .Bind<PlatformHotkeyConfiguration>().ToSingleton<PlatformHotkeyConfiguration>();
-
         }
 
        

--- a/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatformOptions.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatformOptions.cs
@@ -1,0 +1,14 @@
+﻿namespace Avalonia.LinuxFramebuffer
+{
+    /// <summary>
+    /// Platform-specific options which apply to the Linux framebuffer.
+    /// </summary>
+    public class LinuxFramebufferPlatformOptions
+    {
+        /// <summary>
+        /// Gets or sets the number of frames per second at which the renderer should run.
+        /// Default 60.
+        /// </summary>
+        public int Fps { get; set; } = 60;
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Adds a few customization points to Linux Framebuffer backend:

- Respect `IRendererFactory`: if an `IRendererFactory` is registered, use this to supply the renderer; otherwise fall back to the existing `DeferredRenderer`.
- Allow customizing the framebuffer FPS: adds a `LinuxFramebufferPlatformOptions` class that can be used with the existing `.With` AppBuilder pattern to specify the framebuffer frames per second 
