### PR TITLE
Fix DataGridRow resizing issue

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridCellsPresenter.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridCellsPresenter.cs
@@ -218,6 +218,8 @@ namespace Avalonia.Controls.Primitives
             {
                 // No explicit height values were set so we can autosize
                 autoSizeHeight = true;
+                // We need to invalidate desired height in order to grow or shrink as needed
+                InvalidateDesiredHeight();
                 measureHeight = double.PositiveInfinity;
             }
             else


### PR DESCRIPTION
## What does the pull request do?
Fixes #8124 


## What is the current behavior?
See #8124 


## What is the updated/expected behavior with this PR?
DataGridRow grows and shrink if needed 

## How was the solution implemented (if it's not obvious)?
Invalidate the cached row height in the layout pass


## Checklist

- [ ] Added unit tests (if possible)? ► not needed imo
- [ ] Added XML documentation to any related classes? ► not needed
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation ► Not needed

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #8124 