### PR TITLE
Fix initial window size on osx

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -127,7 +127,11 @@
         [self updateRenderTarget];
 
         auto reason = [self inLiveResize] ? ResizeUser : _resizeReason;
-        _parent->BaseEvents->Resized(AvnSize{newSize.width, newSize.height}, reason);
+        
+        if(_parent->IsShown())
+        {
+            _parent->BaseEvents->Resized(AvnSize{newSize.width, newSize.height}, reason);
+        }
     }
 }
 


### PR DESCRIPTION
On OSX if you use ExtendDecorationsToClientArea and supply a MinSize for your window, instead of the typical sensible window size being used when window opens, your window will be made minimum size.

This PR makes the behavior as expected and consistent with other platforms.