### PR TITLE
Remove the need for <Style.Children> around nested styles.

### DIFF
--- a/src/Avalonia.Base/Styling/Style.cs
+++ b/src/Avalonia.Base/Styling/Style.cs
@@ -94,7 +94,6 @@ namespace Avalonia.Styling
         /// <summary>
         /// Gets the style's setters.
         /// </summary>
-        [Content]
         public IList<ISetter> Setters => _setters ??= new List<ISetter>();
 
         /// <summary>
@@ -106,6 +105,9 @@ namespace Avalonia.Styling
         IReadOnlyList<IStyle> IStyle.Children => (IReadOnlyList<IStyle>?)_children ?? Array.Empty<IStyle>();
 
         public event EventHandler? OwnerChanged;
+
+        public void Add(ISetter setter) => Setters.Add(setter);
+        public void Add(IStyle style) => Children.Add(style);
 
         public SelectorMatchResult TryAttach(IStyleable target, IStyleHost? host)
         {

--- a/src/Avalonia.Themes.Fluent/Controls/Button.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/Button.xaml
@@ -40,54 +40,49 @@
       </ControlTemplate>
     </Setter>
 
-    <Style.Children>
+    <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPointerOver}" />
+      <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundPointerOver}" />
+    </Style>
+
+    <Style Selector="^:pressed  /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPressed}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPressed}" />
+      <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundPressed}" />
+    </Style>
+
+    <Style Selector="^:disabled /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushDisabled}" />
+      <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
+    </Style>
+
+    <Style Selector="^.accent">
+      <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource AccentButtonBackground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentButtonForeground}" />
+      </Style>
+
       <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPointerOver}" />
-        <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundPointerOver}" />
+        <Setter Property="Background" Value="{DynamicResource AccentButtonBackgroundPointerOver}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrushPointerOver}" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentButtonForegroundPointerOver}" />
       </Style>
 
       <Style Selector="^:pressed  /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPressed}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPressed}" />
-        <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundPressed}" />
+        <Setter Property="Background" Value="{DynamicResource AccentButtonBackgroundPressed}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrushPressed}" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentButtonForegroundPressed}" />
       </Style>
 
       <Style Selector="^:disabled /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushDisabled}" />
-        <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
+        <Setter Property="Background" Value="{DynamicResource AccentButtonBackgroundDisabled}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrushDisabled}" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentButtonForegroundDisabled}" />
       </Style>
-
-      <Style Selector="^.accent">
-        <Style.Children>
-          <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
-            <Setter Property="Background" Value="{DynamicResource AccentButtonBackground}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrush}" />
-            <Setter Property="Foreground" Value="{DynamicResource AccentButtonForeground}" />
-          </Style>
-
-          <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-            <Setter Property="Background" Value="{DynamicResource AccentButtonBackgroundPointerOver}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrushPointerOver}" />
-            <Setter Property="Foreground" Value="{DynamicResource AccentButtonForegroundPointerOver}" />
-          </Style>
-
-          <Style Selector="^:pressed  /template/ ContentPresenter#PART_ContentPresenter">
-            <Setter Property="Background" Value="{DynamicResource AccentButtonBackgroundPressed}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrushPressed}" />
-            <Setter Property="Foreground" Value="{DynamicResource AccentButtonForegroundPressed}" />
-          </Style>
-
-          <Style Selector="^:disabled /template/ ContentPresenter#PART_ContentPresenter">
-            <Setter Property="Background" Value="{DynamicResource AccentButtonBackgroundDisabled}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrushDisabled}" />
-            <Setter Property="Foreground" Value="{DynamicResource AccentButtonForegroundDisabled}" />
-          </Style>
-        </Style.Children>
-      </Style>
-    </Style.Children>
-  </Style>
+    </Style>  </Style>
 
   <Style Selector="Button, RepeatButton, ToggleButton, DropDownButton">
     <Setter Property="RenderTransform" Value="none" />

--- a/src/Avalonia.Themes.Fluent/Controls/Button.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/Button.xaml
@@ -82,7 +82,8 @@
         <Setter Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrushDisabled}" />
         <Setter Property="Foreground" Value="{DynamicResource AccentButtonForegroundDisabled}" />
       </Style>
-    </Style>  </Style>
+    </Style>
+  </Style>
 
   <Style Selector="Button, RepeatButton, ToggleButton, DropDownButton">
     <Setter Property="RenderTransform" Value="none" />

