### PR TITLE
[Text] fix tab width. It's too long

### DIFF
--- a/samples/ControlCatalog/Pages/TextBoxPage.xaml
+++ b/samples/ControlCatalog/Pages/TextBoxPage.xaml
@@ -38,7 +38,7 @@
                  UseFloatingWatermark="True"
                  PasswordChar="*"
                  Text="Password" />
-        <TextBox Width="200" Text="Left aligned text" TextAlignment="Left" />
+        <TextBox Width="200" Text="Left aligned text" TextAlignment="Left" AcceptsTab="True" />
         <TextBox Width="200" Text="Center aligned text" TextAlignment="Center" />
         <TextBox Width="200" Text="Right aligned text" TextAlignment="Right" />
         <TextBox Width="200" Text="Custom selection brush"

--- a/src/Avalonia.Base/Media/TextFormatting/TextParagraphProperties.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextParagraphProperties.cs
@@ -63,14 +63,11 @@
         {
             get { return 0; }
         }
-        
+
         /// <summary>
         /// Gets the default incremental tab width.
         /// </summary>
-        public virtual double DefaultIncrementalTab
-        {
-            get { return 4 * DefaultTextRunProperties.FontRenderingEmSize; }
-        }
+        public virtual double DefaultIncrementalTab => 0;
 
         /// <summary>
         /// Gets the letter spacing.


### PR DESCRIPTION
## What does the pull request do?
Removes wrong tab width math calculation and uses good math in TextShaperImpl.


## What is the current behavior?
Tab is too long. See "Left Aligned Text" TextBox. It's only a single tab.
![Screenshot 2023-01-06 at 00 45 34](https://user-images.githubusercontent.com/4997065/210888081-193170ca-1f7d-43e4-94fc-51f173a5bdfe.png)


## What is the updated/expected behavior with this PR?
Tab width equals 4 spaces width. See "Left Aligned Text" TextBox again.
![Screenshot 2023-01-06 at 00 57 27](https://user-images.githubusercontent.com/4997065/210888153-cbb35949-8597-4226-b619-13c6ffda50fa.png)



## How was the solution implemented (if it's not obvious)?
Existing math was 4*FontSize, but FontSize!=SpaceWidth. So I've placed 0 to get a good math in TextShaperImpl. 
![Screenshot 2023-01-06 at 01 00 51](https://user-images.githubusercontent.com/4997065/210888390-936a20af-7f58-4dc0-a4be-838498cb35f3.png)
