### PR TITLE
[stable] Fix popup pointer position with touch

### DIFF
--- a/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
@@ -45,6 +45,7 @@ Copyright © 2019 Nikita Tsukanov
 */
 
 using System;
+using Avalonia.Input;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.Primitives.PopupPositioning
@@ -446,13 +447,16 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             PopupAnchor anchor, PopupGravity gravity,
             PopupPositionerConstraintAdjustment constraintAdjustment, Rect? rect)
         {
-            // We need a better way for tracking the last pointer position
-            var pointer = topLevel.PointToClient(topLevel.PlatformImpl.MouseDevice.Position);
-            
+           
             positionerParameters.Offset = offset;
             positionerParameters.ConstraintAdjustment = constraintAdjustment;
             if (placement == PlacementMode.Pointer)
             {
+                // We need a better way for tracking the last pointer position
+                var pointer = topLevel.PointToClient(
+                    (topLevel as ILastPointerPosition)?.LastPointerPosition ??
+                    topLevel.PlatformImpl.MouseDevice.Position);
+
                 positionerParameters.AnchorRectangle = new Rect(pointer, new Size(1, 1));
                 positionerParameters.Anchor = PopupAnchor.TopLeft;
                 positionerParameters.Gravity = PopupGravity.BottomRight;

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -36,7 +36,8 @@ namespace Avalonia.Controls
         IStyleHost,
         ILogicalRoot,
         ITextInputMethodRoot,
-        IWeakEventSubscriber<ResourcesChangedEventArgs>
+        IWeakEventSubscriber<ResourcesChangedEventArgs>,
+        ILastPointerPosition
     {
         /// <summary>
         /// Defines the <see cref="ClientSize"/> property.
@@ -92,6 +93,7 @@ namespace Avalonia.Controls
         private WindowTransparencyLevel _actualTransparencyLevel;
         private ILayoutManager _layoutManager;
         private Border _transparencyFallbackBorder;
+        private PixelPoint? _lastPointerPosition;
 
         /// <summary>
         /// Initializes static members of the <see cref="TopLevel"/> class.
@@ -315,6 +317,8 @@ namespace Avalonia.Controls
 
         IRenderTarget IRenderRoot.CreateRenderTarget() => CreateRenderTarget();
 
+        PixelPoint? ILastPointerPosition.LastPointerPosition => _lastPointerPosition;
+
         /// <inheritdoc/>
         protected virtual IRenderTarget CreateRenderTarget()
         {
@@ -340,7 +344,9 @@ namespace Avalonia.Controls
         {
             return PlatformImpl?.PointToScreen(p) ?? default;
         }
-        
+
+        void ILastPointerPosition.SetLastPointerPosition(PixelPoint point) => _lastPointerPosition = point;
+
         /// <summary>
         /// Creates the layout manager for this <see cref="TopLevel" />.
         /// </summary>

--- a/src/Avalonia.Input/ILastPointerPosition.cs
+++ b/src/Avalonia.Input/ILastPointerPosition.cs
@@ -1,0 +1,8 @@
+﻿namespace Avalonia.Input
+{
+    public interface ILastPointerPosition
+    {
+        PixelPoint? LastPointerPosition { get; }
+        void SetLastPointerPosition(PixelPoint point);
+    }
+}

--- a/src/Avalonia.Input/MouseDevice.cs
+++ b/src/Avalonia.Input/MouseDevice.cs
@@ -150,6 +150,8 @@ namespace Avalonia.Input
             if (e.Type == RawPointerEventType.NonClientLeftButtonDown) return;
 
             _position = e.Root.PointToScreen(e.Position);
+            (e.Root as ILastPointerPosition)?.SetLastPointerPosition(_position.Value);
+
             var props = CreateProperties(e);
             var keyModifiers = KeyModifiersUtils.ConvertToKey(e.InputModifiers);
             switch (e.Type)

--- a/src/Avalonia.Input/TouchDevice.cs
+++ b/src/Avalonia.Input/TouchDevice.cs
@@ -110,7 +110,7 @@ namespace Avalonia.Input
                     GetKeyModifiers(args.InputModifiers), args.IntermediatePoints));
             }
 
-
+            (ev.Root as ILastPointerPosition)?.SetLastPointerPosition(ev.Root.PointToScreen(args.Position));
         }
 
         public void Dispose()


### PR DESCRIPTION
## What does the pull request do?

Hackfix for #10914 on stable branch. Store last pointer position in `TopLevel` for both mouse and touch and use this position in `PopupPositionerExtensions`. To do this added a new interface, as adding to the `IInputRoot` interface would be a breaking change. Ideally this interface would be internal but we don't expose internals between `Avalonia.Input` and Avalonia.Control` in 0.10.x so this isn't possible.

## Fixed issues

Fixes #10914
