### PR TITLE
Fix GlyphRun hit test issue

### DIFF
--- a/src/Avalonia.Base/Rendering/SceneGraph/GlyphRunNode.cs
+++ b/src/Avalonia.Base/Rendering/SceneGraph/GlyphRunNode.cs
@@ -53,7 +53,7 @@ namespace Avalonia.Rendering.SceneGraph
         }
 
         /// <inheritdoc/>
-        public override bool HitTestTransformed(Point p) => Bounds.ContainsExclusive(p);
+        public override bool HitTestTransformed(Point p) => GlyphRun.Item.Bounds.ContainsExclusive(p);
 
         public override void Dispose()
         {

--- a/tests/Avalonia.Base.UnitTests/Rendering/SceneGraph/DrawOperationTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Rendering/SceneGraph/DrawOperationTests.cs
@@ -90,6 +90,23 @@ namespace Avalonia.Base.UnitTests.Rendering.SceneGraph
             Assert.True(actual);
         }
 
+        [Fact]
+        public void HitTest_GlyphRunNode_With_Transform_Hits()
+        {
+            var glyphRun = new Mock<IRef<IGlyphRunImpl>>();
+            glyphRun.Setup(x => x.Clone()).Returns(() => glyphRun.Object);
+            glyphRun.Setup(x => x.Item.Bounds).Returns(new Rect(0,0,10,10));
+
+            var node = new GlyphRunNode(
+                Matrix.CreateTranslation(20, 20),
+                Brushes.Black,
+                glyphRun.Object);
+
+            var actual = node.HitTest(new Point(25, 25));
+
+            Assert.True(actual);
+        }
+
         private class TestRectangleDrawOperation : RectangleNode
         {
             public TestRectangleDrawOperation(Rect bounds, Matrix transform, Pen pen) 


### PR DESCRIPTION
## What does the pull request do?
Fixes the hit test bug I introduced in #11005


## What is the current behavior?
GlyphRun uses the transformed bounds for hit testing.


## What is the updated/expected behavior with this PR?
GlyphRun uses the un transformed bounds for hit testing.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation
