### PR TITLE
Fix NativeMenuBar.

### DIFF
--- a/.ncrunch/SafeAreaDemo.Android.v3.ncrunchproject
+++ b/.ncrunch/SafeAreaDemo.Android.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/.ncrunch/SafeAreaDemo.Desktop.v3.ncrunchproject
+++ b/.ncrunch/SafeAreaDemo.Desktop.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/.ncrunch/SafeAreaDemo.iOS.v3.ncrunchproject
+++ b/.ncrunch/SafeAreaDemo.iOS.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/.ncrunch/SafeAreaDemo.v3.ncrunchproject
+++ b/.ncrunch/SafeAreaDemo.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -378,48 +378,48 @@ namespace Avalonia.Controls
 
             if (container is HeaderedContentControl hcc)
             {
-                hcc.Content = item;
+                SetIfUnset(hcc, HeaderedContentControl.ContentProperty, item);
 
                 if (item is IHeadered headered)
-                    hcc.Header = headered.Header;
+                    SetIfUnset(hcc, HeaderedContentControl.HeaderProperty, headered.Header);
                 else if (item is not Visual)
-                    hcc.Header = item;
+                    SetIfUnset(hcc, HeaderedContentControl.HeaderProperty, item);
 
                 if (itemTemplate is not null)
-                    hcc.HeaderTemplate = itemTemplate;
+                    SetIfUnset(hcc, HeaderedContentControl.HeaderTemplateProperty, itemTemplate);
             }
             else if (container is ContentControl cc)
             {
-                cc.Content = item;
+                SetIfUnset(cc, ContentControl.ContentProperty, item);
                 if (itemTemplate is not null)
-                    cc.ContentTemplate = itemTemplate;
+                    SetIfUnset(cc, ContentControl.ContentTemplateProperty, itemTemplate);
             }
             else if (container is ContentPresenter p)
             {
-                p.Content = item;
+                SetIfUnset(p, ContentPresenter.ContentProperty, item);
                 if (itemTemplate is not null)
-                    p.ContentTemplate = itemTemplate;
+                    SetIfUnset(p, ContentPresenter.ContentTemplateProperty, itemTemplate);
             }
             else if (container is ItemsControl ic)
             {
                 if (itemTemplate is not null)
-                    ic.ItemTemplate = itemTemplate;
-                if (ItemContainerTheme is { } ict && !ict.IsSet(ItemContainerThemeProperty))
-                    ic.ItemContainerTheme = ict;
+                    SetIfUnset(ic, ItemTemplateProperty, itemTemplate);
+                if (ItemContainerTheme is { } ict)
+                    SetIfUnset(ic, ItemContainerThemeProperty, ict);
             }
 
             // These conditions are separate because HeaderedItemsControl and
             // HeaderedSelectingItemsControl also need to run the ItemsControl preparation.
             if (container is HeaderedItemsControl hic)
             {
-                hic.Header = item;
-                hic.HeaderTemplate = itemTemplate;
+                SetIfUnset(hic, HeaderedItemsControl.HeaderProperty, item);
+                SetIfUnset(hic, HeaderedItemsControl.HeaderTemplateProperty, itemTemplate);
                 hic.PrepareItemContainer(this);
             }
             else if (container is HeaderedSelectingItemsControl hsic)
             {
-                hsic.Header = item;
-                hsic.HeaderTemplate = itemTemplate;
+                SetIfUnset(hsic, HeaderedSelectingItemsControl.HeaderProperty, item);
+                SetIfUnset(hsic, HeaderedSelectingItemsControl.HeaderTemplateProperty, itemTemplate);
                 hsic.PrepareItemContainer(this);
             }
         }
