### PR TITLE
ScrollViewer add property to bubble up the scroll event if not handled by nested ScrollViewer 

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -2221,7 +2221,7 @@ namespace Avalonia.Controls
             }
             else
             {
-                e.Handled = e.Handled || !ScrollViewer.GetBubbleUpScrollOnEndReached(this);
+                e.Handled = e.Handled || !ScrollViewer.GetIsScrollChainingEnabled(this);
             }
         }
 

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -2215,7 +2215,14 @@ namespace Avalonia.Controls
         /// <param name="e">PointerWheelEventArgs</param>
         protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
         {
-            e.Handled = e.Handled || UpdateScroll(e.Delta * DATAGRID_mouseWheelDelta);
+            if(UpdateScroll(e.Delta * DATAGRID_mouseWheelDelta))
+            {
+                e.Handled = true;
+            }
+            else
+            {
+                e.Handled = e.Handled || !ScrollViewer.GetBubbleUpScrollOnEndReached(this);
+            }
         }
 
         internal bool UpdateScroll(Vector delta)

--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -60,6 +60,13 @@ namespace Avalonia.Controls.Presenters
                 o => o.Viewport,
                 (o, v) => o.Viewport = v);
 
+        /// <summary>
+        /// Defines the <see cref="BubbleUpScrollOnEndReached"/> property.
+        /// </summary>
+        public static readonly StyledProperty<bool> BubbleUpScrollOnEndReachedProperty =
+            AvaloniaProperty.Register<ScrollContentPresenter, bool>(
+                nameof(BubbleUpScrollOnEndReached));
+
         private bool _canHorizontallyScroll;
         private bool _canVerticallyScroll;
         private bool _arranging;
@@ -136,6 +143,15 @@ namespace Avalonia.Controls.Presenters
         {
             get { return _viewport; }
             private set { SetAndRaise(ViewportProperty, ref _viewport, value); }
+        }
+
+        /// <summary>
+        /// Gets a value that indicates whether the scroll event should be bubbled up to the parent scroll viewer when the end is reached.
+        /// </summary>
+        public bool BubbleUpScrollOnEndReached
+        {
+            get => GetValue(BubbleUpScrollOnEndReachedProperty);
+            set => SetValue(BubbleUpScrollOnEndReachedProperty, value);
         }
 
         /// <inheritdoc/>
@@ -405,8 +421,11 @@ namespace Avalonia.Controls.Presenters
                     _activeLogicalGestureScrolls[e.Id] = delta;
                 }
 
-                Offset = new Vector(x, y);
-                e.Handled = true;
+                Vector newOffset = new Vector(x, y);
+                bool offsetChanged = newOffset != Offset;
+                Offset = newOffset;
+
+                e.Handled = !BubbleUpScrollOnEndReached || offsetChanged;
             }
         }
 
@@ -440,8 +459,11 @@ namespace Avalonia.Controls.Presenters
                     x = Math.Min(x, Extent.Width - Viewport.Width);
                 }
 
-                Offset = new Vector(x, y);
-                e.Handled = true;
+                Vector newOffset = new Vector(x, y);
+                bool offsetChanged = newOffset != Offset;
+                Offset = newOffset;
+
+                e.Handled = !BubbleUpScrollOnEndReached || offsetChanged;
             }
         }
 

--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -61,11 +61,12 @@ namespace Avalonia.Controls.Presenters
                 (o, v) => o.Viewport = v);
 
         /// <summary>
-        /// Defines the <see cref="BubbleUpScrollOnEndReached"/> property.
+        /// Defines the <see cref="IsScrollChainingEnabled"/> property.
         /// </summary>
-        public static readonly StyledProperty<bool> BubbleUpScrollOnEndReachedProperty =
+        public static readonly StyledProperty<bool> IsScrollChainingEnabledProperty =
             AvaloniaProperty.Register<ScrollContentPresenter, bool>(
-                nameof(BubbleUpScrollOnEndReached));
+                nameof(IsScrollChainingEnabled), 
+                defaultValue: true);
 
         private bool _canHorizontallyScroll;
         private bool _canVerticallyScroll;
@@ -146,12 +147,17 @@ namespace Avalonia.Controls.Presenters
         }
 
         /// <summary>
-        /// Gets a value that indicates whether the scroll event should be bubbled up to the parent scroll viewer when the end is reached.
+        ///  Gets or sets if scroll chaining is enabled. The default value is true.
         /// </summary>
-        public bool BubbleUpScrollOnEndReached
+        /// <remarks>
+        ///  After a user hits a scroll limit on an element that has been nested within another scrollable element,
+        /// you can specify whether that parent element should continue the scrolling operation begun in its child element.
+        /// This is called scroll chaining.
+        /// </remarks>
+        public bool IsScrollChainingEnabled
         {
-            get => GetValue(BubbleUpScrollOnEndReachedProperty);
-            set => SetValue(BubbleUpScrollOnEndReachedProperty, value);
+            get => GetValue(IsScrollChainingEnabledProperty);
+            set => SetValue(IsScrollChainingEnabledProperty, value);
         }
 
         /// <inheritdoc/>
@@ -425,7 +431,7 @@ namespace Avalonia.Controls.Presenters
                 bool offsetChanged = newOffset != Offset;
                 Offset = newOffset;
 
-                e.Handled = !BubbleUpScrollOnEndReached || offsetChanged;
+                e.Handled = !IsScrollChainingEnabled || offsetChanged;
             }
         }
 
@@ -463,7 +469,7 @@ namespace Avalonia.Controls.Presenters
                 bool offsetChanged = newOffset != Offset;
                 Offset = newOffset;
 
-                e.Handled = !BubbleUpScrollOnEndReached || offsetChanged;
+                e.Handled = !IsScrollChainingEnabled || offsetChanged;
             }
         }
 

--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -64,9 +64,7 @@ namespace Avalonia.Controls.Presenters
         /// Defines the <see cref="IsScrollChainingEnabled"/> property.
         /// </summary>
         public static readonly StyledProperty<bool> IsScrollChainingEnabledProperty =
-            AvaloniaProperty.Register<ScrollContentPresenter, bool>(
-                nameof(IsScrollChainingEnabled), 
-                defaultValue: true);
+            ScrollViewer.IsScrollChainingEnabledProperty.AddOwner<ScrollContentPresenter>();
 
         private bool _canHorizontallyScroll;
         private bool _canVerticallyScroll;

--- a/src/Avalonia.Controls/ScrollViewer.cs
+++ b/src/Avalonia.Controls/ScrollViewer.cs
@@ -182,12 +182,12 @@ namespace Avalonia.Controls
                 true);
 
         /// <summary>
-        /// Defines the <see cref="BubbleUpScrollOnEndReached"/> property.
+        /// Defines the <see cref="IsScrollChainingEnabled"/> property.
         /// </summary>
-        public static readonly AttachedProperty<bool> BubbleUpScrollOnEndReachedProperty =
+        public static readonly AttachedProperty<bool> IsScrollChainingEnabledProperty =
             AvaloniaProperty.RegisterAttached<ScrollViewer, Control, bool>(
-                nameof(BubbleUpScrollOnEndReached),
-                false);
+                nameof(IsScrollChainingEnabled),
+                defaultValue: true);
 
         /// <summary>
         /// Defines the <see cref="ScrollChanged"/> event.
@@ -427,12 +427,17 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Gets a value that indicates whether the scroll event should be bubbled up to the parent scroll viewer when the end is reached.
+        ///  Gets or sets if scroll chaining is enabled. The default value is true.
         /// </summary>
-        public bool BubbleUpScrollOnEndReached
+        /// <remarks>
+        ///  After a user hits a scroll limit on an element that has been nested within another scrollable element,
+        /// you can specify whether that parent element should continue the scrolling operation begun in its child element.
+        /// This is called scroll chaining.
+        /// </remarks>
+        public bool IsScrollChainingEnabled
         {
-            get => GetValue(BubbleUpScrollOnEndReachedProperty);
-            set => SetValue(BubbleUpScrollOnEndReachedProperty, value);
+            get => GetValue(IsScrollChainingEnabledProperty);
+            set => SetValue(IsScrollChainingEnabledProperty, value);
         }
 
         /// <summary>
@@ -566,23 +571,33 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Gets the value of the BubbleUpScrollOnEndReachedProperty attached property.
+        /// Sets the value of the IsScrollChainingEnabled attached property.
         /// </summary>
         /// <param name="control">The control to set the value on.</param>
         /// <param name="value">The value of the property.</param>
-        public static void SetBubbleUpScrollOnEndReached(Control control, bool value)
+        /// <remarks>
+        ///  After a user hits a scroll limit on an element that has been nested within another scrollable element,
+        /// you can specify whether that parent element should continue the scrolling operation begun in its child element.
+        /// This is called scroll chaining.
+        /// </remarks>
+        public static void SetIsScrollChainingEnabled(Control control, bool value)
         {
-            control.SetValue(BubbleUpScrollOnEndReachedProperty, value);
+            control.SetValue(IsScrollChainingEnabledProperty, value);
         }
 
         /// <summary>
-        /// Gets the value of the BubbleUpScrollOnEndReachedProperty attached property.
+        ///  Gets the value of the IsScrollChainingEnabled attached property.
         /// </summary>
         /// <param name="control">The control to read the value from.</param>
         /// <returns>The value of the property.</returns>
-        public static bool GetBubbleUpScrollOnEndReached(Control control)
+        /// <remarks>
+        ///  After a user hits a scroll limit on an element that has been nested within another scrollable element,
+        /// you can specify whether that parent element should continue the scrolling operation begun in its child element.
+        /// This is called scroll chaining.
+        /// </remarks>
+        public static bool GetIsScrollChainingEnabled(Control control)
         {
-            return control.GetValue(BubbleUpScrollOnEndReachedProperty);
+            return control.GetValue(IsScrollChainingEnabledProperty);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/ScrollViewer.cs
+++ b/src/Avalonia.Controls/ScrollViewer.cs
@@ -182,6 +182,14 @@ namespace Avalonia.Controls
                 true);
 
         /// <summary>
+        /// Defines the <see cref="BubbleUpScrollOnEndReached"/> property.
+        /// </summary>
+        public static readonly AttachedProperty<bool> BubbleUpScrollOnEndReachedProperty =
+            AvaloniaProperty.RegisterAttached<ScrollViewer, Control, bool>(
+                nameof(BubbleUpScrollOnEndReached),
+                false);
+
+        /// <summary>
         /// Defines the <see cref="ScrollChanged"/> event.
         /// </summary>
         public static readonly RoutedEvent<ScrollChangedEventArgs> ScrollChangedEvent =
@@ -419,6 +427,15 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
+        /// Gets a value that indicates whether the scroll event should be bubbled up to the parent scroll viewer when the end is reached.
+        /// </summary>
+        public bool BubbleUpScrollOnEndReached
+        {
+            get => GetValue(BubbleUpScrollOnEndReachedProperty);
+            set => SetValue(BubbleUpScrollOnEndReachedProperty, value);
+        }
+
+        /// <summary>
         /// Scrolls the content up one line.
         /// </summary>
         public void LineUp()
@@ -546,6 +563,26 @@ namespace Avalonia.Controls
         public static bool GetAllowAutoHide(Control control)
         {
             return control.GetValue(AllowAutoHideProperty);
+        }
+
+        /// <summary>
+        /// Gets the value of the BubbleUpScrollOnEndReachedProperty attached property.
+        /// </summary>
+        /// <param name="control">The control to set the value on.</param>
+        /// <param name="value">The value of the property.</param>
+        public static void SetBubbleUpScrollOnEndReached(Control control, bool value)
+        {
+            control.SetValue(BubbleUpScrollOnEndReachedProperty, value);
+        }
+
+        /// <summary>
+        /// Gets the value of the BubbleUpScrollOnEndReachedProperty attached property.
+        /// </summary>
+        /// <param name="control">The control to read the value from.</param>
+        /// <returns>The value of the property.</returns>
+        public static bool GetBubbleUpScrollOnEndReached(Control control)
+        {
+            return control.GetValue(BubbleUpScrollOnEndReachedProperty);
         }
 
         /// <summary>

--- a/src/Avalonia.Themes.Default/Controls/ListBox.xaml
+++ b/src/Avalonia.Themes.Default/Controls/ListBox.xaml
@@ -6,7 +6,7 @@
   <Setter Property="Padding" Value="4"/>
   <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
   <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
-  <Setter Property="ScrollViewer.BubbleUpScrollOnEndReached" Value="True" />
+  <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
   <Setter Property="Template">
     <ControlTemplate>
       <Border Name="border" BorderBrush="{TemplateBinding BorderBrush}"
@@ -16,7 +16,7 @@
                       Background="{TemplateBinding Background}"
                       HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                       VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
-                      BubbleUpScrollOnEndReached="{TemplateBinding (ScrollViewer.BubbleUpScrollOnEndReached)}"
+                      IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
                       AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}">
           <ItemsPresenter Name="PART_ItemsPresenter"
                           Items="{TemplateBinding Items}"

--- a/src/Avalonia.Themes.Default/Controls/ListBox.xaml
+++ b/src/Avalonia.Themes.Default/Controls/ListBox.xaml
@@ -6,6 +6,7 @@
   <Setter Property="Padding" Value="4"/>
   <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
   <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
+  <Setter Property="ScrollViewer.BubbleUpScrollOnEndReached" Value="True" />
   <Setter Property="Template">
     <ControlTemplate>
       <Border Name="border" BorderBrush="{TemplateBinding BorderBrush}"
@@ -15,6 +16,7 @@
                       Background="{TemplateBinding Background}"
                       HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                       VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+                      BubbleUpScrollOnEndReached="{TemplateBinding (ScrollViewer.BubbleUpScrollOnEndReached)}"
                       AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}">
           <ItemsPresenter Name="PART_ItemsPresenter"
                           Items="{TemplateBinding Items}"

--- a/src/Avalonia.Themes.Default/Controls/ScrollViewer.xaml
+++ b/src/Avalonia.Themes.Default/Controls/ScrollViewer.xaml
@@ -16,7 +16,7 @@
                                   Margin="{TemplateBinding Padding}"
                                   Offset="{TemplateBinding Offset, Mode=TwoWay}"
                                   Viewport="{TemplateBinding Viewport, Mode=TwoWay}"
-                                  BubbleUpScrollOnEndReached="{TemplateBinding BubbleUpScrollOnEndReached}">
+                                  IsScrollChainingEnabled="{TemplateBinding IsScrollChainingEnabled}">
             <ScrollContentPresenter.GestureRecognizers>
               <ScrollGestureRecognizer
                 CanHorizontallyScroll="{TemplateBinding CanHorizontallyScroll}"

--- a/src/Avalonia.Themes.Default/Controls/ScrollViewer.xaml
+++ b/src/Avalonia.Themes.Default/Controls/ScrollViewer.xaml
@@ -15,7 +15,8 @@
                                   Extent="{TemplateBinding Extent, Mode=TwoWay}"
                                   Margin="{TemplateBinding Padding}"
                                   Offset="{TemplateBinding Offset, Mode=TwoWay}"
