### PR TITLE
Fix 12PM bug in TimePickerPresenter 

### DIFF
--- a/src/Avalonia.Controls/DateTimePickers/TimePickerPresenter.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePickerPresenter.cs
@@ -194,7 +194,7 @@ namespace Avalonia.Controls
 
             if (ClockIdentifier == "12HourClock")
             {
-                hr = per == 1 ? (hr == 12) ? 12:hr + 12 : per == 0 && hr == 12 ? 0 : hr;
+                hr = per == 1 ? (hr == 12) ? 12 : hr + 12 : per == 0 && hr == 12 ? 0 : hr;
             }
 
             Time = new TimeSpan(hr, min, 0);

--- a/src/Avalonia.Controls/DateTimePickers/TimePickerPresenter.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePickerPresenter.cs
@@ -194,7 +194,7 @@ namespace Avalonia.Controls
 
             if (ClockIdentifier == "12HourClock")
             {
-                hr = per == 1 ? hr + 12 : per == 0 && hr == 12 ? 0 : hr;
+                hr = per == 1 ? (hr == 12) ? 12:hr + 12 : per == 0 && hr == 12 ? 0 : hr;
             }
 
             Time = new TimeSpan(hr, min, 0);


### PR DESCRIPTION
## What does the pull request do?
fixes a bug in TimePickerPresenter, when using 12hour clock and selecting 12:XX PM


## What is the current behavior?
the time span returns 24 hours instead of 12 hours


## What is the updated/expected behavior with this PR?
ignore +12 when hour is exactly 12 and period is 1

