### PR TITLE
Remove Default/Empty Members

### DIFF
--- a/src/Avalonia.Base/CornerRadius.cs
+++ b/src/Avalonia.Base/CornerRadius.cs
@@ -65,10 +65,6 @@ namespace Avalonia
         /// </summary>
         public bool IsDefault => TopLeft == 0 && TopRight == 0 && BottomLeft == 0 && BottomRight == 0;
 
-        /// <inheritdoc cref="IsDefault"/>
-        [Obsolete("Use IsDefault instead.")]
-        public bool IsEmpty => IsDefault;
-
         /// <summary>
         /// Gets a value indicating whether all corner radii are equal.
         /// </summary>

--- a/src/Avalonia.Base/CornerRadius.cs
+++ b/src/Avalonia.Base/CornerRadius.cs
@@ -61,11 +61,6 @@ namespace Avalonia
         public double BottomLeft { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the instance has default values (all corner radii are set to 0).
-        /// </summary>
-        public bool IsDefault => TopLeft == 0 && TopRight == 0 && BottomLeft == 0 && BottomRight == 0;
-
-        /// <summary>
         /// Gets a value indicating whether all corner radii are equal.
         /// </summary>
         public bool IsUniform => TopLeft.Equals(TopRight) && BottomLeft.Equals(BottomRight) && TopRight.Equals(BottomRight);

--- a/src/Avalonia.Base/Input/GestureRecognizers/VelocityTracker.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/VelocityTracker.cs
@@ -180,7 +180,7 @@ namespace Avalonia.Input.GestureRecognizers
         internal Velocity GetVelocity()
         {
             var estimate = GetVelocityEstimate();
-            if (estimate == null || estimate.PixelsPerSecond.IsDefault)
+            if (estimate == null || estimate.PixelsPerSecond == default(Vector))
             {
                 return new Velocity(Vector.Zero);
             }

--- a/src/Avalonia.Base/Media/BoxShadow.cs
+++ b/src/Avalonia.Base/Media/BoxShadow.cs
@@ -45,11 +45,6 @@ namespace Avalonia.Media
             }
         }
 
-        /// <summary>
-        /// Gets a value indicating whether the instance has default values.
-        /// </summary>
-        public bool IsDefault => OffsetX == 0 && OffsetY == 0 && Blur == 0 && Spread == 0;
-
         private readonly static char[] s_Separator = new char[] { ' ', '\t' };
 
         struct ArrayReader
@@ -85,7 +80,7 @@ namespace Avalonia.Media
         {
             var sb = StringBuilderCache.Acquire();
 
-            if (IsDefault)
+            if (this == default)
             {
                 return "none";
             }

--- a/src/Avalonia.Base/Media/BoxShadow.cs
+++ b/src/Avalonia.Base/Media/BoxShadow.cs
@@ -50,10 +50,6 @@ namespace Avalonia.Media
         /// </summary>
         public bool IsDefault => OffsetX == 0 && OffsetY == 0 && Blur == 0 && Spread == 0;
 
-        /// <inheritdoc cref="IsDefault"/>
-        [Obsolete("Use IsDefault instead.")]
-        public bool IsEmpty => IsDefault;
-
         private readonly static char[] s_Separator = new char[] { ' ', '\t' };
 
         struct ArrayReader

--- a/src/Avalonia.Base/Media/BoxShadows.cs
+++ b/src/Avalonia.Base/Media/BoxShadows.cs
@@ -21,7 +21,7 @@ namespace Avalonia.Media
         {
             _first = shadow;
             _list = null;
-            Count = _first.IsDefault ? 0 : 1;
+            Count = _first == default ? 0 : 1;
         }
 
         public BoxShadows(BoxShadow first, BoxShadow[] rest)
@@ -120,7 +120,7 @@ namespace Avalonia.Media
             get
             {
                 foreach(var boxShadow in this)
-                    if (!boxShadow.IsDefault && boxShadow.IsInset)
+                    if (boxShadow != default && boxShadow.IsInset)
                         return true;
                 return false;
             }

--- a/src/Avalonia.Base/Media/FontFamily.cs
+++ b/src/Avalonia.Base/Media/FontFamily.cs
@@ -80,11 +80,6 @@ namespace Avalonia.Media
         public FontFamilyKey? Key { get; }
 
         /// <summary>
-        /// Returns <c>True</c> if this instance is the system's default.
-        /// </summary>
-        public bool IsDefault => Name.Equals(DefaultFontFamilyName);
-
-        /// <summary>
         /// Implicit conversion of string to FontFamily
         /// </summary>
         /// <param name="s"></param>

--- a/src/Avalonia.Base/Media/FormattedText.cs
+++ b/src/Avalonia.Base/Media/FormattedText.cs
@@ -1393,10 +1393,11 @@ namespace Avalonia.Media
                 }
             }
 
