### PR TITLE
Don't set key event to handled if selection control receives Enter or Space key events

### DIFF
--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -588,7 +588,7 @@ namespace Avalonia.Controls.Primitives
                 }
                 else if (e.Key == Key.Space || e.Key == Key.Enter)
                 {
-                    e.Handled = UpdateSelectionFromEventSource(
+                    UpdateSelectionFromEventSource(
                           e.Source,
                           true,
                           e.KeyModifiers.HasFlag(KeyModifiers.Shift),


### PR DESCRIPTION
## What does the pull request do?
Fixes regression caused by #9144 in controls that also handles Enter key events sent from a SelectingItemsControl, esp. ComboBox, and thus, couldn't handle those keys after selection changes.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
