### PR TITLE
Fixes/standard osx item generation

### DIFF
--- a/build/SourceLink.props
+++ b/build/SourceLink.props
@@ -3,7 +3,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>false</IncludeSymbols>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <DebugType>embedded</DebugType>
+    <DebugType>full</DebugType>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   

--- a/build/SourceLink.props
+++ b/build/SourceLink.props
@@ -3,7 +3,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>false</IncludeSymbols>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <DebugType>full</DebugType>
+    <DebugType>embedded</DebugType>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   

--- a/samples/ControlCatalog/App.xaml
+++ b/samples/ControlCatalog/App.xaml
@@ -3,6 +3,7 @@
              xmlns:vm="using:ControlCatalog.ViewModels"
              x:DataType="vm:ApplicationViewModel"
              x:CompileBindings="True"
+             Name="Avalonia ControlCatalog"
              x:Class="ControlCatalog.App">
   <Application.Styles>
     <Style Selector="TextBlock.h1, TextBlock.h2, TextBlock.h3">

--- a/src/Avalonia.Dialogs/AboutAvaloniaDialog.xaml
+++ b/src/Avalonia.Dialogs/AboutAvaloniaDialog.xaml
@@ -95,7 +95,7 @@
       </StackPanel>
       <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" >
         <TextBlock Text="Chat Room | " />
-        <Button Classes="Hyperlink" CommandParameter="https://gitter.im/AvaloniaUI/Avalonia/"  />
+        <Button Classes="Hyperlink" CommandParameter="https://t.me/Avalonia"  />
       </StackPanel>
      </StackPanel> 
     <StackPanel VerticalAlignment="Bottom" Margin="10">

--- a/src/Avalonia.Dialogs/Avalonia.Dialogs.csproj
+++ b/src/Avalonia.Dialogs/Avalonia.Dialogs.csproj
@@ -5,6 +5,7 @@
 
   <ItemGroup>
     <AvaloniaResource Include="Assets\*" />
+    <AvaloniaResource Include="**/*.xaml" />
   </ItemGroup>
 
   <Import Project="..\..\build\BuildTargets.targets" />

--- a/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
+++ b/src/Avalonia.Native/AvaloniaNativeMenuExporter.cs
@@ -70,74 +70,76 @@ namespace Avalonia.Native
             var result = new NativeMenu();
 
             var aboutItem = new NativeMenuItem("About Avalonia");
-            aboutItem.Click += async (sender, e) =>
+            
+            aboutItem.Click += async (_, _) =>
             {
                 var dialog = new AboutAvaloniaDialog();
 
-                var mainWindow = (Application.Current.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow;
-
-                await dialog.ShowDialog(mainWindow);
+                if (Application.Current is
+                    { ApplicationLifetime: IClassicDesktopStyleApplicationLifetime { MainWindow: { } mainWindow } })
+                {
+                    await dialog.ShowDialog(mainWindow);   
+                }
             };
+            
             result.Add(aboutItem);
 
-            var macOpts = AvaloniaLocator.Current.GetService<MacOSPlatformOptions>() ?? new MacOSPlatformOptions();
-            if (!macOpts.DisableDefaultApplicationMenuItems)
-            {
-                result.Add(new NativeMenuItemSeparator());
-
-                var servicesMenu = new NativeMenuItem("Services");
-                servicesMenu.Menu = new NativeMenu
-                {
-                    [MacOSNativeMenuCommands.IsServicesSubmenuProperty] = true
-                };
-                result.Add(servicesMenu);
-
-                result.Add(new NativeMenuItemSeparator());
-
-                var hideItem = new NativeMenuItem("Hide " + Application.Current.Name)
-                {
-                    Gesture = new KeyGesture(Key.H, KeyModifiers.Meta)
-                };
-                hideItem.Click += (sender, args) =>
-                {
-                    _applicationCommands.HideApp();
-                };
-                result.Add(hideItem);
-
-
-                var hideOthersItem = new NativeMenuItem("Hide Others")
-                {
-                    Gesture = new KeyGesture(Key.Q, KeyModifiers.Meta | KeyModifiers.Alt)
-                };
-                hideOthersItem.Click += (sender, args) =>
-                {
-                    _applicationCommands.HideOthers();
-                };
-                result.Add(hideOthersItem);
-
-
-                var showAllItem = new NativeMenuItem("Show All");
-                showAllItem.Click += (sender, args) =>
-                {
-                    _applicationCommands.ShowAll();
-                };
-                result.Add(showAllItem);
-
-                result.Add(new NativeMenuItemSeparator());
-
-                var quitItem = new NativeMenuItem("Quit")
-                {
-                    Gesture = new KeyGesture(Key.Q, KeyModifiers.Meta)
-                };
-                quitItem.Click += (sender, args) =>
-                {
-                    (Application.Current.ApplicationLifetime as IControlledApplicationLifetime)?.Shutdown();
-                };
-                result.Add(quitItem);
-            }
-
-
             return result;
+        }
+
+        private void PopulateStandardOSXMenuItems(NativeMenu appMenu)
+        {
+            appMenu.Add(new NativeMenuItemSeparator());
+
+            var servicesMenu = new NativeMenuItem("Services");
+            servicesMenu.Menu = new NativeMenu { [MacOSNativeMenuCommands.IsServicesSubmenuProperty] = true };
+
+            appMenu.Add(servicesMenu);
+
+            appMenu.Add(new NativeMenuItemSeparator());
+
+            var hideItem = new NativeMenuItem("Hide " + (Application.Current?.Name ?? "Application"))
+            {
+                Gesture = new KeyGesture(Key.H, KeyModifiers.Meta)
+            };
+
+            hideItem.Click += (_, _) =>
+            {
+                _applicationCommands.HideApp();
+            };
+
+            appMenu.Add(hideItem);
+
+            var hideOthersItem = new NativeMenuItem("Hide Others")
+            {
+                Gesture = new KeyGesture(Key.Q, KeyModifiers.Meta | KeyModifiers.Alt)
+            };
+            hideOthersItem.Click += (_, _) =>
+            {
+                _applicationCommands.HideOthers();
+            };
+            appMenu.Add(hideOthersItem);
+
+            var showAllItem = new NativeMenuItem("Show All");
+            showAllItem.Click += (_, _) =>
+            {
+                _applicationCommands.ShowAll();
+            };
+
+            appMenu.Add(showAllItem);
+
+            appMenu.Add(new NativeMenuItemSeparator());
+
+            var quitItem = new NativeMenuItem("Quit") { Gesture = new KeyGesture(Key.Q, KeyModifiers.Meta) };
+            quitItem.Click += (_, _) =>
+            {
+                if (Application.Current is { ApplicationLifetime: IControlledApplicationLifetime lifetime })
+                {
+                    lifetime.Shutdown();
+                }
+            };
+
+            appMenu.Add(quitItem);
         }
 
         private void DoLayoutReset(bool forceUpdate = false)
@@ -219,6 +221,13 @@ namespace Avalonia.Native
                 _nativeMenu = __MicroComIAvnMenuProxy.Create(_factory);
 
                 _nativeMenu.Initialize(this, appMenuHolder, "");
+
+                var macOpts = AvaloniaLocator.Current.GetService<MacOSPlatformOptions>();
+
+                if (macOpts == null || !macOpts.DisableDefaultApplicationMenuItems)
+                {
+                    PopulateStandardOSXMenuItems(menu);
+                }
 
                 setMenu = true;
             }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
- This PR fixes the Native app menu generation on OSX.
- Fixes ability to debug code on OSX (debug symbols)
- Fixes the default app menu on OSX.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Since standard app menu item generation was moved to the managed side of the fence, this was only done on the "Default" app menu, but it should have been done on all menus.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
User supplied app menu gets populated with standard OSX menu items.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
