### PR TITLE
#9992 fix: change ScrollViewer related APIs to async

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/ScrollViewerAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ScrollViewerAutomationPeer.cs
@@ -93,16 +93,16 @@ namespace Avalonia.Automation.Peers
             switch (horizontalAmount)
             {
                 case ScrollAmount.LargeDecrement:
-                    Owner.PageLeft();
+                    Owner.PageLeftAsync();
                     break;
                 case ScrollAmount.SmallDecrement:
-                    Owner.LineLeft();
+                    Owner.LineLeftAsync();
                     break;
                 case ScrollAmount.SmallIncrement:
-                    Owner.LineRight();
+                    Owner.LineRightAsync();
                     break;
                 case ScrollAmount.LargeIncrement:
-                    Owner.PageRight();
+                    Owner.PageRightAsync();
                     break;
                 case ScrollAmount.NoAmount:
                     break;
@@ -113,16 +113,16 @@ namespace Avalonia.Automation.Peers
             switch (verticalAmount)
             {
                 case ScrollAmount.LargeDecrement:
-                    Owner.PageUp();
+                    Owner.PageUpAsync();
                     break;
                 case ScrollAmount.SmallDecrement:
-                    Owner.LineUp();
+                    Owner.LineUpAsync();
                     break;
                 case ScrollAmount.SmallIncrement:
-                    Owner.LineDown();
+                    Owner.LineDownAsync();
                     break;
                 case ScrollAmount.LargeIncrement:
-                    Owner.PageDown();
+                    Owner.PageDownAsync();
                     break;
                 case ScrollAmount.NoAmount:
                     break;

--- a/src/Avalonia.Controls/ScrollViewer.cs
+++ b/src/Avalonia.Controls/ScrollViewer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Avalonia.Reactive;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Metadata;
@@ -6,6 +7,7 @@ using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 
 namespace Avalonia.Controls
 {
@@ -444,84 +446,119 @@ namespace Avalonia.Controls
             set => SetValue(IsScrollChainingEnabledProperty, value);
         }
 
+        private static Task ExecuteInLayoutPriority(Action action)
+        {
+            return Dispatcher.UIThread.InvokeAsync(action, DispatcherPriority.Layout);
+        }
+
         /// <summary>
         /// Scrolls the content up one line.
         /// </summary>
-        public void LineUp()
+        public async Task LineUpAsync()
         {
-            Offset -= new Vector(0, _smallChange.Height);
+            await ExecuteInLayoutPriority(() =>
+            {
+                Offset -= new Vector(0, _smallChange.Height);
+            });
         }
 
         /// <summary>
         /// Scrolls the content down one line.
         /// </summary>
-        public void LineDown()
+        public async Task LineDownAsync()
         {
-            Offset += new Vector(0, _smallChange.Height);
+            await ExecuteInLayoutPriority(() =>
+            {
+                Offset += new Vector(0, _smallChange.Height);
+            });
         }
 
         /// <summary>
         /// Scrolls the content left one line.
         /// </summary>
-        public void LineLeft()
+        public async Task LineLeftAsync()
         {
-            Offset -= new Vector(_smallChange.Width, 0);
+            await ExecuteInLayoutPriority(() =>
+            {
+                Offset -= new Vector(_smallChange.Width, 0);
+            });
         }
 
         /// <summary>
         /// Scrolls the content right one line.
         /// </summary>
-        public void LineRight()
+        public async Task LineRightAsync()
         {
-            Offset += new Vector(_smallChange.Width, 0);
+            await ExecuteInLayoutPriority(() =>
+            {
+                Offset += new Vector(_smallChange.Width, 0);
+            });
         }
 
         /// <summary>
         /// Scrolls the content upward by one page.
         /// </summary>
-        public void PageUp()
+        public async Task PageUpAsync()
         {
-            VerticalScrollBarValue = Math.Max(_offset.Y - _viewport.Height, 0);
+            await ExecuteInLayoutPriority(() =>
+            {
+                VerticalScrollBarValue = Math.Max(_offset.Y - _viewport.Height, 0);
+            });
         }
 
         /// <summary>
         /// Scrolls the content downward by one page.
         /// </summary>
-        public void PageDown()
+        public async Task PageDownAsync()
         {
-            VerticalScrollBarValue = Math.Min(_offset.Y + _viewport.Height, VerticalScrollBarMaximum);
+            await ExecuteInLayoutPriority(() =>
+            {
+                VerticalScrollBarValue = Math.Min(_offset.Y + _viewport.Height, VerticalScrollBarMaximum);
+            });
         }
 
         /// <summary>
         /// Scrolls the content left by one page.
         /// </summary>
-        public void PageLeft()
+        public async Task PageLeftAsync()
         {
-            HorizontalScrollBarValue = Math.Max(_offset.X - _viewport.Width, 0);
+            await ExecuteInLayoutPriority(() =>
+            {
+                HorizontalScrollBarValue = Math.Max(_offset.X - _viewport.Width, 0);
+            });
         }
 
         /// <summary>
         /// Scrolls the content tight by one page.
         /// </summary>
-        public void PageRight()
+        public async Task PageRightAsync()
         {
-            HorizontalScrollBarValue = Math.Min(_offset.X + _viewport.Width, HorizontalScrollBarMaximum);
+            await ExecuteInLayoutPriority(() =>
+            {
+                HorizontalScrollBarValue = Math.Min(_offset.X + _viewport.Width, HorizontalScrollBarMaximum);
+            });
         }
 
         /// <summary>
         /// Scrolls to the top-left corner of the content.
         /// </summary>
-        public void ScrollToHome()
+        public async Task ScrollToHomeAsync()
         {
-            Offset = new Vector(double.NegativeInfinity, double.NegativeInfinity);
+            await ExecuteInLayoutPriority(() =>
+            {
+                Offset = new Vector(double.NegativeInfinity, double.NegativeInfinity);
+            });
         }
 
         /// <summary>
         /// Scrolls to the bottom-left corner of the content.
         /// </summary>
-        public void ScrollToEnd()
+        public async Task ScrollToEndAsync()
         {
-            Offset = new Vector(double.NegativeInfinity, double.PositiveInfinity);
+            await ExecuteInLayoutPriority(() =>
+            {
+                Offset = new Vector(double.NegativeInfinity, double.PositiveInfinity);
+            });
         }
 
         /// <summary>
@@ -733,12 +770,12 @@ namespace Avalonia.Controls
         {
             if (e.Key == Key.PageUp)
             {
-                PageUp();
+                PageUpAsync();
                 e.Handled = true;
             }
             else if (e.Key == Key.PageDown)
             {
-                PageDown();
+                PageDownAsync();
                 e.Handled = true;
             }
         }

--- a/src/Avalonia.Themes.Fluent/Controls/MenuScrollViewer.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/MenuScrollViewer.xaml
@@ -29,7 +29,7 @@
                         HorizontalAlignment="Stretch"
                         HorizontalContentAlignment="Center"
                         RenderTransform="{x:Null}"
-                        Command="{Binding LineUp, RelativeSource={RelativeSource TemplatedParent}}">
+                        Command="{Binding LineUpAsync, RelativeSource={RelativeSource TemplatedParent}}">
             <RepeatButton.IsVisible>
               <MultiBinding Converter="{x:Static converters:MenuScrollingVisibilityConverter.Instance}"
                             ConverterParameter="0">

--- a/src/Avalonia.Themes.Fluent/Controls/MenuScrollViewer.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/MenuScrollViewer.xaml
@@ -55,7 +55,7 @@
                         HorizontalAlignment="Stretch"
                         HorizontalContentAlignment="Center"
                         RenderTransform="{x:Null}"
-                        Command="{Binding LineDown, RelativeSource={RelativeSource TemplatedParent}}">
+                        Command="{Binding LineDownAsync, RelativeSource={RelativeSource TemplatedParent}}">
             <RepeatButton.IsVisible>
               <MultiBinding Converter="{x:Static converters:MenuScrollingVisibilityConverter.Instance}"
                             ConverterParameter="100">

--- a/src/Avalonia.Themes.Simple/Controls/ScrollViewer.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ScrollViewer.xaml
@@ -64,7 +64,7 @@
         <DockPanel>
           <RepeatButton Background="Transparent"
                         BorderThickness="0"
-                        Command="{Binding LineUp, RelativeSource={RelativeSource TemplatedParent}}"
+                        Command="{Binding LineUpAsync, RelativeSource={RelativeSource TemplatedParent}}"
                         DockPanel.Dock="Top">
             <RepeatButton.IsVisible>
               <MultiBinding Converter="{x:Static converters:MenuScrollingVisibilityConverter.Instance}"

--- a/src/Avalonia.Themes.Simple/Controls/ScrollViewer.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ScrollViewer.xaml
@@ -83,7 +83,7 @@
           </RepeatButton>
           <RepeatButton Background="Transparent"
                         BorderThickness="0"
-                        Command="{Binding LineDown, RelativeSource={RelativeSource TemplatedParent}}"
+                        Command="{Binding LineDownAsync, RelativeSource={RelativeSource TemplatedParent}}"
                         DockPanel.Dock="Bottom">
             <RepeatButton.IsVisible>
               <MultiBinding Converter="{x:Static converters:MenuScrollingVisibilityConverter.Instance}"

--- a/tests/Avalonia.Controls.UnitTests/ScrollViewerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ScrollViewerTests.cs
@@ -71,7 +71,7 @@ namespace Avalonia.Controls.UnitTests
             target.SetValue(ScrollViewer.ExtentProperty, new Size(50, 50));
             target.SetValue(ScrollViewer.ViewportProperty, new Size(10, 10));
             target.Offset = new Vector(25, 25);
-            target.ScrollToHome();
+            target.ScrollToHomeAsync();
 
             Assert.Equal(new Vector(0, 0), target.Offset);
         }
@@ -83,7 +83,7 @@ namespace Avalonia.Controls.UnitTests
             target.SetValue(ScrollViewer.ExtentProperty, new Size(50, 50));
             target.SetValue(ScrollViewer.ViewportProperty, new Size(10, 10));
             target.Offset = new Vector(25, 25);
-            target.ScrollToEnd();
+            target.ScrollToEndAsync();
 
             Assert.Equal(new Vector(0, 40), target.Offset);
         }


### PR DESCRIPTION
## What does the pull request do?

According to #9992, when using "Scroll***" APIs. Developers need to manually call the Dispatcher operation with **Layout** priority. This PR adds this step in those APIs and changed them to async functions.


## What is the current behavior?

Currently, developers need to manually call Dispatcher operations in order to apply the changes to the view:
```c#

Dispatcher.UIThread.Post(() =>
{
    ScrollViewer.ScrollToEnd();
}, DispatcherPriority.Layout);

```


## What is the updated/expected behavior with this PR?

Right now, developers only need to call:

```c#

await ScrollViewer.ScrollToEndAsync();

```


## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

There are several API changes:

- LineUp() => LineUpAsync()
- LineDown() => LineDownAsync()
- LineLeft() => LineLeftAsync()
- LineRight() => LineRightAsync()
- PageUp() => PageUpAsync()
- PageDown() => PageDownAsync()
- PageLeft() => PageLeftAsync()
- PageRight() => PageRightAsync()
- ScrollToHome() => ScrollToHomeAsync()
- ScrollToEnd() => ScrollToEndAsync()

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues

Fixes #9992 
