### PR TITLE
Replaced LINQ expressions in the Immediate Renderer with ArrayPools t…

### DIFF
--- a/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
@@ -217,10 +217,7 @@ namespace Avalonia.Rendering
 
         private static void ClearTransformedBounds(IVisual visual)
         {
-            foreach (var e in visual.GetSelfAndVisualDescendants())
-            {
-                visual.TransformedBounds = null;
-            }
+            visual.TransformedBounds = null;
         }
 
         private static Rect GetTransformedBounds(IVisual visual)

--- a/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Visuals/Rendering/ImmediateRenderer.cs
@@ -217,7 +217,10 @@ namespace Avalonia.Rendering
 
         private static void ClearTransformedBounds(IVisual visual)
         {
-            visual.TransformedBounds = null;
+            foreach (var e in visual.GetSelfAndVisualDescendants())
+            {
+                visual.TransformedBounds = null;
+            }
         }
 
         private static Rect GetTransformedBounds(IVisual visual)
@@ -278,18 +281,13 @@ namespace Avalonia.Rendering
 
                         _hitTestElements.Sort(start, end - start, ZOrderHitTestComparer.Instance);
 
-                        bool found = false;
-                        IVisual? child = null;
+                        result = null;
                         for (int i = start; i < end; i++)
-                            if (HitTestFirst(_hitTestElements[i].Item2, p, filter, out child))
-                            {
-                                found = true;
+                            if (HitTestFirst(_hitTestElements[i].Item2, p, filter, out result))
                                 break;
-                            }
 
                         _hitTestElements.RemoveRange(start, end - start);
-                        result = child;
-                        return found;
+                        return result != null;
                     }
                     else if (childrenCount == 1)
                     {

--- a/src/Avalonia.Visuals/Rendering/Utilities/StabilizingComparer.cs
+++ b/src/Avalonia.Visuals/Rendering/Utilities/StabilizingComparer.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+
+namespace Avalonia.Rendering.Utilities
+{
+    /// <summary>
+    /// Comparer used for stable sorting of an Array by matching it up with their current positions using a KeyValuePair.
+    /// The stabilized comparison will be the array of values.
+    /// </summary>
+    internal sealed class StabilizingComparer<T> : IComparer<(int, T)>
+    {
+        private readonly IComparer<T> _comparer;
+
+        /// <summary>
+        /// Initializes a stabilizing comparer with any other comparison criteria required.
+        /// </summary>
+        /// <param name="comparer"></param>
+        public StabilizingComparer(IComparer<T> comparer)
+        {
+            _comparer = comparer;
+        }
+
+        /// <summary>
+        /// Compares according to the provided comparer. In case of a tie preserves the old order.
+        /// </summary>
+        public int Compare((int, T) x, (int, T) y)
+        {
+            var result = _comparer.Compare(x.Item2, y.Item2);
+            return result != 0 ? result : x.Item1.CompareTo(y.Item1);
+        }
+    }
+}

--- a/src/Avalonia.Visuals/Rendering/Utilities/ZOrderHitTestComparer.cs
+++ b/src/Avalonia.Visuals/Rendering/Utilities/ZOrderHitTestComparer.cs
@@ -3,22 +3,22 @@ using Avalonia.VisualTree;
 
 namespace Avalonia.Rendering.Utilities
 {
-    internal class ZOrderHitTestComparer : IComparer<KeyValuePair<int, IVisual>>
+    internal class ZOrderHitTestComparer : IComparer<(int, IVisual)>
     {
-        public static readonly ZOrderHitTestComparer Instance = new ZOrderHitTestComparer();
-        public int Compare(KeyValuePair<int, IVisual> x, KeyValuePair<int, IVisual> y)
+        public static readonly ZOrderHitTestComparer Instance = new();
+        public int Compare((int, IVisual) x, (int, IVisual) y)
         {
-            if (y.Value is null)
+            if (y.Item2 is null)
                 return 1;
 
-            var z = y.Value.ZIndex - x.Value.ZIndex;
+            var z = y.Item2.ZIndex - x.Item2.ZIndex;
 
             if (z != 0)
             {
                 return z;
             }
 
-            return y.Key - x.Key;
+            return y.Item1 - x.Item1;
         }
     }
 }

--- a/src/Avalonia.Visuals/Rendering/Utilities/ZOrderHitTestComparer.cs
+++ b/src/Avalonia.Visuals/Rendering/Utilities/ZOrderHitTestComparer.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using Avalonia.VisualTree;
+
+namespace Avalonia.Rendering.Utilities
+{
+    internal class ZOrderHitTestComparer : IComparer<KeyValuePair<int, IVisual>>
+    {
+        public static readonly ZOrderHitTestComparer Instance = new ZOrderHitTestComparer();
+        public int Compare(KeyValuePair<int, IVisual> x, KeyValuePair<int, IVisual> y)
+        {
+            if (y.Value is null)
+                return 1;
+
+            var z = y.Value.ZIndex - x.Value.ZIndex;
+
+            if (z != 0)
+            {
+                return z;
+            }
+
+            return y.Key - x.Key;
+        }
+    }
+}

--- a/src/Avalonia.Visuals/VisualTree/VisualExtensions.cs
+++ b/src/Avalonia.Visuals/VisualTree/VisualExtensions.cs
@@ -444,49 +444,6 @@ namespace Avalonia.VisualTree
             return null;
         }
 
-        /// <summary>
-        /// Sorts the array of IVisual with a comparer while preserving the order on tied results.
-        /// Stores the elements from 0 to specified length.
-        /// </summary>
-        public static void StableSort(this IVisual[] values, int length, IComparer<IVisual> comparer)
-        {
-            var keys = ArrayPool<KeyValuePair<int, IVisual>>.Shared.Rent(length);
-            for (var i = 0; i < length; i++)
-                keys[i] = new KeyValuePair<int, IVisual>(i, values[i]);
-            Array.Sort(keys, values, 0, length, new StabilizingComparer(comparer));
-
-            ArrayPool<KeyValuePair<int, IVisual>>.Shared.Return(keys, true);
-        }
-
-        /// <summary>
-        /// Sorts the visuals for hit testing keeping with a z-order comparer and keeping the top control first.
-        /// </summary>
-        public static void StableHitTestSort(this IVisual[] values, int length)
-        {
-            var keys = ArrayPool<KeyValuePair<int, IVisual>>.Shared.Rent(length);
-            for (var i = 0; i < length; i++)
-                keys[i] = new KeyValuePair<int, IVisual>(i, values[i]);
-            Array.Sort(keys, values, 0, length, ZOrderHitTestComparer.Instance);
-
-            ArrayPool<KeyValuePair<int, IVisual>>.Shared.Return(keys, true);
-        }
-
-        private sealed class StabilizingComparer : IComparer<KeyValuePair<int, IVisual>>
-        {
-            private readonly IComparer<IVisual> _comparer;
-
-            public StabilizingComparer(IComparer<IVisual> comparer)
-            {
-                _comparer = comparer;
-            }
-
-            public int Compare(KeyValuePair<int, IVisual> x, KeyValuePair<int, IVisual> y)
-            {
-                var result = _comparer.Compare(x.Value, y.Value);
-                return result != 0 ? result : x.Key.CompareTo(y.Key);
-            }
-        }
-
         private class ZOrderElement : IComparable<ZOrderElement>
         {
             public IVisual? Element { get; set; }

--- a/src/Avalonia.Visuals/VisualTree/VisualExtensions.cs
+++ b/src/Avalonia.Visuals/VisualTree/VisualExtensions.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Rendering;
+using Avalonia.Rendering.Utilities;
 
 namespace Avalonia.VisualTree
 {
@@ -440,6 +442,49 @@ namespace Avalonia.VisualTree
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Sorts the array of IVisual with a comparer while preserving the order on tied results.
+        /// Stores the elements from 0 to specified length.
+        /// </summary>
+        public static void StableSort(this IVisual[] values, int length, IComparer<IVisual> comparer)
+        {
+            var keys = ArrayPool<KeyValuePair<int, IVisual>>.Shared.Rent(length);
+            for (var i = 0; i < length; i++)
+                keys[i] = new KeyValuePair<int, IVisual>(i, values[i]);
+            Array.Sort(keys, values, 0, length, new StabilizingComparer(comparer));
+
+            ArrayPool<KeyValuePair<int, IVisual>>.Shared.Return(keys, true);
+        }
+
+        /// <summary>
+        /// Sorts the visuals for hit testing keeping with a z-order comparer and keeping the top control first.
+        /// </summary>
+        public static void StableHitTestSort(this IVisual[] values, int length)
+        {
+            var keys = ArrayPool<KeyValuePair<int, IVisual>>.Shared.Rent(length);
+            for (var i = 0; i < length; i++)
+                keys[i] = new KeyValuePair<int, IVisual>(i, values[i]);
+            Array.Sort(keys, values, 0, length, ZOrderHitTestComparer.Instance);
+
+            ArrayPool<KeyValuePair<int, IVisual>>.Shared.Return(keys, true);
+        }
+
+        private sealed class StabilizingComparer : IComparer<KeyValuePair<int, IVisual>>
+        {
+            private readonly IComparer<IVisual> _comparer;
+
+            public StabilizingComparer(IComparer<IVisual> comparer)
+            {
+                _comparer = comparer;
+            }
+
+            public int Compare(KeyValuePair<int, IVisual> x, KeyValuePair<int, IVisual> y)
+            {
+                var result = _comparer.Compare(x.Value, y.Value);
+                return result != 0 ? result : x.Key.CompareTo(y.Key);
+            }
         }
 
         private class ZOrderElement : IComparable<ZOrderElement>


### PR DESCRIPTION
Immediate renderer does a lot of per frame allocations - especially in the HitTest.

This fix is aimed at replacing the main culprits for this behavior - LINQ expressions.
Both Render and HitTest methods of ImmediateRenderer use .OrderBy and .Select - 
these were replaced by taking ArrayPool resources to stabilize per frame memory usage as well as creating StableSort replacements (that would work the same way as OrderBy).

VisualExtensions - added 
* StableSort(this IVisual[] values, int length, IComparer<IVisual> comparer)
* StableHitTestSort(this IVisual[] values, int length)
* StabilizingComparer : IComparer<KeyValuePair<int, IVisual>> nested class

Added new comparer - ZOrderHitTestComparer for KeyValuePair<int, IVisual> to replace the usage of ZOrderElement arrays that allocate.

ImmediateRenderer - edited HitTest and Render methods to use all of the above with ArrayPools.

TODO: Did not remove the OrderByZIndex because removing it was failing a contract. Needed feedback for that.
HitTest still allocates due to the creation of IEnumerable and might need a more robust solution that would require a system redisgn.

Measured the outcome with dotMemory - per frame allocations of Render are completely gone from HitTest are nearly halved.