### PR TITLE
fix: Warning CS0628 new protected member declared in sealed type

### DIFF
--- a/src/Avalonia.Base/Media/DrawingGroup.cs
+++ b/src/Avalonia.Base/Media/DrawingGroup.cs
@@ -117,10 +117,10 @@ namespace Avalonia.Media
             // root DrawingGroup, and be the same value as the root _currentDrawingGroup.
             //
             // Either way, _rootDrawing always references the root drawing.
-            protected Drawing? _rootDrawing;
+            private Drawing? _rootDrawing;
 
             // Current DrawingGroup that new children are added to
-            protected DrawingGroup? _currentDrawingGroup;
+            private DrawingGroup? _currentDrawingGroup;
 
             // Previous values of _currentDrawingGroup
             private Stack<DrawingGroup?>? _previousDrawingGroupStack;

--- a/src/Avalonia.Base/Styling/TypeNameAndClassSelector.cs
+++ b/src/Avalonia.Base/Styling/TypeNameAndClassSelector.cs
@@ -52,7 +52,7 @@ namespace Avalonia.Styling
             return result;
         }
 
-        protected TypeNameAndClassSelector(Selector? previous)
+        TypeNameAndClassSelector(Selector? previous)
         {
             _previous = previous;
         }


### PR DESCRIPTION
```bash
Warning CS0628 'DrawingGroup.DrawingGroupDrawingContext._rootDrawing': new protected member declared in sealed type Avalonia.Base (net6.0), Avalonia.Base (netstandard2.0) .\src\Avalonia.Base\Media\DrawingGroup.cs 120 Active
Warning CS0628 'DrawingGroup.DrawingGroupDrawingContext._currentDrawingGroup': new protected member declared in sealed type Avalonia.Base (net6.0), Avalonia.Base (netstandard2.0) .\src\Avalonia.Base\Media\DrawingGroup.cs 123 Active
```

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
