### PR TITLE
fix: AVP1021 and AVP1022

### DIFF
--- a/samples/ControlCatalog/Pages/PointerCanvas.cs
+++ b/samples/ControlCatalog/Pages/PointerCanvas.cs
@@ -114,7 +114,7 @@ public class PointerCanvas : Control
 
     private string? _status;
     public static readonly DirectProperty<PointerCanvas, string?> StatusProperty =
-        AvaloniaProperty.RegisterDirect<PointerCanvas, string?>(nameof(DrawOnlyPoints), c => c.Status, (c, v) => c.Status = v,
+        AvaloniaProperty.RegisterDirect<PointerCanvas, string?>(nameof(Status), c => c.Status, (c, v) => c.Status = v,
             defaultBindingMode: Avalonia.Data.BindingMode.TwoWay);
 
     public string? Status

--- a/src/Avalonia.Controls/MaskedTextBox.cs
+++ b/src/Avalonia.Controls/MaskedTextBox.cs
@@ -31,11 +31,6 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<string?> MaskProperty =
              AvaloniaProperty.Register<MaskedTextBox, string?>(nameof(Mask), string.Empty);
 
-        public static new readonly StyledProperty<char> PasswordCharProperty =
-#pragma warning disable AVP1013 // AvaloniaProperty owners should not be added superfluously
-            TextBox.PasswordCharProperty.AddOwner<MaskedTextBox>();
-#pragma warning restore AVP1013 // AvaloniaProperty owners should not be added superfluously
-
         public static readonly StyledProperty<char> PromptCharProperty =
              AvaloniaProperty.Register<MaskedTextBox, char>(nameof(PromptChar), '_');
 

--- a/src/Avalonia.Controls/MaskedTextBox.cs
+++ b/src/Avalonia.Controls/MaskedTextBox.cs
@@ -32,7 +32,9 @@ namespace Avalonia.Controls
              AvaloniaProperty.Register<MaskedTextBox, string?>(nameof(Mask), string.Empty);
 
         public static new readonly StyledProperty<char> PasswordCharProperty =
-             AvaloniaProperty.Register<MaskedTextBox, char>(nameof(PasswordChar), '\0');
+#pragma warning disable AVP1013 // AvaloniaProperty owners should not be added superfluously
+            TextBox.PasswordCharProperty.AddOwner<MaskedTextBox>();
+#pragma warning restore AVP1013 // AvaloniaProperty owners should not be added superfluously
 
         public static readonly StyledProperty<char> PromptCharProperty =
              AvaloniaProperty.Register<MaskedTextBox, char>(nameof(PromptChar), '_');
@@ -50,6 +52,12 @@ namespace Avalonia.Controls
         private bool _ignoreTextChanges;
 
         private bool _resetOnSpace = true;
+
+        static MaskedTextBox()
+        {
+            PasswordCharProperty
+                .OverrideDefaultValue<MaskedTextBox>('\0');
+        }
 
         public MaskedTextBox() { }
 

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/ThicknessEditor.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/ThicknessEditor.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Diagnostics.Controls
                 (o, v) => o.Header = v);
 
         public static readonly DirectProperty<ThicknessEditor, bool> IsPresentProperty =
-            AvaloniaProperty.RegisterDirect<ThicknessEditor, bool>(nameof(Header), o => o.IsPresent,
+            AvaloniaProperty.RegisterDirect<ThicknessEditor, bool>(nameof(IsPresent), o => o.IsPresent,
                 (o, v) => o.IsPresent = v);
 
         public static readonly DirectProperty<ThicknessEditor, double> LeftProperty =


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

```bash
Warning AVP1021 Name collision: Avalonia.Controls.MaskedTextBox owns multiple Avalonia properties with the name 'PasswordChar'  Avalonia.Controls.TextBox.PasswordCharProperty  Avalonia.Controls.MaskedTextBox.PasswordCharProperty Avalonia.Controls (net6.0) .\src\Avalonia.Controls\MaskedTextBox.cs 134 Active
Warning AVP1021 Name collision: Avalonia.Diagnostics.Controls.ThicknessEditor owns multiple Avalonia properties with the name 'Header'  Avalonia.Diagnostics.Controls.ThicknessEditor.HeaderProperty  Avalonia.Diagnostics.Controls.ThicknessEditor.IsPresentProperty Avalonia.Diagnostics (net6.0) .\src\Avalonia.Diagnostics\Diagnostics\Controls\ThicknessEditor.cs 53 Active

```

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