--- a/src/Avalonia.Themes.Fluent/Controls/CheckBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/CheckBox.xaml
@@ -292,5 +292,6 @@
       <Style Selector="^ /template/ Path#CheckGlyph">
         <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundIndeterminateDisabled}" />
       </Style>
-    </Style>  </Style>
+    </Style>
+  </Style>
 </Style>

--- a/src/Avalonia.Themes.Fluent/Controls/CheckBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/CheckBox.xaml
@@ -56,266 +56,241 @@
     </ControlTemplate>
   </Setter>
 
-  <Style.Children>
-    <!-- Unchecked Normal State -->
+  <!-- Unchecked Normal State -->
+  <Style Selector="^ /template/ Border#NormalRectangle">
+    <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeUnchecked}" />
+    <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillUnchecked}" />
+  </Style>
+
+  <Style Selector="^ /template/ Path#CheckGlyph">
+    <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundUnchecked}" />
+    <Setter Property="Opacity" Value="0" />
+  </Style>
+
+  <!-- Unchecked PointerOver State -->
+  <Style Selector="^:pointerover">
+    <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+      <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundUncheckedPointerOver}" />
+    </Style>
+
+    <Style Selector="^ /template/ Border#PART_Border">
+      <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundUncheckedPointerOver}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUncheckedPointerOver}" />
+    </Style>
+
     <Style Selector="^ /template/ Border#NormalRectangle">
-      <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeUnchecked}" />
-      <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillUnchecked}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeUncheckedPointerOver}" />
+      <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillUncheckedPointerOver}" />
     </Style>
 
     <Style Selector="^ /template/ Path#CheckGlyph">
-      <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundUnchecked}" />
-      <Setter Property="Opacity" Value="0" />
+      <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundUncheckedPointerOver}" />
+    </Style>
+  </Style>
+
+  <!-- Unchecked Pressed State -->
+  <Style Selector="^:pressed">
+    <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+      <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundUncheckedPressed}" />
     </Style>
 
-    <!-- Unchecked PointerOver State -->
+    <Style Selector="^ /template/ Border#PART_Border">
+      <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundUncheckedPressed}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUncheckedPressed}" />
+    </Style>
+
+    <Style Selector="^ /template/ Border#NormalRectangle">
+      <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeUncheckedPressed}" />
+      <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillUncheckedPressed}" />
+    </Style>
+
+    <Style Selector="^ /template/ Path#CheckGlyph">
+      <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundUncheckedPressed}" />
+    </Style>
+  </Style>
+
+  <!-- Unchecked Disabled state -->
+  <Style Selector="^:disabled">
+    <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+      <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundUncheckedDisabled}" />
+    </Style>
+
+    <Style Selector="^ /template/ Border#PART_Border">
+      <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundUncheckedDisabled}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUncheckedDisabled}" />
+    </Style>
+
+    <Style Selector="^ /template/ Border#NormalRectangle">
+      <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeUncheckedDisabled}" />
+      <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillUncheckedDisabled}" />
+    </Style>
+
+    <Style Selector="^ /template/ Path#CheckGlyph">
+      <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundUncheckedDisabled}" />
+    </Style>
+  </Style>
+
+  <Style Selector="^:checked">
+    <!-- Checked Normal State -->
+    <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundChecked}" />
+    <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundChecked}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushChecked}" />
+
+    <Style Selector="^ /template/ Border#NormalRectangle">
+      <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundFillChecked}" />
+      <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillChecked}" />
+    </Style>
+
+    <Style Selector="^ /template/ Path#CheckGlyph">
+      <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundChecked}" />
+      <Setter Property="Data" Value="M1507 31L438 1101L-119 543L-29 453L438 919L1417 -59L1507 31Z" />
+      <Setter Property="Width" Value="9" />
+      <Setter Property="Opacity" Value="1" />
+      <Setter Property="FlowDirection" Value="LeftToRight" />
+    </Style>
+
+    <!-- Checked PointerOver State -->
     <Style Selector="^:pointerover">
-      <Style.Children>
-        <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
-          <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundUncheckedPointerOver}" />
-        </Style>
+      <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+        <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundCheckedPointerOver}" />
+      </Style>
 
-        <Style Selector="^ /template/ Border#PART_Border">
-          <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundUncheckedPointerOver}" />
-          <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUncheckedPointerOver}" />
-        </Style>
+      <Style Selector="^ /template/ Border#PART_Border">
+        <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundCheckedPointerOver}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushCheckedPointerOver}" />
+      </Style>
 
-        <Style Selector="^ /template/ Border#NormalRectangle">
-          <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeUncheckedPointerOver}" />
-          <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillUncheckedPointerOver}" />
-        </Style>
+      <Style Selector="^ /template/ Border#NormalRectangle">
+        <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeCheckedPointerOver}" />
+        <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillCheckedPointerOver}" />
+      </Style>
 
-        <Style Selector="^ /template/ Path#CheckGlyph">
-          <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundUncheckedPointerOver}" />
-        </Style>
-      </Style.Children>
+      <Style Selector="^ /template/ Path#CheckGlyph">
+        <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundCheckedPointerOver}" />
+      </Style>
     </Style>
 
-    <!-- Unchecked Pressed State -->
+    <!-- Checked Pressed State -->
     <Style Selector="^:pressed">
-      <Style.Children>
-        <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
-          <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundUncheckedPressed}" />
-        </Style>
+      <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+        <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundCheckedPressed}" />
+      </Style>
 
-        <Style Selector="^ /template/ Border#PART_Border">
-          <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundUncheckedPressed}" />
-          <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUncheckedPressed}" />
-        </Style>
+      <Style Selector="^ /template/ Border#PART_Border">
+        <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundCheckedPressed}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushCheckedPressed}" />
+      </Style>
 
-        <Style Selector="^ /template/ Border#NormalRectangle">
-          <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeUncheckedPressed}" />
-          <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillUncheckedPressed}" />
-        </Style>
+      <Style Selector="^ /template/ Border#NormalRectangle">
+        <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeCheckedPressed}" />
+        <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillCheckedPressed}" />
+      </Style>
 
-        <Style Selector="^ /template/ Path#CheckGlyph">
-          <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundUncheckedPressed}" />
-        </Style>
-      </Style.Children>
+      <Style Selector="^ /template/ Path#CheckGlyph">
+        <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundCheckedPressed}" />
+      </Style>
     </Style>
 
-    <!-- Unchecked Disabled state -->
+    <!-- Checked Disabled State -->
     <Style Selector="^:disabled">
-      <Style.Children>
-        <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
-          <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundUncheckedDisabled}" />
-        </Style>
+      <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+        <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundCheckedDisabled}" />
+      </Style>
 
-        <Style Selector="^ /template/ Border#PART_Border">
-          <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundUncheckedDisabled}" />
-          <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushUncheckedDisabled}" />
-        </Style>
+      <Style Selector="^ /template/ Border#PART_Border">
+        <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundCheckedDisabled}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushCheckedDisabled}" />
+      </Style>
 
-        <Style Selector="^ /template/ Border#NormalRectangle">
-          <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeUncheckedDisabled}" />
-          <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillUncheckedDisabled}" />
-        </Style>
+      <Style Selector="^ /template/ Border#NormalRectangle">
+        <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeCheckedDisabled}" />
+        <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillCheckedDisabled}" />
+      </Style>
 
-        <Style Selector="^ /template/ Path#CheckGlyph">
-          <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundUncheckedDisabled}" />
-        </Style>
-      </Style.Children>
+      <Style Selector="^ /template/ Path#CheckGlyph">
+        <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundCheckedDisabled}" />
+      </Style>
+    </Style>
+  </Style>
+
+  <Style Selector="^:indeterminate">
+    <!-- Indeterminate Normal State -->
+    <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundIndeterminate}" />
+    <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundIndeterminate}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushIndeterminate}" />
+
+    <Style Selector="^ /template/ Border#NormalRectangle">
+      <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeIndeterminate}" />
+      <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillIndeterminate}" />
     </Style>
 
