### PR TITLE
Fix: DataGrid Grouping symbol wrong in Fluent Theme

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -7,7 +7,7 @@
     <StreamGeometry x:Key="DataGridSortIconDescendingPath">M1875 1011l-787 787v-1798h-128v1798l-787 -787l-90 90l941 941l941 -941z</StreamGeometry>
     <StreamGeometry x:Key="DataGridSortIconAscendingPath">M1965 947l-941 -941l-941 941l90 90l787 -787v1798h128v-1798l787 787z</StreamGeometry>
     <StreamGeometry x:Key="DataGridRowGroupHeaderIconClosedPath">M515 93l930 931l-930 931l90 90l1022 -1021l-1022 -1021z</StreamGeometry>
-    <StreamGeometry x:Key="DataGridRowGroupHeaderIconOpenedPath">M1939 1581l90 -90l-1005 -1005l-1005 1005l90 90l915 -915z</StreamGeometry>
+    <StreamGeometry x:Key="DataGridRowGroupHeaderIconOpenedPath">M109 486 19 576 1024 1581 2029 576 1939 486 1024 1401z</StreamGeometry>
 
     <SolidColorBrush x:Key="DataGridColumnHeaderForegroundBrush" Color="{DynamicResource SystemBaseMediumColor}" />
     <SolidColorBrush x:Key="DataGridColumnHeaderBackgroundBrush" Color="{DynamicResource SystemAltHighColor}" />
@@ -499,12 +499,12 @@
   </Style>
 
   <Style Selector="DataGridRowGroupHeader /template/ ToggleButton#ExpanderButton /template/ Path">
-    <Setter Property="Data" Value="{StaticResource DataGridRowGroupHeaderIconOpenedPath}" />
+    <Setter Property="Data" Value="{StaticResource DataGridRowGroupHeaderIconClosedPath}" />
     <Setter Property="Stretch" Value="Uniform" />
   </Style>
 
   <Style Selector="DataGridRowGroupHeader /template/ ToggleButton#ExpanderButton:checked /template/ Path">
-    <Setter Property="Data" Value="{StaticResource DataGridRowGroupHeaderIconClosedPath}" />
+    <Setter Property="Data" Value="{StaticResource DataGridRowGroupHeaderIconOpenedPath}" />
     <Setter Property="Stretch" Value="UniformToFill" />
   </Style>
 


### PR DESCRIPTION
## What does the pull request do?
Corrects the grouping Expander icon in fluent theme


## What is the current behavior?
See #8476 


## What is the updated/expected behavior with this PR?
Arrows now looks like this: 
![image](https://user-images.githubusercontent.com/47110241/178500539-707556f2-c7d1-4e4d-93eb-bfcb38d8dc80.png)


## How was the solution implemented (if it's not obvious)?
Two fixes were needed: 
1. The icon for opened was flipped vertically. Corrected the path data using Inkscape (www.inkscape.org)
2. The icons for `:checked` and `:unchecked` were switched

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
The arrows now looks different. if someones intention was to have the old style, one must override the needed styles on his own.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #8476 

## Additinal hint: 

this issue is possible also present in #8479 . Please be noted @grokys and @Takoooooo 

Happy coding
Tim
