### PR TITLE
Expose CurrentOpacity on ISkiaDrawingContextImpl.

### DIFF
--- a/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
+++ b/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
@@ -126,6 +126,7 @@ namespace Avalonia.Skia
         SKCanvas ISkiaDrawingContextImpl.SkCanvas => Canvas;
         SKSurface ISkiaDrawingContextImpl.SkSurface => Surface;
         GRContext ISkiaDrawingContextImpl.GrContext => _grContext;
+        double ISkiaDrawingContextImpl.CurrentOpacity => _currentOpacity;
 
         /// <inheritdoc />
         public void Clear(Color color)

--- a/src/Skia/Avalonia.Skia/ISkiaDrawingContextImpl.cs
+++ b/src/Skia/Avalonia.Skia/ISkiaDrawingContextImpl.cs
@@ -8,5 +8,6 @@ namespace Avalonia.Skia
         SKCanvas SkCanvas { get; }
         GRContext GrContext { get; }
         SKSurface SkSurface { get; }
+        double CurrentOpacity { get; }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

As requested in #4886, exposes `ISkiaDrawingContextImpl.CurrentOpacity` to allow custom drawing operations to draw with the current skia opacity setting.

## Fixed issues

Fixes #4886 