### PR TITLE
mixing touch and pointer breaks gestures

### DIFF
--- a/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor
+++ b/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor
@@ -1,12 +1,11 @@
 ﻿<div id="container" class="avalonia-container" tabindex="0" oncontextmenu="return false;"
-     @ontouchcancel="OnTouchCancel"
-     @ontouchmove="OnTouchMove"
      @onwheel="OnWheel"
      @onkeydown="OnKeyDown"
      @onkeyup="OnKeyUp"
      @onpointerdown="OnPointerDown"
      @onpointerup="OnPointerUp"
-     @onpointermove="OnPointerMove">
+     @onpointermove="OnPointerMove"
+     @onpointercancel="OnPointerCancel">
     
     <canvas id="htmlCanvas" @ref="_htmlCanvas" @attributes="AdditionalAttributes"/>
 
@@ -19,6 +18,9 @@
 </div>
 
 <style>
+#container{
+    touch-action: none;
+}
 #htmlCanvas {
     opacity: 1;
     background-color: #ccc;

--- a/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor.cs
+++ b/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor.cs
@@ -57,27 +57,23 @@ namespace Avalonia.Web.Blazor
             return _nativeControlHost ?? throw new InvalidOperationException("Blazor View wasn't initialized yet");
         }
         
-        private void OnTouchCancel(TouchEventArgs e)
+        private void OnPointerCancel(Microsoft.AspNetCore.Components.Web.PointerEventArgs e)
         {
-            foreach (var touch in e.ChangedTouches)
+            if (e.PointerType == "touch")
             {
-                _topLevelImpl.RawTouchEvent(RawPointerEventType.TouchCancel, new Point(touch.ClientX, touch.ClientY),
-                    GetModifiers(e), touch.Identifier);
-            }
-        }
-
-        private void OnTouchMove(TouchEventArgs e)
-        {
-            foreach (var touch in e.ChangedTouches)
-            {
-                _topLevelImpl.RawTouchEvent(RawPointerEventType.TouchUpdate, new Point(touch.ClientX, touch.ClientY),
-                    GetModifiers(e), touch.Identifier);
+                _topLevelImpl.RawTouchEvent(RawPointerEventType.TouchCancel, new Point(e.ClientX, e.ClientY),
+                    GetModifiers(e), e.PointerId);
             }
         }
 
         private void OnPointerMove(Microsoft.AspNetCore.Components.Web.PointerEventArgs e)
         {
-            if (e.PointerType != "touch")
+            if (e.PointerType == "touch")
+            {
+                _topLevelImpl.RawTouchEvent(RawPointerEventType.TouchUpdate, new Point(e.ClientX, e.ClientY),
+                    GetModifiers(e), e.PointerId);
+            }
+            else
             {
                 _topLevelImpl.RawMouseEvent(RawPointerEventType.Move, new Point(e.ClientX, e.ClientY), GetModifiers(e));
             }
@@ -170,22 +166,6 @@ namespace Avalonia.Web.Blazor
 
             if ((e.Buttons & 4L) == 4)
                 modifiers |= RawInputModifiers.MiddleMouseButton;
-
-            return modifiers;
-        }
-
-        private static RawInputModifiers GetModifiers(TouchEventArgs e)
-        {
-            var modifiers = RawInputModifiers.None;
-
-            if (e.CtrlKey)
-                modifiers |= RawInputModifiers.Control;
-            if (e.AltKey)
-                modifiers |= RawInputModifiers.Alt;
-            if (e.ShiftKey)
-                modifiers |= RawInputModifiers.Shift;
-            if (e.MetaKey)
-                modifiers |= RawInputModifiers.Meta;
 
             return modifiers;
         }


### PR DESCRIPTION
## What does the pull request do?
Converts AvaloniaView in Avalonia.Web to use only pointer events for all mouse and touch. The current mixing of touch and pointer was breaking gesture tracking (the pointing device id was not the same) so things like scrolling would not work on mobile.

## What is the current behavior?
Multiple pointer ids were generated for the same pointer.

## What is the updated/expected behavior with this PR?
Same pointer id across all events

## How was the solution implemented (if it's not obvious)?
Removed touch events, added compatible pointer events. 
Added touch-action: none to container div css, this is needed to allow for continuous pointer movement with touch.

