### PR TITLE
Warning labels for "not stable yet" features in ControlCatalog

### DIFF
--- a/samples/ControlCatalog/MainView.xaml
+++ b/samples/ControlCatalog/MainView.xaml
@@ -13,69 +13,64 @@
         <Setter Property="HorizontalAlignment" Value="Left" />
       </Style>
 
-      <Style Selector="TabItem:not(.hasWarning) Panel.warning">
-        <Setter Property="IsVisible" Value="False"/>
-      </Style>
-      
-      <Style Selector="Panel:not(controls|HamburgerMenu TabItem Panel).warning">
-        <Setter Property="IsVisible" Value="False"/>
+      <Style Selector="TabItem.hasWarning /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="ContentTemplate">
+          <DataTemplate>
+            <DockPanel>
+              <Panel Classes="warning"
+                      Width="16"
+                      Height="16"
+                      DockPanel.Dock="Right"
+                      Margin="0,0,4,0"
+                      Background="#01000000">
+                <ToolTip.Tip>
+                  <StackPanel Orientation="Vertical"
+                              Spacing="5">
+                    <TextBlock Text="Experimental feature"
+                                Classes="h2"/>
+                    <TextBlock Text="Expect bugs, instability, etc. for the time being."/>
+                  </StackPanel>
+                </ToolTip.Tip>
+                <Path Stretch="Fill"
+                      HorizontalAlignment="Stretch"
+                      VerticalAlignment="Stretch"
+                      Stroke="{DynamicResource SystemControlErrorTextForegroundBrush}"
+                      StrokeThickness="1"
+                      StrokeJoin="Round"
+                      Data="M 7.106 1.789
+                            A 1,1 126.86 0 1 8.894,1.789
+                            L 15.276 14.552
+                            A 1,1 116.57 0 1 14.382,16
+                            L 1.618 16
+                            A 1,1 116.57 0 1 0.724,14.552
+                            Z" />
+                      <UniformGrid Columns="1"
+                                    Width="2">
+                        <Rectangle Fill="Transparent" />
+                        <Rectangle Fill="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+                        <Rectangle Fill="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+                        <Rectangle Fill="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+                        <Rectangle Fill="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+                        <Rectangle Fill="Transparent" />
+                        <Rectangle Fill="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+                        <Rectangle Fill="Transparent" />
+                      </UniformGrid>
+              </Panel>
+              <TextBlock Padding="0"
+                                Margin="0"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                TextAlignment="Left"
+                                Text="{Binding}"
+                                FontFamily="{Binding $parent[TabItem].FontFamily, Mode=OneWay}"
+                                FontSize="{Binding $parent[TabItem].FontSize, Mode=OneWay}"
+                                FontWeight="{Binding $parent[TabItem].FontWeight, Mode=OneWay}" />
+            </DockPanel>
+          </DataTemplate>
+        </Setter>
       </Style>
     </Grid.Styles>
     <controls:HamburgerMenu Name="Sidebar">
-      <controls:HamburgerMenu.DataTemplates>
-        <DataTemplate DataType="{x:Type sys:String}">
-          <DockPanel>
-            <Panel Classes="warning"
-                    Width="16"
-                    Height="16"
-                    DockPanel.Dock="Right"
-                    Margin="0,0,4,0"
-                    Background="#01000000">
-              <ToolTip.Tip>
-                <StackPanel Orientation="Vertical"
-                            Spacing="5">
-                  <TextBlock Text="Experimental feature"
-                              Classes="h2"/>
-                  <TextBlock Text="Expect bugs, instability, etc. for the time being."/>
-                </StackPanel>
-              </ToolTip.Tip>
-              <Path Stretch="Fill"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
-                    Stroke="{DynamicResource SystemControlErrorTextForegroundBrush}"
-                    StrokeThickness="1"
-                    StrokeJoin="Round"
-                    Data="M 7.106 1.789
-                          A 1,1 126.86 0 1 8.894,1.789
-                          L 15.276 14.552
-                          A 1,1 116.57 0 1 14.382,16
-                          L 1.618 16
-                          A 1,1 116.57 0 1 0.724,14.552
-                          Z" />
-                    <UniformGrid Columns="1"
-                                  Width="2">
-                      <Rectangle Fill="Transparent" />
-                      <Rectangle Fill="{DynamicResource SystemControlErrorTextForegroundBrush}" />
-                      <Rectangle Fill="{DynamicResource SystemControlErrorTextForegroundBrush}" />
-                      <Rectangle Fill="{DynamicResource SystemControlErrorTextForegroundBrush}" />
-                      <Rectangle Fill="{DynamicResource SystemControlErrorTextForegroundBrush}" />
-                      <Rectangle Fill="Transparent" />
-                      <Rectangle Fill="{DynamicResource SystemControlErrorTextForegroundBrush}" />
-                      <Rectangle Fill="Transparent" />
-                    </UniformGrid>
-            </Panel>
-            <TextBlock Padding="0"
-                              Margin="0"
-                              HorizontalAlignment="Stretch"
-                              VerticalAlignment="Stretch"
-                              TextAlignment="Left"
-                              Text="{Binding}"
-                              FontFamily="{Binding $parent[TabItem].FontFamily, Mode=OneWay}"
-                              FontSize="{Binding $parent[TabItem].FontSize, Mode=OneWay}"
-                              FontWeight="{Binding $parent[TabItem].FontWeight, Mode=OneWay}" />
-          </DockPanel>
-        </DataTemplate>
-      </controls:HamburgerMenu.DataTemplates>
       <TabItem Header="Composition">
         <pages:CompositionPage/>
       </TabItem>

