### PR TITLE
[WIP] Introduced BeforeClosed callback to allow the TopLevel to stop any actions that might access the native impl

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -83,6 +83,8 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         public IMouseDevice MouseDevice { get; } = new MouseDevice();
 
         public Action Closed { get; set; }
+        
+        public Action BeforeClosed { get; set; }
 
         public Action<RawInputEventArgs> Input { get; set; }
 

--- a/src/Avalonia.Controls/Embedding/Offscreen/OffscreenTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Embedding/Offscreen/OffscreenTopLevelImpl.cs
@@ -85,6 +85,7 @@ namespace Avalonia.Controls.Embedding.Offscreen
         {
         }
 
+        public Action? BeforeClosed { get; set; }
         public Action? Closed { get; set; }
         public Action? LostFocus { get; set; }
         public abstract IMouseDevice MouseDevice { get; }

--- a/src/Avalonia.Controls/Platform/ITopLevelImpl.cs
+++ b/src/Avalonia.Controls/Platform/ITopLevelImpl.cs
@@ -142,6 +142,11 @@ namespace Avalonia.Platform
         Action? Closed { get; set; }
         
         /// <summary>
+        /// Gets or sets a method called right before the underlying implementation is destroyed.
+        /// </summary>
+        Action? BeforeClosed { get; set; }
+        
+        /// <summary>
         /// Gets or sets a method called when the input focus is lost.
         /// </summary>
         Action? LostFocus { get; set; }

--- a/src/Avalonia.DesignerSupport/Remote/Stubs.cs
+++ b/src/Avalonia.DesignerSupport/Remote/Stubs.cs
@@ -35,6 +35,7 @@ namespace Avalonia.DesignerSupport.Remote
         public Action<Size, PlatformResizeReason> Resized { get; set; }
         public Action<double> ScalingChanged { get; set; }
         public Func<WindowCloseReason, bool> Closing { get; set; }
+        public Action BeforeClosed { get; set; }
         public Action Closed { get; set; }
         public Action LostFocus { get; set; }
         public IMouseDevice MouseDevice { get; } = new MouseDevice();

--- a/src/Avalonia.Headless/HeadlessWindowImpl.cs
+++ b/src/Avalonia.Headless/HeadlessWindowImpl.cs
@@ -39,6 +39,7 @@ namespace Avalonia.Headless
 
         public void Dispose()
         {
+            BeforeClosed?.Invoke();
             Closed?.Invoke();
             _lastRenderedFrame?.Dispose();
             _lastRenderedFrame = null;
@@ -77,6 +78,7 @@ namespace Avalonia.Headless
 
         }
 
+        public Action BeforeClosed { get; set; }
         public Action Closed { get; set; }
         public IMouseDevice MouseDevice { get; }
 

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -160,6 +160,7 @@ namespace Avalonia.Native
         
         public Action<Rect> Paint { get; set; }
         public Action<Size, PlatformResizeReason> Resized { get; set; }
+        public Action BeforeClosed { get; set; }
         public Action Closed { get; set; }
         public IMouseDevice MouseDevice => _mouse;
         public abstract IPopupImpl CreatePopup();
@@ -183,6 +184,7 @@ namespace Avalonia.Native
                 var n = _parent._native;
                 try
                 {
+                    _parent?.BeforeClosed?.Invoke();
                     _parent?.Closed?.Invoke();
                 }
                 finally

--- a/src/Browser/Avalonia.Browser/BrowserTopLevelImpl.cs
+++ b/src/Browser/Avalonia.Browser/BrowserTopLevelImpl.cs
@@ -242,6 +242,7 @@ namespace Avalonia.Browser
         public Action<Size, PlatformResizeReason>? Resized { get; set; }
         public Action<double>? ScalingChanged { get; set; }
         public Action<WindowTransparencyLevel>? TransparencyLevelChanged { get; set; }
+        public Action? BeforeClosed { get; set; }
         public Action? Closed { get; set; }
         public Action? LostFocus { get; set; }
         public IMouseDevice MouseDevice { get; } = new MouseDevice();

--- a/src/Linux/Avalonia.LinuxFramebuffer/FramebufferToplevelImpl.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/FramebufferToplevelImpl.cs
@@ -70,6 +70,7 @@ using Avalonia.Rendering.Composition;
 
         public Action<WindowTransparencyLevel> TransparencyLevelChanged { get; set; }
 
+        public Action BeforeClosed { get; set; }
         public Action Closed { get; set; }
         public Action LostFocus { get; set; }
 

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -85,6 +85,8 @@ namespace Avalonia.Win32
 
                 case WindowsMessage.WM_DESTROY:
                     {
+                        BeforeClosed?.Invoke();
+                        
                         if (UiaCoreTypesApi.IsNetComInteropAvailable)
                         {
                             UiaCoreProviderApi.UiaReturnRawElementProvider(_hwnd, IntPtr.Zero, IntPtr.Zero, null);
@@ -95,6 +97,17 @@ namespace Avalonia.Win32
                         {
                             Imm32InputMethod.Current.ClearLanguageAndWindow();
                         }
+                        
+                        (_gl as IDisposable)?.Dispose();
+
+                        if (_dropTarget != null)
+                        {
+                            OleContext.Current?.UnregisterDragDrop(Handle);
+                            _dropTarget.Dispose();
+                            _dropTarget = null;
+                        }
+                        
+                        _framebuffer.Dispose();
 
                         //Window doesn't exist anymore
                         _hwnd = IntPtr.Zero;

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -186,6 +186,7 @@ namespace Avalonia.Win32
 
         public Func<WindowCloseReason, bool>? Closing { get; set; }
 
+        public Action? BeforeClosed { get; set; }
         public Action? Closed { get; set; }
 
         public Action? Deactivated { get; set; }
@@ -613,15 +614,6 @@ namespace Avalonia.Win32
 
         public void Dispose()
         {
-            (_gl as IDisposable)?.Dispose();
-
-            if (_dropTarget != null)
-            {
-                OleContext.Current?.UnregisterDragDrop(Handle);
-                _dropTarget.Dispose();
-                _dropTarget = null;
-            }
-
             if (_hwnd != IntPtr.Zero)
             {
                 // Detect if we are being closed programmatically - this would mean that WM_CLOSE was not called
@@ -634,8 +626,6 @@ namespace Avalonia.Win32
                 DestroyWindow(_hwnd);
                 _hwnd = IntPtr.Zero;
             }
-
-            _framebuffer.Dispose();
         }
 
         public void Invalidate(Rect rect)

--- a/src/iOS/Avalonia.iOS/AvaloniaView.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaView.cs
@@ -149,6 +149,7 @@ namespace Avalonia.iOS
             public Action<Size, PlatformResizeReason> Resized { get; set; }
             public Action<double> ScalingChanged { get; set; }
             public Action<WindowTransparencyLevel> TransparencyLevelChanged { get; set; }
+            public Action BeforeClosed { get; set; }
             public Action Closed { get; set; }
 
             public Action LostFocus { get; set; }

--- a/tests/Avalonia.Controls.UnitTests/WindowBaseTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowBaseTests.cs
@@ -211,7 +211,7 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
-        public void Renderer_Should_Be_Disposed_When_Impl_Signals_Close()
+        public void Renderer_Should_Be_Disposed_When_Impl_Signals_BeforeClose()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
@@ -219,13 +219,13 @@ namespace Avalonia.Controls.UnitTests
                 var windowImpl = new Mock<IPopupImpl>();
                 windowImpl.Setup(x => x.DesktopScaling).Returns(1);
                 windowImpl.Setup(x => x.RenderScaling).Returns(1);
-                windowImpl.SetupProperty(x => x.Closed);
+                windowImpl.SetupProperty(x => x.BeforeClosed);
                 windowImpl.Setup(x => x.CreateRenderer(It.IsAny<IRenderRoot>())).Returns(renderer.Object);
 
                 var target = new TestWindowBase(windowImpl.Object);
 
                 target.Show();
-                windowImpl.Object.Closed();
+                windowImpl.Object.BeforeClosed();
 
                 renderer.Verify(x => x.Dispose(), Times.Once);
             }

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -383,6 +383,7 @@ namespace Avalonia.Controls.UnitTests
                 var windowImpl = new Mock<IWindowImpl>();
                 windowImpl.Setup(x => x.CreateRenderer(It.IsAny<IRenderRoot>()))
                     .Returns(() => RendererMocks.CreateRenderer().Object);
+                windowImpl.SetupProperty(x => x.BeforeClosed);
                 windowImpl.SetupProperty(x => x.Closed);
                 windowImpl.Setup(x => x.DesktopScaling).Returns(1);
                 windowImpl.Setup(x => x.RenderScaling).Returns(1);
@@ -392,6 +393,7 @@ namespace Avalonia.Controls.UnitTests
                 var target = new Window(windowImpl.Object);
                 var task = target.ShowDialog<bool>(parent);
 
+                windowImpl.Object.BeforeClosed();
                 windowImpl.Object.Closed();
                 await task;
 

--- a/tests/Avalonia.LeakTests/ControlTests.cs
+++ b/tests/Avalonia.LeakTests/ControlTests.cs
@@ -468,8 +468,13 @@ namespace Avalonia.LeakTests
                 impl.Setup(r => r.TryGetFeature(It.IsAny<Type>())).Returns(null);
                 impl.SetupGet(x => x.RenderScaling).Returns(1);
                 impl.SetupProperty(x => x.Closed);
+                impl.SetupProperty(x => x.BeforeClosed);
                 impl.Setup(x => x.CreateRenderer(It.IsAny<IRenderRoot>())).Returns(renderer.Object);
-                impl.Setup(x => x.Dispose()).Callback(() => impl.Object.Closed());
+                impl.Setup(x => x.Dispose()).Callback(() =>
+                {
+                    impl.Object.BeforeClosed();
+                    impl.Object.Closed();
+                });
 
                 AvaloniaLocator.CurrentMutable.Bind<IWindowingPlatform>()
                     .ToConstant(new MockWindowingPlatform(() => impl.Object));

--- a/tests/Avalonia.UnitTests/CompositorTestServices.cs
+++ b/tests/Avalonia.UnitTests/CompositorTestServices.cs
@@ -187,6 +187,7 @@ public class CompositorTestServices : IDisposable
         {
         }
 
+        public Action BeforeClosed { get; set; }
         public Action Closed { get; set; }
         public Action LostFocus { get; set; }
         public IMouseDevice MouseDevice { get; } = new MouseDevice();

--- a/tests/Avalonia.UnitTests/MockWindowingPlatform.cs
+++ b/tests/Avalonia.UnitTests/MockWindowingPlatform.cs
@@ -45,6 +45,7 @@ namespace Avalonia.UnitTests
 
             windowImpl.Setup(x => x.Dispose()).Callback(() =>
             {
+                windowImpl.Object.BeforeClosed?.Invoke();
                 windowImpl.Object.Closed?.Invoke();
             });
 


### PR DESCRIPTION
We could probably get away with calling `Closed` earlier, but I remember that it caused other problems a few years ago

Should fix #10057 and #9890