### PR TITLE
Make data templates work again with MenuItem.

### DIFF
--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -460,13 +460,19 @@ namespace Avalonia.Controls
                     ic.ItemContainerTheme = ict;
             }
 
-            // This condition is separate because HeaderedItemsControl needs to also run the
-            // ItemsControl preparation.
+            // These conditions are separate because HeaderedItemsControl and
+            // HeaderedSelectingItemsControl also need to run the ItemsControl preparation.
             if (container is HeaderedItemsControl hic)
             {
                 hic.Header = item;
                 hic.HeaderTemplate = itemTemplate;
-                hic.PrepareItemContainer();
+                hic.PrepareItemContainer(this);
+            }
+            else if (container is HeaderedSelectingItemsControl hsic)
+            {
+                hsic.Header = item;
+                hsic.HeaderTemplate = itemTemplate;
+                hsic.PrepareItemContainer(this);
             }
         }
 

--- a/src/Avalonia.Controls/Primitives/HeaderedItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/HeaderedItemsControl.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Controls.Primitives
     public class HeaderedItemsControl : ItemsControl, IContentPresenterHost
     {
         private IDisposable? _itemsBinding;
-        private bool _prepareItemContainerOnAttach;
+        private ItemsControl? _prepareItemContainerOnAttach;
 
         /// <summary>
         /// Defines the <see cref="Header"/> property.
@@ -69,10 +69,10 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnAttachedToLogicalTree(e);
 
-            if (_prepareItemContainerOnAttach)
+            if (_prepareItemContainerOnAttach is not null)
             {
-                PrepareItemContainer();
-                _prepareItemContainerOnAttach = false;
+                PrepareItemContainer(_prepareItemContainerOnAttach);
+                _prepareItemContainerOnAttach = null;
             }
         }
 
@@ -97,7 +97,7 @@ namespace Avalonia.Controls.Primitives
             return false;
         }
 
