### PR TITLE
macOS: Don't allow window zoom when CanResize=false.

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -394,7 +394,7 @@
 
 - (BOOL)windowShouldZoom:(NSWindow *_Nonnull)window toFrame:(NSRect)newFrame
 {
-    return true;
+    return _parent->CanZoom();
 }
 
 -(void)windowDidResignKey:(NSNotification *)notification

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
@@ -104,6 +104,8 @@ BEGIN_INTERFACE_MAP()
                            
     virtual void BringToFront ();
 
+    virtual bool CanZoom() { return false; }
+                           
 protected:
     virtual NSWindowStyleMask CalculateStyleMask() = 0;
     virtual void UpdateStyle();

--- a/native/Avalonia.Native/src/OSX/WindowImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.h
@@ -97,6 +97,8 @@ BEGIN_INTERFACE_MAP()
     
     bool CanBecomeKeyWindow ();
 
+    bool CanZoom() override { return _isEnabled && _canResize; }
+    
 protected:
     virtual NSWindowStyleMask CalculateStyleMask() override;
     void UpdateStyle () override;

--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -622,5 +622,5 @@ void WindowImpl::UpdateStyle() {
     [miniaturizeButton setHidden:!hasTrafficLights];
     [miniaturizeButton setEnabled:_isEnabled];
     [zoomButton setHidden:!hasTrafficLights];
-    [zoomButton setEnabled:_isEnabled && _canResize];
+    [zoomButton setEnabled:CanZoom()];
 }


### PR DESCRIPTION
Previously, even though the zoom button was disabled the user could still double-click on the title bar to zoom the window. Prevent that by returning the appropriate value from `NSWindow windowShouldZoom` and move the `CanZoom` logic into a central place for use by this method and `UpdateStyle`.

Was unable to create an integration test for this as Appium appears to be unable to perform a double-click on a window title bar (?!?).