### PR TITLE
fix: RowDesiredWidth was missing the RowHeaderWidth

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridRowsPresenter.cs
@@ -97,7 +97,7 @@ namespace Avalonia.Controls.Primitives
 
             OwningGrid.OnFillerColumnWidthNeeded(finalSize.Width);
 
-            double rowDesiredWidth = OwningGrid.ColumnsInternal.VisibleEdgedColumnsWidth + OwningGrid.ColumnsInternal.FillerColumn.FillerWidth;
+            double rowDesiredWidth = OwningGrid.RowHeadersDesiredWidth + OwningGrid.ColumnsInternal.VisibleEdgedColumnsWidth + OwningGrid.ColumnsInternal.FillerColumn.FillerWidth;
             double topEdge = -OwningGrid.NegVerticalOffset;
             foreach (Control element in OwningGrid.DisplayData.GetScrollingElements())
             {


### PR DESCRIPTION
## What does the pull request do?
If one has row headers visible, the last column was clipped by the size the header column uses. This PR should fix it.


## What is the current behavior?
See #8323


## What is the updated/expected behavior with this PR?
Last column is completely visible, also if row headers are visible


## How was the solution implemented (if it's not obvious)?
Add the missing header width during arrangement


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
The DataGrid will now look different, BUT imo this is the intended behavior. So from my point of view no breaking change

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #8323

## Backport?
Dear Avalonia-team. I don't say this often, but this bug is really bugging me. I've an ugly workaround for now, but I would like to see this issue fixed if possible. So if you see the chance to backport this PR, please do. Thank you in advance 🙏 

Happy coding
Tim 