### PR TITLE
Rename to PointerEntered and PointerExited

### DIFF
--- a/src/Avalonia.Base/Input/IInputElement.cs
+++ b/src/Avalonia.Base/Input/IInputElement.cs
@@ -47,7 +47,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when the pointer leaves the control.
         /// </summary>
-        event EventHandler<PointerEventArgs>? PointerLeave;
+        event EventHandler<PointerEventArgs>? PointerExited;
 
         /// <summary>
         /// Occurs when the pointer is pressed over the control.

--- a/src/Avalonia.Base/Input/IInputElement.cs
+++ b/src/Avalonia.Base/Input/IInputElement.cs
@@ -42,7 +42,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when the pointer enters the control.
         /// </summary>
-        event EventHandler<PointerEventArgs>? PointerEnter;
+        event EventHandler<PointerEventArgs>? PointerEntered;
 
         /// <summary>
         /// Occurs when the pointer leaves the control.

--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -136,11 +136,11 @@ namespace Avalonia.Input
                 RoutingStrategies.Direct);
 
         /// <summary>
-        /// Defines the <see cref="PointerLeave"/> event.
+        /// Defines the <see cref="PointerExited"/> event.
         /// </summary>
-        public static readonly RoutedEvent<PointerEventArgs> PointerLeaveEvent =
+        public static readonly RoutedEvent<PointerEventArgs> PointerExitedEvent =
             RoutedEvent.Register<InputElement, PointerEventArgs>(
-                nameof(PointerLeave),
+                nameof(PointerExited),
                 RoutingStrategies.Direct);
 
         /// <summary>
@@ -212,8 +212,8 @@ namespace Avalonia.Input
             KeyDownEvent.AddClassHandler<InputElement>((x, e) => x.OnKeyDown(e));
             KeyUpEvent.AddClassHandler<InputElement>((x, e) => x.OnKeyUp(e));
             TextInputEvent.AddClassHandler<InputElement>((x, e) => x.OnTextInput(e));
-            PointerEnteredEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerEnterCore(e));
-            PointerLeaveEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerLeaveCore(e));
+            PointerEnteredEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerEnteredCore(e));
+            PointerExitedEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerExitedCore(e));
             PointerMovedEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerMoved(e));
             PointerPressedEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerPressed(e));
             PointerReleasedEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerReleased(e));
@@ -292,10 +292,10 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when the pointer leaves the control.
         /// </summary>
-        public event EventHandler<PointerEventArgs>? PointerLeave
+        public event EventHandler<PointerEventArgs>? PointerExited
         {
-            add { AddHandler(PointerLeaveEvent, value); }
-            remove { RemoveHandler(PointerLeaveEvent, value); }
+            add { AddHandler(PointerExitedEvent, value); }
+            remove { RemoveHandler(PointerExitedEvent, value); }
         }
 
         /// <summary>
@@ -551,10 +551,10 @@ namespace Avalonia.Input
         }
 
         /// <summary>
-        /// Called before the <see cref="PointerLeave"/> event occurs.
+        /// Called before the <see cref="PointerExited"/> event occurs.
         /// </summary>
         /// <param name="e">The event args.</param>
-        protected virtual void OnPointerLeave(PointerEventArgs e)
+        protected virtual void OnPointerExited(PointerEventArgs e)
         {
         }
 
@@ -647,20 +647,20 @@ namespace Avalonia.Input
         /// Called before the <see cref="PointerEntered"/> event occurs.
         /// </summary>
         /// <param name="e">The event args.</param>
-        private void OnPointerEnterCore(PointerEventArgs e)
+        private void OnPointerEnteredCore(PointerEventArgs e)
         {
             IsPointerOver = true;
             OnPointerEntered(e);
         }
 
         /// <summary>
-        /// Called before the <see cref="PointerLeave"/> event occurs.
+        /// Called before the <see cref="PointerExited"/> event occurs.
         /// </summary>
         /// <param name="e">The event args.</param>
-        private void OnPointerLeaveCore(PointerEventArgs e)
+        private void OnPointerExitedCore(PointerEventArgs e)
         {
             IsPointerOver = false;
-            OnPointerLeave(e);
+            OnPointerExited(e);
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -128,16 +128,20 @@ namespace Avalonia.Input
                 RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
 
         /// <summary>
-        /// Defines the <see cref="PointerEnter"/> event.
+        /// Defines the <see cref="PointerEntered"/> event.
         /// </summary>
-        public static readonly RoutedEvent<PointerEventArgs> PointerEnterEvent =
-            RoutedEvent.Register<InputElement, PointerEventArgs>(nameof(PointerEnter), RoutingStrategies.Direct);
+        public static readonly RoutedEvent<PointerEventArgs> PointerEnteredEvent =
+            RoutedEvent.Register<InputElement, PointerEventArgs>(
+                nameof(PointerEntered),
+                RoutingStrategies.Direct);
 
         /// <summary>
         /// Defines the <see cref="PointerLeave"/> event.
         /// </summary>
         public static readonly RoutedEvent<PointerEventArgs> PointerLeaveEvent =
-            RoutedEvent.Register<InputElement, PointerEventArgs>(nameof(PointerLeave), RoutingStrategies.Direct);
+            RoutedEvent.Register<InputElement, PointerEventArgs>(
+                nameof(PointerLeave),
+                RoutingStrategies.Direct);
 
         /// <summary>
         /// Defines the <see cref="PointerMoved"/> event.
@@ -208,7 +212,7 @@ namespace Avalonia.Input
             KeyDownEvent.AddClassHandler<InputElement>((x, e) => x.OnKeyDown(e));
             KeyUpEvent.AddClassHandler<InputElement>((x, e) => x.OnKeyUp(e));
             TextInputEvent.AddClassHandler<InputElement>((x, e) => x.OnTextInput(e));
-            PointerEnterEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerEnterCore(e));
+            PointerEnteredEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerEnterCore(e));
             PointerLeaveEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerLeaveCore(e));
             PointerMovedEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerMoved(e));
             PointerPressedEvent.AddClassHandler<InputElement>((x, e) => x.OnPointerPressed(e));
@@ -279,10 +283,10 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when the pointer enters the control.
         /// </summary>
-        public event EventHandler<PointerEventArgs>? PointerEnter
+        public event EventHandler<PointerEventArgs>? PointerEntered
         {
-            add { AddHandler(PointerEnterEvent, value); }
-            remove { RemoveHandler(PointerEnterEvent, value); }
+            add { AddHandler(PointerEnteredEvent, value); }
+            remove { RemoveHandler(PointerEnteredEvent, value); }
         }
 
         /// <summary>
@@ -539,10 +543,10 @@ namespace Avalonia.Input
         }
 
         /// <summary>
-        /// Called before the <see cref="PointerEnter"/> event occurs.
+        /// Called before the <see cref="PointerEntered"/> event occurs.
         /// </summary>
         /// <param name="e">The event args.</param>
-        protected virtual void OnPointerEnter(PointerEventArgs e)
+        protected virtual void OnPointerEntered(PointerEventArgs e)
         {
         }
 
@@ -561,7 +565,9 @@ namespace Avalonia.Input
         protected virtual void OnPointerMoved(PointerEventArgs e)
         {
             if (_gestureRecognizers?.HandlePointerMoved(e) == true)
+            {
                 e.Handled = true;
+            }
         }
 
         /// <summary>
@@ -571,7 +577,9 @@ namespace Avalonia.Input
         protected virtual void OnPointerPressed(PointerPressedEventArgs e)
         {
             if (_gestureRecognizers?.HandlePointerPressed(e) == true)
+            {
                 e.Handled = true;
+            }
         }
 
         /// <summary>
@@ -581,7 +589,9 @@ namespace Avalonia.Input
         protected virtual void OnPointerReleased(PointerReleasedEventArgs e)
         {
             if (_gestureRecognizers?.HandlePointerReleased(e) == true)
+            {
                 e.Handled = true;
+            }
         }
 
         /// <summary>
