### PR TITLE
Use DragEventArgs for DragLeave event.

### DIFF
--- a/src/Avalonia.Base/Input/DragDrop.cs
+++ b/src/Avalonia.Base/Input/DragDrop.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Event which is raised, when a drag-and-drop operation leaves the element.
         /// </summary>
-        public static readonly RoutedEvent<RoutedEventArgs> DragLeaveEvent = RoutedEvent.Register<RoutedEventArgs>("DragLeave", RoutingStrategies.Bubble, typeof(DragDrop));
+        public static readonly RoutedEvent<DragEventArgs> DragLeaveEvent = RoutedEvent.Register<DragEventArgs>("DragLeave", RoutingStrategies.Bubble, typeof(DragDrop));
         /// <summary>
         /// Event which is raised, when a drag-and-drop operation is updated while over the element.
         /// </summary>

--- a/src/Avalonia.Base/Input/DragDropDevice.cs
+++ b/src/Avalonia.Base/Input/DragDropDevice.cs
@@ -54,7 +54,7 @@ namespace Avalonia.Input
             try
             {
                 if (_lastTarget != null)
-                    _lastTarget.RaiseEvent(new RoutedEventArgs(DragDrop.DragLeaveEvent));
+                    RaiseDragEvent(_lastTarget, inputRoot, point, DragDrop.DragLeaveEvent, effects, data, modifiers);
                 return RaiseDragEvent(target, inputRoot, point, DragDrop.DragEnterEvent, effects, data, modifiers);
             }
             finally
@@ -63,13 +63,13 @@ namespace Avalonia.Input
             }            
         }
 
-        private void DragLeave(IInputElement inputRoot)
+        private void DragLeave(IInputRoot inputRoot, Point point, IDataObject data, DragDropEffects effects, KeyModifiers modifiers)
         {
             if (_lastTarget == null)
                 return;
             try
             {
-                _lastTarget.RaiseEvent(new RoutedEventArgs(DragDrop.DragLeaveEvent));
+                RaiseDragEvent(_lastTarget, inputRoot, point, DragDrop.DragLeaveEvent, effects, data, modifiers);
             }
             finally 
             {
@@ -106,7 +106,7 @@ namespace Avalonia.Input
                     e.Effects = DragOver(e.Root, e.Location, e.Data, e.Effects, e.KeyModifiers);
                     break;
                 case RawDragEventType.DragLeave:
-                    DragLeave(e.Root);
+                    DragLeave(e.Root, e.Location, e.Data, e.Effects, e.KeyModifiers);
                     break;
                 case RawDragEventType.Drop:
                     e.Effects = Drop(e.Root, e.Location, e.Data, e.Effects, e.KeyModifiers);


### PR DESCRIPTION
## What does the pull request do?

Use `DragEventArgs` for the `DragLeave` event. This follows the WPF/UWP API and allows pointer information to be retrieved.

## Breaking Changes

The `DragDrop.DragLeave` field was changed from `RoutedEvent<RoutedEventArgs>` to `RoutedEvent<DragEventArgs>`.

## Fixed issues

Fixes item 3 from #7556.