### PR TITLE
Hack to stop VS building everything every time.

### DIFF
--- a/src/tools/MicroComGenerator/Program.cs
+++ b/src/tools/MicroComGenerator/Program.cs
@@ -35,8 +35,16 @@ namespace MicroComGenerator
 
             if (opts.CppOutput != null)
                 File.WriteAllText(opts.CppOutput, CppGen.GenerateCpp(ast));
+            
             if (opts.CSharpOutput != null)
+            {
                 File.WriteAllText(opts.CSharpOutput, new CSharpGen(ast).Generate());
+                
+                // HACK: Can't work out how to get the VS project system's fast up-to-date checks
+                // to ignore the generated code, so as a workaround set the write time to that of
+                // the input.
+                File.SetLastWriteTime(opts.CSharpOutput, File.GetLastWriteTime(opts.Input));
+            }
             
             return 0;
         }


### PR DESCRIPTION
## What does the pull request do?

Building the Avalonia solution in VS resulted in a lots of projects being built every time. This was being caused by the MicroCom generator's output being included in the fast up-to-date check:

```
Input 'D:\projects\AvaloniaUI\Avalonia\src\Windows\Avalonia.Win32\WinRT\WinRT.Generated.cs' (20/10/2021 23:30:53) has been modified since the last up-to-date check (20/10/2021 23:30:44), not up to date. (Avalonia.Win32)
```

I've tried for hours to teach the fast up-to-date check to ignore this file, but with no luck. As a hack suggested by @kekekeks instead just set the modified time of the generated file to match that of the input file. This fixes the unneeded rebuilds for me at least, meaning a MUCH faster dev experience.
