### PR TITLE
Add Toplevel Sound effects

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -26,11 +26,13 @@ using Avalonia.Rendering;
 using Avalonia.Rendering.Composition;
 using Java.Lang;
 using Math = System.Math;
+using SoundEffects = Android.Views.SoundEffects;
 
 namespace Avalonia.Android.Platform.SkiaPlatform
 {
     class TopLevelImpl : IAndroidView, ITopLevelImpl, EglGlPlatformSurfaceBase.IEglWindowGlPlatformSurfaceInfo,
-        ITopLevelImplWithTextInputMethod, ITopLevelImplWithNativeControlHost, ITopLevelImplWithStorageProvider
+        ITopLevelImplWithTextInputMethod, ITopLevelImplWithNativeControlHost, ITopLevelImplWithStorageProvider,
+        ITopLevelImplWithSoundEffects
     {
         private readonly IGlPlatformSurface _gl;
         private readonly IFramebufferPlatformSurface _framebuffer;
@@ -278,6 +280,21 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         public void SetTransparencyLevelHint(WindowTransparencyLevel transparencyLevel)
         {
             throw new NotImplementedException();
+        }
+
+        public void Play(Controls.Platform.SoundEffects soundEffects)
+        {
+            if(_view != null)
+            {
+                var activity = _view.Context as Activity;
+
+                switch (soundEffects)
+                {
+                    case Controls.Platform.SoundEffects.Click:
+                        activity?.Window?.DecorView?.PlaySoundEffect(SoundEffects.Click);
+                        break;
+                }
+            }
         }
     }
 

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -112,6 +112,7 @@ namespace Avalonia.Controls
         /// </summary>
         public Button()
         {
+            IsClickable = true;
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -53,6 +53,12 @@ namespace Avalonia.Controls
             AvaloniaProperty.Register<Control, FlyoutBase?>(nameof(ContextFlyout));
 
         /// <summary>
+        /// Defines the <see cref="IsClickable"/> property
+        /// </summary>
+        public static readonly StyledProperty<bool?> IsClickableProperty =
+            AvaloniaProperty.Register<Control, bool?>(nameof(IsClickable));
+
+        /// <summary>
         /// Event raised when an element wishes to be scrolled into view.
         /// </summary>
         public static readonly RoutedEvent<RequestBringIntoViewEventArgs> RequestBringIntoViewEvent =
@@ -151,6 +157,15 @@ namespace Avalonia.Controls
         {
             get => GetValue(ContextFlyoutProperty);
             set => SetValue(ContextFlyoutProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value representing whether the control is clickable.
+        /// </summary>
+        public bool? IsClickable
+        {
+            get => GetValue(IsClickableProperty);
+            set => SetValue(IsClickableProperty, value);
         }
 
         /// <summary>
@@ -499,6 +514,14 @@ namespace Avalonia.Controls
         protected override void OnPointerReleased(PointerReleasedEventArgs e)
         {
             base.OnPointerReleased(e);
+            
+            if(!e.Handled)
+            {
+                if (IsClickable != null && IsClickable.Value)
+                {
+                    this.PlayClickSound();
+                }
+            }
 
             if (e.Source == this
                 && !e.Handled

--- a/src/Avalonia.Controls/ControlExtensions.cs
+++ b/src/Avalonia.Controls/ControlExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Avalonia.Controls.Platform;
 using Avalonia.Data;
 using Avalonia.LogicalTree;
 using Avalonia.Styling;
@@ -101,6 +102,17 @@ namespace Avalonia.Controls
             _ = classes ?? throw new ArgumentNullException(nameof(classes));
 
             return trigger.Subscribe(x => classes.Set(name, x));
+        }
+
+        internal static void PlayClickSound(this IControl control)
+        {
+            if(control != null)
+            {
+                if((control.VisualRoot as TopLevel)?.PlatformImpl is ITopLevelImplWithSoundEffects effects)
+                {
+                    effects?.Play(SoundEffects.Click);
+                }
+            }
         }
     }
 }

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -167,6 +167,8 @@ namespace Avalonia.Controls
                 });
 
             this.Bind(DefinitionBase.PrivateSharedSizeScopeProperty, parentSharedSizeScope);
+
+            IsClickable = true;
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Platform/ITopLevelImplWithSoundEffects.cs
+++ b/src/Avalonia.Controls/Platform/ITopLevelImplWithSoundEffects.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Avalonia.Controls.Platform
+{
+    public interface ITopLevelImplWithSoundEffects
+    {
+        void Play(SoundEffects soundEffects);
+    }
+
+    public enum SoundEffects
+    {
+        Click
+    }
+}

--- a/src/Avalonia.Controls/TabItem.cs
+++ b/src/Avalonia.Controls/TabItem.cs
@@ -37,6 +37,14 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="TabItem"/> class.
+        /// </summary>
+        public TabItem()
+        {
+            IsClickable = true;
+        }
+
+        /// <summary>
         /// Gets the tab strip placement.
         /// </summary>
         /// <value>


### PR DESCRIPTION
## What does the pull request do?
Adds ability to play system sound effects. This enables controls to play a sound effect when interacted with.This feature is primarily for mobile devices, with android implemented.


## What is the current behavior?
Interactive controls do not play any sound effect as feedback when tapping them. 


## What is the updated/expected behavior with this PR?
Currently, only click effect is implemented, which is enabled by default for `Button`, `MenuItem`, and `TabItem`. Other controls can enable click sound to be played when a pointer is released by setting `IsClickable` to `true`. 


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
