### PR TITLE
DataGrid column resize near edge fix

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
@@ -440,13 +440,10 @@ namespace Avalonia.Controls
             }
 
             Debug.Assert(OwningGrid.Parent is InputElement);
-
-            double distanceFromLeft = mousePosition.X;
-            double distanceFromRight = Bounds.Width - distanceFromLeft;
-
+            
             OnMouseMove_Resize(ref handled, mousePositionHeaders);
 
-            OnMouseMove_Reorder(ref handled, mousePosition, mousePositionHeaders, distanceFromLeft, distanceFromRight);
+            OnMouseMove_Reorder(ref handled, mousePosition, mousePositionHeaders);
 
             SetDragCursor(mousePosition);
         }
@@ -716,7 +713,7 @@ namespace Avalonia.Controls
         }
 
         //TODO DragEvents
-        private void OnMouseMove_Reorder(ref bool handled, Point mousePosition, Point mousePositionHeaders, double distanceFromLeft, double distanceFromRight)
+        private void OnMouseMove_Reorder(ref bool handled, Point mousePosition, Point mousePositionHeaders)
         {
             if (handled)
             {

--- a/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
@@ -724,7 +724,7 @@ namespace Avalonia.Controls
             }
 
             //handle entry into reorder mode
-            if (_dragMode == DragMode.MouseDown && _dragColumn == null && _lastMousePositionHeaders != null && (distanceFromRight > DATAGRIDCOLUMNHEADER_resizeRegionWidth && distanceFromLeft > DATAGRIDCOLUMNHEADER_resizeRegionWidth))
+            if (_dragMode == DragMode.MouseDown && _dragColumn == null && _lastMousePositionHeaders != null)
             {
                 var distanceFromInitial = (Vector)(mousePositionHeaders - _lastMousePositionHeaders);
                 if (distanceFromInitial.Length > DATAGRIDCOLUMNHEADER_columnsDragTreshold)


### PR DESCRIPTION
## What does the pull request do?
Fix header reorder drag support when dragging near the edge.

## What is the current behavior?
If you start dragging near the edge of the header cell the drag is not recognized.
![image](https://user-images.githubusercontent.com/50887170/228464580-e99fcf42-40d8-4664-a4b4-6181510de7df.png)
1. click 5-10 px from the edge
2. drag to the left
3. drag is not recognized

## What is the updated/expected behavior with this PR?
We don't need to check the edge of the cell on **mouse move**. We did that already with the **mouse down**.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
none

## Obsoletions / Deprecations
none

## Fixed issues

If accepted, please backport into 0.10.x as well. Thanks!