### PR TITLE
osx: restore missing api for cef - electron compatibility

### DIFF
--- a/native/Avalonia.Native/src/OSX/app.mm
+++ b/native/Avalonia.Native/src/OSX/app.mm
@@ -82,6 +82,17 @@ ComPtr<IAvnApplicationEvents> _events;
         _isHandlingSendEvent = oldHandling;
     }
 }
+
+// This is needed for certain embedded controls DO NOT REMOVE..
+- (BOOL) isHandlingSendEvent
+{
+    return _isHandlingSendEvent;
+}
+
+- (void)setHandlingSendEvent:(BOOL)handlingSendEvent
+{
+    _isHandlingSendEvent = handlingSendEvent;
+}
 @end
 
 extern void InitializeAvnApp(IAvnApplicationEvents* events)


### PR DESCRIPTION
Unused methods need to be there because electron / cef try to call them.