### PR TITLE
Reduce the priority in AvaloniaSynchronizationContext.

### DIFF
--- a/src/Avalonia.Base/Threading/AvaloniaSynchronizationContext.cs
+++ b/src/Avalonia.Base/Threading/AvaloniaSynchronizationContext.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Threading
         /// <inheritdoc/>
         public override void Post(SendOrPostCallback d, object? state)
         {
-           Dispatcher.UIThread.Post(() => d(state), DispatcherPriority.Send);
+           Dispatcher.UIThread.Post(() => d(state), DispatcherPriority.Background);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
## What does the pull request do?

`AvaloniaSynchronizationContext` was previously queuing continuations with `Send` priority, which is the maximum. This was causing the problem described in https://github.com/AvaloniaUI/Avalonia/issues/6930#issuecomment-1008888711 where `await` continuations were being called on macOS during `Window` construction via `RunRenderPriorityJobs`.

Decrease the priority so that continuations are queued with less than `Render` priority (the options were `Loaded`, `Input` or `Background` priority - I chose `Background` because continuations aren't really a `Loaded` or `Input` job).

## Fixed issues

Fixes #6930 