### PR TITLE
Make all Render overrides sealed

### DIFF
--- a/src/Avalonia.Controls/Border.cs
+++ b/src/Avalonia.Controls/Border.cs
@@ -225,7 +225,7 @@ namespace Avalonia.Controls
         /// Renders the control.
         /// </summary>
         /// <param name="context">The drawing context.</param>
-        public override void Render(DrawingContext context)
+        public sealed override void Render(DrawingContext context)
         {
             _borderRenderHelper.Render(context, Bounds.Size, LayoutThickness, CornerRadius, Background, BorderBrush,
                 BoxShadow, BorderDashOffset, BorderLineCap, BorderLineJoin, BorderDashArray);

--- a/src/Avalonia.Controls/ExperimentalAcrylicBorder.cs
+++ b/src/Avalonia.Controls/ExperimentalAcrylicBorder.cs
@@ -80,7 +80,7 @@ namespace Avalonia.Controls
             _subscription?.Dispose();
         }
 
-        public override void Render(DrawingContext context)
+        public sealed override void Render(DrawingContext context)
         {
             if (context.PlatformImpl is IDrawingContextWithAcrylicLikeSupport idc)
             {

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -3256,7 +3256,7 @@ namespace Avalonia.Controls
             /// <summary>
             /// UpdateRenderBounds.
             /// </summary>
-            public override void Render(DrawingContext drawingContext)
+            public sealed override void Render(DrawingContext drawingContext)
             {
                 var grid = this.GetVisualParent<Grid>();
 

--- a/src/Avalonia.Controls/Image.cs
+++ b/src/Avalonia.Controls/Image.cs
@@ -73,7 +73,7 @@ namespace Avalonia.Controls
         /// Renders the control.
         /// </summary>
         /// <param name="context">The drawing context.</param>
-        public override void Render(DrawingContext context)
+        public sealed override void Render(DrawingContext context)
         {
             var source = Source;
 

--- a/src/Avalonia.Controls/Panel.cs
+++ b/src/Avalonia.Controls/Panel.cs
@@ -68,7 +68,7 @@ namespace Avalonia.Controls
         /// Renders the visual to a <see cref="DrawingContext"/>.
         /// </summary>
         /// <param name="context">The drawing context.</param>
-        public override void Render(DrawingContext context)
+        public sealed override void Render(DrawingContext context)
         {
             var background = Background;
             if (background != null)

--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -534,7 +534,7 @@ namespace Avalonia.Controls.Presenters
         }
 
         /// <inheritdoc/>
-        public override void Render(DrawingContext context)
+        public sealed override void Render(DrawingContext context)
         {
             _borderRenderer.Render(context, Bounds.Size, LayoutThickness, CornerRadius, Background, BorderBrush,
                 BoxShadow);

--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -388,7 +388,7 @@ namespace Avalonia.Controls.Presenters
             TextLayout.Draw(context, new Point(left, top));
         }
 
-        public override void Render(DrawingContext context)
+        public sealed override void Render(DrawingContext context)
         {
             var selectionStart = SelectionStart;
             var selectionEnd = SelectionEnd;

--- a/src/Avalonia.Controls/Primitives/AccessText.cs
+++ b/src/Avalonia.Controls/Primitives/AccessText.cs
@@ -60,10 +60,9 @@ namespace Avalonia.Controls.Primitives
         /// Renders the <see cref="AccessText"/> to a drawing context.
         /// </summary>
         /// <param name="context">The drawing context.</param>
-        public override void Render(DrawingContext context)
+        protected internal override void RenderCore(DrawingContext context)
         {
-            base.Render(context);
-
+            base.RenderCore(context);
             int underscore = Text?.IndexOf('_') ?? -1;
 
             if (underscore != -1 && ShowAccessKey)

--- a/src/Avalonia.Controls/Remote/RemoteWidget.cs
+++ b/src/Avalonia.Controls/Remote/RemoteWidget.cs
@@ -69,7 +69,7 @@ namespace Avalonia.Controls.Remote
             base.ArrangeCore(finalRect);
         }
 
-        public override void Render(DrawingContext context)
+        public sealed override void Render(DrawingContext context)
         {
             if (_lastFrame != null && _lastFrame.Width != 0 && _lastFrame.Height != 0)
             {

--- a/src/Avalonia.Controls/Shapes/Shape.cs
+++ b/src/Avalonia.Controls/Shapes/Shape.cs
@@ -193,7 +193,7 @@ namespace Avalonia.Controls.Shapes
             set { SetValue(StrokeJoinProperty, value); }
         }
 
-        public override void Render(DrawingContext context)
+        public sealed override void Render(DrawingContext context)
         {
             var geometry = RenderedGeometry;
 

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -549,7 +549,13 @@ namespace Avalonia.Controls
         /// Renders the <see cref="TextBlock"/> to a drawing context.
         /// </summary>
         /// <param name="context">The drawing context.</param>
-        public override void Render(DrawingContext context)
+        public sealed override void Render(DrawingContext context)
+        {
+            RenderCore(context);
+        }
+
+        // Workaround to seal Render method, we need to make so because AccessText was overriding Render method which is sealed now.
+        internal protected virtual void RenderCore(DrawingContext context)
         {
             var background = Background;
 

--- a/src/Avalonia.Controls/TickBar.cs
+++ b/src/Avalonia.Controls/TickBar.cs
@@ -213,7 +213,7 @@ namespace Avalonia.Controls
         ///
         /// Brush that use to fill ticks is specified by Fill property.
         /// </summary>
-        public override void Render(DrawingContext dc)
+        public sealed override void Render(DrawingContext dc)
         {
             var size = new Size(Bounds.Width, Bounds.Height);
             var range = Maximum - Minimum;


### PR DESCRIPTION
## What does the pull request do?
This is needed because at some point we might want to change the way built-in primitives are rasterized

## Fixed issues
Fixes #10066 
