### PR TITLE
Fix InvalidCastException when opening a dialog.

### DIFF
--- a/src/Avalonia.Controls/ValidatingToplevel.cs
+++ b/src/Avalonia.Controls/ValidatingToplevel.cs
@@ -236,7 +236,18 @@ internal class ValidatingWindowImpl : ValidatingWindowBaseImpl, IWindowImpl
 
     public void SetTitle(string title) => Inner.SetTitle(title);
 
-    public void SetParent(IWindowImpl parent) => Inner.SetParent(parent);
+    public void SetParent(IWindowImpl parent)
+    {
+        //Workaround. SetParent will cast IWindowImpl to WindowImpl but  ValidatingWindowImpl isn't actual WindowImpl so it will fail with InvalidCastException.
+        if (parent is ValidatingWindowImpl validatingToplevelImpl)
+        {
+            Inner.SetParent(validatingToplevelImpl.Inner);
+        }
+        else
+        {
+            Inner.SetParent(parent);
+        }
+    }
 
     public void SetEnabled(bool enable) => Inner.SetEnabled(enable);
 


### PR DESCRIPTION
## What does the pull request do?
[This](https://github.com/AvaloniaUI/Avalonia/pull/7369) PR introduced *ValidatingWindowImpl* which caused this problem. 
*WindowImp.[SetParent](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Windows/Avalonia.Win32/WindowImpl.cs#L608)* method will cast *IWindowImpl* to *WindowImpl* which will throw the *InvalidCastException* because *ValidatingWindowImpl* isn't a real *WindowImpl*.
