### PR TITLE
Add backpressure for sending batches to the render thread

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
@@ -71,7 +71,7 @@ public class CompositingRenderer : IRendererWithCompositor
         if(_queuedUpdate)
             return;
         _queuedUpdate = true;
-        Dispatcher.UIThread.Post(_update, DispatcherPriority.Composition);
+        _compositor.InvokeWhenReadyForNextCommit(_update);
     }
     
     /// <inheritdoc/>

--- a/src/Avalonia.Base/Rendering/Composition/Compositor.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Compositor.cs
@@ -146,7 +146,9 @@ namespace Avalonia.Rendering.Composition
             if (_lastBatchCompleted == null || _lastBatchCompleted.IsCompleted)
                 Dispatcher.UIThread.Post(action, DispatcherPriority.Composition);
             else
-                _lastBatchCompleted.ContinueWith(_ => Dispatcher.UIThread.Post(action, DispatcherPriority.Composition));
+                _lastBatchCompleted.ContinueWith(
+                    static (_, state) => Dispatcher.UIThread.Post((Action)state!, DispatcherPriority.Composition),
+                    action);
         }
     }
 }

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositor.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositor.cs
@@ -108,6 +108,7 @@ namespace Avalonia.Rendering.Composition.Server
         private void RenderCore()
         {
             ApplyPendingBatches();
+            CompletePendingBatches();
             
             foreach(var animation in _activeAnimations)
                 _animationsToUpdate.Add(animation);
@@ -119,8 +120,6 @@ namespace Avalonia.Rendering.Composition.Server
             
             foreach (var t in _activeTargets)
                 t.Render();
-            
-            CompletePendingBatches();
         }
 
         public void AddCompositionTarget(ServerCompositionTarget target)


### PR DESCRIPTION
Fixes
```cs
        public override void Render(DrawingContext context)
        {
            ...
            Dispatcher.UIThread.InvokeAsync(InvalidateVisual, DispatcherPriority.Background);
        }
 ```
pattern