### PR TITLE
Fix Direct2D1 test runner hanging

### DIFF
--- a/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
+++ b/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
-using Avalonia.Controls;
 using Avalonia.Controls.Platform.Surfaces;
 using Avalonia.Direct2D1.Media;
 using Avalonia.Direct2D1.Media.Imaging;
@@ -55,15 +55,18 @@ namespace Avalonia.Direct2D1
                     return;
                 }
 #if DEBUG
-                try
+                if (Debugger.IsAttached)
                 {
-                    Direct2D1Factory = new SharpDX.Direct2D1.Factory1(
-                        SharpDX.Direct2D1.FactoryType.MultiThreaded,
+                    try
+                    {
+                        Direct2D1Factory = new SharpDX.Direct2D1.Factory1(
+                            SharpDX.Direct2D1.FactoryType.MultiThreaded,
                             SharpDX.Direct2D1.DebugLevel.Error);
-                }
-                catch
-                {
-                    //
+                    }
+                    catch
+                    {
+                        // ignore, retry below without the debug layer
+                    }
                 }
 #endif
                 if (Direct2D1Factory == null)


### PR DESCRIPTION
## What does the pull request do?
This PR enables the Direct2D debug layer for unit tests only when a debugger is attached, allowing the test runner to exit normally.


## Details
I run all Avalonia unit tests in debug mode regularly in Rider. After the D2D ones complete, the test runner process keeps running instead of exiting, locking the assemblies. Rider warns after some time and offer to kill the offending process. VS does nothing and keeps the process running (or I haven't waited enough).

Those unit tests enable the Direct2D Debug Layer when built with the debug configuration, which triggers a breakpoint if there's an error, [as documented](https://learn.microsoft.com/en-us/windows/win32/direct2d/direct2ddebuglayer-portal): _further, a message of level error triggers the breakpoint to help you debug._

When there's no debugger, triggering a breakpoint should crash the process or ask for a debugger. I have no idea why it doesn't (or if it's specific to my environment, but I can reproduce it on two machines).

This PR enables the debug layer only when there's a debugger attached.

For the curious, the error reported by the debug layer is that a memory leak exists since a bunch of D2D objects created by the tests haven't been freed.