### PR TITLE
Add support for drawing ellipses directly via DrawingContext

### DIFF
--- a/samples/ControlCatalog/Pages/PointersPage.cs
+++ b/samples/ControlCatalog/Pages/PointersPage.cs
@@ -99,10 +99,9 @@ namespace ControlCatalog.Pages
             foreach (var pt in _pointers.Values)
             {
                 var brush = new ImmutableSolidColorBrush(pt.Color);
-                context.DrawGeometry(brush, null, new EllipseGeometry(new Rect(pt.Point.X - 75, pt.Point.Y - 75,
-                    150, 150)));
+
+                context.DrawEllipse(brush, null, pt.Point, 75, 75);
             }
-            
         }
     }
 }

--- a/src/Avalonia.Headless/HeadlessPlatformRenderInterface.cs
+++ b/src/Avalonia.Headless/HeadlessPlatformRenderInterface.cs
@@ -447,6 +447,10 @@ namespace Avalonia.Headless
                 
             }
 
+            public void DrawEllipse(IBrush brush, IPen pen, Rect rect)
+            {
+            }
+
             public void DrawGlyphRun(IBrush foreground, GlyphRun glyphRun)
             {
                 

--- a/src/Avalonia.Visuals/ApiCompatBaseline.txt
+++ b/src/Avalonia.Visuals/ApiCompatBaseline.txt
@@ -60,6 +60,7 @@ CannotAddAbstractMembers : Member 'public Avalonia.Media.FlowDirection Avalonia.
 CannotAddAbstractMembers : Member 'public System.Double Avalonia.Media.TextFormatting.TextParagraphProperties.Indent.get()' is abstract in the implementation but is missing in the contract.
 CannotAddAbstractMembers : Member 'public Avalonia.Media.BaselineAlignment Avalonia.Media.TextFormatting.TextRunProperties.BaselineAlignment' is abstract in the implementation but is missing in the contract.
 CannotAddAbstractMembers : Member 'public Avalonia.Media.BaselineAlignment Avalonia.Media.TextFormatting.TextRunProperties.BaselineAlignment.get()' is abstract in the implementation but is missing in the contract.
+InterfacesShouldHaveSameMembers : Interface member 'public void Avalonia.Platform.IDrawingContextImpl.DrawEllipse(Avalonia.Media.IBrush, Avalonia.Media.IPen, Avalonia.Rect)' is present in the implementation but not in the contract.
 InterfacesShouldHaveSameMembers : Interface member 'public void Avalonia.Platform.IDrawingContextImpl.PopBitmapBlendMode()' is present in the implementation but not in the contract.
 InterfacesShouldHaveSameMembers : Interface member 'public void Avalonia.Platform.IDrawingContextImpl.PushBitmapBlendMode(Avalonia.Visuals.Media.Imaging.BitmapBlendingMode)' is present in the implementation but not in the contract.
 InterfacesShouldHaveSameMembers : Interface member 'public System.Double Avalonia.Platform.IGeometryImpl.ContourLength' is present in the implementation but not in the contract.
@@ -76,4 +77,4 @@ InterfacesShouldHaveSameMembers : Interface member 'public Avalonia.Platform.IWr
 InterfacesShouldHaveSameMembers : Interface member 'public Avalonia.Platform.IWriteableBitmapImpl Avalonia.Platform.IPlatformRenderInterface.LoadWriteableBitmap(System.String)' is present in the implementation but not in the contract.
 InterfacesShouldHaveSameMembers : Interface member 'public Avalonia.Platform.IWriteableBitmapImpl Avalonia.Platform.IPlatformRenderInterface.LoadWriteableBitmapToHeight(System.IO.Stream, System.Int32, Avalonia.Visuals.Media.Imaging.BitmapInterpolationMode)' is present in the implementation but not in the contract.
 InterfacesShouldHaveSameMembers : Interface member 'public Avalonia.Platform.IWriteableBitmapImpl Avalonia.Platform.IPlatformRenderInterface.LoadWriteableBitmapToWidth(System.IO.Stream, System.Int32, Avalonia.Visuals.Media.Imaging.BitmapInterpolationMode)' is present in the implementation but not in the contract.
-Total Issues: 77
+Total Issues: 78

--- a/src/Avalonia.Visuals/Media/DrawingContext.cs
+++ b/src/Avalonia.Visuals/Media/DrawingContext.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Avalonia.Rendering.SceneGraph;
 using Avalonia.Threading;
@@ -188,6 +187,33 @@ namespace Avalonia.Media
         public void DrawRectangle(IPen pen, Rect rect, float cornerRadius = 0.0f)
         {
             DrawRectangle(null, pen, rect, cornerRadius, cornerRadius);
+        }
+
+        /// <summary>
+        /// Draws an ellipse with the specified Brush and Pen.
+        /// </summary>
+        /// <param name="brush">The brush used to fill the ellipse, or <c>null</c> for no fill.</param>
+        /// <param name="pen">The pen used to stroke the ellipse, or <c>null</c> for no stroke.</param>
+        /// <param name="center">The location of the center of the ellipse.</param>
+        /// <param name="radiusX">The horizontal radius of the ellipse.</param>
+        /// <param name="radiusY">The vertical radius of the ellipse.</param>
+        /// <remarks>
+        /// The brush and the pen can both be null. If the brush is null, then no fill is performed.
+        /// If the pen is null, then no stoke is performed. If both the pen and the brush are null, then the drawing is not visible.
+        /// </remarks>
+        public void DrawEllipse(IBrush brush, IPen pen, Point center, double radiusX, double radiusY)
+        {
+            if (brush == null && !PenIsVisible(pen))
+            {
+                return;
+            }
+
+            var originX = center.X - radiusX;
+            var originY = center.Y - radiusY;
+            var width = radiusX * 2;
+            var height = radiusY * 2;
+
+            PlatformImpl.DrawEllipse(brush, pen, new Rect(originX, originY, width, height));
         }
 
         /// <summary>

--- a/src/Avalonia.Visuals/Platform/IDrawingContextImpl.cs
+++ b/src/Avalonia.Visuals/Platform/IDrawingContextImpl.cs
@@ -72,6 +72,18 @@ namespace Avalonia.Platform
             BoxShadows boxShadows = default);
 
         /// <summary>
