### PR TITLE
Android: Force punch a hole in the SurfaceView to workaround issue #9230

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -165,6 +165,28 @@ namespace Avalonia.Android.Platform.SkiaPlatform
                 _tl.Draw();
             }
 
+            protected override void DispatchDraw(global::Android.Graphics.Canvas canvas)
+            {
+                // Workaround issue #9230 on where screen remains gray after splash screen.
+                // base.DispatchDraw should punch a hole into the canvas so the surface
+                // can be seen below, but it does not.
+                if (OperatingSystem.IsAndroidVersionAtLeast(29))
+                {
+                    // Android 10+ does this (BlendMode was new)
+                    var paint = new Paint();
+                    paint.SetColor(0);
+                    paint.BlendMode = BlendMode.Clear;
+                    canvas.DrawRect(0, 0, Width, Height, paint);
+                }
+                else
+                {
+                    // Android 9 did this
+                    canvas.DrawColor(Color.Transparent, PorterDuff.Mode.Clear);
+                }
+
+                base.DispatchDraw(canvas);
+            }
+
             protected override bool DispatchGenericPointerEvent(MotionEvent e)
             {
                 bool callBase;


### PR DESCRIPTION
## What does the pull request do?
It fixes #9230 , see current behavior below.

## What is the current behavior?
On some physical Android devices like my Pixel 4 running Android 13, apps render as plain gray after the initial Splash screen transition. After switching to a different app and switching back, the app renders properly. This does not repro in the emulator.

## What is the updated/expected behavior with this PR?
The app should render properly after the Splash screen on previously affected devices.

## How was the solution implemented (if it's not obvious)?
Force the SurfaceView to punch a hole in its canvas so the surface below can be seen by overriding `dispatchDraw`.

## How tested
Ran `MobileSandbox.Android` on:
- Physical Google Pixel 4 running Android 13
- Emulated Pixel 5 running Android 6
- Emulated Pixel 5 running Android 13

In all cases, the app rendered properly immediately after the Splash screen.

## Checklist
- [ ] ~Added unit tests (if possible)?~ Probably impossible?
- [ ] ~Added XML documentation to any related classes?~ Does not apply
- [ ] ~Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation~ Does not apply

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #9230
