### PR TITLE
Browser backend initialization fix and file picker updates

### DIFF
--- a/samples/ControlCatalog.Browser.Blazor/App.razor.cs
+++ b/samples/ControlCatalog.Browser.Blazor/App.razor.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Browser.Blazor;
 
@@ -5,13 +7,4 @@ namespace ControlCatalog.Browser.Blazor;
 
 public partial class App
 {
-    protected override void OnParametersSet()
-    {
-        AppBuilder.Configure<ControlCatalog.App>()
-            .UseBlazor()
-            // .With(new SkiaOptions { CustomGpuFactory = null }) // uncomment to disable GPU/GL rendering
-            .SetupWithSingleViewLifetime();
-
-        base.OnParametersSet();
-    }
 }

--- a/samples/ControlCatalog.Browser.Blazor/Program.cs
+++ b/samples/ControlCatalog.Browser.Blazor/Program.cs
@@ -19,7 +19,7 @@ public class Program
     public static async Task StartAvaloniaApp()
     {
         await AppBuilder.Configure<ControlCatalog.App>()
-            .StartBlazorApp();
+            .StartBlazorAppAsync();
     }
     
     public static WebAssemblyHostBuilder CreateHostBuilder(string[] args)

--- a/samples/ControlCatalog.Browser.Blazor/Program.cs
+++ b/samples/ControlCatalog.Browser.Blazor/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Browser.Blazor;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using ControlCatalog.Browser.Blazor;
@@ -9,9 +11,17 @@ public class Program
 {
     public static async Task  Main(string[] args)
     {
-        await CreateHostBuilder(args).Build().RunAsync();
+        var host = CreateHostBuilder(args).Build();
+        await StartAvaloniaApp();
+        await host.RunAsync();
     }
 
+    public static async Task StartAvaloniaApp()
+    {
+        await AppBuilder.Configure<ControlCatalog.App>()
+            .StartBlazorApp();
+    }
+    
     public static WebAssemblyHostBuilder CreateHostBuilder(string[] args)
     {
         var builder = WebAssemblyHostBuilder.CreateDefault(args);

--- a/samples/ControlCatalog.Browser/Program.cs
+++ b/samples/ControlCatalog.Browser/Program.cs
@@ -1,6 +1,8 @@
 using System.Runtime.Versioning;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Browser;
+using Avalonia.Controls;
 using ControlCatalog;
 using ControlCatalog.Browser;
 
@@ -8,15 +10,27 @@ using ControlCatalog.Browser;
 
 internal partial class Program
 {
-    private static void Main(string[] args)
+    public static async Task Main(string[] args)
     {
-        BuildAvaloniaApp()
+        await BuildAvaloniaApp()
             .AfterSetup(_ =>
             {
                 ControlCatalog.Pages.EmbedSample.Implementation = new EmbedSampleWeb();
-            }).SetupBrowserApp("out");
+            })
+            .StartBrowserApp("out");
     }
 
+    // Example without a ISingleViewApplicationLifetime
+    // private static AvaloniaView _avaloniaView;
+    // public static async Task Main(string[] args)
+    // {
+    //     await BuildAvaloniaApp()
+    //         .SetupBrowserApp();
+    //
+    //     _avaloniaView = new AvaloniaView("out");
+    //     _avaloniaView.Content = new TextBlock { Text = "Hello world" };
+    // }
+    
     public static AppBuilder BuildAvaloniaApp()
            => AppBuilder.Configure<App>();
 }

--- a/samples/ControlCatalog.Browser/Program.cs
+++ b/samples/ControlCatalog.Browser/Program.cs
@@ -17,7 +17,7 @@ internal partial class Program
             {
                 ControlCatalog.Pages.EmbedSample.Implementation = new EmbedSampleWeb();
             })
-            .StartBrowserApp("out");
+            .StartBrowserAppAsync("out");
     }
 
     // Example without a ISingleViewApplicationLifetime

--- a/samples/ControlCatalog.Browser/main.js
+++ b/samples/ControlCatalog.Browser/main.js
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { dotnet } from './dotnet.js'
-import { registerAvaloniaModule } from './avalonia.js';
 
 const is_browser = typeof window != "undefined";
 if (!is_browser) throw new Error(`Expected to be running in a browser`);
@@ -11,8 +10,6 @@ const dotnetRuntime = await dotnet
     .withDiagnosticTracing(false)
     .withApplicationArgumentsFromQuery()
     .create();
-
-await registerAvaloniaModule(dotnetRuntime);
 
 const config = dotnetRuntime.getConfig();
 

--- a/samples/ControlCatalog/Pages/DialogsPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DialogsPage.xaml.cs
@@ -40,7 +40,7 @@ namespace ControlCatalog.Pages
 
                 if (Enum.TryParse<WellKnownFolder>(currentFolderBox.Text, true, out var folderEnum))
                 {
-                    lastSelectedDirectory = await GetStorageProvider().TryGetWellKnownFolder(folderEnum);
+                    lastSelectedDirectory = await GetStorageProvider().TryGetWellKnownFolderAsync(folderEnum);
                 }
                 else
                 {
@@ -51,7 +51,7 @@ namespace ControlCatalog.Pages
 
                     if (folderLink is not null)
                     {
-                        lastSelectedDirectory = await GetStorageProvider().TryGetFolderFromPath(folderLink);
+                        lastSelectedDirectory = await GetStorageProvider().TryGetFolderFromPathAsync(folderLink);
                     }
                 }
             };
@@ -148,7 +148,7 @@ namespace ControlCatalog.Pages
                 }
                 else
                 {
-                    SetFolder(await GetStorageProvider().TryGetFolderFromPath(result));
+                    SetFolder(await GetStorageProvider().TryGetFolderFromPathAsync(result));
                     results.Items = new[] { result };
                     resultsVisible.IsVisible = true;
                 }

--- a/samples/ControlCatalog/Pages/DialogsPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DialogsPage.xaml.cs
@@ -82,7 +82,13 @@ namespace ControlCatalog.Pages
                 return new List<FilePickerFileType>
                             {
                                 FilePickerFileTypes.All,
-                                FilePickerFileTypes.TextPlain
+                                FilePickerFileTypes.TextPlain,
+                                new("Binary Log")
+                                {
+                                    Patterns = new[] { "*.binlog", "*.buildlog" },
+                                    MimeTypes = new[] { "application/binlog", "application/buildlog" },
+                                    AppleUniformTypeIdentifiers = new []{ "public.data" }
+                                }
                             };
             }
 

--- a/samples/ControlCatalog/Pages/DialogsPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DialogsPage.xaml.cs
@@ -223,7 +223,7 @@ namespace ControlCatalog.Pages
                     ShowOverwritePrompt = false
                 });
 
-                if (file is not null && file.CanOpenWrite)
+                if (file is not null)
                 {
                     // Sync disposal of StreamWriter is not supported on WASM
 #if NET6_0_OR_GREATER
@@ -298,31 +298,26 @@ namespace ControlCatalog.Pages
                     if (item is IStorageFile file)
                     {
                         resultText += @$"
-            CanOpenRead: {file.CanOpenRead}
-            CanOpenWrite: {file.CanOpenWrite}
             Content:
             ";
-                        if (file.CanOpenRead)
-                        {
 #if NET6_0_OR_GREATER
-                            await using var stream = await file.OpenReadAsync();
+                        await using var stream = await file.OpenReadAsync();
 #else
-                                        using var stream = await file.OpenReadAsync();
+                        using var stream = await file.OpenReadAsync();
 #endif
-                            using var reader = new System.IO.StreamReader(stream);
+                        using var reader = new System.IO.StreamReader(stream);
 
-                            // 4GB file test, shouldn't load more than 10000 chars into a memory.
-                            const int length = 10000;
-                            var buffer = ArrayPool<char>.Shared.Rent(length);
-                            try
-                            {
-                                var charsRead = await reader.ReadAsync(buffer, 0, length);
-                                resultText += new string(buffer, 0, charsRead);
-                            }
-                            finally
-                            {
-                                ArrayPool<char>.Shared.Return(buffer);
-                            }
+                        // 4GB file test, shouldn't load more than 10000 chars into a memory.
+                        const int length = 10000;
+                        var buffer = ArrayPool<char>.Shared.Rent(length);
+                        try
+                        {
+                            var charsRead = await reader.ReadAsync(buffer, 0, length);
+                            resultText += new string(buffer, 0, charsRead);
+                        }
+                        finally
+                        {
+                            ArrayPool<char>.Shared.Return(buffer);
                         }
                     }
 

--- a/samples/ControlCatalog/Pages/DialogsPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DialogsPage.xaml.cs
@@ -281,7 +281,7 @@ namespace ControlCatalog.Pages
             {
                 ignoreTextChanged = true;
                 lastSelectedDirectory = folder;
-                currentFolderBox.Text = folder?.Path.LocalPath;
+                currentFolderBox.Text = folder?.Path is { IsAbsoluteUri: true } abs ? abs.LocalPath : folder?.Path?.ToString();
                 ignoreTextChanged = false;
             }
             async Task SetPickerResult(IReadOnlyCollection<IStorageItem>? items)

--- a/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageItem.cs
+++ b/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageItem.cs
@@ -177,11 +177,7 @@ internal sealed class AndroidStorageFile : AndroidStorageItem, IStorageBookmarkF
     public AndroidStorageFile(Activity activity, AndroidUri uri) : base(activity, uri, false)
     {
     }
-
-    public bool CanOpenRead => true;
-
-    public bool CanOpenWrite => true;
-
+    
     public Task<Stream> OpenReadAsync() => Task.FromResult(OpenContentStream(Activity, Uri, false)
         ?? throw new InvalidOperationException("Failed to open content stream"));
 

--- a/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageProvider.cs
+++ b/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageProvider.cs
@@ -37,7 +37,7 @@ internal class AndroidStorageProvider : IStorageProvider
         return Task.FromResult<IStorageBookmarkFolder?>(new AndroidStorageFolder(_activity, uri, false));
     }
 
-    public async Task<IStorageFile?> TryGetFileFromPath(Uri filePath)
+    public async Task<IStorageFile?> TryGetFileFromPathAsync(Uri filePath)
     {
         if (filePath is null)
         {
@@ -70,7 +70,7 @@ internal class AndroidStorageProvider : IStorageProvider
         return new AndroidStorageFile(_activity, androidUri);
     }
 
-    public async Task<IStorageFolder?> TryGetFolderFromPath(Uri folderPath)
+    public async Task<IStorageFolder?> TryGetFolderFromPathAsync(Uri folderPath)
     {
         if (folderPath is null)
         {
@@ -103,7 +103,7 @@ internal class AndroidStorageProvider : IStorageProvider
         return new AndroidStorageFolder(_activity, androidUri, false);
     }
 
-    public Task<IStorageFolder?> TryGetWellKnownFolder(WellKnownFolder wellKnownFolder)
+    public Task<IStorageFolder?> TryGetWellKnownFolderAsync(WellKnownFolder wellKnownFolder)
     {
         var dirCode = wellKnownFolder switch
         {

--- a/src/Avalonia.Base/Platform/DefaultPlatformSettings.cs
+++ b/src/Avalonia.Base/Platform/DefaultPlatformSettings.cs
@@ -37,7 +37,7 @@ namespace Avalonia.Platform
             };
         }
 
-        public event EventHandler<PlatformColorValues>? ColorValuesChanged;
+        public virtual event EventHandler<PlatformColorValues>? ColorValuesChanged;
 
         protected void OnColorValuesChanged(PlatformColorValues colorValues)
         {

--- a/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageFile.cs
+++ b/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageFile.cs
@@ -18,11 +18,7 @@ internal class BclStorageFile : IStorageBookmarkFile
     }
 
     public FileInfo FileInfo { get; }
-
-    public bool CanOpenRead => true;
-
-    public bool CanOpenWrite => true;
-
+    
     public string Name => FileInfo.Name;
 
     public virtual bool CanBookmark => true;

--- a/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageProvider.cs
+++ b/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageProvider.cs
@@ -34,7 +34,7 @@ internal abstract class BclStorageProvider : IStorageProvider
             : Task.FromResult<IStorageBookmarkFolder?>(null);
     }
 
-    public virtual Task<IStorageFile?> TryGetFileFromPath(Uri filePath)
+    public virtual Task<IStorageFile?> TryGetFileFromPathAsync(Uri filePath)
     {
         if (filePath.IsAbsoluteUri)
         {
@@ -48,7 +48,7 @@ internal abstract class BclStorageProvider : IStorageProvider
         return Task.FromResult<IStorageFile?>(null);
     }
 
-    public virtual Task<IStorageFolder?> TryGetFolderFromPath(Uri folderPath)
+    public virtual Task<IStorageFolder?> TryGetFolderFromPathAsync(Uri folderPath)
     {
         if (folderPath.IsAbsoluteUri)
         {
@@ -62,7 +62,7 @@ internal abstract class BclStorageProvider : IStorageProvider
         return Task.FromResult<IStorageFolder?>(null);
     }
 
-    public virtual Task<IStorageFolder?> TryGetWellKnownFolder(WellKnownFolder wellKnownFolder)
+    public virtual Task<IStorageFolder?> TryGetWellKnownFolderAsync(WellKnownFolder wellKnownFolder)
     {
         // Note, this BCL API returns different values depending on the .NET version.
         // We should also document it. 

--- a/src/Avalonia.Base/Platform/Storage/FilePickerFileType.cs
+++ b/src/Avalonia.Base/Platform/Storage/FilePickerFileType.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace Avalonia.Platform.Storage;
 
@@ -21,7 +23,7 @@ public sealed class FilePickerFileType
     /// List of extensions in GLOB format. I.e. "*.png" or "*.*".
     /// </summary>
     /// <remarks>
-    /// Used on Windows and Linux systems.
+    /// Used on Windows, Linux and Browser platforms.
     /// </remarks>
     public IReadOnlyList<string>? Patterns { get; set; }
 
@@ -29,7 +31,7 @@ public sealed class FilePickerFileType
     /// List of extensions in MIME format.
     /// </summary>
     /// <remarks>
-    /// Used on Android, Browser and Linux systems.
+    /// Used on Android, Linux and Browser platforms.
     /// </remarks>
     public IReadOnlyList<string>? MimeTypes { get; set; }
 
@@ -41,4 +43,14 @@ public sealed class FilePickerFileType
     /// See https://developer.apple.com/documentation/uniformtypeidentifiers/system_declared_uniform_type_identifiers.
     /// </remarks>
     public IReadOnlyList<string>? AppleUniformTypeIdentifiers { get; set; }
+
+    internal IReadOnlyList<string>? TryGetExtensions()
+    {
+        // Converts random glob pattern to a simple extension name.
+        // GetExtension should be sufficient here.
+        // Only exception is "*.*proj" patterns that should be filtered as well.
+        return Patterns?.Select(Path.GetExtension)
+            .Where(e => !string.IsNullOrEmpty(e) && !e.Contains('*') && e.StartsWith("."))
+            .ToArray()!;
+    }
 }

--- a/src/Avalonia.Base/Platform/Storage/IStorageFile.cs
+++ b/src/Avalonia.Base/Platform/Storage/IStorageFile.cs
@@ -11,21 +11,11 @@ namespace Avalonia.Platform.Storage;
 public interface IStorageFile : IStorageItem
 {
     /// <summary>
-    /// Returns true, if file is readable.
-    /// </summary>
-    bool CanOpenRead { get; }
-
-    /// <summary>
     /// Opens a stream for read access.
     /// </summary>
     /// <exception cref="System.UnauthorizedAccessException" />
     Task<Stream> OpenReadAsync();
-
-    /// <summary>
-    /// Returns true, if file is writeable. 
-    /// </summary>
-    bool CanOpenWrite { get; }
-
+    
     /// <summary>
     /// Opens stream for writing to the file.
     /// </summary>

--- a/src/Avalonia.Base/Platform/Storage/IStorageProvider.cs
+++ b/src/Avalonia.Base/Platform/Storage/IStorageProvider.cs
@@ -66,7 +66,7 @@ public interface IStorageProvider
     /// It also might ask user for the permission, and throw an exception if it was denied.
     /// </remarks>
     /// <returns>File or null if it doesn't exist.</returns>
-    Task<IStorageFile?> TryGetFileFromPath(Uri filePath);
+    Task<IStorageFile?> TryGetFileFromPathAsync(Uri filePath);
     
     /// <summary>
     /// Attempts to read folder from the file-system by its path.
@@ -78,12 +78,12 @@ public interface IStorageProvider
     /// It also might ask user for the permission, and throw an exception if it was denied.
     /// </remarks>
     /// <returns>Folder or null if it doesn't exist.</returns>
-    Task<IStorageFolder?> TryGetFolderFromPath(Uri folderPath);
+    Task<IStorageFolder?> TryGetFolderFromPathAsync(Uri folderPath);
     
     /// <summary>
     /// Attempts to read folder from the file-system by its path
     /// </summary>
     /// <param name="wellKnownFolder">Well known folder identifier.</param>
     /// <returns>Folder or null if it doesn't exist.</returns>
-    Task<IStorageFolder?> TryGetWellKnownFolder(WellKnownFolder wellKnownFolder);
+    Task<IStorageFolder?> TryGetWellKnownFolderAsync(WellKnownFolder wellKnownFolder);
 }

--- a/src/Avalonia.Base/Platform/Storage/StorageProviderExtensions.cs
+++ b/src/Avalonia.Base/Platform/Storage/StorageProviderExtensions.cs
@@ -8,48 +8,47 @@ namespace Avalonia.Platform.Storage;
 /// </summary>
 public static class StorageProviderExtensions
 {
-    /// <inheritdoc cref="IStorageProvider.TryGetFileFromPath"/>
-    public static Task<IStorageFile?> TryGetFileFromPath(this IStorageProvider provider, string filePath)
+    /// <inheritdoc cref="IStorageProvider.TryGetFileFromPathAsync"/>
+    public static Task<IStorageFile?> TryGetFileFromPathAsync(this IStorageProvider provider, string filePath)
     {
-        return provider.TryGetFileFromPath(StorageProviderHelpers.FilePathToUri(filePath));
+        return provider.TryGetFileFromPathAsync(StorageProviderHelpers.FilePathToUri(filePath));
     }
 
-    /// <inheritdoc cref="IStorageProvider.TryGetFolderFromPath"/>
-    public static Task<IStorageFolder?> TryGetFolderFromPath(this IStorageProvider provider, string folderPath)
+    /// <inheritdoc cref="IStorageProvider.TryGetFolderFromPathAsync"/>
+    public static Task<IStorageFolder?> TryGetFolderFromPathAsync(this IStorageProvider provider, string folderPath)
     {
-        return provider.TryGetFolderFromPath(StorageProviderHelpers.FilePathToUri(folderPath));
+        return provider.TryGetFolderFromPathAsync(StorageProviderHelpers.FilePathToUri(folderPath));
     }
 
-    internal static string? TryGetFullPath(this IStorageFolder folder)
+    /// <summary>
+    /// Gets the local file system path of the item as a string.
+    /// </summary>
+    /// <param name="item">Storage folder or file.</param>
+    /// <returns>Full local path to the folder or file if possible, otherwise null.</returns>
+    /// <remarks>
+    /// Android platform usually uses "content:" virtual file paths
+    /// and Browser platform has isolated access without full paths,
+    /// so on these platforms this method will return null.
+    /// </remarks>
+    public static string? TryGetLocalPath(this IStorageItem item)
     {
         // We can avoid double escaping of the path by checking for BclStorageFolder.
         // Ideally, `folder.Path.LocalPath` should also work, as that's only available way for the users.
-        if (folder is BclStorageFolder storageFolder)
+        if (item is BclStorageFolder storageFolder)
         {
             return storageFolder.DirectoryInfo.FullName;
         }
+        if (item is BclStorageFile storageFile)
+        {
+            return storageFile.FileInfo.FullName;
+        }
 
-        if (folder.Path is { IsAbsoluteUri: true, Scheme: "file" } absolutePath)
+        if (item.Path is { IsAbsoluteUri: true, Scheme: "file" } absolutePath)
         {
             return absolutePath.LocalPath;
         }
 
         // android "content:", browser and ios relative links go here. 
-        return null;
-    }
-    
-    internal static string? TryGetFullPath(this IStorageFile file)
-    {
-        if (file is BclStorageFile storageFolder)
-        {
-            return storageFolder.FileInfo.FullName;
-        }
-
-        if (file.Path is { IsAbsoluteUri: true, Scheme: "file" } absolutePath)
-        {
-            return absolutePath.LocalPath;
-        }
-
         return null;
     }
 }

--- a/src/Avalonia.Controls/Platform/Dialogs/SystemDialogImpl.cs
+++ b/src/Avalonia.Controls/Platform/Dialogs/SystemDialogImpl.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Controls.Platform
 
                 var files = await filePicker.OpenFilePickerAsync(options);
                 return files
-                    .Select(file => file.TryGetFullPath() ?? file.Name)
+                    .Select(file => file.TryGetLocalPath() ?? file.Name)
                     .ToArray();
             }
             else if (dialog is SaveFileDialog saveDialog)
@@ -46,7 +46,7 @@ namespace Avalonia.Controls.Platform
                     return null;
                 }
 
-                var filePath = file.TryGetFullPath() ?? file.Name;
+                var filePath = file.TryGetLocalPath() ?? file.Name;
                 return new[] { filePath };
             }
             return null;
@@ -64,7 +64,7 @@ namespace Avalonia.Controls.Platform
 
             var folders = await filePicker.OpenFolderPickerAsync(options);
             return folders
-                .Select(folder => folder.TryGetFullPath() ?? folder.Name)
+                .Select(folder => folder.TryGetLocalPath() ?? folder.Name)
                 .FirstOrDefault(u => u is not null);
         }
     }

