### PR TITLE
Remove perf-expensive DottedLineFocusAdorner style

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/FocusAdorner.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/FocusAdorner.xaml
@@ -19,16 +19,4 @@
       </FocusAdornerTemplate>
     </Setter>
   </Style>
-
-  <!--  DottedLine FocusAdorner  -->
-  <Style Selector="Window.DottedLineFocusAdorner :is(Control)">
-    <Setter Property="FocusAdorner">
-      <FocusAdornerTemplate>
-        <Rectangle Stroke="{StaticResource SystemControlFocusVisualPrimaryBrush}"
-                   StrokeThickness="1"
-                   StrokeDashArray="1,2"
-                   Margin="1" />
-      </FocusAdornerTemplate>
-    </Setter>
-  </Style>
 </Styles>


### PR DESCRIPTION
## What does the pull request do?

Remove perf-expensive and optional style for dotted focus adorner.
Normal focus adorner style is still available.

## Breaking changes

DottedLineFocusAdorner is no longer available in default styles. But it's easy to return it or replace whole default template without usage of class subscriptions.

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/8389
