### PR TITLE
Add missing context.Transform = Transform in EllipseNode

### DIFF
--- a/src/Avalonia.Visuals/Rendering/SceneGraph/EllipseNode.cs
+++ b/src/Avalonia.Visuals/Rendering/SceneGraph/EllipseNode.cs
@@ -59,6 +59,7 @@ namespace Avalonia.Rendering.SceneGraph
 
         public override void Render(IDrawingContextImpl context)
         {
+            context.Transform = Transform;
             context.DrawEllipse(Brush, Pen, Rect);
         }
 


### PR DESCRIPTION
## What does the pull request do?
This PR fixes #7920 by adding a missing `context.Transform = Transform` to `EllipseNode.Render`.  
I've spent more time gathering info for that issue than finding this missing line :sweat_smile:

This line is present in the other nodes as well.


## What is the current behavior?
See #7920 for the repro code used for this screenshot.
![image](https://user-images.githubusercontent.com/1200380/161557640-c0bd51b8-7f17-4d29-961e-9bd9e3ab43cb.png)



## What is the updated/expected behavior with this PR?
See #7920 for the repro code used for this screenshot.
![image](https://user-images.githubusercontent.com/1200380/161557659-f4aa3f91-229b-4d7f-92d1-3dacabe6f16f.png)



## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
I hope nobody relied on the "broken" ellipse positioning 😆

## Fixed issues
Fixes #7920
