### PR TITLE
Convert various `DirectProperty` definitions to `StyledProperty`

### DIFF
--- a/src/Avalonia.Base/AttachedProperty.cs
+++ b/src/Avalonia.Base/AttachedProperty.cs
@@ -32,9 +32,14 @@ namespace Avalonia
         /// </summary>
         /// <typeparam name="TOwner">The owner type.</typeparam>
         /// <returns>The property.</returns>
-        public new AttachedProperty<TValue> AddOwner<TOwner>() where TOwner : AvaloniaObject
+        public new AttachedProperty<TValue> AddOwner<TOwner>(StyledPropertyMetadata<TValue>? metadata = null) where TOwner : AvaloniaObject
         {
             AvaloniaPropertyRegistry.Instance.Register(typeof(TOwner), this);
+            if (metadata != null)
+            {
+                OverrideMetadata<TOwner>(metadata);
+            }
+            
             return this;
         }
     }

--- a/src/Avalonia.Base/Input/GestureRecognizers/GestureRecognizerCollection.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/GestureRecognizerCollection.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.LogicalTree;
-using Avalonia.Styling;
+using Avalonia.Reactive;
 
 namespace Avalonia.Input.GestureRecognizers
 {
@@ -11,13 +11,13 @@ namespace Avalonia.Input.GestureRecognizers
         private readonly IInputElement _inputElement;
         private List<IGestureRecognizer>? _recognizers;
         private Dictionary<IPointer, IGestureRecognizer>? _pointerGrabs;
-        
-        
+
+
         public GestureRecognizerCollection(IInputElement inputElement)
         {
             _inputElement = inputElement;
         }
-        
+
         public void Add(IGestureRecognizer recognizer)
         {
             if (_recognizers == null)
@@ -31,14 +31,13 @@ namespace Avalonia.Input.GestureRecognizers
             recognizer.Initialize(_inputElement, this);
 
             // Hacks to make bindings work
-            
+
             if (_inputElement is ILogical logicalParent && recognizer is ISetLogicalParent logical)
             {
                 logical.SetParent(logicalParent);
                 if (recognizer is StyledElement styleableRecognizer
                     && _inputElement is StyledElement styleableParent)
-                    styleableRecognizer.Bind(StyledElement.TemplatedParentProperty,
-                        styleableParent.GetObservable(StyledElement.TemplatedParentProperty));
+                    styleableParent.GetObservable(StyledElement.TemplatedParentProperty).Subscribe(parent => styleableRecognizer.TemplatedParent = parent);
             }
         }
 
@@ -58,7 +57,7 @@ namespace Avalonia.Input.GestureRecognizers
                 return false;
             foreach (var r in _recognizers)
             {
-                if(e.Handled)
+                if (e.Handled)
                     break;
                 r.PointerPressed(e);
             }

--- a/src/Avalonia.Base/Input/GestureRecognizers/PullGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/PullGestureRecognizer.cs
@@ -13,22 +13,18 @@ namespace Avalonia.Input
         private Point _initialPosition;
         private int _gestureId;
         private IPointer? _tracking;
-        private PullDirection _pullDirection;
         private bool _pullInProgress;
 
         /// <summary>
         /// Defines the <see cref="PullDirection"/> property.
         /// </summary>
-        public static readonly DirectProperty<PullGestureRecognizer, PullDirection> PullDirectionProperty =
-            AvaloniaProperty.RegisterDirect<PullGestureRecognizer, PullDirection>(
-                nameof(PullDirection),
-                o => o.PullDirection,
-                (o, v) => o.PullDirection = v);
+        public static readonly StyledProperty<PullDirection> PullDirectionProperty =
+            AvaloniaProperty.Register<PullGestureRecognizer, PullDirection>(nameof(PullDirection));
 
         public PullDirection PullDirection
         {
-            get => _pullDirection;
-            set => SetAndRaise(PullDirectionProperty, ref _pullDirection, value);
+            get => GetValue(PullDirectionProperty);
+            set => SetValue(PullDirectionProperty, value);
         }
 
         public PullGestureRecognizer(PullDirection pullDirection)

--- a/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
@@ -17,61 +17,45 @@ namespace Avalonia.Input.GestureRecognizers
         private IPointer? _tracking;
         private IInputElement? _target;
         private IGestureRecognizerActionsDispatcher? _actions;
-        private bool _canHorizontallyScroll;
-        private bool _canVerticallyScroll;
         private int _gestureId;
-        private int _scrollStartDistance = 30;
         private Point _pointerPressedPoint;
         private VelocityTracker? _velocityTracker;
 
         // Movement per second
         private Vector _inertia;
         private ulong? _lastMoveTimestamp;
-        private bool _isScrollInertiaEnabled;
 
         /// <summary>
         /// Defines the <see cref="CanHorizontallyScroll"/> property.
         /// </summary>
-        public static readonly DirectProperty<ScrollGestureRecognizer, bool> CanHorizontallyScrollProperty =
-            AvaloniaProperty.RegisterDirect<ScrollGestureRecognizer, bool>(
-                nameof(CanHorizontallyScroll),
-                o => o.CanHorizontallyScroll,
-                (o, v) => o.CanHorizontallyScroll = v);
+        public static readonly StyledProperty<bool> CanHorizontallyScrollProperty =
+            AvaloniaProperty.Register<ScrollGestureRecognizer, bool>(nameof(CanHorizontallyScroll));
 
         /// <summary>
         /// Defines the <see cref="CanVerticallyScroll"/> property.
         /// </summary>
-        public static readonly DirectProperty<ScrollGestureRecognizer, bool> CanVerticallyScrollProperty =
-            AvaloniaProperty.RegisterDirect<ScrollGestureRecognizer, bool>(
-                nameof(CanVerticallyScroll),
-                o => o.CanVerticallyScroll,
-                (o, v) => o.CanVerticallyScroll = v);
+        public static readonly StyledProperty<bool> CanVerticallyScrollProperty =
+            AvaloniaProperty.Register<ScrollGestureRecognizer, bool>(nameof(CanVerticallyScroll));
 
         /// <summary>
         /// Defines the <see cref="IsScrollInertiaEnabled"/> property.
         /// </summary>
-        public static readonly DirectProperty<ScrollGestureRecognizer, bool> IsScrollInertiaEnabledProperty =
-            AvaloniaProperty.RegisterDirect<ScrollGestureRecognizer, bool>(
-                nameof(IsScrollInertiaEnabled),
-                o => o.IsScrollInertiaEnabled,
-                (o, v) => o.IsScrollInertiaEnabled = v);
+        public static readonly StyledProperty<bool> IsScrollInertiaEnabledProperty =
+            AvaloniaProperty.Register<ScrollGestureRecognizer, bool>(nameof(IsScrollInertiaEnabled));
 
         /// <summary>
         /// Defines the <see cref="ScrollStartDistance"/> property.
         /// </summary>
-        public static readonly DirectProperty<ScrollGestureRecognizer, int> ScrollStartDistanceProperty =
-            AvaloniaProperty.RegisterDirect<ScrollGestureRecognizer, int>(
-                nameof(ScrollStartDistance),
-                o => o.ScrollStartDistance,
-                (o, v) => o.ScrollStartDistance = v);
+        public static readonly StyledProperty<int> ScrollStartDistanceProperty =
+            AvaloniaProperty.Register<ScrollGestureRecognizer, int>(nameof(ScrollStartDistance), 30);
         
         /// <summary>
         /// Gets or sets a value indicating whether the content can be scrolled horizontally.
         /// </summary>
         public bool CanHorizontallyScroll
         {
-            get => _canHorizontallyScroll;
-            set => SetAndRaise(CanHorizontallyScrollProperty, ref _canHorizontallyScroll, value);
+            get => GetValue(CanHorizontallyScrollProperty);
+            set => SetValue(CanHorizontallyScrollProperty, value);
         }
 
         /// <summary>
@@ -79,8 +63,8 @@ namespace Avalonia.Input.GestureRecognizers
         /// </summary>
         public bool CanVerticallyScroll
         {
-            get => _canVerticallyScroll;
-            set => SetAndRaise(CanVerticallyScrollProperty, ref _canVerticallyScroll, value);
+            get => GetValue(CanVerticallyScrollProperty);
+            set => SetValue(CanVerticallyScrollProperty, value);
         }
         
         /// <summary>
@@ -88,8 +72,8 @@ namespace Avalonia.Input.GestureRecognizers
         /// </summary>
         public bool IsScrollInertiaEnabled
         {
-            get => _isScrollInertiaEnabled;
-            set => SetAndRaise(IsScrollInertiaEnabledProperty, ref _isScrollInertiaEnabled, value);
+            get => GetValue(IsScrollInertiaEnabledProperty);
+            set => SetValue(IsScrollInertiaEnabledProperty, value);
         }
 
         /// <summary>
@@ -97,8 +81,8 @@ namespace Avalonia.Input.GestureRecognizers
         /// </summary>
         public int ScrollStartDistance
         {
-            get => _scrollStartDistance;
-            set => SetAndRaise(ScrollStartDistanceProperty, ref _scrollStartDistance, value);
+            get => GetValue(ScrollStartDistanceProperty);
+            set => SetValue(ScrollStartDistanceProperty, value);
         }
         
 
@@ -137,8 +121,8 @@ namespace Avalonia.Input.GestureRecognizers
                         
                         // Correct _trackedRootPoint with ScrollStartDistance, so scrolling does not start with a skip of ScrollStartDistance
                         _trackedRootPoint = new Point(
-                            _trackedRootPoint.X - (_trackedRootPoint.X >= rootPoint.X ? _scrollStartDistance : -_scrollStartDistance),
-                            _trackedRootPoint.Y - (_trackedRootPoint.Y >= rootPoint.Y ? _scrollStartDistance : -_scrollStartDistance));
+                            _trackedRootPoint.X - (_trackedRootPoint.X >= rootPoint.X ? ScrollStartDistance : -ScrollStartDistance),
+                            _trackedRootPoint.Y - (_trackedRootPoint.Y >= rootPoint.Y ? ScrollStartDistance : -ScrollStartDistance));
 
                         _actions!.Capture(e.Pointer, this);
                     }

--- a/src/Avalonia.Base/Media/Imaging/CroppedBitmap.cs
+++ b/src/Avalonia.Base/Media/Imaging/CroppedBitmap.cs
@@ -48,8 +48,6 @@ namespace Avalonia.Media.Imaging
 
         public CroppedBitmap()
         {
-            Source = null;
-            SourceRect = default;
         }
 
         public CroppedBitmap(IImage source, PixelRect sourceRect)

--- a/src/Avalonia.Base/StyledElement.cs
+++ b/src/Avalonia.Base/StyledElement.cs
@@ -67,8 +67,7 @@ namespace Avalonia
         public static readonly DirectProperty<StyledElement, AvaloniaObject?> TemplatedParentProperty =
             AvaloniaProperty.RegisterDirect<StyledElement, AvaloniaObject?>(
                 nameof(TemplatedParent),
-                o => o.TemplatedParent,
-                (o ,v) => o.TemplatedParent = v);
+                o => o.TemplatedParent);
         
         /// <summary>
         /// Defines the <see cref="Theme"/> property.

--- a/src/Avalonia.Base/StyledProperty.cs
+++ b/src/Avalonia.Base/StyledProperty.cs
@@ -56,9 +56,14 @@ namespace Avalonia
         /// </summary>
         /// <typeparam name="TOwner">The type of the additional owner.</typeparam>
         /// <returns>The property.</returns>        
-        public StyledProperty<TValue> AddOwner<TOwner>() where TOwner : AvaloniaObject
+        public StyledProperty<TValue> AddOwner<TOwner>(StyledPropertyMetadata<TValue>? metadata = null) where TOwner : AvaloniaObject
         {
             AvaloniaPropertyRegistry.Instance.Register(typeof(TOwner), this);
+            if (metadata != null)
+            {
+                OverrideMetadata<TOwner>(metadata);
+            }
+
             return this;
         }
 

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -1,11 +1,9 @@
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Windows.Input;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
-using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -48,9 +46,8 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="Command"/> property.
         /// </summary>
-        public static readonly DirectProperty<Button, ICommand?> CommandProperty =
-            AvaloniaProperty.RegisterDirect<Button, ICommand?>(nameof(Command),
-                button => button.Command, (button, command) => button.Command = command, enableDataValidation: true);
+        public static readonly StyledProperty<ICommand?> CommandProperty =
+            AvaloniaProperty.Register<Button, ICommand?>(nameof(Command), enableDataValidation: true);
 
         /// <summary>
         /// Defines the <see cref="HotKey"/> property.
@@ -85,8 +82,8 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="IsPressed"/> property.
         /// </summary>
-        public static readonly StyledProperty<bool> IsPressedProperty =
-            AvaloniaProperty.Register<Button, bool>(nameof(IsPressed));
+        public static readonly DirectProperty<Button, bool> IsPressedProperty =
+            AvaloniaProperty.RegisterDirect<Button, bool>(nameof(IsPressed), b => b.IsPressed);
 
         /// <summary>
         /// Defines the <see cref="Flyout"/> property
@@ -94,10 +91,10 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<FlyoutBase?> FlyoutProperty =
             AvaloniaProperty.Register<Button, FlyoutBase?>(nameof(Flyout));
 
-        private ICommand? _command;
         private bool _commandCanExecute = true;
         private KeyGesture? _hotkey;
         private bool _isFlyoutOpen = false;
+        private bool _isPressed = false;
 
         /// <summary>
         /// Initializes static members of the <see cref="Button"/> class.
@@ -138,8 +135,8 @@ namespace Avalonia.Controls
         /// </summary>
         public ICommand? Command
         {
-            get => _command;
-            set => SetAndRaise(CommandProperty, ref _command, value);
+            get => GetValue(CommandProperty);
+            set => SetValue(CommandProperty, value);
         }
 
         /// <summary>
@@ -185,8 +182,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool IsPressed
         {
-            get => GetValue(IsPressedProperty);
-            private set => SetValue(IsPressedProperty, value);
+            get => _isPressed;
+            private set => SetAndRaise(IsPressedProperty, ref _isPressed, value);
         }
 
         /// <summary>
@@ -248,7 +245,7 @@ namespace Avalonia.Controls
         {
             if (_hotkey != null) // Control attached again, set Hotkey to create a hotkey manager for this control
             {
-                HotKey = _hotkey;
+                SetCurrentValue(HotKeyProperty, _hotkey);
             }
 
             base.OnAttachedToLogicalTree(e);
@@ -267,7 +264,7 @@ namespace Avalonia.Controls
             if (HotKey != null)
             {
                 _hotkey = HotKey;
-                HotKey = null;
+                SetCurrentValue(HotKeyProperty, null);
             }
 
             base.OnDetachedFromLogicalTree(e);
@@ -291,16 +288,16 @@ namespace Avalonia.Controls
                     break;
 
                 case Key.Space:
-                {
-                    if (ClickMode == ClickMode.Press)
                     {
-                        OnClick();
-                    }
+                        if (ClickMode == ClickMode.Press)
+                        {
+                            OnClick();
+                        }
 
-                    IsPressed = true;
-                    e.Handled = true;
-                    break;
-                }
+                        IsPressed = true;
+                        e.Handled = true;
+                        break;
+                    }
 
                 case Key.Escape when Flyout != null:
                     // If Flyout doesn't have focusable content, close the flyout here
@@ -592,7 +589,7 @@ namespace Avalonia.Controls
             {
                 flyout.Opened -= Flyout_Opened;
                 flyout.Closed -= Flyout_Closed;
-             }
+            }
         }
 
         /// <summary>
@@ -671,7 +668,7 @@ namespace Avalonia.Controls
         void ICommandSource.CanExecuteChanged(object sender, EventArgs e) => this.CanExecuteChanged(sender, e);
 
         void IClickableControl.RaiseClick() => OnClick();
-        
+
         /// <summary>
         /// Event handler for when the button's flyout is opened.
         /// </summary>

--- a/src/Avalonia.Controls/Calendar/Calendar.cs
+++ b/src/Avalonia.Controls/Calendar/Calendar.cs
@@ -232,13 +232,8 @@ namespace Avalonia.Controls
         internal const int RowsPerYear = 3;
         internal const int ColumnsPerYear = 4;
 
-        private DateTime? _selectedDate;
         private DateTime _selectedMonth;
         private DateTime _selectedYear;
-
-        private DateTime _displayDate = DateTime.Today;
-        private DateTime? _displayDateStart;
-        private DateTime? _displayDateEnd;
 
         private bool _isShiftPressed;
         private bool _displayDateIsChanging;
@@ -396,13 +391,13 @@ namespace Avalonia.Controls
                         }
                     case CalendarMode.Year:
                         {
-                            DisplayDate = SelectedMonth;
+                            SetCurrentValue(DisplayDateProperty, SelectedMonth);
                             SelectedYear = SelectedMonth;
                             break;
                         }
                     case CalendarMode.Decade:
                         {
-                            DisplayDate = SelectedYear;
+                            SetCurrentValue(DisplayDateProperty, SelectedYear);
                             SelectedMonth = SelectedYear;
                             break;
                         }
@@ -472,7 +467,7 @@ namespace Avalonia.Controls
             if (IsValidSelectionMode(e.NewValue!))
             {
                 _displayDateIsChanging = true;
-                SelectedDate = null;
+                SetCurrentValue(SelectedDateProperty, null);
                 _displayDateIsChanging = false;
                 SelectedDates.Clear();
             }
@@ -497,11 +492,8 @@ namespace Avalonia.Controls
                 || mode == CalendarSelectionMode.None;
         }
 
-        public static readonly DirectProperty<Calendar, DateTime?> SelectedDateProperty =
-            AvaloniaProperty.RegisterDirect<Calendar, DateTime?>(
-                nameof(SelectedDate),
-                o => o.SelectedDate,
-                (o, v) => o.SelectedDate = v,
+        public static readonly StyledProperty<DateTime?> SelectedDateProperty =
+            AvaloniaProperty.Register<Calendar, DateTime?>(nameof(SelectedDate),
                 defaultBindingMode: BindingMode.TwoWay);
 
         /// <summary>
@@ -529,8 +521,8 @@ namespace Avalonia.Controls
         /// </remarks>
         public DateTime? SelectedDate
         {
-            get { return _selectedDate; }
-            set { SetAndRaise(SelectedDateProperty, ref _selectedDate, value); }
+            get => GetValue(SelectedDateProperty);
+            set => SetValue(SelectedDateProperty, value);
         }
         private void OnSelectedDateChanged(AvaloniaPropertyChangedEventArgs e)
         {
@@ -726,11 +718,8 @@ namespace Avalonia.Controls
             }
         }
 
-        public static readonly DirectProperty<Calendar, DateTime> DisplayDateProperty =
-            AvaloniaProperty.RegisterDirect<Calendar, DateTime>(
-                nameof(DisplayDate),
-                o => o.DisplayDate,
-                (o, v) => o.DisplayDate = v,
+        public static readonly StyledProperty<DateTime> DisplayDateProperty =
+            AvaloniaProperty.Register<Calendar, DateTime>(nameof(DisplayDate),
                 defaultBindingMode: BindingMode.TwoWay);
 
         /// <summary>
@@ -760,8 +749,8 @@ namespace Avalonia.Controls
         /// </remarks>
         public DateTime DisplayDate
         {
-            get { return _displayDate; }
-            set { SetAndRaise(DisplayDateProperty, ref _displayDate, value); }
+            get => GetValue(DisplayDateProperty);
+            set => SetValue(DisplayDateProperty, value);
         }
         internal DateTime DisplayDateInternal { get; private set; }
 
@@ -796,11 +785,8 @@ namespace Avalonia.Controls
             DisplayDateChanged?.Invoke(this, e);
         }
 
-        public static readonly DirectProperty<Calendar, DateTime?> DisplayDateStartProperty =
-            AvaloniaProperty.RegisterDirect<Calendar, DateTime?>(
-                nameof(DisplayDateStart),
-                o => o.DisplayDateStart,
-                (o, v) => o.DisplayDateStart = v,
+        public static readonly StyledProperty<DateTime?> DisplayDateStartProperty =
+            AvaloniaProperty.Register<Calendar, DateTime?>(nameof(DisplayDateStart),
                 defaultBindingMode: BindingMode.TwoWay);
         /// <summary>
         /// Gets or sets the first date to be displayed.
@@ -814,8 +800,8 @@ namespace Avalonia.Controls
         /// </remarks>
         public DateTime? DisplayDateStart
         {
-            get { return _displayDateStart; }
-            set { SetAndRaise(DisplayDateStartProperty, ref _displayDateStart, value); }
+            get => GetValue(DisplayDateStartProperty);
+            set => SetValue(DisplayDateStartProperty, value);
         }
         private void OnDisplayDateStartChanged(AvaloniaPropertyChangedEventArgs e)
         {
@@ -831,7 +817,7 @@ namespace Avalonia.Controls
 
                     if (selectedDateMin.HasValue && DateTime.Compare(selectedDateMin.Value, newValue.Value) < 0)
                     {
-                        DisplayDateStart = selectedDateMin.Value;
+                        SetCurrentValue(DisplayDateStartProperty, selectedDateMin.Value);
                         return;
                     }
 
@@ -839,14 +825,14 @@ namespace Avalonia.Controls
                     // DisplayDateEnd = DisplayDateStart
                     if (DateTime.Compare(newValue.Value, DisplayDateRangeEnd) > 0)
                     {
-                        DisplayDateEnd = DisplayDateStart;
+                        SetCurrentValue(DisplayDateEndProperty, DisplayDateStart);
                     }
 
                     // If DisplayDate < DisplayDateStart,
                     // DisplayDate = DisplayDateStart
                     if (DateTimeHelper.CompareYearMonth(newValue.Value, DisplayDateInternal) > 0)
                     {
-                        DisplayDate = newValue.Value;
+                        SetCurrentValue(DisplayDateProperty, newValue.Value);
                     }
                 }
                 UpdateMonths();
@@ -905,11 +891,8 @@ namespace Avalonia.Controls
             get { return DisplayDateStart.GetValueOrDefault(DateTime.MinValue); }
         }
 
-        public static readonly DirectProperty<Calendar, DateTime?> DisplayDateEndProperty =
-            AvaloniaProperty.RegisterDirect<Calendar, DateTime?>(
-                nameof(DisplayDateEnd),
-                o => o.DisplayDateEnd,
-                (o, v) => o.DisplayDateEnd = v,
+        public static readonly StyledProperty<DateTime?> DisplayDateEndProperty =
+            AvaloniaProperty.Register<Calendar, DateTime?>(nameof(DisplayDateEnd),
                 defaultBindingMode: BindingMode.TwoWay);
 
         /// <summary>
@@ -924,8 +907,8 @@ namespace Avalonia.Controls
         /// </remarks>
         public DateTime? DisplayDateEnd
         {
-            get { return _displayDateEnd; }
-            set { SetAndRaise(DisplayDateEndProperty, ref _displayDateEnd, value); }
+            get => GetValue(DisplayDateEndProperty);
+            set => SetValue(DisplayDateEndProperty, value);
         }
 
         private void OnDisplayDateEndChanged(AvaloniaPropertyChangedEventArgs e)
@@ -942,7 +925,7 @@ namespace Avalonia.Controls
 
                     if (selectedDateMax.HasValue && DateTime.Compare(selectedDateMax.Value, newValue.Value) > 0)
                     {
-                        DisplayDateEnd = selectedDateMax.Value;
+                        SetCurrentValue(DisplayDateEndProperty, selectedDateMax.Value);
                         return;
                     }
 
@@ -950,7 +933,7 @@ namespace Avalonia.Controls
                     // DisplayDateEnd = DisplayDateStart
                     if (DateTime.Compare(newValue.Value, DisplayDateRangeStart) < 0)
                     {
-                        DisplayDateEnd = DisplayDateStart;
+                        SetCurrentValue(DisplayDateEndProperty, DisplayDateStart);
                         return;
                     }
 
@@ -958,7 +941,7 @@ namespace Avalonia.Controls
                     // DisplayDate = DisplayDateEnd
                     if (DateTimeHelper.CompareYearMonth(newValue.Value, DisplayDateInternal) < 0)
                     {
-                        DisplayDate = newValue.Value;
+                        SetCurrentValue(DisplayDateProperty, newValue.Value);
                     }
                 }
                 UpdateMonths();
@@ -1284,7 +1267,7 @@ namespace Avalonia.Controls
                     {
                         LastSelectedDate = d.Value;
                     }
-                    DisplayDate = d.Value;
+                    SetCurrentValue(DisplayDateProperty, d.Value);
                 }
             }
             else
@@ -1332,7 +1315,7 @@ namespace Avalonia.Controls
                     {
                         LastSelectedDate = d.Value;
                     }
-                    DisplayDate = d.Value;
+                    SetCurrentValue(DisplayDateProperty, d.Value);
                 }
             }
             else
@@ -1719,7 +1702,7 @@ namespace Avalonia.Controls
                         if (ctrl)
                         {
                             SelectedMonth = DisplayDateInternal;
-                            DisplayMode = CalendarMode.Year;
+                            SetCurrentValue(DisplayModeProperty, CalendarMode.Year);
                         }
                         else
                         {
@@ -1733,7 +1716,7 @@ namespace Avalonia.Controls
                         if (ctrl)
                         {
                             SelectedYear = SelectedMonth;
-                            DisplayMode = CalendarMode.Decade;
+                            SetCurrentValue(DisplayModeProperty, CalendarMode.Decade);
                         }
                         else
                         {
@@ -1770,8 +1753,8 @@ namespace Avalonia.Controls
                     {
                         if (ctrl)
                         {
-                            DisplayDate = SelectedMonth;
-                            DisplayMode = CalendarMode.Month;
+                            SetCurrentValue(DisplayDateProperty, SelectedMonth);
+                            SetCurrentValue(DisplayModeProperty, CalendarMode.Month);
                         }
                         else
                         {
@@ -1785,7 +1768,7 @@ namespace Avalonia.Controls
                         if (ctrl)
                         {
                             SelectedMonth = SelectedYear;
-                            DisplayMode = CalendarMode.Year;
+                            SetCurrentValue(DisplayModeProperty, CalendarMode.Year);
                         }
                         else
                         {
@@ -1850,14 +1833,14 @@ namespace Avalonia.Controls
             {
                 case CalendarMode.Year:
                     {
-                        DisplayDate = SelectedMonth;
-                        DisplayMode = CalendarMode.Month;
+                        SetCurrentValue(DisplayDateProperty, SelectedMonth);
+                        SetCurrentValue(DisplayModeProperty, CalendarMode.Month);
                         return true;
                     }
                 case CalendarMode.Decade:
                     {
                         SelectedMonth = SelectedYear;
-                        DisplayMode = CalendarMode.Year;
+                        SetCurrentValue(DisplayModeProperty, CalendarMode.Year);
                         return true;
                     }
             }
@@ -2103,7 +2086,8 @@ namespace Avalonia.Controls
         /// </summary>
         public Calendar()
         {
-            UpdateDisplayDate(this, this.DisplayDate, DateTime.MinValue);
+            SetCurrentValue(DisplayDateProperty, DateTime.Today);
+            UpdateDisplayDate(this, DisplayDate, DateTime.MinValue);
             BlackoutDates = new CalendarBlackoutDatesCollection(this);
             SelectedDates = new SelectedDatesCollection(this);
             RemovedItems = new Collection<DateTime>();

--- a/src/Avalonia.Controls/Calendar/CalendarItem.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarItem.cs
@@ -41,7 +41,6 @@ namespace Avalonia.Controls.Primitives
         private Button? _headerButton;
         private Button? _nextButton;
         private Button? _previousButton;
-        private ITemplate<Control>? _dayTitleTemplate;
         
         private DateTime _currentMonth;
         private bool _isMouseLeftButtonDown;
@@ -61,17 +60,15 @@ namespace Avalonia.Controls.Primitives
             set { SetValue(HeaderBackgroundProperty, value); }
         }
 
-        public static readonly DirectProperty<CalendarItem, ITemplate<Control>?> DayTitleTemplateProperty =
-                AvaloniaProperty.RegisterDirect<CalendarItem, ITemplate<Control>?>(
+        public static readonly StyledProperty<ITemplate<Control>?> DayTitleTemplateProperty =
+                AvaloniaProperty.Register<CalendarItem, ITemplate<Control>?>(
                     nameof(DayTitleTemplate),
-                    o => o.DayTitleTemplate,
-                    (o,v) => o.DayTitleTemplate = v,
                     defaultBindingMode: BindingMode.OneTime);
 
         public ITemplate<Control>? DayTitleTemplate
         {
-            get { return _dayTitleTemplate; }
-            set { SetAndRaise(DayTitleTemplateProperty, ref _dayTitleTemplate, value); }
+            get => GetValue(DayTitleTemplateProperty);
+            set => SetValue(DayTitleTemplateProperty, value);
         }
 
         /// <summary>
@@ -176,9 +173,8 @@ namespace Avalonia.Controls.Primitives
 
                 for (int i = 0; i < Calendar.RowsPerMonth; i++)
                 {
-                    if (_dayTitleTemplate != null)
+                    if (DayTitleTemplate?.Build() is Control cell)
                     {
-                        var cell = _dayTitleTemplate.Build();
                         cell.DataContext = string.Empty;
                         cell.SetValue(Grid.RowProperty, 0);
                         cell.SetValue(Grid.ColumnProperty, i);

--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.Properties.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.Properties.cs
@@ -11,29 +11,22 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="DisplayDate"/> property.
         /// </summary>
-        public static readonly DirectProperty<CalendarDatePicker, DateTime> DisplayDateProperty =
-            AvaloniaProperty.RegisterDirect<CalendarDatePicker, DateTime>(
-                nameof(DisplayDate),
-                o => o.DisplayDate,
-                (o, v) => o.DisplayDate = v);
+        public static readonly StyledProperty<DateTime> DisplayDateProperty =
+            AvaloniaProperty.Register<CalendarDatePicker, DateTime>(nameof(DisplayDate));
 
         /// <summary>
         /// Defines the <see cref="DisplayDateStart"/> property.
         /// </summary>
-        public static readonly DirectProperty<CalendarDatePicker, DateTime?> DisplayDateStartProperty =
-            AvaloniaProperty.RegisterDirect<CalendarDatePicker, DateTime?>(
-                nameof(DisplayDateStart),
-                o => o.DisplayDateStart,
-                (o, v) => o.DisplayDateStart = v);
+        public static readonly StyledProperty<DateTime?> DisplayDateStartProperty =
+            AvaloniaProperty.Register<CalendarDatePicker, DateTime?>(
+                nameof(DisplayDateStart));
 
         /// <summary>
         /// Defines the <see cref="DisplayDateEnd"/> property.
         /// </summary>
-        public static readonly DirectProperty<CalendarDatePicker, DateTime?> DisplayDateEndProperty =
-            AvaloniaProperty.RegisterDirect<CalendarDatePicker, DateTime?>(
-                nameof(DisplayDateEnd),
-                o => o.DisplayDateEnd,
-                (o, v) => o.DisplayDateEnd = v);
+        public static readonly StyledProperty<DateTime?> DisplayDateEndProperty =
+            AvaloniaProperty.Register<CalendarDatePicker, DateTime?>(
+                nameof(DisplayDateEnd));
 
         /// <summary>
         /// Defines the <see cref="FirstDayOfWeek"/> property.
@@ -44,11 +37,9 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="IsDropDownOpen"/> property.
         /// </summary>
-        public static readonly DirectProperty<CalendarDatePicker, bool> IsDropDownOpenProperty =
-            AvaloniaProperty.RegisterDirect<CalendarDatePicker, bool>(
-                nameof(IsDropDownOpen),
-                o => o.IsDropDownOpen,
-                (o, v) => o.IsDropDownOpen = v);
+        public static readonly StyledProperty<bool> IsDropDownOpenProperty =
+            AvaloniaProperty.Register<CalendarDatePicker, bool>(
+                nameof(IsDropDownOpen));
 
         /// <summary>
         /// Defines the <see cref="IsTodayHighlighted"/> property.
@@ -88,11 +79,8 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="Text"/> property.
         /// </summary>
-        public static readonly DirectProperty<CalendarDatePicker, string?> TextProperty =
-            AvaloniaProperty.RegisterDirect<CalendarDatePicker, string?>(
-                nameof(Text),
-                o => o.Text,
-                (o, v) => o.Text = v);
+        public static readonly StyledProperty<string?> TextProperty =
+            AvaloniaProperty.Register<CalendarDatePicker, string?>(nameof(Text));
 
         /// <summary>
         /// Defines the <see cref="Watermark"/> property.
@@ -141,8 +129,8 @@ namespace Avalonia.Controls
         /// </exception>
         public DateTime DisplayDate
         {
-            get => _displayDate;
-            set => SetAndRaise(DisplayDateProperty, ref _displayDate, value);
+            get => GetValue(DisplayDateProperty);
+            set => SetValue(DisplayDateProperty, value);
         }
         
         /// <summary>
@@ -151,8 +139,8 @@ namespace Avalonia.Controls
         /// <value>The first date to display.</value>
         public DateTime? DisplayDateStart
         {
-            get => _displayDateStart;
-            set => SetAndRaise(DisplayDateStartProperty, ref _displayDateStart, value);
+            get => GetValue(DisplayDateStartProperty);
+            set => SetValue(DisplayDateStartProperty, value);
         }
 
         /// <summary>
@@ -161,8 +149,8 @@ namespace Avalonia.Controls
         /// <value>The last date to display.</value>
         public DateTime? DisplayDateEnd
         {
-            get => _displayDateEnd;
-            set => SetAndRaise(DisplayDateEndProperty, ref _displayDateEnd, value);
+            get => GetValue(DisplayDateEndProperty);
+            set => SetValue(DisplayDateEndProperty, value);
         }
 
         /// <summary>
@@ -188,8 +176,8 @@ namespace Avalonia.Controls
         /// </value>
         public bool IsDropDownOpen
         {
-            get => _isDropDownOpen;
-            set => SetAndRaise(IsDropDownOpenProperty, ref _isDropDownOpen, value);
+            get => GetValue(IsDropDownOpenProperty);
+            set => SetValue(IsDropDownOpenProperty, value);
         }
 
         /// <summary>
@@ -264,8 +252,8 @@ namespace Avalonia.Controls
         /// </exception>
         public string? Text
         {
-            get => _text;
-            set => SetAndRaise(TextProperty, ref _text, value);
+            get => GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
         }
 
         /// <inheritdoc cref="TextBox.Watermark"/>

--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.Properties.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.Properties.cs
@@ -50,11 +50,9 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="SelectedDate"/> property.
         /// </summary>
-        public static readonly DirectProperty<CalendarDatePicker, DateTime?> SelectedDateProperty =
-            AvaloniaProperty.RegisterDirect<CalendarDatePicker, DateTime?>(
+        public static readonly StyledProperty<DateTime?> SelectedDateProperty =
+            AvaloniaProperty.Register<CalendarDatePicker, DateTime?>(
                 nameof(SelectedDate),
-                o => o.SelectedDate,
-                (o, v) => o.SelectedDate = v,
                 enableDataValidation: true, 
                 defaultBindingMode:BindingMode.TwoWay);
 
@@ -211,8 +209,8 @@ namespace Avalonia.Controls
         /// </exception>
         public DateTime? SelectedDate
         {
-            get => _selectedDate;
-            set => SetAndRaise(SelectedDateProperty, ref _selectedDate, value);
+            get => GetValue(SelectedDateProperty);
+            set => SetValue(SelectedDateProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
@@ -45,7 +45,6 @@ namespace Avalonia.Controls
         private DateTime? _onOpenSelectedDate;
         private bool _settingSelectedDate;
 
-        private DateTime? _selectedDate;
         private bool _suspendTextChangeHandler;
         private bool _isPopupClosing;
         private bool _ignoreButtonClick;

--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
@@ -45,12 +45,7 @@ namespace Avalonia.Controls
         private DateTime? _onOpenSelectedDate;
         private bool _settingSelectedDate;
 
-        private DateTime _displayDate;
-        private DateTime? _displayDateStart;
-        private DateTime? _displayDateEnd;
-        private bool _isDropDownOpen;
         private DateTime? _selectedDate;
-        private string? _text;
         private bool _suspendTextChangeHandler;
         private bool _isPopupClosing;
         private bool _ignoreButtonClick;
@@ -92,9 +87,9 @@ namespace Avalonia.Controls
         /// </summary>
         public CalendarDatePicker()
         {
-            FirstDayOfWeek = DateTimeHelper.GetCurrentDateFormat().FirstDayOfWeek;
+            SetCurrentValue(FirstDayOfWeekProperty, DateTimeHelper.GetCurrentDateFormat().FirstDayOfWeek);
             _defaultText = string.Empty;
-            DisplayDate = DateTime.Today;
+            SetCurrentValue(DisplayDateProperty, DateTime.Today);
         }
 
         /// <summary>
@@ -257,7 +252,7 @@ namespace Avalonia.Controls
                     Threading.Dispatcher.UIThread.InvokeAsync(() =>
                     {
                         _settingSelectedDate = true;
-                        Text = DateTimeToString(day);
+                        SetCurrentValue(TextProperty, DateTimeToString(day));
                         _settingSelectedDate = false;
                         OnDateSelected(addedDate, removedDate);
                     });
@@ -268,7 +263,7 @@ namespace Avalonia.Controls
                     // be changed by the Calendar
                     if ((day.Month != DisplayDate.Month || day.Year != DisplayDate.Year) && (_calendar == null || !_calendar.CalendarDatePickerDisplayDateFlag))
                     {
-                        DisplayDate = day;
+                        SetCurrentValue(DisplayDateProperty, day);
                     }
 
                     if(_calendar != null)
@@ -317,7 +312,7 @@ namespace Avalonia.Controls
                         if (!_settingSelectedDate)
                         {
                             _settingSelectedDate = true;
-                            SelectedDate = null;
+                            SetCurrentValue(SelectedDateProperty, null);
                             _settingSelectedDate = false;
                         }
                     }
@@ -400,7 +395,7 @@ namespace Avalonia.Controls
                 DateTime? newDate = DateTimeHelper.AddDays(selectedDate, e.Delta.Y > 0 ? -1 : 1);
                 if (newDate.HasValue && Calendar.IsValidDateSelection(_calendar, newDate.Value))
                 {
-                    SelectedDate = newDate;
+                    SetCurrentValue(SelectedDateProperty, newDate);
                     e.Handled = true;
                 }
             }
@@ -478,7 +473,7 @@ namespace Avalonia.Controls
             {
                 if (SelectedDate.HasValue)
                 {
-                    Text = DateTimeToString(SelectedDate.Value);
+                    SetCurrentValue(TextProperty, DateTimeToString(SelectedDate.Value));
                 }
                 else if (string.IsNullOrEmpty(_textBox.Text))
                 {
@@ -491,7 +486,7 @@ namespace Avalonia.Controls
                     if (date != null)
                     {
                         string? s = DateTimeToString((DateTime)date);
-                        Text = s;
+                        SetCurrentValue(TextProperty, s);
                     }
                 }
             }
@@ -547,7 +542,7 @@ namespace Avalonia.Controls
         private void Calendar_DayButtonMouseUp(object? sender, PointerReleasedEventArgs e)
         {
             Focus();
-            IsDropDownOpen = false;
+            SetCurrentValue(IsDropDownOpenProperty, false);
         }
 
         private void Calendar_DisplayDateChanged(object? sender, CalendarDateChangedEventArgs e)
@@ -564,13 +559,13 @@ namespace Avalonia.Controls
 
             if (e.AddedItems.Count > 0 && SelectedDate.HasValue && DateTime.Compare((DateTime)e.AddedItems[0]!, SelectedDate.Value) != 0)
             {
-                SelectedDate = (DateTime?)e.AddedItems[0];
+                SetCurrentValue(SelectedDateProperty, (DateTime?)e.AddedItems[0]);
             }
             else
             {
                 if (e.AddedItems.Count == 0)
                 {
-                    SelectedDate = null;
+                    SetCurrentValue(SelectedDateProperty, null);
                     return;
                 }
 
@@ -578,7 +573,7 @@ namespace Avalonia.Controls
                 {
                     if (e.AddedItems.Count > 0)
                     {
-                        SelectedDate = (DateTime?)e.AddedItems[0];
+                        SetCurrentValue(SelectedDateProperty, (DateTime?)e.AddedItems[0]);
                     }
                 }
             }
@@ -600,18 +595,18 @@ namespace Avalonia.Controls
                 && (e.Key == Key.Enter || e.Key == Key.Space || e.Key == Key.Escape))
             {
                 Focus();
-                IsDropDownOpen = false;
+                SetCurrentValue(IsDropDownOpenProperty, false);
 
                 if (e.Key == Key.Escape)
                 {
-                    SelectedDate = _onOpenSelectedDate;
+                    SetCurrentValue(SelectedDateProperty, _onOpenSelectedDate);
                 }
             }
         }
 
         private void TextBox_GotFocus(object? sender, RoutedEventArgs e)
         {
-            IsDropDownOpen = false;
+            SetCurrentValue(IsDropDownOpenProperty, false);
         }
 
         private void TextBox_KeyDown(object? sender, KeyEventArgs e)
@@ -627,7 +622,7 @@ namespace Avalonia.Controls
             if (_textBox != null)
             {
                 _suspendTextChangeHandler = true;
-                Text = _textBox.Text;
+                SetCurrentValue(TextProperty, _textBox.Text);
                 _suspendTextChangeHandler = false;
             }
         }
@@ -660,7 +655,7 @@ namespace Avalonia.Controls
 
         private void PopUp_Closed(object? sender, EventArgs e)
         {
-            IsDropDownOpen = false;
+            SetCurrentValue(IsDropDownOpenProperty, false);
 
             if(!_isPopupClosing)
             {
@@ -678,12 +673,12 @@ namespace Avalonia.Controls
             if (IsDropDownOpen)
             {
                 Focus();
-                IsDropDownOpen = false;
+                SetCurrentValue(IsDropDownOpenProperty, false);
             }
             else
             {
                 SetSelectedDate();
-                IsDropDownOpen = true;
+                SetCurrentValue(IsDropDownOpenProperty, true);
                 _calendar!.Focus();
             }
         }
@@ -821,14 +816,14 @@ namespace Avalonia.Controls
                     
                     if (SelectedDate != d)
                     {
-                        SelectedDate = d;
+                        SetCurrentValue(SelectedDateProperty, d);
                     }
                 }
                 else
                 {
                     if (SelectedDate != null)
                     {
-                        SelectedDate = null;
+                        SetCurrentValue(SelectedDateProperty, null);
                     }
                 }
             }
@@ -838,7 +833,7 @@ namespace Avalonia.Controls
 
                 if (SelectedDate != d)
                 {
-                    SelectedDate = d;
+                    SetCurrentValue(SelectedDateProperty, d);
                 }
             }
         }
@@ -884,7 +879,7 @@ namespace Avalonia.Controls
                 if (string.IsNullOrEmpty(Watermark) && !UseFloatingWatermark)
                 {
                     DateTimeFormatInfo dtfi = DateTimeHelper.GetCurrentDateFormat();
-                    Text = string.Empty;
+                    SetCurrentValue(TextProperty, string.Empty);
                     _defaultText = string.Empty;
                     var watermarkFormat = "<{0}>";
                     string watermarkText;

--- a/src/Avalonia.Controls/ComboBox.cs
+++ b/src/Avalonia.Controls/ComboBox.cs
@@ -35,11 +35,8 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="IsDropDownOpen"/> property.
         /// </summary>
-        public static readonly DirectProperty<ComboBox, bool> IsDropDownOpenProperty =
-            AvaloniaProperty.RegisterDirect<ComboBox, bool>(
-                nameof(IsDropDownOpen),
-                o => o.IsDropDownOpen,
-                (o, v) => o.IsDropDownOpen = v);
+        public static readonly StyledProperty<bool> IsDropDownOpenProperty =
+            AvaloniaProperty.Register<ComboBox, bool>(nameof(IsDropDownOpen));
 
         /// <summary>
         /// Defines the <see cref="MaxDropDownHeight"/> property.
@@ -77,7 +74,6 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<VerticalAlignment> VerticalContentAlignmentProperty =
             ContentControl.VerticalContentAlignmentProperty.AddOwner<ComboBox>();
 
-        private bool _isDropDownOpen;
         private Popup? _popup;
         private object? _selectionBoxItem;
         private readonly CompositeDisposable _subscriptionsOnOpen = new CompositeDisposable();
@@ -107,8 +103,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool IsDropDownOpen
         {
-            get => _isDropDownOpen;
-            set => SetAndRaise(IsDropDownOpenProperty, ref _isDropDownOpen, value);
+            get => GetValue(IsDropDownOpenProperty);
+            set => SetValue(IsDropDownOpenProperty, value);
         }
 
         /// <summary>
@@ -123,10 +119,10 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets or sets the item to display as the control's content.
         /// </summary>
-        protected object? SelectionBoxItem
+        public object? SelectionBoxItem
         {
             get => _selectionBoxItem;
-            set => SetAndRaise(SelectionBoxItemProperty, ref _selectionBoxItem, value);
+            protected set => SetAndRaise(SelectionBoxItemProperty, ref _selectionBoxItem, value);
         }
 
         /// <summary>
@@ -191,23 +187,23 @@ namespace Avalonia.Controls
             if ((e.Key == Key.F4 && e.KeyModifiers.HasAllFlags(KeyModifiers.Alt) == false) ||
                 ((e.Key == Key.Down || e.Key == Key.Up) && e.KeyModifiers.HasAllFlags(KeyModifiers.Alt)))
             {
-                IsDropDownOpen = !IsDropDownOpen;
+                SetCurrentValue(IsDropDownOpenProperty, !IsDropDownOpen);
                 e.Handled = true;
             }
             else if (IsDropDownOpen && e.Key == Key.Escape)
             {
-                IsDropDownOpen = false;
+                SetCurrentValue(IsDropDownOpenProperty, false);
                 e.Handled = true;
             }
             else if (!IsDropDownOpen && (e.Key == Key.Enter || e.Key == Key.Space))
             {
-                IsDropDownOpen = true;
+                SetCurrentValue(IsDropDownOpenProperty, true);
                 e.Handled = true;
             }
             else if (IsDropDownOpen && (e.Key == Key.Enter || e.Key == Key.Space))
             {
                 SelectFocusedItem();
-                IsDropDownOpen = false;
+                SetCurrentValue(IsDropDownOpenProperty, false);
                 e.Handled = true;
             }
             else if (!IsDropDownOpen)
@@ -291,7 +287,7 @@ namespace Avalonia.Controls
                 }
                 else
                 {
-                    IsDropDownOpen = !IsDropDownOpen;
+                    SetCurrentValue(IsDropDownOpenProperty, !IsDropDownOpen);
                     e.Handled = true;
                 }
             }
@@ -390,7 +386,7 @@ namespace Avalonia.Controls
         {
             if (!isVisible && IsDropDownOpen)
             {
-                IsDropDownOpen = false;
+                SetCurrentValue(IsDropDownOpenProperty, false);
             }
         }
 

--- a/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
@@ -1,7 +1,6 @@
 ﻿using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
-using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
@@ -29,65 +28,56 @@ namespace Avalonia.Controls
         /// <summary>
         /// Define the <see cref="DayFormat"/> Property
         /// </summary>
-        public static readonly DirectProperty<DatePicker, string> DayFormatProperty =
-            AvaloniaProperty.RegisterDirect<DatePicker, string>(nameof(DayFormat),
-                x => x.DayFormat, (x, v) => x.DayFormat = v);
+        public static readonly StyledProperty<string> DayFormatProperty =
+            AvaloniaProperty.Register<DatePicker, string>(nameof(DayFormat), "%d");
 
         /// <summary>
         /// Defines the <see cref="DayVisible"/> Property
         /// </summary>
-        public static readonly DirectProperty<DatePicker, bool> DayVisibleProperty =
-            AvaloniaProperty.RegisterDirect<DatePicker, bool>(nameof(DayVisible),
-                x => x.DayVisible, (x, v) => x.DayVisible = v);
+        public static readonly StyledProperty<bool> DayVisibleProperty =
+            AvaloniaProperty.Register<DatePicker, bool>(nameof(DayVisible), true);
 
         /// <summary>
         /// Defines the <see cref="MaxYear"/> Property
         /// </summary>
-        public static readonly DirectProperty<DatePicker, DateTimeOffset> MaxYearProperty =
-            AvaloniaProperty.RegisterDirect<DatePicker, DateTimeOffset>(nameof(MaxYear), 
-                x => x.MaxYear, (x, v) => x.MaxYear = v);
+        public static readonly StyledProperty<DateTimeOffset> MaxYearProperty =
+            AvaloniaProperty.Register<DatePicker, DateTimeOffset>(nameof(MaxYear), DateTimeOffset.MaxValue, coerce: CoerceMaxYear);
 
         /// <summary>
         /// Defines the <see cref="MinYear"/> Property
         /// </summary>
-        public static readonly DirectProperty<DatePicker, DateTimeOffset> MinYearProperty =
-            AvaloniaProperty.RegisterDirect<DatePicker, DateTimeOffset>(nameof(MinYear), 
-                x => x.MinYear, (x, v) => x.MinYear = v);
+        public static readonly StyledProperty<DateTimeOffset> MinYearProperty =
+            AvaloniaProperty.Register<DatePicker, DateTimeOffset>(nameof(MinYear), DateTimeOffset.MinValue, coerce: CoerceMinYear);
 
         /// <summary>
         /// Defines the <see cref="MonthFormat"/> Property
         /// </summary>
-        public static readonly DirectProperty<DatePicker, string> MonthFormatProperty =
-            AvaloniaProperty.RegisterDirect<DatePicker, string>(nameof(MonthFormat), 
-                x => x.MonthFormat, (x, v) => x.MonthFormat = v);
+        public static readonly StyledProperty<string> MonthFormatProperty =
+            AvaloniaProperty.Register<DatePicker, string>(nameof(MonthFormat), "MMMM");
 
         /// <summary>
         /// Defines the <see cref="MonthVisible"/> Property
         /// </summary>
-        public static readonly DirectProperty<DatePicker, bool> MonthVisibleProperty =
-            AvaloniaProperty.RegisterDirect<DatePicker, bool>(nameof(MonthVisible), 
-                x => x.MonthVisible, (x, v) => x.MonthVisible = v);
+        public static readonly StyledProperty<bool> MonthVisibleProperty =
+            AvaloniaProperty.Register<DatePicker, bool>(nameof(MonthVisible), true);
 
         /// <summary>
         /// Defines the <see cref="YearFormat"/> Property
         /// </summary>
-        public static readonly DirectProperty<DatePicker, string> YearFormatProperty =
-            AvaloniaProperty.RegisterDirect<DatePicker, string>(nameof(YearFormat), 
-                x => x.YearFormat, (x, v) => x.YearFormat = v);
+        public static readonly StyledProperty<string> YearFormatProperty =
+            AvaloniaProperty.Register<DatePicker, string>(nameof(YearFormat), "yyyy");
 
         /// <summary>
         /// Defines the <see cref="YearVisible"/> Property
         /// </summary>
-        public static readonly DirectProperty<DatePicker, bool> YearVisibleProperty =
-            AvaloniaProperty.RegisterDirect<DatePicker, bool>(nameof(YearVisible), 
-                x => x.YearVisible, (x, v) => x.YearVisible = v);
+        public static readonly StyledProperty<bool> YearVisibleProperty =
+            AvaloniaProperty.Register<DatePicker, bool>(nameof(YearVisible), true);
 
         /// <summary>
         /// Defines the <see cref="SelectedDate"/> Property
         /// </summary>
-        public static readonly DirectProperty<DatePicker, DateTimeOffset?> SelectedDateProperty =
-            AvaloniaProperty.RegisterDirect<DatePicker, DateTimeOffset?>(nameof(SelectedDate), 
-                x => x.SelectedDate, (x, v) => x.SelectedDate = v,
+        public static readonly StyledProperty<DateTimeOffset?> SelectedDateProperty =
+            AvaloniaProperty.Register<DatePicker, DateTimeOffset?>(nameof(SelectedDate),
                 defaultBindingMode: BindingMode.TwoWay);
 
         // Template Items
@@ -103,28 +93,20 @@ namespace Avalonia.Controls
 
         private bool _areControlsAvailable;
 
-        private string _dayFormat = "%d";
-        private bool _dayVisible = true;
-        private DateTimeOffset _maxYear;
-        private DateTimeOffset _minYear;
-        private string _monthFormat = "MMMM";
-        private bool _monthVisible = true;
-        private string _yearFormat = "yyyy";
-        private bool _yearVisible = true;
-        private DateTimeOffset? _selectedDate;
-
         public DatePicker()
         {
             PseudoClasses.Set(":hasnodate", true);
             var now = DateTimeOffset.Now;
-            _minYear = new DateTimeOffset(now.Date.Year - 100, 1, 1, 0, 0, 0, now.Offset);
-            _maxYear = new DateTimeOffset(now.Date.Year + 100, 12, 31, 0, 0, 0, now.Offset);
+            SetCurrentValue(MinYearProperty, new DateTimeOffset(now.Date.Year - 100, 1, 1, 0, 0, 0, now.Offset));
+            SetCurrentValue(MaxYearProperty, new DateTimeOffset(now.Date.Year + 100, 12, 31, 0, 0, 0, now.Offset));
         }
+
+        private static void OnGridVisibilityChanged(DatePicker sender, AvaloniaPropertyChangedEventArgs e) => sender.SetGrid();
 
         public string DayFormat
         {
-            get => _dayFormat;
-            set => SetAndRaise(DayFormatProperty, ref _dayFormat, value);
+            get => GetValue(DayFormatProperty);
+            set => SetValue(DayFormatProperty, value);
         }
 
         /// <summary>
@@ -132,12 +114,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool DayVisible
         {
-            get => _dayVisible;
-            set
-            {
-                SetAndRaise(DayVisibleProperty, ref _dayVisible, value);
-                SetGrid();
-            }
+            get => GetValue(DayVisibleProperty);
+            set => SetValue(DayVisibleProperty, value);
         }
 
         /// <summary>
@@ -145,16 +123,24 @@ namespace Avalonia.Controls
         /// </summary>
         public DateTimeOffset MaxYear
         {
-            get => _maxYear;
-            set
-            {
-                if (value < MinYear)
-                    throw new InvalidOperationException("MaxDate cannot be less than MinDate");
-                SetAndRaise(MaxYearProperty, ref _maxYear, value);
+            get => GetValue(MaxYearProperty);
+            set => SetValue(MaxYearProperty, value);
+        }
 
-                if (SelectedDate.HasValue && SelectedDate.Value > value)
-                    SelectedDate = value;
+        private static DateTimeOffset CoerceMaxYear(AvaloniaObject sender, DateTimeOffset value)
+        {
+            if (value < sender.GetValue(MinYearProperty))
+            {
+                throw new InvalidOperationException($"{MaxYearProperty.Name} cannot be less than {MinYearProperty.Name}");
             }
+
+            return value;
+        }
+
+        private void OnMaxYearChanged(DateTimeOffset? value)
+        {
+            if (SelectedDate.HasValue && SelectedDate.Value > value)
+                SetCurrentValue(SelectedDateProperty, value);
         }
 
         /// <summary>
@@ -162,16 +148,24 @@ namespace Avalonia.Controls
         /// </summary>
         public DateTimeOffset MinYear
         {
-            get => _minYear;
-            set
-            {
-                if (value > MaxYear)
-                    throw new InvalidOperationException("MinDate cannot be greater than MaxDate");
-                SetAndRaise(MinYearProperty, ref _minYear, value);
+            get => GetValue(MinYearProperty);
+            set => SetValue(MinYearProperty, value);
+        }
 
-                if (SelectedDate.HasValue && SelectedDate.Value < value)
-                    SelectedDate = value;
+        private static DateTimeOffset CoerceMinYear(AvaloniaObject sender, DateTimeOffset value)
+        {
+            if (value > sender.GetValue(MaxYearProperty))
+            {
+                throw new InvalidOperationException($"{MinYearProperty.Name} cannot be greater than {MaxYearProperty.Name}");
             }
+
+            return value;
+        }
+
+        private void OnMinYearChanged(DateTimeOffset? value)
+        {
+            if (SelectedDate.HasValue && SelectedDate.Value < value)
+                SetCurrentValue(SelectedDateProperty, value);
         }
 
         /// <summary>
@@ -179,8 +173,8 @@ namespace Avalonia.Controls
         /// </summary>
         public string MonthFormat
         {
-            get => _monthFormat;
-            set => SetAndRaise(MonthFormatProperty, ref _monthFormat, value);
+            get => GetValue(MonthFormatProperty);
+            set => SetValue(MonthFormatProperty, value);
         }
 
         /// <summary>
@@ -188,12 +182,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool MonthVisible
         {
-            get => _monthVisible;
-            set
-            {
-                SetAndRaise(MonthVisibleProperty, ref _monthVisible, value);
-                SetGrid();
-            }
+            get => GetValue(MonthVisibleProperty);
+            set => SetValue(MonthVisibleProperty, value);
         }
 
         /// <summary>
@@ -201,8 +191,8 @@ namespace Avalonia.Controls
         /// </summary>
         public string YearFormat
         {
-            get => _yearFormat;
-            set => SetAndRaise(YearFormatProperty, ref _yearFormat, value);
+            get => GetValue(YearFormatProperty);
+            set => SetValue(YearFormatProperty, value);
         }
 
         /// <summary>
@@ -210,12 +200,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool YearVisible
         {
-            get => _yearVisible;
-            set
-            {
-                SetAndRaise(YearVisibleProperty, ref _yearVisible, value);
-                SetGrid();
-            }
+            get => GetValue(YearVisibleProperty);
+            set => SetValue(YearVisibleProperty, value);
         }
 
         /// <summary>
@@ -223,14 +209,8 @@ namespace Avalonia.Controls
         /// </summary>
         public DateTimeOffset? SelectedDate
         {
-            get => _selectedDate;
-            set
-            {
-                var old = _selectedDate;
-                SetAndRaise(SelectedDateProperty, ref _selectedDate, value);
-                SetSelectedDateText();
-                OnSelectedDateChanged(this, new DatePickerSelectedValueChangedEventArgs(old, value));
-            }
+            get => GetValue(SelectedDateProperty);
+            set => SetValue(SelectedDateProperty, value);
         }
 
         /// <summary>
@@ -287,6 +267,31 @@ namespace Avalonia.Controls
             }
         }
 
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == DayVisibleProperty || change.Property == MonthVisibleProperty || change.Property == YearVisibleProperty)
+            {
+                SetGrid();
+            }
+            else if (change.Property == MaxYearProperty)
+            {
+                OnMaxYearChanged(change.GetNewValue<DateTimeOffset>());
+            }
+            else if (change.Property == MinYearProperty)
+            {
+                OnMinYearChanged(change.GetNewValue<DateTimeOffset>());
+            }
+            else if (change.Property == SelectedDateProperty)
+            {
+                SetSelectedDateText();
+
+                var (oldValue, newValue) = change.GetOldAndNewValue<DateTimeOffset?>();
+                OnSelectedDateChanged(this, new DatePickerSelectedValueChangedEventArgs(oldValue, newValue));
+            }
+        }
+
         private void OnDismissPicker(object? sender, EventArgs e)
         {
             _popup!.Close();
@@ -296,7 +301,7 @@ namespace Avalonia.Controls
         private void OnConfirmed(object? sender, EventArgs e)
         {
             _popup!.Close();
-            SelectedDate = _presenter!.Date;
+            SetCurrentValue(SelectedDateProperty, _presenter!.Date);
         }
 
         private void SetGrid()

--- a/src/Avalonia.Controls/DateTimePickers/TimePickerPresenter.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePickerPresenter.cs
@@ -30,28 +30,29 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="MinuteIncrement"/> property
         /// </summary>
-        public static readonly DirectProperty<TimePickerPresenter, int> MinuteIncrementProperty =
-            TimePicker.MinuteIncrementProperty.AddOwner<TimePickerPresenter>(x => x.MinuteIncrement,
-                (x, v) => x.MinuteIncrement = v);
+        public static readonly StyledProperty<int> MinuteIncrementProperty =
+            TimePicker.MinuteIncrementProperty.AddOwner<TimePickerPresenter>();
 
         /// <summary>
         /// Defines the <see cref="ClockIdentifier"/> property
         /// </summary>
-        public static readonly DirectProperty<TimePickerPresenter, string> ClockIdentifierProperty =
-            TimePicker.ClockIdentifierProperty.AddOwner<TimePickerPresenter>(x => x.ClockIdentifier,
-                (x, v) => x.ClockIdentifier = v);
+        public static readonly StyledProperty<string> ClockIdentifierProperty =
+            TimePicker.ClockIdentifierProperty.AddOwner<TimePickerPresenter>();
 
         /// <summary>
         /// Defines the <see cref="Time"/> property
         /// </summary>
-        public static readonly DirectProperty<TimePickerPresenter, TimeSpan> TimeProperty =
-            AvaloniaProperty.RegisterDirect<TimePickerPresenter, TimeSpan>(nameof(Time),
-                x => x.Time, (x, v) => x.Time = v);
+        public static readonly StyledProperty<TimeSpan> TimeProperty =
+            AvaloniaProperty.Register<TimePickerPresenter, TimeSpan>(nameof(Time));
 
         public TimePickerPresenter()
         {
-            Time = DateTime.Now.TimeOfDay;
-            KeyboardNavigation.SetTabNavigation(this, KeyboardNavigationMode.Cycle);
+            SetCurrentValue(TimeProperty, DateTime.Now.TimeOfDay);
+        }
+
+        static TimePickerPresenter()
+        {
+            KeyboardNavigation.TabNavigationProperty.OverrideDefaultValue<TimePickerPresenter>(KeyboardNavigationMode.Cycle);
         }
 
         // TemplateItems
@@ -70,24 +71,13 @@ namespace Avalonia.Controls
         private Button? _minuteDownButton;
         private Button? _periodDownButton;
 
-        // Backing Fields
-        private TimeSpan _time;
-        private int _minuteIncrement = 1;
-        private string _clockIdentifier = "12HourClock";
-
         /// <summary>
         /// Gets or sets the minute increment in the selector
         /// </summary>
         public int MinuteIncrement
         {
-            get => _minuteIncrement;
-            set
-            {
-                if (value < 1 || value > 59)
-                    throw new ArgumentOutOfRangeException("1 >= MinuteIncrement <= 59");
-                SetAndRaise(MinuteIncrementProperty, ref _minuteIncrement, value);
-                InitPicker();
-            }
+            get => GetValue(MinuteIncrementProperty);
+            set => SetValue(MinuteIncrementProperty, value);
         }
 
         /// <summary>
@@ -95,14 +85,8 @@ namespace Avalonia.Controls
         /// </summary>
         public string ClockIdentifier
         {
-            get => _clockIdentifier;
-            set
-            {
-                if (string.IsNullOrEmpty(value) || !(value == "12HourClock" || value == "24HourClock"))
-                    throw new ArgumentException("Invalid ClockIdentifier");
-                SetAndRaise(ClockIdentifierProperty, ref _clockIdentifier, value);
-                InitPicker();
-            }
+            get => GetValue(ClockIdentifierProperty);
+            set => SetValue(ClockIdentifierProperty, value);
         }
 
         /// <summary>
@@ -110,12 +94,8 @@ namespace Avalonia.Controls
         /// </summary>
         public TimeSpan Time
         {
-            get => _time;
-            set
-            {
-                SetAndRaise(TimeProperty, ref _time, value);
-                InitPicker();
-            }
+            get => GetValue(TimeProperty);
+            set => SetValue(TimeProperty, value);
         }
 
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
@@ -162,6 +142,16 @@ namespace Avalonia.Controls
             InitPicker();
         }
 
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == MinuteIncrementProperty || change.Property == ClockIdentifierProperty || change.Property == TimeProperty)
+            {
+                InitPicker();
+            }
+        }
+
         protected override void OnKeyDown(KeyEventArgs e)
         {
             switch (e.Key)
@@ -197,7 +187,7 @@ namespace Avalonia.Controls
                 hr = per == 1 ? (hr == 12) ? 12 : hr + 12 : per == 0 && hr == 12 ? 0 : hr;
             }
 
-            Time = new TimeSpan(hr, min, 0);
+            SetCurrentValue(TimeProperty, new TimeSpan(hr, min, 0));
 
             base.OnConfirmed();
         }

--- a/src/Avalonia.Controls/Documents/InlineCollection.cs
+++ b/src/Avalonia.Controls/Documents/InlineCollection.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Controls.Documents
 
             this.ForEachItem(
                 x =>
-                {                   
+                {
                     x.InlineHost = InlineHost;
                     LogicalChildren?.Add(x);
                     Invalidate();
@@ -92,10 +92,10 @@ namespace Avalonia.Controls.Documents
         public override void Add(Inline inline)
         {
             if (InlineHost is TextBlock textBlock && !string.IsNullOrEmpty(textBlock._text))
-            {          
+            {
                 base.Add(new Run(textBlock._text));
 
-                textBlock._text = null;                
+                textBlock._text = null;
             }
 
             base.Add(inline);
@@ -159,7 +159,7 @@ namespace Avalonia.Controls.Documents
                         oldParent.Remove(child);
                     }
 
-                    if(newParent != null)
+                    if (newParent != null)
                     {
                         newParent.Add(child);
                     }

--- a/src/Avalonia.Controls/Flyouts/FlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/FlyoutBase.cs
@@ -35,17 +35,14 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Defines the <see cref="ShowMode"/> property
         /// </summary>
-        public static readonly DirectProperty<FlyoutBase, FlyoutShowMode> ShowModeProperty =
-            AvaloniaProperty.RegisterDirect<FlyoutBase, FlyoutShowMode>(nameof(ShowMode),
-                x => x.ShowMode, (x, v) => x.ShowMode = v);
+        public static readonly StyledProperty<FlyoutShowMode> ShowModeProperty =
+            AvaloniaProperty.Register<FlyoutBase, FlyoutShowMode>(nameof(ShowMode));
 
         /// <summary>
         /// Defines the <see cref="OverlayInputPassThroughElement"/> property
         /// </summary>
-        public static readonly DirectProperty<FlyoutBase, IInputElement?> OverlayInputPassThroughElementProperty =
-            Popup.OverlayInputPassThroughElementProperty.AddOwner<FlyoutBase>(
-                o => o._overlayInputPassThroughElement,
-                (o, v) => o._overlayInputPassThroughElement = v);
+        public static readonly StyledProperty<IInputElement?> OverlayInputPassThroughElementProperty =
+            Popup.OverlayInputPassThroughElementProperty.AddOwner<FlyoutBase>();
 
         /// <summary>
         /// Defines the AttachedFlyout property
@@ -56,12 +53,10 @@ namespace Avalonia.Controls.Primitives
         private readonly Lazy<Popup> _popupLazy;
         private bool _isOpen;
         private Control? _target;
-        private FlyoutShowMode _showMode = FlyoutShowMode.Standard;
         private Rect? _enlargedPopupRect;
         private PixelRect? _enlargePopupRectScreenPixelRect;
         private IDisposable? _transientDisposable;
         private Action<IPopupHost?>? _popupHostChangedHandler;
-        private IInputElement? _overlayInputPassThroughElement;
 
         static FlyoutBase()
         {
@@ -98,8 +93,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public FlyoutShowMode ShowMode
         {
-            get => _showMode;
-            set => SetAndRaise(ShowModeProperty, ref _showMode, value);
+            get => GetValue(ShowModeProperty);
+            set => SetValue(ShowModeProperty, value);
         }
 
         /// <summary>
@@ -117,8 +112,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public IInputElement? OverlayInputPassThroughElement
         {
-            get => _overlayInputPassThroughElement;
-            set => SetAndRaise(OverlayInputPassThroughElementProperty, ref _overlayInputPassThroughElement, value);
+            get => GetValue(OverlayInputPassThroughElementProperty);
+            set => SetValue(OverlayInputPassThroughElementProperty, value);
         }
 
         IPopupHost? IPopupHostProvider.PopupHost => Popup?.Host;
@@ -244,7 +239,7 @@ namespace Avalonia.Controls.Primitives
             {
                 Popup.PlacementTarget = Target = placementTarget;
                 ((ISetLogicalParent)Popup).SetParent(placementTarget);
-                Popup.SetValue(StyledElement.TemplatedParentProperty, placementTarget.TemplatedParent);
+                Popup.TemplatedParent = placementTarget.TemplatedParent;
             }
 
             if (Popup.Child == null)

--- a/src/Avalonia.Controls/Label.cs
+++ b/src/Avalonia.Controls/Label.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Text;
-using Avalonia.Controls.Primitives;
-using Avalonia.Controls.Templates;
-using Avalonia.Data;
-using Avalonia.Input;
+﻿using Avalonia.Input;
 using Avalonia.Interactivity;
 
 namespace Avalonia.Controls
@@ -18,13 +11,8 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="Target"/> Direct property
         /// </summary>
-        public static readonly DirectProperty<Label, IInputElement?> TargetProperty =
-            AvaloniaProperty.RegisterDirect<Label, IInputElement?>(nameof(Target), lbl => lbl.Target, (lbl, inp) => lbl.Target = inp);
-
-        /// <summary>
-        /// Label focus target storage field
-        /// </summary>
-        private IInputElement? _target;
+        public static readonly StyledProperty<IInputElement?> TargetProperty =
+            AvaloniaProperty.Register<Label, IInputElement?>(nameof(Target));
 
         /// <summary>
         /// Label focus Target
@@ -32,8 +20,8 @@ namespace Avalonia.Controls
         [ResolveByName]
         public IInputElement? Target
         {
-            get => _target;
-            set => SetAndRaise(TargetProperty, ref _target, value);
+            get => GetValue(TargetProperty);
+            set => SetValue(TargetProperty, value);
         }
 
         static Label()

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -27,11 +27,8 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="Command"/> property.
         /// </summary>
-        public static readonly DirectProperty<MenuItem, ICommand?> CommandProperty =
-            Button.CommandProperty.AddOwner<MenuItem>(
-                menuItem => menuItem.Command,
-                (menuItem, command) => menuItem.Command = command,
-                enableDataValidation: true);
+        public static readonly StyledProperty<ICommand?> CommandProperty =
+            Button.CommandProperty.AddOwner<MenuItem>(new(enableDataValidation: true));
 
         /// <summary>
         /// Defines the <see cref="HotKey"/> property.
@@ -113,7 +110,6 @@ namespace Avalonia.Controls
         private static readonly ITemplate<Panel> DefaultPanel =
             new FuncTemplate<Panel>(() => new StackPanel());
 
-        private ICommand? _command;
         private bool _commandCanExecute = true;
         private bool _commandBindingError;
         private Popup? _popup;
@@ -217,8 +213,8 @@ namespace Avalonia.Controls
         /// </summary>
         public ICommand? Command
         {
-            get { return _command; }
-            set { SetAndRaise(CommandProperty, ref _command, value); }
+            get => GetValue(CommandProperty);
+            set => SetValue(CommandProperty, value);
         }
 
         /// <summary>
@@ -337,7 +333,7 @@ namespace Avalonia.Controls
         /// <remarks>
         /// This has the same effect as setting <see cref="IsSubMenuOpen"/> to true.
         /// </remarks>
-        public void Open() => IsSubMenuOpen = true;
+        public void Open() => SetCurrentValue(IsSubMenuOpenProperty, true);
 
         /// <summary>
         /// Closes the submenu.
@@ -345,7 +341,7 @@ namespace Avalonia.Controls
         /// <remarks>
         /// This has the same effect as setting <see cref="IsSubMenuOpen"/> to false.
         /// </remarks>
-        public void Close() => IsSubMenuOpen = false;
+        public void Close() => SetCurrentValue(IsSubMenuOpenProperty, false);
 
         /// <inheritdoc/>
         void IMenuItem.RaiseClick() => RaiseEvent(new RoutedEventArgs(ClickEvent));
@@ -369,7 +365,7 @@ namespace Avalonia.Controls
         {
             if (_hotkey != null) // Control attached again, set Hotkey to create a hotkey manager for this control
             {
-                HotKey = _hotkey;
+                SetCurrentValue(HotKeyProperty, _hotkey);
             }
             
             base.OnAttachedToLogicalTree(e);
@@ -397,7 +393,7 @@ namespace Avalonia.Controls
             if (HotKey != null)
             {
                 _hotkey = HotKey;
-                HotKey = null;
+                SetCurrentValue(HotKeyProperty, null);
             }
 
             base.OnDetachedFromLogicalTree(e);
@@ -663,7 +659,7 @@ namespace Avalonia.Controls
                 }
 
                 RaiseEvent(new RoutedEventArgs(SubmenuOpenedEvent));
-                IsSelected = true;
+                SetCurrentValue(IsSelectedProperty, true);
                 PseudoClasses.Add(":open");
             }
             else

--- a/src/Avalonia.Controls/NativeMenu.cs
+++ b/src/Avalonia.Controls/NativeMenu.cs
@@ -79,12 +79,12 @@ namespace Avalonia.Controls
         }
 
         public static readonly DirectProperty<NativeMenu, NativeMenuItem?> ParentProperty =
-            AvaloniaProperty.RegisterDirect<NativeMenu, NativeMenuItem?>("Parent", o => o.Parent, (o, v) => o.Parent = v);
+            AvaloniaProperty.RegisterDirect<NativeMenu, NativeMenuItem?>(nameof(Parent), o => o.Parent);
 
         public NativeMenuItem? Parent
         {
             get => _parent;
-            set => SetAndRaise(ParentProperty, ref _parent, value);
+            internal set => SetAndRaise(ParentProperty, ref _parent, value);
         }
 
         public void Add(NativeMenuItemBase item) => _items.Add(item);

--- a/src/Avalonia.Controls/NativeMenuItem.cs
+++ b/src/Avalonia.Controls/NativeMenuItem.cs
@@ -4,35 +4,13 @@ using Avalonia.Input;
 using Avalonia.Media.Imaging;
 using Avalonia.Metadata;
 using Avalonia.Utilities;
-using Avalonia.Reactive;
 
 namespace Avalonia.Controls
 {
     public class NativeMenuItem : NativeMenuItemBase, INativeMenuItemExporterEventsImplBridge
     {
-        private string? _header;
-        private KeyGesture? _gesture;
-        private bool _isEnabled = true;
         private ICommand? _command;
-        private bool _isChecked = false;
-        private NativeMenuItemToggleType _toggleType;
-        private IBitmap? _icon;
         private readonly CanExecuteChangedSubscriber _canExecuteChangedSubscriber;
-
-        private NativeMenu? _menu;
-
-        static NativeMenuItem()
-        {
-            MenuProperty.Changed.Subscribe(args =>
-            {
-                var item = (NativeMenuItem)args.Sender;
-                var value = args.NewValue.GetValueOrDefault()!;
-                if (value.Parent != null && value.Parent != item)
-                    throw new InvalidOperationException("NativeMenu already has a parent");
-                value.Parent = item;
-            });
-        }
-
 
         class CanExecuteChangedSubscriber : IWeakEventSubscriber<EventArgs>
         {
@@ -60,71 +38,66 @@ namespace Avalonia.Controls
             Header = header;
         }
 
-        public static readonly DirectProperty<NativeMenuItem, NativeMenu?> MenuProperty =
-            AvaloniaProperty.RegisterDirect<NativeMenuItem, NativeMenu?>(nameof(Menu), o => o.Menu, (o, v) => o.Menu = v);
+        public static readonly StyledProperty<NativeMenu?> MenuProperty =
+            AvaloniaProperty.Register<NativeMenuItem, NativeMenu?>(nameof(Menu), coerce: CoerceMenu);
 
         [Content]
         public NativeMenu? Menu
         {
-            get => _menu;
-            set
-            {
-                if (value != null && value.Parent != null && value.Parent != this)
-                    throw new InvalidOperationException("NativeMenu already has a parent");
-                SetAndRaise(MenuProperty, ref _menu, value);
-            }
+            get => GetValue(MenuProperty);
+            set => SetValue(MenuProperty, value);
         }
 
-        public static readonly DirectProperty<NativeMenuItem, IBitmap?> IconProperty =
-            AvaloniaProperty.RegisterDirect<NativeMenuItem, IBitmap?>(nameof(Icon), o => o.Icon, (o, v) => o.Icon = v);
+        private static NativeMenu? CoerceMenu(AvaloniaObject sender, NativeMenu? value)
+        {
+            if (value != null && value.Parent != null && value.Parent != sender)
+                throw new InvalidOperationException("NativeMenu already has a parent");
+            return value;
+        }
 
+        public static readonly StyledProperty<IBitmap?> IconProperty =
+            AvaloniaProperty.Register<NativeMenuItem, IBitmap?>(nameof(Icon));
 
         public IBitmap? Icon
         {
-            get => _icon;
-            set => SetAndRaise(IconProperty, ref _icon, value);
+            get => GetValue(IconProperty);
+            set => SetValue(IconProperty, value);
         }  
 
-        public static readonly DirectProperty<NativeMenuItem, string?> HeaderProperty =
-            AvaloniaProperty.RegisterDirect<NativeMenuItem, string?>(nameof(Header), o => o.Header, (o, v) => o.Header = v);
+        public static readonly StyledProperty<string?> HeaderProperty =
+            AvaloniaProperty.Register<NativeMenuItem, string?>(nameof(Header));
 
         public string? Header
         {
-            get => _header;
-            set => SetAndRaise(HeaderProperty, ref _header, value);
+            get => GetValue(HeaderProperty);
+            set => SetValue(HeaderProperty, value);
         }
 
-        public static readonly DirectProperty<NativeMenuItem, KeyGesture?> GestureProperty =
-            AvaloniaProperty.RegisterDirect<NativeMenuItem, KeyGesture?>(nameof(Gesture), o => o.Gesture, (o, v) => o.Gesture = v);
+        public static readonly StyledProperty<KeyGesture?> GestureProperty =
+            AvaloniaProperty.Register<NativeMenuItem, KeyGesture?>(nameof(Gesture));
 
         public KeyGesture? Gesture
         {
-            get => _gesture;
-            set => SetAndRaise(GestureProperty, ref _gesture, value);
+            get => GetValue(GestureProperty);
+            set => SetValue(GestureProperty, value);
         }
 
-        public static readonly DirectProperty<NativeMenuItem, bool> IsCheckedProperty =
-            AvaloniaProperty.RegisterDirect<NativeMenuItem, bool>(
-                nameof(IsChecked),
-                o => o.IsChecked,
-                (o, v) => o.IsChecked = v);
+        public static readonly StyledProperty<bool> IsCheckedProperty =
+            AvaloniaProperty.Register<NativeMenuItem, bool>(nameof(IsChecked));
 
         public bool IsChecked
         {
-            get => _isChecked;
-            set => SetAndRaise(IsCheckedProperty, ref _isChecked, value);
+            get => GetValue(IsCheckedProperty);
+            set => SetValue(IsCheckedProperty, value);
         }
         
-        public static readonly DirectProperty<NativeMenuItem, NativeMenuItemToggleType> ToggleTypeProperty =
-            AvaloniaProperty.RegisterDirect<NativeMenuItem, NativeMenuItemToggleType>(
-                nameof(ToggleType),
-                o => o.ToggleType,
-                (o, v) => o.ToggleType = v);
+        public static readonly StyledProperty<NativeMenuItemToggleType> ToggleTypeProperty =
+            AvaloniaProperty.Register<NativeMenuItem, NativeMenuItemToggleType>(nameof(ToggleType));
 
         public NativeMenuItemToggleType ToggleType
         {
-            get => _toggleType;
-            set => SetAndRaise(ToggleTypeProperty, ref _toggleType, value);
+            get => GetValue(ToggleTypeProperty);
+            set => SetValue(ToggleTypeProperty, value);
         }
 
         public static readonly DirectProperty<NativeMenuItem, ICommand?> CommandProperty =
@@ -139,18 +112,18 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<object?> CommandParameterProperty =
             Button.CommandParameterProperty.AddOwner<NativeMenuItem>();
 
-        public static readonly DirectProperty<NativeMenuItem, bool> IsEnabledProperty =
-           AvaloniaProperty.RegisterDirect<NativeMenuItem, bool>(nameof(IsEnabled), o => o.IsEnabled, (o, v) => o.IsEnabled = v, true);
+        public static readonly StyledProperty<bool> IsEnabledProperty =
+           AvaloniaProperty.Register<NativeMenuItem, bool>(nameof(IsEnabled), true);
 
         public bool IsEnabled
         {
-            get => _isEnabled;
-            set => SetAndRaise(IsEnabledProperty, ref _isEnabled, value);
+            get => GetValue(IsEnabledProperty);
+            set => SetValue(IsEnabledProperty, value);
         }
 
         void CanExecuteChanged()
         {
-            IsEnabled = _command?.CanExecute(CommandParameter) ?? true;
+            SetCurrentValue(IsEnabledProperty, Command?.CanExecute(CommandParameter) ?? true);
         }
 
         public bool HasClickHandlers => Click != null;
@@ -196,8 +169,20 @@ namespace Avalonia.Controls
                 Command.Execute(CommandParameter);
             }
         }
+
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == MenuProperty && change.NewValue is NativeMenu newMenu)
+            {
+                if (newMenu.Parent != null && newMenu.Parent != this)
+                    throw new InvalidOperationException("NativeMenu already has a parent");
+                newMenu.Parent = this;
+            }
+        }
     }
-    
+
     public enum NativeMenuItemToggleType
     {
         None,

--- a/src/Avalonia.Controls/NativeMenuItemBase.cs
+++ b/src/Avalonia.Controls/NativeMenuItemBase.cs
@@ -12,12 +12,12 @@ namespace Avalonia.Controls
         }
 
         public static readonly DirectProperty<NativeMenuItemBase, NativeMenu?> ParentProperty =
-            AvaloniaProperty.RegisterDirect<NativeMenuItemBase, NativeMenu?>("Parent", o => o.Parent, (o, v) => o.Parent = v);
+            AvaloniaProperty.RegisterDirect<NativeMenuItemBase, NativeMenu?>(nameof(Parent), o => o.Parent);
 
         public NativeMenu? Parent
         {
             get => _parent;
-            set => SetAndRaise(ParentProperty, ref _parent, value);
+            internal set => SetAndRaise(ParentProperty, ref _parent, value);
         }
     }
 }

--- a/src/Avalonia.Controls/Notifications/NotificationCard.cs
+++ b/src/Avalonia.Controls/Notifications/NotificationCard.cs
@@ -13,7 +13,6 @@ namespace Avalonia.Controls.Notifications
     [PseudoClasses(":error", ":information", ":success", ":warning")]
     public class NotificationCard : ContentControl
     {
-        private bool _isClosed;
         private bool _isClosing;
 
         static NotificationCard()
@@ -84,15 +83,15 @@ namespace Avalonia.Controls.Notifications
         /// </summary>
         public bool IsClosed
         {
-            get { return _isClosed; }
-            set { SetAndRaise(IsClosedProperty, ref _isClosed, value); }
+            get => GetValue(IsClosedProperty);
+            set => SetValue(IsClosedProperty, value);
         }
 
         /// <summary>
         /// Defines the <see cref="IsClosed"/> property.
         /// </summary>
-        public static readonly DirectProperty<NotificationCard, bool> IsClosedProperty =
-            AvaloniaProperty.RegisterDirect<NotificationCard, bool>(nameof(IsClosed), o => o.IsClosed, (o, v) => o.IsClosed = v);
+        public static readonly StyledProperty<bool> IsClosedProperty =
+            AvaloniaProperty.Register<NotificationCard, bool>(nameof(IsClosed));
 
         /// <summary>
         /// Defines the <see cref="NotificationClosed"/> event.

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -43,16 +43,14 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="ClipValueToMinMax"/> property.
         /// </summary>
-        public static readonly DirectProperty<NumericUpDown, bool> ClipValueToMinMaxProperty =
-            AvaloniaProperty.RegisterDirect<NumericUpDown, bool>(nameof(ClipValueToMinMax),
-                updown => updown.ClipValueToMinMax, (updown, b) => updown.ClipValueToMinMax = b);
+        public static readonly StyledProperty<bool> ClipValueToMinMaxProperty =
+            AvaloniaProperty.Register<NumericUpDown, bool>(nameof(ClipValueToMinMax));
 
         /// <summary>
         /// Defines the <see cref="NumberFormat"/> property.
         /// </summary>
-        public static readonly DirectProperty<NumericUpDown, NumberFormatInfo?> NumberFormatProperty =
-            AvaloniaProperty.RegisterDirect<NumericUpDown, NumberFormatInfo?>(nameof(NumberFormat), o => o.NumberFormat,
-                (o, v) => o.NumberFormat = v, NumberFormatInfo.CurrentInfo);
+        public static readonly StyledProperty<NumberFormatInfo?> NumberFormatProperty =
+            AvaloniaProperty.Register<NumericUpDown, NumberFormatInfo?>(nameof(NumberFormat), NumberFormatInfo.CurrentInfo);
 
         /// <summary>
         /// Defines the <see cref="FormatString"/> property.
@@ -87,9 +85,8 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="ParsingNumberStyle"/> property.
         /// </summary>
-        public static readonly DirectProperty<NumericUpDown, NumberStyles> ParsingNumberStyleProperty =
-            AvaloniaProperty.RegisterDirect<NumericUpDown, NumberStyles>(nameof(ParsingNumberStyle),
-                updown => updown.ParsingNumberStyle, (updown, style) => updown.ParsingNumberStyle = style);
+        public static readonly StyledProperty<NumberStyles> ParsingNumberStyleProperty =
+            AvaloniaProperty.Register<NumericUpDown, NumberStyles>(nameof(ParsingNumberStyle), NumberStyles.Any);
 
         /// <summary>
         /// Defines the <see cref="Text"/> property.
@@ -101,9 +98,8 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="TextConverter"/> property.
         /// </summary>
-        public static readonly DirectProperty<NumericUpDown, IValueConverter?> TextConverterProperty =
-            AvaloniaProperty.RegisterDirect<NumericUpDown, IValueConverter?>(nameof(TextConverter),
-                updown => updown.TextConverter, (o, v) => o.TextConverter = v, null, BindingMode.OneWay, false);
+        public static readonly StyledProperty<IValueConverter?> TextConverterProperty =
+            AvaloniaProperty.Register<NumericUpDown, IValueConverter?>(nameof(TextConverter), defaultBindingMode: BindingMode.OneWay);
 
         /// <summary>
         /// Defines the <see cref="Value"/> property.
@@ -134,13 +130,9 @@ namespace Avalonia.Controls
 
         private decimal? _value;
         private string? _text;
-        private IValueConverter? _textConverter;
         private bool _internalValueSet;
-        private bool _clipValueToMinMax;
         private bool _isSyncingTextAndValueProperties;
         private bool _isTextChangedFromUI;
-        private NumberStyles _parsingNumberStyle = NumberStyles.Any;
-        private NumberFormatInfo? _numberFormat;
 
         /// <summary>
         /// Gets the Spinner template part.
@@ -184,8 +176,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool ClipValueToMinMax
         {
-            get { return _clipValueToMinMax; }
-            set { SetAndRaise(ClipValueToMinMaxProperty, ref _clipValueToMinMax, value); }
+            get => GetValue(ClipValueToMinMaxProperty);
+            set => SetValue(ClipValueToMinMaxProperty, value);
         }
 
         /// <summary>
@@ -193,8 +185,8 @@ namespace Avalonia.Controls
         /// </summary>
         public NumberFormatInfo? NumberFormat
         {
-            get { return _numberFormat; }
-            set { SetAndRaise(NumberFormatProperty, ref _numberFormat, value); }
+            get => GetValue(NumberFormatProperty);
+            set => SetValue(NumberFormatProperty, value);
         }
 
         /// <summary>
@@ -249,8 +241,8 @@ namespace Avalonia.Controls
         /// </summary>
         public NumberStyles ParsingNumberStyle
         {
-            get { return _parsingNumberStyle; }
-            set { SetAndRaise(ParsingNumberStyleProperty, ref _parsingNumberStyle, value); }
+            get => GetValue(ParsingNumberStyleProperty);
+            set => SetValue(ParsingNumberStyleProperty, value);
         }
 
         /// <summary>
@@ -269,8 +261,8 @@ namespace Avalonia.Controls
         /// </summary>
         public IValueConverter? TextConverter
         {
-            get { return _textConverter; }
-            set { SetAndRaise(TextConverterProperty, ref _textConverter, value); }
+            get => GetValue(TextConverterProperty);
+            set => SetValue(TextConverterProperty, value);
         }
 
         /// <summary>
@@ -475,7 +467,7 @@ namespace Avalonia.Controls
             }
             if (ClipValueToMinMax && Value.HasValue)
             {
-                Value = MathUtilities.Clamp(Value.Value, Minimum, Maximum);
+                SetCurrentValue(ValueProperty, MathUtilities.Clamp(Value.Value, Minimum, Maximum));
             }
         }
 
@@ -492,7 +484,7 @@ namespace Avalonia.Controls
             }
             if (ClipValueToMinMax && Value.HasValue)
             {
-                Value = MathUtilities.Clamp(Value.Value, Minimum, Maximum);
+                SetCurrentValue(ValueProperty, MathUtilities.Clamp(Value.Value, Minimum, Maximum));
             }
         }
 
@@ -676,7 +668,7 @@ namespace Avalonia.Controls
                 result = Minimum;
             }
             
-            Value = MathUtilities.Clamp(result, Minimum, Maximum);
+            SetCurrentValue(ValueProperty, MathUtilities.Clamp(result, Minimum, Maximum));
         }
 
         /// <summary>
@@ -695,7 +687,7 @@ namespace Avalonia.Controls
                 result = Maximum;
             }
             
-            Value = MathUtilities.Clamp(result, Minimum, Maximum);
+            SetCurrentValue(ValueProperty, MathUtilities.Clamp(result, Minimum, Maximum));
         }
 
         /// <summary>
@@ -862,7 +854,7 @@ namespace Avalonia.Controls
             _internalValueSet = true;
             try
             {
-                Value = value;
+                SetCurrentValue(ValueProperty, value);
             }
             finally
             {
@@ -907,7 +899,7 @@ namespace Avalonia.Controls
                 _isTextChangedFromUI = true;
                 if (TextBox != null)
                 {
-                    Text = TextBox.Text;
+                    SetCurrentValue(TextProperty, TextBox.Text);
                 }
             }
             finally
@@ -1026,7 +1018,7 @@ namespace Avalonia.Controls
                         var newText = ConvertValueToText();
                         if (!Equals(Text, newText))
                         {
-                            Text = newText;
+                            SetCurrentValue(TextProperty, newText);
                         }
                     }
 

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -91,8 +91,8 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="Text"/> property.
         /// </summary>
-        public static readonly DirectProperty<NumericUpDown, string?> TextProperty =
-            AvaloniaProperty.RegisterDirect<NumericUpDown, string?>(nameof(Text), o => o.Text, (o, v) => o.Text = v,
+        public static readonly StyledProperty<string?> TextProperty =
+            AvaloniaProperty.Register<NumericUpDown, string?>(nameof(Text),
                 defaultBindingMode: BindingMode.TwoWay, enableDataValidation: true);
 
         /// <summary>
@@ -104,9 +104,9 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="Value"/> property.
         /// </summary>
-        public static readonly DirectProperty<NumericUpDown, decimal?> ValueProperty =
-            AvaloniaProperty.RegisterDirect<NumericUpDown, decimal?>(nameof(Value), updown => updown.Value,
-                (updown, v) => updown.Value = v, defaultBindingMode: BindingMode.TwoWay, enableDataValidation: true);
+        public static readonly StyledProperty<decimal?> ValueProperty =
+            AvaloniaProperty.Register<NumericUpDown, decimal?>(nameof(Value), coerce: (s,v) => ((NumericUpDown)s).OnCoerceValue(v),
+                defaultBindingMode: BindingMode.TwoWay, enableDataValidation: true);
 
         /// <summary>
         /// Defines the <see cref="Watermark"/> property.
@@ -128,8 +128,6 @@ namespace Avalonia.Controls
 
         private IDisposable? _textBoxTextChangedSubscription;
 
-        private decimal? _value;
-        private string? _text;
         private bool _internalValueSet;
         private bool _isSyncingTextAndValueProperties;
         private bool _isTextChangedFromUI;
@@ -250,8 +248,8 @@ namespace Avalonia.Controls
         /// </summary>
         public string? Text
         {
-            get { return _text; }
-            set { SetAndRaise(TextProperty, ref _text, value); }
+            get => GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
         }
 
         /// <summary>
@@ -270,12 +268,8 @@ namespace Avalonia.Controls
         /// </summary>
         public decimal? Value
         {
-            get { return _value; }
-            set
-            {
-                value = OnCoerceValue(value);
-                SetAndRaise(ValueProperty, ref _value, value);
-            }
+            get => GetValue(ValueProperty);
+            set => SetValue(ValueProperty, value);
         }
 
         /// <summary>
@@ -500,7 +494,7 @@ namespace Avalonia.Controls
                 SyncTextAndValueProperties(true, Text);
             }
         }
-        
+
         /// <summary>
         /// Called when the <see cref="Text"/> property value changed.
         /// </summary>
@@ -667,7 +661,7 @@ namespace Avalonia.Controls
             {
                 result = Minimum;
             }
-            
+
             SetCurrentValue(ValueProperty, MathUtilities.Clamp(result, Minimum, Maximum));
         }
 
@@ -677,7 +671,7 @@ namespace Avalonia.Controls
         private void OnDecrement()
         {
             decimal result;
-            
+
             if (Value.HasValue)
             {
                 result = Value.Value - Increment;
@@ -686,7 +680,7 @@ namespace Avalonia.Controls
             {
                 result = Maximum;
             }
-            
+
             SetCurrentValue(ValueProperty, MathUtilities.Clamp(result, Minimum, Maximum));
         }
 
@@ -704,7 +698,7 @@ namespace Avalonia.Controls
                 {
                     validDirections = ValidSpinDirections.Increase | ValidSpinDirections.Decrease;
                 }
-                
+
                 if (Value < Maximum)
                 {
                     validDirections = validDirections | ValidSpinDirections.Increase;
@@ -1058,7 +1052,7 @@ namespace Avalonia.Controls
             {
                 return null;
             }
-            
+
             if (TextConverter != null)
             {
                 var valueFromText = TextConverter.Convert(text, typeof(decimal?), null, CultureInfo.CurrentCulture);

--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -156,16 +156,13 @@ namespace Avalonia.Controls.Presenters
         /// <summary>
         /// Defines the <see cref="RecognizesAccessKey"/> property
         /// </summary>
-        public static readonly DirectProperty<ContentPresenter, bool> RecognizesAccessKeyProperty =
-            AvaloniaProperty.RegisterDirect<ContentPresenter, bool>(
-                nameof(RecognizesAccessKey),
-                cp => cp.RecognizesAccessKey, (cp, value) => cp.RecognizesAccessKey = value);
+        public static readonly StyledProperty<bool> RecognizesAccessKeyProperty =
+            AvaloniaProperty.Register<ContentPresenter, bool>(nameof(RecognizesAccessKey));
 
         private Control? _child;
         private bool _createdChild;
         private IRecyclingDataTemplate? _recyclingDataTemplate;
         private readonly BorderRenderHelper _borderRenderer = new BorderRenderHelper();
-        private bool _recognizesAccessKey;
 
         /// <summary>
         /// Initializes static members of the <see cref="ContentPresenter"/> class.
@@ -386,8 +383,8 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         public bool RecognizesAccessKey
         {
-            get => _recognizesAccessKey;
-            set => SetAndRaise(RecognizesAccessKeyProperty, ref _recognizesAccessKey, value);
+            get => GetValue(RecognizesAccessKeyProperty);
+            set => SetValue(RecognizesAccessKeyProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
@@ -166,7 +166,7 @@ namespace Avalonia.Controls.Presenters
                 }
 
                 Panel = ItemsPanel.Build();
-                Panel.SetValue(TemplatedParentProperty, TemplatedParent);
+                Panel.TemplatedParent = TemplatedParent;
                 Panel.IsItemsHost = true;
                 _scrollSnapPointsInfo = Panel as IScrollSnapPointsInfo;
                 LogicalChildren.Add(Panel);

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -2,7 +2,6 @@ using System;
 using System.ComponentModel;
 using Avalonia.Reactive;
 using Avalonia.Automation.Peers;
-using Avalonia.Controls.Mixins;
 using Avalonia.Controls.Diagnostics;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives.PopupPositioning;
@@ -41,11 +40,8 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Defines the <see cref="IsOpen"/> property.
         /// </summary>
-        public static readonly DirectProperty<Popup, bool> IsOpenProperty =
-            AvaloniaProperty.RegisterDirect<Popup, bool>(
-                nameof(IsOpen),
-                o => o.IsOpen,
-                (o, v) => o.IsOpen = v);
+        public static readonly StyledProperty<bool> IsOpenProperty =
+            AvaloniaProperty.Register<Popup, bool>(nameof(IsOpen));
 
         /// <summary>
         /// Defines the <see cref="PlacementAnchor"/> property.
@@ -90,11 +86,8 @@ namespace Avalonia.Controls.Primitives
         public static readonly StyledProperty<bool> OverlayDismissEventPassThroughProperty =
             AvaloniaProperty.Register<Popup, bool>(nameof(OverlayDismissEventPassThrough));
 
-        public static readonly DirectProperty<Popup, IInputElement?> OverlayInputPassThroughElementProperty =
-            AvaloniaProperty.RegisterDirect<Popup, IInputElement?>(
-                nameof(OverlayInputPassThroughElement),
-                o => o.OverlayInputPassThroughElement,
-                (o, v) => o.OverlayInputPassThroughElement = v);
+        public static readonly StyledProperty<IInputElement?> OverlayInputPassThroughElementProperty =
+            AvaloniaProperty.Register<Popup, IInputElement?>(nameof(OverlayInputPassThroughElement));
 
         /// <summary>
         /// Defines the <see cref="HorizontalOffset"/> property.
@@ -121,10 +114,8 @@ namespace Avalonia.Controls.Primitives
             AvaloniaProperty.Register<Popup, bool>(nameof(Topmost));
 
         private bool _isOpenRequested;
-        private bool _isOpen;
         private bool _ignoreIsOpenChanged;
         private PopupOpenState? _openState;
-        private IInputElement? _overlayInputPassThroughElement;
         private Action<IPopupHost?>? _popupHostChangedHandler;
 
         /// <summary>
@@ -209,8 +200,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public bool IsOpen
         {
-            get { return _isOpen; }
-            set { SetAndRaise(IsOpenProperty, ref _isOpen, value); }
+            get => GetValue(IsOpenProperty);
+            set => SetValue(IsOpenProperty, value);
         }
 
         /// <summary>
@@ -301,8 +292,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public IInputElement? OverlayInputPassThroughElement
         {
-            get => _overlayInputPassThroughElement;
-            set => SetAndRaise(OverlayInputPassThroughElementProperty, ref _overlayInputPassThroughElement, value);
+            get => GetValue(OverlayInputPassThroughElementProperty);
+            set => SetValue(OverlayInputPassThroughElementProperty, value);
         }
 
         /// <summary>
@@ -486,7 +477,7 @@ namespace Avalonia.Controls.Primitives
 
             using (BeginIgnoringIsOpen())
             {
-                IsOpen = true;
+                SetCurrentValue(IsOpenProperty, true);
             }
 
             Opened?.Invoke(this, EventArgs.Empty);
@@ -704,7 +695,7 @@ namespace Avalonia.Controls.Primitives
             {
                 using (BeginIgnoringIsOpen())
                 {
-                    IsOpen = false;
+                    SetCurrentValue(IsOpenProperty, false);
                 }
 
                 return;
@@ -717,7 +708,7 @@ namespace Avalonia.Controls.Primitives
 
             using (BeginIgnoringIsOpen())
             {
-                IsOpen = false;
+                SetCurrentValue(IsOpenProperty, false);
             }
 
             Closed?.Invoke(this, EventArgs.Empty);

--- a/src/Avalonia.Controls/Primitives/TemplatedControl.cs
+++ b/src/Avalonia.Controls/Primitives/TemplatedControl.cs
@@ -275,7 +275,7 @@ namespace Avalonia.Controls.Primitives
                 {
                     foreach (var child in this.GetTemplateChildren())
                     {
-                        child.SetValue(TemplatedParentProperty, null);
+                        child.TemplatedParent = null;
                         ((ISetLogicalParent)child).SetParent(null);
                     }
 
@@ -377,7 +377,7 @@ namespace Avalonia.Controls.Primitives
         /// <param name="templatedParent">The templated parent to apply.</param>
         internal static void ApplyTemplatedParent(StyledElement control, AvaloniaObject? templatedParent)
         {
-            control.SetValue(TemplatedParentProperty, templatedParent);
+            control.TemplatedParent = templatedParent;
 
             var children = control.LogicalChildren;
             var count = children.Count;

--- a/src/Avalonia.Controls/Primitives/ToggleButton.cs
+++ b/src/Avalonia.Controls/Primitives/ToggleButton.cs
@@ -15,12 +15,8 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Defines the <see cref="IsChecked"/> property.
         /// </summary>
-        public static readonly DirectProperty<ToggleButton, bool?> IsCheckedProperty =
-            AvaloniaProperty.RegisterDirect<ToggleButton, bool?>(
-                nameof(IsChecked),
-                o => o.IsChecked,
-                (o, v) => o.IsChecked = v,
-                unsetValue: false,
+        public static readonly StyledProperty<bool?> IsCheckedProperty =
+            AvaloniaProperty.Register<ToggleButton, bool?>(nameof(IsChecked), false,
                 defaultBindingMode: BindingMode.TwoWay);
 
         /// <summary>
@@ -63,8 +59,6 @@ namespace Avalonia.Controls.Primitives
             RoutedEvent.Register<ToggleButton, RoutedEventArgs>(
                 nameof(IsCheckedChanged),
                 RoutingStrategies.Bubble);
-
-        private bool? _isChecked = false;
 
         static ToggleButton()
         {
@@ -119,12 +113,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public bool? IsChecked
         {
-            get => _isChecked;
-            set 
-            { 
-                SetAndRaise(IsCheckedProperty, ref _isChecked, value);
-                UpdatePseudoClasses(IsChecked);
-            }
+            get => GetValue(IsCheckedProperty);
+            set => SetValue(IsCheckedProperty, value);
         }
 
         /// <summary>
@@ -147,28 +137,31 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         protected virtual void Toggle()
         {
+            bool? newValue;
             if (IsChecked.HasValue)
             {
                 if (IsChecked.Value)
                 {
                     if (IsThreeState)
                     {
-                        IsChecked = null;
+                        newValue = null;
                     }
                     else
                     {
-                        IsChecked = false;
+                        newValue = false;
                     }
                 }
                 else
                 {
-                    IsChecked = true;
+                    newValue = true;
                 }
             }
             else
             {
-                IsChecked = false;
+                newValue = false;
             }
+
+            SetCurrentValue(IsCheckedProperty, newValue);
         }
 
         /// <summary>
@@ -223,6 +216,8 @@ namespace Avalonia.Controls.Primitives
             if (change.Property == IsCheckedProperty)
             {
                 var newValue = change.GetNewValue<bool?>();
+
+                UpdatePseudoClasses(newValue);
 
 #pragma warning disable CS0618 // Type or member is obsolete
                 switch (newValue)

--- a/src/Avalonia.Controls/SplitButton/SplitButton.cs
+++ b/src/Avalonia.Controls/SplitButton/SplitButton.cs
@@ -42,10 +42,8 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="Command"/> property.
         /// </summary>
-        public static readonly DirectProperty<SplitButton, ICommand?> CommandProperty =
-            Button.CommandProperty.AddOwner<SplitButton>(
-                splitButton => splitButton.Command,
-                (splitButton, command) => splitButton.Command = command);
+        public static readonly StyledProperty<ICommand?> CommandProperty =
+            Button.CommandProperty.AddOwner<SplitButton>();
 
         /// <summary>
         /// Defines the <see cref="CommandParameter"/> property.
@@ -58,8 +56,6 @@ namespace Avalonia.Controls
         /// </summary>
         public static readonly StyledProperty<FlyoutBase?> FlyoutProperty =
             Button.FlyoutProperty.AddOwner<SplitButton>();
-
-        private ICommand? _Command;
 
         private Button? _primaryButton   = null;
         private Button? _secondaryButton = null;
@@ -83,8 +79,8 @@ namespace Avalonia.Controls
         /// </summary>
         public ICommand? Command
         {
-            get => _Command;
-            set => SetAndRaise(CommandProperty, ref _Command, value);
+            get => GetValue(CommandProperty);
+            set => SetValue(CommandProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/TrayIcon.cs
+++ b/src/Avalonia.Controls/TrayIcon.cs
@@ -13,13 +13,10 @@ namespace Avalonia.Controls
     public sealed class TrayIcons : AvaloniaList<TrayIcon>
     {
     }
-    
-    
 
     public class TrayIcon : AvaloniaObject, INativeMenuExporterProvider, IDisposable
     {
         private readonly ITrayIconImpl? _impl;
-        private ICommand? _command;
 
         private TrayIcon(ITrayIconImpl? impl)
         {
@@ -85,11 +82,8 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="Command"/> property.
         /// </summary>
-        public static readonly DirectProperty<TrayIcon, ICommand?> CommandProperty =
-            Button.CommandProperty.AddOwner<TrayIcon>(
-                trayIcon => trayIcon.Command,
-                (trayIcon, command) => trayIcon.Command = command,
-                enableDataValidation: true);
+        public static readonly StyledProperty<ICommand?> CommandProperty =
+            Button.CommandProperty.AddOwner<TrayIcon>(new(enableDataValidation: true));
 
         /// <summary>
         /// Defines the <see cref="CommandParameter"/> property.
@@ -136,8 +130,8 @@ namespace Avalonia.Controls
         /// </summary>
         public ICommand? Command
         {
-            get => _command;
-            set => SetAndRaise(CommandProperty, ref _command, value);
+            get => GetValue(CommandProperty);
+            set => SetValue(CommandProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -104,12 +104,12 @@ namespace Avalonia.Controls
 
             if (ItemTemplate == null && _treeView?.ItemTemplate != null)
             {
-                ItemTemplate = _treeView.ItemTemplate;
+                SetCurrentValue(ItemTemplateProperty, _treeView.ItemTemplate);
             }
 
             if (ItemContainerTheme == null && _treeView?.ItemContainerTheme != null)
             {
-                ItemContainerTheme = _treeView.ItemContainerTheme;
+                SetCurrentValue(ItemContainerThemeProperty, _treeView.ItemContainerTheme);
             }
         }
 

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
-using Avalonia.Reactive;
 using System.Threading.Tasks;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Platform;
@@ -11,6 +9,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Platform;
+using Avalonia.Reactive;
 using Avalonia.Styling;
 
 namespace Avalonia.Controls
@@ -149,11 +148,8 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="WindowStartupLocation"/> property.
         /// </summary>
-        public static readonly DirectProperty<Window, WindowStartupLocation> WindowStartupLocationProperty =
-            AvaloniaProperty.RegisterDirect<Window, WindowStartupLocation>(
-                nameof(WindowStartupLocation),
-                o => o.WindowStartupLocation,
-                (o, v) => o.WindowStartupLocation = v);
+        public static readonly StyledProperty<WindowStartupLocation> WindowStartupLocationProperty =
+            AvaloniaProperty.Register<Window, WindowStartupLocation>(nameof(WindowStartupLocation));
 
         public static readonly StyledProperty<bool> CanResizeProperty =
             AvaloniaProperty.Register<Window, bool>(nameof(CanResize), true);
@@ -171,7 +167,6 @@ namespace Avalonia.Controls
             RoutedEvent.Register<Window, RoutedEventArgs>("WindowOpened", RoutingStrategies.Direct);
         private object? _dialogResult;
         private readonly Size _maxPlatformClientSize;
-        private WindowStartupLocation _windowStartupLocation;
         private bool _shown;
         private bool _showingAsDialog;
 
@@ -305,7 +300,7 @@ namespace Avalonia.Controls
         {
             get => GetValue(ExtendClientAreaTitleBarHeightHintProperty);
             set => SetValue(ExtendClientAreaTitleBarHeightHintProperty, value);
-        }        
+        }
 
         /// <summary>
         /// Gets if the ClientArea is Extended into the Window Decorations.
@@ -314,7 +309,7 @@ namespace Avalonia.Controls
         {
             get => _isExtendedIntoWindowDecorations;
             private set => SetAndRaise(IsExtendedIntoWindowDecorationsProperty, ref _isExtendedIntoWindowDecorations, value);
-        }        
+        }
 
         /// <summary>
         /// Gets the WindowDecorationMargin.
@@ -324,7 +319,7 @@ namespace Avalonia.Controls
         {
             get => _windowDecorationMargin;
             private set => SetAndRaise(WindowDecorationMarginProperty, ref _windowDecorationMargin, value);
-        }        
+        }
 
         /// <summary>
         /// Gets the window margin that is hidden off the screen area.
@@ -397,8 +392,8 @@ namespace Avalonia.Controls
         /// </summary>
         public WindowStartupLocation WindowStartupLocation
         {
-            get { return _windowStartupLocation; }
-            set { SetAndRaise(WindowStartupLocationProperty, ref _windowStartupLocation, value); }
+            get => GetValue(WindowStartupLocationProperty);
+            set => SetValue(WindowStartupLocationProperty, value);
         }
 
         /// <summary>
@@ -488,7 +483,7 @@ namespace Avalonia.Controls
                 CloseInternal();
                 return false;
             }
-            
+
             return true;
         }
 
@@ -614,7 +609,7 @@ namespace Avalonia.Controls
 
                 if (_shown != isVisible)
                 {
-                    if(!_shown)
+                    if (!_shown)
                     {
                         Show();
                     }
@@ -657,7 +652,7 @@ namespace Avalonia.Controls
                 throw new InvalidOperationException("Cannot re-show a closed window.");
             }
         }
-        
+
         private void EnsureParentStateBeforeShow(Window owner)
         {
             if (owner.PlatformImpl == null)
@@ -819,7 +814,7 @@ namespace Avalonia.Controls
         {
             bool isEnabled = true;
 
-            foreach (var (_, isDialog)  in _children)
+            foreach (var (_, isDialog) in _children)
             {
                 if (isDialog)
                 {
@@ -856,7 +851,7 @@ namespace Avalonia.Controls
         {
             Window? firstDialogChild = null;
 
-            foreach (var (child, isDialog)  in _children)
+            foreach (var (child, isDialog) in _children)
             {
                 if (isDialog)
                 {
@@ -880,7 +875,7 @@ namespace Avalonia.Controls
             var startupLocation = WindowStartupLocation;
 
             if (startupLocation == WindowStartupLocation.CenterOwner &&
-                (owner is null || 
+                (owner is null ||
                  (Owner is Window ownerWindow && ownerWindow.WindowState == WindowState.Minimized))
                 )
             {
@@ -902,7 +897,7 @@ namespace Avalonia.Controls
 
                 if (owner is not null)
                 {
-                    screen = Screens.ScreenFromWindow(owner) 
+                    screen = Screens.ScreenFromWindow(owner)
                              ?? Screens.ScreenFromPoint(owner.Position);
                 }
 

--- a/src/Avalonia.Controls/WindowBase.cs
+++ b/src/Avalonia.Controls/WindowBase.cs
@@ -27,10 +27,7 @@ namespace Avalonia.Controls
         /// Defines the <see cref="Owner"/> property.
         /// </summary>
         public static readonly DirectProperty<WindowBase, WindowBase?> OwnerProperty =
-            AvaloniaProperty.RegisterDirect<WindowBase, WindowBase?>(
-                nameof(Owner),
-                o => o.Owner,
-                (o, v) => o.Owner = v);
+            AvaloniaProperty.RegisterDirect<WindowBase, WindowBase?>(nameof(Owner), o => o.Owner);
 
         public static readonly StyledProperty<bool> TopmostProperty =
             AvaloniaProperty.Register<WindowBase, bool>(nameof(Topmost));

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/ThicknessEditor.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/ThicknessEditor.cs
@@ -6,84 +6,73 @@ namespace Avalonia.Diagnostics.Controls
 {
     internal class ThicknessEditor : ContentControl
     {
-        public static readonly DirectProperty<ThicknessEditor, Thickness> ThicknessProperty =
-            AvaloniaProperty.RegisterDirect<ThicknessEditor, Thickness>(nameof(Thickness), o => o.Thickness,
-                (o, v) => o.Thickness = v, defaultBindingMode: BindingMode.TwoWay);
+        public static readonly StyledProperty<Thickness> ThicknessProperty =
+            AvaloniaProperty.Register<ThicknessEditor, Thickness>(nameof(Thickness), 
+                defaultBindingMode: BindingMode.TwoWay);
 
-        public static readonly DirectProperty<ThicknessEditor, string?> HeaderProperty =
-            AvaloniaProperty.RegisterDirect<ThicknessEditor, string?>(nameof(Header), o => o.Header,
-                (o, v) => o.Header = v);
+        public static readonly StyledProperty<string?> HeaderProperty =
+            AvaloniaProperty.Register<ThicknessEditor, string?>(nameof(Header));
 
-        public static readonly DirectProperty<ThicknessEditor, bool> IsPresentProperty =
-            AvaloniaProperty.RegisterDirect<ThicknessEditor, bool>(nameof(IsPresent), o => o.IsPresent,
-                (o, v) => o.IsPresent = v);
+        public static readonly StyledProperty<bool> IsPresentProperty =
+            AvaloniaProperty.Register<ThicknessEditor, bool>(nameof(IsPresent), true);
 
-        public static readonly DirectProperty<ThicknessEditor, double> LeftProperty =
-            AvaloniaProperty.RegisterDirect<ThicknessEditor, double>(nameof(Left), o => o.Left, (o, v) => o.Left = v);
+        public static readonly StyledProperty<double> LeftProperty =
+            AvaloniaProperty.Register<ThicknessEditor, double>(nameof(Left));
 
-        public static readonly DirectProperty<ThicknessEditor, double> TopProperty =
-            AvaloniaProperty.RegisterDirect<ThicknessEditor, double>(nameof(Top), o => o.Top, (o, v) => o.Top = v);
+        public static readonly StyledProperty<double> TopProperty =
+            AvaloniaProperty.Register<ThicknessEditor, double>(nameof(Top));
 
-        public static readonly DirectProperty<ThicknessEditor, double> RightProperty =
-            AvaloniaProperty.RegisterDirect<ThicknessEditor, double>(nameof(Right), o => o.Right,
-                (o, v) => o.Right = v);
+        public static readonly StyledProperty<double> RightProperty =
+            AvaloniaProperty.Register<ThicknessEditor, double>(nameof(Right));
 
-        public static readonly DirectProperty<ThicknessEditor, double> BottomProperty =
-            AvaloniaProperty.RegisterDirect<ThicknessEditor, double>(nameof(Bottom), o => o.Bottom,
-                (o, v) => o.Bottom = v);
+        public static readonly StyledProperty<double> BottomProperty =
+            AvaloniaProperty.Register<ThicknessEditor, double>(nameof(Bottom));
 
         public static readonly StyledProperty<IBrush> HighlightProperty =
             AvaloniaProperty.Register<ThicknessEditor, IBrush>(nameof(Highlight));
 
-        private Thickness _thickness;
-        private string? _header;
-        private bool _isPresent = true;
-        private double _left;
-        private double _top;
-        private double _right;
-        private double _bottom;
         private bool _isUpdatingThickness;
 
         public Thickness Thickness
         {
-            get => _thickness;
-            set => SetAndRaise(ThicknessProperty, ref _thickness, value);
+            get => GetValue(ThicknessProperty);
+            set => SetValue(ThicknessProperty, value);
         }
 
         public string? Header
         {
-            get => _header;
-            set => SetAndRaise(HeaderProperty, ref _header, value);
+            get => GetValue(HeaderProperty);
+            set => SetValue(HeaderProperty, value);
         }
 
         public bool IsPresent
         {
-            get => _isPresent;
-            set => SetAndRaise(IsPresentProperty, ref _isPresent, value);
+            get => GetValue(IsPresentProperty);
+            set => SetValue(IsPresentProperty, value);
         }
 
         public double Left
         {
-            get => _left;
-            set => SetAndRaise(LeftProperty, ref _left, value);
+            get => GetValue(LeftProperty);
+            set => SetValue(LeftProperty, value);
         }
 
         public double Top
         {
-            get => _top;
-            set => SetAndRaise(TopProperty, ref _top, value);
+            get => GetValue(TopProperty);
+            set => SetValue(TopProperty, value);
         }
 
         public double Right
         {
-            get => _right;
-            set => SetAndRaise(RightProperty, ref _right, value);
+            get => GetValue(RightProperty);
+            set => SetValue(RightProperty, value);
         }
 
         public double Bottom
         {
-            get => _bottom;
-            set => SetAndRaise(BottomProperty, ref _bottom, value);
+            get => GetValue(BottomProperty);
+            set => SetValue(BottomProperty, value);
         }
 
         public IBrush Highlight
@@ -104,10 +93,10 @@ namespace Avalonia.Diagnostics.Controls
 
                     var value = change.GetNewValue<Thickness>();
 
-                    Left = value.Left;
-                    Top = value.Top;
-                    Right = value.Right;
-                    Bottom = value.Bottom;
+                    SetCurrentValue(LeftProperty, value.Left);
+                    SetCurrentValue(TopProperty, value.Top);
+                    SetCurrentValue(RightProperty, value.Right);
+                    SetCurrentValue(BottomProperty, value.Bottom);
                 }
                 finally
                 {
@@ -118,7 +107,7 @@ namespace Avalonia.Diagnostics.Controls
                      (change.Property == LeftProperty || change.Property == TopProperty ||
                       change.Property == RightProperty || change.Property == BottomProperty))
             {
-                Thickness = new Thickness(Left, Top, Right, Bottom);
+                SetCurrentValue(ThicknessProperty, new(Left, Top, Right, Bottom));
             }
         }
     }

--- a/src/Markup/Avalonia.Markup/Data/TemplateBinding.cs
+++ b/src/Markup/Avalonia.Markup/Data/TemplateBinding.cs
@@ -104,9 +104,7 @@ namespace Avalonia.Data
                         CultureInfo.CurrentCulture);
                 }
 
-                // Use LocalValue priority here, as TemplatedParent doesn't make sense on controls
-                // that aren't template children.
-                templatedParent.SetValue(Property, value, BindingPriority.LocalValue);
+                templatedParent.SetCurrentValue(Property, value);
             }
         }
 

--- a/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Template.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/SelectorTests_Template.cs
@@ -35,7 +35,7 @@ namespace Avalonia.Base.UnitTests.Styling
                 .Template()
                 .OfType<Border>();
 
-            border.SetValue(StyledElement.TemplatedParentProperty, null);
+            border.TemplatedParent = null;
 
             Assert.Equal(SelectorMatchResult.NeverThisInstance, selector.Match(border).Result);
         }
@@ -124,10 +124,10 @@ namespace Avalonia.Base.UnitTests.Styling
             {
                 VisualChildren.Add(new Border
                 {
-                    [TemplatedParentProperty] = this,
+                    TemplatedParent = this,
                     Child = new TextBlock
                     {
-                        [TemplatedParentProperty] = this,
+                        TemplatedParent = this,
                     },
                 });
             }

--- a/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
@@ -131,7 +131,7 @@ namespace Avalonia.Controls.UnitTests
                 root.Content = target;
 
                 var templatedParent = new Button();
-                target.SetValue(StyledElement.TemplatedParentProperty, templatedParent);
+                target.TemplatedParent = templatedParent;
                 target.Template = GetTemplate();
 
                 target.Items = new[] { "Foo" };

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_InTemplate.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ContentPresenterTests_InTemplate.cs
@@ -26,7 +26,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
 
             Assert.Null(host.Presenter);
 
-            target.SetValue(Control.TemplatedParentProperty, host);
+            target.TemplatedParent = host;
 
             Assert.Same(target, host.Presenter);
         }

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ItemsPresenterTests.cs
@@ -22,7 +22,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
 
             Assert.Null(host.Presenter);
 
-            target.SetValue(Control.TemplatedParentProperty, host);
+            target.TemplatedParent = host;
 
             Assert.Same(target, host.Presenter);
         }

--- a/tests/Avalonia.Controls.UnitTests/Templates/TemplateExtensionsTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Templates/TemplateExtensionsTests.cs
@@ -18,17 +18,17 @@ namespace Avalonia.Controls.Templates.UnitTests
             var border1 = new Border
             {
                 Name = "border1",
-                [StyledElement.TemplatedParentProperty] = target,
+                TemplatedParent = target,
             };
             var inner = new TestTemplatedControl
             {
                 Name = "inner",
-                [StyledElement.TemplatedParentProperty] = target,
+                TemplatedParent = target,
             };
-            var border2 = new Border { Name = "border2", [StyledElement.TemplatedParentProperty] = inner };
-            var border3 = new Border { Name = "border3", [StyledElement.TemplatedParentProperty] = inner };
-            var border4 = new Border { Name = "border4", [StyledElement.TemplatedParentProperty] = target };
-            var border5 = new Border { Name = "border5", [StyledElement.TemplatedParentProperty] = null };
+            var border2 = new Border { Name = "border2", TemplatedParent = inner };
+            var border3 = new Border { Name = "border3", TemplatedParent = inner };
+            var border4 = new Border { Name = "border4", TemplatedParent = target };
+            var border5 = new Border { Name = "border5", TemplatedParent = null };
 
             target.AddVisualChild(border1);
             border1.Child = inner;

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/XamlIlTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/XamlIlTests.cs
@@ -22,17 +22,6 @@ namespace Avalonia.Markup.Xaml.UnitTests
     public class XamlIlTests : XamlTestBase
     {
         [Fact]
-        public void Binding_Button_IsPressed_ShouldWork()
-        {
-            var parsed = (Button)AvaloniaRuntimeXamlLoader.Parse(@"
-<Button xmlns='https://github.com/avaloniaui' IsPressed='{Binding IsPressed, Mode=TwoWay}' />");
-            var ctx = new XamlIlBugTestsDataContext();
-            parsed.DataContext = ctx;
-            parsed.SetValue(Button.IsPressedProperty, true);
-            Assert.True(ctx.IsPressed);
-        }
-
-        [Fact]
         public void Transitions_Should_Be_Properly_Parsed()
         {
             var parsed = (Grid)AvaloniaRuntimeXamlLoader.Parse(@"
@@ -426,7 +415,6 @@ namespace Avalonia.Markup.Xaml.UnitTests
 
     public class XamlIlBugTestsDataContext : INotifyPropertyChanged
     {
-        public bool IsPressed { get; set; }
         public event PropertyChangedEventHandler PropertyChanged;
 
         protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)


### PR DESCRIPTION
## What does the pull request do?
This is the first change which directly addresses #9944, the end goal of which is to avoid public `DirectProperty` setters on types which derive from `StyledElement`.

## What is the current behavior?
See #9944.

## What is the updated/expected behavior with this PR?
This PR refactors a large batch of properties from `DirectProperty` to `StyledProperty`. The new `SetCurrentValue` method is now used to set the value of refactored properties, where necessary.

Only properties which could be easily changed are included. Properties with complicated behaviours will be handled in smaller PRs.

There are some additional changes:

* In a few cases, a `DirectProperty` was not changed to `StyledProperty`, but instead had its setter removed. `StyledElement.TemplatedParent` is a notable example: the CLR property has an internal setter, but this could be evaded by calling `SetValue(TemplatedParentProperty)`. Closing backdoors like these reduces Avalonia's API surface.
* `TemplateBinding` now uses `SetCurrentValue`.
* The various property `AddOwner` methods now accept a metadata object, mirroring WPF's API.
* `ComboBox.SelectionBoxItem` has been changed from a protected property to a public property with a protected setter. This better reflects the accessibility of the `DirectProperty` it wraps around.
* `Button.IsPressed` has been changed to a read-only `DirectProperty`, and an old test that tried to data bind to it has been removed.

## Breaking changes
* The refactored properties now function with binding priorities. This means that when a value source is removed, the property now reverts to a different value source (or the default value). Anyone who relied on the old, broken behaviour of the value remaining unchanged in this scenario will have to refactor their code.
* Anyone who calls `AddOwner` on a refactored property will have to refactor their controls to match the new property type.
* Anyone sneakily calling internal C# property setters with the incorrectly-exposed `DirectProperty` setters that this PR removes will have to stop hacking Avalonia. 🤡

## Obsoletions / Deprecations
None

## Fixed issues
Part of #9944