### PR TITLE
Fix integration tests on macOS.

### DIFF
--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
@@ -202,7 +202,7 @@ namespace Avalonia.IntegrationTests.Appium
             window.Click();
 
             var img = SixLabors.ImageSharp.Image.Load<Rgba32>(screenshot.AsByteArray);
-            var topLeftColor = img[1, 1];
+            var topLeftColor = img[10, 10];
             var centerColor = img[img.Width / 2, img.Height / 2];
 
             Assert.Equal(new Rgba32(0, 128, 0), topLeftColor);
@@ -223,7 +223,7 @@ namespace Avalonia.IntegrationTests.Appium
             window.Click();
 
             var img = SixLabors.ImageSharp.Image.Load<Rgba32>(screenshot.AsByteArray);
-            var topLeftColor = img[1, 1];
+            var topLeftColor = img[10, 10];
             var centerColor = img[img.Width / 2, img.Height / 2];
 
             Assert.Equal(new Rgba32(0, 128, 0), topLeftColor);


### PR DESCRIPTION
## What does the pull request do?

#10196 added some integration tests which test pixels in a screenshot. These were failing on CI. Seems that the version of macOS on the test runner applies some shading to the top of the window. Check the color of a pixel lower down.
