### PR TITLE
Add constructor to DrawingImage which accepts Drawing

### DIFF
--- a/src/Avalonia.Visuals/Media/DrawingImage.cs
+++ b/src/Avalonia.Visuals/Media/DrawingImage.cs
@@ -11,6 +11,14 @@ namespace Avalonia.Media
     /// </summary>
     public class DrawingImage : AvaloniaObject, IImage, IAffectsRender
     {
+        public DrawingImage() 
+        { 
+        }
+
+        public DrawingImage(Drawing drawing)
+        {
+            Drawing = drawing;
+        }
         /// <summary>
         /// Defines the <see cref="Drawing"/> property.
         /// </summary>


### PR DESCRIPTION
## What does the pull request do?
This PR updates Avalonia behaviour to match with WPF by adding a constructor to DrawingImage which accepts Drawing.

WPF - https://github.com/dotnet/wpf/blob/main/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/DrawingImage.cs

## Fixed issues
closes #6728
