### PR TITLE
Added tests for attached property resolution edge-cases.

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlTransformInstanceAttachedProperties.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlTransformInstanceAttachedProperties.cs
@@ -25,7 +25,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                     && !declaringRef.Type.IsAssignableFrom(targetRef.Type))
                 {
                     // Instance property
-                    var clrProp = declaringRef.Type.Properties.FirstOrDefault(p => p.Name == prop.Name);
+                    var clrProp = declaringRef.Type.GetAllProperties().FirstOrDefault(p => p.Name == prop.Name);
                     if (clrProp != null
                         && (clrProp.Getter?.IsStatic == false || clrProp.Setter?.IsStatic == false))
                     {

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlTransformInstanceAttachedProperties.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlTransformInstanceAttachedProperties.cs
@@ -25,7 +25,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                     && !declaringRef.Type.IsAssignableFrom(targetRef.Type))
                 {
                     // Instance property
-                    var clrProp = declaringRef.Type.GetAllProperties().FirstOrDefault(p => p.Name == prop.Name);
+                    var clrProp = declaringRef.Type.Properties.FirstOrDefault(p => p.Name == prop.Name);
                     if (clrProp != null
                         && (clrProp.Getter?.IsStatic == false || clrProp.Setter?.IsStatic == false))
                     {

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
@@ -207,6 +207,21 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
         }
 
         [Fact]
+        public void Cannot_Use_Attached_Property_Syntax_From_Another_Control_On_Non_Attached_Property_With_Markup_Extension_2()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <TextBlock TemplatedControl.FontSize='{DynamicResource Size}'/>
+</Window>";
+                Assert.ThrowsAny<Exception>(() => AvaloniaRuntimeXamlLoader.Load(xaml));
+            }
+        }
+
+        [Fact]
         public void NonExistent_Property_Throws()
         {
             var xaml =

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
@@ -115,7 +115,97 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             Assert.Equal("Foo", ToolTip.GetTip(target));
         }
