### PR TITLE
Platform Style Selectors: :windows(),:osx(), :linux()

### DIFF
--- a/src/Avalonia.Styling/Styling/PlatformSelector.cs
+++ b/src/Avalonia.Styling/Styling/PlatformSelector.cs
@@ -1,0 +1,86 @@
+
+
+#nullable enable
+
+using System;
+using System.Runtime.InteropServices;
+using Avalonia.Styling.Activators;
+namespace Avalonia.Styling
+{
+    /// <summary>
+    /// The `:osx()`, `:windows()`, `:linux()` style selectors.
+    /// </summary>
+    internal class PlatformSelector : Selector
+    {
+        private readonly Selector? _previous;
+        private readonly Selector _argument;
+        private readonly string _platform;
+        private string? _selectorString;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlatformSelector"/> class.
+        /// </summary>
+        /// <param name="previous">The previous selector.</param>
+        /// <param name="argument">The selector to be not-ed.</param>
+        public PlatformSelector(Selector? previous, Selector argument, string platform)
+        {
+            if(platform != "osx" && platform != "windows" && platform != "linux")
+            {
+                throw new ArgumentException("Invalid platform selector.");
+            }
+            
+            _previous = previous;
+            _argument = argument ?? throw new InvalidOperationException("Platform selector must have a selector argument.");
+            _platform = platform;
+        }
+
+        /// <inheritdoc/>
+        public override bool InTemplate => _argument.InTemplate;
+
+        /// <inheritdoc/>
+        public override bool IsCombinator => false;
+
+        /// <inheritdoc/>
+        public override Type? TargetType => _previous?.TargetType;
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            if (_selectorString == null)
+            {
+                _selectorString = $"{_previous?.ToString()}:{_platform}({_argument})";
+            }
+
+            return _selectorString;
+        }
+
+        private bool IsPlatform()
+        {
+            if (_platform == "osx")
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+            }
+
+            if (_platform == "windows")
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            }
+
+            if (_platform == "linux")
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            }
+            return false;
+        }
+        
+        protected override SelectorMatch Evaluate(IStyleable control, bool subscribe)
+        {
+            if (!IsPlatform())
+                return SelectorMatch.NeverThisInstance;
+            
+            return _argument.Match(control, subscribe);
+        }
+
+        protected override Selector? MovePrevious() => _previous;
+    }
+}

--- a/src/Avalonia.Styling/Styling/Selectors.cs
+++ b/src/Avalonia.Styling/Styling/Selectors.cs
@@ -121,6 +121,18 @@ namespace Avalonia.Styling
         }
         
         /// <summary>
+        /// Returns a selector which on triggers if platform runtime condition is true.
+        /// </summary>
+        /// <param name="previous">The previous selector.</param>
+        /// <param name="argument">The selector to be not-ed.</param>
+        /// <param name="platform">The platform that needs to be matched.</param>
+        /// <returns>The selector.</returns>
+        public static Selector Platform(this Selector? previous, Func<Selector?, Selector> argument, string platform)
+        {
+            return new PlatformSelector(previous, argument(null), platform);
+        }
+        
+        /// <summary>
         /// Returns a selector which inverts the results of selector argument.
         /// </summary>
         /// <param name="previous">The previous selector.</param>

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlSelectorTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlSelectorTransformer.cs
@@ -139,6 +139,9 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                         case SelectorGrammar.NotSyntax not:
                             result = new XamlIlNotSelector(result, Create(not.Argument, typeResolver));
                             break;
+                        case SelectorGrammar.PlatformSyntax platform:
+                            result = new XamlIlPlatformSelector(result, Create(platform.Argument, typeResolver), platform.Platform);
+                            break;
                         case SelectorGrammar.NthChildSyntax nth:
                             result = new XamlIlNthChildSelector(result, nth.Step, nth.Offset, XamlIlNthChildSelector.SelectorType.NthChild);
                             break;
@@ -184,8 +187,6 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         }
 
     }
-
-
     
     abstract class XamlIlSelectorNode : XamlAstNode, IXamlAstValueNode, IXamlAstEmitableNode<IXamlILEmitter, XamlILNodeEmitResult>
     {
@@ -318,6 +319,28 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             context.Emit(Argument, codeGen, Type.GetClrType());
             EmitCall(context, codeGen,
                 m => m.Name == "Not" && m.Parameters.Count == 2 && m.Parameters[1].Equals(Type.GetClrType()));
+        }
+    }
+    
+    class XamlIlPlatformSelector : XamlIlSelectorNode
+    {
+        public XamlIlSelectorNode Argument { get; }
+
+        private string _platform;
+
+        public XamlIlPlatformSelector(XamlIlSelectorNode previous, XamlIlSelectorNode argument, string platform) : base(previous)
+        {
+            Argument = argument;
+            _platform = platform;
+        }
+
+        public override IXamlType TargetType => Previous?.TargetType;
+        protected override void DoEmit(XamlEmitContext<IXamlILEmitter, XamlILNodeEmitResult> context, IXamlILEmitter codeGen)
+        {
+            context.Emit(Argument, codeGen, Type.GetClrType());
+            codeGen.Ldstr(_platform);
+            EmitCall(context, codeGen,
+                m => m.Name == "Platform" && m.Parameters.Count == 3 && m.Parameters[1].Equals(Type.GetClrType()));
         }
     }
 

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/SelectorGrammar.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/SelectorGrammar.cs
@@ -171,6 +171,9 @@ namespace Avalonia.Markup.Parsers
             const string NotKeyword = "not";
             const string NthChildKeyword = "nth-child";
             const string NthLastChildKeyword = "nth-last-child";
+            const string WindowsKeyword = "windows";
+            const string OsxKeyword = "osx";
+            const string LinuxKeyword = "linux";
 
             if (identifier.SequenceEqual(IsKeyword.AsSpan()) && r.TakeIf('('))
             {
@@ -185,6 +188,30 @@ namespace Avalonia.Markup.Parsers
                 Expect(ref r, ')');
 
                 var syntax = new NotSyntax { Argument = argument };
+                return (State.Middle, syntax);
+            }
+            if (identifier.SequenceEqual(WindowsKeyword.AsSpan()) && r.TakeIf('('))
+            {
+                var argument = Parse(ref r, ')');
+                Expect(ref r, ')');
+
+                var syntax = new PlatformSyntax { Argument = argument, Platform = WindowsKeyword};
+                return (State.Middle, syntax);
+            }
+            if (identifier.SequenceEqual(OsxKeyword.AsSpan()) && r.TakeIf('('))
+            {
+                var argument = Parse(ref r, ')');
+                Expect(ref r, ')');
+
+                var syntax = new PlatformSyntax { Argument = argument, Platform = OsxKeyword};
+                return (State.Middle, syntax);
+            }
+            if (identifier.SequenceEqual(LinuxKeyword.AsSpan()) && r.TakeIf('('))
+            {
+                var argument = Parse(ref r, ')');
+                Expect(ref r, ')');
+
+                var syntax = new PlatformSyntax { Argument = argument, Platform = LinuxKeyword};
                 return (State.Middle, syntax);
             }
             if (identifier.SequenceEqual(NthChildKeyword.AsSpan()) && r.TakeIf('('))
@@ -603,6 +630,18 @@ namespace Avalonia.Markup.Parsers
             public override bool Equals(object? obj)
             {
                 return (obj is NotSyntax not) && Argument.SequenceEqual(not.Argument);
+            }
+        }
+        
+        public class PlatformSyntax : ISyntax
+        {
+            public string? Platform { get; set; }
+            
+            public IEnumerable<ISyntax> Argument { get; set; } = Enumerable.Empty<ISyntax>();
+
+            public override bool Equals(object? obj)
+            {
+                return (obj is PlatformSyntax ps) && Argument.SequenceEqual(ps.Argument) && ps.Platform == Platform;
             }
         }
 

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/SelectorParser.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/SelectorParser.cs
@@ -149,6 +149,9 @@ namespace Avalonia.Markup.Parsers
                     case SelectorGrammar.NotSyntax not:
                         result = result.Not(x => Create(not.Argument)!);
                         break;
+                    case SelectorGrammar.PlatformSyntax platform:
+                        result = result.Platform(x => Create(platform.Argument)!, platform.Platform!);
+                        break;
                     case SelectorGrammar.NthChildSyntax nth:
                         result = result.NthChild(nth.Step, nth.Offset);
                         break;

--- a/tests/Avalonia.Markup.UnitTests/Parsers/SelectorGrammarTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/SelectorGrammarTests.cs
@@ -251,7 +251,67 @@ namespace Avalonia.Markup.UnitTests.Parsers
                 },
                 result);
         }
+        
+        [Fact]
+        public void WindowsPlatform()
+        {
+            var result = SelectorGrammar.Parse(":windows(Button)");
 
+            Assert.Equal(
+                new SelectorGrammar.ISyntax[]
+                {
+                    new SelectorGrammar.PlatformSyntax
+                    {
+                        Platform = "windows",
+                        Argument = new SelectorGrammar.ISyntax[]
+                        {
+                            new SelectorGrammar.OfTypeSyntax { TypeName = "Button" },
+                        },
+                    }
+                },
+                result);
+        }
+        
+        [Fact]
+        public void LinuxPlatform()
+        {
+            var result = SelectorGrammar.Parse(":linux(Button)");
+
+            Assert.Equal(
+                new SelectorGrammar.ISyntax[]
+                {
+                    new SelectorGrammar.PlatformSyntax
+                    {
+                        Platform = "linux",
+                        Argument = new SelectorGrammar.ISyntax[]
+                        {
+                            new SelectorGrammar.OfTypeSyntax { TypeName = "Button" },
+                        },
+                    }
+                },
+                result);
+        }
+
+        [Fact]
+        public void OsxPlatform()
+        {
+            var result = SelectorGrammar.Parse(":osx(Button)");
+
+            Assert.Equal(
+                new SelectorGrammar.ISyntax[]
+                {
+                    new SelectorGrammar.PlatformSyntax
+                    {
+                        Platform = "osx",
+                        Argument = new SelectorGrammar.ISyntax[]
+                        {
+                            new SelectorGrammar.OfTypeSyntax { TypeName = "Button" },
+                        },
+                    }
+                },
+                result);
+        }
+        
         [Fact]
         public void OfType_Not_Class()
         {

--- a/tests/Avalonia.Styling.UnitTests/SelectorTests_Platform.cs
+++ b/tests/Avalonia.Styling.UnitTests/SelectorTests_Platform.cs
@@ -1,0 +1,35 @@
+using System.Reactive.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Xunit;
+
+namespace Avalonia.Styling.UnitTests
+{
+    public class SelectorTests_Platform
+    {
+        [Fact]
+        public void Platform_Selector_Should_Have_Correct_String_Representation()
+        {
+            var target = default(Selector).Platform(x => x.Class("foo"), "windows");
+
+            Assert.Equal(":windows(.foo)", target.ToString());
+        }
+
+        [Fact]
+        public void Platform_Match_Windows()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var control = new Control1();
+                var target = default(Selector).Platform(x => x.OfType<Control1>(), "windows");
+
+                Assert.Equal(SelectorMatchResult.AlwaysThisType, target.Match(control).Result);
+            }
+        }
+        
+        public class Control1 : Control
+        {
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Implements new style selectors:

:windows(<selectors>)
:osx(<selectors>)
:linux(<selectors>)

Example:

Selector=":windows(Button.foo)"
...

Will only match Button.foo if running on windows. 

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

There are unit tests in the appropriate places. :)

## How was the solution implemented (if it's not obvious)?

I looked at how the not selector was built.

Please check the XamlIlPlatformSelector as I'm not really sure about that one.

Uses RuntimeInformation 

## Checklist

- [ x] Added unit tests (if possible)?
- [ x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation (I will when this is approved)

## Breaking changes

Shouldn't be any.

## Obsoletions / Deprecations

Shouldn't be any.

