### PR TITLE
Added AvaloniaLocator.GetRequiredService.

### DIFF
--- a/src/Avalonia.Base/AvaloniaLocator.cs
+++ b/src/Avalonia.Base/AvaloniaLocator.cs
@@ -125,6 +125,16 @@ namespace Avalonia
         {
             return (T?) resolver.GetService(typeof (T));
         }
+
+        public static object GetRequiredService(this IAvaloniaDependencyResolver resolver, Type t)
+        {
+            return resolver.GetService(t) ?? throw new InvalidOperationException($"Unable to locate '{t}'.");
+        }
+
+        public static T GetRequiredService<T>(this IAvaloniaDependencyResolver resolver)
+        {
+            return (T?)resolver.GetService(typeof(T)) ?? throw new InvalidOperationException($"Unable to locate '{typeof(T)}'.");
+        }
     }
 }
 

--- a/src/Avalonia.Base/Threading/Dispatcher.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.cs
@@ -56,11 +56,7 @@ namespace Avalonia.Threading
         /// </param>
         public void MainLoop(CancellationToken cancellationToken)
         {
-            var platform = AvaloniaLocator.Current.GetService<IPlatformThreadingInterface>();
-
-            if (platform is null)
-                throw new InvalidOperationException("Unable to locate IPlatformThreadingInterface");
-
+            var platform = AvaloniaLocator.Current.GetRequiredService<IPlatformThreadingInterface>();
             cancellationToken.Register(() => platform.Signal(DispatcherPriority.Send));
             platform.RunLoop(cancellationToken);
         }

--- a/src/Avalonia.Controls/SystemDialog.cs
+++ b/src/Avalonia.Controls/SystemDialog.cs
@@ -66,8 +66,7 @@ namespace Avalonia.Controls
         {
             if(parent == null)
                 throw new ArgumentNullException(nameof(parent));
-            var service = AvaloniaLocator.Current.GetService<ISystemDialogImpl>() ??
-                throw new InvalidOperationException("Unable to locate ISystemDialogImpl.");
+            var service = AvaloniaLocator.Current.GetRequiredService<ISystemDialogImpl>();
             return (await service.ShowFileDialogAsync(this, parent) ??
              Array.Empty<string>()).FirstOrDefault();
         }
@@ -95,8 +94,7 @@ namespace Avalonia.Controls
         {
             if(parent == null)
                 throw new ArgumentNullException(nameof(parent));
-            var service = AvaloniaLocator.Current.GetService<ISystemDialogImpl>() ??
-                throw new InvalidOperationException("Unable to locate ISystemDialogImpl.");
+            var service = AvaloniaLocator.Current.GetRequiredService<ISystemDialogImpl>();
             return service.ShowFileDialogAsync(this, parent);
         }
     }
@@ -125,8 +123,7 @@ namespace Avalonia.Controls
         {
             if(parent == null)
                 throw new ArgumentNullException(nameof(parent));
-            var service = AvaloniaLocator.Current.GetService<ISystemDialogImpl>() ??
-                throw new InvalidOperationException("Unable to locate ISystemDialogImpl.");
+            var service = AvaloniaLocator.Current.GetRequiredService<ISystemDialogImpl>();
             return service.ShowFolderDialogAsync(this, parent);
         }
     }

