### PR TITLE
Fixes related to `ManagedFileChooser` handling of "complex" volume names

### DIFF
--- a/src/Avalonia.FreeDesktop/LinuxMountedVolumeInfoListener.cs
+++ b/src/Avalonia.FreeDesktop/LinuxMountedVolumeInfoListener.cs
@@ -41,6 +41,8 @@ namespace Avalonia.FreeDesktop
 
         private string UnescapePathFromProcMounts(string input) => UnescapeString(input, @"\\(\d{3})", 8);
 
+        private string UnescapeDeviceLabel(string input) => UnescapeString(input, @"\\x([0-9a-f]{2})", 16);
+
         private void Poll(long _)
         {
             var fProcPartitions = File.ReadAllLines(ProcPartitionsDir)
@@ -59,7 +61,7 @@ namespace Avalonia.FreeDesktop
                                new DirectoryInfo(DevByLabelDir).GetFiles() : Enumerable.Empty<FileInfo>();
 
             var labelDevPathPairs = labelDirEnum
-                                    .Select(x => (GetSymlinkTarget(x.FullName), x.Name));
+                                    .Select(x => (GetSymlinkTarget(x.FullName), UnescapeDeviceLabel(x.Name)));
 
             var q1 = from mount in fProcMounts
                      join device in fProcPartitions on mount.Item1 equals device.Item2
@@ -69,7 +71,7 @@ namespace Avalonia.FreeDesktop
                      {
                          VolumePath = mount.Item2,
                          VolumeSizeBytes = device.Item1,
-                         VolumeLabel = x.Name
+                         VolumeLabel = x.Item2
                      };
 
             var mountVolInfos = q1.ToArray();

--- a/src/Avalonia.FreeDesktop/LinuxMountedVolumeInfoListener.cs
+++ b/src/Avalonia.FreeDesktop/LinuxMountedVolumeInfoListener.cs
@@ -36,6 +36,11 @@ namespace Avalonia.FreeDesktop
 
         private string GetSymlinkTarget(string x) => Path.GetFullPath(Path.Combine(DevByLabelDir, NativeMethods.ReadLink(x)));
 
+        private string UnescapeString(string input, string regexText, int escapeBase) =>
+            new Regex(regexText).Replace(input, m => Convert.ToChar(Convert.ToByte(m.Groups[1].Value, escapeBase)).ToString());
+
+        private string UnescapePathFromProcMounts(string input) => UnescapeString(input, @"\\(\d{3})", 8);
+
         private void Poll(long _)
         {
             var fProcPartitions = File.ReadAllLines(ProcPartitionsDir)
@@ -47,7 +52,7 @@ namespace Avalonia.FreeDesktop
 
             var fProcMounts = File.ReadAllLines(ProcMountsDir)
                                   .Select(x => x.Split(' '))
-                                  .Select(x => (x[0], x[1]))
+                                  .Select(x => (x[0], UnescapePathFromProcMounts(x[1])))
                                   .Where(x => !x.Item2.StartsWith("/snap/", StringComparison.InvariantCultureIgnoreCase));
 
             var labelDirEnum = Directory.Exists(DevByLabelDir) ?

--- a/src/Avalonia.FreeDesktop/NativeMethods.cs
+++ b/src/Avalonia.FreeDesktop/NativeMethods.cs
@@ -14,15 +14,15 @@ namespace Avalonia.FreeDesktop
 
         public static string ReadLink(string path)
         {
-            var symlinkMaxSize = Encoding.ASCII.GetMaxByteCount(path.Length);
+            var symlinkSize = Encoding.UTF8.GetByteCount(path);
             var bufferSize = 4097; // PATH_MAX is (usually?) 4096, but we need to know if the result was truncated
 
-            var symlink = ArrayPool<byte>.Shared.Rent(symlinkMaxSize + 1);
+            var symlink = ArrayPool<byte>.Shared.Rent(symlinkSize + 1);
             var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
 
             try
             {
-                var symlinkSize = Encoding.UTF8.GetBytes(path, 0, path.Length, symlink, 0);
+                Encoding.UTF8.GetBytes(path, 0, path.Length, symlink, 0);
                 symlink[symlinkSize] = 0;
 
                 var size = readlink(symlink, buffer, bufferSize);


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR fixes a few small issues that prevent "complex" volume labels and mountpoints (i.e. having non-ASCII or special characters) to work correctly in the `ManagedFileChooser` dialog.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
1. The program crashes when dialog is opened if there are volumes with non-ASCII characters in the volume label.
2. If the volume mount point path has a whitespace (or a few other special symbols) in the name, the volume wouldn't be shown in the dialog at all.
3. Even after fixing (1) and (2), the volume label would be shown in the dialog incorrectly (with some characters unescaped).

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Dialog can be opened and function correctly even if there are some volumes with non-ASCII or special characters in the mountpoint path or in the label.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
