### PR TITLE
Remove rd.xml for NativeAOT Compilation

### DIFF
--- a/samples/ControlCatalog.NetCore/ControlCatalog.NetCore.csproj
+++ b/samples/ControlCatalog.NetCore/ControlCatalog.NetCore.csproj
@@ -6,7 +6,7 @@
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(RunAotCompilation)' == 'true'">
+  <PropertyGroup Condition="'$(RunNativeAotCompilation)' == 'true'">
     <IlcTrimMetadata>true</IlcTrimMetadata>
     <RestoreAdditionalProjectSources>https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json</RestoreAdditionalProjectSources>
     <NativeAotCompilerVersion>7.0.0-*</NativeAotCompilerVersion>
@@ -22,12 +22,11 @@
     <PackageReference Include="Avalonia.Angle.Windows.Natives" Version="2.1.0.2020091801" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(RunAotCompilation)' == 'true'">
+  <ItemGroup Condition="'$(RunNativeAotCompilation)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="$(NativeAotCompilerVersion)" />
     <!-- Cross-compilation for Windows x64-arm64 and Linux x64-arm64 -->
     <PackageReference Condition="'$(RuntimeIdentifier)'=='win-arm64'" Include="runtime.win-x64.Microsoft.DotNet.ILCompiler" Version="$(NativeAotCompilerVersion)" />
     <PackageReference Condition="'$(RuntimeIdentifier)'=='linux-arm64'" Include="runtime.linux-x64.Microsoft.DotNet.ILCompiler" Version="$(NativeAotCompilerVersion)" />
-    <RdXmlFile Include="rd.xml" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/samples/ControlCatalog.NetCore/rd.xml
+++ b/samples/ControlCatalog.NetCore/rd.xml
@@ -1,7 +1,0 @@
-<Directives>
-  <Application>
-    <Assembly Name="ControlCatalog" Dynamic="Required All"></Assembly>
-    <Assembly Name="Avalonia.Themes.Default" Dynamic="Required All"></Assembly>
-    <Assembly Name="Avalonia.Themes.Fluent" Dynamic="Required All"></Assembly>
-  </Application>
-</Directives>


### PR DESCRIPTION
With recent changes, we no longer need a `rd.xml` for NativeAOT compilation of CC.NetCore. 

Also I changed `RunAotCompilation` to `RunNativeAotCompilation` to distinguish from wasm-aot.