### PR TITLE
Fix DrmCard creation for passed path

### DIFF
--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
@@ -164,7 +164,7 @@ namespace Avalonia.LinuxFramebuffer.Output
             else 
             {
                 Fd = open(path, 2, 0);
-                if(Fd != -1) throw new Win32Exception($"Couldn't open {path}");
+                if(Fd == -1) throw new Win32Exception($"Couldn't open {path}");
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
Fixing DrmCard creation with passed card path as parameter.


## What is the current behavior?
When passing an path like '/dev/dri/card0' as parameter to DrmCard constructor, an Win32Exception is thrown when a filedescriptor is returned on opening.


## What is the updated/expected behavior with this PR?
Working DrmCard creation when an path like '/dev/dri/card0' is passed as parameter to DrmCard constructor.