### PR TITLE
Fix tooltip positioning when using PlacementMode.Pointer

### DIFF
--- a/src/Avalonia.Base/Input/PointerOverPreProcessor.cs
+++ b/src/Avalonia.Base/Input/PointerOverPreProcessor.cs
@@ -158,6 +158,8 @@ namespace Avalonia.Input
                     ClearPointerOver(pointer, root, timestamp, position, properties, inputModifiers);
                 }
             }
+
+            _lastPointer = (pointer, root.PointToScreen(position));
         }
 
         private void SetPointerOverToElement(IPointer pointer, IInputRoot root, IInputElement element,
@@ -195,7 +197,6 @@ namespace Avalonia.Input
             }
 
             el = root.PointerOverElement = element;
-            _lastPointer = (pointer, root.PointToScreen(position));
 
             e.RoutedEvent = InputElement.PointerEnteredEvent;
 


### PR DESCRIPTION
## What does the pull request do?
Fixes the positioning of PlacementMode.Pointer tooltips by updating the content of PointerOverPreProcessor.LastPosition whenever the mouse moves (instead of only updating the position when the mouse moves to another control)

## Fixed issues
Fixes #8730
