### PR TITLE
Improve nullable annotations for ILogicalScrollable.GetControlInDirection

### DIFF
--- a/src/Avalonia.Controls/DateTimePickers/DateTimePickerPanel.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DateTimePickerPanel.cs
@@ -560,7 +560,7 @@ namespace Avalonia.Controls.Primitives
 
         public bool BringIntoView(IControl target, Rect targetRect) { return false; }
 
-        public IControl? GetControlInDirection(NavigationDirection direction, IControl from) { return null; }
+        public IControl? GetControlInDirection(NavigationDirection direction, IControl? from) { return null; }
 
         public void RaiseScrollInvalidated(EventArgs e)
         {

--- a/src/Avalonia.Controls/Generators/IItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/IItemContainerGenerator.cs
@@ -97,6 +97,6 @@ namespace Avalonia.Controls.Generators
         /// </summary>
         /// <param name="container">The container.</param>
         /// <returns>The index of the container, or -1 if not found.</returns>
-        int IndexFromContainer(IControl container);
+        int IndexFromContainer(IControl? container);
     }
 }

--- a/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
@@ -158,7 +158,7 @@ namespace Avalonia.Controls.Generators
         }
 
         /// <inheritdoc/>
-        public int IndexFromContainer(IControl container)
+        public int IndexFromContainer(IControl? container)
         {
             foreach (var i in _containers)
             {

--- a/src/Avalonia.Controls/Presenters/ItemVirtualizer.cs
+++ b/src/Avalonia.Controls/Presenters/ItemVirtualizer.cs
@@ -254,7 +254,7 @@ namespace Avalonia.Controls.Presenters
         /// <param name="direction">The movement direction.</param>
         /// <param name="from">The control from which movement begins.</param>
         /// <returns>The control.</returns>
-        public virtual IControl? GetControlInDirection(NavigationDirection direction, IControl from)
+        public virtual IControl? GetControlInDirection(NavigationDirection direction, IControl? from)
         {
             return null;
         }

--- a/src/Avalonia.Controls/Presenters/ItemVirtualizerSimple.cs
+++ b/src/Avalonia.Controls/Presenters/ItemVirtualizerSimple.cs
@@ -226,7 +226,7 @@ namespace Avalonia.Controls.Presenters
             InvalidateScroll();
         }
 
-        public override IControl? GetControlInDirection(NavigationDirection direction, IControl from)
+        public override IControl? GetControlInDirection(NavigationDirection direction, IControl? from)
         {
             var generator = Owner.ItemContainerGenerator;
             var panel = VirtualizingPanel;

--- a/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
@@ -117,7 +117,7 @@ namespace Avalonia.Controls.Presenters
         }
 
         /// <inheritdoc/>
-        IControl? ILogicalScrollable.GetControlInDirection(NavigationDirection direction, IControl from)
+        IControl? ILogicalScrollable.GetControlInDirection(NavigationDirection direction, IControl? from)
         {
             return Virtualizer?.GetControlInDirection(direction, from);
         }

--- a/src/Avalonia.Controls/Primitives/ILogicalScrollable.cs
+++ b/src/Avalonia.Controls/Primitives/ILogicalScrollable.cs
@@ -64,7 +64,7 @@ namespace Avalonia.Controls.Primitives
         /// <param name="direction">The movement direction.</param>
         /// <param name="from">The control from which movement begins.</param>
         /// <returns>The control.</returns>
-        IControl? GetControlInDirection(NavigationDirection direction, IControl from);
+        IControl? GetControlInDirection(NavigationDirection direction, IControl? from);
 
         /// <summary>
         /// Raises the <see cref="ScrollInvalidated"/> event.

--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -133,7 +133,7 @@ namespace Avalonia.Controls
 
             if (logicalScrollable?.IsLogicalScrollEnabled == true)
             {
-                return logicalScrollable.GetControlInDirection(direction, from!);
+                return logicalScrollable.GetControlInDirection(direction, from);
             }
             else
             {


### PR DESCRIPTION
## What does the pull request do?
Previously parameter with type IControl was marked as non-nullable in [ILogicalScrollable.GetControlInDirection](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Primitives/ILogicalScrollable.cs#L67), but it isn't correct though, all implementations we have at the moment can accept null and it is valid behaviour.

