### PR TITLE
DEvTools: bind read-only properties one-way.

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/Views/PropertyValueEditorView.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/PropertyValueEditorView.cs
@@ -64,11 +64,12 @@ namespace Avalonia.Diagnostics.Views
                 where TControl : Control, new()
             {
                 var control = new TControl();
+                var bindingMode = Property.IsReadonly ? BindingMode.OneWay : BindingMode.TwoWay;
 
                 init?.Invoke(control);
 
                 control.Bind(valueProperty,
-                    new Binding(nameof(Property.Value), BindingMode.TwoWay)
+                    new Binding(nameof(Property.Value), bindingMode)
                     {
                         Source = Property,
                         Converter = converter ?? new ValueConverter(),


### PR DESCRIPTION
## What does the pull request do?

As described in #10680, DevTools was throwing exceptions when read-only properties such as `IsPointerOver` changed. These exceptions were caught so not a user-facing problem, but better not to throw them.

Changes the property editor to only bind one-way on read-only properties.

## Fixed issues

Fixes #10680