### PR TITLE
Exclude iOS, Android and Web samples from CI build

### DIFF
--- a/dirs.proj
+++ b/dirs.proj
@@ -9,21 +9,18 @@
     <ProjectReference Remove="**/*.shproj" />
     <ProjectReference Remove="src/Markup/Avalonia.Markup.Xaml/PortableXaml/**/*.*proj" />
     <ProjectReference Remove="src/Markup/Avalonia.Markup.Xaml.Loader/xamlil.github/**/*.*proj" />
-    <ProjectReference Remove="tests/Avalonia.ReactiveUI.Events.UnitTests/Avalonia.ReactiveUI.Events.UnitTests.csproj" />
-    <ProjectReference Remove="samples/ControlCatalog.iOS/ControlCatalog.iOS.csproj" />
-    <ProjectReference Remove="samples/MobileSandbox.iOS/MobileSandbox.iOS.csproj" />
-    <ProjectReference Remove="samples/ControlCatalog.iOS.Legacy/ControlCatalog.iOS.Legacy.csproj" />
-    <ProjectReference Remove="samples/ControlCatalog.Android/ControlCatalog.Android.csproj" />
-    <ProjectReference Remove="samples/MobileSandbox.Android/MobileSandbox.Android.csproj" />
-    <ProjectReference Remove="src/Android/Avalonia.AndroidTestApplication/Avalonia.AndroidTestApplication.csproj" />
+    <!-- Exclude iOS, Android and Web samples from build -->
+    <ProjectReference Remove="samples/*.iOS/*.csproj" />
+    <ProjectReference Remove="samples/*.Android/*.csproj" />
+    <ProjectReference Remove="samples/*.Web/*.csproj" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsOsPlatform('Windows')) OR '$(MSBuildRuntimeType)' != 'Full'">
     <ProjectReference Remove="src/Windows/Avalonia.Win32.Interop/Avalonia.Win32.Interop.csproj" />
     <ProjectReference Remove="samples/interop/**/*.*proj" />
     <ProjectReference Remove="samples/ControlCatalog.Desktop/*.*proj" />
   </ItemGroup>
-  <!-- Build android and iOS projects only on Windows, where we have installed android workload -->
 
+  <!-- Build android and iOS projects only on Windows, where we have installed android workload -->
   <ItemGroup Condition="!$([MSBuild]::IsOsPlatform('Windows'))">
     <ProjectReference Remove="src/Android/**/*.*proj" />
     <ProjectReference Remove="src/iOS/**/*.*proj" />


### PR DESCRIPTION
Blazorless web backend PR noticeably slowed down CI build speed.
This PR makes it faster, almost how it was before.

Before blazorless:
![image](https://user-images.githubusercontent.com/3163374/195977369-5620e916-01a7-40da-92e8-6373fe25379f.png)

Current master:
![image](https://user-images.githubusercontent.com/3163374/195977376-843b447a-9c41-43ac-ae9f-ec8bc19852dc.png)

This PR:
![image](https://user-images.githubusercontent.com/3163374/195977411-42b84c61-1672-40ec-aa9b-b5f6822673e2.png)
