### PR TITLE
[Deadlock] Fix Monitor.Enter in finally

### DIFF
--- a/src/Avalonia.OpenGL/Egl/EglContext.cs
+++ b/src/Avalonia.OpenGL/Egl/EglContext.cs
@@ -82,7 +82,7 @@ namespace Avalonia.OpenGL.Egl
             finally
             {
                 if(!success)
-                    Monitor.Enter(_lock);
+                    Monitor.Exit(_lock);
             }
         }
         


### PR DESCRIPTION
## What does the pull request do?
Fixes a typo in a code


## What is the current behavior?
If MakeCurrent in EGL returnes false -> deadlock


## What is the updated/expected behavior with this PR?
now we can handle this exception and do something


Also I've checked all other usings of Monitor class. Another issues of that type is not found.