### PR TITLE
Take Transform into account when hit testing DrawOperationWithTransform

### DIFF
--- a/src/Avalonia.Base/Rendering/SceneGraph/CustomDrawOperation.cs
+++ b/src/Avalonia.Base/Rendering/SceneGraph/CustomDrawOperation.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Rendering.SceneGraph
             Custom = custom;
         }
 
-        public override bool HitTest(Point p) => Custom.HitTest(p);
+        public override bool HitTestTransformed(Point p) => Custom.HitTest(p);
 
         public override void Render(IDrawingContextImpl context)
         {

--- a/src/Avalonia.Base/Rendering/SceneGraph/DrawOperation.cs
+++ b/src/Avalonia.Base/Rendering/SceneGraph/DrawOperation.cs
@@ -37,5 +37,20 @@ namespace Avalonia.Rendering.SceneGraph
         }
 
         public Matrix Transform { get; }
+
+        public sealed override bool HitTest(Point p)
+        {
+            if (Transform.IsIdentity)
+                return HitTestTransformed(p);
+
+            if (!Transform.HasInverse)
+                return false;
+
+            var transformedPoint = Transform.Invert().Transform(p);
+
+            return HitTestTransformed(transformedPoint);
+        }
+
+        public abstract bool HitTestTransformed(Point p);
     }
 }

--- a/src/Avalonia.Base/Rendering/SceneGraph/EllipseNode.cs
+++ b/src/Avalonia.Base/Rendering/SceneGraph/EllipseNode.cs
@@ -43,7 +43,7 @@ namespace Avalonia.Rendering.SceneGraph
 
         public override void Render(IDrawingContextImpl context) => context.DrawEllipse(Brush, Pen, Rect);
 
-        public override bool HitTest(Point p)
+        public override bool HitTestTransformed(Point p)
         {
             var center = Rect.Center;
 

--- a/src/Avalonia.Base/Rendering/SceneGraph/ExperimentalAcrylicNode.cs
+++ b/src/Avalonia.Base/Rendering/SceneGraph/ExperimentalAcrylicNode.cs
@@ -65,6 +65,6 @@ namespace Avalonia.Rendering.SceneGraph
         }
 
         /// <inheritdoc/>
-        public override bool HitTest(Point p) => Rect.Rect.ContainsExclusive(p);
+        public override bool HitTestTransformed(Point p) => Rect.Rect.ContainsExclusive(p);
     }
 }

--- a/src/Avalonia.Base/Rendering/SceneGraph/GeometryNode.cs
+++ b/src/Avalonia.Base/Rendering/SceneGraph/GeometryNode.cs
@@ -64,7 +64,7 @@ namespace Avalonia.Rendering.SceneGraph
         }
 
         /// <inheritdoc/>
-        public override bool HitTest(Point p)
+        public override bool HitTestTransformed(Point p)
         {
             return (Brush != null && Geometry.FillContains(p)) ||
                    (Pen != null && Geometry.StrokeContains(Pen, p));

--- a/src/Avalonia.Base/Rendering/SceneGraph/GlyphRunNode.cs
+++ b/src/Avalonia.Base/Rendering/SceneGraph/GlyphRunNode.cs
@@ -53,7 +53,7 @@ namespace Avalonia.Rendering.SceneGraph
         }
 
         /// <inheritdoc/>
-        public override bool HitTest(Point p) => Bounds.ContainsExclusive(p);
+        public override bool HitTestTransformed(Point p) => Bounds.ContainsExclusive(p);
 
         public override void Dispose()
         {

--- a/src/Avalonia.Base/Rendering/SceneGraph/ImageNode.cs
+++ b/src/Avalonia.Base/Rendering/SceneGraph/ImageNode.cs
@@ -94,7 +94,7 @@ namespace Avalonia.Rendering.SceneGraph
         }
 
         /// <inheritdoc/>
-        public override bool HitTest(Point p) => DestRect.ContainsExclusive(p);
+        public override bool HitTestTransformed(Point p) => DestRect.ContainsExclusive(p);
 
         public override void Dispose()
         {

--- a/src/Avalonia.Base/Rendering/SceneGraph/LineNode.cs
+++ b/src/Avalonia.Base/Rendering/SceneGraph/LineNode.cs
@@ -66,7 +66,7 @@ namespace Avalonia.Rendering.SceneGraph
             context.DrawLine(Pen, P1, P2);
         }
 
-        public override bool HitTest(Point p)
+        public override bool HitTestTransformed(Point p)
         {
             var halfThickness = Pen.Thickness / 2;
             var minX = Math.Min(P1.X, P2.X) - halfThickness;

--- a/src/Avalonia.Base/Rendering/SceneGraph/OpacityMaskNode.cs
+++ b/src/Avalonia.Base/Rendering/SceneGraph/OpacityMaskNode.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Rendering.SceneGraph
 
 
         /// <inheritdoc/>
-        public override bool HitTest(Point p) => false;
+        public override bool HitTestTransformed(Point p) => false;
 
         /// <summary>
         /// Determines if this draw operation equals another.

--- a/src/Avalonia.Base/Rendering/SceneGraph/RectangleNode.cs
+++ b/src/Avalonia.Base/Rendering/SceneGraph/RectangleNode.cs
@@ -74,7 +74,7 @@ namespace Avalonia.Rendering.SceneGraph
         public override void Render(IDrawingContextImpl context) => context.DrawRectangle(Brush, Pen, Rect, BoxShadows);
 
         /// <inheritdoc/>
-        public override bool HitTest(Point p)
+        public override bool HitTestTransformed(Point p)
         {
             if (Brush != null)
             {

--- a/tests/Avalonia.Base.UnitTests/Rendering/SceneGraph/DrawOperationTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Rendering/SceneGraph/DrawOperationTests.cs
@@ -82,7 +82,7 @@ namespace Avalonia.Base.UnitTests.Rendering.SceneGraph
 
             }
 
-            public override bool HitTest(Point p) => false;
+            public override bool HitTestTransformed(Point p) => false;
 
             public override void Render(IDrawingContextImpl context) { }
         }

--- a/tests/Avalonia.Base.UnitTests/Rendering/SceneGraph/DrawOperationTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Rendering/SceneGraph/DrawOperationTests.cs
@@ -74,6 +74,22 @@ namespace Avalonia.Base.UnitTests.Rendering.SceneGraph
             geometryNode.HitTest(new Point());
         }
 
+        [Fact]
+        public void HitTest_RectangleNode_With_Transform_Hits()
+        {
+            var geometry = Mock.Of<IGeometryImpl>();
+            var geometryNode = new RectangleNode(
+                Matrix.CreateTranslation(20,20),
+                Brushes.Black,
+                null,
+                new RoundedRect(new Rect(0,0,10,10)),
+                default);
+
+            var actual = geometryNode.HitTest(new Point(25,25));
+
+            Assert.True(actual);
+        }
+
         private class TestRectangleDrawOperation : RectangleNode
         {
             public TestRectangleDrawOperation(Rect bounds, Matrix transform, Pen pen) 


### PR DESCRIPTION
## What does the pull request do?
Takes DrawOperation transform into account when hit testing


## What is the current behavior?
Transform is ignored during hit testing


## What is the updated/expected behavior with this PR?
It takes Transform into account when hit testing.


## How was the solution implemented (if it's not obvious)?
The inverted transform is used to translate the input point when doing hit testing. This is a simple way to solve the bug since it is mainly a change in the base class `DrawOperationWithTransform` and it prevents implementations of this base class to make this mistake in the future.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
Since DrawOperation implementations and DrawOperationWithTransform is internal it should be none.
