### PR TITLE
Fix Default theme popup backgrounds

### DIFF
--- a/src/Avalonia.Controls/Flyouts/MenuFlyoutPresenter.cs
+++ b/src/Avalonia.Controls/Flyouts/MenuFlyoutPresenter.cs
@@ -8,15 +8,6 @@ namespace Avalonia.Controls
 {
     public class MenuFlyoutPresenter : MenuBase
     {
-        public static readonly StyledProperty<CornerRadius> CornerRadiusProperty =
-            Border.CornerRadiusProperty.AddOwner<FlyoutPresenter>();
-
-        public CornerRadius CornerRadius
-        {
-            get => GetValue(CornerRadiusProperty);
-            set => SetValue(CornerRadiusProperty, value);
-        }
-
         public MenuFlyoutPresenter()
             :base(new DefaultMenuInteractionHandler(true))
         {

--- a/src/Avalonia.Controls/Flyouts/MenuFlyoutPresenter.cs
+++ b/src/Avalonia.Controls/Flyouts/MenuFlyoutPresenter.cs
@@ -8,6 +8,15 @@ namespace Avalonia.Controls
 {
     public class MenuFlyoutPresenter : MenuBase
     {
+        public static readonly StyledProperty<CornerRadius> CornerRadiusProperty =
+            Border.CornerRadiusProperty.AddOwner<FlyoutPresenter>();
+
+        public CornerRadius CornerRadius
+        {
+            get => GetValue(CornerRadiusProperty);
+            set => SetValue(CornerRadiusProperty, value);
+        }
+
         public MenuFlyoutPresenter()
             :base(new DefaultMenuInteractionHandler(true))
         {

--- a/src/Avalonia.Themes.Default/AutoCompleteBox.xaml
+++ b/src/Avalonia.Themes.Default/AutoCompleteBox.xaml
@@ -21,7 +21,8 @@
                  MaxHeight="{TemplateBinding MaxDropDownHeight}"
                  PlacementTarget="{TemplateBinding}"
                  IsLightDismissEnabled="True">
-            <Border BorderBrush="{DynamicResource ThemeBorderMidBrush}"
+            <Border Background="{DynamicResource ThemeBackgroundBrush}"
+                    BorderBrush="{DynamicResource ThemeBorderMidBrush}"
                     BorderThickness="1">
               <ListBox Name="PART_SelectingItemsControl"
                        BorderThickness="0"

--- a/src/Avalonia.Themes.Default/ComboBox.xaml
+++ b/src/Avalonia.Themes.Default/ComboBox.xaml
@@ -69,7 +69,8 @@
                    MaxHeight="{TemplateBinding MaxDropDownHeight}"
                    PlacementTarget="{TemplateBinding}"
                    IsLightDismissEnabled="True">
-              <Border BorderBrush="{DynamicResource ThemeBorderMidBrush}"
+              <Border Background="{DynamicResource ThemeBackgroundBrush}"
+                      BorderBrush="{DynamicResource ThemeBorderMidBrush}"                      
                       BorderThickness="1">
                 <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                               VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">

--- a/src/Avalonia.Themes.Default/ContextMenu.xaml
+++ b/src/Avalonia.Themes.Default/ContextMenu.xaml
@@ -1,4 +1,5 @@
 <Style xmlns="https://github.com/avaloniaui" Selector="ContextMenu">
+    <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}"/>
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}"/>
     <Setter Property="BorderThickness" Value="1"/>
     <Setter Property="Padding" Value="4,2"/>

--- a/src/Avalonia.Themes.Default/FlyoutPresenter.xaml
+++ b/src/Avalonia.Themes.Default/FlyoutPresenter.xaml
@@ -2,7 +2,7 @@
   <Style Selector="FlyoutPresenter">
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
     <Setter Property="VerticalContentAlignment" Value="Stretch" />
-    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}"/>
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}" />
     <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Padding" Value="4" />

--- a/src/Avalonia.Themes.Default/MenuFlyoutPresenter.xaml
+++ b/src/Avalonia.Themes.Default/MenuFlyoutPresenter.xaml
@@ -1,6 +1,6 @@
 <Styles xmlns="https://github.com/avaloniaui">
   <Style Selector="MenuFlyoutPresenter">
-    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}"/>
     <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}" />
     <Setter Property="BorderThickness" Value="1" />
     <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />

--- a/src/Avalonia.Themes.Default/MenuItem.xaml
+++ b/src/Avalonia.Themes.Default/MenuItem.xaml
@@ -62,7 +62,7 @@
                    PlacementMode="Right"
                    IsLightDismissEnabled="False"
                    IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}">
