### PR TITLE
Add Skia Helper Methods to allow applying Skia Filter Effects (Blur, DropShadow, Lighting) to DC content

### DIFF
--- a/src/Skia/Avalonia.Skia/Helpers/DrawingContextHelper.cs
+++ b/src/Skia/Avalonia.Skia/Helpers/DrawingContextHelper.cs
@@ -33,35 +33,33 @@ namespace Avalonia.Skia.Helpers
         /// Unsupported - Wraps a GPU Backed SkiaSurface in an Avalonia DrawingContext.
         /// </summary>
         [Obsolete]
-        public static IDrawingContextImpl WrapSkiaSurface(this SKSurface surface, GRContext grContext, Vector dpi, IVisualBrushRenderer visualBrushRenderer = null)
+        public static IDrawingContextImpl WrapSkiaSurface(this SKSurface surface, GRContext grContext, Vector dpi, params IDisposable[] disposables)
         {
             var createInfo = new DrawingContextImpl.CreateInfo
             {
                 GrContext = grContext,
                 Surface = surface,
                 Dpi = dpi,
-                VisualBrushRenderer = visualBrushRenderer,
                 DisableTextLcdRendering = false,
             };
 
-            return new DrawingContextImpl(createInfo);
+            return new DrawingContextImpl(createInfo, disposables);
         }
         
         /// <summary>
         /// Unsupported - Wraps a non-GPU Backed SkiaSurface in an Avalonia DrawingContext.
         /// </summary>
         [Obsolete]
-        public static IDrawingContextImpl WrapSkiaSurface(this SKSurface surface, Vector dpi, IVisualBrushRenderer visualBrushRenderer = null)
+        public static IDrawingContextImpl WrapSkiaSurface(this SKSurface surface, Vector dpi, params IDisposable[] disposables)
         {
             var createInfo = new DrawingContextImpl.CreateInfo
             {
                 Surface = surface,
                 Dpi = dpi,
-                VisualBrushRenderer = visualBrushRenderer,
                 DisableTextLcdRendering = false,
             };
 
-            return new DrawingContextImpl(createInfo);
+            return new DrawingContextImpl(createInfo, disposables);
         }
         
         [Obsolete]

--- a/src/Skia/Avalonia.Skia/Helpers/DrawingContextHelper.cs
+++ b/src/Skia/Avalonia.Skia/Helpers/DrawingContextHelper.cs
@@ -61,6 +61,33 @@ namespace Avalonia.Skia.Helpers
 
             return new DrawingContextImpl(createInfo, disposables);
         }
+
+        [Obsolete]
+        public static ISkiaDrawingContextImpl CreateDrawingContext(Size size, Vector dpi, GRContext grContext = null)
+        {
+            if (grContext is null)
+            {
+                var surface = SKSurface.Create(
+                    new SKImageInfo(
+                        (int)Math.Ceiling(size.Width),
+                        (int)Math.Ceiling(size.Height),
+                        SKImageInfo.PlatformColorType,
+                        SKAlphaType.Premul));
+
+                return WrapSkiaSurface(surface, dpi, surface);
+            }
+            else
+            {
+                var surface = SKSurface.Create(grContext, false,
+                    new SKImageInfo(
+                        (int)Math.Ceiling(size.Width),
+                        (int)Math.Ceiling(size.Height),
+                        SKImageInfo.PlatformColorType,
+                        SKAlphaType.Premul));
+
+                return WrapSkiaSurface(surface, grContext, dpi, surface);
+            }
+        }
         
         [Obsolete]
         public static void DrawTo(this ISkiaDrawingContextImpl source, ISkiaDrawingContextImpl destination, SKPaint paint = null)

--- a/src/Skia/Avalonia.Skia/Helpers/DrawingContextHelper.cs
+++ b/src/Skia/Avalonia.Skia/Helpers/DrawingContextHelper.cs
@@ -33,7 +33,7 @@ namespace Avalonia.Skia.Helpers
         /// Unsupported - Wraps a GPU Backed SkiaSurface in an Avalonia DrawingContext.
         /// </summary>
         [Obsolete]
