### PR TITLE
OSX: Disable parent chrome buttons when modal is shown

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -175,9 +175,10 @@
 
     _isExtended = false;
 
-#ifdef IS_NSPANEL
-    [self setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces|NSWindowCollectionBehaviorFullScreenAuxiliary];
-#endif
+    if(self.isDialog)
+    {
+        [self setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces|NSWindowCollectionBehaviorFullScreenAuxiliary];
+    }
 
     return self;
 }
@@ -259,6 +260,10 @@
 -(void) setEnabled:(bool)enable
 {
     _isEnabled = enable;
+    
+    [[self standardWindowButton:NSWindowCloseButton] setEnabled:enable];
+    [[self standardWindowButton:NSWindowMiniaturizeButton] setEnabled:enable];
+    [[self standardWindowButton:NSWindowZoomButton] setEnabled:enable];
 }
 
 -(void)becomeKeyWindow

--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -29,24 +29,12 @@ void WindowImpl::HideOrShowTrafficLights() {
         return;
     }
 
-    for (id subview in Window.contentView.superview.subviews) {
-        if ([subview isKindOfClass:NSClassFromString(@"NSTitlebarContainerView")]) {
-            NSView *titlebarView = [subview subviews][0];
-            for (id button in titlebarView.subviews) {
-                if ([button isKindOfClass:[NSButton class]]) {
-                    if (_isClientAreaExtended) {
-                        auto wantsChrome = (_extendClientHints & AvnSystemChrome) || (_extendClientHints & AvnPreferSystemChrome);
-
-                        [button setHidden:!wantsChrome];
-                    } else {
-                        [button setHidden:(_decorations != SystemDecorationsFull)];
-                    }
-
-                    [button setWantsLayer:true];
-                }
-            }
-        }
-    }
+    bool wantsChrome = (_extendClientHints & AvnSystemChrome) || (_extendClientHints & AvnPreferSystemChrome);
+    bool hasTrafficLights = _isClientAreaExtended ? !wantsChrome : _decorations != SystemDecorationsFull;
+    
+    [[Window standardWindowButton:NSWindowCloseButton] setHidden:hasTrafficLights];
+    [[Window standardWindowButton:NSWindowMiniaturizeButton] setHidden:hasTrafficLights];
+    [[Window standardWindowButton:NSWindowZoomButton] setHidden:hasTrafficLights];
 }
 
 void WindowImpl::OnInitialiseNSWindow(){

--- a/samples/ControlCatalog/Pages/DialogsPage.xaml
+++ b/samples/ControlCatalog/Pages/DialogsPage.xaml
@@ -20,7 +20,7 @@
                  Text="Window dialogs" />
       <Button Name="DecoratedWindow">Decorated _window</Button>
       <Button Name="DecoratedWindowDialog">Decorated w_indow (dialog)</Button>
-      <Button Name="Dialog">_Dialog</Button>
+      <Button Name="Dialog" ToolTip.Tip="Shows a dialog">_Dialog</Button>
       <Button Name="DialogNoTaskbar">Dialog (_No taskbar icon)</Button>
       <Button Name="OwnedWindow">Own_ed window</Button>
       <Button Name="OwnedWindowNoTaskbar">Owned window (No tas_kbar icon)</Button>

--- a/samples/ControlCatalog/Pages/DialogsPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DialogsPage.xaml.cs
@@ -142,6 +142,7 @@ namespace ControlCatalog.Pages
         private Window CreateSampleWindow()
         {
             Button button;
+            Button dialogButton;
             
             var window = new Window
             {
@@ -158,6 +159,12 @@ namespace ControlCatalog.Pages
                             HorizontalAlignment = HorizontalAlignment.Center,
                             Content = "Click to close",
                             IsDefault = true
+                        }),
+                        (dialogButton = new Button
+                        {
+                            HorizontalAlignment = HorizontalAlignment.Center,
+                            Content = "Dialog",
+                            IsDefault = false
                         })
                     }
                 },
@@ -165,6 +172,12 @@ namespace ControlCatalog.Pages
             };
 
             button.Click += (_, __) => window.Close();
+            dialogButton.Click += (_, __) =>
+            {
+                var dialog = CreateSampleWindow();
+                dialog.Height = 200;
+                dialog.ShowDialog(window);
+            };
 
             return window;
         }


### PR DESCRIPTION
Disable titlebar buttons when child modal is open.