-    <Style Selector="^:checked">
-      <!-- Checked Normal State -->
-      <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundChecked}" />
-      <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundChecked}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushChecked}" />
-
-      <Style.Children>
-        <Style Selector="^ /template/ Border#NormalRectangle">
-          <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundFillChecked}" />
-          <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillChecked}" />
-        </Style>
-
-        <Style Selector="^ /template/ Path#CheckGlyph">
-          <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundChecked}" />
-          <Setter Property="Data" Value="M1507 31L438 1101L-119 543L-29 453L438 919L1417 -59L1507 31Z" />
-          <Setter Property="Width" Value="9" />
-          <Setter Property="Opacity" Value="1" />
-          <Setter Property="FlowDirection" Value="LeftToRight" />
-        </Style>
-
-        <!-- Checked PointerOver State -->
-        <Style Selector="^:pointerover">
-          <Style.Children>
-            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
-              <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundCheckedPointerOver}" />
-            </Style>
-
-            <Style Selector="^ /template/ Border#PART_Border">
-              <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundCheckedPointerOver}" />
-              <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushCheckedPointerOver}" />
-            </Style>
-
-            <Style Selector="^ /template/ Border#NormalRectangle">
-              <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeCheckedPointerOver}" />
-              <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillCheckedPointerOver}" />
-            </Style>
-
-            <Style Selector="^ /template/ Path#CheckGlyph">
-              <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundCheckedPointerOver}" />
-            </Style>
-          </Style.Children>
-        </Style>
-
-        <!-- Checked Pressed State -->
-        <Style Selector="^:pressed">
-          <Style.Children>
-            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
-              <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundCheckedPressed}" />
-            </Style>
-
-            <Style Selector="^ /template/ Border#PART_Border">
-              <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundCheckedPressed}" />
-              <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushCheckedPressed}" />
-            </Style>
-
-            <Style Selector="^ /template/ Border#NormalRectangle">
-              <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeCheckedPressed}" />
-              <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillCheckedPressed}" />
-            </Style>
-
-            <Style Selector="^ /template/ Path#CheckGlyph">
-              <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundCheckedPressed}" />
-            </Style>
-          </Style.Children>
-        </Style>
-
-        <!-- Checked Disabled State -->
-        <Style Selector="^:disabled">
-          <Style.Children>
-            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
-              <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundCheckedDisabled}" />
-            </Style>
-
-            <Style Selector="^ /template/ Border#PART_Border">
-              <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundCheckedDisabled}" />
-              <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushCheckedDisabled}" />
-            </Style>
-
-            <Style Selector="^ /template/ Border#NormalRectangle">
-              <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeCheckedDisabled}" />
-              <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillCheckedDisabled}" />
-            </Style>
-
-            <Style Selector="^ /template/ Path#CheckGlyph">
-              <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundCheckedDisabled}" />
-            </Style>
-          </Style.Children>
-        </Style>
-      </Style.Children>
+    <Style Selector="^ /template/ Path#CheckGlyph">
+      <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundIndeterminate}" />
+      <Setter Property="Data" Value="M1536 1536v-1024h-1024v1024h1024z" />
+      <Setter Property="Width" Value="7" />
+      <Setter Property="Opacity" Value="1" />
     </Style>
 
-    <Style Selector="^:indeterminate">
-      <!-- Indeterminate Normal State -->
-      <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundIndeterminate}" />
-      <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundIndeterminate}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushIndeterminate}" />
+    <!-- Indeterminate PointerOver State -->
+    <Style Selector="^:pointerover">
+      <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+        <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundIndeterminatePointerOver}" />
+      </Style>
 
-      <Style.Children>
-        <Style Selector="^ /template/ Border#NormalRectangle">
-          <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeIndeterminate}" />
-          <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillIndeterminate}" />
-        </Style>
+      <Style Selector="^ /template/ Border#PART_Border">
+        <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundIndeterminatePointerOver}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushIndeterminatePointerOver}" />
+      </Style>
 
-        <Style Selector="^ /template/ Path#CheckGlyph">
-          <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundIndeterminate}" />
-          <Setter Property="Data" Value="M1536 1536v-1024h-1024v1024h1024z" />
-          <Setter Property="Width" Value="7" />
-          <Setter Property="Opacity" Value="1" />
-        </Style>
+      <Style Selector="^ /template/ Border#NormalRectangle">
+        <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeIndeterminatePointerOver}" />
+        <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillIndeterminatePointerOver}" />
+      </Style>
 
