### PR TITLE
Don't hide tooltip if mouse is over it

### DIFF
--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Avalonia.Input;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -102,9 +103,31 @@ namespace Avalonia.Controls
         /// </summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event args.</param>
-        private void ControlPointerExited(object? sender, PointerEventArgs e)
+        private async void ControlPointerExited(object? sender, PointerEventArgs e)
         {
             var control = (Control)sender!;
+            var toolTip = control.GetValue(ToolTip.ToolTipProperty);
+            
+            // wait for the tooltip to activate
+            await Task.Delay(100).ConfigureAwait(true);
+            
+            if (control.IsPointerOver) return;
+            if (toolTip?.IsPointerOver == true)
+            {
+                void ToolTipOnPointerExited(object? _, PointerEventArgs __)
+                {
+                    toolTip.PointerExited -= ToolTipOnPointerExited;
+
+                    if (!control.IsPointerOver)
+                    {
+                        Close(control);
+                    }
+                }
+                
+                toolTip.PointerExited += ToolTipOnPointerExited;
+                return;
+            }
+            
             Close(control);
         }
 


### PR DESCRIPTION
## What does the pull request do?
Prevent's hiding tooltip if mouse is over it. This happens quite often it the tooltip is big and screen edge pushes it back.

## What is the current behavior?
The tooltip hides.


## What is the updated/expected behavior with this PR?
Tooltip should be visible.


## How was the solution implemented (if it's not obvious)?
This is just a draft. The code should be improved.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
nothing big

## Fixed issues
https://github.com/AvaloniaUI/Avalonia/issues/9246