### PR TITLE
Fix TreeView data template handling

### DIFF
--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -383,14 +383,7 @@ namespace Avalonia.Controls
             {
                 hic.Header = item;
                 hic.HeaderTemplate = itemTemplate;
-
-                itemTemplate ??= hic.FindDataTemplate(item) ?? this.FindDataTemplate(item);
-
-                if (itemTemplate is ITreeDataTemplate treeTemplate)
-                {
-                    if (item is not null && treeTemplate.ItemsSelector(item) is { } itemsBinding)
-                        BindingOperations.Apply(hic, ItemsProperty, itemsBinding, null);
-                }
+                hic.PrepareItemContainer();
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
@@ -101,6 +101,31 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Finds_Correct_DataTemplate_When_Application_DataTemplate_Is_Present()
+        {
+            // #10398
+            using var app = UnitTestApplication.Start();
+            
+            Avalonia.Application.Current.DataTemplates.Add(new FuncDataTemplate<object>((x, _) => new Canvas()));
+            AvaloniaLocator.CurrentMutable.Bind<IGlobalDataTemplates>().ToConstant(Avalonia.Application.Current);
+
+            var target = new TreeView
+            {
+                Template = CreateTreeViewTemplate(),
+                Items = CreateTestTreeData(),
+            };
+
+            var root = new TestRoot(target);
+
+            CreateNodeDataTemplate(target);
+            ApplyTemplates(target);
+
+            Assert.Equal(new[] { "Root" }, ExtractItemHeader(target, 0));
+            Assert.Equal(new[] { "Child1", "Child2", "Child3" }, ExtractItemHeader(target, 1));
+            Assert.Equal(new[] { "Grandchild2a" }, ExtractItemHeader(target, 2));
+        }
+
+        [Fact]
         public void Root_ItemContainerGenerator_Containers_Should_Be_Root_Containers()
         {
             var target = new TreeView


### PR DESCRIPTION
## What does the pull request do?

When a `HeaderedItemsControl` is used in an `ItemsControl` it needs to search for an `ITreeDataTemplate` in order to populate the `Items` property. This can't be done properly until it's attached to the logical tree. Previously we had a hacky solution where we searched from the owning `ItemsControl` in case a data template wasn't found, but this caused the wrong template to be selected in the case where data templates were defined in the `App.axaml`.

This PR changes that to do the search on logical tree attachment if no explicit `HeaderTemplate` was provided. It required moving the template search out of the parent `ItemsControl` and into `HeaderedItemsControl` itself.

## Fixed issues

Fixes #10398
