### PR TITLE
[WIP] Linux: Set X11 window's application name

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -171,6 +171,9 @@ namespace Avalonia.X11
             if (platform.Options.WmClass != null)
                 SetWmClass(platform.Options.WmClass);
 
+            // TODO: how do we get the Application.Name here as we don't have direct access to that
+            SetApplicationName("Avalonia Application");
+
             var surfaces = new List<object>
             {
                 new X11FramebufferSurface(_x11.DeferredDisplay, _renderHandle, 
@@ -1143,6 +1146,35 @@ namespace Avalonia.X11
             else
             {
                 XDeleteProperty(_x11.Display, _handle, _x11.Atoms._NET_WM_ICON);
+            }
+        }
+
+        /// <summary>
+        ///   Sets the application name that is visible for example in the Gnome desktop top bar
+        /// </summary>
+        /// <param name="name">The application name to set</param>
+        public void SetApplicationName(string name)
+        {
+            var classHint = XAllocClassHint();
+
+            if (classHint == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var classHintData = Marshal.PtrToStructure<XClassHint>(classHint);
+
+            var classTextData = Encoding.ASCII.GetBytes(name);
+            fixed (void* textPtr = classTextData)
+            {
+                classHintData.ResClass = new IntPtr(textPtr);
+                classHintData.ResName = new IntPtr(textPtr);
+
+                Marshal.StructureToPtr(classHintData, classHint, true);
+
+                XSetClassHint(_x11.Display, _handle, classHint);
+
+                XFree(classHint);
             }
         }
 

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Disposables;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Threading;

--- a/src/Avalonia.X11/XLib.cs
+++ b/src/Avalonia.X11/XLib.cs
@@ -373,6 +373,12 @@ namespace Avalonia.X11
         public static extern void XSetWMHints(IntPtr display, IntPtr window, ref XWMHints wmhints);
 
         [DllImport(libX11)]
+        public static extern IntPtr XAllocClassHint();
+
+        [DllImport(libX11)]
+        public static extern IntPtr XSetClassHint(IntPtr display, IntPtr window, IntPtr classHints);
+
+        [DllImport(libX11)]
         public static extern int XGetIconSizes(IntPtr display, IntPtr window, out IntPtr size_list, out int count);
 
         [DllImport(libX11)]
@@ -643,6 +649,13 @@ namespace Avalonia.X11
         public struct XSyncValue {
             public int Hi;
             public uint Lo;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct XClassHint
+        {
+            public IntPtr ResName;
+            public IntPtr ResClass;
         }
 
         public static bool XGetGeometry(IntPtr display, IntPtr window, out XGeometry geo)


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Once fully complete fixes #7685

I'm opening this as a draft because I can't see a simple way to get the application's name to the X11Window class, so I'm hoping to get guidance as to what the project authors would do in this case. I didn't attempt any approach as I'd likely done something silly that would need to be refactored anyway.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
See the issue, but very briefly there's just a blank space where the application name should go.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
This adds code to set the application name.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
https://github.com/AvaloniaUI/Avalonia/issues/7685#issuecomment-1194038445

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #7685