### PR TITLE
Fix virtualization issue with SizeToContent in VirtualizingStackPanel.cs

### DIFF
--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -132,7 +132,10 @@ namespace Avalonia.Controls
         protected override Size MeasureOverride(Size availableSize)
         {
             if (!IsEffectivelyVisible)
+            {
+                InvalidateMeasure();
                 return default;
+            }
 
             _isInLayout = true;
 


### PR DESCRIPTION
## What does the pull request do?
Fixes an issue that `VirtualizingStackPanel` will not show when it becomes invisible in a SizeToContent = Height/Width window.
See more details in the issue.

## Fixed issues
Fixes #10814
