### PR TITLE
Workaround for SkiaSharp broken image decoding.

### DIFF
--- a/src/Skia/Avalonia.Skia/ImmutableBitmap.cs
+++ b/src/Skia/Avalonia.Skia/ImmutableBitmap.cs
@@ -57,7 +57,8 @@ namespace Avalonia.Skia
         public ImmutableBitmap(Stream stream, int decodeSize, bool horizontal, BitmapInterpolationMode interpolationMode)
         {
             using (var skStream = new SKManagedStream(stream))
-            using (var codec = SKCodec.Create(skStream))
+            using (var skData = SKData.Create(skStream))
+            using (var codec = SKCodec.Create(skData))
             {
                 var info = codec.Info;
 

--- a/src/Skia/Avalonia.Skia/WriteableBitmapImpl.cs
+++ b/src/Skia/Avalonia.Skia/WriteableBitmapImpl.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Avalonia.Skia.Helpers;
-using Avalonia.Media.Imaging;
 using SkiaSharp;
 
 namespace Avalonia.Skia
@@ -25,8 +24,9 @@ namespace Avalonia.Skia
         public WriteableBitmapImpl(Stream stream)
         {
             using (var skiaStream = new SKManagedStream(stream))
+            using (var skData = SKData.Create(skiaStream))
             {
-                _bitmap = SKBitmap.Decode(skiaStream);
+                _bitmap = SKBitmap.Decode(skData);
 
                 if (_bitmap == null)
                 {
@@ -41,7 +41,8 @@ namespace Avalonia.Skia
         public WriteableBitmapImpl(Stream stream, int decodeSize, bool horizontal, BitmapInterpolationMode interpolationMode)
         {
             using (var skStream = new SKManagedStream(stream))
-            using (var codec = SKCodec.Create(skStream))
+            using (var skData = SKData.Create(skStream))
+            using (var codec = SKCodec.Create(skData))
             {
                 var info = codec.Info;
 


### PR DESCRIPTION
## What does the pull request do?

SkiaSharp has broken bitmap decoding in some cases, as described in #7773 and https://github.com/mono/SkiaSharp/issues/1551.

The workaround from https://github.com/mono/SkiaSharp/issues/1551#issuecomment-756685252 seems to fix this from the example image I've tried, so use that.

Fixes #7773
