### PR TITLE
Fix GenerateAvaloniaResourcesDependencyCache target

### DIFF
--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -54,6 +54,7 @@
       <Output TaskParameter="HashResult" PropertyName="AvaloniaResourcesDependencyHash" />
     </Hash>
 
+    <MakeDir Directories="$(IntermediateOutputPath)/Avalonia" />
     <WriteLinesToFile Overwrite="true" File="$(IntermediateOutputPath)/Avalonia/Resources.Inputs.cache" Lines="$(AvaloniaResourcesDependencyHash)" WriteOnlyWhenDifferent="True" />
   </Target>
   


### PR DESCRIPTION
## What does the pull request do?
Sometimes this target is executed even before we create the Avalonia folder in code so we needed to add this code.
The user that originally told us about this issue already confirmed that fix works for him.Original conversation:
https://github.com/AvaloniaUI/Avalonia/pull/6569



