### PR TITLE
Ensure Invariant Culture Rules in Relevant String Interpolation

### DIFF
--- a/src/Avalonia.Base/CornerRadius.cs
+++ b/src/Avalonia.Base/CornerRadius.cs
@@ -100,7 +100,7 @@ namespace Avalonia
 
         public override string ToString()
         {
-            return $"{TopLeft},{TopRight},{BottomRight},{BottomLeft}";
+            return FormattableString.Invariant($"{TopLeft},{TopRight},{BottomRight},{BottomLeft}");
         }
 
         public static CornerRadius Parse(string s)

--- a/src/Avalonia.Base/Media/ArcSegment.cs
+++ b/src/Avalonia.Base/Media/ArcSegment.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 
 namespace Avalonia.Media
@@ -100,6 +101,6 @@ namespace Avalonia.Media
         }
 
         public override string ToString()
-            => $"A {Size} {RotationAngle.ToString(CultureInfo.InvariantCulture)} {(IsLargeArc ? 1 : 0)} {(int)SweepDirection} {Point}";
+            => FormattableString.Invariant($"A {Size} {RotationAngle} {(IsLargeArc ? 1 : 0)} {(int)SweepDirection} {Point}");
     }
 }

--- a/src/Avalonia.Base/Media/BezierSegment .cs
+++ b/src/Avalonia.Base/Media/BezierSegment .cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Avalonia.Media
 {
     public sealed class BezierSegment : PathSegment
@@ -60,6 +62,6 @@ namespace Avalonia.Media
         }
 
         public override string ToString()
-            => $"C {Point1} {Point2} {Point3}";
+            => FormattableString.Invariant($"C {Point1} {Point2} {Point3}");
     }
 }

--- a/src/Avalonia.Base/Media/BoxShadow.cs
+++ b/src/Avalonia.Base/Media/BoxShadow.cs
@@ -94,22 +94,22 @@ namespace Avalonia.Media
 
             if (OffsetX != 0.0)
             {
-                sb.AppendFormat(" {0}", OffsetX.ToString());
+                sb.AppendFormat(" {0}", OffsetX.ToString(CultureInfo.InvariantCulture));
             }
 
             if (OffsetY != 0.0)
             {
-                sb.AppendFormat(" {0}", OffsetY.ToString());
+                sb.AppendFormat(" {0}", OffsetY.ToString(CultureInfo.InvariantCulture));
             }
             
             if (Blur != 0.0)
             {
-                sb.AppendFormat(" {0}", Blur.ToString());
+                sb.AppendFormat(" {0}", Blur.ToString(CultureInfo.InvariantCulture));
             }
 
             if (Spread != 0.0)
             {
-                sb.AppendFormat(" {0}", Spread.ToString());
+                sb.AppendFormat(" {0}", Spread.ToString(CultureInfo.InvariantCulture));
             }
 
             sb.AppendFormat(" {0}", Color.ToString());

--- a/src/Avalonia.Base/Media/LineSegment.cs
+++ b/src/Avalonia.Base/Media/LineSegment.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Avalonia.Media
 {
     public sealed class LineSegment : PathSegment
@@ -26,6 +28,6 @@ namespace Avalonia.Media
         }
 
         public override string ToString()
-            => $"L {Point}";
+            => FormattableString.Invariant($"L {Point}");
     }
 }

--- a/src/Avalonia.Base/Media/PathFigure.cs
+++ b/src/Avalonia.Base/Media/PathFigure.cs
@@ -126,7 +126,7 @@ namespace Avalonia.Media
         }
         
         public override string ToString()
-            => $"M {StartPoint} {string.Join(" ", _segments ?? Enumerable.Empty<PathSegment>())}{(IsClosed ? "Z" : "")}";
+            => FormattableString.Invariant($"M {StartPoint} {string.Join(" ", _segments ?? Enumerable.Empty<PathSegment>())}{(IsClosed ? "Z" : "")}");
 
         internal void ApplyTo(StreamGeometryContext ctx)
         {

--- a/src/Avalonia.Base/Media/PathGeometry.cs
+++ b/src/Avalonia.Base/Media/PathGeometry.cs
@@ -133,7 +133,7 @@ namespace Avalonia.Media
         public override string ToString()
         {
             var figuresString = _figures is not null ? string.Join(" ", _figures) : string.Empty;
-            return $"{(FillRule != FillRule.EvenOdd ? "F1 " : "")}{figuresString}";
+            return FormattableString.Invariant($"{(FillRule != FillRule.EvenOdd ? "F1 " : "")}{figuresString}");
         }
     }
 }

--- a/src/Avalonia.Base/Media/QuadraticBezierSegment .cs
+++ b/src/Avalonia.Base/Media/QuadraticBezierSegment .cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Avalonia.Media
 {
     public sealed class QuadraticBezierSegment : PathSegment
@@ -44,6 +46,6 @@ namespace Avalonia.Media
         }
 
         public override string ToString()
-            => $"Q {Point1} {Point2}";
+            => FormattableString.Invariant($"Q {Point1} {Point2}");
     }
 }

--- a/src/Avalonia.Base/RelativePoint.cs
+++ b/src/Avalonia.Base/RelativePoint.cs
@@ -199,7 +199,7 @@ namespace Avalonia
         {
             return _unit == RelativeUnit.Absolute ?
                 _point.ToString() :
-                 string.Format(CultureInfo.InvariantCulture, "{0}%, {1}%", _point.X * 100, _point.Y * 100);
+                string.Format(CultureInfo.InvariantCulture, "{0}%, {1}%", _point.X * 100, _point.Y * 100);
         }
     }
 }

--- a/src/Avalonia.Base/Rendering/Composition/Server/FpsCounter.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/FpsCounter.cs
@@ -52,7 +52,7 @@ internal class FpsCounter
             _lastFpsUpdate = now;
         }
 
-        var fpsLine = $"Frame #{_totalFrames:00000000} FPS: {_fps:000} " + aux;
+        var fpsLine = FormattableString.Invariant($"Frame #{_totalFrames:00000000} FPS: {_fps:000} ") + aux;
         double width = 0;
         double height = 0;
         foreach (var ch in fpsLine)

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -156,7 +156,7 @@ namespace Avalonia.Rendering.Composition.Server
                         (Compositor.BatchObjectPool.CurrentUsage + Compositor.BatchObjectPool.CurrentPool) *
                                                                      Compositor.BatchObjectPool.ArraySize *
                                                                      IntPtr.Size), false);
-                    _fpsCounter.RenderFps(targetContext, $"M:{managedMem} / N:{nativeMem} R:{RenderedVisuals:0000}");
+                    _fpsCounter.RenderFps(targetContext, FormattableString.Invariant($"M:{managedMem} / N:{nativeMem} R:{RenderedVisuals:0000}"));
                 }
                 RenderedVisuals = 0;
 

--- a/src/Avalonia.Base/Rendering/DeferredRenderer.cs
+++ b/src/Avalonia.Base/Rendering/DeferredRenderer.cs
@@ -725,7 +725,7 @@ namespace Avalonia.Rendering
 
             foreach (var layer in Layers)
             {
-                var fileName = Path.Combine(DebugFramesPath ?? string.Empty, $"frame-{id}-layer-{index++}.png");
+                var fileName = Path.Combine(DebugFramesPath ?? string.Empty, FormattableString.Invariant($"frame-{id}-layer-{index++}.png"));
                 layer.Bitmap.Item.Save(fileName);
             }
         }

--- a/src/Avalonia.Base/Rendering/RendererBase.cs
+++ b/src/Avalonia.Base/Rendering/RendererBase.cs
@@ -36,7 +36,7 @@ namespace Avalonia.Rendering
                 _lastFpsUpdate = now;
             }
 
