### PR TITLE
Media Invalidation

### DIFF
--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -20,6 +20,7 @@ namespace Avalonia
     {
         private readonly ValueStore _values;
         private AvaloniaObject? _inheritanceParent;
+        private List<AvaloniaObject>? _mediaParents;
         private PropertyChangedEventHandler? _inpcChanged;
         private EventHandler<AvaloniaPropertyChangedEventArgs>? _propertyChanged;
         private List<AvaloniaObject>? _inheritanceChildren;
@@ -78,6 +79,9 @@ namespace Avalonia
                 }
             }
         }
+
+        internal List<AvaloniaObject> GetOrCreateMediaParents() => _mediaParents ??= new();
+        internal List<AvaloniaObject>? GetMediaParents() => _mediaParents;
 
         /// <summary>
         /// Gets or sets the value of a <see cref="AvaloniaProperty"/>.

--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using Avalonia.Data;
 using Avalonia.Diagnostics;
 using Avalonia.Logging;
+using Avalonia.Media;
 using Avalonia.PropertyStore;
 using Avalonia.Threading;
 
@@ -20,7 +21,7 @@ namespace Avalonia
     {
         private readonly ValueStore _values;
         private AvaloniaObject? _inheritanceParent;
-        private List<AvaloniaObject>? _mediaParents;
+        private MediaParentsBag<AvaloniaObject>? _mediaParents;
         private PropertyChangedEventHandler? _inpcChanged;
         private EventHandler<AvaloniaPropertyChangedEventArgs>? _propertyChanged;
         private List<AvaloniaObject>? _inheritanceChildren;
@@ -80,8 +81,8 @@ namespace Avalonia
             }
         }
 
-        internal List<AvaloniaObject> GetOrCreateMediaParents() => _mediaParents ??= new();
-        internal List<AvaloniaObject>? GetMediaParents() => _mediaParents;
+        internal MediaParentsBag<AvaloniaObject> GetOrCreateMediaParents() => _mediaParents ??= new();
+        internal MediaParentsBag<AvaloniaObject>? GetMediaParents() => _mediaParents;
 
         /// <summary>
         /// Gets or sets the value of a <see cref="AvaloniaProperty"/>.

--- a/src/Avalonia.Base/AvaloniaPropertyChangedEventArgs.cs
+++ b/src/Avalonia.Base/AvaloniaPropertyChangedEventArgs.cs
@@ -4,8 +4,9 @@ using Avalonia.Data;
 namespace Avalonia
 {
     /// <summary>
-    /// Provides information for a avalonia property change.
+    /// Provides information for an Avalonia property change.
     /// </summary>
+    /// <seealso cref="AvaloniaPropertyChangedEventArgs{T}"/>
     public abstract class AvaloniaPropertyChangedEventArgs : EventArgs
     {
         public AvaloniaPropertyChangedEventArgs(
@@ -42,14 +43,14 @@ namespace Avalonia
         public AvaloniaProperty Property => GetProperty();
 
         /// <summary>
-        /// Gets the old value of the property.
+        /// Gets the old value of the property, or <see cref="AvaloniaProperty.UnsetValue"/>.
         /// </summary>
-        public object? OldValue => GetOldValue();
+        public object? OldValue { get; protected set; }
 
         /// <summary>
-        /// Gets the new value of the property.
+        /// Gets the new value of the property, or <see cref="AvaloniaProperty.UnsetValue"/>.
         /// </summary>
-        public object? NewValue => GetNewValue();
+        public object? NewValue { get; protected set; }
 
         /// <summary>
         /// Gets the priority of the binding that produced the value.
@@ -57,12 +58,10 @@ namespace Avalonia
         /// <value>
         /// The priority of the new value.
         /// </value>
-        public BindingPriority Priority { get; private set; }
+        public BindingPriority Priority { get; }
 
         internal bool IsEffectiveValueChange { get; private set; }
 
         protected abstract AvaloniaProperty GetProperty();
-        protected abstract object? GetOldValue();
-        protected abstract object? GetNewValue();
     }
 }

--- a/src/Avalonia.Base/AvaloniaPropertyChangedEventArgs`1.cs
+++ b/src/Avalonia.Base/AvaloniaPropertyChangedEventArgs`1.cs
@@ -7,6 +7,9 @@ namespace Avalonia
     /// </summary>
     public class AvaloniaPropertyChangedEventArgs<T> : AvaloniaPropertyChangedEventArgs
     {
+        private Optional<T> _oldValue;
+        private BindingValue<T> _newValue;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AvaloniaPropertyChangedEventArgs"/> class.
         /// </summary>
@@ -50,17 +53,29 @@ namespace Avalonia
         /// <summary>
         /// Gets the old value of the property.
         /// </summary>
-        public new Optional<T> OldValue { get; private set; }
+        public new Optional<T> OldValue
+        {
+            get => _oldValue;
+            private set
+            {
+                _oldValue = value;
+                base.OldValue = value.GetValueOrDefault(AvaloniaProperty.UnsetValue);
+            }
+        }
 
         /// <summary>
         /// Gets the new value of the property.
         /// </summary>
-        public new BindingValue<T> NewValue { get; private set; }
+        public new BindingValue<T> NewValue
+        {
+            get => _newValue;
+            private set
+            {
+                _newValue = value;
+                base.NewValue = value.GetValueOrDefault(AvaloniaProperty.UnsetValue);
+            }
+        }
 
         protected override AvaloniaProperty GetProperty() => Property;
-
-        protected override object? GetOldValue() => OldValue.GetValueOrDefault(AvaloniaProperty.UnsetValue);
-
-        protected override object? GetNewValue() => NewValue.GetValueOrDefault(AvaloniaProperty.UnsetValue);
     }
 }

