### PR TITLE
Use `SetCurrentValue` to manipulate sibling `RadioButton`s

### DIFF
--- a/src/Avalonia.Controls/RadioButton.cs
+++ b/src/Avalonia.Controls/RadioButton.cs
@@ -86,7 +86,7 @@ namespace Avalonia.Controls
                                 continue;
                             }
                             if (current != radioButton && current.IsChecked.GetValueOrDefault())
-                                current.IsChecked = false;
+                                current.SetCurrentValue(IsCheckedProperty, false);
                             i++;
                         }
                         if (group.Count == 0)
@@ -193,7 +193,7 @@ namespace Avalonia.Controls
                     foreach (var sibling in siblings)
                     {
                         if (sibling.IsChecked.GetValueOrDefault())
-                            sibling.IsChecked = false;
+                            sibling.SetCurrentValue(IsCheckedProperty, false);
                     }
                 }
             }


### PR DESCRIPTION
## What does the pull request do?
This PR removes two cases where `RadioButton` forcibly sets a local value for `IsChecked`. The analyser doesn't report them because the control isn't setting its own values, but those of a sibling `RadioButton`.

This problem was spotted in #10991 but it is _not_ the cause of the reported issue.

## What is the current behavior?
Bindings of sibling `RadioButton`s can break when a `RadioButton` is clicked.
