### PR TITLE
Fix dwm opaque backdrop

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -765,6 +765,14 @@ namespace Avalonia.Win32.Interop
             DWMWA_CLOAK,
             DWMWA_CLOAKED,
             DWMWA_FREEZE_REPRESENTATION,
+            DWMWA_PASSIVE_UPDATE_MODE,
+            DWMWA_USE_HOSTBACKDROPBRUSH,
+            DWMWA_USE_IMMERSIVE_DARK_MODE = 20,
+            DWMWA_WINDOW_CORNER_PREFERENCE = 33,
+            DWMWA_BORDER_COLOR,
+            DWMWA_CAPTION_COLOR,
+            DWMWA_TEXT_COLOR,
+            DWMWA_VISIBLE_FRAME_BORDER_THICKNESS,
             DWMWA_LAST
         };
 
@@ -1455,6 +1463,9 @@ namespace Avalonia.Win32.Interop
 
         [DllImport("dwmapi.dll")]
         public static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out RECT pvAttribute, int cbAttribute);
+
+        [DllImport("dwmapi.dll")]
+        public static extern int DwmSetWindowAttribute(IntPtr hwnd, int dwAttribute, void* pvAttribute, int cbAttribute);
 
         [DllImport("dwmapi.dll")]
         public static extern int DwmIsCompositionEnabled(out bool enabled);

--- a/src/Windows/Avalonia.Win32/WinRT/Composition/WinUICompositorConnection.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/Composition/WinUICompositorConnection.cs
@@ -17,11 +17,11 @@ namespace Avalonia.Win32.WinRT.Composition
 {
     class WinUICompositorConnection : IRenderTimer
     {
+        public static readonly Version MinHostBackdropVersion = new Version(10, 0, 22000);
         private readonly float? _backdropCornerRadius;
         private readonly EglContext _syncContext;
         private readonly ICompositionBrush _micaBrush;
         private ICompositor _compositor;
-        private ICompositor2 _compositor2;
         private ICompositor5 _compositor5;
         private ICompositorInterop _compositorInterop;
         private AngleWin32EglDisplay _angle;
@@ -39,12 +39,11 @@ namespace Avalonia.Win32.WinRT.Composition
             _syncContext = _gl.PrimaryEglContext;
             _angle = (AngleWin32EglDisplay)_gl.Display;
             _compositor = NativeWinRTMethods.CreateInstance<ICompositor>("Windows.UI.Composition.Compositor");
-            _compositor2 = _compositor.QueryInterface<ICompositor2>();
             _compositor5 = _compositor.QueryInterface<ICompositor5>();
             _compositorInterop = _compositor.QueryInterface<ICompositorInterop>();
             _compositorDesktopInterop = _compositor.QueryInterface<ICompositorDesktopInterop>();
             using var device = MicroComRuntime.CreateProxyFor<IUnknown>(_angle.GetDirect3DDevice(), true);
-            
+
             _device = _compositorInterop.CreateGraphicsDevice(device);
             _blurBrush = CreateAcrylicBlurBackdropBrush();
             _micaBrush = CreateMicaBackdropBrush();
@@ -71,7 +70,7 @@ namespace Avalonia.Win32.WinRT.Composition
                     AvaloniaLocator.CurrentMutable.BindToSelf(connect);
                     AvaloniaLocator.CurrentMutable.Bind<IRenderTimer>().ToConstant(connect);
                     tcs.SetResult(true);
-                    
+
                 }
                 catch (Exception e)
                 {
@@ -99,7 +98,7 @@ namespace Avalonia.Win32.WinRT.Composition
             }
             public void Dispose()
             {
-                
+
             }
 
             public void Invoke(IAsyncAction asyncInfo, AsyncStatus asyncStatus)
@@ -118,12 +117,12 @@ namespace Avalonia.Win32.WinRT.Composition
             {
             }
         }
-        
+
         private void RunLoop()
         {
             {
                 var st = Stopwatch.StartNew();
-                using (var act = _compositor5.RequestCommitAsync()) 
+                using (var act = _compositor5.RequestCommitAsync())
                     act.SetCompleted(new RunLoopHandler(this));
                 while (true)
                 {
@@ -172,12 +171,12 @@ namespace Avalonia.Win32.WinRT.Composition
             using var sc = _syncContext.EnsureLocked();
             using var desktopTarget = _compositorDesktopInterop.CreateDesktopWindowTarget(hWnd, 0);
             using var target = desktopTarget.QueryInterface<ICompositionTarget>();
-            
+
             using var drawingSurface = _device.CreateDrawingSurface(new UnmanagedMethods.SIZE(), DirectXPixelFormat.B8G8R8A8UIntNormalized,
                 DirectXAlphaMode.Premultiplied);
             using var surface = drawingSurface.QueryInterface<ICompositionSurface>();
             using var surfaceInterop = drawingSurface.QueryInterface<ICompositionDrawingSurfaceInterop>();
-            
+
             using var surfaceBrush = _compositor.CreateSurfaceBrushWithSurface(surface);
             using var brush = surfaceBrush.QueryInterface<ICompositionBrush>();
 
@@ -190,7 +189,7 @@ namespace Avalonia.Win32.WinRT.Composition
             using var containerVisual2 = container.QueryInterface<IVisual2>();
             containerVisual2.SetRelativeSizeAdjustment(new Vector2(1, 1));
             using var containerChildren = container.Children;
-            
+
             target.SetRoot(containerVisual);
 
             using var blur = CreateBlurVisual(_blurBrush);
@@ -202,10 +201,10 @@ namespace Avalonia.Win32.WinRT.Composition
             }
 
             var compositionRoundedRectangleGeometry = ClipVisual(blur, mica);
-            
+
             containerChildren.InsertAtTop(blur);
             containerChildren.InsertAtTop(visual);
-            
+
             return new WinUICompositedWindow(_syncContext, _compositor, _pumpLock, target, surfaceInterop, visual,
                 blur, mica, compositionRoundedRectangleGeometry);
         }
@@ -234,10 +233,8 @@ namespace Avalonia.Win32.WinRT.Composition
             var blurEffect = new WinUIGaussianBlurEffect(backDropParameterAsSource);
             using var blurEffectFactory = _compositor.CreateEffectFactory(blurEffect);
             using var compositionEffectBrush = blurEffectFactory.CreateBrush();
-            using var backdrop = _compositor2.CreateBackdropBrush();
-            using var backdropBrush = backdrop.QueryInterface<ICompositionBrush>();
-            
-            
+            using var backdropBrush = CreateBackdropBrush();
+
             var saturateEffect = new SaturationEffect(blurEffect);
             using var satEffectFactory = _compositor.CreateEffectFactory(saturateEffect);
             using var sat = satEffectFactory.CreateBrush();
@@ -261,8 +258,8 @@ namespace Avalonia.Win32.WinRT.Composition
             foreach (var visual in containerVisuals)
             {
                 visual?.SetClip(geometricClipWithGeometry.QueryInterface<ICompositionClip>());
-        }
-        
+            }
+
             return roundedRectangleGeometry.CloneReference();
         }
 
@@ -271,8 +268,8 @@ namespace Avalonia.Win32.WinRT.Composition
             using var spriteVisual = _compositor.CreateSpriteVisual();
             using var visual = spriteVisual.QueryInterface<IVisual>();
             using var visual2 = spriteVisual.QueryInterface<IVisual2>();
-           
-            
+
+
             spriteVisual.SetBrush(compositionBrush);
             visual.SetIsVisible(0);
             visual2.SetRelativeSizeAdjustment(new Vector2(1.0f, 1.0f));
@@ -280,6 +277,29 @@ namespace Avalonia.Win32.WinRT.Composition
             return visual.CloneReference();
         }
 
+        private ICompositionBrush CreateBackdropBrush()
+        {
+            ICompositionBackdropBrush brush = null;
+            try
+            {
+                if (Win32Platform.WindowsVersion >= MinHostBackdropVersion)
+                {
+                    using var compositor3 = _compositor.QueryInterface<ICompositor3>();
+                    brush = compositor3.CreateHostBackdropBrush();
+                }
+                else
+                {
+                    using var compositor2 = _compositor.QueryInterface<ICompositor2>();
+                    brush = compositor2.CreateBackdropBrush();
+                }
+
+                return brush.QueryInterface<ICompositionBrush>();
+            }
+            finally
+            {
+                brush?.Dispose();
+            }
+        }
 
         public event Action<TimeSpan> Tick;
     }

--- a/src/Windows/Avalonia.Win32/WinRT/winrt.idl
+++ b/src/Windows/Avalonia.Win32/WinRT/winrt.idl
@@ -358,6 +358,12 @@ interface ICompositor2 : IInspectable
     [overload("CreateStepEasingFunction")] HRESULT CreateStepEasingFunctionWithStepCount([in] INT32 stepCount, [out] [retval] void** result);
 }
 
