### PR TITLE
when exit and reopen the android application,Static variables cause a…

### DIFF
--- a/src/Avalonia.Controls/AppBuilderBase.cs
+++ b/src/Avalonia.Controls/AppBuilderBase.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Controls
     /// <typeparam name="TAppBuilder">The type of the AppBuilder class itself.</typeparam>
     public abstract class AppBuilderBase<TAppBuilder> where TAppBuilder : AppBuilderBase<TAppBuilder>, new()
     {
-        private static bool s_setupWasAlreadyCalled;
+        private bool s_setupWasAlreadyCalled;
         private Action _optionsInitializers;
         private Func<Application> _appFactory;
         private IApplicationLifetime _lifetime;


### PR DESCRIPTION
… prompt to "Setup was already called on one of AppBuilder instances".

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
when exit and reopen the android application,Static variables cause a prompt to "Setup was already called on one of AppBuilder instances".
now I need to change this variable by reflection each time I close the application.
```
    public class MainActivity : AvaloniaMainActivity
    {
        protected override void OnDestroy()
        {
            base.OnDestroy();
            var s_setupWasAlreadyCalled = typeof(AppBuilderBase<AppBuilder>).GetField("s_setupWasAlreadyCalled", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
            s_setupWasAlreadyCalled?.SetValue(null, false);
        }
    }
```
## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
