### PR TITLE
[Blazor] Prevent input focus leaving the TextBox after first click

### DIFF
--- a/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor
+++ b/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor
@@ -5,7 +5,8 @@
      @onpointerdown="OnPointerDown"
      @onpointerup="OnPointerUp"
      @onpointermove="OnPointerMove"
-     @onpointercancel="OnPointerCancel">
+     @onpointercancel="OnPointerCancel"
+     @onfocus="OnFocus">
     
     <canvas id="htmlCanvas" @ref="_htmlCanvas" @attributes="AdditionalAttributes"/>
 

--- a/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor.cs
+++ b/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor.cs
@@ -37,6 +37,7 @@ namespace Avalonia.Web.Blazor
         private const SKColorType ColorType = SKColorType.Rgba8888;
 
         private bool _initialised;
+        private bool _inputElementFocused;
 
         [Inject] private IJSRuntime Js { get; set; } = null!;
 
@@ -221,6 +222,16 @@ namespace Avalonia.Web.Blazor
             _topLevelImpl.RawKeyboardEvent(RawKeyEventType.KeyUp, e.Code, e.Key, GetModifiers(e));
         }
 
+        private void OnFocus(FocusEventArgs e)
+        {
+            // if focus has unexpectedly moved from the input element to the container element,
+            // shift it back to the input element
+            if (_inputElementFocused && _inputHelper is not null)
+            {
+                _inputHelper.Focus();
+            }
+        }
+
         private void OnInput(ChangeEventArgs e)
         {
             if (e.Value != null)
@@ -374,10 +385,12 @@ namespace Avalonia.Web.Blazor
             if (active)
             {
                 _inputHelper.Show();
+                _inputElementFocused = true;
                 _inputHelper.Focus();
             }
             else
             {
+                _inputElementFocused = false;
                 _inputHelper.Hide();
             }
         }


### PR DESCRIPTION
## What does the pull request do?
Works around an annoying bug in the Avalonia Blazor view that forces users to click twice within a `TextBox` before they can start typing in characters.

## What is the current behavior?
If you click inside a `TextBox` right after a page is rendered it will visually appear like it has input focus, however when you try to type in any characters the `TextBox` will not respond (though backspace and delete work fine). To be able to type in characters you have to click inside the `TextBox` a second time.

This is easily reproducible on the TextBox page of `ControlCatalog.Web`, open the page, click within the first TextBox and begin typing... you'll see nothing happens, click inside the TextBox again then try typing.

![image](https://user-images.githubusercontent.com/95474037/176601496-6b9be8eb-a87a-4a65-84b3-d4b3963fdea5.png)

## What is the updated/expected behavior with this PR?
You only need to click inside a TextBox once to begin typing in characters.

## How was the solution implemented (if it's not obvious)?
In `AvaloniaView.razor` the `inputElement` is a full page element that is used to capture character input that's passed through to the currently focused `TextBox`, in order for `inputElement` to receive input it must have input focus in the browser window. 

```html
<div id="container" class="avalonia-container" tabindex="0" oncontextmenu="return false;"
     @onwheel="OnWheel"
     @onkeydown="OnKeyDown"
     @onkeyup="OnKeyUp"
     @onpointerdown="OnPointerDown"
     @onpointerup="OnPointerUp"
     @onpointermove="OnPointerMove"
     @onpointercancel="OnPointerCancel"
     @onfocus="OnFocus">
    
    <canvas id="htmlCanvas" @ref="_htmlCanvas" @attributes="AdditionalAttributes"/>
    <div id="nativeControlsContainer" @ref="_nativeControlsContainer" />
    <input id="inputElement" @ref="_inputElement" type="text" @oninput="OnInput" 
        onpaste="return false;"
        oncopy="return false;" 
        oncut="return false;"/>
</div>
```

Avalonia will invoke `inputElement.focus()` whenever it gives a text input control like a TextBox input focus, but that doesn't seem to work right after the page is rendered. What happens is:
1. After the page loads `document.activeElement` is the `container` element.
2. When you click inside the TextBox Avalonia invokes `inputElement.focus()`
3. `document.activeElement` changes to `inputElement`, then immediately changes back to `container` element (why that is I have no clue).
4. Avalonia renders the TextBox as if it has input focus, but the `inputElement` doesn't pass through any characters to the TextBox because the `inputElement` doesn't actually have input focus in the browser window.

This PR introduces a workaround that forces the input focus in the browser to remain on the `inputElement` while Avalonia is expecting to receive text input. It works by adding an event handler to the `container` element for the focus event, which fires when the `container` element gains input focus. The `focus` event doesn't bubble up so the event handler will only be invoked when the `container` element gains focus (not some child element). The event handler for the focus event checks to see if the `inputElement` is supposed to have input focus, and if so invokes `inputElement.focus()`, this time around `document.activeElement` changes to `inputElement` and doesn't immediately switch back to the `container` element.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation