### PR TITLE
Register StretchProperty for Viewbox instead of Image

### DIFF
--- a/src/Avalonia.Controls/Viewbox.cs
+++ b/src/Avalonia.Controls/Viewbox.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Controls
         /// Defines the <see cref="Stretch"/> property.
         /// </summary>
         public static readonly StyledProperty<Stretch> StretchProperty =
-            AvaloniaProperty.Register<Image, Stretch>(nameof(Stretch), Stretch.Uniform);
+            AvaloniaProperty.Register<Viewbox, Stretch>(nameof(Stretch), Stretch.Uniform);
 
         /// <summary>
         /// Defines the <see cref="StretchDirection"/> property.


### PR DESCRIPTION
## What does the pull request do?
Fixes #8065 

## What is the current behavior?
The registered type seems to be wrong.

## What is the updated/expected behavior with this PR?
Stretch is registered for ViewBox

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)? ► Not needed
- [ ] Added XML documentation to any related classes? ► Not needed
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation ► Not needed

## Breaking changes
This may be a breaking change as if someone already uses this. But most likely not. 

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #8065
