### PR TITLE
Fix integration tests by disambiguating controls.

### DIFF
--- a/samples/IntegrationTestApp/ShowWindowTest.axaml
+++ b/samples/IntegrationTestApp/ShowWindowTest.axaml
@@ -6,27 +6,27 @@
         Title="Show Window Test">
   <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
     <Label Grid.Column="0" Grid.Row="1">Client Size</Label>
-    <TextBox Name="ClientSize" Grid.Column="1" Grid.Row="1" IsReadOnly="True"
+    <TextBox Name="CurrentClientSize" Grid.Column="1" Grid.Row="1" IsReadOnly="True"
              Text="{Binding ClientSize, Mode=OneWay}"/>
     
     <Label Grid.Column="0" Grid.Row="2">Frame Size</Label>
-    <TextBox Name="FrameSize" Grid.Column="1" Grid.Row="2" IsReadOnly="True"
+    <TextBox Name="CurrentFrameSize" Grid.Column="1" Grid.Row="2" IsReadOnly="True"
              Text="{Binding FrameSize, Mode=OneWay}"/>
 
     <Label Grid.Column="0" Grid.Row="3">Position</Label>
-    <TextBox Name="Position" Grid.Column="1" Grid.Row="3" IsReadOnly="True"/>
+    <TextBox Name="CurrentPosition" Grid.Column="1" Grid.Row="3" IsReadOnly="True"/>
 
     <Label Grid.Column="0" Grid.Row="4">Owner Rect</Label>
-    <TextBox Name="OwnerRect" Grid.Column="1" Grid.Row="4" IsReadOnly="True"/>
+    <TextBox Name="CurrentOwnerRect" Grid.Column="1" Grid.Row="4" IsReadOnly="True"/>
     
     <Label Grid.Column="0" Grid.Row="5">Screen Rect</Label>
-    <TextBox Name="ScreenRect" Grid.Column="1" Grid.Row="5" IsReadOnly="True"/>
+    <TextBox Name="CurrentScreenRect" Grid.Column="1" Grid.Row="5" IsReadOnly="True"/>
 
     <Label Grid.Column="0" Grid.Row="6">Scaling</Label>
-    <TextBox Name="Scaling" Grid.Column="1" Grid.Row="6" IsReadOnly="True"/>
+    <TextBox Name="CurrentScaling" Grid.Column="1" Grid.Row="6" IsReadOnly="True"/>
     
     <Label Grid.Column="0" Grid.Row="7">WindowState</Label>
-    <ComboBox Name="WindowState" Grid.Column="1" Grid.Row="7" SelectedIndex="{Binding WindowState}">
+    <ComboBox Name="CurrentWindowState" Grid.Column="1" Grid.Row="7" SelectedIndex="{Binding WindowState}">
       <ComboBoxItem Name="WindowStateNormal">Normal</ComboBoxItem>
       <ComboBoxItem Name="WindowStateMinimized">Minimized</ComboBoxItem>
       <ComboBoxItem Name="WindowStateMaximized">Maximized</ComboBoxItem>
@@ -34,7 +34,7 @@
     </ComboBox>
 
     <Label Grid.Column="0" Grid.Row="8">Order (mac)</Label>
-    <TextBox Name="Order" Grid.Column="1" Grid.Row="8" IsReadOnly="True"/>
+    <TextBox Name="CurrentOrder" Grid.Column="1" Grid.Row="8" IsReadOnly="True"/>
 
     <Button Name="HideButton" Grid.Row="9" Command="{Binding $parent[Window].Hide}">Hide</Button>
   </Grid>

--- a/samples/IntegrationTestApp/ShowWindowTest.axaml.cs
+++ b/samples/IntegrationTestApp/ShowWindowTest.axaml.cs
@@ -16,11 +16,11 @@ namespace IntegrationTestApp
         {
             InitializeComponent();
             DataContext = this;
-            PositionChanged += (s, e) => this.GetControl<TextBox>("Position").Text = $"{Position}";
+            PositionChanged += (s, e) => this.GetControl<TextBox>("CurrentPosition").Text = $"{Position}";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                _orderTextBox = this.GetControl<TextBox>("Order");
+                _orderTextBox = this.GetControl<TextBox>("CurrentOrder");
                 _timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(250) };
                 _timer.Tick += TimerOnTick;
                 _timer.Start();
@@ -36,13 +36,13 @@ namespace IntegrationTestApp
         {
             base.OnOpened(e);
             var scaling = PlatformImpl!.DesktopScaling;
-            this.GetControl<TextBox>("Position").Text = $"{Position}";
-            this.GetControl<TextBox>("ScreenRect").Text = $"{Screens.ScreenFromVisual(this)?.WorkingArea}";
-            this.GetControl<TextBox>("Scaling").Text = $"{scaling}";
+            this.GetControl<TextBox>("CurrentPosition").Text = $"{Position}";
+            this.GetControl<TextBox>("CurrentScreenRect").Text = $"{Screens.ScreenFromVisual(this)?.WorkingArea}";
+            this.GetControl<TextBox>("CurrentScaling").Text = $"{scaling}";
 
             if (Owner is not null)
             {
-                var ownerRect = this.GetControl<TextBox>("OwnerRect");
+                var ownerRect = this.GetControl<TextBox>("CurrentOwnerRect");
                 var owner = (Window)Owner;
                 ownerRect.Text = $"{owner.Position}, {PixelSize.FromSize(owner.FrameSize!.Value, scaling)}";
             }

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
@@ -92,7 +92,7 @@ namespace Avalonia.IntegrationTests.Appium
                 {
                     try
                     {
-                        _session.FindElementByAccessibilityId("WindowState").SendClick();
+                        _session.FindElementByAccessibilityId("CurrentWindowState").SendClick();
                         _session.FindElementByAccessibilityId("WindowStateNormal").SendClick();
 
                         // Wait for animations to run.
@@ -112,7 +112,7 @@ namespace Avalonia.IntegrationTests.Appium
         {
             using (OpenWindow(new Size(400, 400), ShowWindowMode.NonOwned, WindowStartupLocation.Manual))
             {
-                var windowState = _session.FindElementByAccessibilityId("WindowState");
+                var windowState = _session.FindElementByAccessibilityId("CurrentWindowState");
 
                 Assert.Equal("Normal", windowState.GetComboBoxValue());
                 
@@ -151,7 +151,7 @@ namespace Avalonia.IntegrationTests.Appium
         public void ShowMode(ShowWindowMode mode)
         {
             using var window = OpenWindow(null, mode, WindowStartupLocation.Manual);
-            var windowState = _session.FindElementByAccessibilityId("WindowState");
+            var windowState = _session.FindElementByAccessibilityId("CurrentWindowState");
             var original = GetWindowInfo();
 
             Assert.Equal("Normal", windowState.GetComboBoxValue());
@@ -354,7 +354,7 @@ namespace Avalonia.IntegrationTests.Appium
         {
             PixelRect? ReadOwnerRect()
             {
-                var text = _session.FindElementByAccessibilityId("OwnerRect").Text;
+                var text = _session.FindElementByAccessibilityId("CurrentOwnerRect").Text;
                 return !string.IsNullOrWhiteSpace(text) ? PixelRect.Parse(text) : null;
             }
 
@@ -365,13 +365,13 @@ namespace Avalonia.IntegrationTests.Appium
                 try
                 {
                     return new(
-                        Size.Parse(_session.FindElementByAccessibilityId("ClientSize").Text),
-                        Size.Parse(_session.FindElementByAccessibilityId("FrameSize").Text),
-                        PixelPoint.Parse(_session.FindElementByAccessibilityId("Position").Text),
+                        Size.Parse(_session.FindElementByAccessibilityId("CurrentClientSize").Text),
+                        Size.Parse(_session.FindElementByAccessibilityId("CurrentFrameSize").Text),
+                        PixelPoint.Parse(_session.FindElementByAccessibilityId("CurrentPosition").Text),
                         ReadOwnerRect(),
-                        PixelRect.Parse(_session.FindElementByAccessibilityId("ScreenRect").Text),
-                        double.Parse(_session.FindElementByAccessibilityId("Scaling").Text),
-                        Enum.Parse<WindowState>(_session.FindElementByAccessibilityId("WindowState").Text));
+                        PixelRect.Parse(_session.FindElementByAccessibilityId("CurrentScreenRect").Text),
+                        double.Parse(_session.FindElementByAccessibilityId("CurrentScaling").Text),
+                        Enum.Parse<WindowState>(_session.FindElementByAccessibilityId("CurrentWindowState").Text));
                 }
                 catch (OpenQA.Selenium.NoSuchElementException) when (retry++ < 3)
                 {

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
@@ -393,7 +393,7 @@ namespace Avalonia.IntegrationTests.Appium
         private int GetWindowOrder(string identifier)
         {
             var window = GetWindow(identifier);
-            var order = window.FindElementByXPath("//*[@identifier='Order']");
+            var order = window.FindElementByXPath("//*[@identifier='CurrentOrder']");
             return int.Parse(order.Text);
         }
 


### PR DESCRIPTION
Under the appium-mac2-driver, `FindElementByAccessibilityId` doesn't actually find elements by their accessibility ID, it also finds them by their accessibility name. Since #10531 added an automation peer for `Label` which sets the accessibility name, the wrong control was being located (e.g. it located the "Position" label instead of the `Name="Position"` text box).

Disambiguate these controls by adding a `Current` prefix to make integration tests pass again.
