### PR TITLE
Add a few missing Window APIs back in.

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -91,7 +91,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
 
         public Action<Rect> Paint { get; set; }
 
-        public Action<Size, PlatformResizeReason> Resized { get; set; }
+        public Action<Size, WindowResizeReason> Resized { get; set; }
 
         public Action<double> ScalingChanged { get; set; }
 
@@ -156,12 +156,12 @@ namespace Avalonia.Android.Platform.SkiaPlatform
 
         protected virtual void OnResized(Size size)
         {
-            Resized?.Invoke(size, PlatformResizeReason.Unspecified);
+            Resized?.Invoke(size, WindowResizeReason.Unspecified);
         }
 
         internal void Resize(Size size)
         {
-            Resized?.Invoke(size, PlatformResizeReason.Layout);
+            Resized?.Invoke(size, WindowResizeReason.Layout);
         }
 
         class ViewImpl : InvalidationAwareSurfaceView, ISurfaceHolderCallback, IInitEditorInfo

--- a/src/Avalonia.Controls/Embedding/Offscreen/OffscreenTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Embedding/Offscreen/OffscreenTopLevelImpl.cs
@@ -47,7 +47,7 @@ namespace Avalonia.Controls.Embedding.Offscreen
             set
             {
                 _clientSize = value;
-                Resized?.Invoke(value, PlatformResizeReason.Unspecified);
+                Resized?.Invoke(value, WindowResizeReason.Unspecified);
             }
         }
 
@@ -65,7 +65,7 @@ namespace Avalonia.Controls.Embedding.Offscreen
         
         public Action<RawInputEventArgs>? Input { get; set; }
         public Action<Rect>? Paint { get; set; }
-        public Action<Size, PlatformResizeReason>? Resized { get; set; }
+        public Action<Size, WindowResizeReason>? Resized { get; set; }
         public Action<double>? ScalingChanged { get; set; }
 
         public Action<WindowTransparencyLevel>? TransparencyLevelChanged { get; set; }

--- a/src/Avalonia.Controls/Platform/ITopLevelImpl.cs
+++ b/src/Avalonia.Controls/Platform/ITopLevelImpl.cs
@@ -10,40 +10,6 @@ using Avalonia.Rendering;
 namespace Avalonia.Platform
 {
     /// <summary>
-    /// Describes the reason for a <see cref="ITopLevelImpl.Resized"/> message.
-    /// </summary>
-    public enum PlatformResizeReason
-    {
-        /// <summary>
-        /// The resize reason is unknown or unspecified.
-        /// </summary>
-        Unspecified,
-
-        /// <summary>
-        /// The resize was due to the user resizing the window, for example by dragging the
-        /// window frame.
-        /// </summary>
-        User,
-
-        /// <summary>
-        /// The resize was initiated by the application, for example by setting one of the sizing-
-        /// related properties on <see cref="Window"/> such as <see cref="Layoutable.Width"/> or
-        /// <see cref="Layoutable.Height"/>.
-        /// </summary>
-        Application,
-
-        /// <summary>
-        /// The resize was initiated by the layout system.
-        /// </summary>
-        Layout,
-
-        /// <summary>
-        /// The resize was due to a change in DPI.
-        /// </summary>
-        DpiChange,
-    }
-
-    /// <summary>
     /// Defines a platform-specific top-level window implementation.
     /// </summary>
     /// <remarks>
@@ -93,7 +59,7 @@ namespace Avalonia.Platform
         /// <summary>
         /// Gets or sets a method called when the toplevel is resized.
         /// </summary>
-        Action<Size, PlatformResizeReason>? Resized { get; set; }
+        Action<Size, WindowResizeReason>? Resized { get; set; }
 
         /// <summary>
         /// Gets or sets a method called when the toplevel's scaling changes.

--- a/src/Avalonia.Controls/Platform/IWindowImpl.cs
+++ b/src/Avalonia.Controls/Platform/IWindowImpl.cs
@@ -114,7 +114,7 @@ namespace Avalonia.Platform
         /// </summary>
         /// <param name="clientSize">The new client size.</param>
         /// <param name="reason">The reason for the resize.</param>
-        void Resize(Size clientSize, PlatformResizeReason reason = PlatformResizeReason.Application);
+        void Resize(Size clientSize, WindowResizeReason reason = WindowResizeReason.Application);
 
         /// <summary>
         /// Sets the client size of the top level.

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -569,7 +569,7 @@ namespace Avalonia.Controls
         /// </summary>
         /// <param name="clientSize">The new client size.</param>
         /// <param name="reason">The reason for the resize.</param>
-        protected virtual void HandleResized(Size clientSize, PlatformResizeReason reason)
+        internal virtual void HandleResized(Size clientSize, WindowResizeReason reason)
         {
             ClientSize = clientSize;
             FrameSize = PlatformImpl!.FrameSize;

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -227,7 +227,7 @@ namespace Avalonia.Controls
             impl.WindowStateChanged = HandleWindowStateChanged;
             _maxPlatformClientSize = PlatformImpl?.MaxAutoSizeHint ?? default(Size);
             impl.ExtendClientAreaToDecorationsChanged = ExtendClientAreaToDecorationsChanged;
-            this.GetObservable(ClientSizeProperty).Skip(1).Subscribe(x => PlatformImpl?.Resize(x, PlatformResizeReason.Application));
+            this.GetObservable(ClientSizeProperty).Skip(1).Subscribe(x => PlatformImpl?.Resize(x, WindowResizeReason.Application));
 
             PlatformImpl?.ShowTaskbarIcon(ShowInTaskbar);
         }
@@ -700,7 +700,7 @@ namespace Avalonia.Controls
 
                 if (initialSize != ClientSize)
                 {
-                    PlatformImpl?.Resize(initialSize, PlatformResizeReason.Layout);
+                    PlatformImpl?.Resize(initialSize, WindowResizeReason.Layout);
                 }
 
                 LayoutManager.ExecuteInitialLayoutPass();
@@ -778,7 +778,7 @@ namespace Avalonia.Controls
 
                 if (initialSize != ClientSize)
                 {
-                    PlatformImpl?.Resize(initialSize, PlatformResizeReason.Layout);
+                    PlatformImpl?.Resize(initialSize, WindowResizeReason.Layout);
                 }
 
                 LayoutManager.ExecuteInitialLayoutPass();
@@ -975,7 +975,7 @@ namespace Avalonia.Controls
 
         protected sealed override Size ArrangeSetBounds(Size size)
         {
-            PlatformImpl?.Resize(size, PlatformResizeReason.Layout);
+            PlatformImpl?.Resize(size, WindowResizeReason.Layout);
             return ClientSize;
         }
 
@@ -994,7 +994,7 @@ namespace Avalonia.Controls
         }
 
         /// <inheritdoc/>
-        protected sealed override void HandleResized(Size clientSize, PlatformResizeReason reason)
+        internal override void HandleResized(Size clientSize, WindowResizeReason reason)
         {
             if (ClientSize != clientSize || double.IsNaN(Width) || double.IsNaN(Height))
             {
@@ -1005,8 +1005,8 @@ namespace Avalonia.Controls
                 // to the requested size.
                 if (sizeToContent != SizeToContent.Manual &&
                     CanResize &&
-                    reason == PlatformResizeReason.Unspecified ||
-                    reason == PlatformResizeReason.User)
+                    reason == WindowResizeReason.Unspecified ||
+                    reason == WindowResizeReason.User)
                 {
                     if (clientSize.Width != ClientSize.Width)
                         sizeToContent &= ~SizeToContent.Width;

--- a/src/Avalonia.Controls/WindowBase.cs
+++ b/src/Avalonia.Controls/WindowBase.cs
@@ -161,6 +161,15 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
+        /// Trys to get the platform handle for the window.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="IPlatformHandle"/> describing the window handle, or null if the handle
+        /// could not be retrieved.
+        /// </returns>
+        public IPlatformHandle? TryGetPlatformHandle() => PlatformImpl?.Handle;
+
+        /// <summary>
         /// Ensures that the window is initialized.
         /// </summary>
         protected void EnsureInitialized()

--- a/src/Avalonia.Controls/WindowBase.cs
+++ b/src/Avalonia.Controls/WindowBase.cs
@@ -80,6 +80,11 @@ namespace Avalonia.Controls
         /// </summary>
         public event EventHandler<PixelPointEventArgs>? PositionChanged;
 
+        /// <summary>
+        /// Occurs when the window is resized.
+        /// </summary>
+        public event EventHandler<WindowResizedEventArgs>? Resized;
+
         public new IWindowBaseImpl? PlatformImpl => (IWindowBaseImpl?) base.PlatformImpl;
 
         /// <summary>
@@ -188,6 +193,12 @@ namespace Avalonia.Controls
             base.OnOpened(e);
         }
 
+        /// <summary>
+        /// Raises the <see cref="Resized"/> event.
+        /// </summary>
+        /// <param name="e">An <see cref="EventArgs"/> that contains the event data.</param>
+        protected virtual void OnResized(WindowResizedEventArgs e) => Resized?.Invoke(this, e);
+
         protected override void HandleClosed()
         {
             using (FreezeVisibilityChangeHandling())
@@ -208,7 +219,7 @@ namespace Avalonia.Controls
         /// </summary>
         /// <param name="clientSize">The new client size.</param>
         /// <param name="reason">The reason for the resize.</param>
-        protected override void HandleResized(Size clientSize, PlatformResizeReason reason)
+        internal override void HandleResized(Size clientSize, WindowResizeReason reason)
         {
             FrameSize = PlatformImpl?.FrameSize;
 
@@ -218,6 +229,8 @@ namespace Avalonia.Controls
                 LayoutManager.ExecuteLayoutPass();
                 Renderer.Resized(clientSize);
             }
+
+            OnResized(new WindowResizedEventArgs(clientSize, reason));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/WindowResizedEventArgs.cs
+++ b/src/Avalonia.Controls/WindowResizedEventArgs.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Avalonia.Layout;
+
+namespace Avalonia.Controls
+{
+    /// <summary>
+    /// Describes the reason for a <see cref="WindowBase.Resized"/> event.
+    /// </summary>
+    public enum WindowResizeReason
+    {
+        /// <summary>
+        /// The resize reason is unknown or unspecified.
+        /// </summary>
+        Unspecified,
+
+        /// <summary>
+        /// The resize was due to the user resizing the window, for example by dragging the
+        /// window frame.
+        /// </summary>
+        User,
+
+        /// <summary>
+        /// The resize was initiated by the application, for example by setting one of the sizing-
+        /// related properties on <see cref="Window"/> such as <see cref="Layoutable.Width"/> or
+        /// <see cref="Layoutable.Height"/>.
+        /// </summary>
+        Application,
+
+        /// <summary>
+        /// The resize was initiated by the layout system.
+        /// </summary>
+        Layout,
+
+        /// <summary>
+        /// The resize was due to a change in DPI.
+        /// </summary>
+        DpiChange,
+    }
+
+    /// <summary>
+    /// Provides data for the <see cref="WindowBase.Resized"/> event.
+    /// </summary>
+    public class WindowResizedEventArgs : EventArgs
+    {
+        internal WindowResizedEventArgs(Size clientSize, WindowResizeReason reason)
+        {
+            ClientSize = clientSize;
+            Reason = reason;
+        }
+
+        /// <summary>
+        /// Gets the new client size of the window in device-independent pixels.
+        /// </summary>
+        public Size ClientSize { get; }
+
+        /// <summary>
+        /// Gets the reason for the resize.
+        /// </summary>
+        public WindowResizeReason Reason { get; }
+    }
+}

--- a/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
+++ b/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
@@ -59,7 +59,7 @@ namespace Avalonia.DesignerSupport.Remote
             base.OnMessage(transport, obj);
         }
         
-        public void Resize(Size clientSize, PlatformResizeReason reason)
+        public void Resize(Size clientSize, WindowResizeReason reason)
         {
             _transport.Send(new RequestViewportResizeMessage
             {

--- a/src/Avalonia.DesignerSupport/Remote/Stubs.cs
+++ b/src/Avalonia.DesignerSupport/Remote/Stubs.cs
@@ -32,7 +32,7 @@ namespace Avalonia.DesignerSupport.Remote
         public IEnumerable<object> Surfaces { get; }
         public Action<RawInputEventArgs> Input { get; set; }
         public Action<Rect> Paint { get; set; }
-        public Action<Size, PlatformResizeReason> Resized { get; set; }
+        public Action<Size, WindowResizeReason> Resized { get; set; }
         public Action<double> ScalingChanged { get; set; }
         public Func<WindowCloseReason, bool> Closing { get; set; }
         public Action Closed { get; set; }
@@ -59,7 +59,7 @@ namespace Avalonia.DesignerSupport.Remote
                 PopupPositioner = new ManagedPopupPositioner(new ManagedPopupPositionerPopupImplHelper(parent,
                     (_, size, __) =>
                     {
-                        Resize(size, PlatformResizeReason.Unspecified);
+                        Resize(size, WindowResizeReason.Unspecified);
                     }));
         }
 
@@ -112,7 +112,7 @@ namespace Avalonia.DesignerSupport.Remote
         {
         }
 
-        public void Resize(Size clientSize, PlatformResizeReason reason)
+        public void Resize(Size clientSize, WindowResizeReason reason)
         {
         }
 

--- a/src/Avalonia.Headless/HeadlessWindowImpl.cs
+++ b/src/Avalonia.Headless/HeadlessWindowImpl.cs
@@ -50,7 +50,7 @@ namespace Avalonia.Headless
         public IEnumerable<object> Surfaces { get; }
         public Action<RawInputEventArgs> Input { get; set; }
         public Action<Rect> Paint { get; set; }
-        public Action<Size, PlatformResizeReason> Resized { get; set; }
+        public Action<Size, WindowResizeReason> Resized { get; set; }
         public Action<double> ScalingChanged { get; set; }
 
         public IRenderer CreateRenderer(IRenderRoot root) =>
@@ -111,7 +111,7 @@ namespace Avalonia.Headless
         public Action Activated { get; set; }
         public IPlatformHandle Handle { get; } = new PlatformHandle(IntPtr.Zero, "STUB");
         public Size MaxClientSize { get; } = new Size(1920, 1280);
-        public void Resize(Size clientSize, PlatformResizeReason reason)
+        public void Resize(Size clientSize, WindowResizeReason reason)
         {
             // Emulate X11 behavior here
             if (IsPopup)
@@ -129,7 +129,7 @@ namespace Avalonia.Headless
             if (ClientSize != clientSize)
             {
                 ClientSize = clientSize;
-                Resized?.Invoke(clientSize, PlatformResizeReason.Unspecified);
+                Resized?.Invoke(clientSize, WindowResizeReason.Unspecified);
             }
         }
 

--- a/src/Avalonia.Native/PopupImpl.cs
+++ b/src/Avalonia.Native/PopupImpl.cs
@@ -29,7 +29,7 @@ namespace Avalonia.Native
         private void MoveResize(PixelPoint position, Size size, double scaling)
         {
             Position = position;
-            Resize(size, PlatformResizeReason.Layout);
+            Resize(size, ResizeReason.Layout);
             //TODO: We ignore the scaling override for now
         }
 

--- a/src/Avalonia.Native/PopupImpl.cs
+++ b/src/Avalonia.Native/PopupImpl.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Avalonia.Controls;
 using Avalonia.Controls.Primitives.PopupPositioning;
 using Avalonia.Native.Interop;
 using Avalonia.Platform;
@@ -29,7 +30,7 @@ namespace Avalonia.Native
         private void MoveResize(PixelPoint position, Size size, double scaling)
         {
             Position = position;
-            Resize(size, ResizeReason.Layout);
+            Resize(size, WindowResizeReason.Layout);
             //TODO: We ignore the scaling override for now
         }
 

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -95,7 +95,7 @@ namespace Avalonia.Native
             var monitor = Screen.AllScreens.OrderBy(x => x.Scaling)
                     .FirstOrDefault(m => m.Bounds.Contains(Position));
 
-            Resize(new Size(monitor.WorkingArea.Width * 0.75d, monitor.WorkingArea.Height * 0.7d), PlatformResizeReason.Layout);
+            Resize(new Size(monitor.WorkingArea.Width * 0.75d, monitor.WorkingArea.Height * 0.7d), WindowResizeReason.Layout);
         }
 
         public IAvnWindowBase Native => _native;
@@ -160,7 +160,7 @@ namespace Avalonia.Native
         public Action LostFocus { get; set; }
         
         public Action<Rect> Paint { get; set; }
-        public Action<Size, PlatformResizeReason> Resized { get; set; }
+        public Action<Size, WindowResizeReason> Resized { get; set; }
         public Action Closed { get; set; }
         public IMouseDevice MouseDevice => _mouse;
         public abstract IPopupImpl CreatePopup();
@@ -211,7 +211,7 @@ namespace Avalonia.Native
                 {
                     var s = new Size(size->Width, size->Height);
                     _parent._savedLogicalSize = s;
-                    _parent.Resized?.Invoke(s, (PlatformResizeReason)reason);
+                    _parent.Resized?.Invoke(s, (WindowResizeReason)reason);
                 }
             }
 
@@ -360,7 +360,7 @@ namespace Avalonia.Native
             }
         }
 
-        public void Resize(Size clientSize, PlatformResizeReason reason)
+        public void Resize(Size clientSize, WindowResizeReason reason)
         {
             _native?.Resize(clientSize.Width, clientSize.Height, (AvnPlatformResizeReason)reason);
         }

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -352,7 +352,7 @@ namespace Avalonia.X11
         public IEnumerable<object> Surfaces { get; }
         public Action<RawInputEventArgs>? Input { get; set; }
         public Action<Rect>? Paint { get; set; }
-        public Action<Size, PlatformResizeReason>? Resized { get; set; }
+        public Action<Size, WindowResizeReason>? Resized { get; set; }
         //TODO
         public Action<double>? ScalingChanged { get; set; }
         public Action? Deactivated { get; set; }
@@ -509,7 +509,7 @@ namespace Avalonia.X11
                         UpdateImePosition();
 
                         if (changedSize && !updatedSizeViaScaling && !_popup)
-                            Resized?.Invoke(ClientSize, PlatformResizeReason.Unspecified);
+                            Resized?.Invoke(ClientSize, WindowResizeReason.Unspecified);
 
                     }, DispatcherPriority.Layout);
                 if (_useRenderWindow)
@@ -590,7 +590,7 @@ namespace Avalonia.X11
                 UpdateImePosition();
                 SetMinMaxSize(_scaledMinMaxSize.minSize, _scaledMinMaxSize.maxSize);
                 if(!skipResize)
-                    Resize(oldScaledSize, true, PlatformResizeReason.DpiChange);
+                    Resize(oldScaledSize, true, WindowResizeReason.DpiChange);
                 return true;
             }
             
@@ -642,7 +642,7 @@ namespace Avalonia.X11
             {
                 // Occurs once the window has been mapped, which is the earliest the extents
                 // can be retrieved, so invoke event to force update of TopLevel.FrameSize.
-                Resized?.Invoke(ClientSize, PlatformResizeReason.Unspecified);
+                Resized?.Invoke(ClientSize, WindowResizeReason.Unspecified);
             }
 
             if (atom == _x11.Atoms._NET_WM_STATE)
@@ -959,19 +959,19 @@ namespace Avalonia.X11
         }
 
 
-        public void Resize(Size clientSize, PlatformResizeReason reason) => Resize(clientSize, false, reason);
+        public void Resize(Size clientSize, WindowResizeReason reason) => Resize(clientSize, false, reason);
         public void Move(PixelPoint point) => Position = point;
         private void MoveResize(PixelPoint position, Size size, double scaling)
         {
             Move(position);
             _scalingOverride = scaling;
             UpdateScaling(true);
-            Resize(size, true, PlatformResizeReason.Layout);
+            Resize(size, true, WindowResizeReason.Layout);
         }
 
         private PixelSize ToPixelSize(Size size) => new PixelSize((int)(size.Width * RenderScaling), (int)(size.Height * RenderScaling));
 
-        private void Resize(Size clientSize, bool force, PlatformResizeReason reason)
+        private void Resize(Size clientSize, bool force, WindowResizeReason reason)
         {
             if (!force && clientSize == ClientSize)
                 return;

--- a/src/Browser/Avalonia.Browser/BrowserTopLevelImpl.cs
+++ b/src/Browser/Avalonia.Browser/BrowserTopLevelImpl.cs
@@ -74,7 +74,7 @@ namespace Avalonia.Browser
                     surface.Size = new PixelSize((int)newSize.Width, (int)newSize.Height);
                 }
 
-                Resized?.Invoke(newSize, PlatformResizeReason.User);
+                Resized?.Invoke(newSize, WindowResizeReason.User);
 
                 (_insetsManager as BrowserInsetsManager)?.NotifySafeAreaPaddingChanged();
             }
@@ -241,7 +241,7 @@ namespace Avalonia.Browser
         public Action<string>? SetCssCursor { get; set; }
         public Action<RawInputEventArgs>? Input { get; set; }
         public Action<Rect>? Paint { get; set; }
-        public Action<Size, PlatformResizeReason>? Resized { get; set; }
+        public Action<Size, WindowResizeReason>? Resized { get; set; }
         public Action<double>? ScalingChanged { get; set; }
         public Action<WindowTransparencyLevel>? TransparencyLevelChanged { get; set; }
         public Action? Closed { get; set; }

--- a/src/Linux/Avalonia.LinuxFramebuffer/FramebufferToplevelImpl.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/FramebufferToplevelImpl.cs
@@ -65,7 +65,7 @@ using Avalonia.Rendering.Composition;
         public IEnumerable<object> Surfaces { get; }
         public Action<RawInputEventArgs> Input { get; set; }
         public Action<Rect> Paint { get; set; }
-        public Action<Size, PlatformResizeReason> Resized { get; set; }
+        public Action<Size, WindowResizeReason> Resized { get; set; }
         public Action<double> ScalingChanged { get; set; }
 
         public Action<WindowTransparencyLevel> TransparencyLevelChanged { get; set; }

--- a/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
+++ b/src/Windows/Avalonia.Win32.Interop/Wpf/WpfTopLevelImpl.cs
@@ -108,7 +108,7 @@ namespace Avalonia.Win32.Interop.Wpf
             if (_finalSize == _previousSize)
                 return finalSize;
             _previousSize = _finalSize;
-            _ttl.Resized?.Invoke(finalSize.ToAvaloniaSize(), PlatformResizeReason.Unspecified);
+            _ttl.Resized?.Invoke(finalSize.ToAvaloniaSize(), WindowResizeReason.Unspecified);
             return base.ArrangeOverride(finalSize);
         }
 
@@ -229,7 +229,7 @@ namespace Avalonia.Win32.Interop.Wpf
 
         Action<RawInputEventArgs> ITopLevelImpl.Input { get; set; } //TODO
         Action<Rect> ITopLevelImpl.Paint { get; set; }
-        Action<Size, PlatformResizeReason> ITopLevelImpl.Resized { get; set; }
+        Action<Size, WindowResizeReason> ITopLevelImpl.Resized { get; set; }
         Action<double> ITopLevelImpl.ScalingChanged { get; set; }
 
         Action<WindowTransparencyLevel> ITopLevelImpl.TransparencyLevelChanged { get; set; }

--- a/src/Windows/Avalonia.Win32/PopupImpl.cs
+++ b/src/Windows/Avalonia.Win32/PopupImpl.cs
@@ -1,4 +1,5 @@
 using System;
+using Avalonia.Controls;
 using Avalonia.Controls.Primitives.PopupPositioning;
 using Avalonia.Platform;
 using Avalonia.Win32.Interop;
@@ -135,7 +136,7 @@ namespace Avalonia.Win32
         private void MoveResize(PixelPoint position, Size size, double scaling)
         {
             Move(position);
-            Resize(size, PlatformResizeReason.Layout);
+            Resize(size, WindowResizeReason.Layout);
             //TODO: We ignore the scaling override for now
         }
 

--- a/src/Windows/Avalonia.Win32/TrayIconImpl.cs
+++ b/src/Windows/Avalonia.Win32/TrayIconImpl.cs
@@ -212,7 +212,7 @@ namespace Avalonia.Win32
                 if (PlatformImpl is { } platformImpl)
                 {
                     platformImpl.Move(position);
-                    platformImpl.Resize(size, PlatformResizeReason.Layout);
+                    platformImpl.Resize(size, WindowResizeReason.Layout);
                 }
             }
 

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -133,7 +133,7 @@ namespace Avalonia.Win32
                         _scaling = dpi / 96.0;
                         ScalingChanged?.Invoke(_scaling);
 
-                        using (SetResizeReason(PlatformResizeReason.DpiChange))
+                        using (SetResizeReason(WindowResizeReason.DpiChange))
                         {
                             SetWindowPos(hWnd,
                                 IntPtr.Zero,
@@ -611,7 +611,7 @@ namespace Avalonia.Win32
 
 
                 case WindowsMessage.WM_ENTERSIZEMOVE:
-                    _resizeReason = PlatformResizeReason.User;
+                    _resizeReason = WindowResizeReason.User;
                     break;
 
                 case WindowsMessage.WM_SIZE:
@@ -658,7 +658,7 @@ namespace Avalonia.Win32
                     }
 
                 case WindowsMessage.WM_EXITSIZEMOVE:
-                    _resizeReason = PlatformResizeReason.Unspecified;
+                    _resizeReason = WindowResizeReason.Unspecified;
                     break;
 
                 case WindowsMessage.WM_MOVE:

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -59,7 +59,7 @@ namespace Avalonia.Win32
         private double _extendTitleBarHint = -1;
         private readonly bool _isUsingComposition;
         private readonly IBlurHost? _blurHost;
-        private PlatformResizeReason _resizeReason;
+        private WindowResizeReason _resizeReason;
         private MOUSEMOVEPOINT _lastWmMousePoint;
 
 #if USE_MANAGED_DRAG
@@ -200,7 +200,7 @@ namespace Avalonia.Win32
 
         public Action<Rect>? Paint { get; set; }
 
-        public Action<Size, PlatformResizeReason>? Resized { get; set; }
+        public Action<Size, WindowResizeReason>? Resized { get; set; }
 
         public Action<double>? ScalingChanged { get; set; }
 
@@ -588,7 +588,7 @@ namespace Avalonia.Win32
         public IRenderer CreateRenderer(IRenderRoot root) =>
             new CompositingRenderer(root, Win32Platform.Compositor, () => Surfaces);
 
-        public void Resize(Size value, PlatformResizeReason reason)
+        public void Resize(Size value, WindowResizeReason reason)
         {
             if (WindowState != WindowState.Normal)
                 return;
@@ -1053,7 +1053,7 @@ namespace Avalonia.Win32
                 _offScreenMargin = new Thickness();
                 _extendedMargins = new Thickness();
 
-                Resize(new Size(rcWindow.Width / RenderScaling, rcWindow.Height / RenderScaling), PlatformResizeReason.Layout);
+                Resize(new Size(rcWindow.Width / RenderScaling, rcWindow.Height / RenderScaling), WindowResizeReason.Layout);
 
                 unsafe
                 {
@@ -1462,7 +1462,7 @@ namespace Avalonia.Win32
         /// <inheritdoc/>
         public AcrylicPlatformCompensationLevels AcrylicCompensationLevels { get; } = new AcrylicPlatformCompensationLevels(1, 0.8, 0);
 
-        private ResizeReasonScope SetResizeReason(PlatformResizeReason reason)
+        private ResizeReasonScope SetResizeReason(WindowResizeReason reason)
         {
             var old = _resizeReason;
             _resizeReason = reason;
@@ -1487,9 +1487,9 @@ namespace Avalonia.Win32
         private struct ResizeReasonScope : IDisposable
         {
             private readonly WindowImpl _owner;
-            private readonly PlatformResizeReason _restore;
+            private readonly WindowResizeReason _restore;
 
-            public ResizeReasonScope(WindowImpl owner, PlatformResizeReason restore)
+            public ResizeReasonScope(WindowImpl owner, WindowResizeReason restore)
             {
                 _owner = owner;
                 _restore = restore;

--- a/src/iOS/Avalonia.iOS/AvaloniaView.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaView.cs
@@ -150,7 +150,7 @@ namespace Avalonia.iOS
             public IEnumerable<object> Surfaces { get; set; }
             public Action<RawInputEventArgs> Input { get; set; }
             public Action<Rect> Paint { get; set; }
-            public Action<Size, PlatformResizeReason> Resized { get; set; }
+            public Action<Size, WindowResizeReason> Resized { get; set; }
             public Action<double> ScalingChanged { get; set; }
             public Action<WindowTransparencyLevel> TransparencyLevelChanged { get; set; }
             public Action Closed { get; set; }
@@ -225,7 +225,7 @@ namespace Avalonia.iOS
 
         public override void LayoutSubviews()
         {
-            _topLevelImpl.Resized?.Invoke(_topLevelImpl.ClientSize, PlatformResizeReason.Layout);
+            _topLevelImpl.Resized?.Invoke(_topLevelImpl.ClientSize, WindowResizeReason.Layout);
             base.LayoutSubviews();
         }
 

--- a/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/PopupTests.cs
@@ -830,7 +830,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                         }
                     };
                 }
-                window.PlatformImpl?.Resize(new Size(700D, 500D), PlatformResizeReason.Unspecified);
+                window.PlatformImpl?.Resize(new Size(700D, 500D), WindowResizeReason.Unspecified);
                 Dispatcher.UIThread.RunJobs(DispatcherPriority.Layout);
                 Assert.True(raised);
             }
@@ -886,7 +886,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                         }
                     };
                 }
-                window.PlatformImpl?.Resize(new Size(700D, 500D), PlatformResizeReason.Unspecified);
+                window.PlatformImpl?.Resize(new Size(700D, 500D), WindowResizeReason.Unspecified);
                 Dispatcher.UIThread.RunJobs(DispatcherPriority.Layout);
                 Assert.False(raised);
             }

--- a/tests/Avalonia.Controls.UnitTests/TopLevelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TopLevelTests.cs
@@ -142,7 +142,7 @@ namespace Avalonia.Controls.UnitTests
 
                 // The user has resized the window, so we can no longer auto-size.
                 var target = new TestTopLevel(impl.Object);
-                impl.Object.Resized(new Size(100, 200), PlatformResizeReason.Unspecified);
+                impl.Object.Resized(new Size(100, 200), WindowResizeReason.Unspecified);
 
                 Assert.Equal(100, target.Width);
                 Assert.Equal(200, target.Height);

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -704,8 +704,8 @@ namespace Avalonia.Controls.UnitTests
                     var clientSize = new Size(200, 200);
                     var maxClientSize = new Size(480, 480);
 
-                    windowImpl.Setup(x => x.Resize(It.IsAny<Size>(), It.IsAny<PlatformResizeReason>()))
-                        .Callback<Size, PlatformResizeReason>((size, reason) =>
+                    windowImpl.Setup(x => x.Resize(It.IsAny<Size>(), It.IsAny<WindowResizeReason>()))
+                        .Callback<Size, WindowResizeReason>((size, reason) =>
                     {
                         clientSize = size.Constrain(maxClientSize);
                         windowImpl.Object.Resized?.Invoke(clientSize, reason);
@@ -853,7 +853,7 @@ namespace Avalonia.Controls.UnitTests
                     target.PlatformImpl.ScalingChanged(1.5);
                     target.PlatformImpl.Resized(
                         new Size(210.66666666666666, 118.66666666666667),
-                        PlatformResizeReason.DpiChange);
+                        WindowResizeReason.DpiChange);
 
                     Assert.Equal(SizeToContent.WidthAndHeight, target.SizeToContent);
                 }
@@ -911,7 +911,7 @@ namespace Avalonia.Controls.UnitTests
                     target.LayoutManager.ExecuteLayoutPass();
 
                     var windowImpl = Mock.Get(target.PlatformImpl);
-                    windowImpl.Verify(x => x.Resize(new Size(410, 800), PlatformResizeReason.Application));
+                    windowImpl.Verify(x => x.Resize(new Size(410, 800), WindowResizeReason.Application));
                     Assert.Equal(410, target.Width);
                 }
             }
@@ -936,7 +936,7 @@ namespace Avalonia.Controls.UnitTests
                     Assert.Equal(400, target.Width);
                     Assert.Equal(800, target.Height);
 
-                    target.PlatformImpl.Resized(new Size(410, 800), PlatformResizeReason.User);
+                    target.PlatformImpl.Resized(new Size(410, 800), WindowResizeReason.User);
 
                     Assert.Equal(410, target.Width);
                     Assert.Equal(800, target.Height);
@@ -963,7 +963,7 @@ namespace Avalonia.Controls.UnitTests
                     Assert.Equal(400, target.Width);
                     Assert.Equal(800, target.Height);
 
-                    target.PlatformImpl.Resized(new Size(400, 810), PlatformResizeReason.User);
+                    target.PlatformImpl.Resized(new Size(400, 810), WindowResizeReason.User);
 
                     Assert.Equal(400, target.Width);
                     Assert.Equal(810, target.Height);
@@ -991,7 +991,7 @@ namespace Avalonia.Controls.UnitTests
                     Assert.Equal(400, target.Width);
                     Assert.Equal(800, target.Height);
 
-                    target.PlatformImpl.Resized(new Size(410, 810), PlatformResizeReason.Unspecified);
+                    target.PlatformImpl.Resized(new Size(410, 810), WindowResizeReason.Unspecified);
 
                     Assert.Equal(400, target.Width);
                     Assert.Equal(800, target.Height);

--- a/tests/Avalonia.UnitTests/CompositorTestServices.cs
+++ b/tests/Avalonia.UnitTests/CompositorTestServices.cs
@@ -152,7 +152,7 @@ public class CompositorTestServices : IDisposable
         public IEnumerable<object> Surfaces { get; } = new[] { new DummyFramebufferSurface() };
         public Action<RawInputEventArgs> Input { get; set; }
         public Action<Rect> Paint { get; set; }
-        public Action<Size, PlatformResizeReason> Resized { get; set; }
+        public Action<Size, WindowResizeReason> Resized { get; set; }
         public Action<double> ScalingChanged { get; set; }
         public Action<WindowTransparencyLevel> TransparencyLevelChanged { get; set; }
 

--- a/tests/Avalonia.UnitTests/MockWindowingPlatform.cs
+++ b/tests/Avalonia.UnitTests/MockWindowingPlatform.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls.Primitives.PopupPositioning;
 using Moq;
 using Avalonia.Platform;
 using Avalonia.Rendering;
+using Avalonia.Controls;
 
 namespace Avalonia.UnitTests
 {
@@ -54,8 +55,8 @@ namespace Avalonia.UnitTests
                 windowImpl.Object.PositionChanged?.Invoke(x);
             });
 
-            windowImpl.Setup(x => x.Resize(It.IsAny<Size>(), It.IsAny<PlatformResizeReason>()))
-                .Callback<Size, PlatformResizeReason>((x, y) =>
+            windowImpl.Setup(x => x.Resize(It.IsAny<Size>(), It.IsAny<WindowResizeReason>()))
+                .Callback<Size, WindowResizeReason>((x, y) =>
             {
                 var constrainedSize = x.Constrain(s_screenSize);
                 
@@ -68,7 +69,7 @@ namespace Avalonia.UnitTests
 
             windowImpl.Setup(x => x.Show(true, It.IsAny<bool>())).Callback(() =>
             {
-                windowImpl.Object.Resized?.Invoke(windowImpl.Object.ClientSize, PlatformResizeReason.Unspecified);
+                windowImpl.Object.Resized?.Invoke(windowImpl.Object.ClientSize, WindowResizeReason.Unspecified);
                 windowImpl.Object.Activated?.Invoke();
             });
 
@@ -87,7 +88,7 @@ namespace Avalonia.UnitTests
             {
                 clientSize = size.Constrain(s_screenSize);
                 popupImpl.Object.PositionChanged?.Invoke(pos);
-                popupImpl.Object.Resized?.Invoke(clientSize, PlatformResizeReason.Unspecified);
+                popupImpl.Object.Resized?.Invoke(clientSize, WindowResizeReason.Unspecified);
             });
             
             var positioner = new ManagedPopupPositioner(positionerHelper);


### PR DESCRIPTION
## What does the pull request do?

#11062 made `WindowBase.PlatformImpl` internal, but a couple of APIs from there weren't exposed in our public API surface, so this PR adds alternatives back in:

- [Added WindowBase.TryGetPlatformHandle.](https://github.com/AvaloniaUI/Avalonia/commit/cf52ab43cde367fc12ecad06340ce21b3df31fa7) : `WindowBase.PlatformImpl` is now internal so we need to expose a different want to get the window handle
- [Added WindowBase.Resized event.](https://github.com/AvaloniaUI/Avalonia/commit/981dfd29d74ba2c64b9cca220d2f0e7ec830e201): exposes the resize reason and new client size. Required renaming `PlatformResizeReason` to `WindowResizeReason`. Made `TopLevel.HandleResized` method internal.
