### PR TITLE
Notifications: Correctly set parent

### DIFF
--- a/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
+++ b/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
@@ -146,7 +146,11 @@ namespace Avalonia.Controls.Notifications
         {
             var adornerLayer = host.FindDescendantOfType<VisualLayerManager>()?.AdornerLayer;
 
-            adornerLayer?.Children.Add(this);
+            if (adornerLayer is not null)
+            {
+                adornerLayer.Children.Add(this);
+                AdornerLayer.SetAdornedElement(this, adornerLayer);
+            }
         }
 
         private void UpdatePseudoClasses(NotificationPosition position)


### PR DESCRIPTION
As of Avalonia 11 the notifications are broken and are shown always in the upper left corner. I'm not an expert, but as the parent of the control is not correctly set, we can imagine that the library assumes that the coordinate (0, 0) is going to be used and thus it appears always at a static location. After fixing the assignment of the parent, the notification bubbles are shown at the right corner again.

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com>
Signed-off-by: Thomas Karl Pietrowski <t.pietrowski@item24.com>
Signed-off-by: Malte Lauterjung <malte.lauterjung@trinidat.de>