--- a/src/Avalonia.Visuals/Animation/RenderLoopClock.cs
+++ b/src/Avalonia.Visuals/Animation/RenderLoopClock.cs
@@ -9,9 +9,7 @@ namespace Avalonia.Animation
     {
         protected override void Stop()
         {
-            var loop = AvaloniaLocator.Current.GetService<IRenderLoop>() ??
-                throw new InvalidOperationException("Unable to locate IRenderLoop.");
-            loop.Remove(this);
+            AvaloniaLocator.Current.GetRequiredService<IRenderLoop>().Remove(this);
         }
 
         bool IRenderLoopTask.NeedsUpdate => HasSubscriptions;

--- a/src/Avalonia.Visuals/Media/CombinedGeometry.cs
+++ b/src/Avalonia.Visuals/Media/CombinedGeometry.cs
@@ -154,8 +154,7 @@ namespace Avalonia.Media
 
             if (g1 is object && g2 is object)
             {
-                var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
-                    throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
+                var factory = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
                 return factory.CreateCombinedGeometry(GeometryCombineMode, g1, g2);
             }
             else if (GeometryCombineMode == GeometryCombineMode.Intersect)

--- a/src/Avalonia.Visuals/Media/EllipseGeometry.cs
+++ b/src/Avalonia.Visuals/Media/EllipseGeometry.cs
@@ -98,8 +98,7 @@ namespace Avalonia.Media
         /// <inheritdoc/>
         protected override IGeometryImpl? CreateDefiningGeometry()
         {
-            var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
-                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
+            var factory = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
 
             if (Rect != default) return factory.CreateEllipseGeometry(Rect);
             

--- a/src/Avalonia.Visuals/Media/Fonts/FontFamilyLoader.cs
+++ b/src/Avalonia.Visuals/Media/Fonts/FontFamilyLoader.cs
@@ -32,9 +32,7 @@ namespace Avalonia.Media.Fonts
         /// <returns></returns>
         private static IEnumerable<Uri> GetFontAssetsBySource(FontFamilyKey fontFamilyKey)
         {
-            var assetLoader = AvaloniaLocator.Current.GetService<IAssetLoader>() ??
-                throw new InvalidOperationException("Unable to locate IAssetLoader.");
-
+            var assetLoader = AvaloniaLocator.Current.GetRequiredService<IAssetLoader>();
             var availableAssets = assetLoader.GetAssets(fontFamilyKey.Source, fontFamilyKey.BaseUri);
 
             var matchingAssets =
@@ -51,8 +49,7 @@ namespace Avalonia.Media.Fonts
         /// <returns></returns>
         private static IEnumerable<Uri> GetFontAssetsByExpression(FontFamilyKey fontFamilyKey)
         {
-            var assetLoader = AvaloniaLocator.Current.GetService<IAssetLoader>() ??
-                throw new InvalidOperationException("Unable to locate IAssetLoader.");
+            var assetLoader = AvaloniaLocator.Current.GetRequiredService<IAssetLoader>();
 
             var fileName = GetFileName(fontFamilyKey, out var fileExtension, out var location);
 

--- a/src/Avalonia.Visuals/Media/FormattedText.cs
+++ b/src/Avalonia.Visuals/Media/FormattedText.cs
@@ -24,8 +24,7 @@ namespace Avalonia.Media
         /// </summary>
         public FormattedText()
         {
-            _platform = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
-                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
+            _platform = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
         }
 
         /// <summary>

--- a/src/Avalonia.Visuals/Media/GeometryGroup.cs
+++ b/src/Avalonia.Visuals/Media/GeometryGroup.cs
@@ -61,8 +61,7 @@ namespace Avalonia.Media
         {
             if (_children?.Count > 0)
             {
-                var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
-                    throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
+                var factory = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
                 return factory.CreateGeometryGroup(FillRule, _children);
             }
 

--- a/src/Avalonia.Visuals/Media/GlyphRun.cs
+++ b/src/Avalonia.Visuals/Media/GlyphRun.cs
@@ -627,8 +627,7 @@ namespace Avalonia.Media
                 throw new InvalidOperationException();
             }
 
-            var platformRenderInterface = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
-                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface");
+            var platformRenderInterface = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
 
             _glyphRunImpl = platformRenderInterface.CreateGlyphRun(this);
         }

--- a/src/Avalonia.Visuals/Media/Imaging/Bitmap.cs
+++ b/src/Avalonia.Visuals/Media/Imaging/Bitmap.cs
@@ -169,8 +169,7 @@ namespace Avalonia.Media.Imaging
 
         private static IPlatformRenderInterface GetFactory()
         {
-            return AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
-                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
+            return AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/Imaging/RenderTargetBitmap.cs
+++ b/src/Avalonia.Visuals/Media/Imaging/RenderTargetBitmap.cs
@@ -54,8 +54,7 @@ namespace Avalonia.Media.Imaging
         /// <returns>The platform-specific implementation.</returns>
         private static IRenderTargetBitmapImpl CreateImpl(PixelSize size, Vector dpi)
         {
-            IPlatformRenderInterface factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
-                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
+            IPlatformRenderInterface factory = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
             return factory.CreateRenderTargetBitmap(size, dpi);
         }
 

--- a/src/Avalonia.Visuals/Media/Imaging/WriteableBitmap.cs
+++ b/src/Avalonia.Visuals/Media/Imaging/WriteableBitmap.cs
@@ -93,8 +93,7 @@ namespace Avalonia.Media.Imaging
 
         private static IPlatformRenderInterface GetFactory()
         {
-            return AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
-                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
+            return AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
         }
     }
 }

--- a/src/Avalonia.Visuals/Media/LineGeometry.cs
+++ b/src/Avalonia.Visuals/Media/LineGeometry.cs
@@ -70,8 +70,7 @@ namespace Avalonia.Media
         /// <inheritdoc/>
         protected override IGeometryImpl? CreateDefiningGeometry()
         {
-            var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
-                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
+            var factory = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
 
             return factory.CreateLineGeometry(StartPoint, EndPoint);
         }

--- a/src/Avalonia.Visuals/Media/PathGeometry.cs
+++ b/src/Avalonia.Visuals/Media/PathGeometry.cs
@@ -88,8 +88,7 @@ namespace Avalonia.Media
             if (figures is null)
                 return null;
 
-            var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
-                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
+            var factory = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
             var geometry = factory.CreateStreamGeometry();
 
             using (var ctx = new StreamGeometryContext(geometry.Open()))

--- a/src/Avalonia.Visuals/Media/PolylineGeometry.cs
+++ b/src/Avalonia.Visuals/Media/PolylineGeometry.cs
@@ -76,8 +76,7 @@ namespace Avalonia.Media
 
         protected override IGeometryImpl? CreateDefiningGeometry()
         {
-            var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
-                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
+            var factory = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
             var geometry = factory.CreateStreamGeometry();
 
             using (var context = geometry.Open())

--- a/src/Avalonia.Visuals/Media/RectangleGeometry.cs
+++ b/src/Avalonia.Visuals/Media/RectangleGeometry.cs
@@ -49,8 +49,7 @@ namespace Avalonia.Media
 
         protected override IGeometryImpl? CreateDefiningGeometry()
         {
-            var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
-                throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
+            var factory = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
 
             return factory.CreateRectangleGeometry(Rect);
         }

--- a/src/Avalonia.Visuals/Media/StreamGeometry.cs
+++ b/src/Avalonia.Visuals/Media/StreamGeometry.cs
@@ -66,8 +66,7 @@ namespace Avalonia.Media
         {
             if (_impl == null)
             {
-                var factory = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
-                    throw new InvalidOperationException("Unable to locate IPlatformRenderInterface.");
+                var factory = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
                 _impl = factory.CreateStreamGeometry();
             }
 

--- a/src/Avalonia.Visuals/Rendering/DefaultRenderTimer.cs
+++ b/src/Avalonia.Visuals/Rendering/DefaultRenderTimer.cs
@@ -77,8 +77,7 @@ namespace Avalonia.Rendering
         /// </remarks>
         protected virtual IDisposable StartCore(Action<TimeSpan> tick)
         {
-            _runtime ??= AvaloniaLocator.Current.GetService<IRuntimePlatform>() ??
-                throw new InvalidOperationException("Unable to locate IRuntimePlatform.");
+            _runtime ??= AvaloniaLocator.Current.GetRequiredService<IRuntimePlatform>();
 
             return _runtime.StartSystemTimer(
                 TimeSpan.FromSeconds(1.0 / FramesPerSecond),

--- a/src/Avalonia.X11/X11CursorFactory.cs
+++ b/src/Avalonia.X11/X11CursorFactory.cs
@@ -94,10 +94,8 @@ namespace Avalonia.X11
             {
                 var size = Marshal.SizeOf<XcursorImage>() +
                     (bitmap.PixelSize.Width * bitmap.PixelSize.Height * 4);
-                var runtimePlatform = AvaloniaLocator.Current.GetService<IRuntimePlatform>() ??
-                    throw new InvalidOperationException("Unable to locate IRuntimePlatform");
-                var platformRenderInterface = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() ??
-                    throw new InvalidOperationException("Unable to locate IPlatformRenderInterface");
+                var runtimePlatform = AvaloniaLocator.Current.GetRequiredService<IRuntimePlatform>();
+                var platformRenderInterface = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
 
                 _pixelSize = bitmap.PixelSize;
                 _blob = runtimePlatform.AllocBlob(size);

--- a/src/Web/Avalonia.Web.Blazor/RazorViewTopLevelImpl.cs
+++ b/src/Web/Avalonia.Web.Blazor/RazorViewTopLevelImpl.cs
@@ -106,8 +106,7 @@ namespace Avalonia.Web.Blazor
 
         public IRenderer CreateRenderer(IRenderRoot root)
         {
-            var loop = AvaloniaLocator.Current.GetService<IRenderLoop>() ??
-                throw new InvalidOperationException("Unable to locate IRenderLoop.");
+            var loop = AvaloniaLocator.Current.GetRequiredService<IRenderLoop>();
             return new DeferredRenderer(root, loop);
         }
 

--- a/src/Web/Avalonia.Web.Blazor/WindowingPlatform.cs
+++ b/src/Web/Avalonia.Web.Blazor/WindowingPlatform.cs
@@ -98,8 +98,7 @@ namespace Avalonia.Web.Blazor
 
         private static IRuntimePlatform GetRuntimePlatform()
         {
-            return AvaloniaLocator.Current.GetService<IRuntimePlatform>() ??
-                throw new InvalidOperationException("Unable to locate IRuntimePlatform.");
+            return AvaloniaLocator.Current.GetRequiredService<IRuntimePlatform>();
         }
     }
 }

--- a/src/Windows/Avalonia.Win32/FramebufferManager.cs
+++ b/src/Windows/Avalonia.Win32/FramebufferManager.cs
@@ -107,8 +107,7 @@ namespace Avalonia.Win32
 
         private static FramebufferData AllocateFramebufferData(int width, int height)
         {
-            var service = AvaloniaLocator.Current.GetService<IRuntimePlatform>() ??
-                throw new InvalidOperationException("Unable to locate IRuntimePlatform.");
+            var service = AvaloniaLocator.Current.GetRequiredService<IRuntimePlatform>();
             var bitmapBlob = service.AllocBlob(width * height * _bytesPerPixel);
 
             return new FramebufferData(bitmapBlob, width, height);


### PR DESCRIPTION
## What does the pull request do?

`AvaloniaLocator.GetService` can return null, but often we want to throw when the service isn't found.

This PR adds `AvaloniaLocator.GetRequiredService` methods following the pattern from [elsewhere](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.serviceproviderserviceextensions.getrequiredservice?view=dotnet-plat-ext-6.0) in the .NET stack.

Also replaced a bunch of usages of `GetService<T>()` which threw non-customized exceptions when the service was not found. All other usages I could find either ignored the null result or threw custom error messages.
