### PR TITLE
Fixes #7309 - Each time we retrieve a null *PlatformOptions from AvaloniaLocator, return a default instance

### DIFF
--- a/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
+++ b/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
@@ -80,8 +80,8 @@ namespace Avalonia.Native
             };
             result.Add(aboutItem);
 
-            var macOpts = AvaloniaLocator.Current.GetService<MacOSPlatformOptions>();
-            if (macOpts == null || !macOpts.DisableDefaultApplicationMenuItems)
+            var macOpts = AvaloniaLocator.Current.GetService<MacOSPlatformOptions>() ?? new MacOSPlatformOptions();
+            if (!macOpts.DisableDefaultApplicationMenuItems)
             {
                 result.Add(new NativeMenuItemSeparator());
 
@@ -142,9 +142,9 @@ namespace Avalonia.Native
 
         private void DoLayoutReset(bool forceUpdate = false)
         {
-            var macOpts = AvaloniaLocator.Current.GetService<MacOSPlatformOptions>();
+            var macOpts = AvaloniaLocator.Current.GetService<MacOSPlatformOptions>() ?? new MacOSPlatformOptions();
 
-            if (macOpts != null && macOpts.DisableNativeMenus)
+            if (macOpts.DisableNativeMenus)
             {
                 return;
             }

--- a/src/Avalonia.Native/AvaloniaNativePlatform.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatform.cs
@@ -96,9 +96,9 @@ namespace Avalonia.Native
             _factory.Initialize(new GCHandleDeallocator(), applicationPlatform);
             if (_factory.MacOptions != null)
             {
-                var macOpts = AvaloniaLocator.Current.GetService<MacOSPlatformOptions>();
+                var macOpts = AvaloniaLocator.Current.GetService<MacOSPlatformOptions>() ?? new MacOSPlatformOptions();
 
-                _factory.MacOptions.SetShowInDock(macOpts?.ShowInDock != false ? 1 : 0);
+                _factory.MacOptions.SetShowInDock(macOpts.ShowInDock ? 1 : 0);
             }
 
             AvaloniaLocator.CurrentMutable

--- a/src/Avalonia.X11/Glx/GlxDisplay.cs
+++ b/src/Avalonia.X11/Glx/GlxDisplay.cs
@@ -95,8 +95,8 @@ namespace Avalonia.X11.Glx
 
                 if (Environment.GetEnvironmentVariable("AVALONIA_GLX_IGNORE_RENDERER_BLACKLIST") != "1")
                 {
-                    var blacklist = AvaloniaLocator.Current.GetService<X11PlatformOptions>()
-                        ?.GlxRendererBlacklist;
+                    var opts = AvaloniaLocator.Current.GetService<X11PlatformOptions>() ?? new X11PlatformOptions();
+                    var blacklist = opts.GlxRendererBlacklist;
                     if (blacklist != null)
                         foreach (var item in blacklist)
                             if (glInterface.Renderer.Contains(item))

--- a/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
@@ -38,11 +38,11 @@ namespace Avalonia.LinuxFramebuffer
             if (_fb is IGlOutputBackend gl)
                 AvaloniaLocator.CurrentMutable.Bind<IPlatformOpenGlInterface>().ToConstant(gl.PlatformOpenGlInterface);
             
-            var opts = AvaloniaLocator.Current.GetService<LinuxFramebufferPlatformOptions>();
+            var opts = AvaloniaLocator.Current.GetService<LinuxFramebufferPlatformOptions>() ?? new LinuxFramebufferPlatformOptions();
             
             AvaloniaLocator.CurrentMutable
                 .Bind<IPlatformThreadingInterface>().ToConstant(Threading)
-                .Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(opts?.Fps ?? 60))
+                .Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(opts.Fps))
                 .Bind<IRenderLoop>().ToConstant(new RenderLoop())
                 .Bind<ICursorFactory>().ToTransient<CursorFactoryStub>()
                 .Bind<IKeyboardDevice>().ToConstant(new KeyboardDevice())

--- a/src/Windows/Avalonia.Win32/Win32GlManager.cs
+++ b/src/Windows/Avalonia.Win32/Win32GlManager.cs
@@ -13,19 +13,18 @@ namespace Avalonia.Win32
         {
             AvaloniaLocator.CurrentMutable.Bind<IPlatformOpenGlInterface>().ToLazy<IPlatformOpenGlInterface>(() =>
             {
-                var opts = AvaloniaLocator.Current.GetService<Win32PlatformOptions>();
-                if (opts?.UseWgl == true)
+                var opts = AvaloniaLocator.Current.GetService<Win32PlatformOptions>() ?? new Win32PlatformOptions();
+                if (opts.UseWgl)
                 {
                     var wgl = WglPlatformOpenGlInterface.TryCreate();
                     return wgl;
                 }
 
-                if (opts?.AllowEglInitialization ?? Win32Platform.WindowsVersion > PlatformConstants.Windows7)
+                if (opts.AllowEglInitialization ?? Win32Platform.WindowsVersion > PlatformConstants.Windows7)
                 {
                     var egl = EglPlatformOpenGlInterface.TryCreate(() => new AngleWin32EglDisplay());
 
-                    if (egl != null &&
-                        opts?.UseWindowsUIComposition == true)
+                    if (egl != null && opts.UseWindowsUIComposition)
                     {
                         WinUICompositorConnection.TryCreateAndRegister(egl, opts.CompositionBackdropCornerRadius);
                     }


### PR DESCRIPTION
## What does the pull request do?

All places where this kind of construct is encountered:

```csharp
var opts  = AvaloniaLocator.Current.GetService<***PlatformOptions>();
if (opts?.Something) ...
```

now look like:

```csharp
var opts  = AvaloniaLocator.Current.GetService<***PlatformOptions>() ?? new ***PlatformOptions();
if (opts.Something) ...
```

## What is the current behavior?

In some places, when we retrieve `null` platform options from Avalonia service locator, the logic further ahead:
* either makes decisions inconsistent with the behavior we'd have with a default platform options instance (as was the case in the original issue with GLX black list)
* or reimplements default behavior (thus duplicating logic). For example, in the Linux Framebuffer case, we had:

```csharp
var opts = AvaloniaLocator.Current.GetService<LinuxFramebufferPlatformOptions>();
...
.Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(opts?.Fps ?? 60))
```

This was replaced by:

```csharp
var opts = AvaloniaLocator.Current.GetService<LinuxFramebufferPlatformOptions>() ?? new LinuxFramebufferPlatformOptions();
...
.Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(opts.Fps))
```

There's no need any more to duplicate the **60 fps** default value as it is the default in a new instance of `LinuxFramebufferPlatformOptions`. In this case, the logic does not change, but it is also less subject to a later bug if the platform options defaults were to change in the future.

## What is the updated/expected behavior with this PR?

There is only one expected behavioral change:
* OpenGL rendering that was (unexpectedly) working on Linux machines with no GPU should now stop working...
* ...because the correct way to have it working is to explicitly remove **llvmpipe** from the `X11PlatformOptions.GlxRendererBlacklist`.


## How was the solution implemented (if it's not obvious)?

To sum it up, I made sure instances of WhateverPlatformOptions were never `null` and simplified the code replacing things like `opts?.Property == true` into `opts.Property`.

## Checklist

- [ ] Added unit tests (if possible)? I couldn't find any place to add tests to, nor a way to easily test this
- [ ] Added XML documentation to any related classes? Not needed
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation? Not needed

## Breaking changes

Not sure if this is considered a breaking change as obviously using OpenGL on a Linux box with only the llvmpipe Mesa driver was not supported...

<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues

Fixes #7309
