### PR TITLE
Test Flakyness: always kill testmanagerd

### DIFF
--- a/azure-pipelines-integrationtests.yml
+++ b/azure-pipelines-integrationtests.yml
@@ -24,6 +24,7 @@ jobs:
       fi
       sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
       pkill node
+      pkill testmanagerd
       appium > appium.out &
       pkill IntegrationTestApp
       ./build.sh CompileNative


### PR DESCRIPTION
found that testmanagerd ends up using loads of memory (14gb after a few days and 100gb in virtual memory)
could this be the cause?