### PR TITLE
Use SetCurrentValue() in TreeViewItem

### DIFF
--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -190,7 +190,7 @@ namespace Avalonia.Controls
                 {
                     if (treeViewItem.ItemCount > 0 && !treeViewItem.IsExpanded)
                     {
-                        treeViewItem.IsExpanded = true;
+                        treeViewItem.SetCurrentValue(IsExpandedProperty, true);
                         return true;
                     }
 
@@ -201,7 +201,7 @@ namespace Avalonia.Controls
                 {
                     if (treeViewItem.ItemCount > 0 && treeViewItem.IsExpanded)
                     {
-                        treeViewItem.IsExpanded = false;
+                        treeViewItem.SetCurrentValue(IsExpandedProperty, false);
                         return true;
                     }
 
@@ -214,7 +214,7 @@ namespace Avalonia.Controls
                     {
                         if (treeViewItem.IsFocused)
                         {
-                            treeViewItem.IsExpanded = false;
+                            treeViewItem.SetCurrentValue(IsExpandedProperty, false);
                         }
                         else
                         {
@@ -265,7 +265,7 @@ namespace Avalonia.Controls
         {
             if (ItemCount > 0)
             {
-                IsExpanded = !IsExpanded;
+                SetCurrentValue(IsExpandedProperty, !IsExpanded);
                 e.Handled = true;
             }
         }


### PR DESCRIPTION
## What does the pull request do?

Continuation of https://github.com/AvaloniaUI/Avalonia/pull/10137 based on the comment https://github.com/AvaloniaUI/Avalonia/pull/10137#pullrequestreview-1280709625.

## What is the current behavior?

TreeViewItem sets IsExpanded internally which will overwrite any bindings.

## What is the updated/expected behavior with this PR?

TreeViewItem still sets IsExpanded internally but used SetCurrentValue() so bindings aren't destroyed.

## How was the solution implemented (if it's not obvious)?

Obvious.

## Checklist

- ~[ ] Added unit tests (if possible)?~
- ~[ ] Added XML documentation to any related classes?~
- ~[ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation~

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues

Part of #9944 and #9985/#10324