-                                  Viewport="{TemplateBinding Viewport, Mode=TwoWay}">
+                                  Viewport="{TemplateBinding Viewport, Mode=TwoWay}"
+                                  BubbleUpScrollOnEndReached="{TemplateBinding BubbleUpScrollOnEndReached}">
             <ScrollContentPresenter.GestureRecognizers>
               <ScrollGestureRecognizer
                 CanHorizontallyScroll="{TemplateBinding CanHorizontallyScroll}"

--- a/src/Avalonia.Themes.Default/Controls/TextBox.xaml
+++ b/src/Avalonia.Themes.Default/Controls/TextBox.xaml
@@ -25,7 +25,7 @@
     <Setter Property="SelectionForegroundBrush" Value="{DynamicResource HighlightForegroundBrush}"/>
     <Setter Property="Padding" Value="4"/>
     <Setter Property="ContextFlyout" Value="{StaticResource DefaultTextBoxContextFlyout}" />
-    <Setter Property="ScrollViewer.BubbleUpScrollOnEndReached" Value="True" />
+    <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
     <Setter Property="Template">
       <ControlTemplate>
         <Border Name="border"
@@ -60,7 +60,7 @@
                 <ScrollViewer Grid.Column="1" Grid.ColumnSpan="1"
                               HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                               VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
-                              BubbleUpScrollOnEndReached="{TemplateBinding (ScrollViewer.BubbleUpScrollOnEndReached)}"
+                              IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
                               AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}">
                   <Panel>
                     <TextBlock Name="watermark"

--- a/src/Avalonia.Themes.Default/Controls/TextBox.xaml
+++ b/src/Avalonia.Themes.Default/Controls/TextBox.xaml
@@ -25,6 +25,7 @@
     <Setter Property="SelectionForegroundBrush" Value="{DynamicResource HighlightForegroundBrush}"/>
     <Setter Property="Padding" Value="4"/>
     <Setter Property="ContextFlyout" Value="{StaticResource DefaultTextBoxContextFlyout}" />
+    <Setter Property="ScrollViewer.BubbleUpScrollOnEndReached" Value="True" />
     <Setter Property="Template">
       <ControlTemplate>
         <Border Name="border"
@@ -59,6 +60,7 @@
                 <ScrollViewer Grid.Column="1" Grid.ColumnSpan="1"
                               HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                               VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+                              BubbleUpScrollOnEndReached="{TemplateBinding (ScrollViewer.BubbleUpScrollOnEndReached)}"
                               AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}">
                   <Panel>
                     <TextBlock Name="watermark"

--- a/src/Avalonia.Themes.Default/Controls/TreeView.xaml
+++ b/src/Avalonia.Themes.Default/Controls/TreeView.xaml
@@ -5,6 +5,7 @@
   <Setter Property="Padding" Value="4"/>
   <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
   <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
+  <Setter Property="ScrollViewer.BubbleUpScrollOnEndReached" Value="True" />
   <Setter Property="Template">
     <ControlTemplate>
       <Border BorderBrush="{TemplateBinding BorderBrush}"
@@ -13,6 +14,7 @@
         <ScrollViewer Background="{TemplateBinding Background}"
                       HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                       VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+                      BubbleUpScrollOnEndReached="{TemplateBinding (ScrollViewer.BubbleUpScrollOnEndReached)}"
                       AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}">
           <ItemsPresenter Name="PART_ItemsPresenter"
                           Items="{TemplateBinding Items}"

--- a/src/Avalonia.Themes.Default/Controls/TreeView.xaml
+++ b/src/Avalonia.Themes.Default/Controls/TreeView.xaml
@@ -5,7 +5,7 @@
   <Setter Property="Padding" Value="4"/>
   <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
   <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
-  <Setter Property="ScrollViewer.BubbleUpScrollOnEndReached" Value="True" />
+  <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
   <Setter Property="Template">
     <ControlTemplate>
       <Border BorderBrush="{TemplateBinding BorderBrush}"
