### PR TITLE
RazorViewTopLevel will now test keys first on Code, then Key as a backup

### DIFF
--- a/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor.cs
+++ b/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor.cs
@@ -233,12 +233,12 @@ namespace Avalonia.Web.Blazor
 
         private void OnKeyDown(KeyboardEventArgs e)
         {
-            _topLevelImpl.RawKeyboardEvent(RawKeyEventType.KeyDown, e.Code, GetModifiers(e));
+            _topLevelImpl.RawKeyboardEvent(RawKeyEventType.KeyDown, e.Code, e.Key, GetModifiers(e));
         }
 
         private void OnKeyUp(KeyboardEventArgs e)
         {
-            _topLevelImpl.RawKeyboardEvent(RawKeyEventType.KeyUp, e.Code, GetModifiers(e));
+            _topLevelImpl.RawKeyboardEvent(RawKeyEventType.KeyUp, e.Code, e.Key, GetModifiers(e));
         }
 
         private void OnInput(ChangeEventArgs e)

--- a/src/Web/Avalonia.Web.Blazor/RazorViewTopLevelImpl.cs
+++ b/src/Web/Avalonia.Web.Blazor/RazorViewTopLevelImpl.cs
@@ -91,9 +91,16 @@ namespace Avalonia.Web.Blazor
             }
         }
 
-        public void RawKeyboardEvent(RawKeyEventType type, string key, RawInputModifiers modifiers)
+        public void RawKeyboardEvent(RawKeyEventType type, string code, string key, RawInputModifiers modifiers)
         {
-            if (Keycodes.KeyCodes.TryGetValue(key, out var avkey))
+            if (Keycodes.KeyCodes.TryGetValue(code, out var avkey))
+            {
+                if (_inputRoot is { })
+                {
+                    Input?.Invoke(new RawKeyEventArgs(KeyboardDevice, Timestamp, _inputRoot, type, avkey, modifiers));
+                }
+            }
+            else if (Keycodes.KeyCodes.TryGetValue(key, out avkey))
             {
                 if (_inputRoot is { })
                 {


### PR DESCRIPTION
This is an android specific hack. the chrome browser event sends an empty string on Code property so this will test both Code and Key properties to match to an Avalonia key. If the user is on a sane system then Code will be used to match, else it will failover to try and match with Key.

## What does the pull request do?
allows backspace and enter to work on android


## What is the current behavior?
backspace and enter do not fire events


## What is the updated/expected behavior with this PR?
non char keys should still invoke events


## How was the solution implemented (if it's not obvious)?
added a second try failover in RazorViewTopLevelImpl to test for the event Key property if the event Code property fails to match a key

