### PR TITLE
Skia drawing context: support odd number of dashes

### DIFF
--- a/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
+++ b/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
@@ -1137,11 +1137,14 @@ namespace Avalonia.Skia
             if (pen.DashStyle?.Dashes != null && pen.DashStyle.Dashes.Count > 0)
             {
                 var srcDashes = pen.DashStyle.Dashes;
-                var dashesArray = new float[srcDashes.Count];
 
-                for (var i = 0; i < srcDashes.Count; ++i)
+                var count = srcDashes.Count % 2 == 0 ? srcDashes.Count : srcDashes.Count * 2;
+
+                var dashesArray = new float[count];
+
+                for (var i = 0; i < count; ++i)
                 {
-                    dashesArray[i] = (float) srcDashes[i] * paint.StrokeWidth;
+                    dashesArray[i] = (float) srcDashes[i % srcDashes.Count] * paint.StrokeWidth;
                 }
 
                 var offset = (float)(pen.DashStyle.Offset * pen.Thickness);


### PR DESCRIPTION
## What does the pull request do?
Adds workaround to always pass even number of dashes to `SKPathEffect.CreateDash`.


## What is the current behavior?
Odd number of dashes is not supported by Skia renderer.


## What is the updated/expected behavior with this PR?
Even and odd number of dashes is supported.


## How was the solution implemented (if it's not obvious)?
In case of odd number of dashes target array is doubled in size and contains source dashes repeated twice.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #9692
