### PR TITLE
Update AvaloniaView.razor to use event callback factory

### DIFF
--- a/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor
+++ b/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor
@@ -1,18 +1,18 @@
 ﻿<div id="container" class="avalonia-container" tabindex="0" oncontextmenu="return false;"
-     ontouchcancel="@OnTouchCancel"
-     ontouchmove="@OnTouchMove"
-     onwheel="@OnWheel"
-     onkeydown="@OnKeyDown"
-     onkeyup="@OnKeyUp"
-     onpointerdown="@OnPointerDown"
-     onpointerup="@OnPointerUp"
-     onpointermove="@OnPointerMove">
+     @ontouchcancel="OnTouchCancel"
+     @ontouchmove="OnTouchMove"
+     @onwheel="OnWheel"
+     @onkeydown="OnKeyDown"
+     @onkeyup="OnKeyUp"
+     @onpointerdown="OnPointerDown"
+     @onpointerup="OnPointerUp"
+     @onpointermove="OnPointerMove">
     
     <canvas id="htmlCanvas" @ref="_htmlCanvas" @attributes="AdditionalAttributes"/>
 
 	<div id="nativeControlsContainer" @ref="_nativeControlsContainer" />
 
-    <input id="inputElement" @ref="_inputElement" type="text" oninput="@OnInput" 
+    <input id="inputElement" @ref="_inputElement" type="text" @oninput="OnInput" 
         onpaste="return false;"
         oncopy="return false;" 
         oncut="return false;"/>


### PR DESCRIPTION
change to the razor code so the events are added to and invoked by the AspNetCore.EventCallbackFactory rather than an action pointer attached to the event

## How was the solution implemented (if it's not obvious)?
moved the attribute point in the razor code to the event instead of the event handler
