### PR TITLE
Add support for nested types to XAML compiler.

### DIFF
--- a/samples/BindingDemo/EnumToEnumerable.cs
+++ b/samples/BindingDemo/EnumToEnumerable.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Avalonia.Markup.Xaml;
+
+namespace BindingDemo
+{
+    public class EnumToEnumerable : MarkupExtension
+    {
+        private readonly Type _enumType;
+
+        public EnumToEnumerable(Type type)
+        {
+            if (!type.IsEnum)
+                throw new ArgumentException(nameof(type));
+            _enumType = type;
+        }
+        
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return Enum.GetValues(_enumType);
+        }
+    }
+}

--- a/samples/BindingDemo/MainWindow.xaml
+++ b/samples/BindingDemo/MainWindow.xaml
@@ -42,7 +42,7 @@
           </StackPanel>
           <StackPanel Margin="18" Spacing="4" Width="200">
             <TextBlock FontSize="16" Text="Markup Extensions"/>
-            <ComboBox Items="{local:EnumToEnumerable {x:Type vm:MainWindowViewModel+NestedEnum}}" />
+            <ComboBox Items="{local:EnumToEnumerable {x:Type vm:MainWindowViewModel+NestedEnum}}" SelectedIndex="0"/>
           </StackPanel>
         </StackPanel>
         <StackPanel Orientation="Horizontal">

--- a/samples/BindingDemo/MainWindow.xaml
+++ b/samples/BindingDemo/MainWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:vm="clr-namespace:BindingDemo.ViewModels" 
         xmlns:local="clr-namespace:BindingDemo"
         Title="AvaloniaUI Bindings Test"
-        Width="800"
+        Width="1000"
         Height="600"
         x:DataType="vm:MainWindowViewModel">
   <Window.Styles>
@@ -39,6 +39,10 @@
             <TextBox Watermark="Boolean String" UseFloatingWatermark="True" Text="{Binding Path=BooleanString}"/>
             <CheckBox IsChecked="{Binding !BooleanString}">!BooleanString</CheckBox>
             <CheckBox IsChecked="{Binding !!BooleanString}">!!BooleanString</CheckBox>
+          </StackPanel>
+          <StackPanel Margin="18" Spacing="4" Width="200">
+            <TextBlock FontSize="16" Text="Markup Extensions"/>
+            <ComboBox Items="{local:EnumToEnumerable {x:Type vm:MainWindowViewModel+NestedEnum}}" />
           </StackPanel>
         </StackPanel>
         <StackPanel Orientation="Horizontal">

--- a/samples/BindingDemo/ViewModels/MainWindowViewModel.cs
+++ b/samples/BindingDemo/ViewModels/MainWindowViewModel.cs
@@ -115,5 +115,11 @@ namespace BindingDemo.ViewModels
         {
             return BooleanFlag;
         }
+
+        public enum NestedEnum
+        {
+            Nested,
+            Enum,
+        }
     }
 }

--- a/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
+++ b/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
@@ -255,6 +255,7 @@ namespace Avalonia.Build.Tasks
                                 true),
                             (closureName, closureBaseType) =>
                                 populateBuilder.DefineSubType(closureBaseType, closureName, false),
+                            (s, returnType, parameters) => builder.DefineDelegateSubType(s, false, returnType, parameters),
                             res.Uri, res
                         );
                         

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
@@ -201,7 +201,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             if (type.Equals(types.Classes))
             {
                 var classes = text.Split(' ');
-                var classNodes = classes.Select(c => new XamlAstTextNode(node, c, types.XamlIlTypes.String)).ToArray();
+                var classNodes = classes.Select(c => new XamlAstTextNode(node, c, type: types.XamlIlTypes.String)).ToArray();
 
                 result = new AvaloniaXamlIlAvaloniaListConstantAstNode(node, types, types.Classes, types.XamlIlTypes.String, classNodes);
                 return true;

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlSelectorTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlSelectorTransformer.cs
@@ -77,7 +77,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                                 throw new XamlParseException($"Cannot find '{property.Property}' on '{type}", node);
 
                             if (!XamlTransformHelpers.TryGetCorrectlyTypedValue(context,
-                                new XamlAstTextNode(node, property.Value, context.Configuration.WellKnownTypes.String),
+                                new XamlAstTextNode(node, property.Value, type: context.Configuration.WellKnownTypes.String),
                                 targetProperty.PropertyType, out var typedValue))
                                 throw new XamlParseException(
                                     $"Cannot convert '{property.Value}' to '{targetProperty.PropertyType.GetFqn()}",
@@ -118,7 +118,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                                     .GetAvaloniaPropertyType(targetPropertyField, context.GetAvaloniaTypes(), node);
 
                                 if (!XamlTransformHelpers.TryGetCorrectlyTypedValue(context,
-                                    new XamlAstTextNode(node, attachedProperty.Value, context.Configuration.WellKnownTypes.String),
+                                    new XamlAstTextNode(node, attachedProperty.Value, type: context.Configuration.WellKnownTypes.String),
                                     targetPropertyType, out var typedValue))
                                         throw new XamlParseException(
                                             $"Cannot convert '{attachedProperty.Value}' to '{targetPropertyType.GetFqn()}",

--- a/tests/Avalonia.Markup.Xaml.UnitTests/EnumToEnumerable.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/EnumToEnumerable.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Avalonia.Markup.Xaml.UnitTests
+{
+    public class EnumToEnumerable : MarkupExtension
+    {
+        private readonly Type _enumType;
+
+        public EnumToEnumerable(Type type)
+        {
+            if (!type.IsEnum)
+                throw new ArgumentException(nameof(type));
+            _enumType = type;
+        }
+        
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return Enum.GetValues(_enumType);
+        }
+    }
+}

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/MarkupExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/MarkupExtensionTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections;
+using Avalonia.Controls;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
+{
+    public class MarkupExtensionTests : XamlTestBase
+    {
+        [Fact]
+        public void Markup_Extension_Can_Accept_Nested_Type()
+        {
+            using (UnitTestApplication.Start(TestServices.MockWindowingPlatform))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <ListBox Items='{local:EnumToEnumerable {x:Type local:TestViewModel+NestedEnum}}'/>
+</Window>";
+
+                var window = AvaloniaRuntimeXamlLoader.Parse<Window>(xaml);
+                var listBox = (ListBox)window.Content;
+                var items = (IList)listBox.Items;
+
+                Assert.Equal(2, items.Count);
+                Assert.Equal(TestViewModel.NestedEnum.Item1, items[0]);
+                Assert.Equal(TestViewModel.NestedEnum.Item2, items[1]);
+            }
+        }
+    }
+}

--- a/tests/Avalonia.Markup.Xaml.UnitTests/TestViewModel.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/TestViewModel.cs
@@ -37,5 +37,16 @@ namespace Avalonia.Markup.Xaml.UnitTests
                 RaisePropertyChanged();
             }
         }
+
+        public class NestedType
+        {
+            public string String { get; set; }
+        }
+
+        public enum NestedEnum
+        {
+            Item1,
+            Item2,
+        }
     }
 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/DataTemplateTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/DataTemplateTests.cs
@@ -171,9 +171,5 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
                 Assert.Equal("NestedType", child.Tag);
             }
         }
-
-        public class NestedType
-        {
-        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

As described in #2725, nested types were not working correctly in `{x:Type}` in XAML, however after adding some unit tests I discovered that this was only when using the Cecil emitter: nested types worked fine in unit tests.

This PR updates the XamlX submodule to include https://github.com/kekekeks/XamlX/pull/54 (a few additional changes were required to update to this commit as we weren't up-to-date with XamlX master) and includes the unit tests (even though they didn't demonstrate the problem) and a test case to BindingDemo based on a customer repro (which did demonstrate the problem).

## Fixed issues

Fixes #2725 