@@ -634,13 +644,13 @@ namespace Avalonia.Input
         }
 
         /// <summary>
-        /// Called before the <see cref="PointerEnter"/> event occurs.
+        /// Called before the <see cref="PointerEntered"/> event occurs.
         /// </summary>
         /// <param name="e">The event args.</param>
         private void OnPointerEnterCore(PointerEventArgs e)
         {
             IsPointerOver = true;
-            OnPointerEnter(e);
+            OnPointerEntered(e);
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Input/PointerOverPreProcessor.cs
+++ b/src/Avalonia.Base/Input/PointerOverPreProcessor.cs
@@ -97,7 +97,7 @@ namespace Avalonia.Input
             // Do not pass rootVisual, when we have unknown (negative) position,
             // so GetPosition won't return invalid values.
             var hasPosition = position.X >= 0 && position.Y >= 0;
-            var e = new PointerEventArgs(InputElement.PointerLeaveEvent, element, pointer,
+            var e = new PointerEventArgs(InputElement.PointerExitedEvent, element, pointer,
                 hasPosition ? root : null, hasPosition ? position : default,
                 timestamp, properties, inputModifiers);
 
@@ -177,7 +177,7 @@ namespace Avalonia.Input
 
             el = root.PointerOverElement;
 
-            var e = new PointerEventArgs(InputElement.PointerLeaveEvent, el, pointer, root, position,
+            var e = new PointerEventArgs(InputElement.PointerExitedEvent, el, pointer, root, position,
                 timestamp, properties, inputModifiers);
             if (el != null && branch != null && !el.IsAttachedToVisualTree)
             {

--- a/src/Avalonia.Base/Input/PointerOverPreProcessor.cs
+++ b/src/Avalonia.Base/Input/PointerOverPreProcessor.cs
@@ -195,7 +195,7 @@ namespace Avalonia.Input
             el = root.PointerOverElement = element;
             _lastPointer = (pointer, root.PointToScreen(position));
 
-            e.RoutedEvent = InputElement.PointerEnterEvent;
+            e.RoutedEvent = InputElement.PointerEnteredEvent;
 
             while (el != null && el != branch)
             {

--- a/src/Avalonia.Controls.ColorPicker/ColorSpectrum/ColorSpectrum.cs
+++ b/src/Avalonia.Controls.ColorPicker/ColorSpectrum/ColorSpectrum.cs
@@ -129,7 +129,7 @@ namespace Avalonia.Controls.Primitives
             if (_inputTarget != null)
             {
                 _inputTarget.PointerEntered += InputTarget_PointerEntered;
-                _inputTarget.PointerLeave += InputTarget_PointerLeave;
+                _inputTarget.PointerExited += InputTarget_PointerExited;
                 _inputTarget.PointerPressed += InputTarget_PointerPressed;
                 _inputTarget.PointerMoved += InputTarget_PointerMoved;
                 _inputTarget.PointerReleased += InputTarget_PointerReleased;
@@ -195,7 +195,7 @@ namespace Avalonia.Controls.Primitives
             if (_inputTarget != null)
             {
                 _inputTarget.PointerEntered -= InputTarget_PointerEntered;
-                _inputTarget.PointerLeave -= InputTarget_PointerLeave;
+                _inputTarget.PointerExited -= InputTarget_PointerExited;
                 _inputTarget.PointerPressed -= InputTarget_PointerPressed;
                 _inputTarget.PointerMoved -= InputTarget_PointerMoved;
                 _inputTarget.PointerReleased -= InputTarget_PointerReleased;
@@ -362,7 +362,7 @@ namespace Avalonia.Controls.Primitives
         }
 
         /// <inheritdoc/>
-        protected override void OnPointerLeave(PointerEventArgs e)
+        protected override void OnPointerExited(PointerEventArgs e)
         {
             // We only want to bother with the color name tool tip if we can provide color names.
             if (_selectionEllipsePanel != null &&
@@ -373,7 +373,7 @@ namespace Avalonia.Controls.Primitives
 
             UpdatePseudoClasses();
 
-            base.OnPointerLeave(e);
+            base.OnPointerExited(e);
         }
 
         /// <inheritdoc/>
@@ -856,8 +856,8 @@ namespace Avalonia.Controls.Primitives
             args.Handled = true;
         }
 
-        /// <inheritdoc cref="InputElement.PointerLeave"/>
-        private void InputTarget_PointerLeave(object? sender, PointerEventArgs args)
+        /// <inheritdoc cref="InputElement.PointerExited"/>
+        private void InputTarget_PointerExited(object? sender, PointerEventArgs args)
         {
             _isPointerOver = false;
             UpdatePseudoClasses();

--- a/src/Avalonia.Controls.ColorPicker/ColorSpectrum/ColorSpectrum.cs
+++ b/src/Avalonia.Controls.ColorPicker/ColorSpectrum/ColorSpectrum.cs
@@ -128,7 +128,7 @@ namespace Avalonia.Controls.Primitives
 
             if (_inputTarget != null)
             {
-                _inputTarget.PointerEnter += InputTarget_PointerEnter;
+                _inputTarget.PointerEntered += InputTarget_PointerEntered;
                 _inputTarget.PointerLeave += InputTarget_PointerLeave;
                 _inputTarget.PointerPressed += InputTarget_PointerPressed;
                 _inputTarget.PointerMoved += InputTarget_PointerMoved;
@@ -194,7 +194,7 @@ namespace Avalonia.Controls.Primitives
 
             if (_inputTarget != null)
             {
-                _inputTarget.PointerEnter -= InputTarget_PointerEnter;
+                _inputTarget.PointerEntered -= InputTarget_PointerEntered;
                 _inputTarget.PointerLeave -= InputTarget_PointerLeave;
                 _inputTarget.PointerPressed -= InputTarget_PointerPressed;
                 _inputTarget.PointerMoved -= InputTarget_PointerMoved;
@@ -848,8 +848,8 @@ namespace Avalonia.Controls.Primitives
             UpdatePseudoClasses();
         }
 
-        /// <inheritdoc cref="InputElement.PointerEnter"/>
-        private void InputTarget_PointerEnter(object? sender, PointerEventArgs args)
+        /// <inheritdoc cref="InputElement.PointerEntered"/>
+        private void InputTarget_PointerEntered(object? sender, PointerEventArgs args)
         {
             _isPointerOver = true;
             UpdatePseudoClasses();

--- a/src/Avalonia.Controls.DataGrid/DataGridCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCell.cs
@@ -139,9 +139,9 @@ namespace Avalonia.Controls
             }
 
         }
-        protected override void OnPointerEnter(PointerEventArgs e)
+        protected override void OnPointerEntered(PointerEventArgs e)
         {
-            base.OnPointerEnter(e);
+            base.OnPointerEntered(e);
 
             if (OwningRow != null)
             {

--- a/src/Avalonia.Controls.DataGrid/DataGridCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCell.cs
@@ -148,9 +148,9 @@ namespace Avalonia.Controls
                 IsMouseOver = true;
             }
         }
-        protected override void OnPointerLeave(PointerEventArgs e)
+        protected override void OnPointerExited(PointerEventArgs e)
         {
-            base.OnPointerLeave(e);
+            base.OnPointerExited(e);
 
             if (OwningRow != null)
             {

--- a/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
@@ -85,7 +85,7 @@ namespace Avalonia.Controls
             PointerReleased += DataGridColumnHeader_PointerReleased;
             PointerMoved += DataGridColumnHeader_PointerMoved;
             PointerEntered += DataGridColumnHeader_PointerEntered;
-            PointerLeave += DataGridColumnHeader_PointerLeave;
+            PointerExited += DataGridColumnHeader_PointerExited;
         }
 
         private void OnAreSeparatorsVisibleChanged(AvaloniaPropertyChangedEventArgs e)
@@ -464,7 +464,7 @@ namespace Avalonia.Controls
             UpdatePseudoClasses();
         }
 
-        private void DataGridColumnHeader_PointerLeave(object sender, PointerEventArgs e)
+        private void DataGridColumnHeader_PointerExited(object sender, PointerEventArgs e)
         {
             if (!IsEnabled)
             {

--- a/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
@@ -83,8 +83,8 @@ namespace Avalonia.Controls
         {
             PointerPressed += DataGridColumnHeader_PointerPressed;
             PointerReleased += DataGridColumnHeader_PointerReleased;
-            PointerMoved += DataGridColumnHeader_PointerMove;
-            PointerEnter += DataGridColumnHeader_PointerEnter;
+            PointerMoved += DataGridColumnHeader_PointerMoved;
+            PointerEntered += DataGridColumnHeader_PointerEntered;
             PointerLeave += DataGridColumnHeader_PointerLeave;
         }
 
@@ -452,7 +452,7 @@ namespace Avalonia.Controls
             SetDragCursor(mousePosition);
         }
 
-        private void DataGridColumnHeader_PointerEnter(object sender, PointerEventArgs e)
+        private void DataGridColumnHeader_PointerEntered(object sender, PointerEventArgs e)
         {
             if (!IsEnabled)
             {
@@ -506,7 +506,7 @@ namespace Avalonia.Controls
             UpdatePseudoClasses();
         }
 
-        private void DataGridColumnHeader_PointerMove(object sender, PointerEventArgs e)
+        private void DataGridColumnHeader_PointerMoved(object sender, PointerEventArgs e)
         {
             if (OwningGrid == null || !IsEnabled)
             {

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -607,9 +607,9 @@ namespace Avalonia.Controls
             }
         }
 
-        protected override void OnPointerEnter(PointerEventArgs e)
+        protected override void OnPointerEntered(PointerEventArgs e)
         {
-            base.OnPointerEnter(e);
+            base.OnPointerEntered(e);
             IsMouseOver = true;
         }
         protected override void OnPointerLeave(PointerEventArgs e)

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -612,10 +612,10 @@ namespace Avalonia.Controls
             base.OnPointerEntered(e);
             IsMouseOver = true;
         }
-        protected override void OnPointerLeave(PointerEventArgs e)
+        protected override void OnPointerExited(PointerEventArgs e)
         {
             IsMouseOver = false;
-            base.OnPointerLeave(e);
+            base.OnPointerExited(e);
         }
 
         internal void ApplyCellsState()

--- a/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
@@ -386,7 +386,7 @@ namespace Avalonia.Controls
             base.OnPointerEntered(e);
         }
 
-        protected override void OnPointerLeave(PointerEventArgs e)
+        protected override void OnPointerExited(PointerEventArgs e)
         {
             if (IsEnabled)
             {
@@ -394,7 +394,7 @@ namespace Avalonia.Controls
                 UpdatePseudoClasses();
             }
 
-            base.OnPointerLeave(e);
+            base.OnPointerExited(e);
         }
 
         private void SetIsCheckedNoCallBack(bool value)

--- a/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
@@ -375,7 +375,7 @@ namespace Avalonia.Controls
             ApplyHeaderStatus();
         }
 
-        protected override void OnPointerEnter(PointerEventArgs e)
+        protected override void OnPointerEntered(PointerEventArgs e)
         {
             if (IsEnabled)
             {
@@ -383,7 +383,7 @@ namespace Avalonia.Controls
                 UpdatePseudoClasses();
             }
 
-            base.OnPointerEnter(e);
+            base.OnPointerEntered(e);
         }
 
         protected override void OnPointerLeave(PointerEventArgs e)

--- a/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
@@ -158,14 +158,14 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
-        protected override void OnPointerEnter(PointerEventArgs e)
+        protected override void OnPointerEntered(PointerEventArgs e)
         {
             if (OwningRow != null)
             {
                 OwningRow.IsMouseOver = true;
             }
 
-            base.OnPointerEnter(e);
+            base.OnPointerEntered(e);
         }
         protected override void OnPointerLeave(PointerEventArgs e)
         {

--- a/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
@@ -167,14 +167,14 @@ namespace Avalonia.Controls.Primitives
 
             base.OnPointerEntered(e);
         }
-        protected override void OnPointerLeave(PointerEventArgs e)
+        protected override void OnPointerExited(PointerEventArgs e)
         {
             if (OwningRow != null)
             {
                 OwningRow.IsMouseOver = false;
             }
 
-            base.OnPointerLeave(e);
+            base.OnPointerExited(e);
         }
 
         //TODO TabStop

--- a/src/Avalonia.Controls/Calendar/CalendarItem.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarItem.cs
@@ -189,7 +189,7 @@ namespace Avalonia.Controls.Primitives
 
                 EventHandler<PointerPressedEventArgs> cellMouseLeftButtonDown = Cell_MouseLeftButtonDown;
                 EventHandler<PointerReleasedEventArgs> cellMouseLeftButtonUp = Cell_MouseLeftButtonUp;
-                EventHandler<PointerEventArgs> cellMouseEnter = Cell_MouseEnter;
+                EventHandler<PointerEventArgs> cellMouseEntered = Cell_MouseEntered;
                 EventHandler<RoutedEventArgs> cellClick = Cell_Click;
 
                 for (int i = 1; i < Calendar.RowsPerMonth; i++)
@@ -206,7 +206,7 @@ namespace Avalonia.Controls.Primitives
                         cell.SetValue(Grid.ColumnProperty, j);
                         cell.CalendarDayButtonMouseDown += cellMouseLeftButtonDown;
                         cell.CalendarDayButtonMouseUp += cellMouseLeftButtonUp;
-                        cell.PointerEnter += cellMouseEnter;
+                        cell.PointerEntered += cellMouseEntered;
                         cell.Click += cellClick;
                         children.Add(cell);
                     }
@@ -222,7 +222,7 @@ namespace Avalonia.Controls.Primitives
 
                 EventHandler<PointerPressedEventArgs> monthCalendarButtonMouseDown = Month_CalendarButtonMouseDown;
                 EventHandler<PointerReleasedEventArgs> monthCalendarButtonMouseUp = Month_CalendarButtonMouseUp;
-                EventHandler<PointerEventArgs> monthMouseEnter = Month_MouseEnter;
+                EventHandler<PointerEventArgs> monthMouseEntered = Month_MouseEntered;
 
                 for (int i = 0; i < Calendar.RowsPerYear; i++)
                 {
@@ -238,7 +238,7 @@ namespace Avalonia.Controls.Primitives
                         month.SetValue(Grid.ColumnProperty, j);
                         month.CalendarLeftMouseButtonDown += monthCalendarButtonMouseDown;
                         month.CalendarLeftMouseButtonUp += monthCalendarButtonMouseUp;
-                        month.PointerEnter += monthMouseEnter;
+                        month.PointerEntered += monthMouseEntered;
                         children.Add(month);
                     }
                 }
@@ -876,7 +876,7 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
-        internal void Cell_MouseEnter(object? sender, PointerEventArgs e)
+        internal void Cell_MouseEntered(object? sender, PointerEventArgs e)
         {
             if (Owner != null)
             {
@@ -1162,7 +1162,7 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
-        private void Month_MouseEnter(object? sender, PointerEventArgs e)
+        private void Month_MouseEntered(object? sender, PointerEventArgs e)
         {
             if (_isMouseLeftButtonDownYearView)
             {

--- a/src/Avalonia.Controls/GridSplitter.cs
+++ b/src/Avalonia.Controls/GridSplitter.cs
@@ -349,9 +349,9 @@ namespace Avalonia.Controls
             }
         }
 
-        protected override void OnPointerEnter(PointerEventArgs e)
+        protected override void OnPointerEntered(PointerEventArgs e)
         {
-            base.OnPointerEnter(e);
+            base.OnPointerEntered(e);
 
             GridResizeDirection direction = GetEffectiveResizeDirection();
 

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -79,25 +79,33 @@ namespace Avalonia.Controls
         /// Defines the <see cref="Click"/> event.
         /// </summary>
         public static readonly RoutedEvent<RoutedEventArgs> ClickEvent =
-            RoutedEvent.Register<MenuItem, RoutedEventArgs>(nameof(Click), RoutingStrategies.Bubble);
+            RoutedEvent.Register<MenuItem, RoutedEventArgs>(
+                nameof(Click),
+                RoutingStrategies.Bubble);
 
         /// <summary>
         /// Defines the <see cref="PointerEnteredItem"/> event.
         /// </summary>
         public static readonly RoutedEvent<PointerEventArgs> PointerEnteredItemEvent =
-            RoutedEvent.Register<MenuItem, PointerEventArgs>(nameof(PointerEnteredItem), RoutingStrategies.Bubble);
+            RoutedEvent.Register<MenuItem, PointerEventArgs>(
+                nameof(PointerEnteredItem),
+                RoutingStrategies.Bubble);
 
         /// <summary>
-        /// Defines the <see cref="PointerLeaveItem"/> event.
+        /// Defines the <see cref="PointerExitedItem"/> event.
         /// </summary>
-        public static readonly RoutedEvent<PointerEventArgs> PointerLeaveItemEvent =
-            RoutedEvent.Register<MenuItem, PointerEventArgs>(nameof(PointerLeaveItem), RoutingStrategies.Bubble);
+        public static readonly RoutedEvent<PointerEventArgs> PointerExitedItemEvent =
+            RoutedEvent.Register<MenuItem, PointerEventArgs>(
+                nameof(PointerExitedItem),
+                RoutingStrategies.Bubble);
 
         /// <summary>
         /// Defines the <see cref="SubmenuOpened"/> event.
         /// </summary>
         public static readonly RoutedEvent<RoutedEventArgs> SubmenuOpenedEvent =
-            RoutedEvent.Register<MenuItem, RoutedEventArgs>(nameof(SubmenuOpened), RoutingStrategies.Bubble);
+            RoutedEvent.Register<MenuItem, RoutedEventArgs>(
+                nameof(SubmenuOpened),
+                RoutingStrategies.Bubble);
 
         /// <summary>
         /// The default value for the <see cref="ItemsControl.ItemsPanel"/> property.
@@ -186,12 +194,12 @@ namespace Avalonia.Controls
         /// Raised when the pointer leaves a menu item.
         /// </summary>
         /// <remarks>
-        /// A bubbling version of the <see cref="InputElement.PointerLeave"/> event for menu items.
+        /// A bubbling version of the <see cref="InputElement.PointerExited"/> event for menu items.
         /// </remarks>
-        public event EventHandler<PointerEventArgs>? PointerLeaveItem
+        public event EventHandler<PointerEventArgs>? PointerExitedItem
         {
-            add { AddHandler(PointerLeaveItemEvent, value); }
-            remove { RemoveHandler(PointerLeaveItemEvent, value); }
+            add { AddHandler(PointerExitedItemEvent, value); }
+            remove { RemoveHandler(PointerExitedItemEvent, value); }
         }
 
         /// <summary>
@@ -447,12 +455,12 @@ namespace Avalonia.Controls
         }
 
         /// <inheritdoc/>
-        protected override void OnPointerLeave(PointerEventArgs e)
+        protected override void OnPointerExited(PointerEventArgs e)
         {
-            base.OnPointerLeave(e);
+            base.OnPointerExited(e);
 
             var point = e.GetCurrentPoint(null);
-            RaiseEvent(new PointerEventArgs(PointerLeaveItemEvent, this, e.Pointer, this.VisualRoot, point.Position,
+            RaiseEvent(new PointerEventArgs(PointerExitedItemEvent, this, e.Pointer, this.VisualRoot, point.Position,
                 e.Timestamp, point.Properties, e.KeyModifiers));
         }
 

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -82,10 +82,10 @@ namespace Avalonia.Controls
             RoutedEvent.Register<MenuItem, RoutedEventArgs>(nameof(Click), RoutingStrategies.Bubble);
 
         /// <summary>
-        /// Defines the <see cref="PointerEnterItem"/> event.
+        /// Defines the <see cref="PointerEnteredItem"/> event.
         /// </summary>
-        public static readonly RoutedEvent<PointerEventArgs> PointerEnterItemEvent =
-            RoutedEvent.Register<MenuItem, PointerEventArgs>(nameof(PointerEnterItem), RoutingStrategies.Bubble);
+        public static readonly RoutedEvent<PointerEventArgs> PointerEnteredItemEvent =
+            RoutedEvent.Register<MenuItem, PointerEventArgs>(nameof(PointerEnteredItem), RoutingStrategies.Bubble);
 
         /// <summary>
         /// Defines the <see cref="PointerLeaveItem"/> event.
@@ -174,12 +174,12 @@ namespace Avalonia.Controls
         /// Occurs when the pointer enters a menu item.
         /// </summary>
         /// <remarks>
-        /// A bubbling version of the <see cref="InputElement.PointerEnter"/> event for menu items.
+        /// A bubbling version of the <see cref="InputElement.PointerEntered"/> event for menu items.
         /// </remarks>
-        public event EventHandler<PointerEventArgs>? PointerEnterItem
+        public event EventHandler<PointerEventArgs>? PointerEnteredItem
         {
-            add { AddHandler(PointerEnterItemEvent, value); }
-            remove { RemoveHandler(PointerEnterItemEvent, value); }
+            add { AddHandler(PointerEnteredItemEvent, value); }
+            remove { RemoveHandler(PointerEnteredItemEvent, value); }
         }
 
         /// <summary>
@@ -437,12 +437,12 @@ namespace Avalonia.Controls
         }
 
         /// <inheritdoc/>
-        protected override void OnPointerEnter(PointerEventArgs e)
+        protected override void OnPointerEntered(PointerEventArgs e)
         {
-            base.OnPointerEnter(e);
+            base.OnPointerEntered(e);
 
             var point = e.GetCurrentPoint(null);
-            RaiseEvent(new PointerEventArgs(PointerEnterItemEvent, this, e.Pointer, this.VisualRoot, point.Position,
+            RaiseEvent(new PointerEventArgs(PointerEnteredItemEvent, this, e.Pointer, this.VisualRoot, point.Position,
                 e.Timestamp, point.Properties, e.KeyModifiers));
         }
 

--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -53,8 +53,8 @@ namespace Avalonia.Controls.Platform
             Menu.PointerPressed += PointerPressed;
             Menu.PointerReleased += PointerReleased;
             Menu.AddHandler(AccessKeyHandler.AccessKeyPressedEvent, AccessKeyPressed);
-            Menu.AddHandler(Avalonia.Controls.Menu.MenuOpenedEvent, this.MenuOpened);
-            Menu.AddHandler(MenuItem.PointerEnterItemEvent, PointerEnter);
+            Menu.AddHandler(Avalonia.Controls.Menu.MenuOpenedEvent, MenuOpened);
+            Menu.AddHandler(MenuItem.PointerEnteredItemEvent, PointerEntered);
             Menu.AddHandler(MenuItem.PointerLeaveItemEvent, PointerLeave);
             Menu.AddHandler(InputElement.PointerMovedEvent, PointerMoved);
 
@@ -89,8 +89,8 @@ namespace Avalonia.Controls.Platform
             Menu.PointerPressed -= PointerPressed;
             Menu.PointerReleased -= PointerReleased;
             Menu.RemoveHandler(AccessKeyHandler.AccessKeyPressedEvent, AccessKeyPressed);
-            Menu.RemoveHandler(Avalonia.Controls.Menu.MenuOpenedEvent, this.MenuOpened);
-            Menu.RemoveHandler(MenuItem.PointerEnterItemEvent, PointerEnter);
+            Menu.RemoveHandler(Avalonia.Controls.Menu.MenuOpenedEvent, MenuOpened);
+            Menu.RemoveHandler(MenuItem.PointerEnteredItemEvent, PointerEntered);
             Menu.RemoveHandler(MenuItem.PointerLeaveItemEvent, PointerLeave);
             Menu.RemoveHandler(InputElement.PointerMovedEvent, PointerMoved);
 
@@ -297,7 +297,7 @@ namespace Avalonia.Controls.Platform
             e.Handled = true;
         }
 
-        protected internal virtual void PointerEnter(object? sender, PointerEventArgs e)
+        protected internal virtual void PointerEntered(object? sender, PointerEventArgs e)
         {
             var item = GetMenuItem(e.Source as IControl);
 

--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -55,7 +55,7 @@ namespace Avalonia.Controls.Platform
             Menu.AddHandler(AccessKeyHandler.AccessKeyPressedEvent, AccessKeyPressed);
             Menu.AddHandler(Avalonia.Controls.Menu.MenuOpenedEvent, MenuOpened);
             Menu.AddHandler(MenuItem.PointerEnteredItemEvent, PointerEntered);
-            Menu.AddHandler(MenuItem.PointerLeaveItemEvent, PointerLeave);
+            Menu.AddHandler(MenuItem.PointerExitedItemEvent, PointerExited);
             Menu.AddHandler(InputElement.PointerMovedEvent, PointerMoved);
 
             _root = Menu.VisualRoot;
@@ -91,7 +91,7 @@ namespace Avalonia.Controls.Platform
             Menu.RemoveHandler(AccessKeyHandler.AccessKeyPressedEvent, AccessKeyPressed);
             Menu.RemoveHandler(Avalonia.Controls.Menu.MenuOpenedEvent, MenuOpened);
             Menu.RemoveHandler(MenuItem.PointerEnteredItemEvent, PointerEntered);
-            Menu.RemoveHandler(MenuItem.PointerLeaveItemEvent, PointerLeave);
+            Menu.RemoveHandler(MenuItem.PointerExitedItemEvent, PointerExited);
             Menu.RemoveHandler(InputElement.PointerMovedEvent, PointerMoved);
 
             if (_root is InputElement inputRoot)
@@ -358,7 +358,7 @@ namespace Avalonia.Controls.Platform
             }
         }
 
-        protected internal virtual void PointerLeave(object? sender, PointerEventArgs e)
+        protected internal virtual void PointerExited(object? sender, PointerEventArgs e)
         {
             var item = GetMenuItem(e.Source as IControl);
 

--- a/src/Avalonia.Controls/Primitives/ScrollBar.cs
+++ b/src/Avalonia.Controls/Primitives/ScrollBar.cs
@@ -228,9 +228,9 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
-        protected override void OnPointerLeave(PointerEventArgs e)
+        protected override void OnPointerExited(PointerEventArgs e)
         {
-            base.OnPointerLeave(e);
+            base.OnPointerExited(e);
 
             if (AllowAutoHide)
             {

--- a/src/Avalonia.Controls/Primitives/ScrollBar.cs
+++ b/src/Avalonia.Controls/Primitives/ScrollBar.cs
@@ -218,9 +218,9 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
-        protected override void OnPointerEnter(PointerEventArgs e)
+        protected override void OnPointerEntered(PointerEventArgs e)
         {
-            base.OnPointerEnter(e);
+            base.OnPointerEntered(e);
 
             if (AllowAutoHide)
             {

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -27,13 +27,13 @@ namespace Avalonia.Controls
             if (e.OldValue != null)
             {
                 control.PointerEntered -= ControlPointerEntered;
-                control.PointerLeave -= ControlPointerLeave;
+                control.PointerExited -= ControlPointerExited;
             }
 
             if (e.NewValue != null)
             {
                 control.PointerEntered += ControlPointerEntered;
-                control.PointerLeave += ControlPointerLeave;
+                control.PointerExited += ControlPointerExited;
             }
 
             if (ToolTip.GetIsOpen(control) && e.NewValue != e.OldValue && !(e.NewValue is ToolTip))
@@ -101,7 +101,7 @@ namespace Avalonia.Controls
         /// </summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event args.</param>
-        private void ControlPointerLeave(object? sender, PointerEventArgs e)
+        private void ControlPointerExited(object? sender, PointerEventArgs e)
         {
             var control = (Control)sender!;
             Close(control);

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -26,13 +26,13 @@ namespace Avalonia.Controls
 
             if (e.OldValue != null)
             {
-                control.PointerEnter -= ControlPointerEnter;
+                control.PointerEntered -= ControlPointerEntered;
                 control.PointerLeave -= ControlPointerLeave;
             }
 
             if (e.NewValue != null)
             {
-                control.PointerEnter += ControlPointerEnter;
+                control.PointerEntered += ControlPointerEntered;
                 control.PointerLeave += ControlPointerLeave;
             }
 
@@ -80,7 +80,7 @@ namespace Avalonia.Controls
         /// </summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event args.</param>
-        private void ControlPointerEnter(object? sender, PointerEventArgs e)
+        private void ControlPointerEntered(object? sender, PointerEventArgs e)
         {
             StopTimer();
 

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml.cs
@@ -122,7 +122,7 @@ namespace Avalonia.Diagnostics.Views
             if (header != null)
             {
                 header.PointerEntered += AddAdorner;
-                header.PointerLeave += RemoveAdorner;
+                header.PointerExited += RemoveAdorner;
             }
 
             item.TemplateApplied -= TreeViewItemTemplateApplied;

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml.cs
@@ -121,7 +121,7 @@ namespace Avalonia.Diagnostics.Views
 
             if (header != null)
             {
-                header.PointerEnter += AddAdorner;
+                header.PointerEntered += AddAdorner;
                 header.PointerLeave += RemoveAdorner;
             }
 

--- a/tests/Avalonia.Base.UnitTests/Input/PointerOverTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/PointerOverTests.cs
@@ -248,7 +248,7 @@ namespace Avalonia.Base.UnitTests.Input
                 {
                         ((object?)decorator, nameof(InputElement.PointerEntered)),
                         (decorator, nameof(InputElement.PointerMoved)),
-                        (decorator, nameof(InputElement.PointerLeave)),
+                        (decorator, nameof(InputElement.PointerExited)),
                         (canvas, nameof(InputElement.PointerEntered)),
                         (canvas, nameof(InputElement.PointerMoved))
                 },
@@ -297,7 +297,7 @@ namespace Avalonia.Base.UnitTests.Input
             Assert.Equal(
                 new[]
                 {
-                    ((object?)canvas, nameof(InputElement.PointerLeave)),
+                    ((object?)canvas, nameof(InputElement.PointerExited)),
                     (decorator, nameof(InputElement.PointerEntered)),
                     (border, nameof(InputElement.PointerEntered)),
                 },
@@ -344,8 +344,8 @@ namespace Avalonia.Base.UnitTests.Input
                 {
                     ((object?)canvas, nameof(InputElement.PointerEntered), expectedPosition),
                     (root, nameof(InputElement.PointerEntered), expectedPosition),
-                    (canvas, nameof(InputElement.PointerLeave), expectedPosition),
-                    (root, nameof(InputElement.PointerLeave), expectedPosition)
+                    (canvas, nameof(InputElement.PointerExited), expectedPosition),
+                    (root, nameof(InputElement.PointerExited), expectedPosition)
                 },
                 result);
         }
@@ -431,8 +431,8 @@ namespace Avalonia.Base.UnitTests.Input
                 {
                     ((object?)canvas, nameof(InputElement.PointerEntered), lastClientPosition),
                     (root, nameof(InputElement.PointerEntered), lastClientPosition),
-                    (canvas, nameof(InputElement.PointerLeave), lastClientPosition),
-                    (root, nameof(InputElement.PointerLeave), lastClientPosition),
+                    (canvas, nameof(InputElement.PointerExited), lastClientPosition),
+                    (root, nameof(InputElement.PointerExited), lastClientPosition),
                 },
                 result);
         }
@@ -444,7 +444,7 @@ namespace Avalonia.Base.UnitTests.Input
             foreach (var c in controls)
             {
                 c.PointerEntered += handler;
-                c.PointerLeave += handler;
+                c.PointerExited += handler;
                 c.PointerMoved += handler;
             }
         }

--- a/tests/Avalonia.Base.UnitTests/Input/PointerOverTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/PointerOverTests.cs
@@ -189,7 +189,7 @@ namespace Avalonia.Base.UnitTests.Input
 
             // Ensure that e.Handled is reset between controls.
             root.PointerMoved += (s, e) => e.Handled = true;
-            decorator.PointerEnter += (s, e) => e.Handled = true;
+            decorator.PointerEntered += (s, e) => e.Handled = true;
 
             SetHit(renderer, decorator);
             impl.Object.Input!(CreateRawPointerMovedArgs(device, root));
@@ -231,7 +231,7 @@ namespace Avalonia.Base.UnitTests.Input
                 }
             });
 
-            AddEnterLeaveHandlers(HandleEvent, canvas, decorator);
+            AddEnteredExitedHandlers(HandleEvent, canvas, decorator);
 
             // Enter decorator
             SetHit(renderer, decorator);
@@ -246,17 +246,17 @@ namespace Avalonia.Base.UnitTests.Input
             Assert.Equal(
                 new[]
                 {
-                        ((object?)decorator, "PointerEnter"),
-                        (decorator, "PointerMoved"),
-                        (decorator, "PointerLeave"),
-                        (canvas, "PointerEnter"),
-                        (canvas, "PointerMoved")
+                        ((object?)decorator, nameof(InputElement.PointerEntered)),
+                        (decorator, nameof(InputElement.PointerMoved)),
+                        (decorator, nameof(InputElement.PointerLeave)),
+                        (canvas, nameof(InputElement.PointerEntered)),
+                        (canvas, nameof(InputElement.PointerMoved))
                 },
                 result);
         }
 
         [Fact]
-        public void PointerEnter_Leave_Should_Be_Raised_In_Correct_Order()
+        public void PointerEntered_Exited_Should_Be_Raised_In_Correct_Order()
         {
             using var app = UnitTestApplication.Start(new TestServices(inputManager: new InputManager()));
 
@@ -289,7 +289,7 @@ namespace Avalonia.Base.UnitTests.Input
             SetHit(renderer, canvas);
             impl.Object.Input!(CreateRawPointerMovedArgs(deviceMock.Object, root));
 
-            AddEnterLeaveHandlers(HandleEvent, root, canvas, border, decorator);
+            AddEnteredExitedHandlers(HandleEvent, root, canvas, border, decorator);
 
             SetHit(renderer, decorator);
             impl.Object.Input!(CreateRawPointerMovedArgs(deviceMock.Object, root));
@@ -297,16 +297,16 @@ namespace Avalonia.Base.UnitTests.Input
             Assert.Equal(
                 new[]
                 {
-                    ((object?)canvas, "PointerLeave"),
-                    (decorator, "PointerEnter"),
-                    (border, "PointerEnter"),
+                    ((object?)canvas, nameof(InputElement.PointerLeave)),
+                    (decorator, nameof(InputElement.PointerEntered)),
+                    (border, nameof(InputElement.PointerEntered)),
                 },
                 result);
         }
 
         // https://github.com/AvaloniaUI/Avalonia/issues/7896
         [Fact]
-        public void PointerEnter_Leave_Should_Set_Correct_Position()
+        public void PointerEntered_Exited_Should_Set_Correct_Position()
         {
             using var app = UnitTestApplication.Start(new TestServices(inputManager: new InputManager()));
 
@@ -331,7 +331,7 @@ namespace Avalonia.Base.UnitTests.Input
                 }
             });
 
-            AddEnterLeaveHandlers(HandleEvent, root, canvas);
+            AddEnteredExitedHandlers(HandleEvent, root, canvas);
 
             SetHit(renderer, canvas);
             impl.Object.Input!(CreateRawPointerMovedArgs(deviceMock.Object, root, expectedPosition));
@@ -342,10 +342,10 @@ namespace Avalonia.Base.UnitTests.Input
             Assert.Equal(
                 new[]
                 {
-                    ((object?)canvas, "PointerEnter", expectedPosition),
-                    (root, "PointerEnter", expectedPosition),
-                    (canvas, "PointerLeave", expectedPosition),
-                    (root, "PointerLeave", expectedPosition)
+                    ((object?)canvas, nameof(InputElement.PointerEntered), expectedPosition),
+                    (root, nameof(InputElement.PointerEntered), expectedPosition),
+                    (canvas, nameof(InputElement.PointerLeave), expectedPosition),
+                    (root, nameof(InputElement.PointerLeave), expectedPosition)
                 },
                 result);
         }
@@ -415,7 +415,7 @@ namespace Avalonia.Base.UnitTests.Input
                 }
             });
 
