### PR TITLE
[Text] [Debug] fix Text output of TextRunDebuggerProxy

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextRun.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextRun.cs
@@ -44,7 +44,7 @@ namespace Avalonia.Media.TextFormatting
 
                         fixed (char* charsPtr = characterBuffer.Span)
                         {
-                            return new string(charsPtr, 0, characterBuffer.Span.Length);
+                            return new string(charsPtr, _textRun.CharacterBufferReference.OffsetToFirstChar, _textRun.Length);
                         }
                     }
                 }


### PR DESCRIPTION
## What does the pull request do?
Fixes TextRunDebuggerProxy Text output.


## What is the current behavior?
All runs have same text:
![Screenshot 2023-01-06 at 12 14 12](https://user-images.githubusercontent.com/4997065/210970388-9462bbb0-f189-4beb-a405-3a2af2f5b121.png)



## What is the updated/expected behavior with this PR?
All Runs have specific text parts of the character buffer.
![Screenshot 2023-01-06 at 12 17 41](https://user-images.githubusercontent.com/4997065/210970473-a17ac84d-70fc-4353-9592-e7e92ee0a17e.png)

