### PR TITLE
Prevent a crash that is caused by limited typefaces

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
@@ -477,25 +477,28 @@ namespace Avalonia.Media.TextFormatting
                 {
                     case ShapedTextCharacters shapedTextCharacters:
                         {
-                            var firstCluster = shapedTextCharacters.ShapedBuffer.GlyphClusters[0];
-                            var lastCluster = firstCluster;
-
-                            for (var i = 0; i < shapedTextCharacters.ShapedBuffer.Length; i++)
+                            if(shapedTextCharacters.ShapedBuffer.Length > 0)
                             {
-                                var glyphInfo = shapedTextCharacters.ShapedBuffer[i];
+                                var firstCluster = shapedTextCharacters.ShapedBuffer.GlyphClusters[0];
+                                var lastCluster = firstCluster;
 
-                                if (currentWidth + glyphInfo.GlyphAdvance > paragraphWidth)
+                                for (var i = 0; i < shapedTextCharacters.ShapedBuffer.Length; i++)
                                 {
-                                    measuredLength += Math.Max(0, lastCluster - firstCluster);
+                                    var glyphInfo = shapedTextCharacters.ShapedBuffer[i];
 
-                                    goto found;
+                                    if (currentWidth + glyphInfo.GlyphAdvance > paragraphWidth)
+                                    {
+                                        measuredLength += Math.Max(0, lastCluster - firstCluster);
+
+                                        goto found;
+                                    }
+
+                                    lastCluster = glyphInfo.GlyphCluster;
+                                    currentWidth += glyphInfo.GlyphAdvance;
                                 }
 
-                                lastCluster = glyphInfo.GlyphCluster;
-                                currentWidth += glyphInfo.GlyphAdvance;
-                            }
-
-                            measuredLength += currentRun.TextSourceLength;
+                                measuredLength += currentRun.TextSourceLength;
+                            }                         
 
                             break;
                         }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR prevents a crash caused by typefaces that do not contain any whitespace glyphs. Previously this caused an IndexOutOfRangeException.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes: #9283