### PR TITLE
OSX: fix call to virtual method from ctor.

### DIFF
--- a/native/Avalonia.Native/src/OSX/PopupImpl.mm
+++ b/native/Avalonia.Native/src/OSX/PopupImpl.mm
@@ -26,16 +26,12 @@ private:
     PopupImpl(IAvnWindowEvents* events, IAvnGlContext* gl) : WindowBaseImpl(events, gl)
     {
         WindowEvents = events;
+        [Window setLevel:NSPopUpMenuWindowLevel];
     }
 protected:
     virtual NSWindowStyleMask GetStyle() override
     {
         return NSWindowStyleMaskBorderless;
-    }
-    
-    virtual void OnInitialiseNSWindow () override
-    {
-        [Window setLevel:NSPopUpMenuWindowLevel];
     }
 
 public:

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
@@ -106,8 +106,6 @@ protected:
     virtual NSWindowStyleMask GetStyle();
 
     void UpdateStyle();
-                           
-    virtual void OnInitialiseNSWindow ();
 
 private:
     void CreateNSWindow (bool isDialog);

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -567,11 +567,6 @@ void WindowBaseImpl::CreateNSWindow(bool isDialog) {
     }
 }
 
-void WindowBaseImpl::OnInitialiseNSWindow()
-{
-    
-}
-
 void WindowBaseImpl::InitialiseNSWindow() {
     if(Window != nullptr) {
         [Window setContentView:StandardContainer];
@@ -594,8 +589,6 @@ void WindowBaseImpl::InitialiseNSWindow() {
                 [GetWindowProtocol() showWindowMenuWithAppMenu];
             }
         }
-        
-        OnInitialiseNSWindow();
     }
 }
 

--- a/native/Avalonia.Native/src/OSX/WindowImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.h
@@ -93,8 +93,6 @@ BEGIN_INTERFACE_MAP()
 
     virtual bool IsDialog() override;
     
-    virtual void OnInitialiseNSWindow() override;
-    
     virtual void BringToFront () override;
     
     bool CanBecomeKeyWindow ();
@@ -103,6 +101,7 @@ protected:
     virtual NSWindowStyleMask GetStyle() override;
 
 private:
+    void OnInitialiseNSWindow();
     NSString *_lastTitle;
 };
 

--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -24,6 +24,8 @@ WindowImpl::WindowImpl(IAvnWindowEvents *events, IAvnGlContext *gl) : WindowBase
     _lastTitle = @"";
     _parent = nullptr;
     WindowEvents = events;
+    
+    OnInitialiseNSWindow();
 }
 
 void WindowImpl::HideOrShowTrafficLights() {
@@ -41,6 +43,7 @@ void WindowImpl::HideOrShowTrafficLights() {
 
 void WindowImpl::OnInitialiseNSWindow(){
     [GetWindowProtocol() setCanBecomeKeyWindow:true];
+    
     [Window disableCursorRects];
     [Window setTabbingMode:NSWindowTabbingModeDisallowed];
     [Window setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];


### PR DESCRIPTION
Refactoring, lead to calling method InitialiseNSWindow from ctor... which called virtual method OnInitialiseNSWindow ().

When base class ctor has not completed... vtable isnt setup yet... and the override of OnInitialiseNSWindow would not be called.