-            if (accumulatedBounds?.PlatformImpl == null || accumulatedBounds.PlatformImpl.Bounds.IsDefault)
+            if (accumulatedBounds?.PlatformImpl == null ||
+                (accumulatedBounds.PlatformImpl.Bounds.Width == 0 && accumulatedBounds.PlatformImpl.Bounds.Height == 0))
             {
                 return null;
-            }            
+            }
 
             return accumulatedBounds;
         }

--- a/src/Avalonia.Base/Media/ImageDrawing.cs
+++ b/src/Avalonia.Base/Media/ImageDrawing.cs
@@ -1,7 +1,5 @@
 ﻿#nullable enable
 
-using Avalonia.Rendering;
-
 namespace Avalonia.Media
 {
     /// <summary>

--- a/src/Avalonia.Base/Media/ImageDrawing.cs
+++ b/src/Avalonia.Base/Media/ImageDrawing.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using Avalonia.Rendering;
+
 namespace Avalonia.Media
 {
     /// <summary>
@@ -42,7 +44,7 @@ namespace Avalonia.Media
             var imageSource = ImageSource;
             var rect = Rect;
 
-            if (imageSource is object && !rect.IsDefault)
+            if (imageSource is object && (rect.Width != 0 || rect.Height != 0))
             {
                 context.DrawImage(imageSource, rect);
             }

--- a/src/Avalonia.Base/Media/Imaging/CroppedBitmap.cs
+++ b/src/Avalonia.Base/Media/Imaging/CroppedBitmap.cs
@@ -77,7 +77,7 @@ namespace Avalonia.Media.Imaging
             {
                 if (Source is not IBitmap bmp)
                     return default;
-                if (SourceRect.IsDefault)
+                if (SourceRect.Width == 0 && SourceRect.Height == 0)
                     return Source.Size;
                 return SourceRect.Size.ToSizeWithDpi(bmp.Dpi);
             }

--- a/src/Avalonia.Base/PixelRect.cs
+++ b/src/Avalonia.Base/PixelRect.cs
@@ -128,11 +128,6 @@ namespace Avalonia
         public PixelPoint Center => new PixelPoint(X + (Width / 2), Y + (Height / 2));
 
         /// <summary>
-        /// Gets a value indicating whether the instance has default values (the rectangle is empty).
-        /// </summary>
-        public bool IsDefault => Width == 0 && Height == 0;
-
-        /// <summary>
         /// Checks for equality between two <see cref="PixelRect"/>s.
         /// </summary>
         /// <param name="left">The first rect.</param>
@@ -285,11 +280,11 @@ namespace Avalonia
         /// <returns>The union.</returns>
         public PixelRect Union(PixelRect rect)
         {
-            if (IsDefault)
+            if (Width == 0 && Height == 0)
             {
                 return rect;
             }
-            else if (rect.IsDefault)
+            else if (rect.Width == 0 && rect.Height == 0)
             {
                 return this;
             }

--- a/src/Avalonia.Base/PixelRect.cs
+++ b/src/Avalonia.Base/PixelRect.cs
@@ -10,12 +10,6 @@ namespace Avalonia
     public readonly struct PixelRect : IEquatable<PixelRect>
     {
         /// <summary>
-        /// An empty rectangle.
-        /// </summary>
-        [Obsolete("Use the default keyword instead.")]
-        public static readonly PixelRect Empty = default;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="PixelRect"/> structure.
         /// </summary>
         /// <param name="x">The X position.</param>
@@ -137,10 +131,6 @@ namespace Avalonia
         /// Gets a value indicating whether the instance has default values (the rectangle is empty).
         /// </summary>
         public bool IsDefault => Width == 0 && Height == 0;
-
-        /// <inheritdoc cref="IsDefault"/>
-        [Obsolete("Use IsDefault instead.")]
-        public bool IsEmpty => IsDefault;
 
         /// <summary>
         /// Checks for equality between two <see cref="PixelRect"/>s.

--- a/src/Avalonia.Base/Point.cs
+++ b/src/Avalonia.Base/Point.cs
@@ -288,13 +288,5 @@ namespace Avalonia
             x = this._x;
             y = this._y;
         }
-
-        /// <summary>
-        /// Gets a value indicating whether the X and Y coordinates are zero.
-        /// </summary>
-        public bool IsDefault
-        {
-            get { return (_x == 0) && (_y == 0); }
-        }
     }
 }

--- a/src/Avalonia.Base/Rect.cs
+++ b/src/Avalonia.Base/Rect.cs
@@ -165,13 +165,6 @@ namespace Avalonia
         public Point Center => new Point(_x + (_width / 2), _y + (_height / 2));
 
         /// <summary>
-        /// Gets a value indicating whether the instance has default values (the rectangle is empty).
-        /// </summary>
-        // ReSharper disable CompareOfFloatsByEqualityOperator
-        public bool IsDefault => _width == 0 && _height == 0;
-        // ReSharper restore CompareOfFloatsByEqualityOperator
-
-        /// <summary>
         /// Checks for equality between two <see cref="Rect"/>s.
         /// </summary>
         /// <param name="left">The first rect.</param>
@@ -507,19 +500,18 @@ namespace Avalonia
             return rect;
         }
 
