### PR TITLE
Respect Window MaxWidth and MaxHeight when using any SizeToContent to Auto

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -917,6 +917,15 @@ namespace Avalonia.Controls
             var constraint = clientSize;
             var maxAutoSize = PlatformImpl?.MaxAutoSizeHint ?? Size.Infinity;
 
+            if (MaxWidth > 0 && MaxWidth < maxAutoSize.Width)
+            {
+                maxAutoSize = maxAutoSize.WithWidth(MaxWidth);
+            }
+            if (MaxHeight > 0 && MaxHeight < maxAutoSize.Height)
+            {
+                maxAutoSize = maxAutoSize.WithHeight(MaxHeight);
+            }
+
             if (sizeToContent.HasAllFlags(SizeToContent.Width))
             {
                 constraint = constraint.WithWidth(maxAutoSize.Width);

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -720,6 +720,27 @@ namespace Avalonia.Controls.UnitTests
             }
 
             [Fact]
+            public void MaxWidth_And_MaxHeight_Should_Be_Respected_With_SizeToContent_WidthAndHeight()
+            {
+                using (UnitTestApplication.Start(TestServices.StyledWindow))
+                {
+                    var child = new ChildControl();
+
+                    var target = new Window()
+                    {
+                        SizeToContent = SizeToContent.WidthAndHeight,
+                        MaxWidth = 300,
+                        MaxHeight = 700,
+                        Content = child,
+                    };
+
+                    Show(target);
+
+                    Assert.Equal(new[] { new Size(300, 700) }, child.MeasureSizes);
+                }
+            }
+
+            [Fact]
             public void SizeToContent_Should_Not_Be_Lost_On_Show()
             {
                 using (UnitTestApplication.Start(TestServices.StyledWindow))


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes windows not respecting `MaxWidth` and `MaxHeight` when `SizeToContent` is set to any Auto size system, causing overflow and out-of-view content.
This problem was live since ever and very annoying to deal on apps
Also read: https://github.com/AvaloniaUI/Avalonia/discussions/8082

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Currently with `SizeToContent=AnyAuto` and `MaxWidth` and/or `MaxHeight` set, when size overflow the `Maximum` the content will overflow and be out of the view. In other words, `MaxWidth` nor `MaxHeight` is respected in auto size mode.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Prevents content to overflow from `MaxWidth` and `MaxHeight` when using auto sizing

1. Open **Catalog sample** -> `MainWindow.xaml`
2. Remove `Width` and `Height` properties
3. Add: `MaxWidth="1000" MaxHeight="600" SizeToContent="WidthAndHeight"`
4. Run without this fix and observe the wrong behaviour on **Grid** and **Calendar**
5. Apply the fix, rerun the sample and observe the correct behaviour 

### Before fix:
![image](https://user-images.githubusercontent.com/113281/167161968-cfca4a54-9d11-4370-9b86-4588c40d5e25.png)

### After fix:
![ControlCatalog Desktop_2022-05-06_16-15-02](https://user-images.githubusercontent.com/113281/167162021-f46afa20-27c1-42cd-812d-8c91082f2b8f.png)

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Put  `MaxWidth` and `MaxHeight` in equation when calculating windows Measurement

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Fixed issues
Fixes #5466 
Fixes #6441 
Fixes #2471
Fixes #5973
Fixes #6740