### PR TITLE
fix 32 bit raspberry pi session manager seg fault

### DIFF
--- a/src/Avalonia.X11/SMLib.cs
+++ b/src/Avalonia.X11/SMLib.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Runtime.InteropServices;
 
@@ -7,20 +8,19 @@ namespace Avalonia.X11
     {
         private const string LibSm = "libSM.so.6";
 
-        [DllImport(LibSm, CharSet = CharSet.Ansi)]
+        [DllImport(LibSm, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
         public static extern IntPtr SmcOpenConnection(
-            [MarshalAs(UnmanagedType.LPWStr)] string networkId,
+            [MarshalAs(UnmanagedType.LPStr)] string? networkId,
             IntPtr content,
             int xsmpMajorRev,
             int xsmpMinorRev,
-            ulong mask,
+            nuint mask,
             ref SmcCallbacks callbacks,
-            [MarshalAs(UnmanagedType.LPWStr)] [Out]
-            out string previousId,
-            [MarshalAs(UnmanagedType.LPWStr)] [Out]
-            out string clientIdRet,
+            [MarshalAs(UnmanagedType.LPStr)] string? previousId,
+            ref IntPtr clientIdRet,
             int errorLength,
-            [Out] char[] errorStringRet);
+            [Out] byte[] errorStringRet
+        );
 
         [DllImport(LibSm, CallingConvention = CallingConvention.StdCall)]
         public static extern int SmcCloseConnection(

--- a/src/Avalonia.X11/X11PlatformLifetimeEvents.cs
+++ b/src/Avalonia.X11/X11PlatformLifetimeEvents.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Text;
 using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -14,10 +15,10 @@ namespace Avalonia.X11
     internal unsafe class X11PlatformLifetimeEvents : IDisposable, IPlatformLifetimeEventsImpl
     {
         private readonly AvaloniaX11Platform _platform;
-        private const ulong SmcSaveYourselfProcMask = 1L;
-        private const ulong SmcDieProcMask = 2L;
-        private const ulong SmcSaveCompleteProcMask = 4L;
-        private const ulong SmcShutdownCancelledProcMask = 8L;
+        private const nuint SmcSaveYourselfProcMask = 1;
+        private const nuint SmcDieProcMask = 2;
+        private const nuint SmcSaveCompleteProcMask = 4;
+        private const nuint SmcShutdownCancelledProcMask = 8;
 
         private static readonly ConcurrentDictionary<IntPtr, X11PlatformLifetimeEvents> s_nativeToManagedMapper =
             new ConcurrentDictionary<IntPtr, X11PlatformLifetimeEvents>();
@@ -62,24 +63,24 @@ namespace Avalonia.X11
                 return;
             }
 
-            var errorBuf = new char[255];
-
-            var smcConn = SMLib.SmcOpenConnection(null!,
+            byte[] errorBuf = new byte[255];
+            IntPtr clientIdRet = IntPtr.Zero;
+            var smcConn = SMLib.SmcOpenConnection(null,
                 IntPtr.Zero, 1, 0,
                 SmcSaveYourselfProcMask |
                 SmcSaveCompleteProcMask |
                 SmcShutdownCancelledProcMask |
                 SmcDieProcMask,
                 ref s_callbacks,
-                out _,
-                out _,
+                null,
+                ref clientIdRet,
                 errorBuf.Length,
                 errorBuf);
 
             if (smcConn == IntPtr.Zero)
             {
                 Logger.TryGet(LogEventLevel.Warning, LogArea.X11Platform)?.Log(this,
-                    $"SMLib/ICELib reported a new error: {new string(errorBuf)}");
+                    $"SMLib/ICELib reported a new error: {Encoding.ASCII.GetString(errorBuf)}");
                 return;
             }
 


### PR DESCRIPTION
## What does the pull request do?
This fixes a seg fault on some 32 bit raspberry pi installations see https://github.com/AvaloniaUI/Avalonia/issues/7501


## What is the current behavior?
On a clean Raspbian 32 bit OS install on a RPi 3 apps segfault on startup


## What is the updated/expected behavior with this PR?
No segfault on startup on RPi3

## How was the solution implemented (if it's not obvious)?
SmcOpenConnection was failing and trying to return 'SESSION_MANAGER environment variable not defined' The pinvoke signature was wrong as it treated the mask param as a long which is 64 bit in c# but only 32 bit in the 32 bit linux c world.
Other fields have also been tided up.  The method does return a c string (clientIdRet) which is the users responsibility to delete with c free, I've left this to tidy itself up at program exit as I'm not 100% sure how to do this safely from the managed side.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes https://github.com/AvaloniaUI/Avalonia/issues/7501
