### PR TITLE
Marshal StyledProperty bindings to UI thread.

### DIFF
--- a/src/Avalonia.Base/PropertyStore/BindingEntryBase.cs
+++ b/src/Avalonia.Base/PropertyStore/BindingEntryBase.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Reactive.Disposables;
 using Avalonia.Data;
+using Avalonia.Threading;
 
 namespace Avalonia.PropertyStore
 {
@@ -116,26 +117,42 @@ namespace Avalonia.PropertyStore
 
         private void SetValue(BindingValue<TValue> value)
         {
-            if (Frame.Owner is null)
-                return;
-
-            LoggingUtils.LogIfNecessary(Frame.Owner.Owner, Property, value);
-
-            if (value.HasValue)
+            static void Execute(BindingEntryBase<TValue, TSource> instance, BindingValue<TValue> value)
             {
-                if (!_hasValue || !EqualityComparer<TValue>.Default.Equals(_value, value.Value))
+                if (instance.Frame.Owner is null)
+                    return;
+
+                LoggingUtils.LogIfNecessary(instance.Frame.Owner.Owner, instance.Property, value);
+
+                if (value.HasValue)
                 {
-                    _value = value.Value;
-                    _hasValue = true;
-                    if (_subscription is not null && _subscription != s_creatingQuiet)
-                        Frame.Owner?.OnBindingValueChanged(this, Frame.Priority);
+                    if (!instance._hasValue || !EqualityComparer<TValue>.Default.Equals(instance._value, value.Value))
+                    {
+                        instance._value = value.Value;
+                        instance._hasValue = true;
+                        if (instance._subscription is not null && instance._subscription != s_creatingQuiet)
+                            instance.Frame.Owner?.OnBindingValueChanged(instance, instance.Frame.Priority);
+                    }
+                }
+                else if (value.Type != BindingValueType.DoNothing)
+                {
+                    instance.ClearValue();
+                    if (instance._subscription is not null && instance._subscription != s_creatingQuiet)
+                        instance.Frame.Owner?.OnBindingValueCleared(instance.Property, instance.Frame.Priority);
                 }
             }
-            else if (value.Type != BindingValueType.DoNothing)
+
+            if (Dispatcher.UIThread.CheckAccess())
             {
-                ClearValue();
-                if (_subscription is not null && _subscription != s_creatingQuiet)
-                    Frame.Owner?.OnBindingValueCleared(Property, Frame.Priority);
+                Execute(this, value);
+            }
+            else
+            {
+                // To avoid allocating closure in the outer scope we need to capture variables
+                // locally. This allows us to skip most of the allocations when on UI thread.
+                var instance = this;
+                var newValue = value;
+                Dispatcher.UIThread.Post(() => Execute(instance, newValue));
             }
         }
 

--- a/tests/Avalonia.Base.UnitTests/Avalonia.Base.UnitTests.csproj
+++ b/tests/Avalonia.Base.UnitTests/Avalonia.Base.UnitTests.csproj
@@ -18,6 +18,9 @@
     <EmbeddedResource Include="Media\TextFormatting\BreakPairTable.txt" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Nito.AsyncEx.Context" Version="5.1.2" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Avalonia.Base\Avalonia.Base.csproj" />
     <ProjectReference Include="..\..\src\Markup\Avalonia.Markup.Xaml.Loader\Avalonia.Markup.Xaml.Loader.csproj" />
     <ProjectReference Include="..\Avalonia.UnitTests\Avalonia.UnitTests.csproj" />

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Direct.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Direct.cs
@@ -7,8 +7,10 @@ using System.Threading.Tasks;
 using Avalonia.Data;
 using Avalonia.Logging;
 using Avalonia.Platform;
+using Avalonia.Threading;
 using Avalonia.UnitTests;
 using Moq;
+using Nito.AsyncEx;
 using Xunit;
 
 namespace Avalonia.Base.UnitTests
@@ -519,25 +521,39 @@ namespace Avalonia.Base.UnitTests
         }
 
         [Fact]
-        public async Task Bind_Executes_On_UIThread()
+        public void Bind_Executes_On_UIThread()
         {
-            var target = new Class1();
-            var source = new Subject<object>();
-            var currentThreadId = Thread.CurrentThread.ManagedThreadId;
-
-            var threadingInterfaceMock = new Mock<IPlatformThreadingInterface>();
-            threadingInterfaceMock.SetupGet(mock => mock.CurrentThreadIsLoopThread)
-                .Returns(() => Thread.CurrentThread.ManagedThreadId == currentThreadId);
-
-            var services = new TestServices(
-                threadingInterface: threadingInterfaceMock.Object);
-
-            using (UnitTestApplication.Start(services))
+            AsyncContext.Run(async () =>
             {
-                target.Bind(Class1.FooProperty, source);
+                var target = new Class1();
+                var source = new Subject<object>();
+                var currentThreadId = Thread.CurrentThread.ManagedThreadId;
+                var raised = 0;
 
-                await Task.Run(() => source.OnNext("foobar"));
-            }
+                var threadingInterfaceMock = new Mock<IPlatformThreadingInterface>();
+                threadingInterfaceMock.SetupGet(mock => mock.CurrentThreadIsLoopThread)
+                    .Returns(() => Thread.CurrentThread.ManagedThreadId == currentThreadId);
+
+                var services = new TestServices(
+                    threadingInterface: threadingInterfaceMock.Object);
+
+                target.PropertyChanged += (s, e) =>
+                {
+                    Assert.Equal(currentThreadId, Thread.CurrentThread.ManagedThreadId);
+                    ++raised;
+                };
+
+                using (UnitTestApplication.Start(services))
+                {
+                    target.Bind(Class1.FooProperty, source);
+
+                    await Task.Run(() => source.OnNext("foobar"));
+                    Dispatcher.UIThread.RunJobs();
+
+                    Assert.Equal("foobar", target.Foo);
+                    Assert.Equal(1, raised);
+                }
+            });
         }
 
         [Fact]


### PR DESCRIPTION
## What does the pull request do?

When the value store was refactored in #8600 I forgot to add support for styled property bindings being fired on non-UI threads (direct properties are fine).

Added some tests (also making existing direct property test actually confirm that binding was done on UI thread) and fixed the issue.

Note that this issue is distinct from #8810 and doesn't fix that issue, as this PR marshals to the UI thread at a later stage. The changes in the PR would still be needed even if #8810 is fixed though, as we need to support bindings that don't come via events such as observables that fire on a background thread.

Note also that to get the threading tests working properly I needed a proper async context, so I've added a dependency on `Nito.AsyncEx.Context` _only to our unit tests_. I think this should be acceptable.
