### PR TITLE
Fix AvaloniaDictionary Remove method

### DIFF
--- a/src/Avalonia.Base/Collections/AvaloniaDictionary.cs
+++ b/src/Avalonia.Base/Collections/AvaloniaDictionary.cs
@@ -146,6 +146,7 @@ namespace Avalonia.Collections
         {
             if (_inner.TryGetValue(key, out var value))
             {
+                _inner.Remove(key);
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Count)));
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs($"Item[{key}]"));
 

--- a/tests/Avalonia.Base.UnitTests/Collections/AvaloniaDictionaryTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Collections/AvaloniaDictionaryTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using Avalonia.Collections;
@@ -102,6 +103,16 @@ namespace Avalonia.Base.UnitTests.Collections
             Assert.Equal(-1, tracker.Args.OldStartingIndex);
             Assert.Equal(1, tracker.Args.OldItems.Count);
             Assert.Equal(new KeyValuePair<string, string>("foo", "bar"), tracker.Args.OldItems[0]);
+        }
+
+        [Fact]
+        public void Remove_Method_Should_Remove_Item_From_Collection()
+        {
+            var target = new AvaloniaDictionary<string, string>() { { "foo", "bar" } };
+            Assert.Equal(target.Count, 1);
+
+            target.Remove("foo");
+            Assert.Equal(target.Count, 0);
         }
 
         [Fact]


### PR DESCRIPTION
## What does the pull request do?
It didn't work before, you can call the Remove method but it wouldn't remove anything.

## Fixed issues
closes #7426
