### PR TITLE
replace mouse and touch events to pointer event to fix issue #8200

### DIFF
--- a/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor
+++ b/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor
@@ -1,14 +1,12 @@
 ﻿<div id="container" class="avalonia-container" tabindex="0" oncontextmenu="return false;"
-     ontouchstart="@OnTouchStart"
-     ontouchend="@OnTouchEnd"
      ontouchcancel="@OnTouchCancel"
      ontouchmove="@OnTouchMove"
-     onmousemove="@OnMouseMove"
-     onmousedown="@OnMouseDown"
-     onmouseup="@OnMouseUp"
      onwheel="@OnWheel"
      onkeydown="@OnKeyDown"
-     onkeyup="@OnKeyUp">
+     onkeyup="@OnKeyUp"
+     onpointerdown="@OnPointerDown"
+     onpointerup="@OnPointerUp"
+     onpointermove="@OnPointerMove">
     
     <canvas id="htmlCanvas" @ref="_htmlCanvas" @attributes="AdditionalAttributes"/>
 

--- a/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor.cs
+++ b/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor.cs
@@ -56,25 +56,7 @@ namespace Avalonia.Web.Blazor
         {
             return _nativeControlHost ?? throw new InvalidOperationException("Blazor View wasn't initialized yet");
         }
-
-        private void OnTouchStart(TouchEventArgs e)
-        {
-            foreach (var touch in e.ChangedTouches)
-            {
-                _topLevelImpl.RawTouchEvent(RawPointerEventType.TouchBegin, new Point(touch.ClientX, touch.ClientY),
-                    GetModifiers(e), touch.Identifier);
-            }
-        }
-
-        private void OnTouchEnd(TouchEventArgs e)
-        {
-            foreach (var touch in e.ChangedTouches)
-            {
-                _topLevelImpl.RawTouchEvent(RawPointerEventType.TouchEnd, new Point(touch.ClientX, touch.ClientY),
-                    GetModifiers(e), touch.Identifier);
-            }
-        }
-
+                
         private void OnTouchCancel(TouchEventArgs e)
         {
             foreach (var touch in e.ChangedTouches)
@@ -93,53 +75,72 @@ namespace Avalonia.Web.Blazor
             }
         }
 
-        private void OnMouseMove(MouseEventArgs e)
+        private void OnPointerMove(Microsoft.AspNetCore.Components.Web.PointerEventArgs e)
         {
-            _topLevelImpl.RawMouseEvent(RawPointerEventType.Move, new Point(e.ClientX, e.ClientY), GetModifiers(e));
+            if (e.PointerType == "mouse")
+            {
+                _topLevelImpl.RawMouseEvent(RawPointerEventType.Move, new Point(e.ClientX, e.ClientY), GetModifiers(e));
+            }
         }
 
-        private void OnMouseUp(MouseEventArgs e)
+        private void OnPointerUp(Microsoft.AspNetCore.Components.Web.PointerEventArgs e)
         {
-            RawPointerEventType type = default;
-
-            switch (e.Button)
+            if (e.PointerType == "touch")
             {
-                case 0:
-                    type = RawPointerEventType.LeftButtonUp;
-                    break;
-
-                case 1:
-                    type = RawPointerEventType.MiddleButtonUp;
-                    break;
-
-                case 2:
-                    type = RawPointerEventType.RightButtonUp;
-                    break;
+                _topLevelImpl.RawTouchEvent(RawPointerEventType.TouchEnd, new Point(e.ClientX, e.ClientY),
+                    GetModifiers(e), e.PointerId);
             }
+            else if (e.PointerType == "mouse")
+            {
+                RawPointerEventType type = default;
 
-            _topLevelImpl.RawMouseEvent(type, new Point(e.ClientX, e.ClientY), GetModifiers(e));
+                switch (e.Button)
+                {
+                    case 0:
+                        type = RawPointerEventType.LeftButtonUp;
+                        break;
+
+                    case 1:
+                        type = RawPointerEventType.MiddleButtonUp;
+                        break;
+
+                    case 2:
+                        type = RawPointerEventType.RightButtonUp;
+                        break;
+                }
+
+                _topLevelImpl.RawMouseEvent(type, new Point(e.ClientX, e.ClientY), GetModifiers(e));
+            }
         }
 
