### PR TITLE
Fix emoji input crashing on my Android phone

### DIFF
--- a/src/Avalonia.Base/Media/FontFamily.cs
+++ b/src/Avalonia.Base/Media/FontFamily.cs
@@ -108,29 +108,14 @@ namespace Avalonia.Media
 
         private static FontFamilyIdentifier GetFontFamilyIdentifier(string name)
         {
-            var segments = name.Split('#');
+            var hashIndex = name.IndexOf('#');
 
-            switch (segments.Length)
-            {
-                case 1:
-                    {
-                        return new FontFamilyIdentifier(segments[0], null);
-                    }
-
-                case 2:
-                    {
-                        var source = segments[0].StartsWith("/")
-                            ? new Uri(segments[0], UriKind.Relative)
-                            : new Uri(segments[0], UriKind.RelativeOrAbsolute);
-
-                        return new FontFamilyIdentifier(segments[1], source);
-                    }
-
-                default:
-                    {
-                        throw new ArgumentException("Specified family is not supported.");
-                    }
-            }
+            // SKFontManager.MatchCharacter on Android can return typeface names
+            // like "96##fallback" which should be handled just like other SkiaSharp typefaces.
+            return hashIndex != -1 && hashIndex == name.LastIndexOf('#')
+                ? new FontFamilyIdentifier(name.Substring(hashIndex + 1),
+                    new Uri(name.Substring(0, hashIndex), name.StartsWith("/") ? UriKind.Relative : UriKind.RelativeOrAbsolute))
+                : new FontFamilyIdentifier(name, null);
         }
 
         /// <summary>

--- a/tests/Avalonia.Base.UnitTests/Media/FontFamilyTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/FontFamilyTests.cs
@@ -66,6 +66,11 @@ namespace Avalonia.Base.UnitTests.Media
             var fontFamily = FontFamily.Parse("Courier New");
 
             Assert.Equal("Courier New", fontFamily.Name);
+
+            // Can be returned by SKFontManager.MatchCharacter on Android for emojis
+            fontFamily = FontFamily.Parse("96##fallback");
+
+            Assert.Equal("96##fallback", fontFamily.Name);
         }
 
         [Fact]


### PR DESCRIPTION
## What does the pull request do?
As title.

## What is the current behavior?
My phone is a Redmi Note 9 Pro and when I input emojis via IME keyboard onto TextBoxes, it crashes.
<details><summary>Exception stack trace:</summary>

