### PR TITLE
ItemsRepeater: unsubscribe from ItemsSourceView before disposing it.

### DIFF
--- a/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
+++ b/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
@@ -588,13 +588,13 @@ namespace Avalonia.Controls
                 throw new AvaloniaInternalException("Cannot set ItemsSourceView during layout.");
             }
 
-            ItemsSourceView?.Dispose();
-            ItemsSourceView = newValue;
-
             if (oldValue != null)
             {
                 oldValue.CollectionChanged -= OnItemsSourceViewChanged;
             }
+
+            ItemsSourceView?.Dispose();
+            ItemsSourceView = newValue;
 
             if (newValue != null)
             {

--- a/tests/Avalonia.Controls.UnitTests/ItemsRepeaterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsRepeaterTests.cs
@@ -1,0 +1,24 @@
+using System.Collections.ObjectModel;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests
+{
+    public class ItemsRepeaterTests
+    {
+        [Fact]
+        public void Can_Reassign_Items()
+        {
+            var target = new ItemsRepeater();
+            target.Items = new ObservableCollection<string>();
+            target.Items = new ObservableCollection<string>();
+        }
+
+        [Fact]
+        public void Can_Reassign_Items_To_Null()
+        {
+            var target = new ItemsRepeater();
+            target.Items = new ObservableCollection<string>();
+            target.Items = null;
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

As described by #6729, `ItemsRepeater` was throwing when `Items` was reassigned. This was because we were unsubscribing the `CollectionChanged` handler after disposing the `ItemsSourceView`.

Also added a few unit tests for this problem as we have none for `ItemsRepeater` (as the upstream WinUI implementation doesn't have any).

## Fixed issues

Fixes #6729 