### PR TITLE
Make previewer to properly load ALL referenced assemblies

### DIFF
--- a/src/tools/Avalonia.Designer.HostApp/DesignXamlLoader.cs
+++ b/src/tools/Avalonia.Designer.HostApp/DesignXamlLoader.cs
@@ -1,16 +1,79 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Avalonia.Markup.Xaml;
 using Avalonia.Markup.Xaml.XamlIl;
 
-namespace Avalonia.Designer.HostApp
+namespace Avalonia.Designer.HostApp;
+
+class DesignXamlLoader : AvaloniaXamlLoader.IRuntimeXamlLoader
 {
-    class DesignXamlLoader : AvaloniaXamlLoader.IRuntimeXamlLoader
+    public object Load(RuntimeXamlLoaderDocument document, RuntimeXamlLoaderConfiguration configuration)
     {
-        public object Load(RuntimeXamlLoaderDocument document, RuntimeXamlLoaderConfiguration configuration)
+        PreloadDepsAssemblies(configuration.LocalAssembly ?? Assembly.GetEntryAssembly());
+        
+        return AvaloniaXamlIlRuntimeCompiler.Load(document, configuration);
+    }
+
+    private void PreloadDepsAssemblies(Assembly targetAssembly)
+    {
+        // Assemblies loaded in memory (e.g. single file) return empty string from Location.
+        // In these cases, don't try probing next to the assembly.
+        var assemblyLocation = targetAssembly.Location;
+        if (string.IsNullOrEmpty(assemblyLocation))
         {
-            return AvaloniaXamlIlRuntimeCompiler.Load(document, configuration);
+            return;
+        }
+
+        var depsJsonFile = Path.ChangeExtension(assemblyLocation, ".deps.json");
+        if (!File.Exists(depsJsonFile))
+        {
+            return;
+        }
+
+        using var stream = File.OpenRead(depsJsonFile);
+
+        /*
+         We can't use any references in the Avalonia.Designer.HostApp. Including even json.
+         Ideally we would prefer Microsoft.Extensions.DependencyModel package, but can't use it here.
+         So, instead we need to fallback to some JSON parsing using pretty easy regex.
+         
+         Json part example:
+"Avalonia.Xaml.Interactions/11.0.0-preview5": {
+  "dependencies": {
+    "Avalonia": "11.0.999",
+    "Avalonia.Xaml.Interactivity": "11.0.0-preview5"
+  },
+  "runtime": {
+    "lib/net6.0/Avalonia.Xaml.Interactions.dll": {
+      "assemblyVersion": "11.0.0.0",
+      "fileVersion": "11.0.0.0"
+    }
+  }
+},
+        We want to extract "lib/net6.0/Avalonia.Xaml.Interactions.dll" from here.
+        No need to resolve real path of ref assemblies.
+        No need to handle special cases with .NET Framework and GAC.
+         */
+        var text = new StreamReader(stream).ReadToEnd();
+        var matches = Regex.Matches( text, """runtime"\s*:\s*{\s*"([^"]+)""");
+
+        foreach (Match match in matches)
+        {
+            if (match.Groups[1] is { Success: true } g)
+            {
+                var assemblyName = Path.GetFileNameWithoutExtension(g.Value);
+                try
+                {
+                    _ = Assembly.Load(new AssemblyName(assemblyName));
+                }
+                catch
+                {
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

If assembly wasn't used explicitly in the code/xaml, it won't be automatically loaded. Which will cause XAML runtime compiler to fail.
To avoid that, we need to parse `.deps.json` file from the app directory and preload all assemblies referenced there.
Ideally, I would use [DependencyModel.GetDefaultAssemblyNames()](https://github.com/dotnet/runtime/blob/f41b259d779466068d5f7b1a16608e74e26a5e46/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextExtensions.cs#L112), but we have a limitation, that previewer host by itself cannot have any dependencies that are not referenced by previewing application already. Which means, I had to use the bare minimum (regex) to parse json and copy simplified version of GetDefaultAssemblyNames from DependencyModel.

Hopefully, it is just enough. Locally, works fine with a test application and problematic `xmlns:i="using:Avalonia.Xaml.Interactivity"`.

Tested with:
```
src\tools\Avalonia.Designer.HostApp\bin\Debug\netcoreapp2.0> dotnet exec --runtimeconfig C:\Work\Projects\test\bin\Debug\net6.0\test.runtimeconfig.json --depsfile C:\Work\Projects\test\bin\Debug\net6.0\test.deps.json Avalonia.Designer.HostApp.dll --transport file:///C:\Work\Projects\test\MainWindow.axaml --method html --html-url http://127.0.0.1:6001 C:\Work\Projects\test\bin\Debug\net6.0\test.dll
```

## Fixed issues

Fixes: https://github.com/AvaloniaUI/Avalonia/issues/9574
Fixes: https://github.com/AvaloniaUI/Avalonia/issues/7200
Fixes https://github.com/AvaloniaUI/Avalonia/issues/7126