### PR TITLE
Initial support to defer DRM ModeSet

### DIFF
--- a/src/Avalonia.OpenGL/Egl/EglConsts.cs
+++ b/src/Avalonia.OpenGL/Egl/EglConsts.cs
@@ -211,5 +211,7 @@ namespace Avalonia.OpenGL.Egl
         public const int EGL_TEXTURE_OFFSET_Y_ANGLE = 0x3491;
 
         public const int EGL_FLEXIBLE_SURFACE_COMPATIBILITY_SUPPORTED_ANGLE = 0x33A6;
+
+        public const int EGL_PLATFORM_GBM_MESA = 0x31D7;
     }
 }

--- a/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
@@ -138,8 +138,8 @@ public static class LinuxFramebufferPlatformExtensions
         where T : AppBuilderBase<T>, new() =>
         StartLinuxDirect(builder, args, new FbdevOutput(fileName: fbdev, format: format) { Scaling = scaling });
 
-    public static int StartLinuxDrm<T>(this T builder, string[] args, string card = null, double scaling = 1)
-        where T : AppBuilderBase<T>, new() => StartLinuxDirect(builder, args, new DrmOutput(card) {Scaling = scaling});
+    public static int StartLinuxDrm<T>(this T builder, string[] args, string card = null, double scaling = 1, bool deferModeSet = false)
+        where T : AppBuilderBase<T>, new() => StartLinuxDirect(builder, args, new DrmOutput(card, deferModeSet) {Scaling = scaling});
     
     public static int StartLinuxDirect<T>(this T builder, string[] args, IOutputBackend backend)
         where T : AppBuilderBase<T>, new()

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
@@ -235,7 +235,7 @@ namespace Avalonia.LinuxFramebuffer.Output
 
                 private void DoPageFlipOrModeSet(IntPtr nextBo)
                 {
-                    if (_parent._deferedModesetActivator is not null)
+                    if (_parent._deferedModesetActivator != null)
                     {
                         try
                         {


### PR DESCRIPTION
## What does the pull request do?
This will allow applications to defer the actual modeset (drmModeSetCrtc) until the first frame has been generated.


## What is the current behavior?
When starting Avalonia with the DRM backend you'll get a black screen for a few seconds before the UI appear. This happens because the screen is cleared and configured when the output backend is created and on slower hardware result in a blank screen for up to 8 seconds. When using the framebuffer output instead you can leave a splash screen (or some sort of animation) running until the UI is ready.


## What is the updated/expected behavior with this PR?
This will (optionally) wait with the screen blanking until there's actual content to display.


## How was the solution implemented (if it's not obvious)?
If you opt to defer the mode set the output will do the mode set instead of a page flip on your first presentation.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None as this behavior is opt-in with this patch and handled by using argument defaults.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
