### PR TITLE
Fix FlyoutBase/ContextMenu memory leak

### DIFF
--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -450,6 +450,11 @@ namespace Avalonia.Controls
             if (sender is Control control
                 && control.ContextMenu is ContextMenu contextMenu)
             {
+                if (contextMenu._popup?.Parent == control)
+                {
+                    ((ISetLogicalParent)contextMenu._popup).SetParent(null);
+                }
+
                 contextMenu.Close();
             }
         }

--- a/src/Avalonia.Controls/Flyouts/FlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/FlyoutBase.cs
@@ -175,7 +175,8 @@ namespace Avalonia.Controls.Primitives
 
             IsOpen = false;
             Popup.IsOpen = false;
-
+            ((ISetLogicalParent)Popup).SetParent(null);
+            
             // Ensure this isn't active
             _transientDisposable?.Dispose();
             _transientDisposable = null;

--- a/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
@@ -447,6 +447,27 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Should_Reset_Popup_Parent_On_Target_Detached()
+        {
+            using (Application())
+            {
+                var userControl = new UserControl();
+                var window = PreparedWindow(userControl);
+                window.Show();
+                
+                var menu = new ContextMenu();
+                userControl.ContextMenu = menu;
+                menu.Open();
+                
+                var popup = Assert.IsType<Popup>(menu.Parent);
+                Assert.NotNull(popup.Parent);
+                
+                window.Content = null;
+                Assert.Null(popup.Parent);
+            }
+        }
+
+        [Fact]
         public void Context_Menu_In_Resources_Can_Be_Shared()
         {
             using (Application())

--- a/tests/Avalonia.Controls.UnitTests/FlyoutTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/FlyoutTests.cs
@@ -433,6 +433,26 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Should_Reset_Popup_Parent_On_Target_Detached()
+        {
+            using (CreateServicesWithFocus())
+            {
+                var userControl = new UserControl();
+                var window = PreparedWindow(userControl);
+                window.Show();
+                
+                var flyout = new TestFlyout();
+                flyout.ShowAt(userControl);
+                
+                var popup = Assert.IsType<Popup>(flyout.Popup);
+                Assert.NotNull(popup.Parent);
+                
+                window.Content = null;
+                Assert.Null(popup.Parent);
+            }
+        }
+
+        [Fact]
         public void ContextFlyout_Can_Be_Set_In_Styles()
         {
             using (CreateServicesWithFocus())
@@ -548,6 +568,11 @@ namespace Avalonia.Controls.UnitTests
                 0,
                 new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonPressed),
                 KeyModifiers.None);
+        }
+        
+        public class TestFlyout : Flyout
+        {
+            public new Popup Popup => base.Popup;
         }
     }
 }


### PR DESCRIPTION
## What is the current behavior?

Both FlyoutBase and ContextMenu set Popup.Parent, but do not reset it correctly.
Fixed and added tests.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/8214