### PR TITLE
Fix DBusSystemDialog when path contains spaces

### DIFF
--- a/src/Avalonia.FreeDesktop/DBusSystemDialog.cs
+++ b/src/Avalonia.FreeDesktop/DBusSystemDialog.cs
@@ -72,7 +72,7 @@ namespace Avalonia.FreeDesktop
             using var disposable = await request.WatchResponseAsync(x => tsc.SetResult(x.results["uris"] as string[]), tsc.SetException);
             var uris = await tsc.Task ?? Array.Empty<string>();
 
-            return uris.Select(path => new BclStorageFile(new FileInfo(new Uri(path).AbsolutePath))).ToList();
+            return uris.Select(path => new BclStorageFile(new FileInfo(new Uri(path).LocalPath))).ToList();
         }
 
         public override async Task<IStorageFile?> SaveFilePickerAsync(FilePickerSaveOptions options)
@@ -96,7 +96,7 @@ namespace Avalonia.FreeDesktop
             var tsc = new TaskCompletionSource<string[]?>();
             using var disposable = await request.WatchResponseAsync(x => tsc.SetResult(x.results["uris"] as string[]), tsc.SetException);
             var uris = await tsc.Task;
-            var path = uris?.FirstOrDefault() is { } filePath ? new Uri(filePath).AbsolutePath : null;
+            var path = uris?.FirstOrDefault() is { } filePath ? new Uri(filePath).LocalPath : null;
 
             if (path is null)
             {
@@ -126,7 +126,7 @@ namespace Avalonia.FreeDesktop
             var uris = await tsc.Task ?? Array.Empty<string>();
 
             return uris
-                .Select(path => new Uri(path).AbsolutePath)
+                .Select(path => new Uri(path).LocalPath)
                 // WSL2 freedesktop allows to select files as well in directory picker, filter it out.
                 .Where(Directory.Exists)
                 .Select(path => new BclStorageFolder(new DirectoryInfo(path))).ToList();


### PR DESCRIPTION
## What does the pull request do?
Fixes the DBusSystemDialog when the path contains spaces.

## What is the current behavior?
When using the DBus system dialog, the portal returns an encoded URI as the path, e.g. "New%20Folder".
Non-existent directories are filtered out by checking with Directory.Exists(), though since the undecoded path is passed in, the method returns false for directories with spaces, even though they do exist.
For files, at least the example in the ControlCatalog crashes since it expects (rightfully so) an decoded path.

## What is the updated/expected behavior with this PR?
Decode the path to not crash/not filter out valid directories.

## How was the solution implemented (if it's not obvious)?
Use Uri.LocalPath, which decodes the path, instead of Uri.AbsolutePath.
Note: LocalPath returns an absolute path, even though the name suggests otherwise.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues

