### PR TITLE
Fix WeakHashList losing one item when upgrading storage.

### DIFF
--- a/src/Avalonia.Base/Utilities/WeakHashList.cs
+++ b/src/Avalonia.Base/Utilities/WeakHashList.cs
@@ -104,8 +104,10 @@ internal class WeakHashList<T> where T : class
             if (existing!.TryGetTarget(out var target))
                 Add(target);
         }
-        _arr = null;
         
+        Add(item);
+
+        _arr = null;
     }
 
     public void Remove(T item)


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes `WeakHashList` dropping one item when storage was being upgraded. This was noticeable in `DevTools` when switching tabs.
