### PR TITLE
broken GetRequiredService for _useGL

### DIFF
--- a/src/Browser/Avalonia.Browser/AvaloniaView.cs
+++ b/src/Browser/Avalonia.Browser/AvaloniaView.cs
@@ -106,7 +106,7 @@ namespace Avalonia.Browser
 
             _dpi = DomHelper.ObserveDpi(OnDpiChanged);
 
-            _useGL = AvaloniaLocator.Current.GetRequiredService<IPlatformGraphics>() != null;
+            _useGL = AvaloniaLocator.Current.GetService<IPlatformGraphics>() != null;
 
             if (_useGL)
             {


### PR DESCRIPTION
I assume the use of `GetRequiredService ` is a bug here, since we have a null check.

As the code currently stands GetRequiredService will throw id the service is not registered. 

so either it should be `GetService` or the null check should be removed