### PR TITLE
Fix Flaky Tests: Ensure that the dispatcher jobs queues are emptied after each test

### DIFF
--- a/tests/Avalonia.Controls.UnitTests/TimePickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TimePickerTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Templates;
 using Avalonia.Platform;
+using Avalonia.Threading;
 using Avalonia.UnitTests;
 using Avalonia.VisualTree;
 using Moq;
@@ -17,6 +18,7 @@ namespace Avalonia.Controls.UnitTests
         {
             using (UnitTestApplication.Start(Services))
             {
+                Assert.False(Dispatcher.UIThread.HasJobsWithPriority(0));
                 bool handled = false;
                 TimePicker timePicker = new TimePicker();
                 timePicker.SelectedTimeChanged += (s, e) =>

--- a/tests/Avalonia.Controls.UnitTests/TimePickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TimePickerTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Templates;
 using Avalonia.Platform;
-using Avalonia.Threading;
 using Avalonia.UnitTests;
 using Avalonia.VisualTree;
 using Moq;
@@ -18,7 +17,6 @@ namespace Avalonia.Controls.UnitTests
         {
             using (UnitTestApplication.Start(Services))
             {
-                Assert.False(Dispatcher.UIThread.HasJobsWithPriority(0));
                 bool handled = false;
                 TimePicker timePicker = new TimePicker();
                 timePicker.SelectedTimeChanged += (s, e) =>

--- a/tests/Avalonia.RenderTests/TestBase.cs
+++ b/tests/Avalonia.RenderTests/TestBase.cs
@@ -31,7 +31,7 @@ namespace Avalonia.Skia.RenderTests
 namespace Avalonia.Direct2D1.RenderTests
 #endif
 {
-    public class TestBase
+    public class TestBase : IDisposable
     {
 #if AVALONIA_SKIA
         private static string s_fontUri = "resm:Avalonia.Skia.RenderTests.Assets?assembly=Avalonia.Skia.RenderTests#Noto Mono";
@@ -281,6 +281,11 @@ namespace Avalonia.Direct2D1.RenderTests
                     lock (s_timers) s_timers.Remove(act);
                 });
             }
+        }
+
+        public void Dispose()
+        {
+            Dispatcher.UIThread.RunJobs();
         }
     }
 }

--- a/tests/Avalonia.RenderTests/TestBase.cs
+++ b/tests/Avalonia.RenderTests/TestBase.cs
@@ -285,7 +285,10 @@ namespace Avalonia.Direct2D1.RenderTests
 
         public void Dispose()
         {
-            Dispatcher.UIThread.RunJobs();
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.RunJobs();
+            }
         }
     }
 }

--- a/tests/Avalonia.UnitTests/TestWithServicesBase.cs
+++ b/tests/Avalonia.UnitTests/TestWithServicesBase.cs
@@ -18,7 +18,11 @@ namespace Avalonia.UnitTests
 
         public void Dispose()
         {
-            Dispatcher.UIThread.RunJobs();
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.RunJobs();
+            }
+            
             _scope.Dispose();
         }
     }

--- a/tests/Avalonia.UnitTests/TestWithServicesBase.cs
+++ b/tests/Avalonia.UnitTests/TestWithServicesBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Avalonia.Threading;
 
 namespace Avalonia.UnitTests
 {
@@ -17,6 +18,7 @@ namespace Avalonia.UnitTests
 
         public void Dispose()
         {
+            Dispatcher.UIThread.RunJobs();
             _scope.Dispose();
         }
     }

--- a/tests/Avalonia.UnitTests/UnitTestApplication.cs
+++ b/tests/Avalonia.UnitTests/UnitTestApplication.cs
@@ -46,6 +46,7 @@ namespace Avalonia.UnitTests
             Dispatcher.UIThread.UpdateServices();
             return Disposable.Create(() =>
             {
+                Dispatcher.UIThread.RunJobs();
                 scope.Dispose();
                 Dispatcher.UIThread.UpdateServices();
             });

--- a/tests/Avalonia.UnitTests/UnitTestApplication.cs
+++ b/tests/Avalonia.UnitTests/UnitTestApplication.cs
@@ -46,7 +46,11 @@ namespace Avalonia.UnitTests
             Dispatcher.UIThread.UpdateServices();
             return Disposable.Create(() =>
             {
-                Dispatcher.UIThread.RunJobs();
+                if (Dispatcher.UIThread.CheckAccess())
+                {
+                    Dispatcher.UIThread.RunJobs();
+                }
+
                 scope.Dispose();
                 Dispatcher.UIThread.UpdateServices();
             });


### PR DESCRIPTION
Some intermittent tests were caused by dispatcher having jobs queued before a test starts.

This meant sometimes unexpected code paths could be tested.

This fixes it by calling RunJobs when UnitTestApplication is disposed and also in some other testbase classes.


Before: 

```
using (UnitTestApplication.Start(Services))
    {
        Assert.False(Dispatcher.UIThread.HasJobsWithPriority(0));

```

intermittently this assertion (doesnt exist in any test, added to prove the theory) would happen, and if you didnt catch the assertion your test could intermittently perhaps run a queued layout pass from another test.

Totally depends on test order etc.

After:
Intermittent test failures no longer occur for this reason.