### PR TITLE
[MacOS] fix quit menu item copy paste mistake

### DIFF
--- a/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
+++ b/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
@@ -131,7 +131,7 @@ namespace Avalonia.Native
                 };
                 quitItem.Click += (sender, args) =>
                 {
-                    _applicationCommands.ShowAll();
+                    (Application.Current.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.Shutdown();
                 };
                 result.Add(quitItem);
             }

--- a/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
+++ b/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
@@ -131,7 +131,7 @@ namespace Avalonia.Native
                 };
                 quitItem.Click += (sender, args) =>
                 {
-                    (Application.Current.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.Shutdown();
+                    (Application.Current.ApplicationLifetime as IControlledApplicationLifetime)?.Shutdown();
                 };
                 result.Add(quitItem);
             }


### PR DESCRIPTION
## What does the pull request do?
Fixes Mac App Main Menu Quit Item copy/paste mistake I made on a feature implementation.
This fix makes quit menu Item to shutdown an app

<img width="722" alt="Screenshot 2022-01-03 at 19 18 37" src="https://user-images.githubusercontent.com/4997065/147954047-d60d3395-8a71-44c8-8f18-7887d5f5d2d5.png">
.