### PR TITLE
Fix Viewbox layout invalidation.

### DIFF
--- a/src/Avalonia.Controls/Viewbox.cs
+++ b/src/Avalonia.Controls/Viewbox.cs
@@ -168,6 +168,8 @@ namespace Avalonia.Controls
 
                         if (_child is not null)
                             VisualChildren.Add(_child);
+
+                        InvalidateMeasure();
                     }
                 }
             }

--- a/tests/Avalonia.Controls.UnitTests/ViewboxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ViewboxTests.cs
@@ -181,6 +181,32 @@ namespace Avalonia.Controls.UnitTests
             Assert.Null(child.GetLogicalParent());
         }
 
+        [Fact]
+        public void Changing_Child_Should_Invalidate_Layout()
+        {
+            var target = new Viewbox();
+
+            target.Child = new Canvas
+            {
+                Width = 100,
+                Height = 100,
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(target.DesiredSize));
+            Assert.Equal(new Size(100, 100), target.DesiredSize);
+
+            target.Child = new Canvas
+            {
+                Width = 200,
+                Height = 200,
+            };
+
+            target.Measure(Size.Infinity);
+            target.Arrange(new Rect(target.DesiredSize));
+            Assert.Equal(new Size(200, 200), target.DesiredSize);
+        }
+
         private bool TryGetScale(Viewbox viewbox, out Vector scale)
         {
             if (viewbox.InternalTransform is null)


### PR DESCRIPTION
## What does the pull request do?

#8122 introduced an internal container control which hosts the child of `Viewbox`, but it had a problem in that it wasn't invalidating layout when its child changes.

Added a failing test for this situation and a simple fix.
