### PR TITLE
Make DispatcherPriority values more in line with WPF

### DIFF
--- a/src/Avalonia.Base/Threading/DispatcherPriority.cs
+++ b/src/Avalonia.Base/Threading/DispatcherPriority.cs
@@ -57,7 +57,7 @@ namespace Avalonia.Threading
         /// <summary>
         /// A dispatcher priority for jobs that shouldn't be executed yet
         /// </summary>
-        public static DispatcherPriority Inactive => new(MinimumActiveValue - 1);
+        public static readonly DispatcherPriority Inactive = new(MinimumActiveValue - 1);
         
         /// <summary>
         /// Minimum valid priority
@@ -67,7 +67,7 @@ namespace Avalonia.Threading
         /// <summary>
         /// Used internally in dispatcher code
         /// </summary>
-        public static DispatcherPriority Invalid => new(MinimumActiveValue - 2);
+        public static readonly DispatcherPriority Invalid = new(MinimumActiveValue - 2);
         
         
         /// <summary>
@@ -158,5 +158,42 @@ namespace Avalonia.Threading
             if (priority < Inactive || priority > MaxValue)
                 throw new ArgumentException("Invalid DispatcherPriority value", parameterName);
         }
+        
+#pragma warning disable CS0618
+        public override string ToString()
+        {
+            if (this == Invalid)
+                return nameof(Invalid);
+            if (this == Inactive)
+                return nameof(Inactive);
+            if (this == SystemIdle)
+                return nameof(SystemIdle);
+            if (this == ContextIdle)
+                return nameof(ContextIdle);
+            if (this == ApplicationIdle)
+                return nameof(ApplicationIdle);
+            if (this == Background)
+                return nameof(Background);
+            if (this == Input)
+                return nameof(Input);
+            if (this == Default)
+                return nameof(Default);
+            if (this == Loaded)
+                return nameof(Loaded);
+            if (this == Render)
+                return nameof(Render);
+            if (this == Composition)
+                return nameof(Composition);
+            if (this == PreComposition)
+                return nameof(PreComposition);
+            if (this == DataBind)
+                return nameof(DataBind);
+            if (this == Normal)
+                return nameof(Normal);
+            if (this == Send)
+                return nameof(Send);
+            return Value.ToString();
+        }
+#pragma warning restore CS0618
     }
 }

--- a/src/Avalonia.Base/Threading/DispatcherPriority.cs
+++ b/src/Avalonia.Base/Threading/DispatcherPriority.cs
@@ -16,16 +16,49 @@ namespace Avalonia.Threading
         {
             Value = value;
         }
+
+        /// <summary>
+        /// The lowest foreground dispatcher priority
+        /// </summary>
+        internal static readonly DispatcherPriority Default = new(0);
         
+        /// <summary>
+        /// The job will be processed with the same priority as input.
+        /// </summary>
+        public static readonly DispatcherPriority Input = new(Default - 1);
+        
+        /// <summary>
+        /// The job will be processed after other non-idle operations have completed.
+        /// </summary>
+        public static readonly DispatcherPriority Background = new(Input - 1);
+        
+        /// <summary>
+        /// The job will be processed after background operations have completed.
+        /// </summary>
+        public static readonly DispatcherPriority ContextIdle = new(Background - 1);
+        
+        
+        /// <summary>
+        /// The job will be processed when the application is idle.
+        /// </summary>
+        public static readonly DispatcherPriority ApplicationIdle = new (ContextIdle - 1);
+        
+        /// <summary>
+        /// The job will be processed when the system is idle.
+        /// </summary>
+        public static readonly DispatcherPriority SystemIdle = new(ApplicationIdle - 1);
+
         /// <summary>
         /// Minimum possible priority that's actually dispatched, default value
         /// </summary>
-        internal static readonly DispatcherPriority MinimumActiveValue = new(0);
+        internal static readonly DispatcherPriority MinimumActiveValue = new(SystemIdle);
 
+        
         /// <summary>
         /// A dispatcher priority for jobs that shouldn't be executed yet
         /// </summary>
         public static DispatcherPriority Inactive => new(MinimumActiveValue - 1);
+        
         /// <summary>
         /// Minimum valid priority
         /// </summary>
@@ -37,43 +70,10 @@ namespace Avalonia.Threading
         public static DispatcherPriority Invalid => new(MinimumActiveValue - 2);
         
         
-        
-        /// <summary>
-        /// The job will be processed when the system is idle.
-        /// </summary>
-        [Obsolete("WPF compatibility")] public static readonly DispatcherPriority SystemIdle = MinimumActiveValue;
-
-        /// <summary>
-        /// The job will be processed when the application is idle.
-        /// </summary>
-        [Obsolete("WPF compatibility")] public static readonly DispatcherPriority ApplicationIdle = new (SystemIdle + 1);
-
-        /// <summary>
-        /// The job will be processed after background operations have completed.
-        /// </summary>
-        [Obsolete("WPF compatibility")] public static readonly DispatcherPriority ContextIdle = new(ApplicationIdle + 1);
-
-        /// <summary>
-        /// The job will be processed with normal priority.
-        /// </summary>
-#pragma warning disable CS0618
-        public static readonly DispatcherPriority Normal = new(ContextIdle + 1);
-#pragma warning restore CS0618
-
-        /// <summary>
-        /// The job will be processed after other non-idle operations have completed.
-        /// </summary>
-        public static readonly DispatcherPriority Background = new(MinValue + 1);
-
-        /// <summary>
-        /// The job will be processed with the same priority as input.
-        /// </summary>
-        public static readonly DispatcherPriority Input = new(Background + 1);
-
         /// <summary>
         /// The job will be processed after layout and render but before input.
         /// </summary>
-        public static readonly DispatcherPriority Loaded = new(Input + 1);
+        public static readonly DispatcherPriority Loaded = new(Default + 1);
 
         /// <summary>
         /// The job will be processed with the same priority as render.
@@ -98,12 +98,19 @@ namespace Avalonia.Threading
         /// <summary>
         /// The job will be processed with the same priority as data binding.
         /// </summary>
-        [Obsolete("WPF compatibility")] public static readonly DispatcherPriority DataBind = MinValue;
+        [Obsolete("WPF compatibility")] public static readonly DispatcherPriority DataBind = new(Layout);
+        
+        /// <summary>
+        /// The job will be processed with normal priority.
+        /// </summary>
+#pragma warning disable CS0618
+        public static readonly DispatcherPriority Normal = new(DataBind + 1);
+#pragma warning restore CS0618
 
         /// <summary>
         /// The job will be processed before other asynchronous operations.
         /// </summary>
-        public static readonly DispatcherPriority Send = new(Layout + 1);
+        public static readonly DispatcherPriority Send = new(Normal + 1);
 
         /// <summary>
         /// Maximum possible priority


### PR DESCRIPTION
Previously our Normal priority was made lower because people were using `Dispatcher.UIThread.Post(window.Close)` and wondering why it crashes on macOS.

This PR introduces a separate `Default` priority that's lower than `Render`, so crashes won't occur unless you deliberately use higher dispatcher priority. `Default` priority is the lowest foreground priority that's processed before input but after the rendering.