### PR TITLE
Convert Text properties to StyledProperty

### DIFF
--- a/src/Avalonia.Base/PropertyStore/EffectiveValue`1.cs
+++ b/src/Avalonia.Base/PropertyStore/EffectiveValue`1.cs
@@ -31,7 +31,7 @@ namespace Avalonia.PropertyStore
 
             var value = inherited is null ? _metadata.DefaultValue : inherited.Value;
 
-            if (property.HasCoercion && _metadata.CoerceValue is { } coerce)
+            if (_metadata.CoerceValue is { } coerce)
             {
                 _uncommon = new()
                 {

--- a/src/Avalonia.Base/StyledProperty.cs
+++ b/src/Avalonia.Base/StyledProperty.cs
@@ -34,7 +34,6 @@ namespace Avalonia
         {
             Inherits = inherits;
             ValidateValue = validate;
-            HasCoercion |= metadata.CoerceValue != null;
 
             if (validate?.Invoke(metadata.DefaultValue) == false)
             {
@@ -47,12 +46,6 @@ namespace Avalonia
         /// A method which returns "false" for values that are never valid for this property.
         /// </summary>
         public Func<TValue, bool>? ValidateValue { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether this property has any value coercion callbacks defined
-        /// in its metadata.
-        /// </summary>
-        internal bool HasCoercion { get; private set; }
 
         /// <summary>
         /// Registers the property on another type.
@@ -130,10 +123,7 @@ namespace Avalonia
         /// </summary>
         /// <typeparam name="T">The type.</typeparam>
         /// <param name="metadata">The metadata.</param>
-        public void OverrideMetadata<T>(StyledPropertyMetadata<TValue> metadata) where T : AvaloniaObject
-        {
-            base.OverrideMetadata(typeof(T), metadata);
-        }
+        public void OverrideMetadata<T>(StyledPropertyMetadata<TValue> metadata) where T : AvaloniaObject => OverrideMetadata(typeof(T), metadata);
 
         /// <summary>
         /// Overrides the metadata for the property on the specified type.
@@ -150,8 +140,6 @@ namespace Avalonia
                         $"'{metadata.DefaultValue}' is not a valid default value for '{Name}'.");
                 }
             }
-
-            HasCoercion |= metadata.CoerceValue != null;
 
             base.OverrideMetadata(type, metadata);
         }

--- a/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.Properties.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.Properties.cs
@@ -87,12 +87,10 @@ namespace Avalonia.Controls
         /// Identifies the <see cref="Text" /> property.
         /// </summary>
         /// <value>The identifier for the <see cref="Text" /> property.</value>
-        public static readonly DirectProperty<AutoCompleteBox, string?> TextProperty =
-            TextBlock.TextProperty.AddOwnerWithDataValidation<AutoCompleteBox>(
-                o => o.Text,
-                (o, v) => o.Text = v,
+        public static readonly StyledProperty<string?> TextProperty =
+            TextBlock.TextProperty.AddOwner<AutoCompleteBox>(new(string.Empty,
                 defaultBindingMode: BindingMode.TwoWay,
-                enableDataValidation: true);
+                enableDataValidation: true));
 
         /// <summary>
         /// Identifies the <see cref="SearchText" /> property.
@@ -317,8 +315,8 @@ namespace Avalonia.Controls
         /// <see cref="AutoCompleteBox" /> control.</value>
         public string? Text
         {
-            get => _text;
-            set => SetAndRaise(TextProperty, ref _text, value);
+            get => GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.cs
@@ -198,7 +198,6 @@ namespace Avalonia.Controls
         private bool _isDropDownOpen;
         private bool _isFocused = false;
 
-        private string? _text = string.Empty;
         private string? _searchText = string.Empty;
 
         private AutoCompleteFilterPredicate<object?>? _itemFilter;
@@ -1275,7 +1274,7 @@ namespace Avalonia.Controls
             if ((userInitiated ?? true) && Text != value)
             {
                 _ignoreTextPropertyChange++;
-                Text = value;
+                SetCurrentValue(TextProperty, value);
                 callTextChanged = true;
             }
 

--- a/src/Avalonia.Controls/Documents/InlineCollection.cs
+++ b/src/Avalonia.Controls/Documents/InlineCollection.cs
@@ -91,11 +91,11 @@ namespace Avalonia.Controls.Documents
 
         public override void Add(Inline inline)
         {
-            if (InlineHost is TextBlock textBlock && !string.IsNullOrEmpty(textBlock._text))
+            if (InlineHost is TextBlock textBlock && !string.IsNullOrEmpty(textBlock.Text))
             {
-                base.Add(new Run(textBlock._text));
+                base.Add(new Run(textBlock.Text));
 
-                textBlock._text = null;
+                textBlock.ClearTextInternal();
             }
 
             base.Add(inline);
@@ -113,7 +113,7 @@ namespace Avalonia.Controls.Documents
         {
             if (InlineHost is TextBlock textBlock && !textBlock.HasComplexContent)
             {
-                textBlock._text += text;
+                textBlock.Text += text;
             }
             else
             {

--- a/src/Avalonia.Controls/SelectableTextBlock.cs
+++ b/src/Avalonia.Controls/SelectableTextBlock.cs
@@ -17,17 +17,11 @@ namespace Avalonia.Controls
     /// </summary>
     public class SelectableTextBlock : TextBlock, IInlineHost
     {
-        public static readonly DirectProperty<SelectableTextBlock, int> SelectionStartProperty =
-            AvaloniaProperty.RegisterDirect<SelectableTextBlock, int>(
-                nameof(SelectionStart),
-                o => o.SelectionStart,
-                (o, v) => o.SelectionStart = v);
+        public static readonly StyledProperty<int> SelectionStartProperty =
+            TextBox.SelectionStartProperty.AddOwner<SelectableTextBlock>(new(coerce: TextBox.CoerceCaretIndex));
 
-        public static readonly DirectProperty<SelectableTextBlock, int> SelectionEndProperty =
-            AvaloniaProperty.RegisterDirect<SelectableTextBlock, int>(
-                nameof(SelectionEnd),
-                o => o.SelectionEnd,
-                (o, v) => o.SelectionEnd = v);
+        public static readonly StyledProperty<int> SelectionEndProperty =
+            TextBox.SelectionEndProperty.AddOwner<SelectableTextBlock>(new(coerce: TextBox.CoerceCaretIndex));
 
         public static readonly DirectProperty<SelectableTextBlock, string> SelectedTextProperty =
             AvaloniaProperty.RegisterDirect<SelectableTextBlock, string>(
@@ -35,21 +29,16 @@ namespace Avalonia.Controls
                 o => o.SelectedText);
 
         public static readonly StyledProperty<IBrush?> SelectionBrushProperty =
-            AvaloniaProperty.Register<SelectableTextBlock, IBrush?>(nameof(SelectionBrush), Brushes.Blue);
-
+            TextBox.SelectionBrushProperty.AddOwner<SelectableTextBlock>(new(new Data.Optional<IBrush?>(Brushes.Blue)));
 
         public static readonly DirectProperty<SelectableTextBlock, bool> CanCopyProperty =
-            AvaloniaProperty.RegisterDirect<SelectableTextBlock, bool>(
-                nameof(CanCopy),
-                o => o.CanCopy);
+            TextBox.CanCopyProperty.AddOwner<SelectableTextBlock>(o => o.CanCopy);
 
         public static readonly RoutedEvent<RoutedEventArgs> CopyingToClipboardEvent =
             RoutedEvent.Register<SelectableTextBlock, RoutedEventArgs>(
                 nameof(CopyingToClipboard), RoutingStrategies.Bubble);
 
         private bool _canCopy;
-        private int _selectionStart;
-        private int _selectionEnd;
         private int _wordSelectionStart = -1;
 
         static SelectableTextBlock()
@@ -78,16 +67,8 @@ namespace Avalonia.Controls
         /// </summary>
         public int SelectionStart
         {
-            get => _selectionStart;
-            set
-            {
-                if (SetAndRaise(SelectionStartProperty, ref _selectionStart, value))
-                {
-                    RaisePropertyChanged(SelectedTextProperty, "", "");
-
-                    UpdateCommandStates();
-                }
-            }
+            get => GetValue(SelectionStartProperty);
+            set => SetValue(SelectionStartProperty, value);
         }
 
         /// <summary>
@@ -95,16 +76,8 @@ namespace Avalonia.Controls
         /// </summary>
         public int SelectionEnd
         {
-            get => _selectionEnd;
-            set
-            {
-                if (SetAndRaise(SelectionEndProperty, ref _selectionEnd, value))
-                {
-                    RaisePropertyChanged(SelectedTextProperty, "", "");
-
-                    UpdateCommandStates();
-                }
-            }
+            get => GetValue(SelectionEndProperty);
+            set => SetValue(SelectionEndProperty, value);
         }
 
         /// <summary>
@@ -150,7 +123,7 @@ namespace Avalonia.Controls
                 await ((IClipboard)AvaloniaLocator.Current.GetRequiredService(typeof(IClipboard)))
                     .SetTextAsync(text);
             }
-        }        
+        }
 
         /// <summary>
         /// Select all text in the TextBox
@@ -159,8 +132,8 @@ namespace Avalonia.Controls
         {
             var text = Text;
 
-            SelectionStart = 0;
-            SelectionEnd = text?.Length ?? 0;
+            SetCurrentValue(SelectionStartProperty, 0);
+            SetCurrentValue(SelectionEndProperty, text?.Length ?? 0);
         }
 
         /// <summary>
@@ -168,7 +141,7 @@ namespace Avalonia.Controls
         /// </summary>
         public void ClearSelection()
         {
-            SelectionEnd = SelectionStart;
+            SetCurrentValue(SelectionEndProperty, SelectionStart);
         }
 
         protected override void OnGotFocus(GotFocusEventArgs e)
@@ -240,6 +213,17 @@ namespace Avalonia.Controls
             e.Handled = handled;
         }
 
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == SelectionStartProperty || change.Property == SelectionEndProperty)
+            {
+                RaisePropertyChanged(SelectedTextProperty, "", "");
+                UpdateCommandStates();
+            }
+        }
+
         protected override void OnPointerPressed(PointerPressedEventArgs e)
         {
             base.OnPointerPressed(e);
@@ -271,25 +255,26 @@ namespace Avalonia.Controls
 
                                 if (index > _wordSelectionStart)
                                 {
-                                    SelectionEnd = StringUtils.NextWord(text, index);
+                                    SetCurrentValue(SelectionEndProperty, StringUtils.NextWord(text, index));
                                 }
 
                                 if (index < _wordSelectionStart || previousWord == _wordSelectionStart)
                                 {
-                                    SelectionStart = previousWord;
+                                    SetCurrentValue(SelectionStartProperty, previousWord);
                                 }
                             }
                             else
                             {
-                                SelectionStart = Math.Min(oldIndex, index);
-                                SelectionEnd = Math.Max(oldIndex, index);
+                                SetCurrentValue(SelectionStartProperty, Math.Min(oldIndex, index));
+                                SetCurrentValue(SelectionEndProperty, Math.Max(oldIndex, index));
                             }
                         }
                         else
                         {
                             if (_wordSelectionStart == -1 || index < SelectionStart || index > SelectionEnd)
                             {
-                                SelectionStart = SelectionEnd = index;
+                                SetCurrentValue(SelectionStartProperty, index);
+                                SetCurrentValue(SelectionEndProperty, index);
 
                                 _wordSelectionStart = -1;
                             }
@@ -299,16 +284,16 @@ namespace Avalonia.Controls
                     case 2:
                         if (!StringUtils.IsStartOfWord(text, index))
                         {
-                            SelectionStart = StringUtils.PreviousWord(text, index);
+                            SetCurrentValue(SelectionStartProperty, StringUtils.PreviousWord(text, index));
                         }
 
                         _wordSelectionStart = SelectionStart;
 
                         if (!StringUtils.IsEndOfWord(text, index))
                         {
-                            SelectionEnd = StringUtils.NextWord(text, index);
+                            SetCurrentValue(SelectionEndProperty, StringUtils.NextWord(text, index));
                         }
-                        
+
                         break;
                     case 3:
                         _wordSelectionStart = -1;
@@ -347,22 +332,22 @@ namespace Avalonia.Controls
 
                     if (distance <= 0)
                     {
-                        SelectionStart = StringUtils.PreviousWord(text, textPosition);
+                        SetCurrentValue(SelectionStartProperty, StringUtils.PreviousWord(text, textPosition));
                     }
 
                     if (distance >= 0)
                     {
                         if (SelectionStart != _wordSelectionStart)
                         {
-                            SelectionStart = _wordSelectionStart;
+                            SetCurrentValue(SelectionStartProperty, _wordSelectionStart);
                         }
 
-                        SelectionEnd = StringUtils.NextWord(text, textPosition);
+                        SetCurrentValue(SelectionEndProperty, StringUtils.NextWord(text, textPosition));
                     }
                 }
                 else
                 {
-                    SelectionEnd = textPosition;
+                    SetCurrentValue(SelectionEndProperty, textPosition);
                 }
 
             }
@@ -395,7 +380,8 @@ namespace Avalonia.Controls
                                           caretIndex >= firstSelection && caretIndex <= lastSelection;
                 if (!didClickInSelection)
                 {
-                    SelectionStart = SelectionEnd = caretIndex;
+                    SetCurrentValue(SelectionStartProperty, caretIndex);
+                    SetCurrentValue(SelectionEndProperty, caretIndex);
                 }
             }
 
@@ -411,9 +397,8 @@ namespace Avalonia.Controls
 
         private string GetSelection()
         {
-            var text = GetText();
-
-            if (string.IsNullOrEmpty(text))
+            var textLength = Text?.Length ?? 0;
+            if (textLength == 0)
             {
                 return "";
             }
@@ -423,14 +408,14 @@ namespace Avalonia.Controls
             var start = Math.Min(selectionStart, selectionEnd);
             var end = Math.Max(selectionStart, selectionEnd);
 
-            if (start == end || text.Length < end)
+            if (start == end || textLength < end)
             {
                 return "";
             }
 
             var length = Math.Max(0, end - start);
 
-            var selectedText = text.Substring(start, length);
+            var selectedText = Text!.Substring(start, length);
 
             return selectedText;
         }

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Documents;
 using Avalonia.Layout;
@@ -13,6 +14,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// A control that displays a block of text.
     /// </summary>
