### PR TITLE
Lazy initialized Win32 pointer info buffers

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -793,6 +793,7 @@ namespace Avalonia.Win32
 
                     if (info.pointerType == PointerInputType.PT_TOUCH)
                     {
+                        s_historyTouchInfos ??= new POINTER_TOUCH_INFO[MaxPointerHistorySize];
                         if (GetPointerTouchInfoHistory(info.pointerId, ref historyCount, s_historyTouchInfos))
                         {
                             for (int i = historyCount - 1; i >= 1; i--)
@@ -804,6 +805,7 @@ namespace Avalonia.Win32
                     }
                     else if (info.pointerType == PointerInputType.PT_PEN)
                     {
+                        s_historyPenInfos ??= new POINTER_PEN_INFO[MaxPointerHistorySize];
                         if (GetPointerPenInfoHistory(info.pointerId, ref historyCount, s_historyPenInfos))
                         {
                             for (int i = historyCount - 1; i >= 1; i--)
@@ -815,6 +817,7 @@ namespace Avalonia.Win32
                     }
                     else
                     {
+                        s_historyInfos ??= new POINTER_INFO[MaxPointerHistorySize];
                         // Currently Windows does not return history info for mouse input, but we handle it just for case.
                         if (GetPointerInfoHistory(info.pointerId, ref historyCount, s_historyInfos))
                         {
@@ -836,6 +839,8 @@ namespace Avalonia.Win32
         {
             // To understand some of this code, please check MS docs:
             // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getmousemovepointsex#remarks
+
+            s_mouseHistoryInfos ??= new MOUSEMOVEPOINT[64];
 
             fixed (MOUSEMOVEPOINT* movePoints = s_mouseHistoryInfos)
             {

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -100,10 +100,10 @@ namespace Avalonia.Win32
 
         private const int MaxPointerHistorySize = 512;
         private static readonly PooledList<RawPointerPoint> s_intermediatePointsPooledList = new();
-        private static readonly POINTER_TOUCH_INFO[] s_historyTouchInfos = new POINTER_TOUCH_INFO[MaxPointerHistorySize];
-        private static readonly POINTER_PEN_INFO[] s_historyPenInfos = new POINTER_PEN_INFO[MaxPointerHistorySize];
-        private static readonly POINTER_INFO[] s_historyInfos = new POINTER_INFO[MaxPointerHistorySize];
-        private static readonly MOUSEMOVEPOINT[] s_mouseHistoryInfos = new MOUSEMOVEPOINT[64];
+        private static POINTER_TOUCH_INFO[]? s_historyTouchInfos;
+        private static POINTER_PEN_INFO[]? s_historyPenInfos;
+        private static POINTER_INFO[]? s_historyInfos;
+        private static MOUSEMOVEPOINT[]? s_mouseHistoryInfos;
 
         public WindowImpl()
         {


### PR DESCRIPTION
This PR makes the Win32 `POINTER_*_INFO` history buffers lazy. These are only used when the previous pointer positions are requested (which might be never in most apps).

The structs are quite large: this change saves 180 KB of allocated memory (about 10% of all managed memory in a hello world sample).