### PR TITLE
Fix FluentTheme density style

### DIFF
--- a/src/Avalonia.Themes.Fluent/FluentTheme.cs
+++ b/src/Avalonia.Themes.Fluent/FluentTheme.cs
@@ -83,6 +83,14 @@ namespace Avalonia.Themes.Fluent
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
             base.OnPropertyChanged(change);
+            
+            if (_loaded is null)
+            {
+                // If style wasn't yet loaded, no need to change children styles,
+                // it will be applied later in Loaded getter.
+                return;
+            }
+            
             if (change.Property == ModeProperty)
             {
                 if (Mode == FluentThemeMode.Dark)


### PR DESCRIPTION
## What does the pull request do?

During FluentTheme initialization DensityStyle was trying to be applied twice (in Loader getter and OnPropertyChanged).
Fixed.

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/8289
