### PR TITLE
Fix ICustomDrawOperation HitTest coordinate space.

### DIFF
--- a/src/Avalonia.Visuals/Rendering/SceneGraph/CustomDrawOperation.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/CustomDrawOperation.cs
@@ -17,7 +17,12 @@ namespace Avalonia.Rendering.SceneGraph
 
         public override bool HitTest(Point p)
         {
-            return Custom.HitTest(p * Transform);
+            if (Transform.HasInverse)
+            {
+                return Custom.HitTest(p * Transform.Invert());
+            }
+
+            return false;
         }
 
         public override void Render(IDrawingContextImpl context)


### PR DESCRIPTION
## What does the pull request do?
Fixes the calculation of the point passed to `ICustomDrawOperation.HitTest()` to be local space when the command is submitted, instead of a bogus result.

## What is the current behavior?
The point had the local -> world transformation applied directly, meaning that the actual coordinate was probably bogus.

## What is the updated/expected behavior with this PR?
Inverse matrix is applied instead so the coordinate space is local and matches that of `Render()`.

## Checklist

- [ ] Added unit tests (if possible)? Should I do this?

I tested this by DNSpy-ing the nuget package in my build dir because I couldn't figure out how to set my local repo up with my app. let me know if I should commit a more thorough test into control catalog or something.

