### PR TITLE
Fix Android crash when ime is dismissed on a read only input

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -301,7 +301,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
 
             IsComposing = true;
 
-            _inputMethod.Client.SetPreeditText(ComposingText);
+            _inputMethod.Client?.SetPreeditText(ComposingText);
 
             return base.SetComposingText(text, newCursorPosition);
         }


### PR DESCRIPTION
## What does the pull request do?
Fixes a crash on android that's caused by dismissing the software keyboard on a read only textbox


## What is the current behavior?
App will crash with a null reference exception if ime is dismissed when switching focus from an editable text box to a read only one and android.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
