### PR TITLE
Fix overwriting TemplatedParent when opening a Popup.

### DIFF
--- a/src/Avalonia.Controls/Primitives/TemplatedControl.cs
+++ b/src/Avalonia.Controls/Primitives/TemplatedControl.cs
@@ -396,7 +396,7 @@ namespace Avalonia.Controls.Primitives
 
             for (var i = 0; i < count; i++)
             {
-                if (children[i] is IStyledElement child)
+                if (children[i] is IStyledElement child && child.TemplatedParent is null)
                 {
                     ApplyTemplatedParent(child, templatedParent);
                 }

--- a/src/Avalonia.Controls/Primitives/TemplatedControl.cs
+++ b/src/Avalonia.Controls/Primitives/TemplatedControl.cs
@@ -387,6 +387,7 @@ namespace Avalonia.Controls.Primitives
         /// Sets the TemplatedParent property for the created template children.
         /// </summary>
         /// <param name="control">The control.</param>
+        /// <param name="templatedParent">The templated parent to apply.</param>
         internal static void ApplyTemplatedParent(IStyledElement control, ITemplatedControl? templatedParent)
         {
             control.SetValue(TemplatedParentProperty, templatedParent);

--- a/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
@@ -8,6 +8,7 @@ using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Platform;
 using Avalonia.UnitTests;
+using Avalonia.VisualTree;
 using Moq;
 using Xunit;
 
@@ -301,6 +302,49 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Equal(3, canExecuteCallCount);
             }
         }
+
+
+        [Fact]
+        public void TemplatedParent_Should_Not_Be_Applied_To_Submenus()
+        {
+            using (Application())
+            {
+                MenuItem topLevelMenu;
+                MenuItem childMenu1;
+                MenuItem childMenu2;
+                var menu = new Menu
+                {
+                    Items = new[]
+                    {
+                        (topLevelMenu = new MenuItem
+                        {
+                            Header = "Foo",
+                            Items = new[]
+                            {
+                                (childMenu1 = new MenuItem { Header = "Bar" }),
+                                (childMenu2 = new MenuItem { Header = "Baz" }),
+                            }
+                        }),
+                    }
+                };
+
+                var window = new Window { Content = menu };
+                window.LayoutManager.ExecuteInitialLayoutPass();
+
+                topLevelMenu.IsSubMenuOpen = true;
+
+                Assert.True(((IVisual)childMenu1).IsAttachedToVisualTree);
+                Assert.Null(childMenu1.TemplatedParent);
+                Assert.Null(childMenu2.TemplatedParent);
+
+                topLevelMenu.IsSubMenuOpen = false;
+                topLevelMenu.IsSubMenuOpen = true;
+
+                Assert.Null(childMenu1.TemplatedParent);
+                Assert.Null(childMenu2.TemplatedParent);
+            }
+        }
+
         private IDisposable Application()
         {
             var screen = new PixelRect(new PixelPoint(), new PixelSize(100, 100));


### PR DESCRIPTION
## What does the pull request do?

I came upon this problem on Friday that seems to have been caused by #8412: if you have an `ItemsControl` with a popup in its template and this `ItemsControl` is hosting controls as items (as opposed to using a data template to create the items) then the second time the `Popup` is opened, the control items will have their `TemplatedParent` set to the `ItemsControl` - this is incorrect.

This problem manifested itself in `MenuItem` so I added a test for that case as well as a more general test for `Popup`.

The simple fix for this case is when traversing controls to set the `TemplatedParent`, stop when we find a control which already has `TemplatedParent` set as we can assume that from that point the `TemplatedParent` state is correct.
