### PR TITLE
Added nullable annotations to Avalonia.Visuals.

### DIFF
--- a/src/Android/Avalonia.AndroidTestApplication/Resources/Resource.Designer.cs
+++ b/src/Android/Avalonia.AndroidTestApplication/Resources/Resource.Designer.cs
@@ -14,7 +14,7 @@ namespace Avalonia.AndroidTestApplication
 {
 	
 	
-	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "12.1.99.62")]
 	public partial class Resource
 	{
 		

--- a/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
+++ b/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
@@ -6,7 +6,7 @@
         <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
         <DefineConstants>$(DefineConstants);BUILDTASK;XAMLX_CECIL_INTERNAL;XAMLX_INTERNAL</DefineConstants>
         <CopyLocalLockFileAssemblies Condition="$(TargetFramework) == 'netstandard2.0'">true</CopyLocalLockFileAssemblies>
-        <NoWarn>NU1605</NoWarn>
+        <NoWarn>NU1605;CS8632</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/TreePageViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/TreePageViewModel.cs
@@ -86,14 +86,15 @@ namespace Avalonia.Diagnostics.ViewModels
         public void SelectControl(IControl control)
         {
             var node = default(TreeNode);
+            IControl? c = control;
 
-            while (node == null && control != null)
+            while (node == null && c != null)
             {
-                node = FindNode(control);
+                node = FindNode(c);
 
                 if (node == null)
                 {
-                    control = control.GetVisualParent<IControl>();
+                    c = c.GetVisualParent<IControl>();
                 }
             }
 

--- a/src/Avalonia.Input/AccessKeyHandler.cs
+++ b/src/Avalonia.Input/AccessKeyHandler.cs
@@ -188,7 +188,7 @@ namespace Avalonia.Input
                 // If the menu is open, only match controls in the menu's visual tree.
                 if (menuIsOpen)
                 {
-                    matches = matches.Where(x => MainMenu.IsVisualAncestorOf(x));
+                    matches = matches.Where(x => x is not null && MainMenu!.IsVisualAncestorOf(x));
                 }
 
                 var match = matches.FirstOrDefault();

--- a/src/Avalonia.Input/InputElement.cs
+++ b/src/Avalonia.Input/InputElement.cs
@@ -675,7 +675,7 @@ namespace Avalonia.Input
         /// <see cref="IsEffectivelyEnabled"/>.
         /// </summary>
         /// <param name="parent">The parent control.</param>
-        private void UpdateIsEffectivelyEnabled(InputElement parent)
+        private void UpdateIsEffectivelyEnabled(InputElement? parent)
         {
             IsEffectivelyEnabled = IsEnabledCore && (parent?.IsEffectivelyEnabled ?? true);
 

--- a/src/Avalonia.Input/Pointer.cs
+++ b/src/Avalonia.Input/Pointer.cs
@@ -54,7 +54,7 @@ namespace Avalonia.Input
                 Captured.DetachedFromVisualTree += OnCaptureDetached;
         }
 
-        IInputElement GetNextCapture(IVisual parent)
+        IInputElement? GetNextCapture(IVisual parent)
         {
             return parent as IInputElement ?? parent.FindAncestorOfType<IInputElement>();
         }

--- a/src/Avalonia.Visuals/Animation/Animators/BaseBrushAnimator.cs
+++ b/src/Avalonia.Visuals/Animation/Animators/BaseBrushAnimator.cs
@@ -143,7 +143,7 @@ namespace Avalonia.Animation.Animators
                     if (!match(firstKeyType))
                         continue;
 
-                    animator = (IAnimator)Activator.CreateInstance(animatorType);
+                    animator = (IAnimator?)Activator.CreateInstance(animatorType);
                     if (animator != null)
                     {
                         animator.Property = Property;

--- a/src/Avalonia.Visuals/Animation/Animators/TransformAnimator.cs
+++ b/src/Avalonia.Visuals/Animation/Animators/TransformAnimator.cs
@@ -11,10 +11,10 @@ namespace Avalonia.Animation.Animators
     /// </summary>
     public class TransformAnimator : Animator<double>
     {
-        DoubleAnimator _doubleAnimator;
+        DoubleAnimator? _doubleAnimator;
 
         /// <inheritdoc/>
-        public override IDisposable Apply(Animation animation, Animatable control, IClock clock, IObservable<bool> obsMatch, Action onComplete)
+        public override IDisposable? Apply(Animation animation, Animatable control, IClock clock, IObservable<bool> obsMatch, Action onComplete)
         {
             var ctrl = (Visual)control;
 

--- a/src/Avalonia.Visuals/Animation/CompositePageTransition.cs
+++ b/src/Avalonia.Visuals/Animation/CompositePageTransition.cs
@@ -37,7 +37,7 @@ namespace Avalonia.Animation
         public List<IPageTransition> PageTransitions { get; set; } = new List<IPageTransition>();
 
         /// <inheritdoc />
-        public Task Start(Visual from, Visual to, bool forward, CancellationToken cancellationToken)
+        public Task Start(Visual? from, Visual? to, bool forward, CancellationToken cancellationToken)
         {
             var transitionTasks = PageTransitions
                 .Select(transition => transition.Start(from, to, forward, cancellationToken))

--- a/src/Avalonia.Visuals/Animation/CrossFade.cs
+++ b/src/Avalonia.Visuals/Animation/CrossFade.cs
@@ -100,7 +100,7 @@ namespace Avalonia.Animation
         }
 
         /// <inheritdoc cref="Start(Visual, Visual, CancellationToken)" />
-        public async Task Start(Visual from, Visual to, CancellationToken cancellationToken)
+        public async Task Start(Visual? from, Visual? to, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
@@ -112,7 +112,7 @@ namespace Avalonia.Animation
             {
                 if (to != null)
                 {
-                    disposables.Add(to.SetValue(Visual.OpacityProperty, 0, Data.BindingPriority.Animation));
+                    disposables.Add(to.SetValue(Visual.OpacityProperty, 0, Data.BindingPriority.Animation)!);
                 }
 
                 if (from != null)
@@ -151,7 +151,7 @@ namespace Avalonia.Animation
         /// <returns>
         /// A <see cref="Task"/> that tracks the progress of the animation.
         /// </returns>
-        Task IPageTransition.Start(Visual from, Visual to, bool forward, CancellationToken cancellationToken)
+        Task IPageTransition.Start(Visual? from, Visual? to, bool forward, CancellationToken cancellationToken)
         {
             return Start(from, to, cancellationToken);
         }

--- a/src/Avalonia.Visuals/Animation/IPageTransition.cs
+++ b/src/Avalonia.Visuals/Animation/IPageTransition.cs
@@ -26,6 +26,6 @@ namespace Avalonia.Animation
         /// <returns>
         /// A <see cref="Task"/> that tracks the progress of the animation.
         /// </returns>
-        Task Start(Visual from, Visual to, bool forward, CancellationToken cancellationToken);
+        Task Start(Visual? from, Visual? to, bool forward, CancellationToken cancellationToken);
     }
 }

--- a/src/Avalonia.Visuals/Animation/PageSlide.cs
+++ b/src/Avalonia.Visuals/Animation/PageSlide.cs
@@ -62,7 +62,7 @@ namespace Avalonia.Animation
         public Easing SlideOutEasing { get; set; } = new LinearEasing();
 
         /// <inheritdoc />
-        public async Task Start(Visual from, Visual to, bool forward, CancellationToken cancellationToken)
+        public async Task Start(Visual? from, Visual? to, bool forward, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
@@ -155,17 +155,17 @@ namespace Avalonia.Animation
         /// <remarks>
         /// Any one of the parameters may be null, but not both.
         /// </remarks>
-        private static IVisual GetVisualParent(IVisual from, IVisual to)
+        private static IVisual GetVisualParent(IVisual? from, IVisual? to)
         {
-            var p1 = (from ?? to).VisualParent;
-            var p2 = (to ?? from).VisualParent;
+            var p1 = (from ?? to)!.VisualParent;
+            var p2 = (to ?? from)!.VisualParent;
 
             if (p1 != null && p2 != null && p1 != p2)
             {
                 throw new ArgumentException("Controls for PageSlide must have same parent.");
             }
 
-            return p1;
+            return p1 ?? throw new InvalidOperationException("Cannot determine visual parent.");
         }
     }
 }

--- a/src/Avalonia.Visuals/Animation/RenderLoopClock.cs
+++ b/src/Avalonia.Visuals/Animation/RenderLoopClock.cs
@@ -9,7 +9,9 @@ namespace Avalonia.Animation
     {
         protected override void Stop()
         {
-            AvaloniaLocator.Current.GetService<IRenderLoop>().Remove(this);
+            var loop = AvaloniaLocator.Current.GetService<IRenderLoop>() ??
+                throw new InvalidOperationException("Unable to locate IRenderLoop.");
+            loop.Remove(this);
         }
 
         bool IRenderLoopTask.NeedsUpdate => HasSubscriptions;

--- a/src/Avalonia.Visuals/ApiCompatBaseline.txt
+++ b/src/Avalonia.Visuals/ApiCompatBaseline.txt
@@ -5,6 +5,8 @@ InterfacesShouldHaveSameMembers : Interface member 'public System.Threading.Task
 MembersMustExist : Member 'public System.Threading.Tasks.Task Avalonia.Animation.IPageTransition.Start(Avalonia.Visual, Avalonia.Visual, System.Boolean)' does not exist in the implementation but it does exist in the contract.
 InterfacesShouldHaveSameMembers : Interface member 'public System.Threading.Tasks.Task Avalonia.Animation.IPageTransition.Start(Avalonia.Visual, Avalonia.Visual, System.Boolean, System.Threading.CancellationToken)' is present in the implementation but not in the contract.
 MembersMustExist : Member 'public System.Threading.Tasks.Task Avalonia.Animation.PageSlide.Start(Avalonia.Visual, Avalonia.Visual, System.Boolean)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public void Avalonia.Media.GlyphRun..ctor()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public void Avalonia.Media.GlyphRun.GlyphTypeface.set(Avalonia.Media.GlyphTypeface)' does not exist in the implementation but it does exist in the contract.
 TypeCannotChangeClassification : Type 'Avalonia.Media.Immutable.ImmutableSolidColorBrush' is a 'class' in the implementation but is a 'struct' in the contract.
 MembersMustExist : Member 'public void Avalonia.Media.TextFormatting.DrawableTextRun.Draw(Avalonia.Media.DrawingContext)' does not exist in the implementation but it does exist in the contract.
 CannotAddAbstractMembers : Member 'public void Avalonia.Media.TextFormatting.DrawableTextRun.Draw(Avalonia.Media.DrawingContext, Avalonia.Point)' is abstract in the implementation but is missing in the contract.
@@ -77,4 +79,4 @@ InterfacesShouldHaveSameMembers : Interface member 'public Avalonia.Platform.IWr
 InterfacesShouldHaveSameMembers : Interface member 'public Avalonia.Platform.IWriteableBitmapImpl Avalonia.Platform.IPlatformRenderInterface.LoadWriteableBitmap(System.String)' is present in the implementation but not in the contract.
 InterfacesShouldHaveSameMembers : Interface member 'public Avalonia.Platform.IWriteableBitmapImpl Avalonia.Platform.IPlatformRenderInterface.LoadWriteableBitmapToHeight(System.IO.Stream, System.Int32, Avalonia.Visuals.Media.Imaging.BitmapInterpolationMode)' is present in the implementation but not in the contract.
 InterfacesShouldHaveSameMembers : Interface member 'public Avalonia.Platform.IWriteableBitmapImpl Avalonia.Platform.IPlatformRenderInterface.LoadWriteableBitmapToWidth(System.IO.Stream, System.Int32, Avalonia.Visuals.Media.Imaging.BitmapInterpolationMode)' is present in the implementation but not in the contract.
-Total Issues: 78
+Total Issues: 79

--- a/src/Avalonia.Visuals/Avalonia.Visuals.csproj
+++ b/src/Avalonia.Visuals/Avalonia.Visuals.csproj
@@ -15,4 +15,5 @@
   <Import Project="..\..\build\Rx.props" />
   <Import Project="..\..\build\System.Memory.props" />
   <Import Project="..\..\build\ApiDiff.props" />
+  <Import Project="..\..\build\NullableEnable.props" />
 </Project>

--- a/src/Avalonia.Visuals/CornerRadius.cs
+++ b/src/Avalonia.Visuals/CornerRadius.cs
@@ -91,7 +91,7 @@ namespace Avalonia
         /// </summary>
         /// <param name="obj">The Object to compare against.</param>
         /// <returns>True if the Object is equal to this corner radius; False otherwise.</returns>
-        public override bool Equals(object obj) => obj is CornerRadius other && Equals(other);
+        public override bool Equals(object? obj) => obj is CornerRadius other && Equals(other);
 
         public override int GetHashCode()
         {

--- a/src/Avalonia.Visuals/Matrix.cs
+++ b/src/Avalonia.Visuals/Matrix.cs
@@ -272,7 +272,7 @@ namespace Avalonia
         /// </summary>
         /// <param name="obj">The Object to compare against.</param>
         /// <returns>True if the Object is equal to this matrix; False otherwise.</returns>
-        public override bool Equals(object obj) => obj is Matrix other && Equals(other);
+        public override bool Equals(object? obj) => obj is Matrix other && Equals(other);
 
         /// <summary>
         /// Returns the hash code for this instance.

--- a/src/Avalonia.Visuals/Media/BoxShadow.cs
+++ b/src/Avalonia.Visuals/Media/BoxShadow.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using Avalonia.Animation.Animators;
@@ -26,7 +27,7 @@ namespace Avalonia.Media
             return OffsetX.Equals(other.OffsetX) && OffsetY.Equals(other.OffsetY) && Blur.Equals(other.Blur) && Spread.Equals(other.Spread) && Color.Equals(other.Color);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is BoxShadow other && Equals(other);
         }
@@ -59,7 +60,7 @@ namespace Avalonia.Media
                 _index = 0;
             }
 
-            public bool TryReadString(out string s)
+            public bool TryReadString([MaybeNullWhen(false)] out string s)
             {
                 s = null;
                 if (_index >= _arr.Length)
@@ -152,11 +153,11 @@ namespace Avalonia.Media
             tokenizer.TryReadString(out var token5);
 
             if (token4 != null) 
-                blur = double.Parse(token3, CultureInfo.InvariantCulture);
+                blur = double.Parse(token3!, CultureInfo.InvariantCulture);
             if (token5 != null)
-                spread = double.Parse(token4, CultureInfo.InvariantCulture);
+                spread = double.Parse(token4!, CultureInfo.InvariantCulture);
 
-            var color = Color.Parse(token5 ?? token4 ?? token3);
+            var color = Color.Parse(token5 ?? token4 ?? token3!);
             return new BoxShadow
             {
                 IsInset = inset,

--- a/src/Avalonia.Visuals/Media/BoxShadows.cs
+++ b/src/Avalonia.Visuals/Media/BoxShadows.cs
@@ -8,7 +8,7 @@ namespace Avalonia.Media
     public struct BoxShadows
     {
         private readonly BoxShadow _first;
-        private readonly BoxShadow[] _list;
+        private readonly BoxShadow[]? _list;
         public int Count { get; }
 
         static BoxShadows()
@@ -39,7 +39,7 @@ namespace Avalonia.Media
                     throw new IndexOutOfRangeException();
                 if (c == 0)
                     return _first;
-                return _list[c - 1];
+                return _list![c - 1];
             }
         }
 
@@ -134,7 +134,7 @@ namespace Avalonia.Media
             return true;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is BoxShadows other && Equals(other);
         }

--- a/src/Avalonia.Visuals/Media/Brush.cs
+++ b/src/Avalonia.Visuals/Media/Brush.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Media
             AvaloniaProperty.Register<Brush, double>(nameof(Opacity), 1.0);
 
         /// <inheritdoc/>
-        public event EventHandler Invalidated;
+        public event EventHandler? Invalidated;
 
         static Brush()
         {
@@ -43,18 +43,20 @@ namespace Avalonia.Media
         /// <returns>The <see cref="Color"/>.</returns>
         public static IBrush Parse(string s)
         {
-            Contract.Requires<ArgumentNullException>(s != null);
-            Contract.Requires<FormatException>(s.Length > 0);
+            _ = s ?? throw new ArgumentNullException(nameof(s));
 
-            if (s[0] == '#')
+            if (s.Length > 0)
             {
-                return new ImmutableSolidColorBrush(Color.Parse(s));
-            }
+                if (s[0] == '#')
+                {
+                    return new ImmutableSolidColorBrush(Color.Parse(s));
+                }
 
-            var brush = KnownColors.GetKnownBrush(s);
-            if (brush != null)
-            {
-                return brush;
+                var brush = KnownColors.GetKnownBrush(s);
+                if (brush != null)
+                {
+                    return brush;
+                }
             }
 
             throw new FormatException($"Invalid brush string: '{s}'.");

--- a/src/Avalonia.Visuals/Media/BrushConverter.cs
+++ b/src/Avalonia.Visuals/Media/BrushConverter.cs
@@ -9,14 +9,14 @@ namespace Avalonia.Media
     /// </summary>
     public class BrushConverter : TypeConverter
     {
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
         {
             return sourceType == typeof(string);
         }
 
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object? value)
         {
-            return Brush.Parse((string)value);
+            return value is string s ? Brush.Parse(s) : null;
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/BrushExtensions.cs
+++ b/src/Avalonia.Visuals/Media/BrushExtensions.cs
@@ -18,7 +18,7 @@ namespace Avalonia.Media
         /// </returns>
         public static IBrush ToImmutable(this IBrush brush)
         {
-            Contract.Requires<ArgumentNullException>(brush != null);
+            _ = brush ?? throw new ArgumentNullException(nameof(brush));
 
             return (brush as IMutableBrush)?.ToImmutable() ?? brush;
         }
@@ -33,7 +33,7 @@ namespace Avalonia.Media
         /// </returns>
         public static ImmutableDashStyle ToImmutable(this IDashStyle style)
         {
-            Contract.Requires<ArgumentNullException>(style != null);
+            _ = style ?? throw new ArgumentNullException(nameof(style));
 
             return style as ImmutableDashStyle ?? ((DashStyle)style).ToImmutable();
         }
@@ -48,7 +48,7 @@ namespace Avalonia.Media
         /// </returns>
         public static ImmutablePen ToImmutable(this IPen pen)
         {
-            Contract.Requires<ArgumentNullException>(pen != null);
+            _ = pen ?? throw new ArgumentNullException(nameof(pen));
 
             return pen as ImmutablePen ?? ((Pen)pen).ToImmutable();
         }

--- a/src/Avalonia.Visuals/Media/CharacterHit.cs
+++ b/src/Avalonia.Visuals/Media/CharacterHit.cs
@@ -41,7 +41,7 @@ namespace Avalonia.Media
             return FirstCharacterIndex == other.FirstCharacterIndex && TrailingLength == other.TrailingLength;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is CharacterHit other && Equals(other);
         }

--- a/src/Avalonia.Visuals/Media/Color.cs
+++ b/src/Avalonia.Visuals/Media/Color.cs
@@ -280,7 +280,7 @@ namespace Avalonia.Media
             return A == other.A && R == other.R && G == other.G && B == other.B;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is Color other && Equals(other);
         }

--- a/src/Avalonia.Visuals/Media/DashStyle.cs
+++ b/src/Avalonia.Visuals/Media/DashStyle.cs
@@ -133,7 +133,7 @@ namespace Avalonia.Media
             }
         }
 
-        private void DashesChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void DashesChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             Invalidated?.Invoke(this, e);
         }

--- a/src/Avalonia.Visuals/Media/DrawingContext.cs
+++ b/src/Avalonia.Visuals/Media/DrawingContext.cs
@@ -202,7 +202,7 @@ namespace Avalonia.Media
         /// The brush and the pen can both be null. If the brush is null, then no fill is performed.
         /// If the pen is null, then no stoke is performed. If both the pen and the brush are null, then the drawing is not visible.
         /// </remarks>
-        public void DrawEllipse(IBrush brush, IPen pen, Point center, double radiusX, double radiusY)
+        public void DrawEllipse(IBrush? brush, IPen? pen, Point center, double radiusX, double radiusY)
         {
             if (brush == null && !PenIsVisible(pen))
             {

--- a/src/Avalonia.Visuals/Media/DrawingContext.cs
+++ b/src/Avalonia.Visuals/Media/DrawingContext.cs
@@ -351,6 +351,12 @@ namespace Avalonia.Media
         {
             _ = clip ?? throw new ArgumentNullException(nameof(clip));
 
+            // HACK: This check was added when nullable annotations pointed out that we're potentially
+            // pushing a null value for the clip here. Ideally we'd return an empty PushedState here but
+            // I don't want to make that change as part of adding nullable annotations.
+            if (clip.PlatformImpl is null)
+                throw new InvalidOperationException("Cannot push empty geometry clip.");
+
             PlatformImpl.PushGeometryClip(clip.PlatformImpl);
             return new PushedState(this, PushedState.PushedStateType.GeometryClip);
         }

--- a/src/Avalonia.Visuals/Media/DrawingContext.cs
+++ b/src/Avalonia.Visuals/Media/DrawingContext.cs
@@ -20,9 +20,9 @@ namespace Avalonia.Media
         private static ThreadSafeObjectPool<Stack<TransformContainer>> TransformStackPool { get; } =
             ThreadSafeObjectPool<Stack<TransformContainer>>.Default;
 
-        private Stack<PushedState> _states = StateStackPool.Get();
+        private Stack<PushedState>? _states = StateStackPool.Get();
 
-        private Stack<TransformContainer> _transformContainers = TransformStackPool.Get();
+        private Stack<TransformContainer>? _transformContainers = TransformStackPool.Get();
 
         readonly struct TransformContainer
         {
@@ -80,7 +80,7 @@ namespace Avalonia.Media
         /// <param name="rect">The rect in the output to draw to.</param>
         public void DrawImage(IImage source, Rect rect)
         {
-            Contract.Requires<ArgumentNullException>(source != null);
+            _ = source ?? throw new ArgumentNullException(nameof(source));
 
             DrawImage(source, new Rect(source.Size), rect);
         }
@@ -94,7 +94,7 @@ namespace Avalonia.Media
         /// <param name="bitmapInterpolationMode">The bitmap interpolation mode.</param>
         public void DrawImage(IImage source, Rect sourceRect, Rect destRect, BitmapInterpolationMode bitmapInterpolationMode = default)
         {
-            Contract.Requires<ArgumentNullException>(source != null);
+            _ = source ?? throw new ArgumentNullException(nameof(source));
 
             source.Draw(this, sourceRect, destRect, bitmapInterpolationMode);
         }
@@ -121,7 +121,8 @@ namespace Avalonia.Media
         /// <param name="geometry">The geometry.</param>
         public void DrawGeometry(IBrush brush, IPen pen, Geometry geometry)
         {
-            DrawGeometry(brush, pen, geometry.PlatformImpl);
+            if (geometry.PlatformImpl is not null)
+                DrawGeometry(brush, pen, geometry.PlatformImpl);
         }
 
         /// <summary>
@@ -132,7 +133,7 @@ namespace Avalonia.Media
         /// <param name="geometry">The geometry.</param>
         public void DrawGeometry(IBrush brush, IPen pen, IGeometryImpl geometry)
         {
-            Contract.Requires<ArgumentNullException>(geometry != null);
+            _ = geometry ?? throw new ArgumentNullException(nameof(geometry));
 
             if (brush != null || PenIsVisible(pen))
             {
@@ -157,7 +158,7 @@ namespace Avalonia.Media
         /// The brush and the pen can both be null. If the brush is null, then no fill is performed.
         /// If the pen is null, then no stoke is performed. If both the pen and the brush are null, then the drawing is not visible.
         /// </remarks>
-        public void DrawRectangle(IBrush brush, IPen pen, Rect rect, double radiusX = 0, double radiusY = 0,
+        public void DrawRectangle(IBrush? brush, IPen? pen, Rect rect, double radiusX = 0, double radiusY = 0,
             BoxShadows boxShadows = default)
         {
             if (brush == null && !PenIsVisible(pen))
@@ -230,7 +231,7 @@ namespace Avalonia.Media
         /// <param name="text">The text.</param>
         public void DrawText(IBrush foreground, Point origin, FormattedText text)
         {
-            Contract.Requires<ArgumentNullException>(text != null);
+            _ = text ?? throw new ArgumentNullException(nameof(text));
 
             if (foreground != null)
             {
@@ -245,7 +246,7 @@ namespace Avalonia.Media
         /// <param name="glyphRun">The glyph run.</param>
         public void DrawGlyphRun(IBrush foreground, GlyphRun glyphRun)
         {
-            Contract.Requires<ArgumentNullException>(glyphRun != null);
+            _ = glyphRun ?? throw new ArgumentNullException(nameof(glyphRun));
 
             if (foreground != null)
             {
@@ -279,11 +280,14 @@ namespace Avalonia.Media
                 Clip,
                 MatrixContainer,
                 GeometryClip,
-                OpacityMask
+                OpacityMask,
             }
 
             public PushedState(DrawingContext context, PushedStateType type, Matrix matrix = default(Matrix))
             {
+                if (context._states is null)
+                    throw new ObjectDisposedException(nameof(DrawingContext));
+
                 _context = context;
                 _type = type;
                 _matrix = matrix;
@@ -293,6 +297,8 @@ namespace Avalonia.Media
 
             public void Dispose()
             {
+                if (_context._states is null || _context._transformContainers is null)
+                    throw new ObjectDisposedException(nameof(DrawingContext));
                 if (_type == PushedStateType.None)
                     return;
                 if (_context._currentLevel != _level)
@@ -343,7 +349,8 @@ namespace Avalonia.Media
         /// <returns>A disposable used to undo the clip geometry.</returns>
         public PushedState PushGeometryClip(Geometry clip)
         {
-            Contract.Requires<ArgumentNullException>(clip != null);
+            _ = clip ?? throw new ArgumentNullException(nameof(clip));
+
             PlatformImpl.PushGeometryClip(clip.PlatformImpl);
             return new PushedState(this, PushedState.PushedStateType.GeometryClip);
         }
@@ -407,6 +414,8 @@ namespace Avalonia.Media
         /// <returns>A disposable used to undo the transformation.</returns>
         public PushedState PushTransformContainer()
         {
+            if (_transformContainers is null)
+                throw new ObjectDisposedException(nameof(DrawingContext));
             _transformContainers.Push(new TransformContainer(CurrentTransform, _currentContainerTransform));
             _currentContainerTransform = CurrentTransform * _currentContainerTransform;
             _currentTransform = Matrix.Identity;
@@ -418,6 +427,8 @@ namespace Avalonia.Media
         /// </summary>
         public void Dispose()
         {
+            if (_states is null || _transformContainers is null)
+                throw new ObjectDisposedException(nameof(DrawingContext));
             while (_states.Count != 0)
                 _states.Peek().Dispose();
             StateStackPool.Return(_states);
@@ -430,7 +441,7 @@ namespace Avalonia.Media
                 PlatformImpl.Dispose();
         }
 
-        private static bool PenIsVisible(IPen pen)
+        private static bool PenIsVisible(IPen? pen)
         {
             return pen?.Brush != null && pen.Thickness > 0;
         }

--- a/src/Avalonia.Visuals/Media/DrawingContext.cs
+++ b/src/Avalonia.Visuals/Media/DrawingContext.cs
@@ -297,10 +297,10 @@ namespace Avalonia.Media
 
             public void Dispose()
             {
-                if (_context._states is null || _context._transformContainers is null)
-                    throw new ObjectDisposedException(nameof(DrawingContext));
                 if (_type == PushedStateType.None)
                     return;
+                if (_context._states is null || _context._transformContainers is null)
+                    throw new ObjectDisposedException(nameof(DrawingContext));
                 if (_context._currentLevel != _level)
                     throw new InvalidOperationException("Wrong Push/Pop state order");
                 _context._currentLevel--;

--- a/src/Avalonia.Visuals/Media/DrawingImage.cs
+++ b/src/Avalonia.Visuals/Media/DrawingImage.cs
@@ -26,7 +26,7 @@ namespace Avalonia.Media
             AvaloniaProperty.Register<DrawingImage, Drawing>(nameof(Drawing));
 
         /// <inheritdoc/>
-        public event EventHandler Invalidated;
+        public event EventHandler? Invalidated;
 
         /// <summary>
         /// Gets or sets the drawing content.

--- a/src/Avalonia.Visuals/Media/EllipseGeometry.cs
+++ b/src/Avalonia.Visuals/Media/EllipseGeometry.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Platform;
 
 namespace Avalonia.Media
@@ -95,9 +96,10 @@ namespace Avalonia.Media
         }
 
         /// <inheritdoc/>
-        protected override IGeometryImpl CreateDefiningGeometry()
+        protected override IGeometryImpl? CreateDefiningGeometry()
         {
-            var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+            var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
+                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
 
             if (Rect != default) return factory.CreateEllipseGeometry(Rect);
             

--- a/src/Avalonia.Visuals/Media/ExperimentalAcrylicMaterial.cs
+++ b/src/Avalonia.Visuals/Media/ExperimentalAcrylicMaterial.cs
@@ -78,7 +78,7 @@ namespace Avalonia.Media
             AvaloniaProperty.Register<ExperimentalAcrylicMaterial, Color>(nameof(FallbackColor));
 
         /// <inheritdoc/>
-        public event EventHandler Invalidated;
+        public event EventHandler? Invalidated;
 
         /// <summary>
         /// Gets or Sets the BackgroundSource <seealso cref="AcrylicBackgroundSource"/>.
@@ -299,14 +299,14 @@ namespace Avalonia.Media
 
             var lightness = (max + min) / 2.0;
 
-            lightness = 1 - ((1 - lightness) * luminosityOpacity.Value);
+            lightness = 1 - ((1 - lightness) * (luminosityOpacity ?? 1));
 
             lightness = 0.13 + (lightness * 0.74);
 
             var luminosityColor = new Color(255, Trim(lightness), Trim(lightness), Trim(lightness));
 
             var compensationMultiplier = 1 - PlatformTransparencyCompensationLevel;
-            return new Color((byte)(255 * Math.Max(Math.Min(PlatformTransparencyCompensationLevel + (luminosityOpacity.Value * compensationMultiplier), 1.0), 0.0)), luminosityColor.R, luminosityColor.G, luminosityColor.B);
+            return new Color((byte)(255 * Math.Max(Math.Min(PlatformTransparencyCompensationLevel + ((luminosityOpacity ?? 1) * compensationMultiplier), 1.0), 0.0)), luminosityColor.R, luminosityColor.G, luminosityColor.B);
         }
 
         /// <summary>

--- a/src/Avalonia.Visuals/Media/FontFallback.cs
+++ b/src/Avalonia.Visuals/Media/FontFallback.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// Get or set the fallback <see cref="FontFamily"/>
         /// </summary>
-        public FontFamily FontFamily { get; set; }
+        public FontFamily FontFamily { get; set; } = FontFamily.Default;
 
         /// <summary>
         /// Get or set the <see cref="UnicodeRange"/> that is covered by the fallback.

--- a/src/Avalonia.Visuals/Media/FontFamily.cs
+++ b/src/Avalonia.Visuals/Media/FontFamily.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Media
         /// <param name="baseUri">Specifies the base uri that is used to resolve font family assets.</param>
         /// <param name="name">The name of the <see cref="T:Avalonia.Media.FontFamily" />.</param>
         /// <exception cref="T:System.ArgumentException">Base uri must be an absolute uri.</exception>
-        public FontFamily(Uri baseUri, string name)
+        public FontFamily(Uri? baseUri, string name)
         {
             if (string.IsNullOrEmpty(name))
             {
@@ -77,7 +77,7 @@ namespace Avalonia.Media
         /// The family key.
         /// </value>
         /// <remarks>Key is only used for custom fonts.</remarks>
-        public FontFamilyKey Key { get; }
+        public FontFamilyKey? Key { get; }
 
         /// <summary>
         /// Returns <c>True</c> if this instance is the system's default.
@@ -95,7 +95,7 @@ namespace Avalonia.Media
 
         private struct FontFamilyIdentifier
         {
-            public FontFamilyIdentifier(string name, Uri source)
+            public FontFamilyIdentifier(string name, Uri? source)
             {
                 Name = name;
                 Source = source;
@@ -103,7 +103,7 @@ namespace Avalonia.Media
 
             public string Name { get; }
 
-            public Uri Source { get; }
+            public Uri? Source { get; }
         }
 
         private static FontFamilyIdentifier GetFontFamilyIdentifier(string name)
@@ -152,7 +152,7 @@ namespace Avalonia.Media
         /// <exception cref="ArgumentException">
         /// Specified family is not supported.
         /// </exception>
-        public static FontFamily Parse(string s, Uri baseUri)
+        public static FontFamily Parse(string s, Uri? baseUri)
         {
             if (string.IsNullOrEmpty(s))
             {
@@ -192,12 +192,12 @@ namespace Avalonia.Media
             }
         }
 
-        public static bool operator !=(FontFamily a, FontFamily b)
+        public static bool operator !=(FontFamily? a, FontFamily? b)
         {
             return !(a == b);
         }
 
-        public static bool operator ==(FontFamily a, FontFamily b)
+        public static bool operator ==(FontFamily? a, FontFamily? b)
         {
             if (ReferenceEquals(a, b))
             {
@@ -207,7 +207,7 @@ namespace Avalonia.Media
             return !(a is null) && a.Equals(b);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(this, obj))
             {

--- a/src/Avalonia.Visuals/Media/FontManager.cs
+++ b/src/Avalonia.Visuals/Media/FontManager.cs
@@ -16,7 +16,7 @@ namespace Avalonia.Media
         private readonly ConcurrentDictionary<Typeface, GlyphTypeface> _glyphTypefaceCache =
             new ConcurrentDictionary<Typeface, GlyphTypeface>();
         private readonly FontFamily _defaultFontFamily;
-        private readonly IReadOnlyList<FontFallback> _fontFallbacks;
+        private readonly IReadOnlyList<FontFallback>? _fontFallbacks;
 
         public FontManager(IFontManagerImpl platformImpl)
         {
@@ -87,7 +87,7 @@ namespace Avalonia.Media
         /// <returns>
         ///     The <see cref="GlyphTypeface"/>.
         /// </returns>
-        public GlyphTypeface? GetOrAddGlyphTypeface(Typeface typeface)
+        public GlyphTypeface GetOrAddGlyphTypeface(Typeface typeface)
         {
             while (true)
             {
@@ -105,7 +105,7 @@ namespace Avalonia.Media
 
                 if (typeface.FontFamily == _defaultFontFamily)
                 {
-                    return null;
+                   throw new InvalidOperationException($"Could not create glyph typeface for: {typeface.FontFamily.Name}.");
                 }
 
                 typeface = new Typeface(_defaultFontFamily, typeface.Style, typeface.Weight);
@@ -126,7 +126,7 @@ namespace Avalonia.Media
         /// </returns>
         public bool TryMatchCharacter(int codepoint, FontStyle fontStyle,
             FontWeight fontWeight,
-            FontFamily fontFamily, CultureInfo culture, out Typeface typeface)
+            FontFamily? fontFamily, CultureInfo? culture, out Typeface typeface)
         {
             if(_fontFallbacks != null)
             {

--- a/src/Avalonia.Visuals/Media/FontManager.cs
+++ b/src/Avalonia.Visuals/Media/FontManager.cs
@@ -87,7 +87,7 @@ namespace Avalonia.Media
         /// <returns>
         ///     The <see cref="GlyphTypeface"/>.
         /// </returns>
-        public GlyphTypeface GetOrAddGlyphTypeface(Typeface typeface)
+        public GlyphTypeface? GetOrAddGlyphTypeface(Typeface typeface)
         {
             while (true)
             {

--- a/src/Avalonia.Visuals/Media/FontManagerOptions.cs
+++ b/src/Avalonia.Visuals/Media/FontManagerOptions.cs
@@ -4,8 +4,8 @@ namespace Avalonia.Media
 {
     public class FontManagerOptions
     {
-        public string DefaultFamilyName { get; set; }
+        public string? DefaultFamilyName { get; set; }
 
-        public IReadOnlyList<FontFallback> FontFallbacks { get; set; }
+        public IReadOnlyList<FontFallback>? FontFallbacks { get; set; }
     }
 }

--- a/src/Avalonia.Visuals/Media/Fonts/FamilyNameCollection.cs
+++ b/src/Avalonia.Visuals/Media/Fonts/FamilyNameCollection.cs
@@ -122,12 +122,12 @@ namespace Avalonia.Media.Fonts
             }
         }
 
-        public static bool operator !=(FamilyNameCollection a, FamilyNameCollection b)
+        public static bool operator !=(FamilyNameCollection? a, FamilyNameCollection? b)
         {
             return !(a == b);
         }
 
-        public static bool operator ==(FamilyNameCollection a, FamilyNameCollection b)
+        public static bool operator ==(FamilyNameCollection? a, FamilyNameCollection? b)
         {
             if (ReferenceEquals(a, b))
             {
@@ -144,7 +144,7 @@ namespace Avalonia.Media.Fonts
         /// <returns>
         ///   <c>true</c> if the specified <see cref="object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (!(obj is FamilyNameCollection other))
             {

--- a/src/Avalonia.Visuals/Media/Fonts/FontFamilyKey.cs
+++ b/src/Avalonia.Visuals/Media/Fonts/FontFamilyKey.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Media.Fonts
         /// </summary>
         /// <param name="source"></param>
         /// <param name="baseUri"></param>
-        public FontFamilyKey(Uri source, Uri baseUri = null)
+        public FontFamilyKey(Uri source, Uri? baseUri = null)
         {
             Source = source ?? throw new ArgumentNullException(nameof(source));
 
@@ -27,7 +27,7 @@ namespace Avalonia.Media.Fonts
         /// <summary>
         /// A base URI to use if <see cref="Source"/> is relative
         /// </summary>
-        public Uri BaseUri { get; }
+        public Uri? BaseUri { get; }
 
         /// <summary>
         /// Returns a hash code for this instance.
@@ -55,12 +55,12 @@ namespace Avalonia.Media.Fonts
             }
         }
 
-        public static bool operator !=(FontFamilyKey a, FontFamilyKey b)
+        public static bool operator !=(FontFamilyKey? a, FontFamilyKey? b)
         {
             return !(a == b);
         }
 
-        public static bool operator ==(FontFamilyKey a, FontFamilyKey b)
+        public static bool operator ==(FontFamilyKey? a, FontFamilyKey? b)
         {
             if (ReferenceEquals(a, b))
             {
@@ -77,7 +77,7 @@ namespace Avalonia.Media.Fonts
         /// <returns>
         ///   <c>true</c> if the specified <see cref="object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (!(obj is FontFamilyKey other))
             {

--- a/src/Avalonia.Visuals/Media/Fonts/FontFamilyLoader.cs
+++ b/src/Avalonia.Visuals/Media/Fonts/FontFamilyLoader.cs
@@ -89,7 +89,7 @@ namespace Avalonia.Media.Fonts
             {
                 fileExtension = "." + fontFamilyKey.Source.AbsolutePath.Split('.').LastOrDefault();
 
-                var fileName = fontFamilyKey.Source.LocalPath.Replace(fileExtension, string.Empty).Split('.').LastOrDefault();
+                var fileName = fontFamilyKey.Source.LocalPath.Replace(fileExtension, string.Empty).Split('.').Last();
 
                 location = new Uri(fontFamilyKey.Source.AbsoluteUri.Replace("." + fileName + fileExtension, string.Empty), UriKind.RelativeOrAbsolute);
 

--- a/src/Avalonia.Visuals/Media/Fonts/FontFamilyLoader.cs
+++ b/src/Avalonia.Visuals/Media/Fonts/FontFamilyLoader.cs
@@ -32,7 +32,8 @@ namespace Avalonia.Media.Fonts
         /// <returns></returns>
         private static IEnumerable<Uri> GetFontAssetsBySource(FontFamilyKey fontFamilyKey)
         {
-            var assetLoader = AvaloniaLocator.Current.GetService<IAssetLoader>();
+            var assetLoader = AvaloniaLocator.Current.GetService<IAssetLoader>() ??
+                throw new InvalidOperationException("Unable to locate IAssetLoader.");
 
             var availableAssets = assetLoader.GetAssets(fontFamilyKey.Source, fontFamilyKey.BaseUri);
 
@@ -50,7 +51,8 @@ namespace Avalonia.Media.Fonts
         /// <returns></returns>
         private static IEnumerable<Uri> GetFontAssetsByExpression(FontFamilyKey fontFamilyKey)
         {
-            var assetLoader = AvaloniaLocator.Current.GetService<IAssetLoader>();
+            var assetLoader = AvaloniaLocator.Current.GetService<IAssetLoader>() ??
+                throw new InvalidOperationException("Unable to locate IAssetLoader.");
 
             var fileName = GetFileName(fontFamilyKey, out var fileExtension, out var location);
 

--- a/src/Avalonia.Visuals/Media/FormattedText.cs
+++ b/src/Avalonia.Visuals/Media/FormattedText.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Avalonia.Platform;
 
@@ -10,11 +11,11 @@ namespace Avalonia.Media
     {
         private readonly IPlatformRenderInterface _platform;
         private Size _constraint = Size.Infinity;
-        private IFormattedTextImpl _platformImpl;
-        private IReadOnlyList<FormattedTextStyleSpan> _spans;
+        private IFormattedTextImpl? _platformImpl;
+        private IReadOnlyList<FormattedTextStyleSpan>? _spans;
         private Typeface _typeface;
         private double _fontSize;
-        private string _text;
+        private string? _text;
         private TextAlignment _textAlignment;
         private TextWrapping _textWrapping;
 
@@ -23,7 +24,8 @@ namespace Avalonia.Media
         /// </summary>
         public FormattedText()
         {
-            _platform = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+            _platform = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
+                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
         }
 
         /// <summary>
@@ -98,7 +100,7 @@ namespace Avalonia.Media
         /// Gets or sets a collection of spans that describe the formatting of subsections of the
         /// text.
         /// </summary>
-        public IReadOnlyList<FormattedTextStyleSpan> Spans
+        public IReadOnlyList<FormattedTextStyleSpan>? Spans
         {
             get => _spans;
             set => Set(ref _spans, value);
@@ -107,7 +109,7 @@ namespace Avalonia.Media
         /// <summary>
         /// Gets or sets the text.
         /// </summary>
-        public string Text
+        public string? Text
         {
             get => _text;
             set => Set(ref _text, value);
@@ -141,7 +143,7 @@ namespace Avalonia.Media
                 if (_platformImpl == null)
                 {
                     _platformImpl = _platform.CreateFormattedText(
-                        _text,
+                        _text ?? string.Empty,
                         _typeface,
                         _fontSize,
                         _textAlignment,

--- a/src/Avalonia.Visuals/Media/FormattedTextStyleSpan.cs
+++ b/src/Avalonia.Visuals/Media/FormattedTextStyleSpan.cs
@@ -14,7 +14,7 @@
         public FormattedTextStyleSpan(
             int startIndex,
             int length,
-            IBrush foregroundBrush = null)
+            IBrush? foregroundBrush = null)
         {
             StartIndex = startIndex;
             Length = length;
@@ -34,6 +34,6 @@
         /// <summary>
         /// Gets the span's foreground brush.
         /// </summary>
-        public IBrush ForegroundBrush { get; }
+        public IBrush? ForegroundBrush { get; }
     }
 }

--- a/src/Avalonia.Visuals/Media/Geometry.cs
+++ b/src/Avalonia.Visuals/Media/Geometry.cs
@@ -11,11 +11,11 @@ namespace Avalonia.Media
         /// <summary>
         /// Defines the <see cref="Transform"/> property.
         /// </summary>
-        public static readonly StyledProperty<Transform> TransformProperty =
-            AvaloniaProperty.Register<Geometry, Transform>(nameof(Transform));
+        public static readonly StyledProperty<Transform?> TransformProperty =
+            AvaloniaProperty.Register<Geometry, Transform?>(nameof(Transform));
 
         private bool _isDirty = true;
-        private IGeometryImpl _platformImpl;
+        private IGeometryImpl? _platformImpl;
 
         static Geometry()
         {
@@ -25,7 +25,7 @@ namespace Avalonia.Media
         /// <summary>
         /// Raised when the geometry changes.
         /// </summary>
-        public event EventHandler Changed;
+        public event EventHandler? Changed;
 
         /// <summary>
         /// Gets the geometry's bounding rectangle.
@@ -35,7 +35,7 @@ namespace Avalonia.Media
         /// <summary>
         /// Gets the platform-specific implementation of the geometry.
         /// </summary>
-        public IGeometryImpl PlatformImpl
+        public IGeometryImpl? PlatformImpl
         {
             get
             {
@@ -60,7 +60,7 @@ namespace Avalonia.Media
         /// <summary>
         /// Gets or sets a transform to apply to the geometry.
         /// </summary>
-        public Transform Transform
+        public Transform? Transform
         {
             get { return GetValue(TransformProperty); }
             set { SetValue(TransformProperty, value); }
@@ -127,7 +127,7 @@ namespace Avalonia.Media
         /// Creates the platform implementation of the geometry, without the transform applied.
         /// </summary>
         /// <returns></returns>
-        protected abstract IGeometryImpl CreateDefiningGeometry();
+        protected abstract IGeometryImpl? CreateDefiningGeometry();
 
         /// <summary>
         /// Invalidates the platform implementation of the geometry.
@@ -141,8 +141,8 @@ namespace Avalonia.Media
 
         private void TransformChanged(AvaloniaPropertyChangedEventArgs e)
         {
-            var oldValue = (Transform)e.OldValue;
-            var newValue = (Transform)e.NewValue;
+            var oldValue = (Transform?)e.OldValue;
+            var newValue = (Transform?)e.NewValue;
 
             if (oldValue != null)
             {
@@ -157,9 +157,9 @@ namespace Avalonia.Media
             TransformChanged(newValue, EventArgs.Empty);
         }
 
-        private void TransformChanged(object sender, EventArgs e)
+        private void TransformChanged(object? sender, EventArgs e)
         {
-            var transform = ((Transform)sender)?.Value;
+            var transform = ((Transform?)sender)?.Value;
 
             if (_platformImpl is ITransformedGeometryImpl t)
             {
@@ -174,7 +174,7 @@ namespace Avalonia.Media
             }
             else if (_platformImpl != null && transform != null && transform != Matrix.Identity)
             {
-                _platformImpl = PlatformImpl.WithTransform(transform.Value);
+                _platformImpl = _platformImpl.WithTransform(transform.Value);
             }
 
             Changed?.Invoke(this, EventArgs.Empty);

--- a/src/Avalonia.Visuals/Media/GlyphRun.cs
+++ b/src/Avalonia.Visuals/Media/GlyphRun.cs
@@ -28,14 +28,6 @@ namespace Avalonia.Media
         private ReadOnlySlice<char> _characters;
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="GlyphRun"/> class.
-        /// </summary>
-        public GlyphRun()
-        {
-
-        }
-
-        /// <summary>
         ///     Initializes a new instance of the <see cref="GlyphRun"/> class by specifying properties of the class.
         /// </summary>
         /// <param name="glyphTypeface">The glyph typeface.</param>
@@ -56,7 +48,7 @@ namespace Avalonia.Media
             ReadOnlySlice<ushort> glyphClusters = default,
             int biDiLevel = 0)
         {
-            GlyphTypeface = glyphTypeface;
+            _glyphTypeface = glyphTypeface;
 
             FontRenderingEmSize = fontRenderingEmSize;
 
@@ -74,13 +66,9 @@ namespace Avalonia.Media
         }
 
         /// <summary>
-        ///     Gets or sets the <see cref="Media.GlyphTypeface"/> for the <see cref="GlyphRun"/>.
+        ///     Gets the <see cref="Media.GlyphTypeface"/> for the <see cref="GlyphRun"/>.
         /// </summary>
-        public GlyphTypeface GlyphTypeface
-        {
-            get => _glyphTypeface;
-            set => Set(ref _glyphTypeface, value);
-        }
+        public GlyphTypeface GlyphTypeface => _glyphTypeface;
 
         /// <summary>
         ///     Gets or sets the em size used for rendering the <see cref="GlyphRun"/>.

--- a/src/Avalonia.Visuals/Media/GlyphRun.cs
+++ b/src/Avalonia.Visuals/Media/GlyphRun.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Media
         private static readonly IComparer<ushort> s_ascendingComparer = Comparer<ushort>.Default;
         private static readonly IComparer<ushort> s_descendingComparer = new ReverseComparer<ushort>();
 
-        private IGlyphRunImpl _glyphRunImpl;
+        private IGlyphRunImpl? _glyphRunImpl;
         private GlyphTypeface _glyphTypeface;
         private double _fontRenderingEmSize;
         private int _biDiLevel;
@@ -199,7 +199,7 @@ namespace Avalonia.Media
                     Initialize();
                 }
 
-                return _glyphRunImpl;
+                return _glyphRunImpl!;
             }
         }
 
@@ -639,7 +639,8 @@ namespace Avalonia.Media
                 throw new InvalidOperationException();
             }
 
-            var platformRenderInterface = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+            var platformRenderInterface = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
+                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface");
 
             _glyphRunImpl = platformRenderInterface.CreateGlyphRun(this);
         }
@@ -651,7 +652,7 @@ namespace Avalonia.Media
 
         private class ReverseComparer<T> : IComparer<T>
         {
-            public int Compare(T x, T y)
+            public int Compare(T? x, T? y)
             {
                 return Comparer<T>.Default.Compare(y, x);
             }

--- a/src/Avalonia.Visuals/Media/GlyphTypeface.cs
+++ b/src/Avalonia.Visuals/Media/GlyphTypeface.cs
@@ -8,8 +8,8 @@ namespace Avalonia.Media
         public const int InvisibleGlyph = 3;
 
         public GlyphTypeface(Typeface typeface) 
-            : this(FontManager.Current?.PlatformImpl.CreateGlyphTypeface(typeface))
-        { 
+            : this(FontManager.Current.PlatformImpl.CreateGlyphTypeface(typeface)) 
+        {
         }
 
         public GlyphTypeface(IGlyphTypefaceImpl platformImpl)

--- a/src/Avalonia.Visuals/Media/GradientBrush.cs
+++ b/src/Avalonia.Visuals/Media/GradientBrush.cs
@@ -26,7 +26,7 @@ namespace Avalonia.Media
         public static readonly StyledProperty<GradientStops> GradientStopsProperty =
             AvaloniaProperty.Register<GradientBrush, GradientStops>(nameof(GradientStops));
 
-        private IDisposable _gradientStopsSubscription;
+        private IDisposable? _gradientStopsSubscription;
 
         static GradientBrush()
         {
@@ -64,13 +64,13 @@ namespace Avalonia.Media
         {
             if (e.Sender is GradientBrush brush)
             {
-                var oldValue = (GradientStops)e.OldValue;
-                var newValue = (GradientStops)e.NewValue;
+                var oldValue = (GradientStops?)e.OldValue;
+                var newValue = (GradientStops?)e.NewValue;
 
                 if (oldValue != null)
                 {
                     oldValue.CollectionChanged -= brush.GradientStopsChanged;
-                    brush._gradientStopsSubscription.Dispose();
+                    brush._gradientStopsSubscription?.Dispose();
                 }
 
                 if (newValue != null)
@@ -83,12 +83,12 @@ namespace Avalonia.Media
             }
         }
 
-        private void GradientStopsChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void GradientStopsChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             RaiseInvalidated(EventArgs.Empty);
         }
 
-        private void GradientStopChanged(Tuple<object, PropertyChangedEventArgs> e)
+        private void GradientStopChanged(Tuple<object?, PropertyChangedEventArgs> e)
         {
             RaiseInvalidated(EventArgs.Empty);
         }

--- a/src/Avalonia.Visuals/Media/IPen.cs
+++ b/src/Avalonia.Visuals/Media/IPen.cs
@@ -8,12 +8,12 @@
         /// <summary>
         /// Gets the brush used to draw the stroke.
         /// </summary>
-        IBrush Brush { get; }
+        IBrush? Brush { get; }
 
         /// <summary>
         /// Gets the style of dashed lines drawn with a <see cref="Pen"/> object.
         /// </summary>
-        IDashStyle DashStyle { get; }
+        IDashStyle? DashStyle { get; }
 
         /// <summary>
         /// Gets the type of shape to use on both ends of a line.

--- a/src/Avalonia.Visuals/Media/Imaging/Bitmap.cs
+++ b/src/Avalonia.Visuals/Media/Imaging/Bitmap.cs
@@ -21,8 +21,7 @@ namespace Avalonia.Media.Imaging
         /// <returns>An instance of the <see cref="Bitmap"/> class.</returns>
         public static Bitmap DecodeToWidth(Stream stream, int width, BitmapInterpolationMode interpolationMode = BitmapInterpolationMode.HighQuality)
         {
-            IPlatformRenderInterface factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
-            return new Bitmap(factory.LoadBitmapToWidth(stream, width, interpolationMode));
+            return new Bitmap(GetFactory().LoadBitmapToWidth(stream, width, interpolationMode));
         }
 
         /// <summary>
@@ -35,8 +34,7 @@ namespace Avalonia.Media.Imaging
         /// <returns>An instance of the <see cref="Bitmap"/> class.</returns>
         public static Bitmap DecodeToHeight(Stream stream, int height, BitmapInterpolationMode interpolationMode = BitmapInterpolationMode.HighQuality)
         {
-            IPlatformRenderInterface factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
-            return new Bitmap(factory.LoadBitmapToHeight(stream, height, interpolationMode));
+            return new Bitmap(GetFactory().LoadBitmapToHeight(stream, height, interpolationMode));
         }
 
         /// <summary>
@@ -47,8 +45,7 @@ namespace Avalonia.Media.Imaging
         /// <returns>An instance of the <see cref="Bitmap"/> class.</returns>
         public Bitmap CreateScaledBitmap(PixelSize destinationSize, BitmapInterpolationMode interpolationMode = BitmapInterpolationMode.HighQuality)
         {
-            IPlatformRenderInterface factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
-            return new Bitmap(factory.ResizeBitmap(PlatformImpl.Item, destinationSize, interpolationMode));
+            return new Bitmap(GetFactory().ResizeBitmap(PlatformImpl.Item, destinationSize, interpolationMode));
         }
 
         /// <summary>
@@ -57,8 +54,7 @@ namespace Avalonia.Media.Imaging
         /// <param name="fileName">The filename of the bitmap.</param>
         public Bitmap(string fileName)
         {
-            IPlatformRenderInterface factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
-            PlatformImpl = RefCountable.Create(factory.LoadBitmap(fileName));
+            PlatformImpl = RefCountable.Create(GetFactory().LoadBitmap(fileName));
         }
 
         /// <summary>
@@ -67,8 +63,7 @@ namespace Avalonia.Media.Imaging
         /// <param name="stream">The stream to read the bitmap from.</param>
         public Bitmap(Stream stream)
         {
-            IPlatformRenderInterface factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
-            PlatformImpl = RefCountable.Create(factory.LoadBitmap(stream));
+            PlatformImpl = RefCountable.Create(GetFactory().LoadBitmap(stream));
         }
 
         /// <summary>
@@ -106,9 +101,8 @@ namespace Avalonia.Media.Imaging
         [Obsolete("Use overload taking an AlphaFormat.")]
         public Bitmap(PixelFormat format, IntPtr data, PixelSize size, Vector dpi, int stride)
         {
-            var ri = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
-
-            PlatformImpl = RefCountable.Create(AvaloniaLocator.Current.GetService<IPlatformRenderInterface>()
+            var ri = GetFactory();
+            PlatformImpl = RefCountable.Create(ri
                 .LoadBitmap(format, ri.DefaultAlphaFormat, data, size, dpi, stride));
         }
 
@@ -123,8 +117,7 @@ namespace Avalonia.Media.Imaging
         /// <param name="stride">The number of bytes per row.</param>
         public Bitmap(PixelFormat format, AlphaFormat alphaFormat, IntPtr data, PixelSize size, Vector dpi, int stride)
         {
-            PlatformImpl = RefCountable.Create(AvaloniaLocator.Current.GetService<IPlatformRenderInterface>()
-                .LoadBitmap(format, alphaFormat, data, size, dpi, stride));
+            PlatformImpl = RefCountable.Create(GetFactory().LoadBitmap(format, alphaFormat, data, size, dpi, stride));
         }
 
         /// <inheritdoc/>
@@ -172,6 +165,12 @@ namespace Avalonia.Media.Imaging
                 sourceRect,
                 destRect,
                 bitmapInterpolationMode);
+        }
+
+        private static IPlatformRenderInterface GetFactory()
+        {
+            return AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
+                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/Imaging/CroppedBitmap.cs
+++ b/src/Avalonia.Visuals/Media/Imaging/CroppedBitmap.cs
@@ -11,8 +11,8 @@ namespace Avalonia.Media.Imaging
         /// <summary>
         /// Defines the <see cref="Source"/> property.
         /// </summary>
-        public static readonly StyledProperty<IImage> SourceProperty =
-            AvaloniaProperty.Register<CroppedBitmap, IImage>(nameof(Source));
+        public static readonly StyledProperty<IImage?> SourceProperty =
+            AvaloniaProperty.Register<CroppedBitmap, IImage?>(nameof(Source));
 
         /// <summary>
         /// Defines the <see cref="SourceRect"/> property.
@@ -20,7 +20,7 @@ namespace Avalonia.Media.Imaging
         public static readonly StyledProperty<PixelRect> SourceRectProperty =
             AvaloniaProperty.Register<CroppedBitmap, PixelRect>(nameof(SourceRect));
 
-        public event EventHandler Invalidated;
+        public event EventHandler? Invalidated;
 
         static CroppedBitmap()
         {
@@ -31,7 +31,7 @@ namespace Avalonia.Media.Imaging
         /// <summary>
         /// Gets or sets the source for the bitmap.
         /// </summary>
-        public IImage Source
+        public IImage? Source
         {
             get => GetValue(SourceProperty);
             set => SetValue(SourceProperty, value);
@@ -77,19 +77,19 @@ namespace Avalonia.Media.Imaging
         public Size Size {
             get
             {
-                if (Source == null)
+                if (Source is not IBitmap bmp)
                     return Size.Empty;
                 if (SourceRect.IsEmpty)
                     return Source.Size;
-                return SourceRect.Size.ToSizeWithDpi((Source as IBitmap).Dpi);
+                return SourceRect.Size.ToSizeWithDpi(bmp.Dpi);
             }
         }
 
         public void Draw(DrawingContext context, Rect sourceRect, Rect destRect, BitmapInterpolationMode bitmapInterpolationMode)
         {
-            if (Source == null)
+            if (Source is not IBitmap bmp)
                 return;
-            var topLeft = SourceRect.TopLeft.ToPointWithDpi((Source as IBitmap).Dpi);
+            var topLeft = SourceRect.TopLeft.ToPointWithDpi(bmp.Dpi);
             Source.Draw(context, sourceRect.Translate(new Vector(topLeft.X, topLeft.Y)), destRect, bitmapInterpolationMode);           
         }
     }

--- a/src/Avalonia.Visuals/Media/Imaging/RenderTargetBitmap.cs
+++ b/src/Avalonia.Visuals/Media/Imaging/RenderTargetBitmap.cs
@@ -54,11 +54,12 @@ namespace Avalonia.Media.Imaging
         /// <returns>The platform-specific implementation.</returns>
         private static IRenderTargetBitmapImpl CreateImpl(PixelSize size, Vector dpi)
         {
-            IPlatformRenderInterface factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+            IPlatformRenderInterface factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
+                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
             return factory.CreateRenderTargetBitmap(size, dpi);
         }
 
         /// <inheritdoc/>
-        public IDrawingContextImpl CreateDrawingContext(IVisualBrushRenderer vbr) => PlatformImpl.Item.CreateDrawingContext(vbr);
+        public IDrawingContextImpl CreateDrawingContext(IVisualBrushRenderer? vbr) => PlatformImpl.Item.CreateDrawingContext(vbr);
     }
 }

--- a/src/Avalonia.Visuals/Media/Imaging/WriteableBitmap.cs
+++ b/src/Avalonia.Visuals/Media/Imaging/WriteableBitmap.cs
@@ -46,7 +46,7 @@ namespace Avalonia.Media.Imaging
 
         public static WriteableBitmap Decode(Stream stream)
         {
-            var ri = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+            var ri = GetFactory();
 
             return new WriteableBitmap(ri.LoadWriteableBitmap(stream));
         }
@@ -61,7 +61,7 @@ namespace Avalonia.Media.Imaging
         /// <returns>An instance of the <see cref="WriteableBitmap"/> class.</returns>
         public new static WriteableBitmap DecodeToWidth(Stream stream, int width, BitmapInterpolationMode interpolationMode = BitmapInterpolationMode.HighQuality)
         {
-            var ri = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+            var ri = GetFactory();
 
             return new WriteableBitmap(ri.LoadWriteableBitmapToWidth(stream, width, interpolationMode));
         }
@@ -76,19 +76,25 @@ namespace Avalonia.Media.Imaging
         /// <returns>An instance of the <see cref="WriteableBitmap"/> class.</returns>
         public new static WriteableBitmap DecodeToHeight(Stream stream, int height, BitmapInterpolationMode interpolationMode = BitmapInterpolationMode.HighQuality)
         {
-            var ri = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+            var ri = GetFactory();
 
             return new WriteableBitmap(ri.LoadWriteableBitmapToHeight(stream, height, interpolationMode));
         }
 
         private static IBitmapImpl CreatePlatformImpl(PixelSize size, in Vector dpi, PixelFormat? format, AlphaFormat? alphaFormat)
         {
-            var ri = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+            var ri = GetFactory();
 
             PixelFormat finalFormat = format ?? ri.DefaultPixelFormat;
             AlphaFormat finalAlphaFormat = alphaFormat ?? ri.DefaultAlphaFormat;
 
             return ri.CreateWriteableBitmap(size, dpi, finalFormat, finalAlphaFormat);
+        }
+
+        private static IPlatformRenderInterface GetFactory()
+        {
+            return AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
+                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/Immutable/ImmutableDashStyle.cs
+++ b/src/Avalonia.Visuals/Media/Immutable/ImmutableDashStyle.cs
@@ -30,10 +30,10 @@ namespace Avalonia.Media.Immutable
         public double Offset { get; }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as IDashStyle);
+        public override bool Equals(object? obj) => Equals(obj as IDashStyle);
 
         /// <inheritdoc/>
-        public bool Equals(IDashStyle other)
+        public bool Equals(IDashStyle? other)
         {
             if (ReferenceEquals(this, other))
             {

--- a/src/Avalonia.Visuals/Media/Immutable/ImmutablePen.cs
+++ b/src/Avalonia.Visuals/Media/Immutable/ImmutablePen.cs
@@ -21,7 +21,7 @@ namespace Avalonia.Media.Immutable
         public ImmutablePen(
             uint color,
             double thickness = 1.0,
-            ImmutableDashStyle dashStyle = null,
+            ImmutableDashStyle? dashStyle = null,
             PenLineCap lineCap = PenLineCap.Flat,
             PenLineJoin lineJoin = PenLineJoin.Miter,
             double miterLimit = 10.0) : this(new ImmutableSolidColorBrush(color), thickness, dashStyle, lineCap, lineJoin, miterLimit)
@@ -38,9 +38,9 @@ namespace Avalonia.Media.Immutable
         /// <param name="lineJoin">The line join.</param>
         /// <param name="miterLimit">The miter limit.</param>
         public ImmutablePen(
-            IBrush brush,
+            IBrush? brush,
             double thickness = 1.0,
-            ImmutableDashStyle dashStyle = null,
+            ImmutableDashStyle? dashStyle = null,
             PenLineCap lineCap = PenLineCap.Flat,
             PenLineJoin lineJoin = PenLineJoin.Miter,
             double miterLimit = 10.0)
@@ -58,7 +58,7 @@ namespace Avalonia.Media.Immutable
         /// <summary>
         /// Gets the brush used to draw the stroke.
         /// </summary>
-        public IBrush Brush { get; }
+        public IBrush? Brush { get; }
 
         /// <summary>
         /// Gets the stroke thickness.
@@ -68,7 +68,7 @@ namespace Avalonia.Media.Immutable
         /// <summary>
         /// Specifies the style of dashed lines drawn with a <see cref="Pen"/> object.
         /// </summary>
-        public IDashStyle DashStyle { get; }
+        public IDashStyle? DashStyle { get; }
 
         /// <summary>
         /// Specifies the type of graphic shape to use on both ends of a line.
@@ -87,10 +87,10 @@ namespace Avalonia.Media.Immutable
         public double MiterLimit { get; }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => Equals(obj as IPen);
+        public override bool Equals(object? obj) => Equals(obj as IPen);
 
         /// <inheritdoc/>
-        public bool Equals(IPen other)
+        public bool Equals(IPen? other)
         {
             if (ReferenceEquals(this, other))
             {

--- a/src/Avalonia.Visuals/Media/Immutable/ImmutableSolidColorBrush.cs
+++ b/src/Avalonia.Visuals/Media/Immutable/ImmutableSolidColorBrush.cs
@@ -46,14 +46,14 @@ namespace Avalonia.Media.Immutable
         /// </summary>
         public double Opacity { get; }
 
-        public bool Equals(ImmutableSolidColorBrush other)
+        public bool Equals(ImmutableSolidColorBrush? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return Color.Equals(other.Color) && Opacity.Equals(other.Opacity);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ImmutableSolidColorBrush other && Equals(other);
         }

--- a/src/Avalonia.Visuals/Media/ImmutableExperimentalAcrylicMaterial.cs
+++ b/src/Avalonia.Visuals/Media/ImmutableExperimentalAcrylicMaterial.cs
@@ -34,7 +34,7 @@ namespace Avalonia.Media
 
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ImmutableExperimentalAcrylicMaterial other && Equals(other);
         }

--- a/src/Avalonia.Visuals/Media/KnownColors.cs
+++ b/src/Avalonia.Visuals/Media/KnownColors.cs
@@ -20,7 +20,7 @@ namespace Avalonia.Media
             foreach (var field in typeof(KnownColor).GetRuntimeFields())
             {
                 if (field.FieldType != typeof(KnownColor)) continue;
-                var knownColor = (KnownColor)field.GetValue(null);
+                var knownColor = (KnownColor)field.GetValue(null)!;
                 if (knownColor == KnownColor.None) continue;
 
                 knownColorNames.Add(field.Name, knownColor);
@@ -41,7 +41,7 @@ namespace Avalonia.Media
         }
 
 #if !BUILDTASK
-        public static ISolidColorBrush GetKnownBrush(string s)
+        public static ISolidColorBrush? GetKnownBrush(string s)
         {
             var color = GetKnownColor(s);
             return color != KnownColor.None ? color.ToBrush() : null;
@@ -58,7 +58,7 @@ namespace Avalonia.Media
             return KnownColor.None;
         }
 
-        public static string GetKnownColorName(uint rgb)
+        public static string? GetKnownColorName(uint rgb)
         {
             return _knownColors.TryGetValue(rgb, out var name) ? name : null;
         }

--- a/src/Avalonia.Visuals/Media/LineGeometry.cs
+++ b/src/Avalonia.Visuals/Media/LineGeometry.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Platform;
 
 namespace Avalonia.Media
@@ -67,9 +68,10 @@ namespace Avalonia.Media
         }
 
         /// <inheritdoc/>
-        protected override IGeometryImpl CreateDefiningGeometry()
+        protected override IGeometryImpl? CreateDefiningGeometry()
         {
-            var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+            var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
+                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
 
             return factory.CreateLineGeometry(StartPoint, EndPoint);
         }

--- a/src/Avalonia.Visuals/Media/MaterialExtensions.cs
+++ b/src/Avalonia.Visuals/Media/MaterialExtensions.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Media
         /// </returns>
         public static IExperimentalAcrylicMaterial ToImmutable(this IExperimentalAcrylicMaterial material)
         {
-            Contract.Requires<ArgumentNullException>(material != null);
+            _ = material ?? throw new ArgumentNullException(nameof(material));
 
             return (material as IMutableExperimentalAcrylicMaterial)?.ToImmutable() ?? material;
         }

--- a/src/Avalonia.Visuals/Media/PathGeometry.cs
+++ b/src/Avalonia.Visuals/Media/PathGeometry.cs
@@ -11,8 +11,8 @@ namespace Avalonia.Media
         /// <summary>
         /// Defines the <see cref="Figures"/> property.
         /// </summary>
-        public static readonly DirectProperty<PathGeometry, PathFigures> FiguresProperty =
-            AvaloniaProperty.RegisterDirect<PathGeometry, PathFigures>(nameof(Figures), g => g.Figures, (g, f) => g.Figures = f);
+        public static readonly DirectProperty<PathGeometry, PathFigures?> FiguresProperty =
+            AvaloniaProperty.RegisterDirect<PathGeometry, PathFigures?>(nameof(Figures), g => g.Figures, (g, f) => g.Figures = f);
 
         /// <summary>
         /// Defines the <see cref="FillRule"/> property.
@@ -20,9 +20,9 @@ namespace Avalonia.Media
         public static readonly StyledProperty<FillRule> FillRuleProperty =
                                  AvaloniaProperty.Register<PathGeometry, FillRule>(nameof(FillRule));
 
-        private PathFigures _figures;
-        private IDisposable _figuresObserver;
-        private IDisposable _figuresPropertiesObserver;
+        private PathFigures? _figures;
+        private IDisposable? _figuresObserver;
+        private IDisposable? _figuresPropertiesObserver;
 
         static PathGeometry()
         {
@@ -35,7 +35,7 @@ namespace Avalonia.Media
         /// </summary>
         public PathGeometry()
         {
-            Figures = new PathFigures();
+            _figures = new PathFigures();
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace Avalonia.Media
         /// The figures.
         /// </value>
         [Content]
-        public PathFigures Figures
+        public PathFigures? Figures
         {
             get { return _figures; }
             set { SetAndRaise(FiguresProperty, ref _figures, value); }
@@ -81,15 +81,21 @@ namespace Avalonia.Media
             set { SetValue(FillRuleProperty, value); }
         }
 
-        protected override IGeometryImpl CreateDefiningGeometry()
+        protected override IGeometryImpl? CreateDefiningGeometry()
         {
-            var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+            var figures = Figures;
+
+            if (figures is null)
+                return null;
+
+            var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
+                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
             var geometry = factory.CreateStreamGeometry();
 
             using (var ctx = new StreamGeometryContext(geometry.Open()))
             {
                 ctx.SetFillRule(FillRule);
-                foreach (var f in Figures)
+                foreach (var f in figures)
                 {
                     f.ApplyTo(ctx);
                 }
@@ -98,7 +104,7 @@ namespace Avalonia.Media
             return geometry;
         }
 
-        private void OnFiguresChanged(PathFigures figures)
+        private void OnFiguresChanged(PathFigures? figures)
         {
             _figuresObserver?.Dispose();
             _figuresPropertiesObserver?.Dispose();
@@ -120,12 +126,15 @@ namespace Avalonia.Media
  
         }
 
-        private void InvalidateGeometryFromSegments(object _, EventArgs __)
+        private void InvalidateGeometryFromSegments(object? _, EventArgs __)
         {
             InvalidateGeometry();
         }
 
         public override string ToString()
-            => $"{(FillRule != FillRule.EvenOdd ? "F1 " : "")}{(string.Join(" ", Figures))}";
+        {
+            var figuresString = _figures is not null ? string.Join(" ", _figures) : string.Empty;
+            return $"{(FillRule != FillRule.EvenOdd ? "F1 " : "")}{figuresString}";
+        }
     }
 }

--- a/src/Avalonia.Visuals/Media/PathGeometryCollections.cs
+++ b/src/Avalonia.Visuals/Media/PathGeometryCollections.cs
@@ -20,7 +20,7 @@ namespace Avalonia.Media
                 parser.Parse(pathData);
             }
 
-            return pathGeometry.Figures;
+            return pathGeometry.Figures!;
         }
     }
 

--- a/src/Avalonia.Visuals/Media/PathMarkupParser.cs
+++ b/src/Avalonia.Visuals/Media/PathMarkupParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using Avalonia.Platform;
@@ -27,7 +28,7 @@ namespace Avalonia.Media
                     { 'Z', Command.Close },
                 };
 
-        private IGeometryContext _geometryContext;
+        private IGeometryContext? _geometryContext;
         private Point _currentPoint;
         private Point? _beginFigurePoint;
         private Point? _previousControlPoint;
@@ -98,6 +99,8 @@ namespace Avalonia.Media
         /// <param name="pathData">The path data.</param>
         public void Parse(string pathData)
         {
+            ThrowIfDisposed();
+
             var span = pathData.AsSpan();
             _currentPoint = new Point();
 
@@ -171,6 +174,8 @@ namespace Avalonia.Media
 
         private void CreateFigure()
         {
+            ThrowIfDisposed();
+
             if (_isOpen)
             {
                 _geometryContext.EndFigure(false);
@@ -185,6 +190,8 @@ namespace Avalonia.Media
 
         private void SetFillRule(ref ReadOnlySpan<char> span)
         {
+            ThrowIfDisposed();
+
             if (!ReadArgument(ref span, out var fillRule) || fillRule.Length != 1)
             {
                 throw new InvalidDataException("Invalid fill rule.");
@@ -209,6 +216,8 @@ namespace Avalonia.Media
 
         private void CloseFigure()
         {
+            ThrowIfDisposed();
+
             if (_isOpen)
             {
                 _geometryContext.EndFigure(true);
@@ -244,6 +253,8 @@ namespace Avalonia.Media
 
         private void AddLine(ref ReadOnlySpan<char> span, bool relative)
         {
+            ThrowIfDisposed();
+
             _currentPoint = relative
                                 ? ReadRelativePoint(ref span, _currentPoint)
                                 : ReadPoint(ref span);
@@ -258,6 +269,8 @@ namespace Avalonia.Media
 
         private void AddHorizontalLine(ref ReadOnlySpan<char> span, bool relative)
         {
+            ThrowIfDisposed();
+
             _currentPoint = relative
                                 ? new Point(_currentPoint.X + ReadDouble(ref span), _currentPoint.Y)
                                 : _currentPoint.WithX(ReadDouble(ref span));
@@ -272,6 +285,8 @@ namespace Avalonia.Media
 
         private void AddVerticalLine(ref ReadOnlySpan<char> span, bool relative)
         {
+            ThrowIfDisposed();
+
             _currentPoint = relative
                                 ? new Point(_currentPoint.X, _currentPoint.Y + ReadDouble(ref span))
                                 : _currentPoint.WithY(ReadDouble(ref span));
@@ -286,6 +301,8 @@ namespace Avalonia.Media
 
         private void AddCubicBezierCurve(ref ReadOnlySpan<char> span, bool relative)
         {
+            ThrowIfDisposed();
+
             var point1 = relative
                     ? ReadRelativePoint(ref span, _currentPoint)
                     : ReadPoint(ref span);
@@ -316,6 +333,8 @@ namespace Avalonia.Media
 
         private void AddQuadraticBezierCurve(ref ReadOnlySpan<char> span, bool relative)
         {
+            ThrowIfDisposed();
+
             var start = relative
                     ? ReadRelativePoint(ref span, _currentPoint)
                     : ReadPoint(ref span);
@@ -340,6 +359,8 @@ namespace Avalonia.Media
 
         private void AddSmoothCubicBezierCurve(ref ReadOnlySpan<char> span, bool relative)
         {
+            ThrowIfDisposed();
+
             var point2 = relative
                     ? ReadRelativePoint(ref span, _currentPoint)
                     : ReadPoint(ref span);
@@ -369,6 +390,8 @@ namespace Avalonia.Media
 
         private void AddSmoothQuadraticBezierCurve(ref ReadOnlySpan<char> span, bool relative)
         {
+            ThrowIfDisposed();
+
             var end = relative
                     ? ReadRelativePoint(ref span, _currentPoint)
                     : ReadPoint(ref span);
@@ -390,6 +413,8 @@ namespace Avalonia.Media
 
         private void AddArc(ref ReadOnlySpan<char> span, bool relative)
         {
+            ThrowIfDisposed();
+
             var size = ReadSize(ref span);
 
             span = ReadSeparator(span);
@@ -569,6 +594,13 @@ namespace Avalonia.Media
             relative = char.IsLower(c);
             span = span.Slice(1);
             return true;
+        }
+
+        [MemberNotNull(nameof(_geometryContext))]
+        private void ThrowIfDisposed()
+        {
+            if (_isDisposed || _geometryContext is null)
+                throw new ObjectDisposedException(nameof(PathMarkupParser));
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/Pen.cs
+++ b/src/Avalonia.Visuals/Media/Pen.cs
@@ -12,8 +12,8 @@ namespace Avalonia.Media
         /// <summary>
         /// Defines the <see cref="Brush"/> property.
         /// </summary>
-        public static readonly StyledProperty<IBrush> BrushProperty =
-            AvaloniaProperty.Register<Pen, IBrush>(nameof(Brush));
+        public static readonly StyledProperty<IBrush?> BrushProperty =
+            AvaloniaProperty.Register<Pen, IBrush?>(nameof(Brush));
 
         /// <summary>
         /// Defines the <see cref="Thickness"/> property.
@@ -24,8 +24,8 @@ namespace Avalonia.Media
         /// <summary>
         /// Defines the <see cref="DashStyle"/> property.
         /// </summary>
-        public static readonly StyledProperty<IDashStyle> DashStyleProperty =
-            AvaloniaProperty.Register<Pen, IDashStyle>(nameof(DashStyle));
+        public static readonly StyledProperty<IDashStyle?> DashStyleProperty =
+            AvaloniaProperty.Register<Pen, IDashStyle?>(nameof(DashStyle));
 
         /// <summary>
         /// Defines the <see cref="LineCap"/> property.
@@ -64,7 +64,7 @@ namespace Avalonia.Media
         public Pen(
             uint color,
             double thickness = 1.0,
-            IDashStyle dashStyle = null,
+            IDashStyle? dashStyle = null,
             PenLineCap lineCap = PenLineCap.Flat,
             PenLineJoin lineJoin = PenLineJoin.Miter,
             double miterLimit = 10.0) : this(new SolidColorBrush(color), thickness, dashStyle, lineCap, lineJoin, miterLimit)
@@ -81,9 +81,9 @@ namespace Avalonia.Media
         /// <param name="lineJoin">The line join.</param>
         /// <param name="miterLimit">The miter limit.</param>
         public Pen(
-            IBrush brush,
+            IBrush? brush,
             double thickness = 1.0,
-            IDashStyle dashStyle = null,
+            IDashStyle? dashStyle = null,
             PenLineCap lineCap = PenLineCap.Flat,
             PenLineJoin lineJoin = PenLineJoin.Miter,
             double miterLimit = 10.0)
@@ -110,7 +110,7 @@ namespace Avalonia.Media
         /// <summary>
         /// Gets or sets the brush used to draw the stroke.
         /// </summary>
-        public IBrush Brush
+        public IBrush? Brush
         {
             get => GetValue(BrushProperty);
             set => SetValue(BrushProperty, value);
@@ -128,7 +128,7 @@ namespace Avalonia.Media
         /// <summary>
         /// Gets or sets the style of dashed lines drawn with a <see cref="Pen"/> object.
         /// </summary>
-        public IDashStyle DashStyle
+        public IDashStyle? DashStyle
         {
             get => GetValue(DashStyleProperty);
             set => SetValue(DashStyleProperty, value);
@@ -165,7 +165,7 @@ namespace Avalonia.Media
         /// <summary>
         /// Raised when the pen changes.
         /// </summary>
-        public event EventHandler Invalidated;
+        public event EventHandler? Invalidated;
 
         /// <summary>
         /// Creates an immutable clone of the brush.
@@ -244,6 +244,6 @@ namespace Avalonia.Media
         /// <param name="e">The event args.</param>
         protected void RaiseInvalidated(EventArgs e) => Invalidated?.Invoke(this, e);
 
-        private void AffectsRenderInvalidated(object sender, EventArgs e) => RaiseInvalidated(EventArgs.Empty);
+        private void AffectsRenderInvalidated(object? sender, EventArgs e) => RaiseInvalidated(EventArgs.Empty);
     }
 }

--- a/src/Avalonia.Visuals/Media/PixelPoint.cs
+++ b/src/Avalonia.Visuals/Media/PixelPoint.cs
@@ -144,7 +144,7 @@ namespace Avalonia
         /// <returns>
         /// True if <paramref name="obj"/> is a point that equals the current point.
         /// </returns>
-        public override bool Equals(object obj) => obj is PixelPoint other && Equals(other);
+        public override bool Equals(object? obj) => obj is PixelPoint other && Equals(other);
 
         /// <summary>
         /// Returns a hash code for a <see cref="PixelPoint"/>.

--- a/src/Avalonia.Visuals/Media/PixelRect.cs
+++ b/src/Avalonia.Visuals/Media/PixelRect.cs
@@ -208,7 +208,7 @@ namespace Avalonia
         /// </summary>
         /// <param name="obj">The object to compare against.</param>
         /// <returns>True if the object is equal to this rectangle; false otherwise.</returns>
-        public override bool Equals(object obj) => obj is PixelRect other && Equals(other);
+        public override bool Equals(object? obj) => obj is PixelRect other && Equals(other);
 
         /// <summary>
         /// Returns the hash code for this instance.

--- a/src/Avalonia.Visuals/Media/PixelSize.cs
+++ b/src/Avalonia.Visuals/Media/PixelSize.cs
@@ -94,7 +94,7 @@ namespace Avalonia
         /// <returns>
         /// True if <paramref name="obj"/> is a size that equals the current size.
         /// </returns>
-        public override bool Equals(object obj) => obj is PixelSize other && Equals(other);
+        public override bool Equals(object? obj) => obj is PixelSize other && Equals(other);
 
         /// <summary>
         /// Returns a hash code for a <see cref="PixelSize"/>.

--- a/src/Avalonia.Visuals/Media/PixelVector.cs
+++ b/src/Avalonia.Visuals/Media/PixelVector.cs
@@ -143,7 +143,7 @@ namespace Avalonia
             return Math.Abs(_x - other._x) < tolerance && Math.Abs(_y - other._y) < tolerance;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
 

--- a/src/Avalonia.Visuals/Media/PolylineGeometry.cs
+++ b/src/Avalonia.Visuals/Media/PolylineGeometry.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Media
             AvaloniaProperty.Register<PolylineGeometry, bool>(nameof(IsFilled));
 
         private Points _points;
-        private IDisposable _pointsObserver;
+        private IDisposable? _pointsObserver;
 
         static PolylineGeometry()
         {
@@ -37,7 +37,7 @@ namespace Avalonia.Media
         /// </summary>
         public PolylineGeometry()
         {
-            Points = new Points();
+            _points = new Points();
         }
 
         /// <summary>
@@ -74,9 +74,10 @@ namespace Avalonia.Media
             return new PolylineGeometry(Points, IsFilled);
         }
 
-        protected override IGeometryImpl CreateDefiningGeometry()
+        protected override IGeometryImpl? CreateDefiningGeometry()
         {
-            var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+            var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
+                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
             var geometry = factory.CreateStreamGeometry();
 
             using (var context = geometry.Open())
@@ -97,7 +98,7 @@ namespace Avalonia.Media
             return geometry;
         }
 
-        private void OnPointsChanged(Points newValue)
+        private void OnPointsChanged(Points? newValue)
         {
             _pointsObserver?.Dispose();
             _pointsObserver = newValue?.ForEachItem(

--- a/src/Avalonia.Visuals/Media/RectangleGeometry.cs
+++ b/src/Avalonia.Visuals/Media/RectangleGeometry.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Platform;
 
 namespace Avalonia.Media
@@ -46,9 +47,10 @@ namespace Avalonia.Media
         /// <inheritdoc/>
         public override Geometry Clone() => new RectangleGeometry(Rect);
 
-        protected override IGeometryImpl CreateDefiningGeometry()
+        protected override IGeometryImpl? CreateDefiningGeometry()
         {
-            var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+            var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
+                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
 
             return factory.CreateRectangleGeometry(Rect);
         }

--- a/src/Avalonia.Visuals/Media/StreamGeometry.cs
+++ b/src/Avalonia.Visuals/Media/StreamGeometry.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Platform;
 
 namespace Avalonia.Media
@@ -7,7 +8,7 @@ namespace Avalonia.Media
     /// </summary>
     public class StreamGeometry : Geometry
     {
-        IStreamGeometryImpl _impl;
+        IStreamGeometryImpl? _impl;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StreamGeometry"/> class.
@@ -46,7 +47,7 @@ namespace Avalonia.Media
         /// <inheritdoc/>
         public override Geometry Clone()
         {
-            return new StreamGeometry(((IStreamGeometryImpl)PlatformImpl).Clone());
+            return new StreamGeometry(((IStreamGeometryImpl)PlatformImpl!).Clone());
         }
 
         /// <summary>
@@ -57,15 +58,16 @@ namespace Avalonia.Media
         /// </returns>
         public StreamGeometryContext Open()
         {
-            return new StreamGeometryContext(((IStreamGeometryImpl)PlatformImpl).Open());
+            return new StreamGeometryContext(((IStreamGeometryImpl)PlatformImpl!).Open());
         }
 
         /// <inheritdoc/>
-        protected override IGeometryImpl CreateDefiningGeometry()
+        protected override IGeometryImpl? CreateDefiningGeometry()
         {
             if (_impl == null)
             {
-                var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>();
+                var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
+                    throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
                 _impl = factory.CreateStreamGeometry();
             }
 

--- a/src/Avalonia.Visuals/Media/TextFormatting/GenericTextRunProperties.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/GenericTextRunProperties.cs
@@ -10,9 +10,9 @@ namespace Avalonia.Media.TextFormatting
         private const double DefaultFontRenderingEmSize = 12;
 
         public GenericTextRunProperties(Typeface typeface, double fontRenderingEmSize = DefaultFontRenderingEmSize,
-            TextDecorationCollection textDecorations = null, IBrush foregroundBrush = null,
-            IBrush backgroundBrush = null, BaselineAlignment baselineAlignment = BaselineAlignment.Baseline,
-            CultureInfo cultureInfo = null)
+            TextDecorationCollection? textDecorations = null, IBrush? foregroundBrush = null,
+            IBrush? backgroundBrush = null, BaselineAlignment baselineAlignment = BaselineAlignment.Baseline,
+            CultureInfo? cultureInfo = null)
         {
             Typeface = typeface;
             FontRenderingEmSize = fontRenderingEmSize;
@@ -30,18 +30,18 @@ namespace Avalonia.Media.TextFormatting
         public override double FontRenderingEmSize { get; }
 
         /// <inheritdoc />
-        public override TextDecorationCollection TextDecorations { get; }
+        public override TextDecorationCollection? TextDecorations { get; }
 
         /// <inheritdoc />
-        public override IBrush ForegroundBrush { get; }
+        public override IBrush? ForegroundBrush { get; }
 
         /// <inheritdoc />
-        public override IBrush BackgroundBrush { get; }
+        public override IBrush? BackgroundBrush { get; }
 
         /// <inheritdoc />
         public override BaselineAlignment BaselineAlignment { get; }
 
         /// <inheritdoc />
-        public override CultureInfo CultureInfo { get; }
+        public override CultureInfo? CultureInfo { get; }
     }
 }

--- a/src/Avalonia.Visuals/Media/TextFormatting/ITextSource.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/ITextSource.cs
@@ -10,6 +10,6 @@
         /// </summary>
         /// <param name="textSourceIndex">The text source index.</param>
         /// <returns>The text run.</returns>
-        TextRun GetTextRun(int textSourceIndex);
+        TextRun? GetTextRun(int textSourceIndex);
     }
 }

--- a/src/Avalonia.Visuals/Media/TextFormatting/ShapedTextCharacters.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/ShapedTextCharacters.cs
@@ -166,7 +166,7 @@ namespace Avalonia.Media.TextFormatting
 
         public readonly struct SplitTextCharactersResult
         {
-            public SplitTextCharactersResult(ShapedTextCharacters first, ShapedTextCharacters second)
+            public SplitTextCharactersResult(ShapedTextCharacters first, ShapedTextCharacters? second)
             {
                 First = first;
 
@@ -187,7 +187,7 @@ namespace Avalonia.Media.TextFormatting
             /// <value>
             /// The second text run.
             /// </value>
-            public ShapedTextCharacters Second { get; }
+            public ShapedTextCharacters? Second { get; }
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/TextFormatting/TextFormatter.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextFormatter.cs
@@ -41,6 +41,6 @@ namespace Avalonia.Media.TextFormatting
         /// in terms of where the previous line in the paragraph was broken by the text formatting process.</param>
         /// <returns>The formatted line.</returns>
         public abstract TextLine FormatLine(ITextSource textSource, int firstTextSourceIndex, double paragraphWidth,
-            TextParagraphProperties paragraphProperties, TextLineBreak previousLineBreak = null);
+            TextParagraphProperties paragraphProperties, TextLineBreak? previousLineBreak = null);
     }
 }

--- a/src/Avalonia.Visuals/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextFormatterImpl.cs
@@ -277,7 +277,7 @@ namespace Avalonia.Media.TextFormatting
 
             var textRuns = new List<ShapedTextCharacters>();
 
-            if (previousLineBreak != null)
+            if (previousLineBreak?.RemainingCharacters != null)
             {
                 for (var index = 0; index < previousLineBreak.RemainingCharacters.Count; index++)
                 {
@@ -317,7 +317,7 @@ namespace Avalonia.Media.TextFormatting
 
             while (textRunEnumerator.MoveNext())
             {
-                var textRun = textRunEnumerator.Current;
+                var textRun = textRunEnumerator.Current!;
 
                 switch (textRun)
                 {
@@ -398,7 +398,7 @@ namespace Avalonia.Media.TextFormatting
         /// <param name="currentLineBreak">The current line break if the line was explicitly broken.</param>
         /// <returns>The wrapped text line.</returns>
         private static TextLine PerformTextWrapping(List<ShapedTextCharacters> textRuns, TextRange textRange,
-            double paragraphWidth, TextParagraphProperties paragraphProperties, TextLineBreak currentLineBreak)
+            double paragraphWidth, TextParagraphProperties paragraphProperties, TextLineBreak? currentLineBreak)
         {
             var availableWidth = paragraphWidth;
             var currentWidth = 0.0;
@@ -517,7 +517,7 @@ namespace Avalonia.Media.TextFormatting
 
             var lineBreak = remainingCharacters?.Count > 0 ? new TextLineBreak(remainingCharacters) : null;
 
-            if (lineBreak is null && currentLineBreak.TextEndOfLine != null)
+            if (lineBreak is null && currentLineBreak?.TextEndOfLine != null)
             {
                 lineBreak = new TextLineBreak(currentLineBreak.TextEndOfLine);
             }
@@ -586,11 +586,11 @@ namespace Avalonia.Media.TextFormatting
             {
                 _textSource = textSource;
                 _pos = firstTextSourceIndex;
-                Current = null!;
+                Current = null;
             }
 
             // ReSharper disable once MemberHidesStaticFromOuterClass
-            public TextRun Current { get; private set; }
+            public TextRun? Current { get; private set; }
 
             public bool MoveNext()
             {

--- a/src/Avalonia.Visuals/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextFormatterImpl.cs
@@ -8,7 +8,7 @@ namespace Avalonia.Media.TextFormatting
     {
         /// <inheritdoc cref="TextFormatter.FormatLine"/>
         public override TextLine FormatLine(ITextSource textSource, int firstTextSourceIndex, double paragraphWidth,
-            TextParagraphProperties paragraphProperties, TextLineBreak previousLineBreak = null)
+            TextParagraphProperties paragraphProperties, TextLineBreak? previousLineBreak = null)
         {
             var textWrapping = paragraphProperties.TextWrapping;
 
@@ -241,7 +241,7 @@ namespace Avalonia.Media.TextFormatting
 
                     first.Add(split.First);
 
-                    second.Add(split.Second);
+                    second.Add(split.Second!);
 
                     if (secondCount > 0)
                     {
@@ -269,7 +269,7 @@ namespace Avalonia.Media.TextFormatting
         /// The formatted text runs.
         /// </returns>
         private static List<ShapedTextCharacters> FetchTextRuns(ITextSource textSource,
-            int firstTextSourceIndex, TextLineBreak previousLineBreak, out TextLineBreak nextLineBreak)
+            int firstTextSourceIndex, TextLineBreak? previousLineBreak, out TextLineBreak? nextLineBreak)
         {
             nextLineBreak = default;
 
@@ -298,11 +298,11 @@ namespace Avalonia.Media.TextFormatting
                         {
                             for (; index < previousLineBreak.RemainingCharacters.Count; index++)
                             {
-                                splitResult.Second.Add(previousLineBreak.RemainingCharacters[index]);
+                                splitResult.Second!.Add(previousLineBreak.RemainingCharacters[index]);
                             }
                         }
 
-                        nextLineBreak = new TextLineBreak(splitResult.Second);
+                        nextLineBreak = new TextLineBreak(splitResult.Second!);
 
                         return splitResult.First;
                     }
@@ -346,7 +346,7 @@ namespace Avalonia.Media.TextFormatting
                 {
                     var splitResult = SplitTextRuns(textRuns, currentLength + runLineBreak.PositionWrap);
 
-                    nextLineBreak = new TextLineBreak(splitResult.Second);
+                    nextLineBreak = new TextLineBreak(splitResult.Second!);
 
                     return splitResult.First;
                 }
@@ -553,7 +553,7 @@ namespace Avalonia.Media.TextFormatting
 
         internal readonly struct SplitTextRunsResult
         {
-            public SplitTextRunsResult(List<ShapedTextCharacters> first, List<ShapedTextCharacters> second)
+            public SplitTextRunsResult(List<ShapedTextCharacters> first, List<ShapedTextCharacters>? second)
             {
                 First = first;
 
@@ -574,7 +574,7 @@ namespace Avalonia.Media.TextFormatting
             /// <value>
             /// The second text runs.
             /// </value>
-            public List<ShapedTextCharacters> Second { get; }
+            public List<ShapedTextCharacters>? Second { get; }
         }
 
         private struct TextRunEnumerator
@@ -586,7 +586,7 @@ namespace Avalonia.Media.TextFormatting
             {
                 _textSource = textSource;
                 _pos = firstTextSourceIndex;
-                Current = null;
+                Current = null!;
             }
 
             // ReSharper disable once MemberHidesStaticFromOuterClass

--- a/src/Avalonia.Visuals/Media/TextFormatting/TextLayout.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextLayout.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Avalonia.Utilities;
 
@@ -14,7 +15,7 @@ namespace Avalonia.Media.TextFormatting
 
         private readonly ReadOnlySlice<char> _text;
         private readonly TextParagraphProperties _paragraphProperties;
-        private readonly IReadOnlyList<ValueSpan<TextRunProperties>> _textStyleOverrides;
+        private readonly IReadOnlyList<ValueSpan<TextRunProperties>>? _textStyleOverrides;
         private readonly TextTrimming _textTrimming;
 
         /// <summary>
@@ -41,12 +42,12 @@ namespace Avalonia.Media.TextFormatting
             TextAlignment textAlignment = TextAlignment.Left,
             TextWrapping textWrapping = TextWrapping.NoWrap,
             TextTrimming textTrimming = TextTrimming.None,
-            TextDecorationCollection textDecorations = null,
+            TextDecorationCollection? textDecorations = null,
             double maxWidth = double.PositiveInfinity,
             double maxHeight = double.PositiveInfinity,
             double lineHeight = double.NaN,
             int maxLines = 0,
-            IReadOnlyList<ValueSpan<TextRunProperties>> textStyleOverrides = null)
+            IReadOnlyList<ValueSpan<TextRunProperties>>? textStyleOverrides = null)
         {
             _text = string.IsNullOrEmpty(text) ?
                 new ReadOnlySlice<char>() :
@@ -228,7 +229,7 @@ namespace Avalonia.Media.TextFormatting
             var currentY = 0d;
 
             var lineIndex = 0;
-            TextLine currentLine = null;
+            TextLine? currentLine = null;
             CharacterHit characterHit;
 
             for (; lineIndex < TextLines.Count; lineIndex++)
@@ -289,7 +290,7 @@ namespace Avalonia.Media.TextFormatting
         /// <returns></returns>
         private static TextParagraphProperties CreateTextParagraphProperties(Typeface typeface, double fontSize,
             IBrush foreground, TextAlignment textAlignment, TextWrapping textWrapping,
-            TextDecorationCollection textDecorations, double lineHeight)
+            TextDecorationCollection? textDecorations, double lineHeight)
         {
             var textRunStyle = new GenericTextRunProperties(typeface, fontSize, textDecorations, foreground);
 
@@ -339,6 +340,7 @@ namespace Avalonia.Media.TextFormatting
         /// <summary>
         /// Updates the layout and applies specified text style overrides.
         /// </summary>
+        [MemberNotNull(nameof(TextLines))]
         private void UpdateLayout()
         {
             if (_text.IsEmpty || MathUtilities.IsZero(MaxWidth) || MathUtilities.IsZero(MaxHeight))
@@ -360,7 +362,7 @@ namespace Avalonia.Media.TextFormatting
                 var textSource = new FormattedTextSource(_text,
                     _paragraphProperties.DefaultTextRunProperties, _textStyleOverrides);
 
-                TextLine previousLine = null;
+                TextLine? previousLine = null;
 
                 while (currentPosition < _text.Length)
                 {
@@ -558,17 +560,17 @@ namespace Avalonia.Media.TextFormatting
         {
             private readonly ReadOnlySlice<char> _text;
             private readonly TextRunProperties _defaultProperties;
-            private readonly IReadOnlyList<ValueSpan<TextRunProperties>> _textModifier;
+            private readonly IReadOnlyList<ValueSpan<TextRunProperties>>? _textModifier;
 
             public FormattedTextSource(ReadOnlySlice<char> text, TextRunProperties defaultProperties,
-                IReadOnlyList<ValueSpan<TextRunProperties>> textModifier)
+                IReadOnlyList<ValueSpan<TextRunProperties>>? textModifier)
             {
                 _text = text;
                 _defaultProperties = defaultProperties;
                 _textModifier = textModifier;
             }
 
-            public TextRun GetTextRun(int textSourceIndex)
+            public TextRun? GetTextRun(int textSourceIndex)
             {
                 if (textSourceIndex > _text.Length)
                 {
@@ -597,7 +599,7 @@ namespace Avalonia.Media.TextFormatting
             /// The created text style run.
             /// </returns>
             private static ValueSpan<TextRunProperties> CreateTextStyleRun(ReadOnlySlice<char> text,
-                TextRunProperties defaultProperties, IReadOnlyList<ValueSpan<TextRunProperties>> textModifier)
+                TextRunProperties defaultProperties, IReadOnlyList<ValueSpan<TextRunProperties>>? textModifier)
             {
                 if (textModifier == null || textModifier.Count == 0)
                 {

--- a/src/Avalonia.Visuals/Media/TextFormatting/TextLine.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextLine.cs
@@ -29,7 +29,7 @@ namespace Avalonia.Media.TextFormatting
         /// <returns>
         /// A <see cref="TextLineBreak"/> value that represents the line break.
         /// </returns>
-        public abstract TextLineBreak TextLineBreak { get; }
+        public abstract TextLineBreak? TextLineBreak { get; }
 
         /// <summary>
         /// Gets the distance from the top to the baseline of the current TextLine object.

--- a/src/Avalonia.Visuals/Media/TextFormatting/TextLineBreak.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextLineBreak.cs
@@ -17,11 +17,11 @@ namespace Avalonia.Media.TextFormatting
         /// <summary>
         /// Get the
         /// </summary>
-        public  TextEndOfLine TextEndOfLine { get; }
+        public TextEndOfLine? TextEndOfLine { get; }
 
         /// <summary>
         /// Get the remaining shaped characters that were split up by the <see cref="TextFormatter"/> during the formatting process.
         /// </summary>
-        public IReadOnlyList<ShapedTextCharacters> RemainingCharacters { get; }
+        public IReadOnlyList<ShapedTextCharacters>? RemainingCharacters { get; }
     }
 }

--- a/src/Avalonia.Visuals/Media/TextFormatting/TextLineImpl.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextLineImpl.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Avalonia.Media.TextFormatting.Unicode;
 using Avalonia.Platform;
 using Avalonia.Utilities;
@@ -479,12 +480,13 @@ namespace Avalonia.Media.TextFormatting
         /// </returns>
         internal static ShapedTextCharacters CreateShapedSymbol(TextRun textRun)
         {
-            var formatterImpl = AvaloniaLocator.Current.GetService<ITextShaperImpl>();
+            var properties = textRun.Properties;
 
-            var glyphRun = formatterImpl.ShapeText(textRun.Text, textRun.Properties.Typeface, textRun.Properties.FontRenderingEmSize,
-                textRun.Properties.CultureInfo);
+            _ = properties ?? throw new InvalidOperationException($"{nameof(TextRun.Properties)} should not be null.");
 
-            return new ShapedTextCharacters(glyphRun, textRun.Properties);
+            var glyphRun = TextShaper.Current.ShapeText(textRun.Text, properties.Typeface, properties.FontRenderingEmSize, properties.CultureInfo);
+
+            return new ShapedTextCharacters(glyphRun, properties);
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/TextFormatting/TextLineImpl.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextLineImpl.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Media.TextFormatting
         private readonly TextLineMetrics _textLineMetrics;
 
         public TextLineImpl(List<ShapedTextCharacters> textRuns, TextRange textRange, double paragraphWidth,
-            TextParagraphProperties paragraphProperties, TextLineBreak lineBreak = null, bool hasCollapsed = false)
+            TextParagraphProperties paragraphProperties, TextLineBreak? lineBreak = null, bool hasCollapsed = false)
         {
             TextRange = textRange;
             TextLineBreak = lineBreak;
@@ -33,7 +33,7 @@ namespace Avalonia.Media.TextFormatting
         public override TextRange TextRange { get; }
 
         /// <inheritdoc/>
-        public override TextLineBreak TextLineBreak { get; }
+        public override TextLineBreak? TextLineBreak { get; }
 
         /// <inheritdoc/>
         public override bool HasCollapsed { get; }

--- a/src/Avalonia.Visuals/Media/TextFormatting/TextParagraphProperties.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextParagraphProperties.cs
@@ -44,7 +44,7 @@
         /// If not null, text decorations to apply to all runs in the line. This is in addition
         /// to any text decorations specified by the TextRunProperties for individual text runs.
         /// </summary>
-        public virtual TextDecorationCollection TextDecorations => null;
+        public virtual TextDecorationCollection? TextDecorations => null;
 
         /// <summary>
         /// Gets the text wrapping.

--- a/src/Avalonia.Visuals/Media/TextFormatting/TextRun.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextRun.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Media.TextFormatting
         /// <summary>
         /// A set of properties shared by every characters in the run
         /// </summary>
-        public virtual TextRunProperties Properties => null;
+        public virtual TextRunProperties? Properties => null;
 
         private class TextRunDebuggerProxy
         {
@@ -49,7 +49,7 @@ namespace Avalonia.Media.TextFormatting
                 }
             }
 
-            public TextRunProperties Properties => _textRun.Properties;
+            public TextRunProperties? Properties => _textRun.Properties;
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/TextFormatting/TextRunProperties.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextRunProperties.cs
@@ -25,29 +25,29 @@ namespace Avalonia.Media.TextFormatting
         ///<summary>
         /// Run TextDecorations. 
         ///</summary>
-        public abstract TextDecorationCollection TextDecorations { get; }
+        public abstract TextDecorationCollection? TextDecorations { get; }
 
         /// <summary>
         /// Brush used to fill text.
         /// </summary>
-        public abstract IBrush ForegroundBrush { get; }
+        public abstract IBrush? ForegroundBrush { get; }
 
         /// <summary>
         /// Brush used to paint background of run.
         /// </summary>
-        public abstract IBrush BackgroundBrush { get; }
+        public abstract IBrush? BackgroundBrush { get; }
 
         /// <summary>
         /// Run text culture.
         /// </summary>
-        public abstract CultureInfo CultureInfo { get; }
+        public abstract CultureInfo? CultureInfo { get; }
 
         /// <summary>
         /// Run vertical box alignment
         /// </summary>
         public abstract BaselineAlignment BaselineAlignment { get; }
 
-        public bool Equals(TextRunProperties other)
+        public bool Equals(TextRunProperties? other)
         {
             if (ReferenceEquals(null, other))
                 return false;
@@ -62,7 +62,7 @@ namespace Avalonia.Media.TextFormatting
                    Equals(CultureInfo, other.CultureInfo);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return ReferenceEquals(this, obj) || obj is TextRunProperties other && Equals(other);
         }

--- a/src/Avalonia.Visuals/Media/TextFormatting/TextShaper.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextShaper.cs
@@ -46,7 +46,7 @@ namespace Avalonia.Media.TextFormatting
 
         /// <inheritdoc cref="ITextShaperImpl.ShapeText"/>
         public GlyphRun ShapeText(ReadOnlySlice<char> text, Typeface typeface, double fontRenderingEmSize,
-            CultureInfo culture)
+            CultureInfo? culture)
         {
             return _platformImpl.ShapeText(text, typeface, fontRenderingEmSize, culture);
         }

--- a/src/Avalonia.Visuals/Media/TextFormatting/Unicode/UnicodeData.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/Unicode/UnicodeData.cs
@@ -24,8 +24,8 @@
 
         static UnicodeData()
         {
-            s_unicodeDataTrie = new UnicodeTrie(typeof(UnicodeData).Assembly.GetManifestResourceStream("Avalonia.Assets.UnicodeData.trie"));
-            s_graphemeBreakTrie = new UnicodeTrie(typeof(UnicodeData).Assembly.GetManifestResourceStream("Avalonia.Assets.GraphemeBreak.trie"));
+            s_unicodeDataTrie = new UnicodeTrie(typeof(UnicodeData).Assembly.GetManifestResourceStream("Avalonia.Assets.UnicodeData.trie")!);
+            s_graphemeBreakTrie = new UnicodeTrie(typeof(UnicodeData).Assembly.GetManifestResourceStream("Avalonia.Assets.GraphemeBreak.trie")!);
         }
 
         /// <summary>

--- a/src/Avalonia.Visuals/Media/Transform.cs
+++ b/src/Avalonia.Visuals/Media/Transform.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Media
         /// <summary>
         /// Raised when the transform changes.
         /// </summary>
-        public event EventHandler Changed;
+        public event EventHandler? Changed;
 
         /// <summary>
         /// Gets the transform's <see cref="Matrix"/>.

--- a/src/Avalonia.Visuals/Media/TransformConverter.cs
+++ b/src/Avalonia.Visuals/Media/TransformConverter.cs
@@ -10,14 +10,14 @@ namespace Avalonia.Media
     /// </summary>
     public class TransformConverter : TypeConverter
     {
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
         {
             return sourceType == typeof(string);
         }
 
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object? value)
         {
-            return TransformOperations.Parse((string)value);
+            return value is string s ? TransformOperations.Parse(s) : null;
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/TransformGroup.cs
+++ b/src/Avalonia.Visuals/Media/TransformGroup.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Media
             };
         }
 
-        private void ChildTransform_Changed(object sender, System.EventArgs e)
+        private void ChildTransform_Changed(object? sender, System.EventArgs e)
         {
             this.RaiseChanged();
         }

--- a/src/Avalonia.Visuals/Media/Transformation/TransformOperation.cs
+++ b/src/Avalonia.Visuals/Media/Transformation/TransformOperation.cs
@@ -92,8 +92,8 @@ namespace Avalonia.Media.Transformation
             }
 
             // ReSharper disable PossibleInvalidOperationException
-            TransformOperation fromValue = fromIdentity ? Identity : from.Value;
-            TransformOperation toValue = toIdentity ? Identity : to.Value;
+            TransformOperation fromValue = fromIdentity ? Identity : from!.Value;
+            TransformOperation toValue = toIdentity ? Identity : to!.Value;
             // ReSharper restore PossibleInvalidOperationException
 
             var interpolationType = toIdentity ? fromValue.Type : toValue.Type;

--- a/src/Avalonia.Visuals/Media/Typeface.cs
+++ b/src/Avalonia.Visuals/Media/Typeface.cs
@@ -48,7 +48,7 @@ namespace Avalonia.Media
         /// <summary>
         /// Gets the font family.
         /// </summary>
-        public FontFamily FontFamily { get; }
+        public FontFamily? FontFamily { get; }
 
         /// <summary>
         /// Gets the font style.
@@ -66,7 +66,7 @@ namespace Avalonia.Media
         /// <value>
         /// The glyph typeface.
         /// </value>
-        public GlyphTypeface GlyphTypeface => FontManager.Current.GetOrAddGlyphTypeface(this);
+        public GlyphTypeface? GlyphTypeface => FontManager.Current.GetOrAddGlyphTypeface(this);
 
         public static bool operator !=(Typeface a, Typeface b)
         {
@@ -78,7 +78,7 @@ namespace Avalonia.Media
             return  a.Equals(b);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is Typeface typeface && Equals(typeface);
         }

--- a/src/Avalonia.Visuals/Media/Typeface.cs
+++ b/src/Avalonia.Visuals/Media/Typeface.cs
@@ -66,7 +66,7 @@ namespace Avalonia.Media
         /// <value>
         /// The glyph typeface.
         /// </value>
-        public GlyphTypeface? GlyphTypeface => FontManager.Current.GetOrAddGlyphTypeface(this);
+        public GlyphTypeface GlyphTypeface => FontManager.Current.GetOrAddGlyphTypeface(this);
 
         public static bool operator !=(Typeface a, Typeface b)
         {

--- a/src/Avalonia.Visuals/Media/UnicodeRange.cs
+++ b/src/Avalonia.Visuals/Media/UnicodeRange.cs
@@ -37,7 +37,7 @@ namespace Avalonia.Media
 
         internal UnicodeRangeSegment Single => _single;
 
-        internal IReadOnlyList<UnicodeRangeSegment> Segments => _segments;
+        internal IReadOnlyList<UnicodeRangeSegment>? Segments => _segments;
 
         /// <summary>
         /// Determines if given value is inside the range.

--- a/src/Avalonia.Visuals/Media/UnicodeRange.cs
+++ b/src/Avalonia.Visuals/Media/UnicodeRange.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Media
         public static UnicodeRange Default = Parse("0-10FFFD");
 
         private readonly UnicodeRangeSegment _single;
-        private readonly IReadOnlyList<UnicodeRangeSegment> _segments = null;
+        private readonly IReadOnlyList<UnicodeRangeSegment>? _segments = null;
 
         public UnicodeRange(int start, int end)
         {

--- a/src/Avalonia.Visuals/Platform/ExportRenderingSubsystemAttribute.cs
+++ b/src/Avalonia.Visuals/Platform/ExportRenderingSubsystemAttribute.cs
@@ -6,7 +6,7 @@ namespace Avalonia.Platform
     public class ExportRenderingSubsystemAttribute : Attribute
     {
         public ExportRenderingSubsystemAttribute(OperatingSystemType requiredOS, int priority, string name, Type initializationType, string initializationMethod,
-            Type environmentChecker = null)
+            Type? environmentChecker = null)
         {
             Name = name;
             InitializationType = initializationType;
@@ -17,11 +17,11 @@ namespace Avalonia.Platform
         }
 
         public string InitializationMethod { get; private set; }
-        public Type EnvironmentChecker { get; }
+        public Type? EnvironmentChecker { get; }
         public Type InitializationType { get; private set; }
         public string Name { get; private set; }
         public int Priority { get; private set; }
         public OperatingSystemType RequiredOS { get; private set; }
-        public string RequiresWindowingSubsystem { get; set; }
+        public string? RequiresWindowingSubsystem { get; set; }
     }
 }

--- a/src/Avalonia.Visuals/Platform/IDrawingContextImpl.cs
+++ b/src/Avalonia.Visuals/Platform/IDrawingContextImpl.cs
@@ -55,7 +55,7 @@ namespace Avalonia.Platform
         /// <param name="brush">The fill brush.</param>
         /// <param name="pen">The stroke pen.</param>
         /// <param name="geometry">The geometry.</param>
-        void DrawGeometry(IBrush brush, IPen pen, IGeometryImpl geometry);
+        void DrawGeometry(IBrush? brush, IPen? pen, IGeometryImpl geometry);
 
         /// <summary>
         /// Draws a rectangle with the specified Brush and Pen.
@@ -68,7 +68,7 @@ namespace Avalonia.Platform
         /// The brush and the pen can both be null. If the brush is null, then no fill is performed.
         /// If the pen is null, then no stoke is performed. If both the pen and the brush are null, then the drawing is not visible.
         /// </remarks>
-        void DrawRectangle(IBrush brush, IPen pen, RoundedRect rect,
+        void DrawRectangle(IBrush? brush, IPen? pen, RoundedRect rect,
             BoxShadows boxShadows = default);
 
         /// <summary>

--- a/src/Avalonia.Visuals/Platform/IDrawingContextImpl.cs
+++ b/src/Avalonia.Visuals/Platform/IDrawingContextImpl.cs
@@ -81,7 +81,7 @@ namespace Avalonia.Platform
         /// The brush and the pen can both be null. If the brush is null, then no fill is performed.
         /// If the pen is null, then no stoke is performed. If both the pen and the brush are null, then the drawing is not visible.
         /// </remarks>
-        void DrawEllipse(IBrush brush, IPen pen, Rect rect);
+        void DrawEllipse(IBrush? brush, IPen? pen, Rect rect);
 
         /// <summary>
         /// Draws text.

--- a/src/Avalonia.Visuals/Platform/IFontManagerImpl.cs
+++ b/src/Avalonia.Visuals/Platform/IFontManagerImpl.cs
@@ -31,7 +31,7 @@ namespace Avalonia.Platform
         /// </returns>
         bool TryMatchCharacter(int codepoint, FontStyle fontStyle,
             FontWeight fontWeight,
-            FontFamily fontFamily, CultureInfo culture, out Typeface typeface);
+            FontFamily? fontFamily, CultureInfo? culture, out Typeface typeface);
 
         /// <summary>
         ///     Creates a glyph typeface.

--- a/src/Avalonia.Visuals/Platform/IGeometryImpl.cs
+++ b/src/Avalonia.Visuals/Platform/IGeometryImpl.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Platform
         /// </summary>
         /// <param name="pen">The pen to use. May be null.</param>
         /// <returns>The bounding rectangle.</returns>
-        Rect GetRenderBounds(IPen pen);
+        Rect GetRenderBounds(IPen? pen);
 
         /// <summary>
         /// Indicates whether the geometry's fill contains the specified point.

--- a/src/Avalonia.Visuals/Platform/IPlatformRenderInterface.cs
+++ b/src/Avalonia.Visuals/Platform/IPlatformRenderInterface.cs
@@ -29,7 +29,7 @@ namespace Avalonia.Platform
             TextAlignment textAlignment,
             TextWrapping wrapping,
             Size constraint,
-            IReadOnlyList<FormattedTextStyleSpan> spans);
+            IReadOnlyList<FormattedTextStyleSpan>? spans);
 
         /// <summary>
         /// Creates an ellipse geometry implementation.

--- a/src/Avalonia.Visuals/Platform/IRenderTarget.cs
+++ b/src/Avalonia.Visuals/Platform/IRenderTarget.cs
@@ -18,7 +18,7 @@ namespace Avalonia.Platform
         /// A render to be used to render visual brushes. May be null if no visual brushes are
         /// to be drawn.
         /// </param>
-        IDrawingContextImpl CreateDrawingContext(IVisualBrushRenderer visualBrushRenderer);
+        IDrawingContextImpl CreateDrawingContext(IVisualBrushRenderer? visualBrushRenderer);
     }
 
     public interface IRenderTargetWithCorruptionInfo : IRenderTarget

--- a/src/Avalonia.Visuals/Platform/ITextShaperImpl.cs
+++ b/src/Avalonia.Visuals/Platform/ITextShaperImpl.cs
@@ -17,6 +17,6 @@ namespace Avalonia.Platform
         /// <param name="fontRenderingEmSize">The font rendering em size.</param>
         /// <param name="culture">The culture.</param>
         /// <returns>A shaped glyph run.</returns>
-        GlyphRun ShapeText(ReadOnlySlice<char> text, Typeface typeface, double fontRenderingEmSize, CultureInfo culture);
+        GlyphRun ShapeText(ReadOnlySlice<char> text, Typeface typeface, double fontRenderingEmSize, CultureInfo? culture);
     }
 }

--- a/src/Avalonia.Visuals/Point.cs
+++ b/src/Avalonia.Visuals/Point.cs
@@ -211,7 +211,7 @@ namespace Avalonia
         /// <returns>
         /// True if <paramref name="obj"/> is a point that equals the current point.
         /// </returns>
-        public override bool Equals(object obj) => obj is Point other && Equals(other);
+        public override bool Equals(object? obj) => obj is Point other && Equals(other);
 
         /// <summary>
         /// Returns a hash code for a <see cref="Point"/>.

--- a/src/Avalonia.Visuals/Rect.cs
+++ b/src/Avalonia.Visuals/Rect.cs
@@ -341,7 +341,7 @@ namespace Avalonia
         /// </summary>
         /// <param name="obj">The object to compare against.</param>
         /// <returns>True if the object is equal to this rectangle; false otherwise.</returns>
-        public override bool Equals(object obj) => obj is Rect other && Equals(other);
+        public override bool Equals(object? obj) => obj is Rect other && Equals(other);
 
         /// <summary>
         /// Returns the hash code for this instance.

--- a/src/Avalonia.Visuals/RelativePoint.cs
+++ b/src/Avalonia.Visuals/RelativePoint.cs
@@ -111,7 +111,7 @@ namespace Avalonia
         /// </summary>
         /// <param name="obj">The other object.</param>
         /// <returns>True if the objects are equal, otherwise false.</returns>
-        public override bool Equals(object obj) => obj is RelativePoint other && Equals(other);
+        public override bool Equals(object? obj) => obj is RelativePoint other && Equals(other);
 
         /// <summary>
         /// Checks if the <see cref="RelativePoint"/> equals another point.

--- a/src/Avalonia.Visuals/RelativeRect.cs
+++ b/src/Avalonia.Visuals/RelativeRect.cs
@@ -113,7 +113,7 @@ namespace Avalonia
         /// </summary>
         /// <param name="obj">The other object.</param>
         /// <returns>True if the objects are equal, otherwise false.</returns>
-        public override bool Equals(object obj) => obj is RelativeRect other && Equals(other);
+        public override bool Equals(object? obj) => obj is RelativeRect other && Equals(other);
 
         /// <summary>
         /// Checks if the <see cref="RelativeRect"/> equals another rectangle.

--- a/src/Avalonia.Visuals/Rendering/DefaultRenderTimer.cs
+++ b/src/Avalonia.Visuals/Rendering/DefaultRenderTimer.cs
@@ -14,10 +14,10 @@ namespace Avalonia.Rendering
     /// </remarks>
     public class DefaultRenderTimer : IRenderTimer
     {
-        private IRuntimePlatform _runtime;
+        private IRuntimePlatform? _runtime;
         private int _subscriberCount;
-        private Action<TimeSpan> _tick;
-        private IDisposable _subscription;
+        private Action<TimeSpan>? _tick;
+        private IDisposable? _subscription;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultRenderTimer"/> class.
@@ -77,10 +77,8 @@ namespace Avalonia.Rendering
         /// </remarks>
         protected virtual IDisposable StartCore(Action<TimeSpan> tick)
         {
-            if (_runtime == null)
-            {
-                _runtime = AvaloniaLocator.Current.GetService<IRuntimePlatform>();
-            }
+            _runtime ??= AvaloniaLocator.Current.GetService<IRuntimePlatform>() ??
+                throw new InvalidOperationException("Unable to locate IRuntimePlatform.");
 
             return _runtime.StartSystemTimer(
                 TimeSpan.FromSeconds(1.0 / FramesPerSecond),
@@ -92,13 +90,13 @@ namespace Avalonia.Rendering
         /// </summary>
         protected void Stop()
         {
-            _subscription.Dispose();
+            _subscription?.Dispose();
             _subscription = null;
         }
 
         private void InternalTick(TimeSpan tickCount)
         {
-            _tick(tickCount);
+            _tick?.Invoke(tickCount);
         }
     }
 }

--- a/src/Avalonia.Visuals/Rendering/DirtyVisuals.cs
+++ b/src/Avalonia.Visuals/Rendering/DirtyVisuals.cs
@@ -31,6 +31,11 @@ namespace Avalonia.Rendering
         /// <param name="visual">The dirty visual.</param>
         public void Add(IVisual visual)
         {
+            if (visual.VisualRoot is null)
+            {
+                return;
+            }
+
             if (_deferring > 0)
             {
                 _deferredChanges.Add(visual);

--- a/src/Avalonia.Visuals/Rendering/DirtyVisuals.cs
+++ b/src/Avalonia.Visuals/Rendering/DirtyVisuals.cs
@@ -31,11 +31,6 @@ namespace Avalonia.Rendering
         /// <param name="visual">The dirty visual.</param>
         public void Add(IVisual visual)
         {
-            if (visual.VisualRoot is null)
-            {
-                return;
-            }
-
             if (_deferring > 0)
             {
                 _deferredChanges.Add(visual);

--- a/src/Avalonia.Visuals/Rendering/IDeferredRendererLock.cs
+++ b/src/Avalonia.Visuals/Rendering/IDeferredRendererLock.cs
@@ -4,6 +4,6 @@ namespace Avalonia.Rendering
 {
     public interface IDeferredRendererLock
     {
-        IDisposable TryLock();
+        IDisposable? TryLock();
     }
 }

--- a/src/Avalonia.Visuals/Rendering/IRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/IRenderer.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Rendering
         /// Indicates that the underlying low-level scene information has been updated. Used to
         /// signal that an update to the current pointer-over state may be required.
         /// </remarks>
-        event EventHandler<SceneInvalidatedEventArgs> SceneInvalidated;
+        event EventHandler<SceneInvalidatedEventArgs>? SceneInvalidated;
 
         /// <summary>
         /// Mark a visual as dirty and needing re-rendering.
@@ -57,7 +57,7 @@ namespace Avalonia.Rendering
         /// children will be excluded from the results.
         /// </param>
         /// <returns>The visual at the specified point, topmost first.</returns>
-        IVisual HitTestFirst(Point p, IVisual root, Func<IVisual, bool> filter);
+        IVisual? HitTestFirst(Point p, IVisual root, Func<IVisual, bool> filter);
 
         /// <summary>
         /// Informs the renderer that the z-ordering of a visual's children has changed.

--- a/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
@@ -19,9 +19,9 @@ namespace Avalonia.Rendering
     public class ImmediateRenderer : RendererBase, IRenderer, IVisualBrushRenderer
     {
         private readonly IVisual _root;
-        private readonly IRenderRoot _renderRoot;
+        private readonly IRenderRoot? _renderRoot;
         private bool _updateTransformedBounds = true;
-        private IRenderTarget _renderTarget;
+        private IRenderTarget? _renderTarget;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmediateRenderer"/> class.
@@ -29,9 +29,7 @@ namespace Avalonia.Rendering
         /// <param name="root">The control to render.</param>
         public ImmediateRenderer(IVisual root)
         {
-            Contract.Requires<ArgumentNullException>(root != null);
-
-            _root = root;
+            _root = root ?? throw new ArgumentNullException(nameof(root));
             _renderRoot = root as IRenderRoot;
         }
 
@@ -49,7 +47,7 @@ namespace Avalonia.Rendering
         public bool DrawDirtyRects { get; set; }
 
         /// <inheritdoc/>
-        public event EventHandler<SceneInvalidatedEventArgs> SceneInvalidated;
+        public event EventHandler<SceneInvalidatedEventArgs>? SceneInvalidated;
 
         /// <inheritdoc/>
         public void Paint(Rect rect)
@@ -169,7 +167,7 @@ namespace Avalonia.Rendering
             return HitTest(root, p, filter);
         }
 
-        public IVisual HitTestFirst(Point p, IVisual root, Func<IVisual, bool> filter)
+        public IVisual? HitTestFirst(Point p, IVisual root, Func<IVisual, bool> filter)
         {
             return HitTest(root, p, filter).FirstOrDefault();
         }
@@ -233,9 +231,9 @@ namespace Avalonia.Rendering
         private static IEnumerable<IVisual> HitTest(
            IVisual visual,
            Point p,
-           Func<IVisual, bool> filter)
+           Func<IVisual, bool>? filter)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            _ = visual ?? throw new ArgumentNullException(nameof(visual));
 
             if (filter?.Invoke(visual) != false)
             {

--- a/src/Avalonia.Visuals/Rendering/RenderLayers.cs
+++ b/src/Avalonia.Visuals/Rendering/RenderLayers.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Avalonia.Platform;
 using Avalonia.Rendering.SceneGraph;
 using Avalonia.VisualTree;
@@ -19,9 +20,8 @@ namespace Avalonia.Rendering
             for (var i = scene.Layers.Count - 1; i >= 0; --i)
             {
                 var src = scene.Layers[i];
-                RenderLayer layer;
 
-                if (!_index.TryGetValue(src.LayerRoot, out layer))
+                if (!_index.TryGetValue(src.LayerRoot, out var layer))
                 {
                     layer = new RenderLayer(context, scene.Size, scene.Scaling, src.LayerRoot);
                     _inner.Add(layer);
@@ -59,7 +59,7 @@ namespace Avalonia.Rendering
             _inner.Clear();
         }
 
-        public bool TryGetValue(IVisual layerRoot, out RenderLayer value)
+        public bool TryGetValue(IVisual layerRoot, [NotNullWhen(true)] out RenderLayer? value)
         {
             return _index.TryGetValue(layerRoot, out value);
         }

--- a/src/Avalonia.Visuals/Rendering/RenderLoop.cs
+++ b/src/Avalonia.Visuals/Rendering/RenderLoop.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Rendering
         private readonly IDispatcher _dispatcher;
         private List<IRenderLoopTask> _items = new List<IRenderLoopTask>();
         private List<IRenderLoopTask> _itemsCopy = new List<IRenderLoopTask>();
-        private IRenderTimer _timer;
+        private IRenderTimer? _timer;
         private int _inTick;
         private int _inUpdate;
 
@@ -49,19 +49,15 @@ namespace Avalonia.Rendering
         {
             get
             {
-                if (_timer == null)
-                {
-                    _timer = AvaloniaLocator.Current.GetService<IRenderTimer>();
-                }
-
-                return _timer;
+                return _timer ??= AvaloniaLocator.Current.GetService<IRenderTimer>() ??
+                    throw new InvalidOperationException("Cannot locate IRenderTimer.");
             }
         }
 
         /// <inheritdoc/>
         public void Add(IRenderLoopTask i)
         {
-            Contract.Requires<ArgumentNullException>(i != null);
+            _ = i ?? throw new ArgumentNullException(nameof(i));
             Dispatcher.UIThread.VerifyAccess();
 
             lock (_items)
@@ -78,7 +74,7 @@ namespace Avalonia.Rendering
         /// <inheritdoc/>
         public void Remove(IRenderLoopTask i)
         {
-            Contract.Requires<ArgumentNullException>(i != null);
+            _ = i ?? throw new ArgumentNullException(nameof(i));
             Dispatcher.UIThread.VerifyAccess();
             lock (_items)
             {

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/BrushDrawOperation.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/BrushDrawOperation.cs
@@ -17,6 +17,6 @@ namespace Avalonia.Rendering.SceneGraph
         /// <summary>
         /// Gets a collection of child scenes that are needed to draw visual brushes.
         /// </summary>
-        public abstract IDictionary<IVisual, Scene> ChildScenes { get; }
+        public abstract IDictionary<IVisual, Scene>? ChildScenes { get; }
     }
 }

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/DeferredDrawingContextImpl.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/DeferredDrawingContextImpl.cs
@@ -176,7 +176,7 @@ namespace Avalonia.Rendering.SceneGraph
             }
         }
 
-        public void DrawEllipse(IBrush brush, IPen pen, Rect rect)
+        public void DrawEllipse(IBrush? brush, IPen? pen, Rect rect)
         {
             var next = NextDrawAs<EllipseNode>();
 

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/DeferredDrawingContextImpl.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/DeferredDrawingContextImpl.cs
@@ -48,18 +48,21 @@ namespace Avalonia.Rendering.SceneGraph
         /// </returns>
         public UpdateState BeginUpdate(VisualNode node)
         {
-            _ = _node ?? throw new ArgumentNullException(nameof(node));
+            _ = node ?? throw new ArgumentNullException(nameof(node));
 
-            if (_childIndex < _node.Children.Count)
+            if (_node != null)
             {
-                _node.ReplaceChild(_childIndex, node);
-            }
-            else
-            {
-                _node.AddChild(node);
-            }
+                if (_childIndex < _node.Children.Count)
+                {
+                    _node.ReplaceChild(_childIndex, node);
+                }
+                else
+                {
+                    _node.AddChild(node);
+                }
 
-            ++_childIndex;
+                ++_childIndex;
+            }
 
             var state = new UpdateState(this, _node, _childIndex, _drawOperationindex);
             _node = node;
@@ -406,7 +409,7 @@ namespace Avalonia.Rendering.SceneGraph
         {
             public UpdateState(
                 DeferredDrawingContextImpl owner,
-                VisualNode node,
+                VisualNode? node,
                 int childIndex,
                 int drawOperationIndex)
             {
@@ -436,7 +439,7 @@ namespace Avalonia.Rendering.SceneGraph
             }
 
             public DeferredDrawingContextImpl Owner { get; }
-            public VisualNode Node { get; }
+            public VisualNode? Node { get; }
             public int ChildIndex { get; }
             public int DrawOperationIndex { get; }
         }

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/EllipseNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/EllipseNode.cs
@@ -14,10 +14,10 @@ namespace Avalonia.Rendering.SceneGraph
     {
         public EllipseNode(
             Matrix transform, 
-            IBrush brush, 
-            IPen pen, 
+            IBrush? brush, 
+            IPen? pen, 
             Rect rect, 
-            IDictionary<IVisual, Scene> childScenes = null) 
+            IDictionary<IVisual, Scene>? childScenes = null) 
             : base(rect.Inflate(pen?.Thickness ?? 0), transform)
         {
             Transform = transform;
@@ -30,12 +30,12 @@ namespace Avalonia.Rendering.SceneGraph
         /// <summary>
         /// Gets the fill brush.
         /// </summary>
-        public IBrush Brush { get; }
+        public IBrush? Brush { get; }
 
         /// <summary>
         /// Gets the stroke pen.
         /// </summary>
-        public ImmutablePen Pen { get; }
+        public ImmutablePen? Pen { get; }
 
         /// <summary>
         /// Gets the transform with which the node will be drawn.
@@ -47,9 +47,9 @@ namespace Avalonia.Rendering.SceneGraph
         /// </summary>
         public Rect Rect { get; }
 
-        public override IDictionary<IVisual, Scene> ChildScenes { get; }
+        public override IDictionary<IVisual, Scene>? ChildScenes { get; }
 
-        public bool Equals(Matrix transform, IBrush brush, IPen pen, Rect rect)
+        public bool Equals(Matrix transform, IBrush? brush, IPen? pen, Rect rect)
         {
             return transform == Transform &&
                    Equals(brush, Brush) &&

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/ExperimentalAcrylicNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/ExperimentalAcrylicNode.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Rendering.SceneGraph
             : base(rect.Rect, transform)
         {
             Transform = transform;
-            Material = material?.ToImmutable();
+            Material = material.ToImmutable();
             Rect = rect;
         }
 

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/GeometryClipNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/GeometryClipNode.cs
@@ -33,7 +33,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <summary>
         /// Gets the clip to be pushed or null if the operation represents a pop.
         /// </summary>
-        public IGeometryImpl Clip { get; }
+        public IGeometryImpl? Clip { get; }
 
         /// <summary>
         /// Gets the transform with which the node will be drawn.

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/GeometryNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/GeometryNode.cs
@@ -20,10 +20,10 @@ namespace Avalonia.Rendering.SceneGraph
         /// <param name="geometry">The geometry.</param>
         /// <param name="childScenes">Child scenes for drawing visual brushes.</param>
         public GeometryNode(Matrix transform,
-            IBrush brush,
-            IPen pen,
+            IBrush? brush,
+            IPen? pen,
             IGeometryImpl geometry,
-            IDictionary<IVisual, Scene> childScenes = null)
+            IDictionary<IVisual, Scene>? childScenes = null)
             : base(geometry.GetRenderBounds(pen), transform)
         {
             Transform = transform;
@@ -41,12 +41,12 @@ namespace Avalonia.Rendering.SceneGraph
         /// <summary>
         /// Gets the fill brush.
         /// </summary>
-        public IBrush Brush { get; }
+        public IBrush? Brush { get; }
 
         /// <summary>
         /// Gets the stroke pen.
         /// </summary>
-        public ImmutablePen Pen { get; }
+        public ImmutablePen? Pen { get; }
 
         /// <summary>
         /// Gets the geometry to draw.
@@ -54,7 +54,7 @@ namespace Avalonia.Rendering.SceneGraph
         public IGeometryImpl Geometry { get; }
 
         /// <inheritdoc/>
-        public override IDictionary<IVisual, Scene> ChildScenes { get; }
+        public override IDictionary<IVisual, Scene>? ChildScenes { get; }
 
         /// <summary>
         /// Determines if this draw operation equals another.
@@ -68,7 +68,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// The properties of the other draw operation are passed in as arguments to prevent
         /// allocation of a not-yet-constructed draw operation object.
         /// </remarks>
-        public bool Equals(Matrix transform, IBrush brush, IPen pen, IGeometryImpl geometry)
+        public bool Equals(Matrix transform, IBrush? brush, IPen? pen, IGeometryImpl geometry)
         {
             return transform == Transform &&
                    Equals(brush, Brush) &&

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/GlyphRunNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/GlyphRunNode.cs
@@ -23,11 +23,11 @@ namespace Avalonia.Rendering.SceneGraph
             Matrix transform,
             IBrush foreground,
             GlyphRun glyphRun,
-            IDictionary<IVisual, Scene> childScenes = null)
+            IDictionary<IVisual, Scene>? childScenes = null)
             : base(new Rect(glyphRun.Size), transform)
         {
             Transform = transform;
-            Foreground = foreground?.ToImmutable();
+            Foreground = foreground.ToImmutable();
             GlyphRun = glyphRun;
             ChildScenes = childScenes;
         }
@@ -48,7 +48,7 @@ namespace Avalonia.Rendering.SceneGraph
         public GlyphRun GlyphRun { get; }
 
         /// <inheritdoc/>
-        public override IDictionary<IVisual, Scene> ChildScenes { get; }
+        public override IDictionary<IVisual, Scene>? ChildScenes { get; }
 
         /// <inheritdoc/>
         public override void Render(IDrawingContextImpl context)

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/IVisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/IVisualNode.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <summary>
         /// Gets the parent scene graph node.
         /// </summary>
-        IVisualNode Parent { get; }
+        IVisualNode? Parent { get; }
 
         /// <summary>
         /// Gets the transform for the node from global to control coordinates.
@@ -54,7 +54,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <summary>
         /// Gets the node's clip geometry, if any.
         /// </summary>
-        IGeometryImpl GeometryClip { get; set; }
+        IGeometryImpl? GeometryClip { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether one of the node's ancestors has a geometry clip.

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/LineNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/LineNode.cs
@@ -25,11 +25,11 @@ namespace Avalonia.Rendering.SceneGraph
             IPen pen,
             Point p1,
             Point p2,
-            IDictionary<IVisual, Scene> childScenes = null)
+            IDictionary<IVisual, Scene>? childScenes = null)
             : base(LineBoundsHelper.CalculateBounds(p1, p2, pen), transform)
         {
             Transform = transform;
-            Pen = pen?.ToImmutable();
+            Pen = pen.ToImmutable();
             P1 = p1;
             P2 = p2;
             ChildScenes = childScenes;
@@ -56,7 +56,7 @@ namespace Avalonia.Rendering.SceneGraph
         public Point P2 { get; }
 
         /// <inheritdoc/>
-        public override IDictionary<IVisual, Scene> ChildScenes { get; }
+        public override IDictionary<IVisual, Scene>? ChildScenes { get; }
 
         /// <summary>
         /// Determines if this draw operation equals another.

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/OpacityMaskNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/OpacityMaskNode.cs
@@ -17,10 +17,10 @@ namespace Avalonia.Rendering.SceneGraph
         /// <param name="mask">The opacity mask to push.</param>
         /// <param name="bounds">The bounds of the mask.</param>
         /// <param name="childScenes">Child scenes for drawing visual brushes.</param>
-        public OpacityMaskNode(IBrush mask, Rect bounds, IDictionary<IVisual, Scene> childScenes = null)
+        public OpacityMaskNode(IBrush mask, Rect bounds, IDictionary<IVisual, Scene>? childScenes = null)
             : base(Rect.Empty, Matrix.Identity)
         {
-            Mask = mask?.ToImmutable();
+            Mask = mask.ToImmutable();
             MaskBounds = bounds;
             ChildScenes = childScenes;
         }
@@ -37,7 +37,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <summary>
         /// Gets the mask to be pushed or null if the operation represents a pop.
         /// </summary>
-        public IBrush Mask { get; }
+        public IBrush? Mask { get; }
 
         /// <summary>
         /// Gets the bounds of the opacity mask or null if the operation represents a pop.
@@ -45,7 +45,7 @@ namespace Avalonia.Rendering.SceneGraph
         public Rect? MaskBounds { get; }
 
         /// <inheritdoc/>
-        public override IDictionary<IVisual, Scene> ChildScenes { get; }
+        public override IDictionary<IVisual, Scene>? ChildScenes { get; }
 
         /// <inheritdoc/>
         public override bool HitTest(Point p) => false;
@@ -60,14 +60,14 @@ namespace Avalonia.Rendering.SceneGraph
         /// The properties of the other draw operation are passed in as arguments to prevent
         /// allocation of a not-yet-constructed draw operation object.
         /// </remarks>
-        public bool Equals(IBrush mask, Rect? bounds) => Mask == mask && MaskBounds == bounds;
+        public bool Equals(IBrush? mask, Rect? bounds) => Mask == mask && MaskBounds == bounds;
 
         /// <inheritdoc/>
         public override void Render(IDrawingContextImpl context)
         {
             if (Mask != null)
             {
-                context.PushOpacityMask(Mask, MaskBounds.Value);
+                context.PushOpacityMask(Mask, MaskBounds!.Value);
             }
             else
             {

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/RectangleNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/RectangleNode.cs
@@ -22,11 +22,11 @@ namespace Avalonia.Rendering.SceneGraph
         /// <param name="childScenes">Child scenes for drawing visual brushes.</param>
         public RectangleNode(
             Matrix transform,
-            IBrush brush,
-            IPen pen,
+            IBrush? brush,
+            IPen? pen,
             RoundedRect rect,
             BoxShadows boxShadows,
-            IDictionary<IVisual, Scene> childScenes = null)
+            IDictionary<IVisual, Scene>? childScenes = null)
             : base(boxShadows.TransformBounds(rect.Rect).Inflate((pen?.Thickness ?? 0) / 2), transform)
         {
             Transform = transform;
@@ -45,12 +45,12 @@ namespace Avalonia.Rendering.SceneGraph
         /// <summary>
         /// Gets the fill brush.
         /// </summary>
-        public IBrush Brush { get; }
+        public IBrush? Brush { get; }
 
         /// <summary>
         /// Gets the stroke pen.
         /// </summary>
-        public ImmutablePen Pen { get; }
+        public ImmutablePen? Pen { get; }
 
         /// <summary>
         /// Gets the rectangle to draw.
@@ -63,7 +63,7 @@ namespace Avalonia.Rendering.SceneGraph
         public BoxShadows BoxShadows { get; }
 
         /// <inheritdoc/>
-        public override IDictionary<IVisual, Scene> ChildScenes { get; }
+        public override IDictionary<IVisual, Scene>? ChildScenes { get; }
 
         /// <summary>
         /// Determines if this draw operation equals another.
@@ -78,7 +78,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// The properties of the other draw operation are passed in as arguments to prevent
         /// allocation of a not-yet-constructed draw operation object.
         /// </remarks>
-        public bool Equals(Matrix transform, IBrush brush, IPen pen, RoundedRect rect, BoxShadows boxShadows)
+        public bool Equals(Matrix transform, IBrush? brush, IPen? pen, RoundedRect rect, BoxShadows boxShadows)
         {
             return transform == Transform &&
                    Equals(brush, Brush) &&

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/Scene.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/Scene.cs
@@ -32,7 +32,7 @@ namespace Avalonia.Rendering.SceneGraph
 
         private Scene(VisualNode root, Dictionary<IVisual, IVisualNode> index, SceneLayers layers, int generation)
         {
-            Contract.Requires<ArgumentNullException>(root != null);
+            _ = root ?? throw new ArgumentNullException(nameof(root));
 
             var renderRoot = root.Visual as IRenderRoot;
 
@@ -76,7 +76,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <param name="node">The node.</param>
         public void Add(IVisualNode node)
         {
-            Contract.Requires<ArgumentNullException>(node != null);
+            _ = node ?? throw new ArgumentNullException(nameof(node));
 
             _index.Add(node.Visual, node);
         }
@@ -115,10 +115,9 @@ namespace Avalonia.Rendering.SceneGraph
         /// <returns>
         /// The node representing the visual or null if it could not be found.
         /// </returns>
-        public IVisualNode FindNode(IVisual visual)
+        public IVisualNode? FindNode(IVisual visual)
         {
-            IVisualNode node;
-            _index.TryGetValue(visual, out node);
+            _index.TryGetValue(visual, out var node);
             return node;
         }
 
@@ -129,7 +128,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <param name="root">The root of the subtree to search.</param>
         /// <param name="filter">A filter. May be null.</param>
         /// <returns>The visuals at the specified point.</returns>
-        public IEnumerable<IVisual> HitTest(Point p, IVisual root, Func<IVisual, bool> filter)
+        public IEnumerable<IVisual> HitTest(Point p, IVisual root, Func<IVisual, bool>? filter)
         {
             var node = FindNode(root);
             return (node != null) ? new HitTestEnumerable(node, filter, p, Root) : Enumerable.Empty<IVisual>();
@@ -142,7 +141,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <param name="root">The root of the subtree to search.</param>
         /// <param name="filter">A filter. May be null.</param>
         /// <returns>The visual at the specified point.</returns>
-        public IVisual HitTestFirst(Point p, IVisual root, Func<IVisual, bool> filter)
+        public IVisual? HitTestFirst(Point p, IVisual root, Func<IVisual, bool>? filter)
         {
             var node = FindNode(root);
             return (node != null) ? HitTestFirst(node, p, filter) : null;
@@ -154,14 +153,14 @@ namespace Avalonia.Rendering.SceneGraph
         /// <param name="node">The node.</param>
         public void Remove(IVisualNode node)
         {
-            Contract.Requires<ArgumentNullException>(node != null);
+            _ = node ?? throw new ArgumentNullException(nameof(node));
 
             _index.Remove(node.Visual);
 
             node.Dispose();
         }
 
-        private VisualNode Clone(VisualNode source, IVisualNode parent, Dictionary<IVisual, IVisualNode> index)
+        private VisualNode Clone(VisualNode source, IVisualNode? parent, Dictionary<IVisual, IVisualNode> index)
         {
             var result = source.Clone(parent);
 
@@ -185,7 +184,7 @@ namespace Avalonia.Rendering.SceneGraph
             return result;
         }
 
-        private IVisual HitTestFirst(IVisualNode root, Point p, Func<IVisual, bool> filter)
+        private IVisual HitTestFirst(IVisualNode root, Point p, Func<IVisual, bool>? filter)
         {
             using var enumerator = new HitTestEnumerator(root, filter, p, Root);
 
@@ -197,11 +196,11 @@ namespace Avalonia.Rendering.SceneGraph
         private class HitTestEnumerable : IEnumerable<IVisual>
         {
             private readonly IVisualNode _root;
-            private readonly Func<IVisual, bool> _filter;
+            private readonly Func<IVisual, bool>? _filter;
             private readonly IVisualNode _sceneRoot;
             private readonly Point _point;
             
-            public HitTestEnumerable(IVisualNode root, Func<IVisual, bool> filter, Point point, IVisualNode sceneRoot)
+            public HitTestEnumerable(IVisualNode root, Func<IVisual, bool>? filter, Point point, IVisualNode sceneRoot)
             {
                 _root = root;
                 _filter = filter;
@@ -223,12 +222,12 @@ namespace Avalonia.Rendering.SceneGraph
         private struct HitTestEnumerator : IEnumerator<IVisual>
         {
             private readonly PooledStack<Entry> _nodeStack;
-            private readonly Func<IVisual, bool> _filter;
+            private readonly Func<IVisual, bool>? _filter;
             private readonly IVisualNode _sceneRoot;
-            private IVisual _current;
+            private IVisual? _current;
             private readonly Point _point;
 
-            public HitTestEnumerator(IVisualNode root, Func<IVisual, bool> filter, Point point, IVisualNode sceneRoot)
+            public HitTestEnumerator(IVisualNode root, Func<IVisual, bool>? filter, Point point, IVisualNode sceneRoot)
             {
                 _nodeStack = new PooledStack<Entry>();
                 _nodeStack.Push(new Entry(root, false, null, true));
@@ -283,7 +282,7 @@ namespace Avalonia.Rendering.SceneGraph
                 throw new NotSupportedException();
             }
 
-            public IVisual Current => _current;
+            public IVisual Current => _current!;
 
             object IEnumerator.Current => Current;
 
@@ -307,7 +306,7 @@ namespace Avalonia.Rendering.SceneGraph
                     if (node.GeometryClip != null)
                     {
                         var controlPoint = _sceneRoot.Visual.TranslatePoint(_point, node.Visual);
-                        clipped = !node.GeometryClip.FillContains(controlPoint.Value);
+                        clipped = !node.GeometryClip.FillContains(controlPoint!.Value);
                     }
 
                     if (!clipped && node.Visual is ICustomHitTest custom)

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <inheritdoc/>
         public void UpdateAll(Scene scene)
         {
-            Contract.Requires<ArgumentNullException>(scene != null);
+            _ = scene ?? throw new ArgumentNullException(nameof(scene));
             Dispatcher.UIThread.VerifyAccess();
 
             UpdateSize(scene);
@@ -32,8 +32,8 @@ namespace Avalonia.Rendering.SceneGraph
         /// <inheritdoc/>
         public bool Update(Scene scene, IVisual visual)
         {
-            Contract.Requires<ArgumentNullException>(scene != null);
-            Contract.Requires<ArgumentNullException>(visual != null);
+            _ = scene ?? throw new ArgumentNullException(nameof(scene));
+            _ = visual ?? throw new ArgumentNullException(nameof(visual));
 
             Dispatcher.UIThread.VerifyAccess();
 
@@ -42,7 +42,7 @@ namespace Avalonia.Rendering.SceneGraph
                 throw new AvaloniaInternalException("Cannot update the scene for an invisible root visual.");
             }
 
-            var node = (VisualNode)scene.FindNode(visual);
+            var node = (VisualNode?)scene.FindNode(visual);
 
             if (visual == scene.Root.Visual)
             {
@@ -58,7 +58,7 @@ namespace Avalonia.Rendering.SceneGraph
                     // The control has changed parents. Remove the node and recurse into the new parent node.
                     ((VisualNode)node.Parent).RemoveChild(node);
                     Deindex(scene, node);
-                    node = (VisualNode)scene.FindNode(visual.VisualParent);
+                    node = (VisualNode?)scene.FindNode(visual.VisualParent);
                 }
 
                 if (visual.IsVisible)
@@ -101,7 +101,7 @@ namespace Avalonia.Rendering.SceneGraph
                     {
                         // The control has been hidden so remove it from its parent and deindex the
                         // node and its descendents.
-                        ((VisualNode)node.Parent)?.RemoveChild(node);
+                        ((VisualNode?)node.Parent)?.RemoveChild(node);
                         Deindex(scene, node);
                         return true;
                     }
@@ -112,7 +112,7 @@ namespace Avalonia.Rendering.SceneGraph
                 // The control has been removed so remove it from its parent and deindex the
                 // node and its descendents.
                 var trim = FindFirstDeadAncestor(scene, node);
-                ((VisualNode)trim.Parent).RemoveChild(trim);
+                ((VisualNode)trim.Parent!).RemoveChild(trim);
                 Deindex(scene, trim);
                 return true;
             }
@@ -120,24 +120,24 @@ namespace Avalonia.Rendering.SceneGraph
             return false;
         }
 
-        private static VisualNode FindExistingAncestor(Scene scene, IVisual visual)
+        private static VisualNode? FindExistingAncestor(Scene scene, IVisual visual)
         {
             var node = scene.FindNode(visual);
 
             while (node == null && visual.IsVisible)
             {
-                visual = visual.VisualParent;
+                visual = visual.VisualParent!;
                 node = scene.FindNode(visual);
             }
 
-            return visual.IsVisible ? (VisualNode)node : null;
+            return visual.IsVisible ? (VisualNode?)node : null;
         }
 
         private static VisualNode FindFirstDeadAncestor(Scene scene, IVisualNode node)
         {
             var parent = node.Parent;
 
-            while (parent.Visual.VisualRoot == null)
+            while (parent!.Visual.VisualRoot == null)
             {
                 node = parent;
                 parent = node.Parent;
@@ -148,7 +148,7 @@ namespace Avalonia.Rendering.SceneGraph
 
         private static object GetOrCreateChildNode(Scene scene, IVisual child, VisualNode parent)
         {
-            var result = (VisualNode)scene.FindNode(child);
+            var result = (VisualNode?)scene.FindNode(child);
 
             if (result != null && result.Parent != parent)
             {
@@ -173,7 +173,7 @@ namespace Avalonia.Rendering.SceneGraph
             var bounds = new Rect(visual.Bounds.Size);
             var contextImpl = (DeferredDrawingContextImpl)context.PlatformImpl;
 
-            contextImpl.Layers.Find(node.LayerRoot)?.Dirty.Add(node.Bounds);
+            contextImpl.Layers.Find(node.LayerRoot!)?.Dirty.Add(node.Bounds);
 
             if (visual.IsVisible)
             {
@@ -353,7 +353,7 @@ namespace Avalonia.Rendering.SceneGraph
 
             node.SubTreeUpdated = true;
 
-            scene.Layers[node.LayerRoot].Dirty.Add(node.Bounds);
+            scene.Layers[node.LayerRoot!].Dirty.Add(node.Bounds);
 
             node.Visual.TransformedBounds = null;
 
@@ -365,10 +365,10 @@ namespace Avalonia.Rendering.SceneGraph
 
         private static void ClearLayer(Scene scene, VisualNode node)
         {
-            var parent = (VisualNode)node.Parent;
+            var parent = (VisualNode)node.Parent!;
             var oldLayerRoot = node.LayerRoot;
-            var newLayerRoot = parent.LayerRoot;
-            var existingDirtyRects = scene.Layers[node.LayerRoot].Dirty;
+            var newLayerRoot = parent.LayerRoot!;
+            var existingDirtyRects = scene.Layers[node.LayerRoot!].Dirty;
             var newDirtyRects = scene.Layers[newLayerRoot].Dirty;
 
             existingDirtyRects.Coalesce();
@@ -378,16 +378,16 @@ namespace Avalonia.Rendering.SceneGraph
                 newDirtyRects.Add(r);
             }
 
-            var oldLayer = scene.Layers[oldLayerRoot];
+            var oldLayer = scene.Layers[oldLayerRoot!];
             PropagateLayer(node, scene.Layers[newLayerRoot], oldLayer);
             scene.Layers.Remove(oldLayer);
         }
 
         private static void MakeLayer(Scene scene, VisualNode node)
         {
-            var oldLayerRoot = node.LayerRoot;
+            var oldLayerRoot = node.LayerRoot!;
             var layer = scene.Layers.Add(node.Visual);
-            var oldLayer = scene.Layers[oldLayerRoot];
+            var oldLayer = scene.Layers[oldLayerRoot!];
 
             UpdateLayer(node, layer);
             PropagateLayer(node, layer, scene.Layers[oldLayerRoot]);
@@ -433,22 +433,23 @@ namespace Avalonia.Rendering.SceneGraph
         // HACK: Disabled layers because they're broken in current renderer. See #2244.
         private static bool ShouldStartLayer(IVisual visual) => false;
 
-        private static IGeometryImpl CreateLayerGeometryClip(VisualNode node)
+        private static IGeometryImpl? CreateLayerGeometryClip(VisualNode node)
         {
-            IGeometryImpl result = null;
+            IGeometryImpl? result = null;
+            VisualNode? n = node;
 
             for (;;)
             {
-                node = (VisualNode)node.Parent;
+                n = (VisualNode?)n!.Parent;
 
-                if (node == null || (node.GeometryClip == null && !node.HasAncestorGeometryClip))
+                if (n == null || (n.GeometryClip == null && !n.HasAncestorGeometryClip))
                 {
                     break;
                 }
 
-                if (node?.GeometryClip != null)
+                if (n?.GeometryClip != null)
                 {
-                    var transformed = node.GeometryClip.WithTransform(node.Transform);
+                    var transformed = n.GeometryClip.WithTransform(n.Transform);
 
                     result = result == null ? transformed : result.Intersect(transformed);
                 }

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneLayer.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneLayer.cs
@@ -54,7 +54,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <summary>
         /// Gets or sets the opacity mask for the layer.
         /// </summary>
-        public IBrush OpacityMask { get; set; }
+        public IBrush? OpacityMask { get; set; }
 
         /// <summary>
         /// Gets or sets the target rectangle for the layer opacity mask.
@@ -64,7 +64,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <summary>
         /// Gets the layer's geometry clip.
         /// </summary>
-        public IGeometryImpl GeometryClip { get; set; }
+        public IGeometryImpl? GeometryClip { get; set; }
 
         /// <summary>
         /// Gets the dirty rectangles for the layer.

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneLayers.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneLayers.cs
@@ -80,7 +80,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <returns>The created layer.</returns>
         public SceneLayer Add(IVisual layerRoot)
         {
-            Contract.Requires<ArgumentNullException>(layerRoot != null);
+            _ = layerRoot ?? throw new ArgumentNullException(nameof(layerRoot));
 
             var distance = layerRoot.CalculateDistanceFromAncestor(_root);
             var layer = new SceneLayer(layerRoot, distance);
@@ -117,7 +117,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// </returns>
         public bool Exists(IVisual layerRoot)
         {
-            Contract.Requires<ArgumentNullException>(layerRoot != null);
+            _ = layerRoot ?? throw new ArgumentNullException(nameof(layerRoot));
 
             return _index.ContainsKey(layerRoot);
         }
@@ -127,10 +127,9 @@ namespace Avalonia.Rendering.SceneGraph
         /// </summary>
         /// <param name="layerRoot">The root visual.</param>
         /// <returns>The layer if found, otherwise null.</returns>
-        public SceneLayer Find(IVisual layerRoot)
+        public SceneLayer? Find(IVisual layerRoot)
         {
-            SceneLayer result;
-            _index.TryGetValue(layerRoot, out result);
+            _index.TryGetValue(layerRoot, out var result);
             return result;
         }
 
@@ -141,11 +140,9 @@ namespace Avalonia.Rendering.SceneGraph
         /// <returns>The layer.</returns>
         public SceneLayer GetOrAdd(IVisual layerRoot)
         {
-            Contract.Requires<ArgumentNullException>(layerRoot != null);
+            _ = layerRoot ?? throw new ArgumentNullException(nameof(layerRoot));
 
-            SceneLayer result;
-
-            if (!_index.TryGetValue(layerRoot, out result))
+            if (!_index.TryGetValue(layerRoot, out var result))
             {
                 result = Add(layerRoot);
             }
@@ -160,11 +157,9 @@ namespace Avalonia.Rendering.SceneGraph
         /// <returns>True if a matching layer was removed, otherwise false.</returns>
         public bool Remove(IVisual layerRoot)
         {
-            Contract.Requires<ArgumentNullException>(layerRoot != null);
+            _ = layerRoot ?? throw new ArgumentNullException(nameof(layerRoot));
 
-            SceneLayer layer;
-
-            if (_index.TryGetValue(layerRoot, out layer))
+            if (_index.TryGetValue(layerRoot, out var layer))
             {
                 Remove(layer);
             }
@@ -179,7 +174,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <returns>True if the layer was part of the scene, otherwise false.</returns>
         public bool Remove(SceneLayer layer)
         {
-            Contract.Requires<ArgumentNullException>(layer != null);
+            _ = layer ?? throw new ArgumentNullException(nameof(layer));
 
             _index.Remove(layer.LayerRoot);
             return _inner.Remove(layer);

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/TextNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/TextNode.cs
@@ -23,11 +23,11 @@ namespace Avalonia.Rendering.SceneGraph
             IBrush foreground,
             Point origin,
             IFormattedTextImpl text,
-            IDictionary<IVisual, Scene> childScenes = null)
+            IDictionary<IVisual, Scene>? childScenes = null)
             : base(text.Bounds.Translate(origin), transform)
         {
             Transform = transform;
-            Foreground = foreground?.ToImmutable();
+            Foreground = foreground.ToImmutable();
             Origin = origin;
             Text = text;
             ChildScenes = childScenes;
@@ -54,7 +54,7 @@ namespace Avalonia.Rendering.SceneGraph
         public IFormattedTextImpl Text { get; }
 
         /// <inheritdoc/>
-        public override IDictionary<IVisual, Scene> ChildScenes { get; }
+        public override IDictionary<IVisual, Scene>? ChildScenes { get; }
 
         /// <inheritdoc/>
         public override void Render(IDrawingContextImpl context)

--- a/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/VisualNode.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Disposables;
-using Avalonia.Collections;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Utilities;
@@ -19,9 +19,9 @@ namespace Avalonia.Rendering.SceneGraph
 
         private Rect? _bounds;
         private double _opacity;
-        private List<IVisualNode> _children;
-        private List<IRef<IDrawOperation>> _drawOperations;
-        private IRef<IDisposable> _drawOperationsRefCounter;
+        private List<IVisualNode>? _children;
+        private List<IRef<IDrawOperation>>? _drawOperations;
+        private IRef<IDisposable>? _drawOperationsRefCounter;
         private bool _drawOperationsCloned;
         private Matrix transformRestore;
 
@@ -30,11 +30,9 @@ namespace Avalonia.Rendering.SceneGraph
         /// </summary>
         /// <param name="visual">The visual that this node represents.</param>
         /// <param name="parent">The parent scene graph node, if any.</param>
-        public VisualNode(IVisual visual, IVisualNode parent)
+        public VisualNode(IVisual visual, IVisualNode? parent)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
-
-            Visual = visual;
+            Visual = visual ?? throw new ArgumentNullException(nameof(visual));
             Parent = parent;
             HasAncestorGeometryClip = parent != null && 
                 (parent.HasAncestorGeometryClip || parent.GeometryClip != null);
@@ -44,7 +42,7 @@ namespace Avalonia.Rendering.SceneGraph
         public IVisual Visual { get; }
 
         /// <inheritdoc/>
-        public IVisualNode Parent { get; }
+        public IVisualNode? Parent { get; }
 
         /// <inheritdoc/>
         public CornerRadius ClipToBoundsRadius { get; set; }
@@ -65,7 +63,7 @@ namespace Avalonia.Rendering.SceneGraph
         public bool ClipToBounds { get; set; }
 
         /// <inheritdoc/>
-        public IGeometryImpl GeometryClip { get; set; }
+        public IGeometryImpl? GeometryClip { get; set; }
 
         /// <inheritdoc/>
         public bool HasAncestorGeometryClip { get; }
@@ -87,7 +85,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <summary>
         /// Gets or sets the opacity mask for the scene graph node.
         /// </summary>
-        public IBrush OpacityMask { get; set; }
+        public IBrush? OpacityMask { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether this node in the scene graph has already
@@ -100,7 +98,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// </summary>
         public bool OpacityChanged { get; private set; }
 
-        public IVisual LayerRoot { get; set; }
+        public IVisual? LayerRoot { get; set; }
 
         /// <inheritdoc/>
         public IReadOnlyList<IVisualNode> Children => _children ?? EmptyChildren;
@@ -259,7 +257,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// </summary>
         /// <param name="parent">The new parent node.</param>
         /// <returns>A cloned node.</returns>
-        public VisualNode Clone(IVisualNode parent)
+        public VisualNode Clone(IVisualNode? parent)
         {
             return new VisualNode(Visual, parent)
             {
@@ -382,6 +380,7 @@ namespace Avalonia.Rendering.SceneGraph
             return result;
         }
 
+        [MemberNotNull(nameof(_children))]
         private void EnsureChildrenCreated(int capacity = 0)
         {
             if (_children == null)
@@ -393,6 +392,7 @@ namespace Avalonia.Rendering.SceneGraph
         /// <summary>
         /// Ensures that this node draw operations have been created and are mutable (in case we are using cloned operations).
         /// </summary>
+        [MemberNotNull(nameof(_drawOperations))]
         private void EnsureDrawOperationsCreated()
         {
             if (_drawOperations == null)
@@ -412,7 +412,7 @@ namespace Avalonia.Rendering.SceneGraph
                     _drawOperations.Add(drawOperation.Clone());
                 }
 
-                _drawOperationsRefCounter.Dispose();
+                _drawOperationsRefCounter?.Dispose();
                 _drawOperationsRefCounter = RefCountable.Create(CreateDisposeDrawOperations(_drawOperations));
                 _drawOperationsCloned = false;
             }

--- a/src/Avalonia.Visuals/Rendering/SleepLoopRenderTimer.cs
+++ b/src/Avalonia.Visuals/Rendering/SleepLoopRenderTimer.cs
@@ -6,7 +6,7 @@ namespace Avalonia.Rendering
 {
     public class SleepLoopRenderTimer : IRenderTimer
     {
-        private Action<TimeSpan> _tick;
+        private Action<TimeSpan>? _tick;
         private int _count;
         private readonly object _lock = new object();
         private bool _running;

--- a/src/Avalonia.Visuals/Rendering/ZIndexComparer.cs
+++ b/src/Avalonia.Visuals/Rendering/ZIndexComparer.cs
@@ -9,6 +9,6 @@ namespace Avalonia.Rendering
         public static readonly ZIndexComparer Instance = new ZIndexComparer();
         public static readonly Comparison<IVisual> ComparisonInstance = Instance.Compare;
 
-        public int Compare(IVisual x, IVisual y) => (x?.ZIndex ?? 0).CompareTo(y?.ZIndex ?? 0);
+        public int Compare(IVisual? x, IVisual? y) => (x?.ZIndex ?? 0).CompareTo(y?.ZIndex ?? 0);
     }
 }

--- a/src/Avalonia.Visuals/RoundedRect.cs
+++ b/src/Avalonia.Visuals/RoundedRect.cs
@@ -9,7 +9,7 @@ namespace Avalonia
             return Rect.Equals(other.Rect) && RadiiTopLeft.Equals(other.RadiiTopLeft) && RadiiTopRight.Equals(other.RadiiTopRight) && RadiiBottomLeft.Equals(other.RadiiBottomLeft) && RadiiBottomRight.Equals(other.RadiiBottomRight);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is RoundedRect other && Equals(other);
         }

--- a/src/Avalonia.Visuals/Size.cs
+++ b/src/Avalonia.Visuals/Size.cs
@@ -226,7 +226,7 @@ namespace Avalonia
         /// <returns>
         /// True if <paramref name="obj"/> is a size that equals the current size.
         /// </returns>
-        public override bool Equals(object obj) => obj is Size other && Equals(other);
+        public override bool Equals(object? obj) => obj is Size other && Equals(other);
 
         /// <summary>
         /// Returns a hash code for a <see cref="Size"/>.

--- a/src/Avalonia.Visuals/Thickness.cs
+++ b/src/Avalonia.Visuals/Thickness.cs
@@ -252,7 +252,7 @@ namespace Avalonia
         /// <returns>
         /// True if <paramref name="obj"/> is a size that equals the current size.
         /// </returns>
-        public override bool Equals(object obj) => obj is Thickness other && Equals(other);
+        public override bool Equals(object? obj) => obj is Thickness other && Equals(other);
 
         /// <summary>
         /// Returns a hash code for a <see cref="Thickness"/>.

--- a/src/Avalonia.Visuals/Visual.cs
+++ b/src/Avalonia.Visuals/Visual.cs
@@ -572,7 +572,7 @@ namespace Avalonia
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The event args.</param>
-        private void RenderTransformChanged(object sender, EventArgs e)
+        private void RenderTransformChanged(object? sender, EventArgs e)
         {
             InvalidateVisual();
         }
@@ -593,13 +593,14 @@ namespace Avalonia
 
             if (_visualRoot != null)
             {
-                var e = new VisualTreeAttachmentEventArgs(old, VisualRoot);
+                var e = new VisualTreeAttachmentEventArgs(old!, _visualRoot);
                 OnDetachedFromVisualTreeCore(e);
             }
 
             if (_visualParent is IRenderRoot || _visualParent?.IsAttachedToVisualTree == true)
             {
-                var root = this.FindAncestorOfType<IRenderRoot>();
+                var root = this.FindAncestorOfType<IRenderRoot>() ??
+                    throw new AvaloniaInternalException("Visual is atached to visual tree but root could not be found.");
                 var e = new VisualTreeAttachmentEventArgs(_visualParent, root);
                 OnAttachedToVisualTreeCore(e);
             }
@@ -607,28 +608,28 @@ namespace Avalonia
             OnVisualParentChanged(old, value);
         }
 
-        private void AffectsRenderInvalidated(object sender, EventArgs e) => InvalidateVisual();
+        private void AffectsRenderInvalidated(object? sender, EventArgs e) => InvalidateVisual();
 
         /// <summary>
         /// Called when the <see cref="VisualChildren"/> collection changes.
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The event args.</param>
-        private void VisualChildrenChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void VisualChildrenChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    SetVisualParent(e.NewItems, this);
+                    SetVisualParent(e.NewItems!, this);
                     break;
 
                 case NotifyCollectionChangedAction.Remove:
-                    SetVisualParent(e.OldItems, null);
+                    SetVisualParent(e.OldItems!, null);
                     break;
 
                 case NotifyCollectionChangedAction.Replace:
-                    SetVisualParent(e.OldItems, null);
-                    SetVisualParent(e.NewItems, this);
+                    SetVisualParent(e.OldItems!, null);
+                    SetVisualParent(e.NewItems!, this);
                     break;
             }
         }
@@ -639,7 +640,7 @@ namespace Avalonia
 
             for (var i = 0; i < count; i++)
             {
-                var visual = (Visual) children[i];
+                var visual = (Visual) children[i]!;
                 
                 visual.SetVisualParent(parent);
             }

--- a/src/Avalonia.Visuals/VisualTree/TransformedBounds.cs
+++ b/src/Avalonia.Visuals/VisualTree/TransformedBounds.cs
@@ -54,7 +54,7 @@ namespace Avalonia.VisualTree
             return Bounds == other.Bounds && Clip == other.Clip && Transform == other.Transform;
         }
 
-        public override bool Equals(object obj) => obj is TransformedBounds other && Equals(other);
+        public override bool Equals(object? obj) => obj is TransformedBounds other && Equals(other);
 
         public override int GetHashCode()
         {

--- a/src/Avalonia.Visuals/VisualTree/VisualExtensions.cs
+++ b/src/Avalonia.Visuals/VisualTree/VisualExtensions.cs
@@ -19,7 +19,7 @@ namespace Avalonia.VisualTree
         /// The number of steps from the visual to the ancestor or -1 if
         /// <paramref name="visual"/> is not a descendent of <paramref name="ancestor"/>.
         /// </returns>
-        public static int CalculateDistanceFromAncestor(this IVisual visual, IVisual ancestor)
+        public static int CalculateDistanceFromAncestor(this IVisual visual, IVisual? ancestor)
         {
             IVisual? v = visual ?? throw new ArgumentNullException(nameof(visual));
             var result = 0;

--- a/src/Avalonia.Visuals/VisualTree/VisualExtensions.cs
+++ b/src/Avalonia.Visuals/VisualTree/VisualExtensions.cs
@@ -21,18 +21,17 @@ namespace Avalonia.VisualTree
         /// </returns>
         public static int CalculateDistanceFromAncestor(this IVisual visual, IVisual ancestor)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
-
+            IVisual? v = visual ?? throw new ArgumentNullException(nameof(visual));
             var result = 0;
 
-            while (visual != null && visual != ancestor)
+            while (v != null && v != ancestor)
             {
-                visual = visual.VisualParent;
+                v = v.VisualParent;
 
                 result++;
             }
 
-            return visual != null ? result : -1;
+            return v != null ? result : -1;
         }
 
         /// <summary>
@@ -44,15 +43,14 @@ namespace Avalonia.VisualTree
         /// </returns>
         public static int CalculateDistanceFromRoot(IVisual visual)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
-
+            IVisual? v = visual ?? throw new ArgumentNullException(nameof(visual));
             var result = 0;
 
-            visual = visual?.VisualParent;
+            v = v?.VisualParent;
 
-            while (visual != null)
+            while (v != null)
             {
-                visual = visual.VisualParent;
+                v = v.VisualParent;
 
                 result++;
             }
@@ -66,54 +64,56 @@ namespace Avalonia.VisualTree
         /// <param name="visual">The first visual.</param>
         /// <param name="target">The second visual.</param>
         /// <returns>The common ancestor, or null if not found.</returns>
-        public static IVisual FindCommonVisualAncestor(this IVisual visual, IVisual target)
+        public static IVisual? FindCommonVisualAncestor(this IVisual visual, IVisual target)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            IVisual? v = visual ?? throw new ArgumentNullException(nameof(visual));
 
             if (target is null)
             {
                 return null;
             }
 
-            void GoUpwards(ref IVisual node, int count)
+            IVisual? t = target;
+
+            void GoUpwards(ref IVisual? node, int count)
             {
                 for (int i = 0; i < count; ++i)
                 {
-                    node = node.VisualParent;
+                    node = node?.VisualParent;
                 }
             }
 
             // We want to find lowest node first, then make sure that both nodes are at the same height.
             // By doing that we can sometimes find out that other node is our lowest common ancestor.
-            var firstHeight = CalculateDistanceFromRoot(visual);
-            var secondHeight = CalculateDistanceFromRoot(target);
+            var firstHeight = CalculateDistanceFromRoot(v);
+            var secondHeight = CalculateDistanceFromRoot(t);
 
             if (firstHeight > secondHeight)
             {
-                GoUpwards(ref visual, firstHeight - secondHeight);
+                GoUpwards(ref v, firstHeight - secondHeight);
             }
             else
             {
-                GoUpwards(ref target, secondHeight - firstHeight);
+                GoUpwards(ref t, secondHeight - firstHeight);
             }
 
-            if (visual == target)
+            if (v == t)
             {
-                return visual;
+                return v;
             }
 
-            while (visual != null && target != null)
+            while (v != null && t != null)
             {
-                IVisual firstParent = visual.VisualParent;
-                IVisual secondParent = target.VisualParent;
+                IVisual? firstParent = v.VisualParent;
+                IVisual? secondParent = t.VisualParent;
 
                 if (firstParent == secondParent)
                 {
                     return firstParent;
                 }
 
-                visual = visual.VisualParent;
-                target = target.VisualParent;
+                v = v.VisualParent;
+                t = t.VisualParent;
             }
 
             return null;
@@ -126,14 +126,14 @@ namespace Avalonia.VisualTree
         /// <returns>The visual's ancestors.</returns>
         public static IEnumerable<IVisual> GetVisualAncestors(this IVisual visual)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            IVisual? v = visual ?? throw new ArgumentNullException(nameof(visual));
 
-            visual = visual.VisualParent;
+            v = v.VisualParent;
 
-            while (visual != null)
+            while (v != null)
             {
-                yield return visual;
-                visual = visual.VisualParent;
+                yield return v;
+                v = v.VisualParent;
             }
         }
 
@@ -144,14 +144,14 @@ namespace Avalonia.VisualTree
         /// <param name="visual">The visual.</param>
         /// <param name="includeSelf">If given visual should be included in search.</param>
         /// <returns>First ancestor of given type.</returns>
-        public static T FindAncestorOfType<T>(this IVisual visual, bool includeSelf = false) where T : class
+        public static T? FindAncestorOfType<T>(this IVisual visual, bool includeSelf = false) where T : class
         {
             if (visual is null)
             {
                 return null;
             }
 
-            IVisual parent = includeSelf ? visual : visual.VisualParent;
+            IVisual? parent = includeSelf ? visual : visual.VisualParent;
 
             while (parent != null)
             {
@@ -173,7 +173,7 @@ namespace Avalonia.VisualTree
         /// <param name="visual">The visual.</param>
         /// <param name="includeSelf">If given visual should be included in search.</param>
         /// <returns>First descendant of given type.</returns>
-        public static T FindDescendantOfType<T>(this IVisual visual, bool includeSelf = false) where T : class
+        public static T? FindDescendantOfType<T>(this IVisual visual, bool includeSelf = false) where T : class
         {
             if (visual is null)
             {
@@ -195,7 +195,7 @@ namespace Avalonia.VisualTree
         /// <returns>The visual and its ancestors.</returns>
         public static IEnumerable<IVisual> GetSelfAndVisualAncestors(this IVisual visual)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            _ = visual ?? throw new ArgumentNullException(nameof(visual));
 
             yield return visual;
 
@@ -211,9 +211,9 @@ namespace Avalonia.VisualTree
         /// <param name="visual">The root visual to test.</param>
         /// <param name="p">The point.</param>
         /// <returns>The visual at the requested point.</returns>
-        public static IVisual GetVisualAt(this IVisual visual, Point p)
+        public static IVisual? GetVisualAt(this IVisual visual, Point p)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            _ = visual ?? throw new ArgumentNullException(nameof(visual));
 
             return visual.GetVisualAt(p, x => x.IsVisible);
         }
@@ -228,11 +228,17 @@ namespace Avalonia.VisualTree
         /// children will be excluded from the results.
         /// </param>
         /// <returns>The visual at the requested point.</returns>
-        public static IVisual GetVisualAt(this IVisual visual, Point p, Func<IVisual, bool> filter)
+        public static IVisual? GetVisualAt(this IVisual visual, Point p, Func<IVisual, bool> filter)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            _ = visual ?? throw new ArgumentNullException(nameof(visual));
 
             var root = visual.GetVisualRoot();
+
+            if (root is null)
+            {
+                return null;
+            }
+
             var rootPoint = visual.TranslatePoint(p, root);
 
             if (rootPoint.HasValue)
@@ -253,7 +259,7 @@ namespace Avalonia.VisualTree
             this IVisual visual,
             Point p)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            _ = visual ?? throw new ArgumentNullException(nameof(visual));
 
             return visual.GetVisualsAt(p, x => x.IsVisible);
         }
@@ -273,9 +279,15 @@ namespace Avalonia.VisualTree
             Point p,
             Func<IVisual, bool> filter)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            _ = visual ?? throw new ArgumentNullException(nameof(visual));
 
             var root = visual.GetVisualRoot();
+
+            if (root is null)
+            {
+                return Array.Empty<IVisual>();
+            }
+
             var rootPoint = visual.TranslatePoint(p, root);
 
             if (rootPoint.HasValue)
@@ -334,7 +346,7 @@ namespace Avalonia.VisualTree
         /// </summary>
         /// <param name="visual">The visual.</param>
         /// <returns>The parent, or null if the visual is unparented.</returns>
-        public static IVisual GetVisualParent(this IVisual visual)
+        public static IVisual? GetVisualParent(this IVisual visual)
         {
             return visual.VisualParent;
         }
@@ -347,7 +359,7 @@ namespace Avalonia.VisualTree
         /// <returns>
         /// The parent, or null if the visual is unparented or its parent is not of type <typeparamref name="T"/>.
         /// </returns>
-        public static T GetVisualParent<T>(this IVisual visual) where T : class
+        public static T? GetVisualParent<T>(this IVisual visual) where T : class
         {
             return visual.VisualParent as T;
         }
@@ -359,9 +371,9 @@ namespace Avalonia.VisualTree
         /// <returns>
         /// The root visual or null if the visual is not rooted.
         /// </returns>
-        public static IRenderRoot GetVisualRoot(this IVisual visual)
+        public static IRenderRoot? GetVisualRoot(this IVisual visual)
         {
-            Contract.Requires<ArgumentNullException>(visual != null);
+            _ = visual ?? throw new ArgumentNullException(nameof(visual));
 
             return visual as IRenderRoot ?? visual.VisualRoot;
         }
@@ -377,7 +389,7 @@ namespace Avalonia.VisualTree
         /// </returns>
         public static bool IsVisualAncestorOf(this IVisual visual, IVisual target)
         {
-            IVisual current = target?.VisualParent;
+            IVisual? current = target?.VisualParent;
 
             while (current != null)
             {
@@ -402,10 +414,10 @@ namespace Avalonia.VisualTree
                     ZIndex = element.ZIndex,
                 })
                 .OrderBy(x => x, null)
-                .Select(x => x.Element);
+                .Select(x => x.Element!);
         }
 
-        private static T FindDescendantOfTypeCore<T>(IVisual visual) where T : class
+        private static T? FindDescendantOfTypeCore<T>(IVisual visual) where T : class
         {
             var visualChildren = visual.VisualChildren;
             var visualChildrenCount = visualChildren.Count;
@@ -432,12 +444,15 @@ namespace Avalonia.VisualTree
 
         private class ZOrderElement : IComparable<ZOrderElement>
         {
-            public IVisual Element { get; set; }
+            public IVisual? Element { get; set; }
             public int Index { get; set; }
             public int ZIndex { get; set; }
 
-            public int CompareTo(ZOrderElement other)
+            public int CompareTo(ZOrderElement? other)
             {
+                if (other is null)
+                    return 1;
+
                 var z = other.ZIndex - ZIndex;
 
                 if (z != 0)

--- a/src/Avalonia.Visuals/VisualTree/VisualLocator.cs
+++ b/src/Avalonia.Visuals/VisualTree/VisualLocator.cs
@@ -6,18 +6,18 @@ namespace Avalonia.VisualTree
 {
     public class VisualLocator
     {
-        public static IObservable<IVisual> Track(IVisual relativeTo, int ancestorLevel, Type ancestorType = null)
+        public static IObservable<IVisual?> Track(IVisual relativeTo, int ancestorLevel, Type? ancestorType = null)
         {
             return new VisualTracker(relativeTo, ancestorLevel, ancestorType);
         }
 
-        private class VisualTracker : LightweightObservableBase<IVisual>
+        private class VisualTracker : LightweightObservableBase<IVisual?>
         {
             private readonly IVisual _relativeTo;
             private readonly int _ancestorLevel;
-            private readonly Type _ancestorType;
+            private readonly Type? _ancestorType;
 
-            public VisualTracker(IVisual relativeTo, int ancestorLevel, Type ancestorType)
+            public VisualTracker(IVisual relativeTo, int ancestorLevel, Type? ancestorType)
             {
                 _relativeTo = relativeTo;
                 _ancestorLevel = ancestorLevel;
@@ -36,14 +36,14 @@ namespace Avalonia.VisualTree
                 _relativeTo.DetachedFromVisualTree -= AttachedDetached;
             }
 
-            protected override void Subscribed(IObserver<IVisual> observer, bool first)
+            protected override void Subscribed(IObserver<IVisual?> observer, bool first)
             {
                 observer.OnNext(GetResult());
             }
 
-            private void AttachedDetached(object sender, VisualTreeAttachmentEventArgs e) => PublishNext(GetResult());
+            private void AttachedDetached(object? sender, VisualTreeAttachmentEventArgs e) => PublishNext(GetResult());
 
-            private IVisual GetResult()
+            private IVisual? GetResult()
             {
                 if (_relativeTo.IsAttachedToVisualTree)
                 {

--- a/src/Avalonia.Visuals/VisualTreeAttachmentEventArgs.cs
+++ b/src/Avalonia.Visuals/VisualTreeAttachmentEventArgs.cs
@@ -17,11 +17,8 @@ namespace Avalonia
         /// <param name="root">The root visual.</param>
         public VisualTreeAttachmentEventArgs(IVisual parent, IRenderRoot root)
         {
-            Contract.Requires<ArgumentNullException>(parent != null);
-            Contract.Requires<ArgumentNullException>(root != null);
-
-            Parent = parent;
-            Root = root;
+            Parent = parent ?? throw new ArgumentNullException(nameof(parent));
+            Root = root ?? throw new ArgumentNullException(nameof(root));
         }
 
         /// <summary>

--- a/src/Web/Avalonia.Web.Blazor/RazorViewTopLevelImpl.cs
+++ b/src/Web/Avalonia.Web.Blazor/RazorViewTopLevelImpl.cs
@@ -106,8 +106,8 @@ namespace Avalonia.Web.Blazor
 
         public IRenderer CreateRenderer(IRenderRoot root)
         {
-            var loop = AvaloniaLocator.Current.GetService<IRenderLoop>();
-
+            var loop = AvaloniaLocator.Current.GetService<IRenderLoop>() ??
+                throw new InvalidOperationException("Unable to locate IRenderLoop.");
             return new DeferredRenderer(root, loop);
         }
 

--- a/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/TextNodeTests.cs
+++ b/tests/Avalonia.Visuals.UnitTests/Rendering/SceneGraph/TextNodeTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Rendering.SceneGraph;
 using Moq;
@@ -15,7 +16,7 @@ namespace Avalonia.Visuals.UnitTests.Rendering.SceneGraph
         {
             var target = new TextNode(
                 Matrix.Identity,
-                null,
+                Brushes.Black,
                 new Point(10, 10),
                 Mock.Of<IFormattedTextImpl>(x => x.Bounds == new Rect(5, 5, 50, 50)));
 


### PR DESCRIPTION
## What does the pull request do?

Adds nullable annotations to Avalonia.Visuals. Done with help from @Gillibald who annotated the text-related stuff.  

## Breaking changes

The default `GlyphRun` constructor was removed, but given that using this constructor would have just given you a non-usable `GlyphRun` I'm not sure how breaking it is in reality. If we want to port this to the stable branch we could put it back in.
