### PR TITLE
Implement TemplatePartAttribute from WPF

### DIFF
--- a/src/Avalonia.Styling/Controls/Metadata/PseudoClassesAttribute.cs
+++ b/src/Avalonia.Styling/Controls/Metadata/PseudoClassesAttribute.cs
@@ -5,14 +5,27 @@ using System.Collections.Generic;
 
 namespace Avalonia.Controls.Metadata
 {
+    /// <summary>
+    /// Defines all pseudoclasses by name referenced and implemented by a control.
+    /// </summary>
+    /// <remarks>
+    /// This is currently used for code-completion in certain IDEs.
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public sealed class PseudoClassesAttribute : Attribute
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PseudoClassesAttribute"/> class.
+        /// </summary>
+        /// <param name="pseudoClasses">The list of pseudoclass names.</param>
         public PseudoClassesAttribute(params string[] pseudoClasses)
         {
             PseudoClasses = pseudoClasses;
         }
 
+        /// <summary>
+        /// Gets the list of pseudoclass names.
+        /// </summary>
         public IReadOnlyList<string> PseudoClasses { get; }
     }
 }

--- a/src/Avalonia.Styling/Controls/Metadata/TemplatePartAttribute.cs
+++ b/src/Avalonia.Styling/Controls/Metadata/TemplatePartAttribute.cs
@@ -1,0 +1,55 @@
+﻿// This source file is adapted from the Windows Presentation Foundation project. 
+// (https://github.com/dotnet/wpf/) 
+// 
+// Licensed to The Avalonia Project under MIT License, courtesy of The .NET Foundation.
+
+using System;
+
+#nullable enable
+
+namespace Avalonia.Controls.Metadata
+{
+    /// <summary>
+    /// Defines a control template part referenced by name in code.
+    /// Template part names should begin with the "PART_" prefix.
+    /// </summary>
+    /// <remarks>
+    /// Style authors should be able to identify the part type used for styling the specific control.
+    /// The part is usually required in the style and should have a specific predefined name.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public sealed class TemplatePartAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemplatePartAttribute"/> class.
+        /// </summary>
+        public TemplatePartAttribute()
+        {
+            Name = string.Empty;
+            Type = typeof(object);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemplatePartAttribute"/> class.
+        /// </summary>
+        /// <param name="name">The part name used by the class to identify a required element in the style.</param>
+        /// <param name="type">The type of the element that should be used as a part with name.</param>
+        public TemplatePartAttribute(string name, Type type)
+        {
+            Name = name;
+            Type = type;
+        }
+
+        /// <summary>
+        /// Gets or sets the part name used by the class to identify a required element in the style.
+        /// Template part names should begin with the "PART_" prefix.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of the element that should be used as a part with name specified
+        /// in <see cref="Name"/>.
+        /// </summary>
+        public Type Type { get; set; }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Closes #7432 

## What is the current behavior?

Template parts are completely undefined. Control authors and developers must search various places through code behind for these.

## What is the updated/expected behavior with this PR?

 * Added an attribute allowing each control to define their template parts. 
 * Added comments for the Pseduoclasses attribute while I was there
 * This does NOT define the template parts for controls -- that will have to be done in other PRs over time.

In the future such an attribute could be used by code generators to build strongly typed/named references to template parts in a uniform way. It is also possible for IDEs and designers to use this information in the future.

## How was the solution implemented (if it's not obvious)?

This is the same as what was done in WPF and the source code was copied and then modified from the WPF repo (MIT License).

https://github.com/dotnet/wpf/blob/a71d94d93b4af94061f6cd27c57b1d00efaccaab/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TemplatePartAttribute.cs

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

None

## Obsoletions / Deprecations

None

## Fixed issues

Closes #7432 
