### PR TITLE
fix logic that was broken accidentally in #9553

### DIFF
--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -461,7 +461,7 @@ namespace Avalonia.Controls.Platform
         {
             if (Menu?.IsOpen == true)
             {
-                if (e.Source is ILogical control && Menu.IsLogicalAncestorOf(control))
+                if (e.Source is ILogical control && !Menu.IsLogicalAncestorOf(control))
                 {
                     Menu.Close();
                 }


### PR DESCRIPTION
#9553 accidentally removed a '!' in defaultmenuinterfactionhandler.