### PR TITLE
Make TopLevel can't be in MirrorTransform state

### DIFF
--- a/samples/ControlCatalog/MainView.xaml.cs
+++ b/samples/ControlCatalog/MainView.xaml.cs
@@ -60,7 +60,7 @@ namespace ControlCatalog
             {
                 if (flowDirections.SelectedItem is FlowDirection flowDirection)
                 {
-                    ((TopLevel)this.VisualRoot!).FlowDirection = flowDirection;
+                    TopLevel.GetTopLevel(this).FlowDirection = flowDirection;
                 }
             };
 

--- a/samples/ControlCatalog/MainView.xaml.cs
+++ b/samples/ControlCatalog/MainView.xaml.cs
@@ -60,7 +60,7 @@ namespace ControlCatalog
             {
                 if (flowDirections.SelectedItem is FlowDirection flowDirection)
                 {
-                    this.FlowDirection = flowDirection;
+                    ((TopLevel)this.VisualRoot!).FlowDirection = flowDirection;
                 }
             };
 

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -606,6 +606,13 @@ namespace Avalonia.Controls
                 KeyboardDevice.Instance?.SetFocusedElement(null, NavigationMethod.Unspecified, KeyModifiers.None);
         }
 
+        protected override bool BypassFlowDirectionPolicies => true;
+
+        public override void InvalidateMirrorTransform()
+        {
+            // Do nothing becuase TopLevel should't apply MirrorTransform on himself.
+        }
+
         ITextInputMethodImpl? ITextInputMethodRoot.InputMethod =>
             (PlatformImpl as ITopLevelImplWithTextInputMethod)?.TextInputMethod;
     }


### PR DESCRIPTION
## What does the pull request do?
At first when I implemented `FlowDirection`, I made the `TopLevel` to never be MirrorTransform, then I forgot why I did it, and returned it to normal, this was a mistake, because it causes a problem when `TopLevel` is RTL, the position calculation is done incorrectly.

This is the line that calculates the position according the `TopLevel`:
https://github.com/AvaloniaUI/Avalonia/blob/05eece5196a35c072220200caddd870bab02b0b7/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs#L471

I also changed the apply to `FlowDirection` in ControlCatalog so that it applies to the `MainWindow` instead `MainView.`

## How was the solution implemented (if it's not obvious)?
Make `TopLevel` can't be in MirrorTransform state.

## Breaking changes
No.

## Screenshot
![image](https://user-images.githubusercontent.com/41772276/214290485-5b77e8ec-c0fe-44f8-9168-ef62a59ed75b.png)

