### PR TITLE
ElementManager follows the behavior of ViewManager

### DIFF
--- a/src/Avalonia.Layout/ElementManager.cs
+++ b/src/Avalonia.Layout/ElementManager.cs
@@ -314,12 +314,11 @@ namespace Avalonia.Layout
                         }
                         break;
 
+                    // Remove clear all realized elements just to align the begavior
+                    // with ViewManager which resets realized item indices to defaults.
+                    // Freeing only removed items causes wrong indices to be stored
+                    // in virtualized info of items under some circumstances.
                     case NotifyCollectionChangedAction.Remove:
-                        {
-                            OnItemsRemoved(args.OldStartingIndex, args.OldItems.Count);
-                        }
-                        break;
-
                     case NotifyCollectionChangedAction.Reset:
                         ClearRealizedRange();
                         break;


### PR DESCRIPTION
## What does the pull request do?

This PR fixes a bug which can be caused by a `Remove` event from the source collection which leads to storing wrong indices in virtualized item infos.

## What is the current behavior?

Under some circumanstances virtualized info starts to carry wrong item indices. This happens because `ElementManager` keeps realized items cached while `ViewManager` resets realized item indices when an item is removed:

https://github.com/AvaloniaUI/Avalonia/blob/9eb18b26c4e051a9ede1304bc7f08b0bdf7bd714/src/Avalonia.Layout/ElementManager.cs#L319

https://github.com/AvaloniaUI/Avalonia/blob/9eb18b26c4e051a9ede1304bc7f08b0bdf7bd714/src/Avalonia.Controls/Repeater/ViewManager.cs#L411

## What is the updated/expected behavior with this PR?

`ElementManager` realizes all elements, and therefore, `GetAt` won't return cached elements at all since the realized range is unknown at the moment:

https://github.com/AvaloniaUI/Avalonia/blob/9eb18b26c4e051a9ede1304bc7f08b0bdf7bd714/src/Avalonia.Layout/ElementManager.cs#L78