### PR TITLE
Fix "ContextMenu ignores styles on first open"

### DIFF
--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -351,6 +351,11 @@ namespace Avalonia.Controls
                 ? PlacementMode.Bottom
                 : PlacementMode;
 
+            //Position of the line below is really important. 
+            //All styles are being applied only when control has logical parent.
+            //Line below will add ContextMenu as child to the Popup and this will trigger styles and they would be applied.
+            //If you will move line below somewhere else it may cause that ContextMenu will behave differently from what you are expecting.
+            _popup.Child = this;
             _popup.PlacementTarget = placementTarget;
             _popup.HorizontalOffset = HorizontalOffset;
             _popup.VerticalOffset = VerticalOffset;
@@ -359,7 +364,6 @@ namespace Avalonia.Controls
             _popup.PlacementGravity = PlacementGravity;
             _popup.PlacementRect = PlacementRect;
             _popup.WindowManagerAddShadowHint = WindowManagerAddShadowHint;
-            _popup.Child = this;
             IsOpen = true;
             _popup.IsOpen = true;
 


### PR DESCRIPTION
## What does the pull request do?
Previously if you will set HorizontalOffset, VerticalOffset, PlacementGravity, etc. via style they would be ignored on the first time.

## Fixed issues
Fixes #7793 (probably)
