### PR TITLE
Bump Tmds.DBus.SourceGenerator

### DIFF
--- a/src/Avalonia.FreeDesktop/Avalonia.FreeDesktop.csproj
+++ b/src/Avalonia.FreeDesktop/Avalonia.FreeDesktop.csproj
@@ -5,20 +5,20 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <Import Project="..\..\build\TrimmingEnable.props" />
+  <Import Project="../../build/TrimmingEnable.props" />
 
   <ItemGroup>
-    <Compile Include="..\Shared\IsExternalInit.cs" Link="IsExternalInit.cs" />
+    <Compile Include="../Shared/IsExternalInit.cs" Link="IsExternalInit.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Tmds.DBus.Protocol" Version="0.14.0" />
-    <PackageReference Include="Tmds.DBus.SourceGenerator" Version="0.0.4" />
+    <PackageReference Include="Tmds.DBus.SourceGenerator" Version="0.0.5" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Avalonia.Controls\Avalonia.Controls.csproj" />
-    <ProjectReference Include="..\Avalonia.Dialogs\Avalonia.Dialogs.csproj" />
+    <ProjectReference Include="../Avalonia.Controls/Avalonia.Controls.csproj" />
+    <ProjectReference Include="../Avalonia.Dialogs/Avalonia.Dialogs.csproj" />
   </ItemGroup>
 
   <ItemGroup Label="InternalsVisibleTo">

--- a/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
+++ b/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
@@ -38,7 +38,7 @@ namespace Avalonia.FreeDesktop
             private bool _resetQueued;
             private int _nextId = 1;
 
-            public DBusMenuExporterImpl(Connection connection, IntPtr xid)
+            public DBusMenuExporterImpl(Connection connection, IntPtr xid) : this()
             {
                 Connection = connection;
                 _xid = (uint)xid.ToInt32();
@@ -47,13 +47,20 @@ namespace Avalonia.FreeDesktop
                 _ = InitializeAsync();
             }
 
-            public DBusMenuExporterImpl(Connection connection, string path)
+            public DBusMenuExporterImpl(Connection connection, string path) : this()
             {
                 Connection = connection;
                 _appMenu = false;
                 Path = path;
                 SetNativeMenu(new NativeMenu());
                 _ = InitializeAsync();
+            }
+
+            private DBusMenuExporterImpl()
+            {
+                BackingProperties.Status = string.Empty;
+                BackingProperties.TextDirection = string.Empty;
+                BackingProperties.IconThemePath = Array.Empty<string>();
             }
 
             protected override Connection Connection { get; }
@@ -202,15 +209,9 @@ namespace Avalonia.FreeDesktop
                 return id;
             }
 
-            private void OnMenuItemsChanged(object? sender, NotifyCollectionChangedEventArgs e)
-            {
-                QueueReset();
-            }
+            private void OnMenuItemsChanged(object? sender, NotifyCollectionChangedEventArgs e) => QueueReset();
 
-            private void OnItemPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
-            {
-                QueueReset();
-            }
+            private void OnItemPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e) => QueueReset();
 
             private static readonly string[] s_allProperties = {
                 "type", "label", "enabled", "visible", "shortcut", "toggle-type", "children-display", "toggle-state", "icon-data"

--- a/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
+++ b/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
@@ -220,6 +220,16 @@ namespace Avalonia.FreeDesktop
         {
             Connection = connection;
             BackingProperties.Menu = dbusMenuPath;
+            BackingProperties.Category = string.Empty;
+            BackingProperties.Status = string.Empty;
+            BackingProperties.Id = string.Empty;
+            BackingProperties.Title = string.Empty;
+            BackingProperties.IconPixmap = Array.Empty<(int, int, byte[])>();
+            BackingProperties.AttentionIconName = string.Empty;
+            BackingProperties.AttentionIconPixmap = Array.Empty<(int, int, byte[])>();
+            BackingProperties.AttentionMovieName = string.Empty;
+            BackingProperties.OverlayIconName = string.Empty;
+            BackingProperties.OverlayIconPixmap = Array.Empty<(int, int, byte[])>();
             BackingProperties.ToolTip = (string.Empty, Array.Empty<(int, int, byte[])>(), string.Empty, string.Empty);
             InvalidateAll();
         }
@@ -234,7 +244,7 @@ namespace Avalonia.FreeDesktop
 
         protected override ValueTask OnActivateAsync(int x, int y)
         {
-            Dispatcher.UIThread.Post(() => ActivationDelegate?.Invoke());
+            ActivationDelegate?.Invoke();
             return new ValueTask();
         }
 
@@ -267,7 +277,6 @@ namespace Avalonia.FreeDesktop
             BackingProperties.Category = "ApplicationStatus";
             BackingProperties.Status = text;
             BackingProperties.Title = text;
-            BackingProperties.ToolTip = (string.Empty, Array.Empty<(int, int, byte[])>(), text, string.Empty);
             InvalidateAll();
         }
     }


### PR DESCRIPTION
## What does the pull request do?
Previous versions didn't generate the org.freedesktop.DBus.Properties.Get method correctly which lead to an invalid DBus request and therefore no TrayIcon.

## What is the current behavior?
The TrayIcon doesn't show at all.

## What is the updated/expected behavior with this PR?
The TrayIcon shows correctly.

## How was the solution implemented (if it's not obvious)?
Update the source generator.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #10749
