### PR TITLE
Removed duplicate concatentation in the build task

### DIFF
--- a/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
+++ b/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
@@ -49,9 +49,9 @@ namespace Avalonia.Build.Tasks
             string projectDirectory,
             string output, bool verifyIl, MessageImportance logImportance, string strongNameKey, bool patchCom, bool skipXamlCompilation, bool debuggerLaunch)
         {
-            var typeSystem = new CecilTypeSystem(references
-                .Where(r => !r.ToLowerInvariant().EndsWith("avalonia.build.tasks.dll"))
-                .Concat(new[] { input }), input);
+            var typeSystem = new CecilTypeSystem(
+                references.Where(r => !r.ToLowerInvariant().EndsWith("avalonia.build.tasks.dll")),
+                input);
 
             var asm = typeSystem.TargetAssemblyDefinition;
 


### PR DESCRIPTION
## What does the pull request do?

The type system concatenates the target to references internally, so there's no need to do that once more when creating a `CecilTypeSystem`.


## What is the current behavior?

Concatenate `target` twice. It happens in the callee and the caller.


## What is the updated/expected behavior with this PR?

It happens only in the constructor.