### PR TITLE
[macOS] Fix caret position handling

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -598,13 +598,13 @@
 {
     [[_markedText mutableString] setString:@""];
     
+    [[self inputContext] discardMarkedText];
+    
     if(!_parent->InputMethod->IsActive()){
         return;
     }
     
     _parent->InputMethod->Client->SetPreeditText(nullptr);
-    
-    [[self inputContext] discardMarkedText];
 }
 
 - (NSArray<NSString *> *)validAttributesForMarkedText
@@ -619,17 +619,12 @@
 
 - (void)insertText:(id)string replacementRange:(NSRange)replacementRange
 {
-    //[_text replaceCharactersInRange:replacementRange withString:string];
-    
     [self unmarkText];
-    
-    //if(!_lastKeyHandled)
-    //{
-        if(_parent != nullptr)
-        {
-            _lastKeyHandled = _parent->BaseEvents->RawTextInputEvent(0, [string UTF8String]);
-        }
-    //}
+
+    if(_parent != nullptr)
+    {
+        _lastKeyHandled = _parent->BaseEvents->RawTextInputEvent(0, [string UTF8String]);
+    }
     
     [[self inputContext] invalidateCharacterCoordinates];
 }

--- a/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
+++ b/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
@@ -30,9 +30,7 @@ namespace Avalonia.Controls
                     return default;
                 }
 
-                var visualRoot = _presenter.VisualRoot!;
-
-                var transform = _presenter.TransformToVisual((Visual)visualRoot);
+                var transform = _presenter.TransformToVisual(_parent);
 
                 if (transform == null)
                 {

--- a/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
+++ b/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
@@ -40,7 +40,7 @@ namespace Avalonia.Controls
                 }
 
                 var rect = _presenter.GetCursorRectangle().TransformToAABB(transform.Value);
-                
+
                 return rect;
             }
         }

--- a/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
+++ b/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
@@ -30,7 +30,9 @@ namespace Avalonia.Controls
                     return default;
                 }
 
-                var transform = _presenter.TransformToVisual(_parent);
+                var visualRoot = _presenter.VisualRoot!;
+
+                var transform = _presenter.TransformToVisual((Visual)visualRoot);
 
                 if (transform == null)
                 {
@@ -38,7 +40,7 @@ namespace Avalonia.Controls
                 }
 
                 var rect = _presenter.GetCursorRectangle().TransformToAABB(transform.Value);
-
+                
                 return rect;
             }
         }

--- a/src/Avalonia.Native/AvaloniaNativeTextInputMethod.cs
+++ b/src/Avalonia.Native/AvaloniaNativeTextInputMethod.cs
@@ -60,7 +60,18 @@ namespace Avalonia.Native
                 return;
             }
 
-            _inputMethod.SetCursorRect(_client.CursorRectangle.ToAvnRect());
+            var visualRoot = _client.TextViewVisual.VisualRoot;
+
+            var transform = _client.TextViewVisual.TransformToVisual((Visual)visualRoot);
+
+            if (transform == null)
+            {
+                return;
+            }
+
+            var rect = _client.CursorRectangle.TransformToAABB(transform.Value);         
+
+            _inputMethod.SetCursorRect(rect.ToAvnRect());
         }
 
         private void OnSurroundingTextChanged(object sender, EventArgs e)


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
macOS expects the caret position to be in screen coordinates. This PR makes sure the caret position is transformed accordingly.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
