### PR TITLE
OSX: fix file dialog filter nullable annotation, and osx platform.

### DIFF
--- a/samples/ControlCatalog/ControlCatalog.csproj
+++ b/samples/ControlCatalog/ControlCatalog.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>    
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>    
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="**\*.xaml.cs">

--- a/samples/ControlCatalog/Pages/DialogsPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DialogsPage.xaml.cs
@@ -8,7 +8,6 @@ using Avalonia.Dialogs;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
 #pragma warning disable 4014
-
 namespace ControlCatalog.Pages
 {
     public class DialogsPage : UserControl
@@ -22,7 +21,7 @@ namespace ControlCatalog.Pages
 
             string lastSelectedDirectory = null;
 
-            List<FileDialogFilter> GetFilters()
+            List<FileDialogFilter>? GetFilters()
             {
                 if (this.FindControl<CheckBox>("UseFilters").IsChecked != true)
                     return null;

--- a/src/Avalonia.Controls/SystemDialog.cs
+++ b/src/Avalonia.Controls/SystemDialog.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Controls
         /// Gets or sets a collection of filters which determine the types of files displayed in an
         /// <see cref="OpenFileDialog"/> or an <see cref="SaveFileDialog"/>.
         /// </summary>
-        public List<FileDialogFilter> Filters { get; set; } = new List<FileDialogFilter>();
+        public List<FileDialogFilter>? Filters { get; set; } = new List<FileDialogFilter>();
 
         /// <summary>
         /// Gets or sets initial file name that is displayed when the dialog is opened.

--- a/src/Avalonia.Native/SystemDialogs.cs
+++ b/src/Avalonia.Native/SystemDialogs.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Native
                                         ofd.Title ?? "",
                                         ofd.Directory ?? "",
                                         ofd.InitialFileName ?? "",
-                                        string.Join(";", dialog.Filters.SelectMany(f => f.Extensions)));
+                                        string.Join(";", dialog.Filters?.SelectMany(f => f.Extensions) ?? Array.Empty<string>()));
             }
             else
             {
@@ -39,7 +39,7 @@ namespace Avalonia.Native
                                         dialog.Title ?? "",
                                         dialog.Directory ?? "",
                                         dialog.InitialFileName ?? "",
-                                        string.Join(";", dialog.Filters.SelectMany(f => f.Extensions)));
+                                        string.Join(";", dialog.Filters?.SelectMany(f => f.Extensions) ?? Array.Empty<string>()));
             }
 
             return events.Task.ContinueWith(t => { events.Dispose(); return t.Result; });


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Adds nullable ? to Filters property of the FileDialog.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
