### PR TITLE
#8261 - terminating WinUIComposition loop on process exit to avoid cr…

### DIFF
--- a/src/Windows/Avalonia.Win32/WinRT/Composition/WinUICompositorConnection.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/Composition/WinUICompositorConnection.cs
@@ -120,10 +120,14 @@ namespace Avalonia.Win32.WinRT.Composition
 
         private void RunLoop()
         {
+            var cts = new CancellationTokenSource();
+            AppDomain.CurrentDomain.ProcessExit += (sender, args) =>
+                cts.Cancel();
+                
             using (var act = _compositor5.RequestCommitAsync())
                 act.SetCompleted(new RunLoopHandler(this));
 
-            while (true)
+            while (!cts.IsCancellationRequested)
             {
                 UnmanagedMethods.GetMessage(out var msg, IntPtr.Zero, 0, 0);
                 lock (_pumpLock)


### PR DESCRIPTION
…ashes

## What does the pull request do?
Infinite message loop is terminated on process exit, so WinUIComposition native code does not attempt to assess managed code during cleanup.


## What is the current behavior?
In some cases process crashes on exit, see bug for details


## Fixed issues
Fixes #8261
