### PR TITLE
Android - Fix StorageFolder.GetItemsAsync failing to get children on android

### DIFF
--- a/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageItem.cs
+++ b/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageItem.cs
@@ -138,7 +138,43 @@ internal class AndroidStorageFolder : AndroidStorageItem, IStorageBookmarkFolder
             return Array.Empty<IStorageItem>();
         }
 
-        using var javaFile = new JavaFile(Uri.Path!);
+        List<IStorageItem> files = new List<IStorageItem>();
+
+        var contentResolver = Activity.ContentResolver;
+        if (contentResolver == null)
+        {
+            return files;
+        }
+
+        var childrenUri = DocumentsContract.BuildChildDocumentsUriUsingTree(Uri!, DocumentsContract.GetTreeDocumentId(Uri));
+
+        var projection = new[]
+        {
+            DocumentsContract.Document.ColumnDocumentId,
+            DocumentsContract.Document.ColumnMimeType
+        };
+        if (childrenUri != null)
+        {
+            using var cursor = contentResolver.Query(childrenUri, projection, null, null, null);
+
+            if (cursor != null)
+                while (cursor.MoveToNext())
+                {
+                    var mime = cursor.GetString(1);
+                    var id = cursor.GetString(0);
+                    var uri = DocumentsContract.BuildDocumentUriUsingTree(Uri!, id);
+                    if (uri == null)
+                    {
+                        continue;
+                    }
+
+                    files.Add(mime == DocumentsContract.Document.MimeTypeDir ? new AndroidStorageFolder(Activity, uri, false) :
+                        new AndroidStorageFile(Activity, uri));
+                }
+        }
+
+        return files;
+    }
 
         // Java file represents files AND directories. Don't be confused.
         var files = await javaFile.ListFilesAsync().ConfigureAwait(false);

--- a/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageItem.cs
+++ b/src/Android/Avalonia.Android/Platform/Storage/AndroidStorageItem.cs
@@ -174,27 +174,7 @@ internal class AndroidStorageFolder : AndroidStorageItem, IStorageBookmarkFolder
         }
 
         return files;
-    }
-
-        // Java file represents files AND directories. Don't be confused.
-        var files = await javaFile.ListFilesAsync().ConfigureAwait(false);
-        if (files is null)
-        {
-            return Array.Empty<IStorageItem>();
-        }
-
-        return files
-            .Select(f => (file: f, uri: AndroidUri.FromFile(f)))
-            .Where(t => t.uri is not null)
-            .Select(t => t.file switch
-            {
-                { IsFile: true } => (IStorageItem)new AndroidStorageFile(Activity, t.uri!),
-                { IsDirectory: true } => new AndroidStorageFolder(Activity, t.uri!, false),
-                _ => null
-            })
-            .Where(i => i is not null)
-            .ToArray()!;
-    }
+    }       
 }
 
 internal sealed class WellKnownAndroidStorageFolder : AndroidStorageFolder


### PR DESCRIPTION
## What does the pull request do?
Replaces previously used File api with DocumentsContract for listing children of a directory.


## What is the current behavior?
From Android 11, using the File api is deprecated for content not directly owned by the app. This makes the current implementation return zero items on R and above.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
