### PR TITLE
Fix DirectBindingSubscription NRE

### DIFF
--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -935,7 +935,8 @@ namespace Avalonia
 
             public void Dispose()
             {
-                _subscription.Dispose();
+                // _subscription can be null, if Subscribe failed with an exception.
+                _subscription?.Dispose();
                 _owner._directBindings!.Remove(this);
             }
 


### PR DESCRIPTION
## What does the pull request do?
Fixes NRE in DirectBindingSubscription, when subscription fails with any other error and OnError tries to dispose non-existent subscription. 

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/2855
