### PR TITLE
GetCurrentPoint breaking-change fix

### DIFF
--- a/samples/ControlCatalog/Pages/PointerCanvas.cs
+++ b/samples/ControlCatalog/Pages/PointerCanvas.cs
@@ -74,7 +74,7 @@ public class PointerCanvas : Control
         public void HandleEvent(PointerEventArgs e, Visual v)
         {
             e.Handled = true;
-            var currentPoint = e.GetCurrentPoint(v);
+            var currentPoint = e.GetCurrentPoint(v) ?? default;
             if (e.RoutedEvent == PointerPressedEvent)
                 AddPoint(currentPoint.Position, Brushes.Green, 10);
             else if (e.RoutedEvent == PointerReleasedEvent)
@@ -171,7 +171,7 @@ Twist: {_lastProperties?.Twist}";
         }
         InvalidateVisual();
 
-        var lastPointer = e.GetCurrentPoint(this);
+        var lastPointer = e.GetCurrentPoint(this) ?? default;
         _lastProperties = lastPointer.Properties;
 
         if (_lastProperties?.PointerUpdateKind != PointerUpdateKind.Other)

--- a/samples/ControlCatalog/Pages/PointerContactsTab.cs
+++ b/samples/ControlCatalog/Pages/PointerContactsTab.cs
@@ -64,7 +64,7 @@ public class PointerContactsTab : Control
             _pointers[e.Pointer] = info = new PointerInfo { Color = color };
         }
 
-        info.Point = e.GetPosition(this);
+        info.Point = e.GetPosition(this) ?? default;
         InvalidateVisual();
     }
 

