### PR TITLE
Fix UniformGridLayout ItemsStretch Fill and Uniform

### DIFF
--- a/src/Avalonia.Base/Layout/UniformGridLayoutState.cs
+++ b/src/Avalonia.Base/Layout/UniformGridLayoutState.cs
@@ -117,12 +117,12 @@ namespace Avalonia.Layout
             double extraMinorPixelsForEachItem = 0.0;
             if (!double.IsInfinity(availableSizeMinor))
             {
-                var numItemsPerColumn = Math.Min(
+                var numItemsPerColumn = (int)Math.Min(
                     maxItemsPerLine,
                     Math.Max(1.0, availableSizeMinor / (itemSizeMinor + minorItemSpacing)));
                 var usedSpace = (numItemsPerColumn * (itemSizeMinor + minorItemSpacing)) - minorItemSpacing;
-                var remainingSpace = ((int)(availableSizeMinor - usedSpace));
-                extraMinorPixelsForEachItem = remainingSpace / ((int)numItemsPerColumn);
+                var remainingSpace = availableSizeMinor - usedSpace;
+                extraMinorPixelsForEachItem = (int)(remainingSpace / numItemsPerColumn);
             }
 
             if (stretch == UniformGridLayoutItemsStretch.Fill)


### PR DESCRIPTION
Corrected implementation for UniformGridLayout ItemsStretch Fill and Uniform

## What does the pull request do?

Fixes the behavior for the use of remaining space in `UniformGridLayout` when `ItemsStretch` is set to `Fill` or `Uniform`. 

Given this code:

```
<Window xmlns="https://github.com/avaloniaui"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
        x:Class="AvaloniaApplication2.MainWindow"
        Title="AvaloniaApplication2">
    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
        <ItemsRepeater Name="m_Items">
            <ItemsRepeater.Layout>
                <UniformGridLayout Orientation="Horizontal"
                                   MinColumnSpacing="5"
                                   MinRowSpacing="5"
                                   MinItemHeight="210"
                                   MinItemWidth="210"
                                   ItemsStretch="Uniform" />
            </ItemsRepeater.Layout>
            <ItemsRepeater.ItemTemplate>
                <DataTemplate>
                    <Grid>
                        <Border CornerRadius="5" Background="{DynamicResource SystemAccentColor}">
                            <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Text="{Binding}" />
                        </Border>
                    </Grid>
                </DataTemplate>
            </ItemsRepeater.ItemTemplate>
        </ItemsRepeater>
    </ScrollViewer>
</Window>
```

```
m_Items.Items = Enumerable.Range(1, 12).ToList();
```

This is the current behavior:

![image](https://user-images.githubusercontent.com/96898225/200107868-76506549-8566-433c-99dd-6d4c9595c0df.png)

My understanding is that the black space to the right of items 4, 8 and 12 should not be there; rather it should be taken by all 12 of the items. 

Please see my comment on the related issue for additional details. 

[Related issue](https://github.com/AvaloniaUI/Avalonia/issues/7175)

## What is the current behavior?

See above screenshot.


## What is the updated/expected behavior with this PR?

The above example will continuously have the 12 items take the full width of the window. 


## How was the solution implemented (if it's not obvious)?

Short code fix in `UniformGridLayoutState::SetSize`.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

N/A

## Breaking changes

N/A

## Obsoletions / Deprecations

N/A

## Fixed issues
Fixes #7175
