### PR TITLE
Fix windowicon crash on linux drm

### DIFF
--- a/src/Avalonia.Base/Logging/LogArea.cs
+++ b/src/Avalonia.Base/Logging/LogArea.cs
@@ -5,6 +5,8 @@ namespace Avalonia.Logging
     /// </summary>
     public static class LogArea
     {
+        private static string _platforms;
+
         /// <summary>
         /// The log event comes from the property system.
         /// </summary>
@@ -54,5 +56,10 @@ namespace Avalonia.Logging
         /// The log event comes from IOSPlatform.
         /// </summary>
         public const string IOSPlatform = nameof(IOSPlatform);
+        
+        /// <summary>
+        /// The log event comes from any Platform Implementation.
+        /// </summary>
+        public const string Platforms = nameof(Platforms);
     }
 }

--- a/src/Avalonia.Controls/WindowIcon.cs
+++ b/src/Avalonia.Controls/WindowIcon.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Avalonia.Logging;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 
@@ -11,21 +12,48 @@ namespace Avalonia.Controls
     {
         public WindowIcon(IBitmap bitmap)
         {
-            PlatformImpl = AvaloniaLocator.Current.GetRequiredService<IPlatformIconLoader>().LoadIcon(bitmap.PlatformImpl.Item);
+            if (AvaloniaLocator.Current.GetService<IPlatformIconLoader>() is { } iconLoader)
+            {
+                PlatformImpl = iconLoader.LoadIcon(bitmap.PlatformImpl.Item);
+            }
+            else
+            {
+                DoLogIfNull();
+            }
         }
 
         public WindowIcon(string fileName)
         {
-            PlatformImpl = AvaloniaLocator.Current.GetRequiredService<IPlatformIconLoader>().LoadIcon(fileName);
+            if (AvaloniaLocator.Current.GetService<IPlatformIconLoader>() is { } iconLoader)
+            {
+                PlatformImpl = iconLoader.LoadIcon(fileName);
+            }
+            else
+            {
+                DoLogIfNull();
+            }
         }
 
         public WindowIcon(Stream stream)
         {
-            PlatformImpl = AvaloniaLocator.Current.GetRequiredService<IPlatformIconLoader>().LoadIcon(stream);
+            if (AvaloniaLocator.Current.GetService<IPlatformIconLoader>() is { } iconLoader)
+            {
+                PlatformImpl = iconLoader.LoadIcon(stream);
+            }
+            else
+            {
+                DoLogIfNull();
+            }
         }
 
-        public IWindowIconImpl PlatformImpl { get; }
+        private void DoLogIfNull()
+        {
+            Logger.TryGet(LogEventLevel.Error, LogArea.Platforms)
+                ?.Log(this, "Error: Missing IPlatformIconLoader implementation in current platform.");
+        }
 
-        public void Save(Stream stream) => PlatformImpl.Save(stream);
+        public IWindowIconImpl? PlatformImpl { get; }
+
+        public void Save(Stream stream) => PlatformImpl?.Save(stream);
     }
 }


### PR DESCRIPTION
Adds null checks to WindowIcon class so that it doesnt scream and crash when there's missing platform icon loader implementation.

@kekekeks 