### PR TITLE
Feature: editable `DataGridTemplateColumn`

### DIFF
--- a/samples/ControlCatalog/Models/Person.cs
+++ b/samples/ControlCatalog/Models/Person.cs
@@ -16,6 +16,7 @@ namespace ControlCatalog.Models
         string _firstName;
         string _lastName;
         bool _isBanned;
+        private int _age;
 
         public string FirstName
         {
@@ -56,6 +57,20 @@ namespace ControlCatalog.Models
                 _isBanned = value;
 
                 OnPropertyChanged(nameof(_isBanned));
+            }
+        }
+
+        
+        /// <summary>
+        ///    Gets or sets the age of the person
+        /// </summary>
+        public int Age
+        {
+            get => _age;
+            set
+            {
+                _age = value;
+                OnPropertyChanged(nameof(Age));
             }
         }
 

--- a/samples/ControlCatalog/Pages/DataGridPage.xaml
+++ b/samples/ControlCatalog/Pages/DataGridPage.xaml
@@ -72,7 +72,7 @@
                 </DataGridTemplateColumn.CellTemplate>
                 <DataGridTemplateColumn.CellEditingTemplate>
                   <DataTemplate DataType="local:Person">
-                    <NumericUpDown Value="{Binding Age}" FormatString="N0" HorizontalAlignment="Stretch" Minimum="0" Maximum="120" />
+                    <NumericUpDown Value="{Binding Age}" FormatString="N0" HorizontalAlignment="Stretch" Minimum="0" Maximum="120" TemplateApplied="NumericUpDown_OnTemplateApplied" />
                   </DataTemplate>
                 </DataGridTemplateColumn.CellEditingTemplate>
               </DataGridTemplateColumn>

--- a/samples/ControlCatalog/Pages/DataGridPage.xaml
+++ b/samples/ControlCatalog/Pages/DataGridPage.xaml
@@ -64,6 +64,18 @@
               <DataGridTextColumn Header="First Name" Binding="{Binding FirstName}" Width="2*" FontSize="{Binding #FontSizeSlider.Value, Mode=OneWay}" />
               <DataGridTextColumn Header="Last" Binding="{Binding LastName}" Width="2*" FontSize="{Binding #FontSizeSlider.Value, Mode=OneWay}" />
               <DataGridCheckBoxColumn Header="Is Banned" Binding="{Binding IsBanned}" Width="*" IsThreeState="{Binding #IsThreeStateCheckBox.IsChecked, Mode=OneWay}" />
+              <DataGridTemplateColumn Header="Age" >
+                <DataGridTemplateColumn.CellTemplate>
+                  <DataTemplate DataType="local:Person">
+                    <TextBlock Text="{Binding Age, StringFormat='{}{0} years'}" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                  </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+                <DataGridTemplateColumn.CellEditingTemplate>
+                  <DataTemplate DataType="local:Person">
+                    <NumericUpDown Value="{Binding Age}" FormatString="N0" HorizontalAlignment="Stretch" Minimum="0" Maximum="120" />
+                  </DataTemplate>
+                </DataGridTemplateColumn.CellEditingTemplate>
+              </DataGridTemplateColumn>
             </DataGrid.Columns>
           </DataGrid>
           <Button Grid.Row="1" Name="btnAdd" Margin="12,0,12,12" Content="Add" HorizontalAlignment="Right" />

--- a/samples/ControlCatalog/Pages/DataGridPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DataGridPage.xaml.cs
@@ -6,7 +6,9 @@ using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using ControlCatalog.Models;
 using Avalonia.Collections;
+using Avalonia.Controls.Primitives;
 using Avalonia.Data;
+using Avalonia.Threading;
 
 namespace ControlCatalog.Pages
 {
@@ -82,6 +84,20 @@ namespace ControlCatalog.Pages
                 }
 
                 return Comparer.Default.Compare(x, y);
+            }
+        }
+
+        private void NumericUpDown_OnTemplateApplied(object sender, TemplateAppliedEventArgs e)
+        {
+            // We want to focus the TextBox of the NumericUpDown. To do so we search for this control when the template
+            // is applied, but we postpone the action until the control is actually loaded. 
+            if (e.NameScope.Find<TextBox>("PART_TextBox") is {} textBox)
+            {
+                Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    textBox.Focus();
+                    textBox.SelectAll();
+                }, DispatcherPriority.Loaded);
             }
         }
     }

--- a/samples/ControlCatalog/Pages/DataGridPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DataGridPage.xaml.cs
@@ -48,9 +48,9 @@ namespace ControlCatalog.Pages
 
             var items = new List<Person>
             {
-                new Person { FirstName = "John", LastName = "Doe" },
-                new Person { FirstName = "Elizabeth", LastName = "Thomas", IsBanned = true },
-                new Person { FirstName = "Zack", LastName = "Ward" }
+                new Person { FirstName = "John", LastName = "Doe" , Age = 30},
+                new Person { FirstName = "Elizabeth", LastName = "Thomas", IsBanned = true , Age = 40 },
+                new Person { FirstName = "Zack", LastName = "Ward" , Age = 50 }
             };
             var collectionView3 = new DataGridCollectionView(items);
 

--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
@@ -448,7 +448,7 @@ namespace Avalonia.Controls
             internal set;
         }
 
-        public bool IsReadOnly
+        public virtual bool IsReadOnly
         {
             get
             {

--- a/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
@@ -1,4 +1,4 @@
-﻿// (c) Copyright Microsoft Corporation.
+// (c) Copyright Microsoft Corporation.
 // This source is subject to the Microsoft Public License (Ms-PL).
 // Please see http://go.microsoft.com/fwlink/?LinkID=131993 for details.
 // All other rights reserved.
@@ -50,11 +50,6 @@ namespace Avalonia.Controls
             var value = (IDataTemplate)e.NewValue;
         }
 
-        public DataGridTemplateColumn()
-        {
-            // IsReadOnly = true;
-        }
-        
         protected override IControl GenerateElement(DataGridCell cell, object dataItem)
         {
             if(CellTemplate != null)

--- a/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
@@ -32,12 +32,24 @@ namespace Avalonia.Controls
 
         private IDataTemplate _cellEditingCellTemplate;
 
+        /// <summary>
+        /// Defines the <see cref="CellEditingTemplate"/> property.
+        /// </summary>
         public static readonly DirectProperty<DataGridTemplateColumn, IDataTemplate> CellEditingTemplateProperty =
                 AvaloniaProperty.RegisterDirect<DataGridTemplateColumn, IDataTemplate>(
                     nameof(CellEditingTemplate),
                     o => o.CellEditingTemplate,
                     (o, v) => o.CellEditingTemplate = v);
 
+        /// <summary>
+        /// Gets or sets the <see cref="IDataTemplate"/> which is used for the editing mode of the current <see cref="DataGridCell"/>
+        /// </summary>
+        /// <value>
+        /// An <see cref="IDataTemplate"/> for the editing mode of the current <see cref="DataGridCell"/>
+        /// </value>
+        /// <remarks>
+        /// If this property is <see langword="null"/> the column is read-only.
+        /// </remarks>
         public IDataTemplate CellEditingTemplate
         {
             get => _cellEditingCellTemplate;

--- a/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Controls
 {
     public class DataGridTemplateColumn : DataGridColumn
     {
-        IDataTemplate _cellTemplate;
+        private IDataTemplate _cellTemplate;
 
         public static readonly DirectProperty<DataGridTemplateColumn, IDataTemplate> CellTemplateProperty =
             AvaloniaProperty.RegisterDirect<DataGridTemplateColumn, IDataTemplate>(
@@ -54,7 +54,7 @@ namespace Avalonia.Controls
         {
             // IsReadOnly = true;
         }
-
+        
         protected override IControl GenerateElement(DataGridCell cell, object dataItem)
         {
             if(CellTemplate != null)
@@ -77,6 +77,10 @@ namespace Avalonia.Controls
             if(CellEditingTemplate != null)
             {
                 return CellEditingTemplate.Build(dataItem);
+            }
+            else if (CellTemplate != null)
+            {
+                return CellTemplate.Build(dataItem);
             }
             if (Design.IsDesignMode)
             {
@@ -102,6 +106,23 @@ namespace Avalonia.Controls
             }
 
             base.RefreshCellContent(element, propertyName);
+        }
+        
+        public override bool IsReadOnly
+        {
+            get
+            {
+                if (CellEditingTemplate is null)
+                {
+                    return true;
+                }
+
+                return base.IsReadOnly;
+            }
+            set
+            {
+                base.IsReadOnly = value;
+            }
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
make the `DataGridTemplateColumn` editable


## What is the current behavior?
it is not possible to edit a cell in `DataGridTemplateColumn` out of the box, see Discussion https://github.com/AvaloniaUI/Avalonia/discussions/6553


## What is the updated/expected behavior with this PR?
The developer can provide an `IDataTemplate` to `CellEditingTemplate` and the user can then edit the cell like other cells.


## How was the solution implemented (if it's not obvious)?
- Added property `CellEditingTemplate (type: `IDataTemplate`)
- Make `DataGridColumn.IsReadOnly` virtual, so it can be overridden by `DataGridTemplateColumn`


## Checklist

- [ ] Added unit tests (if possible)? ► Are there any needed? if yes, please guide me which tests are needed
- [X] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation ► should be done after this PR is merged. 

## Breaking changes
None. The `DataGridTemplateColumn` is still read-only if no editing template is provided. 

## Obsoletions / Deprecations
None

## Preview:
https://user-images.githubusercontent.com/47110241/148204429-240d4ee1-1649-4c8c-832b-924caacd8243.mp4


## Fixed issues
Fixes #7314 