@@ -458,30 +458,35 @@ namespace Avalonia.Controls
         {
             if (container is HeaderedContentControl hcc)
             {
-                if (hcc.Content is Control)
-                    hcc.Content = null;
-                if (hcc.Header is Control)
-                    hcc.Header = null;
+                hcc.ClearValue(HeaderedContentControl.ContentProperty);
+                hcc.ClearValue(HeaderedContentControl.HeaderProperty);
+                hcc.ClearValue(HeaderedContentControl.HeaderTemplateProperty);
             }
             else if (container is ContentControl cc)
             {
-                if (cc.Content is Control)
-                    cc.Content = null;
+                cc.ClearValue(ContentControl.ContentProperty);
+                cc.ClearValue(ContentControl.ContentTemplateProperty);
             }
             else if (container is ContentPresenter p)
             {
-                if (p.Content is Control)
-                    p.Content = null;
+                p.ClearValue(ContentPresenter.ContentProperty);
+                p.ClearValue(ContentPresenter.ContentTemplateProperty);
             }
-            else if (container is HeaderedItemsControl hic)
+            else if (container is ItemsControl ic)
             {
-                if (hic.Header is Control)
-                    hic.Header = null;
+                ic.ClearValue(ItemTemplateProperty);
+                ic.ClearValue(ItemContainerThemeProperty);
+            }
+            
+            if (container is HeaderedItemsControl hic)
+            {
+                hic.ClearValue(HeaderedItemsControl.HeaderProperty);
+                hic.ClearValue(HeaderedItemsControl.HeaderTemplateProperty);
             }
             else if (container is HeaderedSelectingItemsControl hsic)
             {
-                if (hsic.Header is Control)
-                    hsic.Header = null;
+                hsic.ClearValue(HeaderedSelectingItemsControl.HeaderProperty);
+                hsic.ClearValue(HeaderedSelectingItemsControl.HeaderTemplateProperty);
             }
 
             // Feels like we should be clearing the HeaderedItemsControl.Items binding here, but looking at
@@ -705,6 +710,12 @@ namespace Avalonia.Controls
 
             if (toAdd is not null)
                 LogicalChildren.AddRange(toAdd);
+        }
+
+        private void SetIfUnset<T>(AvaloniaObject target, StyledProperty<T> property, T value)
+        {
+            if (!target.IsSet(property))
+                target.SetCurrentValue(property, value);
         }
 
         private void RemoveControlItemsFromLogicalChildren(IEnumerable? items)

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
@@ -554,6 +554,36 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new[] { "Bar" }, target.Selection.SelectedItems);
         }
 
+        [Fact]
+        public void Content_Can_Be_Bound_In_ItemContainerTheme()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var items = new[] { new ItemViewModel("Foo"), new ItemViewModel("Bar") };
+                var theme = new ControlTheme(typeof(ListBoxItem))
+                {
+                    Setters =
+                    {
+                        new Setter(ListBoxItem.ContentProperty, new Binding("Caption")),
+                    }
+                };
+
+                var target = new ListBox
+                {
+                    Template = ListBoxTemplate(),
+                    ItemsSource = items,
+                    ItemContainerTheme = theme,
+                };
+
+                Prepare(target);
+
+                var containers = target.GetRealizedContainers().Cast<ListBoxItem>().ToList();
+                Assert.Equal(2, containers.Count);
+                Assert.Equal("Foo", containers[0].Content);
+                Assert.Equal("Bar", containers[1].Content);
+            }
+        }
+
         private static FuncControlTemplate ListBoxTemplate()
         {
             return new FuncControlTemplate<ListBox>((parent, scope) =>
@@ -917,6 +947,8 @@ namespace Avalonia.Controls.UnitTests
 
             Assert.Equal(1, raised);
         }
+
+        private record ItemViewModel(string Caption);
 
         private class ResettingCollection : List<string>, INotifyCollectionChanged
         {

--- a/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
@@ -1,16 +1,16 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 using System.Windows.Input;
-using Avalonia.Collections;
 using Avalonia.Controls.Presenters;
-using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
+using Avalonia.Controls.Utils;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Platform;
+using Avalonia.Styling;
 using Avalonia.UnitTests;
-using Avalonia.VisualTree;
 using Moq;
 using Xunit;
 
@@ -35,7 +35,6 @@ namespace Avalonia.Controls.UnitTests
 
             Assert.False(target.Focusable);
         }
-
 
         [Fact]
         public void MenuItem_Is_Disabled_When_Command_Is_Enabled_But_IsEnabled_Is_False()
@@ -393,6 +392,87 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
+        [Fact]
+        public void Header_And_ItemsSource_Can_Be_Bound_In_Style()
+        {
+            using var app = Application();
+            var items = new[]
+            {
+                new MenuViewModel("Foo")
+                {
+                    Children = new[]
+                    {
+                        new MenuViewModel("FooChild"),
+                    },
+                },
+                new MenuViewModel("Bar"),
+            };
+
+            var target = new Menu
+            {
+                ItemsSource = items,
+                Styles =
+                {
+                    new Style(x => x.OfType<MenuItem>())
+                    {
+                        Setters =
+                        {
+                            new Setter(MenuItem.HeaderProperty, new Binding("Header")),
+                            new Setter(MenuItem.ItemsSourceProperty, new Binding("Children")),
+                        }
+                    }
+                }
+            };
+
+            var root = new TestRoot(true, target);
+            root.LayoutManager.ExecuteInitialLayoutPass();
+
+            var children = target.GetRealizedContainers().Cast<MenuItem>().ToList();
+            Assert.Equal(2, children.Count);
+            Assert.Equal("Foo", children[0].Header);
+            Assert.Equal("Bar", children[1].Header);
+            Assert.Same(items[0].Children, children[0].ItemsSource);
+        }
+
+        [Fact]
+        public void Header_And_ItemsSource_Can_Be_Bound_In_ItemContainerTheme()
+        {
+            using var app = Application();
+            var items = new[]
+            {
+                new MenuViewModel("Foo")
+                {
+                    Children = new[]
+                    {
+                        new MenuViewModel("FooChild"),
+                    },
+                },
+                new MenuViewModel("Bar"),
+            };
+
+            var target = new Menu
+            {
+                ItemsSource = items,
+                ItemContainerTheme = new ControlTheme(typeof(MenuItem))
+                {
+                    Setters =
+                    {
+                        new Setter(MenuItem.HeaderProperty, new Binding("Header")),
+                        new Setter(MenuItem.ItemsSourceProperty, new Binding("Children")),
+                    }
+                }
+            };
+
+            var root = new TestRoot(true, target);
+            root.LayoutManager.ExecuteInitialLayoutPass();
+
+            var children = target.GetRealizedContainers().Cast<MenuItem>().ToList();
+            Assert.Equal(2, children.Count);
+            Assert.Equal("Foo", children[0].Header);
+            Assert.Equal("Bar", children[1].Header);
+            Assert.Same(items[0].Children, children[0].ItemsSource);
+        }
+
         private IDisposable Application()
         {
             var screen = new PixelRect(new PixelPoint(), new PixelSize(100, 100));
@@ -447,6 +527,9 @@ namespace Avalonia.Controls.UnitTests
             public void RaiseCanExecuteChanged() => _canExecuteChanged?.Invoke(this, EventArgs.Empty);
         }
 
-        private record MenuViewModel(string Header);
+        private record MenuViewModel(string Header)
+        {
+            public IList<MenuViewModel> Children { get; set;}
+        }
     }
 }

--- a/tests/Avalonia.IntegrationTests.Appium/NativeMenuTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/NativeMenuTests.cs
@@ -18,7 +18,7 @@ namespace Avalonia.IntegrationTests.Appium
         }
 
         [PlatformFact(TestPlatforms.MacOS)]
-        public void View_Menu_Select_Button_Tab()
+        public void MacOS_View_Menu_Select_Button_Tab()
         {
             var tabs = _session.FindElementByAccessibilityId("MainTabs");
             var buttonTab = tabs.FindElementByName("Button");
@@ -27,6 +27,22 @@ namespace Avalonia.IntegrationTests.Appium
             
             Assert.False(buttonTab.Selected);
             
+            viewMenu.Click();
+            var buttonMenu = viewMenu.FindElementByName("Button");
+            buttonMenu.Click();
+
+            Assert.True(buttonTab.Selected);
+        }
+
+        [PlatformFact(TestPlatforms.Windows)]
+        public void Win32_View_Menu_Select_Button_Tab()
+        {
+            var tabs = _session.FindElementByAccessibilityId("MainTabs");
+            var buttonTab = tabs.FindElementByName("Button");
+            var viewMenu = _session.FindElementByXPath("//MenuItem[@Name='View']");
+
+            Assert.False(buttonTab.Selected);
+
             viewMenu.Click();
             var buttonMenu = viewMenu.FindElementByName("Button");
             buttonMenu.Click();


### PR DESCRIPTION
## What does the pull request do?

`NativeMenuBar` got broken by #10836:

![image](https://user-images.githubusercontent.com/1775141/232472946-47d12b2d-b060-48cc-b9c6-e2803e84cac7.png)

The problem is that the [container setup code](https://github.com/AvaloniaUI/Avalonia/blob/747c6a62d2236638fd570ef351709dfb4867ba6b/src/Avalonia.Controls/ItemsControl.cs#L372) was copied from WPF, but in WPF the item container style is [guaranteed to be applied](https://github.com/dotnet/wpf/blob/main/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemsControl.cs#L1377) before the container setup code is run.

The same technique won't work in Avalonia because styles can target the containers not just in the `ItemContainerTheme`, but in any style [which is what `NativeMenuBar` does](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Fluent/Controls/NativeMenuBar.xaml#L12). 

Instead use `SetCurrentValue` to set the properties, only if the properties are not already set (i.e. from a style). This also requires us to clear the current value when the container is cleared (styles won't be affected as `AvaloniaObject.ClearValue` only clears local or `SetCurrentValue` values).

Also added unit tests and an integration test for `NativeMenuBar`.
