### PR TITLE
[Text]Fix GetTextBounds

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
@@ -701,7 +701,14 @@ namespace Avalonia.Media.TextFormatting
                     if (directionalWidth == 0)
                     {
                         //In case a run only contains a linebreak we don't want to skip it.
-                        if (currentRun is ShapedTextRun shaped && currentRun.Length - shaped.GlyphRun.Metrics.NewLineLength > 0)
+                        if (currentRun is ShapedTextRun shaped)
+                        {
+                            if(currentRun.Length - shaped.GlyphRun.Metrics.NewLineLength > 0)
+                            {
+                                continue;
+                            }
+                        }
+                        else
                         {
                             continue;
                         }
@@ -840,7 +847,14 @@ namespace Avalonia.Media.TextFormatting
                     if (directionalWidth == 0)
                     {
                         //In case a run only contains a linebreak we don't want to skip it.
-                        if (currentRun is ShapedTextRun shaped && currentRun.Length - shaped.GlyphRun.Metrics.NewLineLength > 0)
+                        if (currentRun is ShapedTextRun shaped)
+                        {
+                            if (currentRun.Length - shaped.GlyphRun.Metrics.NewLineLength > 0)
+                            {
+                                continue;
+                            }
+                        }
+                        else
                         {
                             continue;
                         }

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextLineTests.cs
@@ -994,6 +994,33 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
             }
         }
 
+        [Fact]
+        public void Should_GetTextBounds_With_EndOfParagraph_RightToLeft()
+        {
+            var text = "لوحة المفاتيح العربية";
+
+            using (Start())
+            {
+                var defaultProperties = new GenericTextRunProperties(Typeface.Default);
+                var textSource = new SingleBufferTextSource(text, defaultProperties, true);
+
+                var formatter = new TextFormatterImpl();
+
+                var textLine =
+                    formatter.FormatLine(textSource, 0, double.PositiveInfinity,
+                        new GenericTextParagraphProperties(FlowDirection.LeftToRight, TextAlignment.Left,
+                        true, true, defaultProperties, TextWrapping.NoWrap, 0, 0, 0));
+
+                var textBounds = textLine.GetTextBounds(0, 1);
+
+                Assert.Equal(1, textBounds.Count);
+
+                var firstBounds = textBounds.First();
+
+                Assert.True(firstBounds.TextRunBounds.Count > 0);
+            }
+        }
+
         private class FixedRunsTextSource : ITextSource
         {
             private readonly IReadOnlyList<TextRun> _textRuns;


### PR DESCRIPTION
Fix GetTextBounds for combinations of EndOfParargrap and embedded right to left text

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
