### PR TITLE
`ComboBoxMinHeight` should be of Type `double`, not `Thickness`

### DIFF
--- a/src/Avalonia.Themes.Fluent/DensityStyles/Compact.xaml
+++ b/src/Avalonia.Themes.Fluent/DensityStyles/Compact.xaml
@@ -15,7 +15,7 @@
             <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
             <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
             <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
-            <Thickness x:Key="ComboBoxMinHeight">24</Thickness>
+            <x:Double x:Key="ComboBoxMinHeight">24</x:Double>
             <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness>
             <x:Double x:Key="NavigationViewItemOnLeftMinHeight">32</x:Double>
         </Style.Resources>


### PR DESCRIPTION
## What does the pull request do?
corrects a bug in fluent theme (Denstiy-mode only)


## What is the current behavior?
See #8401


## What is the updated/expected behavior with this PR?
ComboBox works as expected


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #8401
