### PR TITLE
A few small fixes for flaky tests

### DIFF
--- a/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests_Method.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Data/BindingTests_Method.cs
@@ -166,6 +166,8 @@ namespace Avalonia.Markup.Xaml.UnitTests.Data
         [Fact]
         public void Binding_Method_To_Command_Collected()
         {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
             WeakReference<ViewModel> MakeRef()
             {
                 var weakVm = new WeakReference<ViewModel>(null);

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/MergeResourceIncludeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/MergeResourceIncludeTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Xml;
 using Avalonia.Controls;
+using Avalonia.Data;
 using Avalonia.Media;
 using Avalonia.Styling;
 using Xunit;
@@ -9,6 +11,11 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml;
 
 public class MergeResourceIncludeTests
 {
+    static MergeResourceIncludeTests()
+    {
+        RuntimeHelpers.RunClassConstructor(typeof(RelativeSource).TypeHandle);
+    }
+
     [Fact]
     public void MergeResourceInclude_Works_With_Single_Resource()
     {

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleIncludeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleIncludeTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Avalonia.Controls;
+using Avalonia.Data;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Markup.Xaml.XamlIl.Runtime;
 using Avalonia.Media;
@@ -15,6 +17,12 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml;
 
 public class StyleIncludeTests
 {
+    static StyleIncludeTests()
+    {
+        RuntimeHelpers.RunClassConstructor(typeof(RelativeSource).TypeHandle);
+        AssetLoader.RegisterResUriParsers();
+    }
+
     [Fact]
     public void StyleInclude_Is_Built()
     {


### PR DESCRIPTION
## What does the pull request do?

I've noticed that we have a few flaky tests at times on my machine, I used ncrunch's [endless churn](https://blog.ncrunch.net/post/NCrunch-v313-Churn-mode-and-UI-enhancements.aspx) mode to try to find all of them:

- A couple of tests complained they couldn't find the type `RelativeSource`
- `StyleIncludeTests` failed at times parsing the `avares:` URLs
- `Binding_Method_To_Command_Collected` failed at times with a missing `IFontManageImpl`

This PR has fixes for these 3 cases.
