### PR TITLE
Update Angle to 2.1.0.2023020321

### DIFF
--- a/samples/ControlCatalog.NetCore/ControlCatalog.NetCore.csproj
+++ b/samples/ControlCatalog.NetCore/ControlCatalog.NetCore.csproj
@@ -31,7 +31,6 @@
     <ProjectReference Include="..\..\src\Linux\Avalonia.LinuxFramebuffer\Avalonia.LinuxFramebuffer.csproj" />
     <ProjectReference Include="..\ControlCatalog\ControlCatalog.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.X11\Avalonia.X11.csproj" />
-    <PackageReference Include="Avalonia.Angle.Windows.Natives" Version="2.1.0.2020091801" />
     <!-- For native controls test -->
     <PackageReference Include="MonoMac.NetStandard" Version="0.0.4" />
   </ItemGroup>

--- a/samples/MobileSandbox.Desktop/MobileSandbox.Desktop.csproj
+++ b/samples/MobileSandbox.Desktop/MobileSandbox.Desktop.csproj
@@ -24,7 +24,6 @@
     <ProjectReference Include="..\..\src\Linux\Avalonia.LinuxFramebuffer\Avalonia.LinuxFramebuffer.csproj" />
     <ProjectReference Include="..\MobileSandbox\MobileSandbox.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.X11\Avalonia.X11.csproj" />
-    <PackageReference Include="Avalonia.Angle.Windows.Natives" Version="2.1.0.2020091801" />
     <!-- For native controls test -->
     <PackageReference Include="MonoMac.NetStandard" Version="0.0.4" />
   </ItemGroup>

--- a/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
+++ b/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />
-    <PackageReference Include="Avalonia.Angle.Windows.Natives" Version="2.1.0.2020091801" />
+    <PackageReference Include="Avalonia.Angle.Windows.Natives" Version="2.1.0.2023020321" />
     <PackageReference Include="MicroCom.CodeGenerator.MSBuild" Version="0.11.0" PrivateAssets="all" />
     <MicroComIdl Include="WinRT\winrt.idl" CSharpInteropPath="WinRT\WinRT.Generated.cs" />
     <MicroComIdl Include="Win32Com\win32.idl" CSharpInteropPath="Win32Com\Win32.Generated.cs" />

--- a/src/tools/Avalonia.Designer.HostApp/Avalonia.Designer.HostApp.csproj
+++ b/src/tools/Avalonia.Designer.HostApp/Avalonia.Designer.HostApp.csproj
@@ -23,7 +23,7 @@
     <Compile Include="..\..\Avalonia.Base\Utilities\StringBuilderCache.cs" Link="Utilities\StringBuilderCache.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia.Angle.Windows.Natives" Version="2.1.0.2020091801" />
+    <PackageReference Include="Avalonia.Angle.Windows.Natives" Version="2.1.0.2023020321" />
   </ItemGroup>
   <Import Project="..\..\..\build\NetFX.props" />
 </Project>


### PR DESCRIPTION
## What does the pull request do?

See https://www.nuget.org/packages/Avalonia.Angle.Windows.Natives/2.1.0.2023020321

1. Fixes win7-x64/x86 limitation, angle is now copied with the app for win-x64/x86 build as well
2. Includes angle custom license (inherited from google/angle repository) with the package.
3. Outside of this PR, but also deprecated technically previously latest angle package, which was never used and never properly worked.

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/9359
Fixes https://github.com/AvaloniaUI/Avalonia/issues/4995
Fixes https://github.com/AvaloniaUI/Avalonia/issues/9531
Fixes https://github.com/AvaloniaUI/Avalonia/issues/6028
Fixes https://github.com/AvaloniaUI/Avalonia/issues/8834
Fixes https://github.com/AvaloniaUI/Avalonia/issues/8888
Fixes https://github.com/AvaloniaUI/Avalonia/issues/9519
