### PR TITLE
Added lost focus-within to pseudo classes attribute

### DIFF
--- a/src/Avalonia.Input/InputElement.cs
+++ b/src/Avalonia.Input/InputElement.cs
@@ -16,7 +16,7 @@ namespace Avalonia.Input
     /// <summary>
     /// Implements input-related functionality for a control.
     /// </summary>
-    [PseudoClasses(":disabled", ":focus", ":focus-visible", ":pointerover")]
+    [PseudoClasses(":disabled", ":focus", ":focus-visible", ":focus-within", ":pointerover")]
     public class InputElement : Interactive, IInputElement
     {
         /// <summary>


### PR DESCRIPTION
## What does the pull request do?

The pull request just adds `:focus-within` to a list of pseudo classes set by `InputElement`.