### PR TITLE
Add Support for Overwrite Prompt option in save dialog

### DIFF
--- a/src/Avalonia.Controls/SystemDialog.cs
+++ b/src/Avalonia.Controls/SystemDialog.cs
@@ -55,7 +55,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets or sets a value indicating whether to display a warning if the user specifies the name of a file that already exists.
         /// </summary>
-        public bool? OverwritePrompt { get; set; }
+        public bool? ShowOverwritePrompt { get; set; }
 
         /// <summary>
         /// Shows the save file dialog.

--- a/src/Avalonia.Controls/SystemDialog.cs
+++ b/src/Avalonia.Controls/SystemDialog.cs
@@ -53,6 +53,11 @@ namespace Avalonia.Controls
         public string? DefaultExtension { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to display a warning if the user specifies the name of a file that already exists.
+        /// </summary>
+        public bool? OverwritePrompt { get; set; }
+
+        /// <summary>
         /// Shows the save file dialog.
         /// </summary>
         /// <param name="parent">The parent window.</param>

--- a/src/Avalonia.Dialogs/ManagedFileChooserViewModel.cs
+++ b/src/Avalonia.Dialogs/ManagedFileChooserViewModel.cs
@@ -17,6 +17,7 @@ namespace Avalonia.Dialogs
         private readonly ManagedFileDialogOptions _options;
         public event Action CancelRequested;
         public event Action<string[]> CompleteRequested;
+        public event Action<string> ShowOverwritePrompt;
 
         public AvaloniaList<ManagedFileChooserItemViewModel> QuickLinks { get; } =
             new AvaloniaList<ManagedFileChooserItemViewModel>();
@@ -39,6 +40,7 @@ namespace Avalonia.Dialogs
         private bool _scheduledSelectionValidation;
         private bool _alreadyCancelled = false;
         private string _defaultExtension;
+        private bool _overwritePrompt;
         private CompositeDisposable _disposables;
 
         public string Location
@@ -167,6 +169,7 @@ namespace Avalonia.Dialogs
             {
                 _savingFile = true;
                 _defaultExtension = sfd.DefaultExtension;
+                _overwritePrompt = (bool)sfd.OverwritePrompt;
                 FileName = sfd.InitialFileName;
             }
 
@@ -360,7 +363,16 @@ namespace Avalonia.Dialogs
                         FileName = Path.ChangeExtension(FileName, _defaultExtension);
                     }
 
-                    CompleteRequested?.Invoke(new[] { Path.Combine(Location, FileName) });
+                    var fullName = Path.Combine(Location, FileName);
+
+                    if (_overwritePrompt && File.Exists(fullName))
+                    {
+                        ShowOverwritePrompt?.Invoke(fullName);
+                    }
+                    else
+                    {
+                        CompleteRequested?.Invoke(new[] { fullName });
+                    }
                 }
             }
             else

--- a/src/Avalonia.Dialogs/ManagedFileChooserViewModel.cs
+++ b/src/Avalonia.Dialogs/ManagedFileChooserViewModel.cs
@@ -17,7 +17,7 @@ namespace Avalonia.Dialogs
         private readonly ManagedFileDialogOptions _options;
         public event Action CancelRequested;
         public event Action<string[]> CompleteRequested;
-        public event Action<string> ShowOverwritePrompt;
+        public event Action<string> OverwritePrompt;
 
         public AvaloniaList<ManagedFileChooserItemViewModel> QuickLinks { get; } =
             new AvaloniaList<ManagedFileChooserItemViewModel>();
@@ -169,7 +169,7 @@ namespace Avalonia.Dialogs
             {
                 _savingFile = true;
                 _defaultExtension = sfd.DefaultExtension;
-                _overwritePrompt = (bool)sfd.OverwritePrompt;
+                _overwritePrompt = sfd.ShowOverwritePrompt ?? true;
                 FileName = sfd.InitialFileName;
             }
 
@@ -367,7 +367,7 @@ namespace Avalonia.Dialogs
 
                     if (_overwritePrompt && File.Exists(fullName))
                     {
-                        ShowOverwritePrompt?.Invoke(fullName);
+                        OverwritePrompt?.Invoke(fullName);
                     }
                     else
                     {

--- a/src/Avalonia.Dialogs/ManagedFileDialogExtensions.cs
+++ b/src/Avalonia.Dialogs/ManagedFileDialogExtensions.cs
@@ -32,14 +32,15 @@ namespace Avalonia.Dialogs
                     dialog.Close();
                 };
 
-                model.ShowOverwritePrompt += async (filename) =>
+                model.OverwritePrompt += async (filename) =>
                 {
                     Window overwritePromptDialog = new Window()
                     {
                         Title = "Confirm Save As",
                         SizeToContent = SizeToContent.WidthAndHeight,
                         WindowStartupLocation = WindowStartupLocation.CenterOwner,
-                        Padding = new Thickness(10)
+                        Padding = new Thickness(10),
+                        MinWidth = 270
                     };
 
                     string name = Path.GetFileName(filename);

--- a/src/Avalonia.Dialogs/ManagedFileDialogExtensions.cs
+++ b/src/Avalonia.Dialogs/ManagedFileDialogExtensions.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
@@ -29,6 +30,74 @@ namespace Avalonia.Dialogs
                 {
                     result = items;
                     dialog.Close();
+                };
+
+                model.ShowOverwritePrompt += async (filename) =>
+                {
+                    Window overwritePromptDialog = new Window()
+                    {
+                        Title = "Confirm Save As",
+                        SizeToContent = SizeToContent.WidthAndHeight,
+                        WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                        Padding = new Thickness(10)
+                    };
+
+                    string name = Path.GetFileName(filename);
+
+                    var panel = new DockPanel()
+                    {
+                        HorizontalAlignment = Layout.HorizontalAlignment.Stretch
+                    };
+
+                    var label = new Label()
+                    {
+                        Content = $"{name} already exists.\nDo you want to replace it?"
+                    };
+
+                    panel.Children.Add(label);
+                    DockPanel.SetDock(label, Dock.Top);
+
+                    var buttonPanel = new StackPanel()
+                    {
+                        HorizontalAlignment = Layout.HorizontalAlignment.Right,
+                        Orientation = Layout.Orientation.Horizontal,
+                        Spacing = 10
+                    };
+
+                    var button = new Button()
+                    {
+                        Content = "Yes",
+                        HorizontalAlignment = Layout.HorizontalAlignment.Right
+                    };
+
+                    button.Click += (sender, args) =>
+                    {
+                        result = new string[1] { filename };
+                        overwritePromptDialog.Close();
+                        dialog.Close();
+                    };
+
+                    buttonPanel.Children.Add(button);
+
+                    button = new Button()
+                    {
+                        Content = "No",
+                        HorizontalAlignment = Layout.HorizontalAlignment.Right
+                    };
+
+                    button.Click += (sender, args) =>
+                    {
+                        overwritePromptDialog.Close();
+                    };
+
+                    buttonPanel.Children.Add(button);
+
+                    panel.Children.Add(buttonPanel);
+                    DockPanel.SetDock(buttonPanel, Dock.Bottom);
+
+                    overwritePromptDialog.Content = panel;
+
+                    await overwritePromptDialog.ShowDialog(dialog);
                 };
 
                 model.CancelRequested += dialog.Close;

--- a/src/Avalonia.X11/NativeDialogs/Gtk.cs
+++ b/src/Avalonia.X11/NativeDialogs/Gtk.cs
@@ -179,6 +179,9 @@ namespace Avalonia.X11.NativeDialogs
 
         [DllImport(GtkName)]
         public static extern void gtk_file_chooser_set_select_multiple(IntPtr chooser, bool allow);
+        
+        [DllImport(GtkName)]
+        public static extern void gtk_file_chooser_set_do_overwrite_confirmation(IntPtr chooser, bool do_overwrite_confirmation);
 
         [DllImport(GtkName)]
         public static extern void

--- a/src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs
+++ b/src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs
@@ -16,7 +16,7 @@ namespace Avalonia.X11.NativeDialogs
     {
         private Task<bool> _initialized;
         private unsafe  Task<string[]> ShowDialog(string title, IWindowImpl parent, GtkFileChooserAction action,
-            bool multiSelect, string initialFileName, IEnumerable<FileDialogFilter> filters, string defaultExtension)
+            bool multiSelect, string initialFileName, IEnumerable<FileDialogFilter> filters, string defaultExtension, bool overwritePrompt)
         {
             IntPtr dlg;
             using (var name = new Utf8Buffer(title))
@@ -109,6 +109,8 @@ namespace Avalonia.X11.NativeDialogs
                         gtk_file_chooser_set_filename(dlg, fn);
                 }
 
+            gtk_file_chooser_set_do_overwrite_confirmation(dlg, overwritePrompt);
+            
             gtk_window_present(dlg);
             return tcs.Task;
         }
@@ -148,7 +150,7 @@ namespace Avalonia.X11.NativeDialogs
                     (dialog as OpenFileDialog)?.AllowMultiple ?? false,
                     Path.Combine(string.IsNullOrEmpty(dialog.Directory) ? "" : dialog.Directory,
                         string.IsNullOrEmpty(dialog.InitialFileName) ? "" : dialog.InitialFileName), dialog.Filters,
-                    (dialog as SaveFileDialog)?.DefaultExtension));
+                    (dialog as SaveFileDialog)?.DefaultExtension, (dialog as SaveFileDialog)?.OverwritePrompt ?? false));
         }
 
         public async Task<string> ShowFolderDialogAsync(OpenFolderDialog dialog, Window parent)
@@ -160,7 +162,7 @@ namespace Avalonia.X11.NativeDialogs
             return await await RunOnGlibThread(async () =>
             {
                 var res = await ShowDialog(dialog.Title, platformImpl,
-                    GtkFileChooserAction.SelectFolder, false, dialog.Directory, null, null);
+                    GtkFileChooserAction.SelectFolder, false, dialog.Directory, null, null, false);
                 return res?.FirstOrDefault();
             });
         }

--- a/src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs
+++ b/src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs
@@ -150,7 +150,7 @@ namespace Avalonia.X11.NativeDialogs
                     (dialog as OpenFileDialog)?.AllowMultiple ?? false,
                     Path.Combine(string.IsNullOrEmpty(dialog.Directory) ? "" : dialog.Directory,
                         string.IsNullOrEmpty(dialog.InitialFileName) ? "" : dialog.InitialFileName), dialog.Filters,
-                    (dialog as SaveFileDialog)?.DefaultExtension, (dialog as SaveFileDialog)?.OverwritePrompt ?? false));
+                    (dialog as SaveFileDialog)?.DefaultExtension, (dialog as SaveFileDialog)?.ShowOverwritePrompt ?? false));
         }
 
         public async Task<string> ShowFolderDialogAsync(OpenFolderDialog dialog, Window parent)

--- a/src/Windows/Avalonia.Win32/SystemDialogImpl.cs
+++ b/src/Windows/Avalonia.Win32/SystemDialogImpl.cs
@@ -40,6 +40,16 @@ namespace Avalonia.Win32
                     {
                         options |= FILEOPENDIALOGOPTIONS.FOS_ALLOWMULTISELECT;
                     }
+
+                    if (dialog is SaveFileDialog saveFileDialog)
+                    {
+                        var overwritePrompt = saveFileDialog.ShowOverwritePrompt ?? true;
+
+                        if (!overwritePrompt)
+                        {
+                            options &= ~FILEOPENDIALOGOPTIONS.FOS_OVERWRITEPROMPT;
+                        }
+                    }
                     frm.SetOptions(options);
 
                     var defaultExtension = (dialog as SaveFileDialog)?.DefaultExtension ?? "";
@@ -66,16 +76,6 @@ namespace Avalonia.Win32
                     }
 
                     frm.SetFileTypeIndex(0);
-
-                    if (dialog is SaveFileDialog saveFileDialog)
-                    {
-                        var overwritePrompt = saveFileDialog.ShowOverwritePrompt ?? true;
-
-                        if (!overwritePrompt)
-                        {
-                            frm.SetOptions(frm.Options &~ FILEOPENDIALOGOPTIONS.FOS_OVERWRITEPROMPT);
-                        }
-                    }
 
                     if (dialog.Directory != null)
                     {

--- a/src/Windows/Avalonia.Win32/SystemDialogImpl.cs
+++ b/src/Windows/Avalonia.Win32/SystemDialogImpl.cs
@@ -67,6 +67,16 @@ namespace Avalonia.Win32
 
                     frm.SetFileTypeIndex(0);
 
+                    if (dialog is SaveFileDialog saveFileDialog)
+                    {
+                        var overwritePrompt = saveFileDialog.OverwritePrompt ?? true;
+
+                        if (!overwritePrompt)
+                        {
+                            frm.SetOptions(frm.Options &~ FILEOPENDIALOGOPTIONS.FOS_OVERWRITEPROMPT);
+                        }
+                    }
+
                     if (dialog.Directory != null)
                     {
                         var riid = UnmanagedMethods.ShellIds.IShellItem;

--- a/src/Windows/Avalonia.Win32/SystemDialogImpl.cs
+++ b/src/Windows/Avalonia.Win32/SystemDialogImpl.cs
@@ -69,7 +69,7 @@ namespace Avalonia.Win32
 
                     if (dialog is SaveFileDialog saveFileDialog)
                     {
-                        var overwritePrompt = saveFileDialog.OverwritePrompt ?? true;
+                        var overwritePrompt = saveFileDialog.ShowOverwritePrompt ?? true;
 
                         if (!overwritePrompt)
                         {


### PR DESCRIPTION
## What does the pull request do?
Add OverwritePrompt property to SaveFileDialog. Native Windows, native GTK and managed save dialogs have all been updated to support it.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #7030
