### PR TITLE
[Blazor] Disable auto-capitalization of input element text in AvaloniaView

### DIFF
--- a/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor
+++ b/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor
@@ -15,7 +15,8 @@
     <input id="inputElement" @ref="_inputElement" type="text" @oninput="OnInput" 
         onpaste="return false;"
         oncopy="return false;" 
-        oncut="return false;"/>
+        oncut="return false;"
+        autocapitalize="none"/>
 </div>
 
 <style>


### PR DESCRIPTION
On Android Chrome the auto-capitalization forces the keyboard to switch to uppercase for each and every character, this made typing in anything rather difficult. Firefox on Android doesn't seem to experience this issue.

## What does the pull request do?
Sets `autocapitalize="none"` on the HTML input element in `AvaloniView` Blazor control, this seems to prevent Chrome from forcing the keyboard into uppercase mode.

## What is the current behavior?
In Chrome on Android when attempting to type into a `TextBox` the on-screen keyboard will switch to uppercase after every character.

**To Reproduce**
1. Open `ControlCatalog.Web` in a mobile browser.
2. Tap on the `TextBox` page.
3. Tap on the top-most `TextBox` placing the cursor at the start of the `TextBox` (though the cursor location doesn't seem to have any effect on the bug).
4. Try to type in `Hello`, note that while you might expect the on-screen keyboard to default to the uppercase `H` since it's the start of a word, the keyboard will remain in uppercase mode for the second letter `E`, and if you switch the keyboard to lowercase to type in `e` it will again switch to uppercase for the next character.

## What is the updated/expected behavior with this PR?
The on-screen keyboard will no longer default to uppercase, the user has to explicitly switch to uppercase.