### PR TITLE
Make `Avalonia.Win32.Input.KeyInterop` public

### DIFF
--- a/src/Windows/Avalonia.Win32/Input/KeyInterop.cs
+++ b/src/Windows/Avalonia.Win32/Input/KeyInterop.cs
@@ -4,7 +4,7 @@ using Avalonia.Win32.Interop;
 
 namespace Avalonia.Win32.Input
 {
-    static class KeyInterop
+    public static class KeyInterop
     {
         private static readonly Dictionary<Key, int> s_virtualKeyFromKey = new Dictionary<Key, int>
         {


### PR DESCRIPTION
## What does the pull request do?
This PR exposes `Avalonia.Win32.Input.KeyInterop` to assembly consumers, allowing them to map between `Avalonia.Input.Key` and Windows' [virtual keys](https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes) without having to locate and duplicate two large dictionaries from Avalonia's source code.

Use case: we have a rendering component which renders into its own window and reports virtual key presses it receives. We forward these events to our Avalonia UI by raising our own key press events, which requires first translating the key identifiers.

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #10322
