### PR TITLE
Setting weak reference target instead of field

### DIFF
--- a/src/Avalonia.Input/Gestures.cs
+++ b/src/Avalonia.Input/Gestures.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Input
                 "ScrollGestureEnded", RoutingStrategies.Bubble, typeof(Gestures));
 
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-        private static WeakReference<IInteractive> s_lastPress = new WeakReference<IInteractive>(null);
+        private static readonly WeakReference<IInteractive> s_lastPress = new WeakReference<IInteractive>(null);
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
         static Gestures()
@@ -86,16 +86,15 @@ namespace Avalonia.Input
 #pragma warning restore CS0618 // Type or member is obsolete
                 if (clickCount <= 1)
                 {
-                    s_lastPress = new WeakReference<IInteractive>(ev.Source);
+                    s_lastPress.SetTarget(ev.Source);
                 }
-                else if (s_lastPress != null && clickCount == 2 && e.GetCurrentPoint(visual).Properties.IsLeftButtonPressed)
+                else if (clickCount == 2 && e.GetCurrentPoint(visual).Properties.IsLeftButtonPressed)
                 {
                     if (s_lastPress.TryGetTarget(out var target) && target == e.Source)
                     {
                         e.Source.RaiseEvent(new TappedEventArgs(DoubleTappedEvent, e));
                     }
                 }
-
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

Reduces memory allocations by changing the target of a weak reference used to keep the last pointer pressed source.

## What is the current behavior?

Allocate a new weak reference each time pointer pressed happens.

## What is the updated/expected behavior with this PR?

Making the field keeping a weak reference to be `readonly` and set the target instead.