### PR TITLE
[AndroidMotionEventsHelper] fixes eventTime to uptime android in mill…

### DIFF
--- a/src/Android/Avalonia.Android/Platform/Specific/Helpers/AndroidMotionEventsHelper.cs
+++ b/src/Android/Avalonia.Android/Platform/Specific/Helpers/AndroidMotionEventsHelper.cs
@@ -38,7 +38,7 @@ namespace Avalonia.Android.Platform.Specific.Helpers
                 return null;
             }
 
-            var eventTime = (ulong)DateTime.Now.Millisecond;
+            var eventTime = (ulong)e.EventTime;
             var inputRoot = _view.InputRoot;
             var actionMasked = e.ActionMasked;
             var modifiers = GetModifiers(e.MetaState, e.ButtonState);


### PR DESCRIPTION
…iseconds

## What does the pull request do?
On Android fixing the `Timestamp` of the pointer events to be uptime android in milliseconds.


## What is the current behavior?
Currently the eventtime is set to `DateTime.Now.Milliseconds` -- problem: this is always a value between 0 and 999, which makes it impossible to calculate timings with a string of events.

## What is the updated/expected behavior with this PR?
On Android the pointer events `Timestamp` should be set to the `uptime of android` in milliseconds, so a newer event will always have a higher timestamp value compared to on older event.


## How was the solution implemented (if it's not obvious)?
Setting timestamp to `Android.Views.MotionEvent.EventTime`, which already looks like the uptime of android in milliseconds.

## Fixed issues
Fixes #9823
Fixes #9687
