### PR TITLE
Use SetCurrentValue to fix HamburgerMenu

### DIFF
--- a/samples/SampleControls/HamburgerMenu/HamburgerMenu.cs
+++ b/samples/SampleControls/HamburgerMenu/HamburgerMenu.cs
@@ -57,7 +57,7 @@ namespace ControlSamples
             {
                 if (_splitView is not null && _splitView.DisplayMode == SplitViewDisplayMode.Overlay)
                 {
-                    _splitView.SetValue(SplitView.IsPaneOpenProperty, false, Avalonia.Data.BindingPriority.Animation);
+                    _splitView.SetCurrentValue(SplitView.IsPaneOpenProperty, false);
                 }
             }
         }


### PR DESCRIPTION
## What does the pull request do?

Fixes https://github.com/AvaloniaUI/Avalonia/issues/10537. Issue located by @amwx here: https://github.com/AvaloniaUI/Avalonia/issues/10537#issuecomment-1468727148. This is caused by the switch of IsPaneOpen from Direct to StyledProperty.

## What is the current behavior?

HamburgerMenu may fail to open in some cases.

## What is the updated/expected behavior with this PR?

HamburgerMenu always opens.

## How was the solution implemented (if it's not obvious)?

Use the new SetCurrentValue() method to avoid breaking bindings or requiring the property to be set with animation priority. This wasn't needed when it was a DirectProperty but is required now that it is a StyledProperty.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

None

## Obsoletions / Deprecations

None

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/10537
