### PR TITLE
fix: Add more copy&paste hotkeys

### DIFF
--- a/src/Avalonia.Base/Input/Platform/PlatformHotkeyConfiguration.cs
+++ b/src/Avalonia.Base/Input/Platform/PlatformHotkeyConfiguration.cs
@@ -20,7 +20,8 @@ namespace Avalonia.Input.Platform
             WholeWordTextActionModifiers = wholeWordTextActionModifiers;
             Copy = new List<KeyGesture>
             {
-                new KeyGesture(Key.C, commandModifiers)
+                new KeyGesture(Key.C, commandModifiers),
+                new KeyGesture(Key.Insert, KeyModifiers.Control)
             };
             Cut = new List<KeyGesture>
             {
@@ -28,7 +29,8 @@ namespace Avalonia.Input.Platform
             };
             Paste = new List<KeyGesture>
             {
-                new KeyGesture(Key.V, commandModifiers)
+                new KeyGesture(Key.V, commandModifiers),
+                new KeyGesture(Key.Insert, KeyModifiers.Shift)
             };
             Undo = new List<KeyGesture>
             {


### PR DESCRIPTION
## What does the pull request do?
Add `Ctrl+Insert` and `Shift+Insert` hotkey to resolve #8901

## What is the current behavior?
Those two hotkey is not working

## What is the updated/expected behavior with this PR?
Works as standard copy&paste hotkey.

## Checklist

~~- [ ] Added unit tests (if possible)?~~
~~- [ ] Added XML documentation to any related classes?~~
~~- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation~~

## Fixed issues
Fixes #8901
