### PR TITLE
Nullable annotations for Avalonia.OpenGL

### DIFF
--- a/src/Avalonia.OpenGL/Avalonia.OpenGL.csproj
+++ b/src/Avalonia.OpenGL/Avalonia.OpenGL.csproj
@@ -13,6 +13,7 @@
     <Import Project="..\..\build\DevAnalyzers.props" />
     <Import Project="..\..\build\SourceGenerators.props" />
     <Import Project="..\..\build\TrimmingEnable.props" />
+    <Import Project="..\..\build\NullableEnable.props" />
 
   <ItemGroup>
     <Compile Remove="..\Shared\SourceGeneratorAttributes.cs" />

--- a/src/Avalonia.OpenGL/Controls/CompositionOpenGlSwapchain.cs
+++ b/src/Avalonia.OpenGL/Controls/CompositionOpenGlSwapchain.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Avalonia.Platform;
 using Avalonia.Rendering;
@@ -22,7 +21,7 @@ internal class CompositionOpenGlSwapchain : SwapchainBase<IGlSwapchainImage>
     }
     
     public CompositionOpenGlSwapchain(IGlContext context, ICompositionGpuInterop interop, CompositionDrawingSurface target,
-        IGlContextExternalObjectsFeature externalObjectsFeature) : base(interop, target)
+        IGlContextExternalObjectsFeature? externalObjectsFeature) : base(interop, target)
     {
         _context = context;
         _externalObjectsFeature = externalObjectsFeature;
@@ -95,7 +94,7 @@ internal class DxgiMutexOpenGlSwapChainImage : IGlSwapchainImage
     public int TextureId => _texture.TextureId;
     public int InternalFormat => _texture.InternalFormat;
     public PixelSize Size => new(_texture.Properties.Width, _texture.Properties.Height);
-    public Task LastPresent => _lastPresent;
+    public Task? LastPresent => _lastPresent;
     public void BeginDraw() => _texture.AcquireKeyedMutex(0);
 
     public void Present()

--- a/src/Avalonia.OpenGL/Controls/OpenGlControlResources.cs
+++ b/src/Avalonia.OpenGL/Controls/OpenGlControlResources.cs
@@ -14,14 +14,14 @@ internal class OpenGlControlBaseResources : IAsyncDisposable
     public int Fbo { get; private set; }
     private PixelSize _depthBufferSize;
     public CompositionDrawingSurface Surface { get; }
-    public CompositionOpenGlSwapchain _swapchain;
+    private readonly CompositionOpenGlSwapchain _swapchain;
     public IGlContext Context { get; private set; }
     
     public static OpenGlControlBaseResources? TryCreate(CompositionDrawingSurface surface,
         ICompositionGpuInterop interop,
         IOpenGlTextureSharingRenderInterfaceContextFeature feature)
     {
-        IGlContext context;
+        IGlContext? context;
         try
         {
             context = feature.CreateSharedContext();
@@ -71,7 +71,7 @@ internal class OpenGlControlBaseResources : IAsyncDisposable
                 new CompositionOpenGlSwapchain(context, interop, Surface, externalObjects);
     }
 
-    void UpdateDepthRenderbuffer(PixelSize size)
+    private void UpdateDepthRenderbuffer(PixelSize size)
     {
         if (size == _depthBufferSize && _depthBuffer != 0)
             return;

--- a/src/Avalonia.OpenGL/Egl/EglContext.cs
+++ b/src/Avalonia.OpenGL/Egl/EglContext.cs
@@ -12,15 +12,15 @@ namespace Avalonia.OpenGL.Egl
     {
         private readonly EglDisplay _disp;
         private readonly EglInterface _egl;
-        private readonly EglContext _sharedWith;
+        private readonly EglContext? _sharedWith;
         private bool _isLost;
         private IntPtr _context;
-        private readonly Action _disposeCallback;
+        private readonly Action? _disposeCallback;
         private readonly Dictionary<Type, object> _features;
         private readonly object _lock;
 
-        internal EglContext(EglDisplay display, EglInterface egl, EglContext sharedWith, IntPtr ctx, EglSurface offscreenSurface,
-            GlVersion version, int sampleCount, int stencilSize, Action disposeCallback, 
+        internal EglContext(EglDisplay display, EglInterface egl, EglContext? sharedWith, IntPtr ctx, EglSurface? offscreenSurface,
+            GlVersion version, int sampleCount, int stencilSize, Action? disposeCallback,
             Dictionary<Type, Func<EglContext, object>> features)
         {
             _disp = display;
@@ -42,19 +42,19 @@ namespace Avalonia.OpenGL.Egl
 
         public IntPtr Context =>
             _context == IntPtr.Zero ? throw new ObjectDisposedException(nameof(EglContext)) : _context; 
-        public EglSurface OffscreenSurface { get; }
+        public EglSurface? OffscreenSurface { get; }
         public GlVersion Version { get; }
         public GlInterface GlInterface { get; }
         public int SampleCount { get; }
         public int StencilSize { get; }
         public EglDisplay Display => _disp;
 
-        class RestoreContext : IDisposable
+        private class RestoreContext : IDisposable
         {
             private readonly EglInterface _egl;
             private readonly object _l;
             private readonly IntPtr _display;
-            public IntPtr _context, _read, _draw;
+            private readonly IntPtr _context, _read, _draw;
 
             public RestoreContext(EglInterface egl, IntPtr defDisplay, object l)
             {
@@ -78,7 +78,7 @@ namespace Avalonia.OpenGL.Egl
 
         public IDisposable MakeCurrent() => MakeCurrent(OffscreenSurface);
 
-        public IDisposable MakeCurrent(EglSurface surface)
+        public IDisposable MakeCurrent(EglSurface? surface)
         {
             if (IsLost)
                 throw new PlatformGraphicsContextLostException();
@@ -147,7 +147,7 @@ namespace Avalonia.OpenGL.Egl
 
         public bool CanCreateSharedContext => _disp.SupportsSharing;
 
-        public IGlContext CreateSharedContext(IEnumerable<GlVersion> preferredVersions = null) =>
+        public IGlContext CreateSharedContext(IEnumerable<GlVersion>? preferredVersions = null) =>
             _disp.CreateContext(new EglContextOptions
             {
                 ShareWith = _sharedWith ?? this
@@ -174,9 +174,9 @@ namespace Avalonia.OpenGL.Egl
             _disposeCallback?.Invoke();
         }
 
-        public object TryGetFeature(Type featureType)
+        public object? TryGetFeature(Type featureType)
         {
-            if (_features?.TryGetValue(featureType, out var feature) == true)
+            if (_features.TryGetValue(featureType, out var feature))
                 return feature;
             return null;
         }

--- a/src/Avalonia.OpenGL/Egl/EglDisplay.cs
+++ b/src/Avalonia.OpenGL/Egl/EglDisplay.cs
@@ -14,14 +14,14 @@ namespace Avalonia.OpenGL.Egl
         private readonly EglDisplayOptions _options;
         private EglConfigInfo _config;
         private bool _isLost;
-        private object _lock = new();
+        private readonly object _lock = new();
         
         public bool SupportsSharing { get; }
 
         public IntPtr Handle => _display;
         public IntPtr Config => _config.Config;
         internal bool SingleContext => !_options.SupportsMultipleContexts;
-        private List<EglContext> _contexts = new();
+        private readonly List<EglContext> _contexts = new();
         
         public EglDisplay() : this(new EglDisplayCreationOptions
         {
@@ -38,7 +38,7 @@ namespace Avalonia.OpenGL.Egl
         
         public EglDisplay(IntPtr display, EglDisplayOptions options)
         {
-            _egl = options.Egl;
+            _egl = options.Egl ?? new EglInterface();
             SupportsSharing = options.SupportsContextSharing;
             _display = display;
             _options = options;
@@ -49,7 +49,7 @@ namespace Avalonia.OpenGL.Egl
         }
         
         public EglInterface EglInterface => _egl;
-        public EglContext CreateContext(EglContextOptions options)
+        public EglContext CreateContext(EglContextOptions? options)
         {
             if (SingleContext && _contexts.Any())
                 throw new OpenGlException("This EGLDisplay can only have one active context");
@@ -129,7 +129,7 @@ namespace Avalonia.OpenGL.Egl
 
         protected virtual bool DisplayLockIsSharedWithContexts => false;
         
-        internal object ContextSharedSyncRoot => DisplayLockIsSharedWithContexts ? _lock : null;
+        internal object? ContextSharedSyncRoot => DisplayLockIsSharedWithContexts ? _lock : null;
 
         internal void OnContextLost(EglContext context)
         {
@@ -171,7 +171,6 @@ namespace Avalonia.OpenGL.Egl
                 if (_display != IntPtr.Zero)
                     _egl.Terminate(_display);
                 _display = IntPtr.Zero;
-                _config = null;
                 _options.DisposeCallback?.Invoke();
             }
         }

--- a/src/Avalonia.OpenGL/Egl/EglDisplayOptions.cs
+++ b/src/Avalonia.OpenGL/Egl/EglDisplayOptions.cs
@@ -5,26 +5,26 @@ namespace Avalonia.OpenGL.Egl;
 
 public class EglDisplayOptions
 {
-    public EglInterface Egl { get; set; }
+    public EglInterface? Egl { get; set; }
     public bool SupportsContextSharing { get; set; }
     public bool SupportsMultipleContexts { get; set; }
     public bool ContextLossIsDisplayLoss { get; set; }
-    public Func<bool> DeviceLostCheckCallback { get; set; }
-    public Action DisposeCallback { get; set; }
-    public IEnumerable<GlVersion> GlVersions { get; set; }
+    public Func<bool>? DeviceLostCheckCallback { get; set; }
+    public Action? DisposeCallback { get; set; }
+    public IEnumerable<GlVersion>? GlVersions { get; set; }
 }
 
 public class EglContextOptions
 {
-    public EglContext ShareWith { get; set; }
-    public EglSurface OffscreenSurface { get; set; }
-    public Action DisposeCallback { get; set; }
-    public Dictionary<Type, Func<EglContext, object>> ExtraFeatures { get; set; }
+    public EglContext? ShareWith { get; set; }
+    public EglSurface? OffscreenSurface { get; set; }
+    public Action? DisposeCallback { get; set; }
+    public Dictionary<Type, Func<EglContext, object>>? ExtraFeatures { get; set; }
 }
 
 public class EglDisplayCreationOptions : EglDisplayOptions
 {
     public int? PlatformType { get; set; }
     public IntPtr PlatformDisplay { get; set; }
-    public int[] PlatformDisplayAttrs { get; set; }
+    public int[]? PlatformDisplayAttrs { get; set; }
 }

--- a/src/Avalonia.OpenGL/Egl/EglDisplayUtils.cs
+++ b/src/Avalonia.OpenGL/Egl/EglDisplayUtils.cs
@@ -1,15 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using static Avalonia.OpenGL.Egl.EglConsts;
 namespace Avalonia.OpenGL.Egl;
 
-static class EglDisplayUtils
+internal static class EglDisplayUtils
 {
     public static IntPtr CreateDisplay(EglDisplayCreationOptions options)
     {
-        var egl = options.Egl;
+        var egl = options.Egl ?? new EglInterface();
         var display = IntPtr.Zero;
         if (options.PlatformType == null)
         {
@@ -30,9 +29,9 @@ static class EglDisplayUtils
         return display;
     }
 
-    public static EglConfigInfo InitializeAndGetConfig(EglInterface egl, IntPtr display, IEnumerable<GlVersion> versions)
+    public static EglConfigInfo InitializeAndGetConfig(EglInterface egl, IntPtr display, IEnumerable<GlVersion>? versions)
     {
-        if (!egl.Initialize(display, out var major, out var minor))
+        if (!egl.Initialize(display, out _, out _))
             throw OpenGlException.GetFormattedException("eglInitialize", egl);
 
         // TODO: AvaloniaLocator.Current.GetService<AngleOptions>()?.GlProfiles
@@ -112,7 +111,7 @@ static class EglDisplayUtils
     
 }
 
-class EglConfigInfo
+internal class EglConfigInfo
 {
     public IntPtr Config { get; }
     public GlVersion Version { get; }

--- a/src/Avalonia.OpenGL/Egl/EglGlPlatformSurface.cs
+++ b/src/Avalonia.OpenGL/Egl/EglGlPlatformSurface.cs
@@ -27,9 +27,9 @@ namespace Avalonia.OpenGL.Egl
             return new RenderTarget(glSurface, eglContext, _info);
         }
 
-        class RenderTarget : EglPlatformSurfaceRenderTargetBase
+        private class RenderTarget : EglPlatformSurfaceRenderTargetBase
         {
-            private EglSurface _glSurface;
+            private EglSurface? _glSurface;
             private readonly IEglWindowGlPlatformSurfaceInfo _info;
             private PixelSize _currentSize;
             private readonly IntPtr _handle;
@@ -42,12 +42,12 @@ namespace Avalonia.OpenGL.Egl
                 _handle = _info.Handle;
             }
 
-            public override void Dispose() => _glSurface.Dispose();
+            public override void Dispose() => _glSurface?.Dispose();
 
             public override IGlPlatformSurfaceRenderingSession BeginDrawCore()
             {
                 if (_info.Size != _currentSize 
-                    || _handle != _info.Handle 
+                    || _handle != _info.Handle
                     || _glSurface == null)
                 {
                     _glSurface?.Dispose();

--- a/src/Avalonia.OpenGL/Egl/EglGlPlatformSurfaceBase.cs
+++ b/src/Avalonia.OpenGL/Egl/EglGlPlatformSurfaceBase.cs
@@ -33,7 +33,7 @@ namespace Avalonia.OpenGL.Egl
         public abstract IGlPlatformSurfaceRenderingSession BeginDrawCore();
 
         protected IGlPlatformSurfaceRenderingSession BeginDraw(EglSurface surface,
-            PixelSize size, double scaling, Action onFinish = null, bool isYFlipped = false)
+            PixelSize size, double scaling, Action? onFinish = null, bool isYFlipped = false)
         {
 
             var restoreContext = Context.MakeCurrent(surface);
@@ -56,19 +56,18 @@ namespace Avalonia.OpenGL.Egl
                     restoreContext.Dispose();
             }
         }
-        
-        class Session : IGlPlatformSurfaceRenderingSession
+
+        private class Session : IGlPlatformSurfaceRenderingSession
         {
             private readonly EglContext _context;
             private readonly EglSurface _glSurface;
             private readonly EglDisplay _display;
             private readonly IDisposable _restoreContext;
-            private readonly Action _onFinish;
-
+            private readonly Action? _onFinish;
 
             public Session(EglDisplay display, EglContext context,
                 EglSurface glSurface, PixelSize size, double scaling,
-                 IDisposable restoreContext, Action onFinish, bool isYFlipped)
+                IDisposable restoreContext, Action? onFinish, bool isYFlipped)
             {
                 Size = size;
                 Scaling = scaling;

--- a/src/Avalonia.OpenGL/Egl/EglInterface.cs
+++ b/src/Avalonia.OpenGL/Egl/EglInterface.cs
@@ -49,7 +49,7 @@ namespace Avalonia.OpenGL.Egl
         public partial IntPtr GetDisplay(IntPtr nativeDisplay);
         
         [GetProcAddress("eglGetPlatformDisplayEXT", true)]
-        public partial IntPtr GetPlatformDisplayExt(int platform, IntPtr nativeDisplay, int[] attrs);
+        public partial IntPtr GetPlatformDisplayExt(int platform, IntPtr nativeDisplay, int[]? attrs);
 
         [GetProcAddress("eglInitialize")]        
         public partial bool Initialize(IntPtr display, out int major, out int minor);
@@ -75,7 +75,7 @@ namespace Avalonia.OpenGL.Egl
         public partial bool DestroyContext(IntPtr display, IntPtr context);
         
         [GetProcAddress("eglCreatePbufferSurface")]
-        public partial IntPtr CreatePBufferSurface(IntPtr display, IntPtr config, int[] attrs);
+        public partial IntPtr CreatePBufferSurface(IntPtr display, IntPtr config, int[]? attrs);
 
         [GetProcAddress("eglMakeCurrent")]
         public partial bool MakeCurrent(IntPtr display, IntPtr draw, IntPtr read, IntPtr context);
@@ -96,7 +96,7 @@ namespace Avalonia.OpenGL.Egl
         public partial void SwapBuffers(IntPtr display, IntPtr surface);
 
         [GetProcAddress("eglCreateWindowSurface")]
-        public partial IntPtr CreateWindowSurface(IntPtr display, IntPtr config, IntPtr window, int[] attrs);
+        public partial IntPtr CreateWindowSurface(IntPtr display, IntPtr config, IntPtr window, int[]? attrs);
 
         [GetProcAddress("eglBindTexImage")]
         public partial int BindTexImage(IntPtr display, IntPtr surface, int buffer);
@@ -116,7 +116,7 @@ namespace Avalonia.OpenGL.Egl
         [GetProcAddress("eglQueryString")]
         public partial IntPtr QueryStringNative(IntPtr display, int i);
         
-        public string QueryString(IntPtr display, int i)
+        public string? QueryString(IntPtr display, int i)
         {
             var rv = QueryStringNative(display, i);
             if (rv == IntPtr.Zero)
@@ -125,7 +125,7 @@ namespace Avalonia.OpenGL.Egl
         }
         
         [GetProcAddress("eglCreatePbufferFromClientBuffer")]
-        public partial IntPtr CreatePbufferFromClientBuffer(IntPtr display, int buftype, IntPtr buffer, IntPtr config, int[] attrib_list);
+        public partial IntPtr CreatePbufferFromClientBuffer(IntPtr display, int buftype, IntPtr buffer, IntPtr config, int[]? attrib_list);
         
         [GetProcAddress("eglQueryDisplayAttribEXT", true)]
         public partial bool QueryDisplayAttribExt(IntPtr display, int attr, out IntPtr res);

--- a/src/Avalonia.OpenGL/Egl/EglPlatformGraphics.cs
+++ b/src/Avalonia.OpenGL/Egl/EglPlatformGraphics.cs
@@ -1,7 +1,6 @@
 using System;
 using Avalonia.Logging;
 using Avalonia.Platform;
-using static Avalonia.OpenGL.Egl.EglConsts;
 
 namespace Avalonia.OpenGL.Egl
 {
@@ -24,7 +23,7 @@ namespace Avalonia.OpenGL.Egl
                 AvaloniaLocator.CurrentMutable.Bind<IPlatformGraphics>().ToConstant(feature);
         }
         
-        public static EglPlatformGraphics TryCreate() => TryCreate(() => new EglDisplay(new EglDisplayCreationOptions
+        public static EglPlatformGraphics? TryCreate() => TryCreate(() => new EglDisplay(new EglDisplayCreationOptions
         {
             Egl = new EglInterface(),
             // Those are expected to be supported by most EGL implementations
@@ -32,7 +31,7 @@ namespace Avalonia.OpenGL.Egl
             SupportsContextSharing = true
         }));
         
-        public static EglPlatformGraphics TryCreate(Func<EglDisplay> displayFactory)
+        public static EglPlatformGraphics? TryCreate(Func<EglDisplay> displayFactory)
         {
             try
             {

--- a/src/Avalonia.OpenGL/GlBasicInfoInterface.cs
+++ b/src/Avalonia.OpenGL/GlBasicInfoInterface.cs
@@ -2,14 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
-using Avalonia.Platform.Interop;
 using Avalonia.SourceGenerator;
 
 namespace Avalonia.OpenGL
 {
     public unsafe partial class GlBasicInfoInterface
     {
-        public GlBasicInfoInterface(Func<string, IntPtr> getProcAddress){
+        public GlBasicInfoInterface(Func<string, IntPtr> getProcAddress)
+        {
             Initialize(getProcAddress);
         }
     
@@ -22,7 +22,7 @@ namespace Avalonia.OpenGL
         [GetProcAddress("glGetStringi")]
         public partial IntPtr GetStringiNative(int v, int v1);
 
-        public string GetString(int v)
+        public string? GetString(int v)
         {
             var ptr = GetStringNative(v);
             if (ptr != IntPtr.Zero)
@@ -30,7 +30,7 @@ namespace Avalonia.OpenGL
             return null;
         }
         
-        public string GetString(int v, int index)
+        public string? GetString(int v, int index)
         {
             var ptr = GetStringiNative(v, index);
             if (ptr != IntPtr.Zero)
@@ -46,7 +46,13 @@ namespace Avalonia.OpenGL
             GetIntegerv(GlConsts.GL_NUM_EXTENSIONS, out int count);
             var rv = new List<string>(count);
             for (var c = 0; c < count; c++)
-                rv.Add(GetString(GlConsts.GL_EXTENSIONS, c));
+            {
+                if (GetString(GlConsts.GL_EXTENSIONS, c) is { } extension)
+                {
+                    rv.Add(extension);
+                }
+            }
+
             return rv;
         }
     }

--- a/src/Avalonia.OpenGL/GlInterface.cs
+++ b/src/Avalonia.OpenGL/GlInterface.cs
@@ -11,9 +11,9 @@ namespace Avalonia.OpenGL
     public unsafe partial class GlInterface : GlBasicInfoInterface
     {
         private readonly Func<string, IntPtr> _getProcAddress;
-        public string Version { get; }
-        public string Vendor { get; }
-        public string Renderer { get; }
+        public string? Version { get; }
+        public string? Vendor { get; }
+        public string? Renderer { get; }
         public GlContextInfo ContextInfo { get; }
 
         public class GlContextInfo
@@ -39,9 +39,9 @@ namespace Avalonia.OpenGL
         {
             _getProcAddress = getProcAddress;
             ContextInfo = info;
-            Version = GetString(GlConsts.GL_VERSION);
-            Renderer = GetString(GlConsts.GL_RENDERER);
-            Vendor = GetString(GlConsts.GL_VENDOR);
+            Version = GetString(GL_VERSION);
+            Renderer = GetString(GL_RENDERER);
+            Vendor = GetString(GL_VENDOR);
             Initialize(getProcAddress, ContextInfo);
         }
 
@@ -203,7 +203,7 @@ namespace Avalonia.OpenGL
         [GetProcAddress("glGetShaderInfoLog")]
         public partial void GetShaderInfoLog(int shader, int maxLength, out int length, void* infoLog);
 
-        public unsafe string CompileShaderAndGetError(int shader, string source)
+        public unsafe string? CompileShaderAndGetError(int shader, string source)
         {
             ShaderSourceString(shader, source);
             CompileShader(shader);
@@ -238,7 +238,7 @@ namespace Avalonia.OpenGL
         [GetProcAddress("glGetProgramInfoLog")]
         public partial void GetProgramInfoLog(int program, int maxLength, out int len, void* infoLog);
 
-        public unsafe string LinkProgramAndGetError(int program)
+        public unsafe string? LinkProgramAndGetError(int program)
         {
             LinkProgram(program);
             int compiled;

--- a/src/Avalonia.OpenGL/IGlContext.cs
+++ b/src/Avalonia.OpenGL/IGlContext.cs
@@ -15,7 +15,7 @@ namespace Avalonia.OpenGL
         IDisposable EnsureCurrent();
         bool IsSharedWith(IGlContext context);
         bool CanCreateSharedContext { get; }
-        IGlContext CreateSharedContext(IEnumerable<GlVersion> preferredVersions = null);
+        IGlContext? CreateSharedContext(IEnumerable<GlVersion>? preferredVersions = null);
     }
 
     public interface IGlPlatformSurfaceRenderTargetFactory

--- a/src/Avalonia.OpenGL/IOpenGlTextureSharingRenderInterfaceContextFeature.cs
+++ b/src/Avalonia.OpenGL/IOpenGlTextureSharingRenderInterfaceContextFeature.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Avalonia.Rendering.Composition;
 
@@ -7,7 +6,7 @@ namespace Avalonia.OpenGL
     public interface IOpenGlTextureSharingRenderInterfaceContextFeature
     {
         bool CanCreateSharedContext { get; }
-        IGlContext CreateSharedContext(IEnumerable<GlVersion> preferredVersions = null);
+        IGlContext? CreateSharedContext(IEnumerable<GlVersion>? preferredVersions = null);
         ICompositionImportableOpenGlSharedTexture CreateSharedTextureForComposition(IGlContext context, PixelSize size);
     }
 

--- a/src/Avalonia.OpenGL/OpenGlException.cs
+++ b/src/Avalonia.OpenGL/OpenGlException.cs
@@ -5,13 +5,13 @@ namespace Avalonia.OpenGL
 {
     public class OpenGlException : Exception
     {
-        public int? ErrorCode { get; private set; }
+        public int? ErrorCode { get; }
 
-        public OpenGlException(string message) : base(message)
+        public OpenGlException(string? message) : base(message)
         {
         }
 
-        private OpenGlException(string message, int errorCode) : base(message)
+        private OpenGlException(string? message, int errorCode) : base(message)
         {
             ErrorCode = errorCode;
         }


### PR DESCRIPTION
Adds nullable annotations for the `Avalonia.OpenGL` project.

This time no renames at all ;)

Non nullability related note: `OpenGlControlBaseResources._swapchain` and `EglContext.RestoreContext._context/_read/_draw` have been made `private`: they had only private usages along with a private name.
