### PR TITLE
Fix #7519 - Reset fb and depth buffer Ids once they are deleted

### DIFF
--- a/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs
+++ b/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs
@@ -89,7 +89,9 @@ namespace Avalonia.OpenGL.Controls
                     gl.BindTexture(GL_TEXTURE_2D, 0);
                     gl.BindFramebuffer(GL_FRAMEBUFFER, 0);
                     gl.DeleteFramebuffers(1, new[] { _fb });
+                    _fb = 0;
                     gl.DeleteRenderbuffers(1, new[] { _depthBuffer });
+                    _depthBuffer = 0;
                     _attachment?.Dispose();
                     _attachment = null;
                     _bitmap?.Dispose();


### PR DESCRIPTION
## What does the pull request do?

This fixes issue #7519 (artifacts appearing in OpenGLControlBase when hidden then shown again)

## What is the current behavior?
See this video: 

https://user-images.githubusercontent.com/79333/152570398-29fec4bf-054b-4af3-850e-46936b27abb9.mp4

## What is the updated/expected behavior with this PR?

No artifacts when hiding/showing again the control

## How was the solution implemented (if it's not obvious)?

* Simply resetted the depth buffer id to 0 when it is deleted
* Note: I did the same with the framebuffer id. Although not strictly necessary, I thought it'd be better for consistency purpose.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

None of these, but here is a video of the behavior after the fix:

https://user-images.githubusercontent.com/79333/152570707-803834cd-e8cc-4a3a-acf0-68df3ef9aa60.mp4

## Breaking changes

None

## Obsoletions / Deprecations

None

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #7519
-->
