### PR TITLE
macOS: Fix interaction between ExtendClientAreaToDecorationsHint and SystemDecorations

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -281,9 +281,12 @@ HRESULT WindowImpl::SetDecorations(SystemDecorations value) {
 
             case SystemDecorationsFull:
                 [Window setHasShadow:YES];
-                [Window setTitleVisibility:NSWindowTitleVisible];
-                [Window setTitlebarAppearsTransparent:NO];
                 [Window setTitle:_lastTitle];
+
+                if (!_isClientAreaExtended) {
+                    [Window setTitleVisibility:NSWindowTitleVisible];
+                    [Window setTitlebarAppearsTransparent:NO];
+                }
 
                 if (currentWindowState == Maximized) {
                     auto newFrame = [Window contentRectForFrameRect:[Window frame]].size;

--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -614,7 +614,8 @@ void WindowImpl::UpdateStyle() {
     }
 
     bool wantsChrome = (_extendClientHints & AvnSystemChrome) || (_extendClientHints & AvnPreferSystemChrome);
-    bool hasTrafficLights = _isClientAreaExtended ? wantsChrome : _decorations == SystemDecorationsFull;
+    bool hasTrafficLights = (_decorations == SystemDecorationsFull) &&
+        (_isClientAreaExtended ? wantsChrome : true);
     
     NSButton* closeButton = [Window standardWindowButton:NSWindowCloseButton];
     NSButton* miniaturizeButton = [Window standardWindowButton:NSWindowMiniaturizeButton];

--- a/samples/IntegrationTestApp/MainWindow.axaml
+++ b/samples/IntegrationTestApp/MainWindow.axaml
@@ -151,6 +151,12 @@
               <ComboBoxItem Name="ShowWindowStateMaximized">Maximized</ComboBoxItem>
               <ComboBoxItem Name="ShowWindowStateFullScreen">FullScreen</ComboBoxItem>
             </ComboBox>
+            <ComboBox Name="ShowWindowSystemDecorations" SelectedIndex="2">
+              <ComboBoxItem Name="ShowWindowSystemDecorationsNone">None</ComboBoxItem>
+              <ComboBoxItem Name="ShowWindowSystemDecorationsBorderOnly">BorderOnly</ComboBoxItem>
+              <ComboBoxItem Name="ShowWindowSystemDecorationsFull">Full</ComboBoxItem>
+            </ComboBox>
+            <CheckBox Name="ShowWindowExtendClientAreaToDecorationsHint">ExtendClientAreaToDecorationsHint</CheckBox>
             <CheckBox Name="ShowWindowCanResize" IsChecked="True">Can Resize</CheckBox>
             <Button Name="ShowWindow">Show Window</Button>
             <Button Name="SendToBack">Send to Back</Button>

--- a/samples/IntegrationTestApp/MainWindow.axaml.cs
+++ b/samples/IntegrationTestApp/MainWindow.axaml.cs
@@ -68,6 +68,8 @@ namespace IntegrationTestApp
             var locationComboBox = this.GetControl<ComboBox>("ShowWindowLocation");
             var stateComboBox = this.GetControl<ComboBox>("ShowWindowState");
             var size = !string.IsNullOrWhiteSpace(sizeTextBox.Text) ? Size.Parse(sizeTextBox.Text) : (Size?)null;
+            var systemDecorations = this.GetControl<ComboBox>("ShowWindowSystemDecorations");
+            var extendClientArea = this.GetControl<CheckBox>("ShowWindowExtendClientAreaToDecorationsHint");
             var canResizeCheckBox = this.GetControl<CheckBox>("ShowWindowCanResize");
             var owner = (Window)this.GetVisualRoot()!;
 
@@ -95,6 +97,8 @@ namespace IntegrationTestApp
             }
 
             sizeTextBox.Text = string.Empty;
+            window.ExtendClientAreaToDecorationsHint = extendClientArea.IsChecked ?? false;
+            window.SystemDecorations = (SystemDecorations)systemDecorations.SelectedIndex;
             window.WindowState = (WindowState)stateComboBox.SelectedIndex;
 
             switch (modeComboBox.SelectedIndex)

--- a/samples/IntegrationTestApp/ShowWindowTest.axaml
+++ b/samples/IntegrationTestApp/ShowWindowTest.axaml
@@ -6,7 +6,7 @@
         x:DataType="Window"
         Title="Show Window Test">
   <integrationTestApp:MeasureBorder Name="MyBorder">
-    <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+    <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
       <Label Grid.Column="0" Grid.Row="1">Client Size</Label>
       <TextBox Name="CurrentClientSize" Grid.Column="1" Grid.Row="1" IsReadOnly="True"
                Text="{Binding ClientSize, Mode=OneWay}" />
@@ -35,13 +35,25 @@
         <ComboBoxItem Name="WindowStateFullScreen">FullScreen</ComboBoxItem>
       </ComboBox>
 
-      <Label Grid.Column="0" Grid.Row="8">Order (mac)</Label>
-      <TextBox Name="CurrentOrder" Grid.Column="1" Grid.Row="8" IsReadOnly="True" />
-      
-      <Label Grid.Row="9" Content="MeasuredWith:" />
-      <TextBlock Grid.Column="1" Grid.Row="9" Name="CurrentMeasuredWithText" Text="{Binding #MyBorder.MeasuredWith}" />
+      <Label Grid.Column="0" Grid.Row="8">SystemDecorations</Label>
+      <ComboBox Name="CurrentSystemDecorations" Grid.Column="1" Grid.Row="8"  SelectedIndex="{Binding SystemDecorations}">
+        <ComboBoxItem Name="SystemDecorationsNone">None</ComboBoxItem>
+        <ComboBoxItem Name="SystemDecorationsBorderOnly">BorderOnly</ComboBoxItem>
+        <ComboBoxItem Name="SystemDecorationsFull">Full</ComboBoxItem>
+      </ComboBox>
 
-      <Button Name="HideButton" Grid.Row="10" Command="{Binding $parent[Window].Hide}">Hide</Button>
+      <CheckBox Name="CurrentExtendClientAreaToDecorationsHint" Grid.ColumnSpan="2" Grid.Row="9"
+                IsChecked="{Binding ExtendClientAreaToDecorationsHint}">
+        ExtendClientAreaToDecorationsHint
+      </CheckBox>
+
+      <Label Grid.Column="0" Grid.Row="10">Order (mac)</Label>
+      <TextBox Name="CurrentOrder" Grid.Column="1" Grid.Row="10" IsReadOnly="True" />
+      
+      <Label Grid.Row="11" Content="MeasuredWith:" />
+      <TextBlock Grid.Column="1" Grid.Row="11" Name="CurrentMeasuredWithText" Text="{Binding #MyBorder.MeasuredWith}" />
+
+      <Button Name="HideButton" Grid.Row="12" Command="{Binding $parent[Window].Hide}">Hide</Button>
       
     </Grid>
   </integrationTestApp:MeasureBorder>

--- a/tests/Avalonia.IntegrationTests.Appium/ElementExtensions.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/ElementExtensions.cs
@@ -145,7 +145,7 @@ namespace Avalonia.IntegrationTests.Appium
                     var text = windows.Select(x => x.Text).ToList();
                     var newWindow = session.FindElements(By.XPath("/XCUIElementTypeApplication/XCUIElementTypeWindow"))
                         .First(x => x.Text == newWindowTitle);
-                    var close = ((AppiumWebElement)newWindow).GetChromeButtons().Close;
+                    var close = ((AppiumWebElement)newWindow).FindElementByAccessibilityId("_XCUI:CloseWindow");
                     close!.Click();
                     Thread.Sleep(1000);
                 });

