### PR TITLE
Fix #6603: PInvokeStackImbalance error caused by incorrect signature

### DIFF
--- a/src/Windows/Avalonia.Win32/WinRT/NativeWinRTMethods.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/NativeWinRTMethods.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Win32.WinRT
 
         [DllImport("api-ms-win-core-winrt-string-l1-1-0.dll", 
             CallingConvention = CallingConvention.StdCall, PreserveSig = false)]
-        internal static extern unsafe IntPtr WindowsDeleteString(IntPtr hString);
+        internal static extern unsafe void WindowsDeleteString(IntPtr hString);
         
         [DllImport("Windows.UI.Composition", EntryPoint = "DllGetActivationFactory",
             CallingConvention = CallingConvention.StdCall, PreserveSig = false)]


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes #6603 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When running WindowsInteropTest in Debug Mode in VS2022, a Managed Debugging Assistant comes up indicating that the call stack has become unbalanced due. This is due to an improper signature on the WindowsCreateString function.
![image](https://user-images.githubusercontent.com/10566929/164156378-8b359f20-dc6d-4040-b0c7-0c016befb25d.png)


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
The exception no longer comes up.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
When PreserveSig=false, a function that natively returns an HRESULT and has no final [out] parameter should instead be marked as void (since the HRESULT value gets translated into an exception if needed rather than being returned). See:
https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.dllimportattribute.preservesig?view=net-6.0

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #6603
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
