### PR TITLE
Fix SelectionChanged event unsubscribtions

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -1296,7 +1296,7 @@ namespace Avalonia.Controls
         public event EventHandler<SelectionChangedEventArgs> SelectionChanged
         {
             add { AddHandler(SelectionChangedEvent, value); }
-            remove { AddHandler(SelectionChangedEvent, value); }
+            remove { RemoveHandler(SelectionChangedEvent, value); }
         }
 
         /// <summary>


### PR DESCRIPTION
## What does the pull request do?
That change fix very tricky bug. Our case:
We have DataTemplate that contains DataGrid inside it. And Datagrid has an AttachedProperty (that deserve us to observe changes in Datagrid's SelectedItems). which  work through event subscription. Memory leaks happen (and the logic for observe selected items breaks) when DataTemplate switches DataContext.

