### PR TITLE
Improve ToolTip show logic

### DIFF
--- a/src/Avalonia.Controls/ToolTip.cs
+++ b/src/Avalonia.Controls/ToolTip.cs
@@ -55,6 +55,12 @@ namespace Avalonia.Controls
             AvaloniaProperty.RegisterAttached<ToolTip, Control, int>("ShowDelay", 400);
 
         /// <summary>
+        /// Defines the ToolTip.ShowDistanceLimit property.
+        /// </summary>
+        public static readonly AttachedProperty<double> ShowDistanceLimitProperty =
+            AvaloniaProperty.RegisterAttached<ToolTip, Control, double>("ShowDistanceLimit", 10);
+
+        /// <summary>
         /// Stores the current <see cref="ToolTip"/> instance in the control.
         /// </summary>
         internal static readonly AttachedProperty<ToolTip?> ToolTipProperty =
@@ -76,6 +82,7 @@ namespace Avalonia.Controls
             VerticalOffsetProperty.Changed.Subscribe(RecalculatePositionOnPropertyChanged);
             PlacementProperty.Changed.Subscribe(RecalculatePositionOnPropertyChanged);
         }
+
 
         /// <summary>
         /// Gets the value of the ToolTip.Tip attached property.
@@ -207,6 +214,28 @@ namespace Avalonia.Controls
         public static void SetShowDelay(Control element, int value)
         {
             element.SetValue(ShowDelayProperty, value);
+        }
+
+        /// <summary>
+        /// Gets the value of the ToolTip.ShowDistanceLimit attached property.
+        /// </summary>
+        /// <param name="element">The control to get the property from.</param>
+        /// <returns>
+        /// A value indicating the distance the pointer travels before resetting the timer.
+        /// </returns>
+        public static double GetShowDistanceLimit(Control element)
+        {
+            return element.GetValue(ShowDistanceLimitProperty);
+        }
+
+        /// <summary>
+        /// Sets the value of the ToolTip.ShowDistanceLimit attached property.
+        /// </summary>
+        /// <param name="element">The control to get the property from.</param>
+        /// <param name="value">A value indicating the distance the pointer travels before resetting the timer.</param>
+        public static void SetShowDistanceLimit(Control element, double value)
+        {
+            element.SetValue(ShowDistanceLimitProperty, value);
         }
 
         private static void IsOpenChanged(AvaloniaPropertyChangedEventArgs e)

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -27,20 +27,20 @@ namespace Avalonia.Controls
 
             if (e.OldValue != null)
             {
-                control.PointerEntered -= ControlPointerEntered;
-                control.PointerExited -= ControlPointerExited;
-                control.PointerPressed -= ControlPointerPressed;
-                control.PointerReleased -= ControlPointerReleased;
-                control.PointerMoved -= ControlPointerMoved;
+                control.RemoveHandler(InputElement.PointerEnteredEvent, ControlPointerEntered);
+                control.RemoveHandler(InputElement.PointerExitedEvent, ControlPointerExited);
+                control.RemoveHandler(InputElement.PointerPressedEvent, ControlPointerPressed);
+                control.RemoveHandler(InputElement.PointerReleasedEvent, ControlPointerReleased);
+                control.RemoveHandler(InputElement.PointerMovedEvent, ControlPointerMoved);
             }
 
             if (e.NewValue != null)
             {
-                control.PointerEntered += ControlPointerEntered;
-                control.PointerExited += ControlPointerExited;
-                control.PointerPressed += ControlPointerPressed;
-                control.PointerReleased += ControlPointerReleased;
-                control.PointerMoved += ControlPointerMoved;
+                control.AddHandler(InputElement.PointerEnteredEvent, ControlPointerEntered, handledEventsToo: true);
+                control.AddHandler(InputElement.PointerExitedEvent, ControlPointerExited, handledEventsToo: true);
+                control.AddHandler(InputElement.PointerPressedEvent, ControlPointerPressed, handledEventsToo: true);
+                control.AddHandler(InputElement.PointerReleasedEvent, ControlPointerReleased, handledEventsToo: true);
+                control.AddHandler(InputElement.PointerMovedEvent, ControlPointerMoved, handledEventsToo: true);
             }
 
             if (ToolTip.GetIsOpen(control) && e.NewValue != e.OldValue && !(e.NewValue is ToolTip))

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -28,12 +28,16 @@ namespace Avalonia.Controls
             {
                 control.PointerEntered -= ControlPointerEntered;
                 control.PointerExited -= ControlPointerExited;
+                control.PointerPressed -= ControlPointerPressed;
+                control.PointerReleased -= ControlPointerReleased;
             }
 
             if (e.NewValue != null)
             {
                 control.PointerEntered += ControlPointerEntered;
                 control.PointerExited += ControlPointerExited;
+                control.PointerPressed += ControlPointerPressed;
+                control.PointerReleased += ControlPointerReleased;
             }
 
             if (ToolTip.GetIsOpen(control) && e.NewValue != e.OldValue && !(e.NewValue is ToolTip))
@@ -105,6 +109,28 @@ namespace Avalonia.Controls
         {
             var control = (Control)sender!;
             Close(control);
+        }
+
+
+        private void ControlPointerReleased(object sender, PointerReleasedEventArgs e)
+        {
+            StopTimer();
+
+            var control = (Control)sender!;
+            var showDelay = ToolTip.GetShowDelay(control);
+            if (showDelay == 0)
+            {
+                Open(control);
+            }
+            else
+            {
+                StartShowTimer(showDelay, control);
+            }
+        }
+
+        private void ControlPointerPressed(object sender, PointerPressedEventArgs e)
+        {
+            StopTimer();
         }
 
         private void ControlEffectiveViewportChanged(object? sender, Layout.EffectiveViewportChangedEventArgs e)

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -112,7 +112,7 @@ namespace Avalonia.Controls
         }
 
 
-        private void ControlPointerReleased(object sender, PointerReleasedEventArgs e)
+        private void ControlPointerReleased(object? sender, PointerReleasedEventArgs e)
         {
             StopTimer();
 
@@ -128,7 +128,7 @@ namespace Avalonia.Controls
             }
         }
 
-        private void ControlPointerPressed(object sender, PointerPressedEventArgs e)
+        private void ControlPointerPressed(object? sender, PointerPressedEventArgs e)
         {
             StopTimer();
         }

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -58,28 +58,6 @@ namespace Avalonia.Controls
             }
         }
 
-        private void ControlPointerMoved(object? sender, PointerEventArgs e)
-        {
-            if (_timer is null)
-                return;
-            
-            var control = (Control)sender!;
-            var distanceLimit = ToolTip.GetShowDistanceLimit(control);
-
-            if (double.IsNaN(distanceLimit) || distanceLimit < 0)
-                return;
-
-            var position = e.GetPosition(control);
-
-            Vector moved = position - _startPosition;
-
-            if (moved.Length > distanceLimit)
-            {
-                _timer.Stop();
-                _timer.Start();
-            }
-        }
-
         internal void TipOpenChanged(AvaloniaPropertyChangedEventArgs e)
         {
             var control = (Control)e.Sender;
@@ -136,6 +114,28 @@ namespace Avalonia.Controls
             Close(control);
         }
 
+        private void ControlPointerMoved(object? sender, PointerEventArgs e)
+        {
+            if (_timer is null)
+                return;
+
+            var control = (Control)sender!;
+            var distanceLimit = ToolTip.GetShowDistanceLimit(control);
+
+            if (double.IsNaN(distanceLimit) || distanceLimit < 0)
+                return;
+
+            var position = e.GetPosition(control);
+
+            Vector moved = position - _startPosition;
+
+            if (moved.Length > distanceLimit)
+            {
+                _startPosition = position;
+                _timer.Stop();
+                _timer.Start();
+            }
+        }
 
         private void ControlPointerReleased(object? sender, PointerReleasedEventArgs e)
         {

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -60,18 +60,23 @@ namespace Avalonia.Controls
 
         private void ControlPointerMoved(object? sender, PointerEventArgs e)
         {
-            if(_timer != null)
+            if (_timer is null)
+                return;
+            
+            var control = (Control)sender!;
+            var distanceLimit = ToolTip.GetShowDistanceLimit(control);
+
+            if (double.IsNaN(distanceLimit) || distanceLimit < 0)
+                return;
+
+            var position = e.GetPosition(control);
+
+            Vector moved = position - _startPosition;
+
+            if (moved.Length > distanceLimit)
             {
-                var control = (Control)sender!;
-                var position = e.GetPosition(control);
-
-                Vector moved = position - _startPosition;
-
-                if (moved.Length > 10)
-                {
-                    _timer.Stop();
-                    _timer.Start();
-                }
+                _timer.Stop();
+                _timer.Start();
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
With this PR the ToolTip will not show during a pointer press. If the ShowDelay is set to 500ms, but the user press the button after 400ms having the tooltip pop up during the press is not only a strange experience, but breaks the pointer capture at least on windows. A ShowDistanceLimit is also introduced to avoid the having the tooltip show up before the pointer comes to a rest. To have the tooltip show up while vigorously moving the mouse around doesn't feel right to me, atleast.


## What is the current behavior?
Simple timer based on ShowDelay.


## What is the updated/expected behavior with this PR?
Timer is stopped on pointer pressed and restarted on pointer released. Also the pointer position is captured on timer start and timer is reset if the pointer moves more than the new attached property ShowDistanceLimit.


## How was the solution implemented (if it's not obvious)?
Adjustments made to ToolTipService.

