### PR TITLE
Fix condition in HotKeyProperty.Changed handler

### DIFF
--- a/src/Avalonia.Controls/HotkeyManager.cs
+++ b/src/Avalonia.Controls/HotkeyManager.cs
@@ -104,6 +104,8 @@ namespace Avalonia.Controls
         {
             HotKeyProperty.Changed.Subscribe(args =>
             {
+                if (args.NewValue.Value is null) return;
+
                 var control = args.Sender as IControl;
                 if (control is not ICommandSource)
                 {

--- a/src/Avalonia.Controls/HotkeyManager.cs
+++ b/src/Avalonia.Controls/HotkeyManager.cs
@@ -105,10 +105,10 @@ namespace Avalonia.Controls
             HotKeyProperty.Changed.Subscribe(args =>
             {
                 var control = args.Sender as IControl;
-                if (args.OldValue != null || control == null || !(control is ICommandSource))
+                if (control is not ICommandSource)
                 {
-                    Logging.Logger.TryGet(Logging.LogEventLevel.Warning, Logging.LogArea.Control)?.
-                        Log(control, $"The element {args.Sender.GetType().Name} does not support binding a HotKey ({args.NewValue}).");
+                    Logging.Logger.TryGet(Logging.LogEventLevel.Warning, Logging.LogArea.Control)?.Log(control,
+                        $"The element {args.Sender.GetType().Name} does not implement ICommandSource and does not support binding a HotKey ({args.NewValue}).");
                     return;
                 }
 


### PR DESCRIPTION
See #7095 for more information. The condition originally existed to warn
about binding the HotKeyProperty to a Control that does not implement
ICommandSource.

<!---
## What does the pull request do?
## What is the current behavior?
## What is the updated/expected behavior with this PR?
## How was the solution implemented (if it's not obvious)?
## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
## Obsoletions / Deprecations

-->


## Fixed issues
Fixes #7095