### PR TITLE
`PlacementMode` -> `Placement`

### DIFF
--- a/samples/IntegrationTestApp/MainWindow.axaml.cs
+++ b/samples/IntegrationTestApp/MainWindow.axaml.cs
@@ -158,7 +158,7 @@ namespace IntegrationTestApp
             var popup = new Popup
             {
                 WindowManagerAddShadowHint = false,
-                PlacementMode = PlacementMode.AnchorAndGravity,
+                Placement = PlacementMode.AnchorAndGravity,
                 PlacementAnchor = PopupAnchor.Top,
                 PlacementGravity = PopupGravity.Bottom,
                 Width= 200,

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -55,10 +55,20 @@ namespace Avalonia.Controls
             Popup.PlacementGravityProperty.AddOwner<ContextMenu>();
 
         /// <summary>
+        /// Defines the <see cref="PlacementMode"/> property.
+        /// </summary>
+        [Obsolete("Use the Placement property instead.")]
+        public static readonly StyledProperty<PlacementMode> PlacementModeProperty = PlacementProperty;
+
+#pragma warning disable AVP1013 // AvaloniaProperty owners should not be added superfluously
+
+        /// <summary>
         /// Defines the <see cref="Placement"/> property.
         /// </summary>
         public static readonly StyledProperty<PlacementMode> PlacementProperty =
             Popup.PlacementProperty.AddOwner<ContextMenu>();
+
+#pragma warning restore AVP1013 // AvaloniaProperty owners should not be added superfluously
 
         /// <summary>
         /// Defines the <see cref="PlacementRect"/> property.
@@ -147,6 +157,14 @@ namespace Avalonia.Controls
         {
             get => GetValue(PlacementGravityProperty);
             set => SetValue(PlacementGravityProperty, value);
+        }
+
+        /// <inheritdoc cref="Placement"/>
+        [Obsolete("Use the Placement property instead.")]
+        public PlacementMode PlacementMode
+        {
+            get => GetValue(PlacementProperty);
+            set => SetValue(PlacementProperty, value);
         }
 
         /// <inheritdoc cref="Popup.Placement"/>

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -114,57 +114,42 @@ namespace Avalonia.Controls
             AutomationProperties.ControlTypeOverrideProperty.OverrideDefaultValue<ContextMenu>(AutomationControlType.Menu);
         }
 
-        /// <summary>
-        /// Gets or sets the Horizontal offset of the context menu in relation to the <see cref="PlacementTarget"/>.
-        /// </summary>
+        /// <inheritdoc cref="Popup.HorizontalOffset"/>
         public double HorizontalOffset
         {
             get => GetValue(HorizontalOffsetProperty);
             set => SetValue(HorizontalOffsetProperty, value);
         }
 
-        /// <summary>
-        /// Gets or sets the Vertical offset of the context menu in relation to the <see cref="PlacementTarget"/>.
-        /// </summary>
+        /// <inheritdoc cref="Popup.VerticalOffset"/>
         public double VerticalOffset
         {
             get => GetValue(VerticalOffsetProperty);
             set => SetValue(VerticalOffsetProperty, value);
         }
 
-        /// <summary>
-        /// Gets or sets the anchor point on the <see cref="PlacementRect"/> when <see cref="Placement"/>
-        /// is <see cref="PlacementMode.AnchorAndGravity"/>.
-        /// </summary>
+        /// <inheritdoc cref="Popup.PlacementAnchor"/>
         public PopupAnchor PlacementAnchor
         {
             get => GetValue(PlacementAnchorProperty);
             set => SetValue(PlacementAnchorProperty, value);
         }
 
-        /// <summary>
-        /// Gets or sets a value describing how the context menu position will be adjusted if the
-        /// unadjusted position would result in the context menu being partly constrained.
-        /// </summary>
+        /// <inheritdoc cref="Popup.PlacementConstraintAdjustment"/>
         public PopupPositionerConstraintAdjustment PlacementConstraintAdjustment
         {
             get => GetValue(PlacementConstraintAdjustmentProperty);
             set => SetValue(PlacementConstraintAdjustmentProperty, value);
         }
 
-        /// <summary>
-        /// Gets or sets a value which defines in what direction the context menu should open
-        /// when <see cref="Placement"/> is <see cref="PlacementMode.AnchorAndGravity"/>.
-        /// </summary>
+        /// <inheritdoc cref="Popup.PlacementGravity"/>
         public PopupGravity PlacementGravity
         {
             get => GetValue(PlacementGravityProperty);
             set => SetValue(PlacementGravityProperty, value);
         }
 
-        /// <summary>
-        /// Gets or sets the desired placement of the context menu in relation to the<see cref="PlacementTarget"/>.
-        /// </summary>
+        /// <inheritdoc cref="Popup.Placement"/>
         public PlacementMode Placement
         {
             get => GetValue(PlacementProperty);
@@ -177,26 +162,14 @@ namespace Avalonia.Controls
             set => SetValue(WindowManagerAddShadowHintProperty, value);
         }
 
