### PR TITLE
win32: Don't raise TextInput event when KeyDown was handled.

### DIFF
--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -189,8 +189,11 @@ namespace Avalonia.Win32
 
             if (UnmanagedMethods.GetMessage(out var msg, IntPtr.Zero, 0, 0) > -1)
             {
-                UnmanagedMethods.TranslateMessage(ref msg);
-                UnmanagedMethods.DispatchMessage(ref msg);
+                if (!WindowImpl.PreProcessMessage(msg))
+                {
+                    UnmanagedMethods.TranslateMessage(ref msg);
+                    UnmanagedMethods.DispatchMessage(ref msg);
+                }
             }
             else
             {
@@ -206,8 +209,11 @@ namespace Avalonia.Win32
             while (!cancellationToken.IsCancellationRequested 
                 && (result = UnmanagedMethods.GetMessage(out var msg, IntPtr.Zero, 0, 0)) > 0)
             {
-                UnmanagedMethods.TranslateMessage(ref msg);
-                UnmanagedMethods.DispatchMessage(ref msg);
+                if (!WindowImpl.PreProcessMessage(msg))
+                {
+                    UnmanagedMethods.TranslateMessage(ref msg);
+                    UnmanagedMethods.DispatchMessage(ref msg);
+                }
             }
             if (result < 0)
             {


### PR DESCRIPTION
## What does the pull request do?

On win32, returning handled from `WM_KEYDOWN` doesn't automatically prevent a `WM_CHAR` message, resulting in #5849.

The `TranslateMessage` call is responsible for translating the `WM_KEYDOWN` event to a `WM_CHAR` event, so one needs to "simply" not call this function if the key down event was handled. However there's a problem: `TranslateMessage` is called before the `DispatchMessage` call which dispatches the key down message to the `WindowImpl`.

To get around this, this PR adds a `PreProcessMessage` step which can be used to handle key down messages and raise events outside of `DispatchMessage`/`WndProc`. This solution broadly comes from WPF, though there the solution is a bit more complicated (it's hooked into using `ComponentDispatcher` events from `HwndSource`).

## Fixed issues

Fixes #5849
