### PR TITLE
perf: micro optimization

### DIFF
--- a/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
+++ b/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
@@ -178,10 +178,11 @@ namespace Avalonia.Build.Tasks
 
             var stringEquals = asm.MainModule.ImportReference(asm.MainModule.TypeSystem.String.Resolve().Methods.First(
                 m =>
-                    m.IsStatic && m.Name == "Equals" && m.Parameters.Count == 2 &&
+                    m.IsStatic && m.Name == "Equals" && m.Parameters.Count == 3 &&
                     m.ReturnType.FullName == "System.Boolean"
                     && m.Parameters[0].ParameterType.FullName == "System.String"
-                    && m.Parameters[1].ParameterType.FullName == "System.String"));
+                    && m.Parameters[1].ParameterType.FullName == "System.String"
+                    && m.Parameters[2].ParameterType.FullName == "System.StringComparison"));
             
             bool CompileGroup(IResourceGroup group)
             {
@@ -384,6 +385,7 @@ namespace Avalonia.Build.Tasks
                                 var nop = Instruction.Create(OpCodes.Nop);
                                 i.Add(Instruction.Create(OpCodes.Ldarg_0));
                                 i.Add(Instruction.Create(OpCodes.Ldstr, res.Uri));
+                                i.Add(Instruction.Create(OpCodes.Ldc_I4, (int)StringComparison.OrdinalIgnoreCase));
                                 i.Add(Instruction.Create(OpCodes.Call, stringEquals));
                                 i.Add(Instruction.Create(OpCodes.Brfalse, nop));
                                 if (parameterlessConstructor != null)

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlCompiler.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlCompiler.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
 
 
             // Before everything else
-            
+
             Transformers.Insert(0, new XNameTransformer());
             Transformers.Insert(1, new IgnoredDirectivesTransformer());
             Transformers.Insert(2, _designTransformer = new AvaloniaXamlIlDesignPropertiesTransformer());
@@ -49,7 +49,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             InsertBefore<ContentConvertTransformer>(
                 new AvaloniaXamlIlControlThemeTransformer(),
                 new AvaloniaXamlIlSelectorTransformer(),
-                new AvaloniaXamlIlControlTemplateTargetTypeMetadataTransformer(),                 
+                new AvaloniaXamlIlControlTemplateTargetTypeMetadataTransformer(),
                 new AvaloniaXamlIlBindingPathParser(),
                 new AvaloniaXamlIlPropertyPathTransformer(),
                 new AvaloniaXamlIlSetterTargetTypeMetadataTransformer(),

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
@@ -270,6 +270,27 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                 }
             }
 
+            if (type.Equals(types.Uri))
+            {
+                var uriText = text.Trim();
+
+                var kind = ((!uriText?.StartsWith("/") == true) ? UriKind.Absolute : UriKind.Relative);
+
+                if (string.IsNullOrWhiteSpace(uriText) || !Uri.TryCreate(uriText, kind, out var _))
+                {
+                        throw new XamlX.XamlLoadException($"Unable to parse text {uriText} as a {kind} uri.", node);
+                }
+                result = new XamlAstNewClrObjectNode(node
+                    , new(node, types.Uri, false)
+                    , types.UriConstructor
+                    , new List<IXamlAstValueNode>()
+                    {
+                        new XamlConstantNode(node, types.String, uriText),
+                        new XamlConstantNode(node, types.UriKind, (int)kind),
+                    });
+                return true;
+            }
+
             result = null;
             return false;
         }

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
@@ -285,7 +285,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                     , types.UriConstructor
                     , new List<IXamlAstValueNode>()
                     {
-                        new XamlConstantNode(node, types.String, uriText),
+                        new XamlConstantNode(node, context.Configuration.WellKnownTypes.String, uriText),
                         new XamlConstantNode(node, types.UriKind, (int)kind),
                     });
                 return true;

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -105,7 +105,6 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType IResourceDictionary { get; }
         public IXamlType ResourceDictionary { get; }
         public IXamlMethod ResourceDictionaryDeferredAdd { get; }
-        public IXamlType String { get; }
         public IXamlType UriKind { get; }
         public IXamlConstructor UriConstructor { get; }
 
@@ -239,9 +238,8 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                 cfg.TypeSystem.GetType("System.Func`2").MakeGenericType(
                     cfg.TypeSystem.GetType("System.IServiceProvider"),
                     XamlIlTypes.Object));
-            String = cfg.TypeSystem.GetType("System.String");
             UriKind = cfg.TypeSystem.GetType("System.UriKind");
-            UriConstructor = Uri.GetConstructor(new List<IXamlType>() { String, UriKind });
+            UriConstructor = Uri.GetConstructor(new List<IXamlType>() { cfg.WellKnownTypes.String, UriKind });
         }
     }
 

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -101,6 +101,9 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType IResourceDictionary { get; }
         public IXamlType ResourceDictionary { get; }
         public IXamlMethod ResourceDictionaryDeferredAdd { get; }
+        public IXamlType String { get; }
+        public IXamlType UriKind { get; }
+        public IXamlConstructor UriConstructor { get; }
 
         public AvaloniaXamlIlWellKnownTypes(TransformerConfiguration cfg)
         {
@@ -227,6 +230,9 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                 cfg.TypeSystem.GetType("System.Func`2").MakeGenericType(
                     cfg.TypeSystem.GetType("System.IServiceProvider"),
                     XamlIlTypes.Object));
