### PR TITLE
Add Control.SizeChanged Event

### DIFF
--- a/src/Avalonia.Base/Interactivity/RoutedEventArgs.cs
+++ b/src/Avalonia.Base/Interactivity/RoutedEventArgs.cs
@@ -3,7 +3,7 @@ using System;
 namespace Avalonia.Interactivity
 {
     /// <summary>
-    /// Provices state information and data specific to a routed event.
+    /// Provides state information and data specific to a routed event.
     /// </summary>
     public class RoutedEventArgs : EventArgs
     {

--- a/src/Avalonia.Base/Interactivity/RoutedEventArgs.cs
+++ b/src/Avalonia.Base/Interactivity/RoutedEventArgs.cs
@@ -2,29 +2,59 @@ using System;
 
 namespace Avalonia.Interactivity
 {
+    /// <summary>
+    /// Provices state information and data specific to a routed event.
+    /// </summary>
     public class RoutedEventArgs : EventArgs
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RoutedEventArgs"/> class.
+        /// </summary>
         public RoutedEventArgs()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RoutedEventArgs"/> class.
+        /// </summary>
+        /// <param name="routedEvent">The routed event associated with these event args.</param>
         public RoutedEventArgs(RoutedEvent? routedEvent)
         {
             RoutedEvent = routedEvent;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RoutedEventArgs"/> class.
+        /// </summary>
+        /// <param name="routedEvent">The routed event associated with these event args.</param>
+        /// <param name="source">The source object that raised the routed event.</param>
         public RoutedEventArgs(RoutedEvent? routedEvent, IInteractive? source)
         {
             RoutedEvent = routedEvent;
             Source = source;
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the routed event has already been handled.
+        /// </summary>
+        /// <remarks>
+        /// Once handled, a routed event should be ignored.
+        /// </remarks>
         public bool Handled { get; set; }
 
+        /// <summary>
+        /// Gets or sets the routed event associated with these event args.
+        /// </summary>
         public RoutedEvent? RoutedEvent { get; set; }
 
+        /// <summary>
+        /// Gets or sets the routing strategy (direct, bubbling, or tunneling) of the routed event.
+        /// </summary>
         public RoutingStrategies Route { get; set; }
 
+        /// <summary>
+        /// Gets or sets the source object that raised the routed event.
+        /// </summary>
         public IInteractive? Source { get; set; }
     }
 }

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -89,7 +89,7 @@ namespace Avalonia.Controls
         /// </summary>
         public static readonly RoutedEvent<SizeChangedEventArgs> SizeChangedEvent =
             RoutedEvent.Register<Control, SizeChangedEventArgs>(
-                nameof(SizeChanged), RoutingStrategies.Bubble);
+                nameof(SizeChanged), RoutingStrategies.Direct);
 
         /// <summary>
         /// Defines the <see cref="FlowDirection"/> property.

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -85,6 +85,13 @@ namespace Avalonia.Controls
                 RoutingStrategies.Direct);
 
         /// <summary>
+        /// Defines the <see cref="SizeChanged"/> event.
+        /// </summary>
+        public static readonly RoutedEvent<SizeChangedEventArgs> SizeChangedEvent =
+            RoutedEvent.Register<Control, SizeChangedEventArgs>(
+                nameof(SizeChanged), RoutingStrategies.Bubble);
+
+        /// <summary>
         /// Defines the <see cref="FlowDirection"/> property.
         /// </summary>
         public static readonly AttachedProperty<FlowDirection> FlowDirectionProperty =
@@ -209,6 +216,15 @@ namespace Avalonia.Controls
         {
             add => AddHandler(UnloadedEvent, value);
             remove => RemoveHandler(UnloadedEvent, value);
+        }
+
+        /// <summary>
+        /// Occurs when the bounds (actual size) of the control have changed.
+        /// </summary>
+        public event EventHandler<SizeChangedEventArgs>? SizeChanged
+        {
+            add => AddHandler(SizeChangedEvent, value);
+            remove => RemoveHandler(SizeChangedEvent, value);
         }
 
         public new IControl? Parent => (IControl?)base.Parent;
@@ -530,14 +546,28 @@ namespace Avalonia.Controls
             }
         }
 
+        /// <inheritdoc/>
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
             base.OnPropertyChanged(change);
 
-            if (change.Property == FlowDirectionProperty)
+            if (change.Property == BoundsProperty)
+            {
+                var oldValue = change.GetOldValue<Rect>();
+                var newValue = change.GetNewValue<Rect>();
+
+                var sizeChangedEventArgs = new SizeChangedEventArgs(
+                    SizeChangedEvent,
+                    source: this,
+                    newSize: new Size(newValue.Width, newValue.Height),
+                    previousSize: new Size(oldValue.Width, oldValue.Height));
+
+                RaiseEvent(sizeChangedEventArgs);
+            }
+            else if (change.Property == FlowDirectionProperty)
             {
                 InvalidateMirrorTransform();
-                
+
                 foreach (var visual in VisualChildren)
                 {
                     if (visual is Control child)

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -559,8 +559,8 @@ namespace Avalonia.Controls
                 var sizeChangedEventArgs = new SizeChangedEventArgs(
                     SizeChangedEvent,
                     source: this,
-                    newSize: new Size(newValue.Width, newValue.Height),
-                    previousSize: new Size(oldValue.Width, oldValue.Height));
+                    previousSize: new Size(oldValue.Width, oldValue.Height),
+                    newSize: new Size(newValue.Width, newValue.Height));
 
                 RaiseEvent(sizeChangedEventArgs);
             }

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -556,13 +556,20 @@ namespace Avalonia.Controls
                 var oldValue = change.GetOldValue<Rect>();
                 var newValue = change.GetNewValue<Rect>();
 
-                var sizeChangedEventArgs = new SizeChangedEventArgs(
-                    SizeChangedEvent,
-                    source: this,
-                    previousSize: new Size(oldValue.Width, oldValue.Height),
-                    newSize: new Size(newValue.Width, newValue.Height));
+                // Bounds is a Rect with an X/Y Position as well as Height/Width.
+                // This means it is possible for the Rect to change position but not size.
+                // Therefore, we want to explicity check only the size and raise an event
+                // only when that size has changed.
+                if (newValue.Size != oldValue.Size)
+                {
+                    var sizeChangedEventArgs = new SizeChangedEventArgs(
+                        SizeChangedEvent,
+                        source: this,
+                        previousSize: new Size(oldValue.Width, oldValue.Height),
+                        newSize: new Size(newValue.Width, newValue.Height));
 
-                RaiseEvent(sizeChangedEventArgs);
+                    RaiseEvent(sizeChangedEventArgs);
+                }
             }
             else if (change.Property == FlowDirectionProperty)
             {

--- a/src/Avalonia.Controls/SizeChangedEventArgs.cs
+++ b/src/Avalonia.Controls/SizeChangedEventArgs.cs
@@ -79,7 +79,7 @@ namespace Avalonia.Controls
         /// </summary>
         /// <remarks>
         /// This will take into account layout epsilon and will not be true if both
-        /// heights are considered equivalent for layout purposes. Remember there can
+        /// widths are considered equivalent for layout purposes. Remember there can
         /// be small variations in the calculations between layout cycles due to
         /// rounding and precision even when the size has not otherwise changed.
         /// </remarks>

--- a/src/Avalonia.Controls/SizeChangedEventArgs.cs
+++ b/src/Avalonia.Controls/SizeChangedEventArgs.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Controls
+{
+    /// <summary>
+    /// Provides data specific to a SizeChanged event.
+    /// </summary>
+    public class SizeChangedEventArgs : RoutedEventArgs
+    {
+        public SizeChangedEventArgs(RoutedEvent? routedEvent)
+            : base (routedEvent)
+        {
+        }
+
+        public SizeChangedEventArgs(RoutedEvent? routedEvent, IInteractive? source)
+            : base(routedEvent, source)
+        {
+        }
+
+        public SizeChangedEventArgs(
+            RoutedEvent? routedEvent,
+            IInteractive? source,
+            Size newSize,
+            Size previousSize)
+            : base(routedEvent, source)
+        {
+            NewSize = newSize;
+            PreviousSize = previousSize;
+            HeightChanged = newSize.Height != previousSize.Height;
+            WidthChanged = newSize.Width != previousSize.Width;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the height of the new size is different
+        /// than the previous size height.
+        /// </summary>
+        public bool HeightChanged { get; init; }
+
+        /// <summary>
+        /// Gets the new size (or bounds) of the object.
+        /// </summary>
+        public Size NewSize { get; init; }
+
+        /// <summary>
+        /// Gets the previous size (or bounds) of the object.
+        /// </summary>
+        public Size PreviousSize { get; init; }
+
+        /// <summary>
+        /// Gets a value indicating whether the width of the new size is different
+        /// than the previous size width.
+        /// </summary>
+        public bool WidthChanged { get; init; }
+    }
+}

--- a/src/Avalonia.Controls/SizeChangedEventArgs.cs
+++ b/src/Avalonia.Controls/SizeChangedEventArgs.cs
@@ -44,11 +44,6 @@ namespace Avalonia.Controls
         {
             PreviousSize = previousSize;
             NewSize = newSize;
-
-            // Only consider changed when the size difference is greater than LayoutEpsilon
-            // This compensates for any rounding or precision difference between layout cycles
-            HeightChanged = !MathUtilities.AreClose(newSize.Height, previousSize.Height, LayoutHelper.LayoutEpsilon);
-            WidthChanged = !MathUtilities.AreClose(newSize.Width, previousSize.Width, LayoutHelper.LayoutEpsilon);
         }
 
         /// <summary>
@@ -61,7 +56,7 @@ namespace Avalonia.Controls
         /// be small variations in the calculations between layout cycles due to
         /// rounding and precision even when the size has not otherwise changed.
         /// </remarks>
-        public bool HeightChanged { get; init; }
+        public bool HeightChanged => !MathUtilities.AreClose(NewSize.Height, PreviousSize.Height, LayoutHelper.LayoutEpsilon);
 
         /// <summary>
         /// Gets the new size (or bounds) of the object.
@@ -83,6 +78,6 @@ namespace Avalonia.Controls
         /// be small variations in the calculations between layout cycles due to
         /// rounding and precision even when the size has not otherwise changed.
         /// </remarks>
-        public bool WidthChanged { get; init; }
+        public bool WidthChanged => !MathUtilities.AreClose(NewSize.Width, PreviousSize.Width, LayoutHelper.LayoutEpsilon);
     }
 }

--- a/src/Avalonia.Controls/SizeChangedEventArgs.cs
+++ b/src/Avalonia.Controls/SizeChangedEventArgs.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Avalonia.Interactivity;
+﻿using Avalonia.Interactivity;
 
 namespace Avalonia.Controls
 {
@@ -12,25 +7,41 @@ namespace Avalonia.Controls
     /// </summary>
     public class SizeChangedEventArgs : RoutedEventArgs
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SizeChangedEventArgs"/> class.
+        /// </summary>
+        /// <param name="routedEvent">The routed event associated with these event args.</param>
         public SizeChangedEventArgs(RoutedEvent? routedEvent)
             : base (routedEvent)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SizeChangedEventArgs"/> class.
+        /// </summary>
+        /// <param name="routedEvent">The routed event associated with these event args.</param>
+        /// <param name="source">The source object that raised the routed event.</param>
         public SizeChangedEventArgs(RoutedEvent? routedEvent, IInteractive? source)
             : base(routedEvent, source)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SizeChangedEventArgs"/> class.
+        /// </summary>
+        /// <param name="routedEvent">The routed event associated with these event args.</param>
+        /// <param name="source">The source object that raised the routed event.</param>
+        /// <param name="previousSize">The previous size (or bounds) of the object.</param>
+        /// <param name="newSize">The new size (or bounds) of the object.</param>
         public SizeChangedEventArgs(
             RoutedEvent? routedEvent,
             IInteractive? source,
-            Size newSize,
-            Size previousSize)
+            Size previousSize,
+            Size newSize)
             : base(routedEvent, source)
         {
-            NewSize = newSize;
             PreviousSize = previousSize;
+            NewSize = newSize;
             HeightChanged = newSize.Height != previousSize.Height;
             WidthChanged = newSize.Width != previousSize.Width;
         }

--- a/src/Avalonia.Controls/SizeChangedEventArgs.cs
+++ b/src/Avalonia.Controls/SizeChangedEventArgs.cs
@@ -1,4 +1,6 @@
 ﻿using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Utilities;
 
 namespace Avalonia.Controls
 {
@@ -42,14 +44,23 @@ namespace Avalonia.Controls
         {
             PreviousSize = previousSize;
             NewSize = newSize;
-            HeightChanged = newSize.Height != previousSize.Height;
-            WidthChanged = newSize.Width != previousSize.Width;
+
+            // Only consider changed when the size difference is greater than LayoutEpsilon
+            // This compensates for any rounding or precision difference between layout cycles
+            HeightChanged = !MathUtilities.AreClose(newSize.Height, previousSize.Height, LayoutHelper.LayoutEpsilon);
+            WidthChanged = !MathUtilities.AreClose(newSize.Width, previousSize.Width, LayoutHelper.LayoutEpsilon);
         }
 
         /// <summary>
-        /// Gets a value indicating whether the height of the new size is different
-        /// than the previous size height.
+        /// Gets a value indicating whether the height of the new size is considered
+        /// different than the previous size height.
         /// </summary>
+        /// <remarks>
+        /// This will take into account layout epsilon and will not be true if both
+        /// heights are considered equivalent for layout purposes. Remember there can
+        /// be small variations in the calculations between layout cycles due to
+        /// rounding and precision even when the size has not otherwise changed.
+        /// </remarks>
         public bool HeightChanged { get; init; }
 
         /// <summary>
@@ -63,9 +74,15 @@ namespace Avalonia.Controls
         public Size PreviousSize { get; init; }
 
         /// <summary>
-        /// Gets a value indicating whether the width of the new size is different
-        /// than the previous size width.
+        /// Gets a value indicating whether the width of the new size is considered
+        /// different than the previous size width.
         /// </summary>
+        /// <remarks>
+        /// This will take into account layout epsilon and will not be true if both
+        /// heights are considered equivalent for layout purposes. Remember there can
+        /// be small variations in the calculations between layout cycles due to
+        /// rounding and precision even when the size has not otherwise changed.
+        /// </remarks>
         public bool WidthChanged { get; init; }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Adds a Control.SizeChanged event.

## What is the current behavior?

There is no size changed event and apps must listen directly to Bounds property changes. This isn't optimal for those with existing WPF/UWP/WinUI code and those that aren't heavily using ReactiveUI.

## What is the updated/expected behavior with this PR?

There is now a Control.SizeChanged event which is the equivalent to WPF's FrameworkElement.SizeChanged.

**NOTE**

In Avalonia this event could probably go much lower and be on Layoutable or Visual. However, I kept it on Control which is the equivalent for FrameworkElement.

## How was the solution implemented (if it's not obvious)?

 1. WPF event details:
     - [WPF FrameworkElement.SizeChanged Event](https://learn.microsoft.com/en-us/dotnet/api/system.windows.frameworkelement.sizechanged?view=windowsdesktop-6.0)
     - [WPF SizeChangedEventArgs Class](https://learn.microsoft.com/en-us/dotnet/api/system.windows.sizechangedeventargs?view=windowsdesktop-6.0)
 3. WinUI event details:
     - [WinUI FrameworkElement.SizeChanged Event](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.frameworkelement.sizechanged?view=winrt-22621)
     - [WinUI SizeChangedEventArgs Class](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.sizechangedeventargs?view=winrt-22621)
 4. The WPF event args class was followed instead of the UWP/WinUI one.
 5. I decided to keep using `Size` for the NewSize/PreviousSize properties instead of `Rect` that is used by the Bounds property in Avalonia. This is for two reasons (1) compatibility with WPF and (2) it ensures the event args are sufficiently generic to be used in other places.
 6. As done elsewhere in most other Avalonia events, no new EventHandler was created for this.

## Checklist

- ~[ ] Added unit tests (if possible)?~
- [x] Added XML documentation to any related classes?
- ~[ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation~

## Breaking changes

None

## Obsoletions / Deprecations

None

## Fixed issues

Closes #9311
Relates to the discussion #8473 
