### PR TITLE
make integration tests intel compatible

### DIFF
--- a/azure-pipelines-integrationtests.yml
+++ b/azure-pipelines-integrationtests.yml
@@ -18,6 +18,10 @@ jobs:
     displayName: 'Get Resolution'
   
   - script: |
+      arch="x64"
+      if [[ $(uname -m) == 'arm64' ]]; then
+      arch="arm64"
+      fi
       sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
       pkill node
       appium > appium.out &
@@ -26,7 +30,7 @@ jobs:
       rm -rf $(osascript -e "POSIX path of (path to application id \"net.avaloniaui.avalonia.integrationtestapp\")")
       pkill IntegrationTestApp
       ./samples/IntegrationTestApp/bundle.sh
-      open -n ./samples/IntegrationTestApp/bin/Debug/net7.0/osx-arm64/publish/IntegrationTestApp.app
+      open -n ./samples/IntegrationTestApp/bin/Debug/net7.0/osx-$arch/publish/IntegrationTestApp.app
       pkill IntegrationTestApp
     displayName: 'Build IntegrationTestApp'
 

--- a/samples/IntegrationTestApp/bundle.sh
+++ b/samples/IntegrationTestApp/bundle.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
 cd $(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
-dotnet restore -r osx-arm64
-dotnet msbuild -t:BundleApp -p:RuntimeIdentifier=osx-arm64 -p:_AvaloniaUseExternalMSBuild=false
+
+arch="x64"
+
+if [[ $(uname -m) == 'arm64' ]]; then
+arch="arm64"
+fi
+
+dotnet restore -r osx-$arch
+dotnet msbuild -t:BundleApp -p:RuntimeIdentifier=osx-$arch -p:_AvaloniaUseExternalMSBuild=false

--- a/tests/Avalonia.IntegrationTests.Appium/macos-clean-build-test.sh
+++ b/tests/Avalonia.IntegrationTests.Appium/macos-clean-build-test.sh
@@ -1,5 +1,11 @@
 # Cleans, builds, and runs integration tests on macOS.
 # Can be used by `git bisect run` to automatically find the commit which introduced a problem. 
+arch="x64"
+
+if [[ $(uname -m) == 'arm64' ]]; then
+arch="arm64"
+fi
+
 SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 cd "$SCRIPT_DIR"/../.. || exit
 git clean -xdf
@@ -10,7 +16,7 @@ pkill IntegrationTestApp
 rm -rf $(osascript -e "POSIX path of (path to application id \"net.avaloniaui.avalonia.integrationtestapp\")")
 pkill IntegrationTestApp
 ./samples/IntegrationTestApp/bundle.sh
-open -n ./samples/IntegrationTestApp/bin/Debug/net7.0/osx-arm64/publish/IntegrationTestApp.app
+open -n ./samples/IntegrationTestApp/bin/Debug/net7.0/osx-$arch/publish/IntegrationTestApp.app
 pkill IntegrationTestApp
 open -b net.avaloniaui.avalonia.integrationtestapp
 dotnet test tests/Avalonia.IntegrationTests.Appium/ -l "console;verbosity=detailed"


### PR DESCRIPTION
bundle script, pipelines and macos clean build and run integrations test scripts all hardcoded to arm64.

This allows intel macs to run them all.