### PR TITLE
More text layout optimizations

### DIFF
--- a/src/Avalonia.Base/Avalonia.Base.csproj
+++ b/src/Avalonia.Base/Avalonia.Base.csproj
@@ -30,6 +30,7 @@
     <InternalsVisibleTo Include="Avalonia.Desktop, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Benchmarks, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Controls, PublicKey=$(AvaloniaPublicKey)" />
+    <InternalsVisibleTo Include="Avalonia.Direct2D1, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Markup, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Markup.Xaml, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.OpenGL, PublicKey=$(AvaloniaPublicKey)" />

--- a/src/Avalonia.Base/Media/FontManager.cs
+++ b/src/Avalonia.Base/Media/FontManager.cs
@@ -132,7 +132,7 @@ namespace Avalonia.Media
                 {
                     typeface = new Typeface(fallback.FontFamily, fontStyle, fontWeight, fontStretch);
 
-                    var glyphTypeface = typeface.GlyphTypeface;
+                    var glyphTypeface = GetOrAddGlyphTypeface(typeface);
 
                     if(glyphTypeface.TryGetGlyph((uint)codepoint, out _)){
                         return true;

--- a/src/Avalonia.Base/Media/TextFormatting/FormattedTextSource.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/FormattedTextSource.cs
@@ -128,11 +128,9 @@ namespace Avalonia.Media.TextFormatting
 
             var graphemeEnumerator = new GraphemeEnumerator(text);
 
-            while (graphemeEnumerator.MoveNext())
+            while (graphemeEnumerator.MoveNext(out var grapheme))
             {
-                var grapheme = graphemeEnumerator.Current;
-
-                finalLength += grapheme.Text.Length;
+                finalLength += grapheme.Length;
 
                 if (finalLength >= length)
                 {

--- a/src/Avalonia.Base/Media/TextFormatting/InterWordJustification.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/InterWordJustification.cs
@@ -60,10 +60,8 @@ namespace Avalonia.Media.TextFormatting
 
                 var lineBreakEnumerator = new LineBreakEnumerator(text.Span);
 
-                while (lineBreakEnumerator.MoveNext())
+                while (lineBreakEnumerator.MoveNext(out var currentBreak))
                 {
-                    var currentBreak = lineBreakEnumerator.Current;
-
                     if (!currentBreak.Required && currentBreak.PositionWrap != textRun.Length)
                     {
                         breakOportunities.Enqueue(currentPosition + currentBreak.PositionMeasure);

--- a/src/Avalonia.Base/Media/TextFormatting/ShapedTextRun.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/ShapedTextRun.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Media.TextFormatting
         {
             ShapedBuffer = shapedBuffer;
             Properties = properties;
-            TextMetrics = new TextMetrics(properties.Typeface.GlyphTypeface, properties.FontRenderingEmSize);
+            TextMetrics = new TextMetrics(properties.CachedGlyphTypeface, properties.FontRenderingEmSize);
         }
 
         public bool IsReversed { get; private set; }

--- a/src/Avalonia.Base/Media/TextFormatting/TextCharacters.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextCharacters.cs
@@ -47,13 +47,13 @@ namespace Avalonia.Media.TextFormatting
         /// </summary>
         /// <returns>The shapeable text characters.</returns>
         internal void GetShapeableCharacters(ReadOnlyMemory<char> text, sbyte biDiLevel,
-            ref TextRunProperties? previousProperties, RentedList<TextRun> results)
+            FontManager fontManager, ref TextRunProperties? previousProperties, RentedList<TextRun> results)
         {
             var properties = Properties;
 
             while (!text.IsEmpty)
             {
-                var shapeableRun = CreateShapeableRun(text, properties, biDiLevel, ref previousProperties);
+                var shapeableRun = CreateShapeableRun(text, properties, biDiLevel, fontManager, ref previousProperties);
 
                 results.Add(shapeableRun);
 
@@ -72,7 +72,8 @@ namespace Avalonia.Media.TextFormatting
         /// <param name="previousProperties"></param>
         /// <returns>A list of shapeable text runs.</returns>
         private static UnshapedTextRun CreateShapeableRun(ReadOnlyMemory<char> text,
-            TextRunProperties defaultProperties, sbyte biDiLevel, ref TextRunProperties? previousProperties)
+            TextRunProperties defaultProperties, sbyte biDiLevel, FontManager fontManager,
+            ref TextRunProperties? previousProperties)
         {
             var defaultTypeface = defaultProperties.Typeface;
             var currentTypeface = defaultTypeface;
@@ -121,7 +122,7 @@ namespace Avalonia.Media.TextFormatting
 
             //ToDo: Fix FontFamily fallback
             var matchFound =
-                FontManager.Current.TryMatchCharacter(codepoint, defaultTypeface.Style, defaultTypeface.Weight,
+                fontManager.TryMatchCharacter(codepoint, defaultTypeface.Style, defaultTypeface.Weight,
                     defaultTypeface.Stretch, defaultTypeface.FontFamily, defaultProperties.CultureInfo,
                     out currentTypeface);
 

--- a/src/Avalonia.Base/Media/TextFormatting/TextCharacters.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextCharacters.cs
@@ -110,14 +110,14 @@ namespace Avalonia.Media.TextFormatting
 
             var codepointEnumerator = new CodepointEnumerator(text.Slice(count).Span);
 
-            while (codepointEnumerator.MoveNext())
+            while (codepointEnumerator.MoveNext(out var cp))
             {
-                if (codepointEnumerator.Current.IsWhiteSpace)
+                if (cp.IsWhiteSpace)
                 {
                     continue;
                 }
 
-                codepoint = codepointEnumerator.Current;
+                codepoint = cp;
 
                 break;
             }

--- a/src/Avalonia.Base/Media/TextFormatting/TextCharacters.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextCharacters.cs
@@ -140,16 +140,14 @@ namespace Avalonia.Media.TextFormatting
 
             var enumerator = new GraphemeEnumerator(textSpan);
 
-            while (enumerator.MoveNext())
+            while (enumerator.MoveNext(out var grapheme))
             {
-                var grapheme = enumerator.Current;
-
                 if (!grapheme.FirstCodepoint.IsWhiteSpace && glyphTypeface.TryGetGlyph(grapheme.FirstCodepoint, out _))
                 {
                     break;
                 }
 
-                count += grapheme.Text.Length;
+                count += grapheme.Length;
             }
 
             return new UnshapedTextRun(text.Slice(0, count), defaultProperties, biDiLevel);
@@ -184,10 +182,8 @@ namespace Avalonia.Media.TextFormatting
 
             var enumerator = new GraphemeEnumerator(text);
 
-            while (enumerator.MoveNext())
+            while (enumerator.MoveNext(out var currentGrapheme))
             {
-                var currentGrapheme = enumerator.Current;
-
                 var currentScript = currentGrapheme.FirstCodepoint.Script;
 
                 if (!currentGrapheme.FirstCodepoint.IsWhiteSpace && defaultFont != null && defaultFont.TryGetGlyph(currentGrapheme.FirstCodepoint, out _))
@@ -217,7 +213,7 @@ namespace Avalonia.Media.TextFormatting
                     }
                 }
 
-                length += currentGrapheme.Text.Length;
+                length += currentGrapheme.Length;
             }
 
             return length > 0;

--- a/src/Avalonia.Base/Media/TextFormatting/TextEllipsisHelper.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextEllipsisHelper.cs
@@ -48,9 +48,9 @@ namespace Avalonia.Media.TextFormatting
 
                                         var lineBreaker = new LineBreakEnumerator(currentRun.Text.Span);
 
-                                        while (currentBreakPosition < measuredLength && lineBreaker.MoveNext())
+                                        while (currentBreakPosition < measuredLength && lineBreaker.MoveNext(out var lineBreak))
                                         {
-                                            var nextBreakPosition = lineBreaker.Current.PositionMeasure;
+                                            var nextBreakPosition = lineBreak.PositionMeasure;
 
                                             if (nextBreakPosition == 0)
                                             {

--- a/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
@@ -393,6 +393,7 @@ namespace Avalonia.Media.TextFormatting
             TextRunProperties? previousProperties = null;
             TextCharacters? currentRun = null;
             ReadOnlyMemory<char> runText = default;
+            var fontManager = FontManager.Current;
 
             for (var i = 0; i < textCharacters.Count; i++)
             {
@@ -427,8 +428,8 @@ namespace Avalonia.Media.TextFormatting
 
                     if (j == runTextSpan.Length)
                     {
-                        currentRun.GetShapeableCharacters(runText.Slice(0, j), runLevel, ref previousProperties,
-                            processedRuns);
+                        currentRun.GetShapeableCharacters(runText.Slice(0, j), runLevel, fontManager,
+                            ref previousProperties, processedRuns);
 
                         runLevel = levels[levelIndex];
 
@@ -441,8 +442,8 @@ namespace Avalonia.Media.TextFormatting
                     }
 
                     // End of this run
-                    currentRun.GetShapeableCharacters(runText.Slice(0, j), runLevel, ref previousProperties,
-                        processedRuns);
+                    currentRun.GetShapeableCharacters(runText.Slice(0, j), runLevel, fontManager,
+                        ref previousProperties, processedRuns);
 
                     runText = runText.Slice(j);
                     runTextSpan = runText.Span;
@@ -459,7 +460,7 @@ namespace Avalonia.Media.TextFormatting
                 return;
             }
 
-            currentRun.GetShapeableCharacters(runText, runLevel, ref previousProperties, processedRuns);
+            currentRun.GetShapeableCharacters(runText, runLevel, fontManager, ref previousProperties, processedRuns);
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
@@ -427,11 +427,12 @@ namespace Avalonia.Media.TextFormatting
         private TextLine[] CreateTextLines()
         {
             var objectPool = FormattingObjectPool.Instance;
+            var fontManager = FontManager.Current;
 
             if (MathUtilities.IsZero(MaxWidth) || MathUtilities.IsZero(MaxHeight))
             {
                 var textLine = TextFormatterImpl.CreateEmptyTextLine(0, double.PositiveInfinity, _paragraphProperties,
-                    FormattingObjectPool.Instance);
+                    fontManager);
 
                 Bounds = new Rect(0, 0, 0, textLine.Height);
 
@@ -458,7 +459,7 @@ namespace Avalonia.Media.TextFormatting
                     if (previousLine != null && previousLine.NewLineLength > 0)
                     {
                         var emptyTextLine = TextFormatterImpl.CreateEmptyTextLine(_textSourceLength, MaxWidth,
-                            _paragraphProperties, objectPool);
+                            _paragraphProperties, fontManager);
 
                         textLines.Add(emptyTextLine);
 
@@ -517,7 +518,7 @@ namespace Avalonia.Media.TextFormatting
             //Make sure the TextLayout always contains at least on empty line
             if (textLines.Count == 0)
             {
-                var textLine = TextFormatterImpl.CreateEmptyTextLine(0, MaxWidth, _paragraphProperties, objectPool);
+                var textLine = TextFormatterImpl.CreateEmptyTextLine(0, MaxWidth, _paragraphProperties, fontManager);
 
                 textLines.Add(textLine);
 

--- a/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
@@ -1256,7 +1256,7 @@ namespace Avalonia.Media.TextFormatting
 
         private TextLineMetrics CreateLineMetrics()
         {
-            var fontMetrics = _paragraphProperties.DefaultTextRunProperties.Typeface.GlyphTypeface.Metrics;
+            var fontMetrics = _paragraphProperties.DefaultTextRunProperties.CachedGlyphTypeface.Metrics;
             var fontRenderingEmSize = _paragraphProperties.DefaultTextRunProperties.FontRenderingEmSize;
             var scale = fontRenderingEmSize / fontMetrics.DesignEmHeight;
 
@@ -1285,12 +1285,13 @@ namespace Avalonia.Media.TextFormatting
                 {
                     case ShapedTextRun textRun:
                         {
+                            var properties = textRun.Properties;
                             var textMetrics =
-                                new TextMetrics(textRun.Properties.Typeface.GlyphTypeface, textRun.Properties.FontRenderingEmSize);
+                                new TextMetrics(properties.CachedGlyphTypeface, properties.FontRenderingEmSize);
 
-                            if (fontRenderingEmSize < textRun.Properties.FontRenderingEmSize)
+                            if (fontRenderingEmSize < properties.FontRenderingEmSize)
                             {
-                                fontRenderingEmSize = textRun.Properties.FontRenderingEmSize;
+                                fontRenderingEmSize = properties.FontRenderingEmSize;
 
                                 if (ascent > textMetrics.Ascent)
                                 {

--- a/src/Avalonia.Base/Media/TextFormatting/TextRunProperties.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextRunProperties.cs
@@ -12,6 +12,8 @@ namespace Avalonia.Media.TextFormatting
     /// </remarks>
     public abstract class TextRunProperties : IEquatable<TextRunProperties>
     {
+        private IGlyphTypeface? _cachedGlyphTypeFace;
+
         /// <summary>
         /// Run typeface
         /// </summary>
@@ -46,6 +48,9 @@ namespace Avalonia.Media.TextFormatting
         /// Run vertical box alignment
         /// </summary>
         public virtual BaselineAlignment BaselineAlignment => BaselineAlignment.Baseline;
+
+        internal IGlyphTypeface CachedGlyphTypeface
+            => _cachedGlyphTypeFace ??= Typeface.GlyphTypeface;
 
         public bool Equals(TextRunProperties? other)
         {

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/BiDiAlgorithm.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/BiDiAlgorithm.cs
@@ -870,73 +870,58 @@ namespace Avalonia.Media.TextFormatting.Unicode
             _runDirection = DirectionFromLevel(runLevel);
             _runLength = _runResolvedClasses.Length;
 
-            // By tracking the types of characters known to be in the current run, we can
-            // skip some of the rules that we know won't apply.  The flags will be
-            // initialized while we're processing rule W1 below.
-            var hasEN = false;
-            var hasAL = false;
-            var hasES = false;
-            var hasCS = false;
-            var hasAN = false;
-            var hasET = false;
-
             // Rule W1
             // Also, set hasXX flags
             int i;
             var previousClass = sos;
             
+            const uint isolateMask =
+                (1U << (int)BidiClass.LeftToRightIsolate) |
+                (1U << (int)BidiClass.RightToLeftIsolate) |
+                (1U << (int)BidiClass.FirstStrongIsolate) |
+                (1U << (int)BidiClass.PopDirectionalIsolate);
+
+            const uint wRulesMask =
+                (1U << (int)BidiClass.EuropeanNumber) |
+                (1U << (int)BidiClass.ArabicLetter) |
+                (1U << (int)BidiClass.EuropeanSeparator) |
+                (1U << (int)BidiClass.CommonSeparator) |
+                (1U << (int)BidiClass.ArabicNumber) |
+                (1U << (int)BidiClass.EuropeanTerminator);
+
+            uint wRules = 0;
+
             for (i = 0; i < _runLength; i++)
             {
                 var resolvedClass = _runResolvedClasses[i];
-                
-                switch (resolvedClass)
+
+                if (resolvedClass == BidiClass.NonspacingMark)
                 {
-                    case BidiClass.NonspacingMark:
-                        _runResolvedClasses[i] = previousClass;
-                        break;
-
-                    case BidiClass.LeftToRightIsolate:
-                    case BidiClass.RightToLeftIsolate:
-                    case BidiClass.FirstStrongIsolate:
-                    case BidiClass.PopDirectionalIsolate:
+                    _runResolvedClasses[i] = previousClass;
+                }
+                else
+                {
+                    var classBit = 1U << (int)resolvedClass;
+                    if ((classBit & isolateMask) != 0U)
+                    {
                         previousClass = BidiClass.OtherNeutral;
-                        break;
-
-                    case BidiClass.EuropeanNumber:
-                        hasEN = true;
+                    }
+                    else
+                    {
+                        wRules |= classBit & wRulesMask;
                         previousClass = resolvedClass;
-                        break;
-
-                    case BidiClass.ArabicLetter:
-                        hasAL = true;
-                        previousClass = resolvedClass;
-                        break;
-
-                    case BidiClass.EuropeanSeparator:
-                        hasES = true;
-                        previousClass = resolvedClass;
-                        break;
-
-                    case BidiClass.CommonSeparator:
-                        hasCS = true;
-                        previousClass = resolvedClass;
-                        break;
-
-                    case BidiClass.ArabicNumber:
-                        hasAN = true;
-                        previousClass = resolvedClass;
-                        break;
-
-                    case BidiClass.EuropeanTerminator:
-                        hasET = true;
-                        previousClass = resolvedClass;
-                        break;
-
-                    default:
-                        previousClass = resolvedClass;
-                        break;
+                    }
                 }
             }
+
+            // By tracking the types of characters known to be in the current run, we can
+            // skip some of the rules that we know won't apply.
+            var hasEN = (wRules & (1U << (int)BidiClass.EuropeanNumber)) != 0U;
+            var hasAL = (wRules & (1U << (int)BidiClass.ArabicLetter)) != 0U;
+            var hasES = (wRules & (1U << (int)BidiClass.EuropeanSeparator)) != 0U;
+            var hasCS = (wRules & (1U << (int)BidiClass.CommonSeparator)) != 0U;
+            var hasAN = (wRules & (1U << (int)BidiClass.ArabicNumber)) != 0U;
+            var hasET = (wRules & (1U << (int)BidiClass.EuropeanTerminator)) != 0U;
 
             // Rule W2
             if (hasEN)
@@ -1549,23 +1534,20 @@ namespace Avalonia.Media.TextFormatting.Unicode
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsWhitespace(BidiClass biDiClass)
         {
-            switch (biDiClass)
-            {
-                    case BidiClass.LeftToRightEmbedding:
-                    case BidiClass.RightToLeftEmbedding:
-                    case BidiClass.LeftToRightOverride:
-                    case BidiClass.RightToLeftOverride:
-                    case BidiClass.PopDirectionalFormat:
-                    case BidiClass.LeftToRightIsolate:
-                    case BidiClass.RightToLeftIsolate:
-                    case BidiClass.FirstStrongIsolate:
-                    case BidiClass.PopDirectionalIsolate:
-                    case BidiClass.BoundaryNeutral:
-                    case BidiClass.WhiteSpace:
-                        return true;
-                default:
-                    return false;
-            }
+            const uint mask =
+                (1U << (int)BidiClass.LeftToRightEmbedding) |
+                (1U << (int)BidiClass.RightToLeftEmbedding) |
+                (1U << (int)BidiClass.LeftToRightOverride) |
+                (1U << (int)BidiClass.RightToLeftOverride) |
+                (1U << (int)BidiClass.PopDirectionalFormat) |
+                (1U << (int)BidiClass.LeftToRightIsolate) |
+                (1U << (int)BidiClass.RightToLeftIsolate) |
+                (1U << (int)BidiClass.FirstStrongIsolate) |
+                (1U << (int)BidiClass.PopDirectionalIsolate) |
+                (1U << (int)BidiClass.BoundaryNeutral) |
+                (1U << (int)BidiClass.WhiteSpace);
+
+            return ((1U << (int)biDiClass) & mask) != 0U;
         }
 
         /// <summary>
@@ -1586,18 +1568,15 @@ namespace Avalonia.Media.TextFormatting.Unicode
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsRemovedByX9(BidiClass biDiClass)
         {
-            switch (biDiClass)
-            {
-                    case BidiClass.LeftToRightEmbedding:
-                    case  BidiClass.RightToLeftEmbedding:
-                    case  BidiClass.LeftToRightOverride:
-                    case  BidiClass.RightToLeftOverride:
-                    case  BidiClass.PopDirectionalFormat:
-                    case  BidiClass.BoundaryNeutral:
-                        return true;
-                default:
-                    return false;
-            }
+            const uint mask =
+                (1U << (int)BidiClass.LeftToRightEmbedding) |
+                (1U << (int)BidiClass.RightToLeftEmbedding) |
+                (1U << (int)BidiClass.LeftToRightOverride) |
+                (1U << (int)BidiClass.RightToLeftOverride) |
+                (1U << (int)BidiClass.PopDirectionalFormat) |
+                (1U << (int)BidiClass.BoundaryNeutral);
+
+            return ((1U << (int)biDiClass) & mask) != 0U;
         }
 
         /// <summary>
@@ -1606,20 +1585,17 @@ namespace Avalonia.Media.TextFormatting.Unicode
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsNeutralClass(BidiClass direction)
         {
-            switch (direction)
-            {
-                    case BidiClass.ParagraphSeparator:
-                    case BidiClass.SegmentSeparator:
-                    case BidiClass.WhiteSpace:
-                    case BidiClass.OtherNeutral:
-                    case BidiClass.RightToLeftIsolate:
-                    case BidiClass.LeftToRightIsolate:
-                    case BidiClass.FirstStrongIsolate:
-                    case BidiClass.PopDirectionalIsolate:
-                        return true;
-                        default:
-                            return false;
-            }
+            const uint mask =
+                (1U << (int)BidiClass.ParagraphSeparator) |
+                (1U << (int)BidiClass.SegmentSeparator) |
+                (1U << (int)BidiClass.WhiteSpace) |
+                (1U << (int)BidiClass.OtherNeutral) |
+                (1U << (int)BidiClass.RightToLeftIsolate) |
+                (1U << (int)BidiClass.LeftToRightIsolate) |
+                (1U << (int)BidiClass.FirstStrongIsolate) |
+                (1U << (int)BidiClass.PopDirectionalIsolate);
+
+            return ((1U << (int)direction) & mask) != 0U;
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/BiDiData.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/BiDiData.cs
@@ -73,6 +73,19 @@ namespace Avalonia.Media.TextFormatting.Unicode
             // bracket values for all code points
 
             int i = Length;
+
+            const uint embeddingMask =
+                (1U << (int)BidiClass.LeftToRightEmbedding) |
+                (1U << (int)BidiClass.LeftToRightOverride) |
+                (1U << (int)BidiClass.RightToLeftEmbedding) |
+                (1U << (int)BidiClass.RightToLeftOverride) |
+                (1U << (int)BidiClass.PopDirectionalFormat);
+
+            const uint isolateMask =
+                (1U << (int)BidiClass.LeftToRightIsolate) |
+                (1U << (int)BidiClass.RightToLeftIsolate) |
+                (1U << (int)BidiClass.FirstStrongIsolate) |
+                (1U << (int)BidiClass.PopDirectionalIsolate);
              
             var codePointEnumerator = new CodepointEnumerator(text);
             
@@ -85,27 +98,9 @@ namespace Avalonia.Media.TextFormatting.Unicode
                 
                 _classes[i] = dir;
 
-                switch (dir)
-                {
-                    case BidiClass.LeftToRightEmbedding:
-                    case BidiClass.LeftToRightOverride:
-                    case BidiClass.RightToLeftEmbedding:
-                    case BidiClass.RightToLeftOverride:
-                    case BidiClass.PopDirectionalFormat:
-                    {
-                        HasEmbeddings = true;
-                        break;
-                    }
-
-                    case BidiClass.LeftToRightIsolate:
-                    case BidiClass.RightToLeftIsolate:
-                    case BidiClass.FirstStrongIsolate:
-                    case BidiClass.PopDirectionalIsolate:
-                    {
-                        HasIsolates = true;
-                        break;
-                    }
-                }
+                var dirBit = 1U << (int)dir;
+                HasEmbeddings = (dirBit & embeddingMask) != 0U;
+                HasIsolates = (dirBit & isolateMask) != 0U;
 
                 // Lookup paired bracket types
                 var pbt = codepoint.PairedBracketType;

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/BiDiData.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/BiDiData.cs
@@ -89,10 +89,8 @@ namespace Avalonia.Media.TextFormatting.Unicode
              
             var codePointEnumerator = new CodepointEnumerator(text);
             
-            while (codePointEnumerator.MoveNext())
+            while (codePointEnumerator.MoveNext(out var codepoint))
             {
-                var codepoint = codePointEnumerator.Current;
-
                 // Look up BiDiClass
                 var dir = codepoint.BiDiClass;
                 

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/Codepoint.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/Codepoint.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 namespace Avalonia.Media.TextFormatting.Unicode
@@ -11,12 +10,18 @@ namespace Avalonia.Media.TextFormatting.Unicode
         /// <summary>
         /// The replacement codepoint that is used for non supported values.
         /// </summary>
-        public static readonly Codepoint ReplacementCodepoint = new Codepoint('\uFFFD');
-
-        public Codepoint(uint value)
+        public static Codepoint ReplacementCodepoint
         {
-            _value = value;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => new('\uFFFD');
         }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="Codepoint"/> with the specified value.
+        /// </summary>
+        /// <param name="value">The codepoint value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Codepoint(uint value) => _value = value;
 
         /// <summary>
         /// Get the codepoint's value.
@@ -87,19 +92,17 @@ namespace Avalonia.Media.TextFormatting.Unicode
         /// </returns>
         public bool IsWhiteSpace
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                switch (GeneralCategory)
-                {
-                    case GeneralCategory.Control:
-                    case GeneralCategory.NonspacingMark:
-                    case GeneralCategory.Format:
-                    case GeneralCategory.SpaceSeparator:
-                    case GeneralCategory.SpacingMark:
-                        return true;
-                }
+                const ulong whiteSpaceMask =
+                    (1UL << (int)GeneralCategory.Control) |
+                    (1UL << (int)GeneralCategory.NonspacingMark) |
+                    (1UL << (int)GeneralCategory.Format) |
+                    (1UL << (int)GeneralCategory.SpaceSeparator) |
+                    (1UL << (int)GeneralCategory.SpacingMark);
 
-                return false;
+                return ((1UL << (int)GeneralCategory) & whiteSpaceMask) != 0L;
             }
         }
         
@@ -166,56 +169,62 @@ namespace Avalonia.Media.TextFormatting.Unicode
         /// <param name="index">The index to read at.</param>
         /// <param name="count">The count of character that were read.</param>
         /// <returns></returns>
+#if NET6_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+#else
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static Codepoint ReadAt(ReadOnlySpan<char> text, int index, out int count)
         {
+            // Perf note: this method is performance critical for text layout, modify with care!
+
             count = 1;
 
-            if (index >= text.Length)
+            // Perf note: uint check allows the JIT to ellide the next bound check
+            if ((uint)index >= (uint)text.Length)
             {
                 return ReplacementCodepoint;
             }
 
-            var code = text[index];
+            uint code = text[index];
 
-            ushort hi, low;
-
-            //# High surrogate
-            if (0xD800 <= code && code <= 0xDBFF)
+            //# Surrogate
+            if (IsInRangeInclusive(code, 0xD800U, 0xDFFFU))
             {
-                hi = code;
+                uint hi, low;
 
-                if (index + 1 == text.Length)
+                //# High surrogate
+                if (code <= 0xDBFF)
                 {
-                    return ReplacementCodepoint;
+                    if ((uint)(index + 1) < (uint)text.Length)
+                    {
+                        hi = code;
+                        low = text[index + 1];
+
+                        if (IsInRangeInclusive(low, 0xDC00U, 0xDFFFU))
+                        {
+                            count = 2;
+                            // Perf note: the code is written as below to become just two instructions: shl, lea.
+                            // See https://github.com/dotnet/runtime/blob/7ec3634ee579d89b6024f72b595bfd7118093fc5/src/libraries/System.Private.CoreLib/src/System/Text/UnicodeUtility.cs#L38
+                            return new Codepoint((hi << 10) + low - ((0xD800U << 10) + 0xDC00U - (1 << 16)));
+                        }
+                    }
                 }
 
-                low = text[index + 1];
-
-                if (0xDC00 <= low && low <= 0xDFFF)
+                //# Low surrogate
+                else
                 {
-                    count = 2;
-                    return new Codepoint((uint)((hi - 0xD800) * 0x400 + (low - 0xDC00) + 0x10000));
-                }
+                    if (index > 0)
+                    {
+                        low = code;
+                        hi = text[index - 1];
 
-                return ReplacementCodepoint;
-            }
-
-            //# Low surrogate
-            if (0xDC00 <= code && code <= 0xDFFF)
-            {
-                if (index == 0)
-                {
-                    return ReplacementCodepoint;
-                }
-
-                hi = text[index - 1];
-
-                low = code;
-
-                if (0xD800 <= hi && hi <= 0xDBFF)
-                {
-                    count = 2;
-                    return new Codepoint((uint)((hi - 0xD800) * 0x400 + (low - 0xDC00) + 0x10000));
+                        if (IsInRangeInclusive(hi, 0xD800U, 0xDBFFU))
+                        {
+                            count = 2;
+                            return new Codepoint((hi << 10) + low - ((0xD800U << 10) + 0xDC00U - (1 << 16)));
+                        }
+                    }
                 }
 
                 return ReplacementCodepoint;
@@ -224,12 +233,16 @@ namespace Avalonia.Media.TextFormatting.Unicode
             return new Codepoint(code);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsInRangeInclusive(uint value, uint lowerBound, uint upperBound)
+            => value - lowerBound <= upperBound - lowerBound;
+
         /// <summary>
         /// Returns <see langword="true"/> if <paramref name="cp"/> is between
         /// <paramref name="lowerBound"/> and <paramref name="upperBound"/>, inclusive.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsInRangeInclusive(Codepoint cp, uint lowerBound, uint upperBound)
-            => (cp._value - lowerBound) <= (upperBound - lowerBound);
+            => IsInRangeInclusive(cp._value, lowerBound, upperBound);
     }
 }

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/Codepoint.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/Codepoint.cs
@@ -102,7 +102,7 @@ namespace Avalonia.Media.TextFormatting.Unicode
                     (1UL << (int)GeneralCategory.SpaceSeparator) |
                     (1UL << (int)GeneralCategory.SpacingMark);
 
-                return ((1UL << (int)GeneralCategory) & whiteSpaceMask) != 0L;
+                return ((1UL << (int)GeneralCategory) & whiteSpaceMask) != 0UL;
             }
         }
         

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/CodepointEnumerator.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/CodepointEnumerator.cs
@@ -4,35 +4,27 @@ namespace Avalonia.Media.TextFormatting.Unicode
 {
     public ref struct CodepointEnumerator
     {
-        private ReadOnlySpan<char> _text;
+        private readonly ReadOnlySpan<char> _text;
+        private int _offset;
 
         public CodepointEnumerator(ReadOnlySpan<char> text)
-        {
-            _text = text;
-            Current = Codepoint.ReplacementCodepoint;
-        }
-
-        /// <summary>
-        /// Gets the current <see cref="Codepoint"/>.
-        /// </summary>
-        public Codepoint Current { get; private set; }
+            => _text = text;
 
         /// <summary>
         /// Moves to the next <see cref="Codepoint"/>.
         /// </summary>
         /// <returns></returns>
-        public bool MoveNext()
+        public bool MoveNext(out Codepoint codepoint)
         {
-            if (_text.IsEmpty)
+            if ((uint)_offset >= (uint)_text.Length)
             {
-                Current = Codepoint.ReplacementCodepoint;
-
+                codepoint = Codepoint.ReplacementCodepoint;
                 return false;
             }
 
-            Current = Codepoint.ReadAt(_text, 0, out var count);
+            codepoint = Codepoint.ReadAt(_text, _offset, out var count);
 
-            _text = _text.Slice(count);
+            _offset += count;
 
             return true;
         }

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/Grapheme.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/Grapheme.cs
@@ -1,16 +1,15 @@
-﻿using System;
-
-namespace Avalonia.Media.TextFormatting.Unicode
+﻿namespace Avalonia.Media.TextFormatting.Unicode
 {
     /// <summary>
     /// Represents the smallest unit of a writing system of any given language.
     /// </summary>
     public readonly ref struct Grapheme
     {
-        public Grapheme(Codepoint firstCodepoint, ReadOnlySpan<char> text)
+        public Grapheme(Codepoint firstCodepoint, int offset, int length)
         {
             FirstCodepoint = firstCodepoint;
-            Text = text;
+            Offset = offset;
+            Length = length;
         }
 
         /// <summary>
@@ -19,12 +18,13 @@ namespace Avalonia.Media.TextFormatting.Unicode
         public Codepoint FirstCodepoint { get; }
 
         /// <summary>
-        /// The text of the grapheme cluster
+        /// Gets the starting code unit offset of this grapheme inside its containing text.
         /// </summary>
-        public ReadOnlySpan<char> Text { get; }
+        public int Offset { get; }
 
-        /// <inheritdoc />
-        public override string ToString()
-            => Text.ToString();
+        /// <summary>
+        /// Gets the length of this grapheme, in code units.
+        /// </summary>
+        public int Length { get; }
     }
 }

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/Grapheme.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/Grapheme.cs
@@ -22,5 +22,9 @@ namespace Avalonia.Media.TextFormatting.Unicode
         /// The text of the grapheme cluster
         /// </summary>
         public ReadOnlySpan<char> Text { get; }
+
+        /// <inheritdoc />
+        public override string ToString()
+            => Text.ToString();
     }
 }

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/GraphemeEnumerator.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/GraphemeEnumerator.cs
@@ -198,10 +198,13 @@ namespace Avalonia.Media.TextFormatting.Unicode
                     break; // nothing but trailers after the final RI
             }
 
+            const uint gb9Mask =
+                (1U << (int)GraphemeBreakClass.Extend) |
+                (1U << (int)GraphemeBreakClass.ZWJ) |
+                (1U << (int)GraphemeBreakClass.SpacingMark);
+
             // rules GB9, GB9a
-            while (_currentType is GraphemeBreakClass.Extend
-                or GraphemeBreakClass.ZWJ
-                or GraphemeBreakClass.SpacingMark)
+            while (((1U << (int)_currentType) & gb9Mask) != 0U)
             {
                 ReadNextCodepoint();
             }

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/GraphemeEnumerator.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/GraphemeEnumerator.cs
@@ -4,57 +4,79 @@
 // Licensed to The Avalonia Project under MIT License, courtesy of The .NET Foundation.
 
 using System;
-using System.Runtime.InteropServices;
 
 namespace Avalonia.Media.TextFormatting.Unicode
 {
     public ref struct GraphemeEnumerator
     {
-        private ReadOnlySpan<char> _text;
+        private readonly ReadOnlySpan<char> _text;
+        private int _currentCodeUnitOffset;
+        private int _codeUnitLengthOfCurrentCodepoint;
+        private Codepoint _currentCodepoint;
+
+        /// <summary>
+        /// Will be <see cref="GraphemeBreakClass.Other"/> if invalid data or EOF reached.
+        /// Caller shouldn't need to special-case this since the normal rules will halt on this condition.
+        /// </summary>
+        private GraphemeBreakClass _currentType;
 
         public GraphemeEnumerator(ReadOnlySpan<char> text)
         {
             _text = text;
-            Current = default;
+            _currentCodeUnitOffset = 0;
+            _codeUnitLengthOfCurrentCodepoint = 0;
+            _currentCodepoint = Codepoint.ReplacementCodepoint;
+            _currentType = GraphemeBreakClass.Other;
         }
-
-        /// <summary>
-        /// Gets the current <see cref="Grapheme"/>.
-        /// </summary>
-        public Grapheme Current { get; private set; }
 
         /// <summary>
         /// Moves to the next <see cref="Grapheme"/>.
         /// </summary>
         /// <returns></returns>
-        public bool MoveNext()
+        public bool MoveNext(out Grapheme grapheme)
         {
-            if (_text.IsEmpty)
+            var startOffset = _currentCodeUnitOffset;
+
+            if ((uint)startOffset >= (uint)_text.Length)
             {
+                grapheme = default;
                 return false;
             }
 
             // Algorithm given at https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundary_Rules.
 
-            var processor = new Processor(_text);
+            if (startOffset == 0)
+            {
+                ReadNextCodepoint();
+            }
 
-            processor.MoveNext();
-
-            var firstCodepoint = processor.CurrentCodepoint;
+            var firstCodepoint = _currentCodepoint;
 
             // First, consume as many Prepend scalars as we can (rule GB9b).
-            while (processor.CurrentType == GraphemeBreakClass.Prepend)
+            if (_currentType == GraphemeBreakClass.Prepend)
             {
-                processor.MoveNext();
+                do
+                {
+                    ReadNextCodepoint();
+                } while (_currentType == GraphemeBreakClass.Prepend);
+
+                // There were only Prepend scalars in the text
+                if ((uint)_currentCodeUnitOffset >= (uint)_text.Length)
+                {
+                    goto Return;
+                }
             }
 
             // Next, make sure we're not about to violate control character restrictions.
             // Essentially, if we saw Prepend data, we can't have Control | CR | LF data afterward (rule GB5).
-            if (processor.CurrentCodeUnitOffset > 0)
+            if (_currentCodeUnitOffset > startOffset)
             {
-                if (processor.CurrentType == GraphemeBreakClass.Control
-                    || processor.CurrentType == GraphemeBreakClass.CR
-                    || processor.CurrentType == GraphemeBreakClass.LF)
+                const uint controlCrLfMask =
+                    (1U << (int)GraphemeBreakClass.Control) |
+                    (1U << (int)GraphemeBreakClass.CR) |
+                    (1U << (int)GraphemeBreakClass.LF);
+
+                if (((1U << (int)_currentType) & controlCrLfMask) != 0U)
                 {
                     goto Return;
                 }
@@ -62,19 +84,19 @@ namespace Avalonia.Media.TextFormatting.Unicode
 
             // Now begin the main state machine.
 
-            var previousClusterBreakType = processor.CurrentType;
+            var previousClusterBreakType = _currentType;
 
-            processor.MoveNext();
+            ReadNextCodepoint();
 
             switch (previousClusterBreakType)
             {
                 case GraphemeBreakClass.CR:
-                    if (processor.CurrentType != GraphemeBreakClass.LF)
+                    if (_currentType != GraphemeBreakClass.LF)
                     {
                         goto Return; // rules GB3 & GB4 (only <LF> can follow <CR>)
                     }
 
-                    processor.MoveNext();
+                    ReadNextCodepoint();
                     goto case GraphemeBreakClass.LF;
 
                 case GraphemeBreakClass.Control:
@@ -82,53 +104,57 @@ namespace Avalonia.Media.TextFormatting.Unicode
                     goto Return; // rule GB4 (no data after Control | LF)
 
                 case GraphemeBreakClass.L:
-                    if (processor.CurrentType == GraphemeBreakClass.L)
+                {
+                    if (_currentType == GraphemeBreakClass.L)
                     {
-                        processor.MoveNext(); // rule GB6 (L x L)
+                        ReadNextCodepoint(); // rule GB6 (L x L)
                         goto case GraphemeBreakClass.L;
                     }
-                    else if (processor.CurrentType == GraphemeBreakClass.V)
+                    else if (_currentType == GraphemeBreakClass.V)
                     {
-                        processor.MoveNext(); // rule GB6 (L x V)
+                        ReadNextCodepoint(); // rule GB6 (L x V)
                         goto case GraphemeBreakClass.V;
                     }
-                    else if (processor.CurrentType == GraphemeBreakClass.LV)
+                    else if (_currentType == GraphemeBreakClass.LV)
                     {
-                        processor.MoveNext(); // rule GB6 (L x LV)
+                        ReadNextCodepoint(); // rule GB6 (L x LV)
                         goto case GraphemeBreakClass.LV;
                     }
-                    else if (processor.CurrentType == GraphemeBreakClass.LVT)
+                    else if (_currentType == GraphemeBreakClass.LVT)
                     {
-                        processor.MoveNext(); // rule GB6 (L x LVT)
+                        ReadNextCodepoint(); // rule GB6 (L x LVT)
                         goto case GraphemeBreakClass.LVT;
                     }
                     else
                     {
                         break;
                     }
+                }
 
                 case GraphemeBreakClass.LV:
                 case GraphemeBreakClass.V:
-                    if (processor.CurrentType == GraphemeBreakClass.V)
+                {
+                    if (_currentType == GraphemeBreakClass.V)
                     {
-                        processor.MoveNext(); // rule GB7 (LV | V x V)
+                        ReadNextCodepoint(); // rule GB7 (LV | V x V)
                         goto case GraphemeBreakClass.V;
                     }
-                    else if (processor.CurrentType == GraphemeBreakClass.T)
+                    else if (_currentType == GraphemeBreakClass.T)
                     {
-                        processor.MoveNext(); // rule GB7 (LV | V x T)
+                        ReadNextCodepoint(); // rule GB7 (LV | V x T)
                         goto case GraphemeBreakClass.T;
                     }
                     else
                     {
                         break;
                     }
+                }
 
                 case GraphemeBreakClass.LVT:
                 case GraphemeBreakClass.T:
-                    if (processor.CurrentType == GraphemeBreakClass.T)
+                    if (_currentType == GraphemeBreakClass.T)
                     {
-                        processor.MoveNext(); // rule GB8 (LVT | T x T)
+                        ReadNextCodepoint(); // rule GB8 (LVT | T x T)
                         goto case GraphemeBreakClass.T;
                     }
                     else
@@ -139,123 +165,76 @@ namespace Avalonia.Media.TextFormatting.Unicode
                 case GraphemeBreakClass.ExtendedPictographic:
                     // Attempt processing extended pictographic (rules GB11, GB9).
                     // First, drain any Extend scalars that might exist
-                    while (processor.CurrentType == GraphemeBreakClass.Extend)
+                    while (_currentType == GraphemeBreakClass.Extend)
                     {
-                        processor.MoveNext();
+                        ReadNextCodepoint();
                     }
 
                     // Now see if there's a ZWJ + extended pictograph again.
-                    if (processor.CurrentType != GraphemeBreakClass.ZWJ)
+                    if (_currentType != GraphemeBreakClass.ZWJ)
                     {
                         break;
                     }
 
-                    processor.MoveNext();
-                    if (processor.CurrentType != GraphemeBreakClass.ExtendedPictographic)
+                    ReadNextCodepoint();
+                    if (_currentType != GraphemeBreakClass.ExtendedPictographic)
                     {
                         break;
                     }
 
-                    processor.MoveNext();
+                    ReadNextCodepoint();
                     goto case GraphemeBreakClass.ExtendedPictographic;
 
                 case GraphemeBreakClass.RegionalIndicator:
                     // We've consumed a single RI scalar. Try to consume another (to make it a pair).
 
-                    if (processor.CurrentType == GraphemeBreakClass.RegionalIndicator)
+                    if (_currentType == GraphemeBreakClass.RegionalIndicator)
                     {
-                        processor.MoveNext();
+                        ReadNextCodepoint();
                     }
 
                     // Standlone RI scalars (or a single pair of RI scalars) can only be followed by trailers.
 
                     break; // nothing but trailers after the final RI
-
-                default:
-                    break;
             }
 
             // rules GB9, GB9a
-            while (processor.CurrentType == GraphemeBreakClass.Extend
-                || processor.CurrentType == GraphemeBreakClass.ZWJ
-                || processor.CurrentType == GraphemeBreakClass.SpacingMark)
+            while (_currentType is GraphemeBreakClass.Extend
+                or GraphemeBreakClass.ZWJ
+                or GraphemeBreakClass.SpacingMark)
             {
-                processor.MoveNext();
+                ReadNextCodepoint();
             }
 
             Return:
 
-            Current = new Grapheme(firstCodepoint, _text.Slice(0, processor.CurrentCodeUnitOffset));
-
-            _text = _text.Slice(processor.CurrentCodeUnitOffset);
+            var graphemeLength = _currentCodeUnitOffset - startOffset;
+            grapheme = new Grapheme(firstCodepoint, startOffset, graphemeLength);
 
             return true; // rules GB2, GB999
         }
 
-        [StructLayout(LayoutKind.Auto)]
-        private ref struct Processor
+        private void ReadNextCodepoint()
         {
-            private readonly ReadOnlySpan<char> _buffer;
-            private int _codeUnitLengthOfCurrentScalar;
+            // For ill-formed subsequences (like unpaired UTF-16 surrogate code points), we rely on
+            // the decoder's default behavior of interpreting these ill-formed subsequences as
+            // equivalent to U+FFFD REPLACEMENT CHARACTER. This code point has a boundary property
+            // of Other (XX), which matches the modifications made to UAX#29, Rev. 35.
+            // See: https://www.unicode.org/reports/tr29/tr29-35.html#Modifications
+            // This change is also reflected in the UCD files. For example, Unicode 11.0's UCD file
+            // https://www.unicode.org/Public/11.0.0/ucd/auxiliary/GraphemeBreakProperty.txt
+            // has the line "D800..DFFF    ; Control # Cs [2048] <surrogate-D800>..<surrogate-DFFF>",
+            // but starting with Unicode 12.0 that line has been removed.
+            //
+            // If a later version of the Unicode Standard further modifies this guidance we should reflect
+            // that here.
 
-            internal Processor(ReadOnlySpan<char> buffer)
-            {
-                _buffer = buffer;
-                _codeUnitLengthOfCurrentScalar = 0;
-                CurrentCodepoint = Codepoint.ReplacementCodepoint;
-                CurrentType = GraphemeBreakClass.Other;
-                CurrentCodeUnitOffset = 0;
-            }
+            _currentCodeUnitOffset += _codeUnitLengthOfCurrentCodepoint;
 
-            public int CurrentCodeUnitOffset { get; private set; }
+            _currentCodepoint = Codepoint.ReadAt(_text, _currentCodeUnitOffset,
+                out _codeUnitLengthOfCurrentCodepoint);
 
-            /// <summary>
-            /// Will be <see cref="GraphemeBreakClass.Other"/> if invalid data or EOF reached.
-            /// Caller shouldn't need to special-case this since the normal rules will halt on this condition.
-            /// </summary>
-            public GraphemeBreakClass CurrentType { get; private set; }
-
-            /// <summary>
-            ///     Get the currently processed <see cref="Codepoint"/>.
-            /// </summary>
-            public Codepoint CurrentCodepoint { get; private set; }
-
-            public void MoveNext()
-            {
-                // For ill-formed subsequences (like unpaired UTF-16 surrogate code points), we rely on
-                // the decoder's default behavior of interpreting these ill-formed subsequences as
-                // equivalent to U+FFFD REPLACEMENT CHARACTER. This code point has a boundary property
-                // of Other (XX), which matches the modifications made to UAX#29, Rev. 35.
-                // See: https://www.unicode.org/reports/tr29/tr29-35.html#Modifications
-                // This change is also reflected in the UCD files. For example, Unicode 11.0's UCD file
-                // https://www.unicode.org/Public/11.0.0/ucd/auxiliary/GraphemeBreakProperty.txt
-                // has the line "D800..DFFF    ; Control # Cs [2048] <surrogate-D800>..<surrogate-DFFF>",
-                // but starting with Unicode 12.0 that line has been removed.
-                //
-                // If a later version of the Unicode Standard further modifies this guidance we should reflect
-                // that here.
-
-                if (CurrentCodeUnitOffset == _buffer.Length)
-                {
-                    CurrentCodepoint = Codepoint.ReplacementCodepoint;
-                }
-                else
-                {
-                    CurrentCodeUnitOffset += _codeUnitLengthOfCurrentScalar;
-
-                    if (CurrentCodeUnitOffset < _buffer.Length)
-                    {
-                        CurrentCodepoint = Codepoint.ReadAt(_buffer, CurrentCodeUnitOffset,
-                            out _codeUnitLengthOfCurrentScalar);
-                    }
-                    else
-                    {
-                        CurrentCodepoint = Codepoint.ReplacementCodepoint;
-                    }
-                }
-
-                CurrentType = CurrentCodepoint.GraphemeBreakClass;
-            }
+            _currentType = _currentCodepoint.GraphemeBreakClass;
         }
     }
 }

--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/LineBreakEnumerator.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/LineBreakEnumerator.cs
@@ -47,10 +47,8 @@ namespace Avalonia.Media.TextFormatting.Unicode
             _lb30 = false;
             _lb30a = 0;
         }
-        
-        public LineBreak Current { get; private set; }
-        
-        public bool MoveNext()
+
+        public bool MoveNext(out LineBreak lineBreak)
         {
             // Get the first char if we're at the beginning of the string.
             if (_first)
@@ -76,7 +74,7 @@ namespace Avalonia.Media.TextFormatting.Unicode
                     case LineBreakClass.CarriageReturn when _nextClass != LineBreakClass.LineFeed:
                     {
                         _currentClass = MapFirst(_nextClass);
-                        Current = new LineBreak(FindPriorNonWhitespace(_lastPosition), _lastPosition, true);
+                        lineBreak = new LineBreak(FindPriorNonWhitespace(_lastPosition), _lastPosition, true);
                         return true;
                     }
                 }
@@ -88,7 +86,7 @@ namespace Avalonia.Media.TextFormatting.Unicode
 
                 if (shouldBreak)
                 {
-                    Current = new LineBreak(FindPriorNonWhitespace(_lastPosition), _lastPosition);
+                    lineBreak = new LineBreak(FindPriorNonWhitespace(_lastPosition), _lastPosition);
                     return true;
                 }
             }
@@ -109,13 +107,12 @@ namespace Avalonia.Media.TextFormatting.Unicode
                             break;
                     }
 
-                    Current = new LineBreak(FindPriorNonWhitespace(_lastPosition), _lastPosition, required);
+                    lineBreak = new LineBreak(FindPriorNonWhitespace(_lastPosition), _lastPosition, required);
                     return true;
                 }
             }
 
-            Current = default;
-            
+            lineBreak = default;
             return false;
         }
 

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -963,10 +963,8 @@ namespace Avalonia.Controls
 
                 var graphemeEnumerator = new GraphemeEnumerator(input.AsSpan());
 
-                while (graphemeEnumerator.MoveNext())
+                while (graphemeEnumerator.MoveNext(out var grapheme))
                 {
-                    var grapheme = graphemeEnumerator.Current;
-
                     if (grapheme.FirstCodepoint.IsBreakChar)
                     {
                         if (lineCount + 1 > MaxLines)
@@ -979,7 +977,7 @@ namespace Avalonia.Controls
                         }
                     }
 
-                    length += grapheme.Text.Length;
+                    length += grapheme.Length;
                 }
 
                 if (length < input.Length)

--- a/src/Skia/Avalonia.Skia/Avalonia.Skia.csproj
+++ b/src/Skia/Avalonia.Skia/Avalonia.Skia.csproj
@@ -23,6 +23,7 @@
   <ItemGroup Label="InternalsVisibleTo">
     <InternalsVisibleTo Include="Avalonia.Skia.RenderTests, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Skia.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
+    <InternalsVisibleTo Include="Avalonia.Benchmarks, PublicKey=$(AvaloniaPublicKey)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Skia/Avalonia.Skia/TextShaperImpl.cs
+++ b/src/Skia/Avalonia.Skia/TextShaperImpl.cs
@@ -52,6 +52,8 @@ namespace Avalonia.Skia
 
                 var shapedBuffer = new ShapedBuffer(text, bufferLength, typeface, fontRenderingEmSize, bidiLevel);
 
+                var targetInfos = shapedBuffer.GlyphInfos;
+
                 var glyphInfos = buffer.GetGlyphInfoSpan();
 
                 var glyphPositions = buffer.GetGlyphPositionSpan();
@@ -77,9 +79,7 @@ namespace Avalonia.Skia
                             4 * typeface.GetGlyphAdvance(glyphIndex) * textScale;
                     }
 
-                    var targetInfo = new Media.TextFormatting.GlyphInfo(glyphIndex, glyphCluster, glyphAdvance, glyphOffset);
-
-                    shapedBuffer[i] = targetInfo;
+                    targetInfos[i] = new Media.TextFormatting.GlyphInfo(glyphIndex, glyphCluster, glyphAdvance, glyphOffset);
                 }
 
                 return shapedBuffer;

--- a/src/Windows/Avalonia.Direct2D1/Media/TextShaperImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/TextShaperImpl.cs
@@ -52,6 +52,8 @@ namespace Avalonia.Direct2D1.Media
 
                 var shapedBuffer = new ShapedBuffer(text, bufferLength, typeface, fontRenderingEmSize, bidiLevel);
 
+                var targetInfos = shapedBuffer.GlyphInfos;
+
                 var glyphInfos = buffer.GetGlyphInfoSpan();
 
                 var glyphPositions = buffer.GetGlyphPositionSpan();
@@ -77,9 +79,7 @@ namespace Avalonia.Direct2D1.Media
                             4 * typeface.GetGlyphAdvance(glyphIndex) * textScale;
                     }
 
-                    var targetInfo = new Avalonia.Media.TextFormatting.GlyphInfo(glyphIndex, glyphCluster, glyphAdvance, glyphOffset);
-
-                    shapedBuffer[i] = targetInfo;
+                    targetInfos[i] = new Avalonia.Media.TextFormatting.GlyphInfo(glyphIndex, glyphCluster, glyphAdvance, glyphOffset);
                 }
 
                 return shapedBuffer;

--- a/tests/Avalonia.Base.UnitTests/Media/TextFormatting/GraphemeBreakClassTrieGeneratorTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/TextFormatting/GraphemeBreakClassTrieGeneratorTests.cs
@@ -40,9 +40,9 @@ namespace Avalonia.Base.UnitTests.Media.TextFormatting
 
             var enumerator = new GraphemeEnumerator(text);
 
-            enumerator.MoveNext();
+            enumerator.MoveNext(out var g);
 
-            var actual = enumerator.Current.Text;
+            var actual = text.AsSpan(g.Offset, g.Length);
 
             bool pass = actual.Length == grapheme.Length;
 
@@ -86,9 +86,9 @@ namespace Avalonia.Base.UnitTests.Media.TextFormatting
 
             var count = 0;
 
-            while (enumerator.MoveNext())
+            while (enumerator.MoveNext(out var grapheme))
             {
-                Assert.Equal(1, enumerator.Current.Text.Length);
+                Assert.Equal(1, grapheme.Length);
 
                 count++;
             }

--- a/tests/Avalonia.Base.UnitTests/Media/TextFormatting/LineBreakEnumuratorTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/TextFormatting/LineBreakEnumuratorTests.cs
@@ -24,32 +24,33 @@ namespace Avalonia.Base.UnitTests.Media.TextFormatting
         public void BasicLatinTest()
         {
             var lineBreaker = new LineBreakEnumerator("Hello World\r\nThis is a test.");
+            LineBreak lineBreak;
 
-            Assert.True(lineBreaker.MoveNext());
-            Assert.Equal(6, lineBreaker.Current.PositionWrap);
-            Assert.False(lineBreaker.Current.Required);
+            Assert.True(lineBreaker.MoveNext(out lineBreak));
+            Assert.Equal(6, lineBreak.PositionWrap);
+            Assert.False(lineBreak.Required);
 
-            Assert.True(lineBreaker.MoveNext());
-            Assert.Equal(13, lineBreaker.Current.PositionWrap);
-            Assert.True(lineBreaker.Current.Required);
+            Assert.True(lineBreaker.MoveNext(out lineBreak));
+            Assert.Equal(13, lineBreak.PositionWrap);
+            Assert.True(lineBreak.Required);
 
-            Assert.True(lineBreaker.MoveNext());
-            Assert.Equal(18, lineBreaker.Current.PositionWrap);
-            Assert.False(lineBreaker.Current.Required);
+            Assert.True(lineBreaker.MoveNext(out lineBreak));
+            Assert.Equal(18, lineBreak.PositionWrap);
+            Assert.False(lineBreak.Required);
 
-            Assert.True(lineBreaker.MoveNext());
-            Assert.Equal(21, lineBreaker.Current.PositionWrap);
-            Assert.False(lineBreaker.Current.Required);
+            Assert.True(lineBreaker.MoveNext(out lineBreak));
+            Assert.Equal(21, lineBreak.PositionWrap);
+            Assert.False(lineBreak.Required);
 
-            Assert.True(lineBreaker.MoveNext());
-            Assert.Equal(23, lineBreaker.Current.PositionWrap);
-            Assert.False(lineBreaker.Current.Required);
+            Assert.True(lineBreaker.MoveNext(out lineBreak));
+            Assert.Equal(23, lineBreak.PositionWrap);
+            Assert.False(lineBreak.Required);
 
-            Assert.True(lineBreaker.MoveNext());
-            Assert.Equal(28, lineBreaker.Current.PositionWrap);
-            Assert.False(lineBreaker.Current.Required);
+            Assert.True(lineBreaker.MoveNext(out lineBreak));
+            Assert.Equal(28, lineBreak.PositionWrap);
+            Assert.False(lineBreak.Required);
 
-            Assert.False(lineBreaker.MoveNext());
+            Assert.False(lineBreaker.MoveNext(out lineBreak));
         }
 
 
@@ -72,9 +73,9 @@ namespace Avalonia.Base.UnitTests.Media.TextFormatting
         {
             var breaks = new List<LineBreak>();
 
-            while (lineBreaker.MoveNext())
+            while (lineBreaker.MoveNext(out var lineBreak))
             {
-                breaks.Add(lineBreaker.Current);
+                breaks.Add(lineBreak);
             }
 
             return breaks;
@@ -104,9 +105,9 @@ namespace Avalonia.Base.UnitTests.Media.TextFormatting
 
             var foundBreaks = new List<int>();
             
-            while (lineBreaker.MoveNext())
+            while (lineBreaker.MoveNext(out var lineBreak))
             {
-                foundBreaks.Add(lineBreaker.Current.PositionWrap);
+                foundBreaks.Add(lineBreak.PositionWrap);
             }
             
             // Check the same

--- a/tests/Avalonia.Benchmarks/Avalonia.Benchmarks.csproj
+++ b/tests/Avalonia.Benchmarks/Avalonia.Benchmarks.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\..\src\Avalonia.Controls\Avalonia.Controls.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Themes.Fluent\Avalonia.Themes.Fluent.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Themes.Simple\Avalonia.Themes.Simple.csproj" />
+    <ProjectReference Include="..\..\src\Skia\Avalonia.Skia\Avalonia.Skia.csproj" />
     <ProjectReference Include="..\Avalonia.UnitTests\Avalonia.UnitTests.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Avalonia.Benchmarks/Text/HugeTextLayout.cs
+++ b/tests/Avalonia.Benchmarks/Text/HugeTextLayout.cs
@@ -77,7 +77,17 @@ In respect that the structure of the sufficient amount poses problems and challe
     public TextLayout BuildEmojisTextLayout() => MakeLayout(Emojis);
 
     [Benchmark]
-    public TextLayout[] BuildManySmallTexts() => _manySmallStrings.Select(MakeLayout).ToArray();
+    public TextLayout[] BuildManySmallTexts()
+    {
+        var results = new TextLayout[_manySmallStrings.Length];
+
+        for (var i = 0; i < _manySmallStrings.Length; i++)
+        {
+            results[i] = MakeLayout(_manySmallStrings[i]);
+        }
+
+        return results;
+    }
 
     [Benchmark]
     public void VirtualizeTextBlocks()

--- a/tests/Avalonia.Benchmarks/Text/HugeTextLayout.cs
+++ b/tests/Avalonia.Benchmarks/Text/HugeTextLayout.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.Media.TextFormatting;
+using Avalonia.Skia;
 using Avalonia.UnitTests;
 using BenchmarkDotNet.Attributes;
 
@@ -13,24 +14,35 @@ namespace Avalonia.Benchmarks.Text;
 [MaxWarmupCount(15)]
 public class HugeTextLayout : IDisposable
 {
+    private static readonly Random s_rand = new();
+    private static readonly bool s_useSkia = true;
+
     private readonly IDisposable _app;
-    private string[] _manySmallStrings;
-    private static Random _rand = new Random();
-    
+    private readonly string[] _manySmallStrings;
+
     private static string RandomString(int length)
     {
         const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789&?%$@";
-        return new string(Enumerable.Repeat(chars, length).Select(s => s[_rand.Next(s.Length)]).ToArray());
+        return new string(Enumerable.Repeat(chars, length).Select(s => s[s_rand.Next(s.Length)]).ToArray());
     }
 
     public HugeTextLayout()
     {
-        _manySmallStrings = Enumerable.Range(0, 1000).Select(x => RandomString(_rand.Next(2, 15))).ToArray();
-        _app = UnitTestApplication.Start(
-            TestServices.StyledWindow.With(
-                renderInterface: new NullRenderingPlatform(),
-                threadingInterface: new NullThreadingPlatform(),
-                standardCursorFactory: new NullCursorFactory()));
+        _manySmallStrings = Enumerable.Range(0, 1000).Select(_ => RandomString(s_rand.Next(2, 15))).ToArray();
+
+        var testServices = TestServices.StyledWindow.With(
+            renderInterface: new NullRenderingPlatform(),
+            threadingInterface: new NullThreadingPlatform(),
+            standardCursorFactory: new NullCursorFactory());
+
+        if (s_useSkia)
+        {
+            testServices = testServices.With(
+                textShaperImpl: new TextShaperImpl(),
+                fontManagerImpl: new FontManagerImpl());
+        }
+
+        _app = UnitTestApplication.Start(testServices);
     }
     
     private const string Text = @"Though, the objectives of the development of the prominent landmarks can be neglected in most cases, it should be realized that after the completion of the strategic decision gives rise to The Expertise of Regular Program (Carlton Cartwright in The Book of the Key Factor) 

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
@@ -283,9 +283,9 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                 var expected = new List<int>();
 
-                while (lineBreaker.MoveNext())
+                while (lineBreaker.MoveNext(out var lineBreak))
                 {
-                    expected.Add(lineBreaker.Current.PositionWrap - 1);
+                    expected.Add(lineBreak.PositionWrap - 1);
                 }
 
                 var typeface = new Typeface("resm:Avalonia.Skia.UnitTests.Assets?assembly=Avalonia.Skia.UnitTests#" +

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLayoutTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLayoutTests.cs
@@ -151,9 +151,10 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                 while (true)
                 {
-                    while (inner.MoveNext())
+                    Grapheme grapheme;
+                    while (inner.MoveNext(out grapheme))
                     {
-                        j += inner.Current.Text.Length;
+                        j += grapheme.Length;
 
                         if (j + i > text.Length)
                         {
@@ -184,14 +185,14 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
                         }
                     }
 
-                    if (!outer.MoveNext())
+                    if (!outer.MoveNext(out grapheme))
                     {
                         break;
                     }
 
                     inner = new GraphemeEnumerator(text);
 
-                    i += outer.Current.Text.Length;
+                    i += grapheme.Length;
                 }
             }
 
@@ -979,13 +980,11 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
 
                 var graphemeEnumerator = new GraphemeEnumerator(text);
 
-                while (graphemeEnumerator.MoveNext())
+                while (graphemeEnumerator.MoveNext(out var grapheme))
                 {
-                    var grapheme = graphemeEnumerator.Current;
+                    var textStyleOverrides = new[] { new ValueSpan<TextRunProperties>(i, grapheme.Length, new GenericTextRunProperties(Typeface.Default, 12, foregroundBrush: Brushes.Red)) };
 
-                    var textStyleOverrides = new[] { new ValueSpan<TextRunProperties>(i, grapheme.Text.Length, new GenericTextRunProperties(Typeface.Default, 12, foregroundBrush: Brushes.Red)) };
-
-                    i += grapheme.Text.Length;
+                    i += grapheme.Length;
 
                     var layout = new TextLayout(
                         text,

--- a/tests/Avalonia.UnitTests/HarfBuzzTextShaperImpl.cs
+++ b/tests/Avalonia.UnitTests/HarfBuzzTextShaperImpl.cs
@@ -52,6 +52,8 @@ namespace Avalonia.UnitTests
 
                 var shapedBuffer = new ShapedBuffer(text, bufferLength, typeface, fontRenderingEmSize, bidiLevel);
 
+                var targetInfos = shapedBuffer.GlyphInfos;
+
                 var glyphInfos = buffer.GetGlyphInfoSpan();
 
                 var glyphPositions = buffer.GetGlyphPositionSpan();
@@ -77,9 +79,7 @@ namespace Avalonia.UnitTests
                             4 * typeface.GetGlyphAdvance(glyphIndex) * textScale;
                     }
 
-                    var targetInfo = new Media.TextFormatting.GlyphInfo(glyphIndex, glyphCluster, glyphAdvance, glyphOffset);
-
-                    shapedBuffer[i] = targetInfo;
+                    targetInfos[i] = new Media.TextFormatting.GlyphInfo(glyphIndex, glyphCluster, glyphAdvance, glyphOffset);
                 }
 
                 return shapedBuffer;

--- a/tests/Avalonia.UnitTests/MockGlyphRun.cs
+++ b/tests/Avalonia.UnitTests/MockGlyphRun.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using Avalonia.Media.TextFormatting;
 using Avalonia.Platform;
 
@@ -9,7 +8,14 @@ namespace Avalonia.UnitTests
     {
         public MockGlyphRun(IReadOnlyList<GlyphInfo> glyphInfos)
         {
-            Size = new Size(glyphInfos.Sum(x=> x.GlyphAdvance), 10);
+            var width = 0.0;
+
+            for (var i = 0; i < glyphInfos.Count; ++i)
+            {
+                width += glyphInfos[i].GlyphAdvance;
+            }
+
+            Size = new Size(width, 10);
         }
 
         public Size Size { get; }

--- a/tests/Avalonia.UnitTests/MockTextShaperImpl.cs
+++ b/tests/Avalonia.UnitTests/MockTextShaperImpl.cs
@@ -13,6 +13,7 @@ namespace Avalonia.UnitTests
             var fontRenderingEmSize = options.FontRenderingEmSize;
             var bidiLevel = options.BidiLevel;
             var shapedBuffer = new ShapedBuffer(text, text.Length, typeface, fontRenderingEmSize, bidiLevel);
+            var targetInfos = shapedBuffer.GlyphInfos;
             var textSpan = text.Span;
             var textStartIndex = TextTestHelper.GetStartCharIndex(text);
 
@@ -26,7 +27,7 @@ namespace Avalonia.UnitTests
 
                 for (var j = 0; j < count; ++j)
                 {
-                    shapedBuffer[i + j] = new GlyphInfo(glyphIndex, glyphCluster, 10);
+                    targetInfos[i + j] = new GlyphInfo(glyphIndex, glyphCluster, 10);
                 }
 
                 i += count;


### PR DESCRIPTION
# What does the pull request do?

Episode 3: Revenge of the Codepoint!

Here's another round of text layout performance improvements, this time focused on optimizing the core of text processing: `Codepoint`, `Grapheme` and their enumerators. These are called so often in the text layout process that even micro optimizations are significant here.

- `Codepoint.ReadAt` is optimized to have less branches, less bound checks added by the JIT, `ReplacementCodepoint` being inlined as const instead of loading a static field, and the whole method being aggressively inlined. It's the very core of text processing, and these simple changes have measurable impact.

- `GraphemeEnumerator` is improved to avoid reading codepoints twice. Previously n+1 codepoints were read to form a grapheme with n codepoints. The extra codepoint acting as a boundary was discarded, then the next grapheme was read, starting again at that codepoint. This PR changes the algorithm so that the extra codepoint is used in the next grapheme instead of having to be read again. This cuts the time spent reading codepoints in half for strings without surrogates.

- `LineBreakEnumerator`, `BidiAlgorithm` and `BidiData` use bitmasks instead of many if/switch when possible to avoid many comparisons.

- At a bit higher level, `FontManager` and `GlyphTypeface` are stored and passed around to avoid having to lookup `FontManager.Current` in the container many times.

- The `Grapheme` changes from #9928 (removal of the `Text` field) are restored, they were lost with the changes in #9982.

- Some `IReadOnlyList<T>` interfaces calls are avoided.

# Perf changes

|                Method |  Wrap |  Trim |      Before |    After   | Change |
|---------------------- |------ |------ |------------:|-----------:|-------:|
|       BuildTextLayout | False | False |    340.5 us |   206.2 us |   -39% |
| BuildEmojisTextLayout | False | False |    735.7 us |   483.3 us |   -34% |
|   BuildManySmallTexts | False | False |  2,579.7 us | 1,958.8 us |   -24% |
|  VirtualizeTextBlocks | False | False |  3,784.5 us | 3,174.9 us |   -16% |
|       BuildTextLayout | False |  True |    362.3 us |   219.5 us |   -39% |
| BuildEmojisTextLayout | False |  True |    773.1 us |   517.8 us |   -33% |
|   BuildManySmallTexts | False |  True |  2,928.5 us | 2,135.9 us |   -27% |
|  VirtualizeTextBlocks | False |  True |  3,772.2 us | 3,207.1 us |   -15% |
|       BuildTextLayout |  True | False |  2,249.2 us | 1,541.5 us |   -31% |
| BuildEmojisTextLayout |  True | False | 11,478.4 us | 8,212.8 us |   -28% |
|   BuildManySmallTexts |  True | False |  3,490.3 us | 2,637.5 us |   -24% |
|  VirtualizeTextBlocks |  True | False |  3,705.2 us | 3,125.1 us |   -16% |
|       BuildTextLayout |  True |  True |  2,284.8 us | 1,558.6 us |   -32% |
| BuildEmojisTextLayout |  True |  True | 11,148.2 us | 8,287.4 us |   -26% |
|   BuildManySmallTexts |  True |  True |  3,711.1 us | 2,973.4 us |   -20% |
|  VirtualizeTextBlocks |  True |  True |  3,798.6 us | 3,117.0 us |   -18% |

The benchmarks were executed on master and this branch with `MockGlyphRun` a bit optimized to avoid LINQ. Mocks aren't meant to be optimized, but it was taking a significant time.

While executing with mocks is nice to see how much the code was improved, I also added an option to execute the benchmark with the Skia renderer. Results are a bit less shiny, but more accurately represent a real usage. HarfBuzz takes most of the time here, which is great (Avalonia shouldn't be the bottleneck).

<details>
  <summary>Results with HarfBuzz</summary>

|                Method |  Wrap |  Trim |      Before |      After | Change |
|---------------------- |------ |------ |------------:|-----------:|-------:|
|       BuildTextLayout | False | False |    758.7 us |   619.3 us |   -18% |
| BuildEmojisTextLayout | False | False |  2,079.1 us | 1,858.9 us |   -11% |
|   BuildManySmallTexts | False | False |  5,564.0 us | 5,085.6 us |    -9% |
|  VirtualizeTextBlocks | False | False |  7,104.4 us | 6,445.8 us |    -9% |
|       BuildTextLayout | False |  True |    813.5 us |   667.5 us |   -18% |
| BuildEmojisTextLayout | False |  True |  2,195.6 us | 1,926.7 us |   -12% |
|   BuildManySmallTexts | False |  True |  5,636.6 us | 4,999.8 us |   -11% |
|  VirtualizeTextBlocks | False |  True |  7,235.0 us | 6,432.8 us |   -11% |
|       BuildTextLayout |  True | False |  1,811.1 us | 1,278.0 us |   -29% |
| BuildEmojisTextLayout |  True | False |  5,412.9 us | 3,888.3 us |   -28% |
|   BuildManySmallTexts |  True | False |  6,645.3 us | 5,772.4 us |   -13% |
|  VirtualizeTextBlocks |  True | False |  7,121.7 us | 6,290.1 us |   -12% |
|       BuildTextLayout |  True |  True |  1,797.3 us | 1,277.2 us |   -29% |
| BuildEmojisTextLayout |  True |  True |  5,609.6 us | 3,872.6 us |   -31% |
|   BuildManySmallTexts |  True |  True |  6,530.3 us | 5,778.6 us |   -12% |
|  VirtualizeTextBlocks |  True |  True |  7,096.7 us | 6,498.6 us |    -8% |

</details>