+[uuid(C9DD8EF0-6EB1-4E3C-A658-675D9C64D4AB)]
+interface ICompositor3 : IInspectable
+{
+    HRESULT CreateHostBackdropBrush([out][retval] ICompositionBackdropBrush** result);
+}
+
 [uuid(0D8FB190-F122-5B8D-9FDD-543B0D8EB7F3)]
 interface ICompositorWithBlurredWallpaperBackdropBrush : IInspectable
 {

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -379,13 +379,24 @@ namespace Avalonia.Win32
         {
             if (_isUsingComposition)
             {
-                _blurHost?.SetBlur(transparencyLevel switch
+                var effect = transparencyLevel switch
                 {
                     WindowTransparencyLevel.Mica => BlurEffect.Mica,
                     WindowTransparencyLevel.AcrylicBlur => BlurEffect.Acrylic,
                     WindowTransparencyLevel.Blur => BlurEffect.Acrylic,
                     _ => BlurEffect.None
-                });
+                };
+
+                if (Win32Platform.WindowsVersion >= WinUICompositorConnection.MinHostBackdropVersion)
+                {
+                    unsafe
+                    {
+                        int pvUseBackdropBrush = effect == BlurEffect.Acrylic ? 1 : 0;
+                        DwmSetWindowAttribute(_hwnd, (int)DwmWindowAttribute.DWMWA_USE_HOSTBACKDROPBRUSH, &pvUseBackdropBrush, sizeof(int));
+                    }
+                }
+
+                _blurHost?.SetBlur(effect);
 
                 return transparencyLevel;
             }

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -86,7 +86,7 @@ namespace Avalonia.Win32
         private Size _minSize;
         private Size _maxSize;
         private POINT _maxTrackSize;
-        private WindowImpl _parent;        
+        private WindowImpl _parent;
         private ExtendClientAreaChromeHints _extendChromeHints = ExtendClientAreaChromeHints.Default;
         private bool _isCloseRequested;
         private bool _shown;
@@ -174,7 +174,7 @@ namespace Avalonia.Win32
         public Action<PixelPoint> PositionChanged { get; set; }
 
         public Action<WindowState> WindowStateChanged { get; set; }
-        
+
         public Action LostFocus { get; set; }
 
         public Action<WindowTransparencyLevel> TransparencyLevelChanged { get; set; }
@@ -247,7 +247,7 @@ namespace Avalonia.Win32
         {
             get
             {
-                if(_isFullScreenActive)
+                if (_isFullScreenActive)
                 {
                     return WindowState.FullScreen;
                 }
@@ -270,7 +270,7 @@ namespace Avalonia.Win32
                     ShowWindow(value, value != WindowState.Minimized); // If the window is minimized, it shouldn't be activated
                 }
 
-                _showWindowState = value;                
+                _showWindowState = value;
             }
         }
 
@@ -278,7 +278,7 @@ namespace Avalonia.Win32
 
         protected IntPtr Hwnd => _hwnd;
 
-        public void SetTransparencyLevelHint (WindowTransparencyLevel transparencyLevel)
+        public void SetTransparencyLevelHint(WindowTransparencyLevel transparencyLevel)
         {
             TransparencyLevel = EnableBlur(transparencyLevel);
         }
@@ -318,12 +318,12 @@ namespace Avalonia.Win32
             }
 
             var blurInfo = new DWM_BLURBEHIND(false);
-            
+
             if (transparencyLevel == WindowTransparencyLevel.Blur)
             {
                 blurInfo = new DWM_BLURBEHIND(true);
             }
-            
+
             DwmEnableBlurBehindWindow(_hwnd, ref blurInfo);
 
             if (transparencyLevel == WindowTransparencyLevel.Transparent)
@@ -483,12 +483,12 @@ namespace Avalonia.Win32
             if (customRendererFactory != null)
                 return customRendererFactory.Create(root, loop);
 
-            return Win32Platform.UseDeferredRendering 
-                ?  _isUsingComposition 
+            return Win32Platform.UseDeferredRendering
+                ? _isUsingComposition
                     ? new DeferredRenderer(root, loop)
                     {
                         RenderOnlyOnRenderThread = true
-                    } 
+                    }
                     : (IRenderer)new DeferredRenderer(root, loop, rendererLock: _rendererLock)
                 : new ImmediateRenderer(root);
         }
