### PR TITLE
Fix memory leak in show notification when content is object type

### DIFF
--- a/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
+++ b/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
@@ -102,15 +102,12 @@ namespace Avalonia.Controls.Notifications
                 Content = content
             };
 
-            if (notification != null)
+            notificationControl.NotificationClosed += (sender, args) =>
             {
-                notificationControl.NotificationClosed += (sender, args) =>
-                {
-                    notification.OnClose?.Invoke();
+                notification?.OnClose?.Invoke();
 
-                    _items?.Remove(sender);
-                };
-            }
+                _items?.Remove(sender);
+            };
 
             notificationControl.PointerPressed += (sender, args) =>
             {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix memory leak in show notification when content is object type

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The NotificationCard is removed after closed and the input content is INotification interface

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
The NotificationCard is removed after closed

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Remove the type check

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
