### PR TITLE
Do not copy UWP behavior with ListBoxItem horizontal alignment

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/ListBoxItem.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ListBoxItem.xaml
@@ -18,7 +18,6 @@
   <Style Selector="ListBoxItem">
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Padding" Value="{DynamicResource ListBoxItemPadding}" />
-    <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="Template">
       <ControlTemplate>
         <ContentPresenter Name="PART_ContentPresenter"


### PR DESCRIPTION
## What is the current behavior?
In Default theme default ListBoxItem horizontal alignment is Stretch. Same as in WPF.
In Fluent theme we copy UWP behavior and set Left value instead. [Note, newer WinUI versions use Stretch as well](https://github.com/microsoft/microsoft-ui-xaml/pull/3914).

## Why is it a problem?
https://stackoverflow.com/questions/43094395/how-to-stretch-listviewitem-in-listview
https://github.com/microsoft/microsoft-ui-xaml/issues/1402

## What is the updated/expected behavior with this PR?
Do not override default value in theme. Which makes it "Stretch" value (HorizontalAlignment enum default value).


## Breaking changes

Technically it is a styling breaking change.