### PR TITLE
Unused Stopwatch removed

### DIFF
--- a/src/Windows/Avalonia.Win32/WinRT/Composition/WinUICompositorConnection.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/Composition/WinUICompositorConnection.cs
@@ -120,16 +120,14 @@ namespace Avalonia.Win32.WinRT.Composition
 
         private void RunLoop()
         {
+            using (var act = _compositor5.RequestCommitAsync())
+                act.SetCompleted(new RunLoopHandler(this));
+
+            while (true)
             {
-                var st = Stopwatch.StartNew();
-                using (var act = _compositor5.RequestCommitAsync())
-                    act.SetCompleted(new RunLoopHandler(this));
-                while (true)
-                {
-                    UnmanagedMethods.GetMessage(out var msg, IntPtr.Zero, 0, 0);
-                    lock (_pumpLock)
-                        UnmanagedMethods.DispatchMessage(ref msg);
-                }
+                UnmanagedMethods.GetMessage(out var msg, IntPtr.Zero, 0, 0);
+                lock (_pumpLock)
+                    UnmanagedMethods.DispatchMessage(ref msg);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
Removes the line Stopwatch.StartNew() in WinUICompositorConnection.RunLoop().
All other StopWatches in the code are used.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. When the PR is merged please add an entry to https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
