### PR TITLE
Don't add ItemsControl items to its panel logical children

### DIFF
--- a/src/Avalonia.Controls/Panel.cs
+++ b/src/Avalonia.Controls/Panel.cs
@@ -26,16 +26,6 @@ namespace Avalonia.Controls
             Border.BackgroundProperty.AddOwner<Panel>();
 
         /// <summary>
-        /// Defines the <see cref="IsItemsHost"/> property.
-        /// </summary>
-        public static readonly DirectProperty<Panel, bool> IsItemsHostProperty =
-            AvaloniaProperty.RegisterDirect<Panel, bool>(
-                nameof(IsItemsHost),
-                o => o.IsItemsHost,
-                (o, v) => o.IsItemsHost = v,
-                unsetValue: false);
-
-        /// <summary>
         /// Initializes static members of the <see cref="Panel"/> class.
         /// </summary>
         static Panel()
@@ -43,7 +33,6 @@ namespace Avalonia.Controls
             AffectsRender<Panel>(BackgroundProperty);
         }
 
-        private bool _isItemsHost;
         private EventHandler<ChildIndexChangedEventArgs>? _childIndexChanged;
 
         /// <summary>
@@ -72,11 +61,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets whether the <see cref="Panel"/> hosts the items created by an <see cref="ItemsPresenter"/>.
         /// </summary>
-        public bool IsItemsHost
-        {
-            get => _isItemsHost;
-            set => SetAndRaise(IsItemsHostProperty, ref _isItemsHost, value);
-        }
+        public bool IsItemsHost { get; internal set; }
 
         event EventHandler<ChildIndexChangedEventArgs>? IChildIndexProvider.ChildIndexChanged
         {

--- a/src/Avalonia.Controls/Panel.cs
+++ b/src/Avalonia.Controls/Panel.cs
@@ -1,13 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
+using Avalonia.Controls.Presenters;
 using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Avalonia.Metadata;
 using Avalonia.Reactive;
-using Avalonia.Styling;
 
 namespace Avalonia.Controls
 {
@@ -27,6 +26,16 @@ namespace Avalonia.Controls
             Border.BackgroundProperty.AddOwner<Panel>();
 
         /// <summary>
+        /// Defines the <see cref="IsItemsHost"/> property.
+        /// </summary>
+        public static readonly DirectProperty<Panel, bool> IsItemsHostProperty =
+            AvaloniaProperty.RegisterDirect<Panel, bool>(
+                nameof(IsItemsHost),
+                o => o.IsItemsHost,
+                (o, v) => o.IsItemsHost = v,
+                unsetValue: false);
+
+        /// <summary>
         /// Initializes static members of the <see cref="Panel"/> class.
         /// </summary>
         static Panel()
@@ -34,6 +43,7 @@ namespace Avalonia.Controls
             AffectsRender<Panel>(BackgroundProperty);
         }
 
+        private bool _isItemsHost;
         private EventHandler<ChildIndexChangedEventArgs>? _childIndexChanged;
 
         /// <summary>
@@ -57,6 +67,15 @@ namespace Avalonia.Controls
         {
             get { return GetValue(BackgroundProperty); }
             set { SetValue(BackgroundProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets whether the <see cref="Panel"/> hosts the items created by an <see cref="ItemsPresenter"/>.
+        /// </summary>
+        public bool IsItemsHost
+        {
+            get => _isItemsHost;
+            set => SetAndRaise(IsItemsHostProperty, ref _isItemsHost, value);
         }
 
         event EventHandler<ChildIndexChangedEventArgs>? IChildIndexProvider.ChildIndexChanged
@@ -129,24 +148,29 @@ namespace Avalonia.Controls
         /// <param name="e">The event args.</param>
         protected virtual void ChildrenChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
-            List<Control> controls;
-
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    controls = e.NewItems!.OfType<Control>().ToList();
-                    LogicalChildren.InsertRange(e.NewStartingIndex, controls);
+                    if (!IsItemsHost)
+                    {
+                        LogicalChildren.InsertRange(e.NewStartingIndex, e.NewItems!.OfType<Control>().ToList());
+                    }
                     VisualChildren.InsertRange(e.NewStartingIndex, e.NewItems!.OfType<Visual>());
                     break;
 
                 case NotifyCollectionChangedAction.Move:
-                    LogicalChildren.MoveRange(e.OldStartingIndex, e.OldItems!.Count, e.NewStartingIndex);
-                    VisualChildren.MoveRange(e.OldStartingIndex, e.OldItems.Count, e.NewStartingIndex);
+                    if (!IsItemsHost)
+                    {
+                        LogicalChildren.MoveRange(e.OldStartingIndex, e.OldItems!.Count, e.NewStartingIndex);
+                    }
+                    VisualChildren.MoveRange(e.OldStartingIndex, e.OldItems!.Count, e.NewStartingIndex);
                     break;
 
                 case NotifyCollectionChangedAction.Remove:
-                    controls = e.OldItems!.OfType<Control>().ToList();
-                    LogicalChildren.RemoveAll(controls);
+                    if (!IsItemsHost)
+                    {
+                        LogicalChildren.RemoveAll(e.OldItems!.OfType<Control>().ToList());
+                    }
                     VisualChildren.RemoveAll(e.OldItems!.OfType<Visual>());
                     break;
 
@@ -155,7 +179,10 @@ namespace Avalonia.Controls
                     {
                         var index = i + e.OldStartingIndex;
                         var child = (Control)e.NewItems![i]!;
-                        LogicalChildren[index] = child;
+                        if (!IsItemsHost)
+                        {
+                            LogicalChildren[index] = child;
+                        }
                         VisualChildren[index] = child;
                     }
                     break;
@@ -200,6 +227,7 @@ namespace Avalonia.Controls
             return child is Control control ? Children.IndexOf(control) : -1;
         }
 
+        /// <inheritdoc />
         public bool TryGetTotalCount(out int count)
         {
             count = Children.Count;

--- a/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ItemsPresenter.cs
@@ -167,6 +167,7 @@ namespace Avalonia.Controls.Presenters
 
                 Panel = ItemsPanel.Build();
                 Panel.SetValue(TemplatedParentProperty, TemplatedParent);
+                Panel.IsItemsHost = true;
                 _scrollSnapPointsInfo = Panel as IScrollSnapPointsInfo;
                 LogicalChildren.Add(Panel);
                 VisualChildren.Add(Panel);

--- a/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
@@ -74,6 +74,19 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Panel_Should_Have_ItemsHost_Set_To_True()
+        {
+            var target = new ItemsControl();
+
+            target.Template = GetTemplate();
+            target.Items = new[] { "Foo" };
+            target.ApplyTemplate();
+            target.Presenter!.ApplyTemplate();
+
+            Assert.True(target.Presenter.Panel!.IsItemsHost);
+        }
+
+        [Fact]
         public void Container_Should_Have_TemplatedParent_Set_To_Null()
         {
             var target = new ItemsControl();
@@ -634,7 +647,7 @@ namespace Avalonia.Controls.UnitTests
             target.ApplyTemplate();
             target.Presenter.ApplyTemplate();
 
-            var item = target.Presenter.Panel.LogicalChildren[0];
+            var item = target.LogicalChildren[0];
             Assert.Null(NameScope.GetNameScope((TextBlock)item));
         }
 

--- a/tests/Avalonia.Controls.UnitTests/PanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/PanelTests.cs
@@ -141,5 +141,20 @@ namespace Avalonia.Controls.UnitTests
             var panel = new Panel();
             Assert.Throws<ArgumentNullException>(() => panel.Children.Add(null!));
         }
+
+        [Fact]
+        public void Adding_Control_To_Items_Host_Panel_Should_Not_Affect_Logical_Children()
+        {
+            var child = new Control();
+            var realParent = new ContentControl { Content = child };
+            var panel = new Panel { IsItemsHost = true };
+
+            panel.Children.Add(child);
+
+            Assert.Empty(panel.LogicalChildren);
+            Assert.Same(child.Parent, realParent);
+            Assert.Same(child.GetLogicalParent(), realParent);
+            Assert.Same(child.GetVisualParent(), panel);
+        }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -327,7 +327,7 @@ namespace Avalonia.Controls.UnitTests
 
             ApplyTemplate(target);
 
-            var logicalChildren = target.ItemsPresenterPart.Panel.GetLogicalChildren();
+            var logicalChildren = target.GetLogicalChildren();
 
             var result = logicalChildren
                 .OfType<TabItem>()

--- a/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
@@ -1178,7 +1178,7 @@ namespace Avalonia.Controls.UnitTests
             target.ApplyTemplate();
             target.Presenter.ApplyTemplate();
 
-            var item = target.Presenter.Panel.LogicalChildren[0];
+            var item = target.LogicalChildren[0];
             Assert.Null(NameScope.GetNameScope((TreeViewItem)item));
         }
 


### PR DESCRIPTION
## What does the pull request do?
This PR prevents performance issues caused by detaching nested `ItemsControl` from the logical tree.

## What is the current behavior?
Detaching nested `ItemsControl` (such as `TreeViewItem`) from the logical tree takes exponential time depending on the nesting level. This is caused by extra traversals of the logical tree: see #10413 for more details.

## What is the updated/expected behavior with this PR?
Detaching nested `ItemsControl` takes linear time.

## How was the solution implemented (if it's not obvious)?
`Panel` has a new propery `IsItemsHost`, which prevents the items from being added to its logical tree. `ItemsControl` sets this property to `true` on its own `ItemsPanel`.

Note: contrary to WPF, this property isn't used to search for an items host inside the template: only `ItemsPanel` is supported. It's public because any custom implementation might need this behavior.

## Checklist

- [✔] Added unit tests (if possible)
- [✔] Added XML documentation to any related classes

## Breaking changes
I initially thought that styles targeting items through the presenter wouldn't work anymore, but it turns out they never did anyway since the selectors match using their "true" logical parent, which has always been the `ItemsControl`.

This still affects the logical tree, so it's affecting code relying directly on the panel's logical children (some unit tests were and have been fixed accordingly).

## Fixed issues

Fixes #10413 
