### PR TITLE
fix(AutoCompleteBox):  PopulateDropDown handler is not unregister when MinimumPopulateDelay is set to Zero

### DIFF
--- a/src/Avalonia.Controls/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox.cs
@@ -392,6 +392,8 @@ namespace Avalonia.Controls
         private AutoCompleteSelector<object>? _itemSelector;
         private AutoCompleteSelector<string?>? _textSelector;
 
+        private readonly EventHandler _populateDropDownHandler;
+
         public static readonly RoutedEvent<SelectionChangedEventArgs> SelectionChangedEvent =
             RoutedEvent.Register<SelectionChangedEventArgs>(nameof(SelectionChanged), RoutingStrategies.Bubble, typeof(AutoCompleteBox));
 
@@ -668,6 +670,7 @@ namespace Avalonia.Controls
 
                 if (newValue == TimeSpan.Zero)
                 {
+                    _delayTimer.Tick -= _populateDropDownHandler;
                     _delayTimer = null;
                 }
             }
@@ -678,7 +681,7 @@ namespace Avalonia.Controls
                 if (_delayTimer == null)
                 {
                     _delayTimer = new DispatcherTimer();
-                    _delayTimer.Tick += PopulateDropDown;
+                    _delayTimer.Tick += _populateDropDownHandler;
                 }
 
                 // Set the new tick interval
@@ -864,6 +867,7 @@ namespace Avalonia.Controls
         /// </summary>
         public AutoCompleteBox()
         {
+            _populateDropDownHandler = PopulateDropDown;
             ClearView();
         }
 
@@ -1771,10 +1775,7 @@ namespace Avalonia.Controls
         /// <param name="e">The event arguments.</param>
         private void PopulateDropDown(object? sender, EventArgs e)
         {
-            if (_delayTimer != null)
-            {
-                _delayTimer.Stop();
-            }
+            _delayTimer?.Stop();
 
             // Update the prefix/search text.
             SearchText = Text;


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
