### PR TITLE
Enable nullable warnings as errors on projects which enabled Nullable Reference Types

### DIFF
--- a/build/NullableEnable.props
+++ b/build/NullableEnable.props
@@ -1,0 +1,11 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- 
+    The Nullable annotations on netstandard2.0 are incomplete and incorrect in places. Ignore
+    nullable warnings on netstandard2.0 and make them errors on later target frameworks.
+  -->
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors Condition="'$(TargetFramework)' != 'netstandard2.0'">$(WarningsAsErrors);nullable</WarningsAsErrors>
+    <NoWarn Condition="'$(TargetFramework)' == 'netstandard2.0'">$(NoWarn);nullable</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/src/Avalonia.Diagnostics/Avalonia.Diagnostics.csproj
+++ b/src/Avalonia.Diagnostics/Avalonia.Diagnostics.csproj
@@ -3,7 +3,6 @@
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>Avalonia</RootNamespace>
     <PackageId>Avalonia.Diagnostics</PackageId>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="**\*.xaml.cs">
@@ -34,4 +33,5 @@
   <Import Project="..\..\build\Rx.props" />
   <Import Project="..\..\build\BuildTargets.targets" />
   <Import Project="..\..\build\ApiDiff.props" />
+  <Import Project="..\..\build\NullableEnable.props" />
 </Project>

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/AvaloniaPropertyViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/AvaloniaPropertyViewModel.cs
@@ -34,7 +34,7 @@ namespace Avalonia.Diagnostics.ViewModels
 
         public override System.Type Type => _type;
 
-        public override string Value
+        public override string? Value
         {
             get => ConvertToString(_value);
             set

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ClrPropertyViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ClrPropertyViewModel.cs
@@ -35,7 +35,7 @@ namespace Avalonia.Diagnostics.ViewModels
 
         public override System.Type Type => _type;
 
-        public override string Value 
+        public override string? Value 
         {
             get => ConvertToString(_value);
             set

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ControlDetailsViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ControlDetailsViewModel.cs
@@ -437,7 +437,7 @@ namespace Avalonia.Diagnostics.ViewModels
             }
         }
         
