### PR TITLE
Support creating OpenGL context with EGL on Linux

### DIFF
--- a/samples/ControlCatalog.NetCore/Program.cs
+++ b/samples/ControlCatalog.NetCore/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
@@ -10,6 +11,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Dialogs;
 using Avalonia.Headless;
 using Avalonia.LogicalTree;
+using Avalonia.OpenGL;
 using Avalonia.Threading;
 
 namespace ControlCatalog.NetCore
@@ -111,6 +113,11 @@ namespace ControlCatalog.NetCore
                     EnableMultiTouch = true,
                     UseDBusMenu = true,
                     EnableIme = true,
+                    UseEGL = true,
+                    GlProfiles = new List<GlVersion>()
+                    {
+                        new GlVersion(GlProfileType.OpenGL, 4, 0)
+                    }
                 })
                 .With(new Win32PlatformOptions
                 {

--- a/src/Avalonia.OpenGL/Angle/AngleWin32EglDisplay.cs
+++ b/src/Avalonia.OpenGL/Angle/AngleWin32EglDisplay.cs
@@ -52,7 +52,7 @@ namespace Avalonia.OpenGL.Angle
             }
         }
 
-        private AngleWin32EglDisplay(EglInterface egl, AngleInfo info) : base(egl, false, info.Display)
+        private AngleWin32EglDisplay(EglInterface egl, AngleInfo info) : base(egl, false, info.Display, AvaloniaLocator.Current.GetService<AngleOptions>()?.GlProfiles)
         {
             PlatformApi = info.PlatformApi;
         }

--- a/src/Avalonia.OpenGL/Egl/EglDisplay.cs
+++ b/src/Avalonia.OpenGL/Egl/EglDisplay.cs
@@ -71,17 +71,20 @@ namespace Avalonia.OpenGL.Egl
 
             var cfgs = glProfiles.Select(x =>
             {
-                var typeBit = EGL_OPENGL_ES3_BIT;
+                var typeBit = x.Type == GlProfileType.OpenGLES ? EGL_OPENGL_ES3_BIT : EGL_OPENGL_BIT;
 
-                switch (x.Major)
+                if (x.Type == GlProfileType.OpenGLES)
                 {
-                    case 2:
-                        typeBit = EGL_OPENGL_ES2_BIT;
-                        break;
+                    switch (x.Major)
+                    {
+                        case 2:
+                            typeBit = EGL_OPENGL_ES2_BIT;
+                            break;
 
-                    case 1:
-                        typeBit = EGL_OPENGL_ES_BIT;
-                        break;
+                        case 1:
+                            typeBit = EGL_OPENGL_ES_BIT;
+                            break;
+                    }
                 }
 
                 return new
@@ -92,7 +95,7 @@ namespace Avalonia.OpenGL.Egl
                         EGL_CONTEXT_MINOR_VERSION, x.Minor,
                         EGL_NONE
                     },
-                    Api = EGL_OPENGL_ES_API,
+                    Api = x.Type == GlProfileType.OpenGLES ? EGL_OPENGL_ES_API : EGL_OPENGL_API,
                     RenderableTypeBit = typeBit,
                     Version = x
                 };
@@ -136,7 +139,7 @@ namespace Avalonia.OpenGL.Egl
                 throw new OpenGlException("No suitable EGL config was found");
         }
 
-        public EglDisplay() : this(false)
+        public EglDisplay() : this(true)
         {
             
         }

--- a/src/Avalonia.OpenGL/Egl/EglDisplay.cs
+++ b/src/Avalonia.OpenGL/Egl/EglDisplay.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using static Avalonia.OpenGL.Egl.EglConsts;
 
@@ -19,7 +21,7 @@ namespace Avalonia.OpenGL.Egl
         private int _stencilSize;
         private GlVersion _version;
 
-        public EglDisplay(EglInterface egl, bool supportsSharing) : this(egl, supportsSharing, -1, IntPtr.Zero, null)
+        public EglDisplay(EglInterface egl, bool supportsSharing, IList<GlVersion> glProfiles) : this(egl, supportsSharing, -1, IntPtr.Zero, null, glProfiles)
         {
             
         }
@@ -44,13 +46,13 @@ namespace Avalonia.OpenGL.Egl
             return display;
         }
 
-        public EglDisplay(EglInterface egl, bool supportsSharing, int platformType, IntPtr platformDisplay, int[] attrs)
-            : this(egl, supportsSharing, CreateDisplay(egl, platformType, platformDisplay, attrs))
+        public EglDisplay(EglInterface egl, bool supportsSharing, int platformType, IntPtr platformDisplay, int[] attrs, IList<GlVersion> glProfiles)
+            : this(egl, supportsSharing, CreateDisplay(egl, platformType, platformDisplay, attrs), glProfiles)
         {
 
         }
 
-        public EglDisplay(EglInterface egl, bool supportsSharing, IntPtr display)
+        public EglDisplay(EglInterface egl, bool supportsSharing, IntPtr display, IList<GlVersion> glProfiles)
         {
             _egl = egl;
             SupportsSharing = supportsSharing;
@@ -61,13 +63,6 @@ namespace Avalonia.OpenGL.Egl
             
             if (!_egl.Initialize(_display, out var major, out var minor))
                 throw OpenGlException.GetFormattedException("eglInitialize", _egl);
-
-            var glProfiles = AvaloniaLocator.Current.GetService<AngleOptions>()?.GlProfiles
-                                    ?? new[]
-                                    {
-                                        new GlVersion(GlProfileType.OpenGLES, 3, 0),
-                                        new GlVersion(GlProfileType.OpenGLES, 2, 0)
-                                    };
 
             var cfgs = glProfiles.Select(x =>
             {
@@ -139,12 +134,12 @@ namespace Avalonia.OpenGL.Egl
                 throw new OpenGlException("No suitable EGL config was found");
         }
 
-        public EglDisplay() : this(true)
+        public EglDisplay() : this(true, new List<GlVersion>())
         {
             
         }
         
-        public EglDisplay(bool supportsSharing) : this(new EglInterface(), supportsSharing)
+        public EglDisplay(bool supportsSharing, IList<GlVersion> glProfiles) : this(new EglInterface(), supportsSharing, glProfiles)
         {
             
         }

--- a/src/Avalonia.OpenGL/Egl/EglPlatformOpenGlInterface.cs
+++ b/src/Avalonia.OpenGL/Egl/EglPlatformOpenGlInterface.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Avalonia.Logging;
 using static Avalonia.OpenGL.Egl.EglConsts;
 
@@ -19,14 +20,13 @@ namespace Avalonia.OpenGL.Egl
             PrimaryEglContext = display.CreateContext(null);
         }
         
-        public static void TryInitialize()
+        public static void TryInitialize(IList<GlVersion> glProfiles)
         {
-            var feature = TryCreate();
+            var feature = TryCreate(() => new EglDisplay(true, glProfiles));
             if (feature != null)
                 AvaloniaLocator.CurrentMutable.Bind<IPlatformOpenGlInterface>().ToConstant(feature);
         }
-        
-        public static EglPlatformOpenGlInterface TryCreate() => TryCreate(() => new EglDisplay());
+
         public static EglPlatformOpenGlInterface TryCreate(Func<EglDisplay> displayFactory)
         {
             try

--- a/src/Avalonia.X11/X11Platform.cs
+++ b/src/Avalonia.X11/X11Platform.cs
@@ -96,7 +96,7 @@ namespace Avalonia.X11
             if (options.UseGpu)
             {
                 if (options.UseEGL)
-                    EglPlatformOpenGlInterface.TryInitialize();
+                    EglPlatformOpenGlInterface.TryInitialize(Options.GlProfiles);
                 else
                     GlxPlatformOpenGlInterface.TryInitialize(Info, Options.GlProfiles);
             }

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
@@ -136,7 +136,12 @@ namespace Avalonia.LinuxFramebuffer.Output
             if(_gbmTargetSurface == null)
                 throw new InvalidOperationException("Unable to create GBM surface");
 
-            _eglDisplay = new EglDisplay(new EglInterface(eglGetProcAddress), false, 0x31D7, device, null);
+            _eglDisplay = new EglDisplay(new EglInterface(eglGetProcAddress), false, 0x31D7, device, null, 
+                new List<GlVersion>
+                {
+                    new (GlProfileType.OpenGLES,3,2),
+                    new (GlProfileType.OpenGLES,2,0)
+                });
             _platformGl = new EglPlatformOpenGlInterface(_eglDisplay);
             _eglSurface =  _platformGl.CreateWindowSurface(_gbmTargetSurface);
 


### PR DESCRIPTION
## What does the pull request do?
Support creating OpenGL context with EGL on Linux and other unix platforms. Linux supports core OpenGL with both GLX and EGL, but only OpenGL ES context is available in avalonia. This pr allows creating a OpenGL context with EGL, using GlProfiles set during AppBuilder initialization.

An OpenGL 4.0 context can be requested with
```csharp
  => AppBuilder.Configure<App>()
                  .UsePlatformDetect()
                  .With(new X11PlatformOptions
                  {
                      EnableMultiTouch = true,
                      UseDBusMenu = true,
                      EnableIme = true,
                      UseEGL = true,
                      GlProfiles = new List<GlVersion>()
                      {
                          new GlVersion(GlProfileType.OpenGL, 4, 0)
                      }
                  })
```


## What is the current behavior?
Only opengl es context is supported. Setting OpenGL in the angle options will cause shaders to fail


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
