### PR TITLE
Fix SkiaSharp broken by 6.0.200 to 6.0.201 sdk not being compatible

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -5,5 +5,6 @@
     <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-eng" value="https://nuget.avaloniaui.net/repository/avalonia-devdeps/index.json" protocolVersion="3" />
+    <add key="skiasharp" value="https://aka.ms/skiasharp-eap/index.json" />
   </packageSources>
 </configuration>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,7 +147,7 @@ jobs:
     displayName: 'Install Workloads'
     inputs:
       script: |
-       dotnet workload install
+       dotnet workload install android ios
 
   - task: CmdLine@2
     displayName: 'Install Nuke'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,7 +147,7 @@ jobs:
     displayName: 'Install Workloads'
     inputs:
       script: |
-       dotnet workload install --no-cache --disable-parallel android ios --skip-manifest-update --source "https://api.nuget.org/v3/index.json"
+       dotnet workload install
 
   - task: CmdLine@2
     displayName: 'Install Nuke'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,9 +31,9 @@ jobs:
     vmImage: 'ubuntu-20.04'
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 3.1.414'
+    displayName: 'Use .NET Core SDK 3.1.418'
     inputs:
-      version: 3.1.414
+      version: 3.1.418
 
   - task: UseDotNet@2
     displayName: 'Use .NET Core SDK 6.0.202'
@@ -62,9 +62,9 @@ jobs:
     vmImage: 'macOS-10.15'
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 3.1.414'
+    displayName: 'Use .NET Core SDK 3.1.418'
     inputs:
-      version: 3.1.414
+      version: 3.1.418
 
   - task: UseDotNet@2
     displayName: 'Use .NET Core SDK 6.0.202'
@@ -134,9 +134,9 @@ jobs:
     SolutionDir: '$(Build.SourcesDirectory)'
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 3.1.414'
+    displayName: 'Use .NET Core SDK 3.1.418'
     inputs:
-      version: 3.1.414
+      version: 3.1.418
 
   - task: UseDotNet@2
     displayName: 'Use .NET Core SDK 6.0.202'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,9 +36,9 @@ jobs:
       version: 3.1.414
 
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 6.0.100'
+    displayName: 'Use .NET Core SDK 6.0.202'
     inputs:
-      version: 6.0.200
+      version: 6.0.202
 
   - task: CmdLine@2
     displayName: 'Run Build'
@@ -67,9 +67,9 @@ jobs:
       version: 3.1.414
 
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 6.0.100'
+    displayName: 'Use .NET Core SDK 6.0.202'
     inputs:
-      version: 6.0.200
+      version: 6.0.202
       
   - task: CmdLine@2
     displayName: 'Install Mono 5.18'
@@ -139,9 +139,9 @@ jobs:
       version: 3.1.414
 
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 6.0.100'
+    displayName: 'Use .NET Core SDK 6.0.202'
     inputs:
-      version: 6.0.200
+      version: 6.0.202
 
   - task: CmdLine@2
     displayName: 'Install Workloads'

--- a/build/HarfBuzzSharp.props
+++ b/build/HarfBuzzSharp.props
@@ -1,7 +1,7 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp" Version="2.8.2-preview.209" />
-    <PackageReference Condition="'$(IncludeLinuxSkia)' == 'true'" Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2-preview.209" />
-    <PackageReference Condition="'$(IncludeWasmSkia)' == 'true'" Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="2.8.2-preview.209"/>
+    <PackageReference Include="HarfBuzzSharp" Version="2.8.2-preview.254" />
+    <PackageReference Condition="'$(IncludeLinuxSkia)' == 'true'" Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2-preview.254" />
+    <PackageReference Condition="'$(IncludeWasmSkia)' == 'true'" Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="2.8.2-preview.254"/>
   </ItemGroup>
 </Project>

--- a/build/SkiaSharp.props
+++ b/build/SkiaSharp.props
@@ -1,7 +1,7 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.0-preview.209" />
-    <PackageReference Condition="'$(IncludeLinuxSkia)' == 'true'" Include="SkiaSharp.NativeAssets.Linux" Version="2.88.0-preview.209" />
-    <PackageReference Condition="'$(IncludeWasmSkia)' == 'true'" Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.0-preview.209"/>
+    <PackageReference Include="SkiaSharp" Version="2.88.0-preview.254" />
+    <PackageReference Condition="'$(IncludeLinuxSkia)' == 'true'" Include="SkiaSharp.NativeAssets.Linux" Version="2.88.0-preview.254" />
+    <PackageReference Condition="'$(IncludeWasmSkia)' == 'true'" Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.0-preview.254"/>
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,11 +1,10 @@
 {
     "sdk": {
-        "version": "6.0.200",
+        "version": "6.0.202",
         "rollForward": "latestFeature"
     },
     "msbuild-sdks": {
         "Microsoft.Build.Traversal": "1.0.43",
-        "Xamarin.Legacy.Sdk": "0.1.2-alpha6",
         "MSBuild.Sdk.Extras": "3.0.22",
         "AggregatePackage.NuGet.Sdk" : "0.1.12"
     }

--- a/src/Android/Avalonia.Android/Avalonia.Android.csproj
+++ b/src/Android/Avalonia.Android/Avalonia.Android.csproj
@@ -1,7 +1,6 @@
-﻿<Project Sdk="Xamarin.Legacy.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0-android</TargetFrameworks>
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' != 'Core'">$(TargetFrameworks);monoandroid11.0</TargetFrameworks>
+    <TargetFramework>net6.0-android</TargetFramework>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MSBuildEnableWorkloadResolver>true</MSBuildEnableWorkloadResolver>

--- a/src/iOS/Avalonia.iOS/Avalonia.iOS.csproj
+++ b/src/iOS/Avalonia.iOS/Avalonia.iOS.csproj
@@ -1,8 +1,6 @@
-﻿<Project>
-  <Import Project="Sdk.props" Sdk="Xamarin.Legacy.Sdk" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0-ios</TargetFrameworks>
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' != 'Core'">$(TargetFrameworks);xamarin.ios10</TargetFrameworks>
+    <TargetFramework>net6.0-ios</TargetFramework>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <MSBuildEnableWorkloadResolver>true</MSBuildEnableWorkloadResolver>
   </PropertyGroup>
@@ -10,8 +8,7 @@
     <ProjectReference Include="..\..\Avalonia.Base\Avalonia.Base.csproj" />
     <ProjectReference Include="..\..\Skia\Avalonia.Skia\Avalonia.Skia.csproj" />
   </ItemGroup>
-  <Import Project="Sdk.targets" Sdk="Xamarin.Legacy.Sdk" />
-
+  
   <!-- Workaround for https://github.com/dotnet/msbuild/issues/4584 -->
   <Target Name="_RemoveNativeReferencesManifest" AfterTargets="BuiltProjectOutputGroup">
     <ItemGroup>

--- a/src/iOS/Avalonia.iOS/Avalonia.iOS.csproj
+++ b/src/iOS/Avalonia.iOS/Avalonia.iOS.csproj
@@ -9,13 +9,5 @@
     <ProjectReference Include="..\..\Skia\Avalonia.Skia\Avalonia.Skia.csproj" />
   </ItemGroup>
   
-  <!-- Workaround for https://github.com/dotnet/msbuild/issues/4584 -->
-  <Target Name="_RemoveNativeReferencesManifest" AfterTargets="BuiltProjectOutputGroup">
-    <ItemGroup>
-      <_BuiltProjectOutputGroupOutputIntermediate Remove="$(OutDir)$(_DeploymentTargetApplicationManifestFileName)" />
-      <BuiltProjectOutputGroupOutput Remove="$(ProjectDir)$(OutDir)$(_DeploymentTargetApplicationManifestFileName)" />
-    </ItemGroup>
-  </Target>
-
   <Import Project="..\..\..\build\DevAnalyzers.props" />
 </Project>


### PR DESCRIPTION
6.0.200 and 6.0.201/202 sdks have breaking changes.

This means that we now have to update skiasharp to newer builds compiled specifically on sdk 201/202.