### PR TITLE
Trying to fix flaky menu integration tests on win32.

### DIFF
--- a/tests/Avalonia.IntegrationTests.Appium/MenuTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/MenuTests.cs
@@ -60,6 +60,8 @@ namespace Avalonia.IntegrationTests.Appium
         [PlatformFact(TestPlatforms.Windows)]
         public void Select_Child_With_Alt_Arrow_Keys()
         {
+            MovePointerOutOfTheWay();
+
             new Actions(_session)
                 .KeyDown(Keys.Alt).KeyUp(Keys.Alt)
                 .SendKeys(Keys.Down + Keys.Enter)
@@ -72,6 +74,8 @@ namespace Avalonia.IntegrationTests.Appium
         [PlatformFact(TestPlatforms.Windows)]
         public void Select_Grandchild_With_Alt_Arrow_Keys()
         {
+            MovePointerOutOfTheWay();
+
             new Actions(_session)
                 .KeyDown(Keys.Alt).KeyUp(Keys.Alt)
                 .SendKeys(Keys.Down + Keys.Down + Keys.Right + Keys.Enter)
@@ -84,6 +88,8 @@ namespace Avalonia.IntegrationTests.Appium
         [PlatformFact(TestPlatforms.Windows)]
         public void Select_Child_With_Alt_Access_Keys()
         {
+            MovePointerOutOfTheWay();
+
             new Actions(_session)
                 .KeyDown(Keys.Alt).KeyUp(Keys.Alt)
                 .SendKeys("rc")
@@ -96,6 +102,8 @@ namespace Avalonia.IntegrationTests.Appium
         [PlatformFact(TestPlatforms.Windows)]
         public void Select_Grandchild_With_Alt_Access_Keys()
         {
+            MovePointerOutOfTheWay();
+
             new Actions(_session)
                 .KeyDown(Keys.Alt).KeyUp(Keys.Alt)
                 .SendKeys("rhg")
@@ -111,6 +119,8 @@ namespace Avalonia.IntegrationTests.Appium
             var rootMenuItem = _session.FindElementByAccessibilityId("RootMenuItem");
             rootMenuItem.SendClick();
 
+            MovePointerOutOfTheWay();
+
             new Actions(_session)
                 .SendKeys(Keys.Down + Keys.Enter)
                 .Perform();
@@ -124,6 +134,8 @@ namespace Avalonia.IntegrationTests.Appium
         {
             var rootMenuItem = _session.FindElementByAccessibilityId("RootMenuItem");
             rootMenuItem.SendClick();
+
+            MovePointerOutOfTheWay();
 
             new Actions(_session)
                 .SendKeys(Keys.Down + Keys.Down + Keys.Right + Keys.Enter)
@@ -158,6 +170,16 @@ namespace Avalonia.IntegrationTests.Appium
             rootMenuItem.MovePointerOver();
 
             Assert.True(textBox.GetIsFocused());
+        }
+
+        private void MovePointerOutOfTheWay()
+        {
+            // Move the pointer to the menu tab item so that it's not over the menu in preparation
+            // for key press tests. This prevents the mouse accidentially selecting the wrong item
+            // by hovering.
+            var tabs = _session.FindElementByAccessibilityId("MainTabs");
+            var tab = tabs.FindElementByName("Menu");
+            tab.MovePointerOver();
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Move the mouse pointer out of the way of the menu when running integration tests on menu keys. Looks like the problem might have been the fact that the pointer was hovering over the `Child 1` menu item, and the hover caused that menu item to be selected depending on timing.