### PR TITLE
Minimization bugfix on Windows

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -265,7 +265,7 @@ namespace Avalonia.Win32
             {
                 if (IsWindowVisible(_hwnd))
                 {
-                    ShowWindow(value, true);
+                    ShowWindow(value, value != WindowState.Minimized); // If the window is minimized, it shouldn't be activated
                 }
 
                 _showWindowState = value;                
@@ -973,7 +973,7 @@ namespace Avalonia.Win32
             {
                 case WindowState.Minimized:
                     newWindowProperties.IsFullScreen = false;
-                    command = activate ? ShowWindowCommand.Minimize : ShowWindowCommand.ShowMinNoActive;
+                    command = ShowWindowCommand.Minimize;
                     break;
                 case WindowState.Maximized:
                     newWindowProperties.IsFullScreen = false;


### PR DESCRIPTION
## What does the pull request do?
This PR fixes a bug regarding window minimization on Windows: the window currently stays activated when minimized programatically, where it should be deactivated.

## What is the current behavior?
When minimizing a Window on Windows using either a custom made button or the self-rendered window decorator, the window stays activated.

## What is the updated/expected behavior with this PR?
When minimizing a Window on Windows using either a custom made button or the self-rendered window decorator, the window is deactivated. Then, the OS will automatically activate the window below.

## How was the solution implemented (if it's not obvious)?
The issue was fixed by:
- Changing the value of the `activated` parameter given to the `ShowWindow` method when the Window is minimized
- Using the `Minimize` Win32 command regardless of the `activated` parameter (when using the `ShowMinNoActive` command, the Window still stays active; the only thing different is that the OS doesn't try to make *the window below* active)
