### PR TITLE
DevTools visual/logical tree context flyout

### DIFF
--- a/src/Avalonia.Base/Input/Cursor.cs
+++ b/src/Avalonia.Base/Input/Cursor.cs
@@ -42,19 +42,21 @@ namespace Avalonia.Input
     public class Cursor : IDisposable
     {
         public static readonly Cursor Default = new Cursor(StandardCursorType.Arrow);
+        private string _name;
 
-        internal Cursor(ICursorImpl platformImpl)
+        private Cursor(ICursorImpl platformImpl, string name)
         {
             PlatformImpl = platformImpl;
+            _name = name;
         }
 
         public Cursor(StandardCursorType cursorType)
-            : this(GetCursorFactory().GetCursor(cursorType))
+            : this(GetCursorFactory().GetCursor(cursorType), cursorType.ToString())
         {
         }
 
         public Cursor(IBitmap cursor, PixelPoint hotSpot)
-            : this(GetCursorFactory().CreateCursor(cursor.PlatformImpl.Item, hotSpot))
+            : this(GetCursorFactory().CreateCursor(cursor.PlatformImpl.Item, hotSpot), "BitmapCursor")
         {
         }
 
@@ -72,6 +74,11 @@ namespace Avalonia.Input
         private static ICursorFactory GetCursorFactory()
         {
             return AvaloniaLocator.Current.GetRequiredService<ICursorFactory>();
+        }
+
+        public override string ToString()
+        {
+            return _name;
         }
     }
 }

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml
@@ -26,6 +26,20 @@
           <Setter Property="Background" Value="Transparent" />
         </Style>
       </TreeView.Styles>
+      <TreeView.ContextFlyout>
+        <MenuFlyout>
+          <MenuItem Header="Copy">
+            <MenuItem Header="Copy individual node selector" Command="{Binding CopySelector}" />
+            <MenuItem Header="Copy selector from template parent" Command="{Binding CopySelectorFromTemplateParent}" />
+          </MenuItem>
+          <MenuItem Header="-" />
+          <MenuItem Header="Expand recursively" Command="{Binding ExpandRecursively}" />
+          <MenuItem Header="Collapse children" Command="{Binding CollapseChildren}" />
+          <MenuItem Header="Capture node screenshot" Command="{Binding CaptureNodeScreenshot}" />
+          <MenuItem Header="Bring into view" Command="{Binding BringIntoView}" />
+          <MenuItem Header="Focus" Command="{Binding Focus}" />
+        </MenuFlyout>
+      </TreeView.ContextFlyout>
     </TreeView>
 
     <GridSplitter Background="{DynamicResource ThemeControlMidBrush}" Width="1" Grid.Column="1"/>

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.Linq;
 using Avalonia.Controls;
@@ -36,6 +37,16 @@ namespace Avalonia.Diagnostics.Views
                 },
             };
             AdornerLayer.SetIsClipEnabled(_adorner, false);
+        }
+
+        protected override void OnDataContextChanged(EventArgs e)
+        {
+            base.OnDataContextChanged(e);
+
+            ((TreePageViewModel)DataContext!).ClipboardCopyRequested += (sender, s) =>
+            {
+                TopLevel.GetTopLevel(this)?.Clipboard?.SetTextAsync(s);
+            };
         }
 
         protected void AddAdorner(object? sender, PointerEventArgs e)


### PR DESCRIPTION
## What does the pull request do?

I felt like I really need it. Probably not me alone.

Ported every context menu node from Chrome DevTools that was easily portable. Some items like "hide element" or "force state" can be added as well in the future.

What is in this PR:
- Copy -> Copy individual node selector
- Copy -> Copy selector from template parent
- Expand recursively
- Collapse children
- Capture node screenshot
- Bring into view
- Focus
- Also fixed devtools exception when it tries to parse Cursor from its ToString.

https://user-images.githubusercontent.com/3163374/233553099-eb71e6c0-0a4f-44d5-9605-1b493fed3dbb.mp4
