### PR TITLE
Set antialias to true when calling ClipRoundRect

### DIFF
--- a/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
+++ b/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
@@ -482,7 +482,7 @@ namespace Avalonia.Skia
         public void PushClip(RoundedRect clip)
         {
             Canvas.Save();
-            Canvas.ClipRoundRect(clip.ToSKRoundRect());
+            Canvas.ClipRoundRect(clip.ToSKRoundRect(), antialias:true);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## What does the pull request do?
Fixes issue #7358. Summary: sets anti alias to true when applying a rounded rectangle clip. This makes it so any controls rendered within, say, a border with a CornerRadius get properly anti-aliased around the corners when cut off.


## What is the current behavior?
antialias is not set to true, so controls clipped off by their parent's CornerRadius show very visible aliasing.


## What is the updated/expected behavior with this PR?
Controls with a CornerRadius now properly anti-alias on corners.

## Fixed issues
Fixes #7358
