### PR TITLE
[OSX] fix border shadow invalidation.

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -296,6 +296,7 @@ HRESULT WindowBaseImpl::Resize(double x, double y, AvnPlatformResizeReason reaso
 
             if(Window != nullptr) {
                 [Window setContentSize:lastSize];
+                [Window invalidateShadow];
             }
         }
         @finally {
@@ -583,6 +584,8 @@ void WindowBaseImpl::InitialiseNSWindow() {
         [Window setContentMaxSize:lastMaxSize];
 
         [Window setOpaque:false];
+        
+        [Window invalidateShadow];
 
         if (lastMenu != nullptr) {
             [GetWindowProtocol() applyMenu:lastMenu];


### PR DESCRIPTION
Since the NSWindow/NSPanel refactor sometimes window shadow doesnt get painted.. restored invalidation code.