### PR TITLE
Fix DataGridTemplateColumn reusing edit control when exiting edit mode

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -4152,6 +4152,7 @@ namespace Avalonia.Controls
 
             if (exitEditingMode)
             {
+                CurrentColumn.EndCellEditInternal();
                 _editingColumnIndex = -1;
                 editingCell.UpdatePseudoClasses();
 

--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
@@ -800,9 +800,20 @@ namespace Avalonia.Controls
         protected internal virtual void RefreshCellContent(Control element, string propertyName)
         { }
 
+        /// <summary>
+        /// When overridden in a derived class, called when a cell in the column exits editing mode.
+        /// </summary>
+        protected virtual void EndCellEdit()
+        { }
+
         internal void CancelCellEditInternal(Control editingElement, object uneditedValue)
         {
             CancelCellEdit(editingElement, uneditedValue);
+        }
+
+        internal void EndCellEditInternal()
+        {
+            EndCellEdit();
         }
 
         /// <summary>

--- a/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridTemplateColumn.cs
@@ -55,17 +55,25 @@ namespace Avalonia.Controls
             get => _cellEditingCellTemplate;
             set => SetAndRaise(CellEditingTemplateProperty, ref _cellEditingCellTemplate, value);
         }
-        
-        private static void OnCellTemplateChanged(AvaloniaPropertyChangedEventArgs e)
+
+        private bool _forceGenerateCellFromTemplate;
+
+        protected override void EndCellEdit()
         {
-            var oldValue = (IDataTemplate)e.OldValue;
-            var value = (IDataTemplate)e.NewValue;
+            //the next call to generate element should not resuse the current content as we need to exit edit mode
+            _forceGenerateCellFromTemplate = true;
+            base.EndCellEdit();
         }
 
         protected override Control GenerateElement(DataGridCell cell, object dataItem)
         {
             if (CellTemplate != null)
             {
+                if (_forceGenerateCellFromTemplate)
+                {
+                    _forceGenerateCellFromTemplate = false;
+                    return CellTemplate.Build(dataItem);
+                }
                 return (CellTemplate is IRecyclingDataTemplate recyclingDataTemplate)
                     ? recyclingDataTemplate.Build(dataItem, cell.Content as Control)
                     : CellTemplate.Build(dataItem);


### PR DESCRIPTION
## What does the pull request do?
Fixes a bug with DataGridTemplateColumn not exiting edit mode


## What is the current behavior?
Run the control catalog, go to the DataGrid Editable tab, double click in the age column then select another row. The numeric updown will remain in place:
![image](https://user-images.githubusercontent.com/7722347/211032193-f7e0d662-2822-4b24-9967-307730e42bb4.png)

This was introduced by this [commit](https://github.com/AvaloniaUI/Avalonia/commit/8b490152d49b1cc310faf86a2aebdc52fd5f1760)


## What is the updated/expected behavior with this PR?
When a cell exits edit mode the column is notified and can handle it accordingly

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation
