### PR TITLE
Disable WindowManagerAddShadowHint by default

### DIFF
--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Controls.Primitives
     public class Popup : Control, IVisualTreeHost, IPopupHostProvider
     {
         public static readonly StyledProperty<bool> WindowManagerAddShadowHintProperty =
-            AvaloniaProperty.Register<PopupRoot, bool>(nameof(WindowManagerAddShadowHint), true);
+            AvaloniaProperty.Register<PopupRoot, bool>(nameof(WindowManagerAddShadowHint), false);
 
         /// <summary>
         /// Defines the <see cref="Child"/> property.


### PR DESCRIPTION
It makes more sense to be disabled by default.

"False" also matches behavior of non-Windows OS.