### PR TITLE
osx: fix crash when modal dialog is opened over fullscreen parent.

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -564,6 +564,11 @@ bool WindowImpl::IsDialog() {
 
 NSWindowStyleMask WindowImpl::GetStyle() {
     unsigned long s = NSWindowStyleMaskBorderless;
+    
+    if(_actualWindowState == FullScreen)
+    {
+        s |= NSWindowStyleMaskFullScreen;
+    }
 
     switch (_decorations) {
         case SystemDecorationsNone:


### PR DESCRIPTION
if you opened a modal dialog from an OSX fullscreen mode window, it would crash, because our update style method, just overwrites flags and doesnt take into account FS flag.
