### PR TITLE
Clear IMM state when window is closed.

### DIFF
--- a/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
+++ b/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
@@ -37,6 +37,24 @@ namespace Avalonia.Win32.Input
             IsComposing = false;
         }
 
+        public void ClearLanguageAndWindow()
+        {
+            if (HWND != IntPtr.Zero && _defaultImc != IntPtr.Zero)
+            {
+                ImmReleaseContext(HWND, _defaultImc);
+            }
+
+            _defaultImc = IntPtr.Zero;
+            HWND = IntPtr.Zero;
+            _parent = null;
+            _active = false;
+            _langId = 0;
+            _showCompositionWindow = false;
+            _showCandidateList = false;
+
+            IsComposing = false;
+        }
+
         //Dependant on CurrentThread. When Avalonia will support Multiple Dispatchers -
         //every Dispatcher should have their own InputMethod.
         public static Imm32InputMethod Current { get; } = new Imm32InputMethod();

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -82,6 +82,12 @@ namespace Avalonia.Win32
                 case WindowsMessage.WM_DESTROY:
                     {
                         UiaCoreProviderApi.UiaReturnRawElementProvider(_hwnd, IntPtr.Zero, IntPtr.Zero, null);
+                        
+                        // We need to release IMM context and state to avoid leaks.
+                        if (Imm32InputMethod.Current.HWND == _hwnd)
+                        {
+                            Imm32InputMethod.Current.ClearLanguageAndWindow();
+                        }
 
                         //Window doesn't exist anymore
                         _hwnd = IntPtr.Zero;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
When checking why certain objects are not collected in my app I did find that on win32 last active window cannot be collected since it is referenced by IMM manager.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When closing last window one can see that IMM input manager keeps it alive due to a reference.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
No references to window are kept in IMM.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation
