### PR TITLE
Fix inherited property change notifications.

### DIFF
--- a/src/Avalonia.Base/PropertyStore/EffectiveValue`1.cs
+++ b/src/Avalonia.Base/PropertyStore/EffectiveValue`1.cs
@@ -140,24 +140,24 @@ namespace Avalonia.PropertyStore
 
             var p = (StyledProperty<T>)property;
             BindingPriority priority;
-            T oldValue;
+            T newValue;
 
             if (property.Inherits && owner.TryGetInheritedValue(property, out var i))
             {
-                oldValue = ((EffectiveValue<T>)i).Value;
+                newValue = ((EffectiveValue<T>)i).Value;
                 priority = BindingPriority.Inherited;
             }
             else
             {
-                oldValue = _metadata.DefaultValue;
+                newValue = _metadata.DefaultValue;
                 priority = BindingPriority.Unset;
             }
 
-            if (!EqualityComparer<T>.Default.Equals(oldValue, Value))
+            if (!EqualityComparer<T>.Default.Equals(newValue, Value))
             {
-                owner.Owner.RaisePropertyChanged(p, Value, oldValue, priority, true);
+                owner.Owner.RaisePropertyChanged(p, Value, newValue, priority, true);
                 if (property.Inherits)
-                    owner.OnInheritedEffectiveValueDisposed(p, Value);
+                    owner.OnInheritedEffectiveValueDisposed(p, Value, newValue);
             }
 
             if (ValueEntry?.GetDataValidationState(out _, out _) ??

--- a/src/Avalonia.Base/PropertyStore/ValueStore.cs
+++ b/src/Avalonia.Base/PropertyStore/ValueStore.cs
@@ -419,7 +419,9 @@ namespace Avalonia.PropertyStore
                 ReevaluateEffectiveValue(property, current);
             }
             else
+            {
                 ReevaluateEffectiveValues();
+            }
         }
 
         /// <summary>
@@ -481,7 +483,8 @@ namespace Avalonia.PropertyStore
         /// </summary>
         /// <param name="property">The property whose value changed.</param>
         /// <param name="oldValue">The old value of the property.</param>
-        public void OnInheritedEffectiveValueDisposed<T>(StyledProperty<T> property, T oldValue)
+        /// <param name="newValue">The new value of the property.</param>
+        public void OnInheritedEffectiveValueDisposed<T>(StyledProperty<T> property, T oldValue, T newValue)
         {
             Debug.Assert(property.Inherits);
 
@@ -489,12 +492,11 @@ namespace Avalonia.PropertyStore
 
             if (children is not null)
             {
-                var defaultValue = property.GetDefaultValue(Owner.GetType());
                 var count = children.Count;
 
                 for (var i = 0; i < count; ++i)
                 {
-                    children[i].GetValueStore().OnAncestorInheritedValueChanged(property, oldValue, defaultValue);
+                    children[i].GetValueStore().OnAncestorInheritedValueChanged(property, oldValue, newValue);
                 }
             }
         }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Inheritance.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Inheritance.cs
@@ -1,5 +1,10 @@
 using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
 using Avalonia.Data;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Base.UnitTests
@@ -86,6 +91,31 @@ namespace Avalonia.Base.UnitTests
             };
 
             child.ClearValue(Class1.BazProperty);
+
+            Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void ClearValue_On_Parent_Raises_PropertyChanged_On_Child_With_Inherited_Grandparent_Value()
+        {
+            var grandparent = new Class1();
+            var parent = new Class2 { Parent = grandparent };
+            var child = new Class2 { Parent = parent };
+            var raised = 0;
+
+            grandparent.SetValue(Class1.BazProperty, "grandparent");
+            parent.SetValue(Class1.BazProperty, "parent");
+
+            child.PropertyChanged += (s, e) =>
+            {
+                Assert.Same(child, e.Sender);
+                Assert.Equal("parent", e.OldValue);
+                Assert.Equal("grandparent", e.NewValue);
+                Assert.Equal(BindingPriority.Inherited, e.Priority);
+                ++raised;
+            };
+
+            parent.ClearValue(Class1.BazProperty);
 
             Assert.Equal(1, raised);
         }


### PR DESCRIPTION
## What does the pull request do?

If an inheritable value was cleared on a parent control, but was also set on a grandparent control then the wrong `newValue` would be passed to any children when raising `PropertyChanged`.

Added a unit test and fixed this:

- `oldValue` was misnamed in `EffectiveValue<T>.DisposeAndRaiseUnset(...)` - it's actually the new value there
- We calculated the new value and then didn't pass it to children for their property changed events: they were using the default value which may be wrong if the value is set further up the tree

Found by @danipen with a repro here: https://github.com/danipen/ThemeIssues and video explanation:

https://user-images.githubusercontent.com/1775141/228909016-e99287bd-2e53-4f31-90b3-b0e97620eb18.mp4

Thanks @danipen!