### PR TITLE
Android - Fix bottom inset value when displaying edge to edge

### DIFF
--- a/src/Android/Avalonia.Android/Platform/AndroidInsetsManager.cs
+++ b/src/Android/Avalonia.Android/Platform/AndroidInsetsManager.cs
@@ -81,7 +81,7 @@ namespace Avalonia.Android.Platform
                     var renderScaling = _topLevel.RenderScaling;
 
                     var inset = insets.GetInsets(
-                        (DisplayEdgeToEdge ?
+                        (_displayEdgeToEdge ?
                             WindowInsetsCompat.Type.StatusBars() | WindowInsetsCompat.Type.NavigationBars() |
                             WindowInsetsCompat.Type.DisplayCutout() :
                             0) | WindowInsetsCompat.Type.Ime());
@@ -91,8 +91,8 @@ namespace Avalonia.Android.Platform
                     return new Thickness(inset.Left / renderScaling,
                         inset.Top / renderScaling,
                         inset.Right / renderScaling,
-                        (imeInset.Bottom > 0 && ((_usesLegacyLayouts && !DisplayEdgeToEdge) || !_usesLegacyLayouts) ?
-                            imeInset.Bottom - navBarInset.Bottom :
+                        (imeInset.Bottom > 0 && ((_usesLegacyLayouts && !_displayEdgeToEdge) || !_usesLegacyLayouts) ?
+                            imeInset.Bottom - (_displayEdgeToEdge ? 0 : navBarInset.Bottom) :
                             inset.Bottom) / renderScaling);
                 }
 


### PR DESCRIPTION
## What does the pull request do?
When displaying from edge to edge, the nav bar insets forms part of the IME insets reported by the system. This pr corrects the bottom inset value that's returned to the toplevel.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
Nav bar bottom inset is no longer removed from the IME bottom inset when the view is displaying edge to edge.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