--- a/samples/ControlCatalog/MainView.xaml
+++ b/samples/ControlCatalog/MainView.xaml
@@ -3,7 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:ControlSamples;assembly=ControlSamples"
              xmlns:models="clr-namespace:ControlCatalog.Models"
-             xmlns:pages="clr-namespace:ControlCatalog.Pages">
+             xmlns:pages="clr-namespace:ControlCatalog.Pages"
+             xmlns:sys="using:System">
   <Grid>
     <Grid.Styles>
       <Style Selector="TextBlock.h2">
@@ -11,8 +12,70 @@
         <Setter Property="MaxWidth" Value="400" />
         <Setter Property="HorizontalAlignment" Value="Left" />
       </Style>
+
+      <Style Selector="TabItem:not(.hasWarning) Panel.warning">
+        <Setter Property="IsVisible" Value="False"/>
+      </Style>
+      
+      <Style Selector="Panel:not(controls|HamburgerMenu TabItem Panel).warning">
+        <Setter Property="IsVisible" Value="False"/>
+      </Style>
     </Grid.Styles>
     <controls:HamburgerMenu Name="Sidebar">
+      <controls:HamburgerMenu.DataTemplates>
+        <DataTemplate DataType="{x:Type sys:String}">
+          <DockPanel>
+            <Panel Classes="warning"
+                    Width="16"
+                    Height="16"
+                    DockPanel.Dock="Right"
+                    Margin="0,0,4,0"
+                    Background="#01000000">
+              <ToolTip.Tip>
+                <StackPanel Orientation="Vertical"
+                            Spacing="5">
+                  <TextBlock Text="Experimental feature"
+                              Classes="h2"/>
+                  <TextBlock Text="Expect bugs, instability, etc. for the time being."/>
+                </StackPanel>
+              </ToolTip.Tip>
+              <Path Stretch="Fill"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Stroke="{DynamicResource SystemControlErrorTextForegroundBrush}"
+                    StrokeThickness="1"
+                    StrokeJoin="Round"
+                    Data="M 7.106 1.789
+                          A 1,1 126.86 0 1 8.894,1.789
+                          L 15.276 14.552
+                          A 1,1 116.57 0 1 14.382,16
+                          L 1.618 16
+                          A 1,1 116.57 0 1 0.724,14.552
+                          Z" />
+                    <UniformGrid Columns="1"
+                                  Width="2">
+                      <Rectangle Fill="Transparent" />
+                      <Rectangle Fill="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+                      <Rectangle Fill="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+                      <Rectangle Fill="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+                      <Rectangle Fill="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+                      <Rectangle Fill="Transparent" />
+                      <Rectangle Fill="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+                      <Rectangle Fill="Transparent" />
+                    </UniformGrid>
+            </Panel>
+            <TextBlock Padding="0"
+                              Margin="0"
+                              HorizontalAlignment="Stretch"
+                              VerticalAlignment="Stretch"
+                              TextAlignment="Left"
+                              Text="{Binding}"
+                              FontFamily="{Binding $parent[TabItem].FontFamily, Mode=OneWay}"
+                              FontSize="{Binding $parent[TabItem].FontSize, Mode=OneWay}"
+                              FontWeight="{Binding $parent[TabItem].FontWeight, Mode=OneWay}" />
+          </DockPanel>
+        </DataTemplate>
+      </controls:HamburgerMenu.DataTemplates>
       <TabItem Header="Composition">
         <pages:CompositionPage/>
       </TabItem>
@@ -163,7 +226,8 @@
       <TabItem Header="Viewbox">
         <pages:ViewboxPage />
       </TabItem>
-      <TabItem Header="Native Embed">
+      <TabItem Header="Native Embed"
+                Classes="hasWarning">
         <pages:NativeEmbedPage />
       </TabItem>
       <TabItem Header="Window Customizations">


### PR DESCRIPTION
## What does the pull request do?
Adds warning labels to tabs in `ControlCatalog` which pertain to features which aren't adequately stable as of yet.

The idea came to me after cloning master, firing up `ControlCatalog.NetCore`, and finding that selecting the "Native Embed" tab caused the whole program to just...exit. Weird crash, but ok.

It occurred to me that, for those evaluating Avalonia for the first time, features inexplicably causing such weird app crashes could be a _really_ bad look, given there was absolutely nothing signalling that the features in question were still being worked on (thus don't represent the level of stability which should be expected of Avalonia's stable feature set). With this in mind, I figured that maybe a little warning marker could to help manage their expectations around such features accordingly.


## What is the current behavior?
![image](https://user-images.githubusercontent.com/34009058/185440005-22c056d2-0b39-443b-be68-d4d3b6ea8aa3.png)


## What is the updated/expected behavior with this PR?
![image](https://user-images.githubusercontent.com/34009058/185439690-b5e28d3b-cb33-4e51-9d5e-08e4ae076bf4.png)


## How was the solution implemented (if it's not obvious)?
I added the warning label icon as part of a new `DataTemplate`, added to the `HamburgerMenu` in `MainView.xaml`. It can be added to any `TabItem` in the `HamburgerMenu` as necessary going forward, by simply adding "warning" to the item's `Classes`. Figured that would ensure the label could be easily applied wherever it may be needed in the future, as existing features become more stable and work on new features begins with the passing of time.