### PR TITLE
Minor CompiledBinding fixes

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlClrPropertyInfoHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlClrPropertyInfoHelper.cs
@@ -59,14 +59,17 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                 
                 var field = _builder.DefineField(types.IPropertyInfo, name + "!Field", false, true);
 
-                void Load(IXamlMethod m, IXamlILEmitter cg)
+                void Load(IXamlMethod m, IXamlILEmitter cg, bool passThis)
                 {
-                    cg
-                        .Ldarg_0();
-                    if (m.DeclaringType.IsValueType)
-                        cg.Unbox(m.DeclaringType);
-                    else
-                        cg.Castclass(m.DeclaringType);
+                    if (passThis)
+                    {
+                        cg
+                            .Ldarg_0();
+                        if (m.DeclaringType.IsValueType)
+                            cg.Unbox(m.DeclaringType);
+                        else
+                            cg.Castclass(m.DeclaringType);
+                    }
 
                     foreach (var indexerArg in indexerArguments)
                     {
@@ -80,7 +83,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                         new[] {types.XamlIlTypes.Object}, name + "!Getter", false, true, false);
                 if (getter != null)
                 {
-                    Load(property.Getter, getter.Generator);
+                    Load(property.Getter, getter.Generator, !property.Getter.IsStatic);
                     
                     getter.Generator.EmitCall(property.Getter);
                     if (property.Getter.ReturnType.IsValueType)
@@ -95,7 +98,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                         name + "!Setter", false, true, false);
                 if (setter != null)
                 {
-                    Load(property.Setter, setter.Generator);
+                    Load(property.Setter, setter.Generator, !property.Getter.IsStatic);
                     
                     setter.Generator.Ldarg(1);
                     if (property.Setter.Parameters[0].IsValueType)

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindings/CompiledBindingPath.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindings/CompiledBindingPath.cs
@@ -75,8 +75,9 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
         }
 
         internal IEnumerable<ICompiledBindingPathElement> Elements => _elements;
-        
-        internal SourceMode SourceMode => _elements.Count > 0 && _elements[0] is IControlSourceBindingPathElement ? SourceMode.Control : SourceMode.Data;
+
+        internal SourceMode SourceMode => _elements.OfType<IControlSourceBindingPathElement>().Any()
+            ? SourceMode.Control : SourceMode.Data;
 
         internal object RawSource { get; }
 

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -734,12 +734,12 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             {
                 var xaml = @"
 <ContentControl xmlns='https://github.com/avaloniaui'
-                Content='Hello'>
+                Focusable='True'>
     <ContentControl.Styles>
         <Style Selector='ContentControl'>
             <Setter Property='Template'>
                 <ControlTemplate>
-                    <ContentPresenter Content='{CompiledBinding Content, RelativeSource={RelativeSource TemplatedParent}}' />
+                    <ContentPresenter Focusable='{CompiledBinding !Focusable, RelativeSource={RelativeSource TemplatedParent}}' />
                 </ControlTemplate>
             </Setter>
         </Style>
@@ -747,10 +747,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </ContentControl>";
 
                 var contentControl = AvaloniaRuntimeXamlLoader.Parse<ContentControl>(xaml);
+                contentControl.DataContext = new TestDataContext(); // should be ignored
                 contentControl.Measure(new Size(10, 10));
                 
                 var result = contentControl.GetTemplateChildren().OfType<ContentPresenter>().First();
-                Assert.Equal("Hello", result.Content);
+                Assert.Equal(false, result.Focusable);
             }
         }
         
@@ -781,6 +782,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 </TextBox>";
 
                 var textBox = AvaloniaRuntimeXamlLoader.Parse<TextBox>(xaml);
+                textBox.DataContext = new TestDataContext(); // should be ignored
                 textBox.Measure(new Size(10, 10));
                 
                 var result = textBox.GetTemplateChildren().OfType<ContentPresenter>().First();

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -139,6 +139,27 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             }
         }
         
+        
+        [Fact]
+        public void ResolvesStaticClrPropertyBased()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
+        x:DataType='local:TestDataContext'>
+    <TextBlock Text='{CompiledBinding StaticProperty}' Name='textBlock' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = window.FindControl<TextBlock>("textBlock");
+                textBlock.DataContext = new TestDataContext();
+
+                Assert.Equal(TestDataContext.StaticProperty, textBlock.Text);
+            }
+        }
+        
         [Fact]
         public void ResolvesDataTypeFromBindingProperty()
         {
@@ -1716,7 +1737,9 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
         string IHasExplicitProperty.ExplicitProperty => "Hello"; 
 
-        public string ExplicitProperty => "Bye"; 
+        public string ExplicitProperty => "Bye";
+
+        public static string StaticProperty => "World"; 
 
         public class NonIntegerIndexer : NotifyingBase, INonIntegerIndexerDerived
         {


### PR DESCRIPTION
## What does the pull request do?

Two fixes:
1. Syntax like "{Binding !$self.IsVisible}" would try to resolve "IsVisible" from the DataContext instead of actual $self. Affected also templated parent bindings.
2. Static properties in bindings. As useless as it sounds, it should at least work (or better throw compiled time, but we can do it later).

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Fixed issues

Fixes #9459
Fixes #9449
