### PR TITLE
Check if BindingValue actually has a value before logging an error

### DIFF
--- a/src/Avalonia.Base/Reactive/TypedBindingAdapter.cs
+++ b/src/Avalonia.Base/Reactive/TypedBindingAdapter.cs
@@ -30,13 +30,15 @@ namespace Avalonia.Reactive
             }
             catch (InvalidCastException e)
             {
+                var unwrappedValue = value.HasValue ? value.Value : null;
+                
                 Logger.TryGet(LogEventLevel.Error, LogArea.Binding)?.Log(
                     _target,
                     "Binding produced invalid value for {$Property} ({$PropertyType}): {$Value} ({$ValueType})",
                     _property.Name,
                     _property.PropertyType,
-                    value.Value,
-                    value.Value?.GetType());
+                    unwrappedValue,
+                    unwrappedValue?.GetType());
                 PublishNext(BindingValue<T>.BindingError(e));
             }
         }


### PR DESCRIPTION
## What does the pull request do?

Yesterday on https://github.com/AvaloniaUI/Avalonia/pull/8215 branch I randomly got NRE while testing it and couldn't reproduce anymore. As "value.Convert" might fail for value types if input is null. And TypedBindingAdapter tried to log this error but failed while reading nonexistent Value.

This PR add safety check before logging.
