### PR TITLE
Backport native control host handle validation

### DIFF
--- a/src/Windows/Avalonia.Win32/Win32NativeControlHost.cs
+++ b/src/Windows/Avalonia.Win32/Win32NativeControlHost.cs
@@ -94,6 +94,10 @@ namespace Avalonia.Win32
                     IntPtr.Zero,
                     IntPtr.Zero,
                     IntPtr.Zero);
+
+                if (Handle == IntPtr.Zero)
+                    throw new InvalidOperationException("Unable to create child window for native control host. Application manifest with supported OS list might be required.");
+
                 if (layered)
                     UnmanagedMethods.SetLayeredWindowAttributes(Handle, 0, 255,
                         UnmanagedMethods.LayeredWindowFlags.LWA_ALPHA);


### PR DESCRIPTION
If developer forgot about app.manifest on windows, NativeControlHost might not work, when layered window is enabled.
It was already part of the master branch for a while, better to backport as well.