### PR TITLE
Investigation of animation system failure issue #6969

### DIFF
--- a/src/Avalonia.Animation/Animators/Animator`1.cs
+++ b/src/Avalonia.Animation/Animators/Animator`1.cs
@@ -79,15 +79,15 @@ namespace Avalonia.Animation.Animators
 
             T oldValue, newValue;
 
-            if (firstKeyframe.isNeutral)
+            if (!firstKeyframe.isNeutral && firstKeyframe.Value is T firstKeyframeValue)
+                oldValue = firstKeyframeValue;
+            else
                 oldValue = neutralValue;
-            else
-                oldValue = (T)firstKeyframe.Value;
 
-            if (lastKeyframe.isNeutral)
-                newValue = neutralValue;
+            if (!lastKeyframe.isNeutral && lastKeyframe.Value is T lastKeyframeValue)
+                newValue = lastKeyframeValue;
             else
-                newValue = (T)lastKeyframe.Value;
+                newValue = neutralValue;
 
             if (lastKeyframe.KeySpline != null)
                 progress = lastKeyframe.KeySpline.GetSplineProgress(progress);

--- a/tests/Avalonia.Animation.UnitTests/AnimatableTests.cs
+++ b/tests/Avalonia.Animation.UnitTests/AnimatableTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using Avalonia.Animation.Animators;
 using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
 using Avalonia.Data;
 using Avalonia.Layout;
 using Avalonia.Media;
@@ -98,6 +100,71 @@ namespace Avalonia.Animation.UnitTests
                 1.0,
                 0.5),
                 Times.Never);
+        }
+
+
+        [Theory]
+        [InlineData(null)] //null value
+        [InlineData("stringValue")] //string value
+        public void Invalid_Values_In_Animation_Should_Not_Crash_Animations(object invalidValue)
+        {
+            var keyframe1 = new KeyFrame()
+            {
+                Setters =
+                {
+                    new Setter(Layoutable.WidthProperty, 1d),
+                },
+                KeyTime = TimeSpan.FromSeconds(0)
+            };
+
+            var keyframe2 = new KeyFrame()
+            {
+                Setters =
+                {
+                    new Setter(Layoutable.WidthProperty, 2d),
+                },
+                KeyTime = TimeSpan.FromSeconds(2),
+            };
+
+            var keyframe3 = new KeyFrame()
+            {
+                Setters =
+                {
+                    new Setter(Layoutable.WidthProperty, invalidValue),
+                },
+                KeyTime = TimeSpan.FromSeconds(3),
+            };
+
+            var animation = new Animation()
+            {
+                Duration = TimeSpan.FromSeconds(3),
+                Children =
+                {
+                    keyframe1,
+                    keyframe2,
+                    keyframe3
+                },
+                IterationCount = new IterationCount(5),
+                PlaybackDirection = PlaybackDirection.Alternate,
+            };
+
+            var rect = new Rectangle()
+            {
+                Width = 11,
+            };
+
+            var originalValue = rect.Width;
+
+            var clock = new TestClock();
+            var animationRun = animation.RunAsync(rect, clock);
+
+            clock.Step(TimeSpan.Zero);
+            Assert.Equal(rect.Width, 1);
+            clock.Step(TimeSpan.FromSeconds(2));
+            Assert.Equal(rect.Width, 2);
+            clock.Step(TimeSpan.FromSeconds(3));
+            //here we have invalid value so value should be expected and set to initial original value
+            Assert.Equal(rect.Width, originalValue);
         }
 
         [Fact]


### PR DESCRIPTION
add unittest for issue #6969 animator crashes because of invalid keyframe value

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

add unittest for issue #6969 animator crashes because of invalid keyframe value
## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
animation subsystem crashes when invalid keyframe value need to be applied

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
add unit test and hopefully fix

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues

Fixes #6969
