### PR TITLE
Make IClickableControl public

### DIFF
--- a/src/Avalonia.Base/Input/IClickableControl.cs
+++ b/src/Avalonia.Base/Input/IClickableControl.cs
@@ -6,7 +6,7 @@ namespace Avalonia.Input
     /// <summary>
     /// 
     /// </summary>
-    internal interface IClickableControl
+    public interface IClickableControl
     {
         event EventHandler<RoutedEventArgs> Click;
         void RaiseClick();


### PR DESCRIPTION
## What does the pull request do?
Make `IClickableControl` public


## What is the current behavior?
[#7500](https://github.com/AvaloniaUI/Avalonia/pull/7500) broke hotkeys for custom controls because the `HotKeyManager` now requires controls to implement `IClickableControl ` instead of just `ICommandSource`


## What is the updated/expected behavior with this PR?
Allow custom controls to implement `IClickableControl`


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
