### PR TITLE
On macOS, Control + Left Click should be treated as a right click

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -290,6 +290,9 @@
 
 - (void)mouseDown:(NSEvent *)event
 {
+    if (event.modifierFlags & NSEventModifierFlagControl)
+        return [self rightMouseDown:event];
+    
     _isLeftPressed = true;
     _lastMouseDownEvent = event;
     [self mouseEvent:event withType:LeftButtonDown];
@@ -329,6 +332,9 @@
 
 - (void)mouseUp:(NSEvent *)event
 {
+    if (event.modifierFlags & NSEventModifierFlagControl)
+        return [self rightMouseUp:event];
+    
     _isLeftPressed = false;
     [self mouseEvent:event withType:LeftButtonUp];
 }


### PR DESCRIPTION
## What does the pull request do?
This PR fix the issue https://github.com/AvaloniaUI/Avalonia/issues/5575


## What is the current behavior?
CTRL + click is not detected as right click on OSX, therefore, all context menus aren't displayed.


## What is the updated/expected behavior with this PR?
CTRL + click should trigger a right click event in avalonia in OSX


## How was the solution implemented (if it's not obvious)?
In avalonia.native ObjectiveC project, the avnview mouseDown and mouseUp event check if the modifier ctrl is on then return a rightMouseUp or rightMouseDown. 


## Checklist

## Breaking changes
none

## Obsoletions / Deprecations
none

## Fixed issues

Fixes #5575