### PR TITLE
Fix loading window icons on X11

### DIFF
--- a/src/Avalonia.X11/X11IconLoader.cs
+++ b/src/Avalonia.X11/X11IconLoader.cs
@@ -80,7 +80,7 @@ namespace Avalonia.X11
                         var r = y * _width;
                         var fbr = y * fb.RowBytes / 4;
                         for (var x = 0; x < _width; x++)
-                            fbp[fbr + x] = Data[r + x].ToUInt32();
+                            fbp[fbr + x] = Data[r + x + 2].ToUInt32();
                     }
                 }
                 wr.Save(outputStream);

--- a/src/Avalonia.X11/X11IconLoader.cs
+++ b/src/Avalonia.X11/X11IconLoader.cs
@@ -48,12 +48,6 @@ namespace Avalonia.X11
             _width = Math.Min(bitmap.PixelSize.Width, 128);
             _height = Math.Min(bitmap.PixelSize.Height, 128);
             _bdata = new uint[_width * _height];
-            fixed (void* ptr = _bdata)
-            {
-                var iptr = (int*)ptr;
-                iptr[0] = _width;
-                iptr[1] = _height;
-            }
             using(var rt = AvaloniaLocator.Current.GetService<IPlatformRenderInterface>().CreateRenderTarget(new[]{this}))
             using (var ctx = rt.CreateDrawingContext(null))
                 ctx.DrawBitmap(bitmap.PlatformImpl, 1, new Rect(bitmap.Size),
@@ -65,7 +59,7 @@ namespace Avalonia.X11
             {
                 var r = y * _width;
                 for (var x = 0; x < _width; x++)
-                    Data[r + x] = new UIntPtr(_bdata[r + x]);
+                    Data[r + x + 2] = new UIntPtr(_bdata[r + x]);
             }
 
             _bdata = null;


### PR DESCRIPTION
## What does the pull request do?
Fixes loading of X11IconData
First 2 values of Data array are supposed to be width and height, but later are being replaced by bitmap data

## What is the current behavior?
Exception or invalid data in a window icon when using X11

## What is the updated/expected behavior with this PR?
No exception

