### PR TITLE
Added --debug switch to benchmarks.

### DIFF
--- a/tests/Avalonia.Benchmarks/Program.cs
+++ b/tests/Avalonia.Benchmarks/Program.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 
 namespace Avalonia.Benchmarks
@@ -19,7 +21,17 @@ namespace Avalonia.Benchmarks
                 .ThenBy(t => t.Name)
                 .ToArray();
             var benchmarkSwitcher = new BenchmarkSwitcher(benchmarks);
-            benchmarkSwitcher.Run(args);
+            IConfig config = null;
+
+            if (args.Contains("--debug"))
+            {
+                config = new DebugInProcessConfig();
+                var a = new List<string>(args);
+                a.Remove("--debug");
+                args = a.ToArray();
+            }
+
+            benchmarkSwitcher.Run(args, config);
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

To be able to run benchmarks in the debugger, you need to pass `DebugInProcessConfig` to the benchmark switcher. There doesn't seem to be any inbuilt switch to enable this from the command-line, so added one to the benchmarks projects in order to be able to debug benchmarks more easily.
