### PR TITLE
Only handle a KeyBinding if it's actually been handled.

### DIFF
--- a/src/Avalonia.Input/KeyBinding.cs
+++ b/src/Avalonia.Input/KeyBinding.cs
@@ -35,9 +35,11 @@ namespace Avalonia.Input
         {
             if (Gesture?.Matches(args) == true)
             {
-                args.Handled = true;
-                if (Command?.CanExecute(CommandParameter) == true)
+                if (Command?.CanExecute(CommandParameter) == true) 
+                {
+                    args.Handled = true;
                     Command.Execute(CommandParameter);
+                }
             }
         }
     }


### PR DESCRIPTION
## What does the pull request do?

In KeyBindings we should only set Handled if it's actually been handled. 

## What is the current behavior?

In KeyBindings.cs:TryHandle, KeyEventArgs are always handled. 

## What is the updated/expected behavior with this PR?

Only set args.Handle = true if CanExectute = true

## How was the solution implemented (if it's not obvious)?

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

## Obsoletions / Deprecations

## Fixed issues

