### PR TITLE
Fast Fluent theme switching

### DIFF
--- a/samples/ControlCatalog/App.xaml
+++ b/samples/ControlCatalog/App.xaml
@@ -5,8 +5,6 @@
              x:CompileBindings="True"
              x:Class="ControlCatalog.App">
   <Application.Styles>
-    <FluentTheme Mode="Light"/>
-    <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
     <Style Selector="TextBlock.h1, TextBlock.h2, TextBlock.h3">
       <Setter Property="TextWrapping" Value="Wrap" />
     </Style>

--- a/samples/ControlCatalog/App.xaml
+++ b/samples/ControlCatalog/App.xaml
@@ -6,6 +6,7 @@
              x:Class="ControlCatalog.App">
   <Application.Styles>
     <FluentTheme Mode="Light"/>
+    <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
     <Style Selector="TextBlock.h1, TextBlock.h2, TextBlock.h3">
       <Setter Property="TextWrapping" Value="Wrap" />
     </Style>

--- a/samples/ControlCatalog/App.xaml
+++ b/samples/ControlCatalog/App.xaml
@@ -5,6 +5,7 @@
              x:CompileBindings="True"
              x:Class="ControlCatalog.App">
   <Application.Styles>
+    <FluentTheme Mode="Light"/>
     <Style Selector="TextBlock.h1, TextBlock.h2, TextBlock.h3">
       <Setter Property="TextWrapping" Value="Wrap" />
     </Style>

--- a/samples/ControlCatalog/App.xaml.cs
+++ b/samples/ControlCatalog/App.xaml.cs
@@ -27,9 +27,7 @@ namespace ControlCatalog
             Source = new Uri("avares://Avalonia.Controls.DataGrid/Themes/Default.xaml")
         };
 
-        public static FluentTheme FluentDark = new FluentTheme(new Uri("avares://ControlCatalog/Styles")) { Mode = FluentThemeMode.Dark };
-
-        public static FluentTheme FluentLight = new FluentTheme(new Uri("avares://ControlCatalog/Styles"));
+        public static FluentTheme Fluent = new FluentTheme(new Uri("avares://ControlCatalog/Styles"));
 
         public static Styles DefaultLight = new Styles
         {
@@ -81,7 +79,7 @@ namespace ControlCatalog
 
         public override void Initialize()
         {
-            Styles.Insert(0, FluentLight);
+            Styles.Insert(0, Fluent);
             Styles.Insert(1, DataGridFluent);
             AvaloniaXamlLoader.Load(this);
         }

--- a/samples/ControlCatalog/App.xaml.cs
+++ b/samples/ControlCatalog/App.xaml.cs
@@ -16,12 +16,12 @@ namespace ControlCatalog
             DataContext = new ApplicationViewModel();
         }
 
-        private static readonly StyleInclude DataGridFluent = new StyleInclude(new Uri("avares://ControlCatalog/Styles"))
+        public static readonly StyleInclude DataGridFluent = new StyleInclude(new Uri("avares://ControlCatalog/Styles"))
         {
             Source = new Uri("avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml")
         };
 
-        private static readonly StyleInclude DataGridDefault = new StyleInclude(new Uri("avares://ControlCatalog/Styles"))
+        public static readonly StyleInclude DataGridDefault = new StyleInclude(new Uri("avares://ControlCatalog/Styles"))
         {
             Source = new Uri("avares://Avalonia.Controls.DataGrid/Themes/Default.xaml")
         };
@@ -31,8 +31,7 @@ namespace ControlCatalog
             new StyleInclude(new Uri("avares://ControlCatalog/Styles"))
             {
                 Source = new Uri("avares://Avalonia.Themes.Fluent/FluentDark.xaml")
-            },
-            DataGridFluent
+            }
         };
 
         public static Styles FluentLight = new Styles
@@ -40,8 +39,7 @@ namespace ControlCatalog
             new StyleInclude(new Uri("avares://ControlCatalog/Styles"))
             {
                 Source = new Uri("avares://Avalonia.Themes.Fluent/FluentLight.xaml")
-            },
-            DataGridFluent
+            }
         };
 
         public static Styles DefaultLight = new Styles
