### PR TITLE
Add data validation support to styled properties

### DIFF
--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -776,17 +776,17 @@ namespace Avalonia
                     break;
             }
 
-            UpdateDataValidationCore(property, value.Type, value.Error);
+            var metadata = property.GetMetadata(GetType());
+
+            if (metadata.EnableDataValidation == true)
+            {
+                UpdateDataValidation(property, value.Type, value.Error);
+            }
         }
 
-        internal void UpdateDataValidationCore(AvaloniaProperty property,
-            BindingValueType state,
-            Exception? error)
+        internal void OnUpdateDataValidation(AvaloniaProperty property, BindingValueType state, Exception? error)
         {
-            if (property.GetMetadata(GetType()) is { EnableDataValidation: true })
-            {
-                UpdateDataValidation(property, state, error);
-            }
+            UpdateDataValidation(property, state, error);
         }
 
         /// <summary>

--- a/src/Avalonia.Base/AvaloniaObject.cs
+++ b/src/Avalonia.Base/AvaloniaObject.cs
@@ -776,11 +776,16 @@ namespace Avalonia
                     break;
             }
 
-            var metadata = property.GetMetadata(GetType());
+            UpdateDataValidationCore(property, value.Type, value.Error);
+        }
 
-            if (metadata.EnableDataValidation == true)
+        internal void UpdateDataValidationCore(AvaloniaProperty property,
+            BindingValueType state,
+            Exception? error)
+        {
+            if (property.GetMetadata(GetType()) is { EnableDataValidation: true })
             {
-                UpdateDataValidation(property, value.Type, value.Error);
+                UpdateDataValidation(property, state, error);
             }
         }
 

--- a/src/Avalonia.Base/AvaloniaObjectExtensions.cs
+++ b/src/Avalonia.Base/AvaloniaObjectExtensions.cs
@@ -199,13 +199,11 @@ namespace Avalonia
             property = property ?? throw new ArgumentNullException(nameof(property));
             binding = binding ?? throw new ArgumentNullException(nameof(binding));
 
-            var metadata = property.GetMetadata(target.GetType()) as IDirectPropertyMetadata;
-
             var result = binding.Initiate(
                 target,
                 property,
                 anchor,
-                metadata?.EnableDataValidation ?? false);
+                property.GetMetadata(target.GetType()).EnableDataValidation ?? false);
 
             if (result != null)
             {

--- a/src/Avalonia.Base/AvaloniaProperty.cs
+++ b/src/Avalonia.Base/AvaloniaProperty.cs
@@ -227,6 +227,7 @@ namespace Avalonia
         /// <param name="defaultBindingMode">The default binding mode for the property.</param>
         /// <param name="validate">A value validation callback.</param>
         /// <param name="coerce">A value coercion callback.</param>
+        /// <param name="enableDataValidation">Whether the property is interested in data validation.</param>
         /// <returns>A <see cref="StyledProperty{TValue}"/></returns>
         public static StyledProperty<TValue> Register<TOwner, TValue>(
             string name,
@@ -234,7 +235,8 @@ namespace Avalonia
             bool inherits = false,
             BindingMode defaultBindingMode = BindingMode.OneWay,
             Func<TValue, bool>? validate = null,
-            Func<AvaloniaObject, TValue, TValue>? coerce = null)
+            Func<AvaloniaObject, TValue, TValue>? coerce = null,
+            bool enableDataValidation = false)
                 where TOwner : AvaloniaObject
         {
             _ = name ?? throw new ArgumentNullException(nameof(name));
@@ -242,7 +244,8 @@ namespace Avalonia
             var metadata = new StyledPropertyMetadata<TValue>(
                 defaultValue,
                 defaultBindingMode: defaultBindingMode,
-                coerce: coerce);
+                coerce: coerce,
+                enableDataValidation: enableDataValidation);
 
             var result = new StyledProperty<TValue>(
                 name,
@@ -253,7 +256,7 @@ namespace Avalonia
             AvaloniaPropertyRegistry.Instance.Register(typeof(TOwner), result);
             return result;
         }
-        
+
         /// <inheritdoc cref="Register{TOwner, TValue}" />
         /// <param name="notifying">
         /// A method that gets called before and after the property starts being notified on an
@@ -267,6 +270,7 @@ namespace Avalonia
             BindingMode defaultBindingMode,
             Func<TValue, bool>? validate,
             Func<AvaloniaObject, TValue, TValue>? coerce,
+            bool enableDataValidation,
             Action<AvaloniaObject, bool>? notifying)
                 where TOwner : AvaloniaObject
         {
@@ -275,7 +279,8 @@ namespace Avalonia
             var metadata = new StyledPropertyMetadata<TValue>(
                 defaultValue,
                 defaultBindingMode: defaultBindingMode,
-                coerce: coerce);
+                coerce: coerce,
+                enableDataValidation: enableDataValidation);
 
             var result = new StyledProperty<TValue>(
                 name,

--- a/src/Avalonia.Base/AvaloniaPropertyMetadata.cs
+++ b/src/Avalonia.Base/AvaloniaPropertyMetadata.cs
@@ -13,10 +13,13 @@ namespace Avalonia
         /// Initializes a new instance of the <see cref="AvaloniaPropertyMetadata"/> class.
         /// </summary>
         /// <param name="defaultBindingMode">The default binding mode.</param>
+        /// <param name="enableDataValidation">Whether the property is interested in data validation.</param>
         public AvaloniaPropertyMetadata(
-            BindingMode defaultBindingMode = BindingMode.Default)
+            BindingMode defaultBindingMode = BindingMode.Default,
+            bool? enableDataValidation = null)
         {
             _defaultBindingMode = defaultBindingMode;
+            EnableDataValidation = enableDataValidation;
         }
 
         /// <summary>
@@ -32,6 +35,17 @@ namespace Avalonia
         }
 
         /// <summary>
+        /// Gets a value indicating whether the property is interested in data validation.
+        /// </summary>
+        /// <remarks>
+        /// Data validation is validation performed at the target of a binding, for example in a
+        /// view model using the INotifyDataErrorInfo interface. Only certain properties on a
+        /// control (such as a TextBox's Text property) will be interested in receiving data
+        /// validation messages so this feature must be explicitly enabled by setting this flag.
+        /// </remarks>
+        public bool? EnableDataValidation { get; private set; }
+
+        /// <summary>
         /// Merges the metadata with the base metadata.
         /// </summary>
         /// <param name="baseMetadata">The base metadata to merge.</param>
@@ -44,6 +58,8 @@ namespace Avalonia
             {
                 _defaultBindingMode = baseMetadata.DefaultBindingMode;
             }
+
+            EnableDataValidation ??= baseMetadata.EnableDataValidation;
         }
     }
 }

--- a/src/Avalonia.Base/DirectPropertyMetadata`1.cs
+++ b/src/Avalonia.Base/DirectPropertyMetadata`1.cs
@@ -21,10 +21,9 @@ namespace Avalonia
             TValue unsetValue = default!,
             BindingMode defaultBindingMode = BindingMode.Default,
             bool? enableDataValidation = null)
-                : base(defaultBindingMode)
+                : base(defaultBindingMode, enableDataValidation)
         {
             UnsetValue = unsetValue;
-            EnableDataValidation = enableDataValidation;
         }
 
         /// <summary>
@@ -32,16 +31,6 @@ namespace Avalonia
         /// </summary>
         public TValue UnsetValue { get; private set; }
 
-        /// <summary>
-        /// Gets a value indicating whether the property is interested in data validation.
-        /// </summary>
-        /// <remarks>
-        /// Data validation is validation performed at the target of a binding, for example in a
-        /// view model using the INotifyDataErrorInfo interface. Only certain properties on a
-        /// control (such as a TextBox's Text property) will be interested in receiving data
-        /// validation messages so this feature must be explicitly enabled by setting this flag.
-        /// </remarks>
-        public bool? EnableDataValidation { get; private set; }
 
         /// <inheritdoc/>
         object? IDirectPropertyMetadata.UnsetValue => UnsetValue;
@@ -51,19 +40,9 @@ namespace Avalonia
         {
             base.Merge(baseMetadata, property);
 
-            var src = baseMetadata as DirectPropertyMetadata<TValue>;
-
-            if (src != null)
+            if (baseMetadata is DirectPropertyMetadata<TValue> src)
             {
-                if (UnsetValue == null)
-                {
-                    UnsetValue = src.UnsetValue;
-                }
-
-                if (EnableDataValidation == null)
-                {
-                    EnableDataValidation = src.EnableDataValidation;
-                }
+                UnsetValue ??= src.UnsetValue;
             }
         }
     }

--- a/src/Avalonia.Base/PropertyStore/BindingEntryBase.cs
+++ b/src/Avalonia.Base/PropertyStore/BindingEntryBase.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Avalonia.Reactive;
 using Avalonia.Data;
 using Avalonia.Threading;
-using static Avalonia.Rendering.Composition.Animations.PropertySetSnapshot;
 
 namespace Avalonia.PropertyStore
 {

--- a/src/Avalonia.Base/PropertyStore/BindingEntryBase.cs
+++ b/src/Avalonia.Base/PropertyStore/BindingEntryBase.cs
@@ -14,23 +14,18 @@ namespace Avalonia.PropertyStore
     {
         private static readonly IDisposable s_creating = Disposable.Empty;
         private static readonly IDisposable s_creatingQuiet = Disposable.Create(() => { });
-        private readonly bool _hasDataValidation;
         private IDisposable? _subscription;
         private bool _hasValue;
         private TValue? _value;
-        private TValue? _defaultValue;
-        private bool _isDefaultValueInitialized;
+        private UncommonFields? _uncommon;
 
         protected BindingEntryBase(
             AvaloniaObject target,
             ValueFrame frame,
             AvaloniaProperty property,
             IObservable<BindingValue<TSource>> source)
+            : this(target, frame, property, (object)source)
         {
-            Frame = frame;
-            Source = source;
-            Property = property;
-            _hasDataValidation = property.GetMetadata(target.GetType()).EnableDataValidation ?? false;
         }
 
         protected BindingEntryBase(
@@ -38,11 +33,21 @@ namespace Avalonia.PropertyStore
             ValueFrame frame,
             AvaloniaProperty property,
             IObservable<TSource> source)
+            : this(target, frame, property, (object)source)
+        {
+        }
+
+        private BindingEntryBase(
+            AvaloniaObject target,
+            ValueFrame frame,
+            AvaloniaProperty property,
+            object source)
         {
             Frame = frame;
-            Source = source;
             Property = property;
-            _hasDataValidation = property.GetMetadata(target.GetType()).EnableDataValidation ?? false;
+            Source = source;
+            if (property.GetMetadata(target.GetType()).EnableDataValidation == true)
+                _uncommon = new() { _hasDataValidation = true };
         }
 
         public bool HasValue
@@ -74,6 +79,20 @@ namespace Avalonia.PropertyStore
             return _value!;
         }
 
+        public bool GetDataValidationState(out BindingValueType state, out Exception? error)
+        {
+            if (_uncommon?._hasDataValidation == true)
+            {
+                state = _uncommon._dataValidationState;
+                error = _uncommon._dataValidationError;
+                return true;
+            }
+
+            state = BindingValueType.Value;
+            error = null;
+            return false;
+        }
+
         public void Start() => Start(true);
 
         public void OnCompleted() => BindingCompleted();
@@ -85,9 +104,6 @@ namespace Avalonia.PropertyStore
         {
             _subscription?.Dispose();
             _subscription = null;
-
-            if (_hasDataValidation)
-                Frame.Owner?.Owner.OnUpdateDataValidation(Property, BindingValueType.UnsetValue, null);
         }
 
         object? IValueEntry.GetValue()
@@ -132,6 +148,12 @@ namespace Avalonia.PropertyStore
                 if (!value.HasValue && value.Type != BindingValueType.DataValidationError)
                     value = value.WithValue(instance.GetCachedDefaultValue());
 
+                if (instance._uncommon?._hasDataValidation == true)
+                {
+                    instance._uncommon._dataValidationState = value.Type;
+                    instance._uncommon._dataValidationError = value.Error;
+                }
+
                 if (value.HasValue &&
                     (!instance._hasValue || !EqualityComparer<TValue>.Default.Equals(instance._value, value.Value)))
                 {
@@ -140,9 +162,6 @@ namespace Avalonia.PropertyStore
                     if (instance._subscription is not null && instance._subscription != s_creatingQuiet)
                         instance.Frame.Owner?.OnBindingValueChanged(instance, instance.Frame.Priority);
                 }
-
-                if (instance._hasDataValidation)
-                    owner.OnUpdateDataValidation(property, originalType, value.Error);
             }
 
             if (value.Type == BindingValueType.DoNothing)
@@ -170,13 +189,23 @@ namespace Avalonia.PropertyStore
 
         private TValue GetCachedDefaultValue()
         {
-            if (!_isDefaultValueInitialized)
+            if (_uncommon?._isDefaultValueInitialized != true)
             {
-                _defaultValue = GetDefaultValue(Frame.Owner!.Owner.GetType());
-                _isDefaultValueInitialized = true;
+                _uncommon ??= new();
+                _uncommon._defaultValue = GetDefaultValue(Frame.Owner!.Owner.GetType());
+                _uncommon._isDefaultValueInitialized = true;
             }
 
-            return _defaultValue!;
+            return _uncommon._defaultValue!;
+        }
+
+        private class UncommonFields
+        {
+            public TValue? _defaultValue;
+            public bool _isDefaultValueInitialized;
+            public bool _hasDataValidation;
+            public BindingValueType _dataValidationState;
+            public Exception? _dataValidationError;
         }
     }
 }

--- a/src/Avalonia.Base/PropertyStore/DirectUntypedBindingObserver.cs
+++ b/src/Avalonia.Base/PropertyStore/DirectUntypedBindingObserver.cs
@@ -10,11 +10,13 @@ namespace Avalonia.PropertyStore
         IDisposable
     {
         private readonly ValueStore _owner;
+        private readonly bool _hasDataValidation;
         private IDisposable? _subscription;
 
         public DirectUntypedBindingObserver(ValueStore owner, DirectPropertyBase<T> property)
         {
             _owner = owner;
+            _hasDataValidation = property.GetMetadata(owner.Owner.GetType())?.EnableDataValidation ?? false;
             Property = property;
         }
 
@@ -30,6 +32,9 @@ namespace Avalonia.PropertyStore
             _subscription?.Dispose();
             _subscription = null;
             _owner.OnLocalValueBindingCompleted(Property, this);
+
+            if (_hasDataValidation)
+                _owner.Owner.OnUpdateDataValidation(Property, BindingValueType.UnsetValue, null);
         }
 
         public void OnCompleted() => _owner.OnLocalValueBindingCompleted(Property, this);

--- a/src/Avalonia.Base/PropertyStore/EffectiveValue.cs
+++ b/src/Avalonia.Base/PropertyStore/EffectiveValue.cs
@@ -11,9 +11,6 @@ namespace Avalonia.PropertyStore
     /// </remarks>
     internal abstract class EffectiveValue
     {
-        private IValueEntry? _valueEntry;
-        private IValueEntry? _baseValueEntry;
-
         /// <summary>
         /// Gets the current effective value as a boxed value.
         /// </summary>
@@ -28,6 +25,16 @@ namespace Avalonia.PropertyStore
         /// Gets the priority of the current base value.
         /// </summary>
         public BindingPriority BasePriority { get; protected set; }
+
+        /// <summary>
+        /// Gets the active value entry for the current effective value.
+        /// </summary>
+        public IValueEntry? ValueEntry { get; private set; }
+
+        /// <summary>
+        /// Gets the active value entry for the current base value.
+        /// </summary>
+        public IValueEntry? BaseValueEntry { get; private set; }
 
         /// <summary>
         /// Gets a value indicating whether the <see cref="Value"/> was overridden by a call to 
@@ -63,14 +70,14 @@ namespace Avalonia.PropertyStore
         {
             if (Priority == BindingPriority.Unset)
             {
-                _valueEntry?.Unsubscribe();
-                _valueEntry = null;
+                ValueEntry?.Unsubscribe();
+                ValueEntry = null;
             }
 
             if (BasePriority == BindingPriority.Unset)
             {
-                _baseValueEntry?.Unsubscribe();
-                _baseValueEntry = null;
+                BaseValueEntry?.Unsubscribe();
+                BaseValueEntry = null;
             }
         }
 
@@ -135,40 +142,34 @@ namespace Avalonia.PropertyStore
                 // value, then the current entry becomes our base entry.
                 if (Priority > BindingPriority.LocalValue && Priority < BindingPriority.Inherited)
                 {
-                    Debug.Assert(_valueEntry is not null);
-                    _baseValueEntry = _valueEntry;
-                    _valueEntry = null;
+                    Debug.Assert(ValueEntry is not null);
+                    BaseValueEntry = ValueEntry;
+                    ValueEntry = null;
                 }
 
-                if (_valueEntry != entry)
+                if (ValueEntry != entry)
                 {
-                    _valueEntry?.Unsubscribe();
-                    _valueEntry = entry;
+                    ValueEntry?.Unsubscribe();
+                    ValueEntry = entry;
                 }
             }
             else if (Priority <= BindingPriority.Animation)
             {
                 // We've received a non-animation value and have an active animation value, so the
                 // new entry becomes our base entry.
-                if (_baseValueEntry != entry)
+                if (BaseValueEntry != entry)
                 {
-                    _baseValueEntry?.Unsubscribe();
-                    _baseValueEntry = entry;
+                    BaseValueEntry?.Unsubscribe();
+                    BaseValueEntry = entry;
                 }
             }
-            else if (_valueEntry != entry)
+            else if (ValueEntry != entry)
             {
                 // Both the current value and the new value are non-animation values, so the new
                 // entry replaces the existing entry.
-                _valueEntry?.Unsubscribe();
-                _valueEntry = entry;
+                ValueEntry?.Unsubscribe();
+                ValueEntry = entry;
             }
-        }
-
-        protected void UnsubscribeValueEntries()
-        {
-            _valueEntry?.Unsubscribe();
-            _baseValueEntry?.Unsubscribe();
         }
     }
 }

--- a/src/Avalonia.Base/PropertyStore/IValueEntry.cs
+++ b/src/Avalonia.Base/PropertyStore/IValueEntry.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Avalonia.Data;
 
 namespace Avalonia.PropertyStore
 {
@@ -21,6 +22,16 @@ namespace Avalonia.PropertyStore
         /// The entry has no value.
         /// </exception>
         object? GetValue();
+
+        /// <summary>
+        /// Gets the data validation state if supported.
+        /// </summary>
+        /// <param name="state">The binding validation state.</param>
+        /// <param name="error">The current binding error, if any.</param>
+        /// <returns>
+        /// True if the entry supports data validation, otherwise false.
+        /// </returns>
+        bool GetDataValidationState(out BindingValueType state, out Exception? error);
 
         /// <summary>
         /// Called when the value entry is removed from the value store.

--- a/src/Avalonia.Base/PropertyStore/ImmediateValueEntry.cs
+++ b/src/Avalonia.Base/PropertyStore/ImmediateValueEntry.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Avalonia.Data;
 
 namespace Avalonia.PropertyStore
 {
@@ -27,5 +28,12 @@ namespace Avalonia.PropertyStore
 
         object? IValueEntry.GetValue() => _value;
         T IValueEntry<T>.GetValue() => _value;
+
+        bool IValueEntry.GetDataValidationState(out BindingValueType state, out Exception? error)
+        {
+            state = BindingValueType.Value;
+            error = null;
+            return false;
+        }
     }
 }

--- a/src/Avalonia.Base/PropertyStore/ImmediateValueFrame.cs
+++ b/src/Avalonia.Base/PropertyStore/ImmediateValueFrame.cs
@@ -18,7 +18,7 @@ namespace Avalonia.PropertyStore
             StyledProperty<T> property,
             IObservable<BindingValue<T>> source)
         {
-            var e = new TypedBindingEntry<T>(this, property, source);
+            var e = new TypedBindingEntry<T>(Owner!.Owner, this, property, source);
             Add(e);
             return e;
         }
@@ -27,7 +27,7 @@ namespace Avalonia.PropertyStore
             StyledProperty<T> property,
             IObservable<T> source)
         {
-            var e = new TypedBindingEntry<T>(this, property, source);
+            var e = new TypedBindingEntry<T>(Owner!.Owner, this, property, source);
             Add(e);
             return e;
         }
@@ -36,7 +36,7 @@ namespace Avalonia.PropertyStore
             StyledProperty<T> property,
             IObservable<object?> source)
         {
-            var e = new SourceUntypedBindingEntry<T>(this, property, source);
+            var e = new SourceUntypedBindingEntry<T>(Owner!.Owner, this, property, source);
             Add(e);
             return e;
         }

--- a/src/Avalonia.Base/PropertyStore/LocalValueBindingObserver.cs
+++ b/src/Avalonia.Base/PropertyStore/LocalValueBindingObserver.cs
@@ -1,126 +1,25 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Avalonia.Data;
-using Avalonia.Threading;
 
 namespace Avalonia.PropertyStore
 {
-    internal class LocalValueBindingObserver<T> : IObserver<T>,
-        IObserver<BindingValue<T>>,
-        IDisposable
+    internal class LocalValueBindingObserver<T> : LocalValueBindingObserverBase<T>,
+        IObserver<object?>
     {
-        private readonly ValueStore _owner;
-        private readonly bool _hasDataValidation;
-        private IDisposable? _subscription;
-        private T? _defaultValue;
-        private bool _isDefaultValueInitialized;
-
         public LocalValueBindingObserver(ValueStore owner, StyledProperty<T> property)
+            : base(owner, property)
         {
-            _owner = owner;
-            Property = property;
-            _hasDataValidation = property.GetMetadata(owner.Owner.GetType()).EnableDataValidation ?? false;
         }
 
-        public StyledProperty<T> Property { get;}
+        public void Start(IObservable<object?> source) => _subscription = source.Subscribe(this);
 
-        public void Start(IObservable<T> source)
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = TrimmingMessages.ImplicitTypeConvertionSupressWarningMessage)]
+        public void OnNext(object? value)
         {
-            _subscription = source.Subscribe(this);
-        }
-
-        public void Start(IObservable<BindingValue<T>> source)
-        {
-            _subscription = source.Subscribe(this);
-        }
-
-        public void Dispose()
-        {
-            _subscription?.Dispose();
-            _subscription = null;
-            _owner.OnLocalValueBindingCompleted(Property, this);
-        }
-
-        public void OnCompleted() => _owner.OnLocalValueBindingCompleted(Property, this);
-        public void OnError(Exception error) => OnCompleted();
-
-        public void OnNext(T value)
-        {
-            static void Execute(LocalValueBindingObserver<T> instance, T value)
-            {
-                var owner = instance._owner;
-                var property = instance.Property;
-
-                if (property.ValidateValue?.Invoke(value) == false)
-                    value = instance.GetCachedDefaultValue();
-
-                owner.SetLocalValue(property, value);
-
-                if (instance._hasDataValidation)
-                    owner.Owner.OnUpdateDataValidation(property, BindingValueType.Value, null);
-            }
-
-            if (Dispatcher.UIThread.CheckAccess())
-            {
-                Execute(this, value);
-            }
-            else
-            {
-                // To avoid allocating closure in the outer scope we need to capture variables
-                // locally. This allows us to skip most of the allocations when on UI thread.
-                var instance = this;
-                var newValue = value;
-                Dispatcher.UIThread.Post(() => Execute(instance, newValue));
-            }
-        }
-
-        public void OnNext(BindingValue<T> value)
-        {
-            static void Execute(LocalValueBindingObserver<T> instance, BindingValue<T> value)
-            {
-                var owner = instance._owner;
-                var property = instance.Property;
-                var originalType = value.Type;
-
-                LoggingUtils.LogIfNecessary(owner.Owner, property, value);
-
-                // Revert to the default value if the binding value fails validation, or if
-                // there was no value (though not if there was a data validation error).
-                if ((value.HasValue && property.ValidateValue?.Invoke(value.Value) == false) ||
-                    (!value.HasValue && value.Type != BindingValueType.DataValidationError))
-                    value = value.WithValue(instance.GetCachedDefaultValue());
-
-                if (value.HasValue)
-                    owner.SetLocalValue(property, value.Value);
-                if (instance._hasDataValidation)
-                    owner.Owner.OnUpdateDataValidation(property, originalType, value.Error);
-            }
-
-            if (value.Type is BindingValueType.DoNothing)
+            if (value == BindingOperations.DoNothing)
                 return;
-
-            if (Dispatcher.UIThread.CheckAccess())
-            {
-                Execute(this, value);
-            }
-            else
-            {
-                // To avoid allocating closure in the outer scope we need to capture variables
-                // locally. This allows us to skip most of the allocations when on UI thread.
-                var instance = this;
-                var newValue = value;
-                Dispatcher.UIThread.Post(() => Execute(instance, newValue));
-            }
-        }
-
-        private T GetCachedDefaultValue()
-        {
-            if (!_isDefaultValueInitialized)
-            {
-                _defaultValue = Property.GetDefaultValue(_owner.Owner.GetType());
-                _isDefaultValueInitialized = true;
-            }
-
-            return _defaultValue!;
+            base.OnNext(BindingValue<T>.FromUntyped(value, Property.PropertyType));
         }
     }
 }

--- a/src/Avalonia.Base/PropertyStore/LocalValueBindingObserverBase.cs
+++ b/src/Avalonia.Base/PropertyStore/LocalValueBindingObserverBase.cs
@@ -37,10 +37,17 @@ namespace Avalonia.PropertyStore
         {
             _subscription?.Dispose();
             _subscription = null;
+            OnCompleted();
+        }
+
+        public void OnCompleted()
+        {
+            if (_hasDataValidation)
+                _owner.Owner.OnUpdateDataValidation(Property, BindingValueType.UnsetValue, null);
+
             _owner.OnLocalValueBindingCompleted(Property, this);
         }
 
-        public void OnCompleted() => _owner.OnLocalValueBindingCompleted(Property, this);
         public void OnError(Exception error) => OnCompleted();
 
         public void OnNext(T value)

--- a/src/Avalonia.Base/PropertyStore/SourceUntypedBindingEntry.cs
+++ b/src/Avalonia.Base/PropertyStore/SourceUntypedBindingEntry.cs
@@ -12,10 +12,11 @@ namespace Avalonia.PropertyStore
         private readonly Func<TTarget, bool>? _validate;
 
         public SourceUntypedBindingEntry(
+            AvaloniaObject target,
             ValueFrame frame, 
             StyledProperty<TTarget> property,
             IObservable<object?> source)
-                : base(frame, property, source)
+                : base(target, frame, property, source)
         {
             _validate = property.ValidateValue;
         }

--- a/src/Avalonia.Base/PropertyStore/TypedBindingEntry.cs
+++ b/src/Avalonia.Base/PropertyStore/TypedBindingEntry.cs
@@ -10,18 +10,20 @@ namespace Avalonia.PropertyStore
     internal sealed class TypedBindingEntry<T> : BindingEntryBase<T, T>
     {
         public TypedBindingEntry(
+            AvaloniaObject target,
             ValueFrame frame, 
             StyledProperty<T> property,
             IObservable<T> source)
-                : base(frame, property, source)
+                : base(target, frame, property, source)
         {
         }
 
         public TypedBindingEntry(
+            AvaloniaObject target,
             ValueFrame frame,
             StyledProperty<T> property,
             IObservable<BindingValue<T>> source)
-                : base(frame, property, source)
+                : base(target, frame, property, source)
         {
         }
 

--- a/src/Avalonia.Base/PropertyStore/UntypedBindingEntry.cs
+++ b/src/Avalonia.Base/PropertyStore/UntypedBindingEntry.cs
@@ -12,10 +12,11 @@ namespace Avalonia.PropertyStore
         private readonly Func<object?, bool>? _validate;
 
         public UntypedBindingEntry(
+            AvaloniaObject target,
             ValueFrame frame,
             AvaloniaProperty property,
             IObservable<object?> source)
-            : base(frame, property, source)
+            : base(target, frame, property, source)
         {
             _validate = ((IStyledPropertyAccessor)property).ValidateValue;
         }

--- a/src/Avalonia.Base/PropertyStore/ValueStore.cs
+++ b/src/Avalonia.Base/PropertyStore/ValueStore.cs
@@ -838,8 +838,6 @@ namespace Avalonia.PropertyStore
                         break;
                 }
 
-                current?.EndReevaluation();
-
                 if (current?.Priority == BindingPriority.Unset)
                 {
                     if (current.BasePriority == BindingPriority.Unset)
@@ -852,6 +850,8 @@ namespace Avalonia.PropertyStore
                         current.RemoveAnimationAndRaise(this, property);
                     }
                 }
+
+                current?.EndReevaluation();
             }
             finally
             {
@@ -923,7 +923,6 @@ namespace Avalonia.PropertyStore
                 for (var i = _effectiveValues.Count - 1; i >= 0; --i)
                 {
                     _effectiveValues.GetKeyValue(i, out var key, out var e);
-                    e.EndReevaluation();
 
                     if (e.Priority == BindingPriority.Unset)
                     {
@@ -933,6 +932,8 @@ namespace Avalonia.PropertyStore
                         if (i > _effectiveValues.Count)
                             break;
                     }
+
+                    e.EndReevaluation();
                 }
             }
             finally

--- a/src/Avalonia.Base/PropertyStore/ValueStore.cs
+++ b/src/Avalonia.Base/PropertyStore/ValueStore.cs
@@ -104,7 +104,7 @@ namespace Avalonia.PropertyStore
         {
             if (priority == BindingPriority.LocalValue)
             {
-                var observer = new LocalValueUntypedBindingObserver<T>(this, property);
+                var observer = new LocalValueBindingObserver<T>(this, property);
                 DisposeExistingLocalValueBinding(property);
                 _localValueBindings ??= new();
                 _localValueBindings[property.Id] = observer;

--- a/src/Avalonia.Base/PropertyStore/ValueStore.cs
+++ b/src/Avalonia.Base/PropertyStore/ValueStore.cs
@@ -193,18 +193,7 @@ namespace Avalonia.PropertyStore
             }
             else
             {
-                if (TryGetEffectiveValue(property, out var existing))
-                {
-                    var effective = (EffectiveValue<T>)existing;
-                    effective.SetLocalValueAndRaise(this, property, value);
-                }
-                else
-                {
-                    var effectiveValue = CreateEffectiveValue(property);
-                    AddEffectiveValue(property, effectiveValue);
-                    effectiveValue.SetLocalValueAndRaise(this, property, value);
-                }
-
+                SetLocalValue(property, value);
                 return null;
             }
         }
@@ -220,6 +209,21 @@ namespace Avalonia.PropertyStore
                 var effectiveValue = CreateEffectiveValue(property);
                 AddEffectiveValue(property, effectiveValue);
                 effectiveValue.SetCurrentValueAndRaise(this, property, value);
+            }
+        }
+
+        public void SetLocalValue<T>(StyledProperty<T> property, T value)
+        {
+            if (TryGetEffectiveValue(property, out var existing))
+            {
+                var effective = (EffectiveValue<T>)existing;
+                effective.SetLocalValueAndRaise(this, property, value);
+            }
+            else
+            {
+                var effectiveValue = CreateEffectiveValue(property);
+                AddEffectiveValue(property, effectiveValue);
+                effectiveValue.SetLocalValueAndRaise(this, property, value);
             }
         }
 

--- a/src/Avalonia.Base/StyledElement.cs
+++ b/src/Avalonia.Base/StyledElement.cs
@@ -46,6 +46,7 @@ namespace Avalonia
                 defaultBindingMode: BindingMode.OneWay,
                 validate: null,
                 coerce: null,
