### PR TITLE
Revert #8860 (removal of public constructors)

### DIFF
--- a/src/Avalonia.Base/Input/DragEventArgs.cs
+++ b/src/Avalonia.Base/Input/DragEventArgs.cs
@@ -34,7 +34,7 @@ namespace Avalonia.Input
         }
 
         [Unstable]
-        [Obsolete("This constructor may be removed in 12.0. Consider replacing it with RawDragEvent.")]
+        [Obsolete("This constructor might be removed in 12.0. For unit testing, consider using DragDrop.DoDragDrop or IHeadlessWindow.DragDrop.")]
         public DragEventArgs(RoutedEvent<DragEventArgs> routedEvent, IDataObject data, Interactive target, Point targetLocation, KeyModifiers keyModifiers)
             : base(routedEvent)
         {

--- a/src/Avalonia.Base/Input/DragEventArgs.cs
+++ b/src/Avalonia.Base/Input/DragEventArgs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Avalonia.Interactivity;
+using Avalonia.Metadata;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Input
@@ -32,7 +33,9 @@ namespace Avalonia.Input
             return point;
         }
 
-        internal DragEventArgs(RoutedEvent<DragEventArgs> routedEvent, IDataObject data, Interactive target, Point targetLocation, KeyModifiers keyModifiers)
+        [Unstable]
+        [Obsolete("This constructor may be removed in 12.0. Consider replacing it with RawDragEvent.")]
+        public DragEventArgs(RoutedEvent<DragEventArgs> routedEvent, IDataObject data, Interactive target, Point targetLocation, KeyModifiers keyModifiers)
             : base(routedEvent)
         {
             Data = data;

--- a/src/Avalonia.Base/Input/GotFocusEventArgs.cs
+++ b/src/Avalonia.Base/Input/GotFocusEventArgs.cs
@@ -7,19 +7,18 @@ namespace Avalonia.Input
     /// </summary>
     public class GotFocusEventArgs : RoutedEventArgs
     {
-        internal GotFocusEventArgs()
+        public GotFocusEventArgs() : base(InputElement.GotFocusEvent)
         {
-
         }
 
         /// <summary>
         /// Gets or sets a value indicating how the change in focus occurred.
         /// </summary>
-        public NavigationMethod NavigationMethod { get; set; }
+        public NavigationMethod NavigationMethod { get; init; }
 
         /// <summary>
         /// Gets or sets any key modifiers active at the time of focus.
         /// </summary>
-        public KeyModifiers KeyModifiers { get; set; }
+        public KeyModifiers KeyModifiers { get; init; }
     }
 }

--- a/src/Avalonia.Base/Input/KeyEventArgs.cs
+++ b/src/Avalonia.Base/Input/KeyEventArgs.cs
@@ -10,10 +10,10 @@ namespace Avalonia.Input
 
         }
 
-        public IKeyboardDevice? Device { get; set; }
+        public IKeyboardDevice? Device { get; init; }
 
-        public Key Key { get; set; }
+        public Key Key { get; init; }
 
-        public KeyModifiers KeyModifiers { get; set; }
+        public KeyModifiers KeyModifiers { get; init; }
     }
 }

--- a/src/Avalonia.Base/Input/KeyEventArgs.cs
+++ b/src/Avalonia.Base/Input/KeyEventArgs.cs
@@ -5,11 +5,6 @@ namespace Avalonia.Input
 {
     public class KeyEventArgs : RoutedEventArgs
     {
-        public KeyEventArgs()
-        {
-
-        }
-
         public IKeyboardDevice? Device { get; init; }
 
         public Key Key { get; init; }

--- a/src/Avalonia.Base/Input/KeyboardDevice.cs
+++ b/src/Avalonia.Base/Input/KeyboardDevice.cs
@@ -156,7 +156,6 @@ namespace Avalonia.Input
 
                 interactive?.RaiseEvent(new GotFocusEventArgs
                 {
-                    RoutedEvent = InputElement.GotFocusEvent,
                     NavigationMethod = method,
                     KeyModifiers = keyModifiers,
                 });

--- a/src/Avalonia.Base/Input/PointerDeltaEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerDeltaEventArgs.cs
@@ -7,7 +7,7 @@ namespace Avalonia.Input
 {
     public class PointerDeltaEventArgs : PointerEventArgs
     {
-        public Vector Delta { get; set; }
+        public Vector Delta { get; }
 
         [Unstable]
         [Obsolete("This constructor might be removed in 12.0.")]

--- a/src/Avalonia.Base/Input/PointerDeltaEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerDeltaEventArgs.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Input
         public Vector Delta { get; set; }
 
         [Unstable]
-        [Obsolete("This constructor may be removed in 12.0. Consider replacing it with RawPointerEventArgs or headless unit tests helpers.")]
+        [Obsolete("This constructor might be removed in 12.0.")]
         public PointerDeltaEventArgs(RoutedEvent routedEvent, object? source, 
             IPointer pointer, Visual rootVisual, Point rootVisualPosition, ulong timestamp,
             PointerPointProperties properties, KeyModifiers modifiers, Vector delta) 

--- a/src/Avalonia.Base/Input/PointerDeltaEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerDeltaEventArgs.cs
@@ -1,4 +1,6 @@
+using System;
 using Avalonia.Interactivity;
+using Avalonia.Metadata;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Input
@@ -7,7 +9,9 @@ namespace Avalonia.Input
     {
         public Vector Delta { get; set; }
 
-        internal PointerDeltaEventArgs(RoutedEvent routedEvent, object? source, 
+        [Unstable]
+        [Obsolete("This constructor may be removed in 12.0. Consider replacing it with RawPointerEventArgs or headless unit tests helpers.")]
+        public PointerDeltaEventArgs(RoutedEvent routedEvent, object? source, 
             IPointer pointer, Visual rootVisual, Point rootVisualPosition, ulong timestamp,
             PointerPointProperties properties, KeyModifiers modifiers, Vector delta) 
             : base(routedEvent, source, pointer, rootVisual, rootVisualPosition,

--- a/src/Avalonia.Base/Input/PointerEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerEventArgs.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Input
         private readonly Lazy<IReadOnlyList<RawPointerPoint>?>? _previousPoints;
 
         [Unstable]
-        [Obsolete("This constructor may be removed in 12.0. Consider replacing it with RawPointerEventArgs or headless unit tests helpers.")]
+        [Obsolete("This constructor might be removed in 12.0. For unit testing, consider using IHeadlessWindow mouse methods.")]
         public PointerEventArgs(RoutedEvent routedEvent,
             object? source,
             IPointer pointer,

--- a/src/Avalonia.Base/Input/PointerEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerEventArgs.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Avalonia.Input.Raw;
 using Avalonia.Interactivity;
+using Avalonia.Metadata;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Input
@@ -13,7 +14,9 @@ namespace Avalonia.Input
         private readonly PointerPointProperties _properties;
         private readonly Lazy<IReadOnlyList<RawPointerPoint>?>? _previousPoints;
 
-        internal PointerEventArgs(RoutedEvent routedEvent,
+        [Unstable]
+        [Obsolete("This constructor may be removed in 12.0. Consider replacing it with RawPointerEventArgs or headless unit tests helpers.")]
+        public PointerEventArgs(RoutedEvent routedEvent,
             object? source,
             IPointer pointer,
             Visual? rootVisual, Point rootVisualPosition,

--- a/src/Avalonia.Base/Input/PointerWheelEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerWheelEventArgs.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Input
         public Vector Delta { get; set; }
 
         [Unstable]
-        [Obsolete("This constructor may be removed in 12.0. Consider replacing it with RawPointerEventArgs or headless unit tests helpers.")]
+        [Obsolete("This constructor might be removed in 12.0. For unit testing, consider using IHeadlessWindow.MouseWheel.")]
         public PointerWheelEventArgs(object source, IPointer pointer, Visual rootVisual,
             Point rootVisualPosition, ulong timestamp,
             PointerPointProperties properties, KeyModifiers modifiers, Vector delta)

--- a/src/Avalonia.Base/Input/PointerWheelEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerWheelEventArgs.cs
@@ -7,7 +7,7 @@ namespace Avalonia.Input
 {
     public class PointerWheelEventArgs : PointerEventArgs
     {
-        public Vector Delta { get; set; }
+        public Vector Delta { get; }
 
         [Unstable]
         [Obsolete("This constructor might be removed in 12.0. For unit testing, consider using IHeadlessWindow.MouseWheel.")]

--- a/src/Avalonia.Base/Input/PointerWheelEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerWheelEventArgs.cs
@@ -1,4 +1,6 @@
+using System;
 using Avalonia.Interactivity;
+using Avalonia.Metadata;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Input
@@ -7,7 +9,9 @@ namespace Avalonia.Input
     {
         public Vector Delta { get; set; }
 
-        internal PointerWheelEventArgs(object source, IPointer pointer, Visual rootVisual,
+        [Unstable]
+        [Obsolete("This constructor may be removed in 12.0. Consider replacing it with RawPointerEventArgs or headless unit tests helpers.")]
+        public PointerWheelEventArgs(object source, IPointer pointer, Visual rootVisual,
             Point rootVisualPosition, ulong timestamp,
             PointerPointProperties properties, KeyModifiers modifiers, Vector delta)
             : base(InputElement.PointerWheelChangedEvent, source, pointer, rootVisual, rootVisualPosition,

--- a/src/Avalonia.Base/Input/Raw/RawTextInputEventArgs.cs
+++ b/src/Avalonia.Base/Input/Raw/RawTextInputEventArgs.cs
@@ -12,6 +12,6 @@ namespace Avalonia.Input.Raw
             Text = text;
         }
 
-        public string Text { get; set; }
+        public string Text { get; }
     }
 }

--- a/src/Avalonia.Base/Input/ScrollGestureEventArgs.cs
+++ b/src/Avalonia.Base/Input/ScrollGestureEventArgs.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Input
 
         public static int GetNextFreeId() => _nextId++;
 
-        internal ScrollGestureEventArgs(int id, Vector delta) : base(Gestures.ScrollGestureEvent)
+        public ScrollGestureEventArgs(int id, Vector delta) : base(Gestures.ScrollGestureEvent)
         {
             Id = id;
             Delta = delta;
@@ -25,7 +25,7 @@ namespace Avalonia.Input
     {
         public int Id { get; }
 
-        internal ScrollGestureEndedEventArgs(int id) : base(Gestures.ScrollGestureEndedEvent)
+        public ScrollGestureEndedEventArgs(int id) : base(Gestures.ScrollGestureEndedEvent)
         {
             Id = id;
         }

--- a/src/Avalonia.Base/Input/TappedEventArgs.cs
+++ b/src/Avalonia.Base/Input/TappedEventArgs.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 
@@ -7,7 +8,7 @@ namespace Avalonia.Input
     {
         private readonly PointerEventArgs lastPointerEventArgs;
 
-        internal TappedEventArgs(RoutedEvent routedEvent, PointerEventArgs lastPointerEventArgs)
+        public TappedEventArgs(RoutedEvent routedEvent, PointerEventArgs lastPointerEventArgs)
             : base(routedEvent)
         {
             this.lastPointerEventArgs = lastPointerEventArgs;

--- a/src/Avalonia.Base/Input/TextInputEventArgs.cs
+++ b/src/Avalonia.Base/Input/TextInputEventArgs.cs
@@ -4,10 +4,6 @@ namespace Avalonia.Input
 {
     public class TextInputEventArgs : RoutedEventArgs
     {
-        public TextInputEventArgs()
-        {
-
-        }
         public IKeyboardDevice? Device { get; set; }
 
         public string? Text { get; set; }

--- a/src/Avalonia.Base/Input/VectorEventArgs.cs
+++ b/src/Avalonia.Base/Input/VectorEventArgs.cs
@@ -5,6 +5,6 @@ namespace Avalonia.Input
 {
     public class VectorEventArgs : RoutedEventArgs
     {
-        public Vector Vector { get; set; }
+        public Vector Vector { get; init; }
     }
 }

--- a/src/Avalonia.Base/Input/VectorEventArgs.cs
+++ b/src/Avalonia.Base/Input/VectorEventArgs.cs
@@ -5,11 +5,6 @@ namespace Avalonia.Input
 {
     public class VectorEventArgs : RoutedEventArgs
     {
-        internal VectorEventArgs()
-        {
-
-        }
-
         public Vector Vector { get; set; }
     }
 }

--- a/src/Avalonia.Base/Layout/EffectiveViewportChangedEventArgs.cs
+++ b/src/Avalonia.Base/Layout/EffectiveViewportChangedEventArgs.cs
@@ -7,7 +7,7 @@ namespace Avalonia.Layout
     /// </summary>
     public class EffectiveViewportChangedEventArgs : EventArgs
     {
-        internal EffectiveViewportChangedEventArgs(Rect effectiveViewport)
+        public EffectiveViewportChangedEventArgs(Rect effectiveViewport)
         {
             EffectiveViewport = effectiveViewport;
         }

--- a/src/Avalonia.Base/Rendering/SceneInvalidatedEventArgs.cs
+++ b/src/Avalonia.Base/Rendering/SceneInvalidatedEventArgs.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Rendering
         /// </summary>
         /// <param name="root">The render root that has been updated.</param>
         /// <param name="dirtyRect">The updated area.</param>
-        internal SceneInvalidatedEventArgs(
+        public SceneInvalidatedEventArgs(
             IRenderRoot root,
             Rect dirtyRect)
         {

--- a/src/Avalonia.Headless/HeadlessWindowImpl.cs
+++ b/src/Avalonia.Headless/HeadlessWindowImpl.cs
@@ -284,6 +284,18 @@ namespace Avalonia.Headless
                 button == 1 ? RawPointerEventType.MiddleButtonUp : RawPointerEventType.RightButtonUp,
                 point, modifiers));
         }
+        
+        void IHeadlessWindow.MouseWheel(Point point, Vector delta, RawInputModifiers modifiers)
+        {
+            Input?.Invoke(new RawMouseWheelEventArgs(MouseDevice, Timestamp, InputRoot,
+                point, delta, modifiers));
+        }
+        
+        void IHeadlessWindow.DragDrop(Point point, RawDragEventType type, IDataObject data, DragDropEffects effects, RawInputModifiers modifiers)
+        {
+            var device = AvaloniaLocator.Current.GetRequiredService<IDragDropDevice>();
+            Input?.Invoke(new RawDragEvent(device, type, InputRoot, point, data, effects, modifiers));
+        }
 
         void IWindowImpl.Move(PixelPoint point)
         {

--- a/src/Avalonia.Headless/IHeadlessWindow.cs
+++ b/src/Avalonia.Headless/IHeadlessWindow.cs
@@ -1,4 +1,5 @@
 using Avalonia.Input;
+using Avalonia.Input.Raw;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Avalonia.Utilities;
@@ -13,5 +14,7 @@ namespace Avalonia.Headless
         void MouseDown(Point point, int button, RawInputModifiers modifiers = RawInputModifiers.None);
         void MouseMove(Point point, RawInputModifiers modifiers = RawInputModifiers.None);
         void MouseUp(Point point, int button, RawInputModifiers modifiers = RawInputModifiers.None);
+        void MouseWheel(Point point, Vector delta, RawInputModifiers modifiers = RawInputModifiers.None);
+        void DragDrop(Point point, RawDragEventType type, IDataObject data, DragDropEffects effects, RawInputModifiers modifiers);
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests_Multiple.cs
@@ -28,7 +28,6 @@ namespace Avalonia.Controls.UnitTests
 
             target.Presenter.Panel.Children[1].RaiseEvent(new GotFocusEventArgs
             {
-                RoutedEvent = InputElement.GotFocusEvent,
                 NavigationMethod = NavigationMethod.Directional,
                 KeyModifiers = KeyModifiers.Shift
             });
@@ -52,7 +51,6 @@ namespace Avalonia.Controls.UnitTests
 
             target.Presenter.Panel.Children[1].RaiseEvent(new GotFocusEventArgs
             {
-                RoutedEvent = InputElement.GotFocusEvent,
                 NavigationMethod = NavigationMethod.Directional,
                 KeyModifiers = KeyModifiers.Control
             });
@@ -77,7 +75,6 @@ namespace Avalonia.Controls.UnitTests
 
             target.Presenter.Panel.Children[0].RaiseEvent(new GotFocusEventArgs
             {
-                RoutedEvent = InputElement.GotFocusEvent,
                 NavigationMethod = NavigationMethod.Directional,
                 KeyModifiers = KeyModifiers.Control
             });

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests_Single.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests_Single.cs
@@ -33,7 +33,6 @@ namespace Avalonia.Controls.UnitTests
 
             target.Presenter.Panel.Children[0].RaiseEvent(new GotFocusEventArgs
             {
-                RoutedEvent = InputElement.GotFocusEvent,
                 NavigationMethod = NavigationMethod.Tab,
             });
 
@@ -53,7 +52,6 @@ namespace Avalonia.Controls.UnitTests
 
             target.Presenter.Panel.Children[0].RaiseEvent(new GotFocusEventArgs
             {
-                RoutedEvent = InputElement.GotFocusEvent,
                 NavigationMethod = NavigationMethod.Directional,
             });
 
@@ -73,7 +71,6 @@ namespace Avalonia.Controls.UnitTests
 
             target.Presenter.Panel.Children[0].RaiseEvent(new GotFocusEventArgs
             {
-                RoutedEvent = InputElement.GotFocusEvent,
                 NavigationMethod = NavigationMethod.Directional,
                 KeyModifiers = KeyModifiers.Control
             });
@@ -96,7 +93,6 @@ namespace Avalonia.Controls.UnitTests
 
                 target.Presenter.Panel.Children[0].RaiseEvent(new GotFocusEventArgs
                 {
-                    RoutedEvent = InputElement.GotFocusEvent,
                     NavigationMethod = NavigationMethod.Directional,
                     KeyModifiers = KeyModifiers.Control
                 });


### PR DESCRIPTION
Binary compatibility is still a problem, as events changing, features adding, and we have to duplicate ctors every time to avoid breaking compatibility.
Also, we want to avoid events faking by developers, as it's not a scenario we can always support.

On the other hand, some of the events are supposed to be raised by the developers.
And for other events we don't have a nice replacement. 

This PR is 11.0 timeline compromise.