### PR TITLE
VirtualizingStackPanel: fix selection wrapping

### DIFF
--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -226,7 +226,7 @@ namespace Avalonia.Controls
             {
                 if (toIndex < 0)
                     toIndex = count - 1;
-                else if (toIndex >= count - 1)
+                else if (toIndex >= count)
                     toIndex = 0;
             }
 

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
@@ -759,6 +759,7 @@ namespace Avalonia.Controls.UnitTests
                 var lbItems = target.GetLogicalChildren().OfType<ListBoxItem>().ToArray();
 
                 var first = lbItems.First();
+                var beforeLast = lbItems[^2];
                 var last = lbItems.Last();
 
                 first.Focus();
@@ -767,6 +768,12 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Equal(true, first.IsSelected);
 
                 RaiseKeyEvent(target, Key.Up);
+                Assert.Equal(true, last.IsSelected);
+
+                RaiseKeyEvent(target, Key.Up);
+                Assert.Equal(true, beforeLast.IsSelected);
+
+                RaiseKeyEvent(target, Key.Down);
                 Assert.Equal(true, last.IsSelected);
 
                 RaiseKeyEvent(target, Key.Down);


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes selection wrapping in `VirtualizingStackPanel` when navigating `Down`


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The last item is skipped

![navigation](https://user-images.githubusercontent.com/4993430/214032244-1e69be3f-01d7-40de-ac90-4d120b935bd4.gif)

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
The last item is selected

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)? - Modified `ListBox` test to check this corner case
