### PR TITLE
[ARM only] Fix incorrect parameters passed to the CreateDrawingSurface method

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -2104,6 +2104,12 @@ namespace Avalonia.Win32.Interop
             public int Y;
         }
 
+        public struct SIZE_F
+        {
+            public float X;
+            public float Y;
+        }
+
         public struct RECT
         {
             public int left;

--- a/src/Windows/Avalonia.Win32/WinRT/Composition/WinUICompositorConnection.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/Composition/WinUICompositorConnection.cs
@@ -174,8 +174,9 @@ namespace Avalonia.Win32.WinRT.Composition
             using var sc = _syncContext.EnsureLocked();
             using var desktopTarget = _compositorDesktopInterop.CreateDesktopWindowTarget(hWnd, 0);
             using var target = desktopTarget.QueryInterface<ICompositionTarget>();
+            using var device2 = _device.QueryInterface<ICompositionGraphicsDevice2>();
 
-            using var drawingSurface = _device.CreateDrawingSurface(new UnmanagedMethods.SIZE(), DirectXPixelFormat.B8G8R8A8UIntNormalized,
+            using var drawingSurface = device2.CreateDrawingSurface2(new UnmanagedMethods.SIZE(), DirectXPixelFormat.B8G8R8A8UIntNormalized,
                 DirectXAlphaMode.Premultiplied);
             using var surface = drawingSurface.QueryInterface<ICompositionSurface>();
             using var surfaceInterop = drawingSurface.QueryInterface<ICompositionDrawingSurfaceInterop>();

--- a/src/Windows/Avalonia.Win32/WinRT/winrt.idl
+++ b/src/Windows/Avalonia.Win32/WinRT/winrt.idl
@@ -472,7 +472,7 @@ interface ICompositionDrawingSurface : IInspectable
 {
     [propget] HRESULT GetAlphaMode([out] [retval] DirectXAlphaMode* value);
     [propget] HRESULT GetPixelFormat([out] [retval] DirectXPixelFormat* value);
-    [propget] HRESULT GetSize([out] [retval] POINT* value);
+    [propget] HRESULT GetSize([out] [retval] SIZE_F* value);
 }
 
 enum CompositionBitmapInterpolationMode

--- a/src/Windows/Avalonia.Win32/WinRT/winrt.idl
+++ b/src/Windows/Avalonia.Win32/WinRT/winrt.idl
@@ -8,6 +8,7 @@
 @clr-map Matrix4x4 System.Numerics.Matrix4x4
 @clr-map RECT Avalonia.Win32.Interop.UnmanagedMethods.RECT
 @clr-map SIZE Avalonia.Win32.Interop.UnmanagedMethods.SIZE
+@clr-map SIZE_F Avalonia.Win32.Interop.UnmanagedMethods.SIZE_F
 @clr-map POINT Avalonia.Win32.Interop.UnmanagedMethods.POINT
 @clr-map HWND IntPtr
 @clr-map BOOL int
@@ -442,7 +443,7 @@ interface IDesktopWindowContentBridgeInterop : IUnknown
 [uuid(FB22C6E1-80A2-4667-9936-DBEAF6EEFE95)]
 interface ICompositionGraphicsDevice : IInspectable
 {
-    HRESULT CreateDrawingSurface([in] SIZE sizePixels, [in] DirectXPixelFormat pixelFormat,
+    HRESULT CreateDrawingSurface([in] SIZE_F sizePixels, [in] DirectXPixelFormat pixelFormat,
         [in] DirectXAlphaMode alphaMode, [out] [retval] ICompositionDrawingSurface** result);
     HRESULT AddRenderingDeviceReplaced(void* handler, void* token);
     HRESULT RemoveRenderingDeviceReplaced([in] int token);

--- a/src/Windows/Avalonia.Win32/WinRT/winrt.idl
+++ b/src/Windows/Avalonia.Win32/WinRT/winrt.idl
@@ -448,6 +448,12 @@ interface ICompositionGraphicsDevice : IInspectable
     HRESULT RemoveRenderingDeviceReplaced([in] int token);
 }
 
+[uuid(0FB8BDF6-C0F0-4BCC-9FB8-084982490D7D)]
+interface ICompositionGraphicsDevice2 : IInspectable
+{
+    HRESULT CreateDrawingSurface2([in] SIZE sizePixels, [in] DirectXPixelFormat pixelFormat, [in] DirectXAlphaMode alphaMode, [out] [retval] ICompositionDrawingSurface** result);
+}
+
 [uuid(1527540D-42C7-47A6-A408-668F79A90DFB)]
 interface ICompositionSurface : IInspectable
 {


### PR DESCRIPTION
As @olifink noticed, we use a wrong method's parameter type.

## What does the pull request do?

1. Uses a CreateDrawingSurface2 method that accepts integer SIZE struct.
2. Fixes old CreateDrawingSurface usage by changing type to a correct one (SIZE_F).

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/8776
