### PR TITLE
WASM: use handled for preventDefault on keydown and up.

### DIFF
--- a/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor
+++ b/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor
@@ -3,9 +3,9 @@
      tabindex="0" oncontextmenu="return false;"
      @onwheel="OnWheel"
      @onkeydown="OnKeyDown"
-     @onkeydown:preventDefault="true"
      @onkeyup="OnKeyUp"
-     @onkeyup:preventDefault="true"
+     @onkeyup:preventDefault="@KeyPreventDefault"
+     @onkeydown:preventDefault="@KeyPreventDefault"
      @onpointerdown="OnPointerDown"
      @onpointerup="OnPointerUp"
      @onpointermove="OnPointerMove"
@@ -20,8 +20,6 @@
         onpaste="return false;"
         oncopy="return false;" 
         oncut="return false;"
-        @onkeydown:preventDefault="true"
-        @onkeyup:preventDefault="true"
         autocapitalize="none"/>
 </div>
 

--- a/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor.cs
+++ b/src/Web/Avalonia.Web.Blazor/AvaloniaView.razor.cs
@@ -63,6 +63,8 @@ namespace Avalonia.Web.Blazor
             }
         }
 
+        public bool KeyPreventDefault { get; set; }
+
         internal INativeControlHostImpl GetNativeControlHostImpl()
         {
             return _nativeControlHost ?? throw new InvalidOperationException("Blazor View wasn't initialized yet");
@@ -203,12 +205,12 @@ namespace Avalonia.Web.Blazor
 
         private void OnKeyDown(KeyboardEventArgs e)
         {
-            _topLevelImpl.RawKeyboardEvent(RawKeyEventType.KeyDown, e.Code, e.Key, GetModifiers(e));
+            KeyPreventDefault = _topLevelImpl.RawKeyboardEvent(RawKeyEventType.KeyDown, e.Code, e.Key, GetModifiers(e));
         }
 
         private void OnKeyUp(KeyboardEventArgs e)
         {
-            _topLevelImpl.RawKeyboardEvent(RawKeyEventType.KeyUp, e.Code, e.Key, GetModifiers(e));
+            KeyPreventDefault = _topLevelImpl.RawKeyboardEvent(RawKeyEventType.KeyUp, e.Code, e.Key, GetModifiers(e));
         }
 
         private void OnFocus(FocusEventArgs e)

--- a/src/Web/Avalonia.Web.Blazor/RazorViewTopLevelImpl.cs
+++ b/src/Web/Avalonia.Web.Blazor/RazorViewTopLevelImpl.cs
@@ -113,22 +113,32 @@ namespace Avalonia.Web.Blazor
             }
         }
 
-        public void RawKeyboardEvent(RawKeyEventType type, string code, string key, RawInputModifiers modifiers)
+        public bool RawKeyboardEvent(RawKeyEventType type, string code, string key, RawInputModifiers modifiers)
         {
             if (Keycodes.KeyCodes.TryGetValue(code, out var avkey))
             {
                 if (_inputRoot is { })
                 {
-                    Input?.Invoke(new RawKeyEventArgs(KeyboardDevice, Timestamp, _inputRoot, type, avkey, modifiers));
+                    var args = new RawKeyEventArgs(KeyboardDevice, Timestamp, _inputRoot, type, avkey, modifiers);
+                    
+                    Input?.Invoke(args);
+                    
+                    return args.Handled;
                 }
             }
             else if (Keycodes.KeyCodes.TryGetValue(key, out avkey))
             {
                 if (_inputRoot is { })
                 {
-                    Input?.Invoke(new RawKeyEventArgs(KeyboardDevice, Timestamp, _inputRoot, type, avkey, modifiers));
+                    var args = new RawKeyEventArgs(KeyboardDevice, Timestamp, _inputRoot, type, avkey, modifiers);
+                    
+                    Input?.Invoke(args);
+
+                    return args.Handled;
                 }
             }
+
+            return false;
         }
 
         public void RawTextEvent(string text)


### PR DESCRIPTION
#8912  broke text input. This provides correct fix.