### PR TITLE
Fixed path to DevAnalyzers.csproj

### DIFF
--- a/build/DevAnalyzers.props
+++ b/build/DevAnalyzers.props
@@ -1,6 +1,6 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\src\Tools\DevAnalyzers\DevAnalyzers.csproj"
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\src\tools\DevAnalyzers\DevAnalyzers.csproj"
                       PrivateAssets="all"
                       ReferenceOutputAssembly="false"
                       OutputItemType="Analyzer"


### PR DESCRIPTION
Linux uses case-sensetive file systems, so MSBuild was unable to find the file
