### PR TITLE
TextBox selection with shift key and left click

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1006,13 +1006,28 @@ namespace Avalonia.Controls
             if (text != null && clickInfo.Properties.IsLeftButtonPressed && !(clickInfo.Pointer?.Captured is Border))
             {
                 var point = e.GetPosition(_presenter);
-                var index = CaretIndex = _presenter.GetCaretIndex(point);
+                var index = _presenter.GetCaretIndex(point);
+                var clickToSelect = index != CaretIndex && e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+
+                if (!clickToSelect)
+                {
+                    CaretIndex = index;
+                }
+
 #pragma warning disable CS0618 // Type or member is obsolete
                 switch (e.ClickCount)
 #pragma warning restore CS0618 // Type or member is obsolete
                 {
                     case 1:
-                        SelectionStart = SelectionEnd = index;
+                        if (clickToSelect)
+                        {
+                            SelectionStart = Math.Min(index, CaretIndex);
+                            SelectionEnd = Math.Max(index, CaretIndex);
+                        }
+                        else
+                        {
+                            SelectionStart = SelectionEnd = index;
+                        }
                         break;
                     case 2:
                         if (!StringUtils.IsStartOfWord(text, index))


### PR DESCRIPTION
## What does the pull request do?
This is common behavior in most UI frameworks for text input control.

![selection](https://user-images.githubusercontent.com/57059775/147598449-20d48bad-ddd8-4253-9f94-c2cc4debf42e.gif)

## What is the current behavior?
`PointerPressedEventArgs` with shift key as modifier only moves caret position.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation