### PR TITLE
Two ValueStore fixes.

### DIFF
--- a/src/Avalonia.Base/PropertyStore/EffectiveValue`1.cs
+++ b/src/Avalonia.Base/PropertyStore/EffectiveValue`1.cs
@@ -19,13 +19,16 @@ namespace Avalonia.PropertyStore
         private T? _baseValue;
         private UncommonFields? _uncommon;
 
-        public EffectiveValue(AvaloniaObject owner, StyledProperty<T> property)
+        public EffectiveValue(
+            AvaloniaObject owner,
+            StyledProperty<T> property,
+            EffectiveValue<T>? inherited)
         {
             Priority = BindingPriority.Unset;
             BasePriority = BindingPriority.Unset;
             _metadata = property.GetMetadata(owner.GetType());
 
-            var value = _metadata.DefaultValue;
+            var value = inherited is null ? _metadata.DefaultValue : inherited.Value;
 
             if (property.HasCoercion && _metadata.CoerceValue is { } coerce)
             {

--- a/src/Avalonia.Base/PropertyStore/ValueStore.cs
+++ b/src/Avalonia.Base/PropertyStore/ValueStore.cs
@@ -799,7 +799,7 @@ namespace Avalonia.PropertyStore
                     // - The value is a non-animation value and its priority is higher than the current
                     //   effective value's base priority
                     var isRelevantPriority = current is null ||
-                        priority < current.Priority ||
+                        (priority < current.Priority && priority < current.BasePriority) ||
                         (priority > BindingPriority.Animation && priority < current.BasePriority);
 
                     if (foundEntry && isRelevantPriority && entry!.HasValue)

--- a/src/Avalonia.Base/PropertyStore/ValueStore.cs
+++ b/src/Avalonia.Base/PropertyStore/ValueStore.cs
@@ -184,7 +184,7 @@ namespace Avalonia.PropertyStore
                 }
                 else
                 {
-                    var effectiveValue = new EffectiveValue<T>(Owner, property);
+                    var effectiveValue = CreateEffectiveValue(property);
                     AddEffectiveValue(property, effectiveValue);
                     effectiveValue.SetAndRaise(this, result, priority);
                 }
@@ -200,7 +200,7 @@ namespace Avalonia.PropertyStore
                 }
                 else
                 {
-                    var effectiveValue = new EffectiveValue<T>(Owner, property);
+                    var effectiveValue = CreateEffectiveValue(property);
                     AddEffectiveValue(property, effectiveValue);
                     effectiveValue.SetLocalValueAndRaise(this, property, value);
                 }
@@ -217,7 +217,7 @@ namespace Avalonia.PropertyStore
             }
             else
             {
-                var effectiveValue = new EffectiveValue<T>(Owner, property);
+                var effectiveValue = CreateEffectiveValue(property);
                 AddEffectiveValue(property, effectiveValue);
                 effectiveValue.SetCurrentValueAndRaise(this, property, value);
             }
@@ -285,6 +285,16 @@ namespace Avalonia.PropertyStore
 
             result = null;
             return false;
+        }
+
+        public EffectiveValue<T> CreateEffectiveValue<T>(StyledProperty<T> property)
+        {
+            EffectiveValue<T>? inherited = null;
+
+            if (property.Inherits && TryGetInheritedValue(property, out var v))
+                inherited = (EffectiveValue<T>)v;
+
+            return new EffectiveValue<T>(Owner, property, inherited);
         }
 
         public void SetInheritanceParent(AvaloniaObject? newParent)

--- a/src/Avalonia.Base/StyledProperty.cs
+++ b/src/Avalonia.Base/StyledProperty.cs
@@ -171,7 +171,7 @@ namespace Avalonia
 
         internal override EffectiveValue CreateEffectiveValue(AvaloniaObject o)
         {
-            return new EffectiveValue<TValue>(o, this);
+            return o.GetValueStore().CreateEffectiveValue(this);
         }
 
         /// <inheritdoc/>

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Binding.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Binding.cs
@@ -168,6 +168,22 @@ namespace Avalonia.Base.UnitTests
         }
 
         [Fact]
+        public void Completing_Animation_Binding_Reverts_To_Set_LocalValue_With_Style_Value()
+        {
+            var target = new Class1();
+            var source = new Subject<BindingValue<string>>();
+            var property = Class1.FooProperty;
+
+            target.SetValue(property, "style", BindingPriority.Style);
+            target.SetValue(property, "foo");
+            target.Bind(property, source, BindingPriority.Animation);
+            source.OnNext("bar");
+            source.OnCompleted();
+
+            Assert.Equal("foo", target.GetValue(property));
+        }
+
+        [Fact]
         public void Completing_LocalValue_Binding_Raises_PropertyChanged()
         {
             var target = new Class1();

--- a/tests/Avalonia.Base.UnitTests/PropertyStore/ValueStoreTests_Inheritance.cs
+++ b/tests/Avalonia.Base.UnitTests/PropertyStore/ValueStoreTests_Inheritance.cs
@@ -98,6 +98,27 @@ namespace Avalonia.Base.UnitTests.PropertyStore
         }
 
         [Fact]
+        public void Child_Notifies_About_Setting_Back_To_Default_Value()
+        {
+            var parent = new Class1();
+            var child = new Class1();
+
+            parent.Foo = "changed";
+            child.Parent = parent;
+
+            bool raised = false;
+            child.PropertyChanged += (_, args) =>
+            {
+                raised = args.Property == Class1.FooProperty && args.GetNewValue<string>() == "foodefault";
+            };
+
+            Assert.Equal("changed", child.Foo); // inherited from parent.
+
+            child.Foo = "foodefault"; // reset back to default.
+            Assert.True(raised); // expect event to be raised, as actual value was changed.
+        }
+
+        [Fact]
         public void Adding_Child_Sets_InheritanceAncestor()
         {
             var parent = new Class1();


### PR DESCRIPTION
## What does the pull request do?

Fixes two issues in the new value store which was added in #8600:

- #10255: when an animation completed, the value wasn't reverting back to a `LocalValue` in the presence of a lower-priority value (such as a style). Fixed in 3e81ed8fbca08a36eeec53db5792a31440283d2f by ensuring that we respect the base value when re-evaluating
- #10345: When changing value from inherited to default, control doesn't raise any property changed events. Fixed in 994897a0238caf1882060f41e0e4634efda4a34a by passing inherited values to the constructor of `EffectiveValue`

## Fixed issues

Fixes #10255 
Fixes #10345 