-        
+
+        [Fact]
+        public void Can_Use_Attached_Property_Syntax_On_NonAttached_Property()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <Border Border.Background='Red'/>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var border = (Border)window.Content;
+
+                window.ApplyTemplate();
+
+                Assert.Equal(Colors.Red, ((ISolidColorBrush)border.Background).Color);
+            }
+        }
+
+        [Fact]
+        public void Can_Use_Attached_Property_Syntax_On_Attached_AddOwnered_Property()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <TextBlock TextBlock.FontSize='48'/>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = (TextBlock)window.Content;
+
+                window.ApplyTemplate();
+
+                Assert.Equal(48, textBlock.FontSize);
+            }
+        }
+
+        [Fact]
+        public void Can_Use_Attached_Property_Syntax_On_Attached_AddOwnered_Property_2()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <TextBlock TextElement.FontSize='48'/>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = (TextBlock)window.Content;
+
+                window.ApplyTemplate();
+
+                Assert.Equal(48, textBlock.FontSize);
+            }
+        }
+
+        [Fact]
+        public void Cannot_Use_Attached_Property_Syntax_From_Another_Control_On_Non_Attached_Property()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <TextBlock TextBox.FontSize='48'/>
+</Window>";
+                Assert.ThrowsAny<Exception>(() => AvaloniaRuntimeXamlLoader.Load(xaml));
+            }
+        }
+
+        [Fact]
+        public void Cannot_Use_Attached_Property_Syntax_From_Another_Control_On_Non_Attached_Property_With_Markup_Extension()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <TextBlock TextBox.FontSize='{DynamicResource Size}'/>
+</Window>";
+                Assert.ThrowsAny<Exception>(() => AvaloniaRuntimeXamlLoader.Load(xaml));
+            }
+        }
+
         [Fact]
         public void NonExistent_Property_Throws()
         {

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Xml;
 using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Markup.Xaml.Templates;
 using Avalonia.Media;
@@ -215,6 +217,135 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
                 window.ApplyTemplate();
 
                 Assert.Equal(Dock.Right, DockPanel.GetDock(textBlock));
+            }
+        }
+
+        [Fact]
+        public void Setter_Can_Use_Attached_Property_Syntax_On_NonAttached_Property()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <Window.Styles>
+        <Style Selector='Border'>
+            <Setter Property='Border.Background' Value='Red'/>
+        </Style>
+    </Window.Styles>
+    <Border/>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var border = (Border)window.Content;
+
+                window.ApplyTemplate();
+
+                Assert.Equal(Colors.Red, ((ISolidColorBrush)border.Background).Color);
+            }
+        }
+
+        [Fact]
+        public void Setter_Can_Use_Attached_Property_Syntax_On_Attached_AddOwnered_Property()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <Window.Styles>
+        <Style Selector='TextBlock'>
+            <Setter Property='TextBlock.FontSize' Value='48'/>
+        </Style>
+    </Window.Styles>
+    <TextBlock/>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = (TextBlock)window.Content;
+
+                window.ApplyTemplate();
+
+                Assert.Equal(48, textBlock.FontSize);
+            }
+        }
+
+        [Fact]
+        public void Setter_Can_Use_Attached_Property_Syntax_On_Attached_AddOwnered_Property_2()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <Window.Styles>
+        <Style Selector='TextBlock'>
+            <Setter Property='TextElement.FontSize' Value='48'/>
+        </Style>
+    </Window.Styles>
+    <TextBlock/>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = (TextBlock)window.Content;
+
+                window.ApplyTemplate();
+
+                Assert.Equal(48, textBlock.FontSize);
+            }
+        }
+
+        [Fact]
+        public void Binding_Setter_Can_Use_NonAttached_Property_Syntax_On_Attached_AddOwnered_Property_3()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <Window.Styles>
+        <Style Selector='ContentPresenter'>
+            <Setter Property='Foreground' Value='{Binding Brush}'/>
+        </Style>
+    </Window.Styles>
+    <ContentPresenter/>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var contentPresenter = (ContentPresenter)window.Content;
+                window.DataContext = new { Brush = Brushes.Red };
+
+                window.ApplyTemplate();
+
+                Assert.Equal(Colors.Red, ((ISolidColorBrush)contentPresenter.Foreground).Color);
+            }
+        }
+
+        [Fact]
+        public void Setter_Can_Use_Attached_Property_Syntax_From_Another_Control_On_Non_Attached_Property()
+        {
+            // This is a weird one, but it follows WPF. Even though <TextBlock TextBox.FontSize="48"/>
+            // is an error in WPF, you can set the same property in a style and it works (because in
+            // the end they're actually the same property).
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <Window.Styles>
+        <Style Selector='TextBlock'>
+            <Setter Property='TextBox.FontSize' Value='48'/>
+        </Style>
+    </Window.Styles>
+    <TextBlock/>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = (TextBlock)window.Content;
+
+                window.ApplyTemplate();
+
+                Assert.Equal(48, textBlock.FontSize);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

While investigating #7925 I added a few tests which tested attached property syntax and cross-referenced them against WPF. It turned out that #7925 was caused by something unrelated, but there is one slight edge-case in our attached property lookup.

In WPF, the following produces an error (although weirdly, it _is_ allowed in a style setter):

```
<TextBlock TextBox.Text="Foo"/>
```

This is allowed in Avalonia because `TextBox.Text` is being resolved to `TemplatedControl.Text` and works because `TemplatedControl.Text` and `TextBlock.Text` actually are the same property - they're both `AddOwner`d attached properties defined on `TextElement`.

~~This PR changes our attached property resolution to only search for attached properties on the stated class, `TextBox` in this case. We retain the same behavior as WPF in that `TextBox.Text` can be set on a `TextBlock` from a style setter.~~

The previous fix was incorrect: leaving the unit tests here for later.

## Breaking changes

~~No API breaking changes but might be best not to port this to stable in case anyone is relying on this edge-case.~~ Now contains only unit tests.

## Fixed issues

Fixes #7925 