+                enableDataValidation: false,
                 notifying: DataContextNotifying);
 
         /// <summary>

--- a/src/Avalonia.Base/StyledPropertyMetadata`1.cs
+++ b/src/Avalonia.Base/StyledPropertyMetadata`1.cs
@@ -16,11 +16,13 @@ namespace Avalonia
         /// <param name="defaultValue">The default value of the property.</param>
         /// <param name="defaultBindingMode">The default binding mode.</param>
         /// <param name="coerce">A value coercion callback.</param>
+        /// <param name="enableDataValidation">Whether the property is interested in data validation.</param>
         public StyledPropertyMetadata(
             Optional<TValue> defaultValue = default,
             BindingMode defaultBindingMode = BindingMode.Default,
-            Func<AvaloniaObject, TValue, TValue>? coerce = null)
-                : base(defaultBindingMode)
+            Func<AvaloniaObject, TValue, TValue>? coerce = null,
+            bool enableDataValidation = false)
+                : base(defaultBindingMode, enableDataValidation)
         {
             _defaultValue = defaultValue;
             CoerceValue = coerce;

--- a/src/Avalonia.Base/Styling/PropertySetterBindingInstance.cs
+++ b/src/Avalonia.Base/Styling/PropertySetterBindingInstance.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Styling
             AvaloniaProperty property,
             BindingMode mode,
             IObservable<object?> source)
-            : base(instance, property, source)
+            : base(target, instance, property, source)
         {
             _target = target;
             _mode = mode;

--- a/src/Avalonia.Base/Styling/PropertySetterTemplateInstance.cs
+++ b/src/Avalonia.Base/Styling/PropertySetterTemplateInstance.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Avalonia.Data;
 using Avalonia.PropertyStore;
 
 namespace Avalonia.Styling
@@ -18,6 +19,13 @@ namespace Avalonia.Styling
         public AvaloniaProperty Property { get; }
 
         public object? GetValue() => _value ??= _template.Build();
+
+        bool IValueEntry.GetDataValidationState(out BindingValueType state, out Exception? error)
+        {
+            state = BindingValueType.Value;
+            error = null;
+            return false;
+        }
 
         void IValueEntry.Unsubscribe() { }
     }