+            String = cfg.TypeSystem.GetType("System.String");
+            UriKind = cfg.TypeSystem.GetType("System.UriKind");
+            UriConstructor = Uri.GetConstructor(new List<IXamlType>() { String, UriKind });
         }
     }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

- [perf: parse uri when xaml compiled](https://github.com/AvaloniaUI/Avalonia/commit/dd61a5d7a8cf313cddfbca0196430314d1d668c1)
- [perf: optimizze TryLoad](https://github.com/AvaloniaUI/Avalonia/commit/8da962a71decdfbd2b65df5b8fee709ad5224328)

```csharp
// Avalonia.Themes.Fluent.Controls.FluentControls
using System;
using System.Collections.Generic;
using Avalonia.Controls;
using Avalonia.Markup.Xaml.MarkupExtensions;
using Avalonia.Markup.Xaml.Styling;
using CompiledAvaloniaXaml;

static void !XamlIlPopulate(IServiceProvider P_0, FluentControls P_1)
{
	CompiledAvaloniaXaml.XamlIlContext.Context<FluentControls> context = new CompiledAvaloniaXaml.XamlIlContext.Context<FluentControls>(P_0, new object[1] { CompiledAvaloniaXaml.!AvaloniaResources.NamespaceInfo:/Controls/FluentControls.xaml.Singleton }, "avares://Avalonia.Themes.Fluent/Controls/FluentControls.xaml");
	context.RootObject = P_1;
	context.IntermediateRoot = P_1;
	FluentControls fluentControls;
	FluentControls fluentControls2 = (fluentControls = P_1);
	context.PushParent(fluentControls);
	ResourceDictionary resourceDictionary;
	ResourceDictionary resources = (resourceDictionary = new ResourceDictionary());
	context.PushParent(resourceDictionary);
	IList<IResourceProvider> mergedDictionaries = resourceDictionary.MergedDictionaries;
	ResourceInclude obj = new ResourceInclude
	{
		Source = new Uri("avares://Avalonia.Themes.Fluent/Controls/Button.xaml", UriKind.Absolute)
	};
        ...
	if (fluentControls2 is StyledElement styled)
	{
		NameScope.SetNameScope(styled, context.AvaloniaNameScope);
	}
	context.AvaloniaNameScope.Complete();
}
```

```csharp
// CompiledAvaloniaXaml.!XamlLoader
using System;
using System.ComponentModel;
using Avalonia.Markup.Xaml.XamlIl.Runtime;
using Avalonia.Themes.Fluent.Controls;
using CompiledAvaloniaXaml;

[EditorBrowsable(EditorBrowsableState.Never)]
internal class !XamlLoader
{
	public static object TryLoad(string P_0)
	{
		if (string.Equals(P_0, "avares://Avalonia.Themes.Fluent/Accents/AccentColors.xaml", StringComparison.OrdinalIgnoreCase))
		{
			return CompiledAvaloniaXaml.!AvaloniaResources.Build:/Accents/AccentColors.xaml(XamlIlRuntimeHelpers.CreateRootServiceProviderV2());
		}
	        ...
		return null;
	}
}
```

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
```csharp
// Avalonia.Themes.Fluent.Controls.FluentControls
using System;
using System.Globalization;
using Avalonia.Controls;
using Avalonia.Markup.Xaml.Converters;
using Avalonia.Markup.Xaml.Styling;
using Avalonia.Styling;
using CompiledAvaloniaXaml;

static void !XamlIlPopulate(IServiceProvider P_0, FluentControls P_1)
{
	XamlIlContext.Context<FluentControls> context = new XamlIlContext.Context<FluentControls>(P_0, new object[1] { !AvaloniaResources.NamespaceInfo:/Controls/FluentControls.xaml.Singleton }, "avares://Avalonia.Themes.Fluent/Controls/FluentControls.xaml");
	context.RootObject = P_1;
	context.IntermediateRoot = P_1;
	FluentControls fluentControls;
	FluentControls fluentControls2 = (fluentControls = P_1);
	context.PushParent(fluentControls);
	StyleInclude styleInclude;
	StyleInclude styleInclude2 = (styleInclude = new StyleInclude(context));
	context.PushParent(styleInclude);
	styleInclude.Source = (Uri)new AvaloniaUriTypeConverter().ConvertFrom(context, CultureInfo.InvariantCulture, "avares://Avalonia.Themes.Fluent/Controls/ToolTip.xaml");
	context.PopParent();
	IStyle item = styleInclude2;
	((Styles)fluentControls).Add(item);
	StyleInclude styleInclude3 = (styleInclude = new StyleInclude(context));
	context.PushParent(styleInclude);
	styleInclude.Source = (Uri)new AvaloniaUriTypeConverter().ConvertFrom(context, CultureInfo.InvariantCulture, "avares://Avalonia.Themes.Fluent/Controls/DataValidationErrors.xaml");
	context.PopParent();
	item = styleInclude3;
	((Styles)fluentControls).Add(item);
	StyleInclude styleInclude4 = (styleInclude = new StyleInclude(context));
	context.PushParent(styleInclude);
        ...
	if (fluentControls2 is StyledElement styled)
	{
		NameScope.SetNameScope(styled, context.AvaloniaNameScope);
	}
	context.AvaloniaNameScope.Complete();
}
```

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
