### PR TITLE
Add 1 px safety offset in order to remove artifacts  

### DIFF
--- a/src/Avalonia.Base/Rendering/DirtyRects.cs
+++ b/src/Avalonia.Base/Rendering/DirtyRects.cs
@@ -32,6 +32,9 @@ namespace Avalonia.Rendering
         {
             if (!rect.IsDefault)
             {
+                // we inflate the rect by 1 px in order to add some safety space
+                rect.Inflate(1);
+                
                 for (var i = 0; i < _rects.Count; ++i)
                 {
                     var r = _rects[i];

--- a/src/Avalonia.Base/Rendering/SceneGraph/DrawOperation.cs
+++ b/src/Avalonia.Base/Rendering/SceneGraph/DrawOperation.cs
@@ -11,7 +11,10 @@ namespace Avalonia.Rendering.SceneGraph
     {
         public DrawOperation(Rect bounds, Matrix transform)
         {
-            bounds = bounds.Normalize().TransformToAABB(transform);
+            bounds = bounds
+                .Inflate(1.0) // add 1 px safety offset in order to remove artifacts  
+                .Normalize()
+                .TransformToAABB(transform);
 
             Bounds = new Rect(
                 new Point(Math.Floor(bounds.X), Math.Floor(bounds.Y)),

--- a/src/Avalonia.Base/Rendering/SceneGraph/DrawOperation.cs
+++ b/src/Avalonia.Base/Rendering/SceneGraph/DrawOperation.cs
@@ -12,7 +12,6 @@ namespace Avalonia.Rendering.SceneGraph
         public DrawOperation(Rect bounds, Matrix transform)
         {
             bounds = bounds
-                .Inflate(1.0) // add 1 px safety offset in order to remove artifacts  
                 .Normalize()
                 .TransformToAABB(transform);
 


### PR DESCRIPTION
## What does the pull request do?
Some geometries are not rendered correctly and some artifacts are left, see https://github.com/AvaloniaUI/Avalonia/issues/9659


## What is the current behavior?
Artifacts are there in some cases

## What is the updated/expected behavior with this PR?
No artifacts


## How was the solution implemented (if it's not obvious)?
Add 1 pixel of safety area to dirty rects


## Checklist

- ~[ ] Added unit tests (if possible)?~
- ~[ ] Added XML documentation to any related classes?~
- ~[ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation~

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #9659 (to be confirmed)
Fixes #2302 (to be confirmed)

This issue is marked as draft as the issues should be confirmed first 