### PR TITLE
Check for null visual parent.

### DIFF
--- a/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/SceneBuilder.cs
@@ -126,7 +126,12 @@ namespace Avalonia.Rendering.SceneGraph
 
             while (node == null && visual.IsVisible)
             {
-                visual = visual.VisualParent!;
+                var parent = visual.VisualParent;
+
+                if (parent is null)
+                    return null;
+
+                visual = parent;
                 node = scene.FindNode(visual);
             }
 


### PR DESCRIPTION
## What does the pull request do?

Fixes an exception in `SceneBuilder` reported in #6930.

It shouldn't be possible to come across a null visual parent here because the visual should be attached to the visual tree, but according to #6930, it is. Because we don't have a repro here, defensively return a null value instead of throwing if we hit this case.

Also because we don't have a repro, I wasn't able to write a unit test to cover this.

## Fixed issues

Fixes #6930.