### PR TITLE
Use the new syntax for a simple theme in DevTools and fix the crash.

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml
@@ -2,6 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="clr-namespace:Avalonia.Diagnostics.Views"
         xmlns:diag="clr-namespace:Avalonia.Diagnostics"
+        xmlns:default="using:Avalonia.Themes.Default"
         Title="Avalonia DevTools"
         x:Class="Avalonia.Diagnostics.Views.MainWindow">
   <Window.DataTemplates>
@@ -9,8 +10,7 @@
   </Window.DataTemplates>
   
   <Window.Styles>
-    <StyleInclude Source="resm:Avalonia.Themes.Default.DefaultTheme.xaml?assembly=Avalonia.Themes.Default"/>
-    <StyleInclude Source="resm:Avalonia.Themes.Default.Accents.BaseLight.xaml?assembly=Avalonia.Themes.Default"/>
+    <default:SimpleTheme Mode="Light"/>
     <StyleInclude Source="resm:Avalonia.Controls.DataGrid.Themes.Default.xaml?assembly=Avalonia.Controls.DataGrid"/>
     <Style Selector="DataGrid ContextMenu">
       <Setter Property="Foreground" Value="Black"/>


### PR DESCRIPTION
## What does the pull request do?
Fixes crash when opening DevTools. [This](https://github.com/AvaloniaUI/Avalonia/pull/7353) PR switched the Default theme from EmbeddedResource to AvaloniaResource which caused this bug.

Marking as "wont-backport" because this PR can be shipped only in pair with #7353