### PR TITLE
Don't update TransformedBounds from RenderTargetBitmap.

### DIFF
--- a/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
@@ -20,6 +20,7 @@ namespace Avalonia.Rendering
     {
         private readonly IVisual _root;
         private readonly IRenderRoot _renderRoot;
+        private bool _updateTransformedBounds = true;
         private IRenderTarget _renderTarget;
 
         /// <summary>
@@ -32,6 +33,13 @@ namespace Avalonia.Rendering
 
             _root = root;
             _renderRoot = root as IRenderRoot;
+        }
+
+        private ImmediateRenderer(IVisual root, bool updateTransformedBounds)
+        {
+            _root = root ?? throw new ArgumentNullException(nameof(root));
+            _renderRoot = root as IRenderRoot;
+            _updateTransformedBounds = updateTransformedBounds;
         }
 
         /// <inheritdoc/>
@@ -98,7 +106,7 @@ namespace Avalonia.Rendering
         /// <param name="target">The render target.</param>
         public static void Render(IVisual visual, IRenderTarget target)
         {
-            using (var renderer = new ImmediateRenderer(visual))
+            using (var renderer = new ImmediateRenderer(visual, updateTransformedBounds: false))
             using (var context = new DrawingContext(target.CreateDrawingContext(renderer)))
             {
                 renderer.Render(context, visual, visual.Bounds);
@@ -112,7 +120,7 @@ namespace Avalonia.Rendering
         /// <param name="context">The drawing context.</param>
         public static void Render(IVisual visual, DrawingContext context)
         {
-            using (var renderer = new ImmediateRenderer(visual))
+            using (var renderer = new ImmediateRenderer(visual, updateTransformedBounds: false))
             {
                 renderer.Render(context, visual, visual.Bounds);
             }
@@ -191,6 +199,12 @@ namespace Avalonia.Rendering
         {
             var visual = brush.Visual;
             Render(new DrawingContext(context), visual, visual.Bounds);
+        }
+
+        internal static void Render(IVisual visual, DrawingContext context, bool updateTransformedBounds)
+        {
+            using var renderer = new ImmediateRenderer(visual, updateTransformedBounds);
+            renderer.Render(context, visual, visual.Bounds);
         }
 
         private static void ClearTransformedBounds(IVisual visual)
@@ -308,7 +322,8 @@ namespace Avalonia.Rendering
                         new TransformedBounds(bounds, new Rect(), context.CurrentContainerTransform);
 #pragma warning restore 0618
 
-                    visual.TransformedBounds = transformed;
+                    if (_updateTransformedBounds)
+                        visual.TransformedBounds = transformed;
 
                     foreach (var child in visual.VisualChildren.OrderBy(x => x, ZIndexComparer.Instance))
                     {
@@ -321,7 +336,7 @@ namespace Avalonia.Rendering
                                 : clipRect;
                             Render(context, child, childClipRect);
                         }
-                        else
+                        else if (_updateTransformedBounds)
                         {
                             ClearTransformedBounds(child);
                         }
@@ -329,7 +344,7 @@ namespace Avalonia.Rendering
                 }
             }
 
-            if (!visual.IsVisible)
+            if (!visual.IsVisible && _updateTransformedBounds)
             {
                 ClearTransformedBounds(visual);
             }

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/ImmediateRendererTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/ImmediateRendererTests.cs
@@ -291,6 +291,24 @@ namespace Avalonia.Visuals.UnitTests.Rendering
             }
         }
 
+        [Fact]
+        public void Static_Render_Method_Does_Not_Update_TransformedBounds()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var target = new Border();
+                var expected = new TransformedBounds(new Rect(1, 2, 3, 4), new Rect(4, 5, 6, 7), Matrix.CreateRotation(0.8));
+
+                ((IVisual)target).TransformedBounds = expected;
+
+                var renderTarget = Mock.Of<IRenderTarget>(x => 
+                    x.CreateDrawingContext(It.IsAny<IVisualBrushRenderer>()) == Mock.Of<IDrawingContextImpl>());
+                ImmediateRenderer.Render(target, renderTarget);
+
+                Assert.Equal(expected, target.TransformedBounds);
+            }
+        }
+
         private class TestControl : Control
         {
             public bool Rendered { get; private set; }

--- a/tests/Avalonia.Visuals.UnitTests/VisualTree/TransformedBoundsTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/VisualTree/TransformedBoundsTests.cs
@@ -40,7 +40,7 @@ namespace Avalonia.Visuals.UnitTests.VisualTree
 
                 tree.Measure(Size.Infinity);
                 tree.Arrange(new Rect(0, 0, 100, 100));
-                ImmediateRenderer.Render(tree, context);
+                ImmediateRenderer.Render(tree, context, true);
 
                 var track = control.GetObservable(Visual.TransformedBoundsProperty);
                 var results = new List<TransformedBounds?>();


### PR DESCRIPTION
## What does the pull request do?

Prevents drawing to a `RenderTargetBitmap` corrupting `TransformedBounds` as described in #6899.

Adds a flag to `ImmediateRenderer` for whether to update `TransformedBounds` and sets it to false when calling any of the static `ImmediateRenderer.Render` methods (which is what RTB uses). An `ImmediateRenderer` which is used as the main renderer (i.e. constructed via the public constructor) retains the previous behavior.

## Fixed issues

Fixes #6899 