### PR TITLE
[OSX] allow child windows to be shown on top of fullscreen windows.

### DIFF
--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -207,7 +207,8 @@ public:
                 Window = nullptr;
                 
                 try{
-                [window close];
+                    // Seems to throw sometimes on application exit.
+                    [window close];
                 }
                 catch(NSException*){}
             }

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -206,7 +206,10 @@ public:
                 auto window = Window;
                 Window = nullptr;
                 
+                try{
                 [window close];
+                }
+                catch(NSException*){}
             }
             
             return S_OK;
@@ -724,6 +727,7 @@ private:
             if (cparent->WindowState() == Minimized)
                 cparent->SetWindowState(Normal);
             
+            [Window setCollectionBehavior:NSWindowCollectionBehaviorFullScreenAuxiliary];
             [cparent->Window addChildWindow:Window ordered:NSWindowAbove];
             
             UpdateStyle();


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
uses NSWindowCollectionBehaviorFullScreenAuxiliary for dialogs.

https://developer.apple.com/documentation/appkit/nswindowcollectionbehavior/nswindowcollectionbehaviorfullscreenauxiliary



## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Bundled apps when in fullscreen will not allow dialogs to be shown correctly.



## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Dialogs shown as expected

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
closes #6866