-        internal void PrepareItemContainer()
+        internal void PrepareItemContainer(ItemsControl parent)
         {
             _itemsBinding?.Dispose();
             _itemsBinding = null;
@@ -106,18 +106,18 @@ namespace Avalonia.Controls.Primitives
 
             if (item is null)
             {
-                _prepareItemContainerOnAttach = false;
+                _prepareItemContainerOnAttach = null;
                 return;
             }
 
-            var headerTemplate = HeaderTemplate;
+            var headerTemplate = HeaderTemplate ?? parent.ItemTemplate;
 
             if (headerTemplate is null)
             {
                 if (((ILogical)this).IsAttachedToLogicalTree)
                     headerTemplate = this.FindDataTemplate(item);
                 else
-                    _prepareItemContainerOnAttach = true;
+                    _prepareItemContainerOnAttach = parent;
             }
 
             if (headerTemplate is ITreeDataTemplate treeTemplate &&

--- a/src/Avalonia.Controls/Primitives/HeaderedSelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/HeaderedSelectingItemsControl.cs
@@ -1,5 +1,8 @@
+using System;
 using Avalonia.Collections;
 using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
 using Avalonia.LogicalTree;
 
 namespace Avalonia.Controls.Primitives
@@ -9,11 +12,20 @@ namespace Avalonia.Controls.Primitives
     /// </summary>
     public class HeaderedSelectingItemsControl : SelectingItemsControl, IContentPresenterHost
     {
+        private IDisposable? _itemsBinding;
+        private ItemsControl? _prepareItemContainerOnAttach;
+
         /// <summary>
         /// Defines the <see cref="Header"/> property.
         /// </summary>
         public static readonly StyledProperty<object?> HeaderProperty =
             HeaderedContentControl.HeaderProperty.AddOwner<HeaderedSelectingItemsControl>();
+
+        /// <summary>
+        /// Defines the <see cref="HeaderTemplate"/> property.
+        /// </summary>
+        public static readonly StyledProperty<IDataTemplate?> HeaderTemplateProperty =
+            HeaderedItemsControl.HeaderTemplateProperty.AddOwner<HeaderedSelectingItemsControl>();
 
         /// <summary>
         /// Initializes static members of the <see cref="ContentControl"/> class.
@@ -30,6 +42,15 @@ namespace Avalonia.Controls.Primitives
         {
             get { return GetValue(HeaderProperty); }
             set { SetValue(HeaderProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the data template used to display the header content of the control.
+        /// </summary>
+        public IDataTemplate? HeaderTemplate
+        {
+            get => GetValue(HeaderTemplateProperty);
+            set => SetValue(HeaderTemplateProperty, value);
         }
 
         /// <summary>
@@ -50,6 +71,17 @@ namespace Avalonia.Controls.Primitives
             return RegisterContentPresenter(presenter);
         }
 
+        protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToLogicalTree(e);
+
+            if (_prepareItemContainerOnAttach is not null)
+            {
+                PrepareItemContainer(_prepareItemContainerOnAttach);
+                _prepareItemContainerOnAttach = null;
+            }
+        }
+
         /// <summary>
         /// Called when an <see cref="IContentPresenter"/> is registered with the control.
         /// </summary>
@@ -63,6 +95,37 @@ namespace Avalonia.Controls.Primitives
             }
 
             return false;
+        }
+
+        internal void PrepareItemContainer(ItemsControl parent)
+        {
+            _itemsBinding?.Dispose();
+            _itemsBinding = null;
+
+            var item = Header;
+
+            if (item is null)
+            {
+                _prepareItemContainerOnAttach = null;
+                return;
+            }
+
+            var headerTemplate = HeaderTemplate ?? parent.ItemTemplate;
+
+            if (headerTemplate is null)
+            {
+                if (((ILogical)this).IsAttachedToLogicalTree)
+                    headerTemplate = this.FindDataTemplate(item);
+                else
+                    _prepareItemContainerOnAttach = parent;
+            }
+
+            if (headerTemplate is ITreeDataTemplate treeTemplate &&
+                treeTemplate.Match(item) &&
+                treeTemplate.ItemsSelector(item) is { } itemsBinding)
+            {
+                _itemsBinding = BindingOperations.Apply(this, ItemsSourceProperty, itemsBinding, null);
+            }
         }
 
         private void HeaderChanged(AvaloniaPropertyChangedEventArgs e)

--- a/src/Avalonia.Themes.Fluent/Controls/Menu.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/Menu.xaml
@@ -28,6 +28,7 @@
           <Panel>
             <ContentPresenter Name="PART_HeaderPresenter"
                               Content="{TemplateBinding Header}"
+                              ContentTemplate="{TemplateBinding HeaderTemplate}"
                               VerticalAlignment="Center"
                               HorizontalAlignment="Stretch"
                               RecognizesAccessKey="True"

--- a/src/Avalonia.Themes.Fluent/Controls/MenuItem.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/MenuItem.xaml
@@ -92,7 +92,7 @@
 
               <ContentPresenter Name="PART_HeaderPresenter"
                                 Content="{TemplateBinding Header}"
-                                ContentTemplate="{TemplateBinding ItemTemplate}"
+                                ContentTemplate="{TemplateBinding HeaderTemplate}"
                                 VerticalAlignment="Center"
                                 HorizontalAlignment="Stretch"
                                 RecognizesAccessKey="True"

--- a/src/Avalonia.Themes.Simple/Controls/Menu.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/Menu.xaml
@@ -17,7 +17,8 @@
           <Panel>
             <ContentPresenter Name="PART_HeaderPresenter"
                               Margin="{TemplateBinding Padding}"
-                              Content="{TemplateBinding Header}">
+                              Content="{TemplateBinding Header}"
+                              ContentTemplate="{TemplateBinding HeaderTemplate}">
               <ContentPresenter.DataTemplates>
                 <DataTemplate DataType="sys:String">
                   <AccessText Text="{Binding}" />

--- a/src/Avalonia.Themes.Simple/Controls/MenuItem.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/MenuItem.xaml
@@ -43,7 +43,7 @@
                               Margin="{TemplateBinding Padding}"
                               VerticalAlignment="Center"
                               Content="{TemplateBinding Header}"
-                              ContentTemplate="{TemplateBinding ItemTemplate}">
+                              ContentTemplate="{TemplateBinding HeaderTemplate}">
               <ContentPresenter.DataTemplates>
                 <DataTemplate DataType="sys:String">
                   <AccessText Text="{Binding}" />

--- a/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
@@ -381,6 +381,7 @@ namespace Avalonia.Controls.UnitTests
                 var menuItem = Assert.IsType<MenuItem>(panel.Children[i]);
 
                 Assert.Equal(items[i], menuItem.Header);
+                Assert.Same(itemTemplate, menuItem.HeaderTemplate);
 
                 var headerPresenter = Assert.IsType<ContentPresenter>(menuItem.HeaderPresenter);
                 Assert.Same(itemTemplate, headerPresenter.ContentTemplate);


### PR DESCRIPTION
## What does the pull request do?

`Menu`s stopped working correctly with data templates after #9677, a few fixes were needed to make them work again:

- `MenuItem` is a `HeaderedSelectingItemsControl` not a `HeaderedItemsControl` so  need to separate logic for that case when preparing items
- Added `HeaderTemplate` to `HeaderedSelectingItemsControl `
- Tweaked logic for selecting header templates: parent's `ItemTemplate` should be used if set (cross-checked with WPF)
- Update menu templates to bind to menu item's `HeaderTemplate`

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/10626
Fixes https://github.com/AvaloniaUI/Avalonia/issues/10718