### PR TITLE
[Android] Changes to allow launch ControlCatalog

### DIFF
--- a/samples/ControlCatalog.Android/ControlCatalog.Android.csproj
+++ b/samples/ControlCatalog.Android/ControlCatalog.Android.csproj
@@ -32,7 +32,7 @@
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
     <BundleAssemblies>False</BundleAssemblies>
     <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
-    <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a;x86;x86_64</AndroidSupportedAbis>
     <Debugger>Xamarin</Debugger>
     <AndroidEnableMultiDex>False</AndroidEnableMultiDex>
     <AotAssemblies>False</AotAssemblies>
@@ -51,7 +51,7 @@
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
     <BundleAssemblies>False</BundleAssemblies>
     <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
-    <AndroidSupportedAbis>armeabi-v7a,x86</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a,x86;x86_64</AndroidSupportedAbis>
     <Debugger>Xamarin</Debugger>
     <AotAssemblies>False</AotAssemblies>
     <EnableLLVM>False</EnableLLVM>
@@ -124,6 +124,10 @@
     <ProjectReference Include="..\..\src\Avalonia.Layout\Avalonia.Layout.csproj">
       <Project>{42472427-4774-4c81-8aff-9f27b8e31721}</Project>
       <Name>Avalonia.Layout</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Avalonia.Themes.Fluent\Avalonia.Themes.Fluent.csproj">
+      <Project>{c42d2fc1-a531-4ed4-84b9-89aec7c962fc}</Project>
+      <Name>Avalonia.Themes.Fluent</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\Avalonia.Visuals\Avalonia.Visuals.csproj">
       <Project>{eb582467-6abb-43a1-b052-e981ba910e3a}</Project>

--- a/src/Android/Avalonia.Android/AndroidPlatform.cs
+++ b/src/Android/Avalonia.Android/AndroidPlatform.cs
@@ -43,11 +43,12 @@ namespace Avalonia.Android
             AvaloniaLocator.CurrentMutable
                 .Bind<IClipboard>().ToTransient<ClipboardImpl>()
                 .Bind<ICursorFactory>().ToTransient<CursorFactory>()
+                .Bind<IWindowingPlatform>().ToConstant(new WindowingPlatformStub())
                 .Bind<IKeyboardDevice>().ToSingleton<AndroidKeyboardDevice>()
                 .Bind<IPlatformSettings>().ToConstant(Instance)
                 .Bind<IPlatformThreadingInterface>().ToConstant(new AndroidThreadingInterface())
                 .Bind<ISystemDialogImpl>().ToTransient<SystemDialogImpl>()
-                .Bind<IPlatformIconLoader>().ToSingleton<PlatformIconLoader>()
+                .Bind<IPlatformIconLoader>().ToSingleton<PlatformIconLoaderStub>()
                 .Bind<IRenderTimer>().ToConstant(new ChoreographerTimer())
                 .Bind<IRenderLoop>().ToConstant(new RenderLoop())
                 .Bind<PlatformHotkeyConfiguration>().ToSingleton<PlatformHotkeyConfiguration>()

--- a/src/Android/Avalonia.Android/Stubs.cs
+++ b/src/Android/Avalonia.Android/Stubs.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.IO;
+using Avalonia.Platform;
+
+namespace Avalonia.Android
+{
+    class WindowingPlatformStub : IWindowingPlatform
+    {
+        public IWindowImpl CreateWindow() => throw new NotSupportedException();
+
+        public IWindowImpl CreateEmbeddableWindow() => throw new NotSupportedException();
+
+        public ITrayIconImpl CreateTrayIcon() => null;
+    }
+
+    class PlatformIconLoaderStub : IPlatformIconLoader
+    {
+        public IWindowIconImpl LoadIcon(IBitmapImpl bitmap)
+        {
+            using (var stream = new MemoryStream())
+            {
+                bitmap.Save(stream);
+                return LoadIcon(stream);
+            }
+        }
+
+        public IWindowIconImpl LoadIcon(Stream stream)
+        {
+            var ms = new MemoryStream();
+            stream.CopyTo(ms);
+            return new IconStub(ms);
+        }
+
+        public IWindowIconImpl LoadIcon(string fileName)
+        {
+            using (var file = File.Open(fileName, FileMode.Open))
+                return LoadIcon(file);
+        }
+    }
+
+    public class IconStub : IWindowIconImpl
+    {
+        private readonly MemoryStream _ms;
+
+        public IconStub(MemoryStream stream)
+        {
+            _ms = stream;
+        }
+
+        public void Save(Stream outputStream)
+        {
+            _ms.Position = 0;
+            _ms.CopyTo(outputStream);
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Changes to allow launch Control Catalog on Android:
- Add reference to `Avalonia.Themes.Fluent` in Android Control.Catalog.
- Changes in the Android Platform to register a fake version of `IWindowingPlatform`.

![avalonia-droid-01](https://user-images.githubusercontent.com/6755973/146968696-56d9d154-7f2d-447e-af4e-e5433ce30e60.PNG)
![avalonia-droid-02](https://user-images.githubusercontent.com/6755973/146968712-cccc6ffe-1f98-41d2-a254-ea5a13d1f494.PNG)


## What is the current behavior?
Cannot launch Control Catalog on Android. Get some crashes trying to start the App (searching the Fluent themes o trying to use the native method to try to create a try icon.

## What is the updated/expected behavior with this PR?
Fixes the issues launching the Control.Catalog on Android.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
Nothing.

## Obsoletions / Deprecations
Nothing.

## Fixed issues
- None (as far as I have seen).
