### PR TITLE
Remove more virtual generic methods.

### DIFF
--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -646,10 +646,12 @@ namespace Avalonia
         /// enabled.
         /// </summary>
         /// <param name="property">The property.</param>
-        /// <param name="value">The new binding value for the property.</param>
-        protected virtual void UpdateDataValidation<T>(
-            AvaloniaProperty<T> property,
-            BindingValue<T> value)
+        /// <param name="state">The current data binding state.</param>
+        /// <param name="error">The current data binding error, if any.</param>
+        protected virtual void UpdateDataValidation(
+            AvaloniaProperty property,
+            BindingValueType state,
+            Exception? error)
         {
         }
 
@@ -860,7 +862,7 @@ namespace Avalonia
 
             if (metadata.EnableDataValidation == true)
             {
-                UpdateDataValidation(property, value);
+                UpdateDataValidation(property, value.Type, value.Error);
             }
         }
 

--- a/src/Avalonia.Base/Interactivity/IInteractive.cs
+++ b/src/Avalonia.Base/Interactivity/IInteractive.cs
@@ -29,35 +29,11 @@ namespace Avalonia.Interactivity
             bool handledEventsToo = false);
 
         /// <summary>
-        /// Adds a handler for the specified routed event.
-        /// </summary>
-        /// <typeparam name="TEventArgs">The type of the event's args.</typeparam>
-        /// <param name="routedEvent">The routed event.</param>
-        /// <param name="handler">The handler.</param>
-        /// <param name="routes">The routing strategies to listen to.</param>
-        /// <param name="handledEventsToo">Whether handled events should also be listened for.</param>
-        /// <returns>A disposable that terminates the event subscription.</returns>
-        void AddHandler<TEventArgs>(
-            RoutedEvent<TEventArgs> routedEvent,
-            EventHandler<TEventArgs> handler,
-            RoutingStrategies routes = RoutingStrategies.Direct | RoutingStrategies.Bubble,
-            bool handledEventsToo = false) where TEventArgs : RoutedEventArgs;
-
-        /// <summary>
         /// Removes a handler for the specified routed event.
         /// </summary>
         /// <param name="routedEvent">The routed event.</param>
         /// <param name="handler">The handler.</param>
         void RemoveHandler(RoutedEvent routedEvent, Delegate handler);
-
-        /// <summary>
-        /// Removes a handler for the specified routed event.
-        /// </summary>
-        /// <typeparam name="TEventArgs">The type of the event's args.</typeparam>
-        /// <param name="routedEvent">The routed event.</param>
-        /// <param name="handler">The handler.</param>
-        void RemoveHandler<TEventArgs>(RoutedEvent<TEventArgs> routedEvent, EventHandler<TEventArgs> handler)
-            where TEventArgs : RoutedEventArgs;
 
         /// <summary>
         /// Adds the object's handlers for a routed event to an event route.

--- a/src/Avalonia.Base/Threading/IDispatcher.cs
+++ b/src/Avalonia.Base/Threading/IDispatcher.cs
@@ -27,29 +27,12 @@ namespace Avalonia.Threading
         void Post(Action action, DispatcherPriority priority = default);
 
         /// <summary>
-        /// Posts an action that will be invoked on the dispatcher thread.
-        /// </summary>
-        /// <typeparam name="T">type of argument</typeparam>
-        /// <param name="action">The method to call.</param>
-        /// <param name="arg">The argument of method to call.</param>
-        /// <param name="priority">The priority with which to invoke the method.</param>
-        void Post<T>(Action<T> action, T arg, DispatcherPriority priority = default);
-
-        /// <summary>
         /// Invokes a action on the dispatcher thread.
         /// </summary>
         /// <param name="action">The method.</param>
         /// <param name="priority">The priority with which to invoke the method.</param>
         /// <returns>A task that can be used to track the method's execution.</returns>
         Task InvokeAsync(Action action, DispatcherPriority priority = default);
-
-        /// <summary>
-        /// Invokes a method on the dispatcher thread.
-        /// </summary>
-        /// <param name="function">The method.</param>
-        /// <param name="priority">The priority with which to invoke the method.</param>
-        /// <returns>A task that can be used to track the method's execution.</returns>
-        Task<TResult> InvokeAsync<TResult>(Func<TResult> function, DispatcherPriority priority = default);
 
         /// <summary>
         /// Queues the specified work to run on the dispatcher thread and returns a proxy for the
@@ -59,14 +42,5 @@ namespace Avalonia.Threading
         /// <param name="priority">The priority with which to invoke the method.</param>
         /// <returns>A task that represents a proxy for the task returned by <paramref name="function"/>.</returns>
         Task InvokeAsync(Func<Task> function, DispatcherPriority priority = default);
-
-        /// <summary>
-        /// Queues the specified work to run on the dispatcher thread and returns a proxy for the
-        /// task returned by <paramref name="function"/>.
-        /// </summary>
-        /// <param name="function">The work to execute asynchronously.</param>
-        /// <param name="priority">The priority with which to invoke the method.</param>
-        /// <returns>A task that represents a proxy for the task returned by <paramref name="function"/>.</returns>
-        Task<TResult> InvokeAsync<TResult>(Func<Task<TResult>> function, DispatcherPriority priority = default);
     }
 }