-            AddEnterLeaveHandlers(HandleEvent, root, canvas);
+            AddEnteredExitedHandlers(HandleEvent, root, canvas);
 
             // Init pointer over.
             SetHit(renderer, canvas);
@@ -429,21 +429,21 @@ namespace Avalonia.Base.UnitTests.Input
             Assert.Equal(
                 new[]
                 {
-                    ((object?)canvas, "PointerEnter", lastClientPosition),
-                    (root, "PointerEnter", lastClientPosition),
-                    (canvas, "PointerLeave", lastClientPosition),
-                    (root, "PointerLeave", lastClientPosition),
+                    ((object?)canvas, nameof(InputElement.PointerEntered), lastClientPosition),
+                    (root, nameof(InputElement.PointerEntered), lastClientPosition),
+                    (canvas, nameof(InputElement.PointerLeave), lastClientPosition),
+                    (root, nameof(InputElement.PointerLeave), lastClientPosition),
                 },
                 result);
         }
 
-        private static void AddEnterLeaveHandlers(
+        private static void AddEnteredExitedHandlers(
             EventHandler<PointerEventArgs> handler,
             params IInputElement[] controls)
         {
             foreach (var c in controls)
             {
-                c.PointerEnter += handler;
+                c.PointerEntered += handler;
                 c.PointerLeave += handler;
                 c.PointerMoved += handler;
             }

--- a/tests/Avalonia.Controls.UnitTests/ButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ButtonTests.cs
@@ -185,7 +185,7 @@ namespace Avalonia.Controls.UnitTests
             RaisePointerEntered(target);
             RaisePointerMove(target, new Point(50,50));
             RaisePointerPressed(target, 1, MouseButton.Left, new Point(50, 50));
-            RaisePointerLeave(target);
+            RaisePointerExited(target);
 
             Assert.Equal(_helper.Captured, target);
 
@@ -427,7 +427,7 @@ namespace Avalonia.Controls.UnitTests
             _helper.Enter(button);
         }
 
-        private void RaisePointerLeave(Button button)
+        private void RaisePointerExited(Button button)
         {
             _helper.Leave(button);
         }

--- a/tests/Avalonia.Controls.UnitTests/ButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ButtonTests.cs
@@ -150,7 +150,7 @@ namespace Avalonia.Controls.UnitTests
 
             target.Click += (s, e) => clicked = true;
 
-            RaisePointerEnter(target);
+            RaisePointerEntered(target);
             RaisePointerMove(target, pt);
             RaisePointerPressed(target, 1, MouseButton.Left, pt);
 
@@ -182,7 +182,7 @@ namespace Avalonia.Controls.UnitTests
 
             target.Click += (s, e) => clicked = true;
 
-            RaisePointerEnter(target);
+            RaisePointerEntered(target);
             RaisePointerMove(target, new Point(50,50));
             RaisePointerPressed(target, 1, MouseButton.Left, new Point(50, 50));
             RaisePointerLeave(target);
@@ -224,7 +224,7 @@ namespace Avalonia.Controls.UnitTests
 
             target.Click += (s, e) => clicked = true;
 
-            RaisePointerEnter(target);
+            RaisePointerEntered(target);
             RaisePointerMove(target, pt);
             RaisePointerPressed(target, 1, MouseButton.Left, pt);
 
@@ -422,7 +422,7 @@ namespace Avalonia.Controls.UnitTests
             _helper.Up(button, mouseButton, pt);
         }
 