--- a/src/Avalonia.Base/Styling/Setter.cs
+++ b/src/Avalonia.Base/Styling/Setter.cs
@@ -99,7 +99,8 @@ namespace Avalonia.Styling
         {
             if (!Property!.IsDirect)
             {
-                var i = binding.Initiate(target, Property)!;
+                var hasDataValidation = Property.GetMetadata(target.GetType()).EnableDataValidation ?? false;
+                var i = binding.Initiate(target, Property, enableDataValidation: hasDataValidation)!;
                 var mode = i.Mode;
 
                 if (mode == BindingMode.Default)

--- a/src/Avalonia.Base/Styling/Setter.cs
+++ b/src/Avalonia.Base/Styling/Setter.cs
@@ -90,6 +90,13 @@ namespace Avalonia.Styling
 
         object? IValueEntry.GetValue() => Value;
 
+        bool IValueEntry.GetDataValidationState(out BindingValueType state, out Exception? error)
+        {
+            state = BindingValueType.Value;
+            error = null;
+            return false;
+        }
+
         private AvaloniaProperty EnsureProperty()
         {
             return Property ?? throw new InvalidOperationException("Setter.Property must be set.");

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Binding.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Binding.cs
@@ -888,7 +888,8 @@ namespace Avalonia.Base.UnitTests
             var target = new Class1();
             var source = new Subject<object?>();
             var called = false;
-            var expectedMessageTemplate = "Error in binding to {Target}.{Property}: expected {ExpectedType}, got {Value} ({ValueType})";
+            var expectedMessageTemplate = "Error in binding to {Target}.{Property}: {Message}";
+            var message = "Unable to convert object 'foo' of type 'System.String' to type 'System.Double'.";
 
             LogCallback checkLogMessage = (level, area, src, mt, pv) =>
             {
@@ -898,9 +899,7 @@ namespace Avalonia.Base.UnitTests
                     src == target &&
                     pv[0].GetType() == typeof(Class1) &&
                     (AvaloniaProperty)pv[1] == Class1.QuxProperty &&
-                    (Type)pv[2] == typeof(double) &&
-                    (string)pv[3] == "foo" &&
-                    (Type)pv[4] == typeof(string))
+                    (string)pv[2] == message)
                 {
                     called = true;
                 }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_DataValidation.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_DataValidation.cs
@@ -1,115 +1,170 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reactive.Subjects;
 using Avalonia.Data;
 using Avalonia.UnitTests;
 using Xunit;
 
+#nullable enable
+
 namespace Avalonia.Base.UnitTests
 {
     public class AvaloniaObjectTests_DataValidation
     {
-        [Fact]
-        public void Binding_Non_Validated_Styled_Property_Does_Not_Call_UpdateDataValidation()
+        public abstract class TestBase<T>
+            where T : AvaloniaProperty<int>
         {
-            var target = new Class1();
-            var source = new Subject<BindingValue<int>>();
-
-            target.Bind(Class1.NonValidatedProperty, source);
-            source.OnNext(6);
-            source.OnNext(BindingValue<int>.BindingError(new Exception()));
-            source.OnNext(BindingValue<int>.DataValidationError(new Exception()));
-            source.OnNext(6);
-
-            Assert.Empty(target.Notifications);
-        }
-
-        [Fact]
-        public void Binding_Non_Validated_Direct_Property_Does_Not_Call_UpdateDataValidation()
-        {
-            var target = new Class1();
-            var source = new Subject<BindingValue<int>>();
-
-            target.Bind(Class1.NonValidatedDirectProperty, source);
-            source.OnNext(6);
-            source.OnNext(BindingValue<int>.BindingError(new Exception()));
-            source.OnNext(BindingValue<int>.DataValidationError(new Exception()));
-            source.OnNext(6);
-
-            Assert.Empty(target.Notifications);
-        }
-
-        [Fact]
-        public void Binding_Validated_Direct_Property_Calls_UpdateDataValidation()
-        {
-            var target = new Class1();
-            var source = new Subject<BindingValue<int>>();
-
-            target.Bind(Class1.ValidatedDirectIntProperty, source);
-            source.OnNext(6);
-            source.OnNext(BindingValue<int>.BindingError(new Exception()));
-            source.OnNext(BindingValue<int>.DataValidationError(new Exception()));
-            source.OnNext(7);
-
-            var result = target.Notifications;
-            Assert.Equal(4, result.Count);
-            Assert.Equal(BindingValueType.Value, result[0].type);
-            Assert.Equal(6, result[0].value);
-            Assert.Equal(BindingValueType.BindingError, result[1].type);
-            Assert.Equal(BindingValueType.DataValidationError, result[2].type);
-            Assert.Equal(BindingValueType.Value, result[3].type);
-            Assert.Equal(7, result[3].value);
-        }
-
-        [Fact]
-        public void Binding_Overridden_Validated_Direct_Property_Calls_UpdateDataValidation()
-        {
-            var target = new Class2();
-            var source = new Subject<BindingValue<int>>();
-
-            // Class2 overrides `NonValidatedDirectProperty`'s metadata to enable data validation.
-            target.Bind(Class1.NonValidatedDirectProperty, source);
-            source.OnNext(1);
-
-            Assert.Equal(1, target.Notifications.Count);
-        }
-
-        [Fact]
-        public void Bound_Validated_Direct_String_Property_Can_Be_Set_To_Null()
-        {
-            var source = new ViewModel
+            [Fact]
+            public void Binding_Non_Validated_Property_Does_Not_Call_UpdateDataValidation()
             {
-                StringValue = "foo",
-            };
+                var target = new Class1();
+                var source = new Subject<BindingValue<int>>();
+                var property = GetNonValidatedProperty();
 
-            var target = new Class1
+                target.Bind(property, source);
+                source.OnNext(6);
+                source.OnNext(BindingValue<int>.BindingError(new Exception()));
+                source.OnNext(BindingValue<int>.DataValidationError(new Exception()));
+                source.OnNext(6);
+
+                Assert.Empty(target.Notifications);
+            }
+
+            [Fact]
+            public void Binding_Validated_Property_Calls_UpdateDataValidation()
             {
-                [!Class1.ValidatedDirectStringProperty] = new Binding
+                var target = new Class1();
+                var source = new Subject<BindingValue<int>>();
+                var property = GetProperty();
+                var error1 = new Exception();
+                var error2 = new Exception();
+
+                target.Bind(property, source);
+                source.OnNext(6);
+                source.OnNext(BindingValue<int>.DataValidationError(error1));
+                source.OnNext(BindingValue<int>.BindingError(error2));
+                source.OnNext(7);
+
+                Assert.Equal(new Notification[]
                 {
-                    Path = nameof(ViewModel.StringValue),
-                    Source = source,
-                },
-            };
+                    new(BindingValueType.Value, 6, null),
+                    new(BindingValueType.DataValidationError, 6, error1),
+                    new(BindingValueType.BindingError, 0, error2),
+                    new(BindingValueType.Value, 7, null),
+                }, target.Notifications);
+            }
 
-            Assert.Equal("foo", target.ValidatedDirectString);
+            [Fact]
+            public void Binding_Validated_Property_Calls_UpdateDataValidation_Untyped()
+            {
+                var target = new Class1();
+                var source = new Subject<object>();
+                var property = GetProperty();
+                var error1 = new Exception();
+                var error2 = new Exception();
 
-            source.StringValue = null;
+                target.Bind(property, source);
+                source.OnNext(6);
+                source.OnNext(new BindingNotification(error1, BindingErrorType.DataValidationError));
+                source.OnNext(new BindingNotification(error2, BindingErrorType.Error));
+                source.OnNext(7);
 
-            Assert.Null(target.ValidatedDirectString);
+                Assert.Equal(new Notification[]
+                {
+                    new(BindingValueType.Value, 6, null),
+                    new(BindingValueType.DataValidationError, 6, error1),
+                    new(BindingValueType.BindingError, 0, error2),
+                    new(BindingValueType.Value, 7, null),
+                }, target.Notifications);
+            }
+
+            [Fact]
+            public void Binding_Overridden_Validated_Property_Calls_UpdateDataValidation()
+            {
+                var target = new Class2();
+                var source = new Subject<BindingValue<int>>();
+                var property = GetNonValidatedProperty();
+
+                // Class2 overrides the non-validated property metadata to enable data validation.
+                target.Bind(property, source);
+                source.OnNext(1);
+
+                Assert.Equal(1, target.Notifications.Count);
+            }
+
+            protected abstract T GetProperty();
+            protected abstract T GetNonValidatedProperty();
         }
+
+        public class DirectPropertyTests : TestBase<DirectPropertyBase<int>>
+        {
+            [Fact]
+            public void Bound_Validated_String_Property_Can_Be_Set_To_Null()
+            {
+                var source = new ViewModel
+                {
+                    StringValue = "foo",
+                };
+
+                var target = new Class1
+                {
+                    [!Class1.ValidatedDirectStringProperty] = new Binding
+                    {
+                        Path = nameof(ViewModel.StringValue),
+                        Source = source,
+                    },
+                };
+
+                Assert.Equal("foo", target.ValidatedDirectString);
+
+                source.StringValue = null;
+
+                Assert.Null(target.ValidatedDirectString);
+            }
+
+            protected override DirectPropertyBase<int> GetProperty() => Class1.ValidatedDirectIntProperty;
+            protected override DirectPropertyBase<int> GetNonValidatedProperty() => Class1.NonValidatedDirectIntProperty;
+        }
+
+        public class StyledPropertyTests : TestBase<StyledProperty<int>>
+        {
+            [Fact]
+            public void Bound_Validated_String_Property_Can_Be_Set_To_Null()
+            {
+                var source = new ViewModel
+                {
+                    StringValue = "foo",
+                };
+
+                var target = new Class1
+                {
+                    [!Class1.ValidatedDirectStringProperty] = new Binding
+                    {
+                        Path = nameof(ViewModel.StringValue),
+                        Source = source,
+                    },
+                };
+
+                Assert.Equal("foo", target.ValidatedDirectString);
+
+                source.StringValue = null;
+
+                Assert.Null(target.ValidatedDirectString);
+            }
+
+            protected override StyledProperty<int> GetProperty() => Class1.ValidatedStyledIntProperty;
+            protected override StyledProperty<int> GetNonValidatedProperty() => Class1.NonValidatedStyledIntProperty;
+        }
+
+        private record class Notification(BindingValueType type, object? value, Exception? error);
 
         private class Class1 : AvaloniaObject
         {
-            public static readonly StyledProperty<int> NonValidatedProperty =
-                AvaloniaProperty.Register<Class1, int>(
-                    nameof(NonValidated));
-
-            public static readonly DirectProperty<Class1, int> NonValidatedDirectProperty =
+            public static readonly DirectProperty<Class1, int> NonValidatedDirectIntProperty =
                 AvaloniaProperty.RegisterDirect<Class1, int>(
-                    nameof(NonValidatedDirect),
-                    o => o.NonValidatedDirect,
-                    (o, v) => o.NonValidatedDirect = v);
+                    nameof(NonValidatedDirectInt),
+                    o => o.NonValidatedDirectInt,
+                    (o, v) => o.NonValidatedDirectInt = v);
 
             public static readonly DirectProperty<Class1, int> ValidatedDirectIntProperty =
                 AvaloniaProperty.RegisterDirect<Class1, int>(
@@ -118,27 +173,30 @@ namespace Avalonia.Base.UnitTests
                     (o, v) => o.ValidatedDirectInt = v,
                     enableDataValidation: true);
 
-            public static readonly DirectProperty<Class1, string> ValidatedDirectStringProperty =
-                AvaloniaProperty.RegisterDirect<Class1, string>(
+            public static readonly DirectProperty<Class1, string?> ValidatedDirectStringProperty =
+                AvaloniaProperty.RegisterDirect<Class1, string?>(
                     nameof(ValidatedDirectString),
                     o => o.ValidatedDirectString,
                     (o, v) => o.ValidatedDirectString = v,
                     enableDataValidation: true);
 
+            public static readonly StyledProperty<int> NonValidatedStyledIntProperty =
+                AvaloniaProperty.Register<Class1, int>(
+                    nameof(NonValidatedStyledInt));
+
+            public static readonly StyledProperty<int> ValidatedStyledIntProperty =
+                AvaloniaProperty.Register<Class1, int>(
+                    nameof(ValidatedStyledInt),
+                    enableDataValidation: true);
+
             private int _nonValidatedDirect;
             private int _directInt;
-            private string _directString;
+            private string? _directString;
 
-            public int NonValidated
-            {
-                get { return GetValue(NonValidatedProperty); }
-                set { SetValue(NonValidatedProperty, value); }
-            }
-
-            public int NonValidatedDirect
+            public int NonValidatedDirectInt
             {
                 get { return _directInt; }
-                set { SetAndRaise(NonValidatedDirectProperty, ref _nonValidatedDirect, value); }
+                set { SetAndRaise(NonValidatedDirectIntProperty, ref _nonValidatedDirect, value); }
             }
 
             public int ValidatedDirectInt
@@ -147,20 +205,32 @@ namespace Avalonia.Base.UnitTests
                 set { SetAndRaise(ValidatedDirectIntProperty, ref _directInt, value); }
             }
 
-            public string ValidatedDirectString
+            public string? ValidatedDirectString
             {
                 get { return _directString; }
                 set { SetAndRaise(ValidatedDirectStringProperty, ref _directString, value); }
             }
 
-            public List<(BindingValueType type, object value)> Notifications { get; } = new();
+            public int NonValidatedStyledInt
+            {
+                get { return GetValue(NonValidatedStyledIntProperty); }
+                set { SetValue(NonValidatedStyledIntProperty, value); }
+            }
+
+            public int ValidatedStyledInt
+            {
+                get => GetValue(ValidatedStyledIntProperty);
+                set => SetValue(ValidatedStyledIntProperty, value);
+            }
+
+            public List<Notification> Notifications { get; } = new();
 
             protected override void UpdateDataValidation(
                 AvaloniaProperty property,
                 BindingValueType state,
-                Exception error)
+                Exception? error)
             {
-                Notifications.Add((state, GetValue(property)));
+                Notifications.Add(new(state, GetValue(property), error));
             }
         }
 