@@ -65,8 +63,7 @@ namespace ControlCatalog
             new StyleInclude(new Uri("resm:Styles?assembly=ControlCatalog"))
             {
                 Source = new Uri("avares://Avalonia.Themes.Default/DefaultTheme.xaml")
-            },
-            DataGridDefault
+            }
         };
 
         public static Styles DefaultDark = new Styles
@@ -90,8 +87,7 @@ namespace ControlCatalog
             new StyleInclude(new Uri("resm:Styles?assembly=ControlCatalog"))
             {
                 Source = new Uri("avares://Avalonia.Themes.Default/DefaultTheme.xaml")
-            },
-            DataGridDefault
+            }
         };
 
         public override void Initialize()

--- a/samples/ControlCatalog/App.xaml.cs
+++ b/samples/ControlCatalog/App.xaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Styling;
+using Avalonia.Themes.Fluent;
 using ControlCatalog.ViewModels;
 
 namespace ControlCatalog
@@ -26,21 +27,9 @@ namespace ControlCatalog
             Source = new Uri("avares://Avalonia.Controls.DataGrid/Themes/Default.xaml")
         };
 
-        public static Styles FluentDark = new Styles
-        {
-            new StyleInclude(new Uri("avares://ControlCatalog/Styles"))
-            {
-                Source = new Uri("avares://Avalonia.Themes.Fluent/FluentDark.xaml")
-            }
-        };
+        public static FluentTheme FluentDark = new FluentTheme(new Uri("avares://ControlCatalog/Styles")) { Mode = FluentThemeMode.Dark };
 
-        public static Styles FluentLight = new Styles
-        {
-            new StyleInclude(new Uri("avares://ControlCatalog/Styles"))
-            {
-                Source = new Uri("avares://Avalonia.Themes.Fluent/FluentLight.xaml")
-            }
-        };
+        public static FluentTheme FluentLight = new FluentTheme(new Uri("avares://ControlCatalog/Styles"));
 
         public static Styles DefaultLight = new Styles
         {
@@ -92,7 +81,8 @@ namespace ControlCatalog
 
         public override void Initialize()
         {
-
+            Styles.Insert(0, FluentLight);
+            Styles.Insert(1, DataGridFluent);
             AvaloniaXamlLoader.Load(this);
         }
 

--- a/samples/ControlCatalog/App.xaml.cs
+++ b/samples/ControlCatalog/App.xaml.cs
@@ -96,7 +96,6 @@ namespace ControlCatalog
 
         public override void Initialize()
         {
-            Styles.Insert(0, FluentLight);
 
             AvaloniaXamlLoader.Load(this);
         }

--- a/samples/ControlCatalog/MainView.xaml.cs
+++ b/samples/ControlCatalog/MainView.xaml.cs
@@ -53,7 +53,7 @@ namespace ControlCatalog
                         }
                         else
                         {
-                            Application.Current.Styles[0] = App.FluentLight;
+                            Application.Current.Styles[0] = App.Fluent;
                             Application.Current.Styles[1] = App.DataGridFluent;
                         }
                     }
@@ -68,7 +68,8 @@ namespace ControlCatalog
                         }
                         else
                         {
-                            Application.Current.Styles[0] = App.FluentDark;
+                            App.Fluent.Mode = FluentThemeMode.Dark;
+                            Application.Current.Styles[0] = App.Fluent;
                             Application.Current.Styles[1] = App.DataGridFluent;
                         }
                     }

--- a/samples/ControlCatalog/MainView.xaml.cs
+++ b/samples/ControlCatalog/MainView.xaml.cs
@@ -11,6 +11,7 @@ using Avalonia.Media.Immutable;
 using Avalonia.Platform;
 using ControlCatalog.Pages;
 using ControlCatalog.Models;
