### PR TITLE
macOS: Fix window order breaking when closing modal dialog

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -298,7 +298,8 @@
     dispatch_async(dispatch_get_main_queue(), ^{
         @try {
             [self invalidateShadow];
-            self->_parent->BringToFront();
+            if (self->_parent != nullptr)
+                self->_parent->BringToFront();
         }
         @finally{
         }

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -292,12 +292,13 @@
 {
     if (_parent == nullptr)
         return;
-        
+    
     _parent->BringToFront();
     
     dispatch_async(dispatch_get_main_queue(), ^{
         @try {
-        [self invalidateShadow];
+            [self invalidateShadow];
+            self->_parent->BringToFront();
         }
         @finally{
         }

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
@@ -150,6 +150,18 @@ namespace Avalonia.IntegrationTests.Appium
             windowState = mainWindow.FindElementByAccessibilityId("MainWindowState");
             Assert.Equal("Normal", windowState.Text);
         }
+        
+        [PlatformFact(TestPlatforms.MacOS)]
+        public void WindowOrder_Owned_Dialog_Stays_InFront_Of_Parent_After_Modal_Closed()
+        {
+            using (OpenWindow(new PixelSize(200, 300), ShowWindowMode.Owned, WindowStartupLocation.Manual))
+            {
+                OpenWindow(null, ShowWindowMode.Modal, WindowStartupLocation.Manual).Dispose();
+                
+                var secondaryWindowIndex = GetWindowOrder("SecondaryWindow");
+                Assert.Equal(1, secondaryWindowIndex);
+            }
+        }
 
         [PlatformFact(TestPlatforms.MacOS)]
         public void Does_Not_Switch_Space_From_FullScreen_To_Main_Desktop_When_FullScreen_Window_Clicked()


### PR DESCRIPTION
## What does the pull request do?

Fixes the following scenario on macOS:

- Open a child window of main window
- Open a modal window as a child of main window
- Close modal window
- First child window should remain in front of main window, but it doesn't - it gets moved behind the main window.

This happens because sometimes (and _always_ in this particular case), after `windowDidBecomeKey` is called and the window order is enforced via `BringToFront`, the window that became key is then moved to the front, breaking window order. Given that we're already invalidating the shadow by scheduling it on the dispatcher, use this opportunity to also enforce the window order again.

Adds an integration test to prevent regressions here.