### PR TITLE
[WIP] Make NumericUpDown nullable

### DIFF
--- a/samples/ControlCatalog/Pages/NumericUpDownPage.xaml
+++ b/samples/ControlCatalog/Pages/NumericUpDownPage.xaml
@@ -54,6 +54,7 @@
       <Grid Grid.Row="0" Grid.Column="2" Margin="8" RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="Auto, Auto">
         <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="10,2,2,2">Minimum:</TextBlock>
         <NumericUpDown Grid.Row="0" Grid.Column="1" Value="{Binding #upDown.Minimum}"
+                       Watermark="Enter a value"
                        CultureInfo="{Binding #upDown.CultureInfo}" VerticalAlignment="Center" Margin="2" HorizontalAlignment="Center"/>
 
         <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Margin="10,2,2,2">Maximum:</TextBlock>

--- a/samples/ControlCatalog/Pages/NumericUpDownPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/NumericUpDownPage.xaml.cs
@@ -32,21 +32,21 @@ namespace ControlCatalog.Pages
         private FormatObject _selectedFormat;
         private IList<Location> _spinnerLocations;
 
-        private double _doubleValue;
-        private decimal _decimalValue;
+        private double? _doubleValue;
+        private decimal? _decimalValue;
 
         public NumbersPageViewModel()
         {
             SelectedFormat = Formats.FirstOrDefault();
         }
 
-        public double DoubleValue
+        public double? DoubleValue
         {
             get { return _doubleValue; }
             set { this.RaiseAndSetIfChanged(ref _doubleValue, value); }
         }
 
