### PR TITLE
Enable data validation on all AvaloniaProperty types

### DIFF
--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -778,11 +778,16 @@ namespace Avalonia
                     break;
             }
 
-            var metadata = property.GetMetadata(GetType());
+            UpdateDataValidationCore(property, value.Type, value.Error);
+        }
 
-            if (metadata.EnableDataValidation == true)
+        internal void UpdateDataValidationCore(AvaloniaProperty property,
+            BindingValueType state,
+            Exception? error)
+        {
+            if (property.GetMetadata(GetType()) is { EnableDataValidation: true })
             {
-                UpdateDataValidation(property, value.Type, value.Error);
+                UpdateDataValidation(property, state, error);
             }
         }
 

--- a/src/Avalonia.Base/AvaloniaObjectExtensions.cs
+++ b/src/Avalonia.Base/AvaloniaObjectExtensions.cs
@@ -199,13 +199,11 @@ namespace Avalonia
             property = property ?? throw new ArgumentNullException(nameof(property));
             binding = binding ?? throw new ArgumentNullException(nameof(binding));
 
-            var metadata = property.GetMetadata(target.GetType()) as IDirectPropertyMetadata;
-
             var result = binding.Initiate(
                 target,
                 property,
                 anchor,
-                metadata?.EnableDataValidation ?? false);
+                property.GetMetadata(target.GetType()).EnableDataValidation ?? false);
 
             if (result != null)
             {

--- a/src/Avalonia.Base/AvaloniaProperty.cs
+++ b/src/Avalonia.Base/AvaloniaProperty.cs
@@ -227,6 +227,7 @@ namespace Avalonia
         /// <param name="defaultBindingMode">The default binding mode for the property.</param>
         /// <param name="validate">A value validation callback.</param>
         /// <param name="coerce">A value coercion callback.</param>
+        /// <param name="enableDataValidation">Whether the property is interested in data validation.</param>
         /// <returns>A <see cref="StyledProperty{TValue}"/></returns>
         public static StyledProperty<TValue> Register<TOwner, TValue>(
             string name,
@@ -234,7 +235,8 @@ namespace Avalonia
             bool inherits = false,
             BindingMode defaultBindingMode = BindingMode.OneWay,
             Func<TValue, bool>? validate = null,
-            Func<AvaloniaObject, TValue, TValue>? coerce = null)
+            Func<AvaloniaObject, TValue, TValue>? coerce = null,
+            bool enableDataValidation = false)
                 where TOwner : AvaloniaObject
         {
             _ = name ?? throw new ArgumentNullException(nameof(name));
@@ -242,7 +244,8 @@ namespace Avalonia
             var metadata = new StyledPropertyMetadata<TValue>(
                 defaultValue,
                 defaultBindingMode: defaultBindingMode,
-                coerce: coerce);
+                coerce: coerce,
+                enableDataValidation: enableDataValidation);
 
             var result = new StyledProperty<TValue>(
                 name,
@@ -253,7 +256,7 @@ namespace Avalonia
             AvaloniaPropertyRegistry.Instance.Register(typeof(TOwner), result);
             return result;
         }
-        
+
         /// <inheritdoc cref="Register{TOwner, TValue}" />
         /// <param name="notifying">
         /// A method that gets called before and after the property starts being notified on an
@@ -267,6 +270,7 @@ namespace Avalonia
             BindingMode defaultBindingMode,
             Func<TValue, bool>? validate,
             Func<AvaloniaObject, TValue, TValue>? coerce,
+            bool enableDataValidation,
             Action<AvaloniaObject, bool>? notifying)
                 where TOwner : AvaloniaObject
         {
@@ -275,7 +279,8 @@ namespace Avalonia
             var metadata = new StyledPropertyMetadata<TValue>(
                 defaultValue,
                 defaultBindingMode: defaultBindingMode,
-                coerce: coerce);
+                coerce: coerce,
+                enableDataValidation: enableDataValidation);
 
             var result = new StyledProperty<TValue>(
                 name,

--- a/src/Avalonia.Base/AvaloniaPropertyMetadata.cs
+++ b/src/Avalonia.Base/AvaloniaPropertyMetadata.cs
@@ -13,10 +13,13 @@ namespace Avalonia
         /// Initializes a new instance of the <see cref="AvaloniaPropertyMetadata"/> class.
         /// </summary>
         /// <param name="defaultBindingMode">The default binding mode.</param>
+        /// <param name="enableDataValidation">Whether the property is interested in data validation.</param>
         public AvaloniaPropertyMetadata(
-            BindingMode defaultBindingMode = BindingMode.Default)
+            BindingMode defaultBindingMode = BindingMode.Default,
+            bool? enableDataValidation = null)
         {
             _defaultBindingMode = defaultBindingMode;
+            EnableDataValidation = enableDataValidation;
         }
 
         /// <summary>
@@ -32,6 +35,17 @@ namespace Avalonia
         }
 
         /// <summary>
+        /// Gets a value indicating whether the property is interested in data validation.
+        /// </summary>
+        /// <remarks>
+        /// Data validation is validation performed at the target of a binding, for example in a
+        /// view model using the INotifyDataErrorInfo interface. Only certain properties on a
+        /// control (such as a TextBox's Text property) will be interested in receiving data
+        /// validation messages so this feature must be explicitly enabled by setting this flag.
+        /// </remarks>
+        public bool? EnableDataValidation { get; private set; }
+
+        /// <summary>
         /// Merges the metadata with the base metadata.
         /// </summary>
         /// <param name="baseMetadata">The base metadata to merge.</param>
@@ -44,6 +58,8 @@ namespace Avalonia
             {
                 _defaultBindingMode = baseMetadata.DefaultBindingMode;
             }
+
+            EnableDataValidation ??= baseMetadata.EnableDataValidation;
         }
     }
 }

--- a/src/Avalonia.Base/DirectPropertyMetadata`1.cs
+++ b/src/Avalonia.Base/DirectPropertyMetadata`1.cs
@@ -21,10 +21,9 @@ namespace Avalonia
             TValue unsetValue = default!,
             BindingMode defaultBindingMode = BindingMode.Default,
             bool? enableDataValidation = null)
-                : base(defaultBindingMode)
+                : base(defaultBindingMode, enableDataValidation)
         {
             UnsetValue = unsetValue;
-            EnableDataValidation = enableDataValidation;
         }
 
         /// <summary>
@@ -32,16 +31,6 @@ namespace Avalonia
         /// </summary>
         public TValue UnsetValue { get; private set; }
 
-        /// <summary>
-        /// Gets a value indicating whether the property is interested in data validation.
-        /// </summary>
-        /// <remarks>
-        /// Data validation is validation performed at the target of a binding, for example in a
-        /// view model using the INotifyDataErrorInfo interface. Only certain properties on a
-        /// control (such as a TextBox's Text property) will be interested in receiving data
-        /// validation messages so this feature must be explicitly enabled by setting this flag.
-        /// </remarks>
-        public bool? EnableDataValidation { get; private set; }
 
         /// <inheritdoc/>
         object? IDirectPropertyMetadata.UnsetValue => UnsetValue;
@@ -51,19 +40,9 @@ namespace Avalonia
         {
             base.Merge(baseMetadata, property);
 
-            var src = baseMetadata as DirectPropertyMetadata<TValue>;
-
-            if (src != null)
+            if (baseMetadata is DirectPropertyMetadata<TValue> src)
             {
-                if (UnsetValue == null)
-                {
-                    UnsetValue = src.UnsetValue;
-                }
-
-                if (EnableDataValidation == null)
-                {
-                    EnableDataValidation = src.EnableDataValidation;
-                }
+                UnsetValue ??= src.UnsetValue;
             }
         }
     }

--- a/src/Avalonia.Base/PropertyStore/BindingEntryBase.cs
+++ b/src/Avalonia.Base/PropertyStore/BindingEntryBase.cs
@@ -125,6 +125,8 @@ namespace Avalonia.PropertyStore
                     if (instance._subscription is not null && instance._subscription != s_creatingQuiet)
                         instance.Frame.Owner?.OnBindingValueChanged(instance, instance.Frame.Priority);
                 }
+
+                instance.Frame.Owner?.Owner.UpdateDataValidationCore(instance.Property, value.Type, value.Error);
             }
 
             if (value.Type == BindingValueType.DoNothing)

--- a/src/Avalonia.Base/PropertyStore/LocalValueBindingObserver.cs
+++ b/src/Avalonia.Base/PropertyStore/LocalValueBindingObserver.cs
@@ -88,6 +88,8 @@ namespace Avalonia.PropertyStore
                 {
                     owner.SetValue(property, instance.GetCachedDefaultValue(), BindingPriority.LocalValue);
                 }
+
+                owner.Owner.UpdateDataValidationCore(property, value.Type, value.Error);
             }
 
             if (value.Type is BindingValueType.DoNothing or BindingValueType.DataValidationError)

--- a/src/Avalonia.Base/PropertyStore/LocalValueUntypedBindingObserver.cs
+++ b/src/Avalonia.Base/PropertyStore/LocalValueUntypedBindingObserver.cs
@@ -42,15 +42,29 @@ namespace Avalonia.PropertyStore
                 var owner = instance._owner;
                 var property = instance.Property;
 
+                var valueType = BindingValueType.Value;
+                Exception? error = null;
+
                 if (value is BindingNotification n)
                 {
                     value = n.Value;
                     LoggingUtils.LogIfNecessary(owner.Owner, property, n);
+
+                    valueType = n.ErrorType switch
+                    {
+                        BindingErrorType.None => n.HasValue ? BindingValueType.Value : BindingValueType.UnsetValue,
+                        BindingErrorType.DataValidationError => BindingValueType.DataValidationError,
+                        BindingErrorType.Error => BindingValueType.BindingError,
+                        _ => throw new NotImplementedException(),
+                    };
+                    error = n.Error;
                 }
 
                 if (value == AvaloniaProperty.UnsetValue)
                 {
                     owner.SetValue(property, instance.GetCachedDefaultValue(), BindingPriority.LocalValue);
+                    if (valueType == BindingValueType.Value) // happens when the method was called with AvaloniaProperty.UnsetValue itself
+                        valueType = BindingValueType.UnsetValue;
                 }
                 else if (UntypedValueUtils.TryConvertAndValidate(property, value, out var typedValue))
                 {
@@ -61,6 +75,8 @@ namespace Avalonia.PropertyStore
                     owner.SetValue(property, instance.GetCachedDefaultValue(), BindingPriority.LocalValue);
                     LoggingUtils.LogInvalidValue(owner.Owner, property, typeof(T), value);
                 }
+
+                owner.Owner.UpdateDataValidationCore(property, valueType, error);
             }
 
             if (value == BindingOperations.DoNothing)

--- a/src/Avalonia.Base/StyledElement.cs
+++ b/src/Avalonia.Base/StyledElement.cs
@@ -46,6 +46,7 @@ namespace Avalonia
                 defaultBindingMode: BindingMode.OneWay,
                 validate: null,
                 coerce: null,
+                enableDataValidation: false,
                 notifying: DataContextNotifying);
 
         /// <summary>

--- a/src/Avalonia.Base/StyledPropertyMetadata`1.cs
+++ b/src/Avalonia.Base/StyledPropertyMetadata`1.cs
@@ -16,11 +16,13 @@ namespace Avalonia
         /// <param name="defaultValue">The default value of the property.</param>
         /// <param name="defaultBindingMode">The default binding mode.</param>
         /// <param name="coerce">A value coercion callback.</param>
+        /// <param name="enableDataValidation">Whether the property is interested in data validation.</param>
         public StyledPropertyMetadata(
             Optional<TValue> defaultValue = default,
             BindingMode defaultBindingMode = BindingMode.Default,
-            Func<AvaloniaObject, TValue, TValue>? coerce = null)
-                : base(defaultBindingMode)
+            Func<AvaloniaObject, TValue, TValue>? coerce = null,
+            bool enableDataValidation = false)
+                : base(defaultBindingMode, enableDataValidation)
         {
             _defaultValue = defaultValue;
             CoerceValue = coerce;

--- a/src/Markup/Avalonia.Markup/Data/Binding.cs
+++ b/src/Markup/Avalonia.Markup/Data/Binding.cs
@@ -61,7 +61,6 @@ namespace Avalonia.Data
             _ = target ?? throw new ArgumentNullException(nameof(target));
 
             anchor ??= DefaultAnchor?.Target;
-            enableDataValidation = enableDataValidation && Priority == BindingPriority.LocalValue;
 
             INameScope? nameScope = null;
             NameScope?.TryGetTarget(out nameScope);

--- a/src/Markup/Avalonia.Markup/Data/BindingBase.cs
+++ b/src/Markup/Avalonia.Markup/Data/BindingBase.cs
@@ -86,9 +86,7 @@ namespace Avalonia.Data
         {
             _ = target ?? throw new ArgumentNullException(nameof(target));
 
-            anchor = anchor ?? DefaultAnchor?.Target;
-
-            enableDataValidation = enableDataValidation && Priority == BindingPriority.LocalValue;
+            anchor ??= DefaultAnchor?.Target;
 
             var observer = CreateExpressionObserver(target, targetProperty, anchor, enableDataValidation);
 

--- a/tests/Avalonia.Base.UnitTests/AvaloniaPropertyTests.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaPropertyTests.cs
@@ -198,6 +198,7 @@ namespace Avalonia.Base.UnitTests
                     defaultBindingMode: BindingMode.OneWay,
                     validate: null,
                     coerce: null,
+                    enableDataValidation: false,
                     notifying: FooNotifying);
 
             public int NotifyCount { get; private set; }

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_DataValidation.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_DataValidation.cs
@@ -46,24 +46,6 @@ namespace Avalonia.Markup.UnitTests.Data
             Assert.Equal(new BindingNotification("foo"), result);
         }
 
-        [Fact]
-        public void Initiate_Should_Not_Enable_Data_Validation_With_BindingPriority_TemplatedParent()
-        {
-            var textBlock = new TextBlock
-            {
-                DataContext = new Class1(),
-            };
-
-            var target = new Binding(nameof(Class1.Foo)) { Priority = BindingPriority.Template };
-            var instanced = target.Initiate(textBlock, TextBlock.TextProperty, enableDataValidation: true);
-            var subject = (BindingExpression)instanced.Source;
-            object result = null;
-
-            subject.Subscribe(x => result = x);
-
-            Assert.IsType<string>(result);
-        }
-
         private class Class1
         {
             public string Foo { get; set; } = "foo";


### PR DESCRIPTION
## What does the pull request do?
Data Validation is current only available on `DirectProperty`. This PR generalises the system to `AvaloniaProperty`, thus allowing `StyledProperty` to also use it. This change is a pre-requisite for #9944.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None