### PR TITLE
Set Viewbox container logical parent. 

### DIFF
--- a/src/Avalonia.Controls/Viewbox.cs
+++ b/src/Avalonia.Controls/Viewbox.cs
@@ -42,6 +42,7 @@ namespace Avalonia.Controls
             // can be applied independently of the Viewbox and Child transforms.
             _containerVisual = new ViewboxContainer();
             _containerVisual.RenderTransformOrigin = RelativePoint.TopLeft;
+            ((ISetLogicalParent)_containerVisual).SetParent(this);
             VisualChildren.Add(_containerVisual);
         }
 

--- a/tests/Avalonia.Controls.UnitTests/ViewboxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ViewboxTests.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls.Shapes;
+using Avalonia.Data;
 using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Avalonia.UnitTests;
@@ -205,6 +206,26 @@ namespace Avalonia.Controls.UnitTests
             target.Measure(Size.Infinity);
             target.Arrange(new Rect(target.DesiredSize));
             Assert.Equal(new Size(200, 200), target.DesiredSize);
+        }
+
+        [Fact]
+        public void Child_DataContext_Binding_Works()
+        {
+            var data = new
+            {
+                Foo = "foo",
+            };
+
+            var target = new Viewbox()
+            {
+                DataContext = data,
+                Child = new Canvas
+                {
+                    [!Canvas.DataContextProperty] = new Binding("Foo"),
+                },
+            };
+
+            Assert.Equal("foo", target.Child.DataContext);
         }
 
         private bool TryGetScale(Viewbox viewbox, out Vector scale)


### PR DESCRIPTION
## What does the pull request do?

The internal container control in `Viewbox` didn't have its logical parent set, meaning that `DataContext` bindings in the `Viewbox.Child` control didn't work properly.

Add a unit test and fix this.
