### PR TITLE
[X11] Added support for the basic version of _NET_WM_SYNC_REQUEST protocol

### DIFF
--- a/src/Avalonia.X11/X11Atoms.cs
+++ b/src/Avalonia.X11/X11Atoms.cs
@@ -155,6 +155,7 @@ namespace Avalonia.X11
         public readonly IntPtr _NET_FRAME_EXTENTS;
         public readonly IntPtr _NET_WM_PING;
         public readonly IntPtr _NET_WM_SYNC_REQUEST;
+        public readonly IntPtr _NET_WM_SYNC_REQUEST_COUNTER;
         public readonly IntPtr _NET_SYSTEM_TRAY_S;
         public readonly IntPtr _NET_SYSTEM_TRAY_ORIENTATION;
         public readonly IntPtr _NET_SYSTEM_TRAY_OPCODE;

--- a/src/Avalonia.X11/X11Info.cs
+++ b/src/Avalonia.X11/X11Info.cs
@@ -33,6 +33,7 @@ namespace Avalonia.X11
         public IntPtr LastActivityTimestamp { get; set; }
         public XVisualInfo? TransparentVisualInfo { get; set; }
         public bool HasXim { get; set; }
+        public bool HasXSync { get; set; }
         public IntPtr DefaultFontSet { get; set; }
         
         public unsafe X11Info(IntPtr display, IntPtr deferredDisplay, bool useXim)
@@ -100,6 +101,15 @@ namespace Avalonia.X11
             catch
             {
                 //Ignore, XI is not supported
+            }
+
+            try
+            {
+                HasXSync = XSyncInitialize(display, out _, out _) != Status.Success;
+            }
+            catch
+            {
+                //Ignore, XSync is not supported
             }
         }
     }

--- a/src/Avalonia.X11/XLib.cs
+++ b/src/Avalonia.X11/XLib.cs
@@ -542,6 +542,18 @@ namespace Avalonia.X11
         public static extern int XRRQueryExtension (IntPtr dpy,
             out int event_base_return,
             out int error_base_return);
+        
+        [DllImport(libX11Ext)]
+        public static extern Status XSyncInitialize(IntPtr dpy, out int event_base_return, out int error_base_return);
+
+        [DllImport(libX11Ext)]
+        public static extern IntPtr XSyncCreateCounter(IntPtr dpy, XSyncValue initialValue);
+        
+        [DllImport(libX11Ext)]
+        public static extern int XSyncDestroyCounter(IntPtr dpy, IntPtr counter);
+        
+        [DllImport(libX11Ext)]
+        public static extern int XSyncSetCounter(IntPtr dpy, IntPtr counter, XSyncValue value);
 
         [DllImport(libX11Randr)]
         public static extern int XRRQueryVersion(IntPtr dpy,
@@ -626,6 +638,11 @@ namespace Avalonia.X11
             public int height;
             public int bw;
             public int d;
+        }
+        
+        public struct XSyncValue {
+            public int Hi;
+            public uint Lo;
         }
 
         public static bool XGetGeometry(IntPtr display, IntPtr window, out XGeometry geo)


### PR DESCRIPTION
This protocol allows us to notify the window manager that we've finished drawing a frame after we got a resize request. That prevents the window manager from resizing the window too often.

Current behavior:

https://user-images.githubusercontent.com/1067584/171918556-ec01edf2-2ed5-402d-b662-b61bb3e9736d.mp4

New behavior:

https://user-images.githubusercontent.com/1067584/171918563-8f1a7a67-d22b-4969-9d90-59f30a895dff.mp4




