### PR TITLE
Only raise non-client click when outside view client area.

### DIFF
--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -2398,11 +2398,18 @@ NSArray* AllLoopModes = [NSArray arrayWithObjects: NSDefaultRunLoopMode, NSEvent
         {
             case NSEventTypeLeftMouseDown:
             {
-                auto avnPoint = [AvnView toAvnPoint:[event locationInWindow]];
-                auto point = [self translateLocalPoint:avnPoint];
-                AvnVector delta;
+                AvnView* view = _parent->View;
+                NSPoint windowPoint = [event locationInWindow];
+                NSPoint viewPoint = [view convertPoint:windowPoint fromView:nil];
                 
-                _parent->BaseEvents->RawMouseEvent(NonClientLeftButtonDown, [event timestamp] * 1000, AvnInputModifiersNone, point, delta);
+                if (!NSPointInRect(viewPoint, view.bounds))
+                {
+                    auto avnPoint = [AvnView toAvnPoint:windowPoint];
+                    auto point = [self translateLocalPoint:avnPoint];
+                    AvnVector delta;
+                   
+                    _parent->BaseEvents->RawMouseEvent(NonClientLeftButtonDown, [event timestamp] * 1000, AvnInputModifiersNone, point, delta);
+                }
             }
             break;
                 


### PR DESCRIPTION
## What does the pull request do?

#6700 implemented non-client click support for macOS but it caused non-client clicks to get sent even for clicks on the client area, causing #6827. Fix this by checking that the click is outside the view's bounds before raising the non-client click.

## Fixed issues

Fixes #6827 