### PR TITLE
[Calendar] Fix vertical alignments

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/CalendarButton.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/CalendarButton.xaml
@@ -11,7 +11,7 @@
     <Setter Property="MinWidth" Value="40"/>
     <Setter Property="MinHeight" Value="40"/>
     <Setter Property="Margin" Value="1"/>
-    <Setter Property="Padding" Value="0,0,0,4"/>
+    <Setter Property="Padding" Value="0,0,0,0"/>
     <!--These are actually set on the CalendarView in WinUI-->
     <Setter Property="Foreground" Value="{DynamicResource CalendarViewCalendarItemForeground}"/>
     <Setter Property="Background" Value="{DynamicResource CalendarViewCalendarItemRevealBackground}"/>

--- a/src/Avalonia.Themes.Fluent/Controls/CalendarDayButton.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/CalendarDayButton.xaml
@@ -11,7 +11,7 @@
     <Setter Property="MinWidth" Value="40"/>
     <Setter Property="MinHeight" Value="40"/>
     <Setter Property="Margin" Value="1"/>
-    <Setter Property="Padding" Value="0,0,0,4"/>
+    <Setter Property="Padding" Value="0,0,0,0"/>
     <!--These are actually set on the CalendarView in WinUI-->
     <Setter Property="Foreground" Value="{DynamicResource CalendarViewCalendarItemForeground}"/>
     <Setter Property="Background" Value="{DynamicResource CalendarViewCalendarItemRevealBackground}"/>

--- a/src/Avalonia.Themes.Fluent/Controls/CalendarItem.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/CalendarItem.xaml
@@ -32,6 +32,7 @@
             <Style Selector="Button.CalendarHeader">
               <Setter Property="HorizontalAlignment" Value="Stretch" />
               <Setter Property="VerticalAlignment" Value="Stretch" />
+              <Setter Property="VerticalContentAlignment" Value="Center" />
               <Setter Property="FontSize" Value="20" />
               <Setter Property="Background" Value="{DynamicResource CalendarViewNavigationButtonBackground}"/>
               <Setter Property="Template">


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes the vertical alignment of various items in the `Calendar` in the Fluent theme. Changed the `VerticalContentAlignment` of the header to `Center` (fixes #7333), and also removed the bottom padding from `CalendarButton` and `CalendarDayButton` to better vertically align the day/year numbers.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
