### PR TITLE
Changed X11 default cursor to XC_left_ptr

### DIFF
--- a/src/Avalonia.X11/X11CursorFactory.cs
+++ b/src/Avalonia.X11/X11CursorFactory.cs
@@ -23,7 +23,7 @@ namespace Avalonia.X11
         private static readonly Dictionary<StandardCursorType, CursorFontShape> s_mapping =
             new Dictionary<StandardCursorType, CursorFontShape>
             {
-                {StandardCursorType.Arrow, CursorFontShape.XC_top_left_arrow},
+                {StandardCursorType.Arrow, CursorFontShape.XC_left_ptr},
                 {StandardCursorType.Cross, CursorFontShape.XC_cross},
                 {StandardCursorType.Hand, CursorFontShape.XC_hand2},
                 {StandardCursorType.Help, CursorFontShape.XC_question_arrow},
@@ -67,7 +67,7 @@ namespace Avalonia.X11
             {
                 handle = s_mapping.TryGetValue(cursorType, out var shape)
                 ? _cursors[shape]
-                : _cursors[CursorFontShape.XC_top_left_arrow];
+                : _cursors[CursorFontShape.XC_left_ptr];
             }
             return new CursorImpl(handle);
         }

--- a/src/Avalonia.X11/X11Info.cs
+++ b/src/Avalonia.X11/X11Info.cs
@@ -42,7 +42,7 @@ namespace Avalonia.X11
             DefaultScreen = XDefaultScreen(display);
             BlackPixel = XBlackPixel(display, DefaultScreen);
             RootWindow = XRootWindow(display, DefaultScreen);
-            DefaultCursor = XCreateFontCursor(display, CursorFontShape.XC_top_left_arrow);
+            DefaultCursor = XCreateFontCursor(display, CursorFontShape.XC_left_ptr);
             DefaultRootWindow = XDefaultRootWindow(display);
             Atoms = new X11Atoms(display);
 


### PR DESCRIPTION
## What does the pull request do?

- Changed X11 default cursor to `XC_left_ptr`. (#6635)

## What is the current behavior?

The default cursor on X11 is not the most correct.

## What is the updated/expected behavior with this PR?

The default cursor on X11 is more correct (same as GTK).

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

Doesn't break binaries, may break expected cursor, but users should expect GTK behavior anyway.
