### PR TITLE
avoid nuget refs on net6

### DIFF
--- a/build/Base.props
+++ b/build/Base.props
@@ -1,5 +1,5 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6'">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
   </ItemGroup>

--- a/build/System.Memory.props
+++ b/build/System.Memory.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6'">
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
System.ValueTuple, Runtime.CompilerServices.Unsafe, and System.Memory should not be required no net6 and up

## What does the pull request do?

uses conditions to avoid some redundant refs


## What is the current behavior?

Avalonia has some redundant nuget refs

![image](https://user-images.githubusercontent.com/122666/210299833-d9b6c7b4-ebaf-44f0-8897-ac7a47471551.png)


## What is the updated/expected behavior with this PR?

those refs should no longer be included