+    [DebuggerDisplay("{DebugText}")]
     public class TextBlock : Control, IInlineHost
     {
         /// <summary>
@@ -103,11 +105,8 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="Text"/> property.
         /// </summary>
-        public static readonly DirectProperty<TextBlock, string?> TextProperty =
-            AvaloniaProperty.RegisterDirect<TextBlock, string?>(
-                nameof(Text),
-                o => o.GetText(),
-                (o, v) => o.SetText(v));
+        public static readonly StyledProperty<string?> TextProperty =
+            AvaloniaProperty.Register<TextBlock, string?>(nameof(Text));
 
         /// <summary>
         /// Defines the <see cref="TextAlignment"/> property.
@@ -142,14 +141,14 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="Inlines"/> property.
         /// </summary>
-        public static readonly StyledProperty<InlineCollection?> InlinesProperty =
-            AvaloniaProperty.Register<TextBlock, InlineCollection?>(
-                nameof(Inlines));
+        public static readonly DirectProperty<TextBlock, InlineCollection?> InlinesProperty =
+            AvaloniaProperty.RegisterDirect<TextBlock, InlineCollection?>(
+                nameof(Inlines), t => t.Inlines, (t, v) => t.Inlines = v);
 
-        internal string? _text;
         protected TextLayout? _textLayout;
         protected Size _constraint;
         private IReadOnlyList<TextRun>? _textRuns;
+        private InlineCollection? _inlines;
 
         /// <summary>
         /// Initializes static members of the <see cref="TextBlock"/> class.
@@ -173,7 +172,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets the <see cref="TextLayout"/> used to render the text.
         /// </summary>
-        public TextLayout TextLayout => _textLayout ??= CreateTextLayout(_text);
+        public TextLayout TextLayout => _textLayout ??= CreateTextLayout(Text);
 
         /// <summary>
         /// Gets or sets the padding to place around the <see cref="Text"/>.
@@ -198,9 +197,11 @@ namespace Avalonia.Controls
         /// </summary>
         public string? Text
         {
-            get => GetText();
-            set => SetText(value);
+            get => GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
         }
+
+        private string? DebugText => Text ?? Inlines?.Text;
 
         /// <summary>
         /// Gets or sets the font family used to draw the control's text.
@@ -325,8 +326,8 @@ namespace Avalonia.Controls
         [Content]
         public InlineCollection? Inlines
         {
-            get => GetValue(InlinesProperty);
-            set => SetValue(InlinesProperty, value);
+            get => _inlines;
+            set => SetAndRaise(InlinesProperty, ref _inlines, value);
         }
 
         protected override bool BypassFlowDirectionPolicies => true;
@@ -590,19 +591,18 @@ namespace Avalonia.Controls
             TextLayout.Draw(context, origin);
         }
 