-            var text = layerCount.HasValue ? $"Layers: {layerCount} FPS: {_fps:000}" : $"FPS: {_fps:000}";
+            var text = layerCount.HasValue ? FormattableString.Invariant($"Layers: {layerCount} FPS: {_fps:000}") : FormattableString.Invariant($"FPS: {_fps:000}");
 
             var formattedText = new FormattedText(text, CultureInfo.CurrentCulture, FlowDirection.LeftToRight, Typeface.Default, s_fontSize, Brushes.White);
 

--- a/src/Avalonia.Base/Thickness.cs
+++ b/src/Avalonia.Base/Thickness.cs
@@ -277,7 +277,7 @@ namespace Avalonia
         /// <returns>The string representation of the thickness.</returns>
         public override string ToString()
         {
-            return $"{_left},{_top},{_right},{_bottom}";
+            return FormattableString.Invariant($"{_left},{_top},{_right},{_bottom}");
         }
 
         /// <summary>

--- a/src/Avalonia.Base/VisualTree/TransformedBounds.cs
+++ b/src/Avalonia.Base/VisualTree/TransformedBounds.cs
@@ -77,6 +77,6 @@ namespace Avalonia.VisualTree
             return !left.Equals(right);
         }
 
-        public override string ToString() => $"Bounds: {Bounds} Clip: {Clip} Transform {Transform}";
+        public override string ToString() => FormattableString.Invariant($"Bounds: {Bounds} Clip: {Clip} Transform {Transform}");
     }
 }

--- a/src/Avalonia.Build.Tasks/Extensions.cs
+++ b/src/Avalonia.Build.Tasks/Extensions.cs
@@ -5,7 +5,7 @@ namespace Avalonia.Build.Tasks
 {
     static class Extensions
     {
-        static string FormatErrorCode(BuildEngineErrorCode code) => $"AVLN:{(int)code:0000}";
+        static string FormatErrorCode(BuildEngineErrorCode code) => FormattableString.Invariant($"AVLN:{(int)code:0000}");
 
         public static void LogError(this IBuildEngine engine, BuildEngineErrorCode code, string file, Exception ex,
             int lineNumber = 0, int linePosition = 0)

--- a/src/Avalonia.Build.Tasks/GenerateAvaloniaResourcesTask.cs
+++ b/src/Avalonia.Build.Tasks/GenerateAvaloniaResourcesTask.cs
@@ -67,7 +67,7 @@ namespace Avalonia.Build.Tasks
            {
               
                var src = new Source(r.ItemSpec, Root);
-               BuildEngine.LogMessage($"avares -> name:{src.Path}, path: {src.SystemPath}, size:{src.Size}, ItemSpec:{r.ItemSpec}", _reportImportance);
+               BuildEngine.LogMessage(FormattableString.Invariant($"avares -> name:{src.Path}, path: {src.SystemPath}, size:{src.Size}, ItemSpec:{r.ItemSpec}"), _reportImportance);
                return src;
            }).ToList();
 

--- a/src/Avalonia.Controls/DateTimePickers/DateTimePickerPanel.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DateTimePickerPanel.cs
@@ -259,7 +259,7 @@ namespace Avalonia.Controls.Primitives
                 SelectedValue = (int)newSel * Increment + MinimumValue;
                 _suppressUpdateOffset = false;
 
-                System.Diagnostics.Debug.WriteLine($"Offset: {_offset} ItemHeight: {ItemHeight}");
+                System.Diagnostics.Debug.WriteLine(FormattableString.Invariant($"Offset: {_offset} ItemHeight: {ItemHeight}"));
             }
         }
 

--- a/src/Avalonia.Controls/Selection/IndexRange.cs
+++ b/src/Avalonia.Controls/Selection/IndexRange.cs
@@ -86,7 +86,7 @@ namespace Avalonia.Controls.Selection
             return hashCode;
         }
 
-        public override string ToString() => $"[{Begin}..{End}]";
+        public override string ToString() => FormattableString.Invariant($"[{Begin}..{End}]");
 
         public static bool operator ==(IndexRange left, IndexRange right) => left.Equals(right);
         public static bool operator !=(IndexRange left, IndexRange right) => !(left == right);

--- a/src/Avalonia.DesignerSupport/Remote/HtmlTransport/HtmlTransport.cs
+++ b/src/Avalonia.DesignerSupport/Remote/HtmlTransport/HtmlTransport.cs
@@ -162,7 +162,7 @@ namespace Avalonia.DesignerSupport.Remote.HtmlTransport
                     if (sendNow != null && socket != null)
                     {
                         await socket.SendMessage(
-                            $"frame:{sendNow.SequenceId}:{sendNow.Width}:{sendNow.Height}:{sendNow.Stride}:{sendNow.DpiX}:{sendNow.DpiY}");
+                            FormattableString.Invariant($"frame:{sendNow.SequenceId}:{sendNow.Width}:{sendNow.Height}:{sendNow.Stride}:{sendNow.DpiX}:{sendNow.DpiY}"));
                         await socket.SendMessage(false, sendNow.Data);
                     }
 

--- a/src/Avalonia.DesignerSupport/Remote/HtmlTransport/SimpleWebSocketHttpServer.cs
+++ b/src/Avalonia.DesignerSupport/Remote/HtmlTransport/SimpleWebSocketHttpServer.cs
@@ -146,7 +146,7 @@ namespace Avalonia.DesignerSupport.Remote.HtmlTransport
 
         public async Task RespondAsync(int code, byte[] data, string contentType)
         {
-            var headers = Encoding.UTF8.GetBytes($"HTTP/1.1 {code} {(HttpStatusCode)code}\r\nConnection: close\r\nContent-Type: {contentType}\r\nContent-Length: {data.Length}\r\n\r\n");
+            var headers = Encoding.UTF8.GetBytes(FormattableString.Invariant($"HTTP/1.1 {code} {(HttpStatusCode)code}\r\nConnection: close\r\nContent-Type: {contentType}\r\nContent-Length: {data.Length}\r\n\r\n"));
             await _stream.WriteAsync(headers, 0, headers.Length);
             await _stream.WriteAsync(data, 0, data.Length);
             _stream.Dispose();

--- a/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
+++ b/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
@@ -127,7 +127,7 @@ namespace Avalonia.FreeDesktop
             var pid = Process.GetCurrentProcess().Id;
             var tid = s_trayIconInstanceId++;
 
-            _sysTrayServiceName = $"org.kde.StatusNotifierItem-{pid}-{tid}";
+            _sysTrayServiceName = FormattableString.Invariant($"org.kde.StatusNotifierItem-{pid}-{tid}");
             _statusNotifierItemDbusObj = new StatusNotifierItemDbusObj(_dbusMenuPath);
 
             try

--- a/src/Browser/Avalonia.Browser/Cursor.cs
+++ b/src/Browser/Avalonia.Browser/Cursor.cs
@@ -20,9 +20,9 @@ namespace Avalonia.Browser
         /// </summary>
         public CssCursor(string base64, string format, PixelPoint hotspot, StandardCursorType fallback)
         {
-            Value = $"url(\"data:image/{format};base64,{base64}\") {hotspot.X} {hotspot.Y}, {ToKeyword(fallback)}";
+            Value = FormattableString.Invariant($"url(\"data:image/{format};base64,{base64}\") {hotspot.X} {hotspot.Y}, {ToKeyword(fallback)}");
         }
-        
+
         /// <summary>
         /// Create a cursor from url to *.cur file.
         /// </summary>
@@ -30,15 +30,15 @@ namespace Avalonia.Browser
         {
             Value = $"url('{url}'), {ToKeyword(fallback)}";
         }
-        
+
         /// <summary>
         /// Create a cursor from png/svg and hotspot position
         /// </summary>
         public CssCursor(string url, PixelPoint hotSpot, StandardCursorType fallback)
         {
-            Value = $"url('{url}') {hotSpot.X} {hotSpot.Y}, {ToKeyword(fallback)}";
+            Value = FormattableString.Invariant($"url('{url}') {hotSpot.X} {hotSpot.Y}, {ToKeyword(fallback)}");
         }
-        
+
         private static string ToKeyword(StandardCursorType type) => type switch
         {
             StandardCursorType.Hand => "pointer",
@@ -49,16 +49,16 @@ namespace Avalonia.Browser
             StandardCursorType.None => "none",
             StandardCursorType.Wait => "progress",
             StandardCursorType.AppStarting => "wait",
-            
+
             StandardCursorType.DragMove => "move",
             StandardCursorType.DragCopy => "copy",
             StandardCursorType.DragLink => "alias",
-            
+
             StandardCursorType.UpArrow => "default",/*not found matching one*/
             StandardCursorType.SizeWestEast => "ew-resize",
             StandardCursorType.SizeNorthSouth => "ns-resize",
             StandardCursorType.SizeAll => "move",
-            
+
             StandardCursorType.TopSide => "n-resize",
             StandardCursorType.BottomSide => "s-resize",
             StandardCursorType.LeftSide => "w-resize",
@@ -67,10 +67,10 @@ namespace Avalonia.Browser
             StandardCursorType.TopRightCorner => "ne-resize",
             StandardCursorType.BottomLeftCorner => "sw-resize",
             StandardCursorType.BottomRightCorner => "se-resize",
-            
+
             _ => Default,
         };
-        
+
         public void Dispose() {}
     }
 

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindings/CompiledBindingPath.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindings/CompiledBindingPath.cs
@@ -275,7 +275,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
         public int Level { get; }
 
         public override string ToString()
