### PR TITLE
OSX: use content min/max size for minsize.

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -225,8 +225,8 @@ HRESULT WindowBaseImpl::SetMinMaxSize(AvnSize minSize, AvnSize maxSize) {
     START_COM_CALL;
 
     @autoreleasepool {
-        [Window setMinSize:ToNSSize(minSize)];
-        [Window setMaxSize:ToNSSize(maxSize)];
+        [Window setContentMinSize:ToNSSize(minSize)];
+        [Window setContentMaxSize:ToNSSize(maxSize)];
 
         return S_OK;
     }
@@ -243,8 +243,8 @@ HRESULT WindowBaseImpl::Resize(double x, double y, AvnPlatformResizeReason reaso
     auto resizeBlock = ResizeScope(View, reason);
 
     @autoreleasepool {
-        auto maxSize = [Window maxSize];
-        auto minSize = [Window minSize];
+        auto maxSize = [Window contentMaxSize];
+        auto minSize = [Window contentMinSize];
 
         if (x < minSize.width) {
             x = minSize.width;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Resizing down to minsize could cause wierd glitch where titlebar and content area seperate.

This was caused by setting the minsize based on window frame size, and setting the size based on the content size.

Since we need to use content size for size, due to other issues on osx, made the minsize use content size also.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
