### PR TITLE
osx: Fixes red flicker on Catalina when resizing

### DIFF
--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -45,6 +45,7 @@ public:
         StandardContainer = [[AutoFitContentView new] initWithContent:View];
 
         Window = [[AvnWindow alloc] initWithParent:this];
+        [Window setContentView: StandardContainer];
         
         lastPositionSet.X = 100;
         lastPositionSet.Y = 100;
@@ -125,8 +126,6 @@ public:
         {
             SetPosition(lastPositionSet);
             UpdateStyle();
-            
-            [Window setContentView: StandardContainer];
             
             [Window setTitle:_lastTitle];
             
@@ -340,7 +339,8 @@ public:
                     BaseEvents->Resized(AvnSize{x,y}, reason);
                 }
                 
-                [Window setContentSize:NSSize{x, y}];
+                [Window setContentSize:NSSize{x,y}];
+                [Window invalidateShadow];
             }
             @finally
             {

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -27,7 +27,6 @@ public:
     AvnPoint lastPositionSet;
     NSString* _lastTitle;
     IAvnMenu* _mainMenu;
-    NSSize _lastSize;
     
     bool _shown;
     bool _inResize;
@@ -36,7 +35,6 @@ public:
     {
         _shown = false;
         _inResize = false;
-        _lastSize = NSSize { 0, 0 };
         _mainMenu = nullptr;
         BaseEvents = events;
         _glContext = gl;
@@ -227,17 +225,9 @@ public:
             if(ret == nullptr)
                 return E_POINTER;
             
-            if(!_shown)
-            {
-                ret->Width = _lastSize.width;
-                ret->Height = _lastSize.height;
-            }
-            else
-            {
-                auto frame = [View frame];
-                ret->Width = frame.size.width;
-                ret->Height = frame.size.height;
-            }
+            auto frame = [View frame];
+            ret->Width = frame.size.width;
+            ret->Height = frame.size.height;
             
             return S_OK;
         }
@@ -332,8 +322,6 @@ public:
             
             @try
             {
-                _lastSize = NSSize{x,y};
-                
                 if(!_shown)
                 {
                     BaseEvents->Resized(AvnSize{x,y}, reason);

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -27,6 +27,7 @@ public:
     AvnPoint lastPositionSet;
     NSString* _lastTitle;
     IAvnMenu* _mainMenu;
+    NSSize _lastSize;
     
     bool _shown;
     bool _inResize;
@@ -35,6 +36,7 @@ public:
     {
         _shown = false;
         _inResize = false;
+        _lastSize = NSSize { 0, 0 };
         _mainMenu = nullptr;
         BaseEvents = events;
         _glContext = gl;
@@ -226,9 +228,17 @@ public:
             if(ret == nullptr)
                 return E_POINTER;
             
-            auto frame = [View frame];
-            ret->Width = frame.size.width;
-            ret->Height = frame.size.height;
+            if(!_shown)
+            {
+                ret->Width = _lastSize.width;
+                ret->Height = _lastSize.height;
+            }
+            else
+            {
+                auto frame = [View frame];
+                ret->Width = frame.size.width;
+                ret->Height = frame.size.height;
+            }
             
             return S_OK;
         }
@@ -323,6 +333,8 @@ public:
             
             @try
             {
+                _lastSize = NSSize{x,y};
+                
                 if(!_shown)
                 {
                     BaseEvents->Resized(AvnSize{x,y}, reason);

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -328,7 +328,6 @@ public:
                     BaseEvents->Resized(AvnSize{x,y}, reason);
                 }
                 
-                [StandardContainer setFrameSize:NSSize{x,y}];
                 [Window setContentSize:NSSize{x, y}];
             }
             @finally


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes the red flicker when resizing windows on Catalina

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
