### PR TITLE
Make AvaloniaPropertyAccessorPlugin use weak events.

### DIFF
--- a/src/Avalonia.Base/Collections/Pooled/PooledList.cs
+++ b/src/Avalonia.Base/Collections/Pooled/PooledList.cs
@@ -587,7 +587,7 @@ namespace Avalonia.Collections.Pooled
             if (size > 0 && _clearOnFree)
             {
                 // Clear the elements so that the gc can reclaim the references.
-                Array.Clear(_items, 0, _size);
+                Array.Clear(_items, 0, size);
             }
         }
 

--- a/src/Avalonia.Base/Utilities/WeakEvents.cs
+++ b/src/Avalonia.Base/Utilities/WeakEvents.cs
@@ -31,6 +31,19 @@ public class WeakEvents
                 return () => s.PropertyChanged -= handler;
             });
 
+
+    /// <summary>
+    /// Represents PropertyChanged event from <see cref="AvaloniaObject"/>
+    /// </summary>
+    public static readonly WeakEvent<AvaloniaObject, AvaloniaPropertyChangedEventArgs>
+        AvaloniaPropertyChanged = WeakEvent.Register<AvaloniaObject, AvaloniaPropertyChangedEventArgs>(
+            (s, h) =>
+            {
+                EventHandler<AvaloniaPropertyChangedEventArgs> handler = (_, e) => h(s, e);
+                s.PropertyChanged += handler;
+                return () => s.PropertyChanged -= handler;
+            });
+
     /// <summary>
     /// Represents CanExecuteChanged event from <see cref="ICommand"/>
     /// </summary>

--- a/tests/Avalonia.LeakTests/ControlTests.cs
+++ b/tests/Avalonia.LeakTests/ControlTests.cs
@@ -2,14 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Runtime.Remoting.Contexts;
 using Avalonia.Controls;
 using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Diagnostics;
 using Avalonia.Input;
-using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Rendering;
@@ -710,11 +708,15 @@ namespace Avalonia.LeakTests
                 window.Show();
                 window.LayoutManager.ExecuteInitialLayoutPass();
 
+                void AssertInitialItemState()
+                {
+                    var item0 = (ListBoxItem)lb.ItemContainerGenerator.Containers.First().ContainerControl;
+                    var canvas0 = (Canvas)item0.Presenter.Child;
+                    Assert.Equal("foo", canvas0.Tag);
+                }
+               
                 Assert.Equal(10, lb.ItemContainerGenerator.Containers.Count());
-
-                var item0 = (ListBoxItem)lb.ItemContainerGenerator.Containers.First().ContainerControl;
-                var canvas0 = (Canvas)item0.Presenter.Child;
-                Assert.Equal("foo", canvas0.Tag);
+                AssertInitialItemState();
 
                 items.Clear();
                 window.LayoutManager.ExecuteLayoutPass();


### PR DESCRIPTION
## What does the pull request do?

`AvaloniaPropertyAccessorPlugin.Accessor` wasn't using weak events (whereas e.g. `InpcPropertyAccessorPlugin` does) which was causing the leak described in #8178.

- Adds a leak test to test the scenario: `ElementName_Binding_In_DataTemplate_Is_Freed`
- Makes `AvaloniaPropertyAccessorPlugin.Accessor` use weak event subscriptions
- Fixes a bug in `PooledList` which was keeping weak event handlers alive (ported from upstream https://github.com/jtmueller/Collections.Pooled/pull/44)
- Adds some cleanup to leak tests to stop `ElementName_Binding_In_DataTemplate_Is_Freed` interfering with subsequently run leak tests (should improve stability of leak tests in general)

## Fixed issues

Fixes #8178 