### PR TITLE
Nullability fixes for Avalonia.Base

### DIFF
--- a/src/Avalonia.Base/Animation/KeySpline.cs
+++ b/src/Avalonia.Base/Animation/KeySpline.cs
@@ -79,15 +79,12 @@ namespace Avalonia.Animation
         /// <param name="culture">culture of the string</param>
         /// <exception cref="FormatException">Thrown if the string does not have 4 values</exception>
         /// <returns>A <see cref="KeySpline"/> with the appropriate values set</returns>
-        public static KeySpline Parse(string value, CultureInfo culture)
+        public static KeySpline Parse(string value, CultureInfo? culture)
         {
-            if (culture is null)
-                culture = CultureInfo.InvariantCulture;
+            culture ??= CultureInfo.InvariantCulture;
 
-            using (var tokenizer = new StringTokenizer((string)value, culture, exceptionMessage: $"Invalid KeySpline string: \"{value}\"."))
-            {
-                return new KeySpline(tokenizer.ReadDouble(), tokenizer.ReadDouble(), tokenizer.ReadDouble(), tokenizer.ReadDouble());
-            }
+            using var tokenizer = new StringTokenizer(value, culture, exceptionMessage: $"Invalid KeySpline string: \"{value}\".");
+            return new KeySpline(tokenizer.ReadDouble(), tokenizer.ReadDouble(), tokenizer.ReadDouble(), tokenizer.ReadDouble());
         }
 
         /// <summary>

--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -152,7 +152,7 @@ namespace Avalonia
             property = property ?? throw new ArgumentNullException(nameof(property));
             VerifyAccess();
 
-            _values?.ClearLocalValue(property);
+            _values.ClearLocalValue(property);
         }
 
         /// <summary>
@@ -242,7 +242,14 @@ namespace Avalonia
             return registered.InvokeGetter(this);
         }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Gets an <see cref="AvaloniaProperty"/> base value.
+        /// </summary>
+        /// <param name="property">The property.</param>
+        /// <remarks>
+        /// Gets the value of the property excluding animated values, otherwise <see cref="Optional{T}.Empty"/>.
+        /// Note that this method does not return property values that come from inherited or default values.
+        /// </remarks>
         public Optional<T> GetBaseValue<T>(StyledProperty<T> property)
         {
             _ = property ?? throw new ArgumentNullException(nameof(property));
@@ -261,7 +268,7 @@ namespace Avalonia
 
             VerifyAccess();
 
-            return _values?.IsAnimating(property) ?? false;
+            return _values.IsAnimating(property);
         }
 
         /// <summary>
@@ -279,7 +286,7 @@ namespace Avalonia
 
             VerifyAccess();
 
-            return _values?.IsSet(property) ?? false;
+            return _values.IsSet(property);
         }
 
         /// <summary>
@@ -515,14 +522,12 @@ namespace Avalonia
         /// <param name="property">The property.</param>
         public void CoerceValue(AvaloniaProperty property) => _values.CoerceValue(property);
 
-        /// <inheritdoc/>
         internal void AddInheritanceChild(AvaloniaObject child)
         {
             _inheritanceChildren ??= new List<AvaloniaObject>();
             _inheritanceChildren.Add(child);
         }
-        
-        /// <inheritdoc/>
+
         internal void RemoveInheritanceChild(AvaloniaObject child)
         {
             _inheritanceChildren?.Remove(child);
@@ -541,24 +546,11 @@ namespace Avalonia
                 return new AvaloniaPropertyValue(
                     property,
                     GetValue(property),
-                    BindingPriority.Unset,
-                    "Local Value");
-            }
-            else if (_values != null)
-            {
-                var result = _values.GetDiagnostic(property);
-
-                if (result != null)
-                {
-                    return result;
-                }
+                    BindingPriority.LocalValue,
+                    null);
             }
 
-            return new AvaloniaPropertyValue(
-                property,
-                GetValue(property),
-                BindingPriority.Unset,
-                "Unset");
+            return _values.GetDiagnostic(property);
         }
 
         internal ValueStore GetValueStore() => _values;

--- a/src/Avalonia.Base/Diagnostics/AvaloniaObjectExtensions.cs
+++ b/src/Avalonia.Base/Diagnostics/AvaloniaObjectExtensions.cs
@@ -1,6 +1,3 @@
-using System;
-using Avalonia.Data;
-
 namespace Avalonia.Diagnostics
 {
     /// <summary>

--- a/src/Avalonia.Base/Input/DragEventArgs.cs
+++ b/src/Avalonia.Base/Input/DragEventArgs.cs
@@ -1,36 +1,28 @@
 ﻿using System;
 using Avalonia.Interactivity;
 using Avalonia.Metadata;
-using Avalonia.VisualTree;
 
 namespace Avalonia.Input
 {
     public class DragEventArgs : RoutedEventArgs
     {
-        private Interactive _target;
-        private Point _targetLocation;
+        private readonly Interactive _target;
+        private readonly Point _targetLocation;
 
         public DragDropEffects DragEffects { get; set; }
 
-        public IDataObject Data { get; private set; }
+        public IDataObject Data { get; }
 
-        public KeyModifiers KeyModifiers { get; private set; }
+        public KeyModifiers KeyModifiers { get; }
 
         public Point GetPosition(Visual relativeTo)
         {
-            var point = new Point(0, 0);
-
             if (relativeTo == null)
             {
                 throw new ArgumentNullException(nameof(relativeTo));
             }
 
-            if (_target != null)
-            {
-                point = _target.TranslatePoint(_targetLocation, relativeTo) ?? point;
-            }
-
-            return point;
+            return _target.TranslatePoint(_targetLocation, relativeTo) ?? new Point(0, 0);
         }
 
         [Unstable]

--- a/src/Avalonia.Base/Input/KeyGesture.cs
+++ b/src/Avalonia.Base/Input/KeyGesture.cs
@@ -136,7 +136,7 @@ namespace Avalonia.Input
             return StringBuilderCache.GetStringAndRelease(s);
         }
 
-        public bool Matches(KeyEventArgs keyEvent) =>
+        public bool Matches(KeyEventArgs? keyEvent) =>
             keyEvent != null &&
             keyEvent.KeyModifiers == KeyModifiers &&
             ResolveNumPadOperationKey(keyEvent.Key) == ResolveNumPadOperationKey(Key);

--- a/src/Avalonia.Base/Input/KeyboardNavigationHandler.cs
+++ b/src/Avalonia.Base/Input/KeyboardNavigationHandler.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Avalonia.Input.Navigation;
 using Avalonia.VisualTree;
 
@@ -51,7 +50,7 @@ namespace Avalonia.Input
 
             // If there's a custom keyboard navigation handler as an ancestor, use that.
             var custom = (element as Visual)?.FindAncestorOfType<ICustomKeyboardNavigation>(true);
-            if (custom is object && HandlePreCustomNavigation(custom, element, direction, out var ce))
+            if (custom is not null && HandlePreCustomNavigation(custom, element, direction, out var ce))
                 return ce;
 
             var result = direction switch
@@ -117,32 +116,27 @@ namespace Avalonia.Input
             NavigationDirection direction,
             [NotNullWhen(true)] out IInputElement? result)
         {
-            if (customHandler != null)
+            var (handled, next) = customHandler.GetNext(element, direction);
+
+            if (handled)
             {
-                var (handled, next) = customHandler.GetNext(element, direction);
-
-                if (handled)
+                if (next is not null)
                 {
-                    if (next != null)
-                    {
-                        result = next;
-                        return true;
-                    }
-                    else if (direction == NavigationDirection.Next || direction == NavigationDirection.Previous)
-                    {
-                        var r = direction switch
-                        {
-                            NavigationDirection.Next => TabNavigation.GetNextTabOutside(customHandler),
-                            NavigationDirection.Previous => TabNavigation.GetPrevTabOutside(customHandler),
-                            _ => throw new NotSupportedException(),
-                        };
+                    result = next;
+                    return true;
+                }
 
-                        if (r is object)
-                        {
-                            result = r;
-                            return true;
-                        }
-                    }
+                var r = direction switch
+                {
+                    NavigationDirection.Next => TabNavigation.GetNextTabOutside(customHandler),
+                    NavigationDirection.Previous => TabNavigation.GetPrevTabOutside(customHandler),
+                    _ => null
+                };
+
+                if (r is not null)
+                {
+                    result = r;
+                    return true;
                 }
             }
 

--- a/src/Avalonia.Base/Input/Navigation/TabNavigation.cs
+++ b/src/Avalonia.Base/Input/Navigation/TabNavigation.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Input.Navigation
@@ -54,8 +52,7 @@ namespace Avalonia.Input.Navigation
                 // Avoid the endless loop here for Cycle groups
                 if (loopStartElement == nextTabElement)
                     break;
-                if (loopStartElement == null)
-                    loopStartElement = nextTabElement;
+                loopStartElement ??= nextTabElement;
 
                 var firstTabElementInside = GetNextTab(null, nextTabElement, true);
                 if (firstTabElementInside != null)
@@ -80,12 +77,9 @@ namespace Avalonia.Input.Navigation
 
         public static IInputElement? GetNextTabOutside(ICustomKeyboardNavigation e)
         {
-            if (e is IInputElement container)
+            if (e is IInputElement container && GetLastInTree(container) is { } last)
             {
-                var last = GetLastInTree(container);
-
-                if (last is object)
-                    return GetNextTab(last, false);
+                return GetNextTab(last, false);
             }
 
             return null;
@@ -93,11 +87,8 @@ namespace Avalonia.Input.Navigation
 
         public static IInputElement? GetPrevTab(IInputElement? e, IInputElement? container, bool goDownOnly)
         {
-            if (e is null && container is null)
-                throw new InvalidOperationException("Either 'e' or 'container' must be non-null.");
-
-            if (container is null)
-                container = GetGroupParent(e!);
+            container ??=
+                GetGroupParent(e ?? throw new InvalidOperationException("Either 'e' or 'container' must be non-null."));
 
             KeyboardNavigationMode tabbingType = GetKeyNavigationMode(container);
 
@@ -163,8 +154,7 @@ namespace Avalonia.Input.Navigation
                 // Avoid the endless loop here
                 if (loopStartElement == nextTabElement)
                     break;
-                if (loopStartElement == null)
-                    loopStartElement = nextTabElement;
+                loopStartElement ??= nextTabElement;
 
                 // At this point nextTabElement is TabGroup
                 var lastTabElementInside = GetPrevTab(null, nextTabElement, true);
@@ -189,22 +179,18 @@ namespace Avalonia.Input.Navigation
 
         public static IInputElement? GetPrevTabOutside(ICustomKeyboardNavigation e)
         {
-            if (e is IInputElement container)
+            if (e is IInputElement container && GetFirstChild(container) is { } first)
             {
-                var first = GetFirstChild(container);
-
-                if (first is object)
-                    return GetPrevTab(first, null, false);
+                return GetPrevTab(first, null, false);
             }
 
             return null;
         }
 
-        private static IInputElement? FocusedElement(IInputElement e)
+        private static IInputElement? FocusedElement(IInputElement? e)
         {
-            var iie = e;
             // Focus delegation is enabled only if keyboard focus is outside the container
-            if (iie != null && !iie.IsKeyboardFocusWithin)
+            if (e != null && !e.IsKeyboardFocusWithin)
             {
                 var focusedElement = (FocusManager.Instance as FocusManager)?.GetFocusedElement(e);
                 if (focusedElement != null)
@@ -229,13 +215,11 @@ namespace Avalonia.Input.Navigation
         private static IInputElement? GetFirstChild(IInputElement e)
         {
             // If the element has a FocusedElement it should be its first child
-            if (FocusedElement(e) is IInputElement focusedElement)
+            if (FocusedElement(e) is { } focusedElement)
                 return focusedElement;
 
             // Return the first visible element.
-            var uiElement = e as InputElement;
-
-            if (uiElement is null || IsVisibleAndEnabled(uiElement))
+            if (e is not InputElement uiElement || IsVisibleAndEnabled(uiElement))
             {
                 if (e is Visual elementAsVisual)
                 {
@@ -265,7 +249,7 @@ namespace Avalonia.Input.Navigation
         private static IInputElement? GetLastChild(IInputElement e)
         {
             // If the element has a FocusedElement it should be its last child
-            if (FocusedElement(e) is IInputElement focusedElement)
+            if (FocusedElement(e) is { } focusedElement)
                 return focusedElement;
 
             // Return the last visible element.
@@ -273,9 +257,7 @@ namespace Avalonia.Input.Navigation
 
             if (uiElement == null || IsVisibleAndEnabled(uiElement))
             {
-                var elementAsVisual = e as Visual;
-
-                if (elementAsVisual != null)
+                if (e is Visual elementAsVisual)
                 {
                     var children = elementAsVisual.VisualChildren;
                     var count = children.Count;
@@ -322,7 +304,7 @@ namespace Avalonia.Input.Navigation
             return firstTabElement;
         }
 
-        private static IInputElement? GetLastInTree(IInputElement container)
+        private static IInputElement GetLastInTree(IInputElement container)
         {
             IInputElement? result;
             IInputElement? c = container;

--- a/src/Avalonia.Base/LogicalTree/LogicalExtensions.cs
+++ b/src/Avalonia.Base/LogicalTree/LogicalExtensions.cs
@@ -48,7 +48,7 @@ namespace Avalonia.LogicalTree
         /// <param name="logical">The logical.</param>
         /// <param name="includeSelf">If given logical should be included in search.</param>
         /// <returns>First ancestor of given type.</returns>
-        public static T? FindLogicalAncestorOfType<T>(this ILogical logical, bool includeSelf = false) where T : class
+        public static T? FindLogicalAncestorOfType<T>(this ILogical? logical, bool includeSelf = false) where T : class
         {
             if (logical is null)
             {
@@ -120,7 +120,7 @@ namespace Avalonia.LogicalTree
         /// <param name="logical">The logical.</param>
         /// <param name="includeSelf">If given logical should be included in search.</param>
         /// <returns>First descendant of given type.</returns>
-        public static T? FindLogicalDescendantOfType<T>(this ILogical logical, bool includeSelf = false) where T : class
+        public static T? FindLogicalDescendantOfType<T>(this ILogical? logical, bool includeSelf = false) where T : class
         {
             if (logical is null)
             {
@@ -185,7 +185,7 @@ namespace Avalonia.LogicalTree
         /// True if <paramref name="logical"/> is an ancestor of <paramref name="target"/>;
         /// otherwise false.
         /// </returns>
-        public static bool IsLogicalAncestorOf(this ILogical logical, ILogical target)
+        public static bool IsLogicalAncestorOf(this ILogical? logical, ILogical? target)
         {
             var current = target?.LogicalParent;
 

--- a/src/Avalonia.Base/Media/Color.cs
+++ b/src/Avalonia.Base/Media/Color.cs
@@ -147,16 +147,11 @@ namespace Avalonia.Media
         /// <param name="s">The color string.</param>
         /// <param name="color">The parsed color</param>
         /// <returns>The status of the operation.</returns>
-        public static bool TryParse(string s, out Color color)
+        public static bool TryParse(string? s, out Color color)
         {
             color = default;
 
-            if (s is null)
-            {
-                return false;
-            }
-
-            if (s.Length == 0)
+            if (string.IsNullOrEmpty(s))
             {
                 return false;
             }

--- a/src/Avalonia.Base/Media/DrawingContext.cs
+++ b/src/Avalonia.Base/Media/DrawingContext.cs
@@ -240,7 +240,7 @@ namespace Avalonia.Media
         /// </summary>
         /// <param name="foreground">The foreground brush.</param>
         /// <param name="glyphRun">The glyph run.</param>
-        public void DrawGlyphRun(IBrush foreground, GlyphRun glyphRun)
+        public void DrawGlyphRun(IBrush? foreground, GlyphRun glyphRun)
         {
             _ = glyphRun ?? throw new ArgumentNullException(nameof(glyphRun));
 

--- a/src/Avalonia.Base/Media/DrawingGroup.cs
+++ b/src/Avalonia.Base/Media/DrawingGroup.cs
@@ -13,14 +13,14 @@ namespace Avalonia.Media
         public static readonly StyledProperty<double> OpacityProperty =
             AvaloniaProperty.Register<DrawingGroup, double>(nameof(Opacity), 1);
 
-        public static readonly StyledProperty<Transform> TransformProperty =
-            AvaloniaProperty.Register<DrawingGroup, Transform>(nameof(Transform));
+        public static readonly StyledProperty<Transform?> TransformProperty =
+            AvaloniaProperty.Register<DrawingGroup, Transform?>(nameof(Transform));
 
-        public static readonly StyledProperty<Geometry> ClipGeometryProperty =
-            AvaloniaProperty.Register<DrawingGroup, Geometry>(nameof(ClipGeometry));
+        public static readonly StyledProperty<Geometry?> ClipGeometryProperty =
+            AvaloniaProperty.Register<DrawingGroup, Geometry?>(nameof(ClipGeometry));
 
-        public static readonly StyledProperty<IBrush> OpacityMaskProperty =
-            AvaloniaProperty.Register<DrawingGroup, IBrush>(nameof(OpacityMask));
+        public static readonly StyledProperty<IBrush?> OpacityMaskProperty =
+            AvaloniaProperty.Register<DrawingGroup, IBrush?>(nameof(OpacityMask));
 
         public static readonly DirectProperty<DrawingGroup, DrawingCollection> ChildrenProperty =
             AvaloniaProperty.RegisterDirect<DrawingGroup, DrawingCollection>(
@@ -36,19 +36,19 @@ namespace Avalonia.Media
             set => SetValue(OpacityProperty, value);
         }
 
-        public Transform Transform
+        public Transform? Transform
         {
             get => GetValue(TransformProperty);
             set => SetValue(TransformProperty, value);
         }
 
-        public Geometry ClipGeometry
+        public Geometry? ClipGeometry
         {
             get => GetValue(ClipGeometryProperty);
             set => SetValue(ClipGeometryProperty, value);
         }
 
-        public IBrush OpacityMask
+        public IBrush? OpacityMask
         {
             get => GetValue(OpacityMaskProperty);
             set => SetValue(OpacityMaskProperty, value);
@@ -159,7 +159,7 @@ namespace Avalonia.Media
 
             public void DrawGeometry(IBrush? brush, IPen? pen, IGeometryImpl geometry)
             {
-                if (((brush == null) && (pen == null)) || (geometry == null))
+                if ((brush == null) && (pen == null))
                 {
                     return;
                 }
@@ -167,9 +167,9 @@ namespace Avalonia.Media
                 AddNewGeometryDrawing(brush, pen, new PlatformGeometry(geometry));
             }
 
-            public void DrawGlyphRun(IBrush foreground, IRef<IGlyphRunImpl> glyphRun)
+            public void DrawGlyphRun(IBrush? foreground, IRef<IGlyphRunImpl> glyphRun)
             {
-                if (foreground == null || glyphRun == null)
+                if (foreground == null)
                 {
                     return;
                 }
@@ -184,7 +184,7 @@ namespace Avalonia.Media
                 AddDrawing(glyphRunDrawing);
             }
 
-            public void DrawLine(IPen pen, Point p1, Point p2)
+            public void DrawLine(IPen? pen, Point p1, Point p2)
             {
                 if (pen == null)
                 {

--- a/src/Avalonia.Base/Media/DrawingImage.cs
+++ b/src/Avalonia.Base/Media/DrawingImage.cs
@@ -20,8 +20,8 @@ namespace Avalonia.Media
         /// <summary>
         /// Defines the <see cref="Drawing"/> property.
         /// </summary>
-        public static readonly StyledProperty<Drawing> DrawingProperty =
-            AvaloniaProperty.Register<DrawingImage, Drawing>(nameof(Drawing));
+        public static readonly StyledProperty<Drawing?> DrawingProperty =
+            AvaloniaProperty.Register<DrawingImage, Drawing?>(nameof(Drawing));
 
         /// <inheritdoc/>
         public event EventHandler? Invalidated;
@@ -30,7 +30,7 @@ namespace Avalonia.Media
         /// Gets or sets the drawing content.
         /// </summary>
         [Content]
-        public Drawing Drawing
+        public Drawing? Drawing
         {
             get => GetValue(DrawingProperty);
             set => SetValue(DrawingProperty, value);

--- a/src/Avalonia.Base/Media/FontFamily.cs
+++ b/src/Avalonia.Base/Media/FontFamily.cs
@@ -119,7 +119,7 @@ namespace Avalonia.Media
 
                 case 2:
                     {
-                        var source = segments[0].StartsWith("/")
+                        var source = segments[0].StartsWith("/", StringComparison.Ordinal)
                             ? new Uri(segments[0], UriKind.Relative)
                             : new Uri(segments[0], UriKind.RelativeOrAbsolute);
 
@@ -188,7 +188,7 @@ namespace Avalonia.Media
         {
             unchecked
             {
-                return ((FamilyNames != null ? FamilyNames.GetHashCode() : 0) * 397) ^ (Key != null ? Key.GetHashCode() : 0);
+                return (FamilyNames.GetHashCode() * 397) ^ (Key is not null ? Key.GetHashCode() : 0);
             }
         }
 

--- a/src/Avalonia.Base/Media/Fonts/FontFamilyKey.cs
+++ b/src/Avalonia.Base/Media/Fonts/FontFamilyKey.cs
@@ -41,10 +41,7 @@ namespace Avalonia.Media.Fonts
             {
                 var hash = (int)2166136261;
 
-                if (Source != null)
-                {
-                    hash = (hash * 16777619) ^ Source.GetHashCode();
-                }
+                hash = (hash * 16777619) ^ Source.GetHashCode();
 
                 if (BaseUri != null)
                 {

--- a/src/Avalonia.Base/Media/FormattedText.cs
+++ b/src/Avalonia.Base/Media/FormattedText.cs
@@ -1354,7 +1354,7 @@ namespace Avalonia.Media
                     {
                         var highlightBounds = currentLine.GetTextBounds(x0,x1 - x0);
 
-                        if (highlightBounds != null)
+                        if (highlightBounds.Count > 0)
                         {
                             foreach (var bound in highlightBounds)
                             {
@@ -1365,7 +1365,7 @@ namespace Avalonia.Media
                                     // Convert logical units (which extend leftward from the right edge
                                     // of the paragraph) to physical units.
                                     //
-                                    // Note that since rect is in logical units, rect.Right corresponds to 
+                                    // Note that since rect is in logical units, rect.Right corresponds to
                                     // the visual *left* edge of the rectangle in the RTL case. Specifically,
                                     // is the distance leftward from the right edge of the formatting rectangle
                                     // whose width is the paragraph width passed to FormatLine.
@@ -1384,7 +1384,7 @@ namespace Avalonia.Media
                                 else
                                 {
                                     accumulatedBounds = Geometry.Combine(accumulatedBounds, rectangleGeometry, GeometryCombineMode.Union);
-                                }                                  
+                                }
                             }
                         }
                     }

--- a/src/Avalonia.Base/Media/GeometryDrawing.cs
+++ b/src/Avalonia.Base/Media/GeometryDrawing.cs
@@ -15,8 +15,8 @@ namespace Avalonia.Media
         /// <summary>
         /// Defines the <see cref="Geometry"/> property.
         /// </summary>
-        public static readonly StyledProperty<Geometry> GeometryProperty =
-            AvaloniaProperty.Register<GeometryDrawing, Geometry>(nameof(Geometry));
+        public static readonly StyledProperty<Geometry?> GeometryProperty =
+            AvaloniaProperty.Register<GeometryDrawing, Geometry?>(nameof(Geometry));
 
         /// <summary>
         /// Defines the <see cref="Brush"/> property.
@@ -34,7 +34,7 @@ namespace Avalonia.Media
         /// Gets or sets the <see cref="Avalonia.Media.Geometry"/> that describes the shape of this <see cref="GeometryDrawing"/>.
         /// </summary>
         [Content]
-        public Geometry Geometry
+        public Geometry? Geometry
         {
             get => GetValue(GeometryProperty);
             set => SetValue(GeometryProperty, value);

--- a/src/Avalonia.Base/Media/GlyphRunDrawing.cs
+++ b/src/Avalonia.Base/Media/GlyphRunDrawing.cs
@@ -2,19 +2,19 @@
 {
     public class GlyphRunDrawing : Drawing
     {
-        public static readonly StyledProperty<IBrush> ForegroundProperty =
-            AvaloniaProperty.Register<GlyphRunDrawing, IBrush>(nameof(Foreground));
+        public static readonly StyledProperty<IBrush?> ForegroundProperty =
+            AvaloniaProperty.Register<GlyphRunDrawing, IBrush?>(nameof(Foreground));
 
-        public static readonly StyledProperty<GlyphRun> GlyphRunProperty =
-            AvaloniaProperty.Register<GlyphRunDrawing, GlyphRun>(nameof(GlyphRun));
+        public static readonly StyledProperty<GlyphRun?> GlyphRunProperty =
+            AvaloniaProperty.Register<GlyphRunDrawing, GlyphRun?>(nameof(GlyphRun));
 
-        public IBrush Foreground
+        public IBrush? Foreground
         {
             get => GetValue(ForegroundProperty);
             set => SetValue(ForegroundProperty, value);
         }
 
-        public GlyphRun GlyphRun
+        public GlyphRun? GlyphRun
         {
             get => GetValue(GlyphRunProperty);
             set => SetValue(GlyphRunProperty, value);

--- a/src/Avalonia.Base/Media/HslColor.cs
+++ b/src/Avalonia.Base/Media/HslColor.cs
@@ -254,7 +254,7 @@ namespace Avalonia.Media
         /// <param name="s">The HSL color string to parse.</param>
         /// <param name="hslColor">The parsed <see cref="HslColor"/>.</param>
         /// <returns>True if parsing was successful; otherwise, false.</returns>
-        public static bool TryParse(string s, out HslColor hslColor)
+        public static bool TryParse(string? s, out HslColor hslColor)
         {
             bool prefixMatched = false;
 

--- a/src/Avalonia.Base/Media/HsvColor.cs
+++ b/src/Avalonia.Base/Media/HsvColor.cs
@@ -254,7 +254,7 @@ namespace Avalonia.Media
         /// <param name="s">The HSV color string to parse.</param>
         /// <param name="hsvColor">The parsed <see cref="HsvColor"/>.</param>
         /// <returns>True if parsing was successful; otherwise, false.</returns>
-        public static bool TryParse(string s, out HsvColor hsvColor)
+        public static bool TryParse(string? s, out HsvColor hsvColor)
         {
             bool prefixMatched = false;
 

--- a/src/Avalonia.Base/Media/IVisualBrush.cs
+++ b/src/Avalonia.Base/Media/IVisualBrush.cs
@@ -1,5 +1,4 @@
 ﻿using Avalonia.Metadata;
-using Avalonia.VisualTree;
 
 namespace Avalonia.Media
 {
@@ -12,6 +11,6 @@ namespace Avalonia.Media
         /// <summary>
         /// Gets the visual to draw.
         /// </summary>
-        Visual Visual { get; }
+        Visual? Visual { get; }
     }
 }

--- a/src/Avalonia.Base/Media/Immutable/ImmutableDashStyle.cs
+++ b/src/Avalonia.Base/Media/Immutable/ImmutableDashStyle.cs
@@ -39,17 +39,8 @@ namespace Avalonia.Media.Immutable
             {
                 return true;
             }
-            else if (other is null)
-            {
-                return false;
-            }
 
-            if (Offset != other.Offset)
-            {
-                return false;
-            }
-
-            return SequenceEqual(Dashes, other.Dashes);
+            return other is not null && Offset == other.Offset && SequenceEqual(_dashes, other.Dashes);
         }
 
         /// <inheritdoc/>
@@ -58,30 +49,27 @@ namespace Avalonia.Media.Immutable
             var hashCode = 717868523;
             hashCode = hashCode * -1521134295 + Offset.GetHashCode();
 
-            if (_dashes != null)
+            foreach (var i in _dashes)
             {
-                foreach (var i in _dashes)
-                {
-                    hashCode = hashCode * -1521134295 + i.GetHashCode();
-                }
+                hashCode = hashCode * -1521134295 + i.GetHashCode();
             }
 
             return hashCode;
         }
 
-        private static bool SequenceEqual(IReadOnlyList<double> left, IReadOnlyList<double>? right)
+        private static bool SequenceEqual(double[] left, IReadOnlyList<double>? right)
         {
             if (ReferenceEquals(left, right))
             {
                 return true;
             }
 
-            if (left == null || right == null || left.Count != right.Count)
+            if (right is null || left.Length != right.Count)
             {
                 return false;
             }
 
-            for (var c = 0; c < left.Count; c++)
+            for (var c = 0; c < left.Length; c++)
             {
                 if (left[c] != right[c])
                 {

--- a/src/Avalonia.Base/Media/Immutable/ImmutableVisualBrush.cs
+++ b/src/Avalonia.Base/Media/Immutable/ImmutableVisualBrush.cs
@@ -1,5 +1,4 @@
 ﻿using Avalonia.Media.Imaging;
-using Avalonia.VisualTree;
 
 namespace Avalonia.Media.Immutable
 {
@@ -31,11 +30,11 @@ namespace Avalonia.Media.Immutable
             RelativeRect? destinationRect = null,
             double opacity = 1,
             ImmutableTransform? transform = null,
-            RelativePoint transformOrigin = new RelativePoint(),
+            RelativePoint transformOrigin = default,
             RelativeRect? sourceRect = null,
             Stretch stretch = Stretch.Uniform,
             TileMode tileMode = TileMode.None,
-            Imaging.BitmapInterpolationMode bitmapInterpolationMode = Imaging.BitmapInterpolationMode.Default)
+            BitmapInterpolationMode bitmapInterpolationMode = BitmapInterpolationMode.Default)
             : base(
                   alignmentX,
                   alignmentY,
@@ -62,6 +61,6 @@ namespace Avalonia.Media.Immutable
         }
 
         /// <inheritdoc/>
-        public Visual Visual { get; }
+        public Visual? Visual { get; }
     }
 }

--- a/src/Avalonia.Base/Media/TextDecoration.cs
+++ b/src/Avalonia.Base/Media/TextDecoration.cs
@@ -22,8 +22,8 @@ namespace Avalonia.Media
         /// <summary>
         /// Defines the <see cref="Stroke"/> property.
         /// </summary>
-        public static readonly StyledProperty<IBrush> StrokeProperty =
-            AvaloniaProperty.Register<TextDecoration, IBrush>(nameof(Stroke));
+        public static readonly StyledProperty<IBrush?> StrokeProperty =
+            AvaloniaProperty.Register<TextDecoration, IBrush?>(nameof(Stroke));
 
         /// <summary>
         /// Defines the <see cref="StrokeThicknessUnit"/> property.
@@ -34,8 +34,8 @@ namespace Avalonia.Media
         /// <summary>
         /// Defines the <see cref="StrokeDashArray"/> property.
         /// </summary>
-        public static readonly StyledProperty<AvaloniaList<double>> StrokeDashArrayProperty =
-            AvaloniaProperty.Register<TextDecoration, AvaloniaList<double>>(nameof(StrokeDashArray));
+        public static readonly StyledProperty<AvaloniaList<double>?> StrokeDashArrayProperty =
+            AvaloniaProperty.Register<TextDecoration, AvaloniaList<double>?>(nameof(StrokeDashArray));
 
         /// <summary>
         /// Defines the <see cref="StrokeDashOffset"/> property.
@@ -82,7 +82,7 @@ namespace Avalonia.Media
         /// <summary>
         /// Gets or sets the <see cref="IBrush"/> that specifies how the <see cref="TextDecoration"/> is painted.
         /// </summary>
-        public IBrush Stroke
+        public IBrush? Stroke
         {
             get { return GetValue(StrokeProperty); }
             set { SetValue(StrokeProperty, value); }
@@ -101,7 +101,7 @@ namespace Avalonia.Media
         /// Gets or sets a collection of <see cref="double"/> values that indicate the pattern of dashes and gaps
         /// that is used to draw the <see cref="TextDecoration"/>.
         /// </summary>
-        public AvaloniaList<double> StrokeDashArray
+        public AvaloniaList<double>? StrokeDashArray
         {
             get { return GetValue(StrokeDashArrayProperty); }
             set { SetValue(StrokeDashArrayProperty, value); }
@@ -220,7 +220,7 @@ namespace Avalonia.Media
 
                 var intersections = glyphRun.PlatformImpl.Item.GetIntersections((float)(thickness * 0.5d - offsetY), (float)(thickness * 1.5d - offsetY));
 
-                if (intersections != null && intersections.Count > 0)
+                if (intersections.Count > 0)
                 {
                     var last = baselineOrigin.X;
                     var finalPos = last + glyphRun.Size.Width;

--- a/src/Avalonia.Base/Media/VisualBrush.cs
+++ b/src/Avalonia.Base/Media/VisualBrush.cs
@@ -1,5 +1,4 @@
 using Avalonia.Media.Immutable;
-using Avalonia.VisualTree;
 
 namespace Avalonia.Media
 {
@@ -11,8 +10,8 @@ namespace Avalonia.Media
         /// <summary>
         /// Defines the <see cref="Visual"/> property.
         /// </summary>
-        public static readonly StyledProperty<Visual> VisualProperty =
-            AvaloniaProperty.Register<VisualBrush, Visual>(nameof(Visual));
+        public static readonly StyledProperty<Visual?> VisualProperty =
+            AvaloniaProperty.Register<VisualBrush, Visual?>(nameof(Visual));
 
         static VisualBrush()
         {
@@ -38,7 +37,7 @@ namespace Avalonia.Media
         /// <summary>
         /// Gets or sets the visual to draw.
         /// </summary>
-        public Visual Visual
+        public Visual? Visual
         {
             get { return GetValue(VisualProperty); }
             set { SetValue(VisualProperty, value); }

--- a/src/Avalonia.Base/Platform/IDrawingContextImpl.cs
+++ b/src/Avalonia.Base/Platform/IDrawingContextImpl.cs
@@ -49,7 +49,7 @@ namespace Avalonia.Platform
         /// <param name="pen">The stroke pen.</param>
         /// <param name="p1">The first point of the line.</param>
         /// <param name="p2">The second point of the line.</param>
-        void DrawLine(IPen pen, Point p1, Point p2);
+        void DrawLine(IPen? pen, Point p1, Point p2);
 
         /// <summary>
         /// Draws a geometry.
@@ -91,7 +91,7 @@ namespace Avalonia.Platform
         /// </summary>
         /// <param name="foreground">The foreground.</param>
         /// <param name="glyphRun">The glyph run.</param>
-        void DrawGlyphRun(IBrush foreground, IRef<IGlyphRunImpl> glyphRun);
+        void DrawGlyphRun(IBrush? foreground, IRef<IGlyphRunImpl> glyphRun);
 
         /// <summary>
         /// Creates a new <see cref="IRenderTargetBitmapImpl"/> that can be used as a render layer

--- a/src/Avalonia.Base/Rendering/Composition/Animations/CompositionAnimation.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Animations/CompositionAnimation.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Rendering.Composition.Animations
     public abstract class CompositionAnimation : CompositionObject,  ICompositionAnimationBase
     {
         private readonly CompositionPropertySet _propertySet;
-        internal CompositionAnimation(Compositor compositor) : base(compositor, null!)
+        internal CompositionAnimation(Compositor compositor) : base(compositor, null)
         {
             _propertySet = new CompositionPropertySet(compositor);
         }

--- a/src/Avalonia.Base/Rendering/Composition/Animations/CompositionAnimationGroup.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Animations/CompositionAnimationGroup.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Rendering.Composition.Animations
         public void Remove(CompositionAnimation value) => Animations.Remove(value);
         public void RemoveAll() => Animations.Clear();
 
-        public CompositionAnimationGroup(Compositor compositor) : base(compositor, null!)
+        public CompositionAnimationGroup(Compositor compositor) : base(compositor, null)
         {
         }
     }

--- a/src/Avalonia.Base/Rendering/Composition/Animations/ImplicitAnimationCollection.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Animations/ImplicitAnimationCollection.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Rendering.Composition.Animations
     {
         private Dictionary<string, ICompositionAnimationBase> _inner = new Dictionary<string, ICompositionAnimationBase>();
         private IDictionary<string, ICompositionAnimationBase> _innerface;
-        internal ImplicitAnimationCollection(Compositor compositor) : base(compositor, null!)
+        internal ImplicitAnimationCollection(Compositor compositor) : base(compositor, null)
         {
             _innerface = _inner;
         }

--- a/src/Avalonia.Base/Rendering/Composition/CompositionDrawingSurface.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositionDrawingSurface.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using Avalonia.Rendering.Composition.Server;
 using Avalonia.Threading;
@@ -7,7 +6,7 @@ namespace Avalonia.Rendering.Composition;
 
 public class CompositionDrawingSurface : CompositionSurface
 {
-    internal new ServerCompositionDrawingSurface Server => (ServerCompositionDrawingSurface)base.Server;
+    internal new ServerCompositionDrawingSurface Server => (ServerCompositionDrawingSurface)base.Server!;
     internal CompositionDrawingSurface(Compositor compositor) : base(compositor, new ServerCompositionDrawingSurface(compositor.Server))
     {
     }

--- a/src/Avalonia.Base/Rendering/Composition/CompositionObject.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositionObject.cs
@@ -22,7 +22,7 @@ namespace Avalonia.Rendering.Composition
         public ImplicitAnimationCollection? ImplicitAnimations { get; set; }
 
         private protected InlineDictionary<CompositionProperty, IAnimationInstance> PendingAnimations;
-        internal CompositionObject(Compositor compositor, ServerObject server)
+        internal CompositionObject(Compositor compositor, ServerObject? server)
         {
             Compositor = compositor;
             Server = server;
@@ -32,7 +32,7 @@ namespace Avalonia.Rendering.Composition
         /// The associated Compositor
         /// </summary>
         public Compositor Compositor { get; }
-        internal ServerObject Server { get; }
+        internal ServerObject? Server { get; }
         public bool IsDisposed { get; private set; }
         private bool _registeredForSerialization;
 

--- a/src/Avalonia.Base/Rendering/Composition/CompositionPropertySet.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositionPropertySet.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Rendering.Composition
         private readonly Dictionary<string, ExpressionVariant> _variants = new Dictionary<string, ExpressionVariant>();
         private readonly Dictionary<string, CompositionObject> _objects = new Dictionary<string, CompositionObject>();
         
-        internal CompositionPropertySet(Compositor compositor) : base(compositor, null!)
+        internal CompositionPropertySet(Compositor compositor) : base(compositor, null)
         {
         }
 

--- a/src/Avalonia.Base/Rendering/Composition/Drawing/CompositionDrawingContext.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Drawing/CompositionDrawingContext.cs
@@ -88,8 +88,13 @@ internal class CompositionDrawingContext : IDrawingContextImpl, IDrawingContextW
     }
 
     /// <inheritdoc/>
-    public void DrawLine(IPen pen, Point p1, Point p2)
+    public void DrawLine(IPen? pen, Point p1, Point p2)
     {
+        if (pen is null)
+        {
+            return;
+        }
+
         var next = NextDrawAs<LineNode>();
 
         if (next == null || !next.Item.Equals(Transform, pen, p1, p2))
@@ -159,8 +164,13 @@ internal class CompositionDrawingContext : IDrawingContextImpl, IDrawingContextW
     public object? GetFeature(Type t) => null;
 
     /// <inheritdoc/>
-    public void DrawGlyphRun(IBrush foreground, IRef<IGlyphRunImpl> glyphRun)
+    public void DrawGlyphRun(IBrush? foreground, IRef<IGlyphRunImpl> glyphRun)
     {
+        if (foreground is null)
+        {
+            return;
+        }
+
         var next = NextDrawAs<GlyphRunNode>();
 
         if (next == null || !next.Item.Equals(Transform, foreground, glyphRun))

--- a/src/Avalonia.Base/Rendering/Composition/Expressions/Expression.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Expressions/Expression.cs
@@ -165,8 +165,6 @@ namespace Avalonia.Rendering.Composition.Expressions
         
         public override ExpressionVariant Evaluate(ref ExpressionEvaluationContext context)
         {
-            if (context.ForeignFunctionInterface == null)
-                return default;
             var args = new List<ExpressionVariant>();
             foreach (var expr in Parameters)
                 args.Add(expr.Evaluate(ref context));

--- a/src/Avalonia.Base/Rendering/Composition/Expressions/ExpressionEvaluationContext.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Expressions/ExpressionEvaluationContext.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Avalonia.Rendering.Composition.Server;
 
 // Special license applies <see href="https://raw.githubusercontent.com/AvaloniaUI/Avalonia/master/src/Avalonia.Base/Rendering/Composition/License.md">License.md</see>
 

--- a/src/Avalonia.Base/Rendering/Composition/Server/DrawingContextProxy.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/DrawingContextProxy.cs
@@ -66,7 +66,7 @@ internal class CompositorDrawingContextProxy : IDrawingContextImpl, IDrawingCont
         _impl.DrawBitmap(source, opacityMask, opacityMaskRect, destRect);
     }
 
-    public void DrawLine(IPen pen, Point p1, Point p2)
+    public void DrawLine(IPen? pen, Point p1, Point p2)
     {
         _impl.DrawLine(pen, p1, p2);
     }
@@ -86,7 +86,7 @@ internal class CompositorDrawingContextProxy : IDrawingContextImpl, IDrawingCont
         _impl.DrawEllipse(brush, pen, rect);
     }
 
-    public void DrawGlyphRun(IBrush foreground, IRef<IGlyphRunImpl> glyphRun)
+    public void DrawGlyphRun(IBrush? foreground, IRef<IGlyphRunImpl> glyphRun)
     {
         _impl.DrawGlyphRun(foreground, glyphRun);
     }

--- a/src/Avalonia.Base/Rendering/ImmediateRenderer.cs
+++ b/src/Avalonia.Base/Rendering/ImmediateRenderer.cs
@@ -48,8 +48,10 @@ namespace Avalonia.Rendering
         /// <inheritdoc/>
         void IVisualBrushRenderer.RenderVisualBrush(IDrawingContextImpl context, IVisualBrush brush)
         {
-            var visual = brush.Visual;
-            Render(new DrawingContext(context), visual, visual.Bounds);
+            if (brush.Visual is { } visual)
+            {
+                Render(new DrawingContext(context), visual, visual.Bounds);
+            }
         }
 
         internal static void Render(Visual visual, DrawingContext context, bool updateTransformedBounds)

--- a/src/Avalonia.Base/Rendering/SceneGraph/ExperimentalAcrylicNode.cs
+++ b/src/Avalonia.Base/Rendering/SceneGraph/ExperimentalAcrylicNode.cs
@@ -80,11 +80,8 @@ namespace Avalonia.Rendering.SceneGraph
             {
                 p *= Transform.Invert();
 
-                if (Material != null)
-                {
-                    var rect = Rect.Rect;
-                    return rect.ContainsExclusive(p);
-                }
+                var rect = Rect.Rect;
+                return rect.ContainsExclusive(p);
             }
 
             return false;

--- a/src/Avalonia.Base/Utilities/TypeUtilities.cs
+++ b/src/Avalonia.Base/Utilities/TypeUtilities.cs
@@ -212,7 +212,7 @@ namespace Avalonia.Utilities
 
             var toTypeConverter = TypeDescriptor.GetConverter(toUnderl);
 
-            if (toTypeConverter.CanConvertFrom(from) == true)
+            if (toTypeConverter.CanConvertFrom(from))
             {
                 result = toTypeConverter.ConvertFrom(null, culture, value);
                 return true;
@@ -220,7 +220,7 @@ namespace Avalonia.Utilities
 
             var fromTypeConverter = TypeDescriptor.GetConverter(from);
 
-            if (fromTypeConverter.CanConvertTo(toUnderl) == true)
+            if (fromTypeConverter.CanConvertTo(toUnderl))
             {
                 result = fromTypeConverter.ConvertTo(null, culture, value, toUnderl);
                 return true;
@@ -329,7 +329,7 @@ namespace Avalonia.Utilities
         }
 
         [RequiresUnreferencedCode(TrimmingMessages.ImplicitTypeConvertionRequiresUnreferencedCodeMessage)]
-        public static T ConvertImplicit<T>(object value)
+        public static T ConvertImplicit<T>(object? value)
         {
             if (TryConvertImplicit(typeof(T), value, out var result))
             {
@@ -369,11 +369,6 @@ namespace Avalonia.Utilities
         /// </remarks>
         public static bool IsNumeric(Type type)
         {
-            if (type == null)
-            {
-                return false;
-            }
-
             var underlyingType = Nullable.GetUnderlyingType(type);
 
             if (underlyingType != null)

--- a/src/Avalonia.Base/Visual.cs
+++ b/src/Avalonia.Base/Visual.cs
@@ -483,17 +483,13 @@ namespace Avalonia
                 parent.HasNonUniformZIndexChildren = true;
 
             var visualChildren = VisualChildren;
+            var visualChildrenCount = visualChildren.Count;
 
-            if (visualChildren != null)
+            for (var i = 0; i < visualChildrenCount; i++)
             {
-                var visualChildrenCount = visualChildren.Count;
-
-                for (var i = 0; i < visualChildrenCount; i++)
+                if (visualChildren[i] is { } child)
                 {
-                    if (visualChildren[i] is Visual child)
-                    {
-                        child.OnAttachedToVisualTreeCore(e);
-                    }
+                    child.OnAttachedToVisualTreeCore(e);
                 }
             }
         }
@@ -543,17 +539,13 @@ namespace Avalonia
             e.Root?.Renderer?.AddDirty(this);
 
             var visualChildren = VisualChildren;
+            var visualChildrenCount = visualChildren.Count;
 
-            if (visualChildren != null)
+            for (var i = 0; i < visualChildrenCount; i++)
             {
-                var visualChildrenCount = visualChildren.Count;
-
-                for (var i = 0; i < visualChildrenCount; i++)
+                if (visualChildren[i] is { } child)
                 {
-                    if (visualChildren[i] is Visual child)
-                    {
-                        child.OnDetachedFromVisualTreeCore(e);
-                    }
+                    child.OnDetachedFromVisualTreeCore(e);
                 }
             }
         }

--- a/src/Avalonia.Base/VisualTree/VisualExtensions.cs
+++ b/src/Avalonia.Base/VisualTree/VisualExtensions.cs
@@ -46,7 +46,7 @@ namespace Avalonia.VisualTree
             Visual? v = visual ?? throw new ArgumentNullException(nameof(visual));
             var result = 0;
 
-            v = v?.VisualParent;
+            v = v.VisualParent;
 
             while (v != null)
             {
@@ -64,16 +64,12 @@ namespace Avalonia.VisualTree
         /// <param name="visual">The first visual.</param>
         /// <param name="target">The second visual.</param>
         /// <returns>The common ancestor, or null if not found.</returns>
-        public static Visual? FindCommonVisualAncestor(this Visual visual, Visual target)
+        public static Visual? FindCommonVisualAncestor(this Visual? visual, Visual? target)
         {
-            Visual? v = visual ?? throw new ArgumentNullException(nameof(visual));
-
-            if (target is null)
+            if (visual is null || target is null)
             {
                 return null;
             }
-
-            Visual? t = target;
 
             void GoUpwards(ref Visual? node, int count)
             {
@@ -82,6 +78,9 @@ namespace Avalonia.VisualTree
                     node = node?.VisualParent;
                 }
             }
+
+            Visual? v = visual;
+            Visual? t = target;
 
             // We want to find lowest node first, then make sure that both nodes are at the same height.
             // By doing that we can sometimes find out that other node is our lowest common ancestor.
@@ -144,7 +143,7 @@ namespace Avalonia.VisualTree
         /// <param name="visual">The visual.</param>
         /// <param name="includeSelf">If given visual should be included in search.</param>
         /// <returns>First ancestor of given type.</returns>
-        public static T? FindAncestorOfType<T>(this Visual visual, bool includeSelf = false) where T : class
+        public static T? FindAncestorOfType<T>(this Visual? visual, bool includeSelf = false) where T : class
         {
             if (visual is null)
             {
@@ -173,7 +172,7 @@ namespace Avalonia.VisualTree
         /// <param name="visual">The visual.</param>
         /// <param name="includeSelf">If given visual should be included in search.</param>
         /// <returns>First descendant of given type.</returns>
-        public static T? FindDescendantOfType<T>(this Visual visual, bool includeSelf = false) where T : class
+        public static T? FindDescendantOfType<T>(this Visual? visual, bool includeSelf = false) where T : class
         {
             if (visual is null)
             {
@@ -392,7 +391,7 @@ namespace Avalonia.VisualTree
         /// True if <paramref name="visual"/> is an ancestor of <paramref name="target"/>;
         /// otherwise false.
         /// </returns>
-        public static bool IsVisualAncestorOf(this Visual visual, Visual target)
+        public static bool IsVisualAncestorOf(this Visual? visual, Visual? target)
         {
             Visual? current = target?.VisualParent;
 

--- a/src/Avalonia.Headless/HeadlessPlatformRenderInterface.cs
+++ b/src/Avalonia.Headless/HeadlessPlatformRenderInterface.cs
@@ -141,9 +141,7 @@ namespace Avalonia.Headless
             }
 
             public IReadOnlyList<float> GetIntersections(float lowerBound, float upperBound)
-            {
-                return null;
-            }
+                => Array.Empty<float>();
         }
 
         class HeadlessGeometryStub : IGeometryImpl

--- a/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
+++ b/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
@@ -208,6 +208,12 @@ namespace Avalonia.Skia
         public void DrawLine(IPen pen, Point p1, Point p2)
         {
             CheckLease();
+
+            if (pen is null)
+            {
+                return;
+            }
+
             using (var paint = CreatePaint(_strokePaint, pen, new Size(Math.Abs(p2.X - p1.X), Math.Abs(p2.Y - p1.Y))))
             {
                 if (paint.Paint is object)
@@ -495,6 +501,12 @@ namespace Avalonia.Skia
         public void DrawGlyphRun(IBrush foreground, IRef<IGlyphRunImpl> glyphRun)
         {
             CheckLease();
+
+            if (foreground is null)
+            {
+                return;
+            }
+
             using (var paintWrapper = CreatePaint(_fillPaint, foreground, glyphRun.Item.Size))
             {
                 var glyphRunImpl = (GlyphRunImpl)glyphRun.Item;

--- a/src/Windows/Avalonia.Direct2D1/Media/GlyphRunImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/GlyphRunImpl.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Avalonia.Platform;
 using SharpDX.DirectWrite;
 
@@ -25,8 +26,6 @@ namespace Avalonia.Direct2D1.Media
         }
 
         public IReadOnlyList<float> GetIntersections(float lowerBound, float upperBound)
-        {
-            return null;
-        }
+            => Array.Empty<float>();
     }
 }

--- a/tests/Avalonia.UnitTests/MockGlyphRun.cs
+++ b/tests/Avalonia.UnitTests/MockGlyphRun.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Avalonia.Media.TextFormatting;
 using Avalonia.Platform;
 
@@ -24,12 +25,9 @@ namespace Avalonia.UnitTests
 
         public void Dispose()
         {
-            
         }
 
         public IReadOnlyList<float> GetIntersections(float lowerBound, float upperBound)
-        {
-            return null;
-        }
+            => Array.Empty<float>();
     }
 }


### PR DESCRIPTION
Fixes various places in `Avalonia.Base` where usages weren't matching nullability annotations:
- Some reference type properties backed by an `AvaloniaProperty` are now nullable
- Some parameters where `null` was accepted are now nullable
- Null checks have been removed where variables definitely couldn't be null

Notable changes:
- `AvaloniaObject.GetDiagnosticInternal` has less branches: some simply couldn't be taken with `_values` never being null. `AvaloniaPropertyValue.Diagnostic` isn't set anymore in the direct property case as it isn't set in any other case. I assume it's a leftover from a previous implementation as this property isn't used anywhere.
- `WeakEvent`: completely removed the unused inner `Entry` type instead of fixing it.
- `IDrawingContextImpl`: `DrawLine` and `DrawGlyphRun` can take null pen/brushes. Some implementations were accepting it (Direct2D1, DrawingGroup), some weren't (Skia). Added checks in Skia to draw nothing in this case. This is consistent with `DrawRectangle`/`DrawGeometry`.
