### PR TITLE
Fix TrayIcon commands executes twice

### DIFF
--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -387,7 +387,7 @@ namespace Avalonia.Controls
                 parent = parent.Parent;
             }
 
-            _isEmbeddedInMenu = parent is IMenu;
+            _isEmbeddedInMenu = parent.FindLogicalAncestorOfType<IMenu>(true) != null;
         }
 
         protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)


### PR DESCRIPTION
I tried adding tests, but it seems to be impossible,I need to simulate clicks, but nativemenuitems on win gets replaced by menuitems..its complete mystery for me
The idea behind this fix - if any of the parents of menuitem is Menu then menuitem is embedded in the menu.
## Fixed issues
closes #6713
