### PR TITLE
fixes FlowDirection issue in ItemsRepeater

### DIFF
--- a/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
+++ b/src/Avalonia.Controls/Repeater/ItemsRepeater.cs
@@ -421,6 +421,7 @@ namespace Avalonia.Controls
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
+            base.OnAttachedToVisualTree(e);
             InvalidateMeasure();
             _viewportManager.ResetScrollers();
         }


### PR DESCRIPTION
## What does the pull request do?
the `ItemsRepeater` don't initialize the correct `HasMirrorTransform` value.
add `base.OnAttachedToVisualTree(e)` call, at `OnAttachedToVisualTree` method in `ItemsRepeater`, don't know why it has not been until now, but it is necessary to reach the `Control` object, that will call to `InvalidateMirrorTransform`.