### PR TITLE
Remove ControlTemplateResult.

### DIFF
--- a/src/Avalonia.Controls/Templates/FuncControlTemplate.cs
+++ b/src/Avalonia.Controls/Templates/FuncControlTemplate.cs
@@ -18,10 +18,10 @@ namespace Avalonia.Controls.Templates
         {
         }
 
-        public new ControlTemplateResult Build(TemplatedControl param)
+        public new TemplateResult<Control> Build(TemplatedControl param)
         {
             var (control, scope) = BuildWithNameScope(param);
-            return new ControlTemplateResult(control, scope);
+            return new(control, scope);
         }
     }
 }

--- a/src/Avalonia.Controls/Templates/IControlTemplate.cs
+++ b/src/Avalonia.Controls/Templates/IControlTemplate.cs
@@ -5,23 +5,7 @@ namespace Avalonia.Controls.Templates
     /// <summary>
     /// Interface representing a template used to build a <see cref="TemplatedControl"/>.
     /// </summary>
-    public interface IControlTemplate : ITemplate<TemplatedControl, ControlTemplateResult?>
+    public interface IControlTemplate : ITemplate<TemplatedControl, TemplateResult<Control>?>
     {
-    }
-
-    public class ControlTemplateResult : TemplateResult<Control>
-    {
-        public Control Control { get; }
-
-        public ControlTemplateResult(Control control, INameScope nameScope) : base(control, nameScope)
-        {
-            Control = control;
-        }
-
-        public new void Deconstruct(out Control control, out INameScope scope)
-        {
-            control = Control;
-            scope = NameScope;
-        }
     }
 }

--- a/src/Markup/Avalonia.Markup.Xaml/Templates/ControlTemplate.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Templates/ControlTemplate.cs
@@ -1,4 +1,5 @@
 using System;
+using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Metadata;
@@ -13,6 +14,6 @@ namespace Avalonia.Markup.Xaml.Templates
 
         public Type? TargetType { get; set; }
 
-        public ControlTemplateResult? Build(TemplatedControl control) => TemplateContent.Load(Content);
+        public TemplateResult<Control>? Build(TemplatedControl control) => TemplateContent.Load(Content);
     }
 }

--- a/src/Markup/Avalonia.Markup.Xaml/Templates/DataTemplate.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Templates/DataTemplate.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Markup.Xaml.Templates
 
         public Control? Build(object? data, Control? existing)
         {
-            return existing ?? TemplateContent.Load(Content)?.Control;
+            return existing ?? TemplateContent.Load(Content)?.Result;
         }
     }
 }

--- a/src/Markup/Avalonia.Markup.Xaml/Templates/ItemsPanelTemplate.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Templates/ItemsPanelTemplate.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Markup.Xaml.Templates
         [TemplateContent]
         public object? Content { get; set; }
 
-        public Panel? Build() => (Panel?)TemplateContent.Load(Content)?.Control;
+        public Panel? Build() => (Panel?)TemplateContent.Load(Content)?.Result;
 
         object? ITemplate.Build() => Build();
     }

--- a/src/Markup/Avalonia.Markup.Xaml/Templates/Template.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Templates/Template.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Markup.Xaml.Templates
         [TemplateContent]
         public object? Content { get; set; }
 
-        public Control? Build() => TemplateContent.Load(Content)?.Control;
+        public Control? Build() => TemplateContent.Load(Content)?.Result;
 
         object? ITemplate.Build() => Build();
     }

--- a/src/Markup/Avalonia.Markup.Xaml/Templates/TemplateContent.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Templates/TemplateContent.cs
@@ -1,15 +1,16 @@
 using System;
+using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 
 namespace Avalonia.Markup.Xaml.Templates
 {
     public static class TemplateContent
     {
-        public static ControlTemplateResult? Load(object? templateContent)
+        public static TemplateResult<Control>? Load(object? templateContent)
         {
             if (templateContent is Func<IServiceProvider?, object?> direct)
             {
-                return (ControlTemplateResult?)direct(null);
+                return (TemplateResult<Control>?)direct(null);
             }
 
             if (templateContent is null)

--- a/src/Markup/Avalonia.Markup.Xaml/Templates/TreeDataTemplate.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Templates/TreeDataTemplate.cs
@@ -54,7 +54,7 @@ namespace Avalonia.Markup.Xaml.Templates
 
         public Control? Build(object? data)
         {
-            var visualTreeForItem = TemplateContent.Load(Content)?.Control;
+            var visualTreeForItem = TemplateContent.Load(Content)?.Result;
             if (visualTreeForItem != null)
             {
                 visualTreeForItem.DataContext = data;

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/Runtime/XamlIlRuntimeHelpers.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/Runtime/XamlIlRuntimeHelpers.cs
@@ -35,7 +35,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.Runtime
                 scope.Complete();
 
                 if(typeof(T) == typeof(Control))
-                    return new ControlTemplateResult((Control)obj, scope);
+                    return new TemplateResult<Control>((Control)obj, scope);
 
                 return new TemplateResult<T>((T)obj, scope);
             };

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -1978,7 +1978,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
         public bool Match(object data) => FancyDataType?.IsInstanceOfType(data) ?? true;
 
-        public Control Build(object data) => TemplateContent.Load(Content)?.Control;
+        public Control Build(object data) => TemplateContent.Load(Content)?.Result;
     }
     
     public class CustomDataTemplateInherit : CustomDataTemplate { }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
@@ -605,7 +605,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             var control = new ContentControl();
 
-            var result = (ContentPresenter)template.Build(control).Control;
+            var result = (ContentPresenter)template.Build(control).Result;
 
             Assert.NotNull(result);
         }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ControlTemplateTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ControlTemplateTests.cs
@@ -258,7 +258,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 ";
             var template = AvaloniaRuntimeXamlLoader.Parse<ControlTemplate>(xaml);
 
-            var parent = (ContentControl)template.Build(new ContentControl()).Control;
+            var parent = (ContentControl)template.Build(new ContentControl()).Result;
 
             Assert.Equal("parent", parent.Name);
 
@@ -283,7 +283,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 
             Assert.Equal(typeof(ContentControl), template.TargetType);
 
-            Assert.IsType(typeof(ContentPresenter), template.Build(new ContentControl()).Control);
+            Assert.IsType(typeof(ContentPresenter), template.Build(new ContentControl()).Result);
         }
 
         [Fact]
@@ -299,7 +299,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
 ";
             var template = AvaloniaRuntimeXamlLoader.Parse<ControlTemplate>(xaml);
 
-            var panel = (Panel)template.Build(new ContentControl()).Control;
+            var panel = (Panel)template.Build(new ContentControl()).Result;
 
             Assert.Equal(2, panel.Children.Count);
 


### PR DESCRIPTION
## What does the pull request do?

Remove `ControlTemplateResult` and use `TempateResult<Control>` instead as described in #6666.

## Breaking changes

`ControlTemplateResult` was removed. Use `TemplateResult<Control>` instead.


## Fixed issues

Fixes #10525.