--- a/tests/Avalonia.IntegrationTests.Appium/ElementExtensions.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/ElementExtensions.cs
@@ -12,9 +12,10 @@ using Xunit;
 namespace Avalonia.IntegrationTests.Appium
 {
     public record class WindowChrome(
-        AppiumWebElement Close,
-        AppiumWebElement Minimize,
-        AppiumWebElement Maximize);
+        AppiumWebElement? Close,
+        AppiumWebElement? Minimize,
+        AppiumWebElement? Maximize,
+        AppiumWebElement? FullScreen);
 
     internal static class ElementExtensions
     {
@@ -25,10 +26,11 @@ namespace Avalonia.IntegrationTests.Appium
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                var closeButton = window.FindElementByXPath("//XCUIElementTypeButton[1]");
-                var fullscreenButton = window.FindElementByXPath("//XCUIElementTypeButton[2]");
-                var minimizeButton = window.FindElementByXPath("//XCUIElementTypeButton[3]");
-                return new(closeButton, minimizeButton, fullscreenButton);
+                var closeButton = window.FindElementsByAccessibilityId("_XCUI:CloseWindow").FirstOrDefault();
+                var fullscreenButton = window.FindElementsByAccessibilityId("_XCUI:FullScreenWindow").FirstOrDefault();
+                var minimizeButton = window.FindElementsByAccessibilityId("_XCUI:MinimizeWindow").FirstOrDefault();
+                var zoomButton = window.FindElementsByAccessibilityId("_XCUI:ZoomWindow").FirstOrDefault();
+                return new(closeButton, minimizeButton, zoomButton, fullscreenButton);
             }
 
             throw new NotSupportedException("GetChromeButtons not supported on this platform.");
