### PR TITLE
Do not require matching ctor, if top level element

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/AvaloniaXamlIlRuntimeCompiler.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/AvaloniaXamlIlRuntimeCompiler.cs
@@ -234,7 +234,7 @@ namespace Avalonia.Markup.Xaml.XamlIl
                 parsedDocuments.Add(new XamlDocumentResource(parsed, document.BaseUri?.ToString(), null, null,
                     builder,
                     compiler.DefinePopulateMethod(builder, parsed, AvaloniaXamlIlCompiler.PopulateName, true),
-                    compiler.DefineBuildMethod(builder, parsed, AvaloniaXamlIlCompiler.BuildName, true)));
+                    document.RootInstance is null ? compiler.DefineBuildMethod(builder, parsed, AvaloniaXamlIlCompiler.BuildName, true) : null));
                 originalDocuments.Add(document);
             }
 

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
@@ -899,6 +899,17 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
             Assert.Equal("Foo", target.Text);
         }
 
+        [Fact]
+        public void Should_Parse_And_Populate_Type_Without_Public_Ctor()
+        {
+            var xaml = @"<ObjectWithoutPublicCtor xmlns='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml' Test2='World' />";
+            var target = (ObjectWithoutPublicCtor)AvaloniaRuntimeXamlLoader.Load(xaml, rootInstance: new ObjectWithoutPublicCtor("Hello"));
+
+            Assert.NotNull(target);
+            Assert.Equal("World", target.Test2);
+            Assert.Equal("Hello", target.Test1);
+        }
+        
         private class SelectedItemsViewModel : INotifyPropertyChanged
         {
             public string[] Items { get; set; }
@@ -927,6 +938,18 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
         {
             Child = child;
         }
+    }
+    
+    public class ObjectWithoutPublicCtor
+    {
+        public ObjectWithoutPublicCtor(string param)
+        {
+            Test1 = param;
+        }
+        
+        public string Test1 { get; set; }
+        
+        public string Test2 { get; set; }
     }
 
     public class ObjectWithAddChildOfT : IAddChild, IAddChild<string>


### PR DESCRIPTION
Blocked on https://github.com/kekekeks/XamlX/pull/81

## What does the pull request do?

Makes XAML compiler less strict about public ctors, when it isn't going to create a Build method which requires one.
Previously it was hard to pass arguments (only IServiceProvider and x:Arguments directive were allowed) into the XAML class ctor, like MainWindow with DI.
Moreover, public ctor isn't required at all now.

Of course, old limitations are still in place, if this XAML type is attempted to be created inside of another XAML file, where compiler wouldn't be able to pass any parameters which it doesn't have ([x:Arguments](https://learn.microsoft.com/en-us/dotnet/desktop/xaml-services/xarguments-directive) directive will work tho).

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Fixed issues

Fixes #2593 
