### PR TITLE
ScrollGestureRecognizer ends its current fling gesture (touch or pen)…

### DIFF
--- a/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
@@ -189,7 +189,14 @@ namespace Avalonia.Input.GestureRecognizers
 
                         var speed = _inertia * Math.Pow(0.15, st.Elapsed.TotalSeconds);
                         var distance = speed * elapsedSinceLastTick.TotalSeconds;
-                        _target!.RaiseEvent(new ScrollGestureEventArgs(_gestureId, distance));
+                        var scrollGestureEventArgs = new ScrollGestureEventArgs(_gestureId, distance);
+                        _target!.RaiseEvent(scrollGestureEventArgs);
+
+                        if (!scrollGestureEventArgs.Handled || scrollGestureEventArgs.ShouldEndScrollGesture)
+                        {
+                            EndGesture();
+                            return false;
+                        }
 
                         // EndGesture using InertialScrollSpeedEnd only in the direction of scrolling
                         if (CanVerticallyScroll && CanHorizontallyScroll && Math.Abs(speed.X) < InertialScrollSpeedEnd && Math.Abs(speed.Y) <= InertialScrollSpeedEnd)

--- a/src/Avalonia.Base/Input/ScrollGestureEventArgs.cs
+++ b/src/Avalonia.Base/Input/ScrollGestureEventArgs.cs
@@ -6,6 +6,10 @@ namespace Avalonia.Input
     {
         public int Id { get; }
         public Vector Delta { get; }
+        /// <summary>
+        /// When set the ScrollGestureRecognizer should stop its current active scroll gesture.
+        /// </summary>
+        public bool ShouldEndScrollGesture { get; set; }
         private static int _nextId = 1;
 
         public static int GetNextFreeId() => _nextId++;

--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -428,6 +428,8 @@ namespace Avalonia.Controls.Presenters
                 Offset = newOffset;
 
                 e.Handled = !IsScrollChainingEnabled || offsetChanged;
+
+                e.ShouldEndScrollGesture = !IsScrollChainingEnabled && !offsetChanged;
             }
         }
 


### PR DESCRIPTION
… if ScrollGestureEventArgs is no longer handled by the Presenter.

## What does the pull request do?
A fling ScrollGesture started by touch or pen swiping will stop as soon as the presenter stops scrolling (no change in offset).

## What is the current behavior?
See #9955.

## What is the updated/expected behavior with this PR?
A fling ScrollGesture will no longer influence scrolling after scrolling reached the end of the scroll area.


## How was the solution implemented (if it's not obvious)?
The ScrollContentPresenter has a `Scroll Chaining` option -- if this is turned `off`, the `ScrollGestureEventArgs.Handled` will always be true -- for this scenario I added `ScrollGestureEventArgs.ShouldEndScrollGesture`.

## Breaking changes
none

## Fixed issues
Fixes #9955