### PR TITLE
Fix and optimize StringFormatConverter.

### DIFF
--- a/src/Avalonia.Controls/Converters/StringFormatConverter.cs
+++ b/src/Avalonia.Controls/Converters/StringFormatConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Avalonia.Data.Converters;
 
 namespace Avalonia.Controls.Converters;
@@ -13,19 +14,11 @@ public class StringFormatConverter : IMultiValueConverter
 {
     public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (values != null &&
-            values.Count == 5 &&
-            values[0] is string format &&
-            values[1] is double &&
-            values[2] is double &&
-            values[3] is double &&
-            values[4] is double)
-
+        if (values[0] is string format)
         {
-
             try
             {
-                return string.Format(format, values[1], values[2], values[3], values[4]);
+                return string.Format(format, values.Skip(1).ToArray());
             }
             catch
             {

--- a/src/Avalonia.Controls/Converters/StringFormatConverter.cs
+++ b/src/Avalonia.Controls/Converters/StringFormatConverter.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using Avalonia.Data;
 using Avalonia.Data.Converters;
 
 namespace Avalonia.Controls.Converters;
@@ -15,13 +13,25 @@ public class StringFormatConverter : IMultiValueConverter
 {
     public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
     {
-        try
+        if (values != null &&
+            values.Count == 5 &&
+            values[0] is string format &&
+            values[1] is double &&
+            values[2] is double &&
+            values[3] is double &&
+            values[4] is double)
+
         {
-            return string.Format((string)values[0]!, values.Skip(1).ToArray());
+
+            try
+            {
+                return string.Format(format, values[1], values[2], values[3], values[4]);
+            }
+            catch
+            {
+                return AvaloniaProperty.UnsetValue;
+            }
         }
-        catch (Exception e)
-        {
-            return new BindingNotification(e, BindingErrorType.Error);
-        }
+        return AvaloniaProperty.UnsetValue;
     }
 }


### PR DESCRIPTION
StringFormatConverter should validate values and return AvaloniaProperty.UnsetValue in case of incorrect value or exception.
Previously it would throw lots of binding notifications which isn't what the user needs to see. Also, we were getting exceptions every time ProgressBar was added to the tree.