### PR TITLE
Fix DashStyle not applying values correctly.

### DIFF
--- a/src/Avalonia.Base/Media/DashStyle.cs
+++ b/src/Avalonia.Base/Media/DashStyle.cs
@@ -35,7 +35,6 @@ namespace Avalonia.Media
         /// Initializes a new instance of the <see cref="DashStyle"/> class.
         /// </summary>
         public DashStyle()
-            : this(null, 0)
         {
         }
 

--- a/tests/Avalonia.Base.UnitTests/Media/PenTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/PenTests.cs
@@ -53,7 +53,10 @@ namespace Avalonia.Base.UnitTests.Media
             var raised = false;
 
             target.Invalidated += (s, e) => raised = true;
-            dashes.Dashes.Add(0.3);
+            dashes.Dashes = new AvaloniaList<double>
+            {
+                0.3
+            };
 
             Assert.True(raised);
         }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ControlTemplateTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ControlTemplateTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Data;
@@ -5,12 +7,49 @@ using Avalonia.Diagnostics;
 using Avalonia.Markup.Xaml.Templates;
 using Avalonia.Media;
 using Avalonia.UnitTests;
+using Avalonia.VisualTree;
 using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 {
     public class ControlTemplateTests : XamlTestBase
     {
+        [Fact]
+        public void StyledProperties_Should_Be_Set_In_The_ControlTemplate()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:controls=""using:Avalonia.Markup.Xaml.UnitTests.Xaml"">
+    <Button>
+        <Button.Template>
+            <ControlTemplate>
+                <controls:ListBoxHierachyLine>
+                    <controls:ListBoxHierachyLine.LineDashStyle>
+                        <DashStyle Dashes=""2,2"" Offset=""1"" />
+                    </controls:ListBoxHierachyLine.LineDashStyle>
+                </controls:ListBoxHierachyLine>
+            </ControlTemplate>
+        </Button.Template>
+    </Button>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var button = (Button)window.Content;
+
+                window.ApplyTemplate();
+                button.ApplyTemplate();
+                var listBoxHierarchyLine = button.GetVisualChildren().ElementAt(0) as ListBoxHierachyLine;
+                Assert.Equal(1, listBoxHierarchyLine.LineDashStyle.Offset);
+                Assert.Equal(2, listBoxHierarchyLine.LineDashStyle.Dashes.Count);
+                Assert.Equal(2, listBoxHierarchyLine.LineDashStyle.Dashes[0]);
+                Assert.Equal(2, listBoxHierarchyLine.LineDashStyle.Dashes[1]);
+            }
+            
+        }
+
         [Fact]
         public void Inline_ControlTemplate_Styled_Values_Are_Set_With_Style_Priority()
         {
@@ -268,6 +307,17 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             Assert.Equal("Foo", foo.Name);
             Assert.Equal("Bar", bar.Name);
+        }
+    }
+    public class ListBoxHierachyLine : Panel
+    {
+        public static readonly StyledProperty<DashStyle> LineDashStyleProperty =
+        AvaloniaProperty.Register<ListBoxHierachyLine, DashStyle>(nameof(LineDashStyle));
+
+        public DashStyle LineDashStyle
+        {
+            get => GetValue(LineDashStyleProperty);
+            set => SetValue(LineDashStyleProperty, value);
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Removing [this](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Base/Media/DashStyle.cs#L38) line helps because it was setting values with "LocalValue" priority which can be overridden only with "LocalValue" priority.
Previously values in ControlTemplate were set with "LocalValue" priority but it was a big source of confusion so we changed a behaviour to [this](https://github.com/AvaloniaUI/Avalonia/pull/7679).

## Breaking changes
If someone tries to:
```xml
<DashStyle>
  <DashStyle.Dashes>
    <x:Int32>1</x:Int32>
  </DashStyle.Dashes>
</DashStyle>
```
then XAML will try to at that int to an existing Dashes collection, which will now not exist.

Also from now when working with ```Dashes``` collection from code you will need to assign a ```new AvaloniaList<double>``` before using because the default value for ```Dashes``` property from now is null.

## Fixed issues
Fixes #8857