-        public static IDrawingContextImpl WrapSkiaSurface(this SKSurface surface, GRContext grContext, Vector dpi, params IDisposable[] disposables)
+        public static ISkiaDrawingContextImpl WrapSkiaSurface(this SKSurface surface, GRContext grContext, Vector dpi, params IDisposable[] disposables)
         {
             var createInfo = new DrawingContextImpl.CreateInfo
             {
@@ -50,7 +50,7 @@ namespace Avalonia.Skia.Helpers
         /// Unsupported - Wraps a non-GPU Backed SkiaSurface in an Avalonia DrawingContext.
         /// </summary>
         [Obsolete]
-        public static IDrawingContextImpl WrapSkiaSurface(this SKSurface surface, Vector dpi, params IDisposable[] disposables)
+        public static ISkiaDrawingContextImpl WrapSkiaSurface(this SKSurface surface, Vector dpi, params IDisposable[] disposables)
         {
             var createInfo = new DrawingContextImpl.CreateInfo
             {

--- a/src/Skia/Avalonia.Skia/Helpers/DrawingContextHelper.cs
+++ b/src/Skia/Avalonia.Skia/Helpers/DrawingContextHelper.cs
@@ -65,17 +65,9 @@ namespace Avalonia.Skia.Helpers
         }
         
         [Obsolete]
-        public static void DrawSurfaceTo(this ISkiaDrawingContextImpl source, ISkiaDrawingContextImpl destination,
-            Size size, SKImageFilter imageFilter = null)
+        public static void DrawTo(this ISkiaDrawingContextImpl source, ISkiaDrawingContextImpl destination, SKPaint paint = null)
         {
-            using (var blurSnapPaint = new SKPaint
-                   {
-                       ImageFilter = imageFilter,
-                       IsAntialias = true
-                   })
-            {
-                destination.SkCanvas.DrawSurface(source.SkSurface, new SKPoint(0, 0), blurSnapPaint);
-            }
+            destination.SkCanvas.DrawSurface(source.SkSurface, new SKPoint(0, 0), paint);
         }
     }
 }

--- a/src/Skia/Avalonia.Skia/Helpers/DrawingContextHelper.cs
+++ b/src/Skia/Avalonia.Skia/Helpers/DrawingContextHelper.cs
@@ -1,10 +1,11 @@
-﻿using Avalonia.Platform;
+﻿using System;
+using Avalonia.Platform;
 using Avalonia.Rendering;
 using SkiaSharp;
 
 namespace Avalonia.Skia.Helpers
 {
-    public class DrawingContextHelper
+    public static class DrawingContextHelper
     {
         /// <summary>
         /// Wrap Skia canvas in drawing context so we can use Avalonia api to render to external skia canvas
@@ -26,6 +27,55 @@ namespace Avalonia.Skia.Helpers
             };
 
             return new DrawingContextImpl(createInfo);
+        }
+        
+        /// <summary>
+        /// Unsupported - Wraps a GPU Backed SkiaSurface in an Avalonia DrawingContext.
+        /// </summary>
+        [Obsolete]
+        public static IDrawingContextImpl WrapSkiaSurface(this SKSurface surface, GRContext grContext, Vector dpi, IVisualBrushRenderer visualBrushRenderer = null)
+        {
+            var createInfo = new DrawingContextImpl.CreateInfo
+            {
+                GrContext = grContext,
+                Surface = surface,
+                Dpi = dpi,
+                VisualBrushRenderer = visualBrushRenderer,
+                DisableTextLcdRendering = false,
+            };
+
+            return new DrawingContextImpl(createInfo);
+        }
+        
+        /// <summary>
+        /// Unsupported - Wraps a non-GPU Backed SkiaSurface in an Avalonia DrawingContext.
+        /// </summary>
+        [Obsolete]
+        public static IDrawingContextImpl WrapSkiaSurface(this SKSurface surface, Vector dpi, IVisualBrushRenderer visualBrushRenderer = null)
+        {
+            var createInfo = new DrawingContextImpl.CreateInfo
+            {
+                Surface = surface,
+                Dpi = dpi,
+                VisualBrushRenderer = visualBrushRenderer,
+                DisableTextLcdRendering = false,
+            };
+
+            return new DrawingContextImpl(createInfo);
+        }
+        
+        [Obsolete]
+        public static void DrawSurfaceTo(this ISkiaDrawingContextImpl source, ISkiaDrawingContextImpl destination,
+            Size size, SKImageFilter imageFilter = null)
+        {
+            using (var blurSnapPaint = new SKPaint
+                   {
+                       ImageFilter = imageFilter,
+                       IsAntialias = true
+                   })
+            {
+                destination.SkCanvas.DrawSurface(source.SkSurface, new SKPoint(0, 0), blurSnapPaint);
+            }
         }
     }
 }


### PR DESCRIPTION
Adds some obsolete (unsupported helpers) for people using custom skia rendering.

Allows you to create an arbitary drawing context.

Rendering to it...

Rendering that drawing context to any other DrawingContext.. with custom skia paint..  meaning drop shadow, lighting, blur.

```
using (var barsLayer = DrawingContextHelper.CreateDrawingContext(bounds.Size, new Vector(96,96), skia.GrContext))
{
    RenderBars(barsLayer);
    
    using (var filter = SKImageFilter.CreateBlur(24, 24, SKShaderTileMode.Clamp))
    using(var paint = new SKPaint{ ImageFilter = filter})    
    {
        barsLayer.DrawTo(skia, paint);
    }
}
```

NOTE! These methods will not be available long term, they are marked as obsolete.