### PR TITLE
Prevent DatePicker and TimePicker fields from being overriden

### DIFF
--- a/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
@@ -399,9 +399,9 @@ namespace Avalonia.Controls
             else
             {
                 PseudoClasses.Set(":hasnodate", true);
-                _monthText!.Text = "month";
-                _yearText!.Text = "year";
-                _dayText!.Text = "day";
+                _monthText!.Text ??= "month";
+                _yearText!.Text ??= "year";
+                _dayText!.Text ??= "day";
             }
         }
 

--- a/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
@@ -251,8 +251,8 @@ namespace Avalonia.Controls
             }
             else
             {
-                _hourText.Text = "hour";
-                _minuteText.Text = "minute";
+                _hourText.Text ??= "hour";
+                _minuteText.Text ??= "minute";
                 PseudoClasses.Set(":hasnotime", true);
 
                 _periodText.Text = DateTime.Now.Hour >= 12 ? CultureInfo.CurrentCulture.DateTimeFormat.PMDesignator :


### PR DESCRIPTION
## What does the pull request do?
The text displayed for a `DatePicker` or `TimePicker` which has no value set is hardcoded. This PR only sets the respective `TextBlock`'s text to the hardcoded value if another value has not yet been supplied (i.e. through styling).

## What is the current behavior?
Currently any text set through styling gets overwritten.

## What is the updated/expected behavior with this PR?
Adding the following style:
```xml
<Style Selector="DatePicker:hasnodate /template/ TextBlock#MonthText">
    <Setter Property="Text" Value="Monat" />
</Style>
```

This should cause an unset `DatePicker` to display the text "Monat" (German for "month") in the month's column.

