### PR TITLE
feat(DevTools): Open DevTools with Focused Element Automatically Selected in Tree

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/DevTools.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/DevTools.cs
@@ -135,7 +135,7 @@ namespace Avalonia.Diagnostics
                 {
                     window.Show();
                 }
-            }           
+            }
             return Disposable.Create(() => window?.Close());
         }
     }

--- a/src/Avalonia.Diagnostics/Diagnostics/DevTools.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/DevTools.cs
@@ -105,13 +105,15 @@ namespace Avalonia.Diagnostics
 
         private static IDisposable Open(Application? application, DevToolsOptions options, Window? owner = default)
         {
+            var focussedControl = KeyboardDevice.Instance?.FocusedElement as IControl;
             if (application is null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
             if (s_open.TryGetValue(application, out var window))
-            {                
+            {
                 window.Activate();
+                window.SelectedControl(focussedControl);
             }
             else
             {
@@ -122,7 +124,7 @@ namespace Avalonia.Diagnostics
                     Height = options.Size.Height,
                 };
                 window.SetOptions(options);
-
+                window.SelectedControl(focussedControl);
                 window.Closed += DevToolsClosed;
                 s_open.Add(application, window);
                 if (options.ShowAsChildWindow && owner is { })
@@ -133,7 +135,7 @@ namespace Avalonia.Diagnostics
                 {
                     window.Show();
                 }
-            }
+            }           
             return Disposable.Create(() => window?.Close());
         }
     }

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml.cs
@@ -110,7 +110,7 @@ namespace Avalonia.Diagnostics.Views
         {
 #pragma warning disable CS0618 // Type or member is obsolete
             var point = (topLevel as IInputRoot)?.MouseDevice?.GetPosition(topLevel) ?? default;
-#pragma warning restore CS0618 // Type or member is obsolete                
+#pragma warning restore CS0618 // Type or member is obsolete
 
             return (IControl?)topLevel.GetVisualsAt(point, x =>
                 {
@@ -253,6 +253,14 @@ namespace Avalonia.Diagnostics.Views
                 {
                     st.Mode = SimpleThemeMode.Dark;
                 }                
+            }
+        }
+
+        internal void SelectedControl(IControl? control)
+        {
+            if (control is { })
+            {
+                (DataContext as MainViewModel)?.SelectControl(control);
             }
         }
     }


### PR DESCRIPTION


## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

1.    Select the focused control in the Visual/Logical Tree when pressing F12 the first time
2.    If DevTools is already open, pressing F12 would automatically update the selection to the latest focused control.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #7869