### PR TITLE
Replaced hard-coded indexer with its actual name

### DIFF
--- a/src/Avalonia.Base/Collections/AvaloniaDictionary.cs
+++ b/src/Avalonia.Base/Collections/AvaloniaDictionary.cs
@@ -81,7 +81,7 @@ namespace Avalonia.Collections
 
                 if (replace)
                 {
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs($"Item[{key}]"));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs($"{CommonPropertyNames.IndexerName}[{key}]"));
 
                     if (CollectionChanged != null)
                     {
@@ -148,7 +148,7 @@ namespace Avalonia.Collections
             {
                 _inner.Remove(key);
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Count)));
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs($"Item[{key}]"));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs($"{CommonPropertyNames.IndexerName}[{key}]"));
 
                 if (CollectionChanged != null)
                 {
@@ -208,7 +208,7 @@ namespace Avalonia.Collections
         private void NotifyAdd(TKey key, TValue value)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Count)));
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs($"Item[{key}]"));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs($"{CommonPropertyNames.IndexerName}[{key}]"));
             
 
             if (CollectionChanged != null)


### PR DESCRIPTION
This was possibly just overlooked since nobody probably ever changed the name from "Item".

## What does the pull request do?
Replaces hard-coded name with actual interpolated value.


## What is the current behavior?
This would probably have gone unnoticed for ages as nobody would rename the indexer anyway.


## What is the updated/expected behavior with this PR?
Just code cleanup. 
 