### PR TITLE
Fix "InputElement doesn't receive PointerEntered call when created under mouse pointer"

### DIFF
--- a/src/Avalonia.Input/Pointer.cs
+++ b/src/Avalonia.Input/Pointer.cs
@@ -61,7 +61,7 @@ namespace Avalonia.Input
 
         private void OnCaptureDetached(object? sender, VisualTreeAttachmentEventArgs e)
         {
-            Capture(GetNextCapture(e.Parent));
+            Capture(null);
         }
 
 

--- a/tests/Avalonia.Input.UnitTests/MouseDeviceTests.cs
+++ b/tests/Avalonia.Input.UnitTests/MouseDeviceTests.cs
@@ -16,7 +16,7 @@ namespace Avalonia.Input.UnitTests
     {
 #pragma warning disable CS0618 // Type or member is obsolete
         [Fact]
-        public void Capture_Is_Transferred_To_Parent_When_Control_Removed()
+        public void Capture_Is_Set_To_Null_When_Control_Removed()
         {
             Canvas control;
             var root = new TestRoot
@@ -30,7 +30,7 @@ namespace Avalonia.Input.UnitTests
 
             root.Child = null;
 
-            Assert.Same(root, target.Captured);
+            Assert.Same(null, target.Captured);
         }
 #pragma warning restore CS0618 // Type or member is obsolete
 


### PR DESCRIPTION
## What does the pull request do?
Previously when the element was detached from the logical tree we have captured its parent element. It will mean that all next events would be sent only for this object until MouseUp wouldn't be triggered which will cause Capture to be re-set to null and all next mouse events will try to find the correct element.

"Fixed" behaviour:
![Анимация](https://user-images.githubusercontent.com/53405089/159895078-6a2277c2-3224-4f10-bf87-d4da9e19afbb.gif)



## Fixed issues
Fixes #7858 
