### PR TITLE
Added BorderCompositionVisual with custom clipping and render ordering

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionDrawListVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionDrawListVisual.cs
@@ -59,12 +59,17 @@ internal class ServerCompositionDrawListVisual : ServerCompositionContainerVisua
         base.DeserializeChangesCore(reader, commitedAt);
     }
 
-    protected override void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip)
+    protected void RenderSelf(CompositorDrawingContextProxy canvas)
     {
         if (_renderCommands != null)
         {
             _renderCommands.Render(canvas);
         }
+    }
+    
+    protected override void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip)
+    {
+        RenderSelf(canvas);
         base.RenderCore(canvas, currentTransformedClip);
     }
     

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.cs
@@ -48,7 +48,7 @@ namespace Avalonia.Rendering.Composition.Server
             if (Opacity != 1)
                 canvas.PushOpacity(Opacity);
             var boundsRect = new Rect(new Size(Size.X, Size.Y));
-            if(ClipToBounds)
+            if (ClipToBounds && !HandlesClipToBounds)
                 canvas.PushClip(Root!.SnapToDevicePixels(boundsRect));
             if (Clip != null) 
                 canvas.PushGeometryClip(Clip);
@@ -65,11 +65,13 @@ namespace Avalonia.Rendering.Composition.Server
                 canvas.PopOpacityMask();
             if (Clip != null)
                 canvas.PopGeometryClip();
-            if (ClipToBounds)
+            if (ClipToBounds && !HandlesClipToBounds)
                 canvas.PopClip();
             if(Opacity != 1)
                 canvas.PopOpacity();
         }
+
+        protected virtual bool HandlesClipToBounds => false;
         
         private ReadbackData _readback0, _readback1, _readback2;
 

--- a/src/Avalonia.Base/Visual.cs
+++ b/src/Avalonia.Base/Visual.cs
@@ -452,12 +452,15 @@ namespace Avalonia
             }
         }
 
+        private protected virtual CompositionDrawListVisual CreateCompositionVisual(Compositor compositor)
+            => new CompositionDrawListVisual(compositor,
+                new ServerCompositionDrawListVisual(compositor.Server, this), this);
+        
         internal CompositionVisual AttachToCompositor(Compositor compositor)
         {
             if (CompositionVisual == null || CompositionVisual.Compositor != compositor)
             {
-                CompositionVisual = new CompositionDrawListVisual(compositor,
-                    new ServerCompositionDrawListVisual(compositor.Server, this), this);
+                CompositionVisual = CreateCompositionVisual(compositor);
             }
 
             return CompositionVisual;

--- a/src/Avalonia.Controls/Border.cs
+++ b/src/Avalonia.Controls/Border.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Utils;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Rendering.Composition;
 using Avalonia.Utilities;
 using Avalonia.VisualTree;
 
@@ -73,6 +74,7 @@ namespace Avalonia.Controls
         private readonly BorderRenderHelper _borderRenderHelper = new BorderRenderHelper();
         private Thickness? _layoutThickness;
         private double _scale;
+        private CompositionBorderVisual? _borderVisual;
 
         /// <summary>
         /// Initializes static members of the <see cref="Border"/> class.
@@ -100,6 +102,10 @@ namespace Avalonia.Controls
                 case nameof(UseLayoutRounding):
                 case nameof(BorderThickness):
                     _layoutThickness = null;
+                    break;
+                case nameof(CornerRadius):
+                    if (_borderVisual != null)
+                        _borderVisual.CornerRadius = CornerRadius;
                     break;
             }
         }
@@ -243,6 +249,14 @@ namespace Avalonia.Controls
         protected override Size ArrangeOverride(Size finalSize)
         {
             return LayoutHelper.ArrangeChild(Child, finalSize, Padding, BorderThickness);
+        }
+
+        private protected override CompositionDrawListVisual CreateCompositionVisual(Compositor compositor)
+        {
+            return new CompositionBorderVisual(compositor, this)
+            {
+                CornerRadius = CornerRadius
+            };
         }
 
         public CornerRadius ClipToBoundsRadius => CornerRadius;

--- a/src/Avalonia.Controls/BorderVisual.cs
+++ b/src/Avalonia.Controls/BorderVisual.cs
@@ -1,0 +1,79 @@
+using System;
+using Avalonia.Rendering.Composition;
+using Avalonia.Rendering.Composition.Server;
+using Avalonia.Rendering.Composition.Transport;
+
+namespace Avalonia.Controls;
+
+class CompositionBorderVisual : CompositionDrawListVisual
+{
+    private CornerRadius _cornerRadius;
+    private bool _cornerRadiusChanged;
+    
+    public CompositionBorderVisual(Compositor compositor, Visual visual) : base(compositor,
+        new ServerBorderVisual(compositor.Server, visual), visual)
+    {
+    }
+
+    public CornerRadius CornerRadius
+    {
+        get => _cornerRadius;
+        set
+        {
+            if (_cornerRadius != value)
+            {
+                _cornerRadiusChanged = true;
+                _cornerRadius = value;
+                RegisterForSerialization();
+            }
+        }
+    }
+
+    private protected override void SerializeChangesCore(BatchStreamWriter writer)
+    {
+        base.SerializeChangesCore(writer);
+        writer.Write(_cornerRadiusChanged);
+        if (_cornerRadiusChanged)
+            writer.Write(_cornerRadius);
+    }
+
+    class ServerBorderVisual : ServerCompositionDrawListVisual
+    {
+        private CornerRadius _cornerRadius;
+        public ServerBorderVisual(ServerCompositor compositor, Visual v) : base(compositor, v)
+        {
+        }
+
+        protected override void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip)
+        {
+            if (ClipToBounds)
+            {
+                var rect = Root!.SnapToDevicePixels(new Rect(new Size(Size.X, Size.Y)));
+                if (_cornerRadius.IsEmpty)
+                    canvas.PushClip(rect);
+                else
+                    canvas.PushClip(new RoundedRect(rect, _cornerRadius));
+            }
+            
+            foreach (var ch in Children)
+            {
+                ch.Render(canvas, currentTransformedClip);
+            }
+
+            if (ClipToBounds)
+                canvas.PopClip();
+            
+            RenderSelf(canvas);
+        }
+
+        protected override void DeserializeChangesCore(BatchStreamReader reader, TimeSpan commitedAt)
+        {
+            base.DeserializeChangesCore(reader, commitedAt);
+            if (reader.Read<bool>())
+                _cornerRadius = reader.Read<CornerRadius>();
+        }
+
+        protected override bool HandlesClipToBounds => true;
+    }
+
+}


### PR DESCRIPTION
```xml
<Border CornerRadius="60" BorderBrush="Blue" BorderThickness="20" ClipToBounds="True">
  <Border Background="Red" Width="400" Height="200"/>
</Border>
```

DeferredRenderer:
![image](https://user-images.githubusercontent.com/1067584/202923920-b39ba643-4ca9-45e6-aa1e-484518ed23b1.png)

CompositingRenderer:
![image](https://user-images.githubusercontent.com/1067584/202923927-79a658f6-b6fd-4a2b-8a65-9bc1488b4919.png)


This is implemented by custom rendering logic which draws the border on top of the children rather than below them.


Fixes #2105, #8916