### PR TITLE
Stopgap measure to fix #7245

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -1157,7 +1157,7 @@ namespace Avalonia.X11
         public ITextInputMethodImpl TextInputMethod => _ime;
 
         public void SetTransparencyLevelHint(WindowTransparencyLevel transparencyLevel) =>
-            _transparencyHelper.SetTransparencyRequest(transparencyLevel);
+            _transparencyHelper?.SetTransparencyRequest(transparencyLevel);
 
         public void SetWindowManagerAddShadowHint(bool enabled)
         {


### PR DESCRIPTION
#7245 is caused by TopLevel.cs using IPlatformImpl after said IPlatformImpl is disposed and is in invalid state. Since fixing TopLevel.cs might cause even more issues, for now I'm just adding a null check to `X11Window::SetTransparencyLevelHint` so it won't throw after X11Window is disposed. 