@@ -168,16 +238,18 @@ namespace Avalonia.Base.UnitTests
         {
             static Class2()
             {
-                NonValidatedDirectProperty.OverrideMetadata<Class2>(
+                NonValidatedDirectIntProperty.OverrideMetadata<Class2>(
                     new DirectPropertyMetadata<int>(enableDataValidation: true));
+                NonValidatedStyledIntProperty.OverrideMetadata<Class2>(
+                    new StyledPropertyMetadata<int>(enableDataValidation: true));
             }
         }
 
         public class ViewModel : NotifyingBase
         {
-            private string _stringValue;
+            private string? _stringValue;
 
-            public string StringValue
+            public string? StringValue
             {
                 get { return _stringValue; }
                 set { _stringValue = value; RaisePropertyChanged(); }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_DataValidation.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_DataValidation.cs
@@ -92,6 +92,48 @@ namespace Avalonia.Base.UnitTests
                 Assert.Equal(1, target.Notifications.Count);
             }
 
+            [Fact]
+            public void Disposing_Binding_Subscription_Clears_DataValidation()
+            {
+                var target = new Class1();
+                var source = new Subject<BindingValue<int>>();
+                var property = GetProperty();
+                var error = new Exception();
+                var sub = target.Bind(property, source);
+
+                source.OnNext(6);
+                source.OnNext(BindingValue<int>.DataValidationError(error));
+                sub.Dispose();
+
+                Assert.Equal(new Notification[]
+                {
+                    new(BindingValueType.Value, 6, null),
+                    new(BindingValueType.DataValidationError, 6, error),
+                    new(BindingValueType.UnsetValue, 6, null),
+                }, target.Notifications);
+            }
+
+            [Fact]
+            public void Completing_Binding_Clears_DataValidation()
+            {
+                var target = new Class1();
+                var source = new Subject<BindingValue<int>>();
+                var property = GetProperty();
+                var error = new Exception();
+                
+                target.Bind(property, source);
+                source.OnNext(6);
+                source.OnNext(BindingValue<int>.DataValidationError(error));
+                source.OnCompleted();
+
+                Assert.Equal(new Notification[]
+                {
+                    new(BindingValueType.Value, 6, null),
+                    new(BindingValueType.DataValidationError, 6, error),
+                    new(BindingValueType.UnsetValue, 6, null),
+                }, target.Notifications);
+            }
+
             protected abstract T GetProperty();
             protected abstract T GetNonValidatedProperty();
         }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaPropertyTests.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaPropertyTests.cs
@@ -198,6 +198,7 @@ namespace Avalonia.Base.UnitTests
                     defaultBindingMode: BindingMode.OneWay,
                     validate: null,
                     coerce: null,
+                    enableDataValidation: false,
                     notifying: FooNotifying);
 
             public int NotifyCount { get; private set; }

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_DataValidation.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_DataValidation.cs
@@ -1,72 +1,289 @@
 using System;
-using System.Reactive.Linq;
+using System.Collections;
+using System.ComponentModel;
 using Avalonia.Controls;
 using Avalonia.Data;
-using Avalonia.Data.Core;
-using Avalonia.Markup.Data;
+using Avalonia.Styling;
+using Avalonia.UnitTests;
 using Xunit;
+
+#nullable enable
 
 namespace Avalonia.Markup.UnitTests.Data
 {
     public class BindingTests_DataValidation
     {
-        [Fact]
-        public void Initiate_Should_Not_Enable_Data_Validation_With_BindingPriority_LocalValue()
+        public abstract class TestBase<T>
+            where T : AvaloniaProperty<int>
         {
-            var textBlock = new TextBlock
+            [Fact]
+            public void Setter_Exception_Causes_DataValidation_Error()
             {
-                DataContext = new Class1(),
-            };
+                var (target, property) = CreateTarget();
+                var binding = new Binding(nameof(ExceptionValidatingModel.Value))
+                {
+                    Mode = BindingMode.TwoWay
+                };
 
-            var target = new Binding(nameof(Class1.Foo));
-            var instanced = target.Initiate(textBlock, TextBlock.TextProperty, enableDataValidation: false);
-            var subject = (BindingExpression)instanced.Source;
-            object result = null;
+                target.DataContext = new ExceptionValidatingModel();
+                target.Bind(property, binding);
 
-            subject.Subscribe(x => result = x);
+                Assert.Equal(20, target.GetValue(property));
 
-            Assert.IsType<string>(result);
+                target.SetValue(property, 200);
+
+                Assert.Equal(200, target.GetValue(property));
+                Assert.IsType<ArgumentOutOfRangeException>(target.DataValidationError);
+
+                target.SetValue(property, 10);
+
+                Assert.Equal(10, target.GetValue(property));
+                Assert.Null(target.DataValidationError);
+            }
+
+            [Fact]
+            public void Indei_Error_Causes_DataValidation_Error()
+            {
+                var (target, property) = CreateTarget();
+                var binding = new Binding(nameof(IndeiValidatingModel.Value))
+                {
+                    Mode = BindingMode.TwoWay
+                };
+
+                target.DataContext = new IndeiValidatingModel();
+                target.Bind(property, binding);
+
+                Assert.Equal(20, target.GetValue(property));
+
+                target.SetValue(property, 200);
+
+                Assert.Equal(200, target.GetValue(property));
+                Assert.IsType<DataValidationException>(target.DataValidationError);
+                Assert.Equal("Invalid value.", target.DataValidationError?.Message);
+
+                target.SetValue(property, 10);
+
+                Assert.Equal(10, target.GetValue(property));
+                Assert.Null(target.DataValidationError);
+            }
+
+            private protected abstract (DataValidationTestControl, T) CreateTarget();
         }
 
-        [Fact]
-        public void Initiate_Should_Enable_Data_Validation_With_BindingPriority_LocalValue()
+        public class DirectPropertyTests : TestBase<DirectPropertyBase<int>>
         {
-            var textBlock = new TextBlock
+            private protected override (DataValidationTestControl, DirectPropertyBase<int>) CreateTarget()
             {
-                DataContext = new Class1(),
-            };
-
-            var target = new Binding(nameof(Class1.Foo));
-            var instanced = target.Initiate(textBlock, TextBlock.TextProperty, enableDataValidation: true);
-            var subject = (BindingExpression)instanced.Source;
-            object result = null;
-
-            subject.Subscribe(x => result = x);
-
-            Assert.Equal(new BindingNotification("foo"), result);
+                return (new ValidatedDirectPropertyClass(), ValidatedDirectPropertyClass.ValueProperty);
+            }
         }
 
