### PR TITLE
Make thumb drag delta relative to root.

### DIFF
--- a/src/Avalonia.Base/Input/PointerEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerEventArgs.cs
@@ -77,14 +77,14 @@ namespace Avalonia.Input
         /// <summary>
         /// Gets the pointer position relative to a control.
         /// </summary>
-        /// <param name="relativeTo">The control.</param>
+        /// <param name="relativeTo">The visual whose coordinate system to use. Pass null for toplevel coordinate system</param>
         /// <returns>The pointer position in the control's coordinates.</returns>
         public Point GetPosition(Visual? relativeTo) => GetPosition(_rootVisualPosition, relativeTo);
 
         /// <summary>
         /// Returns the PointerPoint associated with the current event
         /// </summary>
-        /// <param name="relativeTo">The visual which coordinate system to use. Pass null for toplevel coordinate system</param>
+        /// <param name="relativeTo">The visual whose coordinate system to use. Pass null for toplevel coordinate system</param>
         /// <returns></returns>
         public PointerPoint GetCurrentPoint(Visual? relativeTo)
             => new PointerPoint(Pointer, GetPosition(relativeTo), _properties);

--- a/src/Avalonia.Controls/Primitives/Thumb.cs
+++ b/src/Avalonia.Controls/Primitives/Thumb.cs
@@ -85,7 +85,7 @@ namespace Avalonia.Controls.Primitives
         {
             if (_lastPoint.HasValue)
             {
-                var point = e.GetPosition(this.GetVisualParent());
+                var point = e.GetPosition((Visual?)this.GetVisualRoot());
                 var ev = new VectorEventArgs
                 {
                     RoutedEvent = DragDeltaEvent,
@@ -100,7 +100,7 @@ namespace Avalonia.Controls.Primitives
         protected override void OnPointerPressed(PointerPressedEventArgs e)
         {
             e.Handled = true;
-            _lastPoint = e.GetPosition(this.GetVisualParent());
+            _lastPoint = e.GetPosition((Visual?)this.GetVisualRoot());
 
             var ev = new VectorEventArgs
             {
@@ -123,7 +123,7 @@ namespace Avalonia.Controls.Primitives
                 var ev = new VectorEventArgs
                 {
                     RoutedEvent = DragCompletedEvent,
-                    Vector = (Vector)e.GetPosition(this.GetVisualParent()),
+                    Vector = (Vector)e.GetPosition((Visual?)this.GetVisualRoot()),
                 };
 
                 RaiseEvent(ev);

--- a/src/Avalonia.Controls/Primitives/Thumb.cs
+++ b/src/Avalonia.Controls/Primitives/Thumb.cs
@@ -85,7 +85,7 @@ namespace Avalonia.Controls.Primitives
         {
             if (_lastPoint.HasValue)
             {
-                var point = e.GetPosition((Visual?)this.GetVisualRoot());
+                var point = e.GetPosition(null);
                 var ev = new VectorEventArgs
                 {
                     RoutedEvent = DragDeltaEvent,
@@ -100,7 +100,7 @@ namespace Avalonia.Controls.Primitives
         protected override void OnPointerPressed(PointerPressedEventArgs e)
         {
             e.Handled = true;
-            _lastPoint = e.GetPosition((Visual?)this.GetVisualRoot());
+            _lastPoint = e.GetPosition(null);
 
             var ev = new VectorEventArgs
             {
@@ -123,7 +123,7 @@ namespace Avalonia.Controls.Primitives
                 var ev = new VectorEventArgs
                 {
                     RoutedEvent = DragCompletedEvent,
-                    Vector = (Vector)e.GetPosition((Visual?)this.GetVisualRoot()),
+                    Vector = (Vector)e.GetPosition(null),
                 };
 
                 RaiseEvent(ev);


### PR DESCRIPTION
## What does the pull request do?

#10892 changed the thumb drag delta to be relative to the parent, but the problem was that is that if the thumb controls the position of the parent then the delta will be incorrect.

This caused a bug in `TreeDataGrid` headers which were lagging behind the pointer and jumping around:

https://user-images.githubusercontent.com/1775141/233572657-ad297fc3-bfbb-4030-ac69-673389e61627.mp4

The `Thumb` is a child of the header and causes the header to move, so the drag delta is being calculated relative to a moving control.

Instead, make the drag delta relative to the visual root.