### PR TITLE
Fix TemplateBinding with converter inside of MultiBinding

### DIFF
--- a/src/Markup/Avalonia.Markup/Data/TemplateBinding.cs
+++ b/src/Markup/Avalonia.Markup/Data/TemplateBinding.cs
@@ -137,9 +137,9 @@ namespace Avalonia.Data
                     templatedParent.GetValue(Property) :
                     _target.TemplatedParent;
 
-                if (Converter is not null && _targetType is not null)
+                if (Converter is not null)
                 {
-                    value = Converter.Convert(value, _targetType, ConverterParameter, CultureInfo.CurrentCulture);
+                    value = Converter.Convert(value, _targetType ?? typeof(object), ConverterParameter, CultureInfo.CurrentCulture);
                 }
 
                 PublishNext(value);

--- a/tests/Avalonia.Markup.UnitTests/Data/TemplateBindingTests.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/TemplateBindingTests.cs
@@ -248,6 +248,38 @@ namespace Avalonia.Markup.UnitTests.Data
             // binding is initiated.
             Assert.Equal(new[] { "foo" }, converter.Values);
         }
+        
+        [Fact]
+        public void Should_Execute_Converter_Without_Specific_TargetType()
+        {
+            // See https://github.com/AvaloniaUI/Avalonia/issues/9766
+            var source = new Button
+            {
+                Template = new FuncControlTemplate<Button>((parent, _) =>
+                    new ContentPresenter
+                    {
+                        [~ContentPresenter.IsVisibleProperty] = new MultiBinding
+                        {
+                            Converter = BoolConverters.And,
+                            Bindings =
+                            {
+                                new TemplateBinding(ContentControl.ContentProperty)
+                                {
+                                    Converter = ObjectConverters.IsNotNull
+                                }
+                            }
+                        }
+                    }),
+            };
+
+            source.ApplyTemplate();
+
+            var target = (ContentPresenter)source.GetVisualChildren().Single();
+
+            Assert.False(target.IsVisible);
+            source.Content = "foo";
+            Assert.True(target.IsVisible);
+        }
 
         private class PrefixConverter : IValueConverter
         {


### PR DESCRIPTION
## What does the pull request do?

Similarly how BindingBase does it, now TemplateBinding passes typeof(object), if target property wasn't set in other way.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Fixed issues

Fixes #9766
