### PR TITLE
Add Visual.GetTransformedBounds extension method.

### DIFF
--- a/tests/Avalonia.Base.UnitTests/VisualTree/VisualExtensions_GetTransformedBounds.cs
+++ b/tests/Avalonia.Base.UnitTests/VisualTree/VisualExtensions_GetTransformedBounds.cs
@@ -45,7 +45,7 @@ namespace Avalonia.Base.UnitTests.VisualTree
 
             Assert.Equal(
                 new TransformedBounds(
-                    new Rect(250, 250, 500, 500),
+                    new Rect(0, 0, 500, 500),
                     new Rect(0, 0, 1000, 1000),
                     Matrix.CreateTranslation(250, 250)),
                 target.GetTransformedBounds());
@@ -75,7 +75,7 @@ namespace Avalonia.Base.UnitTests.VisualTree
 
             Assert.Equal(
                 new TransformedBounds(
-                    new Rect(150, 150, 500, 500),
+                    new Rect(0, 0, 500, 500),
                     new Rect(0, 0, 1000, 1000),
                     Matrix.CreateTranslation(250, 250)),
                 target.GetTransformedBounds());
@@ -106,7 +106,7 @@ namespace Avalonia.Base.UnitTests.VisualTree
 
             Assert.Equal(
                 new TransformedBounds(
-                    new Rect(150, 150, 500, 500),
+                    new Rect(0, 0, 500, 500),
                     new Rect(100, 100, 800, 800),
                     Matrix.CreateTranslation(250, 250)),
                 target.GetTransformedBounds());
@@ -138,7 +138,7 @@ namespace Avalonia.Base.UnitTests.VisualTree
 
             Assert.Equal(
                 new TransformedBounds(
-                    new Rect(150, 150, 500, 500),
+                    new Rect(0, 0, 500, 500),
                     new Rect(110, 120, 800, 800),
                     Matrix.CreateTranslation(260, 270)),
                 target.GetTransformedBounds());

--- a/tests/Avalonia.Base.UnitTests/VisualTree/VisualExtensions_GetTransformedBounds.cs
+++ b/tests/Avalonia.Base.UnitTests/VisualTree/VisualExtensions_GetTransformedBounds.cs
@@ -1,0 +1,153 @@
+﻿using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.VisualTree
+{
+    public class VisualExtensions_GetTransformedBounds
+    {
+        [Fact]
+        public void Root()
+        {
+            var root = new Border
+            {
+                Width = 100,
+                Height = 123,
+            };
+
+            Layout(root);
+
+            Assert.Equal(
+                new TransformedBounds(
+                    new Rect(0, 0, 100, 123),
+                    new Rect(0, 0, 100, 123),
+                    Matrix.Identity),
+                root.GetTransformedBounds());
+        }
+
+        [Fact]
+        public void Depth_1_No_Transform_Or_Clip()
+        {
+            Border target;
+            var root = new Border
+            {
+                Width = 1000,
+                Height = 1000,
+                Child = target = new Border
+                {
+                    Width = 500,
+                    Height = 500,
+                }
+            };
+
+            Layout(root);
+
+            Assert.Equal(
+                new TransformedBounds(
+                    new Rect(250, 250, 500, 500),
+                    new Rect(0, 0, 1000, 1000),
+                    Matrix.CreateTranslation(250, 250)),
+                target.GetTransformedBounds());
+        }
+
+        [Fact]
+        public void Depth_2_No_Transform_Or_Clip()
+        {
+            Border target;
+            var root = new Border
+            {
+                Width = 1000,
+                Height = 1000,
+                Child = new Border
+                {
+                    Width = 800,
+                    Height = 800,
+                    Child = target = new Border
+                    {
+                        Width = 500,
+                        Height = 500,
+                    }
+                }
+            };
+
+            Layout(root);
+
+            Assert.Equal(
+                new TransformedBounds(
+                    new Rect(150, 150, 500, 500),
+                    new Rect(0, 0, 1000, 1000),
+                    Matrix.CreateTranslation(250, 250)),
+                target.GetTransformedBounds());
+        }
+
+        [Fact]
+        public void Depth_2_No_Transform_With_Clip()
+        {
+            Border target;
+            var root = new Border
+            {
+                Width = 1000,
+                Height = 1000,
+                Child = new Border
+                {
+                    Width = 800,
+                    Height = 800,
+                    ClipToBounds = true,
+                    Child = target = new Border
+                    {
+                        Width = 500,
+                        Height = 500,
+                    }
+                }
+            };
+
+            Layout(root);
+
+            Assert.Equal(
+                new TransformedBounds(
+                    new Rect(150, 150, 500, 500),
+                    new Rect(100, 100, 800, 800),
+                    Matrix.CreateTranslation(250, 250)),
+                target.GetTransformedBounds());
+        }
+
+        [Fact]
+        public void Depth_2_Transformed_Clip()
+        {
+            Border target;
+            var root = new Border
+            {
+                Width = 1000,
+                Height = 1000,
+                Child = new Border
+                {
+                    Width = 800,
+                    Height = 800,
+                    ClipToBounds = true,
+                    RenderTransform = new MatrixTransform(Matrix.CreateTranslation(10, 20)),
+                    Child = target = new Border
+                    {
+                        Width = 500,
+                        Height = 500,
+                    }
+                }
+            };
+
+            Layout(root);
+
+            Assert.Equal(
+                new TransformedBounds(
+                    new Rect(150, 150, 500, 500),
+                    new Rect(110, 120, 800, 800),
+                    Matrix.CreateTranslation(260, 270)),
+                target.GetTransformedBounds());
+        }
+
+        private void Layout(Control c)
+        {
+            c.Measure(Size.Infinity);
+            c.Arrange(new Rect(c.DesiredSize));
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Changes to the renderer have made it so that the `TransformedBounds` property is no longer feasible to do with decent performance, however if one needs to just calculate the `TransformedBounds` for a control without listening for changes to these bounds, this new method can do that!

Fixes #9569.
