### PR TITLE
Build DevAnalyzers as a very first project to avoid race condition problems with MSBuild

### DIFF
--- a/dirs.proj
+++ b/dirs.proj
@@ -1,7 +1,10 @@
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <!-- Build Avalonia.Build.Tasks first because everything depends on it -->
+    <!-- First priority items because everything depends on it -->
+    <ProjectReference Include="src/tools/DevAnalyzers/DevAnalyzers.csproj" />
+    <ProjectReference Include="src/tools/DevGenerators/DevGenerators.csproj" />
     <ProjectReference Include="src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj" />
+
     <ProjectReference Include="src/**/*.*proj" />
     <ProjectReference Include="samples/**/*.*proj" />
     <ProjectReference Include="tests/**/*.*proj" />


### PR DESCRIPTION
We have randomly failed build because of DevAnalyzers.pdb being used by another process. Locally I was able to easily reproduce this issue. But not after these changes.
Let's see if it will actually help with the CI...