-              <Border Background="{TemplateBinding Background}"
+              <Border Background="{DynamicResource ThemeBackgroundBrush}"
                       BorderBrush="{DynamicResource ThemeBorderMidBrush}"
                       BorderThickness="{TemplateBinding BorderThickness}">
                 <ScrollViewer Classes="menuscroller">                  
@@ -113,7 +113,7 @@
                    IsLightDismissEnabled="True"
                    OverlayInputPassThroughElement="{Binding $parent[Menu]}"
                    IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}">
-              <Border Background="{TemplateBinding Background}"
+              <Border Background="{DynamicResource ThemeBackgroundBrush}"
                       BorderBrush="{DynamicResource ThemeBorderMidBrush}"
                       BorderThickness="{TemplateBinding BorderThickness}">
                 <ScrollViewer Classes="menuscroller">

--- a/src/Avalonia.Themes.Default/OverlayPopupHost.xaml
+++ b/src/Avalonia.Themes.Default/OverlayPopupHost.xaml
@@ -1,13 +1,14 @@
 <Style xmlns="https://github.com/avaloniaui" 
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        Selector="OverlayPopupHost">
-  <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
-  <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}"/>
+  <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
+  <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}" />
   <Setter Property="FontFamily" Value="{x:Static FontFamily.Default}" />
   <Setter Property="FontWeight" Value="400" />
   <Setter Property="FontStyle" Value="Normal" />
   <Setter Property="Template">
     <ControlTemplate>
+      <!--  Do not forget to update Templated_Control_With_Popup_In_Template_Should_Set_TemplatedParent test  -->
       <VisualLayerManager IsPopup="True">
         <ContentPresenter Name="PART_ContentPresenter"
                           Background="{TemplateBinding Background}"

--- a/src/Avalonia.Themes.Default/OverlayPopupHost.xaml
+++ b/src/Avalonia.Themes.Default/OverlayPopupHost.xaml
@@ -8,16 +8,13 @@
   <Setter Property="FontStyle" Value="Normal" />
   <Setter Property="Template">
     <ControlTemplate>
-      <Panel>
-        <Border Name="PART_TransparencyFallback" IsHitTestVisible="False" />
-        <VisualLayerManager IsPopup="True">
-          <ContentPresenter Name="PART_ContentPresenter"
-                            Background="{TemplateBinding Background}"
-                            ContentTemplate="{TemplateBinding ContentTemplate}"
-                            Content="{TemplateBinding Content}"
-                            Padding="{TemplateBinding Padding}"/>
-        </VisualLayerManager>
-      </Panel>
+      <VisualLayerManager IsPopup="True">
+        <ContentPresenter Name="PART_ContentPresenter"
+                          Background="{TemplateBinding Background}"
+                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                          Content="{TemplateBinding Content}"
+                          Padding="{TemplateBinding Padding}"/>
+      </VisualLayerManager>
     </ControlTemplate>
   </Setter>
 </Style>

--- a/src/Avalonia.Themes.Default/PopupRoot.xaml
+++ b/src/Avalonia.Themes.Default/PopupRoot.xaml
@@ -1,6 +1,7 @@
 <Style xmlns="https://github.com/avaloniaui"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        Selector="PopupRoot">
+  <Setter Property="Background" Value="Transparent"/>
   <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
   <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}"/>
   <Setter Property="FontFamily" Value="{x:Static FontFamily.Default}" />

--- a/src/Avalonia.Themes.Default/PopupRoot.xaml
+++ b/src/Avalonia.Themes.Default/PopupRoot.xaml
@@ -2,6 +2,7 @@
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        Selector="PopupRoot">
   <Setter Property="Background" Value="Transparent"/>
+  <Setter Property="TransparencyLevelHint" Value="Transparent" />
   <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
   <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}"/>
   <Setter Property="FontFamily" Value="{x:Static FontFamily.Default}" />

--- a/src/Avalonia.Themes.Default/PopupRoot.xaml
+++ b/src/Avalonia.Themes.Default/PopupRoot.xaml
@@ -1,7 +1,7 @@
 <Style xmlns="https://github.com/avaloniaui"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        Selector="PopupRoot">
-  <Setter Property="Background" Value="Transparent"/>
+  <Setter Property="Background" Value="{x:Null}"/>
   <Setter Property="TransparencyLevelHint" Value="Transparent" />
   <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
   <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}"/>

