### PR TITLE
Made resources index binary

### DIFF
--- a/src/Avalonia.Base/Platform/Internal/AssemblyDescriptor.cs
+++ b/src/Avalonia.Base/Platform/Internal/AssemblyDescriptor.cs
@@ -32,7 +32,7 @@ internal class AssemblyDescriptor : IAssemblyDescriptor
                     Resources.Remove(Constants.AvaloniaResourceName);
 
                     var indexLength = new BinaryReader(resources).ReadInt32();
-                    var index = AvaloniaResourcesIndexReaderWriter.Read(new SlicedStream(resources, 4, indexLength));
+                    var index = AvaloniaResourcesIndexReaderWriter.ReadIndex(new SlicedStream(resources, 4, indexLength));
                     var baseOffset = indexLength + 4;
                     AvaloniaResources = index.ToDictionary(r => GetPathRooted(r), r => (IAssetDescriptor)
                         new AvaloniaResourceDescriptor(assembly, baseOffset + r.Offset, r.Size));

--- a/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
+++ b/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
@@ -18,6 +18,9 @@
       <Compile Include="../Avalonia.Base/Utilities/AvaloniaResourcesIndex.cs">
         <Link>Shared/AvaloniaResourcesIndex.cs</Link>
       </Compile>
+      <Compile Include="../Avalonia.Base/Platform/Internal/Constants.cs">
+        <Link>Shared/Constants.cs</Link>
+      </Compile>
       <Compile Include="../Markup/Avalonia.Markup.Xaml/PortableXaml/AvaloniaResourceXamlInfo.cs">
         <Link>Shared/AvaloniaResourceXamlInfo.cs</Link>
       </Compile>

--- a/src/Avalonia.Build.Tasks/GenerateAvaloniaResourcesTask.cs
+++ b/src/Avalonia.Build.Tasks/GenerateAvaloniaResourcesTask.cs
@@ -77,29 +77,9 @@ namespace Avalonia.Build.Tasks
 
         private void Pack(Stream output, List<Source> sources)
         {
-            var offsets = new Dictionary<Source, int>();
-            var coffset = 0;
-            foreach (var s in sources)
-            {
-                offsets[s] = coffset;
-                coffset += s.Size;
-            }
-            var index = sources.Select(s => new AvaloniaResourcesIndexEntry
-            {
-                Path = s.Path,
-                Size = s.Size,
-                Offset = offsets[s]
-            }).ToList();
-            var ms = new MemoryStream();
-            AvaloniaResourcesIndexReaderWriter.Write(ms, index);
-            new BinaryWriter(output).Write((int)ms.Length);
-            ms.Position = 0;
-            ms.CopyTo(output);
-            foreach (var s in sources)
-            {
-                using (var input = s.Open())
-                    input.CopyTo(output);
-            }
+            AvaloniaResourcesIndexReaderWriter.WriteResources(
+                output,
+                sources.Select(source => (source.Path, source.Size, (Func<Stream>) source.Open)).ToList());
         }
 
         private bool PreProcessXamlFiles(List<Source> sources)

--- a/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.Helpers.cs
+++ b/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.Helpers.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Avalonia.Platform.Internal;
 using Avalonia.Utilities;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -34,13 +36,13 @@ namespace Avalonia.Build.Tasks
             {
                 _asm = asm;
                 _embedded = ((EmbeddedResource)asm.MainModule.Resources.FirstOrDefault(r =>
-                    r.ResourceType == ResourceType.Embedded && r.Name == "!AvaloniaResources"));
+                    r.ResourceType == ResourceType.Embedded && r.Name == Constants.AvaloniaResourceName));
                 if (_embedded == null)
                     return;
                 using (var stream = _embedded.GetResourceStream())
                 {
                     var br = new BinaryReader(stream);
-                    var index = AvaloniaResourcesIndexReaderWriter.Read(new MemoryStream(br.ReadBytes(br.ReadInt32())));
+                    var index = AvaloniaResourcesIndexReaderWriter.ReadIndex(new MemoryStream(br.ReadBytes(br.ReadInt32())));
                     var baseOffset = stream.Position;
                     foreach (var e in index)
                     {
@@ -61,9 +63,18 @@ namespace Avalonia.Build.Tasks
                 if (_resources.Count == 0)
                     return;
 
-                _embedded = new EmbeddedResource("!AvaloniaResources", ManifestResourceAttributes.Public,
-                    AvaloniaResourcesIndexReaderWriter.Create(_resources.ToDictionary(x => x.Key,
-                        x => x.Value.FileContents)));
+                var output = new MemoryStream();
+
+                AvaloniaResourcesIndexReaderWriter.WriteResources(
+                    output,
+                    _resources.Select(x => (
+                        Path: x.Key,
+                        Size: x.Value.FileContents.Length,
+                        Open: (Func<Stream>) (() => new MemoryStream(x.Value.FileContents))
+                    )).ToList());
+
+                output.Position = 0L;
+                _embedded = new EmbeddedResource(Constants.AvaloniaResourceName, ManifestResourceAttributes.Public, output);
                 _asm.MainModule.Resources.Add(_embedded);
             }
 


### PR DESCRIPTION
## What does the pull request do?
This PR changes the Avalonia resources index to a simple binary format that can be read/written using only `BinaryReader/Writer`, instead of relying on `System.Xml.Linq` for reading and `DataContract` for writing. Note that the previous index wasn't pure XML: it contained a binary version header.

Since all XAML files are compiled to IL, this was the last piece of code to reference `System.Xml` at runtime. After this PR, there's no more dependencies on it and it can be trimmed. A XAML-based framework that doesn't require `System.Xml`!

A self-contained hello world app published trimmed for win10-x64 results in 20 (!!) fewer published assemblies, and a 2.2 MB size reduction. (I wasn't expecting so much; it turns out that even trimmed, `System.Xml` has a lot of dependencies.)

Removed assemblies:

- Microsoft.Win32.Registry.dll
- System.Diagnostics.DiagnosticSource.dll
- System.IO.Compression.Brotli.dll
- System.Net.Http.dll
- System.Net.NameResolution.dll
- System.Net.NetworkInformation.dll
- System.Net.Primitives.dll
- System.Net.Quic.dll
- System.Net.Security.dll
- System.Net.Sockets.dll
- System.Private.Xml.dll
- System.Private.Xml.Linq.dll
- System.Runtime.Numerics.dll
- System.Runtime.Serialization.Primitives.dll
- System.Security.Claims.dll
- System.Security.Cryptography.dll
- System.Security.Principal.Windows.dll
- System.Text.RegularExpressions.dll
- System.Threading.Channels.dll
- System.Xml.Linq.dll

On my PC, this also save ≈10ms of JIT time at startup.

## Breaking changes
This is a breaking change since the resources index format has changed. All Avalonia resources need to be recompiled.

Note to devs: if this PR merged, you might need to delete your `obj` folders manually to force the new format to be used due to cached resource files. See https://github.com/AvaloniaUI/Avalonia/pull/9948 (even if that other PR is merged, any build made before it might contain stale resources). NuGet consumers shouldn't be affected by this cache issue since the package version will be different.

## Misc notes

- Replaced `AvaloniaResourcesIndexReaderWriter.Create` with a slightly more generic `WriteResources` method, used to write a full resources file (size + index + resources), to avoid duplicated code in the build tasks.
- Added the existing `Platform\Internal\Constants.cs` file to the build tasks project and replaced the `!AvaloniaResources` by the existing constant.
 - There's still one `DataContract` file generated by the build tasks and included in the resources: `!AvaloniaResourceXamlInfo`. However, it doesn't seem to be read anywhere at runtime so it doesn't really matter. Is this file a leftover from a previous implementation that can be removed?