@@ -143,7 +145,7 @@ namespace Avalonia.IntegrationTests.Appium
                     var text = windows.Select(x => x.Text).ToList();
                     var newWindow = session.FindElements(By.XPath("/XCUIElementTypeApplication/XCUIElementTypeWindow"))
                         .First(x => x.Text == newWindowTitle);
-                    var (close, _, _) = ((AppiumWebElement)newWindow).GetChromeButtons();
+                    var close = ((AppiumWebElement)newWindow).GetChromeButtons().Close;
                     close!.Click();
                     Thread.Sleep(1000);
                 });

--- a/tests/Avalonia.IntegrationTests.Appium/ElementExtensions.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/ElementExtensions.cs
@@ -11,19 +11,24 @@ using Xunit;
 
 namespace Avalonia.IntegrationTests.Appium
 {
+    public record class WindowChrome(
+        AppiumWebElement Close,
+        AppiumWebElement Minimize,
+        AppiumWebElement Maximize);
+
     internal static class ElementExtensions
     {
         public static IReadOnlyList<AppiumWebElement> GetChildren(this AppiumWebElement element) =>
             element.FindElementsByXPath("*/*");
 
-        public static (AppiumWebElement close, AppiumWebElement minimize, AppiumWebElement maximize) GetChromeButtons(this AppiumWebElement window)
+        public static WindowChrome GetChromeButtons(this AppiumWebElement window)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 var closeButton = window.FindElementByXPath("//XCUIElementTypeButton[1]");
                 var fullscreenButton = window.FindElementByXPath("//XCUIElementTypeButton[2]");
                 var minimizeButton = window.FindElementByXPath("//XCUIElementTypeButton[3]");
-                return (closeButton, minimizeButton, fullscreenButton);
+                return new(closeButton, minimizeButton, fullscreenButton);
             }
 
             throw new NotSupportedException("GetChromeButtons not supported on this platform.");

--- a/tests/Avalonia.IntegrationTests.Appium/PlatformFactAttribute.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/PlatformFactAttribute.cs
@@ -17,6 +17,7 @@ namespace Avalonia
     internal class PlatformFactAttribute : FactAttribute
     {
         private readonly string? _reason;
+        private string? _skip;
 
         public PlatformFactAttribute(TestPlatforms platforms, string? reason = null)
         {
@@ -28,8 +29,16 @@ namespace Avalonia
 
         public override string? Skip
         {
-            get => IsSupported() ? null : $"Ignored on {RuntimeInformation.OSDescription}" + (_reason is not null ? $" reason: \"{_reason}\"" : "");
-            set => throw new NotSupportedException();
+            get
+            {
+                if (_skip is not null)
+                    return _skip;
+                if (!IsSupported())
+                    return $"Ignored on {RuntimeInformation.OSDescription}" +
+                           (_reason is not null ? $" reason: '{_reason}'" : "");
+                return null;
+            }
+            set => _skip = value;
         }
 
         private bool IsSupported()

--- a/tests/Avalonia.IntegrationTests.Appium/PlatformTheoryAttribute.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/PlatformTheoryAttribute.cs
@@ -7,14 +7,21 @@ namespace Avalonia.IntegrationTests.Appium
 {
     internal class PlatformTheoryAttribute : TheoryAttribute
     {
+        private string? _skip;
+
         public PlatformTheoryAttribute(TestPlatforms platforms = TestPlatforms.All) => Platforms = platforms;
 
         public TestPlatforms Platforms { get; }
 
         public override string? Skip
         {
-            get => IsSupported() ? null : $"Ignored on {RuntimeInformation.OSDescription}";
-            set => throw new NotSupportedException();
+            get
+            {
+                if (_skip is not null)
+                    return _skip;
+                return !IsSupported() ? $"Ignored on {RuntimeInformation.OSDescription}" : null;
+            }
+            set => _skip = value;
         }
 
         private bool IsSupported()

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
@@ -242,14 +242,14 @@ namespace Avalonia.IntegrationTests.Appium
             var windowChrome = window.GetChromeButtons();
 
             Assert.True(windowChrome.Close!.Enabled);
-            Assert.True(windowChrome.Maximize!.Enabled);
-            Assert.True(windowChrome.Maximize.Enabled);
-            Assert.Null(windowChrome.FullScreen!.Enabled);
+            Assert.True(windowChrome.FullScreen!.Enabled);
+            Assert.True(windowChrome.Minimize!.Enabled);
+            Assert.Null(windowChrome.Maximize);
 
             using (OpenWindow(new PixelSize(200, 100), ShowWindowMode.Modal, WindowStartupLocation.CenterOwner))
             {
-                Assert.False(windowChrome.Close.Enabled);
-                Assert.False(windowChrome.Maximize.Enabled);
+                Assert.False(windowChrome.Close!.Enabled);
+                Assert.False(windowChrome.FullScreen!.Enabled);
                 Assert.False(windowChrome.Minimize!.Enabled);
             }
         }
@@ -345,7 +345,9 @@ namespace Avalonia.IntegrationTests.Appium
             using (OpenWindow(null, mode, WindowStartupLocation.Manual, canResize: false))
             {
                 var secondaryWindow = GetWindow("SecondaryWindow");
-                var zoomButton = secondaryWindow.FindElementByAccessibilityId("_XCUI:ZoomWindow");
+                var zoomButton = mode == ShowWindowMode.NonOwned ?
+                    secondaryWindow.FindElementByAccessibilityId("_XCUI:FullScreenWindow") :
+                    secondaryWindow.FindElementByAccessibilityId("_XCUI:ZoomWindow");
                 Assert.False(zoomButton.Enabled);
             }
         }

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
@@ -83,9 +83,9 @@ namespace Avalonia.IntegrationTests.Appium
         public void WindowOrder_Modal_Dialog_Stays_InFront_Of_Parent_When_In_Fullscreen()
         {
             var mainWindow = GetWindow("MainWindow");
-            var buttons = mainWindow.GetChromeButtons();
+            var fullScreen = mainWindow.FindElementByAccessibilityId("_XCUI:FullScreenWindow");
 
-            buttons.FullScreen.Click();
+            fullScreen.Click();
 
             Thread.Sleep(500);
 
@@ -275,7 +275,7 @@ namespace Avalonia.IntegrationTests.Appium
             using (OpenWindow(new PixelSize(200, 100), mode, WindowStartupLocation.Manual))
             {
                 var secondaryWindow = GetWindow("SecondaryWindow");
-                var miniaturizeButton = secondaryWindow.GetChromeButtons().Minimize;
+                var miniaturizeButton = secondaryWindow.FindElementByAccessibilityId("_XCUI:MinimizeWindow");
 
                 Assert.False(miniaturizeButton.Enabled);
             }
@@ -289,7 +289,7 @@ namespace Avalonia.IntegrationTests.Appium
             using (OpenWindow(new PixelSize(200, 100), mode, WindowStartupLocation.Manual))
             {
                 var secondaryWindow = GetWindow("SecondaryWindow");
-                var miniaturizeButton = secondaryWindow.GetChromeButtons().Minimize;
+                var miniaturizeButton = secondaryWindow.FindElementByAccessibilityId("_XCUI:MinimizeWindow");
 
                 miniaturizeButton.Click();
                 Thread.Sleep(1000);
@@ -333,7 +333,7 @@ namespace Avalonia.IntegrationTests.Appium
 
             // Close the window manually.
             secondaryWindow = GetWindow("SecondaryWindow");
-            secondaryWindow.GetChromeButtons().Close.Click();
+            secondaryWindow.FindElementByAccessibilityId("_XCUI:CloseWindow").Click();
         }
 
         [PlatformTheory(TestPlatforms.MacOS)]
@@ -345,7 +345,7 @@ namespace Avalonia.IntegrationTests.Appium
             using (OpenWindow(null, mode, WindowStartupLocation.Manual, canResize: false))
             {
                 var secondaryWindow = GetWindow("SecondaryWindow");
-                var zoomButton = secondaryWindow.GetChromeButtons().Maximize;
+                var zoomButton = secondaryWindow.FindElementByAccessibilityId("_XCUI:ZoomWindow");
                 Assert.False(zoomButton.Enabled);
             }
         }

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
@@ -241,16 +241,16 @@ namespace Avalonia.IntegrationTests.Appium
             var window = GetWindow("MainWindow");
             var windowChrome = window.GetChromeButtons();
 
-            Assert.True(windowChrome.Close.Enabled);
+            Assert.True(windowChrome.Close!.Enabled);
+            Assert.True(windowChrome.Maximize!.Enabled);
             Assert.True(windowChrome.Maximize.Enabled);
-            Assert.True(windowChrome.Maximize.Enabled);
-            Assert.Null(windowChrome.FullScreen.Enabled);
+            Assert.Null(windowChrome.FullScreen!.Enabled);
 
             using (OpenWindow(new PixelSize(200, 100), ShowWindowMode.Modal, WindowStartupLocation.CenterOwner))
             {
                 Assert.False(windowChrome.Close.Enabled);
                 Assert.False(windowChrome.Maximize.Enabled);
-                Assert.False(windowChrome.Minimize.Enabled);
+                Assert.False(windowChrome.Minimize!.Enabled);
             }
         }
 
@@ -262,9 +262,9 @@ namespace Avalonia.IntegrationTests.Appium
                 var secondaryWindow = GetWindow("SecondaryWindow");
                 var windowChrome = secondaryWindow.GetChromeButtons();
 
-                Assert.True(windowChrome.Close.Enabled);
-                Assert.True(windowChrome.Maximize.Enabled);
-                Assert.False(windowChrome.Minimize.Enabled);
+                Assert.True(windowChrome.Close!.Enabled);
+                Assert.True(windowChrome.Maximize!.Enabled);
+                Assert.False(windowChrome.Minimize!.Enabled);
             }
         }
         

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
@@ -351,8 +351,8 @@ namespace Avalonia.IntegrationTests.Appium
                 Assert.False(zoomButton.Enabled);
             }
         }
-        
-        [Fact]
+
+        [PlatformFact(TestPlatforms.MacOS)]
         public void Toggling_SystemDecorations_Should_Preserve_ExtendClientArea()
         {
             // #10650
@@ -376,8 +376,8 @@ namespace Avalonia.IntegrationTests.Appium
                 Assert.Equal(0, titleBar);
             }
         }
-        
-        [Theory]
+
+        [PlatformTheory(TestPlatforms.MacOS)]
         [InlineData(SystemDecorations.None)]
         [InlineData(SystemDecorations.BorderOnly)]
         [InlineData(SystemDecorations.Full)]

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
@@ -85,7 +85,7 @@ namespace Avalonia.IntegrationTests.Appium
             var mainWindow = GetWindow("MainWindow");
             var buttons = mainWindow.GetChromeButtons();
 
-            buttons.Maximize.Click();
+            buttons.FullScreen.Click();
 
             Thread.Sleep(500);
 
@@ -239,17 +239,18 @@ namespace Avalonia.IntegrationTests.Appium
         public void Parent_Window_Has_Disabled_ChromeButtons_When_Modal_Dialog_Shown()
         {
             var window = GetWindow("MainWindow");
-            var (closeButton, miniaturizeButton, zoomButton) = window.GetChromeButtons();
+            var windowChrome = window.GetChromeButtons();
 
-            Assert.True(closeButton.Enabled);
-            Assert.True(zoomButton.Enabled);
-            Assert.True(miniaturizeButton.Enabled);
+            Assert.True(windowChrome.Close.Enabled);
+            Assert.True(windowChrome.Maximize.Enabled);
+            Assert.True(windowChrome.Maximize.Enabled);
+            Assert.Null(windowChrome.FullScreen.Enabled);
 
             using (OpenWindow(new PixelSize(200, 100), ShowWindowMode.Modal, WindowStartupLocation.CenterOwner))
             {
-                Assert.False(closeButton.Enabled);
-                Assert.False(zoomButton.Enabled);
-                Assert.False(miniaturizeButton.Enabled);
+                Assert.False(windowChrome.Close.Enabled);
+                Assert.False(windowChrome.Maximize.Enabled);
+                Assert.False(windowChrome.Minimize.Enabled);
             }
         }
 
@@ -259,11 +260,11 @@ namespace Avalonia.IntegrationTests.Appium
             using (OpenWindow(new PixelSize(200, 100), ShowWindowMode.Modal, WindowStartupLocation.CenterOwner))
             {
                 var secondaryWindow = GetWindow("SecondaryWindow");
-                var (closeButton, miniaturizeButton, zoomButton) = secondaryWindow.GetChromeButtons();
+                var windowChrome = secondaryWindow.GetChromeButtons();
 
-                Assert.True(closeButton.Enabled);
-                Assert.True(zoomButton.Enabled);
-                Assert.False(miniaturizeButton.Enabled);
+                Assert.True(windowChrome.Close.Enabled);
+                Assert.True(windowChrome.Maximize.Enabled);
+                Assert.False(windowChrome.Minimize.Enabled);
             }
         }
         
@@ -274,7 +275,7 @@ namespace Avalonia.IntegrationTests.Appium
             using (OpenWindow(new PixelSize(200, 100), mode, WindowStartupLocation.Manual))
             {
                 var secondaryWindow = GetWindow("SecondaryWindow");
-                var (_, miniaturizeButton, _) = secondaryWindow.GetChromeButtons();
+                var miniaturizeButton = secondaryWindow.GetChromeButtons().Minimize;
 
                 Assert.False(miniaturizeButton.Enabled);
             }
