### PR TITLE
Devirtualize AvaloniaProperty properties.

### DIFF
--- a/src/Avalonia.Base/AttachedProperty.cs
+++ b/src/Avalonia.Base/AttachedProperty.cs
@@ -24,10 +24,8 @@ namespace Avalonia
             Func<TValue, bool>? validate = null)
             : base(name, ownerType, metadata, inherits, validate)
         {
+            IsAttached = true;
         }
-
-        /// <inheritdoc/>
-        public override bool IsAttached => true;
 
         /// <summary>
         /// Attaches the property as a non-attached property on the specified type.

--- a/src/Avalonia.Base/AvaloniaProperty.cs
+++ b/src/Avalonia.Base/AvaloniaProperty.cs
@@ -107,22 +107,22 @@ namespace Avalonia
         /// <summary>
         /// Gets a value indicating whether the property inherits its value.
         /// </summary>
-        public virtual bool Inherits => false;
+        public bool Inherits { get; private protected set; }
 
         /// <summary>
         /// Gets a value indicating whether this is an attached property.
         /// </summary>
-        public virtual bool IsAttached => false;
+        public bool IsAttached { get; private protected set; }
 
         /// <summary>
         /// Gets a value indicating whether this is a direct property.
         /// </summary>
-        public virtual bool IsDirect => false;
+        public bool IsDirect { get; private protected set; }
 
         /// <summary>
         /// Gets a value indicating whether this is a readonly property.
         /// </summary>
-        public virtual bool IsReadOnly => false;
+        public bool IsReadOnly { get; private protected set; }
 
         /// <summary>
         /// Gets an observable that is fired when this property changes on any

--- a/src/Avalonia.Base/DirectProperty.cs
+++ b/src/Avalonia.Base/DirectProperty.cs
@@ -33,6 +33,8 @@ namespace Avalonia
         {
             Getter = getter ?? throw new ArgumentNullException(nameof(getter));
             Setter = setter;
+            IsDirect = true;
+            IsReadOnly = setter is null;
         }
 
         /// <summary>
@@ -51,16 +53,9 @@ namespace Avalonia
         {
             Getter = getter ?? throw new ArgumentNullException(nameof(getter));
             Setter = setter;
+            IsDirect = true;
+            IsReadOnly = setter is null;
         }
-
-        /// <inheritdoc/>
-        public override bool IsDirect => true;
-
-        /// <inheritdoc/>
-        public override bool IsReadOnly => Setter == null;
-
-        /// <inheritdoc/>
-        public override Type Owner => typeof(TOwner);
 
         /// <summary>
         /// Gets the getter function.

--- a/src/Avalonia.Base/DirectPropertyBase.cs
+++ b/src/Avalonia.Base/DirectPropertyBase.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using Avalonia.Data;
 using Avalonia.PropertyStore;
-using Avalonia.Reactive;
-using Avalonia.Styling;
 
 namespace Avalonia
 {
@@ -28,6 +26,7 @@ namespace Avalonia
             AvaloniaPropertyMetadata metadata)
             : base(name, ownerType, metadata)
         {
+            Owner = ownerType;
         }
 
         /// <summary>
@@ -42,12 +41,13 @@ namespace Avalonia
             AvaloniaPropertyMetadata metadata)
             : base(source, ownerType, metadata)
         {
+            Owner = ownerType;
         }
 
         /// <summary>
         /// Gets the type that registered the property.
         /// </summary>
-        public abstract Type Owner { get; }
+        public Type Owner { get; }
 
         /// <summary>
         /// Gets the value of the property on the instance.

--- a/src/Avalonia.Base/StyledPropertyBase.cs
+++ b/src/Avalonia.Base/StyledPropertyBase.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using Avalonia.Data;
 using Avalonia.PropertyStore;
-using Avalonia.Reactive;
-using Avalonia.Styling;
 using Avalonia.Utilities;
 
 namespace Avalonia
@@ -14,8 +11,6 @@ namespace Avalonia
     /// </summary>
     public abstract class StyledPropertyBase<TValue> : AvaloniaProperty<TValue>, IStyledPropertyAccessor
     {
-        private readonly bool _inherits;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="StyledPropertyBase{T}"/> class.
         /// </summary>
@@ -34,7 +29,7 @@ namespace Avalonia
             Action<AvaloniaObject, bool>? notifying = null)
                 : base(name, ownerType, metadata, notifying)
         {
-            _inherits = inherits;
+            Inherits = inherits;
             ValidateValue = validate;
             HasCoercion |= metadata.CoerceValue != null;
 
@@ -53,16 +48,8 @@ namespace Avalonia
         protected StyledPropertyBase(StyledPropertyBase<TValue> source, Type ownerType)
             : base(source, ownerType, null)
         {
-            _inherits = source.Inherits;
+            Inherits = source.Inherits;
         }
-
-        /// <summary>
-        /// Gets a value indicating whether the property inherits its value.
-        /// </summary>
-        /// <value>
-        /// A value indicating whether the property inherits its value.
-        /// </value>
-        public override bool Inherits => _inherits;
 
         /// <summary>
         /// Gets the value validation callback for the property.


### PR DESCRIPTION
## What does the pull request do?

Instead of having virtual properties on `AvaloniaProperty` for `IsAttached`, `IsDirect` etc, just use a standard property.

There's no point in making each read of these properties virtual: the extra memory taking will be miniscule in comparison to the rest of the application and it's more important to make reading these properties fast.

## Breaking changes

Shouldn't break anyone as creating your own `AvaloniaProperty` types isn't supported anyway.
