### PR TITLE
Ignore handled events in TouchDevice.

### DIFF
--- a/src/Avalonia.Input/TouchDevice.cs
+++ b/src/Avalonia.Input/TouchDevice.cs
@@ -32,7 +32,7 @@ namespace Avalonia.Input
 
         public void ProcessRawEvent(RawInputEventArgs ev)
         {
-            if (_disposed)
+            if (ev.Handled || _disposed)
                 return;
             var args = (RawTouchEventArgs)ev;
             if (!_pointers.TryGetValue(args.TouchPointId, out var pointer))


### PR DESCRIPTION
## What does the pull request do?

Ignore already handed raw events in `TouchDevice`, the same as happens in `MouseDevice` and `KeyboardDevice`. This allows pre-filtering of touch events by subscribing to `InputManager.PreProcess`.
