### PR TITLE
Fix text wrapping behavior

### DIFF
--- a/src/Avalonia.Visuals/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextFormatterImpl.cs
@@ -193,7 +193,7 @@ namespace Avalonia.Media.TextFormatting
             {
                 var currentRun = textRuns[i];
 
-                if (currentLength + currentRun.GlyphRun.Characters.Length < length)
+                if (currentLength + currentRun.GlyphRun.Characters.Length <= length)
                 {
                     currentLength += currentRun.GlyphRun.Characters.Length;
                     continue;

--- a/src/Avalonia.Visuals/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextFormatterImpl.cs
@@ -255,7 +255,7 @@ namespace Avalonia.Media.TextFormatting
                 }
             }
 
-            return new SplitTextRunsResult(textRuns, null);
+            return new SplitTextRunsResult(textRuns, new());
         }
 
         /// <summary>
@@ -298,11 +298,11 @@ namespace Avalonia.Media.TextFormatting
                         {
                             for (; index < previousLineBreak.RemainingCharacters.Count; index++)
                             {
-                                splitResult.Second!.Add(previousLineBreak.RemainingCharacters[index]);
+                                splitResult.Second.Add(previousLineBreak.RemainingCharacters[index]);
                             }
                         }
 
-                        nextLineBreak = new TextLineBreak(splitResult.Second!);
+                        nextLineBreak = new TextLineBreak(splitResult.Second);
 
                         return splitResult.First;
                     }
@@ -346,7 +346,7 @@ namespace Avalonia.Media.TextFormatting
                 {
                     var splitResult = SplitTextRuns(textRuns, currentLength + runLineBreak.PositionWrap);
 
-                    nextLineBreak = new TextLineBreak(splitResult.Second!);
+                    nextLineBreak = new TextLineBreak(splitResult.Second);
 
                     return splitResult.First;
                 }
@@ -515,7 +515,7 @@ namespace Avalonia.Media.TextFormatting
 
             var remainingCharacters = splitResult.Second;
 
-            var lineBreak = remainingCharacters?.Count > 0 ? new TextLineBreak(remainingCharacters) : null;
+            var lineBreak = remainingCharacters.Count > 0 ? new TextLineBreak(remainingCharacters) : null;
 
             if (lineBreak is null && currentLineBreak?.TextEndOfLine != null)
             {
@@ -553,7 +553,7 @@ namespace Avalonia.Media.TextFormatting
 
         internal readonly struct SplitTextRunsResult
         {
-            public SplitTextRunsResult(List<ShapedTextCharacters> first, List<ShapedTextCharacters>? second)
+            public SplitTextRunsResult(List<ShapedTextCharacters> first, List<ShapedTextCharacters> second)
             {
                 First = first;
 
@@ -574,7 +574,7 @@ namespace Avalonia.Media.TextFormatting
             /// <value>
             /// The second text runs.
             /// </value>
-            public List<ShapedTextCharacters>? Second { get; }
+            public List<ShapedTextCharacters> Second { get; }
         }
 
         private struct TextRunEnumerator

--- a/src/Avalonia.Visuals/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextFormatterImpl.cs
@@ -301,7 +301,7 @@ namespace Avalonia.Media.TextFormatting
                                 splitResult.Second.Add(previousLineBreak.RemainingCharacters[index]);
                             }
                         }
-                            
+
                         nextLineBreak = new TextLineBreak(splitResult.Second);
 
                         return splitResult.First;

--- a/src/Avalonia.Visuals/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextFormatterImpl.cs
@@ -255,7 +255,7 @@ namespace Avalonia.Media.TextFormatting
                 }
             }
 
-            return new SplitTextRunsResult(textRuns, new());
+            return new SplitTextRunsResult(textRuns, null);
         }
 
         /// <summary>
@@ -283,16 +283,16 @@ namespace Avalonia.Media.TextFormatting
                 {
                     var shapedCharacters = previousLineBreak.RemainingCharacters[index];
 
-                    if (shapedCharacters == null)
-                    {
-                        continue;
-                    }
-
                     textRuns.Add(shapedCharacters);
 
                     if (TryGetLineBreak(shapedCharacters, out var runLineBreak))
                     {
                         var splitResult = SplitTextRuns(textRuns, currentLength + runLineBreak.PositionWrap);
+
+                        if (splitResult.Second == null)
+                        {
+                            return splitResult.First;
+                        }
 
                         if (++index < previousLineBreak.RemainingCharacters.Count)
                         {
@@ -301,7 +301,7 @@ namespace Avalonia.Media.TextFormatting
                                 splitResult.Second.Add(previousLineBreak.RemainingCharacters[index]);
                             }
                         }
-
+                            
                         nextLineBreak = new TextLineBreak(splitResult.Second);
 
                         return splitResult.First;
@@ -346,7 +346,10 @@ namespace Avalonia.Media.TextFormatting
                 {
                     var splitResult = SplitTextRuns(textRuns, currentLength + runLineBreak.PositionWrap);
 
-                    nextLineBreak = new TextLineBreak(splitResult.Second);
+                    if (splitResult.Second != null)
+                    {
+                        nextLineBreak = new TextLineBreak(splitResult.Second);
+                    }
 
                     return splitResult.First;
                 }
@@ -515,7 +518,7 @@ namespace Avalonia.Media.TextFormatting
 
             var remainingCharacters = splitResult.Second;
 
-            var lineBreak = remainingCharacters.Count > 0 ? new TextLineBreak(remainingCharacters) : null;
+            var lineBreak = remainingCharacters?.Count > 0 ? new TextLineBreak(remainingCharacters) : null;
 
             if (lineBreak is null && currentLineBreak?.TextEndOfLine != null)
             {
@@ -532,7 +535,7 @@ namespace Avalonia.Media.TextFormatting
         /// <returns>The text range that is covered by the text runs.</returns>
         private static TextRange GetTextRange(IReadOnlyList<TextRun> textRuns)
         {
-            if (textRuns is null || textRuns.Count == 0)
+            if (textRuns.Count == 0)
             {
                 return new TextRange();
             }
@@ -553,7 +556,7 @@ namespace Avalonia.Media.TextFormatting
 
         internal readonly struct SplitTextRunsResult
         {
-            public SplitTextRunsResult(List<ShapedTextCharacters> first, List<ShapedTextCharacters> second)
+            public SplitTextRunsResult(List<ShapedTextCharacters> first, List<ShapedTextCharacters>? second)
             {
                 First = first;
 
@@ -574,7 +577,7 @@ namespace Avalonia.Media.TextFormatting
             /// <value>
             /// The second text runs.
             /// </value>
-            public List<ShapedTextCharacters> Second { get; }
+            public List<ShapedTextCharacters>? Second { get; }
         }
 
         private struct TextRunEnumerator

--- a/src/Avalonia.Visuals/Media/TextFormatting/TextLayout.cs
+++ b/src/Avalonia.Visuals/Media/TextFormatting/TextLayout.cs
@@ -401,14 +401,12 @@ namespace Avalonia.Media.TextFormatting
 
                     previousLine = textLine;
 
-                    if (currentPosition != _text.Length || textLine.TextLineBreak?.RemainingCharacters == null)
+                    if (currentPosition == _text.Length && textLine.NewLineLength > 0)
                     {
-                        continue;
+                        var emptyTextLine = CreateEmptyTextLine(currentPosition);
+
+                        textLines.Add(emptyTextLine);
                     }
-
-                    var emptyTextLine = CreateEmptyTextLine(currentPosition);
-
-                    textLines.Add(emptyTextLine);
                 }
 
                 Size = new Size(width, height);


### PR DESCRIPTION
## What does the pull request do?

Modify the conditional expression to determine if a new line is required to display a string.

## What is the current behavior?

`TextFormatterImpl.SplitTextRuns` treats a one-character Run at the end of a line as a character that should be displayed on the next line, even though it is included in the character count.
After the string splitting, this causes character at the end of the first line to be displayed twice : where it should be, but also at the beginning of the following line, overwriting the following character and thus resulting in an incorrect rendering.

![image](https://user-images.githubusercontent.com/5910959/150209580-4232c83b-1f4a-47e4-a9f5-b7e88dbd6b87.png)
↓
![image](https://user-images.githubusercontent.com/5910959/150209659-124baef0-7d9d-4f93-bd0c-63c3af45a60c.png)

example xaml:
```xaml
<Window xmlns="https://github.com/avaloniaui"
        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
        x:Class="Sandbox.MainWindow">
    <StackPanel>
        <TextBlock Text="0123456789☃0123456789" TextWrapping="Wrap" FontSize="50" />
    </StackPanel>
</Window>
```

## What is the updated/expected behavior with this PR?

Characters will not be overwritten and lines will be split correctly.
![image](https://user-images.githubusercontent.com/5910959/150211540-d35da163-7e7b-4665-a417-d429eef89668.png)

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None expected.

## Obsoletions / Deprecations
None

## Fixed issues
None