### PR TITLE
Fix ComboBox keyboard selection when drop-down closed

### DIFF
--- a/.ncrunch/Avalonia.UnitTests.v3.ncrunchproject
+++ b/.ncrunch/Avalonia.UnitTests.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <XUnit2Enabled>False</XUnit2Enabled>
+  </Settings>
+</ProjectConfiguration>

--- a/.ncrunch/GpuInterop.v3.ncrunchproject
+++ b/.ncrunch/GpuInterop.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/Avalonia.Desktop.slnf
+++ b/Avalonia.Desktop.slnf
@@ -45,6 +45,7 @@
       "tests\\Avalonia.Base.UnitTests\\Avalonia.Base.UnitTests.csproj",
       "tests\\Avalonia.Benchmarks\\Avalonia.Benchmarks.csproj",
       "tests\\Avalonia.Controls.DataGrid.UnitTests\\Avalonia.Controls.DataGrid.UnitTests.csproj",
+      "tests\\Avalonia.Controls.ItemsRepeater.UnitTests\\Avalonia.Controls.ItemsRepeater.UnitTests.csproj",
       "tests\\Avalonia.Controls.UnitTests\\Avalonia.Controls.UnitTests.csproj",
       "tests\\Avalonia.DesignerSupport.TestApp\\Avalonia.DesignerSupport.TestApp.csproj",
       "tests\\Avalonia.DesignerSupport.Tests\\Avalonia.DesignerSupport.Tests.csproj",

--- a/samples/IntegrationTestApp/MainWindow.axaml
+++ b/samples/IntegrationTestApp/MainWindow.axaml
@@ -70,6 +70,7 @@
             <ComboBoxItem>Item 0</ComboBoxItem>
             <ComboBoxItem>Item 1</ComboBoxItem>
           </ComboBox>
+          <CheckBox Name="ComboBoxWrapSelection" IsChecked="{Binding #BasicComboBox.WrapSelection}">Wrap Selection</CheckBox>
           <Button Name="ComboBoxSelectionClear">Clear Selection</Button>
           <Button Name="ComboBoxSelectFirst">Select First</Button>
         </StackPanel>

--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Linq;
 using Avalonia.Automation.Peers;
-using Avalonia.Reactive;
-using Avalonia.Controls.Generators;
-using Avalonia.Controls.Mixins;
-using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Templates;
@@ -12,8 +9,8 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Reactive;
 using Avalonia.VisualTree;
-using Avalonia.Controls.Metadata;
 
 namespace Avalonia.Controls
 {
@@ -482,7 +479,22 @@ namespace Avalonia.Controls
         {
             if (ItemCount >= 1)
             {
-                MoveSelection(NavigationDirection.Next, WrapSelection);
+                if (IsDropDownOpen)
+                {
+                    MoveSelection(NavigationDirection.Next, WrapSelection);
+                }
+                else
+                {
+                    var index = SelectedIndex + 1;
+                    var count = ItemCount;
+
+                    if (WrapSelection)
+                        index %= count;
+                    else
+                        index = Math.Min(index, count - 1);
+
+                    SelectedIndex = index;
+                }
             }
         }
 
@@ -490,7 +502,27 @@ namespace Avalonia.Controls
         {
             if (ItemCount >= 1)
             {
-                MoveSelection(NavigationDirection.Previous, WrapSelection);
+                if (IsDropDownOpen)
+                {
+                    MoveSelection(NavigationDirection.Previous, WrapSelection);
+                }
+                else
+                {
+                    var index = SelectedIndex - 1;
+                    var count = ItemCount;
+
+                    if (WrapSelection)
+                    {
+                        if (index < 0)
+                            index += count;
+                    }
+                    else
+                    {
+                        index = Math.Max(index, 0);
+                    }
+
+                    SelectedIndex = index;
+                }
             }
         }
     }

