### PR TITLE
Fix transform problems caused by missing transform data or invalid order of operations

### DIFF
--- a/src/Avalonia.Visuals/Matrix.cs
+++ b/src/Avalonia.Visuals/Matrix.cs
@@ -216,6 +216,28 @@ namespace Avalonia
         }
 
         /// <summary>
+        /// Appends another matrix as post-multiplication operation.
+        /// Equivalent to this * value;
+        /// </summary>
+        /// <param name="value">A matrix.</param>
+        /// <returns>Post-multiplied matrix.</returns>
+        public Matrix Append(Matrix value)
+        {
+            return this * value;
+        }
+
+        /// <summary>
+        /// Prpends another matrix as pre-multiplication operation.
+        /// Equivalent to value * this;
+        /// </summary>
+        /// <param name="value">A matrix.</param>
+        /// <returns>Pre-multiplied matrix.</returns>
+        public Matrix Prepend(Matrix value)
+        {
+            return value * this;
+        }
+
+        /// <summary>
         /// Calculates the determinant for this matrix.
         /// </summary>
         /// <returns>The determinant.</returns>

--- a/src/Avalonia.Visuals/Media/Transformation/InterpolationUtilities.cs
+++ b/src/Avalonia.Visuals/Media/Transformation/InterpolationUtilities.cs
@@ -18,11 +18,11 @@ namespace Avalonia.Media.Transformation
         public static Matrix ComposeTransform(Matrix.Decomposed decomposed)
         {
             // According to https://www.w3.org/TR/css-transforms-1/#recomposing-to-a-2d-matrix
-
-            return Matrix.CreateTranslation(decomposed.Translate) *
-                   Matrix.CreateRotation(decomposed.Angle) *
-                   Matrix.CreateSkew(decomposed.Skew.X, decomposed.Skew.Y) *
-                   Matrix.CreateScale(decomposed.Scale);
+            return Matrix.Identity
+                .Prepend(Matrix.CreateTranslation(decomposed.Translate))
+                .Prepend(Matrix.CreateRotation(decomposed.Angle))
+                .Prepend(Matrix.CreateSkew(decomposed.Skew.X, decomposed.Skew.Y))
+                .Prepend(Matrix.CreateScale(decomposed.Scale));
         }
 
         public static Matrix.Decomposed InterpolateDecomposedTransforms(ref Matrix.Decomposed from, ref Matrix.Decomposed to, double progress)

--- a/src/Avalonia.Visuals/Media/Transformation/TransformOperation.cs
+++ b/src/Avalonia.Visuals/Media/Transformation/TransformOperation.cs
@@ -86,6 +86,8 @@ namespace Avalonia.Media.Transformation
 
             if (fromIdentity && toIdentity)
             {
+                result.Matrix = Matrix.Identity;
+
                 return true;
             }
 
@@ -179,7 +181,8 @@ namespace Avalonia.Media.Transformation
                 }
                 case OperationType.Identity:
                 {
-                    // Do nothing.
+                    result.Matrix = Matrix.Identity;
+
                     break;
                 }
             }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes issues found by https://github.com/AvaloniaUI/Avalonia/issues/6494.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
As in the issue, there is a jump at the end of the transition caused by invalid interpolation. 
Translation wouldn't reach target value so when progress hits 100% we would switch to a target transform and a jump is observed.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
I've checked workarounds too and it seems that something like `translate(0px, 0px) scale(1.0)` was not working as initial transform value. Due to broken interpolation we would end up with a singular matrix and visual would just disappear.

Root of the problem was invalid order of transform multiplication, Avalonia matrix multiplication is post order by default and to compose interpolated transform matrix we need to apply values in pre order (as outlined in the spec and confirmed in Chromium implementation).

![transform-fixed](https://user-images.githubusercontent.com/2588062/142780909-b02e54bc-fe4e-4ce0-9f02-ac15566579c7.gif)

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Added extra `Prepend` and `Append` functions to `Matrix` (naming as in WPF) to better express multiplication semantics.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes: #6494