-        protected virtual string? GetText()
+        private bool _clearTextInternal;
+        internal void ClearTextInternal()
         {
-            return _text ?? Inlines?.Text;
-        }
-
-        protected virtual void SetText(string? text)
-        {
-            if (HasComplexContent)
+            _clearTextInternal = true;
+            try
             {
-                Inlines?.Clear();
+                SetCurrentValue(TextProperty, null);
             }
-           
-            SetAndRaise(TextProperty, ref _text, text);           
+            finally
+            {
+                _clearTextInternal = false;
+            }
         }
 
         /// <summary>
@@ -780,6 +780,14 @@ namespace Avalonia.Controls
         {
             base.OnPropertyChanged(change);
 
+            if (change.Property == TextProperty)
+            {
+                if (HasComplexContent && !_clearTextInternal)
+                {
+                    Inlines?.Clear();
+                }
+            }
+
             switch (change.Property.Name)
             {
                 case nameof(FontSize):
@@ -794,10 +802,10 @@ namespace Avalonia.Controls
 
                 case nameof(FlowDirection):
 
-                case nameof (Padding):
-                case nameof (LineHeight):
-                case nameof (LetterSpacing):
-                case nameof (MaxLines):
+                case nameof(Padding):
+                case nameof(LineHeight):
+                case nameof(LetterSpacing):
+                case nameof(MaxLines):
 
                 case nameof(Text):
                 case nameof(TextDecorations):
@@ -899,7 +907,7 @@ namespace Avalonia.Controls
                         continue;
                     }
 
-                    if (textRun is TextCharacters)                 
+                    if (textRun is TextCharacters)
                     {
                         var skip = Math.Max(0, textSourceIndex - currentPosition);
 

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// A control that displays a block of text.
     /// </summary>
-    [DebuggerDisplay("{DebugText}")]
+    [DebuggerDisplay("Text = {" + nameof(DebugText) + "}")]
     public class TextBlock : Control, IInlineHost
     {
         /// <summary>

--- a/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
+++ b/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
@@ -106,7 +106,7 @@ namespace Avalonia.Controls
         {
             if (_presenter != null && _textEditable != null)
             {
-                _presenter.CompositionRegion = new TextRange(_textEditable.CompositionStart, _textEditable.CompositionEnd);
+                _presenter.SetCurrentValue(TextPresenter.CompositionRegionProperty, new TextRange(_textEditable.CompositionStart, _textEditable.CompositionEnd));
             }
         }
 
@@ -179,7 +179,7 @@ namespace Avalonia.Controls
 
             _presenter.SetCurrentValue(TextPresenter.TextProperty, text);
 
-            _presenter.PreeditText = preeditText;
+            _presenter.SetCurrentValue(TextPresenter.PreeditTextProperty, preeditText);
 
             _presenter.UpdateCaret(new CharacterHit(_compositionStart + (preeditText != null ? preeditText.Length : 0)), false);
 
@@ -201,9 +201,12 @@ namespace Avalonia.Controls
                 return preeditText;
             }
 
-            var text = _presenterText.Substring(0, _compositionStart) + preeditText + _presenterText.Substring(_compositionStart);
+            var sb = StringBuilderCache.Acquire(_presenterText.Length + preeditText.Length);
 
-            return text;
+            sb.Append(_presenterText);
+            sb.Insert(_compositionStart, preeditText);
+
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         public void SetComposingRegion(TextRange? region)
@@ -213,7 +216,7 @@ namespace Avalonia.Controls
                 return;
             }
 
-            _presenter.CompositionRegion = region;
+            _presenter.SetCurrentValue(TextPresenter.CompositionRegionProperty, region);
         }
 
         public void SelectInSurroundingText(int start, int end)
