### PR TITLE
Fix slider behaviour for bigger thumbs

### DIFF
--- a/src/Avalonia.Controls/Slider.cs
+++ b/src/Avalonia.Controls/Slider.cs
@@ -331,16 +331,17 @@ namespace Avalonia.Controls
             }
         }
 
-        private void MoveToPoint(PointerPoint x)
+        private void MoveToPoint(PointerPoint posOnTrack)
         {
             var orient = Orientation == Orientation.Horizontal;
-
-            var pointDen = orient ? _track.Bounds.Width : _track.Bounds.Height;
-            // Just add epsilon to avoid NaN in case 0/0
-            pointDen += double.Epsilon;
-
-            var pointNum = orient ? x.Position.X : x.Position.Y;
-            var logicalPos = MathUtilities.Clamp(pointNum / pointDen, 0.0d, 1.0d);
+            var thumbLength = (orient 
+                ? _track.Thumb.Bounds.Width 
+                : _track.Thumb.Bounds.Height) + double.Epsilon;
+            var trackLength = (orient 
+                ? _track.Bounds.Width 
+                : _track.Bounds.Height) - thumbLength;
+            var trackPos = orient ? posOnTrack.Position.X : posOnTrack.Position.Y;
+            var logicalPos = MathUtilities.Clamp((trackPos - thumbLength * 0.5) / trackLength, 0.0d, 1.0d);
             var invert = orient ? 
                 IsDirectionReversed ? 1 : 0 :
                 IsDirectionReversed ? 0 : 1;


### PR DESCRIPTION
## What does the pull request do?
This PR improves / fixes the behaviour of the slider control, which behaves stranger the bigger the thumb becomes. Dragging the thumb, it now moves synchronusly with the pointer all the time.

## What is the current behavior?
Dragging the thumb, it always jumps to the right side of ther mouse pointer, while dragging to the maximum value, the thumb slowly moves to the left side of the pointer. This feels strange and not intuitive.

## What is the updated/expected behavior with this PR?
Add a slider and drag the thumb. No more jumping to one side of the pointer will occure.


## Fixed issues
Fixes #7011