### PR TITLE
Dev tools: fixed wrong HandledBy for events

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/EventTreeNode.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/EventTreeNode.cs
@@ -115,7 +115,7 @@ namespace Avalonia.Diagnostics.ViewModels
                     var link = _currentEvent.EventChain[linkIndex];
 
                     link.Handled = true;
-                    _currentEvent.HandledBy = link;
+                    _currentEvent.HandledBy ??= link;
                 }
             }
 

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/EventsPageView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/EventsPageView.xaml
@@ -29,6 +29,7 @@
 
     <Style Selector="ListBoxItem.handled" >
       <Setter Property="Background" Value="#d9ffdc" />
+      <Setter Property="Foreground" Value="Black" />
     </Style>
   </UserControl.Styles>
 


### PR DESCRIPTION
In the dev tools event pane, fixes _Handled by_ to display the correct control which handled an event.
Before, it always displayed the top level control.
Two chars fix!

Also changes the handled event foreground, which wasn't readable with the dark theme. More chars though :(