### PR TITLE
fix stuck tooltips on macOS

### DIFF
--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -1494,7 +1494,7 @@ NSArray* AllLoopModes = [NSArray arrayWithObjects: NSDefaultRunLoopMode, NSEvent
     NSRect rect = NSZeroRect;
     rect.size = newSize;
     
-    NSTrackingAreaOptions options = NSTrackingActiveAlways | NSTrackingMouseMoved | NSTrackingEnabledDuringMouseDrag;
+    NSTrackingAreaOptions options = NSTrackingActiveAlways | NSTrackingMouseMoved | NSTrackingMouseEnteredAndExited | NSTrackingEnabledDuringMouseDrag;
     _area = [[NSTrackingArea alloc] initWithRect:rect options:options owner:self userInfo:nullptr];
     [self addTrackingArea:_area];
     


### PR DESCRIPTION
## What does the pull request do?
Fixes stuck tooltips when new window is opened. 

## What is the current behavior?
As described in #6677 if a tooltip is active when a child window is shown, the tooltip remains active until the mouse is once again moved on the parent window.

## What is the updated/expected behavior with this PR?
Tooltip has to disappear when a child window is shown.

## Fixed issues
Fixes #6677
