### PR TITLE
fix: Address Rule  AVP1040 Type mismatch: CLR property type differs from the value type of {type}

### DIFF
--- a/src/Avalonia.Base/Media/GeometryDrawing.cs
+++ b/src/Avalonia.Base/Media/GeometryDrawing.cs
@@ -27,8 +27,8 @@ namespace Avalonia.Media
         /// <summary>
         /// Defines the <see cref="Pen"/> property.
         /// </summary>
-        public static readonly StyledProperty<Pen?> PenProperty =
-            AvaloniaProperty.Register<GeometryDrawing, Pen?>(nameof(Pen));
+        public static readonly StyledProperty<IPen?> PenProperty =
+            AvaloniaProperty.Register<GeometryDrawing, IPen?>(nameof(Pen));
 
         /// <summary>
         /// Gets or sets the <see cref="Avalonia.Media.Geometry"/> that describes the shape of this <see cref="GeometryDrawing"/>.

--- a/src/Avalonia.Base/Media/PolyLineSegment.cs
+++ b/src/Avalonia.Base/Media/PolyLineSegment.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Avalonia.Collections;
 
 namespace Avalonia.Media
 {
@@ -20,7 +19,7 @@ namespace Avalonia.Media
         /// <value>
         /// The points.
         /// </value>
-        public AvaloniaList<Point> Points
+        public Points Points
         {
             get => GetValue(PointsProperty);
             set => SetValue(PointsProperty, value);


### PR DESCRIPTION
```bash
Avalonia.Media.IPen? Avalonia.Base (net6.0) .\src\Avalonia.Base\Media\GeometryDrawing.cs 55 Active
```

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
