### PR TITLE
Fix TextBox-Buttons are missing ClipToBounds="True"

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/TextBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/TextBox.xaml
@@ -235,7 +235,8 @@
       <Setter Property="InnerRightContent">
         <Template>
           <ToggleButton Theme="{StaticResource FluentTextBoxToggleButton}"
-                        IsChecked="{Binding $parent[TextBox].RevealPassword, Mode=TwoWay}">
+                        IsChecked="{Binding $parent[TextBox].RevealPassword, Mode=TwoWay}"
+                        ClipToBounds="True">
             <Panel>
               <PathIcon Data="{StaticResource PasswordBoxRevealButtonData}"
                         Height="8" Width="12"
@@ -253,7 +254,8 @@
       <Setter Property="InnerRightContent">
         <Template>
           <Button Theme="{StaticResource FluentTextBoxButton}"
-                  Command="{Binding $parent[TextBox].Clear}">
+                  Command="{Binding $parent[TextBox].Clear}"
+                  ClipToBounds="True">
             <PathIcon Data="{StaticResource TextBoxClearButtonData}" Height="10" Width="10"/>
           </Button>
         </Template>

--- a/src/Avalonia.Themes.Simple/Controls/TextBox.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/TextBox.xaml
@@ -192,7 +192,8 @@
         <Template>
           <Button Command="{Binding $parent[TextBox].Clear}"
                   Focusable="False"
-                  Theme="{StaticResource SimpleTextBoxClearButtonTheme}" />
+                  Theme="{StaticResource SimpleTextBoxClearButtonTheme}" 
+                  ClipToBounds="True" />
         </Template>
       </Setter>
     </Style>
@@ -212,7 +213,8 @@
             <ToggleButton Background="Transparent"
                           Focusable="False"
                           IsChecked="{Binding $parent[TextBox].RevealPassword, Mode=TwoWay}"
-                          Theme="{StaticResource SimplePasswordBoxRevealButtonTheme}" />
+                          Theme="{StaticResource SimplePasswordBoxRevealButtonTheme}"
+                          ClipToBounds="True" />
           </Panel>
         </Template>
       </Setter>


### PR DESCRIPTION
## What does the pull request do?
Adds `ClipToBounds="True"` to all buttons in the `TextBox`-styles


## What is the current behavior?
See #9302 

## What is the updated/expected behavior with this PR?
buttons are clipping when the TextBox has a CornerRadius set

## How was the solution implemented (if it's not obvious)?
added `ClipToBounds="True"`

## Checklist


~~- [ ] Added unit tests (if possible)?~~
~~- [ ] Added XML documentation to any related classes?~~
~~- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation~~


## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #9302 


@avaloniaui-team should this fix be backported? I can create the needed PR if you want me to. 