### PR TITLE
Use own Pen (if set) in GeometryDrawing.GetBounds

### DIFF
--- a/src/Avalonia.Visuals/Media/GeometryDrawing.cs
+++ b/src/Avalonia.Visuals/Media/GeometryDrawing.cs
@@ -68,7 +68,8 @@ namespace Avalonia.Media
 
         public override Rect GetBounds()
         {
-            return Geometry?.GetRenderBounds(s_boundsPen) ?? Rect.Empty;
+            IPen pen = Pen ?? s_boundsPen;
+            return Geometry?.GetRenderBounds(pen) ?? Rect.Empty;
         }
     }
 }

--- a/tests/Avalonia.RenderTests/Media/GeometryDrawingTests.cs
+++ b/tests/Avalonia.RenderTests/Media/GeometryDrawingTests.cs
@@ -1,0 +1,52 @@
+﻿using Avalonia.Media;
+using Xunit;
+
+#if AVALONIA_SKIA
+namespace Avalonia.Skia.RenderTests
+#else
+
+using Avalonia.Direct2D1.RenderTests;
+
+namespace Avalonia.Direct2D1.RenderTests.Media
+#endif
+{
+    public class GeometryDrawingTests : TestBase
+    {
+        public GeometryDrawingTests()
+            : base(@"Media\GeometryDrawing")
+        {
+        }
+
+        private GeometryDrawing CreateGeometryDrawing()
+        {
+            GeometryDrawing geometryDrawing = new GeometryDrawing();
+            EllipseGeometry ellipse = new EllipseGeometry();
+            ellipse.RadiusX = 100;
+            ellipse.RadiusY = 100;
+            geometryDrawing.Geometry = ellipse;
+            return geometryDrawing;
+        }
+
+        [Fact]
+        public void DrawingGeometry_WithPen()
+        {
+            GeometryDrawing geometryDrawing = CreateGeometryDrawing();
+            geometryDrawing.Pen = new Pen(new SolidColorBrush(Color.FromArgb(255, 0, 0, 0)), 10);
+
+            Assert.Equal(210, geometryDrawing.GetBounds().Height);
+            Assert.Equal(210, geometryDrawing.GetBounds().Width);
+
+        }
+
+        [Fact]
+        public void DrawingGeometry_WithoutPen()
+        {
+            GeometryDrawing geometryDrawing = CreateGeometryDrawing();
+
+            Assert.Equal(200, geometryDrawing.GetBounds().Height);
+            Assert.Equal(200, geometryDrawing.GetBounds().Width);
+        }
+
+
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
Use the GeometryDrawing pen in GetBounds

## What is the current behavior?
The pen thickness wasn't use in GeometryDrawing.GetBounds, leading to a cropped image, see issue #5249 

## What is the updated/expected behavior with this PR?
Fix the GeometryDrawing

## How was the solution implemented (if it's not obvious)?
it is obvious :)
This file was renamed in master from Avalonia.Visuals to Avalonia.Base, the change here is only in 0.10.x but the same change should also be merged in the master if accepted.


## Checklist

- [x] Added unit tests (if possible)?


## Breaking changes

## Obsoletions / Deprecations

## Fixed issues
Fixes #5249