### PR TITLE
Provides dynamic setters type to XamlX

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlTransformInstanceAttachedProperties.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlTransformInstanceAttachedProperties.cs
@@ -163,6 +163,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                 }
                 public AvaloniaAttachedInstanceProperty Parent { get; }
                 public bool IsPublic => true;
+                public bool IsPrivate => false;
                 public bool IsStatic => true;
                 public string Name { get; protected set; }
                 public IXamlType DeclaringType { get; }

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
@@ -641,7 +641,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                 {
                     // In this case, we need to emit our own delegate type.
                     string delegateTypeName = context.Configuration.IdentifierGenerator.GenerateIdentifierPart();
-                    specificDelegateType = newDelegateTypeBuilder = context.DefineDelegateSubType(delegateTypeName, Method.ReturnType, Method.Parameters);
+                    specificDelegateType = newDelegateTypeBuilder = context.DeclaringType.DefineDelegateSubType(delegateTypeName, false, Method.ReturnType, Method.Parameters);
                 }
 
                 codeGen


### PR DESCRIPTION
## What does the pull request do?
- Updates XamlX to https://github.com/kekekeks/XamlX/pull/70 (see this PR for details)
- Creates a `XamlDynamicSetters` type and pass it to XamlX when compiling

## What is the current behavior?
The XAML dynamic setters are generated per type/closure, leading to duplication.

## What is the updated/expected behavior with this PR?
The XAML dynamic setters are shared between all compiled types in an assembly.

Size changes:

| Assembly | Before | After | Reduction |
|---|---|---|---|
| Themes.Fluent | 771 KB | 731 KB | -5.2% |
| Themes.Simple | 324 KB | 310 KB | -4.3% |