### PR TITLE
OSX: fix minimise button being disabled when either a parent or a dialog.

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -63,7 +63,7 @@ HRESULT WindowImpl::Show(bool activate, bool isDialog) {
     START_COM_CALL;
 
     @autoreleasepool {
-        _isDialog = isDialog;
+        _isDialog = isDialog || _parent != nullptr;
 
         WindowBaseImpl::Show(activate, isDialog);
 
@@ -96,6 +96,8 @@ HRESULT WindowImpl::SetParent(IAvnWindow *parent) {
         auto cparent = dynamic_cast<WindowImpl *>(parent);
         
         _parent = cparent;
+
+        _isDialog = _parent != nullptr;
         
         if(_parent != nullptr && Window != nullptr){
             // If one tries to show a child window with a minimized parent window, then the parent window will be


### PR DESCRIPTION
On OSX if a dialog or parented window is shown, the minimise button should be disabled.

This behavior was lost when we implemented our own window parenting due to multi monitor limitations of osx.