### PR TITLE
Add HsvColor.ToString() and TryParse() 

### DIFF
--- a/src/Avalonia.Visuals/Media/Color.cs
+++ b/src/Avalonia.Visuals/Media/Color.cs
@@ -258,7 +258,7 @@ namespace Avalonia.Media
         public override string ToString()
         {
             uint rgb = ToUint32();
-            return KnownColors.GetKnownColorName(rgb) ?? $"#{rgb:x8}";
+            return KnownColors.GetKnownColorName(rgb) ?? $"#{rgb.ToString("x8", CultureInfo.InvariantCulture)}";
         }
 
         /// <summary>

--- a/src/Avalonia.Visuals/Media/HsvColor.cs
+++ b/src/Avalonia.Visuals/Media/HsvColor.cs
@@ -219,16 +219,16 @@ namespace Avalonia.Media
                 return false;
             }
 
-            if (workingString.StartsWith("hsva(", StringComparison.OrdinalIgnoreCase) &&
-                workingString.EndsWith(")", StringComparison.Ordinal) &&
-                workingString.Length > 6)
+            if (workingString.Length > 6 &&
+                workingString.StartsWith("hsva(", StringComparison.OrdinalIgnoreCase) &&
+                workingString.EndsWith(")", StringComparison.Ordinal))
             {
                 workingString = workingString.Substring(5, workingString.Length - 6);
             }
 
-            if (workingString.StartsWith("hsv(", StringComparison.OrdinalIgnoreCase) &&
-                workingString.EndsWith(")", StringComparison.Ordinal) &&
-                workingString.Length > 5)
+            if (workingString.Length > 5 &&
+                workingString.StartsWith("hsv(", StringComparison.OrdinalIgnoreCase) &&
+                workingString.EndsWith(")", StringComparison.Ordinal))
             {
                 workingString = workingString.Substring(4, workingString.Length - 5);
             }

--- a/src/Avalonia.Visuals/Media/HsvColor.cs
+++ b/src/Avalonia.Visuals/Media/HsvColor.cs
@@ -175,13 +175,13 @@ namespace Avalonia.Media
             //
             //   Where:
             //
-            //          hue : integer from 0 to 360
-            //   saturation : double from 0.0 to 1.0
-            //                (HTML uses percentages)
-            //        value : double from 0.0 to 1.0
-            //                (HTML uses percentages)
-            //        alpha : double from 0.0 to 1.0
-            //                (HTML does not use percent for alpha)
+            //          hue : double from 0 to 360
+            //   saturation : double from 0 to 1
+            //                (HTML uses a percentage)
+            //        value : double from 0 to 1
+            //                (HTML uses a percentage)
+            //        alpha : double from 0 to 1
+            //                (HTML does not use a percentage for alpha)
 
             sb.Append("hsva(");
             sb.Append(H.ToString(CultureInfo.InvariantCulture));

--- a/src/Avalonia.Visuals/Media/HsvColor.cs
+++ b/src/Avalonia.Visuals/Media/HsvColor.cs
@@ -22,7 +22,8 @@ namespace Avalonia.Media
         /// Initializes a new instance of the <see cref="HsvColor"/> struct.
         /// </summary>
         /// <param name="alpha">The Alpha (transparency) channel value in the range from 0..1.</param>
-        /// <param name="hue">The Hue channel value in the range from 0..360.</param>
+        /// <param name="hue">The Hue channel value in the range from 0..360.
+        /// Note that 360 is equivalent to 0 and will be adjusted automatically.</param>
         /// <param name="saturation">The Saturation channel value in the range from 0..1.</param>
         /// <param name="value">The Value channel value in the range from 0..1.</param>
         public HsvColor(
@@ -35,6 +36,12 @@ namespace Avalonia.Media
             H = MathUtilities.Clamp(hue,        0.0, 360.0);
             S = MathUtilities.Clamp(saturation, 0.0, 1.0);
             V = MathUtilities.Clamp(value,      0.0, 1.0);
+
+            // The maximum value of Hue is technically 360 minus epsilon (just below 360).
+            // This is because, in a color circle, 360 degrees is equivalent to 0 degrees.
+            // However, that is too tricky to work with in code and isn't as intuitive.
+            // Therefore, since 360 == 0, just wrap 360 if needed back to 0.
+            H = (H == 360.0 ? 0 : H);
         }
 
         /// <summary>
@@ -45,7 +52,8 @@ namespace Avalonia.Media
         /// Whether or not the channel values are in the correct ranges must be known.
         /// </remarks>
         /// <param name="alpha">The Alpha (transparency) channel value in the range from 0..1.</param>
-        /// <param name="hue">The Hue channel value in the range from 0..360.</param>
+        /// <param name="hue">The Hue channel value in the range from 0..360.
+        /// Note that 360 is equivalent to 0 and will be adjusted automatically.</param>
         /// <param name="saturation">The Saturation channel value in the range from 0..1.</param>
         /// <param name="value">The Value channel value in the range from 0..1.</param>
         /// <param name="clampValues">Whether to clamp channel values to their required ranges.</param>
@@ -62,6 +70,9 @@ namespace Avalonia.Media
                 H = MathUtilities.Clamp(hue,        0.0, 360.0);
                 S = MathUtilities.Clamp(saturation, 0.0, 1.0);
                 V = MathUtilities.Clamp(value,      0.0, 1.0);
+
+                // See comments in constructor above
+                H = (H == 360.0 ? 0 : H);
             }
             else
             {
@@ -93,6 +104,7 @@ namespace Avalonia.Media
 
         /// <summary>
         /// Gets the Hue channel value in the range from 0..360.
+        /// Note that 360 is equivalent to 0 and will be adjusted automatically.
         /// </summary>
         public double H { get; }
 

--- a/src/Avalonia.Visuals/Media/HsvColor.cs
+++ b/src/Avalonia.Visuals/Media/HsvColor.cs
@@ -200,7 +200,27 @@ namespace Avalonia.Media
         /// Parses an HSV color string.
         /// </summary>
         /// <param name="s">The HSV color string to parse.</param>
-        /// <param name="hsvColor">The parsed HSV color.</param>
+        /// <returns>The parsed <see cref="HsvColor"/>.</returns>
+        public static HsvColor Parse(string s)
+        {
+            if (s is null)
+            {
+                throw new ArgumentNullException(nameof(s));
+            }
+
+            if (TryParse(s, out HsvColor hsvColor))
+            {
+                return hsvColor;
+            }
+
+            throw new FormatException($"Invalid HSV color string: '{s}'.");
+        }
+
+        /// <summary>
+        /// Parses an HSV color string.
+        /// </summary>
+        /// <param name="s">The HSV color string to parse.</param>
+        /// <param name="hsvColor">The parsed <see cref="HsvColor"/>.</param>
         /// <returns>True if parsing was successful; otherwise, false.</returns>
         public static bool TryParse(string s, out HsvColor hsvColor)
         {

--- a/src/Avalonia.Visuals/Media/HsvColor.cs
+++ b/src/Avalonia.Visuals/Media/HsvColor.cs
@@ -4,6 +4,8 @@
 // Licensed to The Avalonia Project under MIT License, courtesy of The .NET Foundation.
 
 using System;
+using System.Globalization;
+using System.Text;
 using Avalonia.Utilities;
 
 namespace Avalonia.Media
@@ -153,6 +155,109 @@ namespace Avalonia.Media
         {
             // Use the by-channel conversion method directly for performance
             return HsvColor.ToRgb(H, S, V, A);
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+
+            // Use a format similar to HSL in HTML/CSS "hsla(0, 100%, 50%, 0.5)"
+            //
+            // However:
+            //   - To ensure precision is never lost, allow decimal places
+            //   - To maintain numerical consistency do not use percent
+            //
+            // Example:
+            //
+            // hsva(hue, saturation, value, alpha)
+            // hsva(230, 1.0, 0.5, 1.0)
+            //
+            //   Where:
+            //
+            //          hue : integer from 0 to 360
+            //   saturation : double from 0.0 to 1.0
+            //                (HTML uses percentages)
+            //        value : double from 0.0 to 1.0
+            //                (HTML uses percentages)
+            //        alpha : double from 0.0 to 1.0
+            //                (HTML does not use percent for alpha)
+
+            sb.Append("hsva(");
+            sb.Append(H.ToString(CultureInfo.InvariantCulture));
+            sb.Append(", ");
+            sb.Append(S.ToString(CultureInfo.InvariantCulture));
+            sb.Append(", ");
+            sb.Append(V.ToString(CultureInfo.InvariantCulture));
+            sb.Append(", ");
+            sb.Append(A.ToString(CultureInfo.InvariantCulture));
+            sb.Append(')');
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Parses an HSV color string.
+        /// </summary>
+        /// <param name="s">The HSV color string to parse.</param>
+        /// <param name="hsvColor">The parsed HSV color.</param>
+        /// <returns>True if parsing was successful; otherwise, false.</returns>
+        public static bool TryParse(string s, out HsvColor hsvColor)
+        {
+            hsvColor = default;
+
+            if (s is null)
+            {
+                return false;
+            }
+
+            string workingString = s.Trim();
+
+            if (workingString.Length == 0 ||
+                workingString.IndexOf(",", StringComparison.Ordinal) < 0)
+            {
+                return false;
+            }
+
+            if (workingString.StartsWith("hsva(", StringComparison.OrdinalIgnoreCase) &&
+                workingString.EndsWith(")", StringComparison.Ordinal) &&
+                workingString.Length > 6)
+            {
+                workingString = workingString.Substring(5, workingString.Length - 6);
+            }
+
+            if (workingString.StartsWith("hsv(", StringComparison.OrdinalIgnoreCase) &&
+                workingString.EndsWith(")", StringComparison.Ordinal) &&
+                workingString.Length > 5)
+            {
+                workingString = workingString.Substring(4, workingString.Length - 5);
+            }
+
+            string[] components = workingString.Split(',');
+
+            if (components.Length == 3) // HSV
+            {
+                if (double.TryParse(components[0], NumberStyles.Number, CultureInfo.InvariantCulture, out double hue) &&
+                    double.TryParse(components[1], NumberStyles.Number, CultureInfo.InvariantCulture, out double saturation) &&
+                    double.TryParse(components[2], NumberStyles.Number, CultureInfo.InvariantCulture, out double value))
+                {
+                    hsvColor = new HsvColor(1.0, hue, saturation, value);
+                    return true;
+                }
+            }
+            else if (components.Length == 4) // HSVA
+            {
+                if (double.TryParse(components[0], NumberStyles.Number, CultureInfo.InvariantCulture, out double hue) &&
+                    double.TryParse(components[1], NumberStyles.Number, CultureInfo.InvariantCulture, out double saturation) &&
+                    double.TryParse(components[2], NumberStyles.Number, CultureInfo.InvariantCulture, out double value) &&
+                    double.TryParse(components[3], NumberStyles.Number, CultureInfo.InvariantCulture, out double alpha))
+                {
+                    hsvColor = new HsvColor(alpha, hue, saturation, value);
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
## What does the pull request do?

HsvColor does not currently support serialization to strings, this PR enables it using a format similar to HTML/CSS.

## What is the current behavior?

No .ToString() or TryParse() support.

## What is the updated/expected behavior with this PR?

 * HsvColor.ToString() is implemented with a format similar to "hsva(230, 1.0, 0.5, 0.9)"
 * HsvColor.TryParse() is implemented supporting both "hsv(230, 1.0, 0.5)" and "hsva(230, 1.0, 0.5, 0.9)" formats (more forgiving).
 * HsvColor.Parse() is implemented internally using TryParse()
 * I noticed there is risk with Color.ToString() interpolation that the hex format could theoretically be incorrect. The issue is string interpolation uses the CurrentCulture instead of InvariantCulture by default. This hasn't been an issue because all cultures I can think of format hexadecimal numbers the same way. However, just to be theoretically correct, InvariantCulture is now used.
 * Wrap 360 degrees to 0 in the Hue component (since the PR is still open)

## How was the solution implemented (if it's not obvious)?

As stated.

## Checklist

- [ ] Added unit tests (if possible)?
- [X] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

None

## Obsoletions / Deprecations

None

## Fixed issues

