### PR TITLE
Open/Close ComboBox drop-down with Enter and Space

### DIFF
--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -213,7 +213,12 @@ namespace Avalonia.Controls
                 IsDropDownOpen = false;
                 e.Handled = true;
             }
-            else if (IsDropDownOpen && e.Key == Key.Enter)
+            else if (!IsDropDownOpen && (e.Key == Key.Enter || e.Key == Key.Space))
+            {
+                IsDropDownOpen = true;
+                e.Handled = true;
+            }
+            else if (IsDropDownOpen && (e.Key == Key.Enter || e.Key == Key.Space))
             {
                 SelectFocusedItem();
                 IsDropDownOpen = false;


### PR DESCRIPTION
## What does the pull request do?

Add more ways of opening/closing the ComboBox drop-down per #9732 matching WinUI.

## What is the current behavior?

It's sometimes unintuitive to open the ComboBox drop-down because only F4 and Up/Down + Alt are supported.

## What is the updated/expected behavior with this PR?

Both `Enter` and `Space` can be used to open or close the ComboBox drop-down.

## How was the solution implemented (if it's not obvious)?

Obvious

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

None

## Obsoletions / Deprecations

None

## Fixed issues

Closes #9732
