### PR TITLE
Avoid using COM exceptions for dialog control flow.

### DIFF
--- a/src/Windows/Avalonia.Win32/SystemDialogImpl.cs
+++ b/src/Windows/Avalonia.Win32/SystemDialogImpl.cs
@@ -89,7 +89,16 @@ namespace Avalonia.Win32
                         }
                     }
 
-                    frm.Show(hWnd);
+                    var showResult = frm.Show(hWnd);
+
+                    if ((uint)showResult == (uint)UnmanagedMethods.HRESULT.E_CANCELLED)
+                    {
+                        return result;
+                    } 
+                    else if ((uint)showResult != (uint)UnmanagedMethods.HRESULT.S_OK)
+                    {
+                        throw new Win32Exception(showResult);
+                    }
 
                     if (openDialog?.AllowMultiple == true)
                     {
@@ -118,10 +127,6 @@ namespace Avalonia.Win32
                 }
                 catch (COMException ex)
                 {
-                    if ((uint)ex.HResult == (uint)UnmanagedMethods.HRESULT.E_CANCELLED)
-                    {
-                        return result;
-                    }
                     throw new Win32Exception(ex.HResult);
                 }
             })!;
@@ -161,7 +166,17 @@ namespace Avalonia.Win32
                         }
                     }
 
-                    frm.Show(hWnd);
+                    var showResult = frm.Show(hWnd);
+
+                    if ((uint)showResult == (uint)UnmanagedMethods.HRESULT.E_CANCELLED)
+                    {
+                        return result;
+                    }
+                    else if ((uint)showResult != (uint)UnmanagedMethods.HRESULT.S_OK)
+                    {
+                        throw new Win32Exception(showResult);
+                    }
+
                     if (frm.Result is not null)
                     {
                         result = GetAbsoluteFilePath(frm.Result);
@@ -171,10 +186,6 @@ namespace Avalonia.Win32
                 }
                 catch (COMException ex)
                 {
-                    if ((uint)ex.HResult == (uint)UnmanagedMethods.HRESULT.E_CANCELLED)
-                    {
-                        return result;
-                    }
                     throw new Win32Exception(ex.HResult);
                 }
             });

--- a/src/Windows/Avalonia.Win32/Win32Com/win32.idl
+++ b/src/Windows/Avalonia.Win32/Win32Com/win32.idl
@@ -112,7 +112,7 @@ interface IShellItemArray : IUnknown
 interface IModalWindow : IUnknown
 {
     [local]
-    HRESULT Show(
+    int Show(
         [in, unique] HWND hwndOwner);
 }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Currently cancelling file picker dialogs on win32 is throwing exceptions. This is fairly annoying for people like me that run with all exceptions enabled (since exceptions should be exceptional and thus not ignored).

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Cancelling file dialog will throw an exception and trigger debugger breakpoint.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Cancelling file dialog is handled explicitly as an expected case an no exception is thrown.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
