### PR TITLE
fix to remove GridLength.ToString() culture dependency.

### DIFF
--- a/src/Avalonia.Controls/GridLength.cs
+++ b/src/Avalonia.Controls/GridLength.cs
@@ -180,7 +180,7 @@ namespace Avalonia.Controls
                 return "Auto";
             }
 
-            string s = _value.ToString();
+            string s = _value.ToString(CultureInfo.InvariantCulture);
             return IsStar ? s + "*" : s;
         }
 

--- a/tests/Avalonia.Controls.UnitTests/GridLengthTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/GridLengthTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
@@ -99,6 +101,24 @@ namespace Avalonia.Controls.UnitTests
                     new GridLength(4, GridUnitType.Pixel),
                 },
                 result);
+        }
+
+        [Theory]
+        [InlineData(1.2d, GridUnitType.Pixel, "1.2")]
+        [InlineData(1.2d, GridUnitType.Star, "1.2*")]
+        [InlineData(1.2d, GridUnitType.Auto, "Auto")]
+        public async void ToString_AllCulture_Should_Pass(double d, GridUnitType type, string result)
+        {
+            List<CultureInfo> cultureInfos = CultureInfo.GetCultures(CultureTypes.AllCultures).ToList();
+            GridLength length = new GridLength(d, type);
+            foreach(var culture in cultureInfos)
+            {
+                await Task.Run(() =>
+                {
+                    CultureInfo.CurrentCulture = culture;
+                    Assert.Equal(result, length.ToString());
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
To Fix GridLength.ToString() inconsistent behavior under different CultureInfo


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Example: in culture af, `1.1` will be formatted as `1,1`


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
`1.1` will be formatted as `1.1` disregard CultureInfo.CurrentCulture. 

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #8722 