### PR TITLE
Xamlinclude fix

### DIFF
--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -80,7 +80,7 @@
 
   <Target
     Name="CompileAvaloniaXaml"
-    AfterTargets="CoreCompile"
+    AfterTargets="AfterCompile"
     Condition="Exists('@(IntermediateAssembly)') And $(DesignTimeBuild) != true And $(EnableAvaloniaXamlCompilation) != false"
     >
     <PropertyGroup>

--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -80,7 +80,7 @@
 
   <Target
     Name="CompileAvaloniaXaml"
-    AfterTargets="AfterCompile"
+    AfterTargets="CoreCompile"
     Condition="Exists('@(IntermediateAssembly)') And $(DesignTimeBuild) != true And $(EnableAvaloniaXamlCompilation) != false"
     >
     <PropertyGroup>

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
@@ -274,7 +274,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             {
                 var uriText = text.Trim();
 
-                var kind = ((!uriText?.StartsWith("/") == true) ? UriKind.Absolute : UriKind.Relative);
+                var kind = ((!uriText?.StartsWith("/") == true) ? UriKind.RelativeOrAbsolute : UriKind.Relative);
 
                 if (string.IsNullOrWhiteSpace(uriText) || !Uri.TryCreate(uriText, kind, out var _))
                 {

--- a/src/Markup/Avalonia.Markup.Xaml/Converters/AvaloniaUriTypeConverter.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Converters/AvaloniaUriTypeConverter.cs
@@ -17,7 +17,7 @@ namespace Avalonia.Markup.Xaml.Converters
             if (s == null)
                 return null;
             //On Unix Uri tries to interpret paths starting with "/" as file Uris
-            var kind = s.StartsWith("/") ? UriKind.Relative : UriKind.Absolute;
+            var kind = s.StartsWith("/") ? UriKind.Relative : UriKind.RelativeOrAbsolute;
             if (!Uri.TryCreate(s, kind, out var res))
                 throw new ArgumentException("Unable to parse URI: " + s);
             return res;

--- a/src/Markup/Avalonia.Markup.Xaml/Styling/ResourceInclude.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Styling/ResourceInclude.cs
@@ -42,7 +42,8 @@ namespace Avalonia.Markup.Xaml.Styling
                 if (_loaded == null)
                 {
                     _isLoading = true;
-                    _loaded = (IResourceDictionary)AvaloniaXamlLoader.Load(Source, _baseUri);
+                    var source = Source ?? throw new InvalidOperationException("ResourceInclude.Source must be set.");
+                    _loaded = (IResourceDictionary)AvaloniaXamlLoader.Load(source, _baseUri);
                     _isLoading = false;
                 }
 

--- a/src/Markup/Avalonia.Markup.Xaml/Styling/StyleInclude.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Styling/StyleInclude.cs
@@ -51,7 +51,8 @@ namespace Avalonia.Markup.Xaml.Styling
                 if (_loaded == null)
                 {
                     _isLoading = true;
-                    var loaded = (IStyle)AvaloniaXamlLoader.Load(Source, _baseUri);
+                    var source = Source ?? throw new InvalidOperationException("StyleInclude.Source must be set.");
+                    var loaded = (IStyle)AvaloniaXamlLoader.Load(source, _baseUri);
                     _loaded = new[] { loaded };
                     _isLoading = false;
                 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleIncludeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleIncludeTests.cs
@@ -79,7 +79,35 @@ public class StyleIncludeTests
     }
     
     [Fact]
-    public void Relative_StyleInclude_Is_Resolved_With_Two_Files()
+    public void Relative_Back_StyleInclude_Is_Resolved_With_Two_Files()
+    {
+        var documents = new[]
+        {
+            new RuntimeXamlLoaderDocument(new Uri("avares://Tests/Subfolder/Style.xaml"), @"
+<Style xmlns='https://github.com/avaloniaui'
+       xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <Style.Resources>
+        <Color x:Key='Red'>Red</Color>
+    </Style.Resources>
+</Style>"),
+            new RuntimeXamlLoaderDocument(new Uri("avares://Tests/Subfolder/Folder/Root.xaml"), @"
+<ContentControl xmlns='https://github.com/avaloniaui'
+                xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <ContentControl.Resources>
+        <StyleInclude x:Key='Include' Source='../Style.xaml'/>
+    </ContentControl.Resources>
+</ContentControl>")
+        };
+        
+        var objects = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
+        var style = Assert.IsType<Style>(objects[0]);
+        var contentControl = Assert.IsType<ContentControl>(objects[1]);
+
+        Assert.IsType<Style>(contentControl.Resources["Include"]);
+    }
+    
+    [Fact]
+    public void Relative_Root_StyleInclude_Is_Resolved_With_Two_Files()
     {
         var documents = new[]
         {
@@ -94,7 +122,63 @@ public class StyleIncludeTests
 <ContentControl xmlns='https://github.com/avaloniaui'
                 xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
     <ContentControl.Resources>
-        <StyleInclude x:Key='Include' Source='/../Style.xaml'/>
+        <StyleInclude x:Key='Include' Source='/Style.xaml'/>
+    </ContentControl.Resources>
+</ContentControl>")
+        };
+        
+        var objects = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
+        var style = Assert.IsType<Style>(objects[0]);
+        var contentControl = Assert.IsType<ContentControl>(objects[1]);
+
+        Assert.IsType<Style>(contentControl.Resources["Include"]);
+    }
+    
+    [Fact]
+    public void Relative_StyleInclude_Is_Resolved_With_Two_Files()
+    {
+        var documents = new[]
+        {
+            new RuntimeXamlLoaderDocument(new Uri("avares://Tests/Folder/Style.xaml"), @"
+<Style xmlns='https://github.com/avaloniaui'
+       xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <Style.Resources>
+        <Color x:Key='Red'>Red</Color>
+    </Style.Resources>
+</Style>"),
+            new RuntimeXamlLoaderDocument(new Uri("avares://Tests/Folder/Root.xaml"), @"
+<ContentControl xmlns='https://github.com/avaloniaui'
+                xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <ContentControl.Resources>
+        <StyleInclude x:Key='Include' Source='Style.xaml'/>
+    </ContentControl.Resources>
+</ContentControl>")
+        };
+        
+        var objects = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
+        var style = Assert.IsType<Style>(objects[0]);
+        var contentControl = Assert.IsType<ContentControl>(objects[1]);
+
+        Assert.IsType<Style>(contentControl.Resources["Include"]);
+    }
+    
+    [Fact]
+    public void Relative_Dot_Syntax__StyleInclude_Is_Resolved_With_Two_Files()
+    {
+        var documents = new[]
+        {
+            new RuntimeXamlLoaderDocument(new Uri("avares://Tests/Folder/Style.xaml"), @"
+<Style xmlns='https://github.com/avaloniaui'
+       xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <Style.Resources>
+        <Color x:Key='Red'>Red</Color>
+    </Style.Resources>
+</Style>"),
+            new RuntimeXamlLoaderDocument(new Uri("avares://Tests/Folder/Root.xaml"), @"
+<ContentControl xmlns='https://github.com/avaloniaui'
+                xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <ContentControl.Resources>
+        <StyleInclude x:Key='Include' Source='./Style.xaml'/>
     </ContentControl.Resources>
 </ContentControl>")
         };


### PR DESCRIPTION
Two problems:

- Relative paths aren't working exactly how they work in wpf
- Class-xaml files weren't resolved from the ref assemblies properly.