### PR TITLE
Don't use managed dialogs by default in ControlCatalog.

### DIFF
--- a/samples/ControlCatalog.NetCore/Program.cs
+++ b/samples/ControlCatalog.NetCore/Program.cs
@@ -117,7 +117,6 @@ namespace ControlCatalog.NetCore
                     EnableMultitouch = true
                 })
                 .UseSkia()
-                .UseManagedSystemDialogs()
                 .AfterSetup(builder =>
                 {
                     builder.Instance!.AttachDevTools(new Avalonia.Diagnostics.DevToolsOptions()


### PR DESCRIPTION
## What does the pull request do?

Don't use managed dialogs by default in ControlCatalog:

- It's weird to show managed dialogs all the time on platforms where we support native dialogs
- It means that system dialogs never get properly tested
