### PR TITLE
[OSX] cache IsClientAreaExtendedToDecorations, and apply it when NSPa…

### DIFF
--- a/samples/ControlCatalog/ViewModels/MainWindowViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/MainWindowViewModel.cs
@@ -18,7 +18,7 @@ namespace ControlCatalog.ViewModels
         private WindowState _windowState;
         private WindowState[] _windowStates;
         private int _transparencyLevel;
-        private ExtendClientAreaChromeHints _chromeHints;
+        private ExtendClientAreaChromeHints _chromeHints = ExtendClientAreaChromeHints.PreferSystemChrome;
         private bool _extendClientAreaEnabled;
         private bool _systemTitleBarEnabled;        
         private bool _preferSystemChromeEnabled;

--- a/src/Avalonia.Native/WindowImpl.cs
+++ b/src/Avalonia.Native/WindowImpl.cs
@@ -107,6 +107,13 @@ namespace Avalonia.Native
         private bool _isExtended;
         public bool IsClientAreaExtendedToDecorations => _isExtended;
 
+        public override void Show(bool activate, bool isDialog)
+        {
+            base.Show(activate, isDialog);
+            
+            InvalidateExtendedMargins();
+        }
+
         protected override bool ChromeHitTest (RawPointerEventArgs e)
         {
             if(_isExtended)


### PR DESCRIPTION
…nel / NSWindow is created and Shown.

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
With the refactor of NSWindow / NSPanel, if your application was configured to start up with Client Area extended, then this would not happen on OSX any more.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
