### PR TITLE
Use event args to get value instead of field

### DIFF
--- a/src/Avalonia.Input/InputElement.cs
+++ b/src/Avalonia.Input/InputElement.cs
@@ -632,7 +632,7 @@ namespace Avalonia.Input
             }
             else if (change.Property == IsKeyboardFocusWithinProperty)
             {
-                PseudoClasses.Set(":focus-within", _isKeyboardFocusWithin);
+                PseudoClasses.Set(":focus-within", change.NewValue.GetValueOrDefault<bool>());
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

The more correct way to get a new property value is to use the received event args instead of a backing field. `IsKeyboardFocusWithinProperty` handling used the last approach previously, but now it's aligned with the rest of the code. No behavior changes.