### PR TITLE
Fix Menu selection to match UWP.

### DIFF
--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -56,6 +56,7 @@ namespace Avalonia.Controls.Platform
             Menu.AddHandler(Avalonia.Controls.Menu.MenuOpenedEvent, this.MenuOpened);
             Menu.AddHandler(MenuItem.PointerEnterItemEvent, PointerEnter);
             Menu.AddHandler(MenuItem.PointerLeaveItemEvent, PointerLeave);
+            Menu.AddHandler(InputElement.PointerMovedEvent, PointerMoved);
 
             _root = Menu.VisualRoot;
 
@@ -91,6 +92,7 @@ namespace Avalonia.Controls.Platform
             Menu.RemoveHandler(Avalonia.Controls.Menu.MenuOpenedEvent, this.MenuOpened);
             Menu.RemoveHandler(MenuItem.PointerEnterItemEvent, PointerEnter);
             Menu.RemoveHandler(MenuItem.PointerLeaveItemEvent, PointerLeave);
+            Menu.RemoveHandler(InputElement.PointerMovedEvent, PointerMoved);
 
             if (_root is InputElement inputRoot)
             {
@@ -337,6 +339,21 @@ namespace Avalonia.Controls.Platform
                         }
                     }
                 }
+            }
+        }
+
+        protected internal virtual void PointerMoved(object? sender, PointerEventArgs e)
+        {
+            var item = GetMenuItem(e.Source as IControl) as MenuItem;
+            if (item?.TransformedBounds == null)
+            {
+                return;
+            }
+            var point = e.GetCurrentPoint(null);
+
+            if (point.Properties.IsLeftButtonPressed && item.TransformedBounds.Value.Contains(point.Position) == false)
+            {
+                e.Pointer.Capture(null);
             }
         }
 

--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -344,6 +344,7 @@ namespace Avalonia.Controls.Platform
 
         protected internal virtual void PointerMoved(object? sender, PointerEventArgs e)
         {
+            // HACK: #8179 needs to be addressed to correctly implement it in the PointerPressed method.
             var item = GetMenuItem(e.Source as IControl) as MenuItem;
             if (item?.TransformedBounds == null)
             {


### PR DESCRIPTION
## What does the pull request do?
Originally when you hold the left mouse button on MenuItem and try to move your mouse away from it it will stay selected and when you will release the left mouse button command bound to the MenuItem that we have originally pressed will be executed, even though we release the mouse in the separate place.


## What is the current behavior?
![Анимация](https://user-images.githubusercontent.com/53405089/169868502-f883844a-bd7e-497e-8be7-8a90511e66e1.gif)


## What is the updated/expected behavior with this PR?
![Анимация](https://user-images.githubusercontent.com/53405089/169867710-517dae63-62b2-4b57-b819-9c96641c584d.gif)


closes #3609