### PR TITLE
WriteableBitmap Usage Fixes/Improvements in ColorPicker

### DIFF
--- a/src/Avalonia.Controls.ColorPicker/ColorSlider/ColorSlider.cs
+++ b/src/Avalonia.Controls.ColorPicker/ColorSlider/ColorSlider.cs
@@ -121,7 +121,7 @@ namespace Avalonia.Controls.Primitives
 
             if (pixelWidth != 0 && pixelHeight != 0)
             {
-                var bitmap = await ColorPickerHelpers.CreateComponentBitmapAsync(
+                ArrayList<byte> bgraPixelData = await ColorPickerHelpers.CreateComponentBitmapAsync(
                     pixelWidth,
                     pixelHeight,
                     Orientation,
@@ -131,18 +131,18 @@ namespace Avalonia.Controls.Primitives
                     IsAlphaMaxForced,
                     IsSaturationValueMaxForced);
 
-                if (bitmap != null)
+                if (bgraPixelData != null)
                 {
                     if (_backgroundBitmap != null)
                     {
                         // Re-use the existing WriteableBitmap
                         // This assumes the height, width and byte counts are the same and must be set to null
                         // elsewhere if that assumption is ever not true.
-                        ColorPickerHelpers.UpdateBitmapFromPixelData(_backgroundBitmap, bitmap);
+                        ColorPickerHelpers.UpdateBitmapFromPixelData(_backgroundBitmap, bgraPixelData);
                     }
                     else
                     {
-                        _backgroundBitmap = ColorPickerHelpers.CreateBitmapFromPixelData(bitmap, pixelWidth, pixelHeight);
+                        _backgroundBitmap = ColorPickerHelpers.CreateBitmapFromPixelData(bgraPixelData, pixelWidth, pixelHeight);
                     }
 
                     Background = new ImageBrush(_backgroundBitmap);

--- a/src/Avalonia.Controls.ColorPicker/ColorSlider/ColorSlider.cs
+++ b/src/Avalonia.Controls.ColorPicker/ColorSlider/ColorSlider.cs
@@ -135,10 +135,16 @@ namespace Avalonia.Controls.Primitives
                 {
                     if (_backgroundBitmap != null)
                     {
+                        // CURRENTLY DISABLED DUE TO INTERMITTENT CRASHES IN SKIA/RENDERER
+                        //
                         // Re-use the existing WriteableBitmap
                         // This assumes the height, width and byte counts are the same and must be set to null
                         // elsewhere if that assumption is ever not true.
-                        ColorPickerHelpers.UpdateBitmapFromPixelData(_backgroundBitmap, bgraPixelData);
+                        // ColorPickerHelpers.UpdateBitmapFromPixelData(_backgroundBitmap, bgraPixelData);
+
+                        // ALSO DISABLED DISPOSE DUE TO INTERMITTENT CRASHES
+                        //_backgroundBitmap?.Dispose();
+                        _backgroundBitmap = ColorPickerHelpers.CreateBitmapFromPixelData(bgraPixelData, pixelWidth, pixelHeight);
                     }
                     else
                     {

--- a/src/Avalonia.Controls.ColorPicker/ColorSlider/ColorSlider.cs
+++ b/src/Avalonia.Controls.ColorPicker/ColorSlider/ColorSlider.cs
@@ -385,11 +385,11 @@ namespace Avalonia.Controls.Primitives
                 return;
             }
 
-            // Always keep the two color properties in sync
             if (change.Property == ColorProperty)
             {
                 ignorePropertyChanged = true;
 
+                // Always keep the two color properties in sync
                 HsvColor = Color.ToHsv();
 
                 SetColorToSliderValues();
@@ -402,7 +402,10 @@ namespace Avalonia.Controls.Primitives
 
                 ignorePropertyChanged = false;
             }
-            else if (change.Property == ColorModelProperty)
+            else if (change.Property == ColorComponentProperty ||
+                     change.Property == ColorModelProperty ||
+                     change.Property == IsAlphaMaxForcedProperty ||
+                     change.Property == IsSaturationValueMaxForcedProperty)
             {
                 ignorePropertyChanged = true;
 
@@ -416,6 +419,7 @@ namespace Avalonia.Controls.Primitives
             {
                 ignorePropertyChanged = true;
 
+                // Always keep the two color properties in sync
                 Color = HsvColor.ToRgb();
 
                 SetColorToSliderValues();
@@ -440,6 +444,7 @@ namespace Avalonia.Controls.Primitives
                 _backgroundBitmap = null;
 
                 UpdateBackground();
+                UpdatePseudoClasses();
             }
             else if (change.Property == ValueProperty ||
                      change.Property == MinimumProperty ||

--- a/src/Avalonia.Controls.ColorPicker/ColorSlider/ColorSlider.cs
+++ b/src/Avalonia.Controls.ColorPicker/ColorSlider/ColorSlider.cs
@@ -33,9 +33,6 @@ namespace Avalonia.Controls.Primitives
         protected bool ignorePropertyChanged = false;
 
         private WriteableBitmap? _backgroundBitmap;
-        private int _backgroundBitmapPixelCount;
-        private int _backgroundBitmapPixelWidth;
-        private int _backgroundBitmapPixelHeight;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ColorSlider"/> class.
@@ -136,21 +133,15 @@ namespace Avalonia.Controls.Primitives
 
                 if (bitmap != null)
                 {
-                    if (_backgroundBitmap != null &&
-                        _backgroundBitmapPixelCount == bitmap.Length &&
-                        _backgroundBitmapPixelWidth == pixelWidth &&
-                        _backgroundBitmapPixelHeight == pixelHeight)
+                    if (_backgroundBitmap != null)
                     {
                         // Re-use the existing WriteableBitmap
+                        // This assumes the height, width and byte counts are the same and must be set to null
+                        // elsewhere if that assumption is ever not true.
                         ColorPickerHelpers.UpdateBitmapFromPixelData(_backgroundBitmap, bitmap);
                     }
                     else
                     {
-                        _backgroundBitmap?.Dispose();
-                        _backgroundBitmapPixelCount = bitmap.Length;
-                        _backgroundBitmapPixelWidth = pixelWidth;
-                        _backgroundBitmapPixelHeight = pixelHeight;
-
                         _backgroundBitmap = ColorPickerHelpers.CreateBitmapFromPixelData(bitmap, pixelWidth, pixelHeight);
                     }
 
@@ -447,9 +438,6 @@ namespace Avalonia.Controls.Primitives
                 // This means the existing bitmap must be released to be recreated correctly in UpdateBackground().
                 _backgroundBitmap?.Dispose();
                 _backgroundBitmap = null;
-                _backgroundBitmapPixelCount = 0;
-                _backgroundBitmapPixelWidth = 0;
-                _backgroundBitmapPixelHeight = 0;
 
                 UpdateBackground();
             }

--- a/src/Avalonia.Controls.ColorPicker/ColorSlider/ColorSlider.cs
+++ b/src/Avalonia.Controls.ColorPicker/ColorSlider/ColorSlider.cs
@@ -33,6 +33,9 @@ namespace Avalonia.Controls.Primitives
         protected bool ignorePropertyChanged = false;
 
         private WriteableBitmap? _backgroundBitmap;
+        private int _backgroundBitmapPixelCount;
+        private int _backgroundBitmapPixelWidth;
+        private int _backgroundBitmapPixelHeight;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ColorSlider"/> class.
@@ -133,15 +136,21 @@ namespace Avalonia.Controls.Primitives
 
                 if (bitmap != null)
                 {
-                    if (_backgroundBitmap != null)
+                    if (_backgroundBitmap != null &&
+                        _backgroundBitmapPixelCount == bitmap.Length &&
+                        _backgroundBitmapPixelWidth == pixelWidth &&
+                        _backgroundBitmapPixelHeight == pixelHeight)
                     {
                         // Re-use the existing WriteableBitmap
-                        // This assumes the height, width and byte counts are the same and must be set to null
-                        // elsewhere if that assumption is ever not true.
                         ColorPickerHelpers.UpdateBitmapFromPixelData(_backgroundBitmap, bitmap);
                     }
                     else
                     {
+                        _backgroundBitmap?.Dispose();
+                        _backgroundBitmapPixelCount = bitmap.Length;
+                        _backgroundBitmapPixelWidth = pixelWidth;
+                        _backgroundBitmapPixelHeight = pixelHeight;
+
                         _backgroundBitmap = ColorPickerHelpers.CreateBitmapFromPixelData(bitmap, pixelWidth, pixelHeight);
                     }
 
@@ -438,6 +447,9 @@ namespace Avalonia.Controls.Primitives
                 // This means the existing bitmap must be released to be recreated correctly in UpdateBackground().
                 _backgroundBitmap?.Dispose();
                 _backgroundBitmap = null;
+                _backgroundBitmapPixelCount = 0;
+                _backgroundBitmapPixelWidth = 0;
+                _backgroundBitmapPixelHeight = 0;
 
                 UpdateBackground();
             }

--- a/src/Avalonia.Controls.ColorPicker/ColorSpectrum/ColorSpectrum.cs
+++ b/src/Avalonia.Controls.ColorPicker/ColorSpectrum/ColorSpectrum.cs
@@ -973,13 +973,13 @@ namespace Avalonia.Controls.Primitives
 
             // The middle 4 are only needed and used in the case of hue as the third dimension.
             // Saturation and luminosity need only a min and max.
-            List<byte> bgraMinPixelData = new List<byte>();
-            List<byte> bgraMiddle1PixelData = new List<byte>();
-            List<byte> bgraMiddle2PixelData = new List<byte>();
-            List<byte> bgraMiddle3PixelData = new List<byte>();
-            List<byte> bgraMiddle4PixelData = new List<byte>();
-            List<byte> bgraMaxPixelData = new List<byte>();
-            List<Hsv> newHsvValues = new List<Hsv>();
+            ArrayList<byte> bgraMinPixelData;
+            ArrayList<byte> bgraMiddle1PixelData;
+            ArrayList<byte> bgraMiddle2PixelData;
+            ArrayList<byte> bgraMiddle3PixelData;
+            ArrayList<byte> bgraMiddle4PixelData;
+            ArrayList<byte> bgraMaxPixelData;
+            List<Hsv> newHsvValues;
 
             // In Avalonia, Bounds returns the actual device-independent pixel size of a control.
             // However, this is not necessarily the size of the control rendered on a display.
@@ -990,20 +990,27 @@ namespace Avalonia.Controls.Primitives
             int pixelDimension = (int)Math.Round(minDimension * scale);
             var pixelCount = pixelDimension * pixelDimension;
             var pixelDataSize = pixelCount * 4;
-            bgraMinPixelData.Capacity = pixelDataSize;
+
+            bgraMinPixelData = new ArrayList<byte>(pixelDataSize);
+            bgraMaxPixelData = new ArrayList<byte>(pixelDataSize);
+            newHsvValues = new List<Hsv>(pixelCount);
 
             // We'll only save pixel data for the middle bitmaps if our third dimension is hue.
             if (components == ColorSpectrumComponents.ValueSaturation ||
                 components == ColorSpectrumComponents.SaturationValue)
             {
-                bgraMiddle1PixelData.Capacity = pixelDataSize;
-                bgraMiddle2PixelData.Capacity = pixelDataSize;
-                bgraMiddle3PixelData.Capacity = pixelDataSize;
-                bgraMiddle4PixelData.Capacity = pixelDataSize;
+                bgraMiddle1PixelData = new ArrayList<byte>(pixelDataSize);
+                bgraMiddle2PixelData = new ArrayList<byte>(pixelDataSize);
+                bgraMiddle3PixelData = new ArrayList<byte>(pixelDataSize);
+                bgraMiddle4PixelData = new ArrayList<byte>(pixelDataSize);
             }
-
-            bgraMaxPixelData.Capacity = pixelDataSize;
-            newHsvValues.Capacity = pixelCount;
+            else
+            {
+                bgraMiddle1PixelData = new ArrayList<byte>(0);
+                bgraMiddle2PixelData = new ArrayList<byte>(0);
+                bgraMiddle3PixelData = new ArrayList<byte>(0);
+                bgraMiddle4PixelData = new ArrayList<byte>(0);
+            }
 
             await Task.Run(() =>
             {
@@ -1111,12 +1118,12 @@ namespace Avalonia.Controls.Primitives
             double maxSaturation,
             double minValue,
             double maxValue,
-            List<byte> bgraMinPixelData,
-            List<byte> bgraMiddle1PixelData,
-            List<byte> bgraMiddle2PixelData,
-            List<byte> bgraMiddle3PixelData,
-            List<byte> bgraMiddle4PixelData,
-            List<byte> bgraMaxPixelData,
+            ArrayList<byte> bgraMinPixelData,
+            ArrayList<byte> bgraMiddle1PixelData,
+            ArrayList<byte> bgraMiddle2PixelData,
+            ArrayList<byte> bgraMiddle3PixelData,
+            ArrayList<byte> bgraMiddle4PixelData,
+            ArrayList<byte> bgraMaxPixelData,
             List<Hsv> newHsvValues)
         {
             double hMin = minHue;
@@ -1271,12 +1278,12 @@ namespace Avalonia.Controls.Primitives
             double maxSaturation,
             double minValue,
             double maxValue,
-            List<byte> bgraMinPixelData,
-            List<byte> bgraMiddle1PixelData,
-            List<byte> bgraMiddle2PixelData,
-            List<byte> bgraMiddle3PixelData,
-            List<byte> bgraMiddle4PixelData,
-            List<byte> bgraMaxPixelData,
+            ArrayList<byte> bgraMinPixelData,
+            ArrayList<byte> bgraMiddle1PixelData,
+            ArrayList<byte> bgraMiddle2PixelData,
+            ArrayList<byte> bgraMiddle3PixelData,
+            ArrayList<byte> bgraMiddle4PixelData,
+            ArrayList<byte> bgraMaxPixelData,
             List<Hsv> newHsvValues)
         {
             double hMin = minHue;

--- a/src/Avalonia.Controls.ColorPicker/ColorSpectrum/ColorSpectrum.cs
+++ b/src/Avalonia.Controls.ColorPicker/ColorSpectrum/ColorSpectrum.cs
@@ -73,6 +73,8 @@ namespace Avalonia.Controls.Primitives
         private WriteableBitmap? _saturationMaximumBitmap;
 
         private WriteableBitmap? _valueBitmap;
+        private WriteableBitmap? _minBitmap;
+        private WriteableBitmap? _maxBitmap;
 
         // Fields used by UpdateEllipse() to ensure that it's using the data
         // associated with the last call to CreateBitmapsAndColorMap(),
@@ -1063,28 +1065,28 @@ namespace Avalonia.Controls.Primitives
 
                 ColorSpectrumComponents components2 = Components;
 
-                WriteableBitmap minBitmap = ColorPickerHelpers.CreateBitmapFromPixelData(bgraMinPixelData, pixelWidth, pixelHeight);
-                WriteableBitmap maxBitmap = ColorPickerHelpers.CreateBitmapFromPixelData(bgraMaxPixelData, pixelWidth, pixelHeight);
+                _minBitmap = ColorPickerHelpers.CreateBitmapFromPixelData(bgraMinPixelData, pixelWidth, pixelHeight);
+                _maxBitmap = ColorPickerHelpers.CreateBitmapFromPixelData(bgraMaxPixelData, pixelWidth, pixelHeight);
 
                 switch (components2)
                 {
                     case ColorSpectrumComponents.HueValue:
                     case ColorSpectrumComponents.ValueHue:
-                        _saturationMinimumBitmap = minBitmap;
-                        _saturationMaximumBitmap = maxBitmap;
+                        _saturationMinimumBitmap = _minBitmap;
+                        _saturationMaximumBitmap = _maxBitmap;
                         break;
                     case ColorSpectrumComponents.HueSaturation:
                     case ColorSpectrumComponents.SaturationHue:
-                        _valueBitmap = maxBitmap;
+                        _valueBitmap = _maxBitmap;
                         break;
                     case ColorSpectrumComponents.ValueSaturation:
                     case ColorSpectrumComponents.SaturationValue:
-                        _hueRedBitmap = minBitmap;
+                        _hueRedBitmap = _minBitmap;
                         _hueYellowBitmap = ColorPickerHelpers.CreateBitmapFromPixelData(bgraMiddle1PixelData, pixelWidth, pixelHeight);
                         _hueGreenBitmap = ColorPickerHelpers.CreateBitmapFromPixelData(bgraMiddle2PixelData, pixelWidth, pixelHeight);
                         _hueCyanBitmap = ColorPickerHelpers.CreateBitmapFromPixelData(bgraMiddle3PixelData, pixelWidth, pixelHeight);
                         _hueBlueBitmap = ColorPickerHelpers.CreateBitmapFromPixelData(bgraMiddle4PixelData, pixelWidth, pixelHeight);
-                        _huePurpleBitmap = maxBitmap;
+                        _huePurpleBitmap = _maxBitmap;
                         break;
                 }
 

--- a/src/Avalonia.Controls.ColorPicker/Helpers/ArrayList.cs
+++ b/src/Avalonia.Controls.ColorPicker/Helpers/ArrayList.cs
@@ -1,0 +1,71 @@
+﻿namespace Avalonia.Controls.Primitives
+{
+    /// <summary>
+    /// A thin wrapper over an <see cref="System.Array"/> that allows some additional list-like functionality.
+    /// </summary>
+    /// <remarks>
+    /// This is only for internal ColorPicker-related functionality and should not be used elsewhere.
+    /// It is added for performance to enjoy the simplicity of the IList.Add() method without requiring
+    /// an additional copy to turn a list into an array for bitmaps.
+    /// </remarks>
+    /// <typeparam name="T">The type of items in the array.</typeparam>
+    internal class ArrayList<T>
+    {
+        private int _nextIndex = 0;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArrayList{T}"/> class.
+        /// </summary>
+        public ArrayList(int capacity)
+        {
+            Capacity = capacity;
+            Array = new T[capacity];
+        }
+
+        /// <summary>
+        /// Provides access to the underlying array by index.
+        /// This exists for simplification and the <see cref="Array"/> property
+        /// may also be used.
+        /// </summary>
+        /// <param name="i">The index of the item to get or set.</param>
+        /// <returns>The item at the given index.</returns>
+        public T this[int i]
+        {
+            get => Array[i];
+            set => Array[i] = value;
+        }
+
+        /// <summary>
+        /// Gets the underlying array.
+        /// </summary>
+        public T[] Array { get; private set; }
+
+        /// <summary>
+        /// Gets the fixed capacity/size of the array.
+        /// This must be set during construction.
+        /// </summary>
+        public int Capacity { get; private set; }
+
+        /// <summary>
+        /// Adds the given item to the array at the next available index.
+        /// WARNING: This must be used carefully and only once, in sequence.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        public void Add(T item)
+        {
+            if (_nextIndex >= 0 &&
+                _nextIndex < Capacity)
+            {
+                Array[_nextIndex] = item;
+                _nextIndex++;
+            }
+            else
+            {
+                // If necessary an exception could be thrown here
+                // throw new IndexOutOfRangeException();
+            }
+
+            return;
+        }
+    }
+}

--- a/src/Avalonia.Controls.ColorPicker/Helpers/ColorPickerHelpers.cs
+++ b/src/Avalonia.Controls.ColorPicker/Helpers/ColorPickerHelpers.cs
@@ -627,6 +627,7 @@ namespace Avalonia.Controls.Primitives
 
         /// <summary>
         /// Updates the given <see cref="WriteableBitmap"/> with new, raw BGRA pre-multiplied alpha pixel data.
+        /// WARNING: THIS METHOD IS CURRENTLY PROVIDED AS REFERENCE BUT CAUSES INTERMITTENT CRASHES IF USED.
         /// WARNING: The bitmap's width, height and byte count MUST not have changed and MUST be enforced externally.
         /// </summary>
         /// <param name="bitmap">The existing <see cref="WriteableBitmap"/> to update.</param>

--- a/src/Avalonia.Controls.ColorPicker/Helpers/ColorPickerHelpers.cs
+++ b/src/Avalonia.Controls.ColorPicker/Helpers/ColorPickerHelpers.cs
@@ -617,13 +617,30 @@ namespace Avalonia.Controls.Primitives
                 PixelFormat.Bgra8888,
                 AlphaFormat.Premul);
 
-            // Warning: This is highly questionable
             using (var frameBuffer = bitmap.Lock())
             {
                 Marshal.Copy(bgraPixelData.ToArray(), 0, frameBuffer.Address, bgraPixelData.Count);
             }
 
             return bitmap;
+        }
+
+        /// <summary>
+        /// Updates the given <see cref="WriteableBitmap"/> with new, raw BGRA pre-multiplied alpha pixel data.
+        /// WARNING: The bitmap's width, height and byte count MUST not have changed and MUST be enforced externally.
+        /// </summary>
+        /// <param name="bitmap">The existing <see cref="WriteableBitmap"/> to update.</param>
+        /// <param name="bgraPixelData">The bitmap (in raw BGRA pre-multiplied alpha pixels).</param>
+        public static void UpdateBitmapFromPixelData(
+            WriteableBitmap bitmap,
+            IList<byte> bgraPixelData)
+        {
+            using (var frameBuffer = bitmap.Lock())
+            {
+                Marshal.Copy(bgraPixelData.ToArray(), 0, frameBuffer.Address, bgraPixelData.Count);
+            }
+
+            return;
         }
     }
 }

--- a/src/Avalonia.Controls.ColorPicker/Helpers/ColorPickerHelpers.cs
+++ b/src/Avalonia.Controls.ColorPicker/Helpers/ColorPickerHelpers.cs
@@ -37,7 +37,7 @@ namespace Avalonia.Controls.Primitives
         /// during calculation with the HSVA color model.
         /// This will ensure colors are always discernible regardless of saturation/value.</param>
         /// <returns>A new bitmap representing a gradient of color component values.</returns>
-        public static async Task<byte[]> CreateComponentBitmapAsync(
+        public static async Task<ArrayList<byte>> CreateComponentBitmapAsync(
             int width,
             int height,
             Orientation orientation,
@@ -49,14 +49,14 @@ namespace Avalonia.Controls.Primitives
         {
             if (width == 0 || height == 0)
             {
-                return new byte[0];
+                return new ArrayList<byte>(0);
             }
 
-            var bitmap = await Task.Run<byte[]>(() =>
+            var bitmap = await Task.Run<ArrayList<byte>>(() =>
             {
                 int pixelDataIndex = 0;
                 double componentStep;
-                byte[] bgraPixelData;
+                ArrayList<byte> bgraPixelData;
                 Color baseRgbColor = Colors.White;
                 Color rgbColor;
                 int bgraPixelDataHeight;
@@ -64,7 +64,7 @@ namespace Avalonia.Controls.Primitives
 
                 // Allocate the buffer
                 // BGRA formatted color components 1 byte each (4 bytes in a pixel)
-                bgraPixelData       = new byte[width * height * 4];
+                bgraPixelData       = new ArrayList<byte>(width * height * 4);
                 bgraPixelDataHeight = height * 4;
                 bgraPixelDataWidth  = width * 4;
 
@@ -604,7 +604,7 @@ namespace Avalonia.Controls.Primitives
         /// <param name="pixelHeight">The pixel height of the bitmap.</param>
         /// <returns>A new <see cref="WriteableBitmap"/>.</returns>
         public static WriteableBitmap CreateBitmapFromPixelData(
-            IList<byte> bgraPixelData,
+            ArrayList<byte> bgraPixelData,
             int pixelWidth,
             int pixelHeight)
         {
@@ -619,7 +619,7 @@ namespace Avalonia.Controls.Primitives
 
             using (var frameBuffer = bitmap.Lock())
             {
-                Marshal.Copy(bgraPixelData.ToArray(), 0, frameBuffer.Address, bgraPixelData.Count);
+                Marshal.Copy(bgraPixelData.Array, 0, frameBuffer.Address, bgraPixelData.Array.Length);
             }
 
             return bitmap;
@@ -633,11 +633,11 @@ namespace Avalonia.Controls.Primitives
         /// <param name="bgraPixelData">The bitmap (in raw BGRA pre-multiplied alpha pixels).</param>
         public static void UpdateBitmapFromPixelData(
             WriteableBitmap bitmap,
-            IList<byte> bgraPixelData)
+            ArrayList<byte> bgraPixelData)
         {
             using (var frameBuffer = bitmap.Lock())
             {
-                Marshal.Copy(bgraPixelData.ToArray(), 0, frameBuffer.Address, bgraPixelData.Count);
+                Marshal.Copy(bgraPixelData.Array, 0, frameBuffer.Address, bgraPixelData.Array.Length);
             }
 
             return;


### PR DESCRIPTION
## What does the pull request do?

**ColorSlider**
 * ~Adds re-use of existing WriteableBitmap for performance if dimensions have not changes~
   - This was later disabled due to intermittent crashes in Skia and/or the renderer
 * ~Releases/Rebuilds WriteableBitmap when detached/attached to the visual tree.~
   - This was later disabled due to intermittent crashes in Skia and/or the renderer
 * Fixes background updates for all property changes

**ColorPicker**
 * New `ArrayList` class (for internal-use only) that avoids an extra copy of List -> Array creating `WriteableBitmap`.

## What is the current behavior?

See above.

## What is the updated/expected behavior with this PR?

See above.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

None

## Obsoletions / Deprecations

None

## Fixed issues

