### PR TITLE
Fix NRE on window close with opened menu

### DIFF
--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -101,7 +101,7 @@ namespace Avalonia.Controls.Platform
                 root.Deactivated -= WindowDeactivated;
             }
             
-            if (_root is TopLevel tl)
+            if (_root is TopLevel tl && tl.PlatformImpl != null)
                 tl.PlatformImpl.LostFocus -= TopLevelLostPlatformFocus;
 
             _inputManagerSubscription?.Dispose();


### PR DESCRIPTION
## What does the pull request do?
Sometimes when you close a window with the menu opened you will see this NRE.
It is caused by a PlatformImpl that may be null when you close the window.
Here is the video with the issue repro:
https://recordit.co/jCSCTeWCDh

