### PR TITLE
Headless timer should report that it runs on the "UI" thread

### DIFF
--- a/src/Avalonia.Headless/AvaloniaHeadlessPlatform.cs
+++ b/src/Avalonia.Headless/AvaloniaHeadlessPlatform.cs
@@ -43,6 +43,8 @@ namespace Avalonia.Headless
                 _framesPerSecond = framesPerSecond;
             }
 
+            public override bool RunsInBackground => false;
+
             public void ForceTick() => _forceTick?.Invoke();
         }
 


### PR DESCRIPTION
Should fix #10686