### PR TITLE
Fix Generators build

### DIFF
--- a/src/tools/Avalonia.Generators/Avalonia.Generators.csproj
+++ b/src/tools/Avalonia.Generators/Avalonia.Generators.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <Compile Link="Compiler\XamlX\filename" Include="../../Markup/Avalonia.Markup.Xaml.Loader/xamlil.github/src/XamlX/**/*.cs" />
+    <Compile Remove="../../Markup/Avalonia.Markup.Xaml.Loader/xamlil.github/src/XamlX/obj/**/*.cs" />
     <Compile Remove="../../Markup/Avalonia.Markup.Xaml.Loader/xamlil.github/src/XamlX/**/SreTypeSystem.cs" />
     <Compile Include="..\..\Shared\IsExternalInit.cs" Link="IsExternalInit.cs" />
   </ItemGroup>


### PR DESCRIPTION
If `XamlX` has been built locally, the `Avalonia.Generators` project won't compile due to duplicate generated assembly information.

Fixed by not including the `XamlX\obj` folder (like in `Avalonia.Build.Tasks`).
