### PR TITLE
[stable] macOS: Set Window appearance to fix missing white border

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -47,6 +47,7 @@ WindowBaseImpl::WindowBaseImpl(IAvnWindowBaseEvents *events, IAvnGlContext *gl, 
     [Window setContentMaxSize:lastMaxSize];
 
     [Window setOpaque:false];
+    [Window setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameAqua]];
 }
 
 HRESULT WindowBaseImpl::ObtainNSViewHandle(void **ret) {


### PR DESCRIPTION
## What does the pull request do?

On macOS Avalonia windows do not have a light border like other windows.

Sets the window's appearance on macOS to enable this light border.

This PR targets the stable branch as this should be handled better for 11.0 (see #9913)

Not 100% sure of the details of why/how this works. @danwalmsley could you share some details here?