### PR TITLE
Remove duplicate OpenGL members

### DIFF
--- a/src/Avalonia.OpenGL/GlInterface.cs
+++ b/src/Avalonia.OpenGL/GlInterface.cs
@@ -73,9 +73,6 @@ namespace Avalonia.OpenGL
         [GetProcAddress("glFinish")]
         public partial void Finish();
 
-        [GetProcAddress("glGetIntegerv")]
-        public partial void GetIntegerv(int name, out int rv);
-
         [GetProcAddress("glGenFramebuffers")]
         public partial void GenFramebuffers(int count, int* res);
 

--- a/src/Avalonia.OpenGL/IGlContext.cs
+++ b/src/Avalonia.OpenGL/IGlContext.cs
@@ -12,7 +12,6 @@ namespace Avalonia.OpenGL
         int SampleCount { get; }
         int StencilSize { get; }
         IDisposable MakeCurrent();
-        IDisposable EnsureCurrent();
         bool IsSharedWith(IGlContext context);
         bool CanCreateSharedContext { get; }
         IGlContext? CreateSharedContext(IEnumerable<GlVersion>? preferredVersions = null);


### PR DESCRIPTION
Removes two members (and two associated warnings) in `Avalonia.OpenGL` that already exist in their base type:
 - `GlInterface.GetIntegerv` (present in `GlBasicInfoInterface`)
 - `IGlContext.EnsureCurrent` (present in `IPlatformGraphicsContext`)