### PR TITLE
Fix wrong foreground TextBox color in Fluent theme

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/TextBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/TextBox.xaml
@@ -121,7 +121,7 @@
   </Style>
 
   <!-- PointerOver State-->
-  <Style Selector="TextBox:disabled">
+  <Style Selector="TextBox:pointerover">
     <Setter Property="Foreground" Value="{DynamicResource TextControlForegroundPointerOver}" />
   </Style>
 


### PR DESCRIPTION
## What does the pull request do?
Fixes typo that causes wrong color for `pointerover` and `disabled` styles in `TextBox`.

## What is the current behavior?
![obrazek](https://user-images.githubusercontent.com/3685160/158009132-918eece8-e2a2-4f74-882c-a9d8cd86b262.png)

## What is the updated/expected behavior with this PR?
![obrazek](https://user-images.githubusercontent.com/3685160/158009126-d45f04a7-6ad5-439c-bb3a-0c18c91022e5.png)

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Fixed issues
No issue open.
