### PR TITLE
Fix Fluent theme port bugs

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -53,7 +53,6 @@
       <Setter Property="VerticalAlignment" Value="Center" />
     </ControlTheme>
     <ControlTheme x:Key="DataGridCellTextBoxTheme" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
-      <Setter Property="Margin" Value="12,0,12,0" />
       <Setter Property="VerticalAlignment" Value="Stretch" />
       <Setter Property="Background" Value="Transparent" />
       <Style Selector="^ /template/ DataValidationErrors">

--- a/src/Avalonia.Themes.Fluent/Controls/ButtonSpinner.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ButtonSpinner.xaml
@@ -65,6 +65,7 @@
     </Style>
 
     <Style Selector="^:disabled /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource RepeatButtonBackgroundDisabled}" />
       <Setter Property="Foreground" Value="{DynamicResource RepeatButtonForegroundDisabled}" />
     </Style>
   </ControlTheme>

--- a/src/Avalonia.Themes.Fluent/Controls/DatePicker.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/DatePicker.xaml
@@ -56,18 +56,11 @@
       </ControlTemplate>
     </Setter>
     
-    <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-      <Setter Property="BorderBrush" Value="{DynamicResource DatePickerButtonBorderBrushPointerOver}"/>
-      <Setter Property="Background" Value="{DynamicResource DatePickerButtonBackgroundPointerOver}"/>
-      <Setter Property="Foreground" Value="{DynamicResource DatePickerButtonForegroundPointerOver}"/>
-    </Style>
-    
     <Style Selector="^:pressed">
       <Setter Property="RenderTransform" Value="scale(0.98)" />
     </Style>
     
     <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
-      <Setter Property="BorderBrush" Value="{DynamicResource DatePickerButtonBorderBrushPressed}"/>
       <Setter Property="Background" Value="{DynamicResource DatePickerButtonBackgroundPressed}"/>
       <Setter Property="Foreground" Value="{DynamicResource DatePickerButtonForegroundPressed}"/>
     </Style>

--- a/src/Avalonia.Themes.Fluent/Controls/TimePicker.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/TimePicker.xaml
@@ -55,18 +55,11 @@
       </ControlTemplate>
     </Setter>
 
-    <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-      <Setter Property="BorderBrush" Value="{DynamicResource TimePickerButtonBorderBrushPointerOver}"/>
-      <Setter Property="Background" Value="{DynamicResource TimePickerButtonBackgroundPointerOver}"/>
-      <Setter Property="Foreground" Value="{DynamicResource TimePickerButtonForegroundPointerOver}"/>
-    </Style>
-
     <Style Selector="^:pressed">
       <Setter Property="RenderTransform" Value="scale(0.98)" />
     </Style>
 
     <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
-      <Setter Property="BorderBrush" Value="{DynamicResource TimePickerButtonBorderBrushPressed}"/>
       <Setter Property="Background" Value="{DynamicResource TimePickerButtonBackgroundPressed}"/>
       <Setter Property="Foreground" Value="{DynamicResource TimePickerButtonForegroundPressed}"/>
     </Style>


### PR DESCRIPTION
## What does the pull request do?
This pull request fixes various fluent theme bugs that we produced during the port to control themes.
DataGrid editable cells doesn't take up all the available space.
![image](https://user-images.githubusercontent.com/53405089/186157322-a11d8368-1ffe-474d-8f4f-43d04521d304.png)
Fixed:
![image](https://user-images.githubusercontent.com/53405089/186157615-f8425ea8-9adb-469e-a032-9383871e8f64.png)

Date\TimePicker incorrect error pointerover\pressed states
![image](https://user-images.githubusercontent.com/53405089/186178509-5b7832f7-d58a-4500-a1ac-1f3cd354ac24.png)
![image](https://user-images.githubusercontent.com/53405089/186178549-f200d038-afd3-4194-8ef2-382dc3fe402f.png)

Fixed:
![image](https://user-images.githubusercontent.com/53405089/186158267-feb360d5-f20a-4702-b494-c1aa30f29430.png)
![image](https://user-images.githubusercontent.com/53405089/186158340-3015758c-a2a3-48f6-a755-42265f331334.png)

ButtonSpinner incorrect disabled button style
![image](https://user-images.githubusercontent.com/53405089/186179619-88f439c4-3dba-4fdd-ae76-fb182e2e642a.png)

Fixed:
![image](https://user-images.githubusercontent.com/53405089/186179960-04d82078-1872-4157-9317-f50adfc02bb2.png)


