### PR TITLE
Remove ReflectionBinding from NativeMenuBar

### DIFF
--- a/src/Avalonia.Controls/NativeMenuBar.cs
+++ b/src/Avalonia.Controls/NativeMenuBar.cs
@@ -23,15 +23,6 @@ namespace Avalonia.Controls
             });
         }
 
-        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NativeMenu))]
-        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NativeMenuItem))]
-        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NativeMenuItemBase))]
-        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NativeMenuItemSeparator))]
-        public NativeMenuBar()
-        {
-
-        }
-
         public static void SetEnableMenuItemClickForwarding(MenuItem menuItem, bool enable)
         {
             menuItem.SetValue(EnableMenuItemClickForwardingProperty, enable);

--- a/src/Avalonia.Themes.Fluent/Controls/NativeMenuBar.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/NativeMenuBar.xaml
@@ -9,17 +9,16 @@
           IsVisible="{Binding !$parent[TopLevel].(NativeMenu.IsNativeMenuExported)}"
           Items="{Binding $parent[TopLevel].(NativeMenu.Menu).Items}">
           <Menu.Styles>
-            <!-- Don't use x:DataType and compiled bindings here, as it might crash https://github.com/AvaloniaUI/Avalonia/pull/7954  -->
-            <Style Selector="MenuItem">
-              <Setter Property="Header" Value="{ReflectionBinding Header}"/>
-              <Setter Property="IsEnabled" Value="{ReflectionBinding IsEnabled}"/>
-              <Setter Property="InputGesture" Value="{ReflectionBinding Gesture}"/>
-              <Setter Property="Items" Value="{ReflectionBinding Menu.Items}"/>
-              <Setter Property="Command" Value="{ReflectionBinding Command}"/>
-              <Setter Property="CommandParameter" Value="{ReflectionBinding CommandParameter}"/>
+            <Style Selector="MenuItem" x:DataType="NativeMenuItem">
+              <Setter Property="Header" Value="{Binding Header}"/>
+              <Setter Property="IsEnabled" Value="{Binding IsEnabled}"/>
+              <Setter Property="InputGesture" Value="{Binding Gesture}"/>
+              <Setter Property="Items" Value="{Binding Menu.Items}"/>
+              <Setter Property="Command" Value="{Binding Command}"/>
+              <Setter Property="CommandParameter" Value="{Binding CommandParameter}"/>
               <Setter Property="(NativeMenuBar.EnableMenuItemClickForwarding)" Value="True"/>
               <!--NativeMenuItem is IBitmap and MenuItem is Image-->
-              <Setter Property="Icon" Value="{ReflectionBinding Icon , Converter={StaticResource AvaloniaThemesFluentNativeMenuBarIBitmapToImageConverter}}"/>
+              <Setter Property="Icon" Value="{Binding Icon , Converter={StaticResource AvaloniaThemesFluentNativeMenuBarIBitmapToImageConverter}}"/>
             </Style>
           </Menu.Styles>
         </Menu>

--- a/src/Avalonia.Themes.Simple/Controls/NativeMenuBar.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/NativeMenuBar.xaml
@@ -9,17 +9,16 @@
         <Menu IsVisible="{Binding !$parent[TopLevel].(NativeMenu.IsNativeMenuExported)}"
               Items="{Binding $parent[TopLevel].(NativeMenu.Menu).Items}">
           <Menu.Styles>
-            <!-- Don't use x:DataType and compiled bindings here, as it might crash https://github.com/AvaloniaUI/Avalonia/pull/7954  -->
-            <Style Selector="MenuItem">
-              <Setter Property="Header" Value="{ReflectionBinding Header}" />
-              <Setter Property="IsEnabled" Value="{ReflectionBinding IsEnabled}" />
-              <Setter Property="InputGesture" Value="{ReflectionBinding Gesture}" />
-              <Setter Property="Items" Value="{ReflectionBinding Menu.Items}" />
-              <Setter Property="Command" Value="{ReflectionBinding Command}" />
-              <Setter Property="CommandParameter" Value="{ReflectionBinding CommandParameter}" />
-              <Setter Property="(NativeMenuBar.EnableMenuItemClickForwarding)" Value="True" />
-              <!--  NativeMenuItem is IBitmap and MenuItem is Image  -->
-              <Setter Property="Icon" Value="{ReflectionBinding Icon, Converter={StaticResource AvaloniaThemesSimpleNativeMenuBarIBitmapToImageConverter}}" />
+            <Style Selector="MenuItem" x:DataType="NativeMenuItem">
+              <Setter Property="Header" Value="{Binding Header}"/>
+              <Setter Property="IsEnabled" Value="{Binding IsEnabled}"/>
+              <Setter Property="InputGesture" Value="{Binding Gesture}"/>
+              <Setter Property="Items" Value="{Binding Menu.Items}"/>
+              <Setter Property="Command" Value="{Binding Command}"/>
+              <Setter Property="CommandParameter" Value="{Binding CommandParameter}"/>
+              <Setter Property="(NativeMenuBar.EnableMenuItemClickForwarding)" Value="True"/>
+              <!--NativeMenuItem is IBitmap and MenuItem is Image-->
+              <Setter Property="Icon" Value="{Binding Icon , Converter={StaticResource AvaloniaThemesSimpleNativeMenuBarIBitmapToImageConverter}}"/>
             </Style>
           </Menu.Styles>
         </Menu>


### PR DESCRIPTION
After https://github.com/AvaloniaUI/Avalonia/pull/9655 was merged we can set x:DataType to a common type - NativeMenuItem.
Isn't ideal solution, but at least we can remove ReflectionBinding now.