-        protected  void NavigateToProperty(object o, string entityName)
+        protected  void NavigateToProperty(object o, string? entityName)
         {
             var oldSelectedEntity = SelectedEntity;
             if (oldSelectedEntity is IAvaloniaObject ao1)

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/PropertyViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/PropertyViewModel.cs
@@ -16,12 +16,12 @@ namespace Avalonia.Diagnostics.ViewModels
         public abstract string Group { get; }
         public abstract Type Type { get; }
         public abstract Type? DeclaringType { get; }
-        public abstract string Value { get; set; }
+        public abstract string? Value { get; set; }
         public abstract string Priority { get; }
         public abstract bool? IsAttached { get;  }
         public abstract void Update();        
 
-        protected static string ConvertToString(object? value)
+        protected static string? ConvertToString(object? value)
         {
             if (value is null)
             {
@@ -59,8 +59,13 @@ namespace Avalonia.Diagnostics.ViewModels
             throw new InvalidCastException("Unable to convert value.");
         }
 
-        protected static object? ConvertFromString(string s, Type targetType)
+        protected static object? ConvertFromString(string? s, Type targetType)
         {
+            if (s is null)
+            {
+                return null;
+            }
+
             var converter = TypeDescriptor.GetConverter(targetType);
 
             if (converter.CanConvertFrom(typeof(string)))

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml.cs
@@ -17,7 +17,7 @@ namespace Avalonia.Diagnostics.Views
 {
     internal class MainWindow : Window, IStyleHost
     {
-        private readonly IDisposable _keySubscription;
+        private readonly IDisposable? _keySubscription;
         private readonly Dictionary<Popup, IDisposable> _frozenPopupStates;
         private TopLevel? _root;
 
@@ -25,7 +25,7 @@ namespace Avalonia.Diagnostics.Views
         {
             InitializeComponent();
 
-            _keySubscription = InputManager.Instance.Process
+            _keySubscription = InputManager.Instance?.Process
                 .OfType<RawKeyEventArgs>()
                 .Where(x => x.Type == RawKeyEventType.KeyDown)
                 .Subscribe(RawKeyDown);
@@ -82,7 +82,7 @@ namespace Avalonia.Diagnostics.Views
         protected override void OnClosed(EventArgs e)
         {
             base.OnClosed(e);
-            _keySubscription.Dispose();
+            _keySubscription?.Dispose();
 
             foreach (var state in _frozenPopupStates)
             {

--- a/src/Avalonia.Input/AccessKeyHandler.cs
+++ b/src/Avalonia.Input/AccessKeyHandler.cs
@@ -133,7 +133,7 @@ namespace Avalonia.Input
         /// </summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event args.</param>
-        protected virtual void OnPreviewKeyDown(object sender, KeyEventArgs e)
+        protected virtual void OnPreviewKeyDown(object? sender, KeyEventArgs e)
         {
             if (e.Key == Key.LeftAlt || e.Key == Key.RightAlt)
             {
@@ -172,7 +172,7 @@ namespace Avalonia.Input
         /// </summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event args.</param>
-        protected virtual void OnKeyDown(object sender, KeyEventArgs e)
+        protected virtual void OnKeyDown(object? sender, KeyEventArgs e)
         {
             bool menuIsOpen = MainMenu?.IsOpen == true;
 
@@ -207,7 +207,7 @@ namespace Avalonia.Input
         /// </summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event args.</param>
-        protected virtual void OnPreviewKeyUp(object sender, KeyEventArgs e)
+        protected virtual void OnPreviewKeyUp(object? sender, KeyEventArgs e)
         {
             switch (e.Key)
             {
@@ -234,7 +234,7 @@ namespace Avalonia.Input
         /// </summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event args.</param>
-        protected virtual void OnPreviewPointerPressed(object sender, PointerEventArgs e)
+        protected virtual void OnPreviewPointerPressed(object? sender, PointerEventArgs e)
         {
             if (_showingAccessKeys)
             {
@@ -251,7 +251,7 @@ namespace Avalonia.Input
             _owner!.ShowAccessKeys = _showingAccessKeys = false;
         }
 
-        private void MainMenuClosed(object sender, EventArgs e)
+        private void MainMenuClosed(object? sender, EventArgs e)
         {
             _owner!.ShowAccessKeys = false;
         }

--- a/src/Avalonia.Input/Avalonia.Input.csproj
+++ b/src/Avalonia.Input/Avalonia.Input.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <Nullable>Enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Avalonia.Base\Metadata\NullableAttributes.cs" Link="NullableAttributes.cs" />
@@ -15,4 +14,5 @@
   </ItemGroup>  
   <Import Project="..\..\build\Rx.props" />
   <Import Project="..\..\build\ApiDiff.props" />
+  <Import Project="..\..\build\NullableEnable.props" />
 </Project>

--- a/src/Avalonia.Input/FocusManager.cs
+++ b/src/Avalonia.Input/FocusManager.cs
@@ -215,8 +215,11 @@ namespace Avalonia.Input
         /// </summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event args.</param>
-        private static void OnPreviewPointerPressed(object sender, RoutedEventArgs e)
+        private static void OnPreviewPointerPressed(object? sender, RoutedEventArgs e)
         {
+            if (sender is null)
+                return;
+
             var ev = (PointerPressedEventArgs)e;
             var visual = (IVisual)sender;
 

--- a/src/Avalonia.Input/KeyboardNavigationHandler.cs
+++ b/src/Avalonia.Input/KeyboardNavigationHandler.cs
@@ -98,7 +98,7 @@ namespace Avalonia.Input
         /// </summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event args.</param>
-        protected virtual void OnKeyDown(object sender, KeyEventArgs e)
+        protected virtual void OnKeyDown(object? sender, KeyEventArgs e)
         {
             var current = FocusManager.Instance.Current;
 

--- a/src/Avalonia.Input/MouseDevice.cs
+++ b/src/Avalonia.Input/MouseDevice.cs
@@ -298,10 +298,10 @@ namespace Avalonia.Input
             root = root ?? throw new ArgumentNullException(nameof(root));
 
             var hit = HitTest(root, p);
+            var source = GetSource(hit);
 
-            if (hit != null)
+            if (source is not null)
             {
-                var source = GetSource(hit);
                 var e = new PointerReleasedEventArgs(source, _pointer, root, p, timestamp, props, inputModifiers,
                     _lastMouseDownButton);
 
@@ -321,10 +321,10 @@ namespace Avalonia.Input
             root = root ?? throw new ArgumentNullException(nameof(root));
 
             var hit = HitTest(root, p);
+            var source = GetSource(hit);
 
-            if (hit != null)
+            if (source is not null)
             {
-                var source = GetSource(hit);
                 var e = new PointerWheelEventArgs(source, _pointer, root, p, timestamp, props, inputModifiers, delta);
 
                 source?.RaiseEvent(e);
@@ -334,9 +334,10 @@ namespace Avalonia.Input
             return false;
         }
 
-        private IInteractive GetSource(IVisual hit)
+        private IInteractive? GetSource(IVisual? hit)
         {
-            hit = hit ?? throw new ArgumentNullException(nameof(hit));
+            if (hit is null)
+                return null;
 
             return _pointer.Captured ??
                 (hit as IInteractive) ??

--- a/src/Avalonia.Input/Pointer.cs
+++ b/src/Avalonia.Input/Pointer.cs
@@ -59,7 +59,7 @@ namespace Avalonia.Input
             return parent as IInputElement ?? parent.FindAncestorOfType<IInputElement>();
         }
 
-        private void OnCaptureDetached(object sender, VisualTreeAttachmentEventArgs e)
+        private void OnCaptureDetached(object? sender, VisualTreeAttachmentEventArgs e)
         {
             Capture(GetNextCapture(e.Parent));
         }

--- a/src/Avalonia.Input/TextInput/InputMethodManager.cs
+++ b/src/Avalonia.Input/TextInput/InputMethodManager.cs
@@ -8,7 +8,6 @@ namespace Avalonia.Input.TextInput
         private ITextInputMethodImpl? _im;
         private IInputElement? _focusedElement;
         private ITextInputMethodClient? _client;
-        private IDisposable? _subscribeDisposable;
         private readonly TransformTrackingHelper _transformTracker = new TransformTrackingHelper();
 
         public TextInputMethodManager()
@@ -64,7 +63,7 @@ namespace Avalonia.Input.TextInput
             }
         }
 
-        private void OnTextViewVisualChanged(object sender, EventArgs e) 
+        private void OnTextViewVisualChanged(object? sender, EventArgs e) 
             => _transformTracker.SetVisual(_client?.TextViewVisual);
 
         private void UpdateCursorRect()
@@ -79,7 +78,7 @@ namespace Avalonia.Input.TextInput
                 _im.SetCursorRect(_client.CursorRectangle.TransformToAABB(transform.Value));
         }
 
-        private void OnCursorRectangleChanged(object sender, EventArgs e)
+        private void OnCursorRectangleChanged(object? sender, EventArgs e)
         {
             if (sender == _client)
                 UpdateCursorRect();

--- a/src/Avalonia.Input/TextInput/TransformTrackingHelper.cs
+++ b/src/Avalonia.Input/TextInput/TransformTrackingHelper.cs
@@ -80,7 +80,7 @@ namespace Avalonia.Input.TextInput
             }
         }
 
-        private void OnAttachedToVisualTree(object sender, VisualTreeAttachmentEventArgs visualTreeAttachmentEventArgs)
+        private void OnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs visualTreeAttachmentEventArgs)
         {
             SubscribeToParents();
             UpdateMatrix();
@@ -94,13 +94,13 @@ namespace Avalonia.Input.TextInput
             Dispatcher.UIThread.Post(UpdateMatrix, DispatcherPriority.Render);
         }
 
-        private void PropertyChangedHandler(object sender, AvaloniaPropertyChangedEventArgs e)
+        private void PropertyChangedHandler(object? sender, AvaloniaPropertyChangedEventArgs e)
         {
             if (e.IsEffectiveValueChange && e.Property == Visual.BoundsProperty)
                 EnqueueForUpdate();
         }
 
-        private void OnDetachedFromVisualTree(object sender, VisualTreeAttachmentEventArgs visualTreeAttachmentEventArgs)
+        private void OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs visualTreeAttachmentEventArgs)
         {
             UnsubscribeFromParents();
             UpdateMatrix();

--- a/src/Avalonia.Interactivity/Avalonia.Interactivity.csproj
+++ b/src/Avalonia.Interactivity/Avalonia.Interactivity.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <Nullable>Enable</Nullable>
-    <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Avalonia.Animation\Avalonia.Animation.csproj" />
@@ -12,4 +10,5 @@
   </ItemGroup>
   <Import Project="..\..\build\Rx.props" />
   <Import Project="..\..\build\ApiDiff.props" />
+  <Import Project="..\..\build\NullableEnable.props" />
 </Project>

--- a/src/Avalonia.Interactivity/RoutedEvent.cs
+++ b/src/Avalonia.Interactivity/RoutedEvent.cs
@@ -120,7 +120,7 @@ namespace Avalonia.Interactivity
             bool handledEventsToo = false)
             where TTarget : class, IInteractive
         {
-            void Adapter(object sender, RoutedEventArgs e)
+            void Adapter(object? sender, RoutedEventArgs e)
             {
                 if (sender is TTarget target && e is TEventArgs args)
                 {
@@ -136,7 +136,7 @@ namespace Avalonia.Interactivity
             RoutingStrategies routes = RoutingStrategies.Direct | RoutingStrategies.Bubble,
             bool handledEventsToo = false) where TTarget : class, IInteractive
         {
-            void Adapter(object sender, RoutedEventArgs e)
+            void Adapter(object? sender, RoutedEventArgs e)
             {
                 if (sender is TTarget target && e is TEventArgs args)
                 {

--- a/src/Avalonia.ReactiveUI/Avalonia.ReactiveUI.csproj
+++ b/src/Avalonia.ReactiveUI/Avalonia.ReactiveUI.csproj
@@ -3,8 +3,6 @@
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <PackageId>Avalonia.ReactiveUI</PackageId>
     <SignAssembly>false</SignAssembly>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\packages\Avalonia\Avalonia.csproj" />
@@ -12,4 +10,5 @@
   <Import Project="..\..\build\Rx.props" />
   <Import Project="..\..\build\ReactiveUI.props" />
   <Import Project="..\..\build\ApiDiff.props" />
+  <Import Project="..\..\build\NullableEnable.props" />
 </Project>

--- a/src/Markup/Avalonia.Markup/Avalonia.Markup.csproj
+++ b/src/Markup/Avalonia.Markup/Avalonia.Markup.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>Avalonia</RootNamespace>
-    <Nullable>Enable</Nullable>
-    <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Markup\Parsers\Nodes\ExpressionGrammer" />
@@ -19,4 +17,5 @@
   <Import Project="..\..\..\build\Rx.props" />
   <Import Project="..\..\..\build\System.Memory.props" />
   <Import Project="..\..\..\build\ApiDiff.props" />
+  <Import Project="..\..\..\build\NullableEnable.props" />
 </Project>

--- a/src/Markup/Avalonia.Markup/Data/BindingBase.cs
+++ b/src/Markup/Avalonia.Markup/Data/BindingBase.cs
@@ -272,7 +272,7 @@ namespace Avalonia.Data
                 _target.PropertyChanged -= PropertyChanged;
             }
 
-            private void PropertyChanged(object sender, AvaloniaPropertyChangedEventArgs e)
+            private void PropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
             {
                 if (e.Property == _property)
                 {

--- a/src/Markup/Avalonia.Markup/Data/TemplateBinding.cs
+++ b/src/Markup/Avalonia.Markup/Data/TemplateBinding.cs
@@ -160,7 +160,7 @@ namespace Avalonia.Data
             PublishValue();
         }
 
-        private void TargetPropertyChanged(object sender, AvaloniaPropertyChangedEventArgs e)
+        private void TargetPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
         {
             if (e.Property == StyledElement.TemplatedParentProperty)
             {
@@ -173,7 +173,7 @@ namespace Avalonia.Data
             }
         }
 
-        private void TemplatedParentPropertyChanged(object sender, AvaloniaPropertyChangedEventArgs e)
+        private void TemplatedParentPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
         {
             if (e.Property == Property)
             {

--- a/src/Markup/Avalonia.Markup/Markup/Data/DelayedBinding.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Data/DelayedBinding.cs
@@ -95,9 +95,9 @@ namespace Avalonia.Markup.Data
             }
         }
 
-        private static void ApplyBindings(object sender, EventArgs e)
+        private static void ApplyBindings(object? sender, EventArgs e)
         {
-            var target = (IStyledElement)sender;
+            var target = (IStyledElement)sender!;
             ApplyBindings(target);
             target.Initialized -= ApplyBindings;
         }

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/Nodes/StringIndexerNode.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/Nodes/StringIndexerNode.cs
@@ -297,7 +297,7 @@ namespace Avalonia.Markup.Parsers.Nodes
 
         protected override bool ShouldUpdate(object? sender, PropertyChangedEventArgs e)
         {
-            if (sender is null)
+            if (sender is null || e.PropertyName is null)
                 return false;
             var typeInfo = sender.GetType().GetTypeInfo();
             return typeInfo.GetDeclaredProperty(e.PropertyName)?.GetIndexParameters().Any() ?? false;

--- a/src/Web/Avalonia.Web.Blazor/Avalonia.Web.Blazor.csproj
+++ b/src/Web/Avalonia.Web.Blazor/Avalonia.Web.Blazor.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <PackageId>Avalonia.Web.Blazor</PackageId>
     <LangVersion>preview</LangVersion>
@@ -32,7 +31,8 @@
   <Import Project="..\..\..\build\BuildTargets.targets" />
   <Import Project="..\..\..\build\SkiaSharp.props" />
   <Import Project="..\..\..\build\HarfBuzzSharp.props" />
-
+  <Import Project="..\..\..\build\NullableEnable.props" />
+  
   <ItemGroup>
     <Content Include="*.props">
       <Pack>true</Pack>

--- a/src/Web/Avalonia.Web.Blazor/WindowingPlatform.cs
+++ b/src/Web/Avalonia.Web.Blazor/WindowingPlatform.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Web.Blazor
     public class BlazorWindowingPlatform : IWindowingPlatform, IPlatformSettings, IPlatformThreadingInterface
     {
         private bool _signaled;
-        private static int s_uiThreadId = -1;
+        private static KeyboardDevice? s_keyboard;
 
         public IWindowImpl CreateWindow() => throw new NotSupportedException();
 
@@ -26,16 +26,17 @@ namespace Avalonia.Web.Blazor
             return null;
         }
 
-        public static KeyboardDevice Keyboard { get; private set; }
+        public static KeyboardDevice Keyboard => s_keyboard ??
+            throw new InvalidOperationException("BlazorWindowingPlatform not registered.");
 
         public static void Register()
         {
             var instance = new BlazorWindowingPlatform();
-            Keyboard = new KeyboardDevice();
+            s_keyboard = new KeyboardDevice();
             AvaloniaLocator.CurrentMutable
                 .Bind<IClipboard>().ToSingleton<ClipboardStub>()
                 .Bind<ICursorFactory>().ToSingleton<CursorFactoryStub>()
-                .Bind<IKeyboardDevice>().ToConstant(Keyboard)
+                .Bind<IKeyboardDevice>().ToConstant(s_keyboard)
                 .Bind<IPlatformSettings>().ToConstant(instance)
                 .Bind<IPlatformThreadingInterface>().ToConstant(instance)
                 .Bind<IRenderLoop>().ToConstant(new RenderLoop())


### PR DESCRIPTION
## What does the pull request do?

- Enable nullable reference checking via .props file: the Nullable annotations on `netstandard2.0` are incomplete and incorrect in places. Ignore nullable warnings on `netstandard2.0` and **promote them from warnings to errors on later target frameworks**.
- Fix nullable reference errors in the projects that have nullable reference types enabled
