### PR TITLE
Fix transitions memory leak

### DIFF
--- a/src/Avalonia.Base/Animation/Animatable.cs
+++ b/src/Avalonia.Base/Animation/Animatable.cs
@@ -27,6 +27,7 @@ namespace Avalonia.Animation
             AvaloniaProperty.Register<Animatable, Transitions?>(nameof(Transitions));
 
         private bool _transitionsEnabled = true;
+        private bool _isSubscribedToTransitionsCollection = false;
         private Dictionary<ITransition, TransitionState>? _transitionState;
 
         /// <summary>
@@ -62,6 +63,11 @@ namespace Avalonia.Animation
 
                 if (Transitions is object)
                 {
+                    if (!_isSubscribedToTransitionsCollection)
+                    {
+                        _isSubscribedToTransitionsCollection = true;
+                        Transitions.CollectionChanged += TransitionsCollectionChanged;
+                    }
                     AddTransitions(Transitions);
                 }
             }
@@ -72,7 +78,7 @@ namespace Avalonia.Animation
         /// </summary>
         /// <remarks>
         /// This method should not be called from user code, it will be called automatically by the framework
-        /// when a control is added to the visual tree.
+        /// when a control is removed from the visual tree.
         /// </remarks>
         protected void DisableTransitions()
         {
@@ -82,6 +88,11 @@ namespace Avalonia.Animation
 
                 if (Transitions is object)
                 {
+                    if (_isSubscribedToTransitionsCollection)
+                    {
+                        _isSubscribedToTransitionsCollection = false;
+                        Transitions.CollectionChanged -= TransitionsCollectionChanged;
+                    }
                     RemoveTransitions(Transitions);
                 }
             }
@@ -110,6 +121,7 @@ namespace Avalonia.Animation
                     }
 
                     newTransitions.CollectionChanged += TransitionsCollectionChanged;
+                    _isSubscribedToTransitionsCollection = true;
                     AddTransitions(toAdd);
                 }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Manages subscriptions to changes of `Transitions` collection of `Animatable` control.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Subscriptions managed only when `Transitions` property is changed.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Subscriptions additionally managed when control is attached to or detached from visual tree.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #10151