@@ -252,9 +255,9 @@ namespace Avalonia.Controls
 
             if (_presenter != null)
             {
-                _presenter.PreeditText = null;
+                _presenter.ClearValue(TextPresenter.PreeditTextProperty);
 
-                _presenter.CompositionRegion = null;
+                _presenter.ClearValue(TextPresenter.CompositionRegionProperty);
 
                 _presenter.CaretBoundsChanged -= OnCaretBoundsChanged;
             }

--- a/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
+++ b/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
@@ -177,7 +177,7 @@ namespace Avalonia.Controls
 
             var text = GetText(preeditText);
 
-            _presenter._text = text;
+            _presenter.SetCurrentValue(TextPresenter.TextProperty, text);
 
             _presenter.PreeditText = preeditText;
 

--- a/src/Avalonia.Controls/Utils/UndoRedoHelper.cs
+++ b/src/Avalonia.Controls/Utils/UndoRedoHelper.cs
@@ -4,6 +4,8 @@ namespace Avalonia.Controls.Utils
 {
     class UndoRedoHelper<TState>
     {
+        public const int DefaultUndoLimit = 10;
+
         private readonly IUndoRedoHost _host;
 
         public interface IUndoRedoHost
@@ -23,7 +25,7 @@ namespace Avalonia.Controls.Utils
         /// Maximum number of states this helper can store for undo/redo.
         /// If -1, no limit is imposed.
         /// </summary>
-        public int Limit { get; set; } = 10;
+        public int Limit { get; set; } = DefaultUndoLimit;
 
         public bool CanUndo => _currentNode?.Previous != null;
 

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/FilterTextBox.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/FilterTextBox.cs
@@ -7,22 +7,17 @@ namespace Avalonia.Diagnostics.Controls
 {
     internal class FilterTextBox : TextBox, IStyleable
     {
-        public static readonly DirectProperty<FilterTextBox, bool> UseRegexFilterProperty =
-            AvaloniaProperty.RegisterDirect<FilterTextBox, bool>(nameof(UseRegexFilter),
-                o => o.UseRegexFilter, (o, v) => o.UseRegexFilter = v,
+        public static readonly StyledProperty<bool> UseRegexFilterProperty =
+            AvaloniaProperty.Register<FilterTextBox, bool>(nameof(UseRegexFilter),
                 defaultBindingMode: BindingMode.TwoWay);
 
-        public static readonly DirectProperty<FilterTextBox, bool> UseCaseSensitiveFilterProperty =
-            AvaloniaProperty.RegisterDirect<FilterTextBox, bool>(nameof(UseCaseSensitiveFilter),
-                o => o.UseCaseSensitiveFilter, (o, v) => o.UseCaseSensitiveFilter = v,
+        public static readonly StyledProperty<bool> UseCaseSensitiveFilterProperty =
+            AvaloniaProperty.Register<FilterTextBox, bool>(nameof(UseCaseSensitiveFilter),
                 defaultBindingMode: BindingMode.TwoWay);
 
-        public static readonly DirectProperty<FilterTextBox, bool> UseWholeWordFilterProperty =
-            AvaloniaProperty.RegisterDirect<FilterTextBox, bool>(nameof(UseWholeWordFilter),
-                o => o.UseWholeWordFilter, (o, v) => o.UseWholeWordFilter = v,
+        public static readonly StyledProperty<bool> UseWholeWordFilterProperty =
+            AvaloniaProperty.Register<FilterTextBox, bool>(nameof(UseWholeWordFilter),
                 defaultBindingMode: BindingMode.TwoWay);
-
-        private bool _useRegexFilter, _useCaseSensitiveFilter, _useWholeWordFilter;
 
         public FilterTextBox()
         {
@@ -31,20 +26,20 @@ namespace Avalonia.Diagnostics.Controls
 
         public bool UseRegexFilter
         {
-            get => _useRegexFilter;
-            set => SetAndRaise(UseRegexFilterProperty, ref _useRegexFilter, value);
+            get => GetValue(UseRegexFilterProperty);
+            set => SetValue(UseRegexFilterProperty, value);
         }
 
         public bool UseCaseSensitiveFilter
         {
-            get => _useCaseSensitiveFilter;
-            set => SetAndRaise(UseCaseSensitiveFilterProperty, ref _useCaseSensitiveFilter, value);
+            get => GetValue(UseCaseSensitiveFilterProperty);
+            set => SetValue(UseCaseSensitiveFilterProperty,value);
         }
 
         public bool UseWholeWordFilter
         {
-            get => _useWholeWordFilter;
-            set => SetAndRaise(UseWholeWordFilterProperty, ref _useWholeWordFilter, value);
+            get => GetValue(UseWholeWordFilterProperty);
+            set => SetValue(UseWholeWordFilterProperty, value);
         }
 
         Type IStyleable.StyleKey => typeof(TextBox);

--- a/tests/Avalonia.Base.UnitTests/Styling/SetterTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/SetterTests.cs
@@ -72,51 +72,51 @@ namespace Avalonia.Base.UnitTests.Styling
         [Fact]
         public void Can_Set_Direct_Property_In_Style_Without_Activator()
         {
-            var control = new TextBlock();
+            var control = new DirectPropertyClass();
             var target = new Setter();
-            var style = new Style(x => x.Is<TextBlock>())
+            var style = new Style(x => x.Is<DirectPropertyClass>())
             {
                 Setters =
                 {
-                    new Setter(TextBlock.TextProperty, "foo"),
+                    new Setter(DirectPropertyClass.FooProperty, "foo"),
                 }
             };
 
             Apply(style, control);
 
-            Assert.Equal("foo", control.Text);
+            Assert.Equal("foo", control.Foo);
         }
 
         [Fact]
         public void Can_Set_Direct_Property_Binding_In_Style_Without_Activator()
         {
-            var control = new TextBlock();
+            var control = new DirectPropertyClass();
             var target = new Setter();
             var source = new BehaviorSubject<object?>("foo");
-            var style = new Style(x => x.Is<TextBlock>())
+            var style = new Style(x => x.Is<DirectPropertyClass>())
             {
                 Setters =
                 {
-                    new Setter(TextBlock.TextProperty, source.ToBinding()),
+                    new Setter(DirectPropertyClass.FooProperty, source.ToBinding()),
                 }
             };
 
             Apply(style, control);
 
-            Assert.Equal("foo", control.Text);
+            Assert.Equal("foo", control.Foo);
         }
 
         [Fact]
         public void Cannot_Set_Direct_Property_Binding_In_Style_With_Activator()
         {
-            var control = new TextBlock();
+            var control = new DirectPropertyClass();
             var target = new Setter();
             var source = new BehaviorSubject<object?>("foo");
-            var style = new Style(x => x.Is<TextBlock>().Class("foo"))
+            var style = new Style(x => x.Is<DirectPropertyClass>().Class("foo"))
             {
                 Setters =
                 {
-                    new Setter(TextBlock.TextProperty, source.ToBinding()),
+                    new Setter(DirectPropertyClass.FooProperty, source.ToBinding()),
                 }
             };
 
@@ -126,13 +126,13 @@ namespace Avalonia.Base.UnitTests.Styling
         [Fact]
         public void Cannot_Set_Direct_Property_In_Style_With_Activator()
         {
-            var control = new TextBlock();
+            var control = new DirectPropertyClass();
             var target = new Setter();
-            var style = new Style(x => x.Is<TextBlock>().Class("foo"))
+            var style = new Style(x => x.Is<DirectPropertyClass>().Class("foo"))
             {
                 Setters =
                 {
-                    new Setter(TextBlock.TextProperty, "foo"),
+                    new Setter(DirectPropertyClass.FooProperty, "foo"),
                 }
             };
 
@@ -288,18 +288,18 @@ namespace Avalonia.Base.UnitTests.Styling
         {
             using var app = UnitTestApplication.Start(TestServices.MockThreadingInterface);
             var data = new Data { Foo = "foo" };
-            var control = new TextBox
+            var control = new DirectPropertyClass
             {
                 DataContext = data,
             };
 
-            var style = new Style(x => x.OfType<TextBox>())
+            var style = new Style(x => x.OfType<DirectPropertyClass>())
             {
                 Setters =
                 {
                     new Setter
                     {
-                        Property = TextBox.TextProperty,
+                        Property = DirectPropertyClass.FooProperty,
                         Value = new Binding
                         {
                             Path = "Foo",
@@ -310,9 +310,9 @@ namespace Avalonia.Base.UnitTests.Styling
             };
 
             Apply(style, control);
-            Assert.Equal("foo", control.Text);
+            Assert.Equal("foo", control.Foo);
 
-            control.Text = "bar";
+            control.Foo = "bar";
             Assert.Equal("bar", data.Foo);
         }
 
@@ -502,9 +502,9 @@ namespace Avalonia.Base.UnitTests.Styling
             Assert.Equal(Brushes.Blue, data.Bar);
         }
 
-        private void Apply(Style style, Control control)
+        private void Apply(Style style, StyledElement element)
         {
-            StyleHelpers.TryAttach(style, control);
+            StyleHelpers.TryAttach(style, element);
         }
 
         private void Apply(Setter setter, Control control)
@@ -533,6 +533,19 @@ namespace Avalonia.Base.UnitTests.Styling
             public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
             {
                 throw new NotImplementedException();
+            }
+        }
+
+        private class DirectPropertyClass : StyledElement
+        {
+            public static readonly DirectProperty<DirectPropertyClass, string?> FooProperty = AvaloniaProperty.RegisterDirect<DirectPropertyClass, string?>(nameof(Foo),
+                x => x.Foo, (x, v) => x.Foo = v);
+            
+            private string? _foo;
+            public string? Foo
+            {
+                get => _foo;
+                set => SetAndRaise(FooProperty, ref _foo, value);
             }
         }
     }

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -192,7 +192,7 @@ namespace Avalonia.Controls.UnitTests
 
                 target.Inlines.Add(new Run("Hello World"));
 
-                Assert.Equal("Hello World", target.Text);
+                Assert.Equal(null, target.Text);
 
                 Assert.Equal(1, target.Inlines.Count);
 


### PR DESCRIPTION
## What does the pull request do?
This PR converts most properties on `TextBlock`, `TextBox`, and related types to `StyledProperty`, as part of #9944.

It also fixes a bug where `StyledProperty` bypassed some of its own code by calling a base method too soon. This was causing the following bug:

1. Register a property without a coerce method
2. Overriding the metadata of that property and add a coerce method
3. That coerce method will not be called

While fixing this I removed the `HasCoercion` property entirely, since it no longer serves any purpose.

## What is the updated/expected behavior with this PR?
There was code which manipulated `DirectProperty` values without going through the normal set method. This all had to be refactored as this pattern is not supported by `StyledProperty`.

This leads to one intentional change in behaviour: the value of `TextBlock.Text` no longer changes when complex content is added to `TextBlock.Inlines`. On current master, the value is updated every time a new inline is added, but silently, without raising any property change events. This value was not used to render the control, and was not updated when the text value of an existing inline changed (e.g. due to a binding updating). I couldn't see a reason for any of this except debug visualisation, so I moved the entire behaviour into a `DebuggerDisplay` attribute. Now, whenever there is complex content:

* `TextBlock.Text` will be null
* `TextBlock` will be displayed by the debugger with an up to date text rendering of the Inlines collection

Also, I took the opportunity to switch `TextBox` over from raw string manipulation to `StringBuilder`. This change isn't necessary for #9944, but it improves performance and reduces allocations when editing text, especially when the value in `TextBox.Text` is very long.

Lastly, `TextBlock.Inlines` has been converted to `DirectProperty`, because a local value is set in the instance constructor and it thus cannot be styled.

## Breaking changes
Anyone adding new owners or overriding metadata of the affected properties will have to switch to StyledProperty in their own code.

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #7982 
