### PR TITLE
Nullability tweaks in lower-level libraries.

### DIFF
--- a/src/Avalonia.Input/ICloseable.cs
+++ b/src/Avalonia.Input/ICloseable.cs
@@ -4,6 +4,6 @@ namespace Avalonia.Input
 {
     public interface ICloseable
     {
-        event EventHandler Closed;
+        event EventHandler? Closed;
     }
 }

--- a/src/Avalonia.Input/IInputElement.cs
+++ b/src/Avalonia.Input/IInputElement.cs
@@ -15,57 +15,57 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when the control receives focus.
         /// </summary>
-        event EventHandler<GotFocusEventArgs> GotFocus;
+        event EventHandler<GotFocusEventArgs>? GotFocus;
 
         /// <summary>
         /// Occurs when the control loses focus.
         /// </summary>
-        event EventHandler<RoutedEventArgs> LostFocus;
+        event EventHandler<RoutedEventArgs>? LostFocus;
 
         /// <summary>
         /// Occurs when a key is pressed while the control has focus.
         /// </summary>
-        event EventHandler<KeyEventArgs> KeyDown;
+        event EventHandler<KeyEventArgs>? KeyDown;
 
         /// <summary>
         /// Occurs when a key is released while the control has focus.
         /// </summary>
-        event EventHandler<KeyEventArgs> KeyUp;
+        event EventHandler<KeyEventArgs>? KeyUp;
 
         /// <summary>
         /// Occurs when a user typed some text while the control has focus.
         /// </summary>
-        event EventHandler<TextInputEventArgs> TextInput;
+        event EventHandler<TextInputEventArgs>? TextInput;
 
         /// <summary>
         /// Occurs when the pointer enters the control.
         /// </summary>
-        event EventHandler<PointerEventArgs> PointerEnter;
+        event EventHandler<PointerEventArgs>? PointerEnter;
 
         /// <summary>
         /// Occurs when the pointer leaves the control.
         /// </summary>
-        event EventHandler<PointerEventArgs> PointerLeave;
+        event EventHandler<PointerEventArgs>? PointerLeave;
 
         /// <summary>
         /// Occurs when the pointer is pressed over the control.
         /// </summary>
-        event EventHandler<PointerPressedEventArgs> PointerPressed;
+        event EventHandler<PointerPressedEventArgs>? PointerPressed;
 
         /// <summary>
         /// Occurs when the pointer moves over the control.
         /// </summary>
-        event EventHandler<PointerEventArgs> PointerMoved;
+        event EventHandler<PointerEventArgs>? PointerMoved;
 
         /// <summary>
         /// Occurs when the pointer is released over the control.
         /// </summary>
-        event EventHandler<PointerReleasedEventArgs> PointerReleased;
+        event EventHandler<PointerReleasedEventArgs>? PointerReleased;
 
         /// <summary>
         /// Occurs when the mouse wheel is scrolled over the control.
         /// </summary>
-        event EventHandler<PointerWheelEventArgs> PointerWheelChanged;
+        event EventHandler<PointerWheelEventArgs>? PointerWheelChanged;
 
         /// <summary>
         /// Gets or sets a value indicating whether the control can receive keyboard focus.

--- a/src/Avalonia.Input/IMainMenu.cs
+++ b/src/Avalonia.Input/IMainMenu.cs
@@ -27,6 +27,6 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when the main menu closes.
         /// </summary>
-        event EventHandler<RoutedEventArgs> MenuClosed;
+        event EventHandler<RoutedEventArgs>? MenuClosed;
     }
 }

--- a/src/Avalonia.Input/INavigableContainer.cs
+++ b/src/Avalonia.Input/INavigableContainer.cs
@@ -12,6 +12,6 @@ namespace Avalonia.Input
         /// <param name="from">The control from which movement begins.</param>
         /// <param name="wrap">Whether to wrap around when the first or last item is reached.</param>
         /// <returns>The control.</returns>
-        IInputElement GetControl(NavigationDirection direction, IInputElement from, bool wrap);
+        IInputElement? GetControl(NavigationDirection direction, IInputElement? from, bool wrap);
     }
 }

--- a/src/Avalonia.Input/InputElement.cs
+++ b/src/Avalonia.Input/InputElement.cs
@@ -233,7 +233,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when the control receives focus.
         /// </summary>
-        public event EventHandler<GotFocusEventArgs> GotFocus
+        public event EventHandler<GotFocusEventArgs>? GotFocus
         {
             add { AddHandler(GotFocusEvent, value); }
             remove { RemoveHandler(GotFocusEvent, value); }
@@ -242,7 +242,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when the control loses focus.
         /// </summary>
-        public event EventHandler<RoutedEventArgs> LostFocus
+        public event EventHandler<RoutedEventArgs>? LostFocus
         {
             add { AddHandler(LostFocusEvent, value); }
             remove { RemoveHandler(LostFocusEvent, value); }
@@ -251,7 +251,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when a key is pressed while the control has focus.
         /// </summary>
-        public event EventHandler<KeyEventArgs> KeyDown
+        public event EventHandler<KeyEventArgs>? KeyDown
         {
             add { AddHandler(KeyDownEvent, value); }
             remove { RemoveHandler(KeyDownEvent, value); }
@@ -260,7 +260,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when a key is released while the control has focus.
         /// </summary>
-        public event EventHandler<KeyEventArgs> KeyUp
+        public event EventHandler<KeyEventArgs>? KeyUp
         {
             add { AddHandler(KeyUpEvent, value); }
             remove { RemoveHandler(KeyUpEvent, value); }
@@ -269,7 +269,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when a user typed some text while the control has focus.
         /// </summary>
-        public event EventHandler<TextInputEventArgs> TextInput
+        public event EventHandler<TextInputEventArgs>? TextInput
         {
             add { AddHandler(TextInputEvent, value); }
             remove { RemoveHandler(TextInputEvent, value); }
@@ -278,7 +278,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when an input element gains input focus and input method is looking for the corresponding client
         /// </summary>
-        public event EventHandler<TextInputMethodClientRequestedEventArgs> TextInputMethodClientRequested
+        public event EventHandler<TextInputMethodClientRequestedEventArgs>? TextInputMethodClientRequested
         {
             add { AddHandler(TextInputMethodClientRequestedEvent, value); }
             remove { RemoveHandler(TextInputMethodClientRequestedEvent, value); }
@@ -287,7 +287,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when an input element gains input focus and input method is asking for required content options
         /// </summary>
-        public event EventHandler<TextInputOptionsQueryEventArgs> TextInputOptionsQuery
+        public event EventHandler<TextInputOptionsQueryEventArgs>? TextInputOptionsQuery
         {
             add { AddHandler(TextInputOptionsQueryEvent, value); }
             remove { RemoveHandler(TextInputOptionsQueryEvent, value); }
@@ -296,7 +296,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when the pointer enters the control.
         /// </summary>
-        public event EventHandler<PointerEventArgs> PointerEnter
+        public event EventHandler<PointerEventArgs>? PointerEnter
         {
             add { AddHandler(PointerEnterEvent, value); }
             remove { RemoveHandler(PointerEnterEvent, value); }
@@ -305,7 +305,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when the pointer leaves the control.
         /// </summary>
-        public event EventHandler<PointerEventArgs> PointerLeave
+        public event EventHandler<PointerEventArgs>? PointerLeave
         {
             add { AddHandler(PointerLeaveEvent, value); }
             remove { RemoveHandler(PointerLeaveEvent, value); }
@@ -314,7 +314,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when the pointer moves over the control.
         /// </summary>
-        public event EventHandler<PointerEventArgs> PointerMoved
+        public event EventHandler<PointerEventArgs>? PointerMoved
         {
             add { AddHandler(PointerMovedEvent, value); }
             remove { RemoveHandler(PointerMovedEvent, value); }
@@ -323,7 +323,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when the pointer is pressed over the control.
         /// </summary>
-        public event EventHandler<PointerPressedEventArgs> PointerPressed
+        public event EventHandler<PointerPressedEventArgs>? PointerPressed
         {
             add { AddHandler(PointerPressedEvent, value); }
             remove { RemoveHandler(PointerPressedEvent, value); }
@@ -332,7 +332,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when the pointer is released over the control.
         /// </summary>
-        public event EventHandler<PointerReleasedEventArgs> PointerReleased
+        public event EventHandler<PointerReleasedEventArgs>? PointerReleased
         {
             add { AddHandler(PointerReleasedEvent, value); }
             remove { RemoveHandler(PointerReleasedEvent, value); }
@@ -342,7 +342,7 @@ namespace Avalonia.Input
         /// Occurs when the control or its child control loses the pointer capture for any reason,
         /// event will not be triggered for a parent control if capture was transferred to another child of that parent control
         /// </summary>
-        public event EventHandler<PointerCaptureLostEventArgs> PointerCaptureLost
+        public event EventHandler<PointerCaptureLostEventArgs>? PointerCaptureLost
         {
             add => AddHandler(PointerCaptureLostEvent, value);
             remove => RemoveHandler(PointerCaptureLostEvent, value);
@@ -351,7 +351,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when the mouse is scrolled over the control.
         /// </summary>
-        public event EventHandler<PointerWheelEventArgs> PointerWheelChanged
+        public event EventHandler<PointerWheelEventArgs>? PointerWheelChanged
         {
             add { AddHandler(PointerWheelChangedEvent, value); }
             remove { RemoveHandler(PointerWheelChangedEvent, value); }
@@ -360,7 +360,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when a tap gesture occurs on the control.
         /// </summary>
-        public event EventHandler<TappedEventArgs> Tapped
+        public event EventHandler<TappedEventArgs>? Tapped
         {
             add { AddHandler(TappedEvent, value); }
             remove { RemoveHandler(TappedEvent, value); }
@@ -369,7 +369,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when a double-tap gesture occurs on the control.
         /// </summary>
-        public event EventHandler<TappedEventArgs> DoubleTapped
+        public event EventHandler<TappedEventArgs>? DoubleTapped
         {
             add { AddHandler(DoubleTappedEvent, value); }
             remove { RemoveHandler(DoubleTappedEvent, value); }

--- a/src/Avalonia.Input/TextInput/ITextInputMethodClient.cs
+++ b/src/Avalonia.Input/TextInput/ITextInputMethodClient.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Input.TextInput
         /// <summary>
         /// Should be fired when cursor rectangle is changed inside the TextViewVisual
         /// </summary>
-        event EventHandler CursorRectangleChanged;
+        event EventHandler? CursorRectangleChanged;
         /// <summary>
         /// The visual that's showing the text
         /// </summary>
@@ -20,7 +20,7 @@ namespace Avalonia.Input.TextInput
         /// <summary>
         /// Should be fired when text-hosting visual is changed
         /// </summary>
-        event EventHandler TextViewVisualChanged;
+        event EventHandler? TextViewVisualChanged;
         /// <summary>
         /// Indicates if TextViewVisual is capable of displaying non-committed input on the cursor position
         /// </summary>
@@ -40,15 +40,15 @@ namespace Avalonia.Input.TextInput
         /// <summary>
         /// Should be fired when surrounding text changed
         /// </summary>
-        event EventHandler SurroundingTextChanged;
+        event EventHandler? SurroundingTextChanged;
         /// <summary>
         /// Returns the text before the cursor. Must return a non-empty string if cursor is not at the beginning of the text entry
         /// </summary>
-        string TextBeforeCursor { get; }
+        string? TextBeforeCursor { get; }
         /// <summary>
         /// Returns the text before the cursor. Must return a non-empty string if cursor is not at the end of the text entry
         /// </summary>
-        string TextAfterCursor { get; }
+        string? TextAfterCursor { get; }
     }
 
     public struct TextInputMethodSurroundingText

--- a/src/Avalonia.Input/TextInput/ITextInputMethodImpl.cs
+++ b/src/Avalonia.Input/TextInput/ITextInputMethodImpl.cs
@@ -10,6 +10,6 @@ namespace Avalonia.Input.TextInput
     
     public interface ITextInputMethodRoot : IInputRoot
     {
-        ITextInputMethodImpl InputMethod { get; }
+        ITextInputMethodImpl? InputMethod { get; }
     }
 }

--- a/src/Avalonia.Interactivity/Interactive.cs
+++ b/src/Avalonia.Interactivity/Interactive.cs
@@ -50,12 +50,14 @@ namespace Avalonia.Interactivity
         /// <param name="handledEventsToo">Whether handled events should also be listened for.</param>
         public void AddHandler<TEventArgs>(
             RoutedEvent<TEventArgs> routedEvent,
-            EventHandler<TEventArgs> handler,
+            EventHandler<TEventArgs>? handler,
             RoutingStrategies routes = RoutingStrategies.Direct | RoutingStrategies.Bubble,
             bool handledEventsToo = false) where TEventArgs : RoutedEventArgs
         {
             routedEvent = routedEvent ?? throw new ArgumentNullException(nameof(routedEvent));
-            handler = handler ?? throw new ArgumentNullException(nameof(handler));
+
+            if (handler is null)
+                return;
 
             static void InvokeAdapter(Delegate baseHandler, object sender, RoutedEventArgs args)
             {
@@ -99,10 +101,11 @@ namespace Avalonia.Interactivity
         /// <typeparam name="TEventArgs">The type of the event's args.</typeparam>
         /// <param name="routedEvent">The routed event.</param>
         /// <param name="handler">The handler.</param>
-        public void RemoveHandler<TEventArgs>(RoutedEvent<TEventArgs> routedEvent, EventHandler<TEventArgs> handler)
+        public void RemoveHandler<TEventArgs>(RoutedEvent<TEventArgs> routedEvent, EventHandler<TEventArgs>? handler)
             where TEventArgs : RoutedEventArgs
         {
-            RemoveHandler(routedEvent, (Delegate)handler);
+            if (handler is not null)
+                RemoveHandler(routedEvent, (Delegate)handler);
         }
 
         /// <summary>

--- a/src/Avalonia.Layout/ElementManager.cs
+++ b/src/Avalonia.Layout/ElementManager.cs
@@ -263,7 +263,7 @@ namespace Avalonia.Layout
             return intersects;
         }
 
-        public void DataSourceChanged(object source, NotifyCollectionChangedEventArgs args)
+        public void DataSourceChanged(object? source, NotifyCollectionChangedEventArgs args)
         {
             if (_realizedElements.Count > 0)
             {

--- a/src/Avalonia.Layout/FlowLayoutAlgorithm.cs
+++ b/src/Avalonia.Layout/FlowLayoutAlgorithm.cs
@@ -135,7 +135,7 @@ namespace Avalonia.Layout
         }
 
         public void OnItemsSourceChanged(
-            object source,
+            object? source,
             NotifyCollectionChangedEventArgs args,
             VirtualizingLayoutContext context)
         {

--- a/src/Avalonia.Layout/LayoutHelper.cs
+++ b/src/Avalonia.Layout/LayoutHelper.cs
@@ -33,13 +33,13 @@ namespace Avalonia.Layout
                 MathUtilities.Clamp(constraints.Height, minmax.MinHeight, minmax.MaxHeight));
         }
 
-        public static Size MeasureChild(ILayoutable control, Size availableSize, Thickness padding,
+        public static Size MeasureChild(ILayoutable? control, Size availableSize, Thickness padding,
             Thickness borderThickness)
         {
             return MeasureChild(control, availableSize, padding + borderThickness);
         }
 
-        public static Size MeasureChild(ILayoutable control, Size availableSize, Thickness padding)
+        public static Size MeasureChild(ILayoutable? control, Size availableSize, Thickness padding)
         {
             if (control != null)
             {
@@ -50,12 +50,12 @@ namespace Avalonia.Layout
             return new Size(padding.Left + padding.Right, padding.Bottom + padding.Top);
         }
 
-        public static Size ArrangeChild(ILayoutable child, Size availableSize, Thickness padding, Thickness borderThickness)
+        public static Size ArrangeChild(ILayoutable? child, Size availableSize, Thickness padding, Thickness borderThickness)
         {
             return ArrangeChild(child, availableSize, padding + borderThickness);
         }
 
-        public static Size ArrangeChild(ILayoutable child, Size availableSize, Thickness padding)
+        public static Size ArrangeChild(ILayoutable? child, Size availableSize, Thickness padding)
         {
             child?.Arrange(new Rect(availableSize).Deflate(padding));
 

--- a/src/Avalonia.Layout/StackLayout.cs
+++ b/src/Avalonia.Layout/StackLayout.cs
@@ -313,7 +313,7 @@ namespace Avalonia.Layout
             return new Size(value.Width, value.Height);
         }
 
-        protected internal override void OnItemsChangedCore(VirtualizingLayoutContext context, object source, NotifyCollectionChangedEventArgs args)
+        protected internal override void OnItemsChangedCore(VirtualizingLayoutContext context, object? source, NotifyCollectionChangedEventArgs args)
         {
             GetFlowAlgorithm(context).OnItemsSourceChanged(source, args, context);
             // Always invalidate layout to keep the view accurate.

--- a/src/Avalonia.Layout/UniformGridLayout.cs
+++ b/src/Avalonia.Layout/UniformGridLayout.cs
@@ -461,7 +461,7 @@ namespace Avalonia.Layout
             return new Size(value.Width, value.Height);
         }
 
-        protected internal override void OnItemsChangedCore(VirtualizingLayoutContext context, object source, NotifyCollectionChangedEventArgs args)
+        protected internal override void OnItemsChangedCore(VirtualizingLayoutContext context, object? source, NotifyCollectionChangedEventArgs args)
         {
             GetFlowAlgorithm(context).OnItemsSourceChanged(source, args, context);
             // Always invalidate layout to keep the view accurate.

--- a/src/Avalonia.Layout/VirtualizingLayout.cs
+++ b/src/Avalonia.Layout/VirtualizingLayout.cs
@@ -35,7 +35,7 @@ namespace Avalonia.Layout
         /// </remarks>
         public void OnItemsChanged(
             VirtualizingLayoutContext context,
-            object source,
+            object? source,
             NotifyCollectionChangedEventArgs args) => OnItemsChangedCore(context, source, args);
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace Avalonia.Layout
         /// <param name="args">Data about the collection change.</param>
         protected internal virtual void OnItemsChangedCore(
             VirtualizingLayoutContext context,
-            object source,
+            object? source,
             NotifyCollectionChangedEventArgs args) => InvalidateMeasure();
     }
 }

--- a/src/Avalonia.Layout/WrapLayout/WrapLayout.cs
+++ b/src/Avalonia.Layout/WrapLayout/WrapLayout.cs
@@ -86,7 +86,7 @@ namespace Avalonia.Layout
         }
 
         /// <inheritdoc />
-        protected internal override void OnItemsChangedCore(VirtualizingLayoutContext context, object source, NotifyCollectionChangedEventArgs args)
+        protected internal override void OnItemsChangedCore(VirtualizingLayoutContext context, object? source, NotifyCollectionChangedEventArgs args)
         {
             var state = (WrapLayoutState)context.LayoutState!;
 

--- a/src/Avalonia.Styling/Controls/IResourceHost.cs
+++ b/src/Avalonia.Styling/Controls/IResourceHost.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Raised when the resources change on the element or an ancestor of the element.
         /// </summary>
-        event EventHandler<ResourcesChangedEventArgs> ResourcesChanged;
+        event EventHandler<ResourcesChangedEventArgs>? ResourcesChanged;
 
         /// <summary>
         /// Notifies the resource host that one or more of its hosted resources has changed.

--- a/src/Avalonia.Styling/Controls/IResourceProvider.cs
+++ b/src/Avalonia.Styling/Controls/IResourceProvider.cs
@@ -25,7 +25,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Raised when the <see cref="Owner"/> of the resource provider changes.
         /// </summary>
-        event EventHandler OwnerChanged;
+        event EventHandler? OwnerChanged;
 
         /// <summary>
         /// Adds an owner to the resource provider.

--- a/src/Avalonia.Styling/LogicalTree/LogicalTreeAttachmentEventArgs.cs
+++ b/src/Avalonia.Styling/LogicalTree/LogicalTreeAttachmentEventArgs.cs
@@ -17,7 +17,7 @@ namespace Avalonia.LogicalTree
         public LogicalTreeAttachmentEventArgs(
             ILogicalRoot root,
             ILogical source,
-            ILogical parent)
+            ILogical? parent)
         {
             Root = root ?? throw new ArgumentNullException(nameof(root));
             Source = source ?? throw new ArgumentNullException(nameof(source));
@@ -47,6 +47,6 @@ namespace Avalonia.LogicalTree
         /// detachment, holds the old logical parent of <see cref="Source"/>. If the detachment event
         /// was caused by a top-level control being closed, then this property will be null.
         /// </remarks>
-        public ILogical Parent { get; }
+        public ILogical? Parent { get; }
     }
 }

--- a/src/Avalonia.Styling/Styling/IGlobalStyles.cs
+++ b/src/Avalonia.Styling/Styling/IGlobalStyles.cs
@@ -13,11 +13,11 @@ namespace Avalonia.Styling
         /// <summary>
         /// Raised when styles are added to <see cref="Styles"/> or a nested styles collection.
         /// </summary>
-        public event Action<IReadOnlyList<IStyle>> GlobalStylesAdded;
+        public event Action<IReadOnlyList<IStyle>>? GlobalStylesAdded;
 
         /// <summary>
         /// Raised when styles are removed from <see cref="Styles"/> or a nested styles collection.
         /// </summary>
-        public event Action<IReadOnlyList<IStyle>> GlobalStylesRemoved;
+        public event Action<IReadOnlyList<IStyle>>? GlobalStylesRemoved;
     }
 }

--- a/src/Avalonia.Visuals/Media/DrawingContext.cs
+++ b/src/Avalonia.Visuals/Media/DrawingContext.cs
@@ -119,7 +119,7 @@ namespace Avalonia.Media
         /// <param name="brush">The fill brush.</param>
         /// <param name="pen">The stroke pen.</param>
         /// <param name="geometry">The geometry.</param>
-        public void DrawGeometry(IBrush brush, IPen pen, Geometry geometry)
+        public void DrawGeometry(IBrush? brush, IPen? pen, Geometry geometry)
         {
             if (geometry.PlatformImpl is not null)
                 DrawGeometry(brush, pen, geometry.PlatformImpl);
@@ -131,7 +131,7 @@ namespace Avalonia.Media
         /// <param name="brush">The fill brush.</param>
         /// <param name="pen">The stroke pen.</param>
         /// <param name="geometry">The geometry.</param>
-        public void DrawGeometry(IBrush brush, IPen pen, IGeometryImpl geometry)
+        public void DrawGeometry(IBrush? brush, IPen? pen, IGeometryImpl geometry)
         {
             _ = geometry ?? throw new ArgumentNullException(nameof(geometry));
 

--- a/src/Avalonia.Visuals/Platform/LockedFramebuffer.cs
+++ b/src/Avalonia.Visuals/Platform/LockedFramebuffer.cs
@@ -4,10 +4,10 @@ namespace Avalonia.Platform
 {
     public class LockedFramebuffer : ILockedFramebuffer
     {
-        private readonly Action _onDispose;
+        private readonly Action? _onDispose;
 
         public LockedFramebuffer(IntPtr address, PixelSize size, int rowBytes, Vector dpi, PixelFormat format,
-            Action onDispose)
+            Action? onDispose)
         {
             _onDispose = onDispose;
             Address = address;

--- a/src/Avalonia.Visuals/VisualTree/IHostedVisualTreeRoot.cs
+++ b/src/Avalonia.Visuals/VisualTree/IHostedVisualTreeRoot.cs
@@ -11,6 +11,6 @@ namespace Avalonia.VisualTree
         /// <value>
         /// The visual tree host.
         /// </value>
-        IVisual Host { get; }
+        IVisual? Host { get; }
     }
 }

--- a/src/Avalonia.Visuals/VisualTree/IVisualTreeHost.cs
+++ b/src/Avalonia.Visuals/VisualTree/IVisualTreeHost.cs
@@ -14,6 +14,6 @@ namespace Avalonia.VisualTree
         /// <value>
         /// The root of the hosted visual tree.
         /// </value>
-        IVisual Root { get; }
+        IVisual? Root { get; }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

While adding nullable annotations to Avalonia.Controls I came across a few places where nullability needed tweaking in the lower-level libs that already have NRT enabled.

Most of these changes are to make events nullable, including events added via `AddHandler`/`RemoveHandler` - for this I needed to make `AddHandler`/`RemoveHandler` accept null handlers.
