### PR TITLE
Fixed missing XA_WM_NAME remove on empty window Title

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -1026,6 +1026,7 @@ namespace Avalonia.X11
             if (string.IsNullOrEmpty(title))
             {
                 XDeleteProperty(_x11.Display, _handle, _x11.Atoms._NET_WM_NAME);
+                XDeleteProperty(_x11.Display, _handle, _x11.Atoms.XA_WM_NAME);
             }
             else
             {


### PR DESCRIPTION
## What does the pull request do?
Adds removing XA_WM_NAME property when setting empty title

## What is the current behavior?
XA_WM_NAME is not removed when title is empty, leading to broken window title on Linux

```csharp
Title = "Тест";
Title = null;
```
leads to 

![image](https://user-images.githubusercontent.com/10960735/141826811-5385f731-414d-40fb-b94e-be43abde0a4c.png)

## What is the updated/expected behavior with this PR?
Empty window title is displayed
