### PR TITLE
Measure overlay layer children to constraint.

### DIFF
--- a/src/Avalonia.Controls/Primitives/OverlayLayer.cs
+++ b/src/Avalonia.Controls/Primitives/OverlayLayer.cs
@@ -23,7 +23,14 @@ namespace Avalonia.Controls.Primitives
         }
 
         public bool HitTest(Point point) => Children.HitTestCustom(point);
-        
+
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            foreach (Control child in Children)
+                child.Measure(availableSize);
+            return availableSize;
+        }
+
         protected override Size ArrangeOverride(Size finalSize)
         {
             // We are saving it here since child controls might need to know the entire size of the overlay


### PR DESCRIPTION
## What does the pull request do?

`OverlayLayer` inherits its measure behavior from `Canvas` which always measures children with `infinity` as the constraint. This behavior comes from WPF.

However this isn't correct because when using overlay popups, we should ideally fit popups in the available space. The incorrect results of this can be seen in #7815.

This PR changes `OverlayLayer` to measure its children with the constraint passed to `MeasureOverride`.

## Fixed issues

Fixes #7815