### PR TITLE
Publish WndProc of the Main Window

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.WndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.WndProc.cs
@@ -15,10 +15,23 @@ namespace Avalonia.Win32
 {
     public partial class WindowImpl
     {
+        public delegate IntPtr WndProcDelegate(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam, ref bool handled);
+        public WndProcDelegate CustomWndProc;
+
         protected virtual unsafe IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
         {
             IntPtr lRet = IntPtr.Zero;
             bool callDwp = true;
+
+            if (CustomWndProc != null)
+            {
+                var handled = false;
+                lRet = CustomWndProc(hWnd, msg, wParam, lParam, ref handled);
+                if (handled)
+                {
+                    return lRet;
+                }
+            }
 
             if (_isClientAreaExtended)
             {


### PR DESCRIPTION
## What does the pull request do?
Both WinForms and WPF have a solution how to extend the WndProc functionality. We should have that in Avalonia as well. Although this is against the cross-platform nature of Avalonia, many 3rd party components use windows messages for interop. It can't be avoided in many cases.


## What is the current behavior?
It is not possible to hook to WndProc.


## What is the updated/expected behavior with this PR?
One should be able to hook to WndProc. e.g.
```
//TODO: safety checks needed
var mainWindow = (Application.Current.ApplicationLifetime as ClassicDesktopStyleApplicationLifetime).MainWindow;
(mainWindow.PlatformImpl as WindowImpl).CustomWndProc = WndProc;

protected virtual unsafe IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam, ref bool handled)
{
  handled = false;
  // disables mouse wheel in the application
  if (msg == 0x020A/*WM_MOUSEWHEEL*/)
 {
    handled = true;
 }
  return IntPtr.Zero;
}
```