-        [Fact]
-        public void Initiate_Should_Not_Enable_Data_Validation_With_BindingPriority_TemplatedParent()
+        public class StyledPropertyTests : TestBase<StyledProperty<int>>
         {
-            var textBlock = new TextBlock
+            [Fact]
+            public void Style_Binding_Supports_Indei_Data_Validation()
             {
-                DataContext = new Class1(),
-            };
+                var (target, property) = CreateTarget();
+                var binding = new Binding(nameof(IndeiValidatingModel.Value))
+                {
+                    Mode = BindingMode.TwoWay
+                };
 
-            var target = new Binding(nameof(Class1.Foo)) { Priority = BindingPriority.Template };
-            var instanced = target.Initiate(textBlock, TextBlock.TextProperty, enableDataValidation: true);
-            var subject = (BindingExpression)instanced.Source;
-            object result = null;
+                var root = new TestRoot
+                {
+                    DataContext = new IndeiValidatingModel(),
+                    Styles =
+                    {
+                        new Style(x => x.Is<DataValidationTestControl>())
+                        {
+                            Setters =
+                            {
+                                new Setter(property, binding)
+                            }
+                        }
+                    },
+                    Child = target,
+                };
 
-            subject.Subscribe(x => result = x);
+                root.LayoutManager.ExecuteInitialLayoutPass();
 
-            Assert.IsType<string>(result);
+                Assert.Equal(20, target.GetValue(property));
+
+                target.SetValue(property, 200);
+
+                Assert.Equal(200, target.GetValue(property));
+                Assert.IsType<DataValidationException>(target.DataValidationError);
+                Assert.Equal("Invalid value.", target.DataValidationError?.Message);
+
+                target.SetValue(property, 10);
+
+                Assert.Equal(10, target.GetValue(property));
+                Assert.Null(target.DataValidationError);
+            }
+
+            [Fact]
+            public void Style_With_Activator_Binding_Supports_Indei_Data_Validation()
+            {
+                var (target, property) = CreateTarget();
+                var binding = new Binding(nameof(IndeiValidatingModel.Value))
+                {
+                    Mode = BindingMode.TwoWay
+                };
+
+                var model = new IndeiValidatingModel
+                {
+                    Value = 200,
+                };
+
+                var root = new TestRoot
+                {
+                    DataContext = model,
+                    Styles =
+                    {
+                        new Style(x => x.Is<DataValidationTestControl>().Class("foo"))
+                        {
+                            Setters =
+                            {
+                                new Setter(property, binding)
+                            }
+                        }
+                    },
+                    Child = target,
+                };
+
+                root.LayoutManager.ExecuteInitialLayoutPass();
+                target.Classes.Add("foo");
+
+                Assert.Equal(200, target.GetValue(property));
+                Assert.IsType<DataValidationException>(target.DataValidationError);
+                Assert.Equal("Invalid value.", target.DataValidationError?.Message);
+
+                target.Classes.Remove("foo");
+                Assert.Equal(0, target.GetValue(property));
+                Assert.Null(target.DataValidationError);
+
+                target.Classes.Add("foo");
+                Assert.IsType<DataValidationException>(target.DataValidationError);
+                Assert.Equal("Invalid value.", target.DataValidationError?.Message);
+
+                target.SetValue(property, 10);
+
+                Assert.Equal(10, target.GetValue(property));
+                Assert.Null(target.DataValidationError);
+            }
+
+            private protected override (DataValidationTestControl, StyledProperty<int>) CreateTarget()
+            {
+                return (new ValidatedStyledPropertyClass(), ValidatedStyledPropertyClass.ValueProperty);
+            }
         }
 
-        private class Class1
+        internal class DataValidationTestControl : Control
         {
-            public string Foo { get; set; } = "foo";
+            public Exception? DataValidationError { get; protected set; }
+        }
+
+        private class ValidatedStyledPropertyClass : DataValidationTestControl
+        {
+            public static readonly StyledProperty<int> ValueProperty =
+                AvaloniaProperty.Register<ValidatedStyledPropertyClass, int>(
+                    "Value",
+                    enableDataValidation: true);
+
+            public int Value
+            {
+                get => GetValue(ValueProperty);
+                set => SetValue(ValueProperty, value);
+            }
+
+            protected override void UpdateDataValidation(AvaloniaProperty property, BindingValueType state, Exception? error)
+            {
+                if (property == ValueProperty)
+                {
+                    DataValidationError = state.HasAnyFlag(BindingValueType.DataValidationError) ? error : null;
+                }
+            }
+        }
+
+        private class ValidatedDirectPropertyClass : DataValidationTestControl
+        {
+            public static readonly DirectProperty<ValidatedDirectPropertyClass, int> ValueProperty =
+                AvaloniaProperty.RegisterDirect<ValidatedDirectPropertyClass, int>(
+                    "Value",
+                    o => o.Value,
+                    (o, v) => o.Value = v,
+                    enableDataValidation: true);
+
+            private int _value;
+
+            public int Value
+            {
+                get => _value;
+                set => SetAndRaise(ValueProperty, ref _value, value);
+            }
+
+            protected override void UpdateDataValidation(AvaloniaProperty property, BindingValueType state, Exception? error)
+            {
+                if (property == ValueProperty)
+                {
+                    DataValidationError = state.HasAnyFlag(BindingValueType.DataValidationError) ? error : null;
+                }
+            }
+        }
+
+        private class ExceptionValidatingModel
+        {
+            public const int MaxValue = 100;
+            private int _value = 20;
+
+            public int Value
+            {
+                get => _value;
+                set
+                {
+                    if (value > MaxValue)
+                        throw new ArgumentOutOfRangeException(nameof(value));
+                    _value = value;
+                }
+            }
+        }
+
+        private class IndeiValidatingModel : INotifyDataErrorInfo
+        {
+            public const int MaxValue = 100;
+            private bool _hasErrors;
+            private int _value = 20;
+
+            public int Value
+            {
+                get => _value;
+                set
+                {
+                    _value = value;
+                    HasErrors = value > MaxValue;
+                }
+            }
+
+            public bool HasErrors 
+            {
+                get => _hasErrors;
+                private set
+                {
+                    if (_hasErrors != value)
+                    {
+                        _hasErrors = value;
+                        ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(nameof(Value)));
+                    }
+                }
+            }
+
+            public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
+
+            public IEnumerable GetErrors(string? propertyName)
+            {
+                if (propertyName == nameof(Value) && _value > MaxValue)
+                    yield return "Invalid value.";
+            }
         }
     }
 }

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_DataValidation.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_DataValidation.cs
@@ -67,6 +67,30 @@ namespace Avalonia.Markup.UnitTests.Data
                 Assert.Null(target.DataValidationError);
             }
 
+            [Fact]
+            public void Disposing_Binding_Subscription_Clears_DataValidation()
+            {
+                var (target, property) = CreateTarget();
+                var binding = new Binding(nameof(ExceptionValidatingModel.Value))
+                {
+                    Mode = BindingMode.TwoWay
+                };
+
+                target.DataContext = new IndeiValidatingModel
+                {
+                    Value = 200,
+                };
+                
+                var sub = target.Bind(property, binding);
+
+                Assert.Equal(200, target.GetValue(property));
+                Assert.IsType<DataValidationException>(target.DataValidationError);
+
+                sub.Dispose();
+
+                Assert.Null(target.DataValidationError);
+            }
+
             private protected abstract (DataValidationTestControl, T) CreateTarget();
         }
 

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_DataValidation.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_DataValidation.cs
@@ -89,9 +89,10 @@ namespace Avalonia.Markup.UnitTests.Data
                     Mode = BindingMode.TwoWay
                 };
 
+                var model = new IndeiValidatingModel();
                 var root = new TestRoot
                 {
-                    DataContext = new IndeiValidatingModel(),
+                    DataContext = model,
                     Styles =
                     {
                         new Style(x => x.Is<DataValidationTestControl>())
@@ -109,13 +110,13 @@ namespace Avalonia.Markup.UnitTests.Data
 
                 Assert.Equal(20, target.GetValue(property));
 
-                target.SetValue(property, 200);
+                model.Value = 200;
 
                 Assert.Equal(200, target.GetValue(property));
                 Assert.IsType<DataValidationException>(target.DataValidationError);
                 Assert.Equal("Invalid value: 200.", target.DataValidationError?.Message);
 
-                target.SetValue(property, 10);
+                model.Value = 10;
 
                 Assert.Equal(10, target.GetValue(property));
                 Assert.Null(target.DataValidationError);
@@ -166,7 +167,7 @@ namespace Avalonia.Markup.UnitTests.Data
                 Assert.IsType<DataValidationException>(target.DataValidationError);
                 Assert.Equal("Invalid value: 200.", target.DataValidationError?.Message);
 
-                target.SetValue(property, 10);
+                model.Value = 10;
 
                 Assert.Equal(10, target.GetValue(property));
                 Assert.Null(target.DataValidationError);


### PR DESCRIPTION
## What does the pull request do?

Data validation was previously only implemented for direct properties. In order for #9944 to be implemented, styled properties will also need this feature.

Note that data validation with two-way bindings is still only really supported for `LocalValue` bindings due to #6684. That issue will need to be fixed separately.

I ran benchmarks on this PR, comparing to current master and it looks like the feature adds little to no overhead when not enabled.