### PR TITLE
Fixed incorrect initial mouse button on pointer release

### DIFF
--- a/src/Avalonia.Base/Input/MouseDevice.cs
+++ b/src/Avalonia.Base/Input/MouseDevice.cs
@@ -184,6 +184,7 @@ namespace Avalonia.Input
 
                 source?.RaiseEvent(e);
                 _pointer.Capture(null);
+                _lastMouseDownButton = default;
                 return e.Handled;
             }
 

--- a/src/Avalonia.Base/Input/PenDevice.cs
+++ b/src/Avalonia.Base/Input/PenDevice.cs
@@ -131,6 +131,7 @@ namespace Avalonia.Input
 
                 source?.RaiseEvent(e);
                 pointer.Capture(null);
+                _lastMouseDownButton = default;
                 return e.Handled;
             }
 

--- a/tests/Avalonia.Base.UnitTests/Input/MouseDeviceTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/MouseDeviceTests.cs
@@ -1,13 +1,63 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Input.Raw;
 using Avalonia.Media;
+using Avalonia.Platform;
 using Avalonia.UnitTests;
+using Moq;
 using Xunit;
 
 namespace Avalonia.Base.UnitTests.Input
 {
     public class MouseDeviceTests : PointerTestsBase
     {
+        [Fact]
+        public void Initial_Buttons_Are_Not_Set_Without_Corresponding_Mouse_Down()
+        {
+            using var scope = AvaloniaLocator.EnterScope();
+            var settingsMock = new Mock<IPlatformSettings>();
+            var threadingMock = new Mock<IPlatformThreadingInterface>();
+
+            threadingMock.Setup(x => x.CurrentThreadIsLoopThread).Returns(true);
+
+            AvaloniaLocator.CurrentMutable.BindToSelf(this)
+                .Bind<IPlatformSettings>().ToConstant(settingsMock.Object);
+
+            using var app = UnitTestApplication.Start(
+                new TestServices(
+                    inputManager: new InputManager(),
+                    threadingInterface: threadingMock.Object));
+
+            var renderer = RendererMocks.CreateRenderer();
+            var device = new MouseDevice();
+            var impl = CreateTopLevelImplMock(renderer.Object);
+
+            var control = new Control();
+            var root = CreateInputRoot(impl.Object, control);
+           
+            MouseButton button = default;
+
+            root.PointerReleased += (s, e) => button = e.InitialPressMouseButton;
+
+            var down = CreateRawPointerArgs(device, root, RawPointerEventType.LeftButtonDown);
+            var up = CreateRawPointerArgs(device, root, RawPointerEventType.LeftButtonUp);
+
+            SetHit(renderer, control);
+
+            impl.Object.Input!(up);
+
+            Assert.Equal(MouseButton.None, button);
+
+            impl.Object.Input!(down);
+            impl.Object.Input!(up);
+
+            Assert.Equal(MouseButton.Left, button);
+           
+            impl.Object.Input!(up);
+
+            Assert.Equal(MouseButton.None, button);        
+        }
+
         [Fact]
         public void Capture_Is_Transferred_To_Parent_When_Control_Removed()
         {
@@ -37,7 +87,7 @@ namespace Avalonia.Base.UnitTests.Input
             impl.Object.Input!(CreateRawPointerMovedArgs(device, root));
 
             Assert.NotNull(result);
-            
+           
             result.Capture(control);
             Assert.Same(control, result.Captured);
 
@@ -67,8 +117,8 @@ namespace Avalonia.Base.UnitTests.Input
                     })
                 }
             });
-            
-            
+           
+           
             Point? result = null;
             root.PointerMoved += (_, a) =>
             {

--- a/tests/Avalonia.Base.UnitTests/Input/PointerTestsBase.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/PointerTestsBase.cs
@@ -55,20 +55,29 @@ public abstract class PointerTestsBase
         return root;
     }
 
+    protected static RawPointerEventArgs CreateRawPointerArgs(
+        IPointerDevice pointerDevice,
+        IInputRoot root,
+        RawPointerEventType type,
+        Point? position = default)
+    {
+        return new RawPointerEventArgs(pointerDevice, 0, root, type, position ?? default, default);
+    }
+
     protected static RawPointerEventArgs CreateRawPointerMovedArgs(
         IPointerDevice pointerDevice,
         IInputRoot root,
-        Point? positition = null)
+        Point? position = null)
     {
         return new RawPointerEventArgs(pointerDevice, 0, root, RawPointerEventType.Move,
-            positition ?? default, default);
+            position ?? default, default);
     }
 
     protected static PointerEventArgs CreatePointerMovedArgs(
-        IInputRoot root, IInputElement? source, Point? positition = null)
+        IInputRoot root, IInputElement? source, Point? position = null)
     {
         return new PointerEventArgs(InputElement.PointerMovedEvent, source, new Mock<IPointer>().Object, (Visual)root,
-            positition ?? default, default, PointerPointProperties.None, KeyModifiers.None);
+            position ?? default, default, PointerPointProperties.None, KeyModifiers.None);
     }
 
     protected static Mock<IPointerDevice> CreatePointerDeviceMock(


### PR DESCRIPTION
## What does the pull request do?

Fixes an incorrect initial mouse button issue for pointer release events.

## What is the current behavior?

As the issue states, the current behavior is to use an unrelated mouse button to the current pointer release event if there's no corresponding press event.


## What is the updated/expected behavior with this PR?

Clear the last used mouse button on release, and use `None` if there's no initial press event.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues

Fixes #10434.
