### PR TITLE
Fix current values being overridden.

### DIFF
--- a/src/Avalonia.Base/PropertyStore/EffectiveValue.cs
+++ b/src/Avalonia.Base/PropertyStore/EffectiveValue.cs
@@ -54,9 +54,9 @@ namespace Avalonia.PropertyStore
         /// </remarks>
         public void BeginReevaluation(bool clearLocalValue = false)
         {
-            if (clearLocalValue || Priority != BindingPriority.LocalValue)
+            if (clearLocalValue || (Priority != BindingPriority.LocalValue && !IsOverridenCurrentValue))
                 Priority = BindingPriority.Unset;
-            if (clearLocalValue || BasePriority != BindingPriority.LocalValue)
+            if (clearLocalValue || (BasePriority != BindingPriority.LocalValue && !IsOverridenCurrentValue))
                 BasePriority = BindingPriority.Unset;
         }
 

--- a/src/Avalonia.Base/PropertyStore/ValueStore.cs
+++ b/src/Avalonia.Base/PropertyStore/ValueStore.cs
@@ -810,10 +810,13 @@ namespace Avalonia.PropertyStore
                     // We're interested in the value if:
                     // - There is no current effective value, or
                     // - The value's priority is higher than the current effective value's priority, or
+                    // - The value's priority is equal to the current effective value's priority, but the effective
+                    //   value was set via SetCurrentValue, or
                     // - The value is a non-animation value and its priority is higher than the current
                     //   effective value's base priority
                     var isRelevantPriority = current is null ||
                         (priority < current.Priority && priority < current.BasePriority) ||
+                        (priority == current.Priority && current.IsOverridenCurrentValue) ||
                         (priority > BindingPriority.Animation && priority < current.BasePriority);
 
                     if (foundEntry && isRelevantPriority && entry!.HasValue)

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_SetCurrentValue.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_SetCurrentValue.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reactive.Subjects;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Diagnostics;
@@ -392,6 +393,22 @@ namespace Avalonia.Base.UnitTests
             Assert.Equal("inheriteddefault", target.Inherited);
         }
 
+        [Theory]
+        [InlineData(BindingPriority.LocalValue)]
+        [InlineData(BindingPriority.Style)]
+        [InlineData(BindingPriority.Animation)]
+        public void CurrentValue_Is_Replaced_By_Binding_Value(BindingPriority priority)
+        {
+            var target = new Class1();
+            var source = new BehaviorSubject<string>("initial");
+
+            target.Bind(Class1.FooProperty, source, priority);
+            target.SetCurrentValue(Class1.FooProperty, "current");
+            source.OnNext("new");
+            
+            Assert.Equal("new", target.Foo);
+        }
+        
         private BindingPriority GetPriority(AvaloniaObject target, AvaloniaProperty property)
         {
             return target.GetDiagnostic(property).Priority;

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_SetCurrentValue.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_SetCurrentValue.cs
@@ -411,7 +411,7 @@ namespace Avalonia.Base.UnitTests
         }
 
         [Fact]
-        public void CurrentValue_Is_Replaced_By_New_Style_Activation()
+        public void CurrentValue_Is_Replaced_By_New_Style_Activation_1()
         {
             var target = new Class1();
             var root = new TestRoot(target)
@@ -446,7 +446,41 @@ namespace Avalonia.Base.UnitTests
 
             Assert.Equal("new", target.Foo);
         }
-        
+
+        [Fact]
+        public void CurrentValue_Is_Replaced_By_New_Style_Activation_2()
+        {
+            var target = new Class1();
+            var root = new TestRoot(target)
+            {
+                Styles =
+                {
+                    new Style(x => x.OfType<Class1>().Class("foo"))
+                    {
+                        Setters =
+                        {
+                            new Setter(Class1.FooProperty, "foo"),
+                        },
+                    },
+                    new Style(x => x.OfType<Class1>().Class("foo"))
+                    {
+                        Setters =
+                        {
+                            new Setter(Class1.BarProperty, "bar"),
+                        },
+                    },
+                }
+            };
+
+            root.LayoutManager.ExecuteInitialLayoutPass();
+
+            target.SetValue(Class1.FooProperty, "template", BindingPriority.Template);
+            target.SetCurrentValue(Class1.FooProperty, "current");
+
+            target.Classes.Add("foo");
+            Assert.Equal("foo", target.Foo);
+        }
+
         private BindingPriority GetPriority(AvaloniaObject target, AvaloniaProperty property)
         {
             return target.GetDiagnostic(property).Priority;

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_SetCurrentValue.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_SetCurrentValue.cs
@@ -351,6 +351,47 @@ namespace Avalonia.Base.UnitTests
             Assert.Equal("inheriteddefault", target.Inherited);
         }
 
+        [Fact]
+        public void SetCurrent_Value_Persists_When_Toggling_Style_3()
+        {
+            var target = new Class1();
+            var root = new TestRoot(target)
+            {
+                Styles =
+                {
+                    new Style(x => x.OfType<Class1>().Class("foo"))
+                    {
+                        Setters =
+                        {
+                            new Setter(Class1.BarProperty, "bar"),
+                            new Setter(Class1.InheritedProperty, "inherited"),
+                        },
+                    }
+                }
+            };
+
+            root.LayoutManager.ExecuteInitialLayoutPass();
+
+            target.SetValue(Class1.FooProperty, "not current", BindingPriority.Template);
+            target.SetCurrentValue(Class1.FooProperty, "current");
+
+            Assert.Equal("current", target.Foo);
+            Assert.Equal("bardefault", target.Bar);
+            Assert.Equal("inheriteddefault", target.Inherited);
+
+            target.Classes.Add("foo");
+
+            Assert.Equal("current", target.Foo);
+            Assert.Equal("bar", target.Bar);
+            Assert.Equal("inherited", target.Inherited);
+
+            target.Classes.Remove("foo");
+
+            Assert.Equal("current", target.Foo);
+            Assert.Equal("bardefault", target.Bar);
+            Assert.Equal("inheriteddefault", target.Inherited);
+        }
+
         private BindingPriority GetPriority(AvaloniaObject target, AvaloniaProperty property)
         {
             return target.GetDiagnostic(property).Priority;


### PR DESCRIPTION
## What does the pull request do?

At the beginning of a re-evaluation pass we mark all effective values as unset in order to signal that we've not yet found a value for them in the value frames. We do this in all cases except when they have a local value: in the case of a local value, the effective value _is_ the value and so value frames should only take effect when they're higher priority than the effective value. However when I added `SetCurrentValue` support, I neglected to change this logic to also take into account current values.

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/10655
Fixes https://github.com/AvaloniaUI/Avalonia/issues/10671
