### PR TITLE
[OSX] Fixed multi-window freeze on Show when another window is rendering

### DIFF
--- a/native/Avalonia.Native/src/OSX/rendertarget.mm
+++ b/native/Avalonia.Native/src/OSX/rendertarget.mm
@@ -183,8 +183,11 @@ static IAvnGlSurfaceRenderTarget* CreateGlRenderTarget(IOSurfaceRenderTarget* ta
                 [_layer setContents: (__bridge IOSurface*) surface->surface];
             }
             [CATransaction commit];
-            [CATransaction flush];
         }
+        // This can trigger event processing on the main thread
+        // which might need to lock the renderer
+        // which can cause a deadlock. So flush call is outside of the lock
+        [CATransaction flush];
     }
     else
         dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
`[CATransaction flush]` can call event handlers causing unexpected call to `[NSView updateLayer]` when render target is still locked. That can prevent the render thread (which holds the Compositor lock) to acquire the render target lock resulting in a deadlock condition.