### PR TITLE
Added `SetCurrentValue`

### DIFF
--- a/src/Avalonia.Base/AvaloniaProperty.cs
+++ b/src/Avalonia.Base/AvaloniaProperty.cs
@@ -495,6 +495,13 @@ namespace Avalonia
             AvaloniaObject o,
             object? value,
             BindingPriority priority);
+        
+        /// <summary>
+        /// Routes an untyped SetCurrentValue call to a typed call.
+        /// </summary>
+        /// <param name="o">The object instance.</param>
+        /// <param name="value">The value.</param>
+        internal abstract void RouteSetCurrentValue(AvaloniaObject o, object? value);
 
         /// <summary>
         /// Routes an untyped Bind call to a typed call.

--- a/src/Avalonia.Base/Data/BindingPriority.cs
+++ b/src/Avalonia.Base/Data/BindingPriority.cs
@@ -36,6 +36,11 @@ namespace Avalonia.Data
         /// A style value.
         /// </summary>
         Style,
+
+        /// <summary>
+        /// A value generated internally by the control.
+        /// </summary>
+        Internal,
         
         /// <summary>
         /// The value is inherited from an ancestor element.

--- a/src/Avalonia.Base/Diagnostics/AvaloniaPropertyValue.cs
+++ b/src/Avalonia.Base/Diagnostics/AvaloniaPropertyValue.cs
@@ -14,16 +14,19 @@ namespace Avalonia.Diagnostics
         /// <param name="property">The property.</param>
         /// <param name="value">The current property value.</param>
         /// <param name="priority">The priority of the current value.</param>
+        /// <param name="isCurrent">Whether the value originated from a call to <see cref="AvaloniaObject.SetCurrentValue"/></param>
         /// <param name="diagnostic">A diagnostic string.</param>
         public AvaloniaPropertyValue(
             AvaloniaProperty property,
             object? value,
             BindingPriority priority,
+            bool isCurrent,
             string? diagnostic)
         {
             Property = property;
             Value = value;
             Priority = priority;
+            IsCurrent = isCurrent;
             Diagnostic = diagnostic;
         }
 
@@ -33,7 +36,7 @@ namespace Avalonia.Diagnostics
         public AvaloniaProperty Property { get; }
 
         /// <summary>
-        /// Gets the current property value.
+        /// Gets the property value.
         /// </summary>
         public object? Value { get; }
 
@@ -41,6 +44,12 @@ namespace Avalonia.Diagnostics
         /// Gets the priority of the current value.
         /// </summary>
         public BindingPriority Priority { get; }
+
+        /// <summary>
+        /// Gets whether the value originated from a call to <see cref="AvaloniaObject.SetCurrentValue"/>.
+        /// This can cause the value to differ from its source (e.g. a style setter or one-way binding).
+        /// </summary>
+        public bool IsCurrent { get; }
 
         /// <summary>
         /// Gets a diagnostic string.

--- a/src/Avalonia.Base/DirectPropertyBase.cs
+++ b/src/Avalonia.Base/DirectPropertyBase.cs
@@ -152,6 +152,8 @@ namespace Avalonia
             return null;
         }
 
+        internal override void RouteSetCurrentValue(AvaloniaObject o, object? value) => o.SetValue(this, value);
+
         /// <summary>
         /// Routes an untyped Bind call to a typed call.
         /// </summary>

--- a/src/Avalonia.Base/PropertyStore/EffectiveValue.cs
+++ b/src/Avalonia.Base/PropertyStore/EffectiveValue.cs
@@ -81,10 +81,14 @@ namespace Avalonia.PropertyStore
         /// <param name="owner">The associated value store.</param>
         /// <param name="value">The new value of the property.</param>
         /// <param name="priority">The priority of the new value.</param>
+        /// <param name="clearCurrentValue">Whether a value previously passed to
+        /// <see cref="SetCurrentValue"/> should be replaced by the 
+        /// <c><paramref name="value"/></c> of this call.</param>
         public abstract void SetAndRaise(
             ValueStore owner,
             IValueEntry value,
-            BindingPriority priority);
+            BindingPriority priority,
+            bool clearCurrentValue = false);
 
         /// <summary>
         /// Sets the value without changing the value source or binding priority,
@@ -144,7 +148,7 @@ namespace Avalonia.PropertyStore
             {
                 // If we've received an animation value and the current value is a non-animation
                 // value, then the current entry becomes our base entry.
-                if (Priority > BindingPriority.LocalValue && Priority < BindingPriority.Inherited)
+                if (Priority > BindingPriority.LocalValue && Priority < BindingPriority.Internal)
                 {
                     Debug.Assert(_valueEntry is not null);
                     _baseValueEntry = _valueEntry;

--- a/src/Avalonia.Base/PropertyStore/EffectiveValue.cs
+++ b/src/Avalonia.Base/PropertyStore/EffectiveValue.cs
@@ -30,10 +30,16 @@ namespace Avalonia.PropertyStore
         public BindingPriority BasePriority { get; protected set; }
 
         /// <summary>
+        /// Gets whether this value was set via <see cref="ValueStore.SetCurrentValue{T}"/>, instead of coming
+        /// from a value source with a defined <see cref="BindingPriority"/>.
+        /// </summary>
+        public abstract bool IsCurrent { get; }
+
+        /// <summary>
         /// Begins a reevaluation pass on the effective value.
         /// </summary>
         /// <param name="clearLocalValue">
-        /// Determines whether any current local value should be cleared.
+        /// Determines whether any current local/internal value should be cleared.
         /// </param>
         /// <remarks>
         /// This method resets the <see cref="Priority"/> and <see cref="BasePriority"/> properties
@@ -41,9 +47,9 @@ namespace Avalonia.PropertyStore
         /// </remarks>
         public void BeginReevaluation(bool clearLocalValue = false)
         {
-            if (clearLocalValue || Priority != BindingPriority.LocalValue)
+            if (clearLocalValue || Priority is not (BindingPriority.LocalValue or BindingPriority.Internal))
                 Priority = BindingPriority.Unset;
-            if (clearLocalValue || BasePriority != BindingPriority.LocalValue)
+            if (clearLocalValue || BasePriority is not (BindingPriority.LocalValue or BindingPriority.Internal))
                 BasePriority = BindingPriority.Unset;
         }
 
@@ -79,6 +85,17 @@ namespace Avalonia.PropertyStore
             ValueStore owner,
             IValueEntry value,
             BindingPriority priority);
+
+        /// <summary>
+        /// Sets the value without changing the value source or binding priority,
+        /// raising <see cref="AvaloniaObject.PropertyChanged"/> where necessary.
+        /// </summary>
+        /// <param name="owner">The associated value store.</param>
+        /// <param name="property">The property being changed.</param>
+        /// <param name="value">The new value of the property.</param>
+        public abstract void SetCurrentValue(ValueStore owner, AvaloniaProperty property, object? value);
+
+        public abstract void RemoveCurrentValue();
 
         /// <summary>
         /// Raises <see cref="AvaloniaObject.PropertyChanged"/> in response to an inherited value

--- a/src/Avalonia.Base/PropertyStore/ValueStore.cs
+++ b/src/Avalonia.Base/PropertyStore/ValueStore.cs
@@ -180,8 +180,7 @@ namespace Avalonia.PropertyStore
                 if (TryGetEffectiveValue(property, out var existing))
                 {
                     var effective = (EffectiveValue<T>)existing;
-                    existing.RemoveCurrentValue();
-                    effective.SetAndRaise(this, result, priority);
+                    effective.SetAndRaise(this, result, priority, true);
                 }
                 else
                 {
@@ -197,7 +196,6 @@ namespace Avalonia.PropertyStore
                 if (TryGetEffectiveValue(property, out var existing))
                 {
                     var effective = (EffectiveValue<T>)existing;
-                    existing.RemoveCurrentValue();
                     effective.SetLocalValueAndRaise(this, property, value);
                 }
                 else

--- a/src/Markup/Avalonia.Markup/Data/TemplateBinding.cs
+++ b/src/Markup/Avalonia.Markup/Data/TemplateBinding.cs
@@ -104,9 +104,7 @@ namespace Avalonia.Data
                         CultureInfo.CurrentCulture);
                 }
 
-                // Use LocalValue priority here, as TemplatedParent doesn't make sense on controls
-                // that aren't template children.
-                templatedParent.SetValue(Property, value, BindingPriority.LocalValue);
+                templatedParent.SetCurrentValue(Property, value);
             }
         }
 

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_SetCurrentValue.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_SetCurrentValue.cs
@@ -1,0 +1,237 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Animation;
+using Avalonia.Base.UnitTests.Animation;
+using Avalonia.Data;
+using Xunit;
+
+#nullable enable
+
+namespace Avalonia.Base.UnitTests
+{
+    public class AvaloniaObjectTests_SetCurrentValue
+    {
+        private const string NewValue = "newvalue";
+        private const string OtherValue = "otherValue";
+
+        [Fact]
+        public void SetCurrentValue_Sets_Value()
+        {
+            var target = new Class1();
+
+            target.SetCurrentValue(Class1.FooProperty, NewValue);
+
+            Assert.Equal(NewValue, target.Foo);
+        }
+
+        [Fact]
+        public void ClearValue_Clears_CurrentValue()
+        {
+            var target = new Class1();
+
+            target.SetCurrentValue(Class1.FooProperty, NewValue);
+            target.ClearValue(Class1.FooProperty);
+
+            Assert.Equal(Class1.FooProperty.GetDefaultValue(typeof(Class1)), target.Foo);
+        }
+
+        [Fact]
+        public void Setting_UnsetValue_Reverts_To_Default_Value()
+        {
+            var target = new Class1();
+
+            target.SetCurrentValue(Class1.FooProperty, NewValue);
+            target.SetCurrentValue(Class1.FooProperty, AvaloniaProperty.UnsetValue);
+
+            Assert.Equal(Class1.FooProperty.GetDefaultValue(typeof(Class1)), target.Foo);
+            Assert.Equal(BindingPriority.Unset, target.GetDiagnosticInternal(Class1.InheritedProperty).Priority);
+        }
+
+        [Fact]
+        public void CurrentValue_Inherited()
+        {
+            var parent = new Class1();
+            var target = new Class1()
+            {
+                InheritanceParent = parent,
+            };
+
+            parent.SetCurrentValue(Class1.InheritedProperty, NewValue);
+
+            Assert.Equal(NewValue, target.Inherited);
+        }
+
+        [Fact]
+        public void Inherited_Property_Upgraded_To_Internal()
+        {
+            var parent = new Class1();
+            var target = new Class1()
+            {
+                InheritanceParent = parent,
+            };
+
+            parent.SetCurrentValue(Class1.InheritedProperty, NewValue);
+
+            Assert.Equal(BindingPriority.Inherited, target.GetDiagnosticInternal(Class1.InheritedProperty).Priority);
+
+            target.SetCurrentValue(Class1.InheritedProperty, OtherValue);
+
+            Assert.Equal(OtherValue, target.Inherited);
+            Assert.Equal(BindingPriority.Internal, target.GetDiagnosticInternal(Class1.InheritedProperty).Priority);
+        }
+
+        [Fact]
+        public void Unset_Property_Upgraded_To_Internal()
+        {
+            var target = new Class1();
+
+            target.SetCurrentValue(Class1.FooProperty, NewValue);
+
+            Assert.Equal(BindingPriority.Internal, target.GetDiagnosticInternal(Class1.FooProperty).Priority);
+        }
+
+        [Fact]
+        public void Setting_Object_Property_To_DoNothing_Does_Nothing()
+        {
+            var target = new Class1();
+
+            target.SetCurrentValue(Class1.FrankProperty, NewValue);
+            target.SetCurrentValue(Class1.FrankProperty, BindingOperations.DoNothing);
+
+            Assert.Equal(NewValue, target.Frank);
+        }
+
+        [Fact]
+        public void Setting_Higher_Priority_Value_Clears_CurrentValue()
+        {
+            var target = new Class1();
+
+            target.SetValue(Class1.FrankProperty, NewValue, BindingPriority.Style);
+
+            target.SetCurrentValue(Class1.FrankProperty, OtherValue);
+
+            var undoSet = target.SetValue(Class1.FrankProperty, "StyleTriggerValue", BindingPriority.StyleTrigger);
+
+            undoSet!.Dispose();
+
+            Assert.Equal(NewValue, target.Frank);
+        }
+
+        [Fact]
+        public void CurrentValue_Overwritten_By_Animation()
+        {
+            var animatable = new TestAnimatable();
+            var clock = new TestClock();
+            var duration = TimeSpan.FromSeconds(1);
+
+            var transition = new DoubleTransition
+            {
+                Duration = duration,
+                Property = TestAnimatable.NumericProperty,
+            };
+
+            transition.Apply(animatable, clock, 0.0, 1.0);
+
+            clock.Step(TimeSpan.Zero);
+            clock.Step(duration * 0.5);
+
+            Assert.Equal(0.5, animatable.Numeric);
+
+            animatable.SetCurrentValue(TestAnimatable.NumericProperty, 256);
+
+            Assert.Equal(256, animatable.Numeric);
+
+            clock.Step(duration * 0.75);
+
+            Assert.Equal(0.75, animatable.Numeric);
+        }
+
+        [Theory, MemberData(nameof(WriteableBindingPriorities))]
+        public void Binding_Update_Clears_CurrentValue(BindingPriority priority)
+        {
+            var target = new Class1();
+            var source = new Class1();
+
+            target.Bind(Class1.FrankProperty, source.GetBindingObservable(Class1.FrankProperty), priority);
+
+            target.SetCurrentValue(Class1.FrankProperty, OtherValue);
+
+            source.SetValue(Class1.FrankProperty, NewValue);
+            
+            Assert.Equal(NewValue, target.Frank);
+        }
+
+        [Theory, MemberData(nameof(WriteableBindingPriorities))]
+        public void SetCurrentValue_Sets_Value_Without_Changing_Priority(BindingPriority priority)
+        {
+            var target = new Class1();
+
+            target.SetValue(Class1.FooProperty, priority.ToString(), priority);
+
+            target.SetCurrentValue(Class1.FooProperty, NewValue);
+
+            Assert.Equal(NewValue, target.Foo);
+
+            Assert.Equal(priority, target.GetDiagnosticInternal(Class1.FooProperty).Priority);
+        }
+
+        [Theory, MemberData(nameof(WriteableBindingPriorities))]
+        public void SetCurrentValue_Sets_Value_Without_Terminating_Bindings(BindingPriority priority)
+        {
+            var target = new Class1();
+            var source = new Class1();
+
+            source.SetValue(Class1.FrankProperty, NewValue);
+            target.Bind(Class1.FrankProperty, source.GetObservable(Class1.FrankProperty), priority);
+
+            Assert.Equal(NewValue, target.Frank);
+
+            target.SetCurrentValue(Class1.FrankProperty, OtherValue);
+
+            Assert.Equal(OtherValue, target.Frank);
+
+            source.SetValue(Class1.FrankProperty, "thirdValue");
+
+            Assert.Equal("thirdValue", target.Frank);
+        }
+
+        public static TheoryData<BindingPriority> WriteableBindingPriorities()
+        {
+            var data = new TheoryData<BindingPriority>();
+            foreach (var value in Enum.GetValues<BindingPriority>())
+            {
+                if (value is BindingPriority.Unset or BindingPriority.Inherited)
+                {
+                    continue;
+                }
+                data.Add(value);
+            }
+            return data;
+        }
+
+        private class Class1 : AvaloniaObject
+        {
+            public static readonly StyledProperty<string> FooProperty =
+                AvaloniaProperty.Register<Class1, string>(nameof(Foo), "foodefault");
+
+            public static readonly StyledProperty<object> FrankProperty =
+                AvaloniaProperty.Register<Class1, object>(nameof(Frank), "Kups");
+
+            public static readonly StyledProperty<string> InheritedProperty =
+                AvaloniaProperty.Register<Class1, string>(nameof(Inherited), inherits: true);
+
+            public string Foo => GetValue(FooProperty);
+            public object Frank => GetValue(FrankProperty);
+            public object Inherited => GetValue(InheritedProperty);
+        }
+
+        private class TestAnimatable : Animatable
+        {
+            public static readonly StyledProperty<double> NumericProperty =
+                AvaloniaProperty.Register<Class1, double>(nameof(Numeric), -1);
+
+            public double Numeric => GetValue(NumericProperty);
+        }
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/AvaloniaPropertyTests.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaPropertyTests.cs
@@ -179,6 +179,11 @@ namespace Avalonia.Base.UnitTests
                 throw new NotImplementedException();
             }
 
+            internal override void RouteSetCurrentValue(AvaloniaObject o, object value)
+            {
+                throw new NotImplementedException();
+            }
+
             internal override EffectiveValue CreateEffectiveValue(AvaloniaObject o)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
## What does the pull request do?
This change is a prerequisite for #9944. It introduces a direct analogue to WPF's [`DependencyObject.SetCurrentValue`](https://learn.microsoft.com/dotnet/api/system.windows.dependencyobject.setcurrentvalue) method, which sets the effective value of the property without changing its value source or detaching any bindings or style setters applied to it.

The existing `SetValue` method is sufficient when a property's value has `BindingPriority.LocalValue`; see the [`Local_Binding_Overwrites_Local_Value`](https://github.com/AvaloniaUI/Avalonia/blob/55ccecfa5045130395a756c9aa3bf85012945de8/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Binding.cs#L674) test.

If the priority is anything else, or unknown, `SetCurrentValue` should be used instead. In particular, it should be used when a control is setting its own public `StyledProperty` values.

This commit only calls `SetCurrentValue` in one place: `TemplateBinding`. More uses will be added in future commits.

## What is the current behavior?
It is currently not possible to set a value of a `StyledProperty` without the danger of changing its value source.

Controls that want to set their own properties must instead use `DirectProperty`, which can only ever be set with `LocalValue` priority. But this is not ideal for properties that can also be set from styles or templates, and following recent changes `DirectProperty` has been prevented from receiving values from styles with conditional selectors (see #9800).

## What is the updated/expected behavior with this PR?
`SetCurrentValue` can be used instead of `SetValue` to safely update the current value of a `StyledProperty`, no matter where it came from. This enables controls to use `StyledProperty` in many more situations.

If the property is unset or has an inherited value when `SetCurrentValue` is called, an `EffectiveValue` is added with the new `Internal` priority. This is the lowest priority at which a value can be written.

`SetCurrentValue` can also be used with `DirectProperty`, but this call simply redirects to `SetValue`.

## How was the solution implemented (if it's not obvious)?
This change thankfully proved mostly additive. Calls to `SetCurrentValue` alter current behaviour when they reach `EffectiveValue<T>`, where the new value object is stored and returned by `EffectiveValue.Value` until something happens to change the effective value again.

A value object from `SetCurrentValue` is stored alongside the last "prioritized value". This is to support the following sequence of events:

1. A property value is set by a template
2. The control calls `SetCurrentValue` on that property
3. A style trigger becomes active and sets the property to a new value
4. The style trigger deactivates and the template value becomes effective again

The `SetCurrentValue` value object is discarded at step 3. At step 4, the original template value set from step 1 returns.

Additionally, some validation code has been moved into shared methods to avoid further duplication.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Does not directly fix any known issues, but unblocks #9944.