### PR TITLE
TreeView: improve navigation with Left and Right keys

### DIFF
--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -495,6 +495,7 @@ namespace Avalonia.Controls
                     break;
 
                 case NavigationDirection.Down:
+                case NavigationDirection.Right:
                     if (from?.IsExpanded == true && intoChildren && from.ItemCount > 0)
                     {
                         result = (TreeViewItem)from.ItemContainerGenerator.ContainerFromIndex(0)!;

--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -157,17 +157,26 @@ namespace Avalonia.Controls
                 switch (e.Key)
                 {
                     case Key.Right:
-                        if (Items != null && Items.Cast<object>().Any())
+                        if (Items != null && Items.Cast<object>().Any() && !IsExpanded)
                         {
                             IsExpanded = true;
+                            e.Handled = true;
                         }
-
-                        e.Handled = true;
                         break;
 
                     case Key.Left:
-                        IsExpanded = false;
-                        e.Handled = true;
+                        if (Items is not null && Items.Cast<object>().Any() && IsExpanded)
+                        {
+                            if (IsFocused)
+                            {
+                                IsExpanded = false;
+                            }
+                            else
+                            {
+                                FocusManager.Instance?.Focus(this, NavigationMethod.Directional);
+                            }
+                            e.Handled = true;
+                        }
                         break;
                 }
             }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR improves UX when using keyboard for `TreeView` navigation.
This is default behavior of Windows Explorer, IDE Solution Explorer, WPF's TreeView, etc.
 
## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Pressing `Left` key on `TreeViewItem` that has no children or is not expanded does not move keyboard focus to the parent item.
Pressing `Right` key on `TreeViewItem` that has children and is expanded does not move keyboard focus to the first child item.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Pressing `Left` key on `TreeViewItem` that has no children or is not expanded moves keyboard focus to the parent item.
Pressing `Right` key on `TreeViewItem` that has children and is expanded moves keyboard focus to the first child item.
