### PR TITLE
Use indicators parent if available to determine the space

### DIFF
--- a/src/Avalonia.Controls/ProgressBar.cs
+++ b/src/Avalonia.Controls/ProgressBar.cs
@@ -195,7 +195,7 @@ namespace Avalonia.Controls
         /// <inheritdoc/>
         protected override Size ArrangeOverride(Size finalSize)
         {
-            UpdateIndicator(finalSize);
+            UpdateIndicator();
             return base.ArrangeOverride(finalSize);
         }
 
@@ -218,18 +218,21 @@ namespace Avalonia.Controls
         {
             _indicator = e.NameScope.Get<Border>("PART_Indicator");
 
-            UpdateIndicator(Bounds.Size);
+            UpdateIndicator();
         }
 
-        private void UpdateIndicator(Size bounds)
+        private void UpdateIndicator()
         {
+            // Gets the size of the parent indicator container
+            var barSize = _indicator?.Parent?.Bounds.Size ?? Bounds.Size;
+            
             if (_indicator != null)
             {
                 if (IsIndeterminate)
                 {
                     // Pulled from ModernWPF.
 
-                    var dim = Orientation == Orientation.Horizontal ? bounds.Width : bounds.Height;
+                    var dim = Orientation == Orientation.Horizontal ? barSize.Width : barSize.Height;
                     var barIndicatorWidth = dim * 0.4; // Indicator width at 40% of ProgressBar
                     var barIndicatorWidth2 = dim * 0.6; // Indicator width at 60% of ProgressBar
 
@@ -254,8 +257,8 @@ namespace Avalonia.Controls
                         new Rect(
                             padding.Left,
                             padding.Top,
-                            bounds.Width - (padding.Right + padding.Left),
-                            bounds.Height - (padding.Bottom + padding.Top)
+                            barSize.Width - (padding.Right + padding.Left),
+                            barSize.Height - (padding.Bottom + padding.Top)
                             ));
                 }
                 else
@@ -263,9 +266,9 @@ namespace Avalonia.Controls
                     double percent = Maximum == Minimum ? 1.0 : (Value - Minimum) / (Maximum - Minimum);
 
                     if (Orientation == Orientation.Horizontal)
-                        _indicator.Width = bounds.Width * percent;
+                        _indicator.Width = barSize.Width * percent;
                     else
-                        _indicator.Height = bounds.Height * percent;
+                        _indicator.Height = barSize.Height * percent;
 
                     Percentage = percent * 100;
                 }
@@ -274,7 +277,7 @@ namespace Avalonia.Controls
 
         private void UpdateIndicatorWhenPropChanged(AvaloniaPropertyChangedEventArgs e)
         {
-            UpdateIndicator(Bounds.Size);
+            UpdateIndicator();
         }
 
         private void UpdatePseudoClasses(


### PR DESCRIPTION
## What does the pull request do?
As in #4489 written the ProgressBar grows automatically if a border is used near 100 %. This is due to the fact that the indicator sizes to controls actual size. The border is added, control is measured again and has a new size, so the indicator is calculating it's size to the new bounds and we are in a circular reference. 

In this PR:

![image](https://user-images.githubusercontent.com/47110241/178434016-694ccafd-d635-4b08-9894-d89d8c51fee8.png)


## What is the current behavior?
measure parent of the indicator instead of controls bounds, if parent is available. 


## What is the updated/expected behavior with this PR?
ProgressBar does not grow automatically

## How was the solution implemented (if it's not obvious)?
Use indicators parent as available indicator size


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #4489
Fixes #7785