### PR TITLE
Improve ButtonSpinner OnPointerWheel 

### DIFF
--- a/src/Avalonia.Controls/ButtonSpinner.cs
+++ b/src/Avalonia.Controls/ButtonSpinner.cs
@@ -197,7 +197,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerWheelChanged(e);
 
-            if (AllowSpin && IsFocused)
+            if (AllowSpin && IsKeyboardFocusWithin)
             {
                 if (e.Delta.Y != 0)
                 {

--- a/src/Avalonia.Controls/ButtonSpinner.cs
+++ b/src/Avalonia.Controls/ButtonSpinner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
@@ -196,13 +196,14 @@ namespace Avalonia.Controls
         protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
         {
             base.OnPointerWheelChanged(e);
-            if (!e.Handled && AllowSpin)
+
+            if (AllowSpin && IsFocused)
             {
                 if (e.Delta.Y != 0)
                 {
                     var spinnerEventArgs = new SpinEventArgs(SpinEvent, (e.Delta.Y < 0) ? SpinDirection.Decrease : SpinDirection.Increase, true);
                     OnSpin(spinnerEventArgs);
-                    e.Handled = spinnerEventArgs.Handled;
+                    e.Handled = true;
                 }
             }
         }

--- a/src/Avalonia.Themes.Default/ButtonSpinner.xaml
+++ b/src/Avalonia.Themes.Default/ButtonSpinner.xaml
@@ -5,6 +5,7 @@
     <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
     <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
     <Setter Property="VerticalContentAlignment" Value="Center"/>
+    <Setter Property="Focusable" Value="True"/>
   </Style>
   <Style Selector="ButtonSpinner /template/ RepeatButton">
     <Setter Property="Background" Value="Transparent"/>

--- a/src/Avalonia.Themes.Fluent/Controls/ButtonSpinner.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ButtonSpinner.xaml
@@ -64,6 +64,7 @@
     <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="Focusable" Value="True"/>
     <Setter Property="Template">
       <ControlTemplate>
         <DataValidationErrors>


### PR DESCRIPTION
## What does the pull request do?
changes the way the `ButtonSpinner` handles the `PointerWheelEvent`


## What is the current behavior?
The control behaves strange on pointer wheel, see #6869 


## What is the updated/expected behavior with this PR?
- The spin only happens when the control is focused
- If the control did handle this event, mark it as handled so that any surrounding `ScrollViewer` does not handle the scroll. 


## How was the solution implemented (if it's not obvious)?
- Test if the control has focus
- Mark the event as handled if it was handled
- Make the control focus-able by default 


## Checklist

- [ ] Added unit tests (if possible)? ► none
- [ ] Added XML documentation to any related classes? ► not needed
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation ► not needed

## Breaking changes
I am not sure about this, as the interaction changed. But most likely the "old" behavior was a bug, so I think there is no breaking change here.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Question to the Avalonia Team
Right now there is no visual feedback if the control is focused or not. Should this be changed? If yes, can you tell me which other control has a good implementation so that I can align the styles? 

## Fixed issues
Fixes part of #6869 
