### PR TITLE
Fix osx dialog style mask

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -523,7 +523,7 @@ bool WindowImpl::IsDialog() {
 }
 
 NSWindowStyleMask WindowImpl::GetStyle() {
-    unsigned long s = this->_isDialog ? NSWindowStyleMaskUtilityWindow : NSWindowStyleMaskBorderless;
+    unsigned long s = this->_isDialog ? NSWindowStyleMaskDocModalWindow : NSWindowStyleMaskBorderless;
 
     switch (_decorations) {
         case SystemDecorationsNone:


### PR DESCRIPTION
makes the titlebar look like normal window.

before:
<img width="253" alt="image" src="https://user-images.githubusercontent.com/4672627/170244062-81f7a471-e590-42a0-afc6-54983ca76717.png">


after:
<img width="254" alt="image" src="https://user-images.githubusercontent.com/4672627/170244149-cbc70bcb-7114-4f56-9679-ce5e07cf9ec0.png">