+        /// Draws an ellipse with the specified Brush and Pen.
+        /// </summary>
+        /// <param name="brush">The brush used to fill the ellipse, or <c>null</c> for no fill.</param>
+        /// <param name="pen">The pen used to stroke the ellipse, or <c>null</c> for no stroke.</param>
+        /// <param name="rect">The ellipse bounds.</param>
+        /// <remarks>
+        /// The brush and the pen can both be null. If the brush is null, then no fill is performed.
+        /// If the pen is null, then no stoke is performed. If both the pen and the brush are null, then the drawing is not visible.
+        /// </remarks>
+        void DrawEllipse(IBrush brush, IPen pen, Rect rect);
+
+        /// <summary>
         /// Draws text.
         /// </summary>
         /// <param name="foreground">The foreground brush.</param>

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/DeferredDrawingContextImpl.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/DeferredDrawingContextImpl.cs
@@ -179,6 +179,20 @@ namespace Avalonia.Rendering.SceneGraph
             }
         }
 
+        public void DrawEllipse(IBrush brush, IPen pen, Rect rect)
+        {
+            var next = NextDrawAs<EllipseNode>();
+
+            if (next == null || !next.Item.Equals(Transform, brush, pen, rect))
+            {
+                Add(new EllipseNode(Transform, brush, pen, rect, CreateChildScene(brush)));
+            }
+            else
+            {
+                ++_drawOperationindex;
+            }
+        }
+
         public void Custom(ICustomDrawOperation custom)
         {
             var next = NextDrawAs<CustomDrawOperation>();

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/EllipseNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/EllipseNode.cs
@@ -109,7 +109,7 @@ namespace Avalonia.Rendering.SceneGraph
 
                 var distance = ry2 * dx * dx + rx2 * dy * dy;
 
-                return distance < rx2 * ry2;
+                return distance <= rx2 * ry2;
             }
 
             return false;

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/EllipseNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/EllipseNode.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+using Avalonia.Platform;
+using Avalonia.VisualTree;
+
+namespace Avalonia.Rendering.SceneGraph
+{
+    /// <summary>
+    /// A node in the scene graph which represents an ellipse draw.
+    /// </summary>
+    internal class EllipseNode : BrushDrawOperation
+    {
+        public EllipseNode(
+            Matrix transform, 
+            IBrush brush, 
+            IPen pen, 
+            Rect rect, 
+            IDictionary<IVisual, Scene> childScenes = null) 
+            : base(rect.Inflate(pen?.Thickness ?? 0), transform)
+        {
+            Transform = transform;
+            Brush = brush?.ToImmutable();
+            Pen = pen?.ToImmutable();
+            Rect = rect;
+            ChildScenes = childScenes;
+        }
+
+        /// <summary>
+        /// Gets the fill brush.
+        /// </summary>
+        public IBrush Brush { get; }
+
+        /// <summary>
+        /// Gets the stroke pen.
+        /// </summary>
+        public ImmutablePen Pen { get; }
+
+        /// <summary>
+        /// Gets the transform with which the node will be drawn.
+        /// </summary>
+        public Matrix Transform { get; }
+
+        /// <summary>
+        /// Gets the rect of the ellipse to draw.
+        /// </summary>
+        public Rect Rect { get; }
+
+        public override IDictionary<IVisual, Scene> ChildScenes { get; }
+
+        public bool Equals(Matrix transform, IBrush brush, IPen pen, Rect rect)
+        {
+            return transform == Transform &&
+                   Equals(brush, Brush) &&
+                   Equals(Pen, pen) &&
+                   rect.Equals(Rect);
+        }
+
+        public override void Render(IDrawingContextImpl context)
+        {
+            context.DrawEllipse(Brush, Pen, Rect);
+        }
+
+        public override bool HitTest(Point p)
+        {
+            if (!Transform.TryInvert(out Matrix inverted))
+            {
+                return false;
+            }
+
+            p *= inverted;
+
+            var center = Rect.Center;
+
+            var strokeThickness = Pen?.Thickness ?? 0;
+
+            var rx = Rect.Width / 2 + strokeThickness / 2;
+            var ry = Rect.Height / 2 + strokeThickness / 2;
+
+            var dx = p.X - center.X;
+            var dy = p.Y - center.Y;
+
+            if (Math.Abs(dx) > rx || Math.Abs(dy) > ry)
+            {
+                return false;
+            }
+
+            if (Brush != null)
+            {
+                return Contains(rx, ry);
+            }
+            else if (strokeThickness > 0)
+            {
+                bool inStroke = Contains(rx, ry);
+
+                rx = Rect.Width / 2 - strokeThickness / 2;
+                ry = Rect.Height / 2 - strokeThickness / 2;
+
+                bool inInner = Contains(rx, ry);
+
+                return inStroke && !inInner;
+            }
+
+            bool Contains(double radiusX, double radiusY)
+            {
+                var rx2 = radiusX * radiusX;
+                var ry2 = radiusY * radiusY;
+
+                var distance = ry2 * dx * dx + rx2 * dy * dy;
+
+                return distance < rx2 * ry2;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/RectangleNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/RectangleNode.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Avalonia.Media;
 using Avalonia.Media.Immutable;
 using Avalonia.Platform;

--- a/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
+++ b/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
@@ -415,6 +415,34 @@ namespace Avalonia.Skia
         }
 
         /// <inheritdoc />
+        public void DrawEllipse(IBrush brush, IPen pen, Rect rect)
+        {
+            if (rect.Height <= 0 || rect.Width <= 0)
+                return;
+
+            var rc = rect.ToSKRect();
+
+            if (brush != null)
+            {
+                using (var paint = CreatePaint(_fillPaint, brush, rect.Size))
+                {
+                    Canvas.DrawOval(rc, paint.Paint);
+                }
+            }
+
+            if (pen?.Brush != null)
+            {
+                using (var paint = CreatePaint(_strokePaint, pen, rect.Size))
+                {
+                    if (paint.Paint is object)
+                    {
+                        Canvas.DrawOval(rc, paint.Paint);
+                    }
+                }
+            }
+        }
+
+        /// <inheritdoc />
         public void DrawText(IBrush foreground, Point origin, IFormattedTextImpl text)
         {
             using (var paint = CreatePaint(_fillPaint, foreground, text.Bounds.Size))

--- a/src/Windows/Avalonia.Direct2D1/Media/DrawingContextImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/DrawingContextImpl.cs
@@ -337,6 +337,45 @@ namespace Avalonia.Direct2D1.Media
             }
         }
 
+        /// <inheritdoc />
+        public void DrawEllipse(IBrush brush, IPen pen, Rect rect)
+        {
+            var rc = rect.ToDirect2D();
+
+            if (brush != null)
+            {
+                using (var b = CreateBrush(brush, rect.Size))
+                {
+                    if (b.PlatformBrush != null)
+                    {
+                        _deviceContext.FillEllipse(new Ellipse
+                        {
+                            Point = rect.Center.ToSharpDX(),
+                            RadiusX = (float)(rect.Width / 2),
+                            RadiusY = (float)(rect.Height / 2)
+                        }, b.PlatformBrush);
+                    }
+                }
+            }
+
+            if (pen?.Brush != null)
+            {
+                using (var wrapper = CreateBrush(pen.Brush, rect.Size))
+                using (var d2dStroke = pen.ToDirect2DStrokeStyle(_deviceContext))
+                {
+                    if (wrapper.PlatformBrush != null)
+                    {
+                        _deviceContext.DrawEllipse(new Ellipse
+                        {
+                            Point = rect.Center.ToSharpDX(),
+                            RadiusX = (float)(rect.Width / 2),
+                            RadiusY = (float)(rect.Height / 2)
+                        }, wrapper.PlatformBrush, (float)pen.Thickness, d2dStroke);
+                    }
+                }
+            }
+        }
+
         /// <summary>
         /// Draws text.
         /// </summary>

--- a/tests/Avalonia.Benchmarks/NullDrawingContextImpl.cs
+++ b/tests/Avalonia.Benchmarks/NullDrawingContextImpl.cs
@@ -39,6 +39,10 @@ namespace Avalonia.Benchmarks
         {
         }
 
+        public void DrawEllipse(IBrush brush, IPen pen, Rect rect)
+        {
+        }
+
         public void DrawText(IBrush foreground, Point origin, IFormattedTextImpl text)
         {
         }

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/EllipseNodeTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/EllipseNodeTests.cs
@@ -1,0 +1,47 @@
+﻿using Avalonia.Media;
+using Avalonia.Media.Immutable;
+using Avalonia.Rendering.SceneGraph;
+using Xunit;
+
+namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
+{
+    public class EllipseNodeTests
+    {
+        [Theory]
+        [InlineData(50, 50, true)]
+        [InlineData(50, 0, true)]
+        [InlineData(100, 50, true)]
+        [InlineData(50, 100, true)]
+        [InlineData(-1, 0, false)]
+        [InlineData(101, 0, false)]
+        [InlineData(101, 101, false)]
+        [InlineData(0, 101, false)]
+        public void FillOnly_HitTest(double x, double y, bool inside)
+        {
+            var ellipseNode = new EllipseNode(Matrix.Identity, Brushes.Black, null, new Rect(0,0, 100, 100), null);
+
+            var point = new Point(x, y);
+
+            Assert.True(ellipseNode.HitTest(point) == inside);
+        }
+
+        [Theory]
+        [InlineData(50, 0, true)]
+        [InlineData(51, 0, true)]
+        [InlineData(100, 50, true)]
+        [InlineData(50, 100, true)]
+        [InlineData(-1, 50, true)]
+        [InlineData(53, 50, false)]
+        [InlineData(101, 0, false)]
+        [InlineData(101, 101, false)]
+        [InlineData(0, 101, false)]
+        public void StrokeOnly_HitTest(double x, double y, bool inside)
+        {
+            var ellipseNode = new EllipseNode(Matrix.Identity, null, new ImmutablePen(Brushes.Black, 2), new Rect(0, 0, 100, 100), null);
+
+            var point = new Point(x, y);
+
+            Assert.Equal(inside, ellipseNode.HitTest(point));
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Implements `DrawingContext.DrawEllipse` with WPF like API.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
If one wants to draw an ellipse to a DC then geometry needs to be constructed and rendered via `DrawGeometry`. This has higher overhead and needs more boilerplate when compared to a direct DC draw.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
One can just draw ellipses via DC API.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Only "tricky" part is hit testing, apart from that both D2D and Skia backends have facilities to render ellipses.

I was not able to find any tests for such primitives. Also I'm not sure if we want to add more APIs (rectangle has `FillRectangle`).

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

New APIs were added to `DrawingContext` and related platform impl classes.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
