### PR TITLE
Fix multiple enumeration of TrayIcon menu items on win32 causing broken tray icon menus

### DIFF
--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -304,7 +304,7 @@ namespace Avalonia.Controls
         bool IMenuItem.IsPointerOverSubMenu => _popup?.IsPointerOverPopup ?? false;
 
         /// <inheritdoc/>
-        IMenuElement? IMenuItem.Parent => Parent as IMenuElement;
+        IMenuElement? IMenuItem.Parent => this.FindLogicalAncestorOfType<IMenuElement>();
 
         protected override bool IsEnabledCore => base.IsEnabledCore && _commandCanExecute;
 

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -304,7 +304,7 @@ namespace Avalonia.Controls
         bool IMenuItem.IsPointerOverSubMenu => _popup?.IsPointerOverPopup ?? false;
 
         /// <inheritdoc/>
-        IMenuElement? IMenuItem.Parent => this.FindLogicalAncestorOfType<IMenuElement>();
+        IMenuElement? IMenuItem.Parent => Parent as IMenuElement;
 
         protected override bool IsEnabledCore => base.IsEnabledCore && _commandCanExecute;
 

--- a/src/Windows/Avalonia.Win32/Win32NativeToManagedMenuExporter.cs
+++ b/src/Windows/Avalonia.Win32/Win32NativeToManagedMenuExporter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Platform;
 
@@ -15,13 +16,15 @@ namespace Avalonia.Win32
             _nativeMenu = nativeMenu;
         }
 
-        private IEnumerable<MenuItem> Populate(NativeMenu nativeMenu)
+        private AvaloniaList<MenuItem> Populate(NativeMenu nativeMenu)
         {
+            var result = new AvaloniaList<MenuItem>();
+            
             foreach (var menuItem in nativeMenu.Items)
             {
                 if (menuItem is NativeMenuItemSeparator)
                 {
-                    yield return new MenuItem { Header = "-" };
+                    result.Add(new MenuItem { Header = "-" });
                 }
                 else if (menuItem is NativeMenuItem item)
                 {
@@ -36,12 +39,14 @@ namespace Avalonia.Win32
                         newItem.Click += (_, __) => bridge.RaiseClicked();
                     }
 
-                    yield return newItem;
+                    result.Add(newItem);
                 }
             }
+
+            return result;
         }
 
-        public IEnumerable<MenuItem>? GetMenu()
+        public AvaloniaList<MenuItem>? GetMenu()
         {
             if (_nativeMenu != null)
             {


### PR DESCRIPTION
The menu exporter was using yield, meaning that avalonias logic would be given new menuitem instances every time it enumerated the menus.

This basically meant that many things were broken by the time the menu was displayed.

Most significantly the Parent of the menu item was no longer correct, meaning, no closing when item clicked, and no menu items not highlighting when pointer is hovering over.

Fixes https://github.com/AvaloniaUI/Avalonia/issues/8312
Fixes https://github.com/AvaloniaUI/Avalonia/issues/7864