@@ -543,7 +543,7 @@ namespace Avalonia.Win32
                 {
                     BeforeCloseCleanup(true);
                 }
-                
+
                 DestroyWindow(_hwnd);
                 _hwnd = IntPtr.Zero;
             }
@@ -609,7 +609,7 @@ namespace Avalonia.Win32
         public void SetParent(IWindowImpl parent)
         {
             _parent = (WindowImpl)parent;
-            
+
             var parentHwnd = _parent?._hwnd ?? IntPtr.Zero;
 
             if (parentHwnd == IntPtr.Zero && !_windowProperties.ShowInTaskbar)
@@ -723,7 +723,7 @@ namespace Avalonia.Win32
                 _isUsingComposition ? (int)WindowStyles.WS_EX_NOREDIRECTIONBITMAP : 0,
                 atom,
                 null,
-                (int)WindowStyles.WS_OVERLAPPEDWINDOW | (int) WindowStyles.WS_CLIPCHILDREN,
+                (int)WindowStyles.WS_OVERLAPPEDWINDOW | (int)WindowStyles.WS_CLIPCHILDREN,
                 CW_USEDEFAULT,
                 CW_USEDEFAULT,
                 CW_USEDEFAULT,
@@ -779,7 +779,7 @@ namespace Avalonia.Win32
             }
 
             if (ShCoreAvailable && Win32Platform.WindowsVersion > PlatformConstants.Windows8)
-			{
+            {
                 var monitor = MonitorFromWindow(
                     _hwnd,
                     MONITOR.MONITOR_DEFAULTTONEAREST);
@@ -862,14 +862,14 @@ namespace Avalonia.Win32
             }
 
             TaskBarList.MarkFullscreen(_hwnd, fullscreen);
-            
+
             ExtendClientArea();
         }
 
         private MARGINS UpdateExtendMargins()
         {
             RECT borderThickness = new RECT();
-            RECT borderCaptionThickness = new RECT();            
+            RECT borderCaptionThickness = new RECT();
 
             AdjustWindowRectEx(ref borderCaptionThickness, (uint)(GetStyle()), false, 0);
             AdjustWindowRectEx(ref borderThickness, (uint)(GetStyle() & ~WindowStyles.WS_CAPTION), false, 0);
@@ -892,7 +892,7 @@ namespace Avalonia.Win32
 
             if (_extendTitleBarHint != -1)
             {
-                borderCaptionThickness.top = (int)(_extendTitleBarHint * RenderScaling);                
+                borderCaptionThickness.top = (int)(_extendTitleBarHint * RenderScaling);
             }
 
             margins.cyTopHeight = _extendChromeHints.HasAllFlags(ExtendClientAreaChromeHints.SystemChrome) && !_extendChromeHints.HasAllFlags(ExtendClientAreaChromeHints.PreferSystemChrome) ? borderCaptionThickness.top : 1;
@@ -917,7 +917,7 @@ namespace Avalonia.Win32
             {
                 return;
             }
-            
+
             if (DwmIsCompositionEnabled(out bool compositionEnabled) < 0 || !compositionEnabled)
             {
                 _isClientAreaExtended = false;
@@ -945,11 +945,11 @@ namespace Avalonia.Win32
 
                 _offScreenMargin = new Thickness();
                 _extendedMargins = new Thickness();
-                
-                Resize(new Size(rcWindow.Width/ RenderScaling, rcWindow.Height / RenderScaling), PlatformResizeReason.Layout);
+
+                Resize(new Size(rcWindow.Width / RenderScaling, rcWindow.Height / RenderScaling), PlatformResizeReason.Layout);
             }
 
-            if(!_isClientAreaExtended || (_extendChromeHints.HasAllFlags(ExtendClientAreaChromeHints.SystemChrome) &&
+            if (!_isClientAreaExtended || (_extendChromeHints.HasAllFlags(ExtendClientAreaChromeHints.SystemChrome) &&
                 !_extendChromeHints.HasAllFlags(ExtendClientAreaChromeHints.PreferSystemChrome)))
             {
                 EnableCloseButton(_hwnd);
@@ -965,12 +965,12 @@ namespace Avalonia.Win32
         private void ShowWindow(WindowState state, bool activate)
         {
             _shown = true;
-            
+
             if (_isClientAreaExtended)
             {
                 ExtendClientArea();
             }
-            
+
             ShowWindowCommand? command;
 
             var newWindowProperties = _windowProperties;
@@ -988,7 +988,7 @@ namespace Avalonia.Win32
 
                 case WindowState.Normal:
                     newWindowProperties.IsFullScreen = false;
-                    command = IsWindowVisible(_hwnd) ? ShowWindowCommand.Restore : 
+                    command = IsWindowVisible(_hwnd) ? ShowWindowCommand.Restore :
                         activate ? ShowWindowCommand.Normal : ShowWindowCommand.ShowNoActivate;
                     break;
 
@@ -1019,7 +1019,7 @@ namespace Avalonia.Win32
                 SetForegroundWindow(_hwnd);
             }
         }
-        
+
         private void BeforeCloseCleanup(bool isDisposing)
         {
             // Based on https://github.com/dotnet/wpf/blob/master/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs#L4270-L4337
@@ -1037,7 +1037,7 @@ namespace Avalonia.Win32
                     // Our window closed callback will set enabled state to a correct value after child window gets destroyed.
                     _parent.SetEnabled(true);
                 }
-                
+
                 // We also need to activate our parent window since again OS might try to activate a window behind if it is not set.
                 if (wasActive)
                 {
@@ -1064,7 +1064,7 @@ namespace Avalonia.Win32
                     SetWindowPos(_hwnd, WindowPosZOrder.HWND_NOTOPMOST, x, y, cx, cy, SetWindowPosFlags.SWP_SHOWWINDOW);
                 }
             }
-        }        
+        }
 
         private WindowStyles GetWindowStateStyles()
         {
@@ -1241,7 +1241,7 @@ namespace Avalonia.Win32
                         SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_NOACTIVATE |
                         SetWindowPosFlags.SWP_FRAMECHANGED);
                 }
-            }            
+            }
         }
 
         private const int MF_BYCOMMAND = 0x0;
@@ -1291,9 +1291,9 @@ namespace Avalonia.Win32
         public void SetExtendClientAreaToDecorationsHint(bool hint)
         {
             _isClientAreaExtended = hint;
-            
-            ExtendClientArea();            
-        }        
+
+            ExtendClientArea();
+        }
 
         public void SetExtendClientAreaChromeHints(ExtendClientAreaChromeHints hints)
         {
@@ -1301,7 +1301,7 @@ namespace Avalonia.Win32
 
             ExtendClientArea();
         }
-        
+
         /// <inheritdoc/>
         public void SetExtendClientAreaTitleBarHeightHint(double titleBarHeight)
         {
@@ -1315,7 +1315,7 @@ namespace Avalonia.Win32
 
         /// <inheritdoc/>
         public Action<bool> ExtendClientAreaToDecorationsChanged { get; set; }
-        
+
         /// <inheritdoc/>
         public bool NeedsManagedDecorations => _isClientAreaExtended && _extendChromeHints.HasAllFlags(ExtendClientAreaChromeHints.PreferSystemChrome);
 
@@ -1354,7 +1354,7 @@ namespace Avalonia.Win32
         {
             private readonly WindowImpl _owner;
             private readonly PlatformResizeReason _restore;
-            
+
             public ResizeReasonScope(WindowImpl owner, PlatformResizeReason restore)
             {
                 _owner = owner;


### PR DESCRIPTION
## What does the pull request do?
Windows 11 introduced some breaking changes / bugs to DWM [1] [2]. As a result, the behavior of DWM changed from win10. This could cause the acrylic backdrop to become opaque. This PR resolves this issue by setting a new DWM attribute introduced in win11.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Neither `TransparencyLevelHint.Transparent` nor `TransparencyLevelHint.AcrylicBlur` works with extended margins. 

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
`TransparencyLevelHint.Transparent` and `TransparencyLevelHint.AcrylicBlur` now works with  `Window.ExtendClientAreaToDecorationsHint = true`

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
1. Use host backdrop from ICompositor3 instead of backdrop from ICompositor2 if win11.
1. Set  [DWMWA_USE_HOSTBACKDROPBRUSH](https://docs.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute#constants) if the acrylic backdrop is enabled.

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->
No breaking changes.

## Fixed issues
Fixes #7403
Fixes #6465

[1] https://github.com/dotnet/winforms/issues/6364
[2] https://www.youtube.com/watch?v=dH7-rVpssxQ
