### PR TITLE
[DRAFT] Try to use Converter in TreeDataTemplate

### DIFF
--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -390,8 +390,10 @@ namespace Avalonia.Controls
 
                 if (itemTemplate is ITreeDataTemplate treeTemplate)
                 {
-                    if (item is not null && treeTemplate.ItemsSelector(item) is { } itemsBinding)
+                    if (item is not null && treeTemplate.ItemsSelector(item)?.Initiate(hic, ItemsProperty) is { } itemsBinding)
+                    {
                         BindingOperations.Apply(hic, ItemsProperty, itemsBinding, null);
+                    }
                 }
             }
         }

--- a/src/Avalonia.Controls/Templates/FuncTreeDataTemplate.cs
+++ b/src/Avalonia.Controls/Templates/FuncTreeDataTemplate.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using Avalonia.Data;
+using Avalonia.Data.Core;
 
 namespace Avalonia.Controls.Templates
 {
@@ -56,9 +57,10 @@ namespace Avalonia.Controls.Templates
         /// </summary>
         /// <param name="item">The item.</param>
         /// <returns>The child items, or null if no child items.</returns>
-        public InstancedBinding ItemsSelector(object item)
+        public IBinding ItemsSelector(object item)
         {
-            return InstancedBinding.OneTime(_itemsSelector(item));
+            // what should we do here?
+            throw new NotImplementedException();
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Templates/ITreeDataTemplate.cs
+++ b/src/Avalonia.Controls/Templates/ITreeDataTemplate.cs
@@ -15,6 +15,6 @@ namespace Avalonia.Controls.Templates
         /// An <see cref="InstancedBinding"/> holding the items, or an observable that tracks the
         /// items. May return null if no child items.
         /// </returns>
-        InstancedBinding? ItemsSelector(object item);
+        IBinding? ItemsSelector(object item);
     }
 }

--- a/src/Markup/Avalonia.Markup.Xaml/Templates/TreeDataTemplate.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Templates/TreeDataTemplate.cs
@@ -35,21 +35,9 @@ namespace Avalonia.Markup.Xaml.Templates
         }
 
         [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "If ItemsSource is a CompiledBinding, then path members will be preserver")]
-        public InstancedBinding ItemsSelector(object item)
+        public IBinding ItemsSelector(object item)
         {
-            if (ItemsSource != null)
-            {
-                var obs = ItemsSource switch
-                {
-                    Binding reflection => ExpressionObserverBuilder.Build(item, reflection.Path),
-                    CompiledBindingExtension compiled => new ExpressionObserver(item, compiled.Path.BuildExpression(false)),
-                    _ => throw new InvalidOperationException("TreeDataTemplate currently only supports Binding and CompiledBindingExtension!")
-                };
-
-                return InstancedBinding.OneWay(obs, BindingPriority.Style);
-            }
-
-            return null;
+            return ItemsSource;
         }
 
         public Control Build(object data)


### PR DESCRIPTION
## What does the pull request do?
tries to fix an issue where the Binding Converter is ignored by TreeDataTemplate


## What is the current behavior?
See #10379 and #10347 

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
One can use a Converter for ItemsSource

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Return `IBinding` instead of `InstancedBinding` 

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
changed `ITreeDataTemplate`

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #10379