-
-            /// <summary>
-            /// Gets the union of two rectangles.
-            /// </summary>
-            /// <param name="rect">The other rectangle.</param>
-            /// <returns>The union.</returns>
-            public Rect Union(Rect rect)
+        /// <summary>
+        /// Gets the union of two rectangles.
+        /// </summary>
+        /// <param name="rect">The other rectangle.</param>
+        /// <returns>The union.</returns>
+        public Rect Union(Rect rect)
         {
-            if (IsDefault)
+            if (Width == 0 && Height == 0)
             {
                 return rect;
             }
-            else if (rect.IsDefault)
+            else if (rect.Width == 0 && rect.Height == 0)
             {
                 return this;
             }

--- a/src/Avalonia.Base/Rect.cs
+++ b/src/Avalonia.Base/Rect.cs
@@ -17,12 +17,6 @@ namespace Avalonia
         }
 
         /// <summary>
-        /// An empty rectangle.
-        /// </summary>
-        [Obsolete("Use the default keyword instead.")]
-        public static readonly Rect Empty = default;
-
-        /// <summary>
         /// The X position.
         /// </summary>
         private readonly double _x;
@@ -176,10 +170,6 @@ namespace Avalonia
         // ReSharper disable CompareOfFloatsByEqualityOperator
         public bool IsDefault => _width == 0 && _height == 0;
         // ReSharper restore CompareOfFloatsByEqualityOperator
-
-        /// <inheritdoc cref="IsDefault"/>
-        [Obsolete("Use IsDefault instead.")]
-        public bool IsEmpty => IsDefault;
 
         /// <summary>
         /// Checks for equality between two <see cref="Rect"/>s.

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -131,7 +131,7 @@ namespace Avalonia.Rendering.Composition.Server
 
             _renderTarget ??= _compositor.CreateRenderTarget(_surfaces());
 
-            if (_dirtyRect == default && !_redrawRequested)
+            if ((_dirtyRect.Width == 0 && _dirtyRect.Height == 0) && !_redrawRequested)
                 return;
 
             Revision++;

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -130,8 +130,8 @@ namespace Avalonia.Rendering.Composition.Server
             }
 
             _renderTarget ??= _compositor.CreateRenderTarget(_surfaces());
-            
-            if(_dirtyRect.IsDefault && !_redrawRequested)
+
+            if (_dirtyRect == default && !_redrawRequested)
                 return;
 
             Revision++;
@@ -163,7 +163,7 @@ namespace Avalonia.Rendering.Composition.Server
                     _dirtyRect = new Rect(0, 0, layerSize.Width, layerSize.Height);
                 }
 
-                if (!_dirtyRect.IsDefault)
+                if (_dirtyRect.Width != 0 || _dirtyRect.Height != 0)
                 {
                     using (var context = _layer.CreateDrawingContext())
                     {
@@ -260,7 +260,7 @@ namespace Avalonia.Rendering.Composition.Server
         
         public void AddDirtyRect(Rect rect)
         {
-            if(rect.IsDefault)
+            if (rect.Width == 0 && rect.Height == 0)
                 return;
             var snapped = SnapToDevicePixels(rect, Scaling);
             DebugEvents?.RectInvalidated(rect);
@@ -275,7 +275,7 @@ namespace Avalonia.Rendering.Composition.Server
 
         public void Dispose()
         {
-            if(_disposed)
+            if (_disposed)
                 return;
             _disposed = true;
             using (_compositor.RenderInterface.EnsureCurrent())
@@ -302,7 +302,7 @@ namespace Avalonia.Rendering.Composition.Server
         {
             if (_attachedVisuals.Remove(visual) && IsEnabled)
                 visual.Deactivate();
-            if(visual.IsVisibleInFrame)
+            if (visual.IsVisibleInFrame)
                 AddDirtyRect(visual.TransformedOwnContentBounds);
         }
 

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.cs
@@ -149,7 +149,7 @@ namespace Avalonia.Rendering.Composition.Server
             if (ownBounds != _oldOwnContentBounds || positionChanged)
             {
                 _oldOwnContentBounds = ownBounds;
-                if (ownBounds == default)
+                if (ownBounds.Width == 0 && ownBounds.Height == 0)
                     TransformedOwnContentBounds = default;
                 else
                     TransformedOwnContentBounds =
@@ -179,7 +179,7 @@ namespace Avalonia.Rendering.Composition.Server
             IsHitTestVisibleInFrame = _parent?.IsHitTestVisibleInFrame != false
                                       && Visible
                                       && !_isBackface
-                                      && _combinedTransformedClipBounds != default;
+                                      && (_combinedTransformedClipBounds.Width != 0 || _combinedTransformedClipBounds.Height != 0);
 
             IsVisibleInFrame = IsHitTestVisibleInFrame
                                && _parent?.IsVisibleInFrame != false

--- a/src/Avalonia.Base/Rendering/DirtyRects.cs
+++ b/src/Avalonia.Base/Rendering/DirtyRects.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Rendering
         /// </remarks>
         public void Add(Rect rect)
         {
-            if (!rect.IsDefault)
+            if (rect.Width != 0 || rect.Height != 0)
             {
                 for (var i = 0; i < _rects.Count; ++i)
                 {

--- a/src/Avalonia.Base/Size.cs
+++ b/src/Avalonia.Base/Size.cs
@@ -300,10 +300,5 @@ namespace Avalonia
             width = this._width;
             height = this._height;
         }
-
-        /// <summary>
-        /// Gets a value indicating whether the Width and Height values are zero.
-        /// </summary>
-        public bool IsDefault => (_width == 0) && (_height == 0);
     }
 }

--- a/src/Avalonia.Base/Size.cs
+++ b/src/Avalonia.Base/Size.cs
@@ -28,12 +28,6 @@ namespace Avalonia
         public static readonly Size Infinity = new Size(double.PositiveInfinity, double.PositiveInfinity);
 
         /// <summary>
-        /// A size representing zero.
-        /// </summary>
-        [Obsolete("Use the default keyword instead.")]
-        public static readonly Size Empty = new Size(0, 0);
-
-        /// <summary>
         /// The width.
         /// </summary>
         private readonly double _width;

--- a/src/Avalonia.Base/Thickness.cs
+++ b/src/Avalonia.Base/Thickness.cs
@@ -97,10 +97,6 @@ namespace Avalonia
         /// </summary>
         public double Bottom => _bottom;
 
-        /// <inheritdoc cref="IsDefault"/>
-        [Obsolete("Use IsDefault instead.")]
-        public bool IsEmpty => IsDefault;
-
         /// <summary>
         /// Gets a value indicating whether all sides are equal.
         /// </summary>

--- a/src/Avalonia.Base/Thickness.cs
+++ b/src/Avalonia.Base/Thickness.cs
@@ -289,11 +289,5 @@ namespace Avalonia
             right = this._right;
             bottom = this._bottom;
         }
-
-        /// <summary>
-        /// Gets a value indicating whether the instance has default values
-        /// (the left, top, right and bottom values are zero).
-        /// </summary>
-        public bool IsDefault => (_left == 0) && (_top == 0) && (_right == 0) && (_bottom == 0);
     }
 }

--- a/src/Avalonia.Base/Vector.cs
+++ b/src/Avalonia.Base/Vector.cs
@@ -360,13 +360,5 @@ namespace Avalonia
             x = this._x;
             y = this._y;
         }
-
-        /// <summary>
-        /// Gets a value indicating whether the X and Y components are zero.
-        /// </summary>
-        public bool IsDefault
-        {
-            get { return (_x == 0) && (_y == 0); }
-        }
     }
 }

--- a/src/Avalonia.Controls.DataGrid/DataGridCheckBoxColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCheckBoxColumn.cs
@@ -177,14 +177,14 @@ namespace Avalonia.Controls
                 }
 
                 bool? uneditedValue = editingCheckBox.IsChecked;
-                if(editingEventArgs is PointerPressedEventArgs args)
+                if (editingEventArgs is PointerPressedEventArgs args)
                 {
                     void ProcessPointerArgs()
                     {
                         // Editing was triggered by a mouse click
                         Point position = args.GetPosition(editingCheckBox);
                         Rect rect = new Rect(0, 0, editingCheckBox.Bounds.Width, editingCheckBox.Bounds.Height);
-                        if(rect.Contains(position))
+                        if (rect.Contains(position))
                         {
                             EditValue();
                         }
@@ -192,14 +192,14 @@ namespace Avalonia.Controls
                     
                     void OnLayoutUpdated(object sender, EventArgs e)
                     {
-                        if(!editingCheckBox.Bounds.IsDefault)
+                        if (editingCheckBox.Bounds.Width != 0 || editingCheckBox.Bounds.Height != 0)
                         {
                             editingCheckBox.LayoutUpdated -= OnLayoutUpdated;
                             ProcessPointerArgs();
                         }
                     }
 
-                    if(editingCheckBox.Bounds.IsDefault)
+                    if (editingCheckBox.Bounds.Width == 0 && editingCheckBox.Bounds.Height == 0)
                     {
                         editingCheckBox.LayoutUpdated += OnLayoutUpdated;
                     }

--- a/src/Avalonia.Controls.ItemsRepeater/Controls/ViewportManager.cs
+++ b/src/Avalonia.Controls.ItemsRepeater/Controls/ViewportManager.cs
@@ -441,7 +441,7 @@ namespace Avalonia.Controls
 
             _pendingViewportShift = default;
             _unshiftableShift = default;
-            if (_visibleWindow.IsDefault)
+            if (_visibleWindow.Width == 0 && _visibleWindow.Height == 0)
             {
                 // We got cleared.
                 _layoutExtent = default;
@@ -527,7 +527,7 @@ namespace Avalonia.Controls
         private void TryInvalidateMeasure()
         {
             // Don't invalidate measure if we have an invalid window.
-            if (!_visibleWindow.IsDefault)
+            if (_visibleWindow.Width != 0 || _visibleWindow.Height != 0)
             {
                 // We invalidate measure instead of just invalidating arrange because
                 // we don't invalidate measure in UpdateViewport if the view is changing to

--- a/src/Avalonia.Controls/BorderVisual.cs
+++ b/src/Avalonia.Controls/BorderVisual.cs
@@ -50,7 +50,7 @@ class CompositionBorderVisual : CompositionDrawListVisual
             if (ClipToBounds)
             {
                 var clipRect = Root!.SnapToDevicePixels(new Rect(new Size(Size.X, Size.Y)));
-                if (_cornerRadius.IsDefault)
+                if (_cornerRadius == default)
                     canvas.PushClip(clipRect);
                 else
                     canvas.PushClip(new RoundedRect(clipRect, _cornerRadius));

--- a/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
@@ -407,7 +407,7 @@ namespace Avalonia.Controls.Primitives
         {
             Size sz;
             // Popup.Child can't be null here, it was set in ShowAtCore.
-            if (Popup.Child!.DesiredSize.IsDefault)
+            if (Popup.Child!.DesiredSize == default)
             {
                 // Popup may not have been shown yet. Measure content
                 sz = LayoutHelper.MeasureChild(Popup.Child, Size.Infinity, new Thickness());

--- a/src/Avalonia.Controls/LayoutTransformControl.cs
+++ b/src/Avalonia.Controls/LayoutTransformControl.cs
@@ -91,7 +91,7 @@ namespace Avalonia.Controls
             arrangedsize = TransformRoot.Bounds.Size;
 
             // This is the first opportunity under Silverlight to find out the Child's true DesiredSize
-            if (IsSizeSmaller(finalSizeTransformed, arrangedsize) && _childActualSize.IsDefault)
+            if (IsSizeSmaller(finalSizeTransformed, arrangedsize) && _childActualSize == default)
             {
                 //// Unfortunately, all the work so far is invalid because the wrong DesiredSize was used
                 //// Make a note of the actual DesiredSize
@@ -122,7 +122,7 @@ namespace Avalonia.Controls
             }
 
             Size measureSize;
-            if (_childActualSize.IsDefault)
+            if (_childActualSize == default)
             {
                 // Determine the largest size after the transformation
                 measureSize = ComputeLargestTransformedSize(availableSize);

--- a/src/Avalonia.Controls/NativeControlHost.cs
+++ b/src/Avalonia.Controls/NativeControlHost.cs
@@ -141,7 +141,7 @@ namespace Avalonia.Controls
 
             if (IsEffectivelyVisible && bounds.HasValue)
             {
-                if (bounds.Value.IsDefault)
+                if (bounds.Value.Width == 0 && bounds.Value.Height == 0)
                     return false;
                 _attachment?.ShowInBounds(bounds.Value);
             }

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/ManagedPopupPositioner.cs
@@ -112,7 +112,8 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
                                    ?? screens.FirstOrDefault(s => s.Bounds.Intersects(parentGeometry))
                                    ?? screens.FirstOrDefault();
 
-                if (targetScreen != null && targetScreen.WorkingArea.IsDefault)
+                if (targetScreen != null &&
+                    (targetScreen.WorkingArea.Width == 0 && targetScreen.WorkingArea.Height == 0))
                 {
                     return targetScreen.Bounds;
                 }

--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -459,7 +459,8 @@ namespace Avalonia.Controls
 
             while (c is not null)
             {
-                if (!c.Bounds.IsDefault && c.TransformToVisual(this) is Matrix transform)
+                if ((c.Bounds.Width != 0 || c.Bounds.Height != 0) &&
+                    c.TransformToVisual(this) is Matrix transform)
                 {
                     viewport = new Rect(0, 0, c.Bounds.Width, c.Bounds.Height)
                         .TransformToAABB(transform);

--- a/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
+++ b/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
@@ -375,7 +375,7 @@ namespace Avalonia.Skia
 
             foreach (var boxShadow in boxShadows)
             {
-                if (!boxShadow.IsDefault && !boxShadow.IsInset)
+                if (boxShadow != default && !boxShadow.IsInset)
                 {
                     using (var shadow = BoxShadowFilter.Create(_boxShadowPaint, boxShadow, _useOpacitySaveLayer ? 1 : _currentOpacity))
                     {
@@ -432,7 +432,7 @@ namespace Avalonia.Skia
 
             foreach (var boxShadow in boxShadows)
             {
-                if (!boxShadow.IsDefault && boxShadow.IsInset)
+                if (boxShadow != default && boxShadow.IsInset)
                 {
                     using (var shadow = BoxShadowFilter.Create(_boxShadowPaint, boxShadow, _useOpacitySaveLayer ? 1 : _currentOpacity))
                     {


### PR DESCRIPTION
## What does the pull request do?

Implements the changes for Empty/Default members as discussed in https://github.com/AvaloniaUI/Avalonia/issues/10264.

The precise code changes in this PR were discussed starting here: https://github.com/AvaloniaUI/Avalonia/issues/10264#issuecomment-1461462920

## What is the current behavior?

Still some ambiguity and concern over usage and implementation of the `IsDefault` member in relevant types.

## What is the updated/expected behavior with this PR?

 1. `IsDefault` (added in https://github.com/AvaloniaUI/Avalonia/pull/9590) is completely removed.
 2. Older `Empty` and `IsEmpty` members were completely removed from relevant types as well. Previously these were only obsoleted.

## How was the solution implemented (if it's not obvious)?

Deleting members and then re-writing usages.

## Checklist

- ~[ ] Added unit tests (if possible)?~
- ~[ ] Added XML documentation to any related classes?~
- ~[ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation~

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations

Yes:

 1. IsEmpty and Empty members were removed from several types
 1. IsDefault was removed from FontFamily
 1. IsDefault properties added in https://github.com/AvaloniaUI/Avalonia/pull/9590 were completely removed. This is ONLY breaking from past previews.

## Fixed issues

Closes https://github.com/AvaloniaUI/Avalonia/issues/10264
Follow-up to https://github.com/AvaloniaUI/Avalonia/pull/9590
