### PR TITLE
Fix Watermark not shown on CalendarDatePicker when clearing the value in code

### DIFF
--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
@@ -875,10 +875,11 @@ namespace Avalonia.Controls
         {
             if (_textBox != null)
             {
+                SetCurrentValue(TextProperty, String.Empty);
+                
                 if (string.IsNullOrEmpty(Watermark) && !UseFloatingWatermark)
                 {
                     DateTimeFormatInfo dtfi = DateTimeHelper.GetCurrentDateFormat();
-                    SetCurrentValue(TextProperty, string.Empty);
                     _defaultText = string.Empty;
                     var watermarkFormat = "<{0}>";
                     string watermarkText;


### PR DESCRIPTION
## What does the pull request do?
fixes an issue where the watermark will not appear if set to a custom value (works using default watermark)


## What is the current behavior?
See https://github.com/AvaloniaUI/Avalonia/issues/11055

## What is the updated/expected behavior with this PR?
Watermark is set correctly if selected DateTime was cleared

## How was the solution implemented (if it's not obvious)?
moved the clear text statement out of the if node, so it is reached in any case.

## To test the result: 

Add following VM: 

```cs
public partial class VM : ObservableObject
{
    [ObservableProperty] DateTime? _date = DateTime.Now;

    [RelayCommand]
    void Clear() => Date = null;
}
```

In the main view add:
```xml
<StackPanel>
  <CalendarDatePicker SelectedDate="{Binding Date}" Watermark="Select a date" />
  <Button Command="{Binding ClearCommand}" Content="Clear" />
</StackPanel>
```

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #11055 
maybe #5835 (need to be double-checked)
