### PR TITLE
Add support for showing binding paths in DevTools.

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/BindingSetterViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/BindingSetterViewModel.cs
@@ -1,0 +1,22 @@
+﻿using Avalonia.Media;
+
+namespace Avalonia.Diagnostics.ViewModels
+{
+    internal class BindingSetterViewModel : SetterViewModel
+    {
+        public BindingSetterViewModel(AvaloniaProperty property, object? value, string bindingPath, bool isCompiled) : base(property, value)
+        {
+            Path = bindingPath;
+            Tint = isCompiled ? Brushes.DarkGreen : Brushes.CornflowerBlue;
+        }
+
+        public IBrush Tint { get; }
+
+        public string Path { get; }
+
+        public override void CopyValue()
+        {
+            CopyToClipboard(Path);
+        }
+    }
+}

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/BindingSetterViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/BindingSetterViewModel.cs
@@ -1,13 +1,42 @@
-﻿using Avalonia.Media;
+﻿using System;
+using Avalonia.Data;
+using Avalonia.Markup.Xaml.MarkupExtensions;
+using Avalonia.Media;
 
 namespace Avalonia.Diagnostics.ViewModels
 {
     internal class BindingSetterViewModel : SetterViewModel
     {
-        public BindingSetterViewModel(AvaloniaProperty property, object? value, string bindingPath, bool isCompiled) : base(property, value)
+        public BindingSetterViewModel(AvaloniaProperty property, object? value) : base(property, value)
         {
-            Path = bindingPath;
-            Tint = isCompiled ? Brushes.DarkGreen : Brushes.CornflowerBlue;
+            switch (value)
+            {
+                case Binding binding:
+                    Path = binding.Path;
+                    Tint = Brushes.CornflowerBlue;
+
+                    break;
+                case CompiledBindingExtension binding:
+                    Path = binding.Path.ToString();
+                    Tint = Brushes.DarkGreen;
+
+                    break;
+                case TemplateBinding binding:
+                    if (binding.Property is AvaloniaProperty templateProperty)
+                    {
+                        Path = $"{templateProperty.OwnerType.Name}.{templateProperty.Name}";
+                    }
+                    else
+                    {
+                        Path = "Unassigned";
+                    }
+
+                    Tint = Brushes.OrangeRed;
+
+                    break;
+                default:
+                    throw new ArgumentException("Invalid binding type", nameof(value));
+            }
         }
 
         public IBrush Tint { get; }

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ControlDetailsViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ControlDetailsViewModel.cs
@@ -88,11 +88,11 @@ namespace Avalonia.Diagnostics.ViewModels
                                 }
                                 else
                                 {
-                                    var bindingInfo = GetBindingInfo(setterValue);
+                                    var isBinding = IsBinding(setterValue);
 
-                                    if (bindingInfo is not null)
+                                    if (isBinding)
                                     {
-                                        setterVm = new BindingSetterViewModel(regularSetter.Property, setterValue, bindingInfo.Value.path, bindingInfo.Value.isCompiled);
+                                        setterVm = new BindingSetterViewModel(regularSetter.Property, setterValue);
                                     }
                                     else
                                     {
@@ -127,14 +127,17 @@ namespace Avalonia.Diagnostics.ViewModels
             return null;
         }
 
-        private (string path, bool isCompiled)? GetBindingInfo(object? value)
+        private bool IsBinding(object? value)
         {
-            return value switch
+            switch (value)
             {
-                Binding binding => (binding.Path, false),
-                CompiledBindingExtension compiledBinding => (compiledBinding.Path.ToString(), true),
-                _ => null,
-            };
+                case Binding:
+                case CompiledBindingExtension:
+                case TemplateBinding:
+                    return true;
+            }
+
+            return false;
         }
 
         public TreePageViewModel TreePage { get; }

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ControlDetailsViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ControlDetailsViewModel.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
+using Avalonia.Data;
 using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Styling;
 using Avalonia.VisualTree;
@@ -87,7 +88,16 @@ namespace Avalonia.Diagnostics.ViewModels
                                 }
                                 else
                                 {
-                                    setterVm = new SetterViewModel(regularSetter.Property, setterValue);
+                                    var bindingInfo = GetBindingInfo(setterValue);
+
+                                    if (bindingInfo is not null)
+                                    {
+                                        setterVm = new BindingSetterViewModel(regularSetter.Property, setterValue, bindingInfo.Value.path, bindingInfo.Value.isCompiled);
+                                    }
+                                    else
+                                    {
+                                        setterVm = new SetterViewModel(regularSetter.Property, setterValue);
+                                    }
                                 }
 
                                 setters.Add(setterVm);
@@ -115,6 +125,16 @@ namespace Avalonia.Diagnostics.ViewModels
             }
 
             return null;
+        }
+
+        private (string path, bool isCompiled)? GetBindingInfo(object? value)
+        {
+            return value switch
+            {
+                Binding binding => (binding.Path, false),
+                CompiledBindingExtension compiledBinding => (compiledBinding.Path.ToString(), true),
+                _ => null,
+            };
         }
 
         public TreePageViewModel TreePage { get; }

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/SetterViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/SetterViewModel.cs
@@ -34,7 +34,7 @@ namespace Avalonia.Diagnostics.ViewModels
             IsVisible = true;
         }
 
-        public void CopyValue()
+        public virtual void CopyValue()
         {
             var textToCopy = Value?.ToString();
 

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/ControlDetailsView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/ControlDetailsView.xaml
@@ -138,6 +138,26 @@
                           </StackPanel>
                         </DataTemplate>
 
+                        <DataTemplate DataType="vm:BindingSetterViewModel">
+                          <Panel Opacity="{Binding IsActive, Converter={StaticResource BoolToOpacity}}" IsVisible="{Binding IsVisible}" HorizontalAlignment="Left">
+                            <Panel.ContextMenu>
+                              <ContextMenu>
+                                <MenuItem Header="Copy property name" Command="{Binding CopyPropertyName} "/>
+                                <MenuItem Header="Copy value" Command="{Binding CopyValue} "/>
+                              </ContextMenu>
+                            </Panel.ContextMenu>
+                            <StackPanel Orientation="Horizontal" Spacing="2">
+                              <TextBlock Text="{Binding Name}" FontWeight="SemiBold" />
+                              <TextBlock Text=":" />
+                              <TextBlock>{</TextBlock>
+                              <Rectangle Height="8" Width="8" VerticalAlignment="Center" Fill="{Binding Tint}"/>
+                              <TextBlock Text="{Binding Path}" />
+                              <TextBlock>}</TextBlock>
+                            </StackPanel>
+                            <Rectangle Height="1" Fill="#6C6C6C" VerticalAlignment="Center" IsVisible="{Binding !IsActive}" />
+                          </Panel>
+                        </DataTemplate>
+
                         <DataTemplate DataType="Color">
                           <StackPanel Orientation="Horizontal" Spacing="2">
                             <Border BorderThickness="1" BorderBrush="Black" Width="8" Height="8">


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Implements better visualization for bindings used in setters. This includes reflection bindings, compiled bindings and template bindings. When checking recent issues I did find it a bit annoying to troubleshoot setters when bindings are used. So this is aiming to fix this.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
![image](https://user-images.githubusercontent.com/2588062/158845007-5aff1730-4856-46c3-b4be-ca479285c180.png)

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
![image](https://user-images.githubusercontent.com/2588062/158845135-8dac774f-641b-4eea-a3f6-b09cf8403551.png)
![image](https://user-images.githubusercontent.com/2588062/158855026-fc853442-abf0-4c87-a75f-973d8567d311.png)

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation
