### PR TITLE
Fix debugging in Rider after we merged .NET 6

### DIFF
--- a/build/SourceLink.props
+++ b/build/SourceLink.props
@@ -3,7 +3,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>false</IncludeSymbols>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <DebugType>embedded</DebugType>
+    <DebugType>full</DebugType>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   


### PR DESCRIPTION
Since we merged #6902 our debugging infra for this repo is not working with Rider. This PR fixes it.
