### PR TITLE
Don't cast android scaling from double to int

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -40,7 +40,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
             _gl = GlPlatformSurface.TryCreate(this);
             _framebuffer = new FramebufferManager(this);
 
-            RenderScaling = (int)_view.Scaling;
+            RenderScaling = _view.Scaling;
 
             MaxClientSize = new PixelSize(_view.Resources.DisplayMetrics.WidthPixels,
                 _view.Resources.DisplayMetrics.HeightPixels).ToSize(RenderScaling);


### PR DESCRIPTION
While checking https://github.com/AvaloniaUI/Avalonia/issues/8150 issue I noticed that we round trim scaling (i.e. from 2.5d to 2) down casting it to int.
Not sure if it is intended or I am missing something.