### PR TITLE
Fix TrayIcon null pointer exception on application exit

### DIFF
--- a/src/Avalonia.Controls/TrayIcon.cs
+++ b/src/Avalonia.Controls/TrayIcon.cs
@@ -189,7 +189,10 @@ namespace Avalonia.Controls
             var app = Application.Current ?? throw new InvalidOperationException("Application not yet initialized.");
             var trayIcons = GetIcons(app);
 
-            RemoveIcons(trayIcons);
+            if (trayIcons != null)
+            {
+                RemoveIcons(trayIcons);
+            }
         }
 
         private static void Icons_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
## What does the pull request do?
TrayIcon subscribes to the application lifetime shutdown event when initializing. When shutting down the event gets fired and it tries to get a dependency property named `IconsProperty` that it has registered on the current application instance. The value for the IconsProperty is sometimes NULL, which ultimately leads to a null pointer exception. This pull request checks for a null value and fixes the problem.


## What is the current behavior?
Null pointer exception is thrown.


## What is the updated/expected behavior with this PR?
No null pointer exception is thrown

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

