### PR TITLE
Nullable: ItemContainerGenerator cannot be null

### DIFF
--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -360,12 +360,12 @@ namespace Avalonia.Controls
             var selectedIndex = SelectedIndex;
             if (IsDropDownOpen && selectedIndex != -1)
             {
-                var container = ItemContainerGenerator!.ContainerFromIndex(selectedIndex);
+                var container = ItemContainerGenerator.ContainerFromIndex(selectedIndex);
 
                 if (container == null && SelectedIndex != -1)
                 {
                     ScrollIntoView(Selection.SelectedIndex);
-                    container = ItemContainerGenerator!.ContainerFromIndex(selectedIndex);
+                    container = ItemContainerGenerator.ContainerFromIndex(selectedIndex);
                 }
 
                 if (container != null && CanFocus(container))
@@ -415,7 +415,7 @@ namespace Avalonia.Controls
 
         private void SelectFocusedItem()
         {
-            foreach (ItemContainerInfo dropdownItem in ItemContainerGenerator!.Containers)
+            foreach (ItemContainerInfo dropdownItem in ItemContainerGenerator.Containers)
             {
                 if (dropdownItem.ContainerControl.IsFocused)
                 {

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -237,14 +237,8 @@ namespace Avalonia.Controls
         /// Creates the <see cref="ItemContainerGenerator"/> for the control.
         /// </summary>
         /// <returns>
-        /// An <see cref="IItemContainerGenerator"/> or null.
+        /// An <see cref="IItemContainerGenerator"/>.
         /// </returns>
-        /// <remarks>
-        /// Certain controls such as <see cref="TabControl"/> don't actually create item 
-        /// containers; however they want it to be ItemsControls so that they have an Items 
-        /// property etc. In this case, a derived class can override this method to return null
-        /// in order to disable the creation of item containers.
-        /// </remarks>
         protected virtual IItemContainerGenerator CreateItemContainerGenerator()
         {
             return new ItemContainerGenerator(this);

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -79,7 +79,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets the <see cref="IItemContainerGenerator"/> for the control.
         /// </summary>
-        public IItemContainerGenerator? ItemContainerGenerator
+        public IItemContainerGenerator ItemContainerGenerator
         {
             get
             {
@@ -87,13 +87,10 @@ namespace Avalonia.Controls
                 {
                     _itemContainerGenerator = CreateItemContainerGenerator();
 
-                    if (_itemContainerGenerator != null)
-                    {
-                        _itemContainerGenerator.ItemTemplate = ItemTemplate;
-                        _itemContainerGenerator.Materialized += (_, e) => OnContainersMaterialized(e);
-                        _itemContainerGenerator.Dematerialized += (_, e) => OnContainersDematerialized(e);
-                        _itemContainerGenerator.Recycled += (_, e) => OnContainersRecycled(e);
-                    }
+                    _itemContainerGenerator.ItemTemplate = ItemTemplate;
+                    _itemContainerGenerator.Materialized += (_, e) => OnContainersMaterialized(e);
+                    _itemContainerGenerator.Dematerialized += (_, e) => OnContainersDematerialized(e);
+                    _itemContainerGenerator.Recycled += (_, e) => OnContainersRecycled(e);
                 }
 
                 return _itemContainerGenerator;

--- a/src/Avalonia.Controls/MenuBase.cs
+++ b/src/Avalonia.Controls/MenuBase.cs
@@ -81,13 +81,13 @@ namespace Avalonia.Controls
             {
                 var index = SelectedIndex;
                 return (index != -1) ?
-                    (IMenuItem?)ItemContainerGenerator!.ContainerFromIndex(index) :
+                    (IMenuItem?)ItemContainerGenerator.ContainerFromIndex(index) :
                     null;
             }
             set
             {
                 SelectedIndex = value is not null ?
-                    ItemContainerGenerator!.IndexFromContainer(value) : -1;
+                    ItemContainerGenerator.IndexFromContainer(value) : -1;
             }
         }
 
@@ -96,7 +96,7 @@ namespace Avalonia.Controls
         {
             get
             {
-                return ItemContainerGenerator!.Containers
+                return ItemContainerGenerator.Containers
                     .Select(x => x.ContainerControl)
                     .OfType<IMenuItem>();
             }

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -308,12 +308,12 @@ namespace Avalonia.Controls
             {
                 var index = SelectedIndex;
                 return (index != -1) ?
-                    (IMenuItem?)ItemContainerGenerator!.ContainerFromIndex(index) :
+                    (IMenuItem?)ItemContainerGenerator.ContainerFromIndex(index) :
                     null;
             }
             set
             {
-                SelectedIndex = value is not null ? ItemContainerGenerator!.IndexFromContainer(value) : -1;
+                SelectedIndex = value is not null ? ItemContainerGenerator.IndexFromContainer(value) : -1;
             }
         }
 
@@ -322,7 +322,7 @@ namespace Avalonia.Controls
         {
             get
             {
-                return ItemContainerGenerator!.Containers
+                return ItemContainerGenerator.Containers
                     .Select(x => x.ContainerControl)
                     .OfType<IMenuItem>();
             }

--- a/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/CarouselPresenter.cs
@@ -170,7 +170,7 @@ namespace Avalonia.Controls.Presenters
         {
             if (fromIndex != toIndex)
             {
-                var generator = ItemContainerGenerator!;
+                var generator = ItemContainerGenerator;
                 IControl? from = null;
                 IControl? to = null;
 

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -908,7 +908,7 @@ namespace Avalonia.Controls.Primitives
                 {
                     MarkContainerSelected(
                         container,
-                        Selection.IsSelected(ItemContainerGenerator!.IndexFromContainer(container)));
+                        Selection.IsSelected(ItemContainerGenerator.IndexFromContainer(container)));
                 }
             }
         }

--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -164,7 +164,7 @@ namespace Avalonia.Controls
             else
             {
                 var container = SelectedItem as IContentControl ??
-                    ItemContainerGenerator!.ContainerFromIndex(SelectedIndex) as IContentControl;
+                    ItemContainerGenerator.ContainerFromIndex(SelectedIndex) as IContentControl;
                 SelectedContentTemplate = container?.ContentTemplate;
                 SelectedContent = container?.Content;
             }

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -79,7 +79,7 @@ namespace Avalonia.Controls
         /// Gets the <see cref="ITreeItemContainerGenerator"/> for the tree view.
         /// </summary>
         public new ITreeItemContainerGenerator ItemContainerGenerator =>
-            (ITreeItemContainerGenerator)base.ItemContainerGenerator!;
+            (ITreeItemContainerGenerator)base.ItemContainerGenerator;
 
         /// <summary>
         /// Gets or sets a value indicating whether to automatically scroll to newly selected items.

--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -89,7 +89,7 @@ namespace Avalonia.Controls
         /// Gets the <see cref="ITreeItemContainerGenerator"/> for the tree view.
         /// </summary>
         public new ITreeItemContainerGenerator ItemContainerGenerator =>
-            (ITreeItemContainerGenerator)base.ItemContainerGenerator!;
+            (ITreeItemContainerGenerator)base.ItemContainerGenerator;
 
         /// <inheritdoc/>
         protected override IItemContainerGenerator CreateItemContainerGenerator() => CreateTreeItemContainerGenerator<TreeViewItem>();


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes nullable annotations for `ItemsControl.ItemContainerGenerator` since it cannot be null. And most of the code assumes it is always valid (which it is).