-        private void RaisePointerEnter(Button button)
+        private void RaisePointerEntered(Button button)
         {
             _helper.Enter(button);
         }

--- a/tests/Avalonia.Controls.UnitTests/Platform/DefaultMenuInteractionHandlerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Platform/DefaultMenuInteractionHandlerTests.cs
@@ -174,7 +174,7 @@ namespace Avalonia.Controls.UnitTests.Platform
             }
 
             [Fact]
-            public void PointerEnter_Opens_Item_When_Old_Item_Is_Open()
+            public void PointerEntered_Opens_Item_When_Old_Item_Is_Open()
             {
                 var target = new DefaultMenuInteractionHandler(false);
                 var menu = new Mock<IMenu>();
@@ -187,11 +187,11 @@ namespace Avalonia.Controls.UnitTests.Platform
                     x.IsTopLevel == true &&
                     x.HasSubMenu == true &&
                     x.Parent == menu.Object);
-                var e = CreateArgs(MenuItem.PointerEnterItemEvent, nextItem);
+                var e = CreateArgs(MenuItem.PointerEnteredItemEvent, nextItem);
 
                 menu.SetupGet(x => x.SelectedItem).Returns(item);
 
-                target.PointerEnter(nextItem, e);
+                target.PointerEntered(nextItem, e);
 
                 Mock.Get(item).Verify(x => x.Close());
                 menu.VerifySet(x => x.SelectedItem = nextItem);
@@ -382,31 +382,31 @@ namespace Avalonia.Controls.UnitTests.Platform
             }
 
             [Fact]
-            public void PointerEnter_Selects_Item()
+            public void PointerEntered_Selects_Item()
             {
                 var target = new DefaultMenuInteractionHandler(false);
                 var menu = Mock.Of<IMenu>();
                 var parentItem = Mock.Of<IMenuItem>(x => x.IsTopLevel == true && x.HasSubMenu == true && x.Parent == menu);
                 var item = Mock.Of<IMenuItem>(x => x.Parent == parentItem);
-                var e = CreateArgs(MenuItem.PointerEnterItemEvent, item);
+                var e = CreateArgs(MenuItem.PointerEnteredItemEvent, item);
 
-                target.PointerEnter(item, e);
+                target.PointerEntered(item, e);
 
                 Mock.Get(parentItem).VerifySet(x => x.SelectedItem = item);
                 Assert.False(e.Handled);
             }
 
             [Fact]
-            public void PointerEnter_Opens_Submenu_After_Delay()
+            public void PointerEntered_Opens_Submenu_After_Delay()
             {
                 var timer = new TestTimer();
                 var target = new DefaultMenuInteractionHandler(false, null, timer.RunOnce);
                 var menu = Mock.Of<IMenu>();
                 var parentItem = Mock.Of<IMenuItem>(x => x.IsTopLevel == true && x.HasSubMenu == true && x.Parent == menu);
                 var item = Mock.Of<IMenuItem>(x => x.Parent == parentItem && x.HasSubMenu == true);
-                var e = CreateArgs(MenuItem.PointerEnterItemEvent, item);
+                var e = CreateArgs(MenuItem.PointerEnteredItemEvent, item);
 
-                target.PointerEnter(item, e);
+                target.PointerEntered(item, e);
                 Mock.Get(item).Verify(x => x.Open(), Times.Never);
 
                 timer.Pulse();
@@ -416,7 +416,7 @@ namespace Avalonia.Controls.UnitTests.Platform
             }
 
             [Fact]
