### PR TITLE
Defer execution of UnregisterClass to fix RWM atom table leak

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1409,7 +1409,7 @@ namespace Avalonia.Win32.Interop
         [DllImport("user32.dll")]
         public static extern bool TranslateMessage(ref MSG lpMsg);
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
         public static extern bool UnregisterClass(string lpClassName, IntPtr hInstance);
 
         [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "SetWindowTextW")]

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -10,6 +10,7 @@ using Avalonia.Controls.Remote;
 using Avalonia.Input;
 using Avalonia.Input.Raw;
 using Avalonia.Platform;
+using Avalonia.Threading;
 using Avalonia.Win32.Automation;
 using Avalonia.Win32.Input;
 using Avalonia.Win32.Interop.Automation;
@@ -106,6 +107,9 @@ namespace Avalonia.Win32
                         _touchDevice?.Dispose();
                         //Free other resources
                         Dispose();
+
+                        // Schedule cleanup of anything that requires window to be destroyed
+                        Dispatcher.UIThread.Post(AfterCloseCleanup);
                         return IntPtr.Zero;
                     }
 

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -643,12 +643,6 @@ namespace Avalonia.Win32
                 _hwnd = IntPtr.Zero;
             }
 
-            if (_className != null)
-            {
-                UnregisterClass(_className, GetModuleHandle(null));
-                _className = null;
-            }
-
             _framebuffer.Dispose();
         }
 
@@ -1141,6 +1135,15 @@ namespace Avalonia.Win32
                 {
                     SetActiveWindow(_parent._hwnd);
                 }
+            }
+        }
+
+        private void AfterCloseCleanup()
+        {
+            if (_className != null)
+            {
+                UnregisterClass(_className, GetModuleHandle(null));
+                _className = null;
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
This fixes the RegisterWindowMessage (RWM) atom table leak when a window is closed described in #9693 by scheduling `UnregisterClass` to run at a later time.


## What is the current behavior?
The window class registered by `RegisterClassEx` is not cleaned up due to `UnregisterClass` being called before `DestroyWindow` has finished executing, which is an invalid operation and causes `UnregisterClass` to fail, leaving the window class behind. This can lead to an exhaustion of the global RWM atom table if a lot of windows are instantiated during the process's lifetime.


## What is the updated/expected behavior with this PR?
The window class is cleaned up when the window is closed, fixing the leak.


## How was the solution implemented (if it's not obvious)?
Clean-up of the window class is done by scheduling `UnregisterClass` with the dispatcher to run at a later time when called from the windows `WndProc`. This lets `DestroyWindow` finish before `UnregisterClass` is called.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
none

## Obsoletions / Deprecations
none

## Fixed issues
Fixes #9693