--- a/tests/Avalonia.IntegrationTests.Appium/ComboBoxTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/ComboBoxTests.cs
@@ -47,7 +47,64 @@ namespace Avalonia.IntegrationTests.Appium
         }
 
         [PlatformFact(TestPlatforms.Windows)]
-        public void Can_Change_Selection_With_Keyboard()
+        public void Can_Change_Selection_With_Keyboard_When_Closed()
+        {
+            var comboBox = _session.FindElementByAccessibilityId("BasicComboBox");
+            var wrap = _session.FindElementByAccessibilityId("ComboBoxWrapSelection");
+
+            if (wrap.GetIsChecked() != false)
+                wrap.Click();
+
+            _session.FindElementByAccessibilityId("ComboBoxSelectionClear").Click();
+
+            comboBox.SendKeys(Keys.ArrowDown);
+            Assert.Equal("Item 0", comboBox.GetComboBoxValue());
+
+            comboBox.SendKeys(Keys.ArrowDown);
+            Assert.Equal("Item 1", comboBox.GetComboBoxValue());
+
+            comboBox.SendKeys(Keys.ArrowDown);
+            Assert.Equal("Item 1", comboBox.GetComboBoxValue());
+
+            comboBox.SendKeys(Keys.ArrowUp);
+            Assert.Equal("Item 0", comboBox.GetComboBoxValue());
+
+            comboBox.SendKeys(Keys.ArrowUp);
+            Assert.Equal("Item 0", comboBox.GetComboBoxValue());
+        }
+
+        [PlatformFact(TestPlatforms.Windows)]
+        public void Can_Change_Wrapping_Selection_With_Keyboard_When_Closed()
+        {
+            var comboBox = _session.FindElementByAccessibilityId("BasicComboBox");
+            var wrap = _session.FindElementByAccessibilityId("ComboBoxWrapSelection");
+
+            if (wrap.GetIsChecked() != true)
+                wrap.Click();
+
+            _session.FindElementByAccessibilityId("ComboBoxSelectionClear").Click();
+
+            comboBox.SendKeys(Keys.ArrowDown);
+            Assert.Equal("Item 0", comboBox.GetComboBoxValue());
+
+            comboBox.SendKeys(Keys.ArrowDown);
+            Assert.Equal("Item 1", comboBox.GetComboBoxValue());
+
+            comboBox.SendKeys(Keys.ArrowDown);
+            Assert.Equal("Item 0", comboBox.GetComboBoxValue());
+
+            comboBox.SendKeys(Keys.ArrowDown);
+            Assert.Equal("Item 1", comboBox.GetComboBoxValue());
+
+            comboBox.SendKeys(Keys.ArrowUp);
+            Assert.Equal("Item 0", comboBox.GetComboBoxValue());
+
+            comboBox.SendKeys(Keys.ArrowUp);
+            Assert.Equal("Item 1", comboBox.GetComboBoxValue());
+        }
+
+        [PlatformFact(TestPlatforms.Windows)]
+        public void Can_Change_Selection_When_Open_With_Keyboard()
         {
             var comboBox = _session.FindElementByAccessibilityId("BasicComboBox");
 
@@ -64,7 +121,7 @@ namespace Avalonia.IntegrationTests.Appium
         }
 
         [PlatformFact(TestPlatforms.Windows)]
-        public void Can_Change_Selection_With_Keyboard_From_Unselected()
+        public void Can_Change_Selection_When_Open_With_Keyboard_From_Unselected()
         {
             var comboBox = _session.FindElementByAccessibilityId("BasicComboBox");
 


### PR DESCRIPTION
## What does the pull request do?

When a `ComboBox` is closed, then the existing `MoveSelection` method doesn't work because the popup containing the `ItemsPresenter` is not visible, and so has no realized items.

Instead revert to simple index-based selection logic when the dropdown is closed.

Also added a couple of integration tests for this case.

## Fixed issues

Fixes #10232