-           => $"$parent[{AncestorType?.Name},{Level}]";
+           => FormattableString.Invariant($"$parent[{AncestorType?.Name},{Level}]");
     }
 
     internal class VisualAncestorPathElement : ICompiledBindingPathElement, IControlSourceBindingPathElement
@@ -316,7 +316,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
         public int[] Indices { get; }
         public Type ElementType { get; }
         public override string ToString()
-            => $"[{string.Join(",", Indices)}]";
+            => FormattableString.Invariant($"[{string.Join(",", Indices)}]");
     }
 
     internal class TypeCastPathElement<T> : ITypeCastElement

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindings/FindVisualAncestorNode.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindings/FindVisualAncestorNode.cs
@@ -22,11 +22,11 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
             {
                 if (_ancestorType == null)
                 {
-                    return $"$visualparent[{_level}]";
+                    return FormattableString.Invariant($"$visualparent[{_level}]");
                 }
                 else
                 {
-                    return $"$visualparent[{_ancestorType.Name}, {_level}]";
+                    return FormattableString.Invariant($"$visualparent[{_ancestorType.Name}, {_level}]");
                 }
             }
         }


### PR DESCRIPTION
## What does the pull request do?

See: https://github.com/AvaloniaUI/Avalonia/issues/7944

## What is the current behavior?

String interpolation will not use culture invariant rules by default. This can cause unexpected errors on systems with different cultures that, for example:
 1. Do not use Arabic numerals (problem for int types)
 2. Switch comma and period (many in Europe) ( problem for double types)

## What is the updated/expected behavior with this PR?

 * Relevant code paths using string interpolation were updated to ensure the invariant culture rules are used
   * This is primarily related to areas of serialization such as .ToString()
   * int types are included (rare cultures do not use Arabic numerals)
 * Warnings/logs/strings were skipped

## How was the solution implemented (if it's not obvious)?

A search for `$"` and lots of skimming through code. I'm sure I missed something but this should hit the main types.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

None

## Obsoletions / Deprecations

None

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/7944
