### PR TITLE
Ensure Alpha is set for WGL display

### DIFF
--- a/src/Windows/Avalonia.Win32/OpenGl/WglDisplay.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/WglDisplay.cs
@@ -95,6 +95,7 @@ namespace Avalonia.Win32.OpenGl
                 WGL_DOUBLE_BUFFER_ARB, 1,
                 WGL_PIXEL_TYPE_ARB, WGL_TYPE_RGBA_ARB,
                 WGL_COLOR_BITS_ARB, 32,
+                WGL_ALPHA_BITS_ARB, 8,
                 WGL_DEPTH_BITS_ARB, 0,
                 WGL_STENCIL_BITS_ARB, 0,
                 0, // End


### PR DESCRIPTION
## What does the pull request do?
Sets WGL_ALPHA_BITS_ARB property when creating a wgl context


## What is the current behavior?
On Nvidia gpus, the format returned by WglChoosePixelFormatArb does not have alpha bits set. This causes broken transparency when window transparent hints is set to values other than None


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #7282 
Fixes #5543 
