### PR TITLE
SplitView fixes

### DIFF
--- a/src/Avalonia.Controls/SplitView/SplitView.cs
+++ b/src/Avalonia.Controls/SplitView/SplitView.cs
@@ -136,14 +136,9 @@ namespace Avalonia.Controls
 
         private Panel? _pane;
         private IDisposable? _pointerDisposable;
-        private SplitViewTemplateSettings _templateSettings = null!;
+        private SplitViewTemplateSettings _templateSettings = new SplitViewTemplateSettings();
         private string? _lastDisplayModePseudoclass;
         private string? _lastPlacementPseudoclass;
-
-        public SplitView()
-        {
-            TemplateSettings = new SplitViewTemplateSettings();
-        }
 
         /// <summary>
         /// Gets or sets the length of the pane when in <see cref="SplitViewDisplayMode.CompactOverlay"/> 

--- a/src/Avalonia.Controls/SplitView/SplitView.cs
+++ b/src/Avalonia.Controls/SplitView/SplitView.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Controls
         protected const string pcOpen = ":open";
         protected const string pcClosed = ":closed";
         protected const string pcCompactOverlay = ":compactoverlay";
-        protected const string pcCompactInline = ":compactInline";
+        protected const string pcCompactInline = ":compactinline";
         protected const string pcOverlay = ":overlay";
         protected const string pcInline = ":inline";
         protected const string pcLeft = ":left";

--- a/src/Avalonia.Controls/SplitView/SplitView.cs
+++ b/src/Avalonia.Controls/SplitView/SplitView.cs
@@ -382,6 +382,7 @@ namespace Avalonia.Controls
                 if (IsPaneOpen && IsInOverlayMode())
                 {
                     SetCurrentValue(IsPaneOpenProperty, false);
+                    e.Handled = true;
                 }
             }
 

--- a/src/Avalonia.Controls/SplitView/SplitView.cs
+++ b/src/Avalonia.Controls/SplitView/SplitView.cs
@@ -301,7 +301,6 @@ namespace Avalonia.Controls
             base.OnApplyTemplate(e);
             _pane = e.NameScope.Find<Panel>("PART_PaneRoot");
 
-            UpdateVisualStateForCompactPaneLength(CompactPaneLength);
             UpdateVisualStateForDisplayMode(DisplayMode);
         }
 

--- a/src/Avalonia.Controls/SplitView/SplitView.cs
+++ b/src/Avalonia.Controls/SplitView/SplitView.cs
@@ -136,9 +136,9 @@ namespace Avalonia.Controls
 
         private Panel? _pane;
         private IDisposable? _pointerDisposable;
-        private SplitViewTemplateSettings _templateSettings;
-        private string _lastDisplayModePseudoclass;
-        private string _lastPlacementPseudoclass;
+        private SplitViewTemplateSettings _templateSettings = null!;
+        private string? _lastDisplayModePseudoclass;
+        private string? _lastPlacementPseudoclass;
 
         public SplitView()
         {
@@ -575,7 +575,7 @@ namespace Avalonia.Controls
             }
         }
 
-        private void TopLevelBackRequested(object sender, RoutedEventArgs e)
+        private void TopLevelBackRequested(object? sender, RoutedEventArgs e)
         {
             if (!IsInOverlayMode())
                 return;

--- a/src/Avalonia.Controls/SplitView/SplitView.cs
+++ b/src/Avalonia.Controls/SplitView/SplitView.cs
@@ -15,18 +15,21 @@ namespace Avalonia.Controls
     /// A control with two views: A collapsible pane and an area for content
     /// </summary>
     [TemplatePart("PART_PaneRoot", typeof(Panel))]
-    [PseudoClasses(":open", ":closed")]
-    [PseudoClasses(":compactoverlay", ":compactinline", ":overlay", ":inline")]
-    [PseudoClasses(":left", ":right")]
-    [PseudoClasses(":lightdismiss")]
+    [PseudoClasses(pcOpen, pcClosed)]
+    [PseudoClasses(pcCompactOverlay, pcCompactInline, pcOverlay, pcInline)]
+    [PseudoClasses(pcLeft, pcRight)]
+    [PseudoClasses(pcLightDismiss)]
     public class SplitView : ContentControl
     {
-        /*
-            Pseudo classes & combos
-            :open / :closed
-            :compactoverlay :compactinline :overlay :inline
-            :left :right
-        */
+        protected const string pcOpen = ":open";
+        protected const string pcClosed = ":closed";
+        protected const string pcCompactOverlay = ":compactoverlay";
+        protected const string pcCompactInline = ":compactInline";
+        protected const string pcOverlay = ":overlay";
+        protected const string pcInline = ":inline";
+        protected const string pcLeft = ":left";
+        protected const string pcRight = ":right";
+        protected const string pcLightDismiss = ":lightDismiss";
 
         /// <summary>
         /// Defines the <see cref="CompactPaneLength"/> property
@@ -346,15 +349,15 @@ namespace Avalonia.Controls
 
                 if (isPaneOpen)
                 {
-                    PseudoClasses.Add(":open");
-                    PseudoClasses.Remove(":closed");
+                    PseudoClasses.Add(pcOpen);
+                    PseudoClasses.Remove(pcClosed);
 
                     OnPaneOpened(new RoutedEventArgs(PaneOpenedEvent, this));
                 }
                 else
                 {
-                    PseudoClasses.Add(":closed");
-                    PseudoClasses.Remove(":open");
+                    PseudoClasses.Add(pcClosed);
+                    PseudoClasses.Remove(pcOpen);
 
                     OnPaneClosed(new RoutedEventArgs(PaneClosedEvent, this));
                 }
@@ -378,7 +381,7 @@ namespace Avalonia.Controls
             else if (change.Property == UseLightDismissOverlayModeProperty)
             {
                 var mode = change.GetNewValue<bool>();
-                PseudoClasses.Set(":lightdismiss", mode);
+                PseudoClasses.Set(pcLightDismiss, mode);
             }
         }
 
@@ -452,10 +455,10 @@ namespace Avalonia.Controls
         {
             return mode switch
             {
-                SplitViewDisplayMode.Inline => ":inline",
-                SplitViewDisplayMode.CompactInline => ":compactinline",
-                SplitViewDisplayMode.Overlay => ":overlay",
-                SplitViewDisplayMode.CompactOverlay => ":compactoverlay",
+                SplitViewDisplayMode.Inline => pcInline,
+                SplitViewDisplayMode.CompactInline => pcCompactInline,
+                SplitViewDisplayMode.Overlay => pcOverlay,
+                SplitViewDisplayMode.CompactOverlay => pcCompactOverlay,
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
             };
         }
@@ -467,8 +470,8 @@ namespace Avalonia.Controls
         {
             return placement switch
             {
-                SplitViewPanePlacement.Left => ":left",
-                SplitViewPanePlacement.Right => ":right",
+                SplitViewPanePlacement.Left => pcLeft,
+                SplitViewPanePlacement.Right => pcRight,
                 _ => throw new ArgumentOutOfRangeException(nameof(placement), placement, null)
             };
         }

--- a/tests/Avalonia.Controls.UnitTests/SplitViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SplitViewTests.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using Avalonia.Input;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests
@@ -59,6 +58,225 @@ namespace Avalonia.Controls.UnitTests
             };
 
             splitView.IsPaneOpen = false;
+
+            Assert.True(splitView.IsPaneOpen);
+        }
+
+        [Fact]
+        public void SplitView_TemplateSettings_Are_Correct_For_Display_Modes()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+            var wnd = new Window
+            {
+                Width = 1280,
+                Height = 720
+            };
+            var splitView = new SplitView();
+            wnd.Content = splitView;
+            wnd.Show();
+
+            var zeroGridLength = new GridLength(0);
+            var compactLength = splitView.CompactPaneLength;
+            var compactGridLength = new GridLength(compactLength);
+
+            // Overlay is default DisplayMode
+            Assert.Equal(0, splitView.TemplateSettings.ClosedPaneWidth);
+            Assert.Equal(zeroGridLength, splitView.TemplateSettings.PaneColumnGridLength);
+
+            splitView.DisplayMode = SplitViewDisplayMode.CompactOverlay;
+            Assert.Equal(compactLength, splitView.TemplateSettings.ClosedPaneWidth);
+            Assert.Equal(compactGridLength, splitView.TemplateSettings.PaneColumnGridLength);
+
+            splitView.DisplayMode = SplitViewDisplayMode.Inline;
+            Assert.Equal(0, splitView.TemplateSettings.ClosedPaneWidth);
+            Assert.Equal(GridLength.Auto, splitView.TemplateSettings.PaneColumnGridLength);
+
+            splitView.DisplayMode = SplitViewDisplayMode.CompactInline;
+            Assert.Equal(compactLength, splitView.TemplateSettings.ClosedPaneWidth);
+            Assert.Equal(GridLength.Auto, splitView.TemplateSettings.PaneColumnGridLength);
+        }
+
+        [Fact]
+        public void SplitView_TemplateSettings_Update_With_CompactPaneLength()
+        {
+            var splitView = new SplitView();
+            
+            // CompactInline:
+            //    - ClosedPaneWidth = CompactPaneLength
+            //    - PaneColumnGridLength = Auto
+            splitView.DisplayMode = SplitViewDisplayMode.CompactInline;
+
+            var compactLength = splitView.CompactPaneLength;
+            
+            Assert.Equal(GridLength.Auto, splitView.TemplateSettings.PaneColumnGridLength);
+            Assert.Equal(compactLength, splitView.TemplateSettings.ClosedPaneWidth);
+
+            splitView.CompactPaneLength = 100;
+
+            Assert.Equal(GridLength.Auto, splitView.TemplateSettings.PaneColumnGridLength);
+            Assert.Equal(100, splitView.TemplateSettings.ClosedPaneWidth);
+
+            // CompactOverlay:
+            //    - ClosedPaneWidth = CompactPaneLength
+            //    - PaneColumnGridLength = GridLength { CompactPaneLength, Pixel }
+            splitView.DisplayMode = SplitViewDisplayMode.CompactOverlay;
+            splitView.CompactPaneLength = 50;
+
+            Assert.Equal(new GridLength(50), splitView.TemplateSettings.PaneColumnGridLength);
+            Assert.Equal(50, splitView.TemplateSettings.ClosedPaneWidth);
+
+            // Value shouldn't change for these - changing the display mode will update
+            // the template settings with the right value
+            splitView.DisplayMode = SplitViewDisplayMode.Inline;
+            splitView.CompactPaneLength = 1;
+
+            Assert.Equal(GridLength.Auto, splitView.TemplateSettings.PaneColumnGridLength);
+            Assert.Equal(0, splitView.TemplateSettings.ClosedPaneWidth);
+
+            splitView.DisplayMode = SplitViewDisplayMode.Overlay;
+            splitView.CompactPaneLength = 2;
+
+            Assert.Equal(new GridLength(0), splitView.TemplateSettings.PaneColumnGridLength);
+            Assert.Equal(0, splitView.TemplateSettings.ClosedPaneWidth);
+        }
+
+        [Fact]
+        public void SplitView_Pointer_Closes_Pane_In_Overlay_Mode()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow
+                .With(globalClock: new MockGlobalClock()));
+            var wnd = new Window
+            {
+                Width = 1280,
+                Height = 720
+            };
+            var splitView = new SplitView();
+            wnd.Content = splitView;
+            wnd.Show();
+
+            splitView.IsPaneOpen = true;
+
+            splitView.RaiseEvent(new PointerReleasedEventArgs(splitView,
+                null, wnd, new Point(1270, 30), 0,
+                new PointerPointProperties(),
+                KeyModifiers.None,
+                MouseButton.Left));
+
+            Assert.False(splitView.IsPaneOpen);
+
+            // Inline shouldn't close the pane
+            splitView.DisplayMode = SplitViewDisplayMode.Inline;
+            splitView.IsPaneOpen = true;
+
+            splitView.RaiseEvent(new PointerReleasedEventArgs(splitView,
+                null, wnd, new Point(1270, 30), 0,
+                new PointerPointProperties(),
+                KeyModifiers.None,
+                MouseButton.Left));
+
+            Assert.True(splitView.IsPaneOpen);
+        }
+
+        [Fact]
+        public void SplitView_Pointer_Should_Not_Close_Pane_If_Over_Pane()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow
+                .With(globalClock: new MockGlobalClock()));
+            var wnd = new Window
+            {
+                Width = 1280,
+                Height = 720
+            };
+            var clickBorder = new Border
+            {
+                Width = 100,
+                Height = 100,
+                HorizontalAlignment = Layout.HorizontalAlignment.Left,
+                VerticalAlignment = Layout.VerticalAlignment.Top
+            };
+            var splitView = new SplitView
+            {
+                Pane = clickBorder
+            };
+            wnd.Content = splitView;
+            wnd.Show();
+
+            splitView.IsPaneOpen = true;
+
+            clickBorder.RaiseEvent(new PointerReleasedEventArgs(splitView,
+                null, wnd, new Point(5, 5), 0,
+                new PointerPointProperties(),
+                KeyModifiers.None,
+                MouseButton.Left));
+
+            Assert.True(splitView.IsPaneOpen);
+        }
+
+        [Fact]
+        public void SplitView_Escape_Key_Closes_Light_Dismissable_Pane()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow
+                .With(globalClock: new MockGlobalClock()));
+            var wnd = new Window
+            {
+                Width = 1280,
+                Height = 720
+            };
+            var button = new Button();
+            var splitView = new SplitView
+            {
+                Pane = button
+            };
+            wnd.Content = splitView;
+            wnd.Show();
+
+            splitView.IsPaneOpen = true;
+
+            button.RaiseEvent(new KeyEventArgs
+            {
+                Key = Key.Escape,
+                RoutedEvent = InputElement.KeyDownEvent
+            });
+
+            Assert.False(splitView.IsPaneOpen);
+
+            splitView.DisplayMode = SplitViewDisplayMode.Inline;
+
+            splitView.IsPaneOpen = true;
+
+            button.RaiseEvent(new KeyEventArgs
+            {
+                Key = Key.Escape,
+                RoutedEvent = InputElement.KeyDownEvent
+            });
+
+            Assert.True(splitView.IsPaneOpen);
+        }
+
+        [Fact]
+        public void Top_Level_Back_Requested_Closes_Light_Dismissable_Pane()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow
+                .With(globalClock: new MockGlobalClock()));
+            var wnd = new Window
+            {
+                Width = 1280,
+                Height = 720
+            };
+            var splitView = new SplitView();
+            wnd.Content = splitView;
+            wnd.Show();
+
+            splitView.IsPaneOpen = true;
+
+            wnd.RaiseEvent(new Interactivity.RoutedEventArgs(TopLevel.BackRequestedEvent));
+
+            Assert.False(splitView.IsPaneOpen);
+
+            splitView.DisplayMode = SplitViewDisplayMode.Inline;
+            splitView.IsPaneOpen = true;
+
+            wnd.RaiseEvent(new Interactivity.RoutedEventArgs(TopLevel.BackRequestedEvent));
 
             Assert.True(splitView.IsPaneOpen);
         }


### PR DESCRIPTION
## What does the pull request do?
Fixes a couple issues with `SplitView`

- Fixes an issue where Overlay mode didn't have the correct TemplateSettings and layout, fixes #10694
  - changed the psuedoclasses to be `const string` to reduce repetitive strings
- Improves the light-dismiss behavior of the SplitView, closes #10652
  - Uses pointer released instead of pointer pressed
  - Reworked the pointer subscription to not be a lifetime thing and sub/unsub when the pane is opened/closed and is in an Overlay mode
  - Added allowing using the escape key to close a light-dismissable pane
  - Added allowing the `TopLevel.BackRequested` event to close a light-dismissable pane (should improve mobile support here)
- Changed `TemplateSettings` to a read only DirectProperty to get rid of the analyzer warning
- Added some new tests


(I realize the last two added things aren't necessarily critical bug fixes, but I think they're good to have for the light-dismiss stuff as they increase mobile and keyboard accessibility)

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

