### PR TITLE
Fix DevTools when application does not include a theme.

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml
@@ -3,8 +3,7 @@
         xmlns:views="clr-namespace:Avalonia.Diagnostics.Views"
         xmlns:diag="clr-namespace:Avalonia.Diagnostics"
         Title="Avalonia DevTools"
-        x:Class="Avalonia.Diagnostics.Views.MainWindow"
-        Theme="{StaticResource {x:Type Window}}">
+        x:Class="Avalonia.Diagnostics.Views.MainWindow">
   <Window.DataTemplates>
     <diag:ViewLocator/>
   </Window.DataTemplates>

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml.cs
@@ -28,6 +28,11 @@ namespace Avalonia.Diagnostics.Views
         {
             InitializeComponent();
 
+            // Apply the SimpleTheme.Window theme; this must be done after the XAML is parsed as
+            // the theme is included in the MainWindow's XAML.
+            if (Theme is null && this.FindResource(typeof(Window)) is ControlTheme windowTheme)
+                Theme = windowTheme;
+
             _keySubscription = InputManager.Instance?.Process
                 .OfType<RawKeyEventArgs>()
                 .Where(x => x.Type == RawKeyEventType.KeyDown)

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -56,7 +56,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
                 // We need to implement compile-time merging of resource dictionaries and this
                 // hack can be removed.
                 if (previousWasControlTheme &&
-                    parent is ResourceDictionary hack &&
+                    parent is IResourceProvider hack &&
                     hack.Owner?.GetType().FullName == "Avalonia.Diagnostics.Views.MainWindow" &&
                     hack.Owner.TryGetResource(ResourceKey, out value))
                 {


### PR DESCRIPTION
## What does the pull request do?

Fixes two crashes in DevTools when no theme was defined in `App.xaml` (can be repro'ed in Sandbox app by removing fluent theme and pressing F12):

1. DevTools would crash on open
2. DevTools would crash when double-clicking a cell in the `DataGrid` for editing

DevTools is supposed to work even if the theme for the application is broken or missing, and so includes a copy of `SimpleTheme` in its `MainWindow`. However the `StaticResource` lookup that was previously in the `MainWindow.xaml` file would fail if there was no theme defined in `App.xaml` because it would get run before the XAML is parsed to a point where the simple theme was included.

The fixes to the above issues are as follows:

1. Move the theme lookup into code, in the `MainWindow` constructor after `InitializeComponent`, at a point where the `SimpleTheme` is actually loaded.
2. Change the `ResourceDictionary` cast in the hack for #8678 to a cast to `IResourceProvider`

## What is the current behavior?

If one removes the fluent theme from Sandbox then tries to open DevTools, a crash occurs in the `StaticResource` lookup.

## What is the updated/expected behavior with this PR?

DevTools works even if no theme is present in App.xaml.