@@ -14,7 +14,7 @@
         <ScrollViewer Background="{TemplateBinding Background}"
                       HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                       VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
-                      BubbleUpScrollOnEndReached="{TemplateBinding (ScrollViewer.BubbleUpScrollOnEndReached)}"
+                      IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
                       AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}">
           <ItemsPresenter Name="PART_ItemsPresenter"
                           Items="{TemplateBinding Items}"

--- a/src/Avalonia.Themes.Fluent/Controls/ListBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ListBox.xaml
@@ -16,6 +16,7 @@
     <Setter Property="BorderThickness" Value="{DynamicResource ListBoxBorderThemeThickness}" />
     <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
     <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />        
+    <Setter Property="ScrollViewer.BubbleUpScrollOnEndReached" Value="True" />        
     <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />    
     <Setter Property="Template">
       <ControlTemplate>
@@ -28,6 +29,7 @@
           <ScrollViewer Name="PART_ScrollViewer"
                         HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                         VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+                        BubbleUpScrollOnEndReached="{TemplateBinding (ScrollViewer.BubbleUpScrollOnEndReached)}"
                         AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}">
             <ItemsPresenter Name="PART_ItemsPresenter"
                             Items="{TemplateBinding Items}"

--- a/src/Avalonia.Themes.Fluent/Controls/ListBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ListBox.xaml
@@ -16,7 +16,7 @@
     <Setter Property="BorderThickness" Value="{DynamicResource ListBoxBorderThemeThickness}" />
     <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
     <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />        
-    <Setter Property="ScrollViewer.BubbleUpScrollOnEndReached" Value="True" />        
+    <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />        
     <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />    
     <Setter Property="Template">
       <ControlTemplate>
@@ -29,7 +29,7 @@
           <ScrollViewer Name="PART_ScrollViewer"
                         HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                         VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
-                        BubbleUpScrollOnEndReached="{TemplateBinding (ScrollViewer.BubbleUpScrollOnEndReached)}"
+                        IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
                         AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}">
             <ItemsPresenter Name="PART_ItemsPresenter"
                             Items="{TemplateBinding Items}"

--- a/src/Avalonia.Themes.Fluent/Controls/ScrollViewer.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ScrollViewer.xaml
@@ -35,7 +35,7 @@
                                   Margin="{TemplateBinding Padding}"
                                   Offset="{TemplateBinding Offset, Mode=TwoWay}"
                                   Viewport="{TemplateBinding Viewport, Mode=TwoWay}"
-                                  BubbleUpScrollOnEndReached="{TemplateBinding BubbleUpScrollOnEndReached}">
+                                  IsScrollChainingEnabled="{TemplateBinding IsScrollChainingEnabled}">
             <ScrollContentPresenter.GestureRecognizers>
               <ScrollGestureRecognizer
                 CanHorizontallyScroll="{TemplateBinding CanHorizontallyScroll}"

--- a/src/Avalonia.Themes.Fluent/Controls/ScrollViewer.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ScrollViewer.xaml
@@ -34,7 +34,8 @@
                                   Extent="{TemplateBinding Extent, Mode=TwoWay}"
                                   Margin="{TemplateBinding Padding}"
                                   Offset="{TemplateBinding Offset, Mode=TwoWay}"
-                                  Viewport="{TemplateBinding Viewport, Mode=TwoWay}">
+                                  Viewport="{TemplateBinding Viewport, Mode=TwoWay}"
+                                  BubbleUpScrollOnEndReached="{TemplateBinding BubbleUpScrollOnEndReached}">
             <ScrollContentPresenter.GestureRecognizers>
               <ScrollGestureRecognizer
                 CanHorizontallyScroll="{TemplateBinding CanHorizontallyScroll}"

--- a/src/Avalonia.Themes.Fluent/Controls/TextBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/TextBox.xaml
@@ -41,7 +41,7 @@
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="FocusAdorner" Value="{x:Null}" />
-    <Setter Property="ScrollViewer.BubbleUpScrollOnEndReached" Value="True" />
+    <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
     <Setter Property="ContextFlyout" Value="{StaticResource DefaultTextBoxContextFlyout}" />
     <Setter Property="Template">
       <ControlTemplate>
@@ -69,7 +69,7 @@
                              DockPanel.Dock="Top" />
                   <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                                 VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
-                                BubbleUpScrollOnEndReached="{TemplateBinding (ScrollViewer.BubbleUpScrollOnEndReached)}"
+                                IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
                                 AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}">
                       <Panel>
                         <TextBlock Name="PART_Watermark"

--- a/src/Avalonia.Themes.Fluent/Controls/TextBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/TextBox.xaml
@@ -41,6 +41,7 @@
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
     <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="ScrollViewer.BubbleUpScrollOnEndReached" Value="True" />
     <Setter Property="ContextFlyout" Value="{StaticResource DefaultTextBoxContextFlyout}" />
     <Setter Property="Template">
       <ControlTemplate>
@@ -68,6 +69,7 @@
                              DockPanel.Dock="Top" />
                   <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                                 VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+                                BubbleUpScrollOnEndReached="{TemplateBinding (ScrollViewer.BubbleUpScrollOnEndReached)}"
                                 AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}">
                       <Panel>
                         <TextBlock Name="PART_Watermark"

--- a/src/Avalonia.Themes.Fluent/Controls/TreeView.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/TreeView.xaml
@@ -6,7 +6,7 @@
   <Setter Property="Padding" Value="0" />
   <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
   <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
-  <Setter Property="ScrollViewer.BubbleUpScrollOnEndReached" Value="True" />
+  <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
   <Setter Property="Template">
     <ControlTemplate>
       <Border BorderBrush="{TemplateBinding BorderBrush}"
@@ -15,7 +15,7 @@
         <ScrollViewer Background="{TemplateBinding Background}"
                       HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                       VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
-                      BubbleUpScrollOnEndReached="{TemplateBinding (ScrollViewer.BubbleUpScrollOnEndReached)}"
+                      IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
                       AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}">
           <ItemsPresenter Name="PART_ItemsPresenter"
                           Items="{TemplateBinding Items}"

--- a/src/Avalonia.Themes.Fluent/Controls/TreeView.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/TreeView.xaml
@@ -6,6 +6,7 @@
   <Setter Property="Padding" Value="0" />
   <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
   <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+  <Setter Property="ScrollViewer.BubbleUpScrollOnEndReached" Value="True" />
   <Setter Property="Template">
     <ControlTemplate>
       <Border BorderBrush="{TemplateBinding BorderBrush}"
@@ -14,6 +15,7 @@
         <ScrollViewer Background="{TemplateBinding Background}"
                       HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                       VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+                      BubbleUpScrollOnEndReached="{TemplateBinding (ScrollViewer.BubbleUpScrollOnEndReached)}"
                       AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}">
           <ItemsPresenter Name="PART_ItemsPresenter"
                           Items="{TemplateBinding Items}"


### PR DESCRIPTION
## What does the pull request do?
Add an AttachedProperty which can be used to bubble up the scrolling if a nested ScrollViewer didn't handle the scroll. 


## What is the current behavior?
The ScrollViewer eats up the PointerWheel event always, and doesn't respect if the scroll happened or not


## What is the updated/expected behavior with this PR?
Should fix issue #6869


## How was the solution implemented (if it's not obvious)?
- Added an attached property to the ScrollViewer
- Check if the scroll was handled or not and if not, bubble the event up if requested


## Checklist

- [ ] Added unit tests (if possible)?
- [X] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation ► I will need to do this, as it will be a new feature. But first the name and the interface should be approved. 
- [x] Find a way to respect the new property in DataGrid as well.
- [x] Remove Sandbox App

## Breaking changes
If the property should be `true` by defaulft, it is a breaking change. 

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #6869
