### PR TITLE
OSX Shadow invalidation when window sized

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -294,6 +294,7 @@ HRESULT WindowBaseImpl::Resize(double x, double y, AvnPlatformResizeReason reaso
 
             if(Window != nullptr) {
                 [Window setContentSize:lastSize];
+                [Window invalidateShadow];
             }
         }
         @finally {

--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -139,6 +139,8 @@ void WindowImpl::BringToFront()
         [Window orderFront:nullptr];
     }
     
+    [Window invalidateShadow];
+    
     for(auto iterator = _children.begin(); iterator != _children.end(); iterator++)
     {
         (*iterator)->BringToFront();


### PR DESCRIPTION
I think this fix got lost in various merges and refactorings.