--- a/src/Avalonia.Themes.Fluent/Controls/OverlayPopupHost.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/OverlayPopupHost.xaml
@@ -6,16 +6,13 @@
   <Setter Property="FontStyle" Value="Normal" />
   <Setter Property="Template">
     <ControlTemplate>
-      <Panel>
-        <Border Name="PART_TransparencyFallback" IsHitTestVisible="False" />
-        <VisualLayerManager IsPopup="True">
-          <ContentPresenter Name="PART_ContentPresenter"
-                            Background="{TemplateBinding Background}"
-                            ContentTemplate="{TemplateBinding ContentTemplate}"
-                            Content="{TemplateBinding Content}"
-                            Padding="{TemplateBinding Padding}"/>
-        </VisualLayerManager>
-      </Panel>
+      <VisualLayerManager IsPopup="True">
+        <ContentPresenter Name="PART_ContentPresenter"
+                          Background="{TemplateBinding Background}"
+                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                          Content="{TemplateBinding Content}"
+                          Padding="{TemplateBinding Padding}"/>
+      </VisualLayerManager>
     </ControlTemplate>
   </Setter>
 </Style>

--- a/src/Avalonia.Themes.Fluent/Controls/PopupRoot.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/PopupRoot.xaml
@@ -1,6 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <Style Selector="PopupRoot">
+    <Setter Property="Background" Value="Transparent"/>
     <Setter Property="TransparencyLevelHint" Value="Transparent" />
     <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
     <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}"/>

--- a/src/Avalonia.Themes.Fluent/Controls/PopupRoot.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/PopupRoot.xaml
@@ -1,7 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <Style Selector="PopupRoot">
-    <Setter Property="Background" Value="Transparent"/>
+    <Setter Property="Background" Value="{x:Null}"/>
     <Setter Property="TransparencyLevelHint" Value="Transparent" />
     <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
     <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}"/>

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -294,6 +294,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
         [Fact]
         public void Templated_Control_With_Popup_In_Template_Should_Set_TemplatedParent()
         {
+            // Test uses OverlayPopupHost default template
             using (CreateServices())
             {
                 PopupContentControl target;
@@ -316,33 +317,63 @@ namespace Avalonia.Controls.UnitTests.Primitives
                 var children = popupRoot.GetVisualDescendants().ToList();
                 var types = children.Select(x => x.GetType().Name).ToList();
 
-                Assert.Equal(
-                    new[]
-                    {
-                        "Panel",
-                        "Border",
-                        "VisualLayerManager",
-                        "ContentPresenter",
-                        "ContentPresenter",
-                        "Border",
-                    },
-                    types);
+                if (UsePopupHost)
+                {
+                    Assert.Equal(
+                        new[]
+                        {
+                            "VisualLayerManager",
+                            "ContentPresenter",
+                            "ContentPresenter",
+                            "Border",
+                        },
+                        types);
+                }
+                else
+                {
+                    Assert.Equal(
+                        new[]
+                        {
+                            "Panel",
+                            "Border",
+                            "VisualLayerManager",
+                            "ContentPresenter",
+                            "ContentPresenter",
+                            "Border",
+                        },
+                        types);
+                }
 
                 var templatedParents = children
                     .OfType<IControl>()
                     .Select(x => x.TemplatedParent).ToList();
 
-                Assert.Equal(
-                    new object[]
-                    {
-                        popupRoot,
-                        popupRoot,
-                        popupRoot,
-                        popupRoot,
-                        target,
-                        null,
-                    },
-                    templatedParents);
+                if (UsePopupHost)
+                {
+                    Assert.Equal(
+                        new object[]
+                        {
+                            popupRoot,
+                            popupRoot,
+                            target,
+                            null,
+                        },
+                        templatedParents);
+                }
+                else
+                {
+                    Assert.Equal(
+                        new object[]
+                        {
+                            popupRoot,
+                            popupRoot,
+                            popupRoot,
+                            popupRoot,
+                            target,
+                            null,
+                        },
+                        templatedParents);
+                }
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
Continues previous PR https://github.com/AvaloniaUI/Avalonia/pull/6749, fixes couple of regressions (not yet released), fixes old bugs

## What is the current behavior?

Majority of popup controls have transparent background. They rely on transparency fallback color of popup and popup default background (white). It's not easy to make transparent popup, doesn't match Fluent theme, **makes popup control completely transparent if hosted outside of popup** (TrayIcon).


## What is the updated/expected behavior with this PR?

Popups are always transparent by default. Popup controls have preferred background (white or gray depending on theme).


## Fixed issues
Fixes #6788
