### PR TITLE
Detect method BuildAvaloniaApp in base class.

### DIFF
--- a/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
+++ b/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
@@ -168,8 +168,12 @@ namespace Avalonia.DesignerSupport.Remote
             var entryPoint = asm.EntryPoint;
             if (entryPoint == null)
                 throw Die($"Assembly {args.AppPath} doesn't have an entry point");
-            var builderMethod = entryPoint.DeclaringType.GetMethod(BuilderMethodName,
-                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, null, Array.Empty<Type>(), null);
+            var builderMethod = entryPoint.DeclaringType.GetMethod(
+                BuilderMethodName,
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy,
+                null,
+                Array.Empty<Type>(),
+                null);
             if (builderMethod == null)
                 throw Die($"{entryPoint.DeclaringType.FullName} doesn't have a method named {BuilderMethodName}");
             Design.IsDesignMode = true;


### PR DESCRIPTION
## What does the pull request do?

The visual designer uses reflection to look for a `BuildAvaloniaApp` method in the entry point class of a program (e.g. `MyProject.Program`).

This PR allows the visual designer to find the `BuildAvaloniaApp` method not only in the entry point class of a program, but in its ancestor classes as well.

Please note that this PR probably does not cover the case where the ancestor class declaring `BuildAvaloniaApp` is in a different assembly.

## What is the current behavior?

If, for example, `MyProject.Program` is a subclass of `MyProject.ProgramBase`, and `BuildAvaloniaApp` is declared in the latter, the visual designer will bail out with a message stating _"MyProject.Program doesn't have a method named BuildAvaloniaApp"_.

## What is the updated/expected behavior with this PR?

The visual designer will find the `MyProject.ProgramBase.BuildAvaloniaApp` method

## How was the solution implemented (if it's not obvious)?

I added the `BindingFlags.FlattenHierarchy` flag in the relevant call to `GetMethod`.

According to the [.NET API reference](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.bindingflags), this flag

> Specifies that public and protected static members up the hierarchy should be returned.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

None.
