### PR TITLE
Bump collection change event priority.

### DIFF
--- a/src/Avalonia.Controls/Utils/CollectionChangedEventManager.cs
+++ b/src/Avalonia.Controls/Utils/CollectionChangedEventManager.cs
@@ -141,7 +141,7 @@ namespace Avalonia.Controls.Utils
                 else
                 {
                     var eCapture = e;
-                    Dispatcher.UIThread.Post(() => Notify(_collection, eCapture, l));
+                    Dispatcher.UIThread.Post(() => Notify(_collection, eCapture, l), DispatcherPriority.Send);
                 }
             }
         }


### PR DESCRIPTION
## What does the pull request do?

Post collection changes to UI thread with higher priority than `Layout` so that all collection changes are processed before the next layout pass.

`VirtualizingStackPanel` maintains its own mapping of Items -> Containers, and updates that mapping when a `CollectionChanged` event is received, but it also expects that mapping to be up-to-date when a layout is performed.

This fix is one of those where writing a failing unit test would take 100x more time than the actual fix, so I gave up, sorry.

## Fixed issues

Fixes #10399
