### PR TITLE
Throw an exception on unit test assertion fail.

### DIFF
--- a/tests/Avalonia.UnitTests/ModuleInitializer.cs
+++ b/tests/Avalonia.UnitTests/ModuleInitializer.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Avalonia.Base.UnitTests
+{
+    internal static class ModuleInitializer
+    {
+        [ModuleInitializer]
+        internal static void TestInit()
+        {
+            Trace.Listeners.Insert(0, new ThrowListener());
+        }
+
+        private class ThrowListener : TextWriterTraceListener
+        {
+            public override void Fail(string message)
+            {
+                throw new Exception("Assertion Failed. " + message);
+            }
+
+            public override void Fail(string message, string detailMessage)
+            {
+                throw new Exception("Assertion Failed. " + message + detailMessage);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Previously, if an assertion failed in a unit test, the unit test running would just exit with no message, for example add a `Debug.Assert(false)` in an arbitrary unit test and run the test in the VS test runner and you'll see a message like "Test run aborted":

![image](https://user-images.githubusercontent.com/1775141/205464312-82e7de9c-c081-46c2-a9a6-5fd103c45f61.png)

This PR adds a module initializer to `Avalonia.UnitTests` which registers a trace listener which throws an exception on assertion fail:

![image](https://user-images.githubusercontent.com/1775141/205464338-8bde36f2-fdd1-4560-8783-36e7118ef4cd.png)