-            public void PointerEnter_Closes_Sibling_Submenu_After_Delay()
+            public void PointerEntered_Closes_Sibling_Submenu_After_Delay()
             {
                 var timer = new TestTimer();
                 var target = new DefaultMenuInteractionHandler(false, null, timer.RunOnce);
@@ -424,11 +424,11 @@ namespace Avalonia.Controls.UnitTests.Platform
                 var parentItem = Mock.Of<IMenuItem>(x => x.IsTopLevel == true && x.HasSubMenu == true && x.Parent == menu);
                 var item = Mock.Of<IMenuItem>(x => x.Parent == parentItem);
                 var sibling = Mock.Of<IMenuItem>(x => x.Parent == parentItem && x.HasSubMenu == true && x.IsSubMenuOpen == true);
-                var e = CreateArgs(MenuItem.PointerEnterItemEvent, item);
+                var e = CreateArgs(MenuItem.PointerEnteredItemEvent, item);
 
                 Mock.Get(parentItem).SetupGet(x => x.SubItems).Returns(new[] { item, sibling });
 
-                target.PointerEnter(item, e);
+                target.PointerEntered(item, e);
                 Mock.Get(sibling).Verify(x => x.Close(), Times.Never);
 
                 timer.Pulse();
@@ -510,11 +510,11 @@ namespace Avalonia.Controls.UnitTests.Platform
                 var parentItem = Mock.Of<IMenuItem>(x => x.IsTopLevel == true && x.HasSubMenu == true && x.Parent == menu);
                 var item = Mock.Of<IMenuItem>(x => x.Parent == parentItem && x.HasSubMenu == true);
                 var childItem = Mock.Of<IMenuItem>(x => x.Parent == item);
-                var enter = CreateArgs(MenuItem.PointerEnterItemEvent, item);
+                var enter = CreateArgs(MenuItem.PointerEnteredItemEvent, item);
                 var leave = CreateArgs(MenuItem.PointerLeaveItemEvent, item);
 
                 // Pointer enters item; item is selected.
-                target.PointerEnter(item, enter);
+                target.PointerEntered(item, enter);
                 Assert.True(timer.ActionIsQueued);
                 Mock.Get(parentItem).VerifySet(x => x.SelectedItem = item);
                 Mock.Get(parentItem).Invocations.Clear();
@@ -532,7 +532,7 @@ namespace Avalonia.Controls.UnitTests.Platform
 
                 // Pointer enters child item; is selected.
                 enter.Source = childItem;
-                target.PointerEnter(childItem, enter);
+                target.PointerEntered(childItem, enter);
                 Mock.Get(item).VerifySet(x => x.SelectedItem = childItem);
                 Mock.Get(parentItem).VerifySet(x => x.SelectedItem = item);
                 Mock.Get(item).Invocations.Clear();

--- a/tests/Avalonia.Controls.UnitTests/Platform/DefaultMenuInteractionHandlerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Platform/DefaultMenuInteractionHandlerTests.cs
@@ -202,31 +202,31 @@ namespace Avalonia.Controls.UnitTests.Platform
             }
 
             [Fact]
-            public void PointerLeave_Deselects_Item_When_Menu_Not_Open()
+            public void PointerExited_Deselects_Item_When_Menu_Not_Open()
             {
                 var target = new DefaultMenuInteractionHandler(false);
                 var menu = new Mock<IMenu>();
                 var item = Mock.Of<IMenuItem>(x => x.IsTopLevel == true && x.Parent == menu.Object);
-                var e = CreateArgs(MenuItem.PointerLeaveItemEvent, item);
+                var e = CreateArgs(MenuItem.PointerExitedItemEvent, item);
 
                 menu.SetupGet(x => x.SelectedItem).Returns(item);
-                target.PointerLeave(item, e);
+                target.PointerExited(item, e);
 
                 menu.VerifySet(x => x.SelectedItem = null);
                 Assert.False(e.Handled);
             }
 
             [Fact]
-            public void PointerLeave_Doesnt_Deselect_Item_When_Menu_Open()
+            public void PointerExited_Doesnt_Deselect_Item_When_Menu_Open()
             {
                 var target = new DefaultMenuInteractionHandler(false);
                 var menu = new Mock<IMenu>();
                 var item = Mock.Of<IMenuItem>(x => x.IsTopLevel == true && x.Parent == menu.Object);
-                var e = CreateArgs(MenuItem.PointerLeaveItemEvent, item);
+                var e = CreateArgs(MenuItem.PointerExitedItemEvent, item);
 
                 menu.SetupGet(x => x.IsOpen).Returns(true);
                 menu.SetupGet(x => x.SelectedItem).Returns(item);
-                target.PointerLeave(item, e);
+                target.PointerExited(item, e);
 
                 menu.VerifySet(x => x.SelectedItem = null, Times.Never);
                 Assert.False(e.Handled);
@@ -438,48 +438,48 @@ namespace Avalonia.Controls.UnitTests.Platform
             }
 
             [Fact]
