### PR TITLE
Don't layout invisible controls

### DIFF
--- a/src/Avalonia.Base/Layout/LayoutManager.cs
+++ b/src/Avalonia.Base/Layout/LayoutManager.cs
@@ -269,21 +269,25 @@ namespace Avalonia.Layout
             }
         }
 
-        private void Measure(Layoutable control)
+        private bool Measure(Layoutable control)
         {
+            if (!control.IsVisible || !control.IsAttachedToVisualTree)
+                return false;
+
             // Controls closest to the visual root need to be arranged first. We don't try to store
             // ordered invalidation lists, instead we traverse the tree upwards, measuring the
             // controls closest to the root first. This has been shown by benchmarks to be the
             // fastest and most memory-efficient algorithm.
             if (control.VisualParent is Layoutable parent)
             {
-                Measure(parent);
+                if (!Measure(parent))
+                    return false;
             }
 
             // If the control being measured has IsMeasureValid == true here then its measure was
             // handed by an ancestor and can be ignored. The measure may have also caused the
             // control to be removed.
-            if (!control.IsMeasureValid && control.IsAttachedToVisualTree)
+            if (!control.IsMeasureValid)
             {
                 if (control is ILayoutRoot root)
                 {
@@ -294,16 +298,22 @@ namespace Avalonia.Layout
                     control.Measure(control.PreviousMeasure.Value);
                 }
             }
+
+            return true;
         }
 
-        private void Arrange(Layoutable control)
+        private bool Arrange(Layoutable control)
         {
+            if (!control.IsVisible || !control.IsAttachedToVisualTree)
+                return false;
+
             if (control.VisualParent is Layoutable parent)
             {
-                Arrange(parent);
+                if (!Arrange(parent))
+                    return false;
             }
 
-            if (!control.IsArrangeValid && control.IsAttachedToVisualTree)
+            if (control.IsMeasureValid && !control.IsArrangeValid)
             {
                 if (control is IEmbeddedLayoutRoot embeddedRoot)
                     control.Arrange(new Rect(embeddedRoot.AllocatedSize));
@@ -316,6 +326,8 @@ namespace Avalonia.Layout
                     control.Arrange(control.PreviousArrange.Value);
                 }
             }
+
+            return true;
         }
 
         private void QueueLayoutPass()

--- a/tests/Avalonia.Base.UnitTests/Layout/LayoutManagerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Layout/LayoutManagerTests.cs
@@ -42,6 +42,24 @@ namespace Avalonia.Base.UnitTests.Layout
         }
 
         [Fact]
+        public void Doesnt_Measure_And_Arrange_InvalidateMeasured_Control_When_Ancestor_Is_Not_Visible()
+        {
+            var control = new LayoutTestControl();
+            var parent = new Decorator { Child = control };
+            var root = new LayoutTestRoot { Child = parent };
+
+            root.LayoutManager.ExecuteInitialLayoutPass();
+            control.Measured = control.Arranged = false;
+
+            parent.IsVisible = false;
+            control.InvalidateMeasure();
+            root.LayoutManager.ExecuteLayoutPass();
+
+            Assert.False(control.Measured);
+            Assert.False(control.Arranged);
+        }
+
+        [Fact]
         public void Arranges_InvalidateArranged_Control()
         {
             var control = new LayoutTestControl();

--- a/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
@@ -334,6 +334,7 @@ namespace Avalonia.Controls.UnitTests
                 };
 
                 var window = new Window { Content = menu };
+                window.Show();
                 window.LayoutManager.ExecuteInitialLayoutPass();
 
                 topLevelMenu.IsSubMenuOpen = true;
@@ -371,6 +372,7 @@ namespace Avalonia.Controls.UnitTests
             };
 
             var window = new Window { Content = menu };
+            window.Show();
             window.LayoutManager.ExecuteInitialLayoutPass();
 
             var panel = Assert.IsType<StackPanel>(menu.Presenter.Panel);

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -1116,6 +1116,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
         private static Window PreparedWindow(object content = null)
         {
             var w = new Window { Content = content };
+            w.Show();
             w.ApplyStyling();
             w.ApplyTemplate();
             return w;

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ControlThemeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ControlThemeTests.cs
@@ -27,6 +27,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
                 var button = Assert.IsType<TestTemplatedControl>(window.Content);
 
+                window.Show();
                 window.LayoutManager.ExecuteInitialLayoutPass();
 
                 Assert.NotNull(button.Template);
@@ -63,6 +64,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
                 var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
                 var button = Assert.IsType<TestTemplatedControl>(window.Content);
 
+                window.Show();
                 window.LayoutManager.ExecuteInitialLayoutPass();
 
                 Assert.NotNull(button.Template);


### PR DESCRIPTION
## What does the pull request do?

When investigating #10814 and its potential fix #10828 I noticed that our layout manager was calling measure/arrange on controls which are effectively invisible[^1]. Modified `LayoutManager` to exit a measure/arrange pass early if an ancestor is invisible. Turns out that fixing this bug also fixes #10814 and #10815 too.

## Fixed issues

Fixes #10814
Fixes #10815

[^1]: There is a [check](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Base/Layout/Layoutable.cs#L517) in `MeasureCore` that checks the visibility of the control itself but it doesn't check the effective visibility as this would require checking ancestors