### PR TITLE
if the window is closed, we cannot become the key window.

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -238,7 +238,7 @@
 
 -(BOOL)canBecomeKeyWindow
 {
-    if(_canBecomeKeyWindow)
+    if(_canBecomeKeyWindow && !_closed)
     {
         // If the window has a child window being shown as a dialog then don't allow it to become the key window.
         auto parent = dynamic_cast<WindowImpl*>(_parent.getRaw());


### PR DESCRIPTION
It was reported that dialogs could crash on OSX if the app menu was open by the user whilst the app programatically closes the dialog.

This was caused because NSWindow canBecomeKey did not take into account if the window was already closing. In which case it cant become key.

The crash happened because when you remove or add items to a menu that is attached to the window, it calls canBecomeKey and if that returns true it would call becomeKeyWindow, that would then call showWindowMenuWithAppMenu, but we are already manipulating the menu.

The crash was: unable to add an item when its already in another menu, caused by this re-entrancy.

Initially I fixed it with guards, but then realised the source of the issue is that canBecomeKey was not implemented correctly.