### PR TITLE
Add Template Part Attributes to Controls

### DIFF
--- a/src/Avalonia.Controls/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox.cs
@@ -252,6 +252,10 @@ namespace Avalonia.Controls
     /// drop-down that contains possible matches based on the input in the text
     /// box.
     /// </summary>
+    [TemplatePart(ElementPopup,            typeof(Popup))]
+    [TemplatePart(ElementSelector,         typeof(SelectingItemsControl))]
+    [TemplatePart(ElementSelectionAdapter, typeof(ISelectionAdapter))]
+    [TemplatePart(ElementTextBox,          typeof(TextBox))]
     [PseudoClasses(":dropdownopen")]
     public class AutoCompleteBox : TemplatedControl
     {

--- a/src/Avalonia.Controls/ButtonSpinner.cs
+++ b/src/Avalonia.Controls/ButtonSpinner.cs
@@ -16,6 +16,8 @@ namespace Avalonia.Controls
     /// <summary>
     /// Represents a spinner control that includes two Buttons.
     /// </summary>
+    [TemplatePart("PART_DecreaseButton", typeof(Button))]
+    [TemplatePart("PART_IncreaseButton", typeof(Button))]
     [PseudoClasses(":left", ":right")]
     public class ButtonSpinner : Spinner
     {

--- a/src/Avalonia.Controls/Calendar/Calendar.cs
+++ b/src/Avalonia.Controls/Calendar/Calendar.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Input;
@@ -222,6 +223,8 @@ namespace Avalonia.Controls
     /// element in XAML.
     /// </para>
     /// </remarks>
+    [TemplatePart(PART_ElementMonth, typeof(CalendarItem))]
+    [TemplatePart(PART_ElementRoot,  typeof(Panel))]
     public class Calendar : TemplatedControl
     {
         internal const int RowsPerMonth = 7;
@@ -261,6 +264,7 @@ namespace Avalonia.Controls
             AvaloniaProperty.Register<Calendar, DayOfWeek>(
                     nameof(FirstDayOfWeek),
                     defaultValue: DateTimeHelper.GetCurrentDateFormat().FirstDayOfWeek);
+
         /// <summary>
         /// Gets or sets the day that is considered the beginning of the week.
         /// </summary>
@@ -273,6 +277,7 @@ namespace Avalonia.Controls
             get { return GetValue(FirstDayOfWeekProperty); }
             set { SetValue(FirstDayOfWeekProperty, value); }
         }
+
         /// <summary>
         /// FirstDayOfWeekProperty property changed handler.
         /// </summary>
@@ -289,6 +294,7 @@ namespace Avalonia.Controls
                 throw new ArgumentOutOfRangeException("d", "Invalid DayOfWeek");
             }
         }
+
         /// <summary>
         /// Inherited code: Requires comment.
         /// </summary>
@@ -311,6 +317,7 @@ namespace Avalonia.Controls
             AvaloniaProperty.Register<Calendar, bool>(
                 nameof(IsTodayHighlighted),
                 defaultValue: true);
+
         /// <summary>
         /// Gets or sets a value indicating whether the current date is
         /// highlighted.
@@ -324,6 +331,7 @@ namespace Avalonia.Controls
             get { return GetValue(IsTodayHighlightedProperty); }
             set { SetValue(IsTodayHighlightedProperty, value); }
         }
+
         /// <summary>
         /// IsTodayHighlightedProperty property changed handler.
         /// </summary>
@@ -343,6 +351,7 @@ namespace Avalonia.Controls
 
         public static readonly StyledProperty<IBrush> HeaderBackgroundProperty =
             AvaloniaProperty.Register<Calendar, IBrush>(nameof(HeaderBackground));
+
         public IBrush HeaderBackground
         {
             get { return GetValue(HeaderBackgroundProperty); }
@@ -367,6 +376,7 @@ namespace Avalonia.Controls
             get { return GetValue(DisplayModeProperty); }
             set { SetValue(DisplayModeProperty, value); }
         }
+
         /// <summary>
         /// DisplayModeProperty property changed handler.
         /// </summary>
@@ -424,6 +434,7 @@ namespace Avalonia.Controls
                 || mode == CalendarMode.Year
                 || mode == CalendarMode.Decade;
         }
