### PR TITLE
Fix Null Ref when font fallback is used

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextCharacters.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextCharacters.cs
@@ -121,12 +121,11 @@ namespace Avalonia.Media.TextFormatting
                         
             if (matchFound)
             {
+                // Fallback found
                 var fallbackGlyphTypeface = fontManager.GetOrAddGlyphTypeface(fallbackTypeface);
-
-                //Fallback found
+                                
                 if (TryGetShapeableLength(textSpan, fallbackGlyphTypeface, defaultGlyphTypeface, out count))
-                {
-                    
+                {                    
                     return new UnshapedTextRun(text.Slice(0, count), defaultProperties.WithTypeface(fallbackTypeface),
                         biDiLevel);
                 }                

--- a/src/Avalonia.Base/Media/TextFormatting/TextCharacters.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextCharacters.cs
@@ -118,14 +118,18 @@ namespace Avalonia.Media.TextFormatting
                 fontManager.TryMatchCharacter(codepoint, defaultTypeface.Style, defaultTypeface.Weight,
                     defaultTypeface.Stretch, defaultTypeface.FontFamily, defaultProperties.CultureInfo,
                     out var fallbackTypeface);
-
-            var fallbackGlyphTypeface = fontManager.GetOrAddGlyphTypeface(fallbackTypeface);
-
-            if (matchFound && TryGetShapeableLength(textSpan, fallbackGlyphTypeface, defaultGlyphTypeface, out count))
+                        
+            if (matchFound)
             {
+                var fallbackGlyphTypeface = fontManager.GetOrAddGlyphTypeface(fallbackTypeface);
+
                 //Fallback found
-                return new UnshapedTextRun(text.Slice(0, count), defaultProperties.WithTypeface(fallbackTypeface),
-                    biDiLevel);
+                if (TryGetShapeableLength(textSpan, fallbackGlyphTypeface, defaultGlyphTypeface, out count))
+                {
+                    
+                    return new UnshapedTextRun(text.Slice(0, count), defaultProperties.WithTypeface(fallbackTypeface),
+                        biDiLevel);
+                }                
             }
 
             // no fallback found


### PR DESCRIPTION
## What does the pull request do?
Fixes a null ref exception caused by trying to create a glyph typeface in `TextCharacters.CreateShapeableRun()` when the fallbackTypeface has a null font family. This was mostly happening in dev tools when it couldn't find the character, like in the case of a symbol font.

Simple fix was to make sure we only call `fontManager.GetOrAddGlyphTypeface` if `fontManager.TryMatchCharacter` returns true.


Fixes #10205