+using Avalonia.Themes.Fluent;
 
 namespace ControlCatalog
 {
@@ -43,14 +44,7 @@ namespace ControlCatalog
             {
                 if (themes.SelectedItem is CatalogTheme theme)
                 {
-                    Application.Current.Styles[0] = theme switch
-                    {
-                        CatalogTheme.FluentLight => App.FluentLight,
-                        CatalogTheme.FluentDark => App.FluentDark,
-                        CatalogTheme.DefaultLight => App.DefaultLight,
-                        CatalogTheme.DefaultDark => App.DefaultDark,
-                        _ => Application.Current.Styles[0]
-                    };
+                    (Application.Current.Styles[0] as FluentTheme).Mode = FluentThemeMode.Dark;
                 }
             };
 

--- a/samples/ControlCatalog/MainView.xaml.cs
+++ b/samples/ControlCatalog/MainView.xaml.cs
@@ -44,34 +44,22 @@ namespace ControlCatalog
                     var themeStyle = Application.Current.Styles[0];
                     if (theme == CatalogTheme.FluentLight)
                     {
-                        if (themeStyle is FluentTheme fluentTheme)
+                        if (App.Fluent.Mode != FluentThemeMode.Light)
                         {
-                            if (fluentTheme.Mode == FluentThemeMode.Dark)
-                            {
-                                fluentTheme.Mode = FluentThemeMode.Light;
-                            }
+                            App.Fluent.Mode = FluentThemeMode.Light;
                         }
-                        else
-                        {
-                            Application.Current.Styles[0] = App.Fluent;
-                            Application.Current.Styles[1] = App.DataGridFluent;
-                        }
+                        Application.Current.Styles[0] = App.Fluent;
+                        Application.Current.Styles[1] = App.DataGridFluent;
                     }
                     else if (theme == CatalogTheme.FluentDark)
                     {
-                        if (themeStyle is FluentTheme fluentTheme)
-                        {
-                            if (fluentTheme.Mode == FluentThemeMode.Light)
-                            {
-                                fluentTheme.Mode = FluentThemeMode.Dark;
-                            }
-                        }
-                        else
+
+                        if (App.Fluent.Mode != FluentThemeMode.Dark)
                         {
                             App.Fluent.Mode = FluentThemeMode.Dark;
-                            Application.Current.Styles[0] = App.Fluent;
-                            Application.Current.Styles[1] = App.DataGridFluent;
                         }
+                        Application.Current.Styles[0] = App.Fluent;
+                        Application.Current.Styles[1] = App.DataGridFluent;
                     }
                     else if (theme == CatalogTheme.DefaultLight)
                     {

--- a/samples/ControlCatalog/MainView.xaml.cs
+++ b/samples/ControlCatalog/MainView.xaml.cs
@@ -53,7 +53,7 @@ namespace ControlCatalog
                         }
                         else
                         {
-                            Application.Current.Styles[0] = new FluentTheme(new Uri("avares://ControlCatalog/Styles"));
+                            Application.Current.Styles[0] = App.FluentLight;
                             Application.Current.Styles[1] = App.DataGridFluent;
                         }
                     }
@@ -68,7 +68,7 @@ namespace ControlCatalog
                         }
                         else
                         {
-                            Application.Current.Styles[0] = new FluentTheme(new Uri("avares://ControlCatalog/Styles")) { Mode = FluentThemeMode.Dark };
+                            Application.Current.Styles[0] = App.FluentDark;
                             Application.Current.Styles[1] = App.DataGridFluent;
                         }
                     }

--- a/samples/ControlCatalog/MainView.xaml.cs
+++ b/samples/ControlCatalog/MainView.xaml.cs
@@ -3,15 +3,12 @@ using System.Collections;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
-using Avalonia.Markup.Xaml.MarkupExtensions;
-using Avalonia.Markup.Xaml.Styling;
-using Avalonia.Markup.Xaml.XamlIl;
 using Avalonia.Media;
 using Avalonia.Media.Immutable;
 using Avalonia.Platform;
-using ControlCatalog.Pages;
-using ControlCatalog.Models;
 using Avalonia.Themes.Fluent;
+using ControlCatalog.Models;
+using ControlCatalog.Pages;
 
 namespace ControlCatalog
 {
@@ -44,7 +41,47 @@ namespace ControlCatalog
             {
                 if (themes.SelectedItem is CatalogTheme theme)
                 {
-                    (Application.Current.Styles[0] as FluentTheme).Mode = FluentThemeMode.Dark;
+                    var themeStyle = Application.Current.Styles[0];
+                    if (theme == CatalogTheme.FluentLight)
+                    {
+                        if (themeStyle is FluentTheme fluentTheme)
+                        {
+                            if (fluentTheme.Mode == FluentThemeMode.Dark)
+                            {
+                                fluentTheme.Mode = FluentThemeMode.Light;
+                            }
+                        }
+                        else
+                        {
+                            Application.Current.Styles[0] = new FluentTheme(new Uri("avares://ControlCatalog/Styles"));
+                            Application.Current.Styles[1] = App.DataGridFluent;
+                        }
+                    }
+                    else if (theme == CatalogTheme.FluentDark)
+                    {
+                        if (themeStyle is FluentTheme fluentTheme)
+                        {
+                            if (fluentTheme.Mode == FluentThemeMode.Light)
+                            {
+                                fluentTheme.Mode = FluentThemeMode.Dark;
+                            }
+                        }
+                        else
+                        {
+                            Application.Current.Styles[0] = new FluentTheme(new Uri("avares://ControlCatalog/Styles")) { Mode = FluentThemeMode.Dark };
+                            Application.Current.Styles[1] = App.DataGridFluent;
+                        }
+                    }
+                    else if (theme == CatalogTheme.DefaultLight)
+                    {
+                        Application.Current.Styles[0] = App.DefaultLight;
+                        Application.Current.Styles[1] = App.DataGridDefault;
+                    }
+                    else if (theme == CatalogTheme.DefaultDark)
+                    {
+                        Application.Current.Styles[0] = App.DefaultDark;
+                        Application.Current.Styles[1] = App.DataGridDefault;
+                    }
                 }
             };
 

--- a/src/Avalonia.Themes.Fluent/FluentTheme.cs
+++ b/src/Avalonia.Themes.Fluent/FluentTheme.cs
@@ -88,23 +88,19 @@ namespace Avalonia.Themes.Fluent
                 if (_loaded == null)
                 {
                     _isLoading = true;
-                    Styles? resultStyle = new Styles() { _sharedStyles };
 
                     if (Mode == FluentThemeMode.Light)
                     {
-                        resultStyle.Add(_fluentLight[0]);
-                        resultStyle.Add(_fluentLight[1]);
+                        _loaded = new Styles() { _sharedStyles , _fluentLight[0], _fluentLight[1] };
                     }
                     else if (Mode == FluentThemeMode.Dark)
                     {
-                        resultStyle.Add(_fluentDark[0]);
-                        resultStyle.Add(_fluentDark[1]);
+                        _loaded = new Styles() { _sharedStyles, _fluentDark[0], _fluentDark[1] };
                     }
-                    _loaded = resultStyle;
                     _isLoading = false;
                 }
 
-                return _loaded;
+                return _loaded!;
             }
         }
 

--- a/src/Avalonia.Themes.Fluent/FluentTheme.cs
+++ b/src/Avalonia.Themes.Fluent/FluentTheme.cs
@@ -59,8 +59,18 @@ namespace Avalonia.Themes.Fluent
                 if (_mode != value)
                 {
                     _mode = value;
-                    (Loaded as Styles)![1] = _fluentDark[0];
-                    (Loaded as Styles)![2] = _fluentDark[1];
+                    if (_mode == FluentThemeMode.Dark)
+                    {
+                        (Loaded as Styles)![1] = _fluentDark[0];
+                        (Loaded as Styles)![2] = _fluentDark[1];
+                    }
+                    else
+                    {
+                        (Loaded as Styles)![1] = _fluentLight[0];
+                        (Loaded as Styles)![2] = _fluentLight[1];
+                    }
+
+
                 }
 
             }

--- a/src/Avalonia.Themes.Fluent/FluentTheme.cs
+++ b/src/Avalonia.Themes.Fluent/FluentTheme.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Styling;
 
 #nullable enable
@@ -22,6 +23,7 @@ namespace Avalonia.Themes.Fluent
         private readonly Uri _baseUri;
         private IStyle[]? _loaded;
         private bool _isLoading;
+        private FluentThemeMode _mode;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FluentTheme"/> class.
@@ -44,7 +46,20 @@ namespace Avalonia.Themes.Fluent
         /// <summary>
         /// Gets or sets the mode of the fluent theme (light, dark).
         /// </summary>
-        public FluentThemeMode Mode { get; set; }
+        public FluentThemeMode Mode
+        {
+            get => _mode;
+            set
+            {
+                if (_mode != value)
+                {
+                    _mode = value;
+                    (Loaded as Styles)[3] = FluentDark[0];
+                    (Loaded as Styles)[4] = FluentDark[1];
+                }
+
+            }
+        }
 
         public IResourceHost? Owner => (Loaded as IResourceProvider)?.Owner;
 
