### PR TITLE
Hackfix to make DevTools work again.

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -39,6 +39,8 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
                 targetType = setter.Property.PropertyType;
             }
 
+            var previousWasControlTheme = false;
+
             // Look upwards though the ambient context for IResourceNodes
             // which might be able to give us the resource.
             foreach (var parent in stack.Parents)
@@ -47,6 +49,21 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
                 {
                     return ColorToBrushConverter.Convert(value, targetType);
                 }
+
+                // HACK: Temporary fix for #8678. Hard-coded to only work for the DevTools main
+                // window as we don't want 3rd parties to start relying on this hack.
+                //
+                // We need to implement compile-time merging of resource dictionaries and this
+                // hack can be removed.
+                if (previousWasControlTheme &&
+                    parent is ResourceDictionary hack &&
+                    hack.Owner?.GetType().FullName == "Avalonia.Diagnostics.Views.MainWindow" &&
+                    hack.Owner.TryGetResource(ResourceKey, out value))
+                {
+                    return ColorToBrushConverter.Convert(value, targetType);
+                }
+
+                previousWasControlTheme = parent is ControlTheme;
             }
 
             if (provideTarget.TargetObject is IControl target &&
@@ -69,3 +86,4 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
         }
     }
 }
+


### PR DESCRIPTION
## What does the pull request do?

As described in #8678 adds a hackfix specific to DevTools to allow it to work again.

Ideally we'd fix this using a compiler directive to merge control theme dictionaries at compile time, but given that this feature will take a little while and we need DevTools _now_, we decided that a hack fix specific to DevTools would be best. I limited the hackfix to only work on DevTools because we don't want 3rd parties relying on this behavior as otherwise we'll never be able to remove it.
