### PR TITLE
fix: Address Rule RS1036: Specify analyzer banned API enforcement setings

### DIFF
--- a/src/tools/DevAnalyzers/DevAnalyzers.csproj
+++ b/src/tools/DevAnalyzers/DevAnalyzers.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <EnforceExtendedAnalyzerRules>True</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tools/DevGenerators/DevGenerators.csproj
+++ b/src/tools/DevGenerators/DevGenerators.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <EnforceExtendedAnalyzerRules>True</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Address Rule [RS1036](https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.md#rs1036-specify-analyzer-banned-api-enforcement-setting)

```bash
Warning RS1036 'DevAnalyzers.OnPropertyChangedOverrideAnalyzer': A project containing analyzers or source generators should specify the property '<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>' DevAnalyzers .\src\tools\DevAnalyzers\OnPropertyChangedOverrideAnalyzer.cs 11 Active
Warning RS1036 'Avalonia.SourceGenerator.CompositionGenerator.CompositionRoslynGenerator': A project containing analyzers or source generators should specify the property '<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>' DevGenerators .\src\tools\DevGenerators\CompositionGenerator\CompositionRoslynGenerator.cs 8 Active
Warning RS1036 'DevGenerators.EnumMemberDictionaryGenerator': A project containing analyzers or source generators should specify the property '<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>' DevGenerators .\src\tools\DevGenerators\EnumMemberDictionaryGenerator.cs 12 Active
Warning RS1036 'Generator.GetProcAddressInitializationGenerator': A project containing analyzers or source generators should specify the property '<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>' DevGenerators .\src\tools\DevGenerators\GetProcAddressInitialization.cs 16 Active
Warning RS1036 'Avalonia.SourceGenerator.SubtypesFactoryGenerator': A project containing analyzers or source generators should specify the property '<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>' DevGenerators .\src\tools\DevGenerators\SubtypesFactoryGenerator.cs 12 Active
Warning RS1036 'DevGenerators.X11AtomsGenerator': A project containing analyzers or source generators should specify the property '<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>' DevGenerators .\src\tools\DevGenerators\X11AtomsGenerator.cs 12 Active
Warning RS1036 'DevAnalyzers.GenericVirtualAnalyzer': A project containing analyzers or source generators should specify the property '<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>' DevAnalyzers .\src\tools\DevAnalyzers\GenericVirtualAnalyzer.cs 8 Active
```

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
