### PR TITLE
Do not inherit text properties in Popup + do not override default (null) Popup background

### DIFF
--- a/samples/ControlCatalog/Pages/TextBoxPage.xaml
+++ b/samples/ControlCatalog/Pages/TextBoxPage.xaml
@@ -11,7 +11,15 @@
               HorizontalAlignment="Center"
               Spacing="16">
       <StackPanel Orientation="Vertical" Spacing="8">
-        <TextBox Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit." Width="200" />
+        <TextBox Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit." Width="200"
+                 FontFamily="Comic Sans MS"
+                 Foreground="Blue">
+          <TextBox.ContextFlyout>
+            <Flyout>
+              <TextBlock>Custom context flyout</TextBlock>
+            </Flyout>
+          </TextBox.ContextFlyout>        
+        </TextBox>
         <TextBox Width="200" Watermark="ReadOnly" IsReadOnly="True" Text="This is read only"/>
         <TextBox Width="200" Watermark="Numeric Watermark" x:Name="numericWatermark"/>
         <TextBox Width="200"

--- a/src/Avalonia.Themes.Default/OverlayPopupHost.xaml
+++ b/src/Avalonia.Themes.Default/OverlayPopupHost.xaml
@@ -1,5 +1,12 @@
-<Style xmlns="https://github.com/avaloniaui" Selector="OverlayPopupHost">
+<Style xmlns="https://github.com/avaloniaui" 
+       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+       Selector="OverlayPopupHost">
   <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}"/>
+  <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
+  <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}"/>
+  <Setter Property="FontFamily" Value="{x:Static FontFamily.Default}" />
+  <Setter Property="FontWeight" Value="400" />
+  <Setter Property="FontStyle" Value="Normal" />
   <Setter Property="Template">
     <ControlTemplate>
       <Panel>

--- a/src/Avalonia.Themes.Default/OverlayPopupHost.xaml
+++ b/src/Avalonia.Themes.Default/OverlayPopupHost.xaml
@@ -1,7 +1,6 @@
 <Style xmlns="https://github.com/avaloniaui" 
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        Selector="OverlayPopupHost">
-  <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}"/>
   <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
   <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}"/>
   <Setter Property="FontFamily" Value="{x:Static FontFamily.Default}" />

--- a/src/Avalonia.Themes.Default/PopupRoot.xaml
+++ b/src/Avalonia.Themes.Default/PopupRoot.xaml
@@ -1,7 +1,6 @@
 <Style xmlns="https://github.com/avaloniaui"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        Selector="PopupRoot">
-  <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}"/>
   <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
   <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}"/>
   <Setter Property="FontFamily" Value="{x:Static FontFamily.Default}" />

--- a/src/Avalonia.Themes.Default/PopupRoot.xaml
+++ b/src/Avalonia.Themes.Default/PopupRoot.xaml
@@ -1,5 +1,12 @@
-<Style xmlns="https://github.com/avaloniaui" Selector="PopupRoot">
+<Style xmlns="https://github.com/avaloniaui"
+       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+       Selector="PopupRoot">
   <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}"/>
+  <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
+  <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}"/>
+  <Setter Property="FontFamily" Value="{x:Static FontFamily.Default}" />
+  <Setter Property="FontWeight" Value="400" />
+  <Setter Property="FontStyle" Value="Normal" />
   <Setter Property="Template">
     <ControlTemplate>
       <Panel>

--- a/src/Avalonia.Themes.Fluent/Controls/OverlayPopupHost.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/OverlayPopupHost.xaml
@@ -1,5 +1,10 @@
 <Style xmlns="https://github.com/avaloniaui" Selector="OverlayPopupHost">
   <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
+  <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+  <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}"/>
+  <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
+  <Setter Property="FontWeight" Value="400" />
+  <Setter Property="FontStyle" Value="Normal" />
   <Setter Property="Template">
     <ControlTemplate>
       <Panel>

--- a/src/Avalonia.Themes.Fluent/Controls/OverlayPopupHost.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/OverlayPopupHost.xaml
@@ -1,5 +1,4 @@
 <Style xmlns="https://github.com/avaloniaui" Selector="OverlayPopupHost">
-  <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
   <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
   <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}"/>
   <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />

--- a/src/Avalonia.Themes.Fluent/Controls/PopupRoot.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/PopupRoot.xaml
@@ -3,6 +3,11 @@
   <Style Selector="PopupRoot">
     <Setter Property="TransparencyLevelHint" Value="Transparent" />
     <Setter Property="Background" Value="{x:Null}" />
+    <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+    <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}"/>
+    <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
+    <Setter Property="FontWeight" Value="400" />
+    <Setter Property="FontStyle" Value="Normal" />
     <Setter Property="Template">
       <ControlTemplate>
         <Panel>

--- a/src/Avalonia.Themes.Fluent/Controls/PopupRoot.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/PopupRoot.xaml
@@ -2,7 +2,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <Style Selector="PopupRoot">
     <Setter Property="TransparencyLevelHint" Value="Transparent" />
-    <Setter Property="Background" Value="{x:Null}" />
     <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
     <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}"/>
     <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />


### PR DESCRIPTION
## What does the pull request do?
Fixes two Popup bugs:
1. Popup (and all controls using it) inherited text properties from parent controls, which caused unexpected behaviors (see issues below).
2. Popup had white/black background in Overlay mode for both themes.

## Breaking changes
Previously OverlayPopup had white/black background in both Default and Fluent themes, and PopupRoot had white background only on Default and null on Fluent themes. Null is expected default and it's set in the BackgroundProperty (and does not inherit), so we can remove background from the style.

## Fixed issues
Fixes #6568
Fixes #4383
Fixes #5676
Fixes #5373
