### PR TITLE
Simulate font weight bold and font style italic when a fallback is used

### DIFF
--- a/src/Skia/Avalonia.Skia/FontManagerImpl.cs
+++ b/src/Skia/Avalonia.Skia/FontManagerImpl.cs
@@ -140,7 +140,11 @@ namespace Avalonia.Skia
                     $"Could not create glyph typeface for: {typeface.FontFamily.Name}.");
             }
 
-            return new GlyphTypefaceImpl(skTypeface);
+            var isFakeBold = (int)typeface.Weight >= 600 && !skTypeface.IsBold;
+
+            var isFakeItalic = typeface.Style == FontStyle.Italic && !skTypeface.IsItalic;
+            
+            return new GlyphTypefaceImpl(skTypeface, isFakeBold, isFakeItalic);
         }
     }
 }

--- a/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs
+++ b/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Skia
     {
         private bool _isDisposed;
 
-        public GlyphTypefaceImpl(SKTypeface typeface)
+        public GlyphTypefaceImpl(SKTypeface typeface, bool isFakeBold = false, bool isFakeItalic = false)
         {
             Typeface = typeface ?? throw new ArgumentNullException(nameof(typeface));
 
@@ -52,6 +52,10 @@ namespace Avalonia.Skia
                 0;
 
             IsFixedPitch = Typeface.IsFixedPitch;
+
+            IsFakeBold = isFakeBold;
+
+            IsFakeItalic = isFakeItalic;
         }
 
         public Face Face { get; }
@@ -86,6 +90,10 @@ namespace Avalonia.Skia
 
         /// <inheritdoc cref="IGlyphTypefaceImpl"/>
         public bool IsFixedPitch { get; }
+        
+        public bool IsFakeBold { get; }
+        
+        public bool IsFakeItalic { get; }
 
         /// <inheritdoc cref="IGlyphTypefaceImpl"/>
         public ushort GetGlyph(uint codepoint)

--- a/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
+++ b/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
@@ -217,6 +217,8 @@ namespace Avalonia.Skia
 
             s_font.Size = (float)glyphRun.FontRenderingEmSize;
             s_font.Typeface = typeface;
+            s_font.Embolden = glyphTypeface.IsFakeBold;
+            s_font.SkewX = glyphTypeface.IsFakeItalic ? -0.2f : 0;
 
             SKTextBlob textBlob;
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
It introduces the simulation of bold and italic text when a fallback typeface is used that doesn't support that representation.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
For the font weight we use Skia's capability to simulate bold text and for italic text we apply a text skew if no italic typeface is found.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
