### PR TITLE
Update context menu popup parameters on each show.

### DIFF
--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -329,16 +329,8 @@ namespace Avalonia.Controls
             {
                 _popup = new Popup
                 {
-                    HorizontalOffset = HorizontalOffset,
-                    VerticalOffset = VerticalOffset,
-                    PlacementAnchor = PlacementAnchor,
-                    PlacementConstraintAdjustment = PlacementConstraintAdjustment,
-                    PlacementGravity = PlacementGravity,
-                    PlacementMode = PlacementMode,
-                    PlacementRect = PlacementRect,
                     IsLightDismissEnabled = true,
                     OverlayDismissEventPassThrough = true,
-                    WindowManagerAddShadowHint = WindowManagerAddShadowHint,
                 };
 
                 _popup.Opened += PopupOpened;
@@ -358,6 +350,13 @@ namespace Avalonia.Controls
                 : PlacementMode;
 
             _popup.PlacementTarget = placementTarget;
+            _popup.HorizontalOffset = HorizontalOffset;
+            _popup.VerticalOffset = VerticalOffset;
+            _popup.PlacementAnchor = PlacementAnchor;
+            _popup.PlacementConstraintAdjustment = PlacementConstraintAdjustment;
+            _popup.PlacementGravity = PlacementGravity;
+            _popup.PlacementRect = PlacementRect;
+            _popup.WindowManagerAddShadowHint = WindowManagerAddShadowHint;
             _popup.Child = this;
             IsOpen = true;
             _popup.IsOpen = true;


### PR DESCRIPTION
`ContextMenu` hosts a bunch of properties which are passed to the internal popup used to show the menu, however these properties were only being written on popup creation meaning that the state was frozen at the state for the first show.

This PR makes these properties be written each time the context menu is shown.

## Fixed issues

Fixes #6795
