### PR TITLE
Fix NativeMenuBar exception.

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/NativeMenuBar.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/NativeMenuBar.xaml
@@ -12,7 +12,7 @@
         IsVisible="{Binding $parent[TopLevel].(NativeMenu.IsNativeMenuExported), Converter={StaticResource AvaloniaThemesDefaultNativeMenuBarInverseBooleanValueConverter}}"
         Items="{Binding $parent[TopLevel].(NativeMenu.Menu).Items}">
         <Menu.Styles>
-          <Style x:DataType="NativeMenuItem" Selector="MenuItem">
+          <Style x:CompileBindings="False" Selector="MenuItem">
             <Setter Property="Header" Value="{Binding Header}"/>
             <Setter Property="InputGesture" Value="{Binding Gesture}"/>
             <Setter Property="Items" Value="{Binding Menu.Items}"/>


### PR DESCRIPTION
## What does the pull request do?

The recent move to compiled bindings in the fluent theme caused #7780.

The `x:DataType="NativeMenuItem"` directive is incorrect as the items can also be `NativeMenuItemSeparator`s which don't have the bound properties.

Turn off compiled bindings here for now.

## Fixed issues

Fixes #7780
