### PR TITLE
Stop GlyphRunTests leaking IPlatformRenderInterface.

### DIFF
--- a/tests/Avalonia.Base.UnitTests/Media/GlyphRunTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/GlyphRunTests.cs
@@ -1,22 +1,13 @@
 ﻿using System;
-using System.Linq;
 using Avalonia.Media;
 using Avalonia.Media.TextFormatting;
-using Avalonia.Platform;
 using Avalonia.UnitTests;
-using Avalonia.Utilities;
 using Xunit;
 
 namespace Avalonia.Base.UnitTests.Media
 {
     public class GlyphRunTests : TestWithServicesBase
     {
-        public GlyphRunTests()
-        {
-            AvaloniaLocator.CurrentMutable
-                .Bind<IPlatformRenderInterface>().ToSingleton<MockPlatformRenderInterface>();
-        }
-
         [InlineData(new double[] { 30, 0, 0 }, new int[] { 0, 0, 0 }, 0, 0, 0)]
         [InlineData(new double[] { 30, 0, 0 }, new int[] { 0, 0, 0 }, 0, 3, 30)]
         [InlineData(new double[] { 10, 10, 10 }, new int[] { 0, 1, 2 }, 1, 0, 10)]
@@ -25,7 +16,7 @@ namespace Avalonia.Base.UnitTests.Media
         [Theory]
         public void Should_Get_Distance_From_CharacterHit(double[] advances, int[] clusters, int start, int trailingLength, double expectedDistance)
         {
-            using(UnitTestApplication.Start(TestServices.StyledWindow))
+            using (Start())
             using (var glyphRun = CreateGlyphRun(advances, clusters))
             {
                 var characterHit = new CharacterHit(start, trailingLength);
@@ -44,7 +35,7 @@ namespace Avalonia.Base.UnitTests.Media
         public void Should_Get_CharacterHit_FromDistance(double[] advances, int[] clusters, double distance, int start,
             int trailingLengthExpected, bool isInsideExpected)
         {
-            using(UnitTestApplication.Start(TestServices.StyledWindow))
+            using (Start())
             using (var glyphRun = CreateGlyphRun(advances, clusters))
             {
                 var textBounds = glyphRun.GetCharacterHitFromDistance(distance, out var isInside);
@@ -189,6 +180,12 @@ namespace Avalonia.Base.UnitTests.Media
             }
 
             return new GlyphRun(new MockGlyphTypeface(), 10, new string('a', count).AsMemory(), glyphInfos, biDiLevel: bidiLevel);
+        }
+
+        private static IDisposable Start()
+        {
+            return UnitTestApplication.Start(TestServices.StyledWindow.With(
+                renderInterface: new MockPlatformRenderInterface()));
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/MaskedTextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/MaskedTextBoxTests.cs
@@ -109,7 +109,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void CaretIndex_Can_Moved_To_Position_After_The_End_Of_Text_With_Arrow_Key()
         {
-            using (Start(TestServices.StyledWindow))
+            using (Start())
             {
                 var target = new MaskedTextBox
                 {
@@ -184,7 +184,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Control_Backspace_Should_Remove_The_Word_Before_The_Caret_If_There_Is_No_Selection()
         {
-            using (Start(TestServices.StyledWindow))
+            using (Start())
             {
                 MaskedTextBox textBox = new MaskedTextBox
                 {
@@ -226,7 +226,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Control_Delete_Should_Remove_The_Word_After_The_Caret_If_There_Is_No_Selection()
         {
-            using (Start(TestServices.StyledWindow))
+            using (Start())
             {
                 var textBox = new MaskedTextBox
                 {
@@ -812,7 +812,7 @@ namespace Avalonia.Controls.UnitTests
             bool fromClipboard,
             string expected)
         {
-            using (Start(TestServices.StyledWindow))
+            using (Start())
             {
                 var target = new MaskedTextBox
                 {
@@ -898,6 +898,7 @@ namespace Avalonia.Controls.UnitTests
             standardCursorFactory: Mock.Of<ICursorFactory>());
 
         private static TestServices Services => TestServices.MockThreadingInterface.With(
+            renderInterface: new MockPlatformRenderInterface(),
             standardCursorFactory: Mock.Of<ICursorFactory>(),     
             textShaperImpl: new MockTextShaperImpl(), 
             fontManagerImpl: new MockFontManagerImpl());


### PR DESCRIPTION
## What does the pull request do?

`GlyphRunTests` was leaking an `IPlatformRenderInterface` registration, causing flaky tests - in particular `MaskedTextBoxTests` need a registered `IPlatformRenderInterface` and were only passing because `GlyphRunTests` was leaking one.
