### PR TITLE
Fixes/mac os constrain window size

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -127,11 +127,8 @@
         [self updateRenderTarget];
 
         auto reason = [self inLiveResize] ? ResizeUser : _resizeReason;
-        
-        if(_parent->IsShown())
-        {
-            _parent->BaseEvents->Resized(AvnSize{newSize.width, newSize.height}, reason);
-        }
+
+        _parent->BaseEvents->Resized(AvnSize{newSize.width, newSize.height}, reason);
     }
 }
 

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -4,6 +4,7 @@
 //
 
 #import <AppKit/AppKit.h>
+#import <Cocoa/Cocoa.h>
 #include "common.h"
 #include "AvnView.h"
 #include "menu.h"
@@ -293,29 +294,24 @@ HRESULT WindowBaseImpl::Resize(double x, double y, AvnPlatformResizeReason reaso
         }
 
         @try {
-            if(x != lastSize.width || y != lastSize.height) {
-                lastSize = NSSize{x, y};
-
+            if(x != lastSize.width || y != lastSize.height)
+            {
                 if (!_shown) {
-                    // Before the window is shown, Cocoa wont give Resized events
-                    // constraining the window to the maximum size available on the monitor.
-                    // we have to emulated this behavior that Avalonia relies on.
                     auto screenSize = [Window screen].visibleFrame.size;
 
-                    if(x > screenSize.width){
+                    if (x > screenSize.width) {
                         x = screenSize.width;
                     }
 
-                    if(y > screenSize.height)
-                    {
+                    if (y > screenSize.height) {
                         y = screenSize.height;
                     }
-
-                    BaseEvents->Resized(AvnSize{x, y}, reason);
-                } else if (Window != nullptr) {
-                    [Window setContentSize:lastSize];
-                    [Window invalidateShadow];
                 }
+
+                lastSize = NSSize{x, y};
+
+                [Window setContentSize:lastSize];
+                [Window invalidateShadow];
             }
         }
         @finally {

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -273,6 +273,7 @@ HRESULT WindowBaseImpl::Resize(double x, double y, AvnPlatformResizeReason reaso
     auto resizeBlock = ResizeScope(View, reason);
 
     @autoreleasepool {
+        auto screenSize = [Window screen].visibleFrame.size;
         auto maxSize = lastMaxSize;
         auto minSize = lastMinSize;
 
@@ -290,6 +291,15 @@ HRESULT WindowBaseImpl::Resize(double x, double y, AvnPlatformResizeReason reaso
 
         if (y > maxSize.height) {
             y = maxSize.height;
+        }
+
+        if(x > screenSize.width){
+            x = screenSize.width;
+        }
+
+        if(y > screenSize.height)
+        {
+            y = screenSize.height;
         }
 
         @try {

--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -54,7 +54,11 @@ HRESULT WindowImpl::Show(bool activate, bool isDialog) {
 
         WindowBaseImpl::Show(activate, isDialog);
         GetWindowState(&_actualWindowState);
-        _lastWindowState = _actualWindowState;
+
+        if(IsZoomed()) {
+            _lastWindowState = _actualWindowState;
+        }
+
         return SetWindowState(_lastWindowState);
     }
 }

--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -54,6 +54,7 @@ HRESULT WindowImpl::Show(bool activate, bool isDialog) {
 
         WindowBaseImpl::Show(activate, isDialog);
         GetWindowState(&_actualWindowState);
+        _lastWindowState = _actualWindowState;
         return SetWindowState(_lastWindowState);
     }
 }

--- a/samples/IntegrationTestApp/ShowWindowTest.axaml
+++ b/samples/IntegrationTestApp/ShowWindowTest.axaml
@@ -1,41 +1,50 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:integrationTestApp="clr-namespace:IntegrationTestApp"
         x:Class="IntegrationTestApp.ShowWindowTest"
         Name="SecondaryWindow"
         x:DataType="Window"
         Title="Show Window Test">
-  <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
-    <Label Grid.Column="0" Grid.Row="1">Client Size</Label>
-    <TextBox Name="ClientSize" Grid.Column="1" Grid.Row="1" IsReadOnly="True"
-             Text="{Binding ClientSize, Mode=OneWay}"/>
-    
-    <Label Grid.Column="0" Grid.Row="2">Frame Size</Label>
-    <TextBox Name="FrameSize" Grid.Column="1" Grid.Row="2" IsReadOnly="True"
-             Text="{Binding FrameSize, Mode=OneWay}"/>
+  <integrationTestApp:MeasureBorder Name="MyBorder">
+    <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+      <Label Grid.Column="0" Grid.Row="1">Client Size</Label>
+      <TextBox Name="ClientSize" Grid.Column="1" Grid.Row="1" IsReadOnly="True"
+               Text="{Binding ClientSize, Mode=OneWay}" />
 
-    <Label Grid.Column="0" Grid.Row="3">Position</Label>
-    <TextBox Name="Position" Grid.Column="1" Grid.Row="3" IsReadOnly="True"/>
+      <Label Grid.Column="0" Grid.Row="2">Frame Size</Label>
+      <TextBox Name="FrameSize" Grid.Column="1" Grid.Row="2" IsReadOnly="True"
+               Text="{Binding FrameSize, Mode=OneWay}" />
 
-    <Label Grid.Column="0" Grid.Row="4">Owner Rect</Label>
-    <TextBox Name="OwnerRect" Grid.Column="1" Grid.Row="4" IsReadOnly="True"/>
-    
-    <Label Grid.Column="0" Grid.Row="5">Screen Rect</Label>
-    <TextBox Name="ScreenRect" Grid.Column="1" Grid.Row="5" IsReadOnly="True"/>
+      <Label Grid.Column="0" Grid.Row="3">Position</Label>
+      <TextBox Name="Position" Grid.Column="1" Grid.Row="3" IsReadOnly="True" />
 
-    <Label Grid.Column="0" Grid.Row="6">Scaling</Label>
-    <TextBox Name="Scaling" Grid.Column="1" Grid.Row="6" IsReadOnly="True"/>
-    
-    <Label Grid.Column="0" Grid.Row="7">WindowState</Label>
-    <ComboBox Name="WindowState" Grid.Column="1" Grid.Row="7" SelectedIndex="{Binding WindowState}">
-      <ComboBoxItem Name="WindowStateNormal">Normal</ComboBoxItem>
-      <ComboBoxItem Name="WindowStateMinimized">Minimized</ComboBoxItem>
-      <ComboBoxItem Name="WindowStateMaximized">Maximized</ComboBoxItem>
-      <ComboBoxItem Name="WindowStateFullScreen">FullScreen</ComboBoxItem>
-    </ComboBox>
+      <Label Grid.Column="0" Grid.Row="4">Owner Rect</Label>
+      <TextBox Name="OwnerRect" Grid.Column="1" Grid.Row="4" IsReadOnly="True" />
 
-    <Label Grid.Column="0" Grid.Row="8">Order (mac)</Label>
-    <TextBox Name="Order" Grid.Column="1" Grid.Row="8" IsReadOnly="True"/>
+      <Label Grid.Column="0" Grid.Row="5">Screen Rect</Label>
+      <TextBox Name="ScreenRect" Grid.Column="1" Grid.Row="5" IsReadOnly="True" />
 
-    <Button Name="HideButton" Grid.Row="9" Command="{Binding $parent[Window].Hide}">Hide</Button>
-  </Grid>
+      <Label Grid.Column="0" Grid.Row="6">Scaling</Label>
+      <TextBox Name="Scaling" Grid.Column="1" Grid.Row="6" IsReadOnly="True" />
+
+      <Label Grid.Column="0" Grid.Row="7">WindowState</Label>
+      <ComboBox Name="WindowState" Grid.Column="1" Grid.Row="7" SelectedIndex="{Binding WindowState}">
+        <ComboBoxItem Name="WindowStateNormal">Normal</ComboBoxItem>
+        <ComboBoxItem Name="WindowStateMinimized">Minimized</ComboBoxItem>
+        <ComboBoxItem Name="WindowStateMaximized">Maximized</ComboBoxItem>
+        <ComboBoxItem Name="WindowStateFullScreen">FullScreen</ComboBoxItem>
+      </ComboBox>
+
+      <Label Grid.Column="0" Grid.Row="8">Order (mac)</Label>
+      <TextBox Name="Order" Grid.Column="1" Grid.Row="8" IsReadOnly="True" />
+
+      <Button Name="HideButton" Grid.Row="9" Command="{Binding $parent[Window].Hide}">Hide</Button>
+      
+      <StackPanel Grid.Row="10" Orientation="Horizontal">
+        <TextBlock Text="MeasuredWith:" />
+        <TextBlock Name="MeasuredWithText" Text="{Binding #MyBorder.MeasuredWith}" />
+      </StackPanel>
+      
+    </Grid>
+  </integrationTestApp:MeasureBorder>
 </Window>

--- a/samples/IntegrationTestApp/ShowWindowTest.axaml
+++ b/samples/IntegrationTestApp/ShowWindowTest.axaml
@@ -37,13 +37,11 @@
 
       <Label Grid.Column="0" Grid.Row="8">Order (mac)</Label>
       <TextBox Name="CurrentOrder" Grid.Column="1" Grid.Row="8" IsReadOnly="True" />
-
-      <Button Name="HideButton" Grid.Row="9" Command="{Binding $parent[Window].Hide}">Hide</Button>
       
-      <StackPanel Grid.Row="10" Orientation="Horizontal">
-        <TextBlock Text="MeasuredWith:" />
-        <TextBlock Name="MeasuredWithText" Text="{Binding #MyBorder.MeasuredWith}" />
-      </StackPanel>
+      <Label Grid.Row="9" Content="MeasuredWith:" />
+      <TextBlock Grid.Column="1" Grid.Row="9" Name="CurrentMeasuredWithText" Text="{Binding #MyBorder.MeasuredWith}" />
+
+      <Button Name="HideButton" Grid.Row="10" Command="{Binding $parent[Window].Hide}">Hide</Button>
       
     </Grid>
   </integrationTestApp:MeasureBorder>

--- a/samples/IntegrationTestApp/ShowWindowTest.axaml.cs
+++ b/samples/IntegrationTestApp/ShowWindowTest.axaml.cs
@@ -7,6 +7,25 @@ using Avalonia.Threading;
 
 namespace IntegrationTestApp
 {
+    public class MeasureBorder : Border
+    {
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            MeasuredWith = availableSize;
+            
+            return base.MeasureOverride(availableSize);
+        }
+
+        public static readonly StyledProperty<Size> MeasuredWithProperty = AvaloniaProperty.Register<MeasureBorder, Size>(
+            nameof(MeasuredWith));
+
+        public Size MeasuredWith
+        {
+            get => GetValue(MeasuredWithProperty);
+            set => SetValue(MeasuredWithProperty, value);
+        }
+    }
+    
     public class ShowWindowTest : Window
     {
         private readonly DispatcherTimer? _timer;

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
@@ -156,10 +156,10 @@ namespace Avalonia.IntegrationTests.Appium
                 var measuredWithString = measuredWithTextBlock.Text;
                 var workingAreaString = screenRectTextBox.Text;
 
-                var workingArea = Rect.Parse(workingAreaString);
+                var workingArea = Size.Parse(workingAreaString);
                 var measuredWith = Size.Parse(measuredWithString);
 
-                Assert.Equal(workingArea.Size, measuredWith);
+                Assert.Equal(workingArea, measuredWith);
             }
         }
 

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
@@ -151,7 +151,7 @@ namespace Avalonia.IntegrationTests.Appium
             using (OpenWindow(new Size(4000, 2200), ShowWindowMode.NonOwned, WindowStartupLocation.Manual))
             {
                 var measuredWithTextBlock = _session.FindElementById("MeasuredWithText");
-                var screenRectTextBox = _session.FindElementById("ScreenRect");
+                var screenRectTextBox = _session.FindElementById("CurrentScreenRect");
                 
                 var measuredWithString = measuredWithTextBlock.Text;
                 var workingAreaString = screenRectTextBox.Text;

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
@@ -150,8 +150,8 @@ namespace Avalonia.IntegrationTests.Appium
         {
             using (OpenWindow(new Size(4000, 2200), ShowWindowMode.NonOwned, WindowStartupLocation.Manual))
             {
-                var measuredWithTextBlock = _session.FindElementById("MeasuredWithText");
-                var screenRectTextBox = _session.FindElementById("CurrentClientSize");
+                var screenRectTextBox = _session.FindElementByAccessibilityId("CurrentClientSize");
+                var measuredWithTextBlock = _session.FindElementByAccessibilityId("CurrentMeasuredWithText");
                 
                 var measuredWithString = measuredWithTextBlock.Text;
                 var workingAreaString = screenRectTextBox.Text;

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Avalonia.Controls;
+using Avalonia.Utilities;
 using Avalonia.Media.Imaging;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
@@ -141,6 +142,24 @@ namespace Avalonia.IntegrationTests.Appium
                 Assert.Equal(original.Position, current.Position);
                 Assert.Equal(original.FrameSize, current.FrameSize);
 
+            }
+        }
+        
+        [Fact]
+        public void Showing_Window_With_Size_Larger_Than_Screen_Measures_Content_With_Working_Area()
+        {
+            using (OpenWindow(new Size(4000, 2200), ShowWindowMode.NonOwned, WindowStartupLocation.Manual))
+            {
+                var measuredWithTextBlock = _session.FindElementById("MeasuredWithText");
+                var screenRectTextBox = _session.FindElementById("ScreenRect");
+                
+                var measuredWithString = measuredWithTextBlock.Text;
+                var workingAreaString = screenRectTextBox.Text;
+
+                var workingArea = Rect.Parse(workingAreaString);
+                var measuredWith = Size.Parse(measuredWithString);
+
+                Assert.Equal(workingArea.Size, measuredWith);
             }
         }
 

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
@@ -151,7 +151,7 @@ namespace Avalonia.IntegrationTests.Appium
             using (OpenWindow(new Size(4000, 2200), ShowWindowMode.NonOwned, WindowStartupLocation.Manual))
             {
                 var measuredWithTextBlock = _session.FindElementById("MeasuredWithText");
-                var screenRectTextBox = _session.FindElementById("CurrentScreenRect");
+                var screenRectTextBox = _session.FindElementById("CurrentClientSize");
                 
                 var measuredWithString = measuredWithTextBlock.Text;
                 var workingAreaString = screenRectTextBox.Text;


### PR DESCRIPTION
Fixes 2x mac os window issues:

1. before show: if you set the window size to be bigger than the monitor, it must tell avalonia with Resized event immediately with the maximum windows size equal to the working area.

3. If you set the window size to be bigger than the monitor, it was miniturising the window on show.