### PR TITLE
Source generator and trimming improvements

### DIFF
--- a/Avalonia.sln
+++ b/Avalonia.sln
@@ -40,7 +40,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{A689DE
 		.editorconfig = .editorconfig
 		src\Shared\IsExternalInit.cs = src\Shared\IsExternalInit.cs
 		src\Shared\ModuleInitializer.cs = src\Shared\ModuleInitializer.cs
-		src\Shared\SourceGeneratorAttributes.cs = src\Shared\SourceGeneratorAttributes.cs
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.ReactiveUI", "src\Avalonia.ReactiveUI\Avalonia.ReactiveUI.csproj", "{6417B24E-49C2-4985-8DB2-3AB9D898EC91}"
@@ -212,7 +211,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Controls.ColorPick
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.DesignerSupport.Tests", "tests\Avalonia.DesignerSupport.Tests\Avalonia.DesignerSupport.Tests.csproj", "{EABE2161-989B-42BF-BD8D-1E34B20C21F1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DevGenerators", "src\tools\DevGenerators\DevGenerators.csproj", "{1BBFAD42-B99E-47E0-B00A-A4BC6B6BB4BB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DevGenerators", "src\tools\DevGenerators\DevGenerators.csproj", "{1BBFAD42-B99E-47E0-B00A-A4BC6B6BB4BB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/build/SourceGenerators.props
+++ b/build/SourceGenerators.props
@@ -5,6 +5,5 @@
       OutputItemType="Analyzer" 
       ReferenceOutputAssembly="false"
       PrivateAssets="all" />
-    <Compile Include="$(MSBuildThisFileDirectory)/../src/Shared/SourceGeneratorAttributes.cs" />
   </ItemGroup>
 </Project>

--- a/src/Avalonia.Base/Animation/Animation.cs
+++ b/src/Avalonia.Base/Animation/Animation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -222,20 +223,22 @@ namespace Avalonia.Animation
             s_animators[setter] = value;
         }
 
-        private readonly static List<(Func<AvaloniaProperty, bool> Condition, Type Animator)> Animators = new List<(Func<AvaloniaProperty, bool>, Type)>
+        private readonly static List<(Func<AvaloniaProperty, bool> Condition, Type Animator)> Animators = new();
+
+        static Animation()
         {
-            ( prop => typeof(bool).IsAssignableFrom(prop.PropertyType), typeof(BoolAnimator) ),
-            ( prop => typeof(byte).IsAssignableFrom(prop.PropertyType), typeof(ByteAnimator) ),
-            ( prop => typeof(Int16).IsAssignableFrom(prop.PropertyType), typeof(Int16Animator) ),
-            ( prop => typeof(Int32).IsAssignableFrom(prop.PropertyType), typeof(Int32Animator) ),
-            ( prop => typeof(Int64).IsAssignableFrom(prop.PropertyType), typeof(Int64Animator) ),
-            ( prop => typeof(UInt16).IsAssignableFrom(prop.PropertyType), typeof(UInt16Animator) ),
-            ( prop => typeof(UInt32).IsAssignableFrom(prop.PropertyType), typeof(UInt32Animator) ),
-            ( prop => typeof(UInt64).IsAssignableFrom(prop.PropertyType), typeof(UInt64Animator) ),
-            ( prop => typeof(float).IsAssignableFrom(prop.PropertyType), typeof(FloatAnimator) ),
-            ( prop => typeof(double).IsAssignableFrom(prop.PropertyType), typeof(DoubleAnimator) ),
-            ( prop => typeof(decimal).IsAssignableFrom(prop.PropertyType), typeof(DecimalAnimator) ),
-        };
+            RegisterAnimator<BoolAnimator>(prop => typeof(bool).IsAssignableFrom(prop.PropertyType));
+            RegisterAnimator<ByteAnimator>(prop => typeof(byte).IsAssignableFrom(prop.PropertyType));
+            RegisterAnimator<Int16Animator>(prop => typeof(Int16).IsAssignableFrom(prop.PropertyType));
+            RegisterAnimator<Int32Animator>(prop => typeof(Int32).IsAssignableFrom(prop.PropertyType));
+            RegisterAnimator<Int64Animator>(prop => typeof(Int64).IsAssignableFrom(prop.PropertyType));
+            RegisterAnimator<UInt16Animator>(prop => typeof(UInt16).IsAssignableFrom(prop.PropertyType));
+            RegisterAnimator<UInt32Animator>(prop => typeof(UInt32).IsAssignableFrom(prop.PropertyType));
+            RegisterAnimator<UInt64Animator>(prop => typeof(UInt64).IsAssignableFrom(prop.PropertyType));
+            RegisterAnimator<FloatAnimator>(prop => typeof(float).IsAssignableFrom(prop.PropertyType));
+            RegisterAnimator<DoubleAnimator>(prop => typeof(double).IsAssignableFrom(prop.PropertyType));
+            RegisterAnimator<DecimalAnimator>(prop => typeof(decimal).IsAssignableFrom(prop.PropertyType));
+        }
 
         /// <summary>
         /// Registers a <see cref="Animator{T}"/> that can handle
@@ -248,7 +251,11 @@ namespace Avalonia.Animation
         /// <typeparam name="TAnimator">
         /// The type of the animator to instantiate.
         /// </typeparam>
-        public static void RegisterAnimator<TAnimator>(Func<AvaloniaProperty, bool> condition)
+        public static void RegisterAnimator<
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicMethods)]
+#endif
+            TAnimator>(Func<AvaloniaProperty, bool> condition)
             where TAnimator : IAnimator
         {
             Animators.Insert(0, (condition, typeof(TAnimator)));

--- a/src/tools/DevGenerators/DevGenerators.csproj
+++ b/src/tools/DevGenerators/DevGenerators.csproj
@@ -12,7 +12,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
-    <Compile Include="..\..\Shared\SourceGeneratorAttributes.cs" />
     <Compile Include="..\..\Shared\IsExternalInit.cs" Link="IsExternalInit.cs" />
   </ItemGroup>
 

--- a/src/tools/DevGenerators/SubtypesFactoryGenerator.cs
+++ b/src/tools/DevGenerators/SubtypesFactoryGenerator.cs
@@ -12,7 +12,7 @@ namespace Avalonia.SourceGenerator
     public class SubtypesFactoryGenerator : IIncrementalGenerator
     {
         private record struct MethodTarget(IMethodSymbol Method, string MethodDecl, ITypeSymbol BaseType, string Namespace);
-        private static readonly string s_attributeName = typeof(SubtypesFactoryAttribute).FullName;
+        private const string AttributeName = "Avalonia.SourceGenerator.SubtypesFactoryAttribute";
 
         private static bool IsSubtypeOf(ITypeSymbol type, ITypeSymbol baseType)
         {
@@ -63,7 +63,7 @@ namespace {method.ContainingNamespace}
                 {
                     var attributeTypeInfo = semanticModel.GetTypeInfo(attribute);
                     if (attributeTypeInfo.Type is null ||
-                        attributeTypeInfo.Type.ToString() != s_attributeName ||
+                        attributeTypeInfo.Type.ToString() != AttributeName ||
                         attribute.ArgumentList is null)
                     {
                         continue;
@@ -112,6 +112,27 @@ namespace {method.ContainingNamespace}
 
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
+            context.RegisterPostInitializationOutput(ctx =>
+            {
+                ctx.AddSource("Avalonia.SourceGenerator.Attributes.cs", @"using System;
+
+namespace Avalonia.SourceGenerator
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+    internal sealed class SubtypesFactoryAttribute : Attribute
+    {
+        public SubtypesFactoryAttribute(Type baseType, string @namespace)
+        {
+            BaseType = baseType;
+            Namespace = @namespace;
+        }
+
+        public string Namespace { get; }
+        public Type BaseType { get; }
+    }
+}");
+            });
+
             var typesProvider = context.SyntaxProvider.CreateSyntaxProvider(
                 static (syntaxNode, token) =>
                 {


### PR DESCRIPTION
1. Use source generator to generate dev attributes to avoid an extra source dependency
2. Add `DynamicallyAccessedMembers` to `RegisterAnimator` and make sure the initialization process have a call to `RegisterAnimator`, to make `Animator` trimming and aot friendly.