### PR TITLE
Fix Menu Popup Placement

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/Menu.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/Menu.xaml
@@ -37,6 +37,7 @@
                    MinWidth="{Binding Bounds.Width, RelativeSource={RelativeSource TemplatedParent}}"
                    IsLightDismissEnabled="True"
                    IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}"
+                   PlacementMode="BottomEdgeAlignedLeft"
                    OverlayInputPassThroughElement="{Binding $parent[Menu]}">
               <Border Background="{DynamicResource MenuFlyoutPresenterBackground}"
                       BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"

--- a/src/Avalonia.Themes.Simple/Controls/Menu.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/Menu.xaml
@@ -26,8 +26,8 @@
             </ContentPresenter>
             <Popup Name="PART_Popup"
                    IsLightDismissEnabled="True"
-                   IsOpen="{TemplateBinding IsSubMenuOpen,
-                                            Mode=TwoWay}"
+                   IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}"
+                   PlacementMode="BottomEdgeAlignedLeft"
                    OverlayInputPassThroughElement="{Binding $parent[Menu]}">
               <Border Background="{DynamicResource ThemeBackgroundBrush}"
                       BorderBrush="{DynamicResource ThemeBorderMidBrush}"


### PR DESCRIPTION
## What does the pull request do?

Bottom left aligns Menu popups.

## What is the current behavior?

![image](https://user-images.githubusercontent.com/17993847/225068227-2190a5a1-48dc-4a51-99c8-d086b248b779.png)

## What is the updated/expected behavior with this PR?

![image](https://user-images.githubusercontent.com/17993847/225091218-8670b447-f706-4bad-b3a2-6a4da4ed5df6.png)

## How was the solution implemented (if it's not obvious)?

Obvious

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

None

## Obsoletions / Deprecations

None

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/10662
