### PR TITLE
fix: CA1823 Unused field

### DIFF
--- a/src/Avalonia.Base/Media/DrawingContext.cs
+++ b/src/Avalonia.Base/Media/DrawingContext.cs
@@ -277,7 +277,6 @@ namespace Avalonia.Media
         private readonly record struct RestoreState : IDisposable
         {
             private readonly DrawingContext _context;
-            private readonly Matrix _matrix;
             private readonly PushedStateType _type;
 
             public enum PushedStateType

--- a/src/Avalonia.Base/Media/DrawingGroup.cs
+++ b/src/Avalonia.Base/Media/DrawingGroup.cs
@@ -107,8 +107,6 @@ namespace Avalonia.Media
             private readonly DrawingGroup _drawingGroup;
             private readonly IPlatformRenderInterface _platformRenderInterface = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
 
-            private Matrix _transform;
-
             private bool _disposed;
 
             // Root drawing created by this DrawingContext.


### PR DESCRIPTION
```bash
Warning CA1823 Unused field '_transform' Avalonia.Base (net6.0) .\src\Avalonia.Base\Media\DrawingGroup.cs 110 Active
Warning CA1823 Unused field '_matrix' Avalonia.Base (netstandard2.0) .\src\Avalonia.Base\Media\DrawingContext.cs 280 Active
```

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
