### PR TITLE
Don't expose Viewbox container as logical child.

### DIFF
--- a/src/Avalonia.Controls/Viewbox.cs
+++ b/src/Avalonia.Controls/Viewbox.cs
@@ -95,7 +95,7 @@ namespace Avalonia.Controls
                     LogicalChildren.Remove(oldChild);
                 }
 
-                _containerVisual.Child = change.GetNewValue<IControl>();
+                _containerVisual.Child = newChild;
 
                 if (newChild is not null)
                 {

--- a/src/Avalonia.Controls/Viewbox.cs
+++ b/src/Avalonia.Controls/Viewbox.cs
@@ -37,6 +37,8 @@ namespace Avalonia.Controls
 
         public Viewbox()
         {
+            // The Child control is hosted inside a ViewboxContainer control so that the transform
+            // can be applied independently of the Viewbox and Child transforms.
             _containerVisual = new ViewboxContainer();
             _containerVisual.RenderTransformOrigin = RelativePoint.TopLeft;
             VisualChildren.Add(_containerVisual);
@@ -144,6 +146,9 @@ namespace Avalonia.Controls
             return finalSize;
         }
 
+        /// <summary>
+        /// A simple container control which hosts its child as a visual but not logical child.
+        /// </summary>
         private class ViewboxContainer : Control
         {
             private IControl? _child;

--- a/tests/Avalonia.Controls.UnitTests/ViewboxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ViewboxTests.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls.Shapes;
+using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Avalonia.UnitTests;
 using Xunit;
@@ -169,6 +170,25 @@ namespace Avalonia.Controls.UnitTests
             Assert.NotNull(scaleTransform);
             Assert.Equal(expectedScale, scaleTransform.ScaleX);
             Assert.Equal(expectedScale, scaleTransform.ScaleY);
+        }
+
+        [Fact]
+        public void Child_Should_Be_Logical_Child_Of_Viewbox()
+        {
+            var target = new Viewbox();
+
+            Assert.Empty(target.GetLogicalChildren());
+
+            var child = new Canvas();
+            target.Child = child;
+
+            Assert.Single(target.GetLogicalChildren(), child);
+            Assert.Same(child.GetLogicalParent(), target);
+
+            target.Child = null;
+
+            Assert.Empty(target.GetLogicalChildren());
+            Assert.Null(child.GetLogicalParent());
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

#7735 introduced an internal container control which hosts the child of `Viewbox`, but it exposed this child in the logical tree, breaking any styles which relied on the `Viewbox.Child` being the logical child of the `Viewbox`.

Fix this by introducing a simple internal `ViewboxContainer` control as the container.

cc: @amwx 

## Fixed issues

Fixes second part of #8092