-        private void OnMouseDown(MouseEventArgs e)
+        private void OnPointerDown(Microsoft.AspNetCore.Components.Web.PointerEventArgs e)
         {
-            RawPointerEventType type = default;
-
-            switch (e.Button)
+            if (e.PointerType == "touch")
             {
-                case 0:
-                    type = RawPointerEventType.LeftButtonDown;
-                    break;
-
-                case 1:
-                    type = RawPointerEventType.MiddleButtonDown;
-                    break;
-
-                case 2:
-                    type = RawPointerEventType.RightButtonDown;
-                    break;
+                _topLevelImpl.RawTouchEvent(RawPointerEventType.TouchBegin, new Point(e.ClientX, e.ClientY),
+                    GetModifiers(e), e.PointerId);
             }
+            else if (e.PointerType == "mouse")
+            {
+                RawPointerEventType type = default;
 
-            _topLevelImpl.RawMouseEvent(type, new Point(e.ClientX, e.ClientY), GetModifiers(e));
+                switch (e.Button)
+                {
+                    case 0:
+                        type = RawPointerEventType.LeftButtonDown;
+                        break;
+
+                    case 1:
+                        type = RawPointerEventType.MiddleButtonDown;
+                        break;
+
+                    case 2:
+                        type = RawPointerEventType.RightButtonDown;
+                        break;
+                }
+
+                _topLevelImpl.RawMouseEvent(type, new Point(e.ClientX, e.ClientY), GetModifiers(e));
+            }
         }
 
         private void OnWheel(WheelEventArgs e)
@@ -189,7 +190,7 @@ namespace Avalonia.Web.Blazor
             return modifiers;
         }
 
-        private static RawInputModifiers GetModifiers(MouseEventArgs e)
+        private static RawInputModifiers GetModifiers(Microsoft.AspNetCore.Components.Web.PointerEventArgs e)
         {
             var modifiers = RawInputModifiers.None;
 

--- a/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor.cs
+++ b/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor.cs
@@ -56,7 +56,7 @@ namespace Avalonia.Web.Blazor
         {
             return _nativeControlHost ?? throw new InvalidOperationException("Blazor View wasn't initialized yet");
         }
-                
+        
         private void OnTouchCancel(TouchEventArgs e)
         {
             foreach (var touch in e.ChangedTouches)
@@ -77,7 +77,7 @@ namespace Avalonia.Web.Blazor
 
         private void OnPointerMove(Microsoft.AspNetCore.Components.Web.PointerEventArgs e)
         {
-            if (e.PointerType == "mouse")
+            if (e.PointerType != "touch")
             {
                 _topLevelImpl.RawMouseEvent(RawPointerEventType.Move, new Point(e.ClientX, e.ClientY), GetModifiers(e));
             }
@@ -90,7 +90,7 @@ namespace Avalonia.Web.Blazor
                 _topLevelImpl.RawTouchEvent(RawPointerEventType.TouchEnd, new Point(e.ClientX, e.ClientY),
                     GetModifiers(e), e.PointerId);
             }
-            else if (e.PointerType == "mouse")
+            else
             {
                 RawPointerEventType type = default;
 
@@ -120,7 +120,7 @@ namespace Avalonia.Web.Blazor
                 _topLevelImpl.RawTouchEvent(RawPointerEventType.TouchBegin, new Point(e.ClientX, e.ClientY),
                     GetModifiers(e), e.PointerId);
             }
-            else if (e.PointerType == "mouse")
+            else
             {
                 RawPointerEventType type = default;
 


### PR DESCRIPTION
## What does the pull request do?
merges mouse and touch events into pointer events


## What is the current behavior?
on touch devices both mouse and touch events are produced by the browser, then Avalonia produces 2 click events


## What is the updated/expected behavior with this PR?
on touch devices a single click event

## Fixed issues
Fixes #8200 
