### PR TITLE
Fix backspace in textbox not moving caret

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1057,7 +1057,7 @@ namespace Avalonia.Controls
 
                                 SetTextInternal(editedText);
 
-                                CaretIndex = end;
+                                CaretIndex = start;
                             } 
                         }
                         


### PR DESCRIPTION
## What does the pull request do?
It makes the caret move when hitting backspace in textboxes.


## What is the current behavior?
The caret doesn't move when hitting backspace.

![2022-04-08_21-37-55](https://user-images.githubusercontent.com/1200380/162515359-3e3bf438-1038-4ee6-a108-88cb82907703.gif)


## What is the updated/expected behavior with this PR?
The caret moves when hitting backspace.

![2022-04-08_21-40-00](https://user-images.githubusercontent.com/1200380/162515394-4e80414f-c46c-4e26-b256-12301eb3a0a0.gif)


## How was the solution implemented (if it's not obvious)?
A bit of trial and error to find which commit introduced the faulty behavior, noticing that it broke with 9250d9340723554b5a05726f2dffc003c26888f3, then seeing that it ditches `_presenter.MoveCaretHorizontal(LogicalDirection.Backward)` in favor of `CaretIndex = end`. Changing that to `CaretIndex = start` fixes the broken backspace behavior for me, therefore this PR 😅


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation
