### PR TITLE
Add a property to enable or disable the `PointerWheelEvent` on the `Calendar`-control

### DIFF
--- a/samples/ControlCatalog/Pages/CalendarPage.xaml
+++ b/samples/ControlCatalog/Pages/CalendarPage.xaml
@@ -42,6 +42,23 @@
         <Calendar Name="BlackoutDatesCalendar"
                   SelectionMode="SingleDate" />
       </StackPanel>
+
+      <StackPanel Orientation="Vertical">
+        <TextBlock Text="Pointer Wheel Event"/>
+        
+        <Calendar Name="PointerWheelExample" 
+                  SelectionMode="SingleDate"
+                  SwitchPageOnPointerWheel="False"
+                  PointerWheelChanged="Calendar_PointerWheelChanged"
+                  Margin="0,0,0,8"/>
+
+        <ToggleSwitch  IsChecked="{Binding #PointerWheelExample.SwitchPageOnPointerWheel}"
+                       HorizontalContentAlignment="Stretch"
+                       OnContent="Calendar handles pointer wheel"
+                       OffContent="You can handle the pointer wheel"
+                       MaxWidth="{Binding #PointerWheelExample.Bounds.Width}"/>
+        
+      </StackPanel>
       
     </StackPanel> 
   </StackPanel>

--- a/samples/ControlCatalog/Pages/CalendarPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/CalendarPage.xaml.cs
@@ -1,11 +1,17 @@
 using Avalonia.Controls;
+using Avalonia.Controls.Notifications;
+using Avalonia.Input;
 using Avalonia.Markup.Xaml;
+using Avalonia.VisualTree;
+using ControlCatalog.ViewModels;
 using System;
 
 namespace ControlCatalog.Pages
 {
     public class CalendarPage : UserControl
     {
+        private MainWindowViewModel _viewModel => this.DataContext as MainWindowViewModel;
+
         public CalendarPage()
         {
             this.InitializeComponent();
@@ -23,6 +29,15 @@ namespace ControlCatalog.Pages
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
+        }
+
+        private void Calendar_PointerWheelChanged(object sender, PointerWheelEventArgs e)
+        {
+            _viewModel.ShowNotification(
+                new Notification("Congratulation",
+                $"You have changed the pointer wheel by {e.Delta}",
+                NotificationType.Success,
+                TimeSpan.FromSeconds(2)));
         }
     }
 }

--- a/samples/ControlCatalog/ViewModels/MainWindowViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/MainWindowViewModel.cs
@@ -147,6 +147,11 @@ namespace ControlCatalog.ViewModels
             set { this.RaiseAndSetIfChanged(ref _notificationManager, value); }
         }
 
+        internal void ShowNotification(Avalonia.Controls.Notifications.Notification notification)
+        {
+            NotificationManager.Show(notification);
+        }
+
         public bool IsMenuItemChecked
         {
             get { return _isMenuItemChecked; }

--- a/src/Avalonia.Controls/Calendar/Calendar.cs
+++ b/src/Avalonia.Controls/Calendar/Calendar.cs
@@ -76,6 +76,7 @@ namespace Avalonia.Controls
         None = 3,
     }
 
+
     /// <summary>
     /// Provides data for the
     /// <see cref="E:Avalonia.Controls.Calendar.DisplayDateChanged" />
@@ -1579,13 +1580,14 @@ namespace Avalonia.Controls
 
                 if (!ctrl)
                 {
+                    // If we don't have [CTRL] pressed we want the same effect as if we toggle via the RepeatButtons 
                     if (e.Delta.Y > 0)
                     {
-                        ProcessPageUpKey(false);
+                        OnPreviousClick(); 
                     }
                     else
                     {
-                        ProcessPageDownKey(false);
+                        OnNextClick(); 
                     }
                 }
                 else

--- a/src/Avalonia.Controls/Calendar/Calendar.cs
+++ b/src/Avalonia.Controls/Calendar/Calendar.cs
@@ -953,6 +953,31 @@ namespace Avalonia.Controls
             }
         }
 
+
+
+        /// <summary>
+        /// Defines the <see cref="SwitchPageOnPointerWheel"/> property.
+        /// </summary>
+        public static readonly StyledProperty<bool> SwitchPageOnPointerWheelProperty =
+            AvaloniaProperty.Register<Calendar, bool>(nameof(SwitchPageOnPointerWheel), true);
+
+        /// <summary>
+        /// Gets or sets if the displayed calendar page can be switched via pointer wheel.
+        /// </summary>
+        /// <value>
+        /// A <see cref="bool"/> indicating if the calendar should switch the displayed page on pointer wheel.
+        /// The default is <see langword="true"/>.
+        /// </value>
+        /// <remarks>
+        /// If you want to handle the pointer wheel event on your own set this property to <see langword="false"/>.
+        /// </remarks>
+        public bool SwitchPageOnPointerWheel
+        {
+            get { return GetValue(SwitchPageOnPointerWheelProperty); }
+            set { SetValue(SwitchPageOnPointerWheelProperty, value); }
+        }
+
+
         private static DateTime? SelectedDateMax(Calendar cal)
         {
             DateTime selectedDateMax;
@@ -1574,7 +1599,7 @@ namespace Avalonia.Controls
         protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
         {
             base.OnPointerWheelChanged(e);
-            if (!e.Handled)
+            if (!e.Handled && SwitchPageOnPointerWheel)
             {
                 CalendarExtensions.GetMetaKeyState(e.KeyModifiers, out bool ctrl, out bool shift);
 


### PR DESCRIPTION
## What does the pull request do?
First of all this PR changes the way how the pointer wheel event is handled. Instead of selecting a different date it should only switch the displayed date. This prevents from accidently chaning the `SelectedDate`. Moreover the user can opt out this behavior in order to handle the `PointerWheelChanged-Event` on his own.


## What is the current behavior?
The `SelectedDate` will change if you turn the pointer wheel


## What is the updated/expected behavior with this PR?
Instead of chaning the `SelectedDate` only the `DisplayDate` should change if the pointer wheel was turned. Moreover the user should be able to handle the pointer wheel on his own.


## How was the solution implemented (if it's not obvious)?
- Changed the void `OnPointerWheelChanged` 
- Added a new `StyledProperty` named `SwitchPageOnPointerWheel` 


## Checklist

- [ ] Added unit tests (if possible)? 
- [X] Added XML documentation to any related classes? ► For the new property
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation ► Has to be done after this PR is marked as OK.

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->
- Pointer wheel will behave differntly after this PR is merged

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
None

## Fixed issues
Fixes #6579
