### PR TITLE
Change ProgressBar Value binding mode to OneWay by default.

### DIFF
--- a/src/Avalonia.Controls/ProgressBar.cs
+++ b/src/Avalonia.Controls/ProgressBar.cs
@@ -1,6 +1,7 @@
 using System;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
+using Avalonia.Data;
 using Avalonia.Layout;
 using Avalonia.Media;
 
@@ -137,6 +138,7 @@ namespace Avalonia.Controls
 
         static ProgressBar()
         {
+            ValueProperty.OverrideMetadata<ProgressBar>(new DirectPropertyMetadata<double>(defaultBindingMode: BindingMode.OneWay));
             ValueProperty.Changed.AddClassHandler<ProgressBar>((x, e) => x.UpdateIndicatorWhenPropChanged(e));
             MinimumProperty.Changed.AddClassHandler<ProgressBar>((x, e) => x.UpdateIndicatorWhenPropChanged(e));
             MaximumProperty.Changed.AddClassHandler<ProgressBar>((x, e) => x.UpdateIndicatorWhenPropChanged(e));


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Changes `ProgressBar.Value` to bind one-way by default. Two-way was inherited from `RangeBase` but it does not make much sense for "output" control like `ProgressBar`. Usually first thing that I had to do was to change binding mode with each use of `ProgressBar`.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Exceptions when binding `ProgressBar` to read-only properties.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Correct binding by default.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
I hope that nobody was counting on `ProgressBar` writing values back to their view models :)


