### PR TITLE
Add additional null checks to Avalonia.Native.WindowBaseImpl.

### DIFF
--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -28,18 +28,18 @@ namespace Avalonia.Native
 
         public string HandleDescriptor => "NSWindow";
 
-        public IntPtr NSView => _native.ObtainNSViewHandle();
+        public IntPtr NSView => _native?.ObtainNSViewHandle() ?? IntPtr.Zero;
 
-        public IntPtr NSWindow => _native.ObtainNSWindowHandle();
+        public IntPtr NSWindow => _native?.ObtainNSWindowHandle() ?? IntPtr.Zero;
 
         public IntPtr GetNSViewRetained()
         {
-            return _native.ObtainNSViewHandleRetained();
+            return _native?.ObtainNSViewHandleRetained() ?? IntPtr.Zero;
         }
 
         public IntPtr GetNSWindowRetained()
         {
-            return _native.ObtainNSWindowHandleRetained();
+            return _native?.ObtainNSWindowHandleRetained() ?? IntPtr.Zero;
         }
     }
 
@@ -260,7 +260,7 @@ namespace Avalonia.Native
 
         public void Activate()
         {
-            _native.Activate();
+            _native?.Activate();
         }
 
         public bool RawTextInputEvent(uint timeStamp, string text)
@@ -322,7 +322,7 @@ namespace Avalonia.Native
 
         public void Resize(Size clientSize, PlatformResizeReason reason)
         {
-            _native.Resize(clientSize.Width, clientSize.Height, (AvnPlatformResizeReason)reason);
+            _native?.Resize(clientSize.Width, clientSize.Height, (AvnPlatformResizeReason)reason);
         }
 
         public IRenderer CreateRenderer(IRenderRoot root)
@@ -367,14 +367,14 @@ namespace Avalonia.Native
 
         public virtual void Show(bool activate, bool isDialog)
         {
-            _native.Show(activate.AsComBool(), isDialog.AsComBool());
+            _native?.Show(activate.AsComBool(), isDialog.AsComBool());
         }
 
 
         public PixelPoint Position
         {
-            get => _native.Position.ToAvaloniaPixelPoint();
-            set => _native.SetPosition(value.ToAvnPoint());
+            get => _native?.Position.ToAvaloniaPixelPoint() ?? default;
+            set => _native?.SetPosition(value.ToAvnPoint());
         }
 
         public Point PointToClient(PixelPoint point)
@@ -389,12 +389,12 @@ namespace Avalonia.Native
 
         public void Hide()
         {
-            _native.Hide();
+            _native?.Hide();
         }
 
         public void BeginMoveDrag(PointerPressedEventArgs e)
         {
-            _native.BeginMoveDrag();
+            _native?.BeginMoveDrag();
         }
 
         public Size MaxAutoSizeHint => Screen.AllScreens.Select(s => s.Bounds.Size.ToSize(1))
@@ -402,7 +402,7 @@ namespace Avalonia.Native
 
         public void SetTopmost(bool value)
         {
-            _native.SetTopMost(value.AsComBool());
+            _native?.SetTopMost(value.AsComBool());
         }
 
         public double RenderScaling => _native?.Scaling ?? 1;
@@ -438,7 +438,7 @@ namespace Avalonia.Native
 
         public void SetMinMaxSize(Size minSize, Size maxSize)
         {
-            _native.SetMinMaxSize(minSize.ToAvnSize(), maxSize.ToAvnSize());
+            _native?.SetMinMaxSize(minSize.ToAvnSize(), maxSize.ToAvnSize());
         }
 
         public void BeginResizeDrag(WindowEdge edge, PointerPressedEventArgs e)
@@ -449,7 +449,7 @@ namespace Avalonia.Native
         internal void BeginDraggingSession(AvnDragDropEffects effects, AvnPoint point, IAvnClipboard clipboard,
             IAvnDndResultCallback callback, IntPtr sourceHandle)
         {
-            _native.BeginDragAndDropOperation(effects, point, clipboard, callback, sourceHandle);
+            _native?.BeginDragAndDropOperation(effects, point, clipboard, callback, sourceHandle);
         }
 
         public void SetTransparencyLevelHint(WindowTransparencyLevel transparencyLevel) 


### PR DESCRIPTION
## What does the pull request do?

In some places in `WindowBaseImpl` we were checking for a null `_native` reference, but in other places we were assuming it's non-null. Add checks for a null reference there in all places except the `Init` method (which I assume it can't be null).

## Fixed issues

Fixes #7231
