### PR TITLE
[Text] Underline with intercepts

### DIFF
--- a/src/Avalonia.Base/Media/TextDecoration.cs
+++ b/src/Avalonia.Base/Media/TextDecoration.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Avalonia.Collections;
 using Avalonia.Collections.Pooled;
 using Avalonia.Media.TextFormatting;
@@ -200,26 +201,24 @@ namespace Avalonia.Media
                     break;
             }
 
-            var strokeOffset = 0.0;
-
             switch (StrokeOffsetUnit)
             {
                 case TextDecorationUnit.FontRenderingEmSize:
-                    strokeOffset = StrokeOffset * textMetrics.FontRenderingEmSize;
+                    origin += new Point(0, StrokeOffset * textMetrics.FontRenderingEmSize);
                     break;
                 case TextDecorationUnit.Pixel:
-                    strokeOffset = StrokeOffset;
+                    origin += new Point(0, StrokeOffset);
                     break;
             }
-
-            origin += new Point(0, strokeOffset);
 
             var pen = new Pen(Stroke ?? defaultBrush, thickness,
                 new DashStyle(StrokeDashArray, StrokeDashOffset), StrokeLineCap);
 
-            if (Location == TextDecorationLocation.Underline && MathUtilities.IsZero(strokeOffset))
+            if (Location != TextDecorationLocation.Strikethrough)
             {
-                var intersections = glyphRun.GlyphRunImpl.GetIntersections((float)(thickness * 0.5d + strokeOffset), (float)(thickness * 1.5d + strokeOffset));
+                var offsetY = glyphRun.BaselineOrigin.Y - origin.Y;
+
+                var intersections = glyphRun.GlyphRunImpl.GetIntersections((float)(thickness * 0.5d - offsetY), (float)(thickness * 1.5d - offsetY));
 
                 if (intersections != null && intersections.Count > 0)
                 {
@@ -257,7 +256,7 @@ namespace Avalonia.Media
                     }
 
                     return;
-                }              
+                }
             }
 
             drawingContext.DrawLine(pen, origin, origin + new Point(glyphRun.Metrics.Width, 0));

--- a/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
@@ -1438,7 +1438,7 @@ namespace Avalonia.Media.TextFormatting
 
             var lastRunIndex = _textRuns.Count - 1;
 
-            if (_textRuns[lastRunIndex] is TextEndOfLine && lastRunIndex > 0)
+            if (lastRunIndex > 0 && _textRuns[lastRunIndex] is TextEndOfLine)
             {
                 lastRunIndex--;
             }

--- a/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
@@ -1436,6 +1436,13 @@ namespace Avalonia.Media.TextFormatting
 
             var lineHeight = _paragraphProperties.LineHeight;
 
+            var lastRunIndex = _textRuns.Count - 1;
+
+            if (_textRuns[lastRunIndex] is TextEndOfLine && lastRunIndex > 0)
+            {
+                lastRunIndex--;
+            }
+
             for (var index = 0; index < _textRuns.Count; index++)
             {
                 switch (_textRuns[index])
@@ -1470,7 +1477,7 @@ namespace Avalonia.Media.TextFormatting
                                 }
                             }
 
