### PR TITLE
Window dragging bugfix on Windows

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.CustomCaptionProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.CustomCaptionProc.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Win32
             AdjustWindowRectEx(ref rcFrame, (uint)(WindowStyles.WS_OVERLAPPEDWINDOW & ~WindowStyles.WS_CAPTION), false, 0);
 
             var borderThickness = new RECT();
-            if (GetStyle().HasAllFlags(WindowStyles.WS_THICKFRAME))
+            if (GetStyle().HasAllFlags(WindowStyles.WS_CAPTION))
             {
                 AdjustWindowRectEx(ref borderThickness, (uint)(GetStyle()), false, 0);
                 borderThickness.left *= -1;


### PR DESCRIPTION
## What does the pull request do?
This PR fixes a bug regarding window dragging on Windows.

## What is the current behavior?
When a Window that uses custom decorations (with `ExtendClientAreaToDecorationsHint = true`) is declared non resizable (with `CanResize = false`), it cannot be dragged by clicking on the title bar.


## What is the updated/expected behavior with this PR?
Any Window that uses custom decorations while also being non resizable can be dragged, as usual, by clicking on the title bar.

## How was the solution implemented (if it's not obvious)?
This issue is due to a bug in the Windows specific code that handles hit tests: when resizing is disabled for a window, it doesn't have a sizing border anymore. Therefore, the `WS_THICKFRAME` attribute is missing from its Style, resulting in an incorrect value being used for `borderThickness`.

Replacing `WS_THICKFRAME` with `WS_CAPTION` fixes this issue, as this attribute is present in the Window's Style regardless of if it can be resized or not.

**Note**: It may be safe to bypass the style checks entirely, and to compute `borderThickness` from `AdjustWindowRectEx` everytime. However, since I did not extensively test this theory, I did not include this change in this PR. However, the resulting behaviour may be the same regardless, as I did not see anything that might indicate that Avalonia was able to create windows without the `WS_CAPTION` attribute.

Resolves #5526, resolves #6942