### PR TITLE
Fixed glActiveTexture calls

### DIFF
--- a/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs
+++ b/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs
@@ -84,6 +84,7 @@ namespace Avalonia.OpenGL.Controls
                 using (_context.MakeCurrent())
                 {
                     var gl = _context.GlInterface;
+                    gl.ActiveTexture(GL_TEXTURE0);
                     gl.BindTexture(GL_TEXTURE_2D, 0);
                     gl.BindFramebuffer(GL_FRAMEBUFFER, 0);
                     gl.DeleteFramebuffer(_fb);

--- a/src/Skia/Avalonia.Skia/Gpu/OpenGl/OpenGlBitmapImpl.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/OpenGl/OpenGlBitmapImpl.cs
@@ -118,7 +118,7 @@ namespace Avalonia.Skia
                 {
                     var gl = _context.GlInterface;
                     
-                    var textures = new int[2];
+                    Span<int> textures = stackalloc int[2];
                     fixed (int* ptex = textures)
                         gl.GenTextures(2, ptex);
                     _texture = textures[0];
@@ -139,7 +139,6 @@ namespace Avalonia.Skia
 
                     gl.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, _texture, 0);
                     gl.BindTexture(GL_TEXTURE_2D, oldTexture);
-                    
                 }
             }
         }
@@ -161,15 +160,15 @@ namespace Avalonia.Skia
                     gl.GetIntegerv(GL_ACTIVE_TEXTURE, out var oldActive);
                     
                     gl.BindFramebuffer(GL_FRAMEBUFFER, _fbo);
-                    gl.BindTexture(GL_TEXTURE_2D, _frontBuffer);
                     gl.ActiveTexture(GL_TEXTURE0);
+                    gl.BindTexture(GL_TEXTURE_2D, _frontBuffer);
 
                     gl.CopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, _bitmap.PixelSize.Width,
                         _bitmap.PixelSize.Height);
 
                     gl.BindFramebuffer(GL_FRAMEBUFFER, oldFbo);
-                    gl.BindTexture(GL_TEXTURE_2D, oldTexture);
                     gl.ActiveTexture(oldActive);
+                    gl.BindTexture(GL_TEXTURE_2D, oldTexture);
                     
                     gl.Finish();
                 }
@@ -192,9 +191,8 @@ namespace Avalonia.Skia
                 if(_disposed)
                     return;
                 _disposed = true;
-                var tex = new[] { _texture, _frontBuffer };
-                fixed (int* ptex = tex)
-                    gl.DeleteTextures(2, ptex);
+                var ptex = stackalloc[] { _texture, _frontBuffer };
+                gl.DeleteTextures(2, ptex);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

Fixes `glActiveTexture` calls so that the code doesn't assume which texture unit is active.

Also a minor change: replaced 2 array allocations with `stackalloc`.

## What is the current behavior?

Currently `glBindTexture` is called before `glActiveTexture`, which is wrong, because `glBindTexture` binds the texture to the active texture unit, set by `glActiveTexture`. So, for example, if I use texture unit 1 in `OnOpenGlRender`, I have to end the method with `glActiveTexture(GL_TEXTURE0)` or the bitmap will start using texture unit 1 and everything will break.

## What is the updated/expected behavior with this PR?

Texture unit 0 is set to active explicitly on all updates and cleanups.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation
