### PR TITLE
Simplify and improve DropDownGlyph in Fluent ComboBox

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/ComboBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ComboBox.xaml
@@ -101,23 +101,17 @@
                     IsVisible="False"
                     HorizontalAlignment="Right" />
 
-            <Viewbox UseLayoutRounding="False"
-                     MinHeight="{DynamicResource ComboBoxMinHeight}"
-                     Grid.Row="1"
-                     Grid.Column="1"
-                     IsHitTestVisible="False"
-                     Margin="0,0,10,0"
-                     Height="12"
-                     Width="12"
-                     HorizontalAlignment="Right"
-                     VerticalAlignment="Center">
-              <Panel>
-                <Panel Height="12"
-                       Width="12" />
-                <Path x:Name="DropDownGlyph"
+            <PathIcon x:Name="DropDownGlyph"
+                      Grid.Row="1"
+                      Grid.Column="1"
+                      UseLayoutRounding="False"
+                      IsHitTestVisible="False"
+                      Height="12"
+                      Width="12"
+                      Margin="0,0,10,0"
+                      HorizontalAlignment="Right"
                       VerticalAlignment="Center" />
-              </Panel>
-            </Viewbox>
+
             <Popup Name="PART_Popup"
                    WindowManagerAddShadowHint="False"
                    IsOpen="{TemplateBinding IsDropDownOpen, Mode=TwoWay}"
@@ -159,10 +153,9 @@
     <Setter Property="IsVisible" Value="False" />
   </Style>
 
-  <Style Selector="ComboBox /template/ Path#DropDownGlyph">
-    <Setter Property="Fill" Value="{DynamicResource ComboBoxDropDownGlyphForeground}" />
+  <Style Selector="ComboBox /template/ PathIcon#DropDownGlyph">
+    <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForeground}" />
     <Setter Property="Data" Value="M1939 486L2029 576L1024 1581L19 576L109 486L1024 1401L1939 486Z" />
-    <Setter Property="Stretch" Value="Uniform" />
   </Style>
 
   <!--  PointerOver State  -->
@@ -195,8 +188,8 @@
     <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
   </Style>
 
-  <Style Selector="ComboBox:disabled /template/ Path#DropDownGlyph">
-    <Setter Property="Fill" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
+  <Style Selector="ComboBox:disabled /template/ PathIcon#DropDownGlyph">
+    <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
   </Style>
 
   <!--  Focused State  -->
@@ -213,8 +206,8 @@
     <Setter Property="TextBlock.Foreground" Value="{DynamicResource ComboBoxForegroundFocused}" />
   </Style>
 
-  <Style Selector="ComboBox:focus-visible /template/ Path#DropDownGlyph">
-    <Setter Property="Fill" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocused}" />
+  <Style Selector="ComboBox:focus-visible /template/ PathIcon#DropDownGlyph">
+    <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocused}" />
   </Style>
 
   <!--  Focus Pressed State  -->
@@ -226,8 +219,8 @@
     <Setter Property="TextBlock.Foreground" Value="{DynamicResource ComboBoxPlaceHolderForegroundFocusedPressed}" />
   </Style>
 
-  <Style Selector="ComboBox:focused:pressed /template/ Path#DropDownGlyph">
-    <Setter Property="Fill" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocusedPressed}" />
+  <Style Selector="ComboBox:focused:pressed /template/ PathIcon#DropDownGlyph">
+    <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocusedPressed}" />
   </Style>
   
   <!-- Error State -->


### PR DESCRIPTION
## What does the pull request do?

Simplifies and improves the DropDownGlyph in the ComboBox's fluent Style.

Closes #7452 

## What is the current behavior?

The code looks really hacked together after the initial port from WinUI of the style. At the time I don't think PathIcon existed in Avalonia either.

```xaml
            <Viewbox UseLayoutRounding="False"
                     MinHeight="{DynamicResource ComboBoxMinHeight}"
                     Grid.Row="1"
                     Grid.Column="1"
                     IsHitTestVisible="False"
                     Margin="0,0,10,0"
                     Height="12"
                     Width="12"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Center">
              <Panel>
                <Panel Height="12"
                       Width="12" />
                <Path x:Name="DropDownGlyph"
                      VerticalAlignment="Center" />
              </Panel>
            </Viewbox>

```

Visually it looked fine:

![image](https://user-images.githubusercontent.com/17993847/159133493-62bfea0f-e10c-428f-83d6-119422058739.png)

## What is the updated/expected behavior with this PR?

Code is cleaned up and made more sensible.

```xaml
            <PathIcon x:Name="DropDownGlyph"
                      Grid.Row="1"
                      Grid.Column="1"
                      UseLayoutRounding="False"
                      IsHitTestVisible="False"
                      Height="12"
                      Width="12"
                      Margin="0,0,10,0"
                      HorizontalAlignment="Right"
                      VerticalAlignment="Center" />
```

Visually it looks the same:

![image](https://user-images.githubusercontent.com/17993847/159133674-639627f1-bdca-463c-89ad-e07ddcfb099d.png)

It now is much closer to Fluent v1 style as well:

https://github.com/microsoft/microsoft-ui-xaml/blob/09267531b807707138addc9bef3c8e9fa340615a/dev/ComboBox/ComboBox_themeresources_v1.xaml#L695-L707

## How was the solution implemented (if it's not obvious)?

Described above.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

 - Anyone re-templating will have to target `Foreground` instead of `Fill` for the DropDownGlyph. The type is also changing from `Path` to `PathIcon`

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues

Fixes #7452 
