### PR TITLE
Windows interop fixes

### DIFF
--- a/samples/ControlCatalog/Pages/CustomDrawingExampleControl.cs
+++ b/samples/ControlCatalog/Pages/CustomDrawingExampleControl.cs
@@ -59,10 +59,12 @@ namespace ControlCatalog.Pages
 
             };
             StreamGeometry sg = new StreamGeometry();
-            var cntx = sg.Open();
-            cntx.BeginFigure(new Point(-25.0d, -10.0d), false);
-            cntx.ArcTo(new Point(25.0d, -10.0d), new Size(10.0d, 10.0d), 0.0d, false, SweepDirection.Clockwise);
-            cntx.EndFigure(true);
+            using (var cntx = sg.Open())
+            {
+                cntx.BeginFigure(new Point(-25.0d, -10.0d), false);
+                cntx.ArcTo(new Point(25.0d, -10.0d), new Size(10.0d, 10.0d), 0.0d, false, SweepDirection.Clockwise);
+                cntx.EndFigure(true);
+            }
             _smileGeometry = sg.Clone();
         }
 

--- a/samples/interop/WindowsInteropTest/Program.cs
+++ b/samples/interop/WindowsInteropTest/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Avalonia.Controls;
 using ControlCatalog;
 using Avalonia;
 
@@ -15,7 +14,15 @@ namespace WindowsInteropTest
         {
             System.Windows.Forms.Application.EnableVisualStyles();
             System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
-            AppBuilder.Configure<App>().UseWin32().UseDirect2D1().SetupWithoutStarting();
+            AppBuilder.Configure<App>()
+                .UseWin32()
+                .UseDirect2D1()
+                .With(new Win32PlatformOptions
+                {
+                    UseWindowsUIComposition = false,
+                    ShouldRenderOnUIThread = true // necessary for WPF
+                })
+                .SetupWithoutStarting();
             System.Windows.Forms.Application.Run(new SelectorForm());
         }
     }

--- a/samples/interop/WindowsInteropTest/WindowsInteropTest.csproj
+++ b/samples/interop/WindowsInteropTest/WindowsInteropTest.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net461</TargetFramework>
-
+    <PlatformTarget>x64</PlatformTarget>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
@@ -10,9 +10,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Avalonia.Diagnostics\Avalonia.Diagnostics.csproj" />
     <ProjectReference Include="..\..\..\src\Windows\Avalonia.Win32.Interop\Avalonia.Win32.Interop.csproj" />
-    <ProjectReference Include="..\..\ControlCatalog\ControlCatalog.csproj">
-      <Project>{d0a739b9-3c68-4ba6-a328-41606954b6bd}</Project>
-      <Name>ControlCatalog</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\..\ControlCatalog\ControlCatalog.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Avalonia.Base/Rendering/DefaultRenderTimer.cs
+++ b/src/Avalonia.Base/Rendering/DefaultRenderTimer.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
-using System.Threading.Tasks;
 using Avalonia.Platform;
 
 namespace Avalonia.Rendering
@@ -59,7 +57,8 @@ namespace Avalonia.Rendering
             }
         }
 
-        public bool RunsInBackground => true;
+        /// <inheritdoc />
+        public virtual bool RunsInBackground => true;
 
         /// <summary>
         /// Starts the timer.

--- a/src/Avalonia.Base/Rendering/IRenderLoop.cs
+++ b/src/Avalonia.Base/Rendering/IRenderLoop.cs
@@ -27,7 +27,10 @@ namespace Avalonia.Rendering
         /// </summary>
         /// <param name="i">The update task.</param>
         void Remove(IRenderLoopTask i);
-        
+
+        /// <summary>
+        /// Indicates if the rendering is done on a non-UI thread.
+        /// </summary>
         bool RunsInBackground { get; }
     }
 }

--- a/src/Avalonia.Base/Rendering/RenderLoop.cs
+++ b/src/Avalonia.Base/Rendering/RenderLoop.cs
@@ -87,6 +87,7 @@ namespace Avalonia.Rendering
             }
         }
 
+        /// <inheritdoc />
         public bool RunsInBackground => Timer.RunsInBackground;
 
         private void TimerTick(TimeSpan time)

--- a/src/Avalonia.Base/Rendering/UiThreadRenderTimer.cs
+++ b/src/Avalonia.Base/Rendering/UiThreadRenderTimer.cs
@@ -8,13 +8,20 @@ namespace Avalonia.Rendering
     /// <summary>
     /// Render timer that ticks on UI thread. Useful for debugging or bootstrapping on new platforms 
     /// </summary>