```
[mono-rt] [ERROR] FATAL UNHANDLED EXCEPTION: System.ArgumentException: Specified family is not supported.
[mono-rt]    at Avalonia.Media.FontFamily.GetFontFamilyIdentifier(String name) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Media\FontFamily.cs:line 131
[mono-rt]    at Avalonia.Media.FontFamily..ctor(Uri baseUri, String name) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Media\FontFamily.cs:line 37
[mono-rt]    at Avalonia.Media.FontFamily..ctor(String name) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Media\FontFamily.cs:line 20
[mono-rt]    at Avalonia.Media.Typeface..ctor(String fontFamilyName, FontStyle style, FontWeight weight, FontStretch stretch) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Media\Typeface.cs:line 52
[mono-rt]    at Avalonia.Skia.FontManagerImpl.TryMatchCharacter(Int32 codepoint, FontStyle fontStyle, FontWeight fontWeight, FontStretch fontStretch, FontFamily fontFamily, CultureInfo culture, Typeface& fontKey) in C:\Users\hadri\source\repos\Avalonia\src\Skia\Avalonia.Skia\FontManagerImpl.cs:line 94
[mono-rt]    at Avalonia.Media.FontManager.TryMatchCharacter(Int32 codepoint, FontStyle fontStyle, FontWeight fontWeight, FontStretch fontStretch, FontFamily fontFamily, CultureInfo culture, Typeface& typeface) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Media\FontManager.cs:line 146
[mono-rt]    at Avalonia.Media.TextFormatting.TextCharacters.CreateShapeableRun(ReadOnlySlice`1 text, TextRunProperties defaultProperties, SByte biDiLevel, TextRunProperties& previousProperties) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Media\TextFormatting\TextCharacters.cs:line 116
[mono-rt]    at Avalonia.Media.TextFormatting.TextCharacters.GetShapeableCharacters(ReadOnlySlice`1 runText, SByte biDiLevel, TextRunProperties& previousProperties) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Media\TextFormatting\TextCharacters.cs:line 48
[mono-rt]    at Avalonia.Media.TextFormatting.TextFormatterImpl.CoalesceLevels(IReadOnlyList`1 textCharacters, ArraySlice`1 levels)+MoveNext() in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Media\TextFormatting\TextFormatterImpl.cs:line 366
[mono-rt]    at Avalonia.Media.TextFormatting.TextFormatterImpl.ShapeTextRuns(List`1 textRuns, TextParagraphProperties paragraphProperties, FlowDirection& resolvedFlowDirection) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Media\TextFormatting\TextFormatterImpl.cs:line 189
[mono-rt]    at Avalonia.Media.TextFormatting.TextFormatterImpl.FormatLine(ITextSource textSource, Int32 firstTextSourceIndex, Double paragraphWidth, TextParagraphProperties paragraphProperties, TextLineBreak previousLineBreak) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Media\TextFormatting\TextFormatterImpl.cs:line 33
[mono-rt]    at Avalonia.Media.TextFormatting.TextLayout.CreateTextLines() in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Media\TextFormatting\TextLayout.cs:line 433
[mono-rt]    at Avalonia.Media.TextFormatting.TextLayout..ctor(String text, Typeface typeface, Double fontSize, IBrush foreground, TextAlignment textAlignment, TextWrapping textWrapping, TextTrimming textTrimming, TextDecorationCollection textDecorations, FlowDirection flowDirection, Double maxWidth, Double maxHeight, Double lineHeight, Int32 maxLines, IReadOnlyList`1 textStyleOverrides) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Media\TextFormatting\TextLayout.cs:line 68
[mono-rt]    at Avalonia.Controls.Presenters.TextPresenter.CreateTextLayoutInternal(Size constraint, String text, Typeface typeface, IReadOnlyList`1 textStyleOverrides) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Controls\Presenters\TextPresenter.cs:line 318
[mono-rt]    at Avalonia.Controls.Presenters.TextPresenter.CreateTextLayout() in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Controls\Presenters\TextPresenter.cs:line 518
[mono-rt]    at Avalonia.Controls.Presenters.TextPresenter.get_TextLayout() in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Controls\Presenters\TextPresenter.cs:line 220
[mono-rt]    at Avalonia.Controls.Presenters.TextPresenter.MoveCaretToTextPosition(Int32 textPosition, Boolean trailingEdge) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Controls\Presenters\TextPresenter.cs:line 582
[mono-rt]    at Avalonia.Controls.Presenters.TextPresenter.set_CaretIndex(Int32 value) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Controls\Presenters\TextPresenter.cs:line 238
[mono-rt]    at Avalonia.Controls.Presenters.TextPresenter.<>c.<.cctor>b__24_1(TextPresenter o, Int32 v) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Controls\Presenters\TextPresenter.cs:line 21
[mono-rt]    at Avalonia.DirectProperty`2[[Avalonia.Controls.Presenters.TextPresenter, Avalonia.Controls, Version=11.0.999.0, Culture=neutral, PublicKeyToken=c8d484a7012f9a8b],[System.Int32, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].InvokeSetter(IAvaloniaObject instance, BindingValue`1 value) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\DirectProperty.cs:line 169
[mono-rt]    at Avalonia.AvaloniaObject.SetDirectValueUnchecked[Int32](DirectPropertyBase`1 property, BindingValue`1 value) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\AvaloniaObject.cs:line 857
[mono-rt]    at Avalonia.AvaloniaObject.DirectBindingSubscription`1[[System.Int32, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].OnNext(BindingValue`1 value) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\AvaloniaObject.cs:line 949
[mono-rt]    at Avalonia.Reactive.SingleSubscriberObservableBase`1[[Avalonia.Data.BindingValue`1[[System.Int32, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], Avalonia.Base, Version=11.0.999.0, Culture=neutral, PublicKeyToken=c8d484a7012f9a8b]].PublishNext(BindingValue`1 value) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Reactive\SingleSubscriberObservableBase.cs:line 49
[mono-rt]    at Avalonia.Reactive.TypedBindingAdapter`1[[System.Int32, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].OnNext(BindingValue`1 value) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Reactive\TypedBindingAdapter.cs:line 29
[mono-rt]    at Avalonia.Reactive.SingleSubscriberObservableBase`1[[Avalonia.Data.BindingValue`1[[System.Object, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], Avalonia.Base, Version=11.0.999.0, Culture=neutral, PublicKeyToken=c8d484a7012f9a8b]].PublishNext(BindingValue`1 value) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Reactive\SingleSubscriberObservableBase.cs:line 49
[mono-rt]    at Avalonia.Reactive.BindingValueAdapter`1[[System.Object, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].OnNext(Object value) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Reactive\BindingValueAdapter.cs:line 16
[mono-rt]    at Avalonia.Reactive.SingleSubscriberObservableBase`1[[System.Object, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].PublishNext(Object value) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Reactive\SingleSubscriberObservableBase.cs:line 49
[mono-rt]    at Avalonia.Data.TemplateBinding.PublishValue() in C:\Users\hadri\source\repos\Avalonia\src\Markup\Avalonia.Markup\Data\TemplateBinding.cs:line 146
[mono-rt]    at Avalonia.Data.TemplateBinding.TemplatedParentPropertyChanged(Object sender, AvaloniaPropertyChangedEventArgs e) in C:\Users\hadri\source\repos\Avalonia\src\Markup\Avalonia.Markup\Data\TemplateBinding.cs:line 183
[mono-rt]    at Avalonia.AvaloniaObject.RaisePropertyChanged[Int32](AvaloniaPropertyChangedEventArgs`1 change) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\AvaloniaObject.cs:line 780
[mono-rt]    at Avalonia.AvaloniaObject.RaisePropertyChanged[Int32](AvaloniaProperty`1 property, Optional`1 oldValue, BindingValue`1 newValue, BindingPriority priority) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\AvaloniaObject.cs:line 691
[mono-rt]    at Avalonia.AvaloniaObject.SetAndRaise[Int32](AvaloniaProperty`1 property, Int32& field, Int32 value) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\AvaloniaObject.cs:line 721
[mono-rt]    at Avalonia.Controls.TextBox.set_CaretIndex(Int32 value) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Controls\TextBox.cs:line 265
[mono-rt]    at Avalonia.Controls.TextBox.HandleTextInput(String input) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Controls\TextBox.cs:line 752
[mono-rt]    at Avalonia.Controls.TextBox.OnTextInput(TextInputEventArgs e) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Controls\TextBox.cs:line 670
[mono-rt]    at Avalonia.Input.InputElement.<>c.<.cctor>b__31_4(InputElement x, TextInputEventArgs e) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Input\InputElement.cs:line 214
[mono-rt]    at Avalonia.Interactivity.RoutedEvent`1.<>c__DisplayClass1_0`1[[Avalonia.Input.TextInputEventArgs, Avalonia.Base, Version=11.0.999.0, Culture=neutral, PublicKeyToken=c8d484a7012f9a8b],[Avalonia.Input.InputElement, Avalonia.Base, Version=11.0.999.0, Culture=neutral, PublicKeyToken=c8d484a7012f9a8b]].<AddClassHandler>g__Adapter|0(Object sender, RoutedEventArgs e) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Interactivity\RoutedEvent.cs:line 125
[mono-rt]    at Avalonia.Interactivity.RoutedEvent.<>c__DisplayClass23_0.<AddClassHandler>b__0(ValueTuple`2 args) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Interactivity\RoutedEvent.cs:line 92
[mono-rt]    at System.Reactive.AnonymousObserver`1[[System.ValueTuple`2[[System.Object, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Avalonia.Interactivity.RoutedEventArgs, Avalonia.Base, Version=11.0.999.0, Culture=neutral, PublicKeyToken=c8d484a7012f9a8b]], System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].OnNextCore(ValueTuple`2 value) in /_/Rx.NET/Source/src/System.Reactive/AnonymousObserver.cs:line 67
[mono-rt]    at System.Reactive.ObserverBase`1[[System.ValueTuple`2[[System.Object, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Avalonia.Interactivity.RoutedEventArgs, Avalonia.Base, Version=11.0.999.0, Culture=neutral, PublicKeyToken=c8d484a7012f9a8b]], System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].OnNext(ValueTuple`2 value) in /_/Rx.NET/Source/src/System.Reactive/ObserverBase.cs:line 34
[mono-rt]    at System.Reactive.Subjects.Subject`1[[System.ValueTuple`2[[System.Object, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Avalonia.Interactivity.RoutedEventArgs, Avalonia.Base, Version=11.0.999.0, Culture=neutral, PublicKeyToken=c8d484a7012f9a8b]], System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].OnNext(ValueTuple`2 value) in /_/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs:line 147
[mono-rt]    at Avalonia.Interactivity.RoutedEvent.InvokeRaised(Object sender, RoutedEventArgs e) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Interactivity\RoutedEvent.cs:line 100
[mono-rt]    at Avalonia.Interactivity.EventRoute.RaiseEventImpl(RoutedEventArgs e) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Interactivity\EventRoute.cs:line 148
[mono-rt]    at Avalonia.Interactivity.EventRoute.RaiseEvent(IInteractive source, RoutedEventArgs e) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Interactivity\EventRoute.cs:line 101
[mono-rt]    at Avalonia.Interactivity.Interactive.RaiseEvent(RoutedEventArgs e) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Interactivity\Interactive.cs:line 125
[mono-rt]    at Avalonia.Input.KeyboardDevice.ProcessRawEvent(RawInputEventArgs e) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Input\KeyboardDevice.cs:line 244
[mono-rt]    at Avalonia.Input.InputManager.ProcessInput(RawInputEventArgs e) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Base\Input\InputManager.cs:line 35
[mono-rt]    at Avalonia.Controls.TopLevel.HandleInput(RawInputEventArgs e) in C:\Users\hadri\source\repos\Avalonia\src\Avalonia.Controls\TopLevel.cs:line 535
[mono-rt]    at Avalonia.Android.Platform.Specific.Helpers.AndroidKeyboardEventsHelper`1[[Avalonia.Android.Platform.SkiaPlatform.TopLevelImpl, Avalonia.Android, Version=11.0.999.0, Culture=neutral, PublicKeyToken=c8d484a7012f9a8b]].DispatchKeyEventInternal(KeyEvent e, Boolean& callBase) in C:\Users\hadri\source\repos\Avalonia\src\Android\Avalonia.Android\Platform\Specific\Helpers\AndroidKeyboardEventsHelper.cs:line 70
[mono-rt]    at Avalonia.Android.Platform.Specific.Helpers.AndroidKeyboardEventsHelper`1[[Avalonia.Android.Platform.SkiaPlatform.TopLevelImpl, Avalonia.Android, Version=11.0.999.0, Culture=neutral, PublicKeyToken=c8d484a7012f9a8b]].DispatchKeyEvent(KeyEvent e, Boolean& callBase) in C:\Users\hadri\source\repos\Avalonia\src\Android\Avalonia.Android\Platform\Specific\Helpers\AndroidKeyboardEventsHelper.cs:line 30
[mono-rt]    at Avalonia.Android.Platform.SkiaPlatform.TopLevelImpl.ViewImpl.DispatchKeyEvent(KeyEvent e) in C:\Users\hadri\source\repos\Avalonia\src\Android\Avalonia.Android\Platform\SkiaPlatform\TopLevelImpl.cs:line 184
[mono-rt]    at Avalonia.Android.AvaloniaView.DispatchKeyEvent(KeyEvent e) in C:\Users\hadri\source\repos\Avalonia\src\Android\Avalonia.Android\AvaloniaView.cs:line 42
[mono-rt]    at Android.Views.View.n_DispatchKeyEvent_Landroid_view_KeyEvent_(IntPtr jnienv, IntPtr native__this, IntPtr native_e) in /Users/runner/work/1/s/xamarin-android/src/Mono.Android/obj/Release/net6.0/android-31/mcw/Android.Views.View.cs:line 15008
[mono-rt]    at Android.Runtime.JNINativeWrapper.Wrap_JniMarshal_PPL_Z(_JniMarshal_PPL_Z callback, IntPtr jnienv, IntPtr klazz, IntPtr p0) in /Users/runner/work/1/s/xamarin-android/src/Mono.Android/Android.Runtime/JNINativeWrapper.g.cs:line 132
```
</details>

## What is the updated/expected behavior with this PR?
The emoji appears in the TextBox.

## How was the solution implemented (if it's not obvious)?
The problem was that SkiaSharp returned a typeface name of `96##fallback` which conflicts with Avalonia's FontFamilyIdentifier source detection. I have left the implementation for single hashes untouched, only accepting more hashes in the typeface name.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes? Method is not public facing.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation. Method is not public facing.

## Breaking changes
No breaking changes.

## Obsoletions / Deprecations
No obsoletions or deprecations.

## Fixed issues
Probably related to https://github.com/AvaloniaUI/Avalonia/issues/8336