### PR TITLE
Apply template before applying control theme to children

### DIFF
--- a/src/Avalonia.Controls/Primitives/TemplatedControl.cs
+++ b/src/Avalonia.Controls/Primitives/TemplatedControl.cs
@@ -399,6 +399,7 @@ namespace Avalonia.Controls.Primitives
         private protected override void OnControlThemeChanged()
         {
             base.OnControlThemeChanged();
+            ApplyTemplate();
 
             var count = VisualChildren.Count;
             for (var i = 0; i < count; ++i)


### PR DESCRIPTION
## What does the pull request do?

Apply the fix proposed in https://github.com/AvaloniaUI/Avalonia/issues/10226#issuecomment-1421052366. I can add unit tests if needed.

## What is the current behavior?

Expander styles broken in Simple Theme, see https://github.com/AvaloniaUI/Avalonia/issues/10226#issue-1571433120.

## What is the updated/expected behavior with this PR?

Expander styles work as expected.

## How was the solution implemented (if it's not obvious)?

Described in https://github.com/AvaloniaUI/Avalonia/issues/10226#issuecomment-1421052366.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

Technically it's a breaking change, but this code is recent so it shouldn't be a problem.

## Fixed issues

Fixes #10226
