### PR TITLE
Enable compiled bindings by default

### DIFF
--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -4,7 +4,7 @@
     <_AvaloniaUseExternalMSBuild Condition="'$(_AvaloniaForceInternalMSBuild)' == 'true'">false</_AvaloniaUseExternalMSBuild>
     <AvaloniaXamlReportImportance Condition="'$(AvaloniaXamlReportImportance)' == ''">low</AvaloniaXamlReportImportance>
     <_AvaloniaSkipXamlCompilation Condition="'$(_AvaloniaSkipXamlCompilation)' == ''">false</_AvaloniaSkipXamlCompilation>
-    <AvaloniaUseCompiledBindingsByDefault Condition="'$(AvaloniaUseCompiledBindingsByDefault)' == ''">false</AvaloniaUseCompiledBindingsByDefault>
+    <AvaloniaUseCompiledBindingsByDefault Condition="'$(AvaloniaUseCompiledBindingsByDefault)' == ''">true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 
   <!-- Unfortunately we have to update default items in .targets since custom nuget props are improted before Microsoft.NET.Sdk.DefaultItems.props -->


### PR DESCRIPTION
## What does the pull request do?
Enable compiled bindings by default.

It's really easy to forget to enable compiled bindings. 
So we can just enforce it by default, while users can still opt-out compiled bindings by using `/p:AvaloniaUseCompiledBindingsByDefault=false`.
This can contribute to help the entire community build a trimming-compatible ecosystem. 

## What is the current behavior?
Compiled bindings are off by default.

## What is the updated/expected behavior with this PR?
Enable it by default.

## Breaking changes
Now compiled bindings are enabled by default.
