### PR TITLE
Update flags for XSetWMNormalHints

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -302,7 +302,7 @@ namespace Avalonia.X11
                 min_height = min.Height
             };
             hints.height_inc = hints.width_inc = 1;
-            var flags = XSizeHintsFlags.PMinSize | XSizeHintsFlags.PResizeInc;
+            var flags = XSizeHintsFlags.PMinSize | XSizeHintsFlags.PResizeInc | XSizeHintsFlags.PPosition | XSizeHintsFlags.PSize;
             // People might be passing double.MaxValue
             if (max.Width < 100000 && max.Height < 100000)
             {


### PR DESCRIPTION
That small change can fix bug with StartupLocation on Ubuntu ([Same problem on stackoverflow](https://stackoverflow.com/questions/11069666/cannot-get-xcreatesimplewindow-to-open-window-at-the-right-position)).


## What is the current behavior?
On some linux-distros windows managers ignors position and size of you window (set throught XCreateSimpleWindow) until you tell him to consider your settings.

## Fixed issues
Fixes #6433
