### PR TITLE
Add ViewContract to RoutedViewHost and ViewModelViewHost

### DIFF
--- a/src/Avalonia.ReactiveUI/RoutedViewHost.cs
+++ b/src/Avalonia.ReactiveUI/RoutedViewHost.cs
@@ -57,7 +57,13 @@ namespace Avalonia.ReactiveUI
         /// </summary>
         public static readonly StyledProperty<RoutingState?> RouterProperty =
             AvaloniaProperty.Register<RoutedViewHost, RoutingState?>(nameof(Router));
-    
+
+        /// <summary>
+        /// <see cref="AvaloniaProperty"/> for the <see cref="ViewContract"/> property.
+        /// </summary>
+        public static readonly StyledProperty<string?> ViewContractProperty =
+            AvaloniaProperty.Register<ViewModelViewHost, string?>(nameof(ViewContract));
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RoutedViewHost"/> class.
         /// </summary>
@@ -70,15 +76,18 @@ namespace Avalonia.ReactiveUI
                     .Where(router => router == null)!
                     .Cast<object?>();
 
+                var viewContract = this.WhenAnyValue(x => x.ViewContract);
+
                 this.WhenAnyValue(x => x.Router)
                     .Where(router => router != null)
                     .SelectMany(router => router!.CurrentViewModel)
                     .Merge(routerRemoved)
-                    .Subscribe(NavigateToViewModel)
+                    .CombineLatest(viewContract)
+                    .Subscribe(tuple => NavigateToViewModel(tuple.First, tuple.Second))
                     .DisposeWith(disposables);
             });
         }
-        
+
         /// <summary>
         /// Gets or sets the <see cref="RoutingState"/> of the view model stack.
         /// </summary>
@@ -87,17 +96,27 @@ namespace Avalonia.ReactiveUI
             get => GetValue(RouterProperty);
             set => SetValue(RouterProperty, value);
         }
-        
+
+        /// <summary>
+        /// Gets or sets the view contract.
+        /// </summary>
+        public string? ViewContract
+        {
+            get => GetValue(ViewContractProperty);
+            set => SetValue(ViewContractProperty, value);
+        }
+
         /// <summary>
         /// Gets or sets the ReactiveUI view locator used by this router.
         /// </summary>
         public IViewLocator? ViewLocator { get; set; }
-    
+
         /// <summary>
         /// Invoked when ReactiveUI router navigates to a view model.
         /// </summary>
         /// <param name="viewModel">ViewModel to which the user navigates.</param>
-        private void NavigateToViewModel(object? viewModel)
+        /// <param name="contract">The contract for view resolution.</param>
+        private void NavigateToViewModel(object? viewModel, string? contract)
         {
             if (Router == null)
             {
@@ -112,17 +131,33 @@ namespace Avalonia.ReactiveUI
                 Content = DefaultContent;
                 return;
             }
-    
+
             var viewLocator = ViewLocator ?? global::ReactiveUI.ViewLocator.Current;
-            var viewInstance = viewLocator.ResolveView(viewModel);
+            var viewInstance = viewLocator.ResolveView(viewModel, contract);
             if (viewInstance == null)
             {
-                this.Log().Warn($"Couldn't find view for '{viewModel}'. Is it registered? Falling back to default content.");
+                if (contract == null)
+                {
+                    this.Log().Warn($"Couldn't find view for '{viewModel}'. Is it registered? Falling back to default content.");
+                }
+                else
+                {
+                    this.Log().Warn($"Couldn't find view with contract '{contract}' for '{viewModel}'. Is it registered? Falling back to default content.");
+                }
+
                 Content = DefaultContent;
                 return;
             }
-    
-            this.Log().Info($"Ready to show {viewInstance} with autowired {viewModel}.");
+
+            if (contract == null)
+            {
+                this.Log().Info($"Ready to show {viewInstance} with autowired {viewModel}.");
+            }
+            else
+            {
+                this.Log().Info($"Ready to show {viewInstance} with autowired {viewModel} and contract '{contract}'.");
+            }
+
             viewInstance.ViewModel = viewModel;
             if (viewInstance is IDataContextProvider provider)
                 provider.DataContext = viewModel;

--- a/src/Avalonia.ReactiveUI/ViewModelViewHost.cs
+++ b/src/Avalonia.ReactiveUI/ViewModelViewHost.cs
@@ -3,7 +3,7 @@ using System.Reactive.Disposables;
 using ReactiveUI;
 using Splat;
 
-namespace Avalonia.ReactiveUI 
+namespace Avalonia.ReactiveUI
 {
     /// <summary>
     /// This content control will automatically load the View associated with
@@ -19,14 +19,20 @@ namespace Avalonia.ReactiveUI
             AvaloniaProperty.Register<ViewModelViewHost, object?>(nameof(ViewModel));
 
         /// <summary>
+        /// <see cref="AvaloniaProperty"/> for the <see cref="ViewContract"/> property.
+        /// </summary>
+        public static readonly StyledProperty<string?> ViewContractProperty =
+            AvaloniaProperty.Register<ViewModelViewHost, string?>(nameof(ViewContract));
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ViewModelViewHost"/> class.
         /// </summary>
         public ViewModelViewHost()
         {
             this.WhenActivated(disposables =>
             {
-                this.WhenAnyValue(x => x.ViewModel)
-                    .Subscribe(NavigateToViewModel)
+                this.WhenAnyValue(x => x.ViewModel, x => x.ViewContract)
+                    .Subscribe(tuple => NavigateToViewModel(tuple.Item1, tuple.Item2))
                     .DisposeWith(disposables);
             });
         }
@@ -39,7 +45,16 @@ namespace Avalonia.ReactiveUI
             get => GetValue(ViewModelProperty);
             set => SetValue(ViewModelProperty, value);
         }
-        
+
+        /// <summary>
+        /// Gets or sets the view contract.
+        /// </summary>
+        public string? ViewContract
+        {
+            get => GetValue(ViewContractProperty);
+            set => SetValue(ViewContractProperty, value);
+        }
+
         /// <summary>
         /// Gets or sets the view locator.
         /// </summary>
@@ -49,7 +64,8 @@ namespace Avalonia.ReactiveUI
         /// Invoked when ReactiveUI router navigates to a view model.
         /// </summary>
         /// <param name="viewModel">ViewModel to which the user navigates.</param>
-        private void NavigateToViewModel(object? viewModel)
+        /// <param name="contract">The contract for view resolution.</param>
+        private void NavigateToViewModel(object? viewModel, string? contract)
         {
             if (viewModel == null)
             {
@@ -57,17 +73,33 @@ namespace Avalonia.ReactiveUI
                 Content = DefaultContent;
                 return;
             }
-    
+
             var viewLocator = ViewLocator ?? global::ReactiveUI.ViewLocator.Current;
-            var viewInstance = viewLocator.ResolveView(viewModel);
+            var viewInstance = viewLocator.ResolveView(viewModel, contract);
             if (viewInstance == null)
             {
-                this.Log().Warn($"Couldn't find view for '{viewModel}'. Is it registered? Falling back to default content.");
+                if (contract == null)
+                {
+                    this.Log().Warn($"Couldn't find view for '{viewModel}'. Is it registered? Falling back to default content.");
+                }
+                else
+                {
+                    this.Log().Warn($"Couldn't find view with contract '{contract}' for '{viewModel}'. Is it registered? Falling back to default content.");
+                }
+
                 Content = DefaultContent;
                 return;
             }
-    
-            this.Log().Info($"Ready to show {viewInstance} with autowired {viewModel}.");
+
+            if (contract == null)
+            {
+                this.Log().Info($"Ready to show {viewInstance} with autowired {viewModel}.");
+            }
+            else
+            {
+                this.Log().Info($"Ready to show {viewInstance} with autowired {viewModel} and contract '{contract}'.");
+            }
+
             viewInstance.ViewModel = viewModel;
             if (viewInstance is IStyledElement styled)
                 styled.DataContext = viewModel;

--- a/tests/Avalonia.ReactiveUI.UnitTests/RoutedViewHostTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/RoutedViewHostTest.cs
@@ -29,6 +29,8 @@ namespace Avalonia.ReactiveUI.UnitTests
 
         public class FirstRoutableView : ReactiveUserControl<FirstRoutableViewModel> { }
 
+        public class AlternativeFirstRoutableView : ReactiveUserControl<FirstRoutableViewModel> { }
+
         public class SecondRoutableViewModel : ReactiveObject, IRoutableViewModel
         {
             public string UrlPathSegment => "second";
@@ -38,16 +40,22 @@ namespace Avalonia.ReactiveUI.UnitTests
 
         public class SecondRoutableView : ReactiveUserControl<SecondRoutableViewModel> { }
 
+        public class AlternativeSecondRoutableView : ReactiveUserControl<SecondRoutableViewModel> { }
+
         public class ScreenViewModel : ReactiveObject, IScreen
         {
             public RoutingState Router { get; } = new RoutingState();
         }
+
+        public static string AlternativeViewContract => "AlternativeView";
 
         public RoutedViewHostTest()
         {
             Locator.CurrentMutable.RegisterConstant(new AvaloniaActivationForViewFetcher(), typeof(IActivationForViewFetcher));
             Locator.CurrentMutable.Register(() => new FirstRoutableView(), typeof(IViewFor<FirstRoutableViewModel>));
             Locator.CurrentMutable.Register(() => new SecondRoutableView(), typeof(IViewFor<SecondRoutableViewModel>));
+            Locator.CurrentMutable.Register(() => new AlternativeFirstRoutableView(), typeof(IViewFor<FirstRoutableViewModel>), AlternativeViewContract);
+            Locator.CurrentMutable.Register(() => new AlternativeSecondRoutableView(), typeof(IViewFor<SecondRoutableViewModel>), AlternativeViewContract);
         }
 
         [Fact]
@@ -93,6 +101,71 @@ namespace Avalonia.ReactiveUI.UnitTests
             Assert.IsType<FirstRoutableView>(host.Content);
             Assert.Equal(first, ((FirstRoutableView)host.Content).DataContext);
             Assert.Equal(first, ((FirstRoutableView)host.Content).ViewModel);
+
+            screen.Router.NavigateBack.Execute(Unit.Default).Subscribe();
+
+            Assert.NotNull(host.Content);
+            Assert.IsType<TextBlock>(host.Content);
+            Assert.Equal(defaultContent, host.Content);
+        }
+
+        [Fact]
+        public void RoutedViewHost_Should_Stay_In_Sync_With_RoutingState_And_Contract()
+        {
+            var screen = new ScreenViewModel();
+            var defaultContent = new TextBlock();
+            var host = new RoutedViewHost
+            {
+                Router = screen.Router,
+                DefaultContent = defaultContent,
+                PageTransition = null
+            };
+
+            var root = new TestRoot
+            {
+                Child = host
+            };
+
+            Assert.NotNull(host.Content);
+            Assert.IsType<TextBlock>(host.Content);
+            Assert.Equal(defaultContent, host.Content);
+
+            var first = new FirstRoutableViewModel();
+            screen.Router.Navigate.Execute(first).Subscribe();
+
+            host.ViewContract = null;
+            Assert.NotNull(host.Content);
+            Assert.IsType<FirstRoutableView>(host.Content);
+            Assert.Equal(first, ((FirstRoutableView)host.Content).DataContext);
+            Assert.Equal(first, ((FirstRoutableView)host.Content).ViewModel);
+
+            host.ViewContract = AlternativeViewContract;
+            Assert.NotNull(host.Content);
+            Assert.IsType<AlternativeFirstRoutableView>(host.Content);
+            Assert.Equal(first, ((AlternativeFirstRoutableView)host.Content).DataContext);
+            Assert.Equal(first, ((AlternativeFirstRoutableView)host.Content).ViewModel);
+
+            var second = new SecondRoutableViewModel();
+            screen.Router.Navigate.Execute(second).Subscribe();
+
+            host.ViewContract = null;
+            Assert.NotNull(host.Content);
+            Assert.IsType<SecondRoutableView>(host.Content);
+            Assert.Equal(second, ((SecondRoutableView)host.Content).DataContext);
+            Assert.Equal(second, ((SecondRoutableView)host.Content).ViewModel);
+
+            host.ViewContract = AlternativeViewContract;
+            Assert.NotNull(host.Content);
+            Assert.IsType<AlternativeSecondRoutableView>(host.Content);
+            Assert.Equal(second, ((AlternativeSecondRoutableView)host.Content).DataContext);
+            Assert.Equal(second, ((AlternativeSecondRoutableView)host.Content).ViewModel);
+
+            screen.Router.NavigateBack.Execute(Unit.Default).Subscribe();
+
+            Assert.NotNull(host.Content);
+            Assert.IsType<AlternativeFirstRoutableView>(host.Content);
+            Assert.Equal(first, ((AlternativeFirstRoutableView)host.Content).DataContext);
+            Assert.Equal(first, ((AlternativeFirstRoutableView)host.Content).ViewModel);
 
             screen.Router.NavigateBack.Execute(Unit.Default).Subscribe();
 

--- a/tests/Avalonia.ReactiveUI.UnitTests/ViewModelViewHostTest.cs
+++ b/tests/Avalonia.ReactiveUI.UnitTests/ViewModelViewHostTest.cs
@@ -12,15 +12,23 @@ namespace Avalonia.ReactiveUI.UnitTests
 
         public class FirstView : ReactiveUserControl<FirstViewModel> { }
 
+        public class AlternativeFirstView : ReactiveUserControl<FirstViewModel> { }
+
         public class SecondViewModel : ReactiveObject { }
 
         public class SecondView : ReactiveUserControl<SecondViewModel> { }
+
+        public class AlternativeSecondView : ReactiveUserControl<SecondViewModel> { }
+
+        public static string AlternativeViewContract => "AlternativeView";
 
         public ViewModelViewHostTest()
         {
             Locator.CurrentMutable.RegisterConstant(new AvaloniaActivationForViewFetcher(), typeof(IActivationForViewFetcher));
             Locator.CurrentMutable.Register(() => new FirstView(), typeof(IViewFor<FirstViewModel>));
             Locator.CurrentMutable.Register(() => new SecondView(), typeof(IViewFor<SecondViewModel>));
+            Locator.CurrentMutable.Register(() => new AlternativeFirstView(), typeof(IViewFor<FirstViewModel>), AlternativeViewContract);
+            Locator.CurrentMutable.Register(() => new AlternativeSecondView(), typeof(IViewFor<SecondViewModel>), AlternativeViewContract);
         }
 
         [Fact]
@@ -66,6 +74,68 @@ namespace Avalonia.ReactiveUI.UnitTests
             Assert.Equal(typeof(FirstView), host.Content.GetType());
             Assert.Equal(first, ((FirstView)host.Content).DataContext);
             Assert.Equal(first, ((FirstView)host.Content).ViewModel);
+        }
+
+        [Fact]
+        public void ViewModelViewHost_View_Should_Stay_In_Sync_With_ViewModel_And_Contract()
+        {
+            var defaultContent = new TextBlock();
+            var host = new ViewModelViewHost
+            {
+                DefaultContent = defaultContent,
+                PageTransition = null
+            };
+
+            var root = new TestRoot
+            {
+                Child = host
+            };
+
+            Assert.NotNull(host.Content);
+            Assert.Equal(typeof(TextBlock), host.Content.GetType());
+            Assert.Equal(defaultContent, host.Content);
+
+            var first = new FirstViewModel();
+            host.ViewModel = first;
+
+            host.ViewContract = null;
+            Assert.NotNull(host.Content);
+            Assert.Equal(typeof(FirstView), host.Content.GetType());
+            Assert.Equal(first, ((FirstView)host.Content).DataContext);
+            Assert.Equal(first, ((FirstView)host.Content).ViewModel);
+
+            host.ViewContract = AlternativeViewContract;
+            Assert.NotNull(host.Content);
+            Assert.Equal(typeof(AlternativeFirstView), host.Content.GetType());
+            Assert.Equal(first, ((AlternativeFirstView)host.Content).DataContext);
+            Assert.Equal(first, ((AlternativeFirstView)host.Content).ViewModel);
+
+            var second = new SecondViewModel();
+            host.ViewModel = second;
+
+            host.ViewContract = null;
+            Assert.NotNull(host.Content);
+            Assert.Equal(typeof(SecondView), host.Content.GetType());
+            Assert.Equal(second, ((SecondView)host.Content).DataContext);
+            Assert.Equal(second, ((SecondView)host.Content).ViewModel);
+
+            host.ViewContract = AlternativeViewContract;
+            Assert.NotNull(host.Content);
+            Assert.Equal(typeof(AlternativeSecondView), host.Content.GetType());
+            Assert.Equal(second, ((AlternativeSecondView)host.Content).DataContext);
+            Assert.Equal(second, ((AlternativeSecondView)host.Content).ViewModel);
+
+            host.ViewModel = null;
+
+            host.ViewContract = null;
+            Assert.NotNull(host.Content);
+            Assert.Equal(typeof(TextBlock), host.Content.GetType());
+            Assert.Equal(defaultContent, host.Content);
+
+            host.ViewContract = AlternativeViewContract;
+            Assert.NotNull(host.Content);
+            Assert.Equal(typeof(TextBlock), host.Content.GetType());
+            Assert.Equal(defaultContent, host.Content);
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
The PR adds the `ViewContract` property to `RoutedViewHost` and `ViewModelViewHost` to enable the ability to resolve views that were registered with non-`null` contracts.


## What is the current behavior?
View contracts are never resolved.


## What is the updated/expected behavior with this PR?
`RoutedViewHost` and `ViewModelViewHost` can now resolve views with contracts if matching `ViewContract` value is set.


## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation
