### PR TITLE
fix: fix RadioButton empty GroupName behavior.

### DIFF
--- a/src/Avalonia.Controls/RadioButton.cs
+++ b/src/Avalonia.Controls/RadioButton.cs
@@ -180,7 +180,7 @@ namespace Avalonia.Controls
                     var siblings = parent
                         .GetVisualChildren()
                         .OfType<RadioButton>()
-                        .Where(x => x != this);
+                        .Where(x => x != this && string.IsNullOrEmpty(x.GroupName));
 
                     foreach (var sibling in siblings)
                     {

--- a/tests/Avalonia.Controls.UnitTests/RadioButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/RadioButtonTests.cs
@@ -70,5 +70,44 @@ namespace Avalonia.Controls.UnitTests
             Assert.False(radioButton2.IsChecked);
             Assert.True(radioButton3.IsChecked);
         }
+
+        [Fact]
+        public void RadioButton_Empty_GroupName_Not_Influence_Other_Groups()
+        {
+            var parent = new Panel();
+            
+            var radioButton1 = new RadioButton();
+            radioButton1.GroupName = "A";
+            radioButton1.IsChecked = true;
+            var radioButton2 = new RadioButton();
+            radioButton2.GroupName = "A";
+            radioButton2.IsChecked = false;
+
+            var radioButton3 = new RadioButton();
+            radioButton3.GroupName = null;
+            radioButton3.IsChecked = false;
+            var radioButton4 = new RadioButton();
+            radioButton4.GroupName = null;
+            radioButton4.IsChecked = true;
+
+            parent.Children.Add(radioButton1); 
+            parent.Children.Add(radioButton2); 
+            parent.Children.Add(radioButton3);
+            parent.Children.Add(radioButton4);
+
+            Assert.True(radioButton1.IsChecked);
+            Assert.False(radioButton2.IsChecked);
+            Assert.False(radioButton3.IsChecked);
+            Assert.True(radioButton4.IsChecked);
+
+            radioButton3.IsChecked = true;
+
+            Assert.True(radioButton1.IsChecked);
+            Assert.False(radioButton2.IsChecked);
+            Assert.True(radioButton3.IsChecked);
+            Assert.False(radioButton4.IsChecked);
+
+
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Fix https://github.com/AvaloniaUI/Avalonia/issues/10093


## What is the current behavior?
RadioButton with empty GroupName will impact all neighbors. 


## What is the updated/expected behavior with this PR?
RadioButton with empty GroupName will only impact neighbors with empty GroupName. 


## How was the solution implemented (if it's not obvious)?
Filter out RadioButton with Empty GroupName.


## Checklist

- [X] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes https://github.com/AvaloniaUI/Avalonia/issues/10093
Fixes #2717
