### PR TITLE
wasm prevent touch flashing android.

### DIFF
--- a/src/Web/Avalonia.Web/AvaloniaView.cs
+++ b/src/Web/Avalonia.Web/AvaloniaView.cs
@@ -77,8 +77,7 @@ namespace Avalonia.Web
 
             _topLevelImpl.SetCssCursor = (cursor) =>
             {
-                InputHelper.SetCursor(_containerElement, cursor); // macOS
-                InputHelper.SetCursor(_canvas, cursor); // windows
+                InputHelper.SetCursor(_containerElement, cursor);
             };
 
             _topLevel.Prepare();


### PR DESCRIPTION
Setting css cursor on multiple elements causes android chrome to flash with touch input.

Setting it only on the container works normally.

Was a comment about macos and windows needing to be set on different elements, however tested and seems to no longer be the case.