### PR TITLE
macos screen api to return correct scaling.

### DIFF
--- a/native/Avalonia.Native/src/OSX/Screens.mm
+++ b/native/Avalonia.Native/src/OSX/Screens.mm
@@ -41,7 +41,7 @@ public:
             ret->WorkingArea.X = [screen visibleFrame].origin.x;
             ret->WorkingArea.Y = ConvertPointY(ToAvnPoint([screen visibleFrame].origin)).Y - ret->WorkingArea.Height;
             
-            ret->Scaling = [screen backingScaleFactor];
+            ret->Scaling = 1;
             
             ret->IsPrimary = index == 0;
             


### PR DESCRIPTION
Mac OS the screen dimensions and positions should always be reported with scalefactor 1.

Currently we return the "RenderScaling"