### PR TITLE
Use NT shared handles for Vulkan interop on Windows

### DIFF
--- a/samples/GpuInterop/VulkanDemo/D3DMemoryHelper.cs
+++ b/samples/GpuInterop/VulkanDemo/D3DMemoryHelper.cs
@@ -47,7 +47,7 @@ public class D3DMemoryHelper
                 MipLevels = 1,
                 SampleDescription = new SampleDescription { Count = 1, Quality = 0 },
                 CpuAccessFlags = default,
-                OptionFlags = ResourceOptionFlags.SharedKeyedmutex,
+                OptionFlags = ResourceOptionFlags.SharedKeyedmutex|ResourceOptionFlags.SharedNthandle,
                 BindFlags = BindFlags.RenderTarget | BindFlags.ShaderResource
             });
     }

--- a/samples/GpuInterop/VulkanDemo/VulkanContext.cs
+++ b/samples/GpuInterop/VulkanDemo/VulkanContext.cs
@@ -173,7 +173,7 @@ public unsafe class VulkanContext : IDisposable
                 api.GetPhysicalDeviceQueueFamilyProperties(physicalDevice, ref queueFamilyCount, familyProperties);
                 for (uint queueFamilyIndex = 0; queueFamilyIndex < queueFamilyCount; queueFamilyIndex++)
                 {
-                    var family = familyProperties[c];
+                    var family = familyProperties[queueFamilyIndex];
                     if (!family.QueueFlags.HasAllFlags(QueueFlags.GraphicsBit))
                         continue;
 

--- a/samples/GpuInterop/VulkanDemo/VulkanImage.cs
+++ b/samples/GpuInterop/VulkanDemo/VulkanImage.cs
@@ -62,7 +62,7 @@ public unsafe class VulkanImage : IDisposable
             //MipLevels = MipLevels != 0 ? MipLevels : (uint)Math.Floor(Math.Log(Math.Max(Size.Width, Size.Height), 2));
 
             var handleType = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-                ExternalMemoryHandleTypeFlags.D3D11TextureKmtBit :
+                ExternalMemoryHandleTypeFlags.D3D11TextureBit :
                 ExternalMemoryHandleTypeFlags.OpaqueFDBit;
             var externalMemoryCreateInfo = new ExternalMemoryImageCreateInfo
             {

--- a/src/Windows/Avalonia.Win32/DirectX/directx.idl
+++ b/src/Windows/Avalonia.Win32/DirectX/directx.idl
@@ -36,6 +36,8 @@
 @clr-map DXGI_SHARED_RESOURCE void*
 @clr-map LUID ulong
 @clr-map LPSTR ushort*
+@clr-map LPWSTR ushort*
+@clr-map LPCWSTR ushort*
 
 
 enum DXGI_FORMAT
@@ -500,6 +502,44 @@ interface ID3D11Device : IUnknown
     HRESULT SetExceptionMode( UINT RaiseFlags );
     UINT GetExceptionMode();
 }
+
+[uuid(a04bfb29-08ef-43d6-a49c-a9bdbdcbe686)]
+interface ID3D11Device1 : ID3D11Device
+{
+    void GetImmediateContext1( void** ppImmediateContext );
+
+    HRESULT CreateDeferredContext1(
+            UINT ContextFlags, // Reserved parameter; must be 0
+            [out, retval] IUnknown** ppDeferredContext );
+
+    HRESULT CreateBlendState1(
+        void* pBlendStateDesc,
+        [out, retval] IUnknown** ppBlendState );
+
+    HRESULT CreateRasterizerState1(
+        void* pRasterizerDesc,
+        [out, retval] IUnknown** ppRasterizerState );
+
+    HRESULT CreateDeviceContextState(
+        UINT Flags,
+        void* pFeatureLevels,
+        UINT FeatureLevels,
+        UINT SDKVersion,
+        GUID* EmulatedInterface,
+        void* pChosenFeatureLevel,
+        [out, retval] IUnknown** ppContextState);
+
+    HRESULT OpenSharedResource1(
+        IntPtr hResource,
+        Guid* ReturnedInterface,
+        [out, retval] IUnknown** ppResource);
+
+    HRESULT OpenSharedResourceByName(
+        LPCWSTR lpName,
+        DWORD dwDesiredAccess,
+        REFIID returnedInterface,
+        void** ppResource);
+};
 
 
 [uuid( 6f15aaf2-d208-4e89-9ab4-489535d34f9c)]


### PR DESCRIPTION
Apparently that's required for Intel and nVidia GPUs