### PR TITLE
Fixes for null reference exception Avalonia.Skia.FontManagerImpl.CreateGlyphTypeface(Typeface typeface)

### DIFF
--- a/build/SharedVersion.props
+++ b/build/SharedVersion.props
@@ -2,8 +2,8 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Avalonia</Product>
-    <Version>11.0.999</Version>
-    <Copyright>Copyright 2022 &#169; The AvaloniaUI Project</Copyright>
+    <Version>11.0.0-preview5</Version>
+    <Copyright>Copyright 2023 &#169; The AvaloniaUI Project</Copyright>
     <PackageProjectUrl>https://avaloniaui.net</PackageProjectUrl>
     <RepositoryUrl>https://github.com/AvaloniaUI/Avalonia/</RepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
I changed null typeface to fallback default Skia Typeface
Currently it throws exception in WASM
