### PR TITLE
Remove CornerRadius from MenuFlyoutPresenter

### DIFF
--- a/src/Avalonia.Controls/Flyouts/MenuFlyoutPresenter.cs
+++ b/src/Avalonia.Controls/Flyouts/MenuFlyoutPresenter.cs
@@ -8,15 +8,6 @@ namespace Avalonia.Controls
 {
     public class MenuFlyoutPresenter : MenuBase
     {
-        public static readonly StyledProperty<CornerRadius> CornerRadiusProperty =
-            Border.CornerRadiusProperty.AddOwner<FlyoutPresenter>();
-
-        public CornerRadius CornerRadius
-        {
-            get => GetValue(CornerRadiusProperty);
-            set => SetValue(CornerRadiusProperty, value);
-        }
-
         public MenuFlyoutPresenter()
             :base(new DefaultMenuInteractionHandler(true))
         {


### PR DESCRIPTION
## What does the pull request do?

Removes both `CornerRadiusProperty` and `CornerRadius` from `MenuFlyoutPresenter` to fix #7845.

## What is the current behavior?

These properties hide the inherited ones from `TemplatedControl` and cause build warnings. They are also completely unnecessary and left over from the time before `CornerRadius` was added to `TemplatedControl`.

Inheritance:
 * TemplatedControl > ItemsControl > SelectingItemsControl > MenuBase > MenuFlyoutPresenter
 * TemplatedControl has both `CornerRadiusProperty` and `CornerRadius`

## What is the updated/expected behavior with this PR?

 * `CornerRadiusProperty` and `CornerRadius` properties removed from `MenuFlyoutPresenter`
 * No more build warnings for these

## How was the solution implemented (if it's not obvious)?

Deleted and checked for references -- these properties were unused in code. If they were used in XAML it should still work using inherited properties.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

@maxkatz6 
> It's still a binary breaking change.
> But we are good to merge it for 11.0.

## Obsoletions / Deprecations

None

## Fixed issues

Fixes #7845