### PR TITLE
Fixes/wasm fixes

### DIFF
--- a/src/Web/Avalonia.Web/AvaloniaView.cs
+++ b/src/Web/Avalonia.Web/AvaloniaView.cs
@@ -136,6 +136,8 @@ namespace Avalonia.Web
             DomHelper.ObserveSize(host, null, OnSizeChanged);
 
             CanvasHelper.RequestAnimationFrame(_canvas, true);
+            
+            InputHelper.FocusElement(_containerElement);
         }
 
         private static RawPointerPoint ExtractRawPointerFromJSArgs(JSObject args)

--- a/src/Web/Avalonia.Web/webapp/build.js
+++ b/src/Web/Avalonia.Web/webapp/build.js
@@ -5,7 +5,7 @@ require("esbuild").build({
     ],
     outdir: "../wwwroot",
     bundle: true,
-    minify: false,
+    minify: true,
     format: "esm",
     target: "es2016",
     platform: "browser",

--- a/src/Web/Avalonia.Web/webapp/modules/avalonia/dom.ts
+++ b/src/Web/Avalonia.Web/webapp/modules/avalonia/dom.ts
@@ -11,6 +11,7 @@ export class AvaloniaDOM {
         host.tabIndex = 0;
         host.oncontextmenu = function () { return false; };
         host.style.overflow = "hidden";
+        host.style.touchAction = "none";
 
         // Rendering target canvas
         const canvas = document.createElement("canvas");


### PR DESCRIPTION
make sure the canvas is focused on page load.
disable default browser touch gestures. (doesnt affect touch inside avalonia)