@@ -288,7 +289,7 @@ namespace Avalonia.IntegrationTests.Appium
             using (OpenWindow(new PixelSize(200, 100), mode, WindowStartupLocation.Manual))
             {
                 var secondaryWindow = GetWindow("SecondaryWindow");
-                var (_, miniaturizeButton, _) = secondaryWindow.GetChromeButtons();
+                var miniaturizeButton = secondaryWindow.GetChromeButtons().Minimize;
 
                 miniaturizeButton.Click();
                 Thread.Sleep(1000);
@@ -344,7 +345,7 @@ namespace Avalonia.IntegrationTests.Appium
             using (OpenWindow(null, mode, WindowStartupLocation.Manual, canResize: false))
             {
                 var secondaryWindow = GetWindow("SecondaryWindow");
-                var (_, _, zoomButton) = secondaryWindow.GetChromeButtons();
+                var zoomButton = secondaryWindow.GetChromeButtons().Maximize;
                 Assert.False(zoomButton.Enabled);
             }
         }

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
@@ -85,7 +85,7 @@ namespace Avalonia.IntegrationTests.Appium
             var mainWindow = GetWindow("MainWindow");
             var buttons = mainWindow.GetChromeButtons();
 
-            buttons.maximize.Click();
+            buttons.Maximize.Click();
 
             Thread.Sleep(500);
 
@@ -332,7 +332,7 @@ namespace Avalonia.IntegrationTests.Appium
 
             // Close the window manually.
             secondaryWindow = GetWindow("SecondaryWindow");
-            secondaryWindow.GetChromeButtons().close.Click();
+            secondaryWindow.GetChromeButtons().Close.Click();
         }
 
         [PlatformTheory(TestPlatforms.MacOS)]


### PR DESCRIPTION
## What does the pull request do?

Fixes two issues on macOS backend described in #10650 

- [Don't show titlebar when client area is extended.](https://github.com/AvaloniaUI/Avalonia/commit/7c4b4db6df7bccdccf002a91be19a1a6b39c851e) : `SetDecorations` did not take into account the `_isClientAreaExtended` flag when deciding whether to show the title bar.
- [Only show traffic lights with full system decorations.](https://github.com/AvaloniaUI/Avalonia/commit/142547a23f73b3b86418691fa3711d7dae581fb6): The logic for whether to show traffic lights was wrong - they should only be shown when `SystemDecorations == Full`. All other values of `SystemDecorations` should result in the traffic lights being hidden.

In addition, made some tweaks to the integration tests:

- ⚠️ [Fix platform fact/theory attributes.](https://github.com/AvaloniaUI/Avalonia/commit/4c9bf8e53a77e1db5d9b88f7489fb69774bb4f44): turns out that we **weren't running many of our macOS integration tests** because we were throwing an exception in the `PlatformFact.Skip`/`PlatformTheory.Skip` property setter, which was causing any tests after this in the class to be ignored! @danwalmsley this might actually be the reason we've had more stable integration tests recently - we weren't running a load of them :/
- [Don't use a tuple for window chrome buttons.](https://github.com/AvaloniaUI/Avalonia/commit/d46eb22f4e646b7d5576074e21e2f1a3f163353d): a tuple is difficult to extend with new values, the original plan was to return the title bar from this method too, but that wasn't actually needed (see below). However I think it's a good change to make
- [Don't get all window buttons when only one needed.](https://github.com/AvaloniaUI/Avalonia/commit/7005333bc505099237cfad45d0517da28e69f002): we were calling `GetChromeButtons` in a number of cases where only one of the buttons was needed. This would have slowed down tests as we were fetching 3 elements when we only needed one
- [Look up chrome buttons by a11y id.](https://github.com/AvaloniaUI/Avalonia/commit/2cce1d4d784e8fe88f120abb94eb3ea0d4cff958): Don't use XPath to get the window chrome buttons - they have a11y IDs which is both safer and faster


## Fixed issues

Fixes #10650 