### PR TITLE
[Win] Open context menu on pen/touch hold

### DIFF
--- a/src/Avalonia.Controls/ContextRequestedEventArgs.cs
+++ b/src/Avalonia.Controls/ContextRequestedEventArgs.cs
@@ -11,6 +11,7 @@ namespace Avalonia.Controls
     public class ContextRequestedEventArgs : RoutedEventArgs
     {
         private readonly PointerEventArgs? _pointerEventArgs;
+        private readonly Point? _position;
 
         /// <summary>
         /// Initializes a new instance of the ContextRequestedEventArgs class.
@@ -19,6 +20,12 @@ namespace Avalonia.Controls
             : base(Control.ContextRequestedEvent)
         {
 
+        }
+
+        public ContextRequestedEventArgs(Point position)
+            : base(Control.ContextRequestedEvent)
+        {
+            _position = position;
         }
 
         /// <inheritdoc cref="ContextRequestedEventArgs()" />
@@ -45,6 +52,11 @@ namespace Avalonia.Controls
         /// </returns>
         public bool TryGetPosition(Control? relativeTo, out Point point)
         {
+            if (_position != null)
+            {
+                point = _position.Value;
+                return true;
+            }
             if (_pointerEventArgs is null)
             {
                 point = default;

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -340,9 +340,16 @@ namespace Avalonia.Win32
                     }
                 case WindowsMessage.WM_CONTEXTMENU:
                     {
+                        var posPix = PointFromLParam(lParam);
+                        if (posPix.X == -1 && posPix.Y == -1)//this pos means it launched by keyboard
+                        {
+                            //keyboard shortcuts are resolved inside avalonia via handling of keyUP events...
+                            break;
+                        }
+
                         var pos = DipFromLParam(lParam);
                         KeyboardDevice.Instance.FocusedElement?.RaiseEvent(new ContextRequestedEventArgs(pos));
-                        break;
+                        return IntPtr.Zero;
                     }
 
                 case WindowsMessage.WM_NCPAINT:

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -338,6 +338,13 @@ namespace Avalonia.Win32
 
                         break;
                     }
+                case WindowsMessage.WM_CONTEXTMENU:
+                    {
+                        var pos = DipFromLParam(lParam);
+                        KeyboardDevice.Instance.FocusedElement?.RaiseEvent(new ContextRequestedEventArgs(pos));
+                        break;
+                    }
+
                 case WindowsMessage.WM_NCPAINT:
                     {
                         if (!HasFullDecorations)


### PR DESCRIPTION
## What does the pull request do?
Now touch hold and pen hold opens context menu on windows.


## What is the current behavior?
Touch/pen hold does nothing


## Fixed issues
#6538


@maxkatz6 asked for client code solution via gestures. I think this is a bad way of implementation by a number of reasons:
1. this is a system gesture on windows. It has animation, configuration and so on.
2. my solution is way faster to implement. 1 line of code.
3. if we want our custom gesture - we should disable system gesture animations, invoke and make our own animation and invent ways to configure everything.

I do not force my solution. If you don't want it - it's ok. close this PR. I just share my solution to this issue.

After this PR there is a bug: context menu appears in a wrong position. This is because of a bug in `PopupPositionerExtensions.ConfigurePosition`. It uses only mouse device as a source of context menu position.
![Screenshot 2022-01-23 at 23 54 25](https://user-images.githubusercontent.com/4997065/150697903-67c10183-0fe3-44c1-a9d1-759275e52050.png)

I will create a PR that should fix this after a merge on WM_Pointer and PenDevice. Working on this right now in another branch.