### PR TITLE
Fix nullability of List<FileDialogFilter>

### DIFF
--- a/src/Avalonia.Controls/SystemDialog.cs
+++ b/src/Avalonia.Controls/SystemDialog.cs
@@ -18,7 +18,7 @@ namespace Avalonia.Controls
         /// Gets or sets a collection of filters which determine the types of files displayed in an
         /// <see cref="OpenFileDialog"/> or an <see cref="SaveFileDialog"/>.
         /// </summary>
-        public List<FileDialogFilter>? Filters { get; set; } = new List<FileDialogFilter>();
+        public List<FileDialogFilter> Filters { get; set; } = new List<FileDialogFilter>();
 
         /// <summary>
         /// Gets or sets initial file name that is displayed when the dialog is opened.


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the compiler emitting a `CS8670` warning when using a collection initializer with the `Filters` property.


## What is the current behavior?
```csharp
new OpenFileDialog
{
	Filters =
	{
		new FileDialogFilter
		{
		}
	}!
}
```
Produces a CS8670 warning, which does not make sense, since the property is automatically initialized with an empty list.

## What is the updated/expected behavior with this PR?
No warning is emitted by the compiler.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
