### PR TITLE
Add support for using a different template for combox closed state

### DIFF
--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -90,12 +90,6 @@ namespace Avalonia.Controls
         public static StyledProperty<IDataTemplate?> SelectedItemTemplateProperty =
             AvaloniaProperty.Register<ComboBox, IDataTemplate?>(nameof(SelectedItemTemplate));
 
-        /// <summary>
-        /// Defines the <see cref="DisplaySelectedItemTemplate"/> property.
-        /// </summary>
-        public static DirectProperty<ComboBox, IDataTemplate?> DisplaySelectedItemTemplateProperty =
-        AvaloniaProperty.RegisterDirect<ComboBox, IDataTemplate?>(nameof(DisplaySelectedItemTemplate), o => o.DisplaySelectedItemTemplate);
-
         private bool _isDropDownOpen;
         private Popup? _popup;
         private object? _selectionBoxItem;
@@ -110,8 +104,6 @@ namespace Avalonia.Controls
             FocusableProperty.OverrideDefaultValue<ComboBox>(true);
             IsTextSearchEnabledProperty.OverrideDefaultValue<ComboBox>(true);
             IsDropDownOpenProperty.Changed.AddClassHandler<ComboBox>((x, e) => x.IsDropDownOpenChanged(e));
-            ItemTemplateProperty.Changed.AddClassHandler<ComboBox>((x, e) => x.This_ItemTemplateChanged(e));
-            SelectedItemTemplateProperty.Changed.AddClassHandler<ComboBox>((x, e) => x.SelectedItemTemplateChanged(e));
         }
 
         /// <summary>
@@ -203,15 +195,6 @@ namespace Avalonia.Controls
         {
             get => GetValue(SelectedItemTemplateProperty);
             set => SetValue(SelectedItemTemplateProperty, value);
-        }
-
-        /// <summary>
-        /// Get the template for the combo box (not the dropdown). 
-        /// Falls back to <seealso cref="ItemsControl.ItemTemplate"/> if not set
-        /// </summary>
-        public IDataTemplate? DisplaySelectedItemTemplate
-        {
-            get => GetValue(SelectedItemTemplateProperty) ?? GetValue(ItemTemplateProperty);
         }
 
         /// <inheritdoc/>
@@ -555,24 +538,5 @@ namespace Avalonia.Controls
             bool newValue = e.GetNewValue<bool>();
             PseudoClasses.Set(pcDropdownOpen, newValue);
         }
-
-        private void This_ItemTemplateChanged(AvaloniaPropertyChangedEventArgs e)
-        {
-            //we only care about a change if we are not using a different template for selected items
-            if (SelectedItemTemplate != null)
-                return;
-
-            RaisePropertyChanged(DisplaySelectedItemTemplateProperty,
-                new Optional<IDataTemplate?>(e.GetOldValue<IDataTemplate?>()),
-                new BindingValue<IDataTemplate?>(e.GetNewValue<IDataTemplate?>()));
-        }
-
-        private void SelectedItemTemplateChanged(AvaloniaPropertyChangedEventArgs e)
-        {
-            RaisePropertyChanged(DisplaySelectedItemTemplateProperty,
-                new Optional<IDataTemplate?>(e.GetOldValue<IDataTemplate?>()),
-                new BindingValue<IDataTemplate?>(e.GetNewValue<IDataTemplate?>()));
-        }
-
     }
 }

--- a/src/Avalonia.Themes.Fluent/Controls/ComboBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ComboBox.xaml
@@ -84,7 +84,8 @@
                        IsVisible="{TemplateBinding SelectionBoxItem, Converter={x:Static ObjectConverters.IsNull}}" />
             <ContentControl x:Name="ContentPresenter"
                             Content="{TemplateBinding SelectionBoxItem}"
-                            ContentTemplate="{TemplateBinding DisplaySelectedItemTemplate}"
+                            ContentTemplate="{Binding Path=SelectedItemTemplate, RelativeSource={RelativeSource TemplatedParent},
+                                              FallbackValue={TemplateBinding ItemTemplate}}"
                             Grid.Column="0"
                             Margin="{TemplateBinding Padding}"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/src/Avalonia.Themes.Fluent/Controls/ComboBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ComboBox.xaml
@@ -81,14 +81,21 @@
                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                        Margin="{TemplateBinding Padding}"
                        Text="{TemplateBinding PlaceholderText}"
-                       Foreground="{TemplateBinding PlaceholderForeground}"
-                       IsVisible="{TemplateBinding SelectionBoxItem, Converter={x:Static ObjectConverters.IsNull}}" />
+                       Foreground="{TemplateBinding PlaceholderForeground}">
+              <TextBlock.IsVisible>
+                <MultiBinding Converter="{x:Static BoolConverters.And}">
+                  <Binding Path="SelectionBoxItem" RelativeSource="{RelativeSource TemplatedParent}" Converter="{x:Static ObjectConverters.IsNull}" />
+                  <Binding Path="!IsEditable" RelativeSource="{RelativeSource TemplatedParent}" />
+                </MultiBinding>
+              </TextBlock.IsVisible>
+            </TextBlock>
             <ContentControl x:Name="ContentPresenter"
                             Content="{TemplateBinding SelectionBoxItem}"
                             Grid.Column="0"
                             Margin="{TemplateBinding Padding}"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}">
+                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                            IsVisible="{TemplateBinding IsEditable, Converter={x:Static BoolConverters.Not}}">
               <ContentControl.ContentTemplate>
                 <PriorityBinding>
                   <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="SelectedItemTemplate"
@@ -97,6 +104,24 @@
                 </PriorityBinding>
               </ContentControl.ContentTemplate>
             </ContentControl>
+            
+            <TextBox Name="PART_InputText"
+                     Grid.Column="0"
+                     Padding="{TemplateBinding Padding}"
+                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                     Foreground="{TemplateBinding Foreground}"
+                     Background="Transparent"
+                     Text="{TemplateBinding Text, Mode=TwoWay}"
+                     BorderThickness="0"
+                     IsVisible="{TemplateBinding IsEditable}">
+              <TextBox.Resources>
+                <SolidColorBrush x:Key="TextControlBackgroundFocused">Transparent</SolidColorBrush>
+                <SolidColorBrush x:Key="TextControlBackgroundPointerOver">Transparent</SolidColorBrush>
+                <Thickness x:Key="TextControlBorderThemeThicknessFocused">0</Thickness>
+              </TextBox.Resources>
+            </TextBox>
+            
             <Border x:Name="DropDownOverlay"
                     Grid.Column="1"
                     Background="Transparent"

--- a/src/Avalonia.Themes.Fluent/Controls/ComboBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ComboBox.xaml
@@ -84,7 +84,7 @@
                        IsVisible="{TemplateBinding SelectionBoxItem, Converter={x:Static ObjectConverters.IsNull}}" />
             <ContentControl x:Name="ContentPresenter"
                             Content="{TemplateBinding SelectionBoxItem}"
-                            ContentTemplate="{TemplateBinding ItemTemplate}"
+                            ContentTemplate="{TemplateBinding DisplaySelectedItemTemplate}"
                             Grid.Column="0"
                             Margin="{TemplateBinding Padding}"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/src/Avalonia.Themes.Fluent/Controls/ComboBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ComboBox.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:sys="using:System">
+                    xmlns:sys="using:System"
+                    xmlns:avaloniaData="using:Avalonia.Data">
   <Design.PreviewWith>
     <Border Padding="20">
       <StackPanel Spacing="10">
@@ -84,13 +85,18 @@
                        IsVisible="{TemplateBinding SelectionBoxItem, Converter={x:Static ObjectConverters.IsNull}}" />
             <ContentControl x:Name="ContentPresenter"
                             Content="{TemplateBinding SelectionBoxItem}"
-                            ContentTemplate="{Binding Path=SelectedItemTemplate, RelativeSource={RelativeSource TemplatedParent},
-                                              FallbackValue={TemplateBinding ItemTemplate}}"
                             Grid.Column="0"
                             Margin="{TemplateBinding Padding}"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
-
+                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}">
+              <ContentControl.ContentTemplate>
+                <PriorityBinding>
+                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="SelectedItemTemplate"
+                           TargetNullValue="{x:Static avaloniaData:BindingOperations.DoNothing}" />
+                  <TemplateBinding Property="ItemTemplate" />
+                </PriorityBinding>
+              </ContentControl.ContentTemplate>
+            </ContentControl>
             <Border x:Name="DropDownOverlay"
                     Grid.Column="1"
                     Background="Transparent"

--- a/src/Avalonia.Themes.Simple/Controls/ComboBox.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ComboBox.xaml
@@ -32,7 +32,7 @@
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                             Content="{TemplateBinding SelectionBoxItem}"
-                            ContentTemplate="{TemplateBinding ItemTemplate}" />
+                            ContentTemplate="{TemplateBinding DisplaySelectedItemTemplate}" />
             <ToggleButton Name="toggle"
                           Grid.Column="1"
                           Background="Transparent"

--- a/src/Avalonia.Themes.Simple/Controls/ComboBox.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ComboBox.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:avaloniaData="using:Avalonia.Data">
   <ControlTheme x:Key="{x:Type ComboBox}"
                 TargetType="ComboBox">
     <Setter Property="Background" Value="Transparent" />
@@ -31,9 +32,15 @@
             <ContentControl Margin="{TemplateBinding Padding}"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Content="{TemplateBinding SelectionBoxItem}"
-                            ContentTemplate="{Binding Path=SelectedItemTemplate, RelativeSource={RelativeSource TemplatedParent},
-                                              FallbackValue={TemplateBinding ItemTemplate}}" />
+                            Content="{TemplateBinding SelectionBoxItem}">
+              <ContentControl.ContentTemplate>
+                <PriorityBinding>
+                  <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="SelectedItemTemplate"
+                           TargetNullValue="{x:Static avaloniaData:BindingOperations.DoNothing}" />
+                  <TemplateBinding Property="ItemTemplate" />
+                </PriorityBinding>
+              </ContentControl.ContentTemplate>
+            </ContentControl>
             <ToggleButton Name="toggle"
                           Grid.Column="1"
                           Background="Transparent"

--- a/src/Avalonia.Themes.Simple/Controls/ComboBox.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ComboBox.xaml
@@ -32,7 +32,8 @@
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                             Content="{TemplateBinding SelectionBoxItem}"
-                            ContentTemplate="{TemplateBinding DisplaySelectedItemTemplate}" />
+                            ContentTemplate="{Binding Path=SelectedItemTemplate, RelativeSource={RelativeSource TemplatedParent},
+                                              FallbackValue={TemplateBinding ItemTemplate}}" />
             <ToggleButton Name="toggle"
                           Grid.Column="1"
                           Background="Transparent"

--- a/src/Avalonia.Themes.Simple/Controls/ComboBox.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ComboBox.xaml
@@ -26,13 +26,19 @@
                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                        Foreground="{TemplateBinding PlaceholderForeground}"
-                       IsVisible="{TemplateBinding SelectionBoxItem,
-                                                   Converter={x:Static ObjectConverters.IsNull}}"
-                       Text="{TemplateBinding PlaceholderText}" />
+                       Text="{TemplateBinding PlaceholderText}">
+              <TextBlock.IsVisible>
+                <MultiBinding Converter="{x:Static BoolConverters.And}">
+                  <Binding Path="SelectionBoxItem" RelativeSource="{RelativeSource TemplatedParent}" Converter="{x:Static ObjectConverters.IsNull}" />
+                  <Binding Path="!IsEditable" RelativeSource="{RelativeSource TemplatedParent}" />
+                </MultiBinding>
+              </TextBlock.IsVisible>
+            </TextBlock>
             <ContentControl Margin="{TemplateBinding Padding}"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Content="{TemplateBinding SelectionBoxItem}">
+                            Content="{TemplateBinding SelectionBoxItem}"
+                            IsVisible="{TemplateBinding IsEditable, Converter={x:Static BoolConverters.Not}}">
               <ContentControl.ContentTemplate>
                 <PriorityBinding>
                   <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="SelectedItemTemplate"
@@ -41,6 +47,22 @@
                 </PriorityBinding>
               </ContentControl.ContentTemplate>
             </ContentControl>
+            <TextBox Name="PART_InputText"
+                     Grid.Column="0"
+                     Padding="{TemplateBinding Padding}"
+                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                     Foreground="{TemplateBinding Foreground}"
+                     Background="Transparent"
+                     Text="{TemplateBinding Text, Mode=TwoWay}"
+                     BorderThickness="0"
+                     IsVisible="{TemplateBinding IsEditable}">
+              <TextBox.Resources>
+                <SolidColorBrush x:Key="TextControlBackgroundFocused">Transparent</SolidColorBrush>
+                <SolidColorBrush x:Key="TextControlBackgroundPointerOver">Transparent</SolidColorBrush>
+                <Thickness x:Key="TextControlBorderThemeThicknessFocused">0</Thickness>
+              </TextBox.Resources>
+            </TextBox>
             <ToggleButton Name="toggle"
                           Grid.Column="1"
                           Background="Transparent"

--- a/src/Markup/Avalonia.Markup/Data/PriorityBinding.cs
+++ b/src/Markup/Avalonia.Markup/Data/PriorityBinding.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reactive.Linq;
+using Avalonia.Data.Converters;
+using Avalonia.Metadata;
+
+namespace Avalonia.Data
+{
+    /// <summary>
+    /// A XAML binding that uses the first valid result from multiple child <see cref="Bindings"/>.
+    /// </summary>
+    /// <remarks>
+    /// A valid biding result is anything other than <see cref="BindingOperations.DoNothing"/> 
+    /// and <see cref="AvaloniaProperty.UnsetValue"/>.
+    /// </remarks>
+    public class PriorityBinding : IBinding
+    {
+        /// <summary>
+        /// Gets the collection of child bindings.
+        /// </summary>
+        [Content, AssignBinding]
+        public IList<IBinding> Bindings { get; set; } = new List<IBinding>();
+
+        /// <summary>
+        /// Gets or sets the value to use when the binding is unable to produce a value.
+        /// </summary>
+        public object FallbackValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value to use when the binding result is null.
+        /// </summary>
+        public object TargetNullValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the binding mode.
+        /// </summary>
+        public BindingMode Mode { get; set; } = BindingMode.OneWay;
+
+        /// <summary>
+        /// Gets or sets the binding priority.
+        /// </summary>
+        public BindingPriority Priority { get; set; }
+
+        /// <summary>
+        /// Gets or sets the string format.
+        /// </summary>
+        public string? StringFormat { get; set; }
+
+        public PriorityBinding()
+        {
+            FallbackValue = AvaloniaProperty.UnsetValue;
+            TargetNullValue = AvaloniaProperty.UnsetValue;
+        }
+
+        /// <inheritdoc/>
+        public InstancedBinding? Initiate(
+            AvaloniaObject target,
+            AvaloniaProperty? targetProperty,
+            object? anchor = null,
+            bool enableDataValidation = false)
+        {
+            var targetType = targetProperty?.PropertyType ?? typeof(object);
+            IValueConverter? converter = null;
+            // We only respect `StringFormat` if the type of the property we're assigning to will
+            // accept a string. Note that this is slightly different to WPF in that WPF only applies
+            // `StringFormat` for target type `string` (not `object`).
+            if (!string.IsNullOrWhiteSpace(StringFormat) &&
+                (targetType == typeof(string) || targetType == typeof(object)))
+            {
+                converter = new StringFormatValueConverter(StringFormat!, converter);
+            }
+
+            var children = Bindings.Select(x => x.Initiate(target, null));
+
+            var input = children.Select(x => x?.Observable!)
+                                .Where(x => x is not null)
+                                .CombineLatest()
+                                .Select(BoundValuesGetFirstOrDefault)
+                                .Select(x => converter == null ? x : converter.Convert(x, targetType, null, CultureInfo.CurrentCulture));
+
+            var mode = Mode == BindingMode.Default ?
+                targetProperty?.GetMetadata(target.GetType()).DefaultBindingMode : Mode;
+
+            switch (mode)
+            {
+                case BindingMode.OneTime:
+                    return InstancedBinding.OneTime(input, Priority);
+                case BindingMode.OneWay:
+                    return InstancedBinding.OneWay(input, Priority);
+                default:
+                    throw new NotSupportedException(
+                        "PriorityBinding currently only supports OneTime and OneWay BindingMode.");
+            }
+        }
+
+        object? BoundValuesGetFirstOrDefault(IList<object?> values)
+        {
+            object? result = null;
+            foreach (object? i in values)
+            {
+                object? value = i;
+                if (value is BindingNotification notification)
+                {
+                    value = notification.Value;
+                }
+
+                if (value != AvaloniaProperty.UnsetValue && value != BindingOperations.DoNothing)
+                {
+                    result = value;
+                }
+            }
+
+            if(result == null)
+            {
+                result = TargetNullValue;
+            }
+
+            if(result == AvaloniaProperty.UnsetValue)
+            {
+                result = FallbackValue;
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
It provides a way to use a different template for items in the dropdown of a combo box separate to the closed state. If `SelectedItemTemplate` is not set the existing functionality is retained by using `ItemTemplate`

## Fixed issues
Addresses point 1 of https://github.com/AvaloniaUI/Avalonia/issues/7462