### PR TITLE
Fix PathIcon Style Ordering

### DIFF
--- a/src/Avalonia.Themes.Default/DefaultTheme.xaml
+++ b/src/Avalonia.Themes.Default/DefaultTheme.xaml
@@ -3,8 +3,9 @@
         x:Class="Avalonia.Themes.Default.DefaultTheme">
   <!-- Define ToolTip first so its styles can be overriden by other controls (e.g. TextBox) -->
   <StyleInclude Source="avares://Avalonia.Themes.Default/Controls/ToolTip.xaml"/>
+  <!-- PathIcon also needs to be defined early so it can be overriden by other styles (e.g. ComboBox) -->
+  <StyleInclude Source="avares://Avalonia.Themes.Default/Controls/PathIcon.xaml" />
   <StyleInclude Source="avares://Avalonia.Themes.Default/Controls/DataValidationErrors.xaml"/>
-
   <StyleInclude Source="avares://Avalonia.Themes.Default/Controls/FocusAdorner.xaml"/>
   <StyleInclude Source="avares://Avalonia.Themes.Default/Controls/Button.xaml"/>
   <StyleInclude Source="avares://Avalonia.Themes.Default/Controls/Carousel.xaml"/>
@@ -22,7 +23,6 @@
   <StyleInclude Source="avares://Avalonia.Themes.Default/Controls/ContextMenu.xaml"/>
   <StyleInclude Source="avares://Avalonia.Themes.Default/Controls/MenuItem.xaml"/>
   <StyleInclude Source="avares://Avalonia.Themes.Default/Controls/OverlayPopupHost.xaml"/>
-  <StyleInclude Source="avares://Avalonia.Themes.Default/Controls/PathIcon.xaml" />
   <StyleInclude Source="avares://Avalonia.Themes.Default/Controls/PopupRoot.xaml"/>
   <StyleInclude Source="avares://Avalonia.Themes.Default/Controls/ProgressBar.xaml"/>
   <StyleInclude Source="avares://Avalonia.Themes.Default/Controls/RadioButton.xaml"/>

--- a/src/Avalonia.Themes.Fluent/Controls/FluentControls.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/FluentControls.xaml
@@ -3,6 +3,8 @@
         x:Class="Avalonia.Themes.Fluent.Controls.FluentControls">
   <!-- Define ToolTip first so its styles can be overriden by other controls (e.g. TextBox) -->  
   <StyleInclude Source="avares://Avalonia.Themes.Fluent/Controls/ToolTip.xaml"/>
+  <!-- PathIcon also needs to be defined early so it can be overriden by other styles (e.g. ComboBox) -->
+  <StyleInclude Source="avares://Avalonia.Themes.Fluent/Controls/PathIcon.xaml" />
   <StyleInclude Source="avares://Avalonia.Themes.Fluent/Controls/DataValidationErrors.xaml"/>
   <StyleInclude Source="avares://Avalonia.Themes.Fluent/Controls/FocusAdorner.xaml"/>
   <StyleInclude Source="avares://Avalonia.Themes.Fluent/Controls/Button.xaml"/>
@@ -21,7 +23,6 @@
   <StyleInclude Source="avares://Avalonia.Themes.Fluent/Controls/ContextMenu.xaml"/>
   <StyleInclude Source="avares://Avalonia.Themes.Fluent/Controls/MenuItem.xaml"/>
   <StyleInclude Source="avares://Avalonia.Themes.Fluent/Controls/OverlayPopupHost.xaml"/>
-  <StyleInclude Source="avares://Avalonia.Themes.Fluent/Controls/PathIcon.xaml" />
   <StyleInclude Source="avares://Avalonia.Themes.Fluent/Controls/PopupRoot.xaml"/>
   <StyleInclude Source="avares://Avalonia.Themes.Fluent/Controls/ProgressBar.xaml"/>
   <StyleInclude Source="avares://Avalonia.Themes.Fluent/Controls/RadioButton.xaml"/>


### PR DESCRIPTION
## What does the pull request do?

Fixes #7855 

## What is the current behavior?

PathIcon Foreground changes in the ComboBox styles are ignored.

## What is the updated/expected behavior with this PR?

Changes PathIcon style priority so it can be overridden.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

None

## Obsoletions / Deprecations

None

## Fixed issues

Fixes #7855 
