### PR TITLE
Fix changing focus with Tab key for Button

### DIFF
--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -358,6 +358,13 @@ namespace Avalonia.Controls
             IsPressed = false;
         }
 
+        protected override void OnLostFocus(RoutedEventArgs e)
+        {
+            base.OnLostFocus(e);
+
+            IsPressed = false;
+        }
+
         protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)
         {
             base.OnPropertyChanged(change);
@@ -375,10 +382,6 @@ namespace Avalonia.Controls
                 {
                     oldFlyout.Hide();
                 }
-            }
-            else if (change.Property == IsFocusedProperty && change.NewValue.GetValueOrDefault<bool>() == false)
-            {
-                IsPressed = false;
             }
         }
 

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -186,7 +186,7 @@ namespace Avalonia.Controls
             set => SetValue(FlyoutProperty, value);
         }
 
-        protected override bool IsEnabledCore => base.IsEnabledCore && _commandCanExecute;
+        protected override bool IsEnabledCore => base.IsEnabledCore && _commandCanExecute; 
 
         /// <inheritdoc/>
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -229,7 +229,7 @@ namespace Avalonia.Controls
             {
                 HotKey = _hotkey;
             }
-
+            
             base.OnAttachedToLogicalTree(e);
 
             if (Command != null)
@@ -277,10 +277,6 @@ namespace Avalonia.Controls
             {
                 // If Flyout doesn't have focusable content, close the flyout here
                 Flyout.Hide();
-            }
-            else if (e.Key == Key.Tab && IsPressed == true)
-            {
-                IsPressed = false;
             }
 
             base.OnKeyDown(e);
@@ -356,7 +352,7 @@ namespace Avalonia.Controls
                 }
             }
         }
-
+        
         protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
         {
             IsPressed = false;

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -278,10 +278,7 @@ namespace Avalonia.Controls
                 // If Flyout doesn't have focusable content, close the flyout here
                 Flyout.Hide();
             }
-            else if (e.Key == Key.Tab && IsPressed == true)
-            {
-                IsPressed = false;
-            }
+
             base.OnKeyDown(e);
         }
 

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -186,7 +186,7 @@ namespace Avalonia.Controls
             set => SetValue(FlyoutProperty, value);
         }
 
-        protected override bool IsEnabledCore => base.IsEnabledCore && _commandCanExecute; 
+        protected override bool IsEnabledCore => base.IsEnabledCore && _commandCanExecute;
 
         /// <inheritdoc/>
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -229,7 +229,7 @@ namespace Avalonia.Controls
             {
                 HotKey = _hotkey;
             }
-            
+
             base.OnAttachedToLogicalTree(e);
 
             if (Command != null)
@@ -277,10 +277,6 @@ namespace Avalonia.Controls
             {
                 // If Flyout doesn't have focusable content, close the flyout here
                 Flyout.Hide();
-            }
-            else if (e.Key == Key.Tab && IsPressed == true)
-            {
-                IsPressed = false;
             }
             base.OnKeyDown(e);
         }
@@ -355,7 +351,7 @@ namespace Avalonia.Controls
                 }
             }
         }
-        
+
         protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
         {
             IsPressed = false;
@@ -378,6 +374,10 @@ namespace Avalonia.Controls
                 {
                     oldFlyout.Hide();
                 }
+            }
+            else if (change.Property == IsFocusedProperty && change.NewValue.GetValueOrDefault<bool>() == false)
+            {
+                IsPressed = false;
             }
         }
 

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -186,7 +186,7 @@ namespace Avalonia.Controls
             set => SetValue(FlyoutProperty, value);
         }
 
-        protected override bool IsEnabledCore => base.IsEnabledCore && _commandCanExecute; 
+        protected override bool IsEnabledCore => base.IsEnabledCore && _commandCanExecute;
 
         /// <inheritdoc/>
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -229,7 +229,7 @@ namespace Avalonia.Controls
             {
                 HotKey = _hotkey;
             }
-            
+
             base.OnAttachedToLogicalTree(e);
 
             if (Command != null)
@@ -277,6 +277,10 @@ namespace Avalonia.Controls
             {
                 // If Flyout doesn't have focusable content, close the flyout here
                 Flyout.Hide();
+            }
+            else if (e.Key == Key.Tab && IsPressed == true)
+            {
+                IsPressed = false;
             }
 
             base.OnKeyDown(e);
@@ -352,7 +356,7 @@ namespace Avalonia.Controls
                 }
             }
         }
-        
+
         protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
         {
             IsPressed = false;

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -278,7 +278,10 @@ namespace Avalonia.Controls
                 // If Flyout doesn't have focusable content, close the flyout here
                 Flyout.Hide();
             }
-
+            else if (e.Key == Key.Tab && IsPressed == true)
+            {
+                IsPressed = false;
+            }
             base.OnKeyDown(e);
         }
 

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -186,7 +186,7 @@ namespace Avalonia.Controls
             set => SetValue(FlyoutProperty, value);
         }
 
-        protected override bool IsEnabledCore => base.IsEnabledCore && _commandCanExecute;
+        protected override bool IsEnabledCore => base.IsEnabledCore && _commandCanExecute; 
 
         /// <inheritdoc/>
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -229,7 +229,7 @@ namespace Avalonia.Controls
             {
                 HotKey = _hotkey;
             }
-
+            
             base.OnAttachedToLogicalTree(e);
 
             if (Command != null)
@@ -277,6 +277,10 @@ namespace Avalonia.Controls
             {
                 // If Flyout doesn't have focusable content, close the flyout here
                 Flyout.Hide();
+            }
+            else if (e.Key == Key.Tab && IsPressed == true)
+            {
+                IsPressed = false;
             }
             base.OnKeyDown(e);
         }
@@ -351,7 +355,7 @@ namespace Avalonia.Controls
                 }
             }
         }
-
+        
         protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
         {
             IsPressed = false;
@@ -374,10 +378,6 @@ namespace Avalonia.Controls
                 {
                     oldFlyout.Hide();
                 }
-            }
-            else if (change.Property == IsFocusedProperty && change.NewValue.GetValueOrDefault<bool>() == false)
-            {
-                IsPressed = false;
             }
         }
 

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -376,6 +376,10 @@ namespace Avalonia.Controls
                     oldFlyout.Hide();
                 }
             }
+            else if (change.Property == IsFocusedProperty && change.NewValue.GetValueOrDefault<bool>() == false)
+            {
+                IsPressed = false;
+            }
         }
 
         protected override void UpdateDataValidation<T>(AvaloniaProperty<T> property, BindingValue<T> value)


### PR DESCRIPTION
## How was the solution implemented (if it's not obvious)?

This is the gif of how Button behaves before fixes:
http://g.recordit.co/fJEMyNmBqb.gif

This is the gif of how Button behaves after fixes:
http://g.recordit.co/TO3nXhqhqD.gif

The current solution matches WPF and UWP behaviour. The pressed state is being re-set on Tab key press, click event is not invoked, flyout is not opened.

## Fixed issues
fixes #6654
