### PR TITLE
Use top level to inform about pointer input

### DIFF
--- a/src/iOS/Avalonia.iOS/TouchHandler.cs
+++ b/src/iOS/Avalonia.iOS/TouchHandler.cs
@@ -41,7 +41,7 @@ namespace Avalonia.iOS
                         _ => RawPointerEventType.TouchUpdate
                     }, pt, RawInputModifiers.None, id);
 
-                _device.ProcessRawEvent(ev);
+                _tl.Input?.Invoke(ev);
                 
                 if (t.Phase == UITouchPhase.Cancelled || t.Phase == UITouchPhase.Ended)
                     _knownTouches.Remove(t);


### PR DESCRIPTION
## What is the current behavior?
iOS backend sends pointer events directly to the pointer device - deprecated way and doesn't work anymore.

## What is the updated/expected behavior with this PR?
iOS backends sends pointer events to the TopLevelImpl instead.

## Fixed issues
Fixes #8044
