### PR TITLE
Fix missing NotifyCountChanged in AvaloniaList.AddRange

### DIFF
--- a/src/Avalonia.Base/Collections/AvaloniaList.cs
+++ b/src/Avalonia.Base/Collections/AvaloniaList.cs
@@ -394,7 +394,13 @@ namespace Avalonia.Collections
                         } while (en.MoveNext());
 
                         if (notificationItems is not null)
+                        {
                             NotifyAdd(notificationItems, index);
+                        }
+                        else
+                        {
+                            NotifyCountChanged();
+                        }
                     }
                 }
             }

--- a/tests/Avalonia.Base.UnitTests/Collections/AvaloniaListTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Collections/AvaloniaListTests.cs
@@ -147,6 +147,23 @@ namespace Avalonia.Base.UnitTests.Collections
         }
 
         [Fact]
+        public void AddRange_IEnumerable_Should_Raise_Count_PropertyChanged()
+        {
+            var target = new AvaloniaList<int>(new[] { 1, 2, 3, 4, 5 });
+            var raised = false;
+
+            target.PropertyChanged += (s, e) => {
+                Assert.Equal(e.PropertyName, nameof(target.Count));
+                Assert.Equal(target.Count, 7);
+                raised = true;
+            };
+
+            target.AddRange(Enumerable.Range(6, 2));
+
+            Assert.True(raised);
+        }
+
+        [Fact]
         public void AddRange_Items_Should_Raise_Correct_CollectionChanged()
         {
             var target = new AvaloniaList<object>();


### PR DESCRIPTION
## What does the pull request do?
Adds `Count` property changed notification if `AvaloniaList` have no subscribers to `CollectionChanged` and `AddRange` called with `IEnumerable` which is not `IList`


## What is the current behavior?
Currently due to some optimization in 0.10.11 version it is possible that after adding items into AvaloniaList no notification about `Count` changed will be fired.


