### PR TITLE
skip netfx tests on macos.

### DIFF
--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -165,10 +165,10 @@ partial class Build : NukeBuild
         foreach (var fw in targetFrameworks)
         {
             if (fw.StartsWith("net4")
-                && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                && (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 && Environment.GetEnvironmentVariable("FORCE_LINUX_TESTS") != "1")
             {
-                Information($"Skipping {projectName} ({fw}) tests on Linux - https://github.com/mono/mono/issues/13969");
+                Information($"Skipping {projectName} ({fw}) tests on *nix - https://github.com/mono/mono/issues/13969");
                 continue;
             }
 


### PR DESCRIPTION
Some tests running on macos are a bit flaky. Its only when ran as netfx under mono.

fails here:
https://github.com/dotnet/runtime/blob/340508f5c750d190090be93f0c731b1a8055a354/src/mono/mono/eglib/ghashtable.c#L238

Reason for mono was to give confidence they would pass on ios/android, etc

too disruptive, so disabling. Tests are still run on netcore.