### PR TITLE
re-set popup.Parent if its no longer set.

### DIFF
--- a/src/Avalonia.Controls/Flyouts/FlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/FlyoutBase.cs
@@ -219,7 +219,7 @@ namespace Avalonia.Controls.Primitives
                 ((ISetLogicalParent)Popup).SetParent(null);
             }
 
-            if (Popup.PlacementTarget != placementTarget)
+            if (Popup.Parent == null || Popup.PlacementTarget != placementTarget)
             {
                 Popup.PlacementTarget = Target = placementTarget;
                 ((ISetLogicalParent)Popup).SetParent(placementTarget);

--- a/tests/Avalonia.Controls.UnitTests/FlyoutTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/FlyoutTests.cs
@@ -451,6 +451,28 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Null(popup.Parent);
             }
         }
+        
+        [Fact]
+        public void Should_Reset_Popup_Parent_On_Target_Attach_Following_Detach()
+        {
+            using (CreateServicesWithFocus())
+            {
+                var userControl = new UserControl();
+                var window = PreparedWindow(userControl);
+                window.Show();
+                
+                var flyout = new TestFlyout();
+                flyout.ShowAt(userControl);
+                
+                var popup = Assert.IsType<Popup>(flyout.Popup);
+                Assert.NotNull(popup.Parent);
+                
+                flyout.Hide();
+                
+                flyout.ShowAt(userControl);
+                Assert.NotNull(popup.Parent);
+            }
+        }
 
         [Fact]
         public void ContextFlyout_Can_Be_Set_In_Styles()


### PR DESCRIPTION
Since #8236 flyouts would not open more than once.

This was because the Popup.Parent was set to null, and there was no condition to set it again when opening second time.


Added unit test.