### PR TITLE
Tweak API for raising direct property changes.

### DIFF
--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -664,14 +664,12 @@ namespace Avalonia
         /// <param name="property">The property that has changed.</param>
         /// <param name="oldValue">The old property value.</param>
         /// <param name="newValue">The new property value.</param>
-        /// <param name="priority">The priority of the binding that produced the value.</param>
         protected void RaisePropertyChanged<T>(
             DirectPropertyBase<T> property,
-            Optional<T> oldValue,
-            BindingValue<T> newValue,
-            BindingPriority priority = BindingPriority.LocalValue)
+            T oldValue,
+            T newValue)
         {
-            RaisePropertyChanged(property, oldValue, newValue, priority, true);
+            RaisePropertyChanged(property, oldValue, newValue, BindingPriority.LocalValue, true);
         }
 
         /// <summary>
@@ -720,7 +718,7 @@ namespace Avalonia
         /// <returns>
         /// True if the value changed, otherwise false.
         /// </returns>
-        protected bool SetAndRaise<T>(AvaloniaProperty<T> property, ref T field, T value)
+        protected bool SetAndRaise<T>(DirectPropertyBase<T> property, ref T field, T value)
         {
             VerifyAccess();
 

--- a/src/Avalonia.Base/StyledElement.cs
+++ b/src/Avalonia.Base/StyledElement.cs
@@ -524,13 +524,7 @@ namespace Avalonia
                     NotifyResourcesChanged();
                 }
 
-#nullable disable
-                RaisePropertyChanged(
-                    ParentProperty,
-                    new Optional<StyledElement>(old),
-                    new BindingValue<StyledElement>(Parent),
-                    BindingPriority.LocalValue);
-#nullable enable
+                RaisePropertyChanged(ParentProperty, old, Parent);
             }
         }
 

--- a/src/Avalonia.Base/Visual.cs
+++ b/src/Avalonia.Base/Visual.cs
@@ -573,7 +573,7 @@ namespace Avalonia
         /// <param name="newParent">The new visual parent.</param>
         protected virtual void OnVisualParentChanged(Visual? oldParent, Visual? newParent)
         {
-            RaisePropertyChanged(VisualParentProperty, oldParent, newParent, BindingPriority.LocalValue);
+            RaisePropertyChanged(VisualParentProperty, oldParent, newParent);
         }
 
         internal override ParametrizedLogger? GetBindingWarningLogger(

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -345,10 +345,7 @@ namespace Avalonia.Controls.Primitives
 
                     if (_oldSelectedItems != SelectedItems)
                     {
-                        RaisePropertyChanged(
-                            SelectedItemsProperty,
-                            new Optional<IList?>(_oldSelectedItems),
-                            new BindingValue<IList?>(SelectedItems));
+                        RaisePropertyChanged(SelectedItemsProperty, _oldSelectedItems, SelectedItems);
                         _oldSelectedItems = SelectedItems;
                     }
                 }
@@ -909,10 +906,7 @@ namespace Avalonia.Controls.Primitives
             else if (e.PropertyName == nameof(InternalSelectionModel.WritableSelectedItems) &&
                      _oldSelectedItems != (Selection as InternalSelectionModel)?.SelectedItems)
             {
-                RaisePropertyChanged(
-                    SelectedItemsProperty,
-                    new Optional<IList?>(_oldSelectedItems),
-                    new BindingValue<IList?>(SelectedItems));
+                RaisePropertyChanged(SelectedItemsProperty, _oldSelectedItems, SelectedItems);
                 _oldSelectedItems = SelectedItems;
             }
             else if (e.PropertyName == nameof(ISelectionModel.Source))


### PR DESCRIPTION
## What does the pull request do?

While working on adding support for data validation to styled properties, I noticed that the API for raising change notifications for direct properties needed some tweaking:

- Make `SetAndRaise` accept a `DirectPropertyBase` instead of an `AvaloniaProperty`: only direct properties can be changed by this method
- Remove `priority` from `RaisePropertyChanged`: direct property changes are always with `LocalValue` priority
- Remove `Optional` and `BindingValue` wrappers from `RaisePropertyChanged`: concrete values must always be supplied
