### PR TITLE
Fixed theme variant properties

### DIFF
--- a/src/Avalonia.Base/StyledElement.cs
+++ b/src/Avalonia.Base/StyledElement.cs
@@ -76,7 +76,7 @@ namespace Avalonia
         /// </summary>
         public static readonly StyledProperty<ThemeVariant> ActualThemeVariantProperty =
             AvaloniaProperty.Register<StyledElement, ThemeVariant>(
-                nameof(ThemeVariant),
+                nameof(ActualThemeVariant),
                 inherits: true,
                 defaultValue: ThemeVariant.Light);
 
@@ -85,8 +85,21 @@ namespace Avalonia
         /// </summary>
         public static readonly StyledProperty<ThemeVariant?> RequestedThemeVariantProperty =
             AvaloniaProperty.Register<StyledElement, ThemeVariant?>(
-                nameof(ThemeVariant),
+                nameof(RequestedThemeVariant),
                 defaultValue: ThemeVariant.Default);
+
+        /// <summary>
+        /// Gets or sets the UI theme variant that is used by the control (and its child elements) for resource determination.
+        /// The UI theme you specify with ThemeVariant can override the app-level ThemeVariant.
+        /// </summary>
+        /// <remarks>
+        /// Setting RequestedThemeVariant to <see cref="ThemeVariant.Default"/> will apply parent's actual theme variant on the current scope.
+        /// </remarks>
+        public ThemeVariant? RequestedThemeVariant
+        {
+            get => GetValue(RequestedThemeVariantProperty);
+            set => SetValue(RequestedThemeVariantProperty, value);
+        }
 
         private static readonly ControlTheme s_invalidTheme = new ControlTheme();
         private int _initCount;

--- a/src/Avalonia.Controls/ThemeVariantScope.cs
+++ b/src/Avalonia.Controls/ThemeVariantScope.cs
@@ -7,17 +7,5 @@ namespace Avalonia.Controls
     /// </summary>
     public class ThemeVariantScope : Decorator
     {
-        /// <summary>
-        /// Gets or sets the UI theme variant that is used by the control (and its child elements) for resource determination.
-        /// The UI theme you specify with ThemeVariant can override the app-level ThemeVariant.
-        /// </summary>
-        /// <remarks>
-        /// Setting RequestedThemeVariant to <see cref="ThemeVariant.Default"/> will apply parent's actual theme variant on the current scope.
-        /// </remarks>
-        public ThemeVariant? RequestedThemeVariant
-        {
-            get => GetValue(RequestedThemeVariantProperty);
-            set => SetValue(RequestedThemeVariantProperty, value);
-        }
     }
 }

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -297,13 +297,6 @@ namespace Avalonia.Controls
             set => SetValue(TransparencyBackgroundFallbackProperty, value);
         }
 
-        /// <inheritdoc cref="ThemeVariantScope.RequestedThemeVariant"/>
-        public ThemeVariant? RequestedThemeVariant
-        {
-            get => GetValue(RequestedThemeVariantProperty);
-            set => SetValue(RequestedThemeVariantProperty, value);
-        }
-
         /// <summary>
         /// Occurs when physical Back Button is pressed or a back navigation has been requested.
         /// </summary>


### PR DESCRIPTION
## What does the pull request do?

Fixed theme variant properties: the names were wrong and the CLR properties have to be in the same class as the Avalonia property (also, changing the property owner doesn't seem to make any difference).

## What is the current behavior?

It's impossible to bind to `TopLevel.RequestedThemeVariant`.

## What is the updated/expected behavior with this PR?

It's possible to bind to `TopLevel.RequestedThemeVariant`. However, it's also possible to bind to any `StyledElement.RequestedThemeVariant`, so `ThemeVariantScope` seems to be useless (still testing things, not sure).

**EDIT:** Setting `RequestedThemeVariant` on controls works fine, so `ThemeVariantScope` actually doesn't seem to be needed.

## How was the solution implemented (if it's not obvious)?

Moved the CLR property definition to `StyledElement`, where the Avalonia property is declared.

An alternative would be to remove the Avalonia property in `StyledElement` and make the one in `TopLevel` an `AddOwner` of the one in `ThemeVariantScope`.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Fixed issues

Fixes #10309