### PR TITLE
Or Selector benchmark and removal of repeated virtual calls

### DIFF
--- a/src/Avalonia.Base/Styling/DescendentSelector.cs
+++ b/src/Avalonia.Base/Styling/DescendentSelector.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Styling
 
         public DescendantSelector(Selector? parent)
         {
-            _parent = parent ?? throw new InvalidOperationException("Descendant selector must be preceeded by a selector.");
+            _parent = parent ?? throw new InvalidOperationException("Descendant selector must be preceded by a selector.");
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Base/Styling/OrSelector.cs
+++ b/src/Avalonia.Base/Styling/OrSelector.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Styling
     /// <summary>
     /// The OR style selector.
     /// </summary>
-    internal class OrSelector : Selector
+    internal sealed class OrSelector : Selector
     {
         private readonly IReadOnlyList<Selector> _selectors;
         private string? _selectorString;
@@ -42,18 +42,7 @@ namespace Avalonia.Styling
         public override bool IsCombinator => false;
 
         /// <inheritdoc/>
-        public override Type? TargetType
-        {
-            get
-            {
-                if (_targetType == null)
-                {
-                    _targetType = EvaluateTargetType();
-                }
-
-                return _targetType;
-            }
-        }
+        public override Type? TargetType => _targetType ??= EvaluateTargetType();
 
         /// <inheritdoc/>
         public override string ToString(Style? owner)
@@ -71,7 +60,9 @@ namespace Avalonia.Styling
             var activators = new OrActivatorBuilder();
             var neverThisInstance = false;
 
-            for (var i = 0; i < _selectors.Count; i++)
+            var count = _selectors.Count;
+
+            for (var i = 0; i < count; i++)
             {
                 var match = _selectors[i].Match(control, parent, subscribe);
 
@@ -108,7 +99,9 @@ namespace Avalonia.Styling
 
         internal override void ValidateNestingSelector(bool inControlTheme)
         {
-            for (var i = 0; i < _selectors.Count; i++)
+            var count = _selectors.Count;
+
+            for (var i = 0; i < count; i++)
             {
                 _selectors[i].ValidateNestingSelector(inControlTheme);
             }
@@ -118,7 +111,9 @@ namespace Avalonia.Styling
         {
             Type? result = null;
 
-            for (var i = 0; i < _selectors.Count; i++)
+            var count = _selectors.Count;
+
+            for (var i = 0; i < count; i++)
             {
                 var selector = _selectors[i];
                 if (selector.TargetType == null)

--- a/src/Avalonia.Base/Styling/TypeNameAndClassSelector.cs
+++ b/src/Avalonia.Base/Styling/TypeNameAndClassSelector.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Styling
     /// A selector that matches the common case of a type and/or name followed by a collection of
     /// style classes and pseudoclasses.
     /// </summary>
-    internal class TypeNameAndClassSelector : Selector
+    internal sealed class TypeNameAndClassSelector : Selector
     {
         private readonly Selector? _previous;
         private List<string>? _classes;
@@ -85,12 +85,7 @@ namespace Avalonia.Styling
         /// <inheritdoc/>
         public override string ToString(Style? owner)
         {
-            if (_selectorString == null)
-            {
-                _selectorString = BuildSelectorString(owner);
-            }
-
-            return _selectorString;
+            return _selectorString ??= BuildSelectorString(owner);
         }
 
         /// <inheritdoc/>

--- a/tests/Avalonia.Benchmarks/Properties/launchSettings.json
+++ b/tests/Avalonia.Benchmarks/Properties/launchSettings.json
@@ -1,0 +1,15 @@
+{
+  "profiles": {
+    "Avalonia.Benchmarks": {
+      "commandName": "Project"
+    },
+    "Avalonia.Benchmarks (in-process)": {
+      "commandName": "Project",
+      "commandLineArgs": "--inprocess"
+    },
+    "Avalonia.Benchmarks (debug)": {
+      "commandName": "Project",
+      "commandLineArgs": "--debug"
+    }
+  }
+}

--- a/tests/Avalonia.Benchmarks/Styling/SelectorBenchmark.cs
+++ b/tests/Avalonia.Benchmarks/Styling/SelectorBenchmark.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls;
+﻿using System;
+using Avalonia.Controls;
 using Avalonia.Styling;
 using BenchmarkDotNet.Attributes;
 
@@ -11,6 +12,8 @@ namespace Avalonia.Benchmarks.Styling
         private readonly Calendar _matchingControl;
         private readonly Selector _isCalendarSelector;
         private readonly Selector _classSelector;
+        private readonly Selector _orSelectorTwo;
+        private readonly Selector _orSelectorFive;
 
         public SelectorBenchmark()
         {
@@ -23,6 +26,14 @@ namespace Avalonia.Benchmarks.Styling
 
             _isCalendarSelector = Selectors.Is<Calendar>(null);
             _classSelector = Selectors.Class(null, className);
+
+            _orSelectorTwo = Selectors.Or(new AlwaysMatchSelector(), new AlwaysMatchSelector());
+            _orSelectorFive = Selectors.Or(
+                new AlwaysMatchSelector(), 
+                new AlwaysMatchSelector(),
+                new AlwaysMatchSelector(),
+                new AlwaysMatchSelector(),
+                new AlwaysMatchSelector());
         }
 
         [Benchmark]
@@ -48,5 +59,40 @@ namespace Avalonia.Benchmarks.Styling
         {
             return _classSelector.Match(_matchingControl);
         }
+
+        [Benchmark]
+        public SelectorMatch OrSelector_One_Match()
+        {
+            return _orSelectorTwo.Match(_matchingControl);
+        }
+
+        [Benchmark]
+        public SelectorMatch OrSelector_Five_Match()
+        {
+            return _orSelectorFive.Match(_matchingControl);
+        }
+    }
+
+    internal class AlwaysMatchSelector : Selector
+    {
+        public override bool InTemplate => false;
+
+        public override bool IsCombinator => false;
+
+        public override Type TargetType => null;
+
+        public override string ToString(Style owner)
+        {
+            return "Always";
+        }
+
+        protected override SelectorMatch Evaluate(StyledElement control, IStyle parent, bool subscribe)
+        {
+            return SelectorMatch.AlwaysThisType;
+        }
+
+        protected override Selector MovePrevious() => null;
+
+        protected override Selector MovePreviousOrParent() => null;
     }
 }


### PR DESCRIPTION
I had similar changes like in https://github.com/AvaloniaUI/Avalonia/pull/10478 but I didn't have time to wrap it up before leaving for holidays. I've started from writing a benchmark case so we can avoid this issue in the future. More selectors could be covered later too.

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Removes repeated virtual calls to `Count`.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
There are many repeated virtual calls to `Count` that can be easily avoided.
Also it might be the case that a few changes to `StyledElement` might have the same problem, in one case in `ApplyStyles` it might be an actual pessimization to use a for loop since `Styles` have a struct enumerator that does not allocate anything.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Minor perf increase, I didn't bother to measure. But I have benchmarks for or selector with optimization to iteration (as introduced in https://github.com/AvaloniaUI/Avalonia/pull/10478):

Before
|                Method |     Mean |    Error |   StdDev |   Gen0 | Allocated |
|---------------------- |---------:|---------:|---------:|-------:|----------:|
|  OrSelector_One_Match | 50.95 ns | 0.223 ns | 0.198 ns | 0.0076 |      32 B |
| OrSelector_Five_Match | 52.05 ns | 0.265 ns | 0.248 ns | 0.0076 |      32 B |

After
|                Method |     Mean |    Error |   StdDev |   Gen0 | Allocated |
|---------------------- |---------:|---------:|---------:|-------:|----------:|
|  OrSelector_One_Match | 39.70 ns | 0.315 ns | 0.263 ns |      - |         - |
| OrSelector_Five_Match | 39.79 ns | 0.329 ns | 0.275 ns |      - |         - |

So we are saving 32B per match while also getting ~20% perf speedup. So yeah an analyzer would help a lot since this little issue causes trouble all over the place.

Also added extra run configs for benchmark project so we can easily control it without manually changing arguments.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
