### PR TITLE
Fixes/osx nswindow refactor fix issues

### DIFF
--- a/native/Avalonia.Native/src/OSX/AutoFitContentView.mm
+++ b/native/Avalonia.Native/src/OSX/AutoFitContentView.mm
@@ -85,7 +85,7 @@
     _settingSize = true;
     [super setFrameSize:newSize];
 
-    auto window = static_cast<id <AvnWindowProtocol>>([self window]);
+    auto window = (id <AvnWindowProtocol>) [self window];
 
     // TODO get actual titlebar size
 

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -174,6 +174,11 @@
     [self setBackgroundColor: [NSColor clearColor]];
 
     _isExtended = false;
+
+#ifdef IS_NSPANEL
+    [self setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces|NSWindowCollectionBehaviorFullScreenAuxiliary];
+#endif
+
     return self;
 }
 
@@ -212,11 +217,14 @@
     // If the window has a child window being shown as a dialog then don't allow it to become the key window.
     for(NSWindow* uch in [self childWindows])
     {
-        auto ch = static_cast<id <AvnWindowProtocol>>(uch);
-        if(ch == nil)
+        if (![uch conformsToProtocol:@protocol(AvnWindowProtocol)])
+        {
             continue;
-        if (ch.isDialog)
-            return false;
+        }
+
+        id <AvnWindowProtocol> ch = (id <AvnWindowProtocol>) uch;
+
+        return !ch.isDialog;
     }
 
     return true;

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -199,6 +199,8 @@
     [self backingScaleFactor];
 }
 
+
+
 - (void)windowWillClose:(NSNotification *)notification
 {
     _closed = true;
@@ -380,6 +382,11 @@
 
         if(cparent != nullptr)
         {
+            if(!cparent->IsShown())
+            {
+                return;
+            }
+
             if(cparent->WindowState() == Maximized)
             {
                 cparent->SetWindowState(Normal);

--- a/native/Avalonia.Native/src/OSX/PopupImpl.mm
+++ b/native/Avalonia.Native/src/OSX/PopupImpl.mm
@@ -50,10 +50,16 @@ protected:
             return S_OK;
         }
     }
+
 public:
     virtual bool ShouldTakeFocusOnShow() override
     {
         return false;
+    }
+
+    virtual HRESULT Show(bool activate, bool isDialog) override
+    {
+        return WindowBaseImpl::Show(activate, true);
     }
 };
 

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
@@ -72,8 +72,6 @@ BEGIN_INTERFACE_MAP()
 
     virtual HRESULT GetClientSize(AvnSize *ret) override;
 
-    virtual HRESULT GetFrameSize(AvnSize *ret) override;
-
     virtual HRESULT GetScaling(double *ret) override;
 
     virtual HRESULT SetMinMaxSize(AvnSize minSize, AvnSize maxSize) override;

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
@@ -72,6 +72,8 @@ BEGIN_INTERFACE_MAP()
 
     virtual HRESULT GetClientSize(AvnSize *ret) override;
 
+    virtual HRESULT GetFrameSize(AvnSize *ret) override;
+
     virtual HRESULT GetScaling(double *ret) override;
 
     virtual HRESULT SetMinMaxSize(AvnSize minSize, AvnSize maxSize) override;

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
@@ -60,6 +60,8 @@ BEGIN_INTERFACE_MAP()
 
     virtual HRESULT Show(bool activate, bool isDialog) override;
 
+    virtual bool IsShown ();
+
     virtual bool ShouldTakeFocusOnShow();
 
     virtual HRESULT Hide() override;

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -191,7 +191,22 @@ HRESULT WindowBaseImpl::GetClientSize(AvnSize *ret) {
         if (ret == nullptr)
             return E_POINTER;
 
-        auto frame = [View.frame];
+        auto frame = [View frame];
+        ret->Width = frame.size.width;
+        ret->Height = frame.size.height;
+
+        return S_OK;
+    }
+}
+
+HRESULT WindowBaseImpl::GetFrameSize(AvnSize *ret) {
+    START_COM_CALL;
+
+    @autoreleasepool {
+        if (ret == nullptr)
+            return E_POINTER;
+
+        auto frame = [Window frame];
         ret->Width = frame.size.width;
         ret->Height = frame.size.height;
 

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -590,7 +590,7 @@ id <AvnWindowProtocol> WindowBaseImpl::GetWindowProtocol() {
         return nullptr;
     }
 
-    return static_cast<id <AvnWindowProtocol>>(Window);
+    return (id <AvnWindowProtocol>) Window;
 }
 
 extern IAvnWindow* CreateAvnWindow(IAvnWindowEvents*events, IAvnGlContext* gl)

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -30,8 +30,8 @@ WindowBaseImpl::WindowBaseImpl(IAvnWindowBaseEvents *events, IAvnGlContext *gl) 
     View = [[AvnView alloc] initWithParent:this];
     StandardContainer = [[AutoFitContentView new] initWithContent:View];
 
-    lastPositionSet.X = 100;
-    lastPositionSet.Y = 100;
+    lastPositionSet.X = -1;
+    lastPositionSet.Y = -1;
     lastSize = NSSize { 100, 100 };
     lastMaxSize = NSSize { CGFLOAT_MAX, CGFLOAT_MAX};
     lastMinSize = NSSize { 0, 0 };
@@ -91,6 +91,11 @@ HRESULT WindowBaseImpl::Show(bool activate, bool isDialog) {
     @autoreleasepool {
         CreateNSWindow(isDialog);
         InitialiseNSWindow();
+
+        if(lastPositionSet.X >= 0 && lastPositionSet.Y >= 0)
+        {
+            SetPosition(lastPositionSet);
+        }
 
         UpdateStyle();
 
@@ -370,7 +375,10 @@ HRESULT WindowBaseImpl::SetPosition(AvnPoint point) {
 
     @autoreleasepool {
         lastPositionSet = point;
-        [Window setFrameTopLeftPoint:ToNSPoint(ConvertPointY(point))];
+
+        if(Window != nullptr) {
+            [Window setFrameTopLeftPoint:ToNSPoint(ConvertPointY(point))];
+        }
 
         return S_OK;
     }

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -191,9 +191,8 @@ HRESULT WindowBaseImpl::GetClientSize(AvnSize *ret) {
         if (ret == nullptr)
             return E_POINTER;
 
-        auto frame = [View frame];
-        ret->Width = frame.size.width;
-        ret->Height = frame.size.height;
+        ret->Width = lastSize.width;
+        ret->Height = lastSize.height;
 
         return S_OK;
     }
@@ -206,9 +205,15 @@ HRESULT WindowBaseImpl::GetFrameSize(AvnSize *ret) {
         if (ret == nullptr)
             return E_POINTER;
 
-        auto frame = [Window frame];
-        ret->Width = frame.size.width;
-        ret->Height = frame.size.height;
+        if(Window == nullptr){
+            ret->Width = 0;
+            ret->Height = 0;
+        }
+        else {
+            auto frame = [Window frame];
+            ret->Width = frame.size.width;
+            ret->Height = frame.size.height;
+        }
 
         return S_OK;
     }

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -116,6 +116,11 @@ HRESULT WindowBaseImpl::Show(bool activate, bool isDialog) {
     }
 }
 
+bool WindowBaseImpl::IsShown ()
+{
+    return _shown;
+}
+
 bool WindowBaseImpl::ShouldTakeFocusOnShow() {
     return true;
 }
@@ -567,7 +572,6 @@ void WindowBaseImpl::InitialiseNSWindow() {
         [Window setContentMaxSize:lastMaxSize];
 
         [Window setOpaque:false];
-
         [Window center];
 
         if (lastMenu != nullptr) {

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -92,7 +92,6 @@ HRESULT WindowBaseImpl::Show(bool activate, bool isDialog) {
         CreateNSWindow(isDialog);
         InitialiseNSWindow();
 
-        SetPosition(lastPositionSet);
         UpdateStyle();
 
         [Window setTitle:_lastTitle];
@@ -560,6 +559,8 @@ void WindowBaseImpl::InitialiseNSWindow() {
         [Window setContentMaxSize:lastMaxSize];
 
         [Window setOpaque:false];
+
+        [Window center];
 
         if (lastMenu != nullptr) {
             [GetWindowProtocol() applyMenu:lastMenu];

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -191,22 +191,7 @@ HRESULT WindowBaseImpl::GetClientSize(AvnSize *ret) {
         if (ret == nullptr)
             return E_POINTER;
 
-        auto frame = [View frame];
-        ret->Width = frame.size.width;
-        ret->Height = frame.size.height;
-
-        return S_OK;
-    }
-}
-
-HRESULT WindowBaseImpl::GetFrameSize(AvnSize *ret) {
-    START_COM_CALL;
-
-    @autoreleasepool {
-        if (ret == nullptr)
-            return E_POINTER;
-
-        auto frame = [Window frame];
+        auto frame = [View.frame];
         ret->Width = frame.size.width;
         ret->Height = frame.size.height;
 

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -205,11 +205,7 @@ HRESULT WindowBaseImpl::GetFrameSize(AvnSize *ret) {
         if (ret == nullptr)
             return E_POINTER;
 
-        if(Window == nullptr){
-            ret->Width = 0;
-            ret->Height = 0;
-        }
-        else {
+        if(Window != nullptr){
             auto frame = [Window frame];
             ret->Width = frame.size.width;
             ret->Height = frame.size.height;

--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -430,6 +430,9 @@ HRESULT WindowImpl::SetWindowState(AvnWindowState state) {
     START_COM_CALL;
 
     @autoreleasepool {
+        auto currentState = _actualWindowState;
+        _lastWindowState = state;
+
         if (Window == nullptr) {
             return S_OK;
         }
@@ -439,9 +442,6 @@ HRESULT WindowImpl::SetWindowState(AvnWindowState state) {
         }
 
         _inSetWindowState = true;
-
-        auto currentState = _actualWindowState;
-        _lastWindowState = state;
 
         if (currentState == Normal) {
             _preZoomSize = [Window frame];

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -116,8 +116,12 @@ namespace Avalonia.Native
             {
                 if (_native != null)
                 {
-                    var s = _native.FrameSize;
-                    return s.Width == 0 && s.Height == 0 ? null : new Size(s.Width, s.Height);
+                    unsafe
+                    {
+                        var s = new AvnSize { Width = -1, Height = -1 };
+                        _native.GetFrameSize(&s);
+                        return s.Width < 0  && s.Height < 0 ? null : new Size(s.Width, s.Height);
+                    }
                 }
 
                 return default;

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -117,7 +117,7 @@ namespace Avalonia.Native
                 if (_native != null)
                 {
                     var s = _native.FrameSize;
-                    return new Size(s.Width, s.Height);
+                    return s.Width == 0 && s.Height == 0 ? null : new Size(s.Width, s.Height);
                 }
 
                 return default;

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -504,7 +504,7 @@ interface IAvnWindowBase : IUnknown
      HRESULT Close();
      HRESULT Activate();
      HRESULT GetClientSize(AvnSize*ret);
-     HRESULT GetFrameSize(AvnSize*ret);
+     HRESULT GetFrameSize(AvnSize*result);
      HRESULT GetScaling(double*ret);
      HRESULT SetMinMaxSize(AvnSize minSize, AvnSize maxSize);
      HRESULT Resize(double width, double height, AvnPlatformResizeReason reason);

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -504,7 +504,6 @@ interface IAvnWindowBase : IUnknown
      HRESULT Close();
      HRESULT Activate();
      HRESULT GetClientSize(AvnSize*ret);
-     HRESULT GetFrameSize(AvnSize*ret);
      HRESULT GetScaling(double*ret);
      HRESULT SetMinMaxSize(AvnSize minSize, AvnSize maxSize);
      HRESULT Resize(double width, double height, AvnPlatformResizeReason reason);

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -504,6 +504,7 @@ interface IAvnWindowBase : IUnknown
      HRESULT Close();
      HRESULT Activate();
      HRESULT GetClientSize(AvnSize*ret);
+     HRESULT GetFrameSize(AvnSize*ret);
      HRESULT GetScaling(double*ret);
      HRESULT SetMinMaxSize(AvnSize minSize, AvnSize maxSize);
      HRESULT Resize(double width, double height, AvnPlatformResizeReason reason);


### PR DESCRIPTION
Fix some regressions OSX:

 Windows open centrally by default,
 WindowState, Position are obeyed.
 
Fixes some bugs with "static casting" to protocols, causing crashes.
Fixes, popups, context menus and flyouts when in FullScreen mode.
Popups, contextmenus and flyouts are NSPanels.


 FrameSize property will be null (as in invalid) before window is shown.