### PR TITLE
Nullable annotations for Avalonia.Win32

### DIFF
--- a/src/Avalonia.Base/Platform/IPlatformThreadingInterface.cs
+++ b/src/Avalonia.Base/Platform/IPlatformThreadingInterface.cs
@@ -26,6 +26,6 @@ namespace Avalonia.Platform
 
         bool CurrentThreadIsLoopThread { get; }
 
-        event Action<DispatcherPriority?> Signaled;
+        event Action<DispatcherPriority?>? Signaled;
     }
 }

--- a/src/Avalonia.Base/Platform/Storage/FilePickerFileType.cs
+++ b/src/Avalonia.Base/Platform/Storage/FilePickerFileType.cs
@@ -7,9 +7,9 @@ namespace Avalonia.Platform.Storage;
 /// </summary>
 public sealed class FilePickerFileType
 {
-    public FilePickerFileType(string name)
+    public FilePickerFileType(string? name)
     {
-        Name = name;
+        Name = name ?? string.Empty;
     }
 
     /// <summary>

--- a/src/Avalonia.Base/Rendering/IRenderTimer.cs
+++ b/src/Avalonia.Base/Rendering/IRenderTimer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using Avalonia.Metadata;
 
 namespace Avalonia.Rendering

--- a/src/Avalonia.Controls/Platform/IPlatformLifetimeEventsImpl.cs
+++ b/src/Avalonia.Controls/Platform/IPlatformLifetimeEventsImpl.cs
@@ -13,6 +13,6 @@ namespace Avalonia.Platform
         /// <remarks>
         /// Raised on on OSX via the Quit menu or right-clicking on the application icon and selecting Quit.
         /// </remarks>
-        event EventHandler<ShutdownRequestedEventArgs> ShutdownRequested;
+        event EventHandler<ShutdownRequestedEventArgs>? ShutdownRequested;
     }
 }

--- a/src/Avalonia.Controls/Platform/IWindowImpl.cs
+++ b/src/Avalonia.Controls/Platform/IWindowImpl.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Platform
         /// <summary>
         /// Gets or sets a method called when the minimized/maximized state of the window changes.
         /// </summary>
-        Action<WindowState> WindowStateChanged { get; set; }
+        Action<WindowState>? WindowStateChanged { get; set; }
 
         /// <summary>
         /// Sets the title of the window.
@@ -42,7 +42,7 @@ namespace Avalonia.Platform
         /// <summary>
         /// Called when a disabled window received input. Can be used to activate child windows.
         /// </summary>
-        Action GotInputWhenDisabled { get; set; }        
+        Action? GotInputWhenDisabled { get; set; }
 
         /// <summary>
         /// Enables or disables system window decorations (title bar, buttons, etc)
@@ -68,7 +68,7 @@ namespace Avalonia.Platform
         /// Gets or sets a method called before the underlying implementation is destroyed.
         /// Return true to prevent the underlying implementation from closing.
         /// </summary>
-        Func<WindowCloseReason, bool> Closing { get; set; }
+        Func<WindowCloseReason, bool>? Closing { get; set; }
 
         /// <summary>
         /// Gets a value to indicate if the platform was able to extend client area to non-client area.
@@ -78,7 +78,7 @@ namespace Avalonia.Platform
         /// <summary>
         /// Gets or Sets an action that is called whenever one of the extend client area properties changed.
         /// </summary>
-        Action<bool> ExtendClientAreaToDecorationsChanged { get; set; }
+        Action<bool>? ExtendClientAreaToDecorationsChanged { get; set; }
 
         /// <summary>
         /// Gets a flag that indicates if Managed decorations i.e. caption buttons are required.

--- a/src/Avalonia.Controls/WindowBase.cs
+++ b/src/Avalonia.Controls/WindowBase.cs
@@ -94,7 +94,7 @@ namespace Avalonia.Controls
             private set { SetAndRaise(IsActiveProperty, ref _isActive, value); }
         }
         
-        public Screens Screens { get; private set; }
+        public Screens Screens { get; }
 
         /// <summary>
         /// Gets or sets the owner of the window.

--- a/src/Windows/Avalonia.Win32/AngleOptions.cs
+++ b/src/Windows/Avalonia.Win32/AngleOptions.cs
@@ -17,6 +17,6 @@ namespace Avalonia.Win32
             new GlVersion(GlProfileType.OpenGLES, 2, 0)
         };
 
-        public IList<PlatformApi> AllowedPlatformApis { get; set; } = null;
+        public IList<PlatformApi>? AllowedPlatformApis { get; set; } = null;
     }
 }

--- a/src/Windows/Avalonia.Win32/Automation/AutomationNode.ExpandCollapse.cs
+++ b/src/Windows/Avalonia.Win32/Automation/AutomationNode.ExpandCollapse.cs
@@ -2,8 +2,6 @@
 using Avalonia.Automation.Provider;
 using UIA = Avalonia.Win32.Interop.Automation;
 
-#nullable enable
-
 namespace Avalonia.Win32.Automation
 {
     internal partial class AutomationNode : UIA.IExpandCollapseProvider

--- a/src/Windows/Avalonia.Win32/Automation/AutomationNode.RangeValue.cs
+++ b/src/Windows/Avalonia.Win32/Automation/AutomationNode.RangeValue.cs
@@ -1,8 +1,6 @@
 ﻿using Avalonia.Automation.Provider;
 using UIA = Avalonia.Win32.Interop.Automation;
 
-#nullable enable
-
 namespace Avalonia.Win32.Automation
 {
     internal partial class AutomationNode : UIA.IRangeValueProvider

--- a/src/Windows/Avalonia.Win32/Automation/AutomationNode.Scroll.cs
+++ b/src/Windows/Avalonia.Win32/Automation/AutomationNode.Scroll.cs
@@ -1,8 +1,6 @@
 ﻿using Avalonia.Automation.Provider;
 using UIA = Avalonia.Win32.Interop.Automation;
 
-#nullable enable
-
 namespace Avalonia.Win32.Automation
 {
     internal partial class AutomationNode : UIA.IScrollProvider, UIA.IScrollItemProvider

--- a/src/Windows/Avalonia.Win32/Automation/AutomationNode.Selection.cs
+++ b/src/Windows/Avalonia.Win32/Automation/AutomationNode.Selection.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Automation.Peers;
 using Avalonia.Automation.Provider;
 using UIA = Avalonia.Win32.Interop.Automation;
-
-#nullable enable
 
 namespace Avalonia.Win32.Automation
 {
@@ -27,8 +24,7 @@ namespace Avalonia.Win32.Automation
         UIA.IRawElementProviderSimple[] UIA.ISelectionProvider.GetSelection()
         {
             var peers = InvokeSync<ISelectionProvider, IReadOnlyList<AutomationPeer>>(x => x.GetSelection());
-            return peers?.Select(x => (UIA.IRawElementProviderSimple)GetOrCreate(x)!).ToArray() ??
-                Array.Empty<UIA.IRawElementProviderSimple>();
+            return peers.Select(x => (UIA.IRawElementProviderSimple)GetOrCreate(x)).ToArray();
         }
 
         void UIA.ISelectionItemProvider.AddToSelection() => InvokeSync<ISelectionItemProvider>(x => x.AddToSelection());

--- a/src/Windows/Avalonia.Win32/Automation/AutomationNode.Toggle.cs
+++ b/src/Windows/Avalonia.Win32/Automation/AutomationNode.Toggle.cs
@@ -1,8 +1,6 @@
 ﻿using Avalonia.Automation.Provider;
 using UIA = Avalonia.Win32.Interop.Automation;
 
-#nullable enable
-
 namespace Avalonia.Win32.Automation
 {
     internal partial class AutomationNode : UIA.IToggleProvider

--- a/src/Windows/Avalonia.Win32/Automation/AutomationNode.Value.cs
+++ b/src/Windows/Avalonia.Win32/Automation/AutomationNode.Value.cs
@@ -2,8 +2,6 @@
 using Avalonia.Automation.Provider;
 using UIA = Avalonia.Win32.Interop.Automation;
 
-#nullable enable
-
 namespace Avalonia.Win32.Automation
 {
     internal partial class AutomationNode : UIA.IValueProvider

--- a/src/Windows/Avalonia.Win32/Automation/AutomationNode.cs
+++ b/src/Windows/Avalonia.Win32/Automation/AutomationNode.cs
@@ -12,8 +12,6 @@ using Avalonia.Threading;
 using Avalonia.Win32.Interop.Automation;
 using AAP = Avalonia.Automation.Provider;
 
-#nullable enable
-
 namespace Avalonia.Win32.Automation
 {
     [ComVisible(true)]
@@ -25,7 +23,7 @@ namespace Avalonia.Win32.Automation
         IRawElementProviderAdviseEvents,
         IInvokeProvider
     {
-        private static Dictionary<AutomationProperty, UiaPropertyId> s_propertyMap = new Dictionary<AutomationProperty, UiaPropertyId>()
+        private static Dictionary<AutomationProperty, UiaPropertyId> s_propertyMap = new()
         {
             { AutomationElementIdentifiers.BoundingRectangleProperty, UiaPropertyId.BoundingRectangle },
             { AutomationElementIdentifiers.ClassNameProperty, UiaPropertyId.ClassName },
@@ -46,8 +44,7 @@ namespace Avalonia.Win32.Automation
             { SelectionPatternIdentifiers.SelectionProperty, UiaPropertyId.SelectionSelection },
         };
 
-        private static ConditionalWeakTable<AutomationPeer, AutomationNode> s_nodes =
-            new ConditionalWeakTable<AutomationPeer, AutomationNode>();
+        private static ConditionalWeakTable<AutomationPeer, AutomationNode> s_nodes = new();
 
         private readonly int[] _runtimeId;
         private int _raiseFocusChanged;
@@ -174,11 +171,12 @@ namespace Avalonia.Win32.Automation
                     NavigateDirection.LastChild => GetOrCreate(Peer.GetChildren().LastOrDefault()),
                     _ => null,
                 };
-            }) as IRawElementProviderFragment;
+            });
         }
 
         public void SetFocus() => InvokeSync(() => Peer.SetFocus());
 
+        [return: NotNullIfNotNull(nameof(peer))]
         public static AutomationNode? GetOrCreate(AutomationPeer? peer)
         {
             return peer is null ? null : s_nodes.GetValue(peer, Create);

--- a/src/Windows/Avalonia.Win32/Automation/RootAutomationNode.cs
+++ b/src/Windows/Avalonia.Win32/Automation/RootAutomationNode.cs
@@ -6,8 +6,6 @@ using Avalonia.Automation.Provider;
 using Avalonia.Platform;
 using Avalonia.Win32.Interop.Automation;
 
-#nullable enable
-
 namespace Avalonia.Win32.Automation
 {
     [RequiresUnreferencedCode("Requires .NET COM interop")]

--- a/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
+++ b/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <Compile Include="..\..\Avalonia.Base\Metadata\NullableAttributes.cs" Link="NullableAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />
@@ -16,7 +15,8 @@
     <MicroComIdl Include="Win32Com\win32.idl" CSharpInteropPath="Win32Com\Win32.Generated.cs" />
     <MicroComIdl Include="DirectX\directx.idl" CSharpInteropPath="DirectX\directx.Generated.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\build\System.Drawing.Common.props" />
+  <Import Project="..\..\..\build\System.Drawing.Common.props" />
+  <Import Project="..\..\..\build\NullableEnable.props" />
   <Import Project="..\..\..\build\DevAnalyzers.props" />
   <Import Project="..\..\..\build\SourceGenerators.props" />
   <ItemGroup>

--- a/src/Windows/Avalonia.Win32/ClipboardImpl.cs
+++ b/src/Windows/Avalonia.Win32/ClipboardImpl.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Win32
             return Disposable.Create(() => UnmanagedMethods.CloseClipboard());
         }
 
-        public async Task<string> GetTextAsync()
+        public async Task<string?> GetTextAsync()
         {
             using(await OpenClipboard())
             {
@@ -52,19 +52,17 @@ namespace Avalonia.Win32
             }
         }
 
-        public async Task SetTextAsync(string text)
+        public async Task SetTextAsync(string? text)
         {
-            if (text == null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
-
             using(await OpenClipboard())
             {
                 UnmanagedMethods.EmptyClipboard();
 
-                var hGlobal = Marshal.StringToHGlobalUni(text);
-                UnmanagedMethods.SetClipboardData(UnmanagedMethods.ClipboardFormat.CF_UNICODETEXT, hGlobal);
+                if (text is not null)
+                {
+                    var hGlobal = Marshal.StringToHGlobalUni(text);
+                    UnmanagedMethods.SetClipboardData(UnmanagedMethods.ClipboardFormat.CF_UNICODETEXT, hGlobal);
+                }
             }
         }
 
@@ -121,7 +119,7 @@ namespace Avalonia.Win32
             }
         }
 
-        public async Task<object> GetDataAsync(string format)
+        public async Task<object?> GetDataAsync(string format)
         {
             Dispatcher.UIThread.VerifyAccess();
             var i = OleRetryCount;

--- a/src/Windows/Avalonia.Win32/DirectX/DirectXStructs.cs
+++ b/src/Windows/Avalonia.Win32/DirectX/DirectXStructs.cs
@@ -1,17 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 using static Avalonia.Win32.Interop.UnmanagedMethods;
 // ReSharper disable InconsistentNaming
 #pragma warning disable CS0649
 
 namespace Avalonia.Win32.DirectX
 {
-#nullable enable
     public unsafe struct HANDLE
     {
         public readonly void* Value;
@@ -288,5 +281,4 @@ namespace Avalonia.Win32.DirectX
 
         public D3D11_RESOURCE_MISC_FLAG MiscFlags;
     }
-#nullable restore
 }

--- a/src/Windows/Avalonia.Win32/DirectX/DxgiConnection.cs
+++ b/src/Windows/Avalonia.Win32/DirectX/DxgiConnection.cs
@@ -1,24 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading.Tasks;
 using Avalonia.Logging;
-using Avalonia.OpenGL.Angle;
-using Avalonia.OpenGL.Egl;
 using Avalonia.Rendering;
-using Avalonia.Win32.OpenGl.Angle;
 using static Avalonia.Win32.Interop.UnmanagedMethods;
 using static Avalonia.Win32.DirectX.DirectXUnmanagedMethods;
 using MicroCom.Runtime;
 
 namespace Avalonia.Win32.DirectX
 {
-#pragma warning disable CA1416 // This should only be reachable on Windows
-#nullable enable
     public unsafe class DxgiConnection : IRenderTimer
     {
         public const uint ENUM_CURRENT_SETTINGS = unchecked((uint)(-1));
@@ -26,11 +16,11 @@ namespace Avalonia.Win32.DirectX
         public bool RunsInBackground => true;
 
         public event Action<TimeSpan>? Tick;
-        private object _syncLock;
+        private readonly object _syncLock;
 
-        private IDXGIOutput? _output = null;
+        private IDXGIOutput? _output;
 
-        private Stopwatch? _stopwatch = null;
+        private Stopwatch? _stopwatch;
         private const string LogArea = "DXGI";
 
         public DxgiConnection(object syncLock)
@@ -51,9 +41,9 @@ namespace Avalonia.Win32.DirectX
             }
         }
 
-        private unsafe void RunLoop()
+        private void RunLoop()
         {
-            _stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            _stopwatch = Stopwatch.StartNew();
             try
             {
                 GetBestOutputToVWaitOn();
@@ -162,7 +152,7 @@ namespace Avalonia.Win32.DirectX
         }
 
         // Used the windows composition as a blueprint for this startup/creation 
-        static private bool TryCreateAndRegisterCore()
+        private static bool TryCreateAndRegisterCore()
         {
             var tcs = new TaskCompletionSource<bool>();
             var pumpLock = new object();
@@ -170,9 +160,7 @@ namespace Avalonia.Win32.DirectX
             {
                 try
                 {
-                    DxgiConnection connection;
-
-                    connection = new DxgiConnection(pumpLock);
+                    var connection = new DxgiConnection(pumpLock);
 
                     AvaloniaLocator.CurrentMutable.BindToSelf(connection);
                     AvaloniaLocator.CurrentMutable.Bind<IRenderTimer>().ToConstant(connection);
@@ -191,6 +179,4 @@ namespace Avalonia.Win32.DirectX
             return tcs.Task.Result;
         }
     }
-#nullable restore
-#pragma warning restore CA1416 // Validate platform compatibility
 }

--- a/src/Windows/Avalonia.Win32/FramebufferManager.cs
+++ b/src/Windows/Avalonia.Win32/FramebufferManager.cs
@@ -4,8 +4,6 @@ using Avalonia.Controls.Platform.Surfaces;
 using Avalonia.Platform;
 using Avalonia.Win32.Interop;
 
-#nullable enable
-
 namespace Avalonia.Win32
 {
     internal class FramebufferManager : IFramebufferPlatformSurface, IDisposable

--- a/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
+++ b/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Avalonia.Input.TextInput;
 using Avalonia.Threading;
@@ -10,21 +11,21 @@ namespace Avalonia.Win32.Input
     /// <summary>
     /// A Windows input method editor based on Windows Input Method Manager (IMM32).
     /// </summary>
-    class Imm32InputMethod : ITextInputMethodImpl
+    internal class Imm32InputMethod : ITextInputMethodImpl
     {
-        public IntPtr HWND { get; private set; }
+        public IntPtr Hwnd { get; private set; }
         private IntPtr _currentHimc;
-        private WindowImpl _parent;
-        private ITextInputMethodClient _client;
+        private WindowImpl? _parent;
 
-        private Imm32CaretManager _caretManager = new();
+        private Imm32CaretManager _caretManager;
 
         private ushort _langId;
-        private const int _caretMargin = 1;
+        private const int CaretMargin = 1;
 
-        public ITextInputMethodClient Client => _client;
+        public ITextInputMethodClient? Client { get; private set; }
 
-        public bool IsActive => _client != null;
+        [MemberNotNullWhen(true, nameof(Client))]
+        public bool IsActive => Client != null;
 
         public bool IsComposing { get; set; }
 
@@ -32,12 +33,12 @@ namespace Avalonia.Win32.Input
 
         public void CreateCaret()
         {
-            _caretManager.TryCreate(HWND);
+            _caretManager.TryCreate(Hwnd);
         }
 
         public void EnableImm()
         {
-            var himc = ImmGetContext(HWND);
+            var himc = ImmGetContext(Hwnd);
 
             if(himc == IntPtr.Zero)
             {
@@ -51,13 +52,13 @@ namespace Avalonia.Win32.Input
                     DisableImm();
                 }
 
-                ImmAssociateContext(HWND, himc);
+                ImmAssociateContext(Hwnd, himc);
 
-                ImmReleaseContext(HWND, himc);
+                ImmReleaseContext(Hwnd, himc);
 
                 _currentHimc = himc;
 
-                _caretManager.TryCreate(HWND);
+                _caretManager.TryCreate(Hwnd);
             }
         }
 
@@ -67,7 +68,7 @@ namespace Avalonia.Win32.Input
 
             Reset();
 
-            ImmAssociateContext(HWND, IntPtr.Zero);
+            ImmAssociateContext(Hwnd, IntPtr.Zero);
 
             _caretManager.TryDestroy();
 
@@ -76,7 +77,7 @@ namespace Avalonia.Win32.Input
 
         public void SetLanguageAndWindow(WindowImpl parent, IntPtr hwnd, IntPtr HKL)
         {
-            HWND = hwnd;
+            Hwnd = hwnd;
             _parent = parent;
             _langId = PRIMARYLANGID(LGID(HKL));
 
@@ -98,9 +99,9 @@ namespace Avalonia.Win32.Input
         {
             DisableImm();
 
-            HWND = IntPtr.Zero;
+            Hwnd = IntPtr.Zero;
             _parent = null;
-            _client = null;
+            Client = null;
             _langId = 0;
 
             IsComposing = false;
@@ -108,13 +109,13 @@ namespace Avalonia.Win32.Input
 
         //Dependant on CurrentThread. When Avalonia will support Multiple Dispatchers -
         //every Dispatcher should have their own InputMethod.
-        public static Imm32InputMethod Current { get; } = new Imm32InputMethod();    
+        public static Imm32InputMethod Current { get; } = new();
 
         public void Reset()
         {
             Dispatcher.UIThread.Post(() =>
             {
-                var himc = ImmGetContext(HWND);
+                var himc = ImmGetContext(Hwnd);
 
                 if (IsComposing)
                 {
@@ -123,13 +124,13 @@ namespace Avalonia.Win32.Input
                     IsComposing = false;
                 }
 
-                ImmReleaseContext(HWND, himc);
+                ImmReleaseContext(Hwnd, himc);
             });
         }
 
-        public void SetClient(ITextInputMethodClient client)
+        public void SetClient(ITextInputMethodClient? client)
         {
-            _client = client;
+            Client = client;
 
             Dispatcher.UIThread.Post(() =>
             {
@@ -152,7 +153,7 @@ namespace Avalonia.Win32.Input
 
         public void SetCursorRect(Rect rect)
         {
-            var focused = GetActiveWindow() == HWND;
+            var focused = GetActiveWindow() == Hwnd;
 
             if (!focused)
             {
@@ -161,7 +162,7 @@ namespace Avalonia.Win32.Input
 
             Dispatcher.UIThread.Post(() =>
             {
-                var himc = ImmGetContext(HWND);
+                var himc = ImmGetContext(Hwnd);
 
                 if (himc == IntPtr.Zero)
                 {
@@ -170,7 +171,7 @@ namespace Avalonia.Win32.Input
 
                 MoveImeWindow(rect, himc);
 
-                ImmReleaseContext(HWND, himc);
+                ImmReleaseContext(Hwnd, himc);
             });
         }
         
@@ -219,7 +220,7 @@ namespace Avalonia.Win32.Input
                 // the caret to move the position of their candidate windows.
                 // On the other hand, Korean IMEs require the lower-left corner of the
                 // caret to move their candidate windows.
-                y2 += _caretMargin;
+                y2 += CaretMargin;
             }
 
             // Need to return here since some Chinese IMEs would stuck if set
@@ -238,7 +239,7 @@ namespace Avalonia.Win32.Input
                 dwIndex = 0,
                 dwStyle = CFS_EXCLUDE,
                 ptCurrentPos = new POINT {X = x1, Y = y1},
-                rcArea = new RECT {left = x1, top = y1, right = x2, bottom = y2 + _caretMargin}
+                rcArea = new RECT {left = x1, top = y1, right = x2, bottom = y2 + CaretMargin}
             };
 
             ImmSetCandidateWindow(himc, ref excludeRectangle);
@@ -275,34 +276,21 @@ namespace Avalonia.Win32.Input
                 return;
             }
 
-            if(!IsActive || !_client.SupportsPreedit)
+            if(!IsActive || !Client.SupportsPreedit)
             {
                 return;
             }
 
             var composition = GetCompositionString();
 
-            _client.SetPreeditText(composition);
+            Client.SetPreeditText(composition);
         }
         
-        private string GetCompositionString()
+        private string? GetCompositionString()
         {
-            var himc = ImmGetContext(HWND);
+            var himc = ImmGetContext(Hwnd);
 
-            var length = ImmGetCompositionString(himc, GCS.GCS_COMPSTR, IntPtr.Zero, 0);
-
-            var buffer = new byte[length];
-
-            unsafe
-            {
-                fixed (byte* bufferPtr = buffer)
-                {
-                    var error = ImmGetCompositionString(himc, GCS.GCS_COMPSTR, (IntPtr)bufferPtr, (uint)length);
-
-                    return Encoding.Unicode.GetString(buffer, 0, buffer.Length);
-                }
-            }
-          
+            return ImmGetCompositionString(himc, GCS.GCS_COMPSTR);
         }
 
         ~Imm32InputMethod()

--- a/src/Windows/Avalonia.Win32/Input/WindowsMouseDevice.cs
+++ b/src/Windows/Avalonia.Win32/Input/WindowsMouseDevice.cs
@@ -5,9 +5,10 @@ using Avalonia.Win32.Interop;
 
 namespace Avalonia.Win32.Input
 {
-    class WindowsMouseDevice : MouseDevice
+    internal class WindowsMouseDevice : MouseDevice
     {
         private readonly IPointer _pointer;
+
         public WindowsMouseDevice() : base(WindowsMousePointer.CreatePointer(out var pointer))
         {
             _pointer = pointer;
@@ -15,14 +16,14 @@ namespace Avalonia.Win32.Input
 
         // Normally user should use IPointer.Capture instead of MouseDevice.Capture,
         // But on Windows we need to handle WM_MOUSE capture manually without having access to the Pointer. 
-        internal void Capture(IInputElement control)
+        internal void Capture(IInputElement? control)
         {
             _pointer.Capture(control);
         }
         
         internal class WindowsMousePointer : Pointer
         {
-            private WindowsMousePointer() : base(Pointer.GetNextFreeId(),PointerType.Mouse, true)
+            private WindowsMousePointer() : base(GetNextFreeId(),PointerType.Mouse, true)
             {
             }
             
@@ -31,7 +32,7 @@ namespace Avalonia.Win32.Input
                 return pointer = new WindowsMousePointer();
             }
 
-            protected override void PlatformCapture(IInputElement element)
+            protected override void PlatformCapture(IInputElement? element)
             {
                 var hwnd = (TopLevel.GetTopLevel(element as Visual)?.PlatformImpl as WindowImpl)
                     ?.Handle.Handle;

--- a/src/Windows/Avalonia.Win32/Interop/Automation/IGridProvider.cs
+++ b/src/Windows/Avalonia.Win32/Interop/Automation/IGridProvider.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.InteropServices;
 
 namespace Avalonia.Win32.Interop.Automation
@@ -8,7 +7,7 @@ namespace Avalonia.Win32.Interop.Automation
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     public interface IGridProvider
     {
-        IRawElementProviderSimple GetItem(int row, int column); 
+        IRawElementProviderSimple? GetItem(int row, int column);
         int RowCount { get; }
         int ColumnCount { get; }
     }

--- a/src/Windows/Avalonia.Win32/Interop/Automation/IRawElementProviderFragment.cs
+++ b/src/Windows/Avalonia.Win32/Interop/Automation/IRawElementProviderFragment.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Avalonia.Win32.Interop.Automation
 {
     [ComVisible(true)]

--- a/src/Windows/Avalonia.Win32/Interop/Automation/IRawElementProviderFragmentRoot.cs
+++ b/src/Windows/Avalonia.Win32/Interop/Automation/IRawElementProviderFragmentRoot.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.InteropServices;
 
 namespace Avalonia.Win32.Interop.Automation
@@ -8,7 +7,7 @@ namespace Avalonia.Win32.Interop.Automation
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     public interface IRawElementProviderFragmentRoot : IRawElementProviderFragment
     {
-        IRawElementProviderFragment ElementProviderFromPoint(double x, double y);
-        IRawElementProviderFragment GetFocus();
+        IRawElementProviderFragment? ElementProviderFromPoint(double x, double y);
+        IRawElementProviderFragment? GetFocus();
     }
 }

--- a/src/Windows/Avalonia.Win32/Interop/Automation/IRawElementProviderSimple.cs
+++ b/src/Windows/Avalonia.Win32/Interop/Automation/IRawElementProviderSimple.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-#nullable enable
-
 namespace Avalonia.Win32.Interop.Automation
 {
     [Flags]

--- a/src/Windows/Avalonia.Win32/Interop/Automation/IRawElementProviderSimple2.cs
+++ b/src/Windows/Avalonia.Win32/Interop/Automation/IRawElementProviderSimple2.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
-
-#nullable enable
+﻿using System.Runtime.InteropServices;
 
 namespace Avalonia.Win32.Interop.Automation
 {

--- a/src/Windows/Avalonia.Win32/Interop/Automation/ISelectionItemProvider.cs
+++ b/src/Windows/Avalonia.Win32/Interop/Automation/ISelectionItemProvider.cs
@@ -1,5 +1,3 @@
-#nullable enable
-using System;
 using System.Runtime.InteropServices;
 
 namespace Avalonia.Win32.Interop.Automation

--- a/src/Windows/Avalonia.Win32/Interop/Automation/IValueProvider.cs
+++ b/src/Windows/Avalonia.Win32/Interop/Automation/IValueProvider.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Runtime.InteropServices;
-
-#nullable enable
 
 namespace Avalonia.Win32.Interop.Automation
 {

--- a/src/Windows/Avalonia.Win32/Interop/Automation/UiaCoreProviderApi.cs
+++ b/src/Windows/Avalonia.Win32/Interop/Automation/UiaCoreProviderApi.cs
@@ -71,21 +71,21 @@ namespace Avalonia.Win32.Interop.Automation
         public static extern bool UiaClientsAreListening();
         
         [DllImport("UIAutomationCore.dll", CharSet = CharSet.Unicode)]
-        public static extern IntPtr UiaReturnRawElementProvider(IntPtr hwnd, IntPtr wParam, IntPtr lParam, IRawElementProviderSimple el);
+        public static extern IntPtr UiaReturnRawElementProvider(IntPtr hwnd, IntPtr wParam, IntPtr lParam, IRawElementProviderSimple? el);
 
         [DllImport("UIAutomationCore.dll", CharSet = CharSet.Unicode)]
         public static extern int UiaHostProviderFromHwnd(IntPtr hwnd, [MarshalAs(UnmanagedType.Interface)] out IRawElementProviderSimple provider);
 
         [DllImport("UIAutomationCore.dll", CharSet = CharSet.Unicode)]
-        public static extern int UiaRaiseAutomationEvent(IRawElementProviderSimple provider, int id);
+        public static extern int UiaRaiseAutomationEvent(IRawElementProviderSimple? provider, int id);
 
         [DllImport("UIAutomationCore.dll", CharSet = CharSet.Unicode)]
-        public static extern int UiaRaiseAutomationPropertyChangedEvent(IRawElementProviderSimple provider, int id, object oldValue, object newValue);
+        public static extern int UiaRaiseAutomationPropertyChangedEvent(IRawElementProviderSimple? provider, int id, object? oldValue, object? newValue);
 
         [DllImport("UIAutomationCore.dll", CharSet = CharSet.Unicode)]
-        public static extern int UiaRaiseStructureChangedEvent(IRawElementProviderSimple provider, StructureChangeType structureChangeType, int[] runtimeId, int runtimeIdLen);
+        public static extern int UiaRaiseStructureChangedEvent(IRawElementProviderSimple? provider, StructureChangeType structureChangeType, int[]? runtimeId, int runtimeIdLen);
 
         [DllImport("UIAutomationCore.dll", CharSet = CharSet.Unicode)]
-        public static extern int UiaDisconnectProvider(IRawElementProviderSimple provider);
+        public static extern int UiaDisconnectProvider(IRawElementProviderSimple? provider);
     }
 }

--- a/src/Windows/Avalonia.Win32/Interop/Automation/UiaCoreTypesApi.cs
+++ b/src/Windows/Avalonia.Win32/Interop/Automation/UiaCoreTypesApi.cs
@@ -63,8 +63,8 @@ namespace Avalonia.Win32.Interop.Automation
             }
 #endif
 
-            var comConfig = AppContext.GetData("System.Runtime.InteropServices.BuiltInComInterop.IsSupported");
-            return comConfig == null || bool.Parse(comConfig.ToString());
+            var comConfig = AppContext.GetData("System.Runtime.InteropServices.BuiltInComInterop.IsSupported") as string;
+            return comConfig == null || bool.Parse(comConfig);
         }
 
         [DllImport("UIAutomationCore.dll", EntryPoint = "UiaLookupId", CharSet = CharSet.Unicode)]

--- a/src/Windows/Avalonia.Win32/Interop/TaskBarList.cs
+++ b/src/Windows/Avalonia.Win32/Interop/TaskBarList.cs
@@ -7,8 +7,8 @@ namespace Avalonia.Win32.Interop
     internal class TaskBarList
     {
         private static IntPtr s_taskBarList;
-        private static HrInit s_hrInitDelegate;
-        private static MarkFullscreenWindow s_markFullscreenWindowDelegate;
+        private static HrInit? s_hrInitDelegate;
+        private static MarkFullscreenWindow? s_markFullscreenWindowDelegate;
 
         /// <summary>
         /// Ported from https://github.com/chromium/chromium/blob/master/ui/views/win/fullscreen_handler.cc
@@ -28,10 +28,7 @@ namespace Avalonia.Win32.Interop
                 {
                     var ptr = (ITaskBarList2VTable**)s_taskBarList.ToPointer();
 
-                    if (s_hrInitDelegate is null)
-                    {
-                        s_hrInitDelegate = Marshal.GetDelegateForFunctionPointer<HrInit>((*ptr)->HrInit);
-                    }
+                    s_hrInitDelegate ??= Marshal.GetDelegateForFunctionPointer<HrInit>((*ptr)->HrInit);
 
                     if (s_hrInitDelegate(s_taskBarList) != HRESULT.S_OK)
                     {
@@ -44,10 +41,8 @@ namespace Avalonia.Win32.Interop
             {
                 var ptr = (ITaskBarList2VTable**)s_taskBarList.ToPointer();
 
-                if (s_markFullscreenWindowDelegate is null)
-                {
-                    s_markFullscreenWindowDelegate = Marshal.GetDelegateForFunctionPointer<MarkFullscreenWindow>((*ptr)->MarkFullscreenWindow);
-                }
+                s_markFullscreenWindowDelegate ??=
+                    Marshal.GetDelegateForFunctionPointer<MarkFullscreenWindow>((*ptr)->MarkFullscreenWindow);
 
                 s_markFullscreenWindowDelegate(s_taskBarList, hwnd, fullscreen);
             }

--- a/src/Windows/Avalonia.Win32/NonPumpingSyncContext.cs
+++ b/src/Windows/Avalonia.Win32/NonPumpingSyncContext.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Runtime.ConstrainedExecution;
 using System.Threading;
-using Avalonia.Threading;
 using Avalonia.Utilities;
 using Avalonia.Win32.Interop;
 
@@ -18,8 +17,8 @@ namespace Avalonia.Win32
             SetSynchronizationContext(this);
         }
 
-        public override void Post(SendOrPostCallback d, object state) => _inner.Post(d, state);
-        public override void Send(SendOrPostCallback d, object state) => _inner.Send(d, state);
+        public override void Post(SendOrPostCallback d, object? state) => _inner.Post(d, state);
+        public override void Send(SendOrPostCallback d, object? state) => _inner.Send(d, state);
 
 #if !NET6_0_OR_GREATER
         [PrePrepareMethod]
@@ -32,23 +31,15 @@ namespace Avalonia.Win32
 
         public void Dispose() => SetSynchronizationContext(_inner);
 
-        public static IDisposable Use()
+        public static IDisposable? Use()
         {
             var current = Current;
-            if (current == null)
-            {
-                if (Thread.CurrentThread.GetApartmentState() != ApartmentState.STA)
-                    return null;
-            }
-            if (current is NonPumpingSyncContext)
-                return null;
-            
-            return new NonPumpingSyncContext(current);
+            return current is null or NonPumpingSyncContext ? null : new NonPumpingSyncContext(current);
         }
 
         internal class HelperImpl : NonPumpingLockHelper.IHelperImpl
         {
-            IDisposable NonPumpingLockHelper.IHelperImpl.Use() => NonPumpingSyncContext.Use();
+            IDisposable? NonPumpingLockHelper.IHelperImpl.Use() => NonPumpingSyncContext.Use();
         }
     }
 }

--- a/src/Windows/Avalonia.Win32/OffscreenParentWindow.cs
+++ b/src/Windows/Avalonia.Win32/OffscreenParentWindow.cs
@@ -1,17 +1,18 @@
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
-using Avalonia.Platform;
 using Avalonia.Win32.Interop;
 namespace Avalonia.Win32
 {
-    class OffscreenParentWindow
+    internal class OffscreenParentWindow
     {
         public static IntPtr Handle { get; } = CreateParentWindow();
-        private static UnmanagedMethods.WndProc s_wndProcDelegate;
+
+        private static UnmanagedMethods.WndProc? s_wndProcDelegate;
+
         private static IntPtr CreateParentWindow()
         {
-            s_wndProcDelegate = new UnmanagedMethods.WndProc(ParentWndProc);
+            s_wndProcDelegate = ParentWndProc;
 
             var wndClassEx = new UnmanagedMethods.WNDCLASSEX
             {

--- a/src/Windows/Avalonia.Win32/OleContext.cs
+++ b/src/Windows/Avalonia.Win32/OleContext.cs
@@ -11,18 +11,16 @@ namespace Avalonia.Win32
 {
     internal class OleContext
     {
-        private static OleContext s_current;
+        private static OleContext? s_current;
 
-        internal static OleContext Current
+        internal static OleContext? Current
         {
             get
             {
                 if (!IsValidOleThread())
                     return null;
 
-                if (s_current == null)
-                    s_current = new OleContext();
-                return s_current;
+                return s_current ??= new OleContext();
             }
         }
 
@@ -41,7 +39,7 @@ namespace Avalonia.Win32
                    Thread.CurrentThread.GetApartmentState() == ApartmentState.STA;
         }
 
-        internal bool RegisterDragDrop(IPlatformHandle hwnd, IDropTarget target)
+        internal bool RegisterDragDrop(IPlatformHandle? hwnd, IDropTarget? target)
         {
             if (hwnd?.HandleDescriptor != "HWND" || target == null)
             {
@@ -52,7 +50,7 @@ namespace Avalonia.Win32
             return UnmanagedMethods.RegisterDragDrop(hwnd.Handle, trgPtr) == UnmanagedMethods.HRESULT.S_OK;
         }
 
-        internal bool UnregisterDragDrop(IPlatformHandle hwnd)
+        internal bool UnregisterDragDrop(IPlatformHandle? hwnd)
         {
             if (hwnd?.HandleDescriptor != "HWND")
             {

--- a/src/Windows/Avalonia.Win32/OleDataObject.cs
+++ b/src/Windows/Avalonia.Win32/OleDataObject.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Serialization.Formatters.Binary;
 using Avalonia.Input;
-using Avalonia.MicroCom;
 using Avalonia.Utilities;
 using Avalonia.Win32.Interop;
 using MicroCom.Runtime;
@@ -35,23 +34,23 @@ namespace Avalonia.Win32
             return GetDataFormatsCore().Distinct();
         }
 
-        public string GetText()
+        public string? GetText()
         {
-            return (string)GetDataFromOleHGLOBAL(DataFormats.Text, DVASPECT.DVASPECT_CONTENT);
+            return (string?)GetDataFromOleHGLOBAL(DataFormats.Text, DVASPECT.DVASPECT_CONTENT);
         }
 
-        public IEnumerable<string> GetFileNames()
+        public IEnumerable<string>? GetFileNames()
         {
-            return (IEnumerable<string>)GetDataFromOleHGLOBAL(DataFormats.FileNames, DVASPECT.DVASPECT_CONTENT);
+            return (IEnumerable<string>?)GetDataFromOleHGLOBAL(DataFormats.FileNames, DVASPECT.DVASPECT_CONTENT);
         }
 
-        public object Get(string dataFormat)
+        public object? Get(string dataFormat)
         {
             return GetDataFromOleHGLOBAL(dataFormat, DVASPECT.DVASPECT_CONTENT);
         }
 
         [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "We still use BinaryFormatter for WinForms dragndrop compatability")]
-        private unsafe object GetDataFromOleHGLOBAL(string format, DVASPECT aspect)
+        private unsafe object? GetDataFromOleHGLOBAL(string format, DVASPECT aspect)
         {
             var formatEtc = new Interop.FORMATETC();
             formatEtc.cfFormat = ClipboardFormats.GetFormat(format);
@@ -100,7 +99,7 @@ namespace Avalonia.Win32
 
         private static IEnumerable<string> ReadFileNamesFromHGlobal(IntPtr hGlobal)
         {
-            List<string> files = new List<string>();
+            var files = new List<string>();
             int fileCount = UnmanagedMethods.DragQueryFile(hGlobal, -1, null, 0);
             if (fileCount > 0)
             {
@@ -118,7 +117,7 @@ namespace Avalonia.Win32
             return files;
         }
 
-        private static string ReadStringFromHGlobal(IntPtr hGlobal)
+        private static string? ReadStringFromHGlobal(IntPtr hGlobal)
         {
             IntPtr ptr = UnmanagedMethods.GlobalLock(hGlobal);
             try

--- a/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleD3DTextureFeature.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleD3DTextureFeature.cs
@@ -14,7 +14,7 @@ internal class AngleD3DTextureFeature  : IGlPlatformSurfaceRenderTargetFactory
             Display: AngleWin32EglDisplay { PlatformApi: AngleOptions.PlatformApi.DirectX11 }
         } && surface is IDirect3D11TexturePlatformSurface;
 
-    class RenderTargetWrapper : EglPlatformSurfaceRenderTargetBase
+    private class RenderTargetWrapper : EglPlatformSurfaceRenderTargetBase
     {
         private readonly AngleWin32EglDisplay _angle;
         private readonly IDirect3D11TextureRenderTarget _target;
@@ -31,8 +31,8 @@ internal class AngleD3DTextureFeature  : IGlPlatformSurfaceRenderTargetFactory
         {
             var success = false;
             var contextLock = Context.EnsureCurrent();
-            IDirect3D11TextureRenderTargetRenderSession session = null;
-            EglSurface surface = null;
+            IDirect3D11TextureRenderTargetRenderSession? session = null;
+            EglSurface? surface = null;
             try
             {
                 try

--- a/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleEglInterface.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleEglInterface.cs
@@ -22,7 +22,7 @@ namespace Avalonia.OpenGL.Angle
         }
         
         [GetProcAddress("eglCreateDeviceANGLE", true)]
-        public partial IntPtr CreateDeviceANGLE(int deviceType, IntPtr nativeDevice, int[] attribs);
+        public partial IntPtr CreateDeviceANGLE(int deviceType, IntPtr nativeDevice, int[]? attribs);
 
         [GetProcAddress("eglReleaseDeviceANGLE", true)]
         public partial void ReleaseDeviceANGLE(IntPtr device);

--- a/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleExternalObjectsFeature.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleExternalObjectsFeature.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using Avalonia.Controls.Documents;
 using Avalonia.OpenGL;
 using Avalonia.OpenGL.Egl;
 using Avalonia.Platform;
@@ -93,8 +91,8 @@ internal class AngleExternalObjectsFeature : IGlContextExternalObjectsFeature, I
         return default;
     }
 
-    public byte[] DeviceLuid { get; }
-    public byte[] DeviceUuid { get; }
+    public byte[]? DeviceLuid { get; }
+    public byte[]? DeviceUuid => null;
 
     public void Dispose()
     {

--- a/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32EglDisplay.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32EglDisplay.cs
@@ -1,4 +1,3 @@
-#nullable enable annotations
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -97,7 +96,7 @@ namespace Avalonia.Win32.OpenGl.Angle
                 DirectXUnmanagedMethods.D3D11CreateDevice(chosenAdapter?.GetNativeIntPtr() ?? IntPtr.Zero,
                     D3D_DRIVER_TYPE.D3D_DRIVER_TYPE_UNKNOWN,
                     IntPtr.Zero, 0, featureLevels, (uint)featureLevels.Length,
-                    7, out pD3dDevice, out var featureLevel, null);
+                    7, out pD3dDevice, out _, null);
 
 
             if (pD3dDevice == IntPtr.Zero)

--- a/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32PlatformGraphics.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32PlatformGraphics.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Avalonia.Logging;
 using Avalonia.OpenGL;
@@ -12,11 +13,14 @@ namespace Avalonia.Win32.OpenGl.Angle;
 internal class AngleWin32PlatformGraphics : IPlatformGraphics, IPlatformGraphicsOpenGlContextFactory
 {
     private readonly Win32AngleEglInterface _egl;
-    private AngleWin32EglDisplay _sharedDisplay;
-    private EglContext _sharedContext;
-    public bool UsesSharedContext => PlatformApi == AngleOptions.PlatformApi.DirectX9;
+    private readonly AngleWin32EglDisplay? _sharedDisplay;
+    private EglContext? _sharedContext;
 
-    public AngleOptions.PlatformApi PlatformApi { get; } = AngleOptions.PlatformApi.DirectX11;
+    [MemberNotNullWhen(true, nameof(_sharedDisplay))]
+    public bool UsesSharedContext => _sharedDisplay is not null;
+
+    public AngleOptions.PlatformApi PlatformApi { get; }
+
     public IPlatformGraphicsContext CreateContext()
     {
         if (UsesSharedContext)
@@ -72,7 +76,7 @@ internal class AngleWin32PlatformGraphics : IPlatformGraphics, IPlatformGraphics
     }
 
 
-    public static AngleWin32PlatformGraphics TryCreate(AngleOptions options)
+    public static AngleWin32PlatformGraphics? TryCreate(AngleOptions? options)
     {
         Win32AngleEglInterface egl;
         try
@@ -109,7 +113,7 @@ internal class AngleWin32PlatformGraphics : IPlatformGraphics, IPlatformGraphics
             }
             else
             {
-                AngleWin32EglDisplay sharedDisplay = null;
+                AngleWin32EglDisplay? sharedDisplay = null;
                 try
                 {
                     sharedDisplay = AngleWin32EglDisplay.CreateD3D9Display(egl);

--- a/src/Windows/Avalonia.Win32/OpenGl/WglContext.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/WglContext.cs
@@ -7,22 +7,22 @@ using Avalonia.Platform;
 using Avalonia.Reactive;
 using Avalonia.Win32.Interop;
 using static Avalonia.Win32.Interop.UnmanagedMethods;
-using static Avalonia.Win32.OpenGl.WglConsts;
 
 namespace Avalonia.Win32.OpenGl
 {
-    class WglContext : IGlContext
+    internal class WglContext : IGlContext
     {
-        private object _lock = new object();
-        private readonly WglContext _sharedWith;
+        private readonly object _lock = new();
+        private readonly WglContext? _sharedWith;
         private readonly IntPtr _context;
         private readonly IntPtr _hWnd;
         private readonly IntPtr _dc;
         private readonly int _pixelFormat;
         private readonly PixelFormatDescriptor _formatDescriptor;
+
         public IntPtr Handle => _context;
 
-        public WglContext(WglContext sharedWith, GlVersion version, IntPtr context, IntPtr hWnd, IntPtr dc, int pixelFormat,
+        public WglContext(WglContext? sharedWith, GlVersion version, IntPtr context, IntPtr hWnd, IntPtr dc, int pixelFormat,
             PixelFormatDescriptor formatDescriptor)
         {
             Version = version;
@@ -54,7 +54,7 @@ namespace Avalonia.Win32.OpenGl
 
         public GlVersion Version { get; }
         public GlInterface GlInterface { get; }
-        public int SampleCount { get; }
+        public int SampleCount => 0;
         public int StencilSize { get; }
 
         private bool IsCurrent => wglGetCurrentContext() == _context && wglGetCurrentDC() == _dc;
@@ -97,12 +97,12 @@ namespace Avalonia.Win32.OpenGl
         }
 
         public bool CanCreateSharedContext => true;
-        public IGlContext CreateSharedContext(IEnumerable<GlVersion> preferredVersions = null)
+        public IGlContext? CreateSharedContext(IEnumerable<GlVersion>? preferredVersions = null)
         {
             var versions = preferredVersions?.Append(Version).ToArray() ?? new[] { Version };
             return WglDisplay.CreateContext(versions, _sharedWith ?? this);
         }
 
-        public object TryGetFeature(Type featureType) => null;
+        public object? TryGetFeature(Type featureType) => null;
     }
 }

--- a/src/Windows/Avalonia.Win32/OpenGl/WglPlatformOpenGlInterface.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/WglPlatformOpenGlInterface.cs
@@ -6,27 +6,31 @@ using Avalonia.Platform;
 
 namespace Avalonia.Win32.OpenGl
 {
-    class WglPlatformOpenGlInterface : IPlatformGraphics
+    internal class WglPlatformOpenGlInterface : IPlatformGraphics
     {
         public WglContext PrimaryContext { get; }
         public bool UsesSharedContext => false;
         IPlatformGraphicsContext IPlatformGraphics.CreateContext() => CreateContext();
         public IPlatformGraphicsContext GetSharedContext() => throw new NotSupportedException();
-        
-        public IGlContext CreateContext() => WglDisplay.CreateContext(new[] { PrimaryContext.Version }, null);
 
-        private  WglPlatformOpenGlInterface(WglContext primary)
+        public IGlContext CreateContext()
+            => WglDisplay.CreateContext(new[] { PrimaryContext.Version }, null)
+               ?? throw new OpenGlException("Unable to create additional WGL context");
+
+        private WglPlatformOpenGlInterface(WglContext primary)
         {
             PrimaryContext = primary;
         }
 
-        public static WglPlatformOpenGlInterface TryCreate()
+        public static WglPlatformOpenGlInterface? TryCreate()
         {
             try
             {
                 var opts = AvaloniaLocator.Current.GetService<Win32PlatformOptions>() ?? new Win32PlatformOptions();
-                var primary = WglDisplay.CreateContext(opts.WglProfiles.ToArray(), null);
-                return new WglPlatformOpenGlInterface(primary);
+                if (WglDisplay.CreateContext(opts.WglProfiles.ToArray(), null) is { } primary)
+                {
+                    return new WglPlatformOpenGlInterface(primary);
+                }
             }
             catch (Exception e)
             {

--- a/src/Windows/Avalonia.Win32/OpenGl/WglRestoreContext.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/WglRestoreContext.cs
@@ -8,11 +8,11 @@ namespace Avalonia.Win32.OpenGl
 {
     internal class WglRestoreContext : IDisposable
     {
-        private readonly object _monitor;
+        private readonly object? _monitor;
         private readonly IntPtr _oldDc;
         private readonly IntPtr _oldContext;
 
-        public WglRestoreContext(IntPtr gc, IntPtr context, object monitor, bool takeMonitor = true)
+        public WglRestoreContext(IntPtr gc, IntPtr context, object? monitor, bool takeMonitor = true)
         {
             _monitor = monitor;
             _oldDc = wglGetCurrentDC();

--- a/src/Windows/Avalonia.Win32/PopupImpl.cs
+++ b/src/Windows/Avalonia.Win32/PopupImpl.cs
@@ -5,9 +5,9 @@ using Avalonia.Win32.Interop;
 
 namespace Avalonia.Win32
 {
-    class PopupImpl : WindowImpl, IPopupImpl
+    internal class PopupImpl : WindowImpl, IPopupImpl
     {
-        private readonly IWindowBaseImpl _parent;
+        private readonly IWindowBaseImpl? _parent;
         private bool _dropShadowHint = true;
         private Size? _maxAutoSize;
 
@@ -92,7 +92,7 @@ namespace Avalonia.Win32
                 IntPtr.Zero);
             s_parentHandle = IntPtr.Zero;
 
-            PopupImpl.EnableBoxShadow(result, _dropShadowHint);
+            EnableBoxShadow(result, _dropShadowHint);
 
             return result;
         }
@@ -113,7 +113,7 @@ namespace Avalonia.Win32
 
         // This is needed because we are calling virtual methods from constructors
         // One fabulous design decision leads to another, I guess
-        static IWindowBaseImpl SaveParentHandle(IWindowBaseImpl parent)
+        private static IWindowBaseImpl SaveParentHandle(IWindowBaseImpl parent)
         {
             s_parentHandle = parent.Handle.Handle;
             return parent;
@@ -126,7 +126,7 @@ namespace Avalonia.Win32
 
         }
 
-        private PopupImpl(IWindowBaseImpl parent, bool dummy) : base()
+        private PopupImpl(IWindowBaseImpl parent, bool dummy)
         {
             _parent = parent;
             PopupPositioner = new ManagedPopupPositioner(new ManagedPopupPositionerPopupImplHelper(parent, MoveResize));
@@ -159,10 +159,7 @@ namespace Avalonia.Win32
         {
             _dropShadowHint = enabled;
 
-            if (Handle != null)
-            {
-                PopupImpl.EnableBoxShadow(Handle.Handle, enabled);
-            }
+            EnableBoxShadow(Handle.Handle, enabled);
         }
 
         public IPopupPositioner PopupPositioner { get; }

--- a/src/Windows/Avalonia.Win32/ScreenImpl.cs
+++ b/src/Windows/Avalonia.Win32/ScreenImpl.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Metadata;
 using Avalonia.Platform;
-using Avalonia.Win32.Interop;
 using static Avalonia.Win32.Interop.UnmanagedMethods;
 
 namespace Avalonia.Win32
@@ -11,12 +10,15 @@ namespace Avalonia.Win32
     [Unstable]
     public class ScreenImpl : IScreenImpl
     {
+        private Screen[]? _allScreens;
+
+        /// <inheritdoc />
         public int ScreenCount
         {
             get => GetSystemMetrics(SystemMetric.SM_CMONITORS);
         }
 
-        private Screen[] _allScreens;
+        /// <inheritdoc />
         public IReadOnlyList<Screen> AllScreens
         {
             get
@@ -38,7 +40,7 @@ namespace Avalonia.Win32
                                 if (method != IntPtr.Zero)
                                 {
                                     GetDpiForMonitor(monitor, MONITOR_DPI_TYPE.MDT_EFFECTIVE_DPI, out var x, out _);
-                                    dpi = (double)x;
+                                    dpi = x;
                                 }
                                 else
                                 {
@@ -74,7 +76,8 @@ namespace Avalonia.Win32
             _allScreens = null;
         }
 
-        public Screen ScreenFromWindow(IWindowBaseImpl window)
+        /// <inheritdoc />
+        public Screen? ScreenFromWindow(IWindowBaseImpl window)
         {
             var handle = window.Handle.Handle;
 
@@ -83,7 +86,8 @@ namespace Avalonia.Win32
             return FindScreenByHandle(monitor);
         }
 
-        public Screen ScreenFromPoint(PixelPoint point)
+        /// <inheritdoc />
+        public Screen? ScreenFromPoint(PixelPoint point)
         {
             var monitor = MonitorFromPoint(new POINT
             {
@@ -94,7 +98,8 @@ namespace Avalonia.Win32
             return FindScreenByHandle(monitor);
         }
 
-        public Screen ScreenFromRect(PixelRect rect)
+        /// <inheritdoc />
+        public Screen? ScreenFromRect(PixelRect rect)
         {
             var monitor = MonitorFromRect(new RECT
             {
@@ -107,7 +112,7 @@ namespace Avalonia.Win32
             return FindScreenByHandle(monitor);
         }
 
-        private Screen FindScreenByHandle(IntPtr handle)
+        private Screen? FindScreenByHandle(IntPtr handle)
         {
             return AllScreens.Cast<WinScreen>().FirstOrDefault(m => m.Handle == handle);
         }

--- a/src/Windows/Avalonia.Win32/TrayIconImpl.cs
+++ b/src/Windows/Avalonia.Win32/TrayIconImpl.cs
@@ -11,8 +11,6 @@ using Avalonia.Styling;
 using Avalonia.Win32.Interop;
 using static Avalonia.Win32.Interop.UnmanagedMethods;
 
-#nullable enable
-
 namespace Avalonia.Win32
 {
     [Unstable]
@@ -25,9 +23,9 @@ namespace Avalonia.Win32
         private IconImpl? _icon;
         private string? _tooltipText;
         private readonly Win32NativeToManagedMenuExporter _exporter;
-        private static readonly Dictionary<int, TrayIconImpl> s_trayIcons = new Dictionary<int, TrayIconImpl>();
+        private static readonly Dictionary<int, TrayIconImpl> s_trayIcons = new();
         private bool _disposedValue;
-        private static readonly uint WM_TASKBARCREATED = UnmanagedMethods.RegisterWindowMessage("TaskbarCreated");
+        private static readonly uint WM_TASKBARCREATED = RegisterWindowMessage("TaskbarCreated");
 
         public TrayIconImpl()
         {
@@ -62,17 +60,20 @@ namespace Avalonia.Win32
             }
         }
 
+        /// <inheritdoc />
         public void SetIcon(IWindowIconImpl? icon)
         {
             _icon = icon as IconImpl;
             UpdateIcon();
         }
 
+        /// <inheritdoc />
         public void SetIsVisible(bool visible)
         {
             UpdateIcon(!visible);
         }
 
+        /// <inheritdoc />
         public void SetToolTipText(string? text)
         {
             _tooltipText = text;
@@ -209,8 +210,11 @@ namespace Avalonia.Win32
 
             private void MoveResize(PixelPoint position, Size size, double scaling)
             {
-                PlatformImpl!.Move(position);
-                PlatformImpl!.Resize(size, PlatformResizeReason.Layout);
+                if (PlatformImpl is { } platformImpl)
+                {
+                    platformImpl.Move(position);
+                    platformImpl.Resize(size, PlatformResizeReason.Layout);
+                }
             }
 
             protected override void ArrangeCore(Rect finalRect)
@@ -221,7 +225,7 @@ namespace Avalonia.Win32
                 {
                     Anchor = PopupAnchor.TopLeft,
                     Gravity = PopupGravity.BottomRight,
-                    AnchorRectangle = new Rect(Position.ToPoint(1) / Screens.Primary.Scaling, new Size(1, 1)),
+                    AnchorRectangle = new Rect(Position.ToPoint(Screens.Primary?.Scaling ?? 1.0), new Size(1, 1)),
                     Size = finalRect.Size,
                     ConstraintAdjustment = PopupPositionerConstraintAdjustment.FlipX | PopupPositionerConstraintAdjustment.FlipY,
                 });
@@ -247,18 +251,22 @@ namespace Avalonia.Win32
                 {
                     get
                     {
-                        var point = _hiddenWindow.Screens.Primary.Bounds.TopLeft;
-                        var size = _hiddenWindow.Screens.Primary.Bounds.Size;
-                        return new Rect(point.X, point.Y, size.Width * _hiddenWindow.Screens.Primary.Scaling, size.Height * _hiddenWindow.Screens.Primary.Scaling);
+                        if (_hiddenWindow.Screens.Primary is { } screen)
+                        {
+                            var point = screen.Bounds.TopLeft;
+                            var size = screen.Bounds.Size;
+                            return new Rect(point.X, point.Y, size.Width * screen.Scaling, size.Height * screen.Scaling);
+                        }
+                        return default;
                     }
                 }
 
                 public void MoveAndResize(Point devicePoint, Size virtualSize)
                 {
-                    _moveResize(new PixelPoint((int)devicePoint.X, (int)devicePoint.Y), virtualSize, _hiddenWindow.Screens.Primary.Scaling);
+                    _moveResize(new PixelPoint((int)devicePoint.X, (int)devicePoint.Y), virtualSize, Scaling);
                 }
 
-                public double Scaling => _hiddenWindow.Screens.Primary.Scaling;
+                public double Scaling => _hiddenWindow.Screens.Primary?.Scaling ?? 1.0;
             }
         }
 

--- a/src/Windows/Avalonia.Win32/Win32GlManager.cs
+++ b/src/Windows/Avalonia.Win32/Win32GlManager.cs
@@ -1,6 +1,4 @@
 using Avalonia.OpenGL;
-using Avalonia.OpenGL.Angle;
-using Avalonia.OpenGL.Egl;
 using Avalonia.Platform;
 using Avalonia.Win32.DirectX;
 using Avalonia.Win32.OpenGl;
@@ -11,16 +9,19 @@ namespace Avalonia.Win32
 {
     static class Win32GlManager
     {
-
-        public static IPlatformGraphics Initialize()
+        public static IPlatformGraphics? Initialize()
         {
             var gl = InitializeCore();
-            AvaloniaLocator.CurrentMutable.Bind<IPlatformGraphics>().ToConstant(gl);
-            AvaloniaLocator.CurrentMutable.Bind<IPlatformGraphics>().ToConstant(gl);
+
+            if (gl is not null)
+            {
+                AvaloniaLocator.CurrentMutable.Bind<IPlatformGraphics>().ToConstant(gl);
+            }
+
             return gl;
         }
         
-        static IPlatformGraphics InitializeCore()
+        private static IPlatformGraphics? InitializeCore()
         {
 
             var opts = AvaloniaLocator.Current.GetService<Win32PlatformOptions>() ?? new Win32PlatformOptions();
@@ -55,7 +56,5 @@ namespace Avalonia.Win32
 
             return null;
         }
-        
-        
     }
 }

--- a/src/Windows/Avalonia.Win32/Win32NativeToManagedMenuExporter.cs
+++ b/src/Windows/Avalonia.Win32/Win32NativeToManagedMenuExporter.cs
@@ -1,12 +1,7 @@
-﻿using System.Collections.Generic;
-using Avalonia.Reactive;
+﻿using Avalonia.Reactive;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Platform;
-using Avalonia.Media.Imaging;
-using Avalonia.Utilities;
-
-#nullable enable
 
 namespace Avalonia.Win32
 {
@@ -19,7 +14,7 @@ namespace Avalonia.Win32
             _nativeMenu = nativeMenu;
         }
 
-        private AvaloniaList<MenuItem> Populate(NativeMenu nativeMenu)
+        private static AvaloniaList<MenuItem> Populate(NativeMenu nativeMenu)
         {
             var result = new AvaloniaList<MenuItem>();
             

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -17,12 +17,10 @@ using Avalonia.Rendering.Composition;
 using Avalonia.Threading;
 using Avalonia.Utilities;
 using Avalonia.Win32.Input;
-using Avalonia.Win32.Interop;
 using static Avalonia.Win32.Interop.UnmanagedMethods;
 
 namespace Avalonia
 {
-#nullable enable
     public static class Win32ApplicationExtensions
     {
         public static AppBuilder UseWin32(this AppBuilder builder)
@@ -106,17 +104,19 @@ namespace Avalonia
         public IPlatformGraphics? CustomPlatformGraphics { get; set; }
     }
 }
-#nullable restore
 
 namespace Avalonia.Win32
 {
     public class Win32Platform : IPlatformThreadingInterface, IWindowingPlatform, IPlatformIconLoader, IPlatformLifetimeEventsImpl
     {
-        private static readonly Win32Platform s_instance = new Win32Platform();
-        private static Thread _uiThread;
-        private UnmanagedMethods.WndProc _wndProcDelegate;
+        private static readonly Win32Platform s_instance = new();
+        private static Thread? s_uiThread;
+        private static Win32PlatformOptions? s_options;
+        private static Compositor? s_compositor;
+
+        private WndProc? _wndProcDelegate;
         private IntPtr _hwnd;
-        private readonly List<Delegate> _delegates = new List<Delegate>();
+        private readonly List<Delegate> _delegates = new();
 
         public Win32Platform()
         {
@@ -135,9 +135,12 @@ namespace Avalonia.Win32
         public static Version WindowsVersion { get; } = RtlGetVersion();
 
         internal static bool UseOverlayPopups => Options.OverlayPopups;
-        public static Win32PlatformOptions Options { get; private set; }
 
-        internal static Compositor Compositor { get; private set; }
+        public static Win32PlatformOptions Options
+            => s_options ?? throw new InvalidOperationException($"{nameof(Win32Platform)} hasn't been initialized");
+
+        internal static Compositor Compositor
+            => s_compositor ?? throw new InvalidOperationException($"{nameof(Win32Platform)} hasn't been initialized");
 
         public static void Initialize()
         {
@@ -146,7 +149,7 @@ namespace Avalonia.Win32
 
         public static void Initialize(Win32PlatformOptions options)
         {
-            Options = options;
+            s_options = options;
             var renderTimer = options.ShouldRenderOnUIThread ? new UiThreadRenderTimer(60) : new DefaultRenderTimer(60);
 
             AvaloniaLocator.CurrentMutable
@@ -171,26 +174,24 @@ namespace Avalonia.Win32
                 .Bind<IMountedVolumeInfoProvider>().ToConstant(new WindowsMountedVolumeInfoProvider())
                 .Bind<IPlatformLifetimeEventsImpl>().ToConstant(s_instance);
             
-            _uiThread = Thread.CurrentThread;
+            s_uiThread = Thread.CurrentThread;
 
-            var platformGraphics = options?.CustomPlatformGraphics
+            var platformGraphics = options.CustomPlatformGraphics
                                    ?? Win32GlManager.Initialize();
             
             if (OleContext.Current != null)
                 AvaloniaLocator.CurrentMutable.Bind<IPlatformDragSource>().ToSingleton<DragSource>();
             
-            Compositor = new Compositor(AvaloniaLocator.Current.GetRequiredService<IRenderLoop>(), platformGraphics);
+            s_compositor = new Compositor(AvaloniaLocator.Current.GetRequiredService<IRenderLoop>(), platformGraphics);
         }
 
         public bool HasMessages()
         {
-            UnmanagedMethods.MSG msg;
-            return PeekMessage(out msg, IntPtr.Zero, 0, 0, 0);
+            return PeekMessage(out _, IntPtr.Zero, 0, 0, 0);
         }
 
         public void ProcessMessage()
         {
-
             if (GetMessage(out var msg, IntPtr.Zero, 0, 0) > -1)
             {
                 TranslateMessage(ref msg);
@@ -222,8 +223,7 @@ namespace Avalonia.Win32
 
         public IDisposable StartTimer(DispatcherPriority priority, TimeSpan interval, Action callback)
         {
-            UnmanagedMethods.TimerProc timerDelegate =
-                (hWnd, uMsg, nIDEvent, dwTime) => callback();
+            TimerProc timerDelegate = (_, _, _, _) => callback();
 
             IntPtr handle = SetTimer(
                 IntPtr.Zero,
@@ -253,11 +253,11 @@ namespace Avalonia.Win32
                 new IntPtr(SignalL));
         }
 
-        public bool CurrentThreadIsLoopThread => _uiThread == Thread.CurrentThread;
+        public bool CurrentThreadIsLoopThread => s_uiThread == Thread.CurrentThread;
 
-        public event Action<DispatcherPriority?> Signaled;
+        public event Action<DispatcherPriority?>? Signaled;
 
-        public event EventHandler<ShutdownRequestedEventArgs> ShutdownRequested;
+        public event EventHandler<ShutdownRequestedEventArgs>? ShutdownRequested;
 
         [SuppressMessage("Microsoft.StyleCop.CSharp.NamingRules", "SA1305:FieldNamesMustNotUseHungarianNotation", Justification = "Using Win32 naming for consistency.")]
         private IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
@@ -301,11 +301,11 @@ namespace Avalonia.Win32
         private void CreateMessageWindow()
         {
             // Ensure that the delegate doesn't get garbage collected by storing it as a field.
-            _wndProcDelegate = new UnmanagedMethods.WndProc(WndProc);
+            _wndProcDelegate = WndProc;
 
-            UnmanagedMethods.WNDCLASSEX wndClassEx = new UnmanagedMethods.WNDCLASSEX
+            WNDCLASSEX wndClassEx = new WNDCLASSEX
             {
-                cbSize = Marshal.SizeOf<UnmanagedMethods.WNDCLASSEX>(),
+                cbSize = Marshal.SizeOf<WNDCLASSEX>(),
                 lpfnWndProc = _wndProcDelegate,
                 hInstance = GetModuleHandle(null),
                 lpszClassName = "AvaloniaMessageWindow " + Guid.NewGuid(),
@@ -326,7 +326,7 @@ namespace Avalonia.Win32
             }
         }
 
-        public ITrayIconImpl CreateTrayIcon ()
+        public ITrayIconImpl CreateTrayIcon()
         {
             return new TrayIconImpl();
         }

--- a/src/Windows/Avalonia.Win32/Win32PlatformSettings.cs
+++ b/src/Windows/Avalonia.Win32/Win32PlatformSettings.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Runtime.InteropServices;
 using Avalonia.Input;
 using Avalonia.Platform;
-using Avalonia.Win32.Interop;
 using Avalonia.Win32.WinRT;
 using static Avalonia.Win32.Interop.UnmanagedMethods;
 
@@ -10,14 +8,14 @@ namespace Avalonia.Win32;
 
 internal class Win32PlatformSettings : DefaultPlatformSettings
 {
-    private PlatformColorValues _lastColorValues;
+    private PlatformColorValues? _lastColorValues;
 
     public override Size GetTapSize(PointerType type)
     {
         return type switch
         {
             PointerType.Touch => new(10, 10),
-            _ => new(GetSystemMetrics(UnmanagedMethods.SystemMetric.SM_CXDRAG), GetSystemMetrics(UnmanagedMethods.SystemMetric.SM_CYDRAG)),
+            _ => new(GetSystemMetrics(SystemMetric.SM_CXDRAG), GetSystemMetrics(SystemMetric.SM_CYDRAG)),
         };
     }
 
@@ -26,7 +24,7 @@ internal class Win32PlatformSettings : DefaultPlatformSettings
         return type switch
         {
             PointerType.Touch => new(16, 16),
-            _ => new(GetSystemMetrics(UnmanagedMethods.SystemMetric.SM_CXDOUBLECLK), GetSystemMetrics(UnmanagedMethods.SystemMetric.SM_CYDOUBLECLK)),
+            _ => new(GetSystemMetrics(SystemMetric.SM_CXDOUBLECLK), GetSystemMetrics(SystemMetric.SM_CYDOUBLECLK)),
         };
     }
 

--- a/src/Windows/Avalonia.Win32/Win32StorageProvider.cs
+++ b/src/Windows/Avalonia.Win32/Win32StorageProvider.cs
@@ -1,13 +1,10 @@
-﻿#nullable enable
-
-using System;
+﻿using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.IO;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using Avalonia.MicroCom;
 using Avalonia.Platform.Storage;
 using Avalonia.Platform.Storage.FileIO;
 using Avalonia.Win32.Interop;
@@ -146,7 +143,7 @@ namespace Avalonia.Win32
                         }
                     }
 
-                    var showResult = frm.Show(_windowImpl.Handle!.Handle);
+                    var showResult = frm.Show(_windowImpl.Handle.Handle);
 
                     if ((uint)showResult == (uint)UnmanagedMethods.HRESULT.E_CANCELLED)
                     {
@@ -188,7 +185,7 @@ namespace Avalonia.Win32
                     var message = new Win32Exception(ex.HResult).Message;
                     throw new COMException(message, ex);
                 }
-            })!;
+            });
         }
 
 
@@ -220,7 +217,6 @@ namespace Avalonia.Win32
             }
 
             var size = Marshal.SizeOf<UnmanagedMethods.COMDLG_FILTERSPEC>();
-            var arr = new byte[size];
             var resultArr = new byte[size * filters.Count];
 
             for (int i = 0; i < filters.Count; i++)
@@ -236,7 +232,7 @@ namespace Avalonia.Win32
                 {
                     var filterStr = new UnmanagedMethods.COMDLG_FILTERSPEC
                     {
-                        pszName = filter.Name ?? string.Empty,
+                        pszName = filter.Name,
                         pszSpec = string.Join(";", filter.Patterns)
                     };
 

--- a/src/Windows/Avalonia.Win32/WinRT/Composition/WinUIEffectBase.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/Composition/WinUIEffectBase.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Linq;
 using System.Runtime.InteropServices;
-using Avalonia.MicroCom;
 using MicroCom.Runtime;
 
 namespace Avalonia.Win32.WinRT.Composition
 {
-    abstract class WinUIEffectBase : WinRTInspectable, IGraphicsEffect,  IGraphicsEffectSource, IGraphicsEffectD2D1Interop
+    internal abstract class WinUIEffectBase : WinRTInspectable, IGraphicsEffect,  IGraphicsEffectSource, IGraphicsEffectD2D1Interop
     {
-        private IGraphicsEffectSource[] _sources;
+        private IGraphicsEffectSource[]? _sources;
 
         public WinUIEffectBase(params IGraphicsEffectSource[] _sources)
         {
@@ -32,7 +31,7 @@ namespace Avalonia.Win32.WinRT.Composition
             throw new COMException("Not supported", unchecked((int)0x80004001));
 
         public abstract uint PropertyCount { get; }
-        public abstract IPropertyValue GetProperty(uint index);
+        public abstract IPropertyValue? GetProperty(uint index);
 
         public IGraphicsEffectSource GetSource(uint index)
         {
@@ -53,14 +52,14 @@ namespace Avalonia.Win32.WinRT.Composition
             _sources = null;
         }
     }
-    
-    class WinUIGaussianBlurEffect : WinUIEffectBase
+
+    internal class WinUIGaussianBlurEffect : WinUIEffectBase
     {
         public WinUIGaussianBlurEffect(IGraphicsEffectSource source) : base(source)
         {
         }
 
-        enum D2D1_GAUSSIANBLUR_OPTIMIZATION
+        private enum D2D1_GAUSSIANBLUR_OPTIMIZATION
         {
             D2D1_GAUSSIANBLUR_OPTIMIZATION_SPEED,
             D2D1_GAUSSIANBLUR_OPTIMIZATION_BALANCED,
@@ -68,14 +67,14 @@ namespace Avalonia.Win32.WinRT.Composition
             D2D1_GAUSSIANBLUR_OPTIMIZATION_FORCE_DWORD
         };
 
-        enum D2D1_BORDER_MODE
+        private enum D2D1_BORDER_MODE
         {
             D2D1_BORDER_MODE_SOFT,
             D2D1_BORDER_MODE_HARD,
             D2D1_BORDER_MODE_FORCE_DWORD
         };
 
-        enum D2D1GaussianBlurProp
+        private enum D2D1GaussianBlurProp
         {
             D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION,
             D2D1_GAUSSIANBLUR_PROP_OPTIMIZATION,
@@ -87,7 +86,7 @@ namespace Avalonia.Win32.WinRT.Composition
 
         public override uint PropertyCount => 3;
 
-        public override IPropertyValue GetProperty(uint index)
+        public override IPropertyValue? GetProperty(uint index)
         {
             switch ((D2D1GaussianBlurProp)index)
             {
@@ -105,14 +104,14 @@ namespace Avalonia.Win32.WinRT.Composition
             return null;
         }
     }
-    
-    class SaturationEffect : WinUIEffectBase
+
+    internal class SaturationEffect : WinUIEffectBase
     {
         public SaturationEffect(IGraphicsEffectSource source) : base(source)
         {
         }
 
-        enum D2D1_SATURATION_PROP
+        private enum D2D1_SATURATION_PROP
         {
             D2D1_SATURATION_PROP_SATURATION,
             D2D1_SATURATION_PROP_FORCE_DWORD
@@ -122,7 +121,7 @@ namespace Avalonia.Win32.WinRT.Composition
 
         public override uint PropertyCount => 1;
 
-        public override IPropertyValue GetProperty(uint index)
+        public override IPropertyValue? GetProperty(uint index)
         {
             switch ((D2D1_SATURATION_PROP)index)
             {

--- a/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositedWindow.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositedWindow.cs
@@ -3,7 +3,6 @@ using System.Numerics;
 using System.Threading;
 using Avalonia.OpenGL.Egl;
 using Avalonia.Reactive;
-using Avalonia.Win32.Interop;
 using MicroCom.Runtime;
 
 namespace Avalonia.Win32.WinRT.Composition;
@@ -12,8 +11,8 @@ internal class WinUiCompositedWindow : IDisposable
 {
     public EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo WindowInfo { get; }
     private readonly WinUiCompositionShared _shared;
-    private readonly ICompositionRoundedRectangleGeometry _compositionRoundedRectangleGeometry;
-    private readonly IVisual _mica;
+    private readonly ICompositionRoundedRectangleGeometry? _compositionRoundedRectangleGeometry;
+    private readonly IVisual? _mica;
     private readonly IVisual _blur;
     private readonly IVisual _visual;
     private PixelSize _size;
@@ -25,7 +24,7 @@ internal class WinUiCompositedWindow : IDisposable
         lock (_shared.SyncRoot)
         {
             _compositionRoundedRectangleGeometry?.Dispose();
-            _blur?.Dispose();
+            _blur.Dispose();
             _mica?.Dispose();
             _visual.Dispose();
             _surfaceBrush.Dispose();

--- a/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositionShared.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositionShared.cs
@@ -8,11 +8,11 @@ internal class WinUiCompositionShared : IDisposable
     public ICompositor Compositor { get; }
     public ICompositor5 Compositor5 { get; }
     public ICompositorDesktopInterop DesktopInterop { get; }
-    public ICompositionBrush BlurBrush;
-    public ICompositionBrush MicaBrush;
+    public ICompositionBrush BlurBrush { get; }
+    public ICompositionBrush? MicaBrush { get; }
     public object SyncRoot { get; } = new();
 
-    public static readonly Version MinHostBackdropVersion = new Version(10, 0, 22000);
+    public static readonly Version MinHostBackdropVersion = new(10, 0, 22000);
     
     public WinUiCompositionShared(ICompositor compositor)
     {
@@ -26,7 +26,7 @@ internal class WinUiCompositionShared : IDisposable
     public void Dispose()
     {
         BlurBrush.Dispose();
-        MicaBrush.Dispose();
+        MicaBrush?.Dispose();
         DesktopInterop.Dispose();
         Compositor.Dispose();
         Compositor5.Dispose();

--- a/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositionUtils.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/Composition/WinUiCompositionUtils.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Numerics;
 using MicroCom.Runtime;
 
@@ -6,7 +5,7 @@ namespace Avalonia.Win32.WinRT.Composition;
 
 internal static class WinUiCompositionUtils
 {
-    public static ICompositionBrush CreateMicaBackdropBrush(ICompositor compositor)
+    public static ICompositionBrush? CreateMicaBackdropBrush(ICompositor compositor)
     {
         if (Win32Platform.WindowsVersion.Build < 22000)
             return null;
@@ -18,7 +17,7 @@ internal static class WinUiCompositionUtils
         return blurredWallpaperBackdropBrush?.QueryInterface<ICompositionBrush>();
     }
 
-    public static unsafe ICompositionBrush CreateAcrylicBlurBackdropBrush(ICompositor compositor)
+    public static ICompositionBrush CreateAcrylicBlurBackdropBrush(ICompositor compositor)
     {
         using var backDropParameterFactory =
             NativeWinRTMethods.CreateActivationFactory<ICompositionEffectSourceParameterFactory>(
@@ -39,7 +38,7 @@ internal static class WinUiCompositionUtils
         return compositionEffectBrush.QueryInterface<ICompositionBrush>();
     }
 
-    public static ICompositionRoundedRectangleGeometry ClipVisual(ICompositor compositor, float? _backdropCornerRadius,  params IVisual[] containerVisuals)
+    public static ICompositionRoundedRectangleGeometry? ClipVisual(ICompositor compositor, float? _backdropCornerRadius,  params IVisual?[] containerVisuals)
     {
         if (!_backdropCornerRadius.HasValue)
             return null;
@@ -77,7 +76,7 @@ internal static class WinUiCompositionUtils
 
     public static ICompositionBrush CreateBackdropBrush(ICompositor compositor)
     {
-        ICompositionBackdropBrush brush = null;
+        ICompositionBackdropBrush? brush = null;
         try
         {
             if (Win32Platform.WindowsVersion >= WinUiCompositionShared.MinHostBackdropVersion)

--- a/src/Windows/Avalonia.Win32/WinRT/NativeWinRTMethods.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/NativeWinRTMethods.cs
@@ -1,12 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.IO;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Avalonia.MicroCom;
-using Avalonia.Win32.Interop;
 using MicroCom.Runtime;
 
 namespace Avalonia.Win32.WinRT
@@ -108,24 +102,24 @@ namespace Avalonia.Win32.WinRT
         [DllImport("combase.dll", PreserveSig = false)]
         private static extern IntPtr RoGetActivationFactory(IntPtr activatableClassId, ref Guid iid);
         
-        private static bool _initialized;
+        private static bool s_initialized;
         private static void EnsureRoInitialized()
         {
-            if (_initialized)
+            if (s_initialized)
                 return;
             RoInitialize(Thread.CurrentThread.GetApartmentState() == ApartmentState.STA ?
                 RO_INIT_TYPE.RO_INIT_SINGLETHREADED :
                 RO_INIT_TYPE.RO_INIT_MULTITHREADED);
-            _initialized = true;
+            s_initialized = true;
         }
     }
 
-    class HStringInterop : IDisposable
+    internal class HStringInterop : IDisposable
     {
         private IntPtr _s;
-        private bool _owns;
+        private readonly bool _owns;
 
-        public HStringInterop(string s)
+        public HStringInterop(string? s)
         {
             _s = s == null ? IntPtr.Zero : NativeWinRTMethods.WindowsCreateString(s);
             _owns = true;
@@ -139,7 +133,7 @@ namespace Avalonia.Win32.WinRT
 
         public IntPtr Handle => _s;
 
-        public unsafe string Value
+        public unsafe string? Value
         {
             get
             {

--- a/src/Windows/Avalonia.Win32/WinRT/WinRTInspectable.cs
+++ b/src/Windows/Avalonia.Win32/WinRT/WinRTInspectable.cs
@@ -2,12 +2,11 @@
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Avalonia.MicroCom;
 using MicroCom.Runtime;
 
 namespace Avalonia.Win32.WinRT
 {
-    class WinRTInspectable : IInspectable, IMicroComShadowContainer
+    internal class WinRTInspectable : IInspectable, IMicroComShadowContainer
     {
         public virtual void Dispose()
         {
@@ -25,9 +24,9 @@ namespace Avalonia.Win32.WinRT
             *iidCount = (ulong) interfaces.Length;
         }
 
-        public IntPtr RuntimeClassName => NativeWinRTMethods.WindowsCreateString(GetType().FullName);
+        public IntPtr RuntimeClassName => NativeWinRTMethods.WindowsCreateString(GetType().FullName!);
         public TrustLevel TrustLevel => TrustLevel.BaseTrust;
-        public MicroComShadow Shadow { get; set; }
+        public MicroComShadow? Shadow { get; set; }
         public virtual void OnReferencedFromNative()
         {
         }

--- a/src/Windows/Avalonia.Win32/WinScreen.cs
+++ b/src/Windows/Avalonia.Win32/WinScreen.cs
@@ -15,14 +15,16 @@ namespace Avalonia.Win32
 
         public IntPtr Handle => _hMonitor;
 
+        /// <inheritdoc />
         public override int GetHashCode()
         {
-            return (int)_hMonitor;
+            return _hMonitor.GetHashCode();
         }
 
-        public override bool Equals(object obj)
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
         {
-            return (obj is WinScreen screen) ? _hMonitor == screen._hMonitor : base.Equals(obj);
+            return obj is WinScreen screen && _hMonitor == screen._hMonitor;
         }
     }
 }

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -137,12 +137,12 @@ namespace Avalonia.Win32
                     {
                         var key = KeyInterop.KeyFromVirtualKey(ToInt32(wParam), ToInt32(lParam));
 
-                        if (key != Key.None && _owner is not null)
+                        if (key != Key.None)
                         {
                             e = new RawKeyEventArgs(
                                 WindowsKeyboardDevice.Instance,
                                 timestamp,
-                                _owner,
+                                Owner,
                                 RawKeyEventType.KeyDown,
                                 key,
                                 WindowsKeyboardDevice.Instance.Modifiers);
@@ -167,12 +167,12 @@ namespace Avalonia.Win32
                     {
                         var key = KeyInterop.KeyFromVirtualKey(ToInt32(wParam), ToInt32(lParam));
 
-                        if (key != Key.None && _owner is not null)
+                        if (key != Key.None)
                         {
                             e = new RawKeyEventArgs(
                             WindowsKeyboardDevice.Instance,
                             timestamp,
-                            _owner,
+                            Owner,
                             RawKeyEventType.KeyUp,
                             key,
                             WindowsKeyboardDevice.Instance.Modifiers);
@@ -182,9 +182,9 @@ namespace Avalonia.Win32
                 case WindowsMessage.WM_CHAR:
                     {
                         // Ignore control chars and chars that were handled in WM_KEYDOWN.
-                        if (ToInt32(wParam) >= 32 && !_ignoreWmChar && _owner is not null)
+                        if (ToInt32(wParam) >= 32 && !_ignoreWmChar)
                         {
-                            e = new RawTextInputEventArgs(WindowsKeyboardDevice.Instance, timestamp, _owner,
+                            e = new RawTextInputEventArgs(WindowsKeyboardDevice.Instance, timestamp, Owner,
                                 new string((char)ToInt32(wParam), 1));
                         }
 
@@ -201,7 +201,7 @@ namespace Avalonia.Win32
                             break;
                         }
                         shouldTakeFocus = ShouldTakeFocusOnClick;
-                        if (ShouldIgnoreTouchEmulatedMessage() || _owner is null)
+                        if (ShouldIgnoreTouchEmulatedMessage())
                         {
                             break;
                         }
@@ -209,7 +209,7 @@ namespace Avalonia.Win32
                         e = new RawPointerEventArgs(
                             _mouseDevice,
                             timestamp,
-                            _owner,
+                            Owner,
 #pragma warning disable CS8509
                             message switch
 #pragma warning restore CS8509
@@ -235,7 +235,7 @@ namespace Avalonia.Win32
                         {
                             break;
                         }
-                        if (ShouldIgnoreTouchEmulatedMessage() || _owner is null)
+                        if (ShouldIgnoreTouchEmulatedMessage())
                         {
                             break;
                         }
@@ -243,7 +243,7 @@ namespace Avalonia.Win32
                         e = new RawPointerEventArgs(
                             _mouseDevice,
                             timestamp,
-                            _owner,
+                            Owner,
 #pragma warning disable CS8509
                             message switch
 #pragma warning restore CS8509
@@ -310,15 +310,10 @@ namespace Avalonia.Win32
                         var prevPoint = _lastWmMousePoint;
                         _lastWmMousePoint = currPoint;
 
-                        if (_owner is null)
-                        {
-                            break;
-                        }
-
                         e = new RawPointerEventArgs(
                             _mouseDevice,
                             timestamp,
-                            _owner,
+                            Owner,
                             RawPointerEventType.Move,
                             point,
                             GetMouseModifiers(wParam))
@@ -331,14 +326,14 @@ namespace Avalonia.Win32
 
                 case WindowsMessage.WM_MOUSEWHEEL:
                     {
-                        if (IsMouseInPointerEnabled || _owner is null)
+                        if (IsMouseInPointerEnabled)
                         {
                             break;
                         }
                         e = new RawMouseWheelEventArgs(
                             _mouseDevice,
                             timestamp,
-                            _owner,
+                            Owner,
                             PointToClient(PointFromLParam(lParam)),
                             new Vector(0, (ToInt32(wParam) >> 16) / wheelDelta),
                             GetMouseModifiers(wParam));
@@ -347,14 +342,14 @@ namespace Avalonia.Win32
 
                 case WindowsMessage.WM_MOUSEHWHEEL:
                     {
-                        if (IsMouseInPointerEnabled || _owner is null)
+                        if (IsMouseInPointerEnabled)
                         {
                             break;
                         }
                         e = new RawMouseWheelEventArgs(
                             _mouseDevice,
                             timestamp,
-                            _owner,
+                            Owner,
                             PointToClient(PointFromLParam(lParam)),
                             new Vector(-(ToInt32(wParam) >> 16) / wheelDelta, 0),
                             GetMouseModifiers(wParam));
@@ -368,14 +363,10 @@ namespace Avalonia.Win32
                             break;
                         }
                         _trackingMouse = false;
-                        if (_owner is null)
-                        {
-                            break;
-                        }
                         e = new RawPointerEventArgs(
                             _mouseDevice,
                             timestamp,
-                            _owner,
+                            Owner,
                             RawPointerEventType.LeaveWindow,
                             new Point(-1, -1),
                             WindowsKeyboardDevice.Instance.Modifiers);
@@ -387,14 +378,14 @@ namespace Avalonia.Win32
                 case WindowsMessage.WM_NCMBUTTONDOWN:
                 case WindowsMessage.WM_NCXBUTTONDOWN:
                     {
-                        if (IsMouseInPointerEnabled || _owner is null)
+                        if (IsMouseInPointerEnabled)
                         {
                             break;
                         }
                         e = new RawPointerEventArgs(
                             _mouseDevice,
                             timestamp,
-                            _owner,
+                            Owner,
 #pragma warning disable CS8509
                             message switch
 #pragma warning restore CS8509
@@ -413,7 +404,7 @@ namespace Avalonia.Win32
                     }
                 case WindowsMessage.WM_TOUCH:
                     {
-                        if (_wmPointerEnabled || _owner is null || Input is not { } input)
+                        if (_wmPointerEnabled || Input is not { } input)
                         {
                             break;
                         }
@@ -427,7 +418,7 @@ namespace Avalonia.Win32
                             foreach (var touchInput in touchInputs)
                             {
                                 input.Invoke(new RawTouchEventArgs(_touchDevice, touchInput.Time,
-                                    _owner,
+                                    Owner,
                                     touchInput.Flags.HasAllFlags(TouchInputFlags.TOUCHEVENTF_UP) ?
                                         RawPointerEventType.TouchEnd :
                                         touchInput.Flags.HasAllFlags(TouchInputFlags.TOUCHEVENTF_DOWN) ?
@@ -450,14 +441,14 @@ namespace Avalonia.Win32
                 case WindowsMessage.WM_POINTERUP:
                 case WindowsMessage.WM_POINTERUPDATE:
                     {
-                        if (!_wmPointerEnabled || _owner is null)
+                        if (!_wmPointerEnabled)
                         {
                             break;
                         }
                         GetDevicePointerInfo(wParam, out var device, out var info, out var point, out var modifiers, ref timestamp);
                         var eventType = GetEventType(message, info);
 
-                        var args = CreatePointerArgs(device, timestamp, _owner, eventType, point, modifiers, info.pointerId);
+                        var args = CreatePointerArgs(device, timestamp, eventType, point, modifiers, info.pointerId);
                         args.IntermediatePoints = CreateLazyIntermediatePoints(info);
                         e = args;
                         break;
@@ -466,19 +457,19 @@ namespace Avalonia.Win32
                 case WindowsMessage.WM_POINTERLEAVE:
                 case WindowsMessage.WM_POINTERCAPTURECHANGED:
                     {
-                        if (!_wmPointerEnabled || _owner is null)
+                        if (!_wmPointerEnabled)
                         {
                             break;
                         }
                         GetDevicePointerInfo(wParam, out var device, out var info, out var point, out var modifiers, ref timestamp);
                         var eventType = device is TouchDevice ? RawPointerEventType.TouchCancel : RawPointerEventType.LeaveWindow;
-                        e = CreatePointerArgs(device, timestamp, _owner, eventType, point, modifiers, info.pointerId);
+                        e = CreatePointerArgs(device, timestamp, eventType, point, modifiers, info.pointerId);
                         break;
                     }
                 case WindowsMessage.WM_POINTERWHEEL:
                 case WindowsMessage.WM_POINTERHWHEEL:
                     {
-                        if (!_wmPointerEnabled || _owner is null)
+                        if (!_wmPointerEnabled)
                         {
                             break;
                         }
@@ -486,7 +477,7 @@ namespace Avalonia.Win32
 
                         var val = (ToInt32(wParam) >> 16) / wheelDelta;
                         var delta = message == WindowsMessage.WM_POINTERWHEEL ? new Vector(0, val) : new Vector(val, 0);
-                        e = new RawMouseWheelEventArgs(device, timestamp, _owner, point.Position, delta, modifiers)
+                        e = new RawMouseWheelEventArgs(device, timestamp, Owner, point.Position, delta, modifiers)
                         {
                             RawPointerId = info.pointerId
                         };
@@ -900,11 +891,11 @@ namespace Avalonia.Win32
             }
         }
 
-        private RawPointerEventArgs CreatePointerArgs(IInputDevice device, ulong timestamp, IInputRoot owner, RawPointerEventType eventType, RawPointerPoint point, RawInputModifiers modifiers, uint rawPointerId)
+        private RawPointerEventArgs CreatePointerArgs(IInputDevice device, ulong timestamp, RawPointerEventType eventType, RawPointerPoint point, RawInputModifiers modifiers, uint rawPointerId)
         {
             return device is TouchDevice
-                ? new RawTouchEventArgs(device, timestamp, owner, eventType, point, modifiers, rawPointerId)
-                : new RawPointerEventArgs(device, timestamp, owner, eventType, point, modifiers)
+                ? new RawTouchEventArgs(device, timestamp, Owner, eventType, point, modifiers, rawPointerId)
+                : new RawPointerEventArgs(device, timestamp, Owner, eventType, point, modifiers)
                 {
                     RawPointerId = rawPointerId
                 };

--- a/src/Windows/Avalonia.Win32/WindowImpl.CustomCaptionProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.CustomCaptionProc.cs
@@ -3,8 +3,6 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using static Avalonia.Win32.Interop.UnmanagedMethods;
 
-#nullable enable
-
 namespace Avalonia.Win32
 {
     public partial class WindowImpl
@@ -13,7 +11,7 @@ namespace Avalonia.Win32
         private HitTestValues HitTestNCA(IntPtr hWnd, IntPtr wParam, IntPtr lParam)
         {
             // Get the point coordinates for the hit test (screen space).
-            var ptMouse = WindowImpl.PointFromLParam(lParam);
+            var ptMouse = PointFromLParam(lParam);
 
             // Get the window rectangle.
             GetWindowRect(hWnd, out var rcWindow);
@@ -101,11 +99,9 @@ namespace Avalonia.Win32
 
                         lRet = (IntPtr)hittestResult;
 
-                        uint timestamp = unchecked((uint)GetMessageTime());
-
                         if (hittestResult == HitTestValues.HTCAPTION)
                         {
-                            var position = PointToClient(WindowImpl.PointFromLParam(lParam));
+                            var position = PointToClient(PointFromLParam(lParam));
 
                             if (_owner is Window window)
                             {

--- a/src/Windows/Avalonia.Win32/WindowImpl.WndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.WndProc.cs
@@ -2,14 +2,7 @@
 // Licensed under the MIT license. See licence.md file in the project root for full license information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
-using Avalonia.Controls;
 using Avalonia.Controls.Platform;
-using Avalonia.Input;
-using Avalonia.Input.Raw;
-using Avalonia.Win32.Input;
-using static Avalonia.Win32.Interop.UnmanagedMethods;
 
 namespace Avalonia.Win32
 {

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -180,40 +180,31 @@ namespace Avalonia.Win32
             s_instances.Add(this);
         }
 
-        /// <inheritdoc />
+        private IInputRoot Owner
+            => _owner ?? throw new InvalidOperationException($"{nameof(SetInputRoot)} must have been called");
+
         public Action? Activated { get; set; }
 
-        /// <inheritdoc />
         public Func<WindowCloseReason, bool>? Closing { get; set; }
 
-        /// <inheritdoc />
         public Action? Closed { get; set; }
 
-        /// <inheritdoc />
         public Action? Deactivated { get; set; }
 
-        /// <inheritdoc />
         public Action<RawInputEventArgs>? Input { get; set; }
 
-        /// <inheritdoc />
         public Action<Rect>? Paint { get; set; }
 
-        /// <inheritdoc />
         public Action<Size, PlatformResizeReason>? Resized { get; set; }
 
-        /// <inheritdoc />
         public Action<double>? ScalingChanged { get; set; }
 
-        /// <inheritdoc />
         public Action<PixelPoint>? PositionChanged { get; set; }
 
-        /// <inheritdoc />
         public Action<WindowState>? WindowStateChanged { get; set; }
 
-        /// <inheritdoc />
         public Action? LostFocus { get; set; }
 
-        /// <inheritdoc />
         public Action<WindowTransparencyLevel>? TransparencyLevelChanged { get; set; }
 
         public Thickness BorderThickness
@@ -245,13 +236,10 @@ namespace Avalonia.Win32
 
         private double PrimaryScreenRenderScaling => Screen.AllScreens.FirstOrDefault(screen => screen.IsPrimary)?.Scaling ?? 1;
 
-        /// <inheritdoc />
         public double RenderScaling => _scaling;
 
-        /// <inheritdoc />
         public double DesktopScaling => RenderScaling;
 
-        /// <inheritdoc />
         public Size ClientSize
         {
             get
@@ -262,7 +250,6 @@ namespace Avalonia.Win32
             }
         }
 
-        /// <inheritdoc />
         public Size? FrameSize
         {
             get
@@ -278,18 +265,14 @@ namespace Avalonia.Win32
             }
         }
 
-        /// <inheritdoc />
         public IScreenImpl Screen { get; }
 
-        /// <inheritdoc />
         public IPlatformHandle Handle { get; private set; }
 
-        /// <inheritdoc />
         public virtual Size MaxAutoSizeHint => new Size(_maxTrackSize.X / RenderScaling, _maxTrackSize.Y / RenderScaling);
 
         public IMouseDevice MouseDevice => _mouseDevice;
 
-        /// <inheritdoc />
         public WindowState WindowState
         {
             get
@@ -327,14 +310,12 @@ namespace Avalonia.Win32
             }
         }
 
-        /// <inheritdoc />
         public WindowTransparencyLevel TransparencyLevel { get; private set; }
 
         protected IntPtr Hwnd => _hwnd;
 
         private bool IsMouseInPointerEnabled => _wmPointerEnabled && IsMouseInPointerEnabled();
 
-        /// <inheritdoc />
         public object? TryGetFeature(Type featureType)
         {
             if (featureType == typeof(ITextInputMethodImpl))
@@ -355,7 +336,6 @@ namespace Avalonia.Win32
             return null;
         }
 
-        /// <inheritdoc />
         public void SetTransparencyLevelHint(WindowTransparencyLevel transparencyLevel)
         {
             TransparencyLevel = EnableBlur(transparencyLevel);
@@ -537,13 +517,11 @@ namespace Avalonia.Win32
             }
         }
 
-        /// <inheritdoc />
         public IEnumerable<object> Surfaces
             => _gl is null ?
                 new object[] { Handle, _framebuffer } :
                 new object[] { Handle, _gl, _framebuffer };
 
-        /// <inheritdoc />
         public PixelPoint Position
         {
             get
@@ -589,21 +567,17 @@ namespace Avalonia.Win32
             }
         }
 
-        /// <inheritdoc />
         public void Move(PixelPoint point) => Position = point;
 
-        /// <inheritdoc />
         public void SetMinMaxSize(Size minSize, Size maxSize)
         {
             _minSize = minSize;
             _maxSize = maxSize;
         }
 
-        /// <inheritdoc />
         public IRenderer CreateRenderer(IRenderRoot root) =>
             new CompositingRenderer(root, Win32Platform.Compositor, () => Surfaces);
 
-        /// <inheritdoc />
         public void Resize(Size value, PlatformResizeReason reason)
         {
             if (WindowState != WindowState.Normal)
@@ -631,16 +605,13 @@ namespace Avalonia.Win32
             }
         }
 
-        /// <inheritdoc />
         public void Activate()
         {
             SetForegroundWindow(_hwnd);
         }
 
-        /// <inheritdoc />
         public IPopupImpl? CreatePopup() => Win32Platform.UseOverlayPopups ? null : new PopupImpl(this);
 
-        /// <inheritdoc />
         public void Dispose()
         {
             (_gl as IDisposable)?.Dispose();
@@ -682,7 +653,6 @@ namespace Avalonia.Win32
             InvalidateRect(_hwnd, ref r, false);
         }
 
-        /// <inheritdoc />
         public Point PointToClient(PixelPoint point)
         {
             var p = new POINT { X = point.X, Y = point.Y };
@@ -690,7 +660,6 @@ namespace Avalonia.Win32
             return new Point(p.X, p.Y) / RenderScaling;
         }
 
-        /// <inheritdoc />
         public PixelPoint PointToScreen(Point point)
         {
             point *= RenderScaling;
@@ -699,31 +668,26 @@ namespace Avalonia.Win32
             return new PixelPoint(p.X, p.Y);
         }
 
-        /// <inheritdoc />
         public void SetInputRoot(IInputRoot inputRoot)
         {
             _owner = inputRoot;
             CreateDropTarget(inputRoot);
         }
 
-        /// <inheritdoc />
         public void Hide()
         {
             UnmanagedMethods.ShowWindow(_hwnd, ShowWindowCommand.Hide);
             _shown = false;
         }
 
-        /// <inheritdoc />
         public virtual void Show(bool activate, bool isDialog)
         {
             SetParent(_parent);
             ShowWindow(_showWindowState, activate);
         }
 
-        /// <inheritdoc />
         public Action? GotInputWhenDisabled { get; set; }
 
-        /// <inheritdoc />
         public void SetParent(IWindowImpl? parent)
         {
             _parent = parent as WindowImpl;
@@ -739,10 +703,8 @@ namespace Avalonia.Win32
             SetWindowLongPtr(_hwnd, (int)WindowLongParam.GWL_HWNDPARENT, parentHwnd);
         }
 
-        /// <inheritdoc />
         public void SetEnabled(bool enable) => EnableWindow(_hwnd, enable);
 
-        /// <inheritdoc />
         public void BeginMoveDrag(PointerPressedEventArgs e)
         {
             e.Pointer.Capture(null);
@@ -750,7 +712,6 @@ namespace Avalonia.Win32
                 new IntPtr((int)HitTestValues.HTCAPTION), IntPtr.Zero);
         }
 
-        /// <inheritdoc />
         public void BeginResizeDrag(WindowEdge edge, PointerPressedEventArgs e)
         {
             if (_windowProperties.IsResizable)
@@ -765,13 +726,11 @@ namespace Avalonia.Win32
             }
         }
 
-        /// <inheritdoc />
         public void SetTitle(string? title)
         {
             SetWindowText(_hwnd, title);
         }
 
-        /// <inheritdoc />
         public void SetCursor(ICursorImpl? cursor)
         {
             var impl = cursor as CursorImpl;
@@ -779,13 +738,12 @@ namespace Avalonia.Win32
             var hCursor = impl?.Handle ?? s_defaultCursor;
             SetClassLong(_hwnd, ClassLongIndex.GCLP_HCURSOR, hCursor);
 
-            if (_owner?.IsPointerOver == true)
+            if (Owner.IsPointerOver)
             {
                 UnmanagedMethods.SetCursor(hCursor);
             }
         }
 
-        /// <inheritdoc />
         public void SetIcon(IWindowIconImpl? icon)
         {
             var impl = icon as IconImpl;
@@ -795,7 +753,6 @@ namespace Avalonia.Win32
                 new IntPtr((int)Icons.ICON_BIG), hIcon);
         }
 
-        /// <inheritdoc />
         public void ShowTaskbarIcon(bool value)
         {
             var newWindowProperties = _windowProperties;
@@ -805,7 +762,6 @@ namespace Avalonia.Win32
             UpdateWindowProperties(newWindowProperties);
         }
 
-        /// <inheritdoc />
         public void CanResize(bool value)
         {
             var newWindowProperties = _windowProperties;
@@ -815,7 +771,6 @@ namespace Avalonia.Win32
             UpdateWindowProperties(newWindowProperties);
         }
 
-        /// <inheritdoc />
         public void SetSystemDecorations(SystemDecorations value)
         {
             var newWindowProperties = _windowProperties;
@@ -825,7 +780,6 @@ namespace Avalonia.Win32
             UpdateWindowProperties(newWindowProperties);
         }
 
-        /// <inheritdoc />
         public void SetTopmost(bool value)
         {
             if (value == _topmost)
@@ -842,7 +796,6 @@ namespace Avalonia.Win32
             _topmost = value;
         }
 
-        /// <inheritdoc />
         public unsafe void SetFrameThemeVariant(PlatformThemeVariant themeVariant)
         {
             if (Win32Platform.WindowsVersion.Build >= 22000)
@@ -1457,7 +1410,6 @@ namespace Avalonia.Win32
 
         IntPtr EglGlPlatformSurface.IEglWindowGlPlatformSurfaceInfo.Handle => Handle.Handle;
 
-        /// <inheritdoc />
         public void SetExtendClientAreaToDecorationsHint(bool hint)
         {
             _isClientAreaExtended = hint;
@@ -1465,7 +1417,6 @@ namespace Avalonia.Win32
             ExtendClientArea();
         }
 
-        /// <inheritdoc />
         public void SetExtendClientAreaChromeHints(ExtendClientAreaChromeHints hints)
         {
             _extendChromeHints = hints;

--- a/src/Windows/Avalonia.Win32/WindowsMountedVolumeInfoListener.cs
+++ b/src/Windows/Avalonia.Win32/WindowsMountedVolumeInfoListener.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-using Avalonia.Reactive;
 using Avalonia.Controls.Platform;
 using Avalonia.Logging;
 using Avalonia.Threading;
@@ -12,12 +11,12 @@ namespace Avalonia.Win32
     internal class WindowsMountedVolumeInfoListener : IDisposable
     {
         private readonly IDisposable _disposable;
-        private bool _beenDisposed = false;
-        private ObservableCollection<MountedVolumeInfo> mountedDrives;
+        private bool _beenDisposed;
+        private readonly ObservableCollection<MountedVolumeInfo> _mountedDrives;
 
         public WindowsMountedVolumeInfoListener(ObservableCollection<MountedVolumeInfo> mountedDrives)
         {
-            this.mountedDrives = mountedDrives;
+            _mountedDrives = mountedDrives;
 
             _disposable = DispatcherTimer.Run(Poll, TimeSpan.FromSeconds(1));
 
@@ -51,14 +50,14 @@ namespace Avalonia.Win32
                                 })
                                 .ToArray();
 
-            if (mountedDrives.SequenceEqual(mountVolInfos))
+            if (_mountedDrives.SequenceEqual(mountVolInfos))
                 return true;
             else
             {
-                mountedDrives.Clear();
+                _mountedDrives.Clear();
 
                 foreach (var i in mountVolInfos)
-                    mountedDrives.Add(i);
+                    _mountedDrives.Add(i);
                 return true;
             }
         }

--- a/src/tools/DevGenerators/Helpers.cs
+++ b/src/tools/DevGenerators/Helpers.cs
@@ -6,16 +6,21 @@ namespace Generator;
 
 static class Helpers
 {
+    private static readonly SymbolDisplayFormat s_symbolDisplayFormat =
+        SymbolDisplayFormat.FullyQualifiedFormat.WithMiscellaneousOptions(
+            SymbolDisplayFormat.FullyQualifiedFormat.MiscellaneousOptions |
+            SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
+
     public static StringBuilder Pad(this StringBuilder sb, int count) => sb.Append(' ', count * 4);
 
     public static string GetFullyQualifiedName(this ISymbol symbol)
     {
-        return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        return symbol.ToDisplayString(s_symbolDisplayFormat);
     }
     
     public static bool HasFullyQualifiedName(this ISymbol symbol, string name)
     {
-        return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == name;
+        return symbol.ToDisplayString(s_symbolDisplayFormat) == name;
     }
 
     public static bool HasAttributeWithFullyQualifiedName(this ISymbol symbol, string name)


### PR DESCRIPTION
Enables nullable annotations for Avalonia.Win32.

Potential bug fixes:
- `DataObject`: the checks in the constructor were always false because they were checking the non-assigned field instead of the parameter.
- `NonPumpingSyncContext`: removed the `STA` check as it caused a `new NonPumpingSyncContext(null)`, which will throw on use. This code path was never taken since there's always a sync context on the UI thread.
- `WindowImpl.WndProc`: checks for `_owner` nullness. In practice callers currently always call `SetInputRoot` before, but that's not really part of the contract. (Overall `WindowImpl` could benefit from a refactoring – as already noted in some comments – but it's out of scope here).
- `WglPlatformOpenGlInterface.CreateContext` now throws instead of returning null, which wasn't expected by callers. It's unlikely to fail since at this point a primary WGL context has already been created before.

Misc changes:
- `ImmGetCompositionString` uses `stackalloc` for small buffers (composition strings are typically very small).
- Removed some `#pragma warning disable CA1416` as it's already disabled in the csproj file.
- The source generator for `GetProcAddressAttribute` now copies nullable annotations from the `partial` method.
