### PR TITLE
[macOS] Fix popup topmost

### DIFF
--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -2473,6 +2473,7 @@ protected:
             return S_OK;
         }
     }
+
     virtual HRESULT SetTopMost (bool value) override
     {
         START_COM_CALL;

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -2449,6 +2449,7 @@ private:
     {
         WindowEvents = events;
         [Window setLevel:NSPopUpMenuWindowLevel];
+        [Window setHidesOnDeactivate:YES];
     }
 protected:
     virtual NSWindowStyleMask GetStyle() override
@@ -2468,6 +2469,18 @@ protected:
             
                 [Window setFrameTopLeftPoint:ToNSPoint(ConvertPointY(lastPositionSet))];
             }
+            
+            return S_OK;
+        }
+    }
+    virtual HRESULT SetTopMost (bool value) override
+    {
+        START_COM_CALL;
+        
+        @autoreleasepool
+        {
+            // Don't change level of the window, because NSPopUpMenuWindowLevel already sets it top most, unless we disable setHidesOnDeactivate
+            [Window setHidesOnDeactivate: !value];
             
             return S_OK;
         }

--- a/samples/ControlCatalog/MainView.xaml
+++ b/samples/ControlCatalog/MainView.xaml
@@ -151,6 +151,9 @@
       <TabItem Header="Window Customizations">
         <pages:WindowCustomizationsPage />
       </TabItem>
+      <TabItem Header="Popup">
+        <pages:PopupPage/>
+      </TabItem>
       <FlyoutBase.AttachedFlyout>
         <Flyout>
           <StackPanel Width="152" Spacing="8">

--- a/samples/ControlCatalog/Pages/PopupPage.xaml
+++ b/samples/ControlCatalog/Pages/PopupPage.xaml
@@ -1,0 +1,35 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="ControlCatalog.Pages.PopupPage">
+  <StackPanel>
+    <TextBlock Classes="h1">Popup</TextBlock>
+    <WrapPanel x:Name="RootGrid"
+               Orientation="Horizontal">
+      <ToggleSwitch x:Name="TogglePopup"
+                    Margin="0,0,20,0"
+                    Content="Toggle popup" />
+      <ToggleSwitch x:Name="ToggleTopMost"
+                    Margin="0,0,20,0"
+                    Content="Toggle Topmost" />
+      <ToggleSwitch x:Name="ToggleIsLightDismissEnabled"
+                    Margin="0,0,20,0"
+                    Content="Toggle IsLightDismissEnabled" />
+      <Popup PlacementMode="Bottom"
+             PlacementTarget="TogglePopup"
+             Width="300"
+             Height="300"
+             IsOpen="{Binding #TogglePopup.IsChecked, Mode=TwoWay}"
+             Topmost="{Binding #ToggleTopMost.IsChecked, Mode=TwoWay}"
+             IsLightDismissEnabled="{Binding #ToggleIsLightDismissEnabled.IsChecked, Mode=TwoWay}">
+        <Panel Background="Green">
+          <Button Content="Hello World"
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Center" />
+        </Panel>
+      </Popup>
+    </WrapPanel>
+  </StackPanel>
+</UserControl>

--- a/samples/ControlCatalog/Pages/PopupPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/PopupPage.xaml.cs
@@ -1,0 +1,19 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace ControlCatalog.Pages;
+
+public class PopupPage : UserControl
+{
+    public PopupPage()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}
+


### PR DESCRIPTION
## What is the current behavior?

Right now macOS implementation of popup has two problems with topmost:
1. Initial Popup.Topmost=false value acts like it's "true". I.e. popup is always topmost.
2. Setting Popup.Topmost=true changes window type from NSPopUpMenuWindowLevel to NSFloatingWindowLevel (not really an issue, I think, but unwanted)
3. Setting Popup.Topmost=false after it was set to true once, will reset it to NSNormalWindowLevel. It will cause popup to go behind of parent window.

https://user-images.githubusercontent.com/3163374/144787201-9bef4fc3-80d0-4a6c-842d-d3e9d5798aac.mov


## What is the updated/expected behavior with this PR?
1. Topmost value doesn't affects NSPopUpMenuWindowLevel type
2. When window is deactivated, popup is hiding, so it's not staying top most

**NOTE**
This PR introduces another issue. Now when parent loses focus, but still visible on screen, popup will hide anyway. See the video. Workaround is easy - set Topmost=true, so this popup will act as it was before this PR. So I don't think it block this PR from merging. But ideally this should be fixed as well, preferably by somebody who is more familiar with macos backend.


https://user-images.githubusercontent.com/3163374/144787283-f13ddbef-f26b-43bf-9887-77c429a9265b.mov


## Fixed issues
Partially fixes #4630 and #4227 (only macos)
