### PR TITLE
Set window margin to 0 WinUiComp is used - issue #8316

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -904,17 +904,20 @@ namespace Avalonia.Win32
                 borderCaptionThickness.top = 1;
             }
 
+            //using a default margin of 0 when using WinUiComp removes artefacts when resizing. See issue #8316
+            var defaultMargin = _isUsingComposition ? 0 : 1;
+
             MARGINS margins = new MARGINS();
-            margins.cxLeftWidth = 1;
-            margins.cxRightWidth = 1;
-            margins.cyBottomHeight = 1;
+            margins.cxLeftWidth = defaultMargin;
+            margins.cxRightWidth = defaultMargin;
+            margins.cyBottomHeight = defaultMargin;
 
             if (_extendTitleBarHint != -1)
             {
                 borderCaptionThickness.top = (int)(_extendTitleBarHint * RenderScaling);
             }
 
-            margins.cyTopHeight = _extendChromeHints.HasAllFlags(ExtendClientAreaChromeHints.SystemChrome) && !_extendChromeHints.HasAllFlags(ExtendClientAreaChromeHints.PreferSystemChrome) ? borderCaptionThickness.top : 1;
+            margins.cyTopHeight = _extendChromeHints.HasAllFlags(ExtendClientAreaChromeHints.SystemChrome) && !_extendChromeHints.HasAllFlags(ExtendClientAreaChromeHints.PreferSystemChrome) ? borderCaptionThickness.top : defaultMargin;
 
             if (WindowState == WindowState.Maximized)
             {


### PR DESCRIPTION
## What does the pull request do?
This sets the default window margin on Windows using WinUIComp to 0 to avoid artefacts when resizing the window with ExtendClientAreaToDecorationsHint="true" .

This avoids graphic artefacts, especially visible when using dark themes, as resizing will draw a white background.

Using a margin of 0 will make the background transparent, and thus remove the visual artefact.

See issue #8316 .


## What is the current behavior?
The window margin is always set to 1


## What is the updated/expected behavior with this PR?
If window margin will be set to 0 if WinUIComp is used


## How was the solution implemented (if it's not obvious)?


## Checklist

- [ ] Added unit tests (if possible)? Not possible
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixed #8316 
