### PR TITLE
Use `SetCurrentValue` in `Slider`

### DIFF
--- a/src/Avalonia.Controls/Slider.cs
+++ b/src/Avalonia.Controls/Slider.cs
@@ -246,11 +246,11 @@ namespace Avalonia.Controls
                     break;
 
                 case Key.Home:
-                    Value = Minimum;
+                    SetCurrentValue(ValueProperty, Minimum);
                     break;
 
                 case Key.End:
-                    Value = Maximum;
+                    SetCurrentValue(ValueProperty, Maximum);
                     break;
 
                 default:
@@ -313,7 +313,7 @@ namespace Avalonia.Controls
             // Update if we've found a better value
             if (Math.Abs(next - value) > Tolerance)
             {
-                Value = next;
+                SetCurrentValue(ValueProperty, next);
             }
         }
 
@@ -366,7 +366,7 @@ namespace Avalonia.Controls
             var range = Maximum - Minimum;
             var finalValue = calcVal * range + Minimum;
 
-            Value = IsSnapToTickEnabled ? SnapToTick(finalValue) : finalValue;
+            SetCurrentValue(ValueProperty, IsSnapToTickEnabled ? SnapToTick(finalValue) : finalValue);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## What does the pull request do?
`Slider` now uses styled properties, but is still assigning local values when updating its own value. This PR switches it to `SetCurrentValue`.

## What is the current behavior?
Two-way slider value bindings set from a template or style break when the user interacts with the slider.