### PR TITLE
Fix `SetCurrent` value in combination with certain styles

### DIFF
--- a/src/Avalonia.Base/PropertyStore/ValueStore.cs
+++ b/src/Avalonia.Base/PropertyStore/ValueStore.cs
@@ -924,7 +924,7 @@ namespace Avalonia.PropertyStore
                 {
                     _effectiveValues.GetKeyValue(i, out var key, out var e);
 
-                    if (e.Priority == BindingPriority.Unset)
+                    if (e.Priority == BindingPriority.Unset && !e.IsOverridenCurrentValue)
                     {
                         RemoveEffectiveValue(key, i);
                         e.DisposeAndRaiseUnset(this, key);


### PR DESCRIPTION
## What does the pull request do?

`SetCurrentValue`'s value was being discarded if a style with _more than one setter_ was was re-evaluated because `ValueStore.ReevaluationEffectiveValues` removed the effective value.

Add a check for a current value before removing the effective value, and a unit test.

Should unblock #10370