### PR TITLE
Android - Keep AppBuilder instance

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaSplashActivity.cs
+++ b/src/Android/Avalonia.Android/AvaloniaSplashActivity.cs
@@ -1,6 +1,5 @@
 using Android.OS;
 using AndroidX.AppCompat.App;
-using Avalonia.Controls;
 
 namespace Avalonia.Android
 {
@@ -8,15 +7,22 @@ namespace Avalonia.Android
     {
         protected abstract AppBuilder CreateAppBuilder();
 
+        private static AppBuilder s_appBuilder;
+
         protected override void OnCreate(Bundle? savedInstanceState)
         {
             base.OnCreate(savedInstanceState);
 
-            var builder = CreateAppBuilder();
+            if (s_appBuilder == null)
+            {
+                var builder = CreateAppBuilder();
 
-            var lifetime = new SingleViewLifetime();
+                var lifetime = new SingleViewLifetime();
 
-            builder.SetupWithLifetime(lifetime);
+                builder.SetupWithLifetime(lifetime);
+
+                s_appBuilder = builder;
+            }
         }
     }
 


### PR DESCRIPTION
## What does the pull request do?
Keeps AppBuilder instance in memory, and skips initializing it on conservative launched unless the app process has been terminated.


## What is the current behavior?
On consecutive launches, a new app builder instance is created and initialized. If the app's process hasn't been previously terminated, this re-initialization causes a crash with the following message, `**System.InvalidOperationException:** 'Setup was already called on one of AppBuilder instances'`, as a check for re-initialization fails.


## What is the updated/expected behavior with this PR?
When an app is launched with a new process, the AppBuilder is saved in a static field. On consecutive launches, as long as it isn't a new process, the initialization of a new AppBuilder is skipped. This also has the effect of speeding up consecutive launches.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #9842