### PR TITLE
prevent segfault when closing app with child windows open.

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -91,11 +91,8 @@ HRESULT WindowImpl::SetParent(IAvnWindow *parent) {
         if(_parent != nullptr)
         {
             _parent->_children.remove(this);
-            auto parent = _parent;
             
-            dispatch_async(dispatch_get_main_queue(), ^{
-                parent->BringToFront();
-            });
+            _parent->BringToFront();
         }
 
         auto cparent = dynamic_cast<WindowImpl *>(parent);
@@ -122,20 +119,23 @@ HRESULT WindowImpl::SetParent(IAvnWindow *parent) {
 
 void WindowImpl::BringToFront()
 {
-    if(IsDialog())
+    if(Window != nullptr)
     {
-        Activate();
-    }
-    else
-    {
-        [Window orderFront:nullptr];
-    }
-    
-    [Window invalidateShadow];
-    
-    for(auto iterator = _children.begin(); iterator != _children.end(); iterator++)
-    {
-        (*iterator)->BringToFront();
+        if(IsDialog())
+        {
+            Activate();
+        }
+        else
+        {
+            [Window orderFront:nullptr];
+        }
+        
+        [Window invalidateShadow];
+        
+        for(auto iterator = _children.begin(); iterator != _children.end(); iterator++)
+        {
+            (*iterator)->BringToFront();
+        }
     }
 }
 


### PR DESCRIPTION
was possible to get a segfault on app close due to a dispatch.

Seems to be unnecessary.