-        /// <summary>
-        /// Gets or sets the the anchor rectangle within the parent that the context menu will be placed
-        /// relative to when <see cref="Placement"/> is <see cref="PlacementMode.AnchorAndGravity"/>.
-        /// </summary>
-        /// <remarks>
-        /// The placement rect defines a rectangle relative to <see cref="PlacementTarget"/> around
-        /// which the popup will be opened, with <see cref="PlacementAnchor"/> determining which edge
-        /// of the placement target is used.
-        /// 
-        /// If unset, the anchor rectangle will be the bounds of the <see cref="PlacementTarget"/>.
-        /// </remarks>
+        /// <inheritdoc cref="Popup.PlacementRect"/>
         public Rect? PlacementRect
         {
             get => GetValue(PlacementRectProperty);
             set => SetValue(PlacementRectProperty, value);
         }
 
-        /// <summary>
-        /// Gets or sets the control that is used to determine the popup's position.
-        /// </summary>
+        /// <inheritdoc cref="Popup.PlacementTarget"/>
         public Control? PlacementTarget
         {
             get => GetValue(PlacementTargetProperty);

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -58,7 +58,7 @@ namespace Avalonia.Controls
         /// Defines the <see cref="PlacementMode"/> property.
         /// </summary>
         [Obsolete("Use the Placement property instead.")]
-        public static readonly StyledProperty<PlacementMode> PlacementModeProperty = PlacementProperty;
+        public static readonly StyledProperty<PlacementMode> PlacementModeProperty = PlacementProperty!;
 
 #pragma warning disable AVP1013 // AvaloniaProperty owners should not be added superfluously
 

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -55,20 +55,16 @@ namespace Avalonia.Controls
             Popup.PlacementGravityProperty.AddOwner<ContextMenu>();
 
         /// <summary>
-        /// Defines the <see cref="PlacementMode"/> property.
-        /// </summary>
-        [Obsolete("Use the Placement property instead.")]
-        public static readonly StyledProperty<PlacementMode> PlacementModeProperty = PlacementProperty;
-
-#pragma warning disable AVP1013 // AvaloniaProperty owners should not be added superfluously
-
-        /// <summary>
         /// Defines the <see cref="Placement"/> property.
         /// </summary>
         public static readonly StyledProperty<PlacementMode> PlacementProperty =
             Popup.PlacementProperty.AddOwner<ContextMenu>();
 
-#pragma warning restore AVP1013 // AvaloniaProperty owners should not be added superfluously
+        /// <summary>
+        /// Defines the <see cref="PlacementMode"/> property.
+        /// </summary>
+        [Obsolete("Use the Placement property instead.")]
+        public static readonly StyledProperty<PlacementMode> PlacementModeProperty = PlacementProperty;
 
         /// <summary>
         /// Defines the <see cref="PlacementRect"/> property.

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -55,9 +55,9 @@ namespace Avalonia.Controls
             Popup.PlacementGravityProperty.AddOwner<ContextMenu>();
 
         /// <summary>
-        /// Defines the <see cref="PlacementMode"/> property.
+        /// Defines the <see cref="Placement"/> property.
         /// </summary>
-        public static readonly StyledProperty<PlacementMode> PlacementModeProperty =
+        public static readonly StyledProperty<PlacementMode> PlacementProperty =
             Popup.PlacementProperty.AddOwner<ContextMenu>();
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace Avalonia.Controls
         static ContextMenu()
         {
             ItemsPanelProperty.OverrideDefaultValue<ContextMenu>(DefaultPanel);
-            PlacementModeProperty.OverrideDefaultValue<ContextMenu>(PlacementMode.Pointer);
+            PlacementProperty.OverrideDefaultValue<ContextMenu>(PlacementMode.Pointer);
             ContextMenuProperty.Changed.Subscribe(ContextMenuChanged);
             AutomationProperties.AccessibilityViewProperty.OverrideDefaultValue<ContextMenu>(AccessibilityView.Control);
             AutomationProperties.ControlTypeOverrideProperty.OverrideDefaultValue<ContextMenu>(AutomationControlType.Menu);
@@ -133,7 +133,7 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Gets or sets the anchor point on the <see cref="PlacementRect"/> when <see cref="PlacementMode"/>
+        /// Gets or sets the anchor point on the <see cref="PlacementRect"/> when <see cref="Placement"/>
         /// is <see cref="PlacementMode.AnchorAndGravity"/>.
         /// </summary>
         public PopupAnchor PlacementAnchor
@@ -154,7 +154,7 @@ namespace Avalonia.Controls
 
         /// <summary>
         /// Gets or sets a value which defines in what direction the context menu should open
-        /// when <see cref="PlacementMode"/> is <see cref="PlacementMode.AnchorAndGravity"/>.
+        /// when <see cref="Placement"/> is <see cref="PlacementMode.AnchorAndGravity"/>.
         /// </summary>
         public PopupGravity PlacementGravity
         {
@@ -163,12 +163,12 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Gets or sets the placement mode of the context menu in relation to the<see cref="PlacementTarget"/>.
+        /// Gets or sets the desired placement of the context menu in relation to the<see cref="PlacementTarget"/>.
         /// </summary>
-        public PlacementMode PlacementMode
+        public PlacementMode Placement
         {
-            get { return GetValue(PlacementModeProperty); }
-            set { SetValue(PlacementModeProperty, value); }
+            get { return GetValue(PlacementProperty); }
+            set { SetValue(PlacementProperty, value); }
         }
 
         public bool WindowManagerAddShadowHint
@@ -179,7 +179,7 @@ namespace Avalonia.Controls
 
         /// <summary>
         /// Gets or sets the the anchor rectangle within the parent that the context menu will be placed
-        /// relative to when <see cref="PlacementMode"/> is <see cref="PlacementMode.AnchorAndGravity"/>.
+        /// relative to when <see cref="Placement"/> is <see cref="PlacementMode.AnchorAndGravity"/>.
         /// </summary>
         /// <remarks>
         /// The placement rect defines a rectangle relative to <see cref="PlacementTarget"/> around
@@ -343,9 +343,9 @@ namespace Avalonia.Controls
                 ((ISetLogicalParent)_popup).SetParent(control);
             }
 
-            _popup.Placement = !requestedByPointer && PlacementMode == PlacementMode.Pointer
+            _popup.Placement = !requestedByPointer && Placement == PlacementMode.Pointer
                 ? PlacementMode.Bottom
-                : PlacementMode;
+                : Placement;
 
             //Position of the line below is really important. 
             //All styles are being applied only when control has logical parent.

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -119,8 +119,8 @@ namespace Avalonia.Controls
         /// </summary>
         public double HorizontalOffset
         {
-            get { return GetValue(HorizontalOffsetProperty); }
-            set { SetValue(HorizontalOffsetProperty, value); }
+            get => GetValue(HorizontalOffsetProperty);
+            set => SetValue(HorizontalOffsetProperty, value);
         }
 
         /// <summary>
@@ -128,8 +128,8 @@ namespace Avalonia.Controls
         /// </summary>
         public double VerticalOffset
         {
-            get { return GetValue(VerticalOffsetProperty); }
-            set { SetValue(VerticalOffsetProperty, value); }
+            get => GetValue(VerticalOffsetProperty);
+            set => SetValue(VerticalOffsetProperty, value);
         }
 
         /// <summary>
@@ -138,8 +138,8 @@ namespace Avalonia.Controls
         /// </summary>
         public PopupAnchor PlacementAnchor
         {
-            get { return GetValue(PlacementAnchorProperty); }
-            set { SetValue(PlacementAnchorProperty, value); }
+            get => GetValue(PlacementAnchorProperty);
+            set => SetValue(PlacementAnchorProperty, value);
         }
 
         /// <summary>
@@ -148,8 +148,8 @@ namespace Avalonia.Controls
         /// </summary>
         public PopupPositionerConstraintAdjustment PlacementConstraintAdjustment
         {
-            get { return GetValue(PlacementConstraintAdjustmentProperty); }
-            set { SetValue(PlacementConstraintAdjustmentProperty, value); }
+            get => GetValue(PlacementConstraintAdjustmentProperty);
+            set => SetValue(PlacementConstraintAdjustmentProperty, value);
         }
 
         /// <summary>
@@ -158,8 +158,8 @@ namespace Avalonia.Controls
         /// </summary>
         public PopupGravity PlacementGravity
         {
-            get { return GetValue(PlacementGravityProperty); }
-            set { SetValue(PlacementGravityProperty, value); }
+            get => GetValue(PlacementGravityProperty);
+            set => SetValue(PlacementGravityProperty, value);
         }
 
         /// <summary>
@@ -167,14 +167,14 @@ namespace Avalonia.Controls
         /// </summary>
         public PlacementMode Placement
         {
-            get { return GetValue(PlacementProperty); }
-            set { SetValue(PlacementProperty, value); }
+            get => GetValue(PlacementProperty);
+            set => SetValue(PlacementProperty, value);
         }
 
         public bool WindowManagerAddShadowHint
         {
-            get { return GetValue(WindowManagerAddShadowHintProperty); }
-            set { SetValue(WindowManagerAddShadowHintProperty, value); }
+            get => GetValue(WindowManagerAddShadowHintProperty);
+            set => SetValue(WindowManagerAddShadowHintProperty, value);
         }
 
         /// <summary>
@@ -190,8 +190,8 @@ namespace Avalonia.Controls
         /// </remarks>
         public Rect? PlacementRect
         {
-            get { return GetValue(PlacementRectProperty); }
-            set { SetValue(PlacementRectProperty, value); }
+            get => GetValue(PlacementRectProperty);
+            set => SetValue(PlacementRectProperty, value);
         }
 
         /// <summary>
@@ -199,8 +199,8 @@ namespace Avalonia.Controls
         /// </summary>
         public Control? PlacementTarget
         {
-            get { return GetValue(PlacementTargetProperty); }
-            set { SetValue(PlacementTargetProperty, value); }
+            get => GetValue(PlacementTargetProperty);
+            set => SetValue(PlacementTargetProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -58,7 +58,7 @@ namespace Avalonia.Controls
         /// Defines the <see cref="PlacementMode"/> property.
         /// </summary>
         public static readonly StyledProperty<PlacementMode> PlacementModeProperty =
-            Popup.PlacementModeProperty.AddOwner<ContextMenu>();
+            Popup.PlacementProperty.AddOwner<ContextMenu>();
 
         /// <summary>
         /// Defines the <see cref="PlacementRect"/> property.
@@ -343,7 +343,7 @@ namespace Avalonia.Controls
                 ((ISetLogicalParent)_popup).SetParent(control);
             }
 
-            _popup.PlacementMode = !requestedByPointer && PlacementMode == PlacementMode.Pointer
+            _popup.Placement = !requestedByPointer && PlacementMode == PlacementMode.Pointer
                 ? PlacementMode.Bottom
                 : PlacementMode;
 

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -58,7 +58,7 @@ namespace Avalonia.Controls
         /// Defines the <see cref="PlacementMode"/> property.
         /// </summary>
         [Obsolete("Use the Placement property instead.")]
-        public static readonly StyledProperty<PlacementMode> PlacementModeProperty = PlacementProperty!;
+        public static readonly StyledProperty<PlacementMode> PlacementModeProperty = PlacementProperty;
 
 #pragma warning disable AVP1013 // AvaloniaProperty owners should not be added superfluously
 

--- a/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
@@ -389,7 +389,7 @@ namespace Avalonia.Controls
 
             _presenter.Date = SelectedDate ?? DateTimeOffset.Now;
 
-            _popup.PlacementMode = PlacementMode.AnchorAndGravity;
+            _popup.Placement = PlacementMode.AnchorAndGravity;
             _popup.PlacementAnchor = Primitives.PopupPositioning.PopupAnchor.Bottom;
             _popup.PlacementGravity = Primitives.PopupPositioning.PopupGravity.Bottom;
             _popup.PlacementConstraintAdjustment = Primitives.PopupPositioning.PopupPositionerConstraintAdjustment.SlideY;

--- a/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
@@ -255,7 +255,7 @@ namespace Avalonia.Controls
 
             _presenter.Time = SelectedTime ?? DateTime.Now.TimeOfDay;
 
-            _popup.PlacementMode = PlacementMode.AnchorAndGravity;
+            _popup.Placement = PlacementMode.AnchorAndGravity;
             _popup.PlacementAnchor = Primitives.PopupPositioning.PopupAnchor.Bottom;
             _popup.PlacementGravity = Primitives.PopupPositioning.PopupGravity.Bottom;
             _popup.PlacementConstraintAdjustment = Primitives.PopupPositioning.PopupPositionerConstraintAdjustment.SlideY;

--- a/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
@@ -14,9 +14,9 @@ namespace Avalonia.Controls.Primitives
 {
     public abstract class PopupFlyoutBase : FlyoutBase, IPopupHostProvider
     {
-        /// <inheritdoc cref="Popup.PlacementModeProperty"/>
+        /// <inheritdoc cref="Popup.PlacementProperty"/>
         public static readonly StyledProperty<PlacementMode> PlacementProperty =
-            Popup.PlacementModeProperty.AddOwner<PopupFlyoutBase>();
+            Popup.PlacementProperty.AddOwner<PopupFlyoutBase>();
 
         /// <inheritdoc cref="Popup.HorizontalOffsetProperty"/>
         public static readonly StyledProperty<double> HorizontalOffsetProperty =
@@ -64,15 +64,13 @@ namespace Avalonia.Controls.Primitives
 
         protected Popup Popup => _popupLazy.Value;
 
-        /// <summary>
-        /// Gets or sets the desired placement.
-        /// </summary>
+        /// <inheritdoc cref="Popup.Placement"/>
         public PlacementMode Placement
         {
             get => GetValue(PlacementProperty);
             set => SetValue(PlacementProperty, value);
         }
-        
+
         /// <inheritdoc cref="Popup.PlacementGravity"/>
         public PopupGravity PlacementGravity
         {
@@ -423,11 +421,11 @@ namespace Avalonia.Controls.Primitives
             Popup.PlacementGravity = PlacementGravity;
             if (showAtPointer)
             {
-                Popup.PlacementMode = PlacementMode.Pointer;
+                Popup.Placement = PlacementMode.Pointer;
             }
             else
             {
-                Popup.PlacementMode = Placement;
+                Popup.Placement = Placement;
                 Popup.PlacementConstraintAdjustment =
                     PopupPositioning.PopupPositionerConstraintAdjustment.SlideX |
                     PopupPositioning.PopupPositionerConstraintAdjustment.SlideY;

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -69,7 +69,7 @@ namespace Avalonia.Controls.Primitives
         /// Defines the <see cref="PlacementMode"/> property.
         /// </summary>
         [Obsolete("Use the Placement property instead.")]
-        public static readonly StyledProperty<PlacementMode> PlacementModeProperty = PlacementProperty!;
+        public static readonly StyledProperty<PlacementMode> PlacementModeProperty = PlacementProperty;
 
         /// <summary>
         /// Defines the <see cref="Placement"/> property.

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -66,16 +66,16 @@ namespace Avalonia.Controls.Primitives
             AvaloniaProperty.Register<Popup, PopupGravity>(nameof(PlacementGravity));
 
         /// <summary>
-        /// Defines the <see cref="PlacementMode"/> property.
-        /// </summary>
-        [Obsolete("Use the Placement property instead.")]
-        public static readonly StyledProperty<PlacementMode> PlacementModeProperty = PlacementProperty;
-
-        /// <summary>
         /// Defines the <see cref="Placement"/> property.
         /// </summary>
         public static readonly StyledProperty<PlacementMode> PlacementProperty =
             AvaloniaProperty.Register<Popup, PlacementMode>(nameof(Placement), defaultValue: PlacementMode.Bottom);
+
+        /// <summary>
+        /// Defines the <see cref="PlacementMode"/> property.
+        /// </summary>
+        [Obsolete("Use the Placement property instead.")]
+        public static readonly StyledProperty<PlacementMode> PlacementModeProperty = PlacementProperty;
 
         /// <summary>
         /// Defines the <see cref="PlacementRect"/> property.

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -146,8 +146,8 @@ namespace Avalonia.Controls.Primitives
 
         public bool WindowManagerAddShadowHint
         {
-            get { return GetValue(WindowManagerAddShadowHintProperty); }
-            set { SetValue(WindowManagerAddShadowHintProperty, value); }
+            get => GetValue(WindowManagerAddShadowHintProperty);
+            set => SetValue(WindowManagerAddShadowHintProperty, value);
         }
 
         /// <summary>
@@ -156,8 +156,8 @@ namespace Avalonia.Controls.Primitives
         [Content]
         public Control? Child
         {
-            get { return GetValue(ChildProperty); }
-            set { SetValue(ChildProperty, value); }
+            get => GetValue(ChildProperty);
+            set => SetValue(ChildProperty, value);
         }
 
         /// <summary>
@@ -210,8 +210,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public PopupAnchor PlacementAnchor
         {
-            get { return GetValue(PlacementAnchorProperty); }
-            set { SetValue(PlacementAnchorProperty, value); }
+            get => GetValue(PlacementAnchorProperty);
+            set => SetValue(PlacementAnchorProperty, value);
         }
 
         /// <summary>
@@ -220,8 +220,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public PopupPositionerConstraintAdjustment PlacementConstraintAdjustment
         {
-            get { return GetValue(PlacementConstraintAdjustmentProperty); }
-            set { SetValue(PlacementConstraintAdjustmentProperty, value); }
+            get => GetValue(PlacementConstraintAdjustmentProperty);
+            set => SetValue(PlacementConstraintAdjustmentProperty, value);
         }
 
         /// <summary>
@@ -230,8 +230,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public PopupGravity PlacementGravity
         {
-            get { return GetValue(PlacementGravityProperty); }
-            set { SetValue(PlacementGravityProperty, value); }
+            get => GetValue(PlacementGravityProperty);
+            set => SetValue(PlacementGravityProperty, value);
         }
 
         /// <summary>
@@ -239,8 +239,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public PlacementMode Placement
         {
-            get { return GetValue(PlacementProperty); }
-            set { SetValue(PlacementProperty, value); }
+            get => GetValue(PlacementProperty);
+            set => SetValue(PlacementProperty, value);
         }
 
         /// <summary>
@@ -256,8 +256,8 @@ namespace Avalonia.Controls.Primitives
         /// </remarks>
         public Rect? PlacementRect
         {
-            get { return GetValue(PlacementRectProperty); }
-            set { SetValue(PlacementRectProperty, value); }
+            get => GetValue(PlacementRectProperty);
+            set => SetValue(PlacementRectProperty, value);
         }
 
         /// <summary>
@@ -266,8 +266,8 @@ namespace Avalonia.Controls.Primitives
         [ResolveByName]
         public Control? PlacementTarget
         {
-            get { return GetValue(PlacementTargetProperty); }
-            set { SetValue(PlacementTargetProperty, value); }
+            get => GetValue(PlacementTargetProperty);
+            set => SetValue(PlacementTargetProperty, value);
         }
 
         /// <summary>
@@ -301,8 +301,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public double HorizontalOffset
         {
-            get { return GetValue(HorizontalOffsetProperty); }
-            set { SetValue(HorizontalOffsetProperty, value); }
+            get => GetValue(HorizontalOffsetProperty);
+            set => SetValue(HorizontalOffsetProperty, value);
         }
 
         /// <summary>
@@ -310,8 +310,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public double VerticalOffset
         {
-            get { return GetValue(VerticalOffsetProperty); }
-            set { SetValue(VerticalOffsetProperty, value); }
+            get => GetValue(VerticalOffsetProperty);
+            set => SetValue(VerticalOffsetProperty, value);
         }
 
         /// <summary>
@@ -319,8 +319,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public bool Topmost
         {
-            get { return GetValue(TopmostProperty); }
-            set { SetValue(TopmostProperty, value); }
+            get => GetValue(TopmostProperty);
+            set => SetValue(TopmostProperty, value);
         }
 
         IPopupHost? IPopupHostProvider.PopupHost => Host;

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -66,10 +66,10 @@ namespace Avalonia.Controls.Primitives
             AvaloniaProperty.Register<Popup, PopupGravity>(nameof(PlacementGravity));
 
         /// <summary>
-        /// Defines the <see cref="PlacementMode"/> property.
+        /// Defines the <see cref="Placement"/> property.
         /// </summary>
-        public static readonly StyledProperty<PlacementMode> PlacementModeProperty =
-            AvaloniaProperty.Register<Popup, PlacementMode>(nameof(PlacementMode), defaultValue: PlacementMode.Bottom);
+        public static readonly StyledProperty<PlacementMode> PlacementProperty =
+            AvaloniaProperty.Register<Popup, PlacementMode>(nameof(Placement), defaultValue: PlacementMode.Bottom);
 
         /// <summary>
         /// Defines the <see cref="PlacementRect"/> property.
@@ -205,7 +205,7 @@ namespace Avalonia.Controls.Primitives
         }
 
         /// <summary>
-        /// Gets or sets the anchor point on the <see cref="PlacementRect"/> when <see cref="PlacementMode"/>
+        /// Gets or sets the anchor point on the <see cref="PlacementRect"/> when <see cref="Placement"/>
         /// is <see cref="PlacementMode.AnchorAndGravity"/>.
         /// </summary>
         public PopupAnchor PlacementAnchor
@@ -226,7 +226,7 @@ namespace Avalonia.Controls.Primitives
 
         /// <summary>
         /// Gets or sets a value which defines in what direction the popup should open
-        /// when <see cref="PlacementMode"/> is <see cref="PlacementMode.AnchorAndGravity"/>.
+        /// when <see cref="Placement"/> is <see cref="PlacementMode.AnchorAndGravity"/>.
         /// </summary>
         public PopupGravity PlacementGravity
         {
@@ -235,17 +235,17 @@ namespace Avalonia.Controls.Primitives
         }
 
         /// <summary>
-        /// Gets or sets the placement mode of the popup in relation to the <see cref="PlacementTarget"/>.
+        /// Gets or sets the desired placement of the popup in relation to the <see cref="PlacementTarget"/>.
         /// </summary>
-        public PlacementMode PlacementMode
+        public PlacementMode Placement
         {
-            get { return GetValue(PlacementModeProperty); }
-            set { SetValue(PlacementModeProperty, value); }
+            get { return GetValue(PlacementProperty); }
+            set { SetValue(PlacementProperty, value); }
         }
 
         /// <summary>
         /// Gets or sets the the anchor rectangle within the parent that the popup will be placed
-        /// relative to when <see cref="PlacementMode"/> is <see cref="PlacementMode.AnchorAndGravity"/>.
+        /// relative to when <see cref="Placement"/> is <see cref="PlacementMode.AnchorAndGravity"/>.
         /// </summary>
         /// <remarks>
         /// The placement rect defines a rectangle relative to <see cref="PlacementTarget"/> around
@@ -404,7 +404,7 @@ namespace Avalonia.Controls.Primitives
                     (x, handler) => x.LostFocus -= handler).DisposeWith(handlerCleanup);
 
                 // Recalculate popup position on parent moved/resized, but not if placement was on pointer
-                if (PlacementMode != PlacementMode.Pointer)
+                if (Placement != PlacementMode.Pointer)
                 {
                     SubscribeToEventHandler<IWindowImpl, Action<PixelPoint>>(window.PlatformImpl, WindowPositionChanged,
                         (x, handler) => x.PositionChanged += handler,
@@ -534,7 +534,7 @@ namespace Avalonia.Controls.Primitives
                     UpdateHostSizing(_openState.PopupHost, _openState.TopLevel, _openState.PlacementTarget);
                 }
                 else if (change.Property == PlacementTargetProperty ||
-                         change.Property == PlacementModeProperty ||
+                         change.Property == PlacementProperty ||
                          change.Property == HorizontalOffsetProperty ||
                          change.Property == VerticalOffsetProperty ||
                          change.Property == PlacementAnchorProperty ||
@@ -567,7 +567,7 @@ namespace Avalonia.Controls.Primitives
         {
             popupHost.ConfigurePosition(
                 placementTarget,
-                PlacementMode,
+                Placement,
                 new Point(HorizontalOffset, VerticalOffset),
                 PlacementAnchor,
                 PlacementGravity,
@@ -615,7 +615,7 @@ namespace Avalonia.Controls.Primitives
                     return;
                 _openState.PopupHost.ConfigurePosition(
                     placementTarget,
-                    PlacementMode,
+                    Placement,
                     new Point(HorizontalOffset, VerticalOffset),
                     PlacementAnchor,
                     PlacementGravity,

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -69,7 +69,7 @@ namespace Avalonia.Controls.Primitives
         /// Defines the <see cref="PlacementMode"/> property.
         /// </summary>
         [Obsolete("Use the Placement property instead.")]
-        public static readonly StyledProperty<PlacementMode> PlacementModeProperty = PlacementProperty;
+        public static readonly StyledProperty<PlacementMode> PlacementModeProperty = PlacementProperty!;
 
         /// <summary>
         /// Defines the <see cref="Placement"/> property.

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -66,6 +66,12 @@ namespace Avalonia.Controls.Primitives
             AvaloniaProperty.Register<Popup, PopupGravity>(nameof(PlacementGravity));
 
         /// <summary>
+        /// Defines the <see cref="PlacementMode"/> property.
+        /// </summary>
+        [Obsolete("Use the Placement property instead.")]
+        public static readonly StyledProperty<PlacementMode> PlacementModeProperty = PlacementProperty;
+
+        /// <summary>
         /// Defines the <see cref="Placement"/> property.
         /// </summary>
         public static readonly StyledProperty<PlacementMode> PlacementProperty =
@@ -232,6 +238,14 @@ namespace Avalonia.Controls.Primitives
         {
             get => GetValue(PlacementGravityProperty);
             set => SetValue(PlacementGravityProperty, value);
+        }
+
+        /// <inheritdoc cref="Placement"/>
+        [Obsolete("Use the Placement property instead.")]
+        public PlacementMode PlacementMode
+        {
+            get => GetValue(PlacementProperty);
+            set => SetValue(PlacementProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/SplitButton/SplitButton.cs
+++ b/src/Avalonia.Controls/SplitButton/SplitButton.cs
@@ -172,7 +172,7 @@ namespace Avalonia.Controls
                 flyout.Opened += Flyout_Opened;
                 flyout.Closed += Flyout_Closed;
 
-                _flyoutPropertyChangedDisposable = flyout.GetPropertyChangedObservable(Popup.PlacementModeProperty).Subscribe(Flyout_PlacementPropertyChanged);
+                _flyoutPropertyChangedDisposable = flyout.GetPropertyChangedObservable(Popup.PlacementProperty).Subscribe(Flyout_PlacementPropertyChanged);
             }
         }
 

--- a/src/Avalonia.Themes.Fluent/Controls/DatePicker.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/DatePicker.xaml
@@ -127,7 +127,7 @@
 
             <Popup Name="PART_Popup" WindowManagerAddShadowHint="False"
                    IsLightDismissEnabled="True" PlacementTarget="{TemplateBinding}"
-                   PlacementMode="Bottom">
+                   Placement="Bottom">
               <DatePickerPresenter Name="PART_PickerPresenter" />
             </Popup>
 

--- a/src/Avalonia.Themes.Fluent/Controls/Menu.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/Menu.xaml
@@ -37,7 +37,7 @@
                    MinWidth="{Binding Bounds.Width, RelativeSource={RelativeSource TemplatedParent}}"
                    IsLightDismissEnabled="True"
                    IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}"
-                   PlacementMode="BottomEdgeAlignedLeft"
+                   Placement="BottomEdgeAlignedLeft"
                    OverlayInputPassThroughElement="{Binding $parent[Menu]}">
               <Border Background="{DynamicResource MenuFlyoutPresenterBackground}"
                       BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"

--- a/src/Avalonia.Themes.Fluent/Controls/MenuItem.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/MenuItem.xaml
@@ -118,7 +118,7 @@
           </Border>
           <Popup Name="PART_Popup"
                  WindowManagerAddShadowHint="False"
-                 PlacementMode="Right"
+                 Placement="Right"
                  HorizontalOffset="{DynamicResource MenuFlyoutSubItemPopupHorizontalOffset}"
                  IsLightDismissEnabled="False"
                  IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}">

--- a/src/Avalonia.Themes.Fluent/Controls/TimePicker.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/TimePicker.xaml
@@ -151,7 +151,7 @@
                    WindowManagerAddShadowHint="False"
                    IsLightDismissEnabled="True"
                    PlacementTarget="{TemplateBinding}"
-                   PlacementMode="Bottom">
+                   Placement="Bottom">
               <TimePickerPresenter Name="PART_PickerPresenter" />
             </Popup>
 

--- a/src/Avalonia.Themes.Simple/Controls/DatePicker.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/DatePicker.xaml
@@ -142,7 +142,7 @@
 
             <Popup Name="PART_Popup"
                    IsLightDismissEnabled="True"
-                   PlacementMode="Bottom"
+                   Placement="Bottom"
                    PlacementTarget="{TemplateBinding}"
                    WindowManagerAddShadowHint="False">
               <DatePickerPresenter Name="PART_PickerPresenter" />

--- a/src/Avalonia.Themes.Simple/Controls/Menu.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/Menu.xaml
@@ -27,7 +27,7 @@
             <Popup Name="PART_Popup"
                    IsLightDismissEnabled="True"
                    IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}"
-                   PlacementMode="BottomEdgeAlignedLeft"
+                   Placement="BottomEdgeAlignedLeft"
                    OverlayInputPassThroughElement="{Binding $parent[Menu]}">
               <Border Background="{DynamicResource ThemeBackgroundBrush}"
                       BorderBrush="{DynamicResource ThemeBorderMidBrush}"

--- a/src/Avalonia.Themes.Simple/Controls/MenuItem.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/MenuItem.xaml
@@ -65,7 +65,7 @@
                    IsLightDismissEnabled="False"
                    IsOpen="{TemplateBinding IsSubMenuOpen,
                                             Mode=TwoWay}"
-                   PlacementMode="Right">
+                   Placement="Right">
               <Border Background="{DynamicResource ThemeBackgroundBrush}"
                       BorderBrush="{DynamicResource ThemeBorderMidBrush}"
                       BorderThickness="{TemplateBinding BorderThickness}">

--- a/src/Avalonia.Themes.Simple/Controls/TimePicker.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/TimePicker.xaml
@@ -156,7 +156,7 @@
 
             <Popup Name="PART_Popup"
                    IsLightDismissEnabled="True"
-                   PlacementMode="Bottom"
+                   Placement="Bottom"
                    PlacementTarget="{TemplateBinding}"
                    WindowManagerAddShadowHint="False">
               <TimePickerPresenter Name="PART_PickerPresenter" />

--- a/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
@@ -303,7 +303,7 @@ namespace Avalonia.Controls.UnitTests
                 window.Show();
 
                 var c = new ContextMenu();
-                c.PlacementMode = PlacementMode.Bottom;
+                c.Placement = PlacementMode.Bottom;
                 c.Open(button);
 
                 var overlay = LightDismissOverlayLayer.GetLightDismissOverlayLayer(window);

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupRootTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupRootTests.cs
@@ -67,7 +67,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
                 var window = new Window();
-                var target = new Popup {PlacementMode = PlacementMode.Pointer};
+                var target = new Popup {Placement = PlacementMode.Pointer};
                 var child = new Control();
 
                 window.Content = target;

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -207,7 +207,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
         {
             using (CreateServices())
             {
-                var target = new Popup() {PlacementMode = PlacementMode.Pointer};
+                var target = new Popup() {Placement = PlacementMode.Pointer};
                 var root = PreparedWindow(target);
 
                 target.Open();
@@ -226,7 +226,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             using (CreateServices())
             {
                 var window = PreparedWindow();
-                var target = new Popup() {PlacementMode = PlacementMode.Pointer};
+                var target = new Popup() {Placement = PlacementMode.Pointer};
 
                 window.Content = target;
 
@@ -249,7 +249,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             using (CreateServices())
             {
                 var window = PreparedWindow();
-                var target = new Popup() {PlacementMode = PlacementMode.Pointer};
+                var target = new Popup() {Placement = PlacementMode.Pointer};
 
                 window.Content = target;
                 window.ApplyTemplate();
@@ -274,7 +274,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             using (CreateServices())
             {
                 var window = PreparedWindow();
-                var target = new Popup() { PlacementMode = PlacementMode.Pointer };
+                var target = new Popup() { Placement = PlacementMode.Pointer };
 
                 window.Content = target;
                 window.ApplyTemplate();
@@ -742,7 +742,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                 {
                     Width = 400,
                     Height = 200,
-                    PlacementMode = PlacementMode.Pointer
+                    Placement = PlacementMode.Pointer
                 };
                 var window = PreparedWindow(popup);
                 window.Show();
@@ -791,7 +791,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                 var popup = new Popup()
                 {
                     PlacementTarget = placementTarget,
-                    PlacementMode = PlacementMode.Bottom,
+                    Placement = PlacementMode.Bottom,
                     Width = 10,
                     Height = 10
                 };
@@ -852,7 +852,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                 var popup = new Popup()
                 {
                     PlacementTarget = placementTarget,
-                    PlacementMode = PlacementMode.Pointer,
+                    Placement = PlacementMode.Pointer,
                     Width = 10,
                     Height = 10
                 };
@@ -907,7 +907,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                 var popup = new Popup()
                 {
                     PlacementTarget = placementTarget,
-                    PlacementMode = PlacementMode.Bottom,
+                    Placement = PlacementMode.Bottom,
                     Width = 10,
                     Height = 10
                 };
@@ -967,7 +967,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                 var popup = new Popup()
                 {
                     PlacementTarget = placementTarget,
-                    PlacementMode = PlacementMode.Pointer,
+                    Placement = PlacementMode.Pointer,
                     Width = 10,
                     Height = 10
                 };
@@ -1020,7 +1020,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                     Width = 20,
                     Height = 20,
                     PlacementTarget = parentPopup, 
-                    PlacementMode = PlacementMode.AnchorAndGravity,
+                    Placement = PlacementMode.AnchorAndGravity,
                     PlacementAnchor = PopupAnchor.TopLeft,
                     PlacementGravity = PopupGravity.BottomRight
                 };


### PR DESCRIPTION
## What does the pull request do?

Follow-up to https://github.com/AvaloniaUI/Avalonia/pull/10492 as discussed starting here: https://github.com/AvaloniaUI/Avalonia/pull/10492#issuecomment-1459449102

## What is the current behavior?

 * `PlacementMode` and `Placement` are used interchangeably in a non-standardized way
 * `PlacementMode` doesn't match WPF property naming
   * [Popup.Placement Property](https://learn.microsoft.com/en-us/dotnet/api/system.windows.controls.primitives.popup.placement?view=windowsdesktop-7.0)
   * [ContextMenu.Placement Property](https://learn.microsoft.com/en-us/dotnet/api/system.windows.controls.contextmenu.placement?view=windowsdesktop-7.0)

## What is the updated/expected behavior with this PR?

All properties standardized to use `Placement` naming.

## How was the solution implemented (if it's not obvious)?

Obvious.

## Checklist

- ~[ ] Added unit tests (if possible)?~
- [x] Added XML documentation to any related classes?
- ~[ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation~

## Breaking changes

Yes, property name change:

 1. Popup.PlacementMode to Popup.Placement
 1. ContextMenu.PlacementMode to ContextMenu.Placement

## Obsoletions / Deprecations

None

## Fixed issues

Also fixes https://github.com/AvaloniaUI/Avalonia/issues/9583
