### PR TITLE
Increase GenerateElement performance

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
@@ -67,7 +67,7 @@ namespace Avalonia.Controls
             if (CellTemplate != null)
             {
                 return (CellTemplate is IRecyclingDataTemplate recyclingDataTemplate)
-                    ? recyclingDataTemplate.Build(dataItem, cell.Content as IControl)
+                    ? recyclingDataTemplate.Build(dataItem, cell.Content as Control)
                     : CellTemplate.Build(dataItem);
             }
             if (Design.IsDesignMode)

--- a/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
@@ -64,9 +64,11 @@ namespace Avalonia.Controls
 
         protected override Control GenerateElement(DataGridCell cell, object dataItem)
         {
-            if(CellTemplate != null)
+            if (CellTemplate != null)
             {
-                return CellTemplate.Build(dataItem);
+                return (CellTemplate is IRecyclingDataTemplate recyclingDataTemplate)
+                    ? recyclingDataTemplate.Build(dataItem, cell.Content as IControl)
+                    : CellTemplate.Build(dataItem);
             }
             if (Design.IsDesignMode)
             {


### PR DESCRIPTION
Use ability of the IRecyclingDataTemplate to speed up performance, when CellTemplate is an instance of DataTemplate type.