-            public void PointerLeave_Deselects_Item()
+            public void PointerExited_Deselects_Item()
             {
                 var target = new DefaultMenuInteractionHandler(false);
                 var menu = Mock.Of<IMenu>();
                 var parentItem = Mock.Of<IMenuItem>(x => x.IsTopLevel == true && x.HasSubMenu == true && x.Parent == menu);
                 var item = Mock.Of<IMenuItem>(x => x.Parent == parentItem);
-                var e = CreateArgs(MenuItem.PointerLeaveItemEvent, item);
+                var e = CreateArgs(MenuItem.PointerExitedItemEvent, item);
 
                 Mock.Get(parentItem).SetupGet(x => x.SelectedItem).Returns(item);
-                target.PointerLeave(item, e);
+                target.PointerExited(item, e);
 
                 Mock.Get(parentItem).VerifySet(x => x.SelectedItem = null);
                 Assert.False(e.Handled);
             }
 
             [Fact]
-            public void PointerLeave_Doesnt_Deselect_Sibling()
+            public void PointerExited_Doesnt_Deselect_Sibling()
             {
                 var target = new DefaultMenuInteractionHandler(false);
                 var menu = Mock.Of<IMenu>();
                 var parentItem = Mock.Of<IMenuItem>(x => x.IsTopLevel == true && x.HasSubMenu == true && x.Parent == menu);
                 var item = Mock.Of<IMenuItem>(x => x.Parent == parentItem);
                 var sibling = Mock.Of<IMenuItem>(x => x.Parent == parentItem);
-                var e = CreateArgs(MenuItem.PointerLeaveItemEvent, item);
+                var e = CreateArgs(MenuItem.PointerExitedItemEvent, item);
 
                 Mock.Get(parentItem).SetupGet(x => x.SelectedItem).Returns(sibling);
-                target.PointerLeave(item, e);
+                target.PointerExited(item, e);
 
                 Mock.Get(parentItem).VerifySet(x => x.SelectedItem = null, Times.Never);
                 Assert.False(e.Handled);
             }
 
             [Fact]
-            public void PointerLeave_Doesnt_Deselect_Item_If_Pointer_Over_Submenu()
+            public void PointerExited_Doesnt_Deselect_Item_If_Pointer_Over_Submenu()
             {
                 var target = new DefaultMenuInteractionHandler(false);
                 var menu = Mock.Of<IMenu>();
                 var parentItem = Mock.Of<IMenuItem>(x => x.IsTopLevel == true && x.HasSubMenu == true && x.Parent == menu);
                 var item = Mock.Of<IMenuItem>(x => x.Parent == parentItem && x.HasSubMenu == true && x.IsPointerOverSubMenu == true);
-                var e = CreateArgs(MenuItem.PointerLeaveItemEvent, item);
+                var e = CreateArgs(MenuItem.PointerExitedItemEvent, item);
 
-                target.PointerLeave(item, e);
+                target.PointerExited(item, e);
 
                 Mock.Get(parentItem).VerifySet(x => x.SelectedItem = null, Times.Never);
                 Assert.False(e.Handled);
@@ -511,7 +511,7 @@ namespace Avalonia.Controls.UnitTests.Platform
                 var item = Mock.Of<IMenuItem>(x => x.Parent == parentItem && x.HasSubMenu == true);
                 var childItem = Mock.Of<IMenuItem>(x => x.Parent == item);
                 var enter = CreateArgs(MenuItem.PointerEnteredItemEvent, item);
-                var leave = CreateArgs(MenuItem.PointerLeaveItemEvent, item);
+                var leave = CreateArgs(MenuItem.PointerExitedItemEvent, item);
 
                 // Pointer enters item; item is selected.
                 target.PointerEntered(item, enter);
@@ -526,7 +526,7 @@ namespace Avalonia.Controls.UnitTests.Platform
                 Mock.Get(item).Invocations.Clear();
 
                 // Pointer briefly exits item, but submenu remains open.
-                target.PointerLeave(item, leave);
+                target.PointerExited(item, leave);
                 Mock.Get(item).Verify(x => x.Close(), Times.Never);
                 Mock.Get(item).Invocations.Clear();
 

--- a/tests/Avalonia.UnitTests/MouseTestHelper.cs
+++ b/tests/Avalonia.UnitTests/MouseTestHelper.cs
@@ -107,7 +107,7 @@ namespace Avalonia.UnitTests
         
         public void Enter(IInteractive target)
         {
-            target.RaiseEvent(new PointerEventArgs(InputElement.PointerEnterEvent, target, _pointer, (IVisual)target, default,
+            target.RaiseEvent(new PointerEventArgs(InputElement.PointerEnteredEvent, target, _pointer, (IVisual)target, default,
                 Timestamp(), new PointerPointProperties((RawInputModifiers)_pressedButtons, PointerUpdateKind.Other), KeyModifiers.None));
         }
 

--- a/tests/Avalonia.UnitTests/MouseTestHelper.cs
+++ b/tests/Avalonia.UnitTests/MouseTestHelper.cs
@@ -113,7 +113,7 @@ namespace Avalonia.UnitTests
 
         public void Leave(IInteractive target)
         {
-            target.RaiseEvent(new PointerEventArgs(InputElement.PointerLeaveEvent, target, _pointer, (IVisual)target, default,
+            target.RaiseEvent(new PointerEventArgs(InputElement.PointerExitedEvent, target, _pointer, (IVisual)target, default,
                 Timestamp(), new PointerPointProperties((RawInputModifiers)_pressedButtons, PointerUpdateKind.Other), KeyModifiers.None));
         }
 


### PR DESCRIPTION
**Warning: This is a big breaking change for almost all apps and libraries.**

## What does the pull request do?

Per discussion in https://github.com/AvaloniaUI/Avalonia/discussions/7907 and issue https://github.com/AvaloniaUI/Avalonia/issues/8058, this standardizes event naming with ~WPF~/UWP/WinUI as follows:

 1. PointerEnter -> PointerEntered
 2. PointerLeave -> PointerExited

Several secondary members and unit tests were also renamed to match.

## What is the current behavior?

Two pointer events use the non-standardized PointerEnter and PointerLeave terminology.

## What is the updated/expected behavior with this PR?

The two pointer events use standardized PointerEntered and PointerExited terminology aligning with other XAML frameworks.

## How was the solution implemented (if it's not obvious)?

Find and replace.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

Yes, this is a bad one for breaking changes.

## Obsoletions / Deprecations

None

## Fixed issues

Closes https://github.com/AvaloniaUI/Avalonia/issues/8058
