### PR TITLE
bugfix: Avoid compositor issue of CalendarDatePicker

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/CalendarButton.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/CalendarButton.xaml
@@ -35,13 +35,13 @@
           <!-- To mimic WinUI SystemFocusVisual, Focus visual is drawn outside the bounds of the item -->
           <Border Name="Root" Background="{TemplateBinding Background}"
                   BorderThickness="0" ClipToBounds="True">
-            <ContentControl Name="Content"
-                            ContentTemplate="{TemplateBinding ContentTemplate}"
-                            Content="{TemplateBinding Content}"
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            FontSize="{TemplateBinding FontSize}"
-                            Margin="{TemplateBinding Padding}" />
+            <ContentPresenter Name="Content"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                              Content="{TemplateBinding Content}"
+                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                              FontSize="{TemplateBinding FontSize}"
+                              Margin="{TemplateBinding Padding}" />
           </Border>
 
           <!-- Drawn Border should render on top of background to preserve the 1px margin between items -->
@@ -70,7 +70,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource CalendarViewSelectedBorderBrush}" />
       </Style>
 
-      <Style Selector="^ /template/ ContentControl#Content">
+      <Style Selector="^ /template/ ContentPresenter#Content">
         <Setter Property="Foreground" Value="{DynamicResource CalendarViewTodayForeground}" />
         <Setter Property="FontWeight" Value="SemiBold" />
       </Style>

--- a/src/Avalonia.Themes.Simple/Controls/CalendarButton.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/CalendarButton.xaml
@@ -32,14 +32,14 @@
                      Opacity="0.5" />
 
           <!--  Focusable="False"  -->
-          <ContentControl Name="Content"
-                          Margin="1,0,1,1"
-                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                          Content="{TemplateBinding Content}"
-                          ContentTemplate="{TemplateBinding ContentTemplate}"
-                          FontSize="{TemplateBinding FontSize}"
-                          Foreground="{TemplateBinding Foreground}" />
+          <ContentPresenter Name="Content"
+                            Margin="1,0,1,1"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            FontSize="{TemplateBinding FontSize}"
+                            Foreground="{TemplateBinding Foreground}" />
 
           <Rectangle Name="FocusVisual"
                      IsHitTestVisible="False"
@@ -62,7 +62,7 @@
       <Setter Property="IsVisible" Value="True" />
     </Style>
 
-    <Style Selector="^:inactive /template/ ContentControl#Content">
+    <Style Selector="^:inactive /template/ ContentPresenter#Content">
       <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundLowBrush}" />
     </Style>
 


### PR DESCRIPTION
## What does the pull request do?
We met the same issue in #8864, but I found one way to avoid the compositor issue of CalendarDatePicker

## What is the current behavior?
As described in #8864.

## What is the updated/expected behavior with this PR?
Calendar month names shown as normal.
Tested on both Fluent and Simple Theme.
![SimpleLight](https://user-images.githubusercontent.com/7337992/205007104-79561342-9f68-4261-9031-5bb2e27746b0.gif)
![FluentLight](https://user-images.githubusercontent.com/7337992/205007151-e4d91d45-77f7-42eb-94c9-8af2a71c5130.gif)


## How was the solution implemented (if it's not obvious)?
Replace ContentControl to ContentPresenter

## Checklist

~~- [ ] Added unit tests (if possible)?~~
~~- [ ] Added XML documentation to any related classes?~~
~~- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation~~


## Fixed issues
Fixes #8864
