### PR TITLE
Class Handlers: fix handlers with `handledEventsToo` parameter set ot `true`

### DIFF
--- a/src/Avalonia.Base/Interactivity/EventRoute.cs
+++ b/src/Avalonia.Base/Interactivity/EventRoute.cs
@@ -143,10 +143,7 @@ namespace Avalonia.Interactivity
                 // If we've got to a new control then call any RoutedEvent.Raised listeners.
                 if (entry.Target != lastTarget)
                 {
-                    if (!e.Handled)
-                    {
-                        _event.InvokeRaised(entry.Target, e);
-                    }
+                    _event.InvokeRaised(entry.Target, e);
 
                     // If this is a direct event and we've already raised events then we're finished.
                     if (e.Route == RoutingStrategies.Direct && lastTarget is object)

--- a/tests/Avalonia.Base.UnitTests/Interactivity/InteractiveTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Interactivity/InteractiveTests.cs
@@ -338,6 +338,27 @@ namespace Avalonia.Base.UnitTests.Interactivity
         }
 
         [Fact]
+        public void Typed_Class_Handlers_Should_Be_Called_For_Handled_Events()
+        {
+            var ev = new RoutedEvent<RoutedEventArgs>(
+                "test",
+                RoutingStrategies.Bubble | RoutingStrategies.Tunnel,
+                typeof(TestInteractive));
+
+            var target = CreateTree(ev, null, 0);
+
+            ev.AddClassHandler<TestInteractive>((x, e) => x.MarkEventAsHandled(e), RoutingStrategies.Bubble);
+            ev.AddClassHandler<TestInteractive>((x, e) => x.ClassHandler(e), RoutingStrategies.Bubble, handledEventsToo: true);
+
+            var args = new RoutedEventArgs(ev, target);
+            target.RaiseEvent(args);
+
+            Assert.True(args.Handled);
+            Assert.True(target.ClassHandlerInvoked);
+            Assert.True(target.GetVisualParent<TestInteractive>().ClassHandlerInvoked);
+        }
+
+        [Fact]
         public void GetObservable_Should_Listen_To_Event()
         {
             var ev = new RoutedEvent<RoutedEventArgs>("test", RoutingStrategies.Direct, typeof(TestInteractive));
@@ -442,6 +463,11 @@ namespace Avalonia.Base.UnitTests.Interactivity
             public void ClassHandler(RoutedEventArgs e)
             {
                 ClassHandlerInvoked = true;
+            }
+
+            public void MarkEventAsHandled(RoutedEventArgs e)
+            {
+                e.Handled = true;
             }
         }
     }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Allows `Class Handlers` to process already handled routed events when subscribing with `handledEventsToo = true`

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Already handled events are not routed to `Class Handlers` when `handledEventsToo = true`

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Events are routed as expected

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Removed additional check whether event was handled or not before `Class Handler` invocation. This check is performed in the handler itself and takes `handledEventsToo` parameter into account.

## Checklist

- [x] Added unit tests (if possible)?

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #9559
