### PR TITLE
Allow DevTools to use dark mode

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/DevToolsOptions.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/DevToolsOptions.cs
@@ -41,5 +41,10 @@ namespace Avalonia.Diagnostics
         /// <remarks>Default handler is <see cref="Screenshots.FilePickerHandler"/></remarks>
         public IScreenshotHandler ScreenshotHandler { get; set; }
           = Convetions.DefaultScreenshotHandler;
+
+        /// <summary>
+        /// Gets or sets whether DevTools should use the dark mode theme
+        /// </summary>
+        public bool UseDarkMode { get; set; }
     }
 }

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/LayoutExplorerView.axaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/LayoutExplorerView.axaml
@@ -15,6 +15,7 @@
         <SolidColorBrush x:Key="PaddingHighlightBrush" Color="#CEDA8E" />
         <SolidColorBrush x:Key="SizeBackgroundBrush" Color="#88B2BD" />
         <SolidColorBrush x:Key="SizeHighlightBrush" Color="#9ED0DC" />
+        <SolidColorBrush x:Key="ThicknessEditorForeground" Color="Black" />
     </UserControl.Resources>
 
     <Grid RowDefinitions="*,Auto">
@@ -46,6 +47,7 @@
 
                 <controls:ThicknessEditor Grid.Row="0" Grid.Column="0" Header="margin" VerticalAlignment="Top"
                                           HorizontalAlignment="Center"
+                                          TextBlock.Foreground="{StaticResource ThicknessEditorForeground}"
                                           Background="{StaticResource MarginBackgroundBrush}"
                                           Highlight="{StaticResource MarginHighlightBrush}"
                                           Thickness="{Binding MarginThickness}">

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml.cs
@@ -11,6 +11,7 @@ using Avalonia.Input;
 using Avalonia.Input.Raw;
 using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
+using Avalonia.Themes.Default;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Diagnostics.Views
@@ -242,7 +243,17 @@ namespace Avalonia.Diagnostics.Views
 
         private void RootClosed(object? sender, EventArgs e) => Close();
 
-        public void SetOptions(DevToolsOptions options) =>
+        public void SetOptions(DevToolsOptions options)
+        {
             (DataContext as MainViewModel)?.SetOptions(options);
+
+            if (options.UseDarkMode)
+            {
+                if (Styles[0] is SimpleTheme st)
+                {
+                    st.Mode = SimpleThemeMode.Dark;
+                }                
+            }
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Adds a property (`UseDarkMode`) to `DevToolsOptions` to allow DevTools to launch using Dark mode.

usage:
```C#
this.AttachDevTools(new DevToolsOptions
{
    UseDarkMode = true
});
```

result:
EDIT: Fixed layout visualizer to always use black foreground for better readibility
![image](https://user-images.githubusercontent.com/40413319/160254423-11c221ce-1ca0-40a3-aa5a-bbe34a848883.png)




## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
