### PR TITLE
Android - Fix crash when accessing clipbord on android

### DIFF
--- a/src/Android/Avalonia.Android/AndroidPlatform.cs
+++ b/src/Android/Avalonia.Android/AndroidPlatform.cs
@@ -38,7 +38,7 @@ namespace Avalonia.Android
             Options = AvaloniaLocator.Current.GetService<AndroidPlatformOptions>() ?? new AndroidPlatformOptions();
 
             AvaloniaLocator.CurrentMutable
-                .Bind<IClipboard>().ToTransient<ClipboardImpl>()
+                .Bind<IClipboard>().ToConstant(new ClipboardImpl())
                 .Bind<ICursorFactory>().ToTransient<CursorFactory>()
                 .Bind<IWindowingPlatform>().ToConstant(new WindowingPlatformStub())
                 .Bind<IKeyboardDevice>().ToSingleton<AndroidKeyboardDevice>()

--- a/src/Android/Avalonia.Android/Platform/ClipboardImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/ClipboardImpl.cs
@@ -2,32 +2,26 @@ using System;
 using System.Threading.Tasks;
 
 using Android.Content;
-using Android.Runtime;
-using Android.Views;
 
 using Avalonia.Input;
 using Avalonia.Input.Platform;
-using Avalonia.Platform;
 
 namespace Avalonia.Android.Platform
 {
     internal class ClipboardImpl : IClipboard
     {
-        private Context context = (AvaloniaLocator.Current.GetService<IWindowImpl>() as View).Context;
+        private ClipboardManager? _clipboardManager;
 
-        private ClipboardManager ClipboardManager
+        internal void SetClipboardManager(ClipboardManager? value)
         {
-            get
-            {
-                return this.context.GetSystemService(Context.ClipboardService).JavaCast<ClipboardManager>();
-            }
+            _clipboardManager = value;
         }
 
         public Task<string> GetTextAsync()
         {
-            if (ClipboardManager.HasPrimaryClip)
+            if (_clipboardManager?.HasPrimaryClip == true)
             {
-                return Task.FromResult<string>(ClipboardManager.PrimaryClip.GetItemAt(0).Text);
+                return Task.FromResult<string>(_clipboardManager.PrimaryClip.GetItemAt(0).Text);
             }
 
             return Task.FromResult<string>(null);
@@ -35,15 +29,25 @@ namespace Avalonia.Android.Platform
 
         public Task SetTextAsync(string text)
         {
+            if(_clipboardManager == null)
+            {
+                return Task.CompletedTask;
+            }
+
             ClipData clip = ClipData.NewPlainText("text", text);
-            ClipboardManager.PrimaryClip = clip;
+            _clipboardManager.PrimaryClip = clip;
 
             return Task.FromResult<object>(null);
         }
 
         public Task ClearAsync()
         {
-            ClipboardManager.PrimaryClip = null;
+            if (_clipboardManager == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            _clipboardManager.PrimaryClip = null;
 
             return Task.FromResult<object>(null);
         }

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -29,6 +29,8 @@ using Window = Android.Views.Window;
 using Android.Graphics.Drawables;
 using Android.OS;
 using Android.Text;
+using Avalonia.Input.Platform;
+using ClipboardManager = Android.Content.ClipboardManager;
 
 namespace Avalonia.Android.Platform.SkiaPlatform
 {
@@ -54,6 +56,9 @@ namespace Avalonia.Android.Platform.SkiaPlatform
             _pointerHelper = new AndroidMotionEventsHelper(this);
             _gl = new EglGlPlatformSurface(this);
             _framebuffer = new FramebufferManager(this);
+
+            (AvaloniaLocator.Current.GetRequiredService<IClipboard>() as ClipboardImpl)?
+                .SetClipboardManager(avaloniaView.Context?.GetSystemService(Context.ClipboardService).JavaCast<ClipboardManager>());
 
             RenderScaling = _view.Scaling;
 


### PR DESCRIPTION
## What does the pull request do?
Fixes a crash when the clipboard is accessed on android.


## What is the current behavior?
ClipboardImpl incorrectly tries to access a registered IWindowImpl, which doesn't exist on android.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #10722
