### PR TITLE
[TransitioningContentControl] Don't reomve old content from LogicalTree unitl the out animation is over

### DIFF
--- a/src/Avalonia.Controls/ContentControl.cs
+++ b/src/Avalonia.Controls/ContentControl.cs
@@ -116,14 +116,19 @@ namespace Avalonia.Controls
             return false;
         }
 
-        private void ContentChanged(AvaloniaPropertyChangedEventArgs e)
+        protected virtual void ContentChanged(AvaloniaPropertyChangedEventArgs e)
         {
-            if (e.OldValue is ILogical oldChild)
+            UpdateLogicalTree(e.OldValue, e.NewValue);
+        }
+
+        protected void UpdateLogicalTree(object? toRemove, object? toAdd)
+        {
+            if (toRemove is ILogical oldChild)
             {
                 LogicalChildren.Remove(oldChild);
             }
 
-            if (e.NewValue is ILogical newChild)
+            if (toAdd is ILogical newChild)
             {
                 LogicalChildren.Add(newChild);
             }

--- a/src/Avalonia.Controls/TransitioningContentControl.cs
+++ b/src/Avalonia.Controls/TransitioningContentControl.cs
@@ -71,6 +71,11 @@ public class TransitioningContentControl : ContentControl
         }
     }
 
+    protected override void ContentChanged(AvaloniaPropertyChangedEventArgs e)
+    {
+        // We do nothing becuse we should not remove old Content until the animation is over
+    }
+
     /// <summary>
     /// Updates the content with transitions.
     /// </summary>
@@ -88,6 +93,8 @@ public class TransitioningContentControl : ContentControl
 
         if (PageTransition != null)
             await PageTransition.Start(this, null, true, localToken);
+
+        UpdateLogicalTree(CurrentContent, content);
 
         if (localToken.IsCancellationRequested)
         {

--- a/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Old_Content_Shuold_Be_Removed__From_Logical_Tree_After_Out_Animation()
         {
-            using (UnitTestApplication.Start(TestServices.MockThreadingInterface))
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
                 var testTransition = new TestTransition();
 

--- a/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
@@ -1,0 +1,63 @@
+using System;
+using Avalonia.LogicalTree;
+using Avalonia.UnitTests;
+using Xunit;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Animation;
+
+namespace Avalonia.Controls.UnitTests
+{
+    public class TransitioningContentControlTests
+    {
+        [Fact]
+        public void Old_Content_Shuold_Be_Removed__From_Logical_Tree_After_Out_Animation()
+        {
+            var testTransition = new TestTransition();
+
+            var target = new TransitioningContentControl();
+            target.PageTransition = testTransition;
+
+            var root = new TestRoot() { Child = target };
+
+            var oldControl = new Control();
+            var newControl = new Control();
+
+            target.Content = oldControl;
+            Threading.Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(target, oldControl.GetLogicalParent());
+            Assert.Equal(null, newControl.GetLogicalParent());
+
+            testTransition.BeginTransition += isFrom =>
+            {
+                // Old out
+                if (isFrom)
+                {
+                    Assert.Equal(target, oldControl.GetLogicalParent());
+                    Assert.Equal(null, newControl.GetLogicalParent());
+                }
+                // New in
+                else
+                {
+                    Assert.Equal(null, oldControl.GetLogicalParent());
+                    Assert.Equal(target, newControl.GetLogicalParent());
+                }
+            };
+
+            target.Content = newControl;
+            Threading.Dispatcher.UIThread.RunJobs();
+        }
+    }
+    public class TestTransition : IPageTransition
+    {
+        public event Action<bool> BeginTransition;
+
+        public Task Start(Visual from, Visual to, bool forward, CancellationToken cancellationToken)
+        {
+            bool isFrom = from != null && to == null;
+            BeginTransition?.Invoke(isFrom);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
@@ -13,40 +13,43 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Old_Content_Shuold_Be_Removed__From_Logical_Tree_After_Out_Animation()
         {
-            var testTransition = new TestTransition();
-
-            var target = new TransitioningContentControl();
-            target.PageTransition = testTransition;
-
-            var root = new TestRoot() { Child = target };
-
-            var oldControl = new Control();
-            var newControl = new Control();
-
-            target.Content = oldControl;
-            Threading.Dispatcher.UIThread.RunJobs();
-
-            Assert.Equal(target, oldControl.GetLogicalParent());
-            Assert.Equal(null, newControl.GetLogicalParent());
-
-            testTransition.BeginTransition += isFrom =>
+            using (UnitTestApplication.Start(TestServices.MockThreadingInterface))
             {
-                // Old out
-                if (isFrom)
-                {
-                    Assert.Equal(target, oldControl.GetLogicalParent());
-                    Assert.Equal(null, newControl.GetLogicalParent());
-                }
-                // New in
-                else
-                {
-                    Assert.Equal(null, oldControl.GetLogicalParent());
-                    Assert.Equal(target, newControl.GetLogicalParent());
-                }
-            };
+                var testTransition = new TestTransition();
 
-            target.Content = newControl;
-            Threading.Dispatcher.UIThread.RunJobs();
+                var target = new TransitioningContentControl();
+                target.PageTransition = testTransition;
+
+                var root = new TestRoot() { Child = target };
+
+                var oldControl = new Control();
+                var newControl = new Control();
+
+                target.Content = oldControl;
+                Threading.Dispatcher.UIThread.RunJobs();
+
+                Assert.Equal(target, oldControl.GetLogicalParent());
+                Assert.Equal(null, newControl.GetLogicalParent());
+
+                testTransition.BeginTransition += isFrom =>
+                {
+                    // Old out
+                    if (isFrom)
+                    {
+                        Assert.Equal(target, oldControl.GetLogicalParent());
+                        Assert.Equal(null, newControl.GetLogicalParent());
+                    }
+                    // New in
+                    else
+                    {
+                        Assert.Equal(null, oldControl.GetLogicalParent());
+                        Assert.Equal(target, newControl.GetLogicalParent());
+                    }
+                };
+
+                target.Content = newControl;
+                Threading.Dispatcher.UIThread.RunJobs();
+            }
         }
     }
     public class TestTransition : IPageTransition


### PR DESCRIPTION
## What does the pull request do?
- [ContentControl] Make `ContentChanged` method `protected virtual`, so that a method inheriting can override it and do nothing.
- [TransitioningContentControl] override `ContentChanged` method and do nothing until the out animation over.
- Add unit test.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
No.

## Fixed issues
Fixes #9802
