### PR TITLE
Don't multi-target MicroComGenerator.

### DIFF
--- a/nukebuild/_build.csproj
+++ b/nukebuild/_build.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="JetBrains.dotMemoryUnit" Version="3.0.20171219.105559" />
     <PackageReference Include="vswhere" Version="2.6.7" Condition=" '$(OS)' == 'Windows_NT' " />
     <PackageReference Include="ILRepack.NETStandard" Version="2.0.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" />
     <!-- Keep in sync with Avalonia.Build.Tasks -->
     <PackageReference Include="Mono.Cecil" Version="0.11.2" />
   </ItemGroup>
@@ -36,10 +37,10 @@
     <None Include="..\GitVersion.yml" Condition="Exists('..\GitVersion.yml')" />
     <Compile Remove="Numerge/**/*.*" />
     <Compile Include="Numerge/Numerge/**/*.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\src\tools\MicroComGenerator\MicroComGenerator.csproj" />
+    <Compile Include="..\src\tools\MicroComGenerator\**\*.cs" Exclude="..\src\tools\MicroComGenerator\obj\**">
+      <Link>MicroComGenerator\%(Filename)%(Extension)</Link>
+    </Compile>
+    <Compile Remove="..\src\tools\MicroComGenerator\Program.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/tools/MicroComGenerator/MicroComGenerator.csproj
+++ b/src/tools/MicroComGenerator/MicroComGenerator.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" />


### PR DESCRIPTION
## What does the pull request do?

#6902 changed `MicroComGenerator` to be multi-targeted which was causing problems building in VS. When building a `<ProjectReference>` with `ReferenceOutputAssembly == false` the project was getting built with no target framework, causing:

```
error MSB4057: The target "GetTargetPath" does not exist in the project.
```

Instead single-target `MicroComGenerator` to `net6.0` and include the source files directly into `_build.csproj` (which can't yet be converted to `net6.0`).