### PR TITLE
Fix empty batch nested updates.

### DIFF
--- a/src/Avalonia.Base/ValueStore.cs
+++ b/src/Avalonia.Base/ValueStore.cs
@@ -462,10 +462,6 @@ namespace Avalonia
                                 values.Remove(entry.property);
                             }
                         }
-                        else
-                        {
-                            throw new AvaloniaInternalException("Value could not be found at the end of batch update.");
-                        }
 
                         // If a new batch update was started while ending this one, abort.
                         if (_batchUpdateCount > 0)

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_BatchUpdate.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_BatchUpdate.cs
@@ -611,6 +611,36 @@ namespace Avalonia.Base.UnitTests
             Assert.Equal("foo", notifications[1].NewValue);
         }
 
+        [Fact]
+        public void Can_Run_Empty_Batch_Update_When_Ending_Batch_Update()
+        {
+            var target = new TestClass();
+            var raised = 0;
+            var notifications = new List<AvaloniaPropertyChangedEventArgs>();
+
+            target.Foo = "foo";
+            target.Bar = "bar";
+
+            target.BeginBatchUpdate();
+            target.ClearValue(TestClass.FooProperty);
+            target.ClearValue(TestClass.BarProperty);
+            target.PropertyChanged += (sender, e) =>
+            {
+                if (e.Property == TestClass.BarProperty)
+                {
+                    target.BeginBatchUpdate();
+                    target.EndBatchUpdate();
+                }
+
+                ++raised;
+            };
+            target.EndBatchUpdate();
+
+            Assert.Null(target.Foo);
+            Assert.Null(target.Bar);
+            Assert.Equal(2, raised);
+        }
+
         public class TestClass : AvaloniaObject
         {
             public static readonly StyledProperty<string> FooProperty =


### PR DESCRIPTION
## What does the pull request do?

While working on #8263, we found this error: when running an empty batch update of >1 value which causes new, empty batch update to run in a `PropertyChanged` handler triggered from the first batch update, an `AvaloniaInternalException` was thrown.

Turns out that the invalid state that was being checked for by this exception was not actually invalid - it can happen on a nested empty back update, so just remove the check.