--- a/src/Avalonia.Base/CombinedGeometry.cs
+++ b/src/Avalonia.Base/CombinedGeometry.cs
@@ -64,6 +64,11 @@ namespace Avalonia.Media
         {
         }
 
+        static CombinedGeometry()
+        {
+            MediaInvalidation.AffectsMediaRender(Geometry1Property, Geometry2Property, GeometryCombineModeProperty);
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CombinedGeometry"/> class with the
         /// specified <see cref="Geometry"/> objects.

--- a/src/Avalonia.Base/Media/Brush.cs
+++ b/src/Avalonia.Base/Media/Brush.cs
@@ -111,6 +111,8 @@ namespace Avalonia.Media
             {
                 property.Changed.Subscribe(invalidateObserver);
             }
+
+            MediaInvalidation.AffectsMediaRender(properties);
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Media/DashStyle.cs
+++ b/src/Avalonia.Base/Media/DashStyle.cs
@@ -57,6 +57,8 @@ namespace Avalonia.Media
 
             DashesProperty.Changed.Subscribe(invalidateObserver);
             OffsetProperty.Changed.Subscribe(invalidateObserver);
+
+            MediaInvalidation.AffectsMediaRender(DashesProperty, OffsetProperty);
         }
 
         /// <summary>
@@ -132,6 +134,7 @@ namespace Avalonia.Media
 
         private void DashesChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
+            MediaInvalidation.InvalidateAncestors(this);
             Invalidated?.Invoke(this, e);
         }
     }

--- a/src/Avalonia.Base/Media/DrawingCollection.cs
+++ b/src/Avalonia.Base/Media/DrawingCollection.cs
@@ -3,16 +3,14 @@ using Avalonia.Collections;
 
 namespace Avalonia.Media
 {
-    public sealed class DrawingCollection : AvaloniaList<Drawing>
+    public sealed class DrawingCollection : MediaCollection<Drawing>
     {
         public DrawingCollection()
         {
-            ResetBehavior = ResetBehavior.Remove;
         }
 
         public DrawingCollection(IEnumerable<Drawing> items) : base(items)
         {
-            ResetBehavior = ResetBehavior.Remove;
         }
     }
 }

--- a/src/Avalonia.Base/Media/DrawingGroup.cs
+++ b/src/Avalonia.Base/Media/DrawingGroup.cs
@@ -28,7 +28,17 @@ namespace Avalonia.Media
                 o => o.Children,
                 (o, v) => o.Children = v);
 
-        private DrawingCollection _children = new DrawingCollection();
+        private DrawingCollection _children;
+
+        public DrawingGroup()
+        {
+            _children = Children = new DrawingCollection();
+        }
+
+        static DrawingGroup()
+        {
+            MediaInvalidation.AffectsMediaRender(OpacityProperty, OpacityMaskProperty, TransformProperty, ClipGeometryProperty, ChildrenProperty);
+        }
 
         public double Opacity
         {
@@ -61,10 +71,7 @@ namespace Avalonia.Media
         public DrawingCollection Children
         {
             get => _children;
-            set
-            {
-                SetAndRaise(ChildrenProperty, ref _children, value);
-            }
+            set => SetAndRaise(ChildrenProperty, ref _children, value ?? throw new ArgumentNullException(nameof(value)));
         }
 
         public DrawingContext Open()

--- a/src/Avalonia.Base/Media/DrawingImage.cs
+++ b/src/Avalonia.Base/Media/DrawingImage.cs
@@ -17,6 +17,12 @@ namespace Avalonia.Media
         {
             Drawing = drawing;
         }
+
+        static DrawingImage()
+        {
+            MediaInvalidation.AffectsMediaRender(DrawingProperty);
+        }
+
         /// <summary>
         /// Defines the <see cref="Drawing"/> property.
         /// </summary>

--- a/src/Avalonia.Base/Media/Geometry.cs
+++ b/src/Avalonia.Base/Media/Geometry.cs
@@ -127,6 +127,8 @@ namespace Avalonia.Media
             {
                 property.Changed.Subscribe(invalidateObserver);
             }
+
+            MediaInvalidation.AffectsMediaRender(properties);
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Media/GeometryCollection.cs
+++ b/src/Avalonia.Base/Media/GeometryCollection.cs
@@ -1,45 +1,35 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Avalonia.Collections;
 
 #nullable enable
 
 namespace Avalonia.Media
 {
-    public sealed class GeometryCollection : AvaloniaList<Geometry> 
+    public sealed class GeometryCollection : MediaCollection<Geometry>
     {
         public GeometryCollection()
         {
-            ResetBehavior = ResetBehavior.Remove;
-
-            this.ForEachItem(
-               x =>
-               {
-                   Parent?.Invalidate();
-               },
-               x =>
-               {
-                   Parent?.Invalidate();
-               },
-               () => throw new NotSupportedException());
+            Setup();
         }
 
         public GeometryCollection(IEnumerable<Geometry> items) : base(items)
         {
-            ResetBehavior = ResetBehavior.Remove;
-
-            this.ForEachItem(
-               x =>
-               {
-                   Parent?.Invalidate();
-               },
-               x =>
-               {
-                   Parent?.Invalidate();
-               },
-               () => throw new NotSupportedException());
+            Setup();
         }
 
-        public GeometryGroup? Parent { get; set; }
+        private void Setup()
+        {
+            this.ForEachItem(Invalidate, Invalidate, () => throw new NotSupportedException());
+        }
+
+        private void Invalidate(Geometry child)
+        {
+            foreach (var parent in Parents.OfType<GeometryGroup>())
+            {
+                parent.Invalidate();
+            }
+        }
     }
 }

--- a/src/Avalonia.Base/Media/GeometryDrawing.cs
+++ b/src/Avalonia.Base/Media/GeometryDrawing.cs
@@ -58,6 +58,11 @@ namespace Avalonia.Media
             set => SetValue(PenProperty, value);
         }
 
+        static GeometryDrawing()
+        {
+            MediaInvalidation.AffectsMediaRender(GeometryProperty, BrushProperty, PenProperty);
+        }
+
         public override void Draw(DrawingContext context)
         {
             if (Geometry != null)

--- a/src/Avalonia.Base/Media/GlyphRunDrawing.cs
+++ b/src/Avalonia.Base/Media/GlyphRunDrawing.cs
@@ -20,6 +20,11 @@
             set => SetValue(GlyphRunProperty, value);
         }
 
+        static GlyphRunDrawing()
+        {
+            MediaInvalidation.AffectsMediaRender(ForegroundProperty, GlyphRunProperty);
+        }
+
         public override void Draw(DrawingContext context)
         {
             if (GlyphRun == null)

--- a/src/Avalonia.Base/Media/GradientBrush.cs
+++ b/src/Avalonia.Base/Media/GradientBrush.cs
@@ -33,6 +33,8 @@ namespace Avalonia.Media
         {
             GradientStopsProperty.Changed.Subscribe(GradientStopsChanged);
             AffectsRender<LinearGradientBrush>(SpreadMethodProperty);
+
+            MediaInvalidation.AffectsMediaRender(SpreadMethodProperty, GradientStopsProperty);
         }
 
         /// <summary>
@@ -40,7 +42,7 @@ namespace Avalonia.Media
         /// </summary>
         public GradientBrush()
         {
-            this.GradientStops = new GradientStops();
+            GradientStops = new GradientStops();
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Base/Media/GradientStop.cs
+++ b/src/Avalonia.Base/Media/GradientStop.cs
@@ -33,6 +33,11 @@ namespace Avalonia.Media
             Offset = offset;
         }
 
+        static GradientStop()
+        {
+            MediaInvalidation.AffectsMediaRender(OffsetProperty, ColorProperty);
+        }
+
         /// <inheritdoc/>
         public double Offset
         {

--- a/src/Avalonia.Base/Media/GradientStops.cs
+++ b/src/Avalonia.Base/Media/GradientStops.cs
@@ -8,7 +8,7 @@ namespace Avalonia.Media
     /// <summary>
     /// A collection of <see cref="GradientStop"/>s.
     /// </summary>
-    public class GradientStops : AvaloniaList<GradientStop>
+    public class GradientStops : MediaCollection<GradientStop>
     {
         public GradientStops()
         {

--- a/src/Avalonia.Base/Media/ImageDrawing.cs
+++ b/src/Avalonia.Base/Media/ImageDrawing.cs
@@ -37,6 +37,11 @@ namespace Avalonia.Media
             set => SetValue(RectProperty, value);
         }
 
+        static ImageDrawing()
+        {
+            MediaInvalidation.AffectsMediaRender(ImageSourceProperty, RectProperty);
+        }
+
         public override void Draw(DrawingContext context)
         {
             var imageSource = ImageSource;

--- a/src/Avalonia.Base/Media/MediaCollection.cs
+++ b/src/Avalonia.Base/Media/MediaCollection.cs
@@ -2,15 +2,26 @@
 using System.Collections;
 using System.Collections.Generic;
 using Avalonia.Collections;
+using Avalonia.Metadata;
 
 #nullable enable
 
 namespace Avalonia.Media
 {
+    /// <summary>
+    /// Base type for collections of objects that participate in <see cref="MediaInvalidation"/>.
+    /// </summary>
     public abstract class MediaCollection<T> : AvaloniaList<T>, IMediaCollection where T : AvaloniaObject
     {
         private readonly MediaParentsBag<AvaloniaObject> _parentHandles = new();
 
+        /// <summary>
+        /// Gets an enumeration of living media parents of this collection.
+        /// </summary>
+        /// <remarks>
+        /// To invoke changes to this property, assign the <see cref="MediaCollection{T}"/> to an <see cref="AvaloniaProperty"/> 
+        /// which has been passed to <see cref="MediaInvalidation.AffectsMediaRender"/>.
+        /// </remarks>
         public IEnumerable<AvaloniaObject> Parents => _parentHandles;
 
         protected MediaCollection()

--- a/src/Avalonia.Base/Media/MediaCollection.cs
+++ b/src/Avalonia.Base/Media/MediaCollection.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using Avalonia.Collections;
-using Avalonia.Metadata;
 
 #nullable enable
 
@@ -39,49 +37,30 @@ namespace Avalonia.Media
             ResetBehavior = ResetBehavior.Remove;
 
             this.ForEachItem(
-               x =>
+               child =>
                {
                    foreach (var parent in Parents)
                    {
-                       MediaInvalidation.AddMediaChild(x, parent);
+                       MediaInvalidation.AddMediaChild(parent, child);
                    }
                },
-               x =>
+               child =>
                {
                    foreach (var parent in Parents)
                    {
-                       MediaInvalidation.RemoveMediaChild(x, parent);
+                       MediaInvalidation.RemoveMediaChild(parent, child);
                    }
                },
                () => throw new NotSupportedException());
         }
 
-        void IMediaCollection.AddParent(AvaloniaObject parent)
-        {
-            _parentHandles.Add(parent);
-
-            foreach (var child in this)
-            {
-                MediaInvalidation.AddMediaChild(child, parent);
-            }
-        }
-
-        void IMediaCollection.RemoveParent(AvaloniaObject parent)
-        {
-            foreach (var child in this)
-            {
-                MediaInvalidation.RemoveMediaChild(child, parent);
-            }
-
-            _parentHandles.Remove(parent);
-        }
+        MediaParentsBag<AvaloniaObject> IMediaCollection.Parents => _parentHandles;
+        IEnumerable<AvaloniaObject> IMediaCollection.Items => this;
     }
 
-    internal interface IMediaCollection : IEnumerable
+    internal interface IMediaCollection
     {
-        IEnumerable<AvaloniaObject> Parents { get; }
-
-        void AddParent(AvaloniaObject parent);
-        void RemoveParent(AvaloniaObject parent);
+        MediaParentsBag<AvaloniaObject> Parents { get; }
+        IEnumerable<AvaloniaObject> Items { get; } // Inheriting from IEnumerable<AvaloniaObject> would cause MediaCollection<T> to have two IEnumerable<T> interfaces
     }
 }

--- a/src/Avalonia.Base/Media/MediaCollection.cs
+++ b/src/Avalonia.Base/Media/MediaCollection.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using Avalonia.Collections;
+
+#nullable enable
+
+namespace Avalonia.Media
+{
+    public abstract class MediaCollection<T> : AvaloniaList<T>, IMediaCollection where T : AvaloniaObject
+    {
+        public AvaloniaList<AvaloniaObject> Parents { get; } = new() { ResetBehavior = ResetBehavior.Remove };
+
+        protected MediaCollection()
+        {
+            Setup();
+        }
+
+        protected MediaCollection(IEnumerable<T> items) : base(items)
+        {
+            Setup();
+        }
+
+        private void Setup()
+        {
+            ResetBehavior = ResetBehavior.Remove;
+
+            this.ForEachItem(
+               x =>
+               {
+                   foreach (var parent in Parents)
+                   {
+                       MediaInvalidation.AddMediaChild(x, parent);
+                   }
+               },
+               x =>
+               {
+                   foreach (var parent in Parents)
+                   {
+                       MediaInvalidation.RemoveMediaChild(x, parent);
+                   }
+               },
+               () => throw new NotSupportedException());
+
+            Parents.ForEachItem(
+                x =>
+                {
+                    foreach (var child in this)
+                    {
+                        MediaInvalidation.AddMediaChild(child, x);
+                    }
+                },
+                x =>
+                {
+                    foreach (var child in this)
+                    {
+                        MediaInvalidation.RemoveMediaChild(child, x);
+                    }
+                },
+               () => throw new NotSupportedException());
+        }
+    }
+
+    public interface IMediaCollection
+    {
+        AvaloniaList<AvaloniaObject> Parents { get; }
+    }
+}

--- a/src/Avalonia.Base/Media/MediaInvalidation.cs
+++ b/src/Avalonia.Base/Media/MediaInvalidation.cs
@@ -41,7 +41,7 @@ namespace Avalonia.Media
 
             if (e.NewValue is IMediaCollection newCollection)
             {
-                newCollection.Parents.Add(e.Sender);
+                newCollection.AddParent(e.Sender);
             }
 
             InvalidateAncestors(e.Sender);
@@ -53,7 +53,7 @@ namespace Avalonia.Media
 
             if (e.OldValue is IMediaCollection oldCollection)
             {
-                oldCollection.Parents.Remove(e.Sender);
+                oldCollection.RemoveParent(e.Sender);
             }
         }
 

--- a/src/Avalonia.Base/Media/MediaInvalidation.cs
+++ b/src/Avalonia.Base/Media/MediaInvalidation.cs
@@ -5,10 +5,18 @@ using Avalonia.Reactive;
 
 namespace Avalonia.Media
 {
+    /// <summary>
+    /// A system which consumes changes to <see cref="AvaloniaObject"/> instances which exist outside the visual tree, locates the <see cref="Visual"/> objects which 
+    /// depend on them for their rendered appearance, and calls the <see cref="Visual.InvalidateVisual"/> method on each one.
+    /// </summary>
     public static class MediaInvalidation
     {
         private static readonly HashSet<AvaloniaProperty> s_registeredProperties = new();
 
+
+        /// <summary>
+        /// Marks one or more instances of <see cref="AvaloniaProperty"/> as affecting the appearance of the owner type.
+        /// </summary>
         public static void AffectsMediaRender(params AvaloniaProperty[] properties)
         {
             foreach (var property in properties)
@@ -57,6 +65,18 @@ namespace Avalonia.Media
             }
         }
 
+        /// <summary>
+        /// Finds all <see cref="Visual"/> media ancestors of the given object and calls <see cref="Visual.InvalidateVisual"/> on each one.
+        /// </summary>
+        /// <remarks>
+        /// <para>You should only need to manually call this method if your object has mutable children which do not derive from <see cref="AvaloniaObject"/>.</para>
+        /// <para>To automatically include an <see cref="AvaloniaObject"/> in the media ancestors tree:</para>
+        /// <list type="bullet">
+        /// <item>Pass the <see cref="AvaloniaProperty"/> that will contain the object/collection to <see cref="AffectsMediaRender"/>.</item>
+        /// <item>Use <see cref="MediaCollection{T}"/> as the base type of any collections of child objects.</item>
+        /// <item>Ensure that *all* assignments to direct properties are reported (e.g. by calling <see cref="AvaloniaObject.SetAndRaise"/>).</item>
+        /// </list>
+        /// </remarks>
         public static void InvalidateAncestors(AvaloniaObject mediaObject)
         {
             foreach (var ancestor in GetMediaAncestors<Visual>(mediaObject, new()))

--- a/src/Avalonia.Base/Media/MediaInvalidation.cs
+++ b/src/Avalonia.Base/Media/MediaInvalidation.cs
@@ -13,6 +13,9 @@ namespace Avalonia.Media
     {
         private static readonly HashSet<AvaloniaProperty> s_registeredProperties = new();
 
+        private static readonly AnonymousObserver<AvaloniaPropertyChangedEventArgs> s_referenceTypePropertyChangeObserver = new(OnMediaRenderPropertyChanged);
+        private static readonly AnonymousObserver<AvaloniaPropertyChangedEventArgs> s_valueTypePropertyChangeObserver = new(OnMediaRenderPropertyChanged_Struct);
+
         /// <summary>
         /// Marks one or more instances of <see cref="AvaloniaProperty"/> as affecting the appearance of the owner type.
         /// </summary>
@@ -22,7 +25,7 @@ namespace Avalonia.Media
             {
                 if (s_registeredProperties.Add(property))
                 {
-                    property.Changed.Subscribe(property.PropertyType.IsValueType ? OnMediaRenderPropertyChanged_Struct : OnMediaRenderPropertyChanged);
+                    property.Changed.Subscribe(property.PropertyType.IsValueType ? s_valueTypePropertyChangeObserver : s_referenceTypePropertyChangeObserver);
                 }
             }
         }

--- a/src/Avalonia.Base/Media/MediaInvalidation.cs
+++ b/src/Avalonia.Base/Media/MediaInvalidation.cs
@@ -1,0 +1,97 @@
+﻿using System.Collections.Generic;
+using Avalonia.Reactive;
+
+#nullable enable
+
+namespace Avalonia.Media
+{
+    public static class MediaInvalidation
+    {
+        private static readonly HashSet<AvaloniaProperty> s_registeredProperties = new();
+
+        public static void AffectsMediaRender(params AvaloniaProperty[] properties)
+        {
+            foreach (var property in properties)
+            {
+                if (s_registeredProperties.Add(property))
+                {
+                    property.Changed.Subscribe(OnMediaRenderPropertyChanged);
+                }
+            }
+        }
+
+        internal static void AddMediaChild(AvaloniaObject child, AvaloniaObject parent)
+        {
+            child.GetOrCreateMediaParents().Add(parent);
+            InvalidateAncestors(child);
+        }
+
+        internal static void RemoveMediaChild(AvaloniaObject child, AvaloniaObject parent)
+        {
+            InvalidateAncestors(child);
+            child.GetMediaParents()?.Remove(parent);
+        }
+
+        private static void OnMediaRenderPropertyChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is AvaloniaObject newChild)
+            {
+                newChild.GetOrCreateMediaParents().Add(e.Sender);
+            }
+
+            if (e.NewValue is IMediaCollection newCollection)
+            {
+                newCollection.Parents.Add(e.Sender);
+            }
+
+            InvalidateAncestors(e.Sender);
+
+            if (e.OldValue is AvaloniaObject oldChild)
+            {
+                oldChild.GetMediaParents()?.Remove(e.Sender);
+            }
+
+            if (e.OldValue is IMediaCollection oldCollection)
+            {
+                oldCollection.Parents.Remove(e.Sender);
+            }
+        }
+
+        public static void InvalidateAncestors(AvaloniaObject mediaObject)
+        {
+            foreach (var ancestor in GetMediaAncestors<Visual>(mediaObject, new()))
+            {
+                ancestor.InvalidateVisual();
+            }
+        }
+
+        private static IEnumerable<T> GetMediaAncestors<T>(AvaloniaObject current, HashSet<AvaloniaObject> visited) where T : AvaloniaObject
+        {
+            var parents = current.GetMediaParents();
+            if (parents == null)
+            {
+                yield break;
+            }
+
+            foreach (var parent in parents)
+            {
+                if (!visited.Add(parent))
+                {
+                    continue;
+                }
+
+                if (parent is T target)
+                {
+                    yield return target;
+                }
+                else
+                {
+                    foreach (var ancestor in GetMediaAncestors<T>(parent, visited))
+                    {
+                        yield return ancestor;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Avalonia.Base/Media/MediaParentsBag.cs
+++ b/src/Avalonia.Base/Media/MediaParentsBag.cs
@@ -1,0 +1,177 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+#nullable enable
+
+namespace Avalonia.Media
+{
+    /// <summary>
+    /// A unordered collection of weak references to objects of type <typeparamref name="T"/>. Specialised for use with <see cref="MediaInvalidation"/>.
+    /// </summary>
+    /// <seealso cref="Utilities.WeakHashList{T}"/>
+    [DebuggerDisplay("Count upper bound = {CountUpperBound}")]
+    internal class MediaParentsBag<T> : IEnumerable<T> where T : class
+    {
+        /// <summary>
+        /// This dictionary exists only to accelerate <see cref="Remove(T)"/>. An item can be added to the same bag any number of times.
+        /// </summary>
+        private Dictionary<int, List<GCHandle>>? _handleBuckets;
+
+        /// <summary>
+        /// The most common case is for an object to only ever have one parent, which is never removed.
+        /// </summary>
+        private (int hash, GCHandle handle)? _singleParent;
+
+        public int CountUpperBound => _singleParent.HasValue ? 1 : _handleBuckets?.Values.Sum(l => l.Count) ?? 0;
+
+        ~MediaParentsBag()
+        {
+            if (_singleParent.HasValue)
+            {
+                _singleParent.Value.handle.Free();
+            }
+            else if (_handleBuckets != null)
+            {
+                foreach (var handle in _handleBuckets.Values.SelectMany(l => l))
+                {
+                    handle.Free();
+                }
+            }
+        }
+
+        public void Add(T item)
+        {
+            var handle = GCHandle.Alloc(item, GCHandleType.Weak);
+            var hashCode = item.GetHashCode();
+
+            if (_handleBuckets == null)
+            {
+                if (_singleParent == null) // first item
+                {
+                    _singleParent = (hashCode, handle);
+                }
+                else // second item
+                {
+                    _handleBuckets = new()
+                    {
+                        { _singleParent.Value.hash, new(1) { _singleParent.Value.handle } },
+                        { hashCode , new(1) { handle } },
+                    };
+                    _singleParent = null;
+                }
+            }
+            else // third and subsequent items
+            {
+                if (_handleBuckets.TryGetValue(hashCode, out var parentReferences))
+                {
+                    parentReferences.Add(handle);
+                }
+                else
+                {
+                    _handleBuckets[hashCode] = new(1) { handle };
+                }
+            }
+        }
+
+        public bool Remove(T item)
+        {
+            if (_singleParent.HasValue)
+            {
+                if (ReferenceEquals(_singleParent.Value.handle.Target, item))
+                {
+                    var handle = _singleParent.Value.handle;
+                    _singleParent = null;
+                    handle.Free();
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            if (_handleBuckets == null)
+            {
+                return false;
+            }
+
+            var hashCode = item.GetHashCode();
+            if (!_handleBuckets.TryGetValue(hashCode, out var list))
+            {
+                return false;
+            }
+
+            int i = 0;
+            var removed = false;
+            foreach (var parent in EnumerateAndTrimHandles(list))
+            {
+                if (ReferenceEquals(parent, item))
+                {
+                    var handle = list[i];
+                    list.RemoveAt(i);
+                    handle.Free();
+
+                    removed = true;
+                    break;
+                }
+                i++;
+            }
+
+            if (list.Count == 0)
+            {
+                _handleBuckets.Remove(hashCode);
+            }
+
+            return removed;
+        }
+
+        private IEnumerable<T> EnumerateAndTrimHandles(List<GCHandle> list)
+        {
+            for (var i = 0; i < list.Count; i++)
+            {
+                var target = list[i].Target; // create a strong reference
+
+                while (target == null)
+                {
+                    var staleHandle = list[i];
+                    list.RemoveAt(i);
+                    staleHandle.Free();
+
+                    if (i >= list.Count)
+                    {
+                        yield break;
+                    }
+
+                    target = list[i].Target;
+                }
+
+                yield return (T)target;
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            if (_singleParent.HasValue)
+            {
+                var singleTarget = _singleParent.Value.handle.Target;
+                if (singleTarget != null)
+                {
+                    yield return (T)singleTarget;
+                }
+            }
+            else if (_handleBuckets != null)
+            {
+                foreach (var target in _handleBuckets.Values.SelectMany(EnumerateAndTrimHandles))
+                {
+                    yield return target;
+                }
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}
+

--- a/src/Avalonia.Base/Media/PathFigure.cs
+++ b/src/Avalonia.Base/Media/PathFigure.cs
@@ -56,6 +56,8 @@ namespace Avalonia.Media
             SegmentsProperty.Changed.AddClassHandler<PathFigure>(
                 (s, e) =>
                 s.OnSegmentsChanged());
+
+            MediaInvalidation.AffectsMediaRender(IsClosedProperty, IsFilledProperty, SegmentsProperty, StartPointProperty);
         }
 
         private void OnSegmentsChanged()

--- a/src/Avalonia.Base/Media/PathGeometry.cs
+++ b/src/Avalonia.Base/Media/PathGeometry.cs
@@ -28,6 +28,8 @@ namespace Avalonia.Media
         {
             FiguresProperty.Changed.AddClassHandler<PathGeometry>((s, e) =>
                 s.OnFiguresChanged(e.NewValue as PathFigures));
+
+            MediaInvalidation.AffectsMediaRender(FiguresProperty, FillRuleProperty);
         }
 
         /// <summary>
@@ -35,7 +37,7 @@ namespace Avalonia.Media
         /// </summary>
         public PathGeometry()
         {
-            _figures = new PathFigures();
+            Figures = new PathFigures();
         }
 
         /// <summary>
@@ -120,9 +122,9 @@ namespace Avalonia.Media
                     InvalidateGeometry();
                 },
                 InvalidateGeometry);
-            
+
             _figuresPropertiesObserver = figures?.TrackItemPropertyChanged(_ => InvalidateGeometry());
- 
+
         }
 
         private void InvalidateGeometryFromSegments(object? _, EventArgs __)

--- a/src/Avalonia.Base/Media/PathGeometryCollections.cs
+++ b/src/Avalonia.Base/Media/PathGeometryCollections.cs
@@ -3,7 +3,7 @@ using Avalonia.Visuals.Platform;
 
 namespace Avalonia.Media
 {
-    public sealed class PathFigures : AvaloniaList<PathFigure>
+    public sealed class PathFigures : MediaCollection<PathFigure>
     {
         /// <summary>
         /// Parses the specified path data to a <see cref="PathFigures"/>.
@@ -24,7 +24,7 @@ namespace Avalonia.Media
         }
     }
 
-    public sealed class PathSegments : AvaloniaList<PathSegment>
+    public sealed class PathSegments : MediaCollection<PathSegment>
     {
     }
 }

--- a/src/Avalonia.Base/Media/PolylineGeometry.cs
+++ b/src/Avalonia.Base/Media/PolylineGeometry.cs
@@ -99,11 +99,17 @@ namespace Avalonia.Media
 
         private void OnPointsChanged(Points? newValue)
         {
+            void Invalidate()
+            {
+                MediaInvalidation.InvalidateAncestors(this);
+                InvalidateGeometry();
+            }
+
             _pointsObserver?.Dispose();
             _pointsObserver = newValue?.ForEachItem(
-                _ => InvalidateGeometry(),
-                _ => InvalidateGeometry(),
-                InvalidateGeometry);
+                _ => Invalidate(),
+                _ => Invalidate(),
+                Invalidate);
         }
     }
 }

--- a/src/Avalonia.Base/Visual.cs
+++ b/src/Avalonia.Base/Visual.cs
@@ -428,6 +428,8 @@ namespace Avalonia
                     property.Changed.Subscribe(invalidateObserver);
                 }
             }
+
+            MediaInvalidation.AffectsMediaRender(properties);
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/Shapes/Shape.cs
+++ b/src/Avalonia.Controls/Shapes/Shape.cs
@@ -247,6 +247,8 @@ namespace Avalonia.Controls.Shapes
                     }
                 });
             }
+
+            MediaInvalidation.AffectsMediaRender(properties);
         }
 
         /// <summary>

--- a/tests/Avalonia.Base.UnitTests/Media/PenTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/PenTests.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia.Collections;
-using Avalonia.Media;
+﻿using Avalonia.Media;
 using Avalonia.Media.Immutable;
 using Xunit;
 
@@ -7,60 +6,6 @@ namespace Avalonia.Base.UnitTests.Media
 {
     public class PenTests
     {
-        [Fact]
-        public void Changing_Thickness_Raises_Invalidated()
-        {
-            var target = new Pen();
-            var raised = false;
-
-            target.Invalidated += (s, e) => raised = true;
-            target.Thickness = 18;
-
-            Assert.True(raised);
-        }
-
-        [Fact]
-        public void Changing_Brush_Color_Raises_Invalidated()
-        {
-            var brush = new SolidColorBrush(Colors.Red);
-            var target = new Pen { Brush = brush };
-            var raised = false;
-
-            target.Invalidated += (s, e) => raised = true;
-            brush.Color = Colors.Green;
-
-            Assert.True(raised);
-        }
-
-        [Fact]
-        public void Changing_DashStyle_Dashes_Raises_Invalidated()
-        {
-            var dashes = new DashStyle();
-            var target = new Pen { DashStyle = dashes };
-            var raised = false;
-
-            target.Invalidated += (s, e) => raised = true;
-            dashes.Dashes = new AvaloniaList<double> { 0.1, 0.2 };
-
-            Assert.True(raised);
-        }
-
-        [Fact]
-        public void Adding_DashStyle_Dashes_Raises_Invalidated()
-        {
-            var dashes = new DashStyle();
-            var target = new Pen { DashStyle = dashes };
-            var raised = false;
-
-            target.Invalidated += (s, e) => raised = true;
-            dashes.Dashes = new AvaloniaList<double>
-            {
-                0.3
-            };
-
-            Assert.True(raised);
-        }
-
         [Fact]
         public void Equality_Is_Implemented_Between_Immutable_And_Mutable_Pens()
         {

--- a/tests/Avalonia.Controls.UnitTests/MediaInvalidationTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/MediaInvalidationTests.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using Avalonia.Media;
+using Avalonia.UnitTests;
+using Moq;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests
+{
+    public class MediaInvalidationTests
+    {
+        [Fact]
+        public void NestedMediaChanges_InvalidateParentVisual()
+        {
+            var root = new TestRoot();
+            var rendererMock = Mock.Get(root.Renderer);
+
+            var rectGeometry = new RectangleGeometry();
+            var brush = new LinearGradientBrush
+            {
+                GradientStops = new()
+                {
+                    new(),
+                    new(),
+                }
+            };
+            var dashStyle = new DashStyle() { Dashes = new() };
+
+            var image = root.Child = new Image
+            {
+                Source = new DrawingImage
+                {
+                    Drawing = new DrawingGroup
+                    {
+                        Children = new()
+                        {
+                            new GeometryDrawing
+                            {
+                                Brush = brush,
+                                Geometry = rectGeometry,
+                                Pen = new Pen
+                                {
+                                    Brush = Brushes.Black,
+                                    DashStyle = dashStyle,
+                                },
+                            }
+                        }
+                    }
+                }
+            };
+
+            VerifyInvalidation(() => rectGeometry.Rect = new(0, 0, 20, 20), nameof(RectangleGeometry.RectProperty));
+
+            VerifyInvalidation(() => brush.GradientStops.Add(new()), nameof(GradientBrush.GradientStopsProperty));
+
+            VerifyInvalidation(() => dashStyle.Dashes.Add(0.5), nameof(DashStyle.DashesProperty));
+
+            void VerifyInvalidation(Action action, string description)
+            {
+                rendererMock.Reset();
+
+                action();
+
+                rendererMock.Verify(r => r.AddDirty(image), Times.Once, $"A change to {description} did not trigger invalidation.");
+            }
+        }
+
+        [Fact]
+        public void MultipleMediaParents_EachParentInvalidatedExactlyOnce()
+        {
+            var root = new TestRoot();
+            var rendererMock = Mock.Get(root.Renderer);
+
+            var pen = new Pen();
+
+            var drawingImage = new DrawingImage
+            {
+                Drawing = new DrawingGroup
+                {
+                    Children = new()
+                    {
+                        new GeometryDrawing { Pen = pen },
+                        new GeometryDrawing { Pen = pen },
+                    }
+                }
+            };
+
+            var panel = new StackPanel();
+
+            root.Child = panel;
+
+            for (var i = 0; i < 5; i++)
+            {
+                panel.Children.Add(new Image { Source = drawingImage });
+            }
+
+            rendererMock.Reset();
+
+            pen.DashStyle = DashStyle.Dash;
+
+            foreach(var image in panel.Children)
+            {
+                rendererMock.Verify(r => r.AddDirty(image), Times.Once);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

This PR introduces Media Invalidation, a fast and low-maintenance system which consumes changes to `AvaloniaObject` instances which exist outside the visual tree, locates the `Visual` objects which depend on them for their rendered appearance, and calls the `Visual.InvalidateVisual` method on each one. Object nesting and collections are supported. These changes fix #8767.

Here is a scenario that Media Invalidation adds support for:

```xaml
<Image>
  <DrawingImage>
    <DrawingGroup>
      <GeometryDrawing>
        <GeometryDrawing.Brush>
          <SolidColorBrush Color="Green"/>
        </GeometryDrawing.Brush>
        <RectangleGeometry Rect="0,0,120,120"/>
      </GeometryDrawing>
    </DrawingGroup>
  </DrawingImage>
</Image>
```

(See the `MediaInvalidationTests` class for real implementations similar to this sample.)

With Media Invalidation, changes to the value of `SolidColorBrush.Color` or `RectangleGeometryRect` both result in the `Image` control being invalidated and redrawing. Previously, the Image would never update unless manually forced to. Invalidation occurs even though the value that changed was deeply nested underneath the `Image`, and the path between the two passes through a `DrawingGroup` collection.

## What is the current behavior?

Currently, invalidation of media objects is implemented in a very haphazard way. There are multiple bespoke systems in multiple classes, often involving complicated `WeakEvent` subscriptions. These systems are not recursive; links between parents and children must be explicitly made, and they are generally not.

One such system raises the event `Pen.Invalidated`. The event is not subscribed to, so I removed it and all the supporting code. The other systems I found do actually have effects, so I left them in place. They should be reviewed before being removed as some may also need to support recursive invalidation, and/or could execute without an associated `AvaloniaProperty` change.

Currently, tests which check for the old media invalidation systems are failing because they expect one invalidation but get two, due to both systems running at the same time. These failures will clear as the old systems are removed.

## What is the updated/expected behavior with this PR?

Media Invalidation is an automated and low-maintenance solution for all Avalonia properties. Recursion is automatically handled if the property's value type is an `AvaloniaObject`. The only steps required are to register each relevant `AvaloniaProperty` with the Media Invalidation system, to ensure that property changed events are always raised (not guaranteed with `DirectProperty`) and to use collections which derive from `MediaCollection<T>`.

## How was the solution implemented?

The core of the PR is the static class `MediaInvalidation`. This has a public method called `AffectsMediaRender`, which accepts a `params` array of `AvaloniaProperty` objects. It subscribes to changes on each property, and registers (with weak references, to prevent GC rooting) the property owner as a "media parent" of any `AvaloniaObject` which is assigned. Note that unlike objects in the visual and logical trees, a media object can have multiple parents, and can even have the same parent twice (e.g. `Fill` and `Stroke` being the same brush).

When the value of a registered media property changes, the media parents tree of the target object is recursively searched for all `Visual` objects, and each of these objects is visually invalidated.

A second important type is the abstract class `MediaCollection<T>`. This handles the invalidation of `AvaloniaObject` collections, by linking each collection member to each of the collection's parents. Everything is handled automatically once the the base type is implemented and assigned to a property registered with the media invalidation system.

### Performance note: theme resources

A given `AvaloniaObject` can always change, so the Media Invalidation system must always track its parents. This can become a problem when a theme resource is frequently used, such as the standard `Foreground` brush. When I start the Avalonia control gallery, I see that a `SolidColorBrush` with the colour "Black" has over 1000 parents! This tree won't be searched unless the brush changes, but there is still a runtime and memory cost to all this book-keeping.

To avoid this situation, a new property called `AvaloniaObject.IsSealed` could be added. Changes to any `AvaloniaProperty` of a sealed object would be rejected, allowing `MediaInvalidation` to ignore it. This is exactly what WPF does to solve the same issue: media objects always derive from [`Freezable`](https://docs.microsoft.com/en-us/dotnet/api/system.windows.freezable?view=windowsdesktop-6.0), which sets `DependencyObject.IsSealed` when its `Freeze` method is called. This happens automatically when such an object is inserted into a resource dictionary.

(Since opening the PR I have spotted #6387, which proposes transforming resources into immutable forms with a XAML directive. That would also resolve the problem.)

## Benchmarks

There is a benchmark called `SetPropertyThatAffectsRender`, but it's not measuring anything on master. It sets and then clears the value of a `Pen` property on a test object, but because `Pen` does not implement `IAffectsRender` no subscriptions are made by `Visual.AffectsRender`. The only special behaviour being benchmarked is the `InvalidateVisual` call itself...which also does nothing, because the test object does not have a visual root.

So I fixed the benchmark locally by making it instead set and unset a `Brush` property. There is no need to commit this change as the changes in this PR cause the unmodified benchmark to become valid.

**master**

(After correcting the benchmark)

|                       Method |     Mean |     Error |    StdDev |  Gen 0 |  Gen 1 |  Gen 2 | Allocated |
|----------------------------- |---------:|----------:|----------:|-------:|-------:|-------:|----------:|
| SetPropertyThatAffectsRender | 1.059 us | 0.0211 us | 0.0187 us | 0.0858 | 0.0067 | 0.0019 |     713 B |

**MediaInvalidation**

(After correcting the benchmark and redirecting `Visual.AffectsRender` to `MediaInvalidation.AffectsMediaRender`)

|                       Method |     Mean |   Error |  StdDev |  Gen 0 | Allocated |
|----------------------------- |---------:|--------:|--------:|-------:|----------:|
| SetPropertyThatAffectsRender | 384.5 ns | 0.59 ns | 0.55 ns | 0.0229 |     192 B |

That's 62% faster, which is pretty good considering all the extra functionality that this PR adds! Instrumentation shows that after the `InvalidateVisual` call itself, the next biggest chunks of work are allocating and freeing weak GC handles, in that order.

## Checklist
* [x]  Added unit tests
* [x]  Added XML documentation to any related classes
* [ ]  What happens to a property created with `AddOwner`?
* [ ]  Remove old notification systems (this will fix the failing tests)
* [ ]  Investigate #5813
* [ ]  Handle theme resources with many parents
* [ ]  Handle `GlyphRun`, which is mutable but not an `AvaloniaObject`

### Event handlers to investigate

* [ ] `Visual.AffectsRender` (turn into a pass-through)
* [ ] `Visual.RenderTransformChanged`
* [ ] `Geometry.TransformChanged`
* [ ] `Geometry.AffectsGeometryInvalidate` (should this receive recursive events?)
* [ ] `GeometryCollection.Invalidate`
* [ ] `PathGeometry.InvalidateGeometryFromSegments`
* [ ] `Path.GeometryChangedHandler`
* [ ] `GradientBrush.GradientStopsChanged` / `GradientBrush.GradientStopChanged`

## Fixed issues
Fixes #8767