### PR TITLE
Stop TransitioningContentControl if it was cancelled

### DIFF
--- a/src/Avalonia.Controls/TransitioningContentControl.cs
+++ b/src/Avalonia.Controls/TransitioningContentControl.cs
@@ -84,13 +84,19 @@ public class TransitioningContentControl : ContentControl
 
         _lastTransitionCts?.Cancel();
         _lastTransitionCts = new CancellationTokenSource();
+        var localToken = _lastTransitionCts.Token;
 
         if (PageTransition != null)
-            await PageTransition.Start(this, null, true, _lastTransitionCts.Token);
+            await PageTransition.Start(this, null, true, localToken);
+
+        if (localToken.IsCancellationRequested)
+        {
+            return;
+        }
 
         CurrentContent = content;
 
         if (PageTransition != null)
-            await PageTransition.Start(null, this, true, _lastTransitionCts.Token);
+            await PageTransition.Start(null, this, true, localToken);
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Fixes misuse of the transitions in the TransitionContentControl.

## What is the current behavior?

1. When animation was cancelled, method will continue execution.
2. Global cancellation variable used per control.

I can't point what exactly causes known bug, but both these problems should be avoided. Can't reproduce issue anymore after.

## What is the updated/expected behavior with this PR?

1. When animation was cancelled, method stops.
2. Single cancellation is saved locally in the method.

## Fixed issues

Fixes #7922
