### PR TITLE
Ensure Control Inspection in Diagnostics tool window is triggered on Key Down

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Diagnostics.Views
 
             _keySubscription = InputManager.Instance?.Process
                 .OfType<RawKeyEventArgs>()
-                .Where(x => x.Type == RawKeyEventType.KeyDown)
+                .Where(x => x.Type == RawKeyEventType.KeyUp)
                 .Subscribe(RawKeyDown);
 
             _frozenPopupStates = new Dictionary<Popup, IDisposable>();

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Diagnostics.Views
 
             _keySubscription = InputManager.Instance?.Process
                 .OfType<RawKeyEventArgs>()
-                .Where(x => x.Type == RawKeyEventType.KeyUp)
+                .Where(x => x.Type == RawKeyEventType.KeyDown)
                 .Subscribe(RawKeyDown);
 
             _frozenPopupStates = new Dictionary<Popup, IDisposable>();
@@ -169,7 +169,9 @@ namespace Avalonia.Diagnostics.Views
 
             switch (e.Modifiers)
             {
-                case RawInputModifiers.Control | RawInputModifiers.Shift:
+                case RawInputModifiers.Control when (e.Key == Key.LeftShift || e.Key == Key.RightShift):
+                case RawInputModifiers.Shift when (e.Key == Key.LeftCtrl || e.Key == Key.RightCtrl):
+                case RawInputModifiers.Shift | RawInputModifiers.Control:
                 {
                     IControl? control = null;
 


### PR DESCRIPTION
## What does the pull request do?
Fixes an issue on Linux where you can't use CTRL + SHIFT to trigger an inspection of a hovered control when the diagnostic tool window is open


## What is the current behavior?
Currently, the key gesture to trigger inspection triggers on KeyDown, but key modifiers aren't set at that point when the modifier is the first key to be pressed.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
Added extra cases to handled when CTRL or SHIFT is pressed after the other key.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