-        <!-- Indeterminate PointerOver State -->
-        <Style Selector="^:pointerover">
-          <Style.Children>
-            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
-              <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundIndeterminatePointerOver}" />
-            </Style>
-
-            <Style Selector="^ /template/ Border#PART_Border">
-              <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundIndeterminatePointerOver}" />
-              <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushIndeterminatePointerOver}" />
-            </Style>
-
-            <Style Selector="^ /template/ Border#NormalRectangle">
-              <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeIndeterminatePointerOver}" />
-              <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillIndeterminatePointerOver}" />
-            </Style>
-
-            <Style Selector="^ /template/ Path#CheckGlyph">
-              <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundIndeterminatePointerOver}" />
-            </Style>
-          </Style.Children>
-        </Style>
-
-        <!-- Indeterminate Pressed State -->
-        <Style Selector="^:pressed">
-          <Style.Children>
-            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
-              <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundIndeterminatePressed}" />
-            </Style>
-
-            <Style Selector="^ /template/ Border#PART_Border">
-              <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundIndeterminatePressed}" />
-              <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushIndeterminatePressed}" />
-            </Style>
-
-            <Style Selector="^ /template/ Border#NormalRectangle">
-              <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeIndeterminatePressed}" />
-              <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillIndeterminatePressed}" />
-            </Style>
-
-            <Style Selector="^ /template/ Path#CheckGlyph">
-              <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundIndeterminatePressed}" />
-            </Style>
-          </Style.Children>
-        </Style>
-
-        <!-- Indeterminate Disabled State -->
-        <Style Selector="^:disabled">
-          <Style.Children>
-            <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
-              <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundIndeterminateDisabled}" />
-            </Style>
-
-            <Style Selector="^ /template/ Border#PART_Border">
-              <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundIndeterminateDisabled}" />
-              <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushIndeterminateDisabled}" />
-            </Style>
-
-            <Style Selector="^ /template/ Border#NormalRectangle">
-              <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeIndeterminateDisabled}" />
-              <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillIndeterminateDisabled}" />
-            </Style>
-
-            <Style Selector="^ /template/ Path#CheckGlyph">
-              <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundIndeterminateDisabled}" />
-            </Style>
-          </Style.Children>
-        </Style>
-      </Style.Children>
+      <Style Selector="^ /template/ Path#CheckGlyph">
+        <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundIndeterminatePointerOver}" />
+      </Style>
     </Style>
-  </Style.Children>
+
+    <!-- Indeterminate Pressed State -->
+    <Style Selector="^:pressed">
+      <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+        <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundIndeterminatePressed}" />
+      </Style>
+
+      <Style Selector="^ /template/ Border#PART_Border">
+        <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundIndeterminatePressed}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushIndeterminatePressed}" />
+      </Style>
+
+      <Style Selector="^ /template/ Border#NormalRectangle">
+        <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeIndeterminatePressed}" />
+        <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillIndeterminatePressed}" />
+      </Style>
+
+      <Style Selector="^ /template/ Path#CheckGlyph">
+        <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundIndeterminatePressed}" />
+      </Style>
+    </Style>
+
+    <!-- Indeterminate Disabled State -->
+    <Style Selector="^:disabled">
+      <Style Selector="^ /template/ ContentPresenter#ContentPresenter">
+        <Setter Property="Foreground" Value="{DynamicResource CheckBoxForegroundIndeterminateDisabled}" />
+      </Style>
+
+      <Style Selector="^ /template/ Border#PART_Border">
+        <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundIndeterminateDisabled}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxBorderBrushIndeterminateDisabled}" />
+      </Style>
+
+      <Style Selector="^ /template/ Border#NormalRectangle">
+        <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckBackgroundStrokeIndeterminateDisabled}" />
+        <Setter Property="Background" Value="{DynamicResource CheckBoxCheckBackgroundFillIndeterminateDisabled}" />
+      </Style>
+
+      <Style Selector="^ /template/ Path#CheckGlyph">
+        <Setter Property="Fill" Value="{DynamicResource CheckBoxCheckGlyphForegroundIndeterminateDisabled}" />
+      </Style>
+    </Style>  </Style>
 </Style>

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
@@ -628,11 +628,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
              xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
     <Window.Styles>
         <Style Selector='Border'>
-            <Style.Children>
-                <Style Selector='^.foo'>
-                    <Setter Property='Background' Value='Red'/>
-                </Style>
-            </Style.Children>
+            <Style Selector='^.foo'>
+                <Setter Property='Background' Value='Red'/>
+            </Style>
         </Style>
     </Window.Styles>
     <StackPanel>


### PR DESCRIPTION
## What does the pull request do?

One of the most requested changes from #8024 was to remove the need to enclose nested styles in a `<Style.Children>` element, so:

```xml
<Style Selector='Border'>
  <Setter Property='Background' Value='Blue'/>

  <Style.Children>
    <Style Selector='^.foo'>
	  <Setter Property='Background' Value='Red'/>
    </Style>
  </Style.Children>
</Style>
```

Could be written as:

```xml
<Style Selector='Border'>
  <Setter Property='Background' Value='Blue'/>

  <Style Selector='^.foo'>
    <Setter Property='Background' Value='Red'/>
  </Style>
</Style>
```

I thought this was going to be difficult to do, but turns out it's really easy: I just needed to remove the `[Content]` attribute from `Style` and add two `Add` methods to add the relevant types (`ISetter` and `IStyle`).