@@ -58,8 +73,25 @@ namespace Avalonia.Themes.Fluent
                 if (_loaded == null)
                 {
                     _isLoading = true;
-                    var loaded = (IStyle)AvaloniaXamlLoader.Load(GetUri(), _baseUri);
-                    _loaded = new[] { loaded };
+                    Styles? resultStyle = new Styles();
+
+                    resultStyle.AddRange(SharedStyles);
+
+                    if (Mode == FluentThemeMode.Light)
+                    {
+                        for (int i = 0; i < FluentLight.Count; i++)
+                        {
+                            resultStyle.Add(FluentLight[i]);
+                        }
+                    }
+                    else if (Mode == FluentThemeMode.Dark)
+                    {
+                        for (int i = 0; i < FluentDark.Count; i++)
+                        {
+                            resultStyle.Add(FluentDark[i]);
+                        }
+                    }
+                    _loaded = new[] { resultStyle };
                     _isLoading = false;
                 }
 
@@ -105,10 +137,43 @@ namespace Avalonia.Themes.Fluent
         void IResourceProvider.AddOwner(IResourceHost owner) => (Loaded as IResourceProvider)?.AddOwner(owner);
         void IResourceProvider.RemoveOwner(IResourceHost owner) => (Loaded as IResourceProvider)?.RemoveOwner(owner);
 
-        private Uri GetUri() => Mode switch
+        private static Styles SharedStyles = new Styles
         {
-            FluentThemeMode.Dark => new Uri("avares://Avalonia.Themes.Fluent/FluentDark.xaml", UriKind.Absolute),
-            _ => new Uri("avares://Avalonia.Themes.Fluent/FluentLight.xaml", UriKind.Absolute),
+            new StyleInclude(new Uri("resm:Styles?assembly=Avalonia.Themes.Fluent"))
+            {
+                Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/AccentColors.xaml")
+            },
+            new StyleInclude(new Uri("resm:Styles?assembly=Avalonia.Themes.Fluent"))
+            {
+                Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/Base.xaml")
+            },
+            new StyleInclude(new Uri("resm:Styles?assembly=Avalonia.Themes.Fluent"))
+            {
+                Source = new Uri("avares://Avalonia.Themes.Fluent/Controls/FluentControls.xaml")
+            }
+        };
+
+        private static Styles FluentLight = new Styles
+        {
+            new StyleInclude(new Uri("resm:Styles?assembly=Avalonia.Themes.Fluent"))
+            {
+                Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/BaseLight.xaml")
+            },
+            new StyleInclude(new Uri("resm:Styles?assembly=Avalonia.Themes.Fluent"))
+            {
+                Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/FluentControlResourcesLight.xaml")
+            }
+        };
+        private static Styles FluentDark = new Styles
+        {
+            new StyleInclude(new Uri("resm:Styles?assembly=Avalonia.Themes.Fluent"))
+            {
+                Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/BaseDark.xaml")
+            },
+            new StyleInclude(new Uri("resm:Styles?assembly=Avalonia.Themes.Fluent"))
+            {
+                Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/FluentControlResourcesDark.xaml")
+            }
         };
     }
 }

--- a/src/Avalonia.Themes.Fluent/FluentTheme.cs
+++ b/src/Avalonia.Themes.Fluent/FluentTheme.cs
@@ -21,7 +21,7 @@ namespace Avalonia.Themes.Fluent
     public class FluentTheme : IStyle, IResourceProvider
     {
         private readonly Uri _baseUri;
-        private IStyle[]? _loaded;
+        private IStyle? _loaded;
         private bool _isLoading;
         private FluentThemeMode _mode;
 
@@ -91,17 +91,17 @@ namespace Avalonia.Themes.Fluent
                             resultStyle.Add(FluentDark[i]);
                         }
                     }
-                    _loaded = new[] { resultStyle };
+                    _loaded = resultStyle;
                     _isLoading = false;
                 }
 
-                return _loaded?[0]!;
+                return _loaded;
             }
         }
 
         bool IResourceNode.HasResources => (Loaded as IResourceProvider)?.HasResources ?? false;
 
-        IReadOnlyList<IStyle> IStyle.Children => _loaded ?? Array.Empty<IStyle>();
+        IReadOnlyList<IStyle> IStyle.Children => _loaded?.Children ?? Array.Empty<IStyle>();
 
         public event EventHandler OwnerChanged
         {

--- a/src/Avalonia.Themes.Fluent/FluentTheme.cs
+++ b/src/Avalonia.Themes.Fluent/FluentTheme.cs
@@ -18,7 +18,7 @@ namespace Avalonia.Themes.Fluent
     /// <summary>
     /// Includes the fluent theme in an application.
     /// </summary>
-    public class FluentTheme : IStyle, IResourceProvider
+    public class FluentTheme : AvaloniaObject, IStyle, IResourceProvider
     {
         private readonly Uri _baseUri;
         private Styles _fluentDark = new();
@@ -26,7 +26,6 @@ namespace Avalonia.Themes.Fluent
         private Styles _sharedStyles = new();
         private bool _isLoading;
         private IStyle? _loaded;
-        private FluentThemeMode _mode;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FluentTheme"/> class.
@@ -48,31 +47,32 @@ namespace Avalonia.Themes.Fluent
             InitStyles(_baseUri);
         }
 
+
+        public static readonly StyledProperty<FluentThemeMode> ModeProperty =
+            AvaloniaProperty.Register<FluentTheme, FluentThemeMode>(nameof(Mode));
         /// <summary>
         /// Gets or sets the mode of the fluent theme (light, dark).
         /// </summary>
         public FluentThemeMode Mode
         {
-            get => _mode;
-            set
+            get => GetValue(ModeProperty);
+            set => SetValue(ModeProperty, value);
+        }
+        protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)
+        {
+            base.OnPropertyChanged(change);
+            if (change.Property == ModeProperty)
             {
-                if (_mode != value)
+                if (Mode == FluentThemeMode.Dark)
                 {
-                    _mode = value;
-                    if (_mode == FluentThemeMode.Dark)
-                    {
-                        (Loaded as Styles)![1] = _fluentDark[0];
-                        (Loaded as Styles)![2] = _fluentDark[1];
-                    }
-                    else
-                    {
-                        (Loaded as Styles)![1] = _fluentLight[0];
-                        (Loaded as Styles)![2] = _fluentLight[1];
-                    }
-
-
+                    (Loaded as Styles)![1] = _fluentDark[0];
+                    (Loaded as Styles)![2] = _fluentDark[1];
                 }
-
+                else
+                {
+                    (Loaded as Styles)![1] = _fluentLight[0];
+                    (Loaded as Styles)![2] = _fluentLight[1];
+                }
             }
         }
 

--- a/src/Avalonia.Themes.Fluent/FluentTheme.cs
+++ b/src/Avalonia.Themes.Fluent/FluentTheme.cs
@@ -21,8 +21,11 @@ namespace Avalonia.Themes.Fluent
     public class FluentTheme : IStyle, IResourceProvider
     {
         private readonly Uri _baseUri;
-        private IStyle? _loaded;
+        private Styles _fluentDark = new();
+        private Styles _fluentLight = new();
+        private Styles _sharedStyles = new();
         private bool _isLoading;
+        private IStyle? _loaded;
         private FluentThemeMode _mode;
 
         /// <summary>
@@ -32,6 +35,7 @@ namespace Avalonia.Themes.Fluent
         public FluentTheme(Uri baseUri)
         {
             _baseUri = baseUri;
+            InitStyles(baseUri);
         }
 
         /// <summary>
@@ -41,6 +45,7 @@ namespace Avalonia.Themes.Fluent
         public FluentTheme(IServiceProvider serviceProvider)
         {
             _baseUri = ((IUriContext)serviceProvider.GetService(typeof(IUriContext))).BaseUri;
+            InitStyles(_baseUri);
         }
 
         /// <summary>
@@ -54,8 +59,8 @@ namespace Avalonia.Themes.Fluent
                 if (_mode != value)
                 {
                     _mode = value;
-                    (Loaded as Styles)[3] = FluentDark[0];
-                    (Loaded as Styles)[4] = FluentDark[1];
+                    (Loaded as Styles)![1] = _fluentDark[0];
+                    (Loaded as Styles)![2] = _fluentDark[1];
                 }
 
             }
@@ -73,23 +78,17 @@ namespace Avalonia.Themes.Fluent
                 if (_loaded == null)
                 {
                     _isLoading = true;
-                    Styles? resultStyle = new Styles();
-
-                    resultStyle.AddRange(SharedStyles);
+                    Styles? resultStyle = new Styles() { _sharedStyles };
 
                     if (Mode == FluentThemeMode.Light)
                     {
-                        for (int i = 0; i < FluentLight.Count; i++)
-                        {
-                            resultStyle.Add(FluentLight[i]);
-                        }
+                        resultStyle.Add(_fluentLight[0]);
+                        resultStyle.Add(_fluentLight[1]);
                     }
                     else if (Mode == FluentThemeMode.Dark)
                     {
-                        for (int i = 0; i < FluentDark.Count; i++)
-                        {
-                            resultStyle.Add(FluentDark[i]);
-                        }
+                        resultStyle.Add(_fluentDark[0]);
+                        resultStyle.Add(_fluentDark[1]);
                     }
                     _loaded = resultStyle;
                     _isLoading = false;
@@ -137,43 +136,47 @@ namespace Avalonia.Themes.Fluent
         void IResourceProvider.AddOwner(IResourceHost owner) => (Loaded as IResourceProvider)?.AddOwner(owner);
         void IResourceProvider.RemoveOwner(IResourceHost owner) => (Loaded as IResourceProvider)?.RemoveOwner(owner);
 
-        private static Styles SharedStyles = new Styles
+        private void InitStyles(Uri baseUri)
         {
-            new StyleInclude(new Uri("resm:Styles?assembly=Avalonia.Themes.Fluent"))
+            _sharedStyles = new Styles
             {
-                Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/AccentColors.xaml")
-            },
-            new StyleInclude(new Uri("resm:Styles?assembly=Avalonia.Themes.Fluent"))
-            {
-                Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/Base.xaml")
-            },
-            new StyleInclude(new Uri("resm:Styles?assembly=Avalonia.Themes.Fluent"))
-            {
-                Source = new Uri("avares://Avalonia.Themes.Fluent/Controls/FluentControls.xaml")
-            }
-        };
+                new StyleInclude(baseUri)
+                {
+                    Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/AccentColors.xaml")
+                },
+                new StyleInclude(baseUri)
+                {
+                    Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/Base.xaml")
+                },
+                new StyleInclude(baseUri)
+                {
+                    Source = new Uri("avares://Avalonia.Themes.Fluent/Controls/FluentControls.xaml")
+                }
+            };
 
-        private static Styles FluentLight = new Styles
-        {
-            new StyleInclude(new Uri("resm:Styles?assembly=Avalonia.Themes.Fluent"))
+            _fluentLight = new Styles
             {
-                Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/BaseLight.xaml")
-            },
-            new StyleInclude(new Uri("resm:Styles?assembly=Avalonia.Themes.Fluent"))
+                new StyleInclude(baseUri)
+                {
+                    Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/BaseLight.xaml")
+                },
+                new StyleInclude(baseUri)
+                {
+                    Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/FluentControlResourcesLight.xaml")
+                }
+            };
+
+            _fluentDark = new Styles
             {
-                Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/FluentControlResourcesLight.xaml")
-            }
-        };
-        private static Styles FluentDark = new Styles
-        {
-            new StyleInclude(new Uri("resm:Styles?assembly=Avalonia.Themes.Fluent"))
-            {
-                Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/BaseDark.xaml")
-            },
-            new StyleInclude(new Uri("resm:Styles?assembly=Avalonia.Themes.Fluent"))
-            {
-                Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/FluentControlResourcesDark.xaml")
-            }
-        };
+                new StyleInclude(baseUri)
+                {
+                    Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/BaseDark.xaml")
+                },
+                new StyleInclude(baseUri)
+                {
+                    Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/FluentControlResourcesDark.xaml")
+                }
+            };
+        }
     }
 }


### PR DESCRIPTION
Now switching between Fluent theme Light->Dark and Dark->Light takes ~0.3s for ControlCatalog which is much better than before. The idea behind this PR is to allow to switch modes in the Fluent Theme itself and put here a small optimisation. There are only two files that are different between Dark and Light theme, it's BaseDark\BaseLight and  FluentControlResourcesDark\FluentControlResourcesLight, if we will switch only those two files it will massively reduce the time we spend switching themes because it will not cause retemplating of every control. Inspired by @amwx .
