### PR TITLE
Fix ScrollGestureEndedEvent type.

### DIFF
--- a/src/Avalonia.Input/ApiCompatBaseline.txt
+++ b/src/Avalonia.Input/ApiCompatBaseline.txt
@@ -1,5 +1,6 @@
 Compat issues with assembly Avalonia.Input:
 MembersMustExist : Member 'public Avalonia.Platform.IPlatformHandle Avalonia.Input.Cursor.PlatformCursor.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public Avalonia.Interactivity.RoutedEvent<Avalonia.Input.ScrollGestureEventArgs> Avalonia.Interactivity.RoutedEvent<Avalonia.Input.ScrollGestureEventArgs> Avalonia.Input.Gestures.ScrollGestureEndedEvent' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'public Avalonia.Interactivity.RoutedEvent<Avalonia.Interactivity.RoutedEventArgs> Avalonia.Interactivity.RoutedEvent<Avalonia.Interactivity.RoutedEventArgs> Avalonia.Input.Gestures.DoubleTappedEvent' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'public Avalonia.Interactivity.RoutedEvent<Avalonia.Interactivity.RoutedEventArgs> Avalonia.Interactivity.RoutedEvent<Avalonia.Interactivity.RoutedEventArgs> Avalonia.Input.Gestures.RightTappedEvent' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'public Avalonia.Interactivity.RoutedEvent<Avalonia.Interactivity.RoutedEventArgs> Avalonia.Interactivity.RoutedEvent<Avalonia.Interactivity.RoutedEventArgs> Avalonia.Input.Gestures.TappedEvent' does not exist in the implementation but it does exist in the contract.
@@ -26,4 +27,4 @@ MembersMustExist : Member 'public Avalonia.Input.TextInput.TextInputContentType 
 EnumValuesMustMatch : Enum value 'Avalonia.Input.TextInput.TextInputContentType Avalonia.Input.TextInput.TextInputContentType.Url' is (System.Int32)6 in the implementation but (System.Int32)4 in the contract.
 TypesMustExist : Type 'Avalonia.Input.TextInput.TextInputOptionsQueryEventArgs' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'Avalonia.Platform.IStandardCursorFactory' does not exist in the implementation but it does exist in the contract.
-Total Issues: 27
+Total Issues: 28

--- a/src/Avalonia.Input/Gestures.cs
+++ b/src/Avalonia.Input/Gestures.cs
@@ -26,8 +26,8 @@ namespace Avalonia.Input
             RoutedEvent.Register<ScrollGestureEventArgs>(
                 "ScrollGesture", RoutingStrategies.Bubble, typeof(Gestures));
 
-        public static readonly RoutedEvent<ScrollGestureEventArgs> ScrollGestureEndedEvent =
-            RoutedEvent.Register<ScrollGestureEventArgs>(
+        public static readonly RoutedEvent<ScrollGestureEndedEventArgs> ScrollGestureEndedEvent =
+            RoutedEvent.Register<ScrollGestureEndedEventArgs>(
                 "ScrollGestureEnded", RoutingStrategies.Bubble, typeof(Gestures));
         
         public static readonly RoutedEvent<PointerDeltaEventArgs> PointerTouchPadGestureMagnifyEvent =


### PR DESCRIPTION
## What does the pull request do?

While working on #7964 I noticed that the event type in the field for `ScrollGestureEndedEvent` is incorrect: it's a `ScrollGestureEndedEventArgs` object that gets passed, not a `ScrollGestureEventArgs`.

## Breaking changes

Yes :D That's why it's in a different PR to #7964 .