+
         private void OnDisplayModeChanged(CalendarModeChangedEventArgs args)
         {
             DisplayModeChanged?.Invoke(this, args);
@@ -433,6 +444,7 @@ namespace Avalonia.Controls
             AvaloniaProperty.Register<Calendar, CalendarSelectionMode>(
                 nameof(SelectionMode),
                 defaultValue: CalendarSelectionMode.SingleDate);
+
         /// <summary>
         /// Gets or sets a value that indicates what kind of selections are
         /// allowed.
@@ -457,6 +469,7 @@ namespace Avalonia.Controls
             get { return GetValue(SelectionModeProperty); }
             set { SetValue(SelectionModeProperty, value); }
         }
+
         private void OnSelectionModeChanged(AvaloniaPropertyChangedEventArgs e)
         {
             if (IsValidSelectionMode(e.NewValue!))
@@ -471,6 +484,7 @@ namespace Avalonia.Controls
                 throw new ArgumentOutOfRangeException("d", "Invalid SelectionMode");
             }
         }
+
         /// <summary>
         /// Inherited code: Requires comment.
         /// </summary>
@@ -492,6 +506,7 @@ namespace Avalonia.Controls
                 o => o.SelectedDate,
                 (o, v) => o.SelectedDate = v,
                 defaultBindingMode: BindingMode.TwoWay);
+
         /// <summary>
         /// Gets or sets the currently selected date.
         /// </summary>
@@ -720,6 +735,7 @@ namespace Avalonia.Controls
                 o => o.DisplayDate,
                 (o, v) => o.DisplayDate = v,
                 defaultBindingMode: BindingMode.TwoWay);
+
         /// <summary>
         /// Gets or sets the date to display.
         /// </summary>
@@ -1973,6 +1989,7 @@ namespace Avalonia.Controls
                     }
             }
         }
+
         private void Calendar_KeyUp(KeyEventArgs e)
         {
             if (!e.Handled && (e.Key == Key.LeftShift || e.Key == Key.RightShift))
@@ -1980,6 +1997,7 @@ namespace Avalonia.Controls
                 ProcessShiftKeyUp();
             }
         }
+
         internal void ProcessShiftKeyUp()
         {
             if (_isShiftPressed && (SelectionMode == CalendarSelectionMode.SingleRange || SelectionMode == CalendarSelectionMode.MultipleRange))
@@ -2028,6 +2046,7 @@ namespace Avalonia.Controls
                     }
             }
         }
+
         protected override void OnLostFocus(RoutedEventArgs e)
         {
             base.OnLostFocus(e);
@@ -2054,6 +2073,7 @@ namespace Avalonia.Controls
                     }
             }
         }
+
         /// <summary>
         ///  Called when the IsEnabled property changes.
         /// </summary>
@@ -2098,6 +2118,7 @@ namespace Avalonia.Controls
 
         private const string PART_ElementRoot = "Root";
         private const string PART_ElementMonth = "CalendarItem";
+
         /// <summary>
         /// Builds the visual tree for the
         /// <see cref="T:System.Windows.Controls.Calendar" /> when a new

--- a/src/Avalonia.Controls/Calendar/CalendarDatePicker.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarDatePicker.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Input;
@@ -116,6 +117,10 @@ namespace Avalonia.Controls
         Custom = 2
     }
 
+    [TemplatePart(ElementButton,   typeof(Button))]
+    [TemplatePart(ElementCalendar, typeof(Calendar))]
+    [TemplatePart(ElementPopup,    typeof(Popup))]
+    [TemplatePart(ElementTextBox,  typeof(TextBox))]
     public class CalendarDatePicker : TemplatedControl
     {
         private const string ElementTextBox = "PART_TextBox";

--- a/src/Avalonia.Controls/Calendar/CalendarItem.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarItem.cs
@@ -19,6 +19,11 @@ namespace Avalonia.Controls.Primitives
     /// Represents the currently displayed month or year on a
     /// <see cref="T:Avalonia.Controls.Calendar" />.
     /// </summary>
+    [TemplatePart(PART_ElementHeaderButton,   typeof(Button))]
+    [TemplatePart(PART_ElementMonthView,      typeof(Grid))]
+    [TemplatePart(PART_ElementNextButton,     typeof(Button))]
+    [TemplatePart(PART_ElementPreviousButton, typeof(Button))]
+    [TemplatePart(PART_ElementYearView,       typeof(Grid))]
     [PseudoClasses(":calendardisabled")]
     public sealed class CalendarItem : TemplatedControl
     {

--- a/src/Avalonia.Controls/Chrome/CaptionButtons.cs
+++ b/src/Avalonia.Controls/Chrome/CaptionButtons.cs
@@ -8,6 +8,10 @@ namespace Avalonia.Controls.Chrome
     /// <summary>
     /// Draws window minimize / maximize / close buttons in a <see cref="TitleBar"/> when managed client decorations are enabled.
     /// </summary>
+    [TemplatePart("PART_CloseButton",      typeof(Panel))]
+    [TemplatePart("PART_RestoreButton",    typeof(Panel))]
+    [TemplatePart("PART_MinimiseButton",   typeof(Panel))]
+    [TemplatePart("PART_FullScreenButton", typeof(Panel))]
     [PseudoClasses(":minimized", ":normal", ":maximized", ":fullscreen")]
     public class CaptionButtons : TemplatedControl
     {

--- a/src/Avalonia.Controls/Chrome/TitleBar.cs
+++ b/src/Avalonia.Controls/Chrome/TitleBar.cs
@@ -8,6 +8,7 @@ namespace Avalonia.Controls.Chrome
     /// <summary>
     /// Draws a titlebar when managed client decorations are enabled.
     /// </summary>
+    [TemplatePart("PART_CaptionButtons", typeof(CaptionButtons))]
     [PseudoClasses(":minimized", ":normal", ":maximized", ":fullscreen")]
     public class TitleBar : TemplatedControl
     {

--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -13,12 +13,14 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.VisualTree;
+using Avalonia.Controls.Metadata;
 
 namespace Avalonia.Controls
 {
     /// <summary>
     /// A drop-down list control.
     /// </summary>
+    [TemplatePart("PART_Popup", typeof(Popup))]
     public class ComboBox : SelectingItemsControl
     {
         /// <summary>

--- a/src/Avalonia.Controls/ContentControl.cs
+++ b/src/Avalonia.Controls/ContentControl.cs
@@ -1,4 +1,5 @@
 using Avalonia.Collections;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Mixins;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
@@ -12,6 +13,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// Displays <see cref="Content"/> according to a <see cref="FuncDataTemplate"/>.
     /// </summary>
+    [TemplatePart("PART_ContentPresenter", typeof(IContentPresenter))]
     public class ContentControl : TemplatedControl, IContentControl, IContentPresenterHost
     {
         /// <summary>

--- a/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
@@ -14,6 +14,15 @@ namespace Avalonia.Controls
     /// <summary>
     /// A control to allow the user to select a date
     /// </summary>
+    [TemplatePart("ButtonContentGrid", typeof(Grid))]
+    [TemplatePart("DayText",           typeof(TextBlock))]
+    [TemplatePart("FirstSpacer",       typeof(Rectangle))]
+    [TemplatePart("FlyoutButton",      typeof(Button))]
+    [TemplatePart("MonthText",         typeof(TextBlock))]
+    [TemplatePart("PickerPresenter",   typeof(DatePickerPresenter))]
+    [TemplatePart("Popup",             typeof(Popup))]
+    [TemplatePart("SecondSpacer",      typeof(Rectangle))]
+    [TemplatePart("YearText",          typeof(TextBlock))]
     [PseudoClasses(":hasnodate")]
     public class DatePicker : TemplatedControl
     {

--- a/src/Avalonia.Controls/DateTimePickers/DatePickerPresenter.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DatePickerPresenter.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls.Primitives;
+﻿using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -12,6 +13,23 @@ namespace Avalonia.Controls
     /// Defines the presenter used for selecting a date for a 
     /// <see cref="DatePicker"/>
     /// </summary>
+    [TemplatePart("AcceptButton",    typeof(Button))]
+    [TemplatePart("DayDownButton",   typeof(RepeatButton))]
+    [TemplatePart("DayHost",         typeof(Panel))]
+    [TemplatePart("DaySelector",     typeof(DateTimePickerPanel))]
+    [TemplatePart("DayUpButton",     typeof(RepeatButton))]
+    [TemplatePart("DismissButton",   typeof(Button))]
+    [TemplatePart("FirstSpacer",     typeof(Rectangle))]
+    [TemplatePart("MonthDownButton", typeof(RepeatButton))]
+    [TemplatePart("MonthHost",       typeof(Panel))]
+    [TemplatePart("MonthSelector",   typeof(DateTimePickerPanel))]
+    [TemplatePart("MonthUpButton",   typeof(RepeatButton))]
+    [TemplatePart("PickerContainer", typeof(Grid))]
+    [TemplatePart("SecondSpacer",    typeof(Rectangle))]
+    [TemplatePart("YearDownButton",  typeof(RepeatButton))]
+    [TemplatePart("YearHost",        typeof(Panel))]
+    [TemplatePart("YearSelector",    typeof(DateTimePickerPanel))]
+    [TemplatePart("YearUpButton",    typeof(RepeatButton))]
     public class DatePickerPresenter : PickerPresenterBase
     {
         /// <summary>

--- a/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
@@ -12,6 +12,18 @@ namespace Avalonia.Controls
     /// <summary>
     /// A control to allow the user to select a time.
     /// </summary>
+    [TemplatePart("FirstColumnDivider",      typeof(Rectangle))]
+    [TemplatePart("FirstPickerHost",         typeof(Border))]
+    [TemplatePart("FlyoutButton",            typeof(Button))]
+    [TemplatePart("FlyoutButtonContentGrid", typeof(Grid))]
+    [TemplatePart("HourTextBlock",           typeof(TextBlock))]
+    [TemplatePart("MinuteTextBlock",         typeof(TextBlock))]
+    [TemplatePart("PeriodTextBlock",         typeof(TextBlock))]
+    [TemplatePart("PickerPresenter",         typeof(TimePickerPresenter))]
+    [TemplatePart("Popup",                   typeof(Popup))]
+    [TemplatePart("SecondColumnDivider",     typeof(Rectangle))]
+    [TemplatePart("SecondPickerHost",        typeof(Border))]
+    [TemplatePart("ThirdPickerHost",         typeof(Border))]
     [PseudoClasses(":hasnotime")]
     public class TimePicker : TemplatedControl
     {

--- a/src/Avalonia.Controls/DateTimePickers/TimePickerPresenter.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePickerPresenter.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls.Primitives;
+﻿using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -10,6 +11,20 @@ namespace Avalonia.Controls
     /// Defines the presenter used for selecting a time. Intended for use with
     /// <see cref="TimePicker"/> but can be used independently
     /// </summary>
+    [TemplatePart("AcceptButton",     typeof(Button))]
+    [TemplatePart("DismissButton",    typeof(Button))]
+    [TemplatePart("HourDownButton",   typeof(RepeatButton))]
+    [TemplatePart("HourSelector",     typeof(DateTimePickerPanel))]
+    [TemplatePart("HourUpButton",     typeof(RepeatButton))]
+    [TemplatePart("MinuteDownButton", typeof(RepeatButton))]
+    [TemplatePart("MinuteSelector",   typeof(DateTimePickerPanel))]
+    [TemplatePart("MinuteUpButton",   typeof(RepeatButton))]
+    [TemplatePart("PeriodDownButton", typeof(RepeatButton))]
+    [TemplatePart("PeriodHost",       typeof(Panel))]
+    [TemplatePart("PeriodSelector",   typeof(DateTimePickerPanel))]
+    [TemplatePart("PeriodUpButton",   typeof(RepeatButton))]
+    [TemplatePart("PickerContainer",  typeof(Grid))]
+    [TemplatePart("SecondSpacer",     typeof(Rectangle))]
     public class TimePickerPresenter : PickerPresenterBase
     {
         /// <summary>

--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using Avalonia.Controls.Generators;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Selection;
@@ -12,6 +13,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// An <see cref="ItemsControl"/> in which individual items can be selected.
     /// </summary>
+    [TemplatePart("PART_ScrollViewer", typeof(IScrollable))]
     public class ListBox : SelectingItemsControl
     {
         /// <summary>

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -20,6 +20,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// A menu item control.
     /// </summary>
+    [TemplatePart("PART_Popup", typeof(Popup))]
     [PseudoClasses(":separator", ":icon", ":open", ":pressed", ":selected")]
     public class MenuItem : HeaderedSelectingItemsControl, IMenuItem, ISelectable, ICommandSource
     {

--- a/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
+++ b/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
@@ -14,6 +14,7 @@ namespace Avalonia.Controls.Notifications
     /// <summary>
     /// An <see cref="INotificationManager"/> that displays notifications in a <see cref="Window"/>.
     /// </summary>
+    [TemplatePart("PART_Items", typeof(Panel))]
     [PseudoClasses(":topleft", ":topright", ":bottomleft", ":bottomright")]
     public class WindowNotificationManager : TemplatedControl, IManagedNotificationManager, ICustomSimpleHitTest
     {

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Input;
@@ -15,6 +16,8 @@ namespace Avalonia.Controls
     /// <summary>
     /// Control that represents a TextBox with button spinners that allow incrementing and decrementing numeric values.
     /// </summary>
+    [TemplatePart("PART_Spinner", typeof(Spinner))]
+    [TemplatePart("PART_TextBox", typeof(TextBox))]
     public class NumericUpDown : TemplatedControl
     {
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/ScrollBar.cs
+++ b/src/Avalonia.Controls/Primitives/ScrollBar.cs
@@ -22,6 +22,10 @@ namespace Avalonia.Controls.Primitives
     /// <summary>
     /// A scrollbar control.
     /// </summary>
+    [TemplatePart("PART_LineDownButton", typeof(Button))]
+    [TemplatePart("PART_LineUpButton",   typeof(Button))]
+    [TemplatePart("PART_PageDownButton", typeof(Button))]
+    [TemplatePart("PART_PageUpButton",   typeof(Button))]
     [PseudoClasses(":vertical", ":horizontal")]
     public class ScrollBar : RangeBase
     {

--- a/src/Avalonia.Controls/ProgressBar.cs
+++ b/src/Avalonia.Controls/ProgressBar.cs
@@ -10,6 +10,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// A control used to indicate the progress of an operation.
     /// </summary>
+    [TemplatePart("PART_Indicator", typeof(Border))]
     [PseudoClasses(":vertical", ":horizontal", ":indeterminate")]
     public class ProgressBar : RangeBase
     {

--- a/src/Avalonia.Controls/ScrollViewer.cs
+++ b/src/Avalonia.Controls/ScrollViewer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reactive.Linq;
 using Avalonia.Automation.Peers;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
@@ -11,6 +12,8 @@ namespace Avalonia.Controls
     /// <summary>
     /// A control which scrolls its content if the content is bigger than the space available.
     /// </summary>
+    [TemplatePart("PART_HorizontalScrollBar", typeof(ScrollBar))]
+    [TemplatePart("PART_VerticalScrollBar",   typeof(ScrollBar))]
     public class ScrollViewer : ContentControl, IScrollable, IScrollAnchorProvider
     {
         /// <summary>

--- a/src/Avalonia.Controls/Slider.cs
+++ b/src/Avalonia.Controls/Slider.cs
@@ -42,6 +42,9 @@ namespace Avalonia.Controls
     /// <summary>
     /// A control that lets the user select from a range of values by moving a Thumb control along a Track.
     /// </summary>
+    [TemplatePart("PART_DecreaseButton", typeof(Button))]
+    [TemplatePart("PART_IncreaseButton", typeof(Button))]
+    [TemplatePart("PART_Track",          typeof(Track))]
     [PseudoClasses(":vertical", ":horizontal", ":pressed")]
     public class Slider : RangeBase
     {

--- a/src/Avalonia.Controls/SplitButton/SplitButton.cs
+++ b/src/Avalonia.Controls/SplitButton/SplitButton.cs
@@ -13,6 +13,8 @@ namespace Avalonia.Controls
     /// A button with primary and secondary parts that can each be pressed separately.
     /// The primary part behaves like a <see cref="Button"/> and the secondary part opens a flyout.
     /// </summary>
+    [TemplatePart("PART_PrimaryButton",   typeof(Button))]
+    [TemplatePart("PART_SecondaryButton", typeof(Button))]
     [PseudoClasses(pcFlyoutOpen, pcPressed)]
     public class SplitButton : ContentControl, ICommandSource
     {

--- a/src/Avalonia.Controls/SplitView.cs
+++ b/src/Avalonia.Controls/SplitView.cs
@@ -77,6 +77,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// A control with two views: A collapsible pane and an area for content
     /// </summary>
+    [TemplatePart("PART_PaneRoot", typeof(Panel))]
     [PseudoClasses(":open", ":closed")]
     [PseudoClasses(":compactoverlay", ":compactinline", ":overlay", ":inline")]
     [PseudoClasses(":left", ":right")]

--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -11,12 +11,14 @@ using Avalonia.Layout;
 using Avalonia.LogicalTree;
 using Avalonia.VisualTree;
 using Avalonia.Automation;
+using Avalonia.Controls.Metadata;
 
 namespace Avalonia.Controls
 {
     /// <summary>
     /// A tab control that displays a tab strip along with the content of the selected tab.
     /// </summary>
+    [TemplatePart("PART_ItemsPresenter", typeof(ItemsPresenter))]
     public class TabControl : SelectingItemsControl, IContentPresenterHost
     {
         /// <summary>

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -23,6 +23,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// Represents a control that can be used to display or edit unformatted text.
     /// </summary>
+    [TemplatePart("PART_TextPresenter", typeof(TextPresenter))]
     [PseudoClasses(":empty")]
     public class TextBox : TemplatedControl, UndoRedoHelper<TextBox.UndoRedoState>.IUndoRedoHost
     {

--- a/src/Avalonia.Controls/ToggleSwitch.cs
+++ b/src/Avalonia.Controls/ToggleSwitch.cs
@@ -9,6 +9,8 @@ namespace Avalonia.Controls
     /// <summary>
     /// A Toggle Switch control.
     /// </summary>
+    [TemplatePart("MovingKnobs", typeof(Panel))]
+    [TemplatePart("SwitchKnob",  typeof(Panel))]
     [PseudoClasses(":dragging")]
     public class ToggleSwitch : ToggleButton
     {

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reactive.Linq;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Platform;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
@@ -26,6 +27,7 @@ namespace Avalonia.Controls
     /// It handles scheduling layout, styling and rendering as well as
     /// tracking the widget's <see cref="ClientSize"/>.
     /// </remarks>
+    [TemplatePart("PART_TransparencyFallback", typeof(Border))]
     public abstract class TopLevel : ContentControl,
         IInputRoot,
         ILayoutRoot,

--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -12,6 +12,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// An item in a <see cref="TreeView"/>.
     /// </summary>
+    [TemplatePart("PART_Header", typeof(IControl))]
     [PseudoClasses(":pressed", ":selected")]
     public class TreeViewItem : HeaderedItemsControl, ISelectable
     {

--- a/src/Avalonia.Dialogs/ManagedFileChooser.cs
+++ b/src/Avalonia.Dialogs/ManagedFileChooser.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -9,6 +10,8 @@ using Avalonia.LogicalTree;
 
 namespace Avalonia.Dialogs
 {
+    [TemplatePart("QuickLinks", typeof(Control))]
+    [TemplatePart("Files",      typeof(ListBox))]
     public class ManagedFileChooser : TemplatedControl
     {
         private Control _quickLinksRoot;


### PR DESCRIPTION
## What does the pull request do?

Uses the new TemplatePartAttribute defining the parts for each control.

 - No renames were done. If a template part was missing the "PART_" prefix it will be addressed in a future PR. This was done so this can be merged quickly just to get the metadata in.
 - Some controls (AutoCompleteBox) declare constants for the template part names. These constants were used instead of new strings for consistency.
 - Template parts were added in alphabetical order

## What is the current behavior?

Template parts are not defined in a standard way.

## What is the updated/expected behavior with this PR?

Template parts added. For reasons see #7432 and #7854 

## How was the solution implemented (if it's not obvious)?

Since reading through each control isn't feasible at this point, a search was done for the following:

 * `NameScope.Get<`
 * `NameScope.Find<`

Any places these were found a template part attribute was added.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

None, but it should be discussed to standardize names in another PR.

## Obsoletions / Deprecations

None

## Fixed issues

Relates to #7432 