### PR TITLE
Fix SelectionModelSelectionChangedEventArgs.SelectedItems indexer.

### DIFF
--- a/src/Avalonia.Controls/Selection/SelectedItems.cs
+++ b/src/Avalonia.Controls/Selection/SelectedItems.cs
@@ -35,9 +35,9 @@ namespace Avalonia.Controls.Selection
                 {
                     return _owner.SelectedItem;
                 }
-                else if (Items is object)
+                else if (Items is not null && Ranges is not null)
                 {
-                    return Items[index];
+                    return Items[IndexRange.GetAt(Ranges, index)];
                 }
                 else
                 {

--- a/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Single.cs
+++ b/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Single.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Specialized;
+using System.Linq;
 using Avalonia.Collections;
 using Avalonia.Controls.Selection;
 using Avalonia.Controls.Utils;
@@ -1143,6 +1144,24 @@ namespace Avalonia.Controls.UnitTests.Selection
                 Assert.Equal("foo", target.SelectedItem);
                 Assert.Equal(new[] { "foo" }, target.SelectedItems);
                 Assert.Equal(0, target.AnchorIndex);
+            }
+
+            [Fact]
+            public void SelectedItems_Indexer_Is_Correct()
+            {
+                // Issue #7974
+                var target = CreateTarget();
+                var raised = 0;
+
+                target.SelectionChanged += (s, e) =>
+                {
+                    Assert.Equal("bar", e.SelectedItems.First());
+                    Assert.Equal("bar", e.SelectedItems[0]);
+                    ++raised;
+                };
+
+                target.Select(1);
+                Assert.Equal(1, raised);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

As described in #7974 the `SelectionModelSelectionChangedEventArgs.SelectedItems` indexer was returning an incorrect value. this was because the index is an index into `Ranges`, not `Items`.

Add a unit test and fix the logic.

## Fixed issues

Fixes #7974