### PR TITLE
Avoid lock in timers

### DIFF
--- a/src/Avalonia.Controls/Platform/InternalPlatformThreadingInterface.cs
+++ b/src/Avalonia.Controls/Platform/InternalPlatformThreadingInterface.cs
@@ -43,7 +43,7 @@ namespace Avalonia.Controls.Platform
                 _priority = priority;
                 _interval = interval;
                 _tick = tick;
-                _timer = new Timer(OnTimer, null, interval, TimeSpan.FromMilliseconds(-1));
+                _timer = new Timer(OnTimer, null, interval, Timeout.InfiniteTimeSpan);
                 _handle = GCHandle.Alloc(_timer);
             }
 
@@ -57,7 +57,7 @@ namespace Avalonia.Controls.Platform
                     if (_timer == null)
                         return;
                     _tick();
-                    _timer?.Change(_interval, TimeSpan.FromMilliseconds(-1));
+                    _timer?.Change(_interval, Timeout.InfiniteTimeSpan);
                 });
             }
 


### PR DESCRIPTION
## What does the pull request do?
Avoid `lock` in timers.

## What is the current behavior?
Some timers do use interval + locks, some - `Timer.Change()`.

## What is the updated/expected behavior with this PR?
`Timer.Change()` can avoid unnessessary timer fiering and thread locking.


Connected with: #8691 
