### PR TITLE
Move WithInterFont to the global Avalonia namespace

### DIFF
--- a/src/Avalonia.Fonts.Inter/AppBuilderExtension.cs
+++ b/src/Avalonia.Fonts.Inter/AppBuilderExtension.cs
@@ -1,4 +1,6 @@
-﻿namespace Avalonia.Fonts.Inter
+using Avalonia.Fonts.Inter;
+
+namespace Avalonia
 {
     public static class AppBuilderExtension
     {


### PR DESCRIPTION
To keep it in line with other AppBuilder extensions, keeping Program.cs file simpler