-    
     public class UiThreadRenderTimer : DefaultRenderTimer
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UiThreadRenderTimer"/> class.
+        /// </summary>
+        /// <param name="framesPerSecond">The number of frames per second at which the loop should run.</param>
         public UiThreadRenderTimer(int framesPerSecond) : base(framesPerSecond)
         {
         }
 
+        /// <inheritdoc />
+        public override bool RunsInBackground => false;
+
+        /// <inheritdoc />
         protected override IDisposable StartCore(Action<TimeSpan> tick)
         {
             bool cancelled = false;

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
@@ -45,13 +45,6 @@ namespace Avalonia.Win32.Interop.Wpf
                 ((FrameworkElement)PlatformImpl)?.InvalidateMeasure();
             }
 
-            protected override void HandleResized(Size clientSize, PlatformResizeReason reason)
-            {
-                ClientSize = clientSize;
-                LayoutManager.ExecuteLayoutPass();
-                Renderer?.Resized(clientSize);
-            }
-
             public Size AllocatedSize => ClientSize;
         }
 
@@ -223,7 +216,7 @@ namespace Avalonia.Win32.Interop.Wpf
                 (Key)e.Key,
                 GetModifiers(null)));
 
-        protected override void OnTextInput(TextCompositionEventArgs e) 
+        protected override void OnTextInput(TextCompositionEventArgs e)
             => _ttl.Input?.Invoke(new RawTextInputEventArgs(_keyboard, (uint) e.Timestamp, _inputRoot, e.Text));
 
         void ITopLevelImpl.SetCursor(ICursorImpl cursor)

--- a/src/Windows/Avalonia.Win32/TrayIconImpl.cs
+++ b/src/Windows/Avalonia.Win32/TrayIconImpl.cs
@@ -81,19 +81,18 @@ namespace Avalonia.Win32
 
         private void UpdateIcon(bool remove = false)
         {
-            var iconData = new NOTIFYICONDATA()
+            var iconData = new NOTIFYICONDATA
             {
                 hWnd = Win32Platform.Instance.Handle,
-                uID = _uniqueId,
-                uFlags = NIF.TIP | NIF.MESSAGE,
-                uCallbackMessage = (int)CustomWindowsMessage.WM_TRAYMOUSE,
-                hIcon = _icon?.HIcon ?? s_emptyIcon,
-                szTip = _tooltipText ?? ""
+                uID = _uniqueId
             };
 
             if (!remove)
             {
-                iconData.uFlags |= NIF.ICON;
+                iconData.uFlags = NIF.TIP | NIF.MESSAGE | NIF.ICON;
+                iconData.uCallbackMessage = (int)CustomWindowsMessage.WM_TRAYMOUSE;
+                iconData.hIcon = _icon?.HIcon ?? s_emptyIcon;
+                iconData.szTip = _tooltipText ?? "";
 
                 if (!_iconAdded)
                 {
@@ -107,6 +106,7 @@ namespace Avalonia.Win32
             }
             else
             {
+                iconData.uFlags = 0;
                 Shell_NotifyIcon(NIM.DELETE, iconData);
                 _iconAdded = false;
             }


### PR DESCRIPTION
The `WindowsInteropTest` sample wasn't working for several reasons, all fixed by this PR:

- The ControlCatalog's `CustomDrawingExampleControl` was crashing with the Direct2D1 renderer: a `StreamGeometry` was being cloned while being open, which is invalid.
- WindowsInteropTest had the 32bit native DLLs copied to the output for some reason, which can't be loaded by a 64bit host. Adjusted the `PlatformTarget` to `x64`, like in `ControlCatalog.Desktop`.
- WPF's `WriteableBitmap` must be accessed only on the UI thread. Added a new `Win32PlatformOptions.ShouldRenderOnUIThread` to use a `UiThreadRenderTimer` (also fixed `UiThreadRenderTimer.RunsInBackground` which should be `false`).
- The `WpfAvaloniaHost` had the wrong size, fixed by removing the `HandleResized` override.
- `TrayIconImpl`'s finalizer was throwing when exiting the sample because the tray icon removal was trying to access a disposed `Icon`. Fixed by not setting the `hIcon` at all when removing the icon.

Misc remarks:
- Should `UiThreadRenderTimer` be renamed to `UIThreadRenderTimer` for naming consistency (breaking change)?
- Technically WPF could still use a separate render thread by using a `Direct2DImageSurface`, synchronizing only the needed properties with it (size, scaling) and managing a D3D Device for the surface. I don't believe it's worth spending time on it: this PR basically restores the old immediate rendering behavior, which should be sufficient.