### PR TITLE
Only use scoped keyword when building with .NET 7 SDK

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup Condition="$(NETCoreSdkVersion.StartsWith('7.0'))">
+    <DefineConstants>$(DefineConstants);NET7SDK</DefineConstants>
+  </PropertyGroup>  
+</Project>

--- a/src/Avalonia.Base/Media/PathMarkupParser.cs
+++ b/src/Avalonia.Base/Media/PathMarkupParser.cs
@@ -188,7 +188,11 @@ namespace Avalonia.Media
             _isOpen = true;
         }
 
-        private void SetFillRule(scoped ref ReadOnlySpan<char> span)
+        private void SetFillRule(
+#if NET7SDK
+            scoped
+#endif
+            ref ReadOnlySpan<char> span)
         {
             ThrowIfDisposed();
 
@@ -452,7 +456,11 @@ namespace Avalonia.Media
             return !span.IsEmpty && (span[0] == ',' || span[0] == '-' || span[0] == '.' || char.IsDigit(span[0]));
         }
 
-        private static bool ReadArgument(scoped ref ReadOnlySpan<char> remaining, out ReadOnlySpan<char> argument)
+        private static bool ReadArgument(
+#if NET7SDK
+            scoped
+#endif
+            ref ReadOnlySpan<char> remaining, out ReadOnlySpan<char> argument)
         {
             remaining = SkipWhitespace(remaining);
             if (remaining.IsEmpty)

--- a/src/Avalonia.Base/Utilities/IdentifierParser.cs
+++ b/src/Avalonia.Base/Utilities/IdentifierParser.cs
@@ -8,7 +8,11 @@ namespace Avalonia.Utilities
 #endif
     static class IdentifierParser
     {
-        public static ReadOnlySpan<char> ParseIdentifier(this scoped ref CharacterReader r)
+        public static ReadOnlySpan<char> ParseIdentifier(this
+#if NET7SDK
+            scoped
+#endif
+            ref CharacterReader r)
         {
             if (IsValidIdentifierStart(r.Peek))
             {

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/BindingExpressionGrammar.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/BindingExpressionGrammar.cs
@@ -168,7 +168,11 @@ namespace Avalonia.Markup.Parsers
             }
         }
 
-        private static State ParseAttachedProperty(scoped ref CharacterReader r, List<INode> nodes)
+        private static State ParseAttachedProperty(
+#if NET7SDK
+            scoped
+#endif
+            ref CharacterReader r, List<INode> nodes)
         {
             var (ns, owner) = ParseTypeName(ref r);
 
@@ -318,7 +322,11 @@ namespace Avalonia.Markup.Parsers
             return State.AfterMember;
         }
 
-        private static TypeName ParseTypeName(scoped ref CharacterReader r)
+        private static TypeName ParseTypeName(
+#if NET7SDK
+            scoped
+#endif
+            ref CharacterReader r)
         {
             ReadOnlySpan<char> ns, typeName;
             ns = ReadOnlySpan<char>.Empty;


### PR DESCRIPTION
This should allow to build Avalonia locally with .NET 6.0.400 SDK (with web stuff unloaded).