### PR TITLE
Updated GpuInterop sample (fixed calculating yaw, pitch and row; vertically flipped Vulkan image)

### DIFF
--- a/samples/GpuInterop/D3DDemo/D3D11DemoControl.cs
+++ b/samples/GpuInterop/D3DDemo/D3D11DemoControl.cs
@@ -98,13 +98,12 @@ public class D3D11DemoControl : DrawingSurfaceDemoBase
             context.ClearRenderTargetView(renderView,
                 new RawColor4(1 - colorOff, colorOff, (float)0.5 + colorOff / 2, 1));
 
-            
-            var ypr = Matrix4x4.CreateFromYawPitchRoll(Yaw, Pitch, Roll);
+
+            var ypr = Matrix.RotationYawPitchRoll(Yaw, Pitch, Roll);
+
             // Update WorldViewProj Matrix
-            var worldViewProj = Matrix.RotationX((float)Yaw) * Matrix.RotationY((float)Pitch)
-                                                                          * Matrix.RotationZ((float)Roll)
-                                                                          * Matrix.Scaling(new Vector3(scaleX, scaleY, 1))
-                                                                          * viewProj;
+            var worldViewProj = Matrix.Scaling(new Vector3(scaleX, scaleY, 1)) * ypr * viewProj;
+
             worldViewProj.Transpose();
             context.UpdateSubresource(ref worldViewProj, _constantBuffer);
 

--- a/samples/GpuInterop/D3DDemo/D3D11Swapchain.cs
+++ b/samples/GpuInterop/D3DDemo/D3D11Swapchain.cs
@@ -94,6 +94,7 @@ public class D3D11SwapchainImage : ISwapchainImage
     public async ValueTask DisposeAsync()
     {
         if (LastPresent != null)
+        {
             try
             {
                 await LastPresent;
@@ -102,6 +103,19 @@ public class D3D11SwapchainImage : ISwapchainImage
             {
                 // Ignore
             }
+        }
+
+        if (_imported != null)
+        {
+            try
+            {
+                await _imported.DisposeAsync();
+            }
+            catch
+            {
+                // Ignore
+            }
+        }
 
         RenderTargetView.Dispose();
         _mutex.Dispose();

--- a/samples/GpuInterop/GpuDemo.axaml.cs
+++ b/samples/GpuInterop/GpuDemo.axaml.cs
@@ -11,7 +11,7 @@ public class GpuDemo : UserControl
         AvaloniaXamlLoader.Load(this);
     }
     
-    private float _yaw = 5;
+    private float _yaw = 0;
 
     public static readonly DirectProperty<GpuDemo, float> YawProperty =
         AvaloniaProperty.RegisterDirect<GpuDemo, float>("Yaw", o => o.Yaw, (o, v) => o.Yaw = v);
@@ -22,7 +22,7 @@ public class GpuDemo : UserControl
         set => SetAndRaise(YawProperty, ref _yaw, value);
     }
 
-    private float _pitch = 5;
+    private float _pitch = 0;
 
     public static readonly DirectProperty<GpuDemo, float> PitchProperty =
         AvaloniaProperty.RegisterDirect<GpuDemo, float>("Pitch", o => o.Pitch, (o, v) => o.Pitch = v);
@@ -34,7 +34,7 @@ public class GpuDemo : UserControl
     }
 
 
-    private float _roll = 5;
+    private float _roll = 0;
 
     public static readonly DirectProperty<GpuDemo, float> RollProperty =
         AvaloniaProperty.RegisterDirect<GpuDemo, float>("Roll", o => o.Roll, (o, v) => o.Roll = v);

--- a/samples/GpuInterop/VulkanDemo/VulkanContent.cs
+++ b/samples/GpuInterop/VulkanDemo/VulkanContent.cs
@@ -141,10 +141,6 @@ unsafe class VulkanContent : IDisposable
 
         
         var model = Matrix4x4.CreateFromYawPitchRoll((float)yaw, (float)pitch, (float)roll);
-        var view = Matrix4x4.CreateLookAt(new Vector3(25, 25, 25), new Vector3(), new Vector3(0, -1, 0));
-        var projection =
-            Matrix4x4.CreatePerspectiveFieldOfView((float)(Math.PI / 4), (float)((float)image.Size.Width / image.Size.Height),
-                0.01f, 1000);
         
         var vertexConstant = new VertextPushConstant()
         {
@@ -391,7 +387,7 @@ unsafe class VulkanContent : IDisposable
     {
         DestroyTemporalObjects();
         
-        var view = Matrix4x4.CreateLookAt(new Vector3(25, 25, 25), new Vector3(), new Vector3(0, -1, 0));
+        var view = Matrix4x4.CreateLookAt(new Vector3(0, 0, 50), new Vector3(), new Vector3(0, 1, 0));
         var projection =
             Matrix4x4.CreatePerspectiveFieldOfView((float)(Math.PI / 4), (float)((float)size.Width / size.Height),
                 0.01f, 1000);

--- a/samples/GpuInterop/VulkanDemo/VulkanContent.cs
+++ b/samples/GpuInterop/VulkanDemo/VulkanContent.cs
@@ -160,15 +160,18 @@ unsafe class VulkanContent : IDisposable
 
         var commandBufferHandle = new CommandBuffer(commandBuffer.Handle);
 
+        // Set Viewport and also vertically flip the image so that on the rendered 2D image y axis will point up.
+        // To flip the image we set Height to negative height value and add Y offset to height.
+        // See more: https://www.saschawillems.de/blog/2019/03/29/flipping-the-vulkan-viewport/
         api.CmdSetViewport(commandBufferHandle, 0, 1,
             new Viewport()
             {
                 Width = (float)image.Size.Width,
-                Height = (float)image.Size.Height,
+                Height = -(float)image.Size.Height,
                 MaxDepth = 1,
                 MinDepth = 0,
                 X = 0,
-                Y = 0
+                Y = (float)image.Size.Height
             });
 
         var scissor = new Rect2D


### PR DESCRIPTION
The first commit in the PR updates the sample so that when yaw, pitch and roll are zero the model is viewed straight into the front side. Commit also fixes calculating worldViewProj in D3D11DemoControl (before changing the Yaw slider changed pitch angle).

In the second commit in the PR, the rendered Vulkan image is vertically flipped so that on the rendered 2D image the y axis will point up. To flip the image the Height in Viewport is set to negative height value and Y value is offset by height value. See more: https://www.saschawillems.de/blog/2019/03/29/flipping-the-vulkan-viewport/


## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
