### PR TITLE
Fixed double value validation in RangeBase

### DIFF
--- a/src/Avalonia.Controls/Primitives/RangeBase.cs
+++ b/src/Avalonia.Controls/Primitives/RangeBase.cs
@@ -175,7 +175,7 @@ namespace Avalonia.Controls.Primitives
         /// <param name="value">The value.</param>
         private static bool ValidateDouble(double value)
         {
-            return !double.IsInfinity(value) || !double.IsNaN(value);
+            return !double.IsInfinity(value) && !double.IsNaN(value);
         }
 
         /// <summary>


### PR DESCRIPTION
## What does the pull request do?
Slider has problems in specific cases. 

## What is the current behavior?
This check always returns true. Value validation in RangeBase.Value setter currently does not work and setter logic can be triggered with NaN value 

