### PR TITLE
Fix calculation of inverted matrix

### DIFF
--- a/src/Avalonia.Base/Matrix.cs
+++ b/src/Avalonia.Base/Matrix.cs
@@ -450,13 +450,13 @@ namespace Avalonia
             
             inverted = new Matrix(
                 (_m22 * _m33 - _m32 * _m23) * invdet,
-                (_m13 * _m31 - _m12 * _m33) * invdet,
+                (_m13 * _m32 - _m12 * _m33) * invdet,
                 (_m12 * _m23 - _m13 * _m22) * invdet,
                 (_m23 * _m31 - _m21 * _m33) * invdet,
                 (_m11 * _m33 - _m13 * _m31) * invdet,
                 (_m21 * _m13 - _m11 * _m23) * invdet,
                 (_m21 * _m32 - _m31 * _m22) * invdet,
-                (_m21 * _m12 - _m11 * _m32) * invdet,
+                (_m31 * _m12 - _m11 * _m32) * invdet,
                 (_m11 * _m22 - _m21 * _m12) * invdet
                 );
             

--- a/tests/Avalonia.Base.UnitTests/Media/MatrixTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/MatrixTests.cs
@@ -35,9 +35,9 @@ namespace Avalonia.Base.UnitTests.Media
         {
             var matrix = new Matrix(1, 2, 3, 0, 1, 4, 5, 6, 0);
             var inverted = matrix.Invert();
-            var expected = new Matrix(-24, 18, 5, 20, -15, -4, -5, 4, 1);
 
-            Assert.Equal(expected, inverted);
+            Assert.Equal(matrix * inverted, Matrix.Identity);
+            Assert.Equal(inverted * matrix, Matrix.Identity);
         }
 
         [Fact]

--- a/tests/Avalonia.Base.UnitTests/Media/MatrixTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/MatrixTests.cs
@@ -31,6 +31,16 @@ namespace Avalonia.Base.UnitTests.Media
         }
 
         [Fact]
+        public void Invert_Should_Work()
+        {
+            var matrix = new Matrix(1, 2, 3, 0, 1, 4,5,6,0);
+            var inverted = matrix.Invert();
+            var expected = new Matrix(-24, 18, 5, 20, -15, -4, -5, 4, 1);
+
+            Assert.Equal(expected, inverted);
+        }
+
+        [Fact]
         public void Can_Decompose_Translation()
         {
             var matrix = Matrix.CreateTranslation(5, 10);

--- a/tests/Avalonia.Base.UnitTests/Media/MatrixTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/MatrixTests.cs
@@ -33,7 +33,7 @@ namespace Avalonia.Base.UnitTests.Media
         [Fact]
         public void Invert_Should_Work()
         {
-            var matrix = new Matrix(1, 2, 3, 0, 1, 4,5,6,0);
+            var matrix = new Matrix(1, 2, 3, 0, 1, 4, 5, 6, 0);
             var inverted = matrix.Invert();
             var expected = new Matrix(-24, 18, 5, 20, -15, -4, -5, 4, 1);
 


### PR DESCRIPTION
## What does the pull request do?
Fix calculation of the inverted matrix.


## What is the current behavior?
After 3D Transformation implementation transforms were broken. For example, if the transform is applied, pointer events are not raised.  Repro:
```
<Panel Width="100" Height="100" Background="Red" RenderTransform="rotate(45deg)" PointerPressed="OnPointerPressed" />

private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
{
    //this is not called
    ...
}
```
      
## What is the updated/expected behavior with this PR?
This PR fixes transforms calculations.
