### PR TITLE
[TransitioningContentControl] Move UpdateLogicalTree Call to CurrentContent PropertyChange

### DIFF
--- a/src/Avalonia.Controls/TransitioningContentControl.cs
+++ b/src/Avalonia.Controls/TransitioningContentControl.cs
@@ -69,6 +69,10 @@ public class TransitioningContentControl : ContentControl
         {
             Dispatcher.UIThread.Post(() => UpdateContentWithTransition(Content));
         }
+        else if (change.Property == CurrentContentProperty)
+        {
+            UpdateLogicalTree(change.OldValue, change.NewValue);
+        }
     }
 
     protected override void ContentChanged(AvaloniaPropertyChangedEventArgs e)
@@ -93,8 +97,6 @@ public class TransitioningContentControl : ContentControl
 
         if (PageTransition != null)
             await PageTransition.Start(this, null, true, localToken);
-
-        UpdateLogicalTree(CurrentContent, content);
 
         if (localToken.IsCancellationRequested)
         {


### PR DESCRIPTION
## What does the pull request do?
Move `UpdateLogicalTree` Call to `CurrentContent` PropertyChange, more simple, and solves a problem if the transition is canceled after the logical tree has been updated.


## What is the current behavior?


## What is the updated/expected behavior with this PR?


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
No.