### PR TITLE
Fix handling of full-length hex values with '#' symbol in ColorPicker

### DIFF
--- a/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorPicker.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorPicker.xaml
@@ -245,11 +245,12 @@
                                        VerticalAlignment="Center" />
                           </Border>
                           <!-- Color updated in code-behind -->
+                          <!-- Max length must include an optional '#' prefix (#FFFFFFFF) -->
                           <TextBox x:Name="PART_HexTextBox"
                                    Grid.Column="1"
                                    AutomationProperties.Name="Hexadecimal Color"
                                    Height="32"
-                                   MaxLength="8"
+                                   MaxLength="9"
                                    HorizontalAlignment="Stretch"
                                    CornerRadius="0,4,4,0" />
                         </Grid>

--- a/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorView.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorView.xaml
@@ -494,11 +494,12 @@
                                  VerticalAlignment="Center" />
                     </Border>
                     <!-- Color updated in code-behind -->
+                    <!-- Max length must include an optional '#' prefix (#FFFFFFFF) -->
                     <TextBox x:Name="PART_HexTextBox"
                              Grid.Column="1"
                              AutomationProperties.Name="Hexadecimal Color"
                              Height="32"
-                             MaxLength="8"
+                             MaxLength="9"
                              HorizontalAlignment="Stretch"
                              CornerRadius="0,4,4,0" />
                   </Grid>

--- a/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorPicker.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorPicker.xaml
@@ -245,11 +245,12 @@
                                        VerticalAlignment="Center" />
                           </Border>
                           <!-- Color updated in code-behind -->
+                          <!-- Max length must include an optional '#' prefix (#FFFFFFFF) -->
                           <TextBox x:Name="PART_HexTextBox"
                                    Grid.Column="1"
                                    AutomationProperties.Name="Hexadecimal Color"
                                    Height="32"
-                                   MaxLength="8"
+                                   MaxLength="9"
                                    HorizontalAlignment="Stretch"
                                    CornerRadius="0,0,0,0" />
                         </Grid>

--- a/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorView.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorView.xaml
@@ -456,11 +456,12 @@
                                  VerticalAlignment="Center" />
                     </Border>
                     <!-- Color updated in code-behind -->
+                    <!-- Max length must include an optional '#' prefix (#FFFFFFFF) -->
                     <TextBox x:Name="PART_HexTextBox"
                              Grid.Column="1"
                              AutomationProperties.Name="Hexadecimal Color"
                              Height="32"
-                             MaxLength="8"
+                             MaxLength="9"
                              HorizontalAlignment="Stretch"
                              CornerRadius="0,0,0,0" />
                   </Grid>


### PR DESCRIPTION
## What does the pull request do?

Fixes the issue of pasting "#FFFFFFFF" in the hex input text box first reported by @cirrusone here https://github.com/AvaloniaUI/Avalonia/discussions/10079#discussioncomment-4778482.

## What is the current behavior?

Pasting "#FFFFFF" would work but "#FFFFFFFF" would not.

## What is the updated/expected behavior with this PR?

Pasting "#FFFFFFFF" now works along with any other 8-digit hex color with a `#` prefix.

## How was the solution implemented (if it's not obvious)?

Increased the TextBox max length to account for the `#` symbol.

## Checklist

- ~[ ] Added unit tests (if possible)?~
- ~[ ] Added XML documentation to any related classes?~
- ~[ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation~

## Breaking changes

None

## Obsoletions / Deprecations

None

## Fixed issues

None opened, see https://github.com/AvaloniaUI/Avalonia/discussions/10079#discussioncomment-4778482