--- a/src/Avalonia.Controls/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox.cs
@@ -1346,12 +1346,16 @@ namespace Avalonia.Controls
         /// enabled.
         /// </summary>
         /// <param name="property">The property.</param>
-        /// <param name="value">The new binding value for the property.</param>
-        protected override void UpdateDataValidation<T>(AvaloniaProperty<T> property, BindingValue<T> value)
+        /// <param name="state">The current data binding state.</param>
+        /// <param name="error">The current data binding error, if any.</param>
+        protected override void UpdateDataValidation(
+            AvaloniaProperty property,
+            BindingValueType state,
+            Exception? error)
         {
             if (property == TextProperty || property == SelectedItemProperty)
             {
-                DataValidationErrors.SetError(this, value.Error);
+                DataValidationErrors.SetError(this, error);
             }
         }
 

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -498,12 +498,15 @@ namespace Avalonia.Controls
         protected override AutomationPeer OnCreateAutomationPeer() => new ButtonAutomationPeer(this);
 
         /// <inheritdoc/>
-        protected override void UpdateDataValidation<T>(AvaloniaProperty<T> property, BindingValue<T> value)
+        protected override void UpdateDataValidation(
+            AvaloniaProperty property,
+            BindingValueType state,
+            Exception? error)
         {
-            base.UpdateDataValidation(property, value);
+            base.UpdateDataValidation(property, state, error);
             if (property == CommandProperty)
             {
-                if (value.Type == BindingValueType.BindingError)
+                if (state == BindingValueType.BindingError)
                 {
                     if (_commandCanExecute)
                     {

--- a/src/Avalonia.Controls/Calendar/CalendarDatePicker.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarDatePicker.cs
@@ -540,11 +540,11 @@ namespace Avalonia.Controls
             }
         }
 
-        protected override void UpdateDataValidation<T>(AvaloniaProperty<T> property, BindingValue<T> value)
+        protected override void UpdateDataValidation(AvaloniaProperty property, BindingValueType state, Exception? error)
         {
             if (property == SelectedDateProperty)
             {
-                DataValidationErrors.SetError(this, value.Error);
+                DataValidationErrors.SetError(this, error);
             }
         }
 

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -501,12 +501,15 @@ namespace Avalonia.Controls
             return new MenuItemAutomationPeer(this);
         }
 
-        protected override void UpdateDataValidation<T>(AvaloniaProperty<T> property, BindingValue<T> value)
+        protected override void UpdateDataValidation(
+            AvaloniaProperty property,
+            BindingValueType state,
+            Exception? error)
         {
-            base.UpdateDataValidation(property, value);
+            base.UpdateDataValidation(property, state, error);
             if (property == CommandProperty)
             {
-                _commandBindingError = value.Type == BindingValueType.BindingError;
+                _commandBindingError = state == BindingValueType.BindingError;
                 if (_commandBindingError && _commandCanExecute)
                 {
                     _commandCanExecute = false;

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -403,12 +403,16 @@ namespace Avalonia.Controls
         /// enabled.
         /// </summary>
         /// <param name="property">The property.</param>
-        /// <param name="value">The new binding value for the property.</param>
-        protected override void UpdateDataValidation<T>(AvaloniaProperty<T> property, BindingValue<T> value)
+        /// <param name="state">The current data binding state.</param>
+        /// <param name="error">The current data binding error, if any.</param>
+        protected override void UpdateDataValidation(
+            AvaloniaProperty property,
+            BindingValueType state,
+            Exception? error)
         {
             if (property == TextProperty || property == ValueProperty)
             {
-                DataValidationErrors.SetError(this, value.Error);
+                DataValidationErrors.SetError(this, error);
             }
         }
 

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -501,12 +501,16 @@ namespace Avalonia.Controls.Primitives
         /// enabled.
         /// </summary>
         /// <param name="property">The property.</param>
-        /// <param name="value">The new binding value for the property.</param>
-        protected override void UpdateDataValidation<T>(AvaloniaProperty<T> property, BindingValue<T> value)
+        /// <param name="state">The current data binding state.</param>
+        /// <param name="error">The current data binding error, if any.</param>
+        protected override void UpdateDataValidation(
+            AvaloniaProperty property,
+            BindingValueType state,
+            Exception? error)
         {
             if (property == SelectedItemProperty)
             {
-                DataValidationErrors.SetError(this, value.Error);
+                DataValidationErrors.SetError(this, error);
             }
         }
         

--- a/src/Avalonia.Controls/Slider.cs
+++ b/src/Avalonia.Controls/Slider.cs
@@ -361,11 +361,14 @@ namespace Avalonia.Controls
             Value = IsSnapToTickEnabled ? SnapToTick(finalValue) : finalValue;
         }
 
-        protected override void UpdateDataValidation<T>(AvaloniaProperty<T> property, BindingValue<T> value)
+        protected override void UpdateDataValidation(
+            AvaloniaProperty property,
+            BindingValueType state,
+            Exception? error)
         {
             if (property == ValueProperty)
             {
-                DataValidationErrors.SetError(this, value.Error);
+                DataValidationErrors.SetError(this, error);
             }
         }
 

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1262,11 +1262,14 @@ namespace Avalonia.Controls
             return new TextBoxAutomationPeer(this);
         }
 
-        protected override void UpdateDataValidation<T>(AvaloniaProperty<T> property, BindingValue<T> value)
+        protected override void UpdateDataValidation(
+            AvaloniaProperty property,
+            BindingValueType state,
+            Exception? error)
         {
             if (property == TextProperty)
             {
-                DataValidationErrors.SetError(this, value.Error);
+                DataValidationErrors.SetError(this, error);
             }
         }
 

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -401,7 +401,7 @@ namespace Avalonia.Controls
         protected virtual ITreeItemContainerGenerator CreateTreeItemContainerGenerator() =>
             CreateTreeItemContainerGenerator<TreeViewItem>();
 
-        protected virtual ITreeItemContainerGenerator CreateTreeItemContainerGenerator<TVItem>() where TVItem: TreeViewItem, new()
+        protected ITreeItemContainerGenerator CreateTreeItemContainerGenerator<TVItem>() where TVItem: TreeViewItem, new()
         {
             return new TreeItemContainerGenerator<TVItem>(
                 this,

--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -96,7 +96,7 @@ namespace Avalonia.Controls
         protected override IItemContainerGenerator CreateItemContainerGenerator() => CreateTreeItemContainerGenerator<TreeViewItem>();
 
         /// <inheritdoc/>
-        protected virtual ITreeItemContainerGenerator CreateTreeItemContainerGenerator<TVItem>()
+        protected ITreeItemContainerGenerator CreateTreeItemContainerGenerator<TVItem>()
             where TVItem: TreeViewItem, new()
         {
             return new TreeItemContainerGenerator<TVItem>(

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_DataValidation.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_DataValidation.cs
@@ -52,14 +52,14 @@ namespace Avalonia.Base.UnitTests
             source.OnNext(BindingValue<int>.DataValidationError(new Exception()));
             source.OnNext(7);
 
-            var result = target.Notifications.Cast<BindingValue<int>>().ToList();
+            var result = target.Notifications;
             Assert.Equal(4, result.Count);
-            Assert.Equal(BindingValueType.Value, result[0].Type);
-            Assert.Equal(6, result[0].Value);
-            Assert.Equal(BindingValueType.BindingError, result[1].Type);
-            Assert.Equal(BindingValueType.DataValidationError, result[2].Type);
-            Assert.Equal(BindingValueType.Value, result[3].Type);
-            Assert.Equal(7, result[3].Value);
+            Assert.Equal(BindingValueType.Value, result[0].type);
+            Assert.Equal(6, result[0].value);
+            Assert.Equal(BindingValueType.BindingError, result[1].type);
+            Assert.Equal(BindingValueType.DataValidationError, result[2].type);
+            Assert.Equal(BindingValueType.Value, result[3].type);
+            Assert.Equal(7, result[3].value);
         }
 
         [Fact]
@@ -72,8 +72,7 @@ namespace Avalonia.Base.UnitTests
             target.Bind(Class1.NonValidatedDirectProperty, source);
             source.OnNext(1);
 
-            var result = target.Notifications.Cast<BindingValue<int>>().ToList();
-            Assert.Equal(1, result.Count);
+            Assert.Equal(1, target.Notifications.Count);
         }
 
         [Fact]
@@ -154,13 +153,14 @@ namespace Avalonia.Base.UnitTests
                 set { SetAndRaise(ValidatedDirectStringProperty, ref _directString, value); }
             }
 
-            public IList<object> Notifications { get; } = new List<object>();
+            public List<(BindingValueType type, object value)> Notifications { get; } = new();
 
-            protected override void UpdateDataValidation<T>(
-                AvaloniaProperty<T> property,
-                BindingValue<T> value)
+            protected override void UpdateDataValidation(
+                AvaloniaProperty property,
+                BindingValueType state,
+                Exception error)
             {
-                Notifications.Add(value);
+                Notifications.Add((state, GetValue(property)));
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

Following on from #7980, more removal of generic virtual methds:

- [Make AvaloniaObject.UpdateDataValidation non-generic.](https://github.com/AvaloniaUI/Avalonia/commit/f9dbbb3da1d42b6450ac10b6485d118fcc5fa0aa)
- [Remove generic methods from IDispatcher.](https://github.com/AvaloniaUI/Avalonia/commit/4ec36c97e2810c8e1bb48f85339d76e96e502b78)
- [Remove generic methods from IInteractive.](https://github.com/AvaloniaUI/Avalonia/commit/7f469752d55097d4dcf014e23fd2f0798f199e68)
- [Make `TreeView`/`TreeViewItem` utility methods non-virtual.](https://github.com/AvaloniaUI/Avalonia/commit/fa44075d26873d80b6fba5df8492d774fadec589): Not sure why these method were virtual anyway - any customization should be done by overriding the non-generic `CreateItemContainerGenerator` method.

## Breaking Changes

Yes.
