### PR TITLE
Add missing call to base class in ReactiveUserControl.OnDataContextChanged 

### DIFF
--- a/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
+++ b/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
@@ -48,6 +48,7 @@ namespace Avalonia.ReactiveUI
 
         protected override void OnDataContextChanged(EventArgs e)
         {
+            base.OnDataContextChanged(e);
             ViewModel = DataContext as TViewModel;
         }
 


### PR DESCRIPTION
## What does the pull request do?
Adds the missing call to `base.OnDataContextChanged`


## What is the current behavior?
the control does not call `base.OnDataContextChanged`, so `DataContextChanged` - event is not raised


## What is the updated/expected behavior with this PR?
the control does call `base.OnDataContextChanged`


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #7636
