### PR TITLE
Add DropDownOpened and DropDownClosed events to ComboBox

### DIFF
--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -95,10 +95,9 @@ namespace Avalonia.Controls
         {
             ItemsPanelProperty.OverrideDefaultValue<ComboBox>(DefaultPanel);
             FocusableProperty.OverrideDefaultValue<ComboBox>(true);
-            SelectedItemProperty.Changed.AddClassHandler<ComboBox>((x, e) => x.SelectedItemChanged(e));
-            KeyDownEvent.AddClassHandler<ComboBox>((x, e) => x.OnKeyDown(e), Interactivity.RoutingStrategies.Tunnel);
             IsTextSearchEnabledProperty.OverrideDefaultValue<ComboBox>(true);
-            IsDropDownOpenProperty.Changed.AddClassHandler<ComboBox>((x, e) => x.DropdownChanged(e));
+
+            KeyDownEvent.AddClassHandler<ComboBox>((x, e) => x.OnKeyDown(e), Interactivity.RoutingStrategies.Tunnel);
         }
 
         /// <summary>
@@ -106,8 +105,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool IsDropDownOpen
         {
-            get { return _isDropDownOpen; }
-            set { SetAndRaise(IsDropDownOpenProperty, ref _isDropDownOpen, value); }
+            get => _isDropDownOpen;
+            set => SetAndRaise(IsDropDownOpenProperty, ref _isDropDownOpen, value);
         }
 
         /// <summary>
@@ -115,8 +114,8 @@ namespace Avalonia.Controls
         /// </summary>
         public double MaxDropDownHeight
         {
-            get { return GetValue(MaxDropDownHeightProperty); }
-            set { SetValue(MaxDropDownHeightProperty, value); }
+            get => GetValue(MaxDropDownHeightProperty);
+            set => SetValue(MaxDropDownHeightProperty, value);
         }
 
         /// <summary>
@@ -124,8 +123,8 @@ namespace Avalonia.Controls
         /// </summary>
         protected object? SelectionBoxItem
         {
-            get { return _selectionBoxItem; }
-            set { SetAndRaise(SelectionBoxItemProperty, ref _selectionBoxItem, value); }
+            get => _selectionBoxItem;
+            set => SetAndRaise(SelectionBoxItemProperty, ref _selectionBoxItem, value);
         }
 
         /// <summary>
@@ -133,8 +132,8 @@ namespace Avalonia.Controls
         /// </summary>
         public string? PlaceholderText
         {
-            get { return GetValue(PlaceholderTextProperty); }
-            set { SetValue(PlaceholderTextProperty, value); }
+            get => GetValue(PlaceholderTextProperty);
+            set => SetValue(PlaceholderTextProperty, value);
         }
 
         /// <summary>
@@ -142,8 +141,8 @@ namespace Avalonia.Controls
         /// </summary>
         public IBrush? PlaceholderForeground
         {
-            get { return GetValue(PlaceholderForegroundProperty); }
-            set { SetValue(PlaceholderForegroundProperty, value); }
+            get => GetValue(PlaceholderForegroundProperty);
+            set => SetValue(PlaceholderForegroundProperty, value);
         }
 
         /// <summary>
@@ -151,8 +150,8 @@ namespace Avalonia.Controls
         /// </summary>
         public ItemVirtualizationMode VirtualizationMode
         {
-            get { return GetValue(VirtualizationModeProperty); }
-            set { SetValue(VirtualizationModeProperty, value); }
+            get => GetValue(VirtualizationModeProperty);
+            set => SetValue(VirtualizationModeProperty, value);
         }
 
         /// <summary>
@@ -160,8 +159,8 @@ namespace Avalonia.Controls
         /// </summary>
         public HorizontalAlignment HorizontalContentAlignment
         {
-            get { return GetValue(HorizontalContentAlignmentProperty); }
-            set { SetValue(HorizontalContentAlignmentProperty, value); }
+            get => GetValue(HorizontalContentAlignmentProperty);
+            set => SetValue(HorizontalContentAlignmentProperty, value);
         }
 
         /// <summary>
@@ -169,8 +168,8 @@ namespace Avalonia.Controls
         /// </summary>
         public VerticalAlignment VerticalContentAlignment
         {
-            get { return GetValue(VerticalContentAlignmentProperty); }
-            set { SetValue(VerticalContentAlignmentProperty, value); }
+            get => GetValue(VerticalContentAlignmentProperty);
+            set => SetValue(VerticalContentAlignmentProperty, value);
         }
 
         /// <inheritdoc/>
@@ -182,6 +181,7 @@ namespace Avalonia.Controls
                 ComboBoxItem.ContentTemplateProperty);
         }
 
+        /// <inheritdoc/>
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
@@ -234,7 +234,7 @@ namespace Avalonia.Controls
             }
             // This part of code is needed just to acquire initial focus, subsequent focus navigation will be done by ItemsControl.
             else if (IsDropDownOpen && SelectedIndex < 0 && ItemCount > 0 &&
-                      (e.Key == Key.Up || e.Key == Key.Down) && IsFocused == true)
+                     (e.Key == Key.Up || e.Key == Key.Down) && IsFocused == true)
             {
                 var firstChild = Presenter?.Panel?.Children.FirstOrDefault(c => CanFocus(c));
                 if (firstChild != null)
@@ -304,11 +304,10 @@ namespace Avalonia.Controls
                     e.Handled = true;
                 }
             }
+
             PseudoClasses.Set(pcPressed, false);
             base.OnPointerReleased(e);
-            
         }
-
 
         /// <inheritdoc/>
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
@@ -322,6 +321,22 @@ namespace Avalonia.Controls
             _popup = e.NameScope.Get<Popup>("PART_Popup");
             _popup.Opened += PopupOpened;
             _popup.Closed += PopupClosed;
+        }
+
+        /// <inheritdoc/>
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            if (change.Property == SelectedItemProperty)
+            {
+                UpdateSelectionBoxItem(change.NewValue);
+                TryFocusSelectedItem();
+            }
+            else if (change.Property == IsDropDownOpenProperty)
+            {
+                PseudoClasses.Set(pcDropdownOpen, change.GetNewValue<bool>());
+            }
+
+            base.OnPropertyChanged(change);
         }
 
         protected override AutomationPeer OnCreateAutomationPeer()
@@ -382,12 +397,6 @@ namespace Avalonia.Controls
             {
                 IsDropDownOpen = false;
             }
-        }
-
-        private void SelectedItemChanged(AvaloniaPropertyChangedEventArgs e)
-        {
-            UpdateSelectionBoxItem(e.NewValue);
-            TryFocusSelectedItem();
         }
 
         private void TryFocusSelectedItem()
@@ -488,12 +497,6 @@ namespace Avalonia.Controls
             {
                 MoveSelection(NavigationDirection.Previous, WrapSelection);
             }
-        }
-
-        private void DropdownChanged(AvaloniaPropertyChangedEventArgs e)
-        {
-            bool newValue = e.GetNewValue<bool>();
-            PseudoClasses.Set(pcDropdownOpen, newValue);
         }
     }
 }

--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -99,6 +99,16 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
+        /// Occurs after the drop-down (popup) list of the <see cref="ComboBox"/> closes.
+        /// </summary>
+        public event EventHandler? DropDownClosed;
+
+        /// <summary>
+        /// Occurs after the drop-down (popup) list of the <see cref="ComboBox"/> opens.
+        /// </summary>
+        public event EventHandler? DropDownOpened;
+
+        /// <summary>
         /// Gets or sets a value indicating whether the dropdown is currently open.
         /// </summary>
         public bool IsDropDownOpen
@@ -358,6 +368,8 @@ namespace Avalonia.Controls
             {
                 Focus();
             }
+
+            DropDownClosed?.Invoke(this, EventArgs.Empty);
         }
 
         private void PopupOpened(object? sender, EventArgs e)
@@ -387,6 +399,8 @@ namespace Avalonia.Controls
             }
 
             UpdateFlowDirection();
+
+            DropDownOpened?.Invoke(this, EventArgs.Empty);
         }
 
         private void IsVisibleChanged(bool isVisible)

--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -96,8 +96,6 @@ namespace Avalonia.Controls
             ItemsPanelProperty.OverrideDefaultValue<ComboBox>(DefaultPanel);
             FocusableProperty.OverrideDefaultValue<ComboBox>(true);
             IsTextSearchEnabledProperty.OverrideDefaultValue<ComboBox>(true);
-
-            KeyDownEvent.AddClassHandler<ComboBox>((x, e) => x.OnKeyDown(e), Interactivity.RoutingStrategies.Tunnel);
         }
 
         /// <summary>


### PR DESCRIPTION
## What does the pull request do?

Add the `DropDownOpened` and `DropDownClosed` events to ComboBox from WPF.

## What is the current behavior?

ComboBox has no events.

## What is the updated/expected behavior with this PR?

 * Added `public event EventHandler? DropDownClosed;`
   * This is **NOT** a routed event following WPF/WinUI (there is no reason for it to be one anyway).
   * https://learn.microsoft.com/en-us/dotnet/api/system.windows.controls.combobox.dropdownclosed?view=windowsdesktop-7.0
   * Note that [WinUI's signature](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.combobox.dropdownclosed?view=winrt-22621) (using `object` instead of `EventArgs`) was not followed.
 * Added `public event EventHandler? DropDownOpened;`
   * This is **NOT** a routed event following WPF/WinUI (there is no reason for it to be one anyway).
   * https://learn.microsoft.com/en-us/dotnet/api/system.windows.controls.combobox.dropdownopened?view=windowsdesktop-7.0
   * Note that [WinUI's signature](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.combobox.dropdownopened?view=winrt-22621) (using `object` instead of `EventArgs`) was not followed.

## How was the solution implemented (if it's not obvious)?

The new events are invoked directly from the Popup Opened/Closed event handlers. This is easiest and seems to make the most sense. However, it would also be possible to invoke the events from the `IsDropDownOpen` property.

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

None

## Obsoletions / Deprecations

None

## Fixed issues

None