-                            if (index == _textRuns.Count - 1)
+                            if (index == lastRunIndex)
                             {
                                 width = widthIncludingWhitespace + textRun.GlyphRun.Metrics.Width;
                                 trailingWhitespaceLength = textRun.GlyphRun.Metrics.TrailingWhitespaceLength;
@@ -1490,7 +1497,7 @@ namespace Avalonia.Media.TextFormatting
                             {
                                 case FlowDirection.LeftToRight:
                                     {
-                                        if (index == _textRuns.Count - 1)
+                                        if (index == lastRunIndex)
                                         {
                                             width = widthIncludingWhitespace;
                                             trailingWhitespaceLength = 0;
@@ -1502,7 +1509,7 @@ namespace Avalonia.Media.TextFormatting
 
                                 case FlowDirection.RightToLeft:
                                     {
-                                        if (index == _textRuns.Count - 1)
+                                        if (index == lastRunIndex)
                                         {
                                             width = widthIncludingWhitespace;
                                             trailingWhitespaceLength = 0;

--- a/src/Avalonia.Base/Platform/IGlyphRunImpl.cs
+++ b/src/Avalonia.Base/Platform/IGlyphRunImpl.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Avalonia.Metadata;
 
 namespace Avalonia.Platform
@@ -7,5 +8,8 @@ namespace Avalonia.Platform
     ///     Actual implementation of a glyph run that stores platform dependent resources.
     /// </summary>
     [Unstable]
-    public interface IGlyphRunImpl : IDisposable { }
+    public interface IGlyphRunImpl : IDisposable 
+    {
+        IReadOnlyList<float> GetIntersections(float lowerBound, float upperBound);
+    }
 }

--- a/src/Avalonia.Headless/HeadlessPlatformRenderInterface.cs
+++ b/src/Avalonia.Headless/HeadlessPlatformRenderInterface.cs
@@ -128,6 +128,11 @@ namespace Avalonia.Headless
             public void Dispose()
             {
             }
+
+            public IReadOnlyList<float> GetIntersections(float lowerBound, float upperBound)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         class HeadlessGeometryStub : IGeometryImpl

--- a/src/Skia/Avalonia.Skia/GlyphRunImpl.cs
+++ b/src/Skia/Avalonia.Skia/GlyphRunImpl.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Avalonia.Metadata;
 using Avalonia.Platform;
 using SkiaSharp;
@@ -19,6 +20,9 @@ namespace Avalonia.Skia
         ///     Gets the text blob to draw.
         /// </summary>
         public SKTextBlob TextBlob { get; }
+
+        public IReadOnlyList<float> GetIntersections(float upperBound, float lowerBound) => 
+            TextBlob.GetIntercepts(lowerBound, upperBound);
 
         void IDisposable.Dispose()
         {

--- a/src/Windows/Avalonia.Direct2D1/Media/GlyphRunImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/GlyphRunImpl.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Platform;
+﻿using System.Collections.Generic;
+using Avalonia.Platform;
 
 namespace Avalonia.Direct2D1.Media
 {
@@ -14,6 +15,11 @@ namespace Avalonia.Direct2D1.Media
         public void Dispose()
         {
             GlyphRun?.Dispose();
+        }
+
+        public IReadOnlyList<float> GetIntersections(float lowerBound, float upperBound)
+        {
+            return null;
         }
     }
 }

--- a/tests/Avalonia.Benchmarks/NullGlyphRun.cs
+++ b/tests/Avalonia.Benchmarks/NullGlyphRun.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Platform;
+﻿using System.Collections.Generic;
+using Avalonia.Platform;
 
 namespace Avalonia.Benchmarks
 {
@@ -6,6 +7,11 @@ namespace Avalonia.Benchmarks
     {
         public void Dispose()
         {
+        }
+
+        public IReadOnlyList<float> GetIntersections(float lowerBound, float upperBound)
+        {
+            return null;
         }
     }
 }

--- a/tests/Avalonia.UnitTests/MockGlyphRun.cs
+++ b/tests/Avalonia.UnitTests/MockGlyphRun.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Platform;
+﻿using System.Collections.Generic;
+using Avalonia.Platform;
 
 namespace Avalonia.UnitTests
 {
@@ -7,6 +8,11 @@ namespace Avalonia.UnitTests
         public void Dispose()
         {
             
+        }
+
+        public IReadOnlyList<float> GetIntersections(float lowerBound, float upperBound)
+        {
+            return null;
         }
     }
 }


### PR DESCRIPTION
What's is underline intercepts? - g,j,y,p chars are intercepting underline and to render it good some render engines are making spaces before and after intercepts.
See underline on screenshot below. It's splitted.
![underline-in-ios-safari](https://user-images.githubusercontent.com/4997065/210881031-6e9d8fd2-a52d-4853-8036-9d2180ce71f1.png)


This feature was implemented in Lunacy. I'm just sharing it. I hope you need it. It's ok to reject/rework.
Sorry for a huge screenshots. To see a difference you should zoom in.

## What does the pull request do?
Adds intercepts to underline. 

## What is the current behavior?
Now it works like this:
![Screenshot 2023-01-05 at 21 36 45](https://user-images.githubusercontent.com/4997065/210879513-4c5bd22b-1a12-4193-97b8-b9fd7b70c0c1.png)

## What is the updated/expected behavior with this PR?

Should work like in chrome:
![Screenshot 2023-01-06 at 00 00 07](https://user-images.githubusercontent.com/4997065/210879550-b4a19652-1108-4018-a24a-7b67d0f5a674.png)

After implementation it works like in chrome:
![Screenshot 2023-01-05 at 23 57 29](https://user-images.githubusercontent.com/4997065/210879809-6f9c8812-9f2c-462d-8d5e-5d42276b4460.png)


## How was the solution implemented (if it's not obvious)?
I use SKTextBlob.GetIntercepts method to get underline intercepts.
I didnt' implement this method to dx2d render platform. Don't know how. Anyway code fallbacks to previous non-intercepted underline.


## Checklist

- [ x] Added unit tests (if possible)?
- [ x] Added XML documentation to any related classes?
- [ x] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation
