### PR TITLE
Add nullable ref annotation to Windows.Close

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -450,7 +450,7 @@ namespace Avalonia.Controls
         /// resulting task will produce the <see cref="_dialogResult"/> value when the window
         /// is closed.
         /// </remarks>
-        public void Close(object dialogResult)
+        public void Close(object? dialogResult)
         {
             _dialogResult = dialogResult;
             CloseCore(WindowCloseReason.WindowClosing, true);


### PR DESCRIPTION
## What does the pull request do?

Adds a nullable ref annotation to the parameter of the `Window.Close(object)` method.

The value is only assigned to a nullable field. Nullable values work fine, but with NRTs added to Avalonia, the lack of an annotation on the parameter type creates new compiler warnings when updating to the latest Avalonia version.
