### PR TITLE
Moved commit/frame throttling logic to Compositor

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/CompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositionTarget.cs
@@ -129,7 +129,7 @@ namespace Avalonia.Rendering.Composition
         /// </summary>
         internal void ImmediateUIThreadRender()
         {
-            Compositor.RequestCommitAsync();
+            Compositor.Commit();
             Compositor.Server.Render();
         }
     }

--- a/src/Avalonia.Base/Rendering/Composition/Compositor.Factories.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Compositor.Factories.cs
@@ -1,0 +1,32 @@
+using System;
+using Avalonia.Platform;
+using Avalonia.Rendering.Composition.Animations;
+using Avalonia.Rendering.Composition.Server;
+
+namespace Avalonia.Rendering.Composition;
+
+public partial class Compositor
+{
+    /// <summary>
+    /// Creates a new CompositionTarget
+    /// </summary>
+    /// <param name="renderTargetFactory">A factory method to create IRenderTarget to be called from the render thread</param>
+    /// <returns></returns>
+    public CompositionTarget CreateCompositionTarget(Func<IRenderTarget> renderTargetFactory)
+    {
+        return new CompositionTarget(this, new ServerCompositionTarget(_server, renderTargetFactory));
+    }
+    
+    public CompositionContainerVisual CreateContainerVisual() => new(this, new ServerCompositionContainerVisual(_server));
+        
+    public ExpressionAnimation CreateExpressionAnimation() => new ExpressionAnimation(this);
+
+    public ExpressionAnimation CreateExpressionAnimation(string expression) => new ExpressionAnimation(this)
+    {
+        Expression = expression
+    };
+
+    public ImplicitAnimationCollection CreateImplicitAnimationCollection() => new ImplicitAnimationCollection(this);
+
+    public CompositionAnimationGroup CreateAnimationGroup() => new CompositionAnimationGroup(this);
+}

--- a/src/Avalonia.Base/Rendering/Composition/Transport/Batch.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Transport/Batch.cs
@@ -15,16 +15,19 @@ namespace Avalonia.Rendering.Composition.Transport
     {
         private static long _nextSequenceId = 1;
         private static ConcurrentBag<BatchStreamData> _pool = new();
+        private readonly TaskCompletionSource<int>? _tcs;
         public long SequenceId { get; }
         
-        public Batch()
+        public Batch(TaskCompletionSource<int>? tcs)
         {
+            _tcs = tcs;
             SequenceId = Interlocked.Increment(ref _nextSequenceId);
             if (!_pool.TryTake(out var lst))
                 lst = new BatchStreamData();
             Changes = lst;
         }
-        private TaskCompletionSource<int> _tcs = new TaskCompletionSource<int>();
+
+        
         public BatchStreamData Changes { get; private set; }
         public TimeSpan CommitedAt { get; set; }
         
@@ -33,9 +36,8 @@ namespace Avalonia.Rendering.Composition.Transport
             _pool.Add(Changes);
             Changes = null!;
 
-            _tcs.TrySetResult(0);
+            _tcs?.TrySetResult(0);
         }
 
-        public Task Completed => _tcs.Task;
     }
 }

--- a/src/Avalonia.Base/Threading/DispatcherPriority.cs
+++ b/src/Avalonia.Base/Threading/DispatcherPriority.cs
@@ -61,21 +61,16 @@ namespace Avalonia.Threading
         /// The job will be processed with the same priority as render.
         /// </summary>
         public static readonly DispatcherPriority Render = new(5);
-
-        /// <summary>
-        /// The job will be processed with the same priority as composition batch commit.
-        /// </summary>
-        public static readonly DispatcherPriority CompositionBatch = new(6);
         
         /// <summary>
         /// The job will be processed with the same priority as composition updates.
         /// </summary>
-        public static readonly DispatcherPriority Composition = new(7);
+        public static readonly DispatcherPriority Composition = new(6);
         
         /// <summary>
         /// The job will be processed with the same priority as render.
         /// </summary>
-        public static readonly DispatcherPriority Layout = new(8);
+        public static readonly DispatcherPriority Layout = new(7);
 
         /// <summary>
         /// The job will be processed with the same priority as data binding.
@@ -85,7 +80,7 @@ namespace Avalonia.Threading
         /// <summary>
         /// The job will be processed before other asynchronous operations.
         /// </summary>
-        public static readonly DispatcherPriority Send = new(9);
+        public static readonly DispatcherPriority Send = new(8);
 
         /// <summary>
         /// Maximum possible priority


### PR DESCRIPTION
Should fix #8996

Normally, the following sequence happens:
1) Visual is attached to the visual tree, CompositionVisual is created, which implicitly queues a composition commit
2) InvalidateVisual is called, that queues renderer's Update
3) renderers updates the visual
4) commit happens

However there is throttling logic that prevents the renderer from doing updates faster than rendering happens

So if there is a commit in flight, the following happens:

0) previous visual gets removed, which implicitly queues a composition commit
1) new visual is attached to the visual tree, CompositionVisual is created but not yet attached anywhere
2) InvalidateVisual is called, that queues renderer's Update after the last commit is completed
3) commit from (0) happens and removes the visual from (0)¸ but visual from (1) didn't have a chance to be processed by the renderer
4) render thread starts to render the frame
5) renderer updates the visual from (1) which triggers another commit
6) commit from (4) happens with correct state

So we have one frame with invalid state which causes flicker


This PR moves the throttling logic to the compositor itself (`RequestCommitAsync` will return the same task for the planned batch until the previous batch is applied) and calls renderer's Update method right before the batch is serialized.