### PR TITLE
Make IBlurHost internal 

### DIFF
--- a/src/Windows/Avalonia.Win32/WinRT/IBlurHost.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/IBlurHost.cs
@@ -7,7 +7,7 @@
         Mica
     }
     
-    public interface IBlurHost
+    internal interface IBlurHost
     {
         void SetBlur(BlurEffect enable);
     }


### PR DESCRIPTION
Its platform implementation so we don't maintain compatibility here so that's not a breaking change. I think it is not needed externally.