### PR TITLE
Add missing ClipToBounds for inner Grid

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -516,7 +516,9 @@
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"
                   CornerRadius="{TemplateBinding CornerRadius}">
-            <Grid ColumnDefinitions="Auto,*,Auto" RowDefinitions="Auto,*,Auto,Auto">
+            <Grid ColumnDefinitions="Auto,*,Auto" 
+                  RowDefinitions="Auto,*,Auto,Auto"
+                  ClipToBounds="True">
               <DataGridColumnHeader Name="PART_TopLeftCornerHeader"
                                     Theme="{StaticResource DataGridTopLeftColumnHeader}" />
               <DataGridColumnHeadersPresenter Name="PART_ColumnHeadersPresenter"

--- a/src/Avalonia.Controls.DataGrid/Themes/Simple.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Simple.xaml
@@ -319,7 +319,8 @@
                   BorderThickness="{TemplateBinding BorderThickness}"
                   CornerRadius="{TemplateBinding CornerRadius}">
             <Grid ColumnDefinitions="Auto,*,Auto"
-                  RowDefinitions="Auto,*,Auto,Auto">
+                  RowDefinitions="Auto,*,Auto,Auto"
+                  ClipToBounds="True">
               <DataGridColumnHeader Name="PART_TopLeftCornerHeader"
                                     Width="22" />
               <DataGridColumnHeadersPresenter Name="PART_ColumnHeadersPresenter"


### PR DESCRIPTION
## What does the pull request do?
Adds a missing ClipToBounds to DataGrid-ControlTheme

## What is the current behavior?
No clipping and therefore the content can leak into the Border

## What is the updated/expected behavior with this PR?

Before:
![image](https://user-images.githubusercontent.com/47110241/223099477-f0f9714b-d398-4740-a9de-f3c488bc73a9.png)

After: 
![image](https://user-images.githubusercontent.com/47110241/223099286-97c0ada9-d757-4e3c-839f-fecf266f4fbd.png)

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/10562