--- a/src/Avalonia.Diagnostics/Diagnostics/Screenshots/FilePickerHandler.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Screenshots/FilePickerHandler.cs
@@ -68,10 +68,6 @@ namespace Avalonia.Diagnostics.Screenshots
             {
                 return null;
             }
-            if (!result.CanOpenWrite)
-            {
-                throw new InvalidOperationException("Read-only file was selected.");
-            }
 
             return await result.OpenWriteAsync();
         }

--- a/src/Avalonia.Diagnostics/Diagnostics/Screenshots/FilePickerHandler.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Screenshots/FilePickerHandler.cs
@@ -54,8 +54,8 @@ namespace Avalonia.Diagnostics.Screenshots
         protected override async Task<Stream?> GetStream(Control control)
         {
             var storageProvider = GetTopLevel(control).StorageProvider;
-            var defaultFolder = await storageProvider.TryGetFolderFromPath(_screenshotRoot)
-                                ?? await storageProvider.TryGetWellKnownFolder(WellKnownFolder.Pictures);
+            var defaultFolder = await storageProvider.TryGetFolderFromPathAsync(_screenshotRoot)
+                                ?? await storageProvider.TryGetWellKnownFolderAsync(WellKnownFolder.Pictures);
 
             var result = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
             {

--- a/src/Avalonia.Dialogs/Internal/ManagedFileChooserViewModel.cs
+++ b/src/Avalonia.Dialogs/Internal/ManagedFileChooserViewModel.cs
@@ -260,7 +260,7 @@ namespace Avalonia.Dialogs.Internal
 
         public void Navigate(IStorageFolder path, string initialSelectionName = null)
         {
-            var fullDirectoryPath = path?.TryGetFullPath() ?? Directory.GetCurrentDirectory();
+            var fullDirectoryPath = path?.TryGetLocalPath() ?? Directory.GetCurrentDirectory();
             
             Navigate(fullDirectoryPath, initialSelectionName);
         }

--- a/src/Avalonia.Dialogs/ManagedFileDialogExtensions.cs
+++ b/src/Avalonia.Dialogs/ManagedFileDialogExtensions.cs
@@ -51,7 +51,7 @@ namespace Avalonia.Dialogs
 
             var files = await impl.OpenFilePickerAsync(dialog.ToFilePickerOpenOptions());
             return files
-                .Select(file => file.TryGetFullPath() ?? file.Name)
+                .Select(file => file.TryGetLocalPath() ?? file.Name)
                 .ToArray();
         }
     }

--- a/src/Avalonia.FreeDesktop/DBusSystemDialog.cs
+++ b/src/Avalonia.FreeDesktop/DBusSystemDialog.cs
@@ -88,7 +88,7 @@ namespace Avalonia.FreeDesktop
 
             if (options.SuggestedFileName is { } currentName)
                 chooserOptions.Add("current_name", currentName);
-            if (options.SuggestedStartLocation?.TryGetFullPath() is { } folderPath)
+            if (options.SuggestedStartLocation?.TryGetLocalPath() is { } folderPath)
                 chooserOptions.Add("current_folder", Encoding.UTF8.GetBytes(folderPath));
             objectPath = await _fileChooser.SaveFileAsync(parentWindow, options.Title ?? string.Empty, chooserOptions);
 

--- a/src/Avalonia.Native/SystemDialogs.cs
+++ b/src/Avalonia.Native/SystemDialogs.cs
@@ -33,7 +33,7 @@ namespace Avalonia.Native
         {
             using var events = new SystemDialogEvents();
 
-            var suggestedDirectory = options.SuggestedStartLocation?.TryGetFullPath() ?? string.Empty;
+            var suggestedDirectory = options.SuggestedStartLocation?.TryGetLocalPath() ?? string.Empty;
 
             _native.OpenFileDialog((IAvnWindow)_window.Native,
                                     events,
@@ -53,7 +53,7 @@ namespace Avalonia.Native
         {
             using var events = new SystemDialogEvents();
 
-            var suggestedDirectory = options.SuggestedStartLocation?.TryGetFullPath() ?? string.Empty;
+            var suggestedDirectory = options.SuggestedStartLocation?.TryGetLocalPath() ?? string.Empty;
 
             _native.SaveFileDialog((IAvnWindow)_window.Native,
                         events,
@@ -72,7 +72,7 @@ namespace Avalonia.Native
         {
             using var events = new SystemDialogEvents();
 
-            var suggestedDirectory = options.SuggestedStartLocation?.TryGetFullPath() ?? string.Empty;
+            var suggestedDirectory = options.SuggestedStartLocation?.TryGetLocalPath() ?? string.Empty;
 
             _native.SelectFolderDialog((IAvnWindow)_window.Native, events, options.AllowMultiple.AsComBool(), options.Title ?? "", suggestedDirectory);
 

--- a/src/Avalonia.X11/NativeDialogs/CompositeStorageProvider.cs
+++ b/src/Avalonia.X11/NativeDialogs/CompositeStorageProvider.cs
@@ -62,21 +62,21 @@ internal class CompositeStorageProvider : IStorageProvider
         return await provider.OpenFolderBookmarkAsync(bookmark).ConfigureAwait(false);
     }
 
-    public async Task<IStorageFile?> TryGetFileFromPath(Uri filePath)
+    public async Task<IStorageFile?> TryGetFileFromPathAsync(Uri filePath)
     {
         var provider = await EnsureStorageProvider().ConfigureAwait(false);
-        return await provider.TryGetFileFromPath(filePath).ConfigureAwait(false);
+        return await provider.TryGetFileFromPathAsync(filePath).ConfigureAwait(false);
     }
 
-    public async Task<IStorageFolder?> TryGetFolderFromPath(Uri folderPath)
+    public async Task<IStorageFolder?> TryGetFolderFromPathAsync(Uri folderPath)
     {
         var provider = await EnsureStorageProvider().ConfigureAwait(false);
-        return await provider.TryGetFolderFromPath(folderPath).ConfigureAwait(false);
+        return await provider.TryGetFolderFromPathAsync(folderPath).ConfigureAwait(false);
     }
 
-    public async Task<IStorageFolder?> TryGetWellKnownFolder(WellKnownFolder wellKnownFolder)
+    public async Task<IStorageFolder?> TryGetWellKnownFolderAsync(WellKnownFolder wellKnownFolder)
     {
         var provider = await EnsureStorageProvider().ConfigureAwait(false);
-        return await provider.TryGetWellKnownFolder(wellKnownFolder).ConfigureAwait(false);
+        return await provider.TryGetWellKnownFolderAsync(wellKnownFolder).ConfigureAwait(false);
     }
 }

--- a/src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs
+++ b/src/Avalonia.X11/NativeDialogs/GtkNativeFileDialogs.cs
@@ -196,7 +196,7 @@ namespace Avalonia.X11.NativeDialogs
                 gtk_dialog_add_button(dlg, open, GtkResponseType.Cancel);
             }
 
-            var folderLocalPath = initialFolder?.TryGetFullPath();
+            var folderLocalPath = initialFolder?.TryGetLocalPath();
             if (folderLocalPath is not null)
             {
                 using var dir = new Utf8Buffer(folderLocalPath);

--- a/src/Browser/Avalonia.Browser.Blazor/AvaloniaView.cs
+++ b/src/Browser/Avalonia.Browser.Blazor/AvaloniaView.cs
@@ -30,17 +30,23 @@ public class AvaloniaView : ComponentBase
         builder.CloseElement();
     }
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnAfterRender(bool firstRender)
     {
-        if (OperatingSystem.IsBrowser())
+        if (firstRender)
         {
-            await AvaloniaModule.ImportMain();
-
             _browserView = new Browser.AvaloniaView(_containerId);
             if (Application.Current?.ApplicationLifetime is ISingleViewApplicationLifetime lifetime)
             {
                 _browserView.Content = lifetime.MainView;
             }
+        }
+    }
+
+    protected override void OnInitialized()
+    {
+        if (!OperatingSystem.IsBrowser())
+        {
+            throw new NotSupportedException("Avalonia doesn't support server-side Blazor");
         }
     }
 }

--- a/src/Browser/Avalonia.Browser.Blazor/BlazorSingleViewLifetime.cs
+++ b/src/Browser/Avalonia.Browser.Blazor/BlazorSingleViewLifetime.cs
@@ -15,7 +15,7 @@ public static class BlazorAppBuilder
     /// </summary>
     /// <param name="builder">Application builder.</param>
     /// <param name="options">Browser backend specific options.</param>
-    public static async Task StartBlazorApp(this AppBuilder builder, BrowserPlatformOptions? options = null)
+    public static async Task StartBlazorAppAsync(this AppBuilder builder, BrowserPlatformOptions? options = null)
     {
         options ??= new BrowserPlatformOptions();
         options.FrameworkAssetPathResolver ??= filePath => $"/_content/Avalonia.Browser.Blazor/{filePath}";

--- a/src/Browser/Avalonia.Browser.Blazor/BlazorSingleViewLifetime.cs
+++ b/src/Browser/Avalonia.Browser.Blazor/BlazorSingleViewLifetime.cs
@@ -1,33 +1,28 @@
-﻿using System.Runtime.Versioning;
-
+﻿using System;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Browser.Interop;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 
 namespace Avalonia.Browser.Blazor;
 
-public static class WebAppBuilder
+public static class BlazorAppBuilder
 {
-    public static AppBuilder SetupWithSingleViewLifetime(
-        this AppBuilder builder)
+    /// <summary>
+    /// Configures blazor backend, loads avalonia javascript modules and creates a single view lifetime.
+    /// </summary>
+    /// <param name="builder">Application builder.</param>
+    /// <param name="options">Browser backend specific options.</param>
+    public static async Task StartBlazorApp(this AppBuilder builder, BrowserPlatformOptions? options = null)
     {
-        return builder.SetupWithLifetime(new BlazorSingleViewLifetime());
-    }
+        options ??= new BrowserPlatformOptions();
+        options.FrameworkAssetPathResolver ??= filePath => $"/_content/Avalonia.Browser.Blazor/{filePath}";
 
-    public static AppBuilder UseBlazor(this AppBuilder builder)
-    {
-        return builder
-            .UseBrowser()
-            .With(new BrowserPlatformOptions
-            {
-                FrameworkAssetPathResolver = new(filePath => $"/_content/Avalonia.Browser.Blazor/{filePath}")
-            });
-    }
+        builder = await BrowserAppBuilder.PreSetupBrowser(builder, options);
 
-    public static AppBuilder Configure<TApp>()
-        where TApp : Application, new()
-    {
-        return AppBuilder.Configure<TApp>()
-            .UseBlazor();
+        builder.SetupWithLifetime(new BlazorSingleViewLifetime());
     }
 
     internal class BlazorSingleViewLifetime : ISingleViewApplicationLifetime

--- a/src/Browser/Avalonia.Browser/AvaloniaView.cs
+++ b/src/Browser/Avalonia.Browser/AvaloniaView.cs
@@ -381,12 +381,10 @@ namespace Avalonia.Browser
         {
             if (_useGL && (_jsGlInfo == null))
             {
-                Console.WriteLine("nothing to render");
                 return;
             }
             if (_canvasSize.Width <= 0 || _canvasSize.Height <= 0 || _dpi <= 0)
             {
-                Console.WriteLine("nothing to render");
                 return;
             }
 
@@ -459,7 +457,6 @@ namespace Avalonia.Browser
 
         void ITextInputMethodImpl.SetClient(ITextInputMethodClient? client)
         {
-            Console.WriteLine("Set Client");
             if (_client != null)
             {
                 _client.SurroundingTextChanged -= SurroundingTextChanged;
@@ -482,8 +479,6 @@ namespace Avalonia.Browser
                 var surroundingText = _client.SurroundingText;
 
                 InputHelper.SetSurroundingText(_inputElement, surroundingText.Text, surroundingText.AnchorOffset, surroundingText.CursorOffset);
-
-                Console.WriteLine("Shown, focused and surrounded.");
             }
             else
             {

--- a/src/Browser/Avalonia.Browser/AvaloniaView.cs
+++ b/src/Browser/Avalonia.Browser/AvaloniaView.cs
@@ -20,7 +20,7 @@ using static System.Runtime.CompilerServices.RuntimeHelpers;
 
 namespace Avalonia.Browser
 {
-    public partial class AvaloniaView : ITextInputMethodImpl
+    public class AvaloniaView : ITextInputMethodImpl
     {
         private static readonly PooledList<RawPointerPoint> s_intermediatePointsPooledList = new(ClearMode.Never);
         private readonly BrowserTopLevelImpl _topLevelImpl;
@@ -43,8 +43,9 @@ namespace Avalonia.Browser
         private bool _useGL;        
         private ITextInputMethodClient? _client;
 
+        /// <param name="divId">ID of the html element where avalonia content should be rendered.</param>
         public AvaloniaView(string divId)
-            : this(DomHelper.GetElementById(divId) ?? throw new Exception($"Element with id {divId} was not found in the html document."))
+            : this(DomHelper.GetElementById(divId) ?? throw new Exception($"Element with id '{divId}' was not found in the html document."))
         {
         }
 

--- a/src/Browser/Avalonia.Browser/BrowserAppBuilder.cs
+++ b/src/Browser/Avalonia.Browser/BrowserAppBuilder.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Threading.Tasks;
+using Avalonia.Browser.Interop;
+
+namespace Avalonia.Browser;
+
+public class BrowserPlatformOptions
+{
+    /// <summary>
+    /// Defines paths where avalonia modules and service locator should be resolved.
+    /// If null, default path resolved depending on the backend (browser or blazor) is used.
+    /// </summary>
+    public Func<string, string>? FrameworkAssetPathResolver { get; set; }
+}
+
+public static class BrowserAppBuilder
+{
+    /// <summary>
+    /// Configures browser backend, loads avalonia javascript modules and creates a single view lifetime from the passed <see cref="mainDivId"/> parameter.
+    /// </summary>
+    /// <param name="builder">Application builder.</param>
+    /// <param name="mainDivId">ID of the html element where avalonia content should be rendered.</param>
+    /// <param name="options">Browser backend specific options.</param>
+    public static async Task StartBrowserApp(this AppBuilder builder, string mainDivId, BrowserPlatformOptions? options = null)
+    {
+        if (mainDivId is null)
+        {
+            throw new ArgumentNullException(nameof(mainDivId));
+        }
+        
+        builder = await PreSetupBrowser(builder, options);
+
+        var lifetime = new BrowserSingleViewLifetime();
+        builder
+            .AfterSetup(_ =>
+            {
+                lifetime.View = new AvaloniaView(mainDivId);
+            })
+            .SetupWithLifetime(lifetime);
+    }
+
+    /// <summary>
+    /// Loads avalonia javascript modules and configures browser backend.
+    /// </summary>
+    /// <param name="builder">Application builder.</param>
+    /// <param name="options">Browser backend specific options.</param>
+    /// <remarks>
+    /// This method doesn't creates any avalonia views to be rendered. To do so create an <see cref="AvaloniaView"/> object.
+    /// Alternatively, you can call <see cref="StartBrowserApp"/> method instead of <see cref="SetupBrowserApp"/>.
+    /// </remarks>
+    public static async Task SetupBrowserApp(this AppBuilder builder, BrowserPlatformOptions? options = null)
+    {
+        builder = await PreSetupBrowser(builder, options);
+
+        builder
+            .SetupWithoutStarting();
+    }
+
+    internal static async Task<AppBuilder> PreSetupBrowser(AppBuilder builder, BrowserPlatformOptions? options)
+    {
+        options ??= new BrowserPlatformOptions();
+        options.FrameworkAssetPathResolver ??= fileName => $"./{fileName}";
+
+        AvaloniaLocator.CurrentMutable.Bind<BrowserPlatformOptions>().ToConstant(options);
+        
+        await AvaloniaModule.ImportMain();
+
+        if (builder.WindowingSubsystemInitializer is null)
+        {
+            builder = builder.UseBrowser();
+        }
+
+        return builder;
+    }
+    
+    public static AppBuilder UseBrowser(
+        this AppBuilder builder)
+    {
+        return builder
+            .UseWindowingSubsystem(BrowserWindowingPlatform.Register)
+            .UseSkia();
+    }
+}

--- a/src/Browser/Avalonia.Browser/BrowserAppBuilder.cs
+++ b/src/Browser/Avalonia.Browser/BrowserAppBuilder.cs
@@ -21,7 +21,7 @@ public static class BrowserAppBuilder
     /// <param name="builder">Application builder.</param>
     /// <param name="mainDivId">ID of the html element where avalonia content should be rendered.</param>
     /// <param name="options">Browser backend specific options.</param>
-    public static async Task StartBrowserApp(this AppBuilder builder, string mainDivId, BrowserPlatformOptions? options = null)
+    public static async Task StartBrowserAppAsync(this AppBuilder builder, string mainDivId, BrowserPlatformOptions? options = null)
     {
         if (mainDivId is null)
         {
@@ -46,9 +46,9 @@ public static class BrowserAppBuilder
     /// <param name="options">Browser backend specific options.</param>
     /// <remarks>
     /// This method doesn't creates any avalonia views to be rendered. To do so create an <see cref="AvaloniaView"/> object.
-    /// Alternatively, you can call <see cref="StartBrowserApp"/> method instead of <see cref="SetupBrowserApp"/>.
+    /// Alternatively, you can call <see cref="StartBrowserAppAsync"/> method instead of <see cref="SetupBrowserAppAsync"/>.
     /// </remarks>
-    public static async Task SetupBrowserApp(this AppBuilder builder, BrowserPlatformOptions? options = null)
+    public static async Task SetupBrowserAppAsync(this AppBuilder builder, BrowserPlatformOptions? options = null)
     {
         builder = await PreSetupBrowser(builder, options);
 

--- a/src/Browser/Avalonia.Browser/BrowserPlatformSettings.cs
+++ b/src/Browser/Avalonia.Browser/BrowserPlatformSettings.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Browser.Interop;
+﻿using System;
+using Avalonia.Browser.Interop;
 using Avalonia.Platform;
 
 namespace Avalonia.Browser;
@@ -7,25 +8,44 @@ internal class BrowserPlatformSettings : DefaultPlatformSettings
 {
     private bool _isDarkMode;
     private bool _isHighContrast;
-    
-    public BrowserPlatformSettings()
+    private bool _isInitialized;
+
+    public override event EventHandler<PlatformColorValues>? ColorValuesChanged
     {
-        var obj = DomHelper.ObserveDarkMode((isDarkMode, isHighContrast) =>
+        add
         {
-            _isDarkMode = isDarkMode;
-            _isHighContrast = isHighContrast;
-            OnColorValuesChanged(GetColorValues());
-        });
-        _isDarkMode = obj.GetPropertyAsBoolean("isDarkMode");
-        _isHighContrast = obj.GetPropertyAsBoolean("isHighContrast");
+            EnsureBackend();
+            base.ColorValuesChanged += value;
+        }
+        remove => base.ColorValuesChanged -= value;
     }
 
     public override PlatformColorValues GetColorValues()
     {
+        EnsureBackend();
+
         return base.GetColorValues() with
         {
             ThemeVariant = _isDarkMode ? PlatformThemeVariant.Dark : PlatformThemeVariant.Light,
             ContrastPreference = _isHighContrast ? ColorContrastPreference.High : ColorContrastPreference.NoPreference
         };
+    }
+
+    private void EnsureBackend()
+    {
+        if (!_isInitialized)
+        {
+            // WASM module has async nature of initialization. We can't native code right away during components registration. 
+            _isInitialized = true;
+
+            var obj = DomHelper.ObserveDarkMode((isDarkMode, isHighContrast) =>
+            {
+                _isDarkMode = isDarkMode;
+                _isHighContrast = isHighContrast;
+                OnColorValuesChanged(GetColorValues());
+            });
+            _isDarkMode = obj.GetPropertyAsBoolean("isDarkMode");
+            _isHighContrast = obj.GetPropertyAsBoolean("isHighContrast");
+        }
     }
 }

--- a/src/Browser/Avalonia.Browser/BrowserSingleViewLifetime.cs
+++ b/src/Browser/Avalonia.Browser/BrowserSingleViewLifetime.cs
@@ -1,47 +1,36 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using System.Runtime.Versioning;
+using Avalonia.Browser;
 
-namespace Avalonia.Browser;
+namespace Avalonia;
 
-public class BrowserSingleViewLifetime : ISingleViewApplicationLifetime
+internal class BrowserSingleViewLifetime : ISingleViewApplicationLifetime
 {
     public AvaloniaView? View;
 
     public Control? MainView
     {
-        get => View!.Content;
-        set => View!.Content = value;
-    }
-}
-
-public class BrowserPlatformOptions
-{
-    public Func<string, string> FrameworkAssetPathResolver { get; set; } = new(fileName => $"./{fileName}");
-}
-
-public static class WebAppBuilder
-{
-    public static AppBuilder SetupBrowserApp(
-        this AppBuilder builder, string mainDivId)
-    {
-        var lifetime = new BrowserSingleViewLifetime();
-
-        return builder
-            .UseBrowser()
-            .AfterSetup(b =>
-            {
-                lifetime.View = new AvaloniaView(mainDivId);
-            })
-            .SetupWithLifetime(lifetime);
+        get
+        {
+            EnsureView();
+            return View.Content;
+        }
+        set
+        {
+            EnsureView();
+            View.Content = value;
+        }
     }
 
-    public static AppBuilder UseBrowser(
-        this AppBuilder builder)
+    [MemberNotNull(nameof(View))]
+    private void EnsureView()
     {
-        return builder
-            .UseWindowingSubsystem(BrowserWindowingPlatform.Register)
-            .UseSkia();
+        if (View is null)
+        {
+            throw new InvalidOperationException("Browser lifetime was not initialized. Make sure AppBuilder.StartBrowserApp was called.");
+        }
     }
 }

--- a/src/Browser/Avalonia.Browser/Interop/AvaloniaModule.cs
+++ b/src/Browser/Avalonia.Browser/Interop/AvaloniaModule.cs
@@ -11,13 +11,13 @@ internal static partial class AvaloniaModule
     public static Task ImportMain()
     {
         var options = AvaloniaLocator.Current.GetService<BrowserPlatformOptions>() ?? new BrowserPlatformOptions();
-        return JSHost.ImportAsync(MainModuleName, options.FrameworkAssetPathResolver("avalonia.js"));
+        return JSHost.ImportAsync(MainModuleName, options.FrameworkAssetPathResolver!("avalonia.js"));
     }
 
     public static Task ImportStorage()
     {
         var options = AvaloniaLocator.Current.GetService<BrowserPlatformOptions>() ?? new BrowserPlatformOptions();
-        return JSHost.ImportAsync(StorageModuleName, options.FrameworkAssetPathResolver("storage.js"));
+        return JSHost.ImportAsync(StorageModuleName, options.FrameworkAssetPathResolver!("storage.js"));
     }
 
     [JSImport("Caniuse.isMobile", AvaloniaModule.MainModuleName)]

--- a/src/Browser/Avalonia.Browser/Interop/StorageHelper.cs
+++ b/src/Browser/Avalonia.Browser/Interop/StorageHelper.cs
@@ -54,5 +54,5 @@ internal static partial class StorageHelper
     public static partial JSObject[] ItemsArray(JSObject item);
 
     [JSImport("StorageProvider.createAcceptType", AvaloniaModule.StorageModuleName)]
-    public static partial JSObject CreateAcceptType(string description, string[] mimeTypes);
+    public static partial JSObject CreateAcceptType(string description, string[] mimeTypes, string[]? extensions);
 }

--- a/src/Browser/Avalonia.Browser/Interop/StorageHelper.cs
+++ b/src/Browser/Avalonia.Browser/Interop/StorageHelper.cs
@@ -5,14 +5,8 @@ namespace Avalonia.Browser.Interop;
 
 internal static partial class StorageHelper
 {
-    [JSImport("Caniuse.canShowOpenFilePicker", AvaloniaModule.MainModuleName)]
-    public static partial bool CanShowOpenFilePicker();
-
-    [JSImport("Caniuse.canShowSaveFilePicker", AvaloniaModule.MainModuleName)]
-    public static partial bool CanShowSaveFilePicker();
-
-    [JSImport("Caniuse.canShowDirectoryPicker", AvaloniaModule.MainModuleName)]
-    public static partial bool CanShowDirectoryPicker();
+    [JSImport("Caniuse.hasNativeFilePicker", AvaloniaModule.MainModuleName)]
+    public static partial bool HasNativeFilePicker();
 
     [JSImport("StorageProvider.selectFolderDialog", AvaloniaModule.StorageModuleName)]
     public static partial Task<JSObject?> SelectFolderDialog(JSObject? startIn);

--- a/src/Browser/Avalonia.Browser/Storage/BrowserStorageProvider.cs
+++ b/src/Browser/Avalonia.Browser/Storage/BrowserStorageProvider.cs
@@ -216,7 +216,6 @@ internal class JSStorageFile : JSStorageItem, IStorageBookmarkFile
     {
     }
 
-    public bool CanOpenRead => true;
     public async Task<Stream> OpenReadAsync()
     {
         try
@@ -230,7 +229,6 @@ internal class JSStorageFile : JSStorageItem, IStorageBookmarkFile
         }
     }
 
-    public bool CanOpenWrite => true;
     public async Task<Stream> OpenWriteAsync()
     {
         try

--- a/src/Browser/Avalonia.Browser/Storage/BrowserStorageProvider.cs
+++ b/src/Browser/Avalonia.Browser/Storage/BrowserStorageProvider.cs
@@ -20,9 +20,9 @@ internal class BrowserStorageProvider : IStorageProvider
 
     private readonly Lazy<Task> _lazyModule = new(() => AvaloniaModule.ImportStorage());
 
-    public bool CanOpen => StorageHelper.CanShowOpenFilePicker();
-    public bool CanSave => StorageHelper.CanShowSaveFilePicker();
-    public bool CanPickFolder => StorageHelper.CanShowDirectoryPicker();
+    public bool CanOpen => true;
+    public bool CanSave => StorageHelper.HasNativeFilePicker();
+    public bool CanPickFolder => true;
 
     public async Task<IReadOnlyList<IStorageFile>> OpenFilePickerAsync(FilePickerOpenOptions options)
     {
@@ -186,10 +186,15 @@ internal abstract class JSStorageItem : IStorageBookmarkItem
             dateModified: lastModified > 0 ? DateTimeOffset.FromUnixTimeMilliseconds(lastModified.Value) : null);
     }
 
-    public bool CanBookmark => true;
+    public bool CanBookmark => StorageHelper.HasNativeFilePicker();
 
     public Task<string?> SaveBookmarkAsync()
     {
+        if (!CanBookmark)
+        {
+            return Task.FromResult<string?>(null);
+        }
+
         return StorageHelper.SaveBookmark(FileHandle);
     }
 
@@ -200,6 +205,11 @@ internal abstract class JSStorageItem : IStorageBookmarkItem
 
     public Task ReleaseBookmarkAsync()
     {
+        if (!CanBookmark)
+        {
+            return Task.CompletedTask;
+        }
+
         return StorageHelper.DeleteBookmark(FileHandle);
     }
 

--- a/src/Browser/Avalonia.Browser/Storage/BrowserStorageProvider.cs
+++ b/src/Browser/Avalonia.Browser/Storage/BrowserStorageProvider.cs
@@ -147,7 +147,7 @@ internal class BrowserStorageProvider : IStorageProvider
     {
         var types = input?
             .Where(t => t.MimeTypes?.Any() == true && t != FilePickerFileTypes.All)
-            .Select(t => StorageHelper.CreateAcceptType(t.Name, t.MimeTypes!.ToArray()))
+            .Select(t => StorageHelper.CreateAcceptType(t.Name, t.MimeTypes!.ToArray(), t.TryGetExtensions()?.ToArray()))
             .ToArray();
         if (types?.Length == 0)
         {

--- a/src/Browser/Avalonia.Browser/Storage/BrowserStorageProvider.cs
+++ b/src/Browser/Avalonia.Browser/Storage/BrowserStorageProvider.cs
@@ -116,17 +116,17 @@ internal class BrowserStorageProvider : IStorageProvider
         return item is not null ? new JSStorageFolder(item) : null;
     }
 
-    public Task<IStorageFile?> TryGetFileFromPath(Uri filePath)
+    public Task<IStorageFile?> TryGetFileFromPathAsync(Uri filePath)
     {
         return Task.FromResult<IStorageFile?>(null);
     }
 
-    public Task<IStorageFolder?> TryGetFolderFromPath(Uri folderPath)
+    public Task<IStorageFolder?> TryGetFolderFromPathAsync(Uri folderPath)
     {
         return Task.FromResult<IStorageFolder?>(null);
     }
 
-    public async Task<IStorageFolder?> TryGetWellKnownFolder(WellKnownFolder wellKnownFolder)
+    public async Task<IStorageFolder?> TryGetWellKnownFolderAsync(WellKnownFolder wellKnownFolder)
     {
         await _lazyModule.Value;
         var directory = StorageHelper.CreateWellKnownDirectory(wellKnownFolder switch

--- a/src/Browser/Avalonia.Browser/webapp/.eslintrc.json
+++ b/src/Browser/Avalonia.Browser/webapp/.eslintrc.json
@@ -43,5 +43,5 @@
       }
     ]
   },
-  "ignorePatterns": ["types/*"]
+  "ignorePatterns": ["types/*","node_modules/*"]
 }

--- a/src/Browser/Avalonia.Browser/webapp/build.js
+++ b/src/Browser/Avalonia.Browser/webapp/build.js
@@ -7,7 +7,7 @@ require("esbuild").build({
     bundle: true,
     minify: true,
     format: "esm",
-    target: "es2016",
+    target: "es2018",
     platform: "browser",
     sourcemap: "linked",
     loader: { ".ts": "ts" }

--- a/src/Browser/Avalonia.Browser/webapp/modules/avalonia.ts
+++ b/src/Browser/Avalonia.Browser/webapp/modules/avalonia.ts
@@ -1,4 +1,3 @@
-import { RuntimeAPI } from "../types/dotnet";
 import { SizeWatcher, DpiWatcher, Canvas } from "./avalonia/canvas";
 import { InputHelper } from "./avalonia/input";
 import { AvaloniaDOM } from "./avalonia/dom";
@@ -7,19 +6,6 @@ import { StreamHelper } from "./avalonia/stream";
 import { NativeControlHost } from "./avalonia/nativeControlHost";
 import { NavigationHelper } from "./avalonia/navigationHelper";
 
-async function registerAvaloniaModule(api: RuntimeAPI): Promise<void> {
-    api.setModuleImports("avalonia", {
-        Caniuse,
-        Canvas,
-        InputHelper,
-        SizeWatcher,
-        DpiWatcher,
-        AvaloniaDOM,
-        StreamHelper,
-        NativeControlHost,
-        NavigationHelper
-    });
-}
 export {
     Caniuse,
     Canvas,
@@ -29,7 +15,5 @@ export {
     AvaloniaDOM,
     StreamHelper,
     NativeControlHost,
-    NavigationHelper,
-
-    registerAvaloniaModule
+    NavigationHelper
 };

--- a/src/Browser/Avalonia.Browser/webapp/modules/avalonia/caniuse.ts
+++ b/src/Browser/Avalonia.Browser/webapp/modules/avalonia/caniuse.ts
@@ -1,14 +1,6 @@
 export class Caniuse {
-    public static canShowOpenFilePicker(): boolean {
-        return typeof globalThis.showOpenFilePicker !== "undefined";
-    }
-
-    public static canShowSaveFilePicker(): boolean {
-        return typeof globalThis.showSaveFilePicker !== "undefined";
-    }
-
-    public static canShowDirectoryPicker(): boolean {
-        return typeof globalThis.showDirectoryPicker !== "undefined";
+    public static hasNativeFilePicker(): boolean {
+        return "showSaveFilePicker" in globalThis;
     }
 
     public static isMobile(): boolean {

--- a/src/Browser/Avalonia.Browser/webapp/modules/avalonia/stream.ts
+++ b/src/Browser/Avalonia.Browser/webapp/modules/avalonia/stream.ts
@@ -1,3 +1,4 @@
+import FileSystemWritableFileStream from "native-file-system-adapter/types/src/FileSystemWritableFileStream";
 import { IMemoryView } from "../../types/dotnet";
 
 export class StreamHelper {
@@ -17,7 +18,7 @@ export class StreamHelper {
         const array = new Uint8Array(span.byteLength);
         span.copyTo(array);
 
-        const data: WriteParams = {
+        const data = {
             type: "write",
             data: array
         };

--- a/src/Browser/Avalonia.Browser/webapp/modules/storage/storageProvider.ts
+++ b/src/Browser/Avalonia.Browser/webapp/modules/storage/storageProvider.ts
@@ -62,9 +62,9 @@ export class StorageProvider {
         }
     }
 
-    public static createAcceptType(description: string, mimeTypes: string[]): FilePickerAcceptType {
+    public static createAcceptType(description: string, mimeTypes: string[], extensions: string[] | undefined): FilePickerAcceptType {
         const accept: Record<string, string[]> = {};
-        mimeTypes.forEach(a => { accept[a] = []; });
+        mimeTypes.forEach(a => { accept[a] = extensions ?? []; });
         return { description, accept };
     }
 }

--- a/src/Browser/Avalonia.Browser/webapp/modules/storage/storageProvider.ts
+++ b/src/Browser/Avalonia.Browser/webapp/modules/storage/storageProvider.ts
@@ -1,14 +1,12 @@
 import { avaloniaDb, fileBookmarksStore } from "./indexedDb";
 import { StorageItem, StorageItems } from "./storageItem";
+import { showOpenFilePicker, showDirectoryPicker, FileSystemFileHandle } from "native-file-system-adapter";
 
 declare global {
     type WellKnownDirectory = "desktop" | "documents" | "downloads" | "music" | "pictures" | "videos";
-    type StartInDirectory = WellKnownDirectory | FileSystemHandle;
-    interface OpenFilePickerOptions {
-        startIn?: StartInDirectory;
-    }
-    interface SaveFilePickerOptions {
-        startIn?: StartInDirectory;
+    interface FilePickerAcceptType {
+        description?: string | undefined;
+        accept: Record<string, string | string[]>;
     }
 }
 
@@ -16,39 +14,40 @@ export class StorageProvider {
     public static async selectFolderDialog(
         startIn: StorageItem | null): Promise<StorageItem> {
         // 'Picker' API doesn't accept "null" as a parameter, so it should be set to undefined.
-        const options: DirectoryPickerOptions = {
+        const options = {
             startIn: (startIn?.wellKnownType ?? startIn?.handle ?? undefined)
         };
 
-        const handle = await window.showDirectoryPicker(options);
+        const handle = await showDirectoryPicker(options as any);
         return new StorageItem(handle);
     }
 
     public static async openFileDialog(
         startIn: StorageItem | null, multiple: boolean,
         types: FilePickerAcceptType[] | null, excludeAcceptAllOption: boolean): Promise<StorageItems> {
-        const options: OpenFilePickerOptions = {
+        const options = {
             startIn: (startIn?.wellKnownType ?? startIn?.handle ?? undefined),
             multiple,
             excludeAcceptAllOption,
             types: (types ?? undefined)
         };
 
-        const handles = await window.showOpenFilePicker(options);
-        return new StorageItems(handles.map((handle: FileSystemHandle) => new StorageItem(handle)));
+        const handles = await showOpenFilePicker(options);
+        return new StorageItems(handles.map((handle: FileSystemFileHandle) => new StorageItem(handle)));
     }
 
     public static async saveFileDialog(
         startIn: StorageItem | null, suggestedName: string | null,
         types: FilePickerAcceptType[] | null, excludeAcceptAllOption: boolean): Promise<StorageItem> {
-        const options: SaveFilePickerOptions = {
+        const options = {
             startIn: (startIn?.wellKnownType ?? startIn?.handle ?? undefined),
             suggestedName: (suggestedName ?? undefined),
             excludeAcceptAllOption,
             types: (types ?? undefined)
         };
 
-        const handle = await window.showSaveFilePicker(options);
+        // Always prefer native save file picker, as polyfill solutions are not reliable.
+        const handle = await (globalThis as any).showSaveFilePicker(options);
         return new StorageItem(handle);
     }
 

--- a/src/Browser/Avalonia.Browser/webapp/package-lock.json
+++ b/src/Browser/Avalonia.Browser/webapp/package-lock.json
@@ -5,9 +5,11 @@
   "packages": {
     "": {
       "name": "avalonia.browser",
+      "dependencies": {
+        "native-file-system-adapter": "github:jimmywarting/native-file-system-adapter#d43ad841581c2cc3ce47bbd1e8f11950ebdff027"
+      },
       "devDependencies": {
         "@types/emscripten": "^1.39.6",
-        "@types/wicg-file-system-access": "^2020.9.5",
         "@typescript-eslint/eslint-plugin": "^5.38.1",
         "esbuild": "^0.15.7",
         "eslint": "^8.24.0",
@@ -168,12 +170,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true
-    },
-    "node_modules/@types/wicg-file-system-access": {
-      "version": "2020.9.5",
-      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.5.tgz",
-      "integrity": "sha512-UYK244awtmcUYQfs7FR8710MJcefL2WvkyHMjA8yJzxd1mo0Gfn88sRZ1Bls7hiUhA2w7ne1gpJ9T5g3G0wOyA==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1573,6 +1569,29 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2289,6 +2308,27 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/native-file-system-adapter": {
+      "version": "3.0.0",
+      "resolved": "git+ssh://git@github.com/jimmywarting/native-file-system-adapter.git#d43ad841581c2cc3ce47bbd1e8f11950ebdff027",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.8.0"
+      },
+      "optionalDependencies": {
+        "fetch-blob": "^3.2.0"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2300,6 +2340,25 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "optional": true,
+      "engines": {
+        "node": ">=10.5.0"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -3196,6 +3255,15 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "optional": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3364,12 +3432,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true
-    },
-    "@types/wicg-file-system-access": {
-      "version": "2020.9.5",
-      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.5.tgz",
-      "integrity": "sha512-UYK244awtmcUYQfs7FR8710MJcefL2WvkyHMjA8yJzxd1mo0Gfn88sRZ1Bls7hiUhA2w7ne1gpJ9T5g3G0wOyA==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -4275,6 +4337,16 @@
         "reusify": "^1.0.4"
       }
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "optional": true,
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4796,6 +4868,13 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "native-file-system-adapter": {
+      "version": "git+ssh://git@github.com/jimmywarting/native-file-system-adapter.git#d43ad841581c2cc3ce47bbd1e8f11950ebdff027",
+      "from": "native-file-system-adapter@github:jimmywarting/native-file-system-adapter#d43ad841581c2cc3ce47bbd1e8f11950ebdff027",
+      "requires": {
+        "fetch-blob": "^3.2.0"
+      }
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4807,6 +4886,12 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "optional": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -5445,6 +5530,12 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "optional": true
     },
     "which": {
       "version": "2.0.2",

--- a/src/Browser/Avalonia.Browser/webapp/package.json
+++ b/src/Browser/Avalonia.Browser/webapp/package.json
@@ -8,7 +8,6 @@
   },
   "devDependencies": {
     "@types/emscripten": "^1.39.6",
-    "@types/wicg-file-system-access": "^2020.9.5",
     "@typescript-eslint/eslint-plugin": "^5.38.1",
     "esbuild": "^0.15.7",
     "eslint": "^8.24.0",
@@ -18,5 +17,8 @@
     "eslint-plugin-promise": "^6.0.1",
     "npm-run-all": "^4.1.5",
     "typescript": "^4.8.3"
+  },
+  "dependencies": {
+    "native-file-system-adapter": "github:jimmywarting/native-file-system-adapter#d43ad841581c2cc3ce47bbd1e8f11950ebdff027"
   }
 }

--- a/src/Browser/Avalonia.Browser/webapp/tsconfig.json
+++ b/src/Browser/Avalonia.Browser/webapp/tsconfig.json
@@ -1,14 +1,16 @@
 {
     "compilerOptions": {
-      "target": "es2016",
+      "target": "es2018",
       "module": "es2020",
       "strict": true,
       "sourceMap": true,
       "noEmitOnError": true,
+      "moduleResolution": "node",
+      "skipLibCheck": true,
       "isolatedModules": true, // we need it for esbuild
       "lib": [
         "dom",
-        "es2016",
+        "es2018",
         "esnext.asynciterable"
       ]
     },

--- a/src/Windows/Avalonia.Win32/Win32StorageProvider.cs
+++ b/src/Windows/Avalonia.Win32/Win32StorageProvider.cs
@@ -131,7 +131,7 @@ namespace Avalonia.Win32
                         }
                     }
 
-                    if (folder?.TryGetFullPath() is { } folderPath)
+                    if (folder?.TryGetLocalPath() is { } folderPath)
                     {
                         var riid = UnmanagedMethods.ShellIds.IShellItem;
                         if (UnmanagedMethods.SHCreateItemFromParsingName(folderPath, IntPtr.Zero, ref riid, out var directoryShellItem)

--- a/src/iOS/Avalonia.iOS/Storage/IOSStorageItem.cs
+++ b/src/iOS/Avalonia.iOS/Storage/IOSStorageItem.cs
@@ -94,11 +94,7 @@ internal sealed class IOSStorageFile : IOSStorageItem, IStorageBookmarkFile
     public IOSStorageFile(NSUrl url) : base(url)
     {
     }
-
-    public bool CanOpenRead => true;
-
-    public bool CanOpenWrite => true;
-
+    
     public Task<Stream> OpenReadAsync()
     {
         return Task.FromResult<Stream>(new IOSSecurityScopedStream(Url, FileAccess.Read));

--- a/src/iOS/Avalonia.iOS/Storage/IOSStorageProvider.cs
+++ b/src/iOS/Avalonia.iOS/Storage/IOSStorageProvider.cs
@@ -104,19 +104,19 @@ internal class IOSStorageProvider : IStorageProvider
             ? new IOSStorageFolder(url) : null);
     }
 
-    public Task<IStorageFile?> TryGetFileFromPath(Uri filePath)
+    public Task<IStorageFile?> TryGetFileFromPathAsync(Uri filePath)
     {
         // TODO: research if it's possible, maybe with additional permissions.
         return Task.FromResult<IStorageFile?>(null);
     }
 
-    public Task<IStorageFolder?> TryGetFolderFromPath(Uri folderPath)
+    public Task<IStorageFolder?> TryGetFolderFromPathAsync(Uri folderPath)
     {
         // TODO: research if it's possible, maybe with additional permissions.
         return Task.FromResult<IStorageFolder?>(null);
     }
 
-    public Task<IStorageFolder?> TryGetWellKnownFolder(WellKnownFolder wellKnownFolder)
+    public Task<IStorageFolder?> TryGetWellKnownFolderAsync(WellKnownFolder wellKnownFolder)
     {
         var directoryType = wellKnownFolder switch
         {

--- a/src/iOS/Avalonia.iOS/Storage/IOSStorageProvider.cs
+++ b/src/iOS/Avalonia.iOS/Storage/IOSStorageProvider.cs
@@ -43,6 +43,10 @@ internal class IOSStorageProvider : IStorageProvider
                     {
                         return f.AppleUniformTypeIdentifiers.Select(id => UTType.CreateFromIdentifier(id));
                     }
+                    if (f.TryGetExtensions() is { } extensions && extensions.Any())
+                    {
+                        return extensions.Select(id => UTType.CreateFromExtension(id.TrimStart('.')));
+                    }
                     if (f.MimeTypes?.Any() == true)
                     {
                         return f.MimeTypes.Select(id => UTType.CreateFromMimeType(id));


### PR DESCRIPTION
## What does the pull request do?

1. Changed AppBuilder API:
```diff
public static class BrowserAppBuilder
{
-    AppBuilder SetupBrowserApp()
+    Task StartBrowserAppAsync(this AppBuilder builder, string mainDivId, BrowserPlatformOptions? options = null);
+    Task SetupBrowserAppAsync(this AppBuilder builder, BrowserPlatformOptions? options = null);
     AppBuilder UseBrowser(AppBuilder builder);
}

public static class BlazorAppBuilder
{
-    AppBuilder SetupWithSingleViewLifetime(this AppBuilder builder);
-    AppBuilder UseBlazor(this AppBuilder builder)
-    AppBuilder Configure<TApp>()
+    Task StartBlazorAppAsync(this AppBuilder builder, BrowserPlatformOptions? options = null);
}
```
Where new async methods will properly resolve Avalonia scripts loading instead of relying on preloading. Also, consistency.

3. Fixed initialization order in the blazor. AppBuilder should be set up in the Main method.
4. Fixed custom file extensions in the open file picker on the browser backend.
5. Used [polyfill](https://github.com/jimmywarting/native-file-system-adapter) for the open file and folder pickers. Save file picker technically can be supported with hacks, but not in this PR.
6. Removed unused CanOpenRead/CanOpenWrite, these properties always returned "true" in all cases. 
7. Renamed TryGetFileFromPath-like methods added in preview5 to end with Async suffix.
8. Added new public IStorageItem.TryGetLocalPath() method to simplify API usage on desktop.


## Breaking changes

Breaking comparing to previous preview versions. AppBuilder method were changed.