### PR TITLE
fix: Waring CS0618 ListItemAutomationPeer

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/ListItemAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ListItemAutomationPeer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Avalonia.Automation.Provider;
+﻿using Avalonia.Automation.Provider;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Selection;
@@ -64,7 +63,7 @@ namespace Avalonia.Automation.Peers
             if (Owner.Parent is ItemsControl parent &&
                 parent.GetValue(ListBox.SelectionProperty) is ISelectionModel selectionModel)
             {
-                var index = parent.ItemContainerGenerator.IndexFromContainer(Owner);
+                var index = parent.IndexFromContainer(Owner);
 
                 if (index != -1)
                     selectionModel.Deselect(index);


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
```cmd
Warning	CS0618	'ItemContainerGenerator.IndexFromContainer(Control)' is obsolete: 'Use ItemsControl.IndexFromContainer'	Avalonia.Controls (net6.0)	src\Avalonia.Controls\Automation\Peers\ListItemAutomationPeer.cs	67	N/A
```
## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
