### PR TITLE
[Text] [Rename] ShapeableTextCharacters to UnshapedTextRun and ShapedTextCharacters to ShapedTextRun

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/InterWordJustification.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/InterWordJustification.cs
@@ -91,7 +91,7 @@ namespace Avalonia.Media.TextFormatting
                     continue;
                 }
 
-                if (textRun is ShapedTextCharacters shapedText)
+                if (textRun is ShapedTextRun shapedText)
                 {
                     var glyphRun = shapedText.GlyphRun;
                     var shapedBuffer = shapedText.ShapedBuffer;

--- a/src/Avalonia.Base/Media/TextFormatting/ShapedTextRun.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/ShapedTextRun.cs
@@ -6,11 +6,11 @@ namespace Avalonia.Media.TextFormatting
     /// <summary>
     /// A text run that holds shaped characters.
     /// </summary>
-    public sealed class ShapedTextCharacters : DrawableTextRun
+    public sealed class ShapedTextRun : DrawableTextRun
     {
         private GlyphRun? _glyphRun;
 
-        public ShapedTextCharacters(ShapedBuffer shapedBuffer, TextRunProperties properties)
+        public ShapedTextRun(ShapedBuffer shapedBuffer, TextRunProperties properties)
         {
             ShapedBuffer = shapedBuffer;
             CharacterBufferReference = shapedBuffer.CharacterBufferRange.CharacterBufferReference;
@@ -155,7 +155,7 @@ namespace Avalonia.Media.TextFormatting
             return length > 0;
         }
 
-        internal SplitResult<ShapedTextCharacters> Split(int length)
+        internal SplitResult<ShapedTextRun> Split(int length)
         {
             if (IsReversed)
             {
@@ -171,7 +171,7 @@ namespace Avalonia.Media.TextFormatting
             
             var splitBuffer = ShapedBuffer.Split(length);
 
-            var first = new ShapedTextCharacters(splitBuffer.First, Properties);
+            var first = new ShapedTextRun(splitBuffer.First, Properties);
 
             #if DEBUG
 
@@ -182,9 +182,9 @@ namespace Avalonia.Media.TextFormatting
 
 #endif
 
-            var second = new ShapedTextCharacters(splitBuffer.Second!, Properties);
+            var second = new ShapedTextRun(splitBuffer.Second!, Properties);
 
-            return new SplitResult<ShapedTextCharacters>(first, second);
+            return new SplitResult<ShapedTextRun>(first, second);
         }
 
         internal GlyphRun CreateGlyphRun()

--- a/src/Avalonia.Base/Media/TextFormatting/TextCharacters.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextCharacters.cs
@@ -91,12 +91,12 @@ namespace Avalonia.Media.TextFormatting
         public override TextRunProperties Properties { get; }
 
         /// <summary>
-        /// Gets a list of <see cref="ShapeableTextCharacters"/>.
+        /// Gets a list of <see cref="UnshapedTextRun"/>.
         /// </summary>
         /// <returns>The shapeable text characters.</returns>
-        internal IReadOnlyList<ShapeableTextCharacters> GetShapeableCharacters(CharacterBufferRange characterBufferRange, sbyte biDiLevel, ref TextRunProperties? previousProperties)
+        internal IReadOnlyList<UnshapedTextRun> GetShapeableCharacters(CharacterBufferRange characterBufferRange, sbyte biDiLevel, ref TextRunProperties? previousProperties)
         {
-            var shapeableCharacters = new List<ShapeableTextCharacters>(2);
+            var shapeableCharacters = new List<UnshapedTextRun>(2);
 
             while (characterBufferRange.Length > 0)
             {
@@ -120,7 +120,7 @@ namespace Avalonia.Media.TextFormatting
         /// <param name="biDiLevel">The bidi level of the run.</param>
         /// <param name="previousProperties"></param>
         /// <returns>A list of shapeable text runs.</returns>
-        private static ShapeableTextCharacters CreateShapeableRun(CharacterBufferRange characterBufferRange,
+        private static UnshapedTextRun CreateShapeableRun(CharacterBufferRange characterBufferRange,
             TextRunProperties defaultProperties, sbyte biDiLevel, ref TextRunProperties? previousProperties)
         {
             var defaultTypeface = defaultProperties.Typeface;
@@ -133,12 +133,12 @@ namespace Avalonia.Media.TextFormatting
                 {
                     if (TryGetShapeableLength(characterBufferRange, previousTypeface.Value, null, out var fallbackCount, out _))
                     {
-                        return new ShapeableTextCharacters(characterBufferRange.CharacterBufferReference, fallbackCount,
+                        return new UnshapedTextRun(characterBufferRange.CharacterBufferReference, fallbackCount,
                             defaultProperties.WithTypeface(previousTypeface.Value), biDiLevel);
                     }
                 }
 
-                return new ShapeableTextCharacters(characterBufferRange.CharacterBufferReference, count, defaultProperties.WithTypeface(currentTypeface),
+                return new UnshapedTextRun(characterBufferRange.CharacterBufferReference, count, defaultProperties.WithTypeface(currentTypeface),
                     biDiLevel);
             }
 
@@ -146,7 +146,7 @@ namespace Avalonia.Media.TextFormatting
             {
                 if (TryGetShapeableLength(characterBufferRange, previousTypeface.Value, defaultTypeface, out count, out _))
                 {
-                    return new ShapeableTextCharacters(characterBufferRange.CharacterBufferReference, count,
+                    return new UnshapedTextRun(characterBufferRange.CharacterBufferReference, count,
                         defaultProperties.WithTypeface(previousTypeface.Value), biDiLevel);
                 }
             }
@@ -176,7 +176,7 @@ namespace Avalonia.Media.TextFormatting
             if (matchFound && TryGetShapeableLength(characterBufferRange, currentTypeface, defaultTypeface, out count, out _))
             {
                 //Fallback found
-                return new ShapeableTextCharacters(characterBufferRange.CharacterBufferReference, count, defaultProperties.WithTypeface(currentTypeface),
+                return new UnshapedTextRun(characterBufferRange.CharacterBufferReference, count, defaultProperties.WithTypeface(currentTypeface),
                     biDiLevel);
             }
 
@@ -199,7 +199,7 @@ namespace Avalonia.Media.TextFormatting
                 count += grapheme.Text.Length;
             }
 
-            return new ShapeableTextCharacters(characterBufferRange.CharacterBufferReference, count, defaultProperties, biDiLevel);
+            return new UnshapedTextRun(characterBufferRange.CharacterBufferReference, count, defaultProperties, biDiLevel);
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Media/TextFormatting/TextEllipsisHelper.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextEllipsisHelper.cs
@@ -31,7 +31,7 @@ namespace Avalonia.Media.TextFormatting
 
                 switch (currentRun)
                 {
-                    case ShapedTextCharacters shapedRun:
+                    case ShapedTextRun shapedRun:
                         {
                             currentWidth += shapedRun.Size.Width;
 

--- a/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
@@ -124,7 +124,7 @@ namespace Avalonia.Media.TextFormatting
 
                     var second = new List<DrawableTextRun>(secondCount);
 
-                    if (currentRun is ShapedTextCharacters shapedTextCharacters)
+                    if (currentRun is ShapedTextRun shapedTextCharacters)
                     {
                         var split = shapedTextCharacters.Split(length - currentLength);
 
@@ -206,16 +206,16 @@ namespace Avalonia.Media.TextFormatting
                             break;
                         }
 
-                    case ShapeableTextCharacters shapeableRun:
+                    case UnshapedTextRun shapeableRun:
                         {
-                            var groupedRuns = new List<ShapeableTextCharacters>(2) { shapeableRun };
+                            var groupedRuns = new List<UnshapedTextRun>(2) { shapeableRun };
                             var characterBufferReference = currentRun.CharacterBufferReference;
                             var length = currentRun.Length;
                             var offsetToFirstCharacter = characterBufferReference.OffsetToFirstChar;
 
                             while (index + 1 < processedRuns.Count)
                             {
-                                if (processedRuns[index + 1] is not ShapeableTextCharacters nextRun)
+                                if (processedRuns[index + 1] is not UnshapedTextRun nextRun)
                                 {
                                     break;
                                 }
@@ -258,10 +258,10 @@ namespace Avalonia.Media.TextFormatting
             return drawableTextRuns;
         }
 
-        private static IReadOnlyList<ShapedTextCharacters> ShapeTogether(
-            IReadOnlyList<ShapeableTextCharacters> textRuns, CharacterBufferReference text, int length, TextShaperOptions options)
+        private static IReadOnlyList<ShapedTextRun> ShapeTogether(
+            IReadOnlyList<UnshapedTextRun> textRuns, CharacterBufferReference text, int length, TextShaperOptions options)
         {
-            var shapedRuns = new List<ShapedTextCharacters>(textRuns.Count);
+            var shapedRuns = new List<ShapedTextRun>(textRuns.Count);
 
             var shapedBuffer = TextShaper.Current.ShapeText(text, length, options);
 
@@ -271,7 +271,7 @@ namespace Avalonia.Media.TextFormatting
 
                 var splitResult = shapedBuffer.Split(currentRun.Length);
 
-                shapedRuns.Add(new ShapedTextCharacters(splitResult.First, currentRun.Properties));
+                shapedRuns.Add(new ShapedTextRun(splitResult.First, currentRun.Properties));
 
                 shapedBuffer = splitResult.Second!;
             }
@@ -280,9 +280,9 @@ namespace Avalonia.Media.TextFormatting
         }
 
         /// <summary>
-        /// Coalesces ranges of the same bidi level to form <see cref="ShapeableTextCharacters"/>
+        /// Coalesces ranges of the same bidi level to form <see cref="UnshapedTextRun"/>
         /// </summary>
-        /// <param name="textCharacters">The text characters to form <see cref="ShapeableTextCharacters"/> from.</param>
+        /// <param name="textCharacters">The text characters to form <see cref="UnshapedTextRun"/> from.</param>
         /// <param name="levels">The bidi levels.</param>
         /// <returns></returns>
         private static IEnumerable<IReadOnlyList<TextRun>> CoalesceLevels(IReadOnlyList<TextRun> textCharacters, ArraySlice<sbyte> levels)
@@ -474,7 +474,7 @@ namespace Avalonia.Media.TextFormatting
             {
                 switch (currentRun)
                 {
-                    case ShapedTextCharacters shapedTextCharacters:
+                    case ShapedTextRun shapedTextCharacters:
                         {
                             if(shapedTextCharacters.ShapedBuffer.Length > 0)
                             {
@@ -538,7 +538,7 @@ namespace Avalonia.Media.TextFormatting
             var shapedBuffer = new ShapedBuffer(characterBufferRange, glyphInfos, glyphTypeface, properties.FontRenderingEmSize,
                 (sbyte)flowDirection);
 
-            var textRuns = new List<DrawableTextRun> { new ShapedTextCharacters(shapedBuffer, properties) };
+            var textRuns = new List<DrawableTextRun> { new ShapedTextRun(shapedBuffer, properties) };
 
             return new TextLineImpl(textRuns, firstTextSourceIndex, 0, paragraphWidth, paragraphProperties, flowDirection).FinalizeLine();
         }
@@ -744,7 +744,7 @@ namespace Avalonia.Media.TextFormatting
         /// <returns>
         /// The shaped symbol.
         /// </returns>
-        internal static ShapedTextCharacters CreateSymbol(TextRun textRun, FlowDirection flowDirection)
+        internal static ShapedTextRun CreateSymbol(TextRun textRun, FlowDirection flowDirection)
         {
             var textShaper = TextShaper.Current;
 
@@ -760,7 +760,7 @@ namespace Avalonia.Media.TextFormatting
 
             var shapedBuffer = textShaper.ShapeText(characterBuffer, textRun.Length, shaperOptions);
 
-            return new ShapedTextCharacters(shapedBuffer, textRun.Properties);
+            return new ShapedTextRun(shapedBuffer, textRun.Properties);
         }
     }
 }

--- a/src/Avalonia.Base/Media/TextFormatting/TextLeadingPrefixCharacterEllipsis.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLeadingPrefixCharacterEllipsis.cs
@@ -65,7 +65,7 @@ namespace Avalonia.Media.TextFormatting
 
                 switch (currentRun)
                 {
-                    case ShapedTextCharacters shapedRun:
+                    case ShapedTextRun shapedRun:
                     {
                         currentWidth += currentRun.Size.Width;
 
@@ -118,7 +118,7 @@ namespace Avalonia.Media.TextFormatting
 
                                     switch (run)
                                     {
-                                        case ShapedTextCharacters endShapedRun:
+                                        case ShapedTextRun endShapedRun:
                                         {
                                             if (endShapedRun.TryMeasureCharactersBackwards(availableSuffixWidth,
                                                     out var suffixCount, out var suffixWidth))

--- a/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
@@ -192,14 +192,14 @@ namespace Avalonia.Media.TextFormatting
             {
                 var currentRun = _textRuns[i];
 
-                if (currentRun is ShapedTextCharacters shapedRun && !shapedRun.ShapedBuffer.IsLeftToRight)
+                if (currentRun is ShapedTextRun shapedRun && !shapedRun.ShapedBuffer.IsLeftToRight)
                 {
                     var rightToLeftIndex = i;
                     currentPosition += currentRun.Length;
 
                     while (rightToLeftIndex + 1 <= _textRuns.Count - 1)
                     {
-                        var nextShaped = _textRuns[++rightToLeftIndex] as ShapedTextCharacters;
+                        var nextShaped = _textRuns[++rightToLeftIndex] as ShapedTextRun;
 
                         if (nextShaped == null || nextShaped.ShapedBuffer.IsLeftToRight)
                         {
@@ -255,7 +255,7 @@ namespace Avalonia.Media.TextFormatting
 
             switch (run)
             {
-                case ShapedTextCharacters shapedRun:
+                case ShapedTextRun shapedRun:
                     {
                         characterHit = shapedRun.GlyphRun.GetCharacterHitFromDistance(distance, out _);
 
@@ -303,7 +303,7 @@ namespace Avalonia.Media.TextFormatting
                 {
                     var currentRun = _textRuns[index];
 
-                    if (currentRun is ShapedTextCharacters shapedRun && !shapedRun.ShapedBuffer.IsLeftToRight)
+                    if (currentRun is ShapedTextRun shapedRun && !shapedRun.ShapedBuffer.IsLeftToRight)
                     {
                         var i = index;
 
@@ -313,7 +313,7 @@ namespace Avalonia.Media.TextFormatting
                         {
                             var nextRun = _textRuns[i + 1];
 
-                            if (nextRun is ShapedTextCharacters nextShapedRun && !nextShapedRun.ShapedBuffer.IsLeftToRight)
+                            if (nextRun is ShapedTextRun nextShapedRun && !nextShapedRun.ShapedBuffer.IsLeftToRight)
                             {
                                 i++;
 
@@ -407,7 +407,7 @@ namespace Avalonia.Media.TextFormatting
 
             switch (currentRun)
             {
-                case ShapedTextCharacters shapedTextCharacters:
+                case ShapedTextRun shapedTextCharacters:
                     {
                         currentGlyphRun = shapedTextCharacters.GlyphRun;
 
@@ -476,7 +476,7 @@ namespace Avalonia.Media.TextFormatting
 
             switch (currentRun)
             {
-                case ShapedTextCharacters shapedRun:
+                case ShapedTextRun shapedRun:
                     {
                         nextCharacterHit = shapedRun.GlyphRun.GetNextCaretCharacterHit(characterHit);
                         break;
@@ -550,7 +550,7 @@ namespace Avalonia.Media.TextFormatting
 
                 double combinedWidth;
 
-                if (currentRun is ShapedTextCharacters currentShapedRun)
+                if (currentRun is ShapedTextRun currentShapedRun)
                 {
                     var firstCluster = currentShapedRun.GlyphRun.Metrics.FirstCluster;
 
@@ -592,7 +592,7 @@ namespace Avalonia.Media.TextFormatting
                         var rightToLeftIndex = index;
                         var rightToLeftWidth = currentShapedRun.Size.Width;
 
-                        while (rightToLeftIndex + 1 <= _textRuns.Count - 1 && _textRuns[rightToLeftIndex + 1] is ShapedTextCharacters nextShapedRun)
+                        while (rightToLeftIndex + 1 <= _textRuns.Count - 1 && _textRuns[rightToLeftIndex + 1] is ShapedTextRun nextShapedRun)
                         {
                             if (nextShapedRun == null || nextShapedRun.ShapedBuffer.IsLeftToRight)
                             {
@@ -624,12 +624,12 @@ namespace Avalonia.Media.TextFormatting
 
                         for (int i = rightToLeftIndex - 1; i >= index; i--)
                         {
-                            if (TextRuns[i] is not ShapedTextCharacters)
+                            if (TextRuns[i] is not ShapedTextRun)
                             {
                                 continue;
                             }
 
-                            currentShapedRun = (ShapedTextCharacters)TextRuns[i];
+                            currentShapedRun = (ShapedTextRun)TextRuns[i];
 
                             currentRunBounds = GetRightToLeftTextRunBounds(currentShapedRun, startX, firstTextSourceIndex, characterIndex, currentPosition, remainingLength);
 
@@ -769,7 +769,7 @@ namespace Avalonia.Media.TextFormatting
                 var characterLength = 0;
                 var endX = startX;
 
-                if (currentRun is ShapedTextCharacters currentShapedRun)
+                if (currentRun is ShapedTextRun currentShapedRun)
                 {
                     var offset = Math.Max(0, firstTextSourceIndex - currentPosition);
 
@@ -883,7 +883,7 @@ namespace Avalonia.Media.TextFormatting
             return result;
         }
 
-        private TextRunBounds GetRightToLeftTextRunBounds(ShapedTextCharacters currentRun, double endX, int firstTextSourceIndex, int characterIndex, int currentPosition, int remainingLength)
+        private TextRunBounds GetRightToLeftTextRunBounds(ShapedTextRun currentRun, double endX, int firstTextSourceIndex, int characterIndex, int currentPosition, int remainingLength)
         {
             var startX = endX;
 
@@ -945,7 +945,7 @@ namespace Avalonia.Media.TextFormatting
 
         private static sbyte GetRunBidiLevel(DrawableTextRun run, FlowDirection flowDirection)
         {
-            if (run is ShapedTextCharacters shapedTextCharacters)
+            if (run is ShapedTextRun shapedTextCharacters)
             {
                 return shapedTextCharacters.BidiLevel;
             }
@@ -1027,7 +1027,7 @@ namespace Avalonia.Media.TextFormatting
                 {
                     if (current.Level >= minLevelToReverse && current.Level % 2 != 0)
                     {
-                        if (current.Run is ShapedTextCharacters { IsReversed: false } shapedTextCharacters)
+                        if (current.Run is ShapedTextRun { IsReversed: false } shapedTextCharacters)
                         {
                             shapedTextCharacters.Reverse();
                         }
@@ -1145,7 +1145,7 @@ namespace Avalonia.Media.TextFormatting
 
                 switch (currentRun)
                 {
-                    case ShapedTextCharacters shapedRun:
+                    case ShapedTextRun shapedRun:
                         {
                             var foundCharacterHit = shapedRun.GlyphRun.FindNearestCharacterHit(characterHit.FirstCharacterIndex + characterHit.TrailingLength, out _);
 
@@ -1230,7 +1230,7 @@ namespace Avalonia.Media.TextFormatting
 
                 switch (currentRun)
                 {
-                    case ShapedTextCharacters shapedRun:
+                    case ShapedTextRun shapedRun:
                         {
                             var foundCharacterHit = shapedRun.GlyphRun.FindNearestCharacterHit(characterHit.FirstCharacterIndex - 1, out _);
 
@@ -1294,7 +1294,7 @@ namespace Avalonia.Media.TextFormatting
 
                 switch (currentRun)
                 {
-                    case ShapedTextCharacters shapedRun:
+                    case ShapedTextRun shapedRun:
                         {
                             var firstCluster = shapedRun.GlyphRun.Metrics.FirstCluster;
 
@@ -1303,7 +1303,7 @@ namespace Avalonia.Media.TextFormatting
                                 break;
                             }
 
-                            if (previousRun is ShapedTextCharacters previousShaped && !previousShaped.ShapedBuffer.IsLeftToRight)
+                            if (previousRun is ShapedTextRun previousShaped && !previousShaped.ShapedBuffer.IsLeftToRight)
                             {
                                 if (shapedRun.ShapedBuffer.IsLeftToRight)
                                 {
@@ -1394,7 +1394,7 @@ namespace Avalonia.Media.TextFormatting
             {
                 switch (_textRuns[index])
                 {
-                    case ShapedTextCharacters textRun:
+                    case ShapedTextRun textRun:
                         {
                             var textMetrics =
                                 new TextMetrics(textRun.Properties.Typeface.GlyphTypeface, textRun.Properties.FontRenderingEmSize);

--- a/src/Avalonia.Base/Media/TextFormatting/UnshapedTextRun.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/UnshapedTextRun.cs
@@ -5,9 +5,9 @@ namespace Avalonia.Media.TextFormatting
     /// <summary>
     /// A group of characters that can be shaped.
     /// </summary>
-    public sealed class ShapeableTextCharacters : TextRun
+    public sealed class UnshapedTextRun : TextRun
     {
-        public ShapeableTextCharacters(CharacterBufferReference characterBufferReference, int length,
+        public UnshapedTextRun(CharacterBufferReference characterBufferReference, int length,
             TextRunProperties properties, sbyte biDiLevel)
         {
             CharacterBufferReference = characterBufferReference;
@@ -24,30 +24,30 @@ namespace Avalonia.Media.TextFormatting
 
         public sbyte BidiLevel { get; }
 
-        public bool CanShapeTogether(ShapeableTextCharacters shapeableTextCharacters)
+        public bool CanShapeTogether(UnshapedTextRun unshapedTextRun)
         {
-            if (!CharacterBufferReference.Equals(shapeableTextCharacters.CharacterBufferReference))
+            if (!CharacterBufferReference.Equals(unshapedTextRun.CharacterBufferReference))
             {
                 return false;
             }
 
-            if (BidiLevel != shapeableTextCharacters.BidiLevel)
+            if (BidiLevel != unshapedTextRun.BidiLevel)
             {
                 return false;
             }
 
             if (!MathUtilities.AreClose(Properties.FontRenderingEmSize,
-                    shapeableTextCharacters.Properties.FontRenderingEmSize))
+                    unshapedTextRun.Properties.FontRenderingEmSize))
             {
                 return false;
             }
 
-            if (Properties.Typeface != shapeableTextCharacters.Properties.Typeface)
+            if (Properties.Typeface != unshapedTextRun.Properties.Typeface)
             {
                 return false;
             }
 
-            if (Properties.BaselineAlignment != shapeableTextCharacters.Properties.BaselineAlignment)
+            if (Properties.BaselineAlignment != unshapedTextRun.Properties.BaselineAlignment)
             {
                 return false;
             }

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
@@ -520,7 +520,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                 var expectedTextLine = formatter.FormatLine(new SingleBufferTextSource(text, defaultProperties),
                     0, double.PositiveInfinity, paragraphProperties);
 
-                var expectedRuns = expectedTextLine.TextRuns.Cast<ShapedTextCharacters>().ToList();
+                var expectedRuns = expectedTextLine.TextRuns.Cast<ShapedTextRun>().ToList();
 
                 var expectedGlyphs = expectedRuns.SelectMany(x => x.GlyphRun.GlyphIndices).ToList();
 
@@ -539,7 +539,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                         var textLine =
                             formatter.FormatLine(textSource, 0, double.PositiveInfinity, paragraphProperties);
 
-                        var shapedRuns = textLine.TextRuns.Cast<ShapedTextCharacters>().ToList();
+                        var shapedRuns = textLine.TextRuns.Cast<ShapedTextRun>().ToList();
 
                         var actualGlyphs = shapedRuns.SelectMany(x => x.GlyphRun.GlyphIndices).ToList();
 

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLayoutTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLayoutTests.cs
@@ -141,7 +141,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                     black,
                     textWrapping: TextWrapping.Wrap);
 
-                var expectedGlyphs = expected.TextLines.Select(x => string.Join('|', x.TextRuns.Cast<ShapedTextCharacters>()
+                var expectedGlyphs = expected.TextLines.Select(x => string.Join('|', x.TextRuns.Cast<ShapedTextRun>()
                     .SelectMany(x => x.ShapedBuffer.GlyphIndices))).ToList();
 
                 var outer = new GraphemeEnumerator(new CharacterBufferRange(text));
@@ -174,7 +174,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                             textWrapping: TextWrapping.Wrap,
                             textStyleOverrides: spans);
 
-                        var actualGlyphs = actual.TextLines.Select(x => string.Join('|', x.TextRuns.Cast<ShapedTextCharacters>()
+                        var actualGlyphs = actual.TextLines.Select(x => string.Join('|', x.TextRuns.Cast<ShapedTextRun>()
                             .SelectMany(x => x.ShapedBuffer.GlyphIndices))).ToList();
 
                         Assert.Equal(expectedGlyphs.Count, actualGlyphs.Count);
@@ -447,7 +447,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                     12.0f,
                     Brushes.Black.ToImmutable());
 
-                var shapedRun = (ShapedTextCharacters)layout.TextLines[0].TextRuns[0];
+                var shapedRun = (ShapedTextRun)layout.TextLines[0].TextRuns[0];
 
                 var glyphRun = shapedRun.GlyphRun;
 
@@ -481,7 +481,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                 foreach (var textRun in textLine.TextRuns)
                 {
-                    var shapedRun = (ShapedTextCharacters)textRun;
+                    var shapedRun = (ShapedTextRun)textRun;
 
                     var glyphClusters = shapedRun.ShapedBuffer.GlyphClusters;
 
@@ -514,13 +514,13 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                 Assert.Equal(1, layout.TextLines[0].TextRuns.Count);
 
-                Assert.Equal(expectedLength, ((ShapedTextCharacters)layout.TextLines[0].TextRuns[0]).GlyphRun.GlyphClusters.Count);
+                Assert.Equal(expectedLength, ((ShapedTextRun)layout.TextLines[0].TextRuns[0]).GlyphRun.GlyphClusters.Count);
 
-                Assert.Equal(5, ((ShapedTextCharacters)layout.TextLines[0].TextRuns[0]).ShapedBuffer.GlyphClusters[5]);
+                Assert.Equal(5, ((ShapedTextRun)layout.TextLines[0].TextRuns[0]).ShapedBuffer.GlyphClusters[5]);
 
                 if (expectedLength == 7)
                 {
-                    Assert.Equal(5, ((ShapedTextCharacters)layout.TextLines[0].TextRuns[0]).ShapedBuffer.GlyphClusters[6]);
+                    Assert.Equal(5, ((ShapedTextRun)layout.TextLines[0].TextRuns[0]).ShapedBuffer.GlyphClusters[6]);
                 }
             }
         }
@@ -555,7 +555,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                 var textLine = layout.TextLines[0];
 
-                var textRun = (ShapedTextCharacters)textLine.TextRuns[0];
+                var textRun = (ShapedTextRun)textLine.TextRuns[0];
 
                 Assert.Equal(7, textRun.Length);
 
@@ -775,7 +775,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                     Assert.Equal(textLine.WidthIncludingTrailingWhitespace, rect.Width);
                 }
 
-                var rects = layout.TextLines.SelectMany(x => x.TextRuns.Cast<ShapedTextCharacters>())
+                var rects = layout.TextLines.SelectMany(x => x.TextRuns.Cast<ShapedTextRun>())
                     .SelectMany(x => x.ShapedBuffer.GlyphAdvances).ToArray();
 
                 for (var i = 0; i < SingleLineText.Length; i++)
@@ -814,7 +814,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                     {
                         Assert.True(textLine.Width <= maxWidth);
 
-                        var actual = new string(textLine.TextRuns.Cast<ShapedTextCharacters>()
+                        var actual = new string(textLine.TextRuns.Cast<ShapedTextRun>()
                             .OrderBy(x => x.CharacterBufferReference.OffsetToFirstChar)
                             .SelectMany(x => new CharacterBufferRange(x.CharacterBufferReference, x.Length)).ToArray());
 
@@ -855,7 +855,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                     Brushes.Black,
                     flowDirection: FlowDirection.RightToLeft);
 
-                var firstRun = layout.TextLines[0].TextRuns[0] as ShapedTextCharacters;
+                var firstRun = layout.TextLines[0].TextRuns[0] as ShapedTextRun;
 
                 var hit = layout.HitTestPoint(new Point());
 
@@ -881,7 +881,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                     currentX += advance;
                 }
 
-                var secondRun = layout.TextLines[0].TextRuns[1] as ShapedTextCharacters;
+                var secondRun = layout.TextLines[0].TextRuns[1] as ShapedTextRun;
 
                 hit = layout.HitTestPoint(new Point(firstRun.Size.Width, 0));
 
@@ -928,7 +928,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                 var textLine = layout.TextLines[0];
 
-                var firstRun = (ShapedTextCharacters)textLine.TextRuns[0];
+                var firstRun = (ShapedTextRun)textLine.TextRuns[0];
 
                 var firstCluster = firstRun.ShapedBuffer.GlyphClusters[0];
 
@@ -987,7 +987,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                     var textLine = layout.TextLines[0];
 
-                    var shapedRuns = textLine.TextRuns.Cast<ShapedTextCharacters>().ToList();
+                    var shapedRuns = textLine.TextRuns.Cast<ShapedTextRun>().ToList();
 
                     var clusters = shapedRuns.SelectMany(x => x.ShapedBuffer.GlyphClusters).ToList();
 

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
@@ -92,7 +92,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                 foreach (var textRun in textLine.TextRuns.OrderBy(x => x.CharacterBufferReference.OffsetToFirstChar))
                 {
-                    var shapedRun = (ShapedTextCharacters)textRun;
+                    var shapedRun = (ShapedTextRun)textRun;
 
                     clusters.AddRange(shapedRun.IsReversed ?
                         shapedRun.ShapedBuffer.GlyphClusters.Reverse() :
@@ -139,7 +139,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                 foreach (var textRun in textLine.TextRuns.OrderBy(x => x.CharacterBufferReference.OffsetToFirstChar))
                 {
-                    var shapedRun = (ShapedTextCharacters)textRun;
+                    var shapedRun = (ShapedTextRun)textRun;
 
                     clusters.AddRange(shapedRun.IsReversed ?
                         shapedRun.ShapedBuffer.GlyphClusters.Reverse() :
@@ -246,7 +246,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                     formatter.FormatLine(textSource, 0, double.PositiveInfinity,
                         new GenericTextParagraphProperties(defaultProperties));
 
-                var clusters = textLine.TextRuns.Cast<ShapedTextCharacters>().SelectMany(x => x.ShapedBuffer.GlyphClusters)
+                var clusters = textLine.TextRuns.Cast<ShapedTextRun>().SelectMany(x => x.ShapedBuffer.GlyphClusters)
                     .ToArray();
 
                 var previousCharacterHit = new CharacterHit(text.Length);
@@ -308,7 +308,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                 foreach (var run in textLine.TextRuns)
                 {
-                    var textRun = (ShapedTextCharacters)run;
+                    var textRun = (ShapedTextRun)run;
 
                     var glyphRun = textRun.GlyphRun;
 
@@ -634,7 +634,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                     formatter.FormatLine(textSource, 0, double.PositiveInfinity,
                         new GenericTextParagraphProperties(defaultProperties));
 
-                var textRuns = textLine.TextRuns.Cast<ShapedTextCharacters>().ToList();
+                var textRuns = textLine.TextRuns.Cast<ShapedTextRun>().ToList();
 
                 var lineWidth = textLine.WidthIncludingTrailingWhitespace;
 
@@ -732,14 +732,14 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
         private static bool IsRightToLeft(TextLine textLine)
         {
-            return textLine.TextRuns.Cast<ShapedTextCharacters>().Any(x => !x.ShapedBuffer.IsLeftToRight);
+            return textLine.TextRuns.Cast<ShapedTextRun>().Any(x => !x.ShapedBuffer.IsLeftToRight);
         }
 
         private static List<int> BuildGlyphClusters(TextLine textLine)
         {
             var glyphClusters = new List<int>();
 
-            var shapedTextRuns = textLine.TextRuns.Cast<ShapedTextCharacters>().ToList();
+            var shapedTextRuns = textLine.TextRuns.Cast<ShapedTextRun>().ToList();
 
             var lastCluster = -1;
 
@@ -774,7 +774,7 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
             var lastCluster = -1;
 
-            var shapedTextRuns = textLine.TextRuns.Cast<ShapedTextCharacters>().ToList();
+            var shapedTextRuns = textLine.TextRuns.Cast<ShapedTextRun>().ToList();
 
             foreach (var textRun in shapedTextRuns)
             {
@@ -820,16 +820,16 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                 var text = "0123";
                 var shaperOption = new TextShaperOptions(Typeface.Default.GlyphTypeface, 10, 0, CultureInfo.CurrentCulture);
 
-                var firstRun = new ShapedTextCharacters(TextShaper.Current.ShapeText(text, shaperOption), defaultProperties);
+                var firstRun = new ShapedTextRun(TextShaper.Current.ShapeText(text, shaperOption), defaultProperties);
 
                 var textRuns = new List<TextRun>
                 {
                     new CustomDrawableRun(),
                     firstRun,
                     new CustomDrawableRun(),
-                    new ShapedTextCharacters(TextShaper.Current.ShapeText(text, shaperOption), defaultProperties),
+                    new ShapedTextRun(TextShaper.Current.ShapeText(text, shaperOption), defaultProperties),
                     new CustomDrawableRun(),
-                    new ShapedTextCharacters(TextShaper.Current.ShapeText(text, shaperOption), defaultProperties)
+                    new ShapedTextRun(TextShaper.Current.ShapeText(text, shaperOption), defaultProperties)
                 };
 
                 var textSource = new FixedRunsTextSource(textRuns);
@@ -885,14 +885,14 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                 var textBounds = textLine.GetTextBounds(0, 3);
 
-                var firstRun = textLine.TextRuns[0] as ShapedTextCharacters;
+                var firstRun = textLine.TextRuns[0] as ShapedTextRun;
 
                 Assert.Equal(1, textBounds.Count);
                 Assert.Equal(firstRun.Size.Width, textBounds.Sum(x => x.Rectangle.Width));
 
                 textBounds = textLine.GetTextBounds(3, 4);
 
-                var secondRun = textLine.TextRuns[1] as ShapedTextCharacters;
+                var secondRun = textLine.TextRuns[1] as ShapedTextRun;
 
                 Assert.Equal(1, textBounds.Count);
                 Assert.Equal(secondRun.Size.Width, textBounds.Sum(x => x.Rectangle.Width));
@@ -932,14 +932,14 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                 var textBounds = textLine.GetTextBounds(0, 4);
 
-                var secondRun = textLine.TextRuns[1] as ShapedTextCharacters;
+                var secondRun = textLine.TextRuns[1] as ShapedTextRun;
 
                 Assert.Equal(1, textBounds.Count);
                 Assert.Equal(secondRun.Size.Width, textBounds.Sum(x => x.Rectangle.Width));
 
                 textBounds = textLine.GetTextBounds(4, 3);
 
-                var firstRun = textLine.TextRuns[0] as ShapedTextCharacters;
+                var firstRun = textLine.TextRuns[0] as ShapedTextRun;
 
                 Assert.Equal(1, textBounds.Count);
 


### PR DESCRIPTION
## What does the pull request do?
Renames bad(in my opinion) names for TextRun ascendants that was inherited from WPF.
I'm suggesting new names because in my opinion this fixes a lot of confusions and names objects as is better than before.

`ShapeableTextCharacters` => `UnshapedTextRun`
`ShapedTextCharacters` => `ShapedTextRun`

This PR is created after proposal to @Gillibald and approve from him.
I will create next 2-3 text-related PR's based on this PR to reduce conflicts.

PR contains rename only. no other changes included.