### PR TITLE
Revert "FontManager fixes"

### DIFF
--- a/src/Avalonia.Base/Media/FontManager.cs
+++ b/src/Avalonia.Base/Media/FontManager.cs
@@ -119,9 +119,7 @@ namespace Avalonia.Media
                     }
                 }
 
-                var familyName = fontFamily.FamilyNames.PrimaryFamilyName.ToUpperInvariant();
-
-                if (fontCollection != null && fontCollection.TryGetGlyphTypeface(familyName,
+                if (fontCollection != null && fontCollection.TryGetGlyphTypeface(fontFamily.FamilyNames.PrimaryFamilyName,
                     typeface.Style, typeface.Weight, typeface.Stretch, out glyphTypeface))
                 {
                     return true;
@@ -135,7 +133,7 @@ namespace Avalonia.Media
 
             foreach (var familyName in fontFamily.FamilyNames)
             {
-                if (SystemFonts.TryGetGlyphTypeface(familyName.ToUpperInvariant(), typeface.Style, typeface.Weight, typeface.Stretch, out glyphTypeface))
+                if (SystemFonts.TryGetGlyphTypeface(familyName, typeface.Style, typeface.Weight, typeface.Stretch, out glyphTypeface))
                 {
                     return true;
                 }

--- a/src/Avalonia.Base/Media/Fonts/EmbeddedFontCollection.cs
+++ b/src/Avalonia.Base/Media/Fonts/EmbeddedFontCollection.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Avalonia.Platform;
 
 namespace Avalonia.Media.Fonts
@@ -42,13 +43,11 @@ namespace Avalonia.Media.Fonts
 
                 if (fontManager.TryCreateGlyphTypeface(stream, out var glyphTypeface))
                 {
-                    var familyName = glyphTypeface.FamilyName.ToUpperInvariant();
-
-                    if (!_glyphTypefaceCache.TryGetValue(familyName, out var glyphTypefaces))
+                    if (!_glyphTypefaceCache.TryGetValue(glyphTypeface.FamilyName, out var glyphTypefaces))
                     {
                         glyphTypefaces = new ConcurrentDictionary<FontCollectionKey, IGlyphTypeface>();
 
-                        if (_glyphTypefaceCache.TryAdd(familyName, glyphTypefaces))
+                        if (_glyphTypefaceCache.TryAdd(glyphTypeface.FamilyName, glyphTypefaces))
                         {
                             _fontFamilies.Add(new FontFamily(_key, glyphTypeface.FamilyName));
                         }
@@ -87,8 +86,6 @@ namespace Avalonia.Media.Fonts
         public bool TryGetGlyphTypeface(string familyName, FontStyle style, FontWeight weight,
             FontStretch stretch, [NotNullWhen(true)] out IGlyphTypeface? glyphTypeface)
         {
-            familyName = familyName.ToUpperInvariant();
-
             var key = new FontCollectionKey(style, weight, stretch);
 
             if (_glyphTypefaceCache.TryGetValue(familyName, out var glyphTypefaces))
@@ -104,11 +101,9 @@ namespace Avalonia.Media.Fonts
             {
                 var fontFamily = _fontFamilies[i];
 
-                if (fontFamily.Name.ToUpperInvariant().StartsWith(familyName.ToUpperInvariant()))
+                if (fontFamily.Name.ToLower(CultureInfo.InvariantCulture).StartsWith(familyName.ToLower(CultureInfo.InvariantCulture)))
                 {
-                    familyName = fontFamily.Name.ToUpperInvariant();
-
-                    if (_glyphTypefaceCache.TryGetValue(familyName, out glyphTypefaces) &&
+                    if (_glyphTypefaceCache.TryGetValue(fontFamily.Name, out glyphTypefaces) &&
                         TryGetNearestMatch(glyphTypefaces, key, out glyphTypeface))
                     {
                         return true;

--- a/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
+++ b/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
@@ -42,8 +42,6 @@ namespace Avalonia.Media.Fonts
                 familyName = _fontManager.DefaultFontFamilyName;
             }
 
-            familyName = familyName.ToUpperInvariant();
-
             var key = new FontCollectionKey(style, weight, stretch);
 
             if (_glyphTypefaceCache.TryGetValue(familyName, out var glyphTypefaces))

--- a/tests/Avalonia.Skia.UnitTests/Media/CustomFontManagerImpl.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/CustomFontManagerImpl.cs
@@ -68,6 +68,66 @@ namespace Avalonia.Skia.UnitTests.Media
             return true;
         }
 
+        public IGlyphTypeface CreateGlyphTypeface(Typeface typeface)
+        {
+            SKTypeface skTypeface;
+
+            Uri source = null;
+
+            switch (typeface.FontFamily.Name)
+            {
+                case "Twitter Color Emoji":
+                    {
+                        source = _emojiTypeface.FontFamily.Key.Source;
+                        break;
+                    }
+                case "Noto Sans":
+                    {
+                        source = _italicTypeface.FontFamily.Key.Source;
+                        break;
+                    }
+                case "Noto Sans Arabic":
+                    {
+                        source = _arabicTypeface.FontFamily.Key.Source;
+                        break;
+                    }
+                case "Noto Sans Hebrew":
+                    {
+                        source = _hebrewTypeface.FontFamily.Key.Source;
+                        break;
+                    }
+                case FontFamily.DefaultFontFamilyName:
+                case "Noto Mono":
+                    {
+                        source = _defaultTypeface.FontFamily.Key.Source;
+                        break;
+                    }
+                default:
+                    {
+
+                        break;
+                    }
+            }
+
+            if (source is null)
+            {
+                skTypeface = SKTypeface.FromFamilyName(typeface.FontFamily.Name,
+                           (SKFontStyleWeight)typeface.Weight, SKFontStyleWidth.Normal, (SKFontStyleSlant)typeface.Style);
+            }
+            else
+            {
+                var assetLoader = AvaloniaLocator.Current.GetRequiredService<IAssetLoader>();
+
+                var assetUri = FontFamilyLoader.LoadFontAssets(source).First();
+
+                var stream = assetLoader.Open(assetUri);
+
+                skTypeface = SKTypeface.FromStream(stream);
+            }
+
+            return new GlyphTypefaceImpl(skTypeface, FontSimulations.None);
+        }
+
         public bool TryCreateGlyphTypeface(string familyName, FontStyle style, FontWeight weight,
             FontStretch stretch, [NotNullWhen(true)] out IGlyphTypeface glyphTypeface)
         {
@@ -77,40 +137,54 @@ namespace Avalonia.Skia.UnitTests.Media
 
             switch (familyName)
             {
-                case "TWITTER COLOR EMOJI":
+                case "Twitter Color Emoji":
                     {
                         source = _emojiTypeface.FontFamily.Key.Source;
                         break;
                     }
-                case "NOTO SANS":
+                case "Noto Sans":
                     {
                         source = _italicTypeface.FontFamily.Key.Source;
                         break;
                     }
-                case "NOTO SANS ARABIC":
+                case "Noto Sans Arabic":
                     {
                         source = _arabicTypeface.FontFamily.Key.Source;
                         break;
                     }
-                case "NOTO SANS HEBREW":
+                case "Noto Sans Hebrew":
                     {
                         source = _hebrewTypeface.FontFamily.Key.Source;
                         break;
                     }
-                default:
+                case FontFamily.DefaultFontFamilyName:
+                case "Noto Mono":
                     {
                         source = _defaultTypeface.FontFamily.Key.Source;
                         break;
                     }
+                default:
+                    {
+
+                        break;
+                    }
             }
 
-            var assetLoader = AvaloniaLocator.Current.GetRequiredService<IAssetLoader>();
+            if (source is null)
+            {
+                skTypeface = SKTypeface.FromFamilyName(familyName,
+                           (SKFontStyleWeight)weight, SKFontStyleWidth.Normal, (SKFontStyleSlant)style);
+            }
+            else
+            {
+                var assetLoader = AvaloniaLocator.Current.GetRequiredService<IAssetLoader>();
 
-            var assetUri = FontFamilyLoader.LoadFontAssets(source).First();
+                var assetUri = FontFamilyLoader.LoadFontAssets(source).First();
 
-            var stream = assetLoader.Open(assetUri);
+                var stream = assetLoader.Open(assetUri);
 
-            skTypeface = SKTypeface.FromStream(stream);
+                skTypeface = SKTypeface.FromStream(stream);
+            }
 
             glyphTypeface = new GlyphTypefaceImpl(skTypeface, FontSimulations.None);
 

--- a/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
@@ -38,10 +38,10 @@ namespace Avalonia.Skia.UnitTests.Media
         public void Should_Yield_Default_GlyphTypeface_For_Invalid_FamilyName()
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface.With(fontManagerImpl: new FontManagerImpl())))
-            {           
-               var glyphTypeface = new Typeface(new FontFamily("Unknown")).GlyphTypeface;
+            {
+                var glyphTypeface = new Typeface(new FontFamily("Unknown")).GlyphTypeface;
 
-                Assert.Equal(FontManager.Current.DefaultFontFamilyName, glyphTypeface.FamilyName);             
+                Assert.Equal(FontManager.Current.DefaultFontFamilyName, glyphTypeface.FamilyName);
             }
         }
 
@@ -84,19 +84,6 @@ namespace Avalonia.Skia.UnitTests.Media
                 var result = FontManager.Current.TryGetGlyphTypeface(new Typeface("fonts:invalid#Something"), out _);
 
                 Assert.False(result);
-            }
-        }
-
-        [Fact]
-        public void Should_Load_Embedded_Font_With_Wrong_CharacterCasing()
-        {
-            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface.With(fontManagerImpl: new FontManagerImpl())))
-            {
-                var result = FontManager.Current.TryGetGlyphTypeface(new Typeface("resm:Avalonia.Skia.UnitTests.Assets?assembly=Avalonia.Skia.UnitTests#noto mOnO"), out var glyphTypeface);
-
-                Assert.True(result);
-
-                Assert.Equal("Noto Mono", glyphTypeface.FamilyName);
             }
         }
 


### PR DESCRIPTION
Reverts AvaloniaUI/Avalonia#10620

Some font managers need exact character casing to be able to match fonts so we need to revert this