### PR TITLE
Grammatical corrections to product names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,7 +192,7 @@ dirs.sln
 
 
 ##################
-# XCode
+# Xcode
 ##################
 Index/
 Logs/

--- a/build/SharedVersion.props
+++ b/build/SharedVersion.props
@@ -11,7 +11,7 @@
     <LangVersion>latest</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>Icon.png</PackageIcon>
-    <PackageDescription>Avalonia is a cross-platform UI framework for .NET providing a flexible styling system and supporting a wide range of Operating Systems such as Windows, Linux, MacOS and with experimental support for Android, iOS and WebAssembly.</PackageDescription>
+    <PackageDescription>Avalonia is a cross-platform UI framework for .NET providing a flexible styling system and supporting a wide range of Operating Systems such as Windows, Linux, macOS and with experimental support for Android, iOS and WebAssembly.</PackageDescription>
     <PackageTags>avalonia;avaloniaui;mvvm;rx;reactive extensions;android;ios;mac;forms;wpf;net;netstandard;net461;uwp;xamarin</PackageTags>
     <PackageReleaseNotes>https://github.com/AvaloniaUI/Avalonia/releases</PackageReleaseNotes>
     <RepositoryType>git</RepositoryType>

--- a/native/Avalonia.Native/src/OSX/window.mm
+++ b/native/Avalonia.Native/src/OSX/window.mm
@@ -735,7 +735,7 @@ private:
                 return E_INVALIDARG;
             
             // If one tries to show a child window with a minimized parent window, then the parent window will be
-            // restored but MacOS isn't kind enough to *tell* us that, so the window will be left in a non-interactive
+            // restored but macOS isn't kind enough to *tell* us that, so the window will be left in a non-interactive
             // state. Detect this and explicitly restore the parent window ourselves to avoid this situation.
             if (cparent->WindowState() == Minimized)
                 cparent->SetWindowState(Normal);

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 
 ## 📖 About 
 
-Avalonia is a cross-platform UI framework for dotnet, providing a flexible styling system and supporting a wide range of Operating Systems such as Windows, Linux, MacOs. Avalonia is mature and production ready. We also have in beta release support for iOS, Android and in early stages support for browser via WASM.
+Avalonia is a cross-platform UI framework for dotnet, providing a flexible styling system and supporting a wide range of Operating Systems such as Windows, Linux, macOS. Avalonia is mature and production ready. We also have in beta release support for iOS, Android and in early stages support for browser via WASM.
 
 ![image](https://user-images.githubusercontent.com/4672627/152126443-932966cf-57e7-4e77-9be6-62463a66b9f8.png)
 

--- a/src/Avalonia.DesignerSupport/Remote/HtmlTransport/webapp/src/index.html
+++ b/src/Avalonia.DesignerSupport/Remote/HtmlTransport/webapp/src/index.html
@@ -9,6 +9,6 @@
 <div id="app">
     <center>Loading...</center>
 </div>
-<noscript>Javascript is required</noscript>
+<noscript>JavaScript is required</noscript>
 </body>
 </html>

--- a/src/Web/Avalonia.Web.Blazor/Interop/Typescript/types/dotnet/index.d.ts
+++ b/src/Web/Avalonia.Web.Blazor/Interop/Typescript/types/dotnet/index.d.ts
@@ -6,7 +6,7 @@
 
 // Here be dragons!
 // This is community-maintained definition file intended to ease the process of developing
-// high quality JavaScript interop code to be used in Blazor application from your C# .Net code.
+// high quality JavaScript interop code to be used in Blazor application from your C# .NET code.
 // Could be removed without a notice in case official definition types ships with Blazor itself.
 
 // tslint:disable:no-unnecessary-generics

--- a/tests/Avalonia.IntegrationTests.Appium/readme.md
+++ b/tests/Avalonia.IntegrationTests.Appium/readme.md
@@ -11,12 +11,12 @@
 - Run WinAppDriver (it gets installed to the start menu)
 - Run the tests in this project
 
-## MacOS
+## macOS
 
 ### Prerequisites
 
 - Install Appium: https://appium.io/
-- Give [XCode helper the required permissions](https://apple.stackexchange.com/questions/334008)
+- Give [Xcode helper the required permissions](https://apple.stackexchange.com/questions/334008)
 - `cd samples/IntegrationTestApp` then `./bundle.sh` to create an app bundle for `IntegrationTestApp`
 - Register the app bundle by running `open -n ./bin/Debug/net6.0/osx-arm64/publish/IntegrationTestApp.app` 
 


### PR DESCRIPTION
Grammatical corrections to product names: XCode -> Xcode, .Net -> .NET, Javascript -> JavaScript, MacOS -> macOS, MacOs -> macOS