--- a/samples/ControlCatalog/Pages/PointersPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/PointersPage.xaml.cs
@@ -33,7 +33,7 @@ public class PointersPage : UserControl
     {
         if (sender is Border border && border.Child is TextBlock textBlock)
         {
-            var position = e.GetPosition(border);
+            var position = e.GetPosition(border) ?? default;
             textBlock.Text = @$"Type: {e.Pointer.Type}
 Captured: {e.Pointer.Captured == sender}
 PointerId: {e.Pointer.Id}

--- a/samples/Sandbox/MainWindow.axaml
+++ b/samples/Sandbox/MainWindow.axaml
@@ -1,4 +1,5 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
         x:Class="Sandbox.MainWindow">
+  <TextBlock Text="{Binding ., StringFormat=0:0.0}" />
 </Window>

--- a/samples/Sandbox/MainWindow.axaml.cs
+++ b/samples/Sandbox/MainWindow.axaml.cs
@@ -10,7 +10,7 @@ namespace Sandbox
         public MainWindow()
         {
             this.InitializeComponent();
-            this.AttachDevTools();
+            this.AttachDevTools();DataContext = 5.6;
         }
 
         private void InitializeComponent()

--- a/src/Avalonia.Base/Input/FocusManager.cs
+++ b/src/Avalonia.Base/Input/FocusManager.cs
@@ -221,9 +221,8 @@ namespace Avalonia.Input
                 return;
 
             var ev = (PointerPressedEventArgs)e;
-            var visual = (IVisual)sender;
 
-            if (sender == e.Source && ev.GetCurrentPoint(visual)?.Properties.IsLeftButtonPressed == true)
+            if (sender == e.Source && ev.Properties.IsLeftButtonPressed)
             {
                 IVisual? element = ev.Pointer?.Captured ?? e.Source as IInputElement;
 

--- a/src/Avalonia.Base/Input/FocusManager.cs
+++ b/src/Avalonia.Base/Input/FocusManager.cs
@@ -223,7 +223,7 @@ namespace Avalonia.Input
             var ev = (PointerPressedEventArgs)e;
             var visual = (IVisual)sender;
 
-            if (sender == e.Source && ev.GetCurrentPoint(visual).Properties.IsLeftButtonPressed)
+            if (sender == e.Source && ev.GetCurrentPoint(visual)?.Properties.IsLeftButtonPressed == true)
             {
                 IVisual? element = ev.Pointer?.Captured ?? e.Source as IInputElement;
 

--- a/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
@@ -9,7 +9,7 @@ namespace Avalonia.Input.GestureRecognizers
             IGestureRecognizer
     {
         private bool _scrolling;
-        private Point _trackedRootPoint;
+        private Point? _trackedRootPoint;
         private IPointer? _tracking;
         private IInputElement? _target;
         private IGestureRecognizerActionsDispatcher? _actions;
@@ -84,14 +84,15 @@ namespace Avalonia.Input.GestureRecognizers
         
         public void PointerMoved(PointerEventArgs e)
         {
-            if (e.Pointer == _tracking)
+            if (e.Pointer == _tracking
+                && _trackedRootPoint is { } trackedRootPoint
+                && e.GetPosition(_target) is { } rootPoint)
             {
-                var rootPoint = e.GetPosition(_target);
                 if (!_scrolling)
                 {
-                    if (CanHorizontallyScroll && Math.Abs(_trackedRootPoint.X - rootPoint.X) > ScrollStartDistance)
+                    if (CanHorizontallyScroll && Math.Abs(trackedRootPoint.X - rootPoint.X) > ScrollStartDistance)
                         _scrolling = true;
-                    if (CanVerticallyScroll && Math.Abs(_trackedRootPoint.Y - rootPoint.Y) > ScrollStartDistance)
+                    if (CanVerticallyScroll && Math.Abs(trackedRootPoint.Y - rootPoint.Y) > ScrollStartDistance)
                         _scrolling = true;
                     if (_scrolling)
                     {
@@ -101,7 +102,7 @@ namespace Avalonia.Input.GestureRecognizers
 
                 if (_scrolling)
                 {
-                    var vector = _trackedRootPoint - rootPoint;
+                    var vector = trackedRootPoint - rootPoint;
                     var elapsed = _lastMoveTimestamp.HasValue && _lastMoveTimestamp < e.Timestamp ?
                         TimeSpan.FromMilliseconds(e.Timestamp - _lastMoveTimestamp.Value) :
                         TimeSpan.Zero;

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -98,7 +98,7 @@ namespace Avalonia.Input
                     s_isDoubleTapped = false;
                     s_lastPress.SetTarget(ev.Source);
                 }
-                else if (e.ClickCount % 2 == 0 && e.GetCurrentPoint(null)?.Properties.IsLeftButtonPressed == true)
+                else if (e.ClickCount % 2 == 0 && e.Properties.IsLeftButtonPressed)
                 {
                     if (s_lastPress.TryGetTarget(out var target) && target == e.Source)
                     {

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -92,14 +92,13 @@ namespace Avalonia.Input
             if (ev.Route == RoutingStrategies.Bubble)
             {
                 var e = (PointerPressedEventArgs)ev;
-                var visual = (IVisual)ev.Source;
 
                 if (e.ClickCount <= 1)
                 {
                     s_isDoubleTapped = false;
                     s_lastPress.SetTarget(ev.Source);
                 }
-                else if (e.ClickCount % 2 == 0 && e.GetCurrentPoint(visual).Properties.IsLeftButtonPressed)
+                else if (e.ClickCount % 2 == 0 && e.GetCurrentPoint(null)?.Properties.IsLeftButtonPressed == true)
                 {
                     if (s_lastPress.TryGetTarget(out var target) && target == e.Source)
                     {

--- a/src/Avalonia.Base/Input/PointerEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerEventArgs.cs
@@ -62,6 +62,11 @@ namespace Avalonia.Input
         public KeyModifiers KeyModifiers { get; }
 
         /// <summary>
+        /// Returns the current pointer point properties
+        /// </summary>
+        public PointerPointProperties Properties { get; private set; }
+
+        /// <summary>
         /// Gets the pointer position relative to a control.
         /// </summary>
         /// <param name="relativeTo">The control.</param>
@@ -81,15 +86,6 @@ namespace Avalonia.Input
         }
 
         /// <summary>
-        /// Gets the pointer position relative to the input root.
-        /// </summary>
-        /// <returns>The pointer position in the root's coordinates.</returns>
-        public Point GetPosition()
-        {
-            return _rootVisualPosition;
-        }
-
-        /// <summary>
         /// Returns the PointerPoint associated with the current event.
         /// </summary>
         /// <param name="relativeTo">The visual which coordinate system to use. Pass null for toplevel coordinate system</param>
@@ -100,15 +96,6 @@ namespace Avalonia.Input
             => GetPosition(relativeTo) is { } position
             ? new PointerPoint(Pointer, position, Properties)
             : null;
-
-        /// <summary>
-        /// Returns the PointerPoint associated with the current event.
-        /// </summary>
-        /// <returns>
-        /// Returns current point in the root's coordinates. 
-        /// </returns>
-        public PointerPoint GetCurrentPoint()
-            => new PointerPoint(Pointer, _rootVisualPosition, Properties);
 
         /// <summary>
         /// Retrieves position and state information for the specified pointer, from the last pointer event up to and including the current pointer event.
@@ -153,11 +140,6 @@ namespace Avalonia.Input
             points[points.Length - 1] = currentPoint;
             return points;
         }
-
-        /// <summary>
-        /// Returns the current pointer point properties
-        /// </summary>
-        protected PointerPointProperties Properties { get; private set; }
     }
     
     public enum MouseButton

--- a/src/Avalonia.Base/Input/PointerEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerEventArgs.cs
@@ -81,16 +81,34 @@ namespace Avalonia.Input
         }
 
         /// <summary>
+        /// Gets the pointer position relative to the input root.
+        /// </summary>
+        /// <returns>The pointer position in the root's coordinates.</returns>
+        public Point GetPosition()
+        {
+            return _rootVisualPosition;
+        }
+
+        /// <summary>
         /// Returns the PointerPoint associated with the current event.
         /// </summary>
         /// <param name="relativeTo">The visual which coordinate system to use. Pass null for toplevel coordinate system</param>
         /// <returns>
-        /// Returns current point or null if not possible to transform to relative visual. 
+        /// The Returns current point in the visual's coordinates or null if not possible to transform to relative visual. 
         /// </returns>
         public PointerPoint? GetCurrentPoint(IVisual? relativeTo)
             => GetPosition(relativeTo) is { } position
             ? new PointerPoint(Pointer, position, Properties)
             : null;
+
+        /// <summary>
+        /// Returns the PointerPoint associated with the current event.
+        /// </summary>
+        /// <returns>
+        /// Returns current point in the root's coordinates. 
+        /// </returns>
+        public PointerPoint GetCurrentPoint()
+            => new PointerPoint(Pointer, _rootVisualPosition, Properties);
 
         /// <summary>
         /// Retrieves position and state information for the specified pointer, from the last pointer event up to and including the current pointer event.

--- a/src/Avalonia.Base/Input/TappedEventArgs.cs
+++ b/src/Avalonia.Base/Input/TappedEventArgs.cs
@@ -3,6 +3,9 @@ using Avalonia.VisualTree;
 
 namespace Avalonia.Input
 {
+    /// <summary>
+    /// Arguments for <see cref="InputElement.Tapped"/> and <see cref="InputElement.DoubleTapped"/> events.
+    /// </summary>
     public class TappedEventArgs : RoutedEventArgs
     {
         private readonly PointerEventArgs lastPointerEventArgs;
@@ -13,10 +16,16 @@ namespace Avalonia.Input
             this.lastPointerEventArgs = lastPointerEventArgs;
         }
 
+        /// <inheritdoc cref="PointerEventArgs.Pointer" />
         public IPointer Pointer => lastPointerEventArgs.Pointer;
+
+        /// <inheritdoc cref="PointerEventArgs.KeyModifiers" />
         public KeyModifiers KeyModifiers => lastPointerEventArgs.KeyModifiers;
+
+        /// <inheritdoc cref="PointerEventArgs.Timestamp" />
         public ulong Timestamp => lastPointerEventArgs.Timestamp;
-        
-        public Point GetPosition(IVisual? relativeTo) => lastPointerEventArgs.GetPosition(relativeTo);
+
+        /// <inheritdoc cref="PointerEventArgs.GetPosition(IVisual?)" />
+        public Point? GetPosition(IVisual? relativeTo) => lastPointerEventArgs.GetPosition(relativeTo);
     }
 }

--- a/src/Avalonia.Controls.ColorPicker/ColorSlider/ColorSlider.cs
+++ b/src/Avalonia.Controls.ColorPicker/ColorSlider/ColorSlider.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls.Metadata;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Media.Imaging;
 using Avalonia.Utilities;
 
 namespace Avalonia.Controls.Primitives
@@ -110,7 +111,15 @@ namespace Avalonia.Controls.Primitives
 
                 if (bitmap != null)
                 {
-                    Background = new ImageBrush(ColorPickerHelpers.CreateBitmapFromPixelData(bitmap, pixelWidth, pixelHeight));
+                    if ((Background as ImageBrush)?.Source is WriteableBitmap existingBitmap)
+                    {
+                        ColorPickerHelpers.UpdateBitmapFromPixelData(existingBitmap, bitmap);
+                        Background = new ImageBrush(existingBitmap);
+                    }
+                    else
+                    {
+                        Background = new ImageBrush(ColorPickerHelpers.CreateBitmapFromPixelData(bitmap, pixelWidth, pixelHeight));
+                    }
                 }
             }
         }

--- a/src/Avalonia.Controls.ColorPicker/ColorSpectrum/ColorSpectrum.cs
+++ b/src/Avalonia.Controls.ColorPicker/ColorSpectrum/ColorSpectrum.cs
@@ -865,33 +865,33 @@ namespace Avalonia.Controls.Primitives
         private void InputTarget_PointerPressed(object? sender, PointerPressedEventArgs args)
         {
             var inputTarget = _inputTarget;
+            if (args.GetCurrentPoint(inputTarget) is { } point)
+            {
+                Focus();
 
-            Focus();
+                _isPointerPressed = true;
+                _shouldShowLargeSelection =
+                    args.Pointer.Type == PointerType.Pen ||
+                    args.Pointer.Type == PointerType.Touch;
 
-            _isPointerPressed = true;
-            _shouldShowLargeSelection =
-                // TODO: After Pen PR is merged: https://github.com/AvaloniaUI/Avalonia/pull/7412
-                // args.Pointer.Type == PointerType.Pen ||
-                args.Pointer.Type == PointerType.Touch;
+                args.Pointer.Capture(inputTarget);
+                UpdateColorFromPoint(point);
+                UpdatePseudoClasses();
+                UpdateEllipse();
 
-            args.Pointer.Capture(inputTarget);
-            UpdateColorFromPoint(args.GetCurrentPoint(inputTarget));
-            UpdatePseudoClasses();
-            UpdateEllipse();
-
-            args.Handled = true;
+                args.Handled = true;
+            }
         }
 
         /// <inheritdoc cref="InputElement.PointerMoved"/>
         private void InputTarget_PointerMoved(object? sender, PointerEventArgs args)
         {
-            if (!_isPointerPressed)
+            if (_isPointerPressed
+                && args.GetCurrentPoint(_inputTarget) is { } point)
             {
-                return;
+                UpdateColorFromPoint(point);
+                args.Handled = true;
             }
-
-            UpdateColorFromPoint(args.GetCurrentPoint(_inputTarget));
-            args.Handled = true;
         }
 
         /// <inheritdoc cref="InputElement.PointerReleased"/>

--- a/src/Avalonia.Controls.ColorPicker/Helpers/ColorPickerHelpers.cs
+++ b/src/Avalonia.Controls.ColorPicker/Helpers/ColorPickerHelpers.cs
@@ -617,13 +617,18 @@ namespace Avalonia.Controls.Primitives
                 PixelFormat.Bgra8888,
                 AlphaFormat.Premul);
 
+            UpdateBitmapFromPixelData(bitmap, bgraPixelData);
+
+            return bitmap;
+        }
+
+        public static void UpdateBitmapFromPixelData(WriteableBitmap bitmap, IList<byte> bgraPixelData)
+        {
             // Warning: This is highly questionable
             using (var frameBuffer = bitmap.Lock())
             {
-                Marshal.Copy(bgraPixelData.ToArray(), 0, frameBuffer.Address, bgraPixelData.Count);
+                Marshal.Copy((bgraPixelData as byte[]) ?? bgraPixelData.ToArray(), 0, frameBuffer.Address, bgraPixelData.Count);
             }
-
-            return bitmap;
         }
     }
 }

--- a/src/Avalonia.Controls.DataGrid/DataGridCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCell.cs
@@ -167,7 +167,7 @@ namespace Avalonia.Controls
                 return;
             }
             OwningGrid.OnCellPointerPressed(new DataGridCellPointerPressedEventArgs(this, OwningRow, OwningColumn, e));
-            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
             {
                 if (!e.Handled)
                 //if (!e.Handled && OwningGrid.IsTabStop)
@@ -188,7 +188,7 @@ namespace Avalonia.Controls
                     OwningGrid.UpdatedStateOnMouseLeftButtonDown = true;
                 }
             }
-            else if (e.GetCurrentPoint(this).Properties.IsRightButtonPressed)
+            else if (e.GetCurrentPoint(this)?.Properties.IsRightButtonPressed == true)
             {
                 if (!e.Handled)
                 //if (!e.Handled && OwningGrid.IsTabStop)

--- a/src/Avalonia.Controls.DataGrid/DataGridCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCell.cs
@@ -167,7 +167,7 @@ namespace Avalonia.Controls
                 return;
             }
             OwningGrid.OnCellPointerPressed(new DataGridCellPointerPressedEventArgs(this, OwningRow, OwningColumn, e));
-            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
+            if (e.Properties.IsLeftButtonPressed)
             {
                 if (!e.Handled)
                 //if (!e.Handled && OwningGrid.IsTabStop)
@@ -188,7 +188,7 @@ namespace Avalonia.Controls
                     OwningGrid.UpdatedStateOnMouseLeftButtonDown = true;
                 }
             }
-            else if (e.GetCurrentPoint(this)?.Properties.IsRightButtonPressed == true)
+            else if (e.Properties.IsRightButtonPressed)
             {
                 if (!e.Handled)
                 //if (!e.Handled && OwningGrid.IsTabStop)

--- a/src/Avalonia.Controls.DataGrid/DataGridCheckBoxColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCheckBoxColumn.cs
@@ -182,11 +182,13 @@ namespace Avalonia.Controls
                     void ProcessPointerArgs()
                     {
                         // Editing was triggered by a mouse click
-                        Point position = args.GetPosition(editingCheckBox);
-                        Rect rect = new Rect(0, 0, editingCheckBox.Bounds.Width, editingCheckBox.Bounds.Height);
-                        if(rect.Contains(position))
+                        if (args.GetPosition(editingCheckBox) is { } position)
                         {
-                            EditValue();
+                            Rect rect = new Rect(0, 0, editingCheckBox.Bounds.Width, editingCheckBox.Bounds.Height);
+                            if (rect.Contains(position))
+                            {
+                                EditValue();
+                            }
                         }
                     }
                     

--- a/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
@@ -459,9 +459,11 @@ namespace Avalonia.Controls
                 return;
             }
 
-            Point mousePosition = e.GetPosition(this);
-            OnMouseEnter(mousePosition);
-            UpdatePseudoClasses();
+            if (e.GetPosition(this) is { } mousePosition)
+            {
+                OnMouseEnter(mousePosition);
+                UpdatePseudoClasses();
+            }
         }
 
         private void DataGridColumnHeader_PointerExited(object sender, PointerEventArgs e)
@@ -477,14 +479,19 @@ namespace Avalonia.Controls
 
         private void DataGridColumnHeader_PointerPressed(object sender, PointerPressedEventArgs e)
         {
-            if (OwningColumn == null || e.Handled || !IsEnabled || !e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            if (OwningColumn == null || e.Handled || !IsEnabled)
             {
                 return;
             }
 
-            Point mousePosition = e.GetPosition(this);
+            var point = e.GetCurrentPoint(this);
+            if (point is null || !point.Value.Properties.IsLeftButtonPressed)
+            {
+                return;
+            }
+
             bool handled = e.Handled;
-            OnMouseLeftButtonDown(ref handled, e, mousePosition);
+            OnMouseLeftButtonDown(ref handled, e, point.Value.Position);
             e.Handled = handled;
 
             UpdatePseudoClasses();
@@ -497,13 +504,15 @@ namespace Avalonia.Controls
                 return;
             }
 
-            Point mousePosition = e.GetPosition(this);
-            Point mousePositionHeaders = e.GetPosition(OwningGrid.ColumnHeaders);
-            bool handled = e.Handled;
-            OnMouseLeftButtonUp(ref handled, e, mousePosition, mousePositionHeaders);
-            e.Handled = handled;
+            if (e.GetPosition(this) is { } mousePosition
+                && e.GetPosition(OwningGrid.ColumnHeaders) is { } mousePositionHeaders)
+            {
+                bool handled = e.Handled;
+                OnMouseLeftButtonUp(ref handled, e, mousePosition, mousePositionHeaders);
+                e.Handled = handled;
 
-            UpdatePseudoClasses();
+                UpdatePseudoClasses();
+            }
         }
 
         private void DataGridColumnHeader_PointerMoved(object sender, PointerEventArgs e)
@@ -513,10 +522,11 @@ namespace Avalonia.Controls
                 return;
             }
 
-            Point mousePosition = e.GetPosition(this);
-            Point mousePositionHeaders = e.GetPosition(OwningGrid.ColumnHeaders);
-
-            OnMouseMove(e, mousePosition, mousePositionHeaders);
+            if (e.GetPosition(this) is { } mousePosition
+                && e.GetPosition(OwningGrid.ColumnHeaders) is { } mousePositionHeaders)
+            {
+                OnMouseMove(e, mousePosition, mousePositionHeaders);
+            }
         }
 
         /// <summary>

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -761,7 +761,7 @@ namespace Avalonia.Controls
 
         private void DataGridRow_PointerPressed(PointerPressedEventArgs e)
         {
-            if (!e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
+            if (!e.Properties.IsLeftButtonPressed)
             {
                 return;
             }

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -761,7 +761,7 @@ namespace Avalonia.Controls
 
         private void DataGridRow_PointerPressed(PointerPressedEventArgs e)
         {
-            if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            if (!e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
             {
                 return;
             }

--- a/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
@@ -292,7 +292,7 @@ namespace Avalonia.Controls
             {
                 return;
             }
-            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
             {
                 if (OwningGrid.IsDoubleClickRecordsClickOnCall(this) && !e.Handled)
                 {
@@ -309,7 +309,7 @@ namespace Avalonia.Controls
                     e.Handled = OwningGrid.UpdateStateOnMouseLeftButtonDown(e, OwningGrid.CurrentColumnIndex, RowGroupInfo.Slot, allowEdit: false);
                 }
             }
-            else if (e.GetCurrentPoint(this).Properties.IsRightButtonPressed)
+            else if (e.GetCurrentPoint(this)?.Properties.IsRightButtonPressed == true)
             {
                 if (!e.Handled)
                 {

--- a/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
@@ -292,7 +292,7 @@ namespace Avalonia.Controls
             {
                 return;
             }
-            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
+            if (e.Properties.IsLeftButtonPressed)
             {
                 if (OwningGrid.IsDoubleClickRecordsClickOnCall(this) && !e.Handled)
                 {
@@ -309,7 +309,7 @@ namespace Avalonia.Controls
                     e.Handled = OwningGrid.UpdateStateOnMouseLeftButtonDown(e, OwningGrid.CurrentColumnIndex, RowGroupInfo.Slot, allowEdit: false);
                 }
             }
-            else if (e.GetCurrentPoint(this)?.Properties.IsRightButtonPressed == true)
+            else if (e.Properties.IsRightButtonPressed)
             {
                 if (!e.Handled)
                 {

--- a/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
@@ -185,7 +185,7 @@ namespace Avalonia.Controls.Primitives
                 return;
             }
 
-            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
+            if (e.Properties.IsLeftButtonPressed == true)
             {
                 if (!e.Handled)
                 //if (!e.Handled && OwningGrid.IsTabStop)
@@ -200,7 +200,7 @@ namespace Avalonia.Controls.Primitives
                     OwningGrid.UpdatedStateOnMouseLeftButtonDown = true;
                 }
             }
-            else if (e.GetCurrentPoint(this)?.Properties.IsRightButtonPressed == true)
+            else if (e.Properties.IsRightButtonPressed == true)
             {
                 if (!e.Handled)
                 {

--- a/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
@@ -185,7 +185,7 @@ namespace Avalonia.Controls.Primitives
                 return;
             }
 
-            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
             {
                 if (!e.Handled)
                 //if (!e.Handled && OwningGrid.IsTabStop)
@@ -200,7 +200,7 @@ namespace Avalonia.Controls.Primitives
                     OwningGrid.UpdatedStateOnMouseLeftButtonDown = true;
                 }
             }
-            else if (e.GetCurrentPoint(this).Properties.IsRightButtonPressed)
+            else if (e.GetCurrentPoint(this)?.Properties.IsRightButtonPressed == true)
             {
                 if (!e.Handled)
                 {

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -390,7 +390,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerPressed(e);
 
-            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
+            if (e.Properties.IsLeftButtonPressed)
             {
                 IsPressed = true;
                 e.Handled = true;

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -390,7 +390,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerPressed(e);
 
-            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
             {
                 IsPressed = true;
                 e.Handled = true;
@@ -412,8 +412,9 @@ namespace Avalonia.Controls
                 IsPressed = false;
                 e.Handled = true;
 
-                if (ClickMode == ClickMode.Release &&
-                    this.GetVisualsAt(e.GetPosition(this)).Any(c => this == c || this.IsVisualAncestorOf(c)))
+                if (ClickMode == ClickMode.Release
+                    && e.GetPosition(this) is { } position
+                    && this.GetVisualsAt(position).Any(c => this == c || this.IsVisualAncestorOf(c)))
                 {
                     OnClick();
                 }

--- a/src/Avalonia.Controls/ButtonSpinner.cs
+++ b/src/Avalonia.Controls/ButtonSpinner.cs
@@ -136,11 +136,10 @@ namespace Avalonia.Controls
         protected override void OnPointerReleased(PointerReleasedEventArgs e)
         {
             base.OnPointerReleased(e);
-            Point mousePosition;
             if (IncreaseButton != null && IncreaseButton.IsEnabled == false)
             {
-                mousePosition = e.GetPosition(IncreaseButton);
-                if (mousePosition.X > 0 && mousePosition.X < IncreaseButton.Width &&
+                if (e.GetPosition(IncreaseButton) is { } mousePosition &&
+                    mousePosition.X > 0 && mousePosition.X < IncreaseButton.Width &&
                     mousePosition.Y > 0 && mousePosition.Y < IncreaseButton.Height)
                 {
                     e.Handled = true;
@@ -149,8 +148,8 @@ namespace Avalonia.Controls
 
             if (DecreaseButton != null && DecreaseButton.IsEnabled == false)
             {
-                mousePosition = e.GetPosition(DecreaseButton);
-                if (mousePosition.X > 0 && mousePosition.X < DecreaseButton.Width &&
+                if (e.GetPosition(DecreaseButton) is { } mousePosition &&
+                    mousePosition.X > 0 && mousePosition.X < DecreaseButton.Width &&
                     mousePosition.Y > 0 && mousePosition.Y < DecreaseButton.Height)
                 {
                     e.Handled = true;

--- a/src/Avalonia.Controls/Calendar/CalendarButton.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarButton.cs
@@ -151,7 +151,7 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnPointerPressed(e);
 
-            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
+            if (e.Properties.IsLeftButtonPressed)
                 CalendarLeftMouseButtonDown?.Invoke(this, e);
         }
 

--- a/src/Avalonia.Controls/Calendar/CalendarButton.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarButton.cs
@@ -151,7 +151,7 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnPointerPressed(e);
 
-            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
                 CalendarLeftMouseButtonDown?.Invoke(this, e);
         }
 

--- a/src/Avalonia.Controls/Calendar/CalendarDayButton.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarDayButton.cs
@@ -208,7 +208,7 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnPointerPressed(e);
 
-            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
+            if (e.Properties.IsLeftButtonPressed)
                 CalendarDayButtonMouseDown?.Invoke(this, e);
         }
 

--- a/src/Avalonia.Controls/Calendar/CalendarDayButton.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarDayButton.cs
@@ -208,7 +208,7 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnPointerPressed(e);
 
-            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
                 CalendarDayButtonMouseDown?.Invoke(this, e);
         }
 

--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
@@ -347,7 +347,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerPressed(e);
 
-            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
+            if (e.Properties.IsLeftButtonPressed)
             {
                 e.Handled = true;
 

--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
@@ -347,7 +347,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerPressed(e);
 
-            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
             {
                 e.Handled = true;
 

--- a/src/Avalonia.Controls/ContextRequestedEventArgs.cs
+++ b/src/Avalonia.Controls/ContextRequestedEventArgs.cs
@@ -43,14 +43,14 @@ namespace Avalonia.Controls
         /// </returns>
         public bool TryGetPosition(Control? relativeTo, out Point point)
         {
-            if (_pointerEventArgs is null)
+            if (_pointerEventArgs?.GetPosition(relativeTo) is { } position)
             {
-                point = default;
-                return false;
+                point = position;
+                return true;
             }
 
-            point = _pointerEventArgs.GetPosition(relativeTo);
-            return true;
+            point = default;
+            return false;
         }
     }
 }

--- a/src/Avalonia.Controls/Label.cs
+++ b/src/Avalonia.Controls/Label.cs
@@ -65,7 +65,7 @@ namespace Avalonia.Controls
         /// <param name="e">Event Arguments</param>
         protected override void OnPointerPressed(PointerPressedEventArgs e)
         {
-            if (e.GetCurrentPoint(this).Properties.PointerUpdateKind == PointerUpdateKind.LeftButtonPressed)
+            if (e.GetCurrentPoint(this)?.Properties.PointerUpdateKind == PointerUpdateKind.LeftButtonPressed)
             {
                 LabelActivated(e);
             }

--- a/src/Avalonia.Controls/Label.cs
+++ b/src/Avalonia.Controls/Label.cs
@@ -65,7 +65,7 @@ namespace Avalonia.Controls
         /// <param name="e">Event Arguments</param>
         protected override void OnPointerPressed(PointerPressedEventArgs e)
         {
-            if (e.GetCurrentPoint(this)?.Properties.PointerUpdateKind == PointerUpdateKind.LeftButtonPressed)
+            if (e.Properties.IsLeftButtonPressed)
             {
                 LabelActivated(e);
             }

--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -148,19 +148,14 @@ namespace Avalonia.Controls
         {
             base.OnPointerPressed(e);
 
-            if (e.Source is IVisual source)
+            if (e.Properties.IsLeftButtonPressed || e.Properties.IsRightButtonPressed)
             {
-                var point = e.GetCurrentPoint(source) ?? default;
-
-                if (point.Properties.IsLeftButtonPressed || point.Properties.IsRightButtonPressed)
-                {
-                    e.Handled = UpdateSelectionFromEventSource(
-                        e.Source,
-                        true,
-                        e.KeyModifiers.HasAllFlags(KeyModifiers.Shift),
-                        e.KeyModifiers.HasAllFlags(AvaloniaLocator.Current.GetRequiredService<PlatformHotkeyConfiguration>().CommandModifiers),
-                        point.Properties.IsRightButtonPressed);
-                }
+                e.Handled = UpdateSelectionFromEventSource(
+                    e.Source,
+                    true,
+                    e.KeyModifiers.HasAllFlags(KeyModifiers.Shift),
+                    e.KeyModifiers.HasAllFlags(AvaloniaLocator.Current.GetRequiredService<PlatformHotkeyConfiguration>().CommandModifiers),
+                    e.Properties.IsRightButtonPressed);
             }
         }
 

--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -150,7 +150,7 @@ namespace Avalonia.Controls
 
             if (e.Source is IVisual source)
             {
-                var point = e.GetCurrentPoint(source);
+                var point = e.GetCurrentPoint(source) ?? default;
 
                 if (point.Properties.IsLeftButtonPressed || point.Properties.IsRightButtonPressed)
                 {

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -449,7 +449,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerEntered(e);
 
-            var point = e.GetCurrentPoint(null);
+            var point = e.GetCurrentPoint(null) ?? default;
             RaiseEvent(new PointerEventArgs(PointerEnteredItemEvent, this, e.Pointer, this.VisualRoot, point.Position,
                 e.Timestamp, point.Properties, e.KeyModifiers));
         }
@@ -459,7 +459,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerExited(e);
 
-            var point = e.GetCurrentPoint(null);
+            var point = e.GetCurrentPoint(null) ?? default;
             RaiseEvent(new PointerEventArgs(PointerExitedItemEvent, this, e.Pointer, this.VisualRoot, point.Position,
                 e.Timestamp, point.Properties, e.KeyModifiers));
         }

--- a/src/Avalonia.Controls/Mixins/PressedMixin.cs
+++ b/src/Avalonia.Controls/Mixins/PressedMixin.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Controls.Mixins
 
         private static void HandlePointerPressed<TControl>(TControl sender, PointerPressedEventArgs e) where TControl : Control
         {
-            if (e.GetCurrentPoint(sender).Properties.IsLeftButtonPressed)
+            if (e.GetCurrentPoint(sender)?.Properties.IsLeftButtonPressed == true)
             {
                 ((IPseudoClasses)sender.Classes).Set(":pressed", true);
             }

--- a/src/Avalonia.Controls/Mixins/PressedMixin.cs
+++ b/src/Avalonia.Controls/Mixins/PressedMixin.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Controls.Mixins
 
         private static void HandlePointerPressed<TControl>(TControl sender, PointerPressedEventArgs e) where TControl : Control
         {
-            if (e.GetCurrentPoint(sender)?.Properties.IsLeftButtonPressed == true)
+            if (e.Properties.IsLeftButtonPressed)
             {
                 ((IPseudoClasses)sender.Classes).Set(":pressed", true);
             }

--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -354,9 +354,10 @@ namespace Avalonia.Controls.Platform
             {
                 return;
             }
-            var point = e.GetCurrentPoint(null) ?? default;
 
-            if (point.Properties.IsLeftButtonPressed && item.TransformedBounds.Value.Contains(point.Position) == false)
+            if (e.Properties.IsLeftButtonPressed
+                && e.GetCurrentPoint(null) is { } point
+                && item.TransformedBounds.Value.Contains(point.Position) == false)
             {
                 e.Pointer.Capture(null);
             }
@@ -401,8 +402,7 @@ namespace Avalonia.Controls.Platform
         {
             var item = GetMenuItem(e.Source as IControl);
 
-            if (sender is IVisual visual &&
-                e.GetCurrentPoint(visual)?.Properties.IsLeftButtonPressed == true && item?.HasSubMenu == true)
+            if (e.Properties.IsLeftButtonPressed && item?.HasSubMenu == true)
             {
                 if (item.IsSubMenuOpen)
                 {

--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -354,7 +354,7 @@ namespace Avalonia.Controls.Platform
             {
                 return;
             }
-            var point = e.GetCurrentPoint(null);
+            var point = e.GetCurrentPoint(null) ?? default;
 
             if (point.Properties.IsLeftButtonPressed && item.TransformedBounds.Value.Contains(point.Position) == false)
             {
@@ -402,7 +402,7 @@ namespace Avalonia.Controls.Platform
             var item = GetMenuItem(e.Source as IControl);
 
             if (sender is IVisual visual &&
-                e.GetCurrentPoint(visual).Properties.IsLeftButtonPressed && item?.HasSubMenu == true)
+                e.GetCurrentPoint(visual)?.Properties.IsLeftButtonPressed == true && item?.HasSubMenu == true)
             {
                 if (item.IsSubMenuOpen)
                 {

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -772,9 +772,9 @@ namespace Avalonia.Controls.Primitives
         private void PassThroughEvent(PointerPressedEventArgs e)
         {
             if (e.Source is LightDismissOverlayLayer layer &&
-                layer.GetVisualRoot() is IInputElement root)
+                layer.GetVisualRoot() is IInputElement root &&
+                e.GetCurrentPoint(root) is { } p)
             {
-                var p = e.GetCurrentPoint(root);
                 var hit = root.InputHitTest(p.Position, x => x != layer);
 
                 if (hit != null)

--- a/src/Avalonia.Controls/Primitives/TabStrip.cs
+++ b/src/Avalonia.Controls/Primitives/TabStrip.cs
@@ -46,7 +46,7 @@ namespace Avalonia.Controls.Primitives
             {
                 var point = e.GetCurrentPoint(source);
 
-                if (point.Properties.IsLeftButtonPressed)
+                if (point?.Properties.IsLeftButtonPressed == true)
                 {
                     e.Handled = UpdateSelectionFromEventSource(e.Source);
                 }

--- a/src/Avalonia.Controls/Primitives/TabStrip.cs
+++ b/src/Avalonia.Controls/Primitives/TabStrip.cs
@@ -42,14 +42,9 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnPointerPressed(e);
 
-            if (e.Source is IVisual source)
+            if (e.Properties.IsLeftButtonPressed == true)
             {
-                var point = e.GetCurrentPoint(source);
-
-                if (point?.Properties.IsLeftButtonPressed == true)
-                {
-                    e.Handled = UpdateSelectionFromEventSource(e.Source);
-                }
+                e.Handled = UpdateSelectionFromEventSource(e.Source);
             }
         }
     }

--- a/src/Avalonia.Controls/Primitives/Thumb.cs
+++ b/src/Avalonia.Controls/Primitives/Thumb.cs
@@ -78,12 +78,13 @@ namespace Avalonia.Controls.Primitives
 
         protected override void OnPointerMoved(PointerEventArgs e)
         {
-            if (_lastPoint.HasValue)
+            if (_lastPoint is { } lastPoint
+                && e.GetPosition(this) is { } newPoint)
             {
                 var ev = new VectorEventArgs
                 {
                     RoutedEvent = DragDeltaEvent,
-                    Vector = e.GetPosition(this) - _lastPoint.Value,
+                    Vector = (Vector)(newPoint - lastPoint),
                 };
 
                 RaiseEvent(ev);
@@ -95,20 +96,24 @@ namespace Avalonia.Controls.Primitives
             e.Handled = true;
             _lastPoint = e.GetPosition(this);
 
-            var ev = new VectorEventArgs
+            if (_lastPoint is { } lastPoint)
             {
-                RoutedEvent = DragStartedEvent,
-                Vector = (Vector)_lastPoint,
-            };
+                var ev = new VectorEventArgs
+                {
+                    RoutedEvent = DragStartedEvent,
+                    Vector = (Vector)lastPoint,
+                };
 
-            PseudoClasses.Add(":pressed");
+                PseudoClasses.Add(":pressed");
 
-            RaiseEvent(ev);
+                RaiseEvent(ev);
+            }
         }
 
         protected override void OnPointerReleased(PointerReleasedEventArgs e)
         {
-            if (_lastPoint.HasValue)
+            if (_lastPoint is { } lastPoint
+                && e.GetPosition(this) is { } newPoint)
             {
                 e.Handled = true;
                 _lastPoint = null;
@@ -116,7 +121,7 @@ namespace Avalonia.Controls.Primitives
                 var ev = new VectorEventArgs
                 {
                     RoutedEvent = DragCompletedEvent,
-                    Vector = (Vector)e.GetPosition(this),
+                    Vector = (Vector)newPoint,
                 };
 
                 RaiseEvent(ev);

--- a/src/Avalonia.Controls/RepeatButton.cs
+++ b/src/Avalonia.Controls/RepeatButton.cs
@@ -101,7 +101,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerPressed(e);
 
-            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
             {
                 StartTimer();
             }

--- a/src/Avalonia.Controls/RepeatButton.cs
+++ b/src/Avalonia.Controls/RepeatButton.cs
@@ -101,7 +101,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerPressed(e);
 
-            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true)
+            if (e.Properties.IsLeftButtonPressed == true)
             {
                 StartTimer();
             }

--- a/src/Avalonia.Controls/RichTextBlock.cs
+++ b/src/Avalonia.Controls/RichTextBlock.cs
@@ -366,13 +366,13 @@ namespace Avalonia.Controls
             }
 
             var text = Text;
-            var clickInfo = e.GetCurrentPoint(this);
+            var clickInfo = e.GetCurrentPoint(this) ?? default;
 
             if (text != null && clickInfo.Properties.IsLeftButtonPressed)
             {
                 var padding = Padding;
 
-                var point = e.GetPosition(this) - new Point(padding.Left, padding.Top);
+                var point = clickInfo.Position - new Point(padding.Left, padding.Top);
 
                 var clickToSelect = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
 
@@ -449,12 +449,14 @@ namespace Avalonia.Controls
             }
 
             // selection should not change during pointer move if the user right clicks
-            if (e.Pointer.Captured == this && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            if (e.Pointer.Captured == this
+                && e.GetCurrentPoint(this) is { } currentPoint
+                && currentPoint.Properties.IsLeftButtonPressed)
             {
                 var text = Text;
                 var padding = Padding;
 
-                var point = e.GetPosition(this) - new Point(padding.Left, padding.Top);
+                var point = currentPoint.Position - new Point(padding.Left, padding.Top);
 
                 point = new Point(
                     MathUtilities.Clamp(point.X, 0, Math.Max(TextLayout.Bounds.Width, 0)),
@@ -504,11 +506,12 @@ namespace Avalonia.Controls
                 return;
             }
 
-            if (e.InitialPressMouseButton == MouseButton.Right)
+            if (e.InitialPressMouseButton == MouseButton.Right
+                && e.GetPosition(this) is { } position)
             {
                 var padding = Padding;
 
-                var point = e.GetPosition(this) - new Point(padding.Left, padding.Top);
+                var point = position - new Point(padding.Left, padding.Top);
 
                 var hit = TextLayout.HitTestPoint(point);
 

--- a/src/Avalonia.Controls/RichTextBlock.cs
+++ b/src/Avalonia.Controls/RichTextBlock.cs
@@ -366,9 +366,9 @@ namespace Avalonia.Controls
             }
 
             var text = Text;
-            var clickInfo = e.GetCurrentPoint(this) ?? default;
 
-            if (text != null && clickInfo.Properties.IsLeftButtonPressed)
+            if (text != null && e.Properties.IsLeftButtonPressed
+                && e.GetCurrentPoint(this) is { } clickInfo)
             {
                 var padding = Padding;
 
@@ -449,9 +449,8 @@ namespace Avalonia.Controls
             }
 
             // selection should not change during pointer move if the user right clicks
-            if (e.Pointer.Captured == this
-                && e.GetCurrentPoint(this) is { } currentPoint
-                && currentPoint.Properties.IsLeftButtonPressed)
+            if (e.Pointer.Captured == this && e.Properties.IsLeftButtonPressed
+                && e.GetCurrentPoint(this) is { } currentPoint)
             {
                 var text = Text;
                 var padding = Padding;

--- a/src/Avalonia.Controls/Slider.cs
+++ b/src/Avalonia.Controls/Slider.cs
@@ -317,9 +317,10 @@ namespace Avalonia.Controls
 
         private void TrackMoved(object? sender, PointerEventArgs e)
         {
-            if (_isDragging)
+            if (_isDragging
+                && e.GetCurrentPoint(_track) is { } point)
             {
-                MoveToPoint(e.GetCurrentPoint(_track));
+                MoveToPoint(point);
             }
         }
 
@@ -330,9 +331,10 @@ namespace Avalonia.Controls
 
         private void TrackPressed(object? sender, PointerPressedEventArgs e)
         {
-            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            if (e.GetCurrentPoint(_track) is { } point
+                && point.Properties.IsLeftButtonPressed)
             {
-                MoveToPoint(e.GetCurrentPoint(_track));
+                MoveToPoint(point);
                 _isDragging = true;
             }
         }

--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -216,7 +216,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerPressed(e);
 
-            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true && e.Pointer.Type == PointerType.Mouse)
+            if (e.Properties.IsLeftButtonPressed == true && e.Pointer.Type == PointerType.Mouse)
             {
                 e.Handled = UpdateSelectionFromEventSource(e.Source);
             }

--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -216,7 +216,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerPressed(e);
 
-            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed && e.Pointer.Type == PointerType.Mouse)
+            if (e.GetCurrentPoint(this)?.Properties.IsLeftButtonPressed == true && e.Pointer.Type == PointerType.Mouse)
             {
                 e.Handled = UpdateSelectionFromEventSource(e.Source);
             }
@@ -228,7 +228,8 @@ namespace Avalonia.Controls
             {
                 var container = GetContainerFromEventSource(e.Source);
                 if (container != null
-                    && container.GetVisualsAt(e.GetPosition(container))
+                    && e.GetPosition(container) is { } position
+                    && container.GetVisualsAt(position)
                         .Any(c => container == c || container.IsVisualAncestorOf(c)))
                 {
                     e.Handled = UpdateSelectionFromEventSource(e.Source);

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1148,12 +1148,12 @@ namespace Avalonia.Controls
             }
 
             var text = Text;
-            var clickInfo = e.GetCurrentPoint(this);
 
-            if (text != null && clickInfo.Properties.IsLeftButtonPressed &&
+            if (text != null && e.GetCurrentPoint(_presenter) is { } clickInfo &&
+                clickInfo.Properties.IsLeftButtonPressed &&
                 !(clickInfo.Pointer?.Captured is Border))
             {
-                var point = e.GetPosition(_presenter);
+                var point = clickInfo.Position;
 
                 var oldIndex = CaretIndex;
 
@@ -1231,10 +1231,10 @@ namespace Avalonia.Controls
             }
 
             // selection should not change during pointer move if the user right clicks
-            if (e.Pointer.Captured == _presenter && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            if (e.Pointer.Captured == _presenter && e.GetCurrentPoint(_presenter) is { } clickInfo &&
+                clickInfo.Properties.IsLeftButtonPressed)
             {
-                var point = e.GetPosition(_presenter);
-
+                var point = clickInfo.Position;
                 point = new Point(
                     MathUtilities.Clamp(point.X, 0, Math.Max(_presenter.Bounds.Width - 1, 0)),
                     MathUtilities.Clamp(point.Y, 0, Math.Max(_presenter.Bounds.Height - 1, 0)));
@@ -1283,10 +1283,9 @@ namespace Avalonia.Controls
                 return;
             }
 
-            if (e.InitialPressMouseButton == MouseButton.Right)
+            if (e.InitialPressMouseButton == MouseButton.Right
+                && e.GetPosition(_presenter) is { } point)
             {
-                var point = e.GetPosition(_presenter);
-
                 _presenter.MoveCaretToPoint(point);
 
                 var caretIndex = _presenter.CaretIndex;

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1148,9 +1148,9 @@ namespace Avalonia.Controls
             }
 
             var text = Text;
-
-            if (text != null && e.GetCurrentPoint(_presenter) is { } clickInfo &&
-                clickInfo.Properties.IsLeftButtonPressed &&
+            
+            if (text != null && e.Properties.IsLeftButtonPressed
+                && e.GetCurrentPoint(this) is { } clickInfo &&
                 !(clickInfo.Pointer?.Captured is Border))
             {
                 var point = clickInfo.Position;
@@ -1231,8 +1231,8 @@ namespace Avalonia.Controls
             }
 
             // selection should not change during pointer move if the user right clicks
-            if (e.Pointer.Captured == _presenter && e.GetCurrentPoint(_presenter) is { } clickInfo &&
-                clickInfo.Properties.IsLeftButtonPressed)
+            if (e.Pointer.Captured == _presenter && e.Properties.IsLeftButtonPressed
+                && e.GetCurrentPoint(_presenter) is { } clickInfo)
             {
                 var point = clickInfo.Position;
                 point = new Point(

--- a/src/Avalonia.Controls/ToggleSwitch.cs
+++ b/src/Avalonia.Controls/ToggleSwitch.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Controls
         private Panel? _knobsPanel;
         private Panel? _switchKnob;
         private bool _knobsPanelPressed = false;
-        private Point _switchStartPoint = new Point();
+        private Point? _switchStartPoint = new Point();
         private double _initLeft = -1;
         private bool _isDragging = false;
 
@@ -218,17 +218,18 @@ namespace Avalonia.Controls
         {
             if (_knobsPanelPressed)
             {
-                var difference = e.GetPosition(_switchKnob) - _switchStartPoint;
-
-                if ((!_isDragging) && (System.Math.Abs(difference.X) > 3))
+                if ((e.GetPosition(_switchKnob) - _switchStartPoint) is { } difference)
                 {
-                    _isDragging = true;
-                    PseudoClasses.Set(":dragging", true);
-                }
+                    if ((!_isDragging) && (System.Math.Abs(difference.X) > 3))
+                    {
+                        _isDragging = true;
+                        PseudoClasses.Set(":dragging", true);
+                    }
 
-                if (_isDragging)
-                {
-                    Canvas.SetLeft(_knobsPanel!, System.Math.Min(_switchKnob!.Bounds.Width, System.Math.Max(0, (_initLeft + difference.X))));
+                    if (_isDragging)
+                    {
+                        Canvas.SetLeft(_knobsPanel!, System.Math.Min(_switchKnob!.Bounds.Width, System.Math.Max(0, (_initLeft + difference.X))));
+                    }
                 }
             }
         }

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -520,18 +520,16 @@ namespace Avalonia.Controls
         {
             base.OnPointerPressed(e);
 
-            if (e.Source is IVisual source)
+            if (e.Source is IInteractive)
             {
-                var point = e.GetCurrentPoint(source) ?? default;
-
-                if (point.Properties.IsLeftButtonPressed || point.Properties.IsRightButtonPressed)
+                if (e.Properties.IsLeftButtonPressed || e.Properties.IsRightButtonPressed)
                 {
                     e.Handled = UpdateSelectionFromEventSource(
                         e.Source,
                         true,
                         e.KeyModifiers.HasAllFlags(KeyModifiers.Shift),
                         e.KeyModifiers.HasAllFlags(AvaloniaLocator.Current.GetRequiredService<PlatformHotkeyConfiguration>().CommandModifiers),
-                        point.Properties.IsRightButtonPressed);
+                        e.Properties.IsRightButtonPressed);
                 }
             }
         }

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -522,7 +522,7 @@ namespace Avalonia.Controls
 
             if (e.Source is IVisual source)
             {
-                var point = e.GetCurrentPoint(source);
+                var point = e.GetCurrentPoint(source) ?? default;
 
                 if (point.Properties.IsLeftButtonPressed || point.Properties.IsRightButtonPressed)
                 {

--- a/src/Avalonia.Native/AvaloniaNativeDragSource.cs
+++ b/src/Avalonia.Native/AvaloniaNativeDragSource.cs
@@ -66,7 +66,7 @@ namespace Avalonia.Native
                     clipboard.SetTextAsync(data.GetText()).Wait();
                 
                 view.BeginDraggingSession((AvnDragDropEffects)allowedEffects,
-                    triggerEvent.GetPosition(tl).ToAvnPoint(), clipboardImpl, cb,
+                    triggerEvent.GetPosition(tl)?.ToAvnPoint() ?? default, clipboardImpl, cb,
                     GCHandle.ToIntPtr(GCHandle.Alloc(data)));
             }
 

--- a/tests/Avalonia.Base.UnitTests/Input/PointerOverTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/PointerOverTests.cs
@@ -310,7 +310,7 @@ namespace Avalonia.Base.UnitTests.Input
             var renderer = new Mock<IRenderer>();
             var deviceMock = CreatePointerDeviceMock();
             var impl = CreateTopLevelImplMock(renderer.Object);
-            var result = new List<(object?, string, Point)>();
+            var result = new List<(object?, string, Point?)>();
 
             void HandleEvent(object? sender, PointerEventArgs e)
             {
@@ -338,7 +338,7 @@ namespace Avalonia.Base.UnitTests.Input
             Assert.Equal(
                 new[]
                 {
-                    ((object?)canvas, nameof(InputElement.PointerEntered), expectedPosition),
+                    ((object?)canvas, nameof(InputElement.PointerEntered), (Point?)expectedPosition),
                     (root, nameof(InputElement.PointerEntered), expectedPosition),
                     (canvas, nameof(InputElement.PointerExited), expectedPosition),
                     (root, nameof(InputElement.PointerExited), expectedPosition)
@@ -448,7 +448,7 @@ namespace Avalonia.Base.UnitTests.Input
 
             var lastClientPosition = new Point(1, 5);
             var invalidateRect = new Rect(0, 0, 15, 15);
-            var result = new List<(object?, string, Point)>();
+            var result = new List<(object?, string, Point?)>();
 
             void HandleEvent(object? sender, PointerEventArgs e)
             {
@@ -479,7 +479,7 @@ namespace Avalonia.Base.UnitTests.Input
             Assert.Equal(
                 new[]
                 {
-                    ((object?)canvas, nameof(InputElement.PointerEntered), lastClientPosition),
+                    ((object?)canvas, nameof(InputElement.PointerEntered), (Point?)lastClientPosition),
                     (root, nameof(InputElement.PointerEntered), lastClientPosition),
                     (canvas, nameof(InputElement.PointerExited), lastClientPosition),
                     (root, nameof(InputElement.PointerExited), lastClientPosition),

--- a/tests/Avalonia.Base.UnitTests/Input/PointerOverTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/PointerOverTests.cs
@@ -358,7 +358,7 @@ namespace Avalonia.Base.UnitTests.Input
             var invalidateRect = new Rect(0, 0, 15, 15);
             var lastClientPosition = new Point(1, 5);
 
-            var result = new List<(object?, string, Point)>();
+            var result = new List<(object?, string, Point?)>();
             void HandleEvent(object? sender, PointerEventArgs e)
             {
                 result.Add((sender, e.RoutedEvent!.Name, e.GetPosition(null)));
@@ -392,7 +392,7 @@ namespace Avalonia.Base.UnitTests.Input
             Assert.Equal(
                 new[]
                 {
-                    ((object?)canvas, nameof(InputElement.PointerEntered), lastClientPosition),
+                    ((object?)canvas, nameof(InputElement.PointerEntered), (Point?)lastClientPosition),
                     (root, nameof(InputElement.PointerEntered), lastClientPosition),
                     (canvas, nameof(InputElement.PointerExited), lastClientPosition),
                     (root, nameof(InputElement.PointerExited), lastClientPosition),


### PR DESCRIPTION
## What is the current behavior?

Currently if point cannot be transformed to the relativeTo visual, it returns default point (0,0). Which can cause wrong behavior in the apps.
Typical use case, when visual root and relative to element might not have common visual, which might happen if event was raised in the popup/tooltip, but handled in the parent control. Exactly what happens in #8796 when tooltip is enabled.

## What is the updated/expected behavior with this PR?

GetPosition and GetCurrentPoint returns null if it can't be transformed. Developer then can decide what to do with this result.
Also added public Properties prop to simplify access. 


## Breaking changes

Yes. Pretty annoying one.
@grokys @danwalmsley @kekekeks 

## Fixed issues

Fixes #8796