-        public decimal DecimalValue
+        public decimal? DecimalValue
         {
             get { return _decimalValue; }
             set { this.RaiseAndSetIfChanged(ref _decimalValue, value); }

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -616,7 +616,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Converts the formatted text to a value.
         /// </summary>
-        private decimal? ConvertTextToValue(string text)
+        private decimal? ConvertTextToValue(string? text)
         {
             decimal? result = null; // Todo Add default value property
 
@@ -688,6 +688,10 @@ namespace Avalonia.Controls
             // Zero increment always prevents spin.
             if (Increment != 0 && !IsReadOnly)
             {
+                if (!Value.HasValue)
+                {
+                    validDirections = ValidSpinDirections.Increase | ValidSpinDirections.Decrease;
+                }
                 if (Value < Maximum)
                 {
                     validDirections = validDirections | ValidSpinDirections.Increase;
@@ -978,20 +982,17 @@ namespace Avalonia.Controls
             {
                 if (updateValueFromText)
                 {
-                    if (!string.IsNullOrEmpty(text))
+                    try
                     {
-                        try
+                        var newValue = ConvertTextToValue(text);
+                        if (!Equals(newValue, Value))
                         {
-                            var newValue = ConvertTextToValue(text);
-                            if (!Equals(newValue, Value))
-                            {
-                                SetValueInternal(newValue);
-                            }
+                            SetValueInternal(newValue);
                         }
-                        catch
-                        {
-                            parsedTextIsValid = false;
-                        }
+                    }
+                    catch
+                    {
+                        parsedTextIsValid = false;
                     }
                 }
 

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -112,6 +112,13 @@ namespace Avalonia.Controls
                 (updown, v) => updown.Value = v, defaultBindingMode: BindingMode.TwoWay, enableDataValidation: true);
 
         /// <summary>
+        /// Defines the <see cref="DefaultValue"/> property.
+        /// </summary>
+        public static readonly DirectProperty<NumericUpDown, decimal?> DefaultValueProperty =
+            AvaloniaProperty.RegisterDirect<NumericUpDown, decimal?>(nameof(DefaultValue), updown => updown.DefaultValue,
+                (updown, v) => updown.DefaultValue = v);
+
+        /// <summary>
         /// Defines the <see cref="Watermark"/> property.
         /// </summary>
         public static readonly StyledProperty<string?> WatermarkProperty =
@@ -132,6 +139,7 @@ namespace Avalonia.Controls
         private IDisposable? _textBoxTextChangedSubscription;
 
         private decimal? _value;
+        private decimal? _defaultValue;
         private string? _text;
         private bool _internalValueSet;
         private bool _clipValueToMinMax;
@@ -284,6 +292,19 @@ namespace Avalonia.Controls
             {
                 value = OnCoerceValue(value);
                 SetAndRaise(ValueProperty, ref _value, value);
+            }
+        }
+        
+        /// <summary>
+        /// Gets or sets the default value which is set if the <see cref="Value"/> is <see langword="null"/>.
+        /// </summary>
+        public decimal? DefaultValue
+        {
+            get { return _defaultValue; }
+            set
+            {
+                value = OnCoerceValue(value);
+                SetAndRaise(DefaultValueProperty, ref _defaultValue, value);
             }
         }
 
@@ -618,11 +639,11 @@ namespace Avalonia.Controls
         /// </summary>
         private decimal? ConvertTextToValue(string? text)
         {
-            decimal? result = null; // Todo Add default value property
+            decimal? result;
 
             if (string.IsNullOrEmpty(text))
             {
-                return result;
+                return DefaultValue;
             }
 
             // Since the conversion from Value to text using a FormatString may not be parsable,
@@ -665,7 +686,7 @@ namespace Avalonia.Controls
         /// </summary>
         private void OnIncrement()
         {
-            var result = (Value ?? 0) + Increment; // Todo: Use default value instead
+            var result = GetValueOrDefault() + Increment;
             Value = MathUtilities.Clamp(result, Minimum, Maximum);
         }
 
@@ -674,8 +695,29 @@ namespace Avalonia.Controls
         /// </summary>
         private void OnDecrement()
         {
-            var result = (Value ?? 0) - Increment; // Todo: Use default value instead
+            var result = GetValueOrDefault() - Increment;
             Value = MathUtilities.Clamp(result, Minimum, Maximum);
+        }
+
+        /// <summary>
+        ///   Used to get a non-nullable value.
+        /// </summary>
+        /// <returns>
+        /// The actual value if set <br/>
+        /// or the default value if set <br/>
+        /// otherwise 0
+        /// </returns>
+        private decimal GetValueOrDefault()
+        {
+            if (Value.HasValue)
+            {
+                return Value.Value;
+            }
+            if (DefaultValue.HasValue)
+            {
+                return DefaultValue.Value;
+            }
+            return default;
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -665,7 +665,7 @@ namespace Avalonia.Controls
         /// </summary>
         private void OnIncrement()
         {
-            var result = Value ?? 0 + Increment; // Todo: Use default value instead
+            var result = (Value ?? 0) + Increment; // Todo: Use default value instead
             Value = MathUtilities.Clamp(result, Minimum, Maximum);
         }
 
@@ -674,7 +674,7 @@ namespace Avalonia.Controls
         /// </summary>
         private void OnDecrement()
         {
-            var result = Value ?? 0 - Increment; // Todo: Use default value instead
+            var result = (Value ?? 0) - Increment; // Todo: Use default value instead
             Value = MathUtilities.Clamp(result, Minimum, Maximum);
         }
 

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDownValueChangedEventArgs.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDownValueChangedEventArgs.cs
@@ -4,13 +4,13 @@ namespace Avalonia.Controls
 {
     public class NumericUpDownValueChangedEventArgs : RoutedEventArgs
     {
-        public NumericUpDownValueChangedEventArgs(RoutedEvent routedEvent, decimal oldValue, decimal newValue) : base(routedEvent)
+        public NumericUpDownValueChangedEventArgs(RoutedEvent routedEvent, decimal? oldValue, decimal? newValue) : base(routedEvent)
         {
             OldValue = oldValue;
             NewValue = newValue;
         }
 
-        public decimal OldValue { get; }
-        public decimal NewValue { get; }
+        public decimal? OldValue { get; }
+        public decimal? NewValue { get; }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Allows binding to nullable values. A default value can be set if the user don't want to allow null values


## What is the current behavior?
null is not allowed, instead the property will be set to 0 if the user clears the TextBox part


## What is the updated/expected behavior with this PR?
null is allowed

## How was the solution implemented (if it's not obvious)?
- Made Value nullable (`decimal?`)
- Added a new property `DefaultValue`

## Checklist

- [ ] Added unit tests (if possible)? ► ToDo
- [ ] Added XML documentation to any related classes? ► ToDo
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation ► ToDo 

## Breaking changes
Not sure if this is a breaking change as the functionality is just extended

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #7725 