### PR TITLE
Fix unaligned accesses

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Transport/BatchStream.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Transport/BatchStream.cs
@@ -72,7 +72,7 @@ internal class BatchStreamWriter : IDisposable
         var size = Unsafe.SizeOf<T>();
         if (_currentDataSegment.Data == IntPtr.Zero || _currentDataSegment.ElementCount + size > _memoryPool.BufferSize)
             NextDataSegment();
-        *(T*)((byte*)_currentDataSegment.Data + _currentDataSegment.ElementCount) = item;
+        Unsafe.WriteUnaligned<T>((byte*)_currentDataSegment.Data + _currentDataSegment.ElementCount, item);
         _currentDataSegment.ElementCount += size;
     }
 
@@ -123,7 +123,7 @@ internal class BatchStreamReader : IDisposable
         if (_memoryOffset + size > _currentDataSegment.ElementCount)
             throw new InvalidOperationException("Attempted to read more memory then left in the current segment");
 
-        var rv = *(T*)((byte*)_currentDataSegment.Data + _memoryOffset);
+        var rv = Unsafe.ReadUnaligned<T>((byte*)_currentDataSegment.Data + _memoryOffset);
         _memoryOffset += size;
         if (_memoryOffset == _currentDataSegment.ElementCount)
         {

--- a/src/Avalonia.X11/X11Structs.cs
+++ b/src/Avalonia.X11/X11Structs.cs
@@ -32,6 +32,7 @@ using System.Collections;
 using System.Drawing;
 using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 // ReSharper disable FieldCanBeMadeReadOnly.Global
 // ReSharper disable IdentifierTypo
@@ -545,7 +546,7 @@ namespace Avalonia.X11 {
         {
             if (data == null)
                 throw new InvalidOperationException();
-            return *(T*)data;
+            return Unsafe.ReadUnaligned<T>(data);
         }
     }
 


### PR DESCRIPTION
## What does the pull request do?
Makes avalonia use safe unaligned accesses.

## What is the current behavior?
Crash on unaligned access on platforms that don't support it such as ARM32.

## What is the updated/expected behavior with this PR?
No crash.

## How was the solution implemented (if it's not obvious)?
Looked through pointer casts and changed suspicious ones to Unsafe.Write/ReadUnaligned

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #8525
