### PR TITLE
Fix DevTools style list not updating correctly

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/Conventions.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Conventions.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Reflection;
-using Avalonia.Controls;
-using Avalonia.VisualTree;
 
 namespace Avalonia.Diagnostics
 {
-    static class Convetions
+    internal static class Conventions
     {
         public static string DefaultScreenshotsRoot =>
              System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyPictures, Environment.SpecialFolderOption.Create),

--- a/src/Avalonia.Diagnostics/Diagnostics/DevToolsOptions.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/DevToolsOptions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Avalonia.Input;
+﻿using Avalonia.Input;
 
 namespace Avalonia.Diagnostics
 {

--- a/src/Avalonia.Diagnostics/Diagnostics/DevToolsOptions.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/DevToolsOptions.cs
@@ -36,11 +36,11 @@ namespace Avalonia.Diagnostics
         public bool ShowImplementedInterfaces { get; set; } = true;
         
         /// <summary>
-        /// Allow to customizze SreenshotHandler
+        /// Allow to customize SreenshotHandler
         /// </summary>
         /// <remarks>Default handler is <see cref="Screenshots.FilePickerHandler"/></remarks>
         public IScreenshotHandler ScreenshotHandler { get; set; }
-          = Convetions.DefaultScreenshotHandler;
+          = Conventions.DefaultScreenshotHandler;
 
         /// <summary>
         /// Gets or sets whether DevTools should use the dark mode theme

--- a/src/Avalonia.Diagnostics/Diagnostics/Screenshots/FilePickerHandler.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Screenshots/FilePickerHandler.cs
@@ -40,7 +40,7 @@ namespace Avalonia.Diagnostics.Screenshots
         /// The default root folder is [Environment.SpecialFolder.MyPictures]/Screenshots.
         /// </summary>
         public string ScreenshotsRoot { get; }
-            = Convetions.DefaultScreenshotsRoot;
+            = Conventions.DefaultScreenshotsRoot;
 
         /// <summary>
         /// SaveFilePicker Title

--- a/src/Avalonia.Diagnostics/Diagnostics/Screenshots/FilePickerHandler.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Screenshots/FilePickerHandler.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/AvaloniaPropertyViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/AvaloniaPropertyViewModel.cs
@@ -1,6 +1,5 @@
 using System;
 using Avalonia.Data;
-using Avalonia.Media;
 
 namespace Avalonia.Diagnostics.ViewModels
 {

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ClrPropertyViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ClrPropertyViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Avalonia.Media;
 
 namespace Avalonia.Diagnostics.ViewModels
 {

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ControlDetailsViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ControlDetailsViewModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
@@ -15,7 +14,7 @@ using Avalonia.VisualTree;
 
 namespace Avalonia.Diagnostics.ViewModels
 {
-    internal class ControlDetailsViewModel : ViewModelBase, IDisposable
+    internal class ControlDetailsViewModel : ViewModelBase, IDisposable, IClassesChangedListener
     {
         private readonly IAvaloniaObject _avaloniaObject;
         private IDictionary<object, PropertyViewModel[]>? _propertyIndex;
@@ -46,7 +45,7 @@ namespace Avalonia.Diagnostics.ViewModels
 
             if (avaloniaObject is StyledElement styledElement)
             {
-                styledElement.Classes.CollectionChanged += OnClassesChanged;
+                styledElement.Classes.AddListener(this);
 
                 var pseudoClassAttributes = styledElement.GetType().GetCustomAttributes<PseudoClassesAttribute>(true);
 
@@ -250,7 +249,7 @@ namespace Avalonia.Diagnostics.ViewModels
 
             if (_avaloniaObject is StyledElement se)
             {
-                se.Classes.CollectionChanged -= OnClassesChanged;
+                se.Classes.RemoveListener(this);
             }
         }
 
@@ -325,7 +324,7 @@ namespace Avalonia.Diagnostics.ViewModels
             }
         }
 
-        private void OnClassesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        void IClassesChangedListener.Changed()
         {
             if (!SnapshotStyles)
             {

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/MainViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/MainViewModel.cs
@@ -96,7 +96,9 @@ namespace Avalonia.Diagnostics.ViewModels
                     changed = false;
                 }
                 if (changed)
-                RaiseAndSetIfChanged(ref _shouldVisualizeDirtyRects, value);
+                {
+                    RaiseAndSetIfChanged(ref _shouldVisualizeDirtyRects, value);
+                }
             }
         }
 
@@ -331,7 +333,7 @@ namespace Avalonia.Diagnostics.ViewModels
             private set => RaiseAndSetIfChanged(ref _showImplementedInterfaces , value); 
         }
 
-        public void ToggleShowImplementedInterfaces(object parametr)
+        public void ToggleShowImplementedInterfaces(object parameter)
         {
             ShowImplementedInterfaces = !ShowImplementedInterfaces;
             if (Content is TreePageViewModel viewModel)
@@ -340,15 +342,15 @@ namespace Avalonia.Diagnostics.ViewModels
             }
         }
 
-        public bool ShowDettailsPropertyType 
+        public bool ShowDetailsPropertyType
         { 
             get => _showPropertyType; 
             private set => RaiseAndSetIfChanged(ref  _showPropertyType , value); 
         }
 
-        public void ToggleShowDettailsPropertyType(object paramter)
+        public void ToggleShowDetailsPropertyType(object parameter)
         {
-            ShowDettailsPropertyType = !ShowDettailsPropertyType;
+            ShowDetailsPropertyType = !ShowDetailsPropertyType;
         }
     }
 }

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/MainViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/MainViewModel.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Reactive.Linq;
-using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Diagnostics.Models;
 using Avalonia.Input;
 using Avalonia.Metadata;
 using Avalonia.Threading;
-using System.Linq;
 
 namespace Avalonia.Diagnostics.ViewModels
 {

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/TreeNode.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/TreeNode.cs
@@ -6,7 +6,6 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.LogicalTree;
 using Avalonia.Media;
-using Avalonia.VisualTree;
 
 namespace Avalonia.Diagnostics.ViewModels
 {

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/ControlDetailsView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/ControlDetailsView.xaml
@@ -19,7 +19,7 @@
       <ColumnDefinition Width="Auto"/>
       <!--
       When selecting the Application node, we need this trick to hide Layout Visualizer 
-      because when using the GridSplitter it sets the Witdth property of ColumnDefinition
+      because when using the GridSplitter it sets the Width property of ColumnDefinition
       (see https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/GridSplitter.cs#L528) 
       and if we hide the contents of the column, the space is not reclaimed 
       (see discussion https://github.com/AvaloniaUI/Avalonia/discussions/6773). 
@@ -62,15 +62,15 @@
           <DataGridTextColumn Header="Value" Binding="{Binding Value}" />
           <DataGridTextColumn Header="Type" Binding="{Binding Type}"
                               IsReadOnly="True"
-                              IsVisible="{Binding !$parent[UserControl;2].DataContext.ShowDettailsPropertyType}"
+                              IsVisible="{Binding !$parent[UserControl;2].DataContext.ShowDetailsPropertyType}"
                               />
-          <DataGridTextColumn Header="Assinged Type" Binding="{Binding AssignedType, Converter={StaticResource GetTypeName}}"
+          <DataGridTextColumn Header="Assigned Type" Binding="{Binding AssignedType, Converter={StaticResource GetTypeName}}"
                               IsReadOnly="True"
-                              IsVisible="{Binding $parent[UserControl;2].DataContext.ShowDettailsPropertyType}"
+                              IsVisible="{Binding $parent[UserControl;2].DataContext.ShowDetailsPropertyType}"
                               />
           <DataGridTextColumn Header="Property Type" Binding="{Binding PropertyType, Converter={StaticResource GetTypeName}}"
                               IsReadOnly="True"
-                              IsVisible="{Binding $parent[UserControl;2].DataContext.ShowDettailsPropertyType}"
+                              IsVisible="{Binding $parent[UserControl;2].DataContext.ShowDetailsPropertyType}"
                               />
           <DataGridTextColumn Header="Priority" Binding="{Binding Priority}" IsReadOnly="True" />
         </DataGrid.Columns>

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/MainView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/MainView.xaml
@@ -53,10 +53,10 @@
                         IsEnabled="False" />
             </MenuItem.Icon>
           </MenuItem>
-          <MenuItem Header="Split Property Type" Command="{Binding ToggleShowDettailsPropertyType}">
+          <MenuItem Header="Split Property Type" Command="{Binding ToggleShowDetailsPropertyType}">
             <MenuItem.Icon>
               <CheckBox BorderThickness="0"
-                        IsChecked="{Binding ShowDettailsPropertyType}"
+                        IsChecked="{Binding ShowDetailsPropertyType}"
                         IsEnabled="False"/>
             </MenuItem.Icon>
 


### PR DESCRIPTION
## What does the pull request do?
Changes the way the DevTools register for class change notifications so they are updated _after_ the actual style instances.


## What is the current behavior?
The DevTools style list currently does not update properly when the pseudo classes of the selected control change.


## What is the updated/expected behavior with this PR?
The style list now shows the correct styles as active.


## How was the solution implemented (if it's not obvious)?
The issue was that `Avalonia.Diagnostics.ViewModels.ControlDetailsViewModel.UpdateStyles` was run before the actual `StyleInstance`'s `IsActive` property was updated, so the DevTools were always lagging one update behind.

The stack traces revealed that the two notification paths diverged in `Avalonia.Controls.Classes`'s implementation of `Avalonia.Controls.IPseudoClasses.Add`. The DevTools used to hook directly into the `AvaloniaList`'s `CollectionChanged` event, while the style instance is notified through a style activator, which is registered as a `ClassesChangedListener` and therefore gets notified later.

The fix was simply to make `ControlDetailsViewModel` receive updates via an `IClassesChangedListener` instead of through the backing list's `CollectionChanged` event.

I also included a second commit with some typo fixes. Not sure if this is the right place for them.

```
Avalonia.Diagnostics.dll!Avalonia.Diagnostics.ViewModels.ControlDetailsViewModel.UpdateStyles() Line 342	C#
Avalonia.Diagnostics.dll!Avalonia.Diagnostics.ViewModels.ControlDetailsViewModel.OnClassesChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
Avalonia.Base.dll!Avalonia.Collections.AvaloniaList<string>.NotifyAdd(string item, int index)
Avalonia.Base.dll!Avalonia.Collections.AvaloniaList<string>.Add(string item)
Avalonia.Base.dll!Avalonia.Controls.Classes.Avalonia.Controls.IPseudoClasses.Add(string name)
Avalonia.Base.dll!Avalonia.Controls.PseudolassesExtensions.Set(Avalonia.Controls.IPseudoClasses classes, string name, bool value)

Avalonia.Base.dll!Avalonia.Styling.StyleInstance.ActivatorChanged(bool value)
Avalonia.Base.dll!Avalonia.Styling.StyleInstance.Avalonia.Styling.Activators.IStyleActivatorSink.OnNext(bool value, int tag)
Avalonia.Base.dll!Avalonia.Styling.Activators.StyleActivatorBase.PublishNext(bool value)
Avalonia.Base.dll!Avalonia.Styling.Activators.StyleClassActivator.Avalonia.Controls.IClassesChangedListener.Changed()
Avalonia.Base.dll!Avalonia.Controls.Classes.NotifyChanged()
Avalonia.Base.dll!Avalonia.Controls.Classes.Avalonia.Controls.IPseudoClasses.Add(string name)
Avalonia.Base.dll!Avalonia.Controls.PseudolassesExtensions.Set(Avalonia.Controls.IPseudoClasses classes, string name, bool value)
```
```cs
// From src/Avalonia.Base/Controls/Classes.cs, line 284
void IPseudoClasses.Add(string name)
{
    if (!Contains(name))
    {
        base.Add(name);     // DevTools view model was updated here
        NotifyChanged();    // StyleInstance.IsActive is updated here
    }
}
```

## Fixed issues
Fixes #9382
