### PR TITLE
Add DensityStyle property in Fluent Theme provider

### DIFF
--- a/src/Avalonia.Themes.Fluent/FluentTheme.cs
+++ b/src/Avalonia.Themes.Fluent/FluentTheme.cs
@@ -15,6 +15,12 @@ namespace Avalonia.Themes.Fluent
         Dark,
     }
 
+    public enum DensityStyle
+    {
+        Normal,
+        Compact
+    }
+
     /// <summary>
     /// Includes the fluent theme in an application.
     /// </summary>
@@ -24,6 +30,7 @@ namespace Avalonia.Themes.Fluent
         private Styles _fluentDark = new();
         private Styles _fluentLight = new();
         private Styles _sharedStyles = new();
+        private Styles _densityStyles = new();
         private bool _isLoading;
         private IStyle? _loaded;
 
@@ -47,7 +54,6 @@ namespace Avalonia.Themes.Fluent
             InitStyles(_baseUri);
         }
 
-
         public static readonly StyledProperty<FluentThemeMode> ModeProperty =
             AvaloniaProperty.Register<FluentTheme, FluentThemeMode>(nameof(Mode));
         /// <summary>
@@ -58,6 +64,18 @@ namespace Avalonia.Themes.Fluent
             get => GetValue(ModeProperty);
             set => SetValue(ModeProperty, value);
         }
+        
+        public static readonly StyledProperty<DensityStyle> DensityStyleProperty =
+            AvaloniaProperty.Register<FluentTheme, DensityStyle>(nameof(DensityStyle));
+        /// <summary>
+        /// Gets or sets the density style of the fluent theme (normal, compact).
+        /// </summary>
+        public DensityStyle DensityStyle
+        {
+            get => GetValue(DensityStyleProperty);
+            set => SetValue(DensityStyleProperty, value);
+        }
+        
         protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)
         {
             base.OnPropertyChanged(change);
@@ -72,6 +90,25 @@ namespace Avalonia.Themes.Fluent
                 {
                     (Loaded as Styles)![1] = _fluentLight[0];
                     (Loaded as Styles)![2] = _fluentLight[1];
+                }
+            }
+
+            if (change.Property == DensityStyleProperty)
+            {
+                if (DensityStyle == DensityStyle.Compact)
+                {
+                    if ((Loaded as Styles)!.Count > 3)
+                    {
+                        (Loaded as Styles)![3] = _densityStyles[0];
+                    }
+                    else
+                    {
+                        (Loaded as Styles)!.Add( _densityStyles[0]);
+                    }
+                }
+                else if(DensityStyle == DensityStyle.Normal)
+                {
+                    (Loaded as Styles)!.Remove(_densityStyles[0]);
                 }
             }
         }
@@ -97,6 +134,12 @@ namespace Avalonia.Themes.Fluent
                     {
                         _loaded = new Styles() { _sharedStyles, _fluentDark[0], _fluentDark[1] };
                     }
+
+                    if (DensityStyle == DensityStyle.Compact)
+                    {
+                        (_loaded as Styles)!.Add(_densityStyles[0]);
+                    }
+
                     _isLoading = false;
                 }
 
@@ -181,6 +224,14 @@ namespace Avalonia.Themes.Fluent
                 new StyleInclude(baseUri)
                 {
                     Source = new Uri("avares://Avalonia.Themes.Fluent/Accents/FluentControlResourcesDark.xaml")
+                }
+            };
+            
+            _densityStyles = new Styles
+            {
+                new StyleInclude(baseUri)
+                {
+                    Source = new Uri("avares://Avalonia.Themes.Fluent/DensityStyles/Compact.xaml")
                 }
             };
         }

--- a/src/Avalonia.Themes.Fluent/FluentTheme.cs
+++ b/src/Avalonia.Themes.Fluent/FluentTheme.cs
@@ -56,6 +56,10 @@ namespace Avalonia.Themes.Fluent
 
         public static readonly StyledProperty<FluentThemeMode> ModeProperty =
             AvaloniaProperty.Register<FluentTheme, FluentThemeMode>(nameof(Mode));
+
+        public static readonly StyledProperty<DensityStyle> DensityStyleProperty =
+            AvaloniaProperty.Register<FluentTheme, DensityStyle>(nameof(DensityStyle));
+
         /// <summary>
         /// Gets or sets the mode of the fluent theme (light, dark).
         /// </summary>
@@ -64,9 +68,7 @@ namespace Avalonia.Themes.Fluent
             get => GetValue(ModeProperty);
             set => SetValue(ModeProperty, value);
         }
-        
-        public static readonly StyledProperty<DensityStyle> DensityStyleProperty =
-            AvaloniaProperty.Register<FluentTheme, DensityStyle>(nameof(DensityStyle));
+
         /// <summary>
         /// Gets or sets the density style of the fluent theme (normal, compact).
         /// </summary>
@@ -97,16 +99,9 @@ namespace Avalonia.Themes.Fluent
             {
                 if (DensityStyle == DensityStyle.Compact)
                 {
-                    if ((Loaded as Styles)!.Count > 3)
-                    {
-                        (Loaded as Styles)![3] = _densityStyles[0];
-                    }
-                    else
-                    {
-                        (Loaded as Styles)!.Add( _densityStyles[0]);
-                    }
+                    (Loaded as Styles)!.Add(_densityStyles[0]);
                 }
-                else if(DensityStyle == DensityStyle.Normal)
+                else if (DensityStyle == DensityStyle.Normal)
                 {
                     (Loaded as Styles)!.Remove(_densityStyles[0]);
                 }


### PR DESCRIPTION
## What does the pull request do?
Add DensityStyle property to the fluent theme. Available values are `Normal` and `Compact`.
```xml
<Application.Styles>
        <FluentTheme Mode="Light" DensityStyle="Compact" />
</Application.Styles>
```


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #5321