### PR TITLE
Optimize memory usage of styles and fix ordering issue in devtools.

### DIFF
--- a/src/Avalonia.Base/DirectPropertyBase.cs
+++ b/src/Avalonia.Base/DirectPropertyBase.cs
@@ -2,7 +2,6 @@
 using Avalonia.Data;
 using Avalonia.Reactive;
 using Avalonia.Styling;
-using Avalonia.Utilities;
 
 namespace Avalonia
 {
@@ -188,10 +187,10 @@ namespace Avalonia
             }
             else if (value is ITemplate template && !typeof(ITemplate).IsAssignableFrom(PropertyType))
             {
-                return new PropertySetterLazyInstance<TValue>(
+                return new PropertySetterTemplateInstance<TValue>(
                     target,
                     this,
-                    () => (TValue)template.Build());
+                    template);
             }
             else
             {

--- a/src/Avalonia.Base/StyledPropertyBase.cs
+++ b/src/Avalonia.Base/StyledPropertyBase.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Diagnostics;
 using Avalonia.Data;
 using Avalonia.Reactive;
 using Avalonia.Styling;
-using Avalonia.Utilities;
 
 namespace Avalonia
 {
@@ -12,7 +10,7 @@ namespace Avalonia
     /// </summary>
     public abstract class StyledPropertyBase<TValue> : AvaloniaProperty<TValue>, IStyledPropertyAccessor
     {
-        private bool _inherits;
+        private readonly bool _inherits;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StyledPropertyBase{T}"/> class.
@@ -243,10 +241,10 @@ namespace Avalonia
             }
             else if (value is ITemplate template && !typeof(ITemplate).IsAssignableFrom(PropertyType))
             {
-                return new PropertySetterLazyInstance<TValue>(
+                return new PropertySetterTemplateInstance<TValue>(
                     target,
                     this,
-                    () => (TValue)template.Build());
+                    template);
             }
             else
             {

--- a/src/Avalonia.Base/Styling/IStyleInstance.cs
+++ b/src/Avalonia.Base/Styling/IStyleInstance.cs
@@ -15,6 +15,11 @@ namespace Avalonia.Styling
         IStyle Source { get; }
 
         /// <summary>
+        /// Gets a value indicating whether this style has an activator.
+        /// </summary>
+        bool HasActivator { get; }
+        
+        /// <summary>
         /// Gets a value indicating whether this style is active.
         /// </summary>
         bool IsActive { get; }

--- a/src/Avalonia.Base/Styling/PropertySetterInstance.cs
+++ b/src/Avalonia.Base/Styling/PropertySetterInstance.cs
@@ -44,7 +44,7 @@ namespace Avalonia.Styling
         {
             if (hasActivator)
             {
-                if (_styledProperty is object)
+                if (_styledProperty is not null)
                 {
                     _subscription = _target.Bind(_styledProperty, this, BindingPriority.StyleTrigger);
                 }
@@ -55,13 +55,15 @@ namespace Avalonia.Styling
             }
             else
             {
-                if (_styledProperty is object)
+                var target = (AvaloniaObject) _target;
+                
+                if (_styledProperty is not null)
                 {
-                    _subscription = _target.SetValue(_styledProperty!, _value, BindingPriority.Style);
+                    _subscription = target.SetValue(_styledProperty!, _value, BindingPriority.Style);
                 }
                 else
                 {
-                    _target.SetValue(_directProperty!, _value);
+                    target.SetValue(_directProperty!, _value);
                 }
             }
         }

--- a/src/Avalonia.Base/Styling/Setter.cs
+++ b/src/Avalonia.Base/Styling/Setter.cs
@@ -1,9 +1,7 @@
 using System;
 using Avalonia.Animation;
 using Avalonia.Data;
-using Avalonia.Data.Core;
 using Avalonia.Metadata;
-using Avalonia.Utilities;
 
 #nullable enable
 
@@ -69,13 +67,6 @@ namespace Avalonia.Styling
             }
 
             return Property.CreateSetterInstance(target, Value);
-        }
-
-        private struct SetterVisitorData
-        {
-            public IStyleable target;
-            public object? value;
-            public ISetterInstance? result;
         }
     }
 }

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ControlDetailsViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ControlDetailsViewModel.cs
@@ -60,7 +60,8 @@ namespace Avalonia.Diagnostics.ViewModels
 
                 var styleDiagnostics = styledElement.GetStyleDiagnostics();
 
-                foreach (var appliedStyle in styleDiagnostics.AppliedStyles)
+                // We need to place styles without activator first, such styles will be overwritten by ones with activators.
+                foreach (var appliedStyle in styleDiagnostics.AppliedStyles.OrderBy(s => s.HasActivator))
                 {
                     var styleSource = appliedStyle.Source;
 

--- a/tests/Avalonia.Base.UnitTests/Styling/SetterTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/SetterTests.cs
@@ -91,16 +91,13 @@ namespace Avalonia.Base.UnitTests.Styling
         [Fact]
         public void Setter_Should_Apply_Value_Without_Activator_With_Style_Priority()
         {
-            var control = new Mock<IStyleable>();
-            var style = Mock.Of<Style>();
+            var control = new Control();
             var setter = new Setter(TextBlock.TagProperty, "foo");
 
-            setter.Instance(control.Object).Start(false);
+            setter.Instance(control).Start(false);
 
-            control.Verify(x => x.SetValue(
-                TextBlock.TagProperty,
-                "foo",
-                BindingPriority.Style));
+            Assert.Equal("foo", control.Tag);
+            Assert.Equal(BindingPriority.Style, control.GetDiagnostic(TextBlock.TagProperty).Priority);
         }
 
         [Fact]


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes #8111 and a few memory usage optimisations since I was looking at that code anyway.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Styles are shown in a wrong order.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
![image](https://user-images.githubusercontent.com/2588062/168394581-9d5be394-1992-4b97-8640-ae7c431ca3eb.png)

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Styles with activators have higher priority so order in devtools needs to reflect that.
Also fixed one side-effect of `IAvaloniaObject` interface changes - it was boxing now since generic variants were moved to `AvaloniaObject`. One more reason to ditch `IAvaloniaObject` in the framework.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #8111
