### PR TITLE
ListBox should respect ClipToBounds

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/ListBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ListBox.xaml
@@ -20,6 +20,7 @@
     <Setter Property="Template">
       <ControlTemplate>
         <Border Name="border"
+                ClipToBounds="{TemplateBinding ClipToBounds}"
                 Background="{TemplateBinding Background}"
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}"


### PR DESCRIPTION
## What does the pull request do?
Now when you will set e.g CornerRadius to the ListBox it will respect it. 
![image](https://user-images.githubusercontent.com/53405089/148419303-cf2c4769-f916-4991-a9e7-4d8aacec12d3.png)
Before:
![image](https://user-images.githubusercontent.com/53405089/148419485-76fc0544-70ab-4b72-a406-fa7c608d3b1e.png)

**Note**: WPF somewhy doesn't respect ClipToBounds also, but I think it isn't correct.

