### PR TITLE
Make sure that HandleClosed is called only once

### DIFF
--- a/src/Avalonia.Controls/Primitives/PopupRoot.cs
+++ b/src/Avalonia.Controls/Primitives/PopupRoot.cs
@@ -90,7 +90,6 @@ namespace Avalonia.Controls.Primitives
         public void Dispose()
         {
             PlatformImpl?.Dispose();
-            HandleClosed();
         }
 
         private void UpdatePosition()

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using Avalonia.Reactive;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Platform;
@@ -531,6 +532,7 @@ namespace Avalonia.Controls
             // We need to wait for the renderer to complete any in-flight operations
             Renderer.Dispose();
             
+            Debug.Assert(PlatformImpl != null);
             // The PlatformImpl is completely invalid at this point
             PlatformImpl = null;
             

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -898,7 +898,6 @@ namespace Avalonia.X11
                 _platform.XI2?.OnWindowDestroyed(_handle);
                 var handle = _handle;
                 _handle = IntPtr.Zero;
-                Closed?.Invoke();
                 _mouse.Dispose();
                 _touch.Dispose();
                 if (!fromDestroyNotification)

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -115,7 +115,6 @@ namespace Avalonia.Win32
                         _hwnd = IntPtr.Zero;
                         //Remove root reference to this class, so unmanaged delegate can be collected
                         s_instances.Remove(this);
-                        Closed?.Invoke();
 
                         _mouseDevice.Dispose();
                         _touchDevice.Dispose();


### PR DESCRIPTION
1) fixed bug in X11Window
2) PopupRoot should not, in fact, call HandleClosed, it's the job of the platform implementation