### PR TITLE
Used ToArray where it benefits over ToList

### DIFF
--- a/src/Avalonia.Animation/Easing/Easing.cs
+++ b/src/Avalonia.Animation/Easing/Easing.cs
@@ -39,7 +39,7 @@ namespace Avalonia.Animation.Easings
                 var derivedTypes = typeof(Easing).Assembly.GetTypes()
                                       .Where(p => p.Namespace == s_thisType.Namespace)
                                       .Where(p => p.IsSubclassOf(s_thisType))
-                                      .Select(p => p).ToList();
+                                      .Select(p => p);
 
                 foreach (var easingType in derivedTypes)
                     _easingTypes.Add(easingType.Name, easingType);

--- a/src/Avalonia.Base/Collections/AvaloniaDictionary.cs
+++ b/src/Avalonia.Base/Collections/AvaloniaDictionary.cs
@@ -123,7 +123,7 @@ namespace Avalonia.Collections
             {
                 var e = new NotifyCollectionChangedEventArgs(
                     NotifyCollectionChangedAction.Remove,
-                    old.ToList(),
+                    old.ToArray(),
                     -1);
                 CollectionChanged(this, e);
             }

--- a/src/Avalonia.Base/Collections/AvaloniaList.cs
+++ b/src/Avalonia.Base/Collections/AvaloniaList.cs
@@ -222,7 +222,7 @@ namespace Avalonia.Collections
                 {
                     var e = ResetBehavior == ResetBehavior.Reset ?
                         EventArgsCache.ResetCollectionChanged :
-                        new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, _inner.ToList(), 0);
+                        new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, _inner.ToArray(), 0);
 
                     _inner.Clear();
 

--- a/src/Avalonia.Base/Data/Core/PropertyPath.cs
+++ b/src/Avalonia.Base/Data/Core/PropertyPath.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Data.Core
 
         public PropertyPath(IEnumerable<IPropertyPathElement> elements)
         {
-            Elements = elements.ToList();
+            Elements = elements.ToArray();
         }
     }
 

--- a/src/Avalonia.Base/Utilities/AvaloniaResourcesIndex.cs
+++ b/src/Avalonia.Base/Utilities/AvaloniaResourcesIndex.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Utilities
 
             var assetDoc = XDocument.Load(stream);
             XNamespace assetNs = assetDoc.Root!.Attribute("xmlns")!.Value;
-            List<AvaloniaResourcesIndexEntry> entries=         
+            List<AvaloniaResourcesIndexEntry> entries =         
                 (from entry in assetDoc.Root.Element(assetNs + "Entries")!.Elements(assetNs + "AvaloniaResourcesIndexEntry")
                     select new AvaloniaResourcesIndexEntry
                     {

--- a/src/Avalonia.Build.Tasks/GenerateAvaloniaResourcesTask.cs
+++ b/src/Avalonia.Build.Tasks/GenerateAvaloniaResourcesTask.cs
@@ -105,7 +105,7 @@ namespace Avalonia.Build.Tasks
         {
             var typeToXamlIndex = new Dictionary<string, string>(); 
             
-            foreach (var s in sources.ToList())
+            foreach (var s in sources.ToArray())
             {
                 if (s.Path.ToLowerInvariant().EndsWith(".xaml") || s.Path.ToLowerInvariant().EndsWith(".paml") || s.Path.ToLowerInvariant().EndsWith(".axaml"))
                 {

--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
@@ -3946,7 +3946,7 @@ namespace Avalonia.Collections
             {
                 sort.Initialize(itemType); 
 
-                if(seq is IOrderedEnumerable<object> orderedEnum)
+                if (seq is IOrderedEnumerable<object> orderedEnum)
                 {
                     seq = sort.ThenBy(orderedEnum);
                 }

--- a/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
@@ -65,7 +65,7 @@ namespace Avalonia.Controls.ApplicationLifetimes
         /// <inheritdoc/>
         public Window? MainWindow { get; set; }
 
-        public IReadOnlyList<Window> Windows => _windows.ToList();
+        public IReadOnlyList<Window> Windows => _windows.ToArray();
 
         private void HandleWindowClosed(Window window)
         {

--- a/src/Avalonia.Controls/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox.cs
@@ -2180,7 +2180,7 @@ namespace Avalonia.Controls
             }
 
             // Store a local cached copy of the data
-            _items = newValue == null ? null : new List<object>(newValue.Cast<object>().ToList());
+            _items = newValue == null ? null : new List<object>(newValue.Cast<object>());
 
             // Clear and set the view on the selection adapter
             ClearView();
@@ -2239,7 +2239,7 @@ namespace Avalonia.Controls
                 ClearView();
                 if (Items != null)
                 {
-                    _items = new List<object>(Items.Cast<object>().ToList());
+                    _items = new List<object>(Items.Cast<object>());
                 }
             }
 

--- a/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
@@ -82,7 +82,7 @@ namespace Avalonia.Controls.Generators
             {
                 var toMove = _containers.Where(x => x.Key >= index)
                     .OrderByDescending(x => x.Key)
-                    .ToList();
+                    .ToArray();
 
                 foreach (var i in toMove)
                 {
@@ -111,7 +111,7 @@ namespace Avalonia.Controls.Generators
                 }
 
                 var toMove = _containers.Where(x => x.Key >= startingIndex)
-                                        .OrderBy(x => x.Key).ToList();
+                                        .OrderBy(x => x.Key).ToArray();
 
                 foreach (var i in toMove)
                 {
@@ -122,9 +122,9 @@ namespace Avalonia.Controls.Generators
 
                 Dematerialized?.Invoke(this, new ItemContainerEventArgs(startingIndex, result));
 
-                if (toMove.Count > 0)
+                if (toMove.Length > 0)
                 {
-                    var containers = toMove.Select(x => x.Value).ToList();
+                    var containers = toMove.Select(x => x.Value).ToArray();
                     Recycled?.Invoke(this, new ItemContainerEventArgs(containers[0].Index, containers));
                 }
             }
@@ -138,10 +138,10 @@ namespace Avalonia.Controls.Generators
         /// <inheritdoc/>
         public virtual IEnumerable<ItemContainerInfo> Clear()
         {
-            var result = Containers.ToList();
+            var result = Containers.ToArray();
             _containers.Clear();
 
-            if (result.Count > 0)
+            if (result.Length > 0)
             {
                 Dematerialized?.Invoke(this, new ItemContainerEventArgs(0, result));
             }

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -1051,7 +1051,7 @@ namespace Avalonia.Controls
                         var currentValueTextSpecialCharacters = currentValueText.Where(c => !char.IsDigit(c));
                         var textSpecialCharacters = text.Where(c => !char.IsDigit(c));
                         // same non-digit characters on currentValueText and new text => remove them on new Text to parse it again.
-                        if (currentValueTextSpecialCharacters.Except(textSpecialCharacters).ToList().Count == 0)
+                        if (!currentValueTextSpecialCharacters.Except(textSpecialCharacters).Any())
                         {
                             foreach (var character in textSpecialCharacters)
                             {

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositionerPopupImplHelper.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositionerPopupImplHelper.cs
@@ -23,8 +23,9 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
 
         public IReadOnlyList<ManagedPopupPositionerScreenInfo> Screens =>
 
-            _parent.Screen.AllScreens.Select(s => new ManagedPopupPositionerScreenInfo(
-                s.Bounds.ToRect(1), s.WorkingArea.ToRect(1))).ToList();
+            _parent.Screen.AllScreens
+                .Select(s => new ManagedPopupPositionerScreenInfo(s.Bounds.ToRect(1), s.WorkingArea.ToRect(1)))
+                .ToArray();
 
         public Rect ParentClientAreaScreenGeometry
         {

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -292,11 +292,11 @@ namespace Avalonia.Controls.Primitives
                             "collection is different to the Items on the control.");
                     }
 
-                    var oldSelection = _selection?.SelectedItems.ToList();
+                    var oldSelection = _selection?.SelectedItems.ToArray();
                     DeinitializeSelectionModel(_selection);
                     _selection = value;
 
-                    if (oldSelection?.Count > 0)
+                    if (oldSelection?.Length > 0)
                     {
                         RaiseEvent(new SelectionChangedEventArgs(
                             SelectionChangedEvent,
@@ -845,8 +845,8 @@ namespace Avalonia.Controls.Primitives
             {
                 var ev = new SelectionChangedEventArgs(
                     SelectionChangedEvent,
-                    e.DeselectedItems.ToList(),
-                    e.SelectedItems.ToList());
+                    e.DeselectedItems.ToArray(),
+                    e.SelectedItems.ToArray());
                 RaiseEvent(ev);
             }
         }
@@ -988,7 +988,7 @@ namespace Avalonia.Controls.Primitives
                 RaiseEvent(new SelectionChangedEventArgs(
                     SelectionChangedEvent,
                     Array.Empty<object>(),
-                    Selection.SelectedItems.ToList()));
+                    Selection.SelectedItems.ToArray()));
             }
         }
 

--- a/src/Avalonia.Controls/Selection/InternalSelectionModel.cs
+++ b/src/Avalonia.Controls/Selection/InternalSelectionModel.cs
@@ -182,8 +182,8 @@ namespace Avalonia.Controls.Selection
             try
             {
                 var items = WritableSelectedItems;
-                var deselected = e.DeselectedItems.ToList();
-                var selected = e.SelectedItems.ToList();
+                var deselected = e.DeselectedItems.ToArray();
+                var selected = e.SelectedItems.ToArray();
 
                 _ignoreSelectedItemsChanges = true;
 

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -849,7 +849,7 @@ namespace Avalonia.Controls
         /// <param name="desired">The desired items.</param>
         private static void SynchronizeItems(IList items, IEnumerable<object> desired)
         {
-            var list = items.Cast<object>().ToList();
+            var list = items.Cast<object>();
             var toRemove = list.Except(desired).ToList();
             var toAdd = desired.Except(list).ToList();
 

--- a/src/Avalonia.Controls/Utils/CollectionChangedEventManager.cs
+++ b/src/Avalonia.Controls/Utils/CollectionChangedEventManager.cs
@@ -105,7 +105,7 @@ namespace Avalonia.Controls.Utils
                 static void Notify(
                     INotifyCollectionChanged incc,
                     NotifyCollectionChangedEventArgs args,
-                    List<WeakReference<ICollectionChangedListener>> listeners)
+                    WeakReference<ICollectionChangedListener>[] listeners)
                 {
                     foreach (var l in listeners)
                     {
@@ -132,7 +132,7 @@ namespace Avalonia.Controls.Utils
                     }
                 }
 
-                var l = Listeners.ToList();
+                var l = Listeners.ToArray();
 
                 if (Dispatcher.UIThread.CheckAccess())
                 {

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -258,7 +258,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets a collection of child windows owned by this window.
         /// </summary>
-        public IReadOnlyList<Window> OwnedWindows => _children.Select(x => x.child).ToList();
+        public IReadOnlyList<Window> OwnedWindows => _children.Select(x => x.child).ToArray();
 
         /// <summary>
         /// Gets or sets a value indicating how the window will size itself to fit its content.
@@ -527,7 +527,7 @@ namespace Avalonia.Controls
 
         private void CloseInternal()
         {
-            foreach (var (child, _) in _children.ToList())
+            foreach (var (child, _) in _children.ToArray())
             {
                 child.CloseInternal();
             }
@@ -551,7 +551,7 @@ namespace Avalonia.Controls
             
             bool canClose = true;
 
-            foreach (var (child, _) in _children.ToList())
+            foreach (var (child, _) in _children.ToArray())
             {
                 if (child.ShouldCancelClose(args))
                 {

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ControlDetailsViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ControlDetailsViewModel.cs
@@ -18,7 +18,7 @@ namespace Avalonia.Diagnostics.ViewModels
     internal class ControlDetailsViewModel : ViewModelBase, IDisposable
     {
         private readonly IAvaloniaObject _avaloniaObject;
-        private IDictionary<object, List<PropertyViewModel>>? _propertyIndex;
+        private IDictionary<object, PropertyViewModel[]>? _propertyIndex;
         private PropertyViewModel? _selectedProperty;
         private DataGridCollectionView? _propertiesView;
         private bool _snapshotStyles;
@@ -472,9 +472,9 @@ namespace Avalonia.Diagnostics.ViewModels
                 .Concat(GetClrProperties(o, _showImplementedInterfaces))
                 .OrderBy(x => x, PropertyComparer.Instance)
                 .ThenBy(x => x.Name)
-                .ToList();
+                .ToArray();
 
-            _propertyIndex = properties.GroupBy(x => x.Key).ToDictionary(x => x.Key, x => x.ToList());
+            _propertyIndex = properties.GroupBy(x => x.Key).ToDictionary(x => x.Key, x => x.ToArray());
 
             var view = new DataGridCollectionView(properties);
             view.GroupDescriptions.Add(new DataGridPathGroupDescription(nameof(AvaloniaPropertyViewModel.Group)));

--- a/src/Avalonia.Input/FocusManager.cs
+++ b/src/Avalonia.Input/FocusManager.cs
@@ -73,7 +73,7 @@ namespace Avalonia.Input
             else if (Current != null)
             {
                 // If control is null, set focus to the topmost focus scope.
-                foreach (var scope in GetFocusScopeAncestors(Current).Reverse().ToList())
+                foreach (var scope in GetFocusScopeAncestors(Current).Reverse().ToArray())
                 {
                     if (scope != Scope &&
                         _focusScopes.TryGetValue(scope, out var element) &&

--- a/src/Avalonia.Input/TouchDevice.cs
+++ b/src/Avalonia.Input/TouchDevice.cs
@@ -114,7 +114,7 @@ namespace Avalonia.Input
         {
             if (_disposed)
                 return;
-            var values = _pointers.Values.ToList();
+            var values = _pointers.Values.ToArray();
             _pointers.Clear();
             _disposed = true;
             foreach (var p in values)

--- a/src/Avalonia.Visuals/Animation/CompositePageTransition.cs
+++ b/src/Avalonia.Visuals/Animation/CompositePageTransition.cs
@@ -41,7 +41,7 @@ namespace Avalonia.Animation
         {
             var transitionTasks = PageTransitions
                 .Select(transition => transition.Start(from, to, forward, cancellationToken))
-                .ToList();
+                .ToArray();
             return Task.WhenAll(transitionTasks);
         }
     }

--- a/src/Avalonia.Visuals/Media/GradientStops.cs
+++ b/src/Avalonia.Visuals/Media/GradientStops.cs
@@ -17,7 +17,7 @@ namespace Avalonia.Media
 
         public IReadOnlyList<ImmutableGradientStop> ToImmutable()
         {
-            return this.Select(x => new ImmutableGradientStop(x.Offset, x.Color)).ToList();
+            return this.Select(x => new ImmutableGradientStop(x.Offset, x.Color)).ToArray();
         }
     }
 }

--- a/src/Avalonia.X11/Glx/GlxDisplay.cs
+++ b/src/Avalonia.X11/Glx/GlxDisplay.cs
@@ -9,7 +9,7 @@ namespace Avalonia.X11.Glx
     unsafe class GlxDisplay
     {
         private readonly X11Info _x11;
-        private readonly List<GlVersion> _probeProfiles;
+        private readonly GlVersion[] _probeProfiles;
         private readonly IntPtr _fbconfig;
         private readonly XVisualInfo* _visual;
         private string[] _displayExtensions;
@@ -21,7 +21,7 @@ namespace Avalonia.X11.Glx
         public GlxDisplay(X11Info x11, IList<GlVersion> probeProfiles) 
         {
             _x11 = x11;
-            _probeProfiles = probeProfiles.ToList();
+            _probeProfiles = probeProfiles.ToArray();
             _displayExtensions = Glx.GetExtensions(_x11.Display);
 
             var baseAttribs = new[]
@@ -76,10 +76,10 @@ namespace Avalonia.X11.Glx
             if (Glx.GetFBConfigAttrib(_x11.Display, _fbconfig, GLX_STENCIL_SIZE, out var stencil) == 0)
                 stencilSize = stencil;
 
-            var pbuffers = Enumerable.Range(0, 2).Select(_ => Glx.CreatePbuffer(_x11.Display, _fbconfig, new[]
-            {
-                GLX_PBUFFER_WIDTH, 1, GLX_PBUFFER_HEIGHT, 1, 0
-            })).ToList();
+            var attributes = new[] { GLX_PBUFFER_WIDTH, 1, GLX_PBUFFER_HEIGHT, 1, 0 };
+            
+            Glx.CreatePbuffer(_x11.Display, _fbconfig, attributes);
+            Glx.CreatePbuffer(_x11.Display, _fbconfig, attributes);
             
             XLib.XFlush(_x11.Display);
 
@@ -104,7 +104,6 @@ namespace Avalonia.X11.Glx
                                     $"Renderer '{glInterface.Renderer}' is blacklisted by '{item}'");
                 }
             }
-
         }
 
         IntPtr CreatePBuffer()

--- a/src/Avalonia.X11/X11Globals.cs
+++ b/src/Avalonia.X11/X11Globals.cs
@@ -41,7 +41,7 @@ namespace Avalonia.X11
                 {
                     _wmName = value;
                     // The collection might change during enumeration
-                    foreach (var s in _subscribers.ToList()) 
+                    foreach (var s in _subscribers.ToArray()) 
                         s.WmChanged(value);
                 }
             }
@@ -69,7 +69,7 @@ namespace Avalonia.X11
                 {
                     _isCompositionEnabled = value;
                     // The collection might change during enumeration
-                    foreach (var s in _subscribers.ToList()) 
+                    foreach (var s in _subscribers.ToArray()) 
                         s.CompositionChanged(value);
                 }
             }

--- a/src/Windows/Avalonia.Win32/TrayIconImpl.cs
+++ b/src/Windows/Avalonia.Win32/TrayIconImpl.cs
@@ -217,8 +217,9 @@ namespace Avalonia.Win32
                 }
 
                 public IReadOnlyList<ManagedPopupPositionerScreenInfo> Screens =>
-                _hiddenWindow.Screens.All.Select(s => new ManagedPopupPositionerScreenInfo(
-                    s.Bounds.ToRect(1), s.Bounds.ToRect(1))).ToList();
+                    _hiddenWindow.Screens.All
+                        .Select(s => new ManagedPopupPositionerScreenInfo(s.Bounds.ToRect(1), s.Bounds.ToRect(1)))
+                        .ToArray();
 
                 public Rect ParentClientAreaScreenGeometry
                 {


### PR DESCRIPTION
## What does the pull request do?

This PR optimizes memory usage by allocation only an array without a wrapping it `List<T>`. Changes are made only in those places where it's clear that no copy happens for array size reduction, i.e. only when the size of any result is determined before `ToArray<T>()`.


## What is the current behavior?

Use `ToList<T>()` in any case and cause additional allocations.


## What is the updated/expected behavior with this PR?

Less allocations of wrappers and intermediate buffers.


## How was the solution implemented (if it's not obvious)?

Call `ToArray<T>()` when the source is a sized collection or when the LINQ iterator chain produces `IListProvider<T>` and knows the source size.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation