### PR TITLE
Fix theme-dependend markup extensions not knowing current theme context

### DIFF
--- a/src/Avalonia.Base/Controls/IResourceDictionary.cs
+++ b/src/Avalonia.Base/Controls/IResourceDictionary.cs
@@ -18,6 +18,6 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets a collection of merged resource dictionaries that are specifically keyed and composed to address theme scenarios.
         /// </summary>
-        IDictionary<ThemeVariant, IResourceProvider> ThemeDictionaries { get; }
+        IDictionary<ThemeVariant, IThemeVariantProvider> ThemeDictionaries { get; }
     }
 }

--- a/src/Avalonia.Base/Controls/IThemeVariantProvider.cs
+++ b/src/Avalonia.Base/Controls/IThemeVariantProvider.cs
@@ -1,0 +1,22 @@
+﻿using Avalonia.Metadata;
+using Avalonia.Styling;
+
+namespace Avalonia.Controls;
+
+/// <summary>
+/// Resource provider with theme variant awareness.
+/// Can be used with <see cref="IResourceDictionary.ThemeDictionaries"/>.
+/// </summary>
+/// <remarks>
+/// This is a helper interface for the XAML compiler to make Key property accessibly by the markup extensions.
+/// Which means, it can only be used with ResourceDictionaries and markup extensions in the XAML code.
+/// This API might be removed in the future minor updates.
+/// </remarks>
+[Unstable]
+public interface IThemeVariantProvider : IResourceProvider
+{
+    /// <summary>
+    /// Key property set by the compiler.
+    /// </summary>
+    ThemeVariant? Key { get; set; }
+}

--- a/src/Avalonia.Base/Controls/ResourceDictionary.cs
+++ b/src/Avalonia.Base/Controls/ResourceDictionary.cs
@@ -13,13 +13,13 @@ namespace Avalonia.Controls
     /// <summary>
     /// An indexed dictionary of resources.
     /// </summary>
-    public class ResourceDictionary : IResourceDictionary
+    public class ResourceDictionary : IResourceDictionary, IThemeVariantProvider
     {
         private object? lastDeferredItemKey;
         private Dictionary<object, object?>? _inner;
         private IResourceHost? _owner;
         private AvaloniaList<IResourceProvider>? _mergedDictionaries;
-        private AvaloniaDictionary<ThemeVariant, IResourceProvider>? _themeDictionary;
+        private AvaloniaDictionary<ThemeVariant, IThemeVariantProvider>? _themeDictionary;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ResourceDictionary"/> class.
@@ -93,13 +93,13 @@ namespace Avalonia.Controls
             }
         }
 
-        public IDictionary<ThemeVariant, IResourceProvider> ThemeDictionaries
+        public IDictionary<ThemeVariant, IThemeVariantProvider> ThemeDictionaries
         {
             get
             {
                 if (_themeDictionary == null)
                 {
-                    _themeDictionary = new AvaloniaDictionary<ThemeVariant, IResourceProvider>(2);
+                    _themeDictionary = new AvaloniaDictionary<ThemeVariant, IThemeVariantProvider>(2);
                     _themeDictionary.ForEachItem(
                         (_, x) =>
                         {
@@ -120,6 +120,8 @@ namespace Avalonia.Controls
                 return _themeDictionary;
             }
         }
+        
+        ThemeVariant? IThemeVariantProvider.Key { get; set; }
 
         bool IResourceNode.HasResources
         {
@@ -192,7 +194,7 @@ namespace Avalonia.Controls
 
             if (_themeDictionary is not null)
             {
-                IResourceProvider? themeResourceProvider;
+                IThemeVariantProvider? themeResourceProvider;
                 if (theme is not null && theme != ThemeVariant.Default)
                 {
                     if (_themeDictionary.TryGetValue(theme, out themeResourceProvider)

--- a/src/Avalonia.Base/Styling/IThemeVariantHost.cs
+++ b/src/Avalonia.Base/Styling/IThemeVariantHost.cs
@@ -7,7 +7,6 @@ namespace Avalonia.Styling;
 /// <summary>
 /// Interface for the host element with a theme variant.
 /// </summary>
-[Unstable]
 public interface IThemeVariantHost : IResourceHost
 {
     /// <summary>

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlCompiler.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlCompiler.cs
@@ -58,7 +58,8 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                 new AvaloniaXamlIlSetterTransformer(),
                 new AvaloniaXamlIlConstructorServiceProviderTransformer(),
                 new AvaloniaXamlIlTransitionsTypeMetadataTransformer(),
-                new AvaloniaXamlIlResolveByNameMarkupExtensionReplacer()
+                new AvaloniaXamlIlResolveByNameMarkupExtensionReplacer(),
+                new AvaloniaXamlIlThemeVariantProviderTransformer()
             );
             InsertBefore<ConvertPropertyValuesToAssignmentsTransformer>(
                 new AvaloniaXamlIlOptionMarkupExtensionTransformer());

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlThemeVariantProviderTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlThemeVariantProviderTransformer.cs
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+using XamlX;
+using XamlX.Ast;
+using XamlX.Transform;
+using XamlX.TypeSystem;
+
+namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers;
+
+internal class AvaloniaXamlIlThemeVariantProviderTransformer : IXamlAstTransformer
+{
+    public IXamlAstNode Transform(AstTransformationContext context, IXamlAstNode node)
+    {
+        var type = context.GetAvaloniaTypes().IThemeVariantProvider;
+        if (!(node is XamlAstObjectNode on
+              && type.IsAssignableFrom(on.Type.GetClrType())))
+            return node;
+
+        var keyDirective = on.Children.FirstOrDefault(n => n is XamlAstXmlDirective d
+                                                           && d.Namespace == XamlNamespaces.Xaml2006 &&
+                                                           d.Name == "Key") as XamlAstXmlDirective;
+        if (keyDirective is null)
+            return node;
+
+        var keyProp = type.Properties.First(p => p.Name == "Key");
+        on.Children.Add(new XamlAstXamlPropertyValueNode(keyDirective,
+            new XamlAstClrProperty(keyDirective, keyProp, context.Configuration),
+            keyDirective.Values, true));
+
+        return node;
+    }
+}

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -110,6 +110,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType IResourceDictionary { get; }
         public IXamlType ResourceDictionary { get; }
         public IXamlMethod ResourceDictionaryDeferredAdd { get; }
+        public IXamlType IThemeVariantProvider { get; }
         public IXamlType UriKind { get; }
         public IXamlConstructor UriConstructor { get; }
         public IXamlType Style { get; }
@@ -250,6 +251,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                 cfg.TypeSystem.GetType("System.Func`2").MakeGenericType(
                     cfg.TypeSystem.GetType("System.IServiceProvider"),
                     XamlIlTypes.Object));
+            IThemeVariantProvider = cfg.TypeSystem.GetType("Avalonia.Controls.IThemeVariantProvider");
             UriKind = cfg.TypeSystem.GetType("System.UriKind");
             UriConstructor = Uri.GetConstructor(new List<IXamlType>() { cfg.WellKnownTypes.String, UriKind });
             Style = cfg.TypeSystem.GetType("Avalonia.Styling.Style");

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/DynamicResourceExtension.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/DynamicResourceExtension.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Markup.Xaml.Converters;
 using Avalonia.Media;
+using Avalonia.Styling;
 
 namespace Avalonia.Markup.Xaml.MarkupExtensions
 {
@@ -10,6 +11,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
     {
         private object? _anchor;
         private BindingPriority _priority;
+        private ThemeVariant? _currentThemeVariant;
 
         public DynamicResourceExtension()
         {
@@ -36,6 +38,8 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
                     (object?)serviceProvider.GetFirstParent<IResourceHost>();
             }
 
+            _currentThemeVariant = StaticResourceExtension.GetDictionaryVariant(serviceProvider);
+
             return this;
         }
 
@@ -59,7 +63,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
             }
             else if (_anchor is IResourceProvider resourceProvider)
             {
-                var source = resourceProvider.GetResourceObservable(ResourceKey, GetConverter(targetProperty));
+                var source = resourceProvider.GetResourceObservable(ResourceKey, _currentThemeVariant, GetConverter(targetProperty));
                 return InstancedBinding.OneWay(source, _priority);
             }
 

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/StaticResourceExtension.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/StaticResourceExtension.cs
@@ -33,7 +33,8 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
             var provideTarget = serviceProvider.GetService<IProvideValueTarget>();
             var targetObject = provideTarget?.TargetObject;
             var targetProperty = provideTarget?.TargetProperty;
-            var themeVariant = (targetObject as IThemeVariantHost)?.ActualThemeVariant;
+            var themeVariant = (targetObject as IThemeVariantHost)?.ActualThemeVariant
+                ?? GetDictionaryVariant(serviceProvider);
 
             var targetType = targetProperty switch
             {
@@ -77,6 +78,25 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
         private object? GetValue(StyledElement control, Type? targetType)
         {
             return ColorToBrushConverter.Convert(control.FindResource(ResourceKey!), targetType);
+        }
+
+        internal static ThemeVariant? GetDictionaryVariant(IServiceProvider serviceProvider)
+        {
+            var parents = serviceProvider.GetService<IAvaloniaXamlIlParentStackProvider>()?.Parents;
+            if (parents is null)
+            {
+                return null;
+            }
+
+            foreach (var parent in parents)
+            {
+                if (parent is IThemeVariantProvider { Key: { } setKey })
+                {
+                    return setKey;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/Markup/Avalonia.Markup.Xaml/Styling/ResourceInclude.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Styling/ResourceInclude.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Markup.Xaml.Styling
     /// When used in runtime, this type might be unsafe with trimming and AOT.
     /// </remarks>
     [RequiresUnreferencedCode(TrimmingMessages.StyleResourceIncludeRequiresUnreferenceCodeMessage)]
-    public class ResourceInclude : IResourceProvider
+    public class ResourceInclude : IResourceProvider, IThemeVariantProvider
     {
         private readonly IServiceProvider? _serviceProvider;
         private readonly Uri? _baseUri;
@@ -65,6 +65,8 @@ namespace Avalonia.Markup.Xaml.Styling
         /// </summary>
         public Uri? Source { get; set; }
 
+        ThemeVariant? IThemeVariantProvider.Key { get; set; }
+        
         bool IResourceNode.HasResources => Loaded.HasResources;
 
         public event EventHandler? OwnerChanged

--- a/tests/Avalonia.Benchmarks/Themes/FluentBenchmark.cs
+++ b/tests/Avalonia.Benchmarks/Themes/FluentBenchmark.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using Avalonia.Controls;
 using Avalonia.Platform;
 using Avalonia.Styling;
+using Avalonia.Threading;
 using Avalonia.UnitTests;
 using BenchmarkDotNet.Attributes;
 using Moq;
@@ -30,27 +32,23 @@ namespace Avalonia.Benchmarks.Themes
             _app.Dispose();
         }
 
-        [Benchmark]
-        public void RepeatButton()
+        [Benchmark()]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void CreateButton()
         {
-            var button = new RepeatButton();
+            var button = new Button();
             _root.Child = button;
             _root.LayoutManager.ExecuteLayoutPass();
+            Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
         }
 
         private static IDisposable CreateApp()
         {
             var services = new TestServices(
-                assetLoader: new AssetLoader(),
-                globalClock: new MockGlobalClock(),
-                platform: new AppBuilder().RuntimePlatform,
-                renderInterface: new MockPlatformRenderInterface(),
-                standardCursorFactory: Mock.Of<ICursorFactory>(),
-                theme: () => LoadFluentTheme(),
+                renderInterface: new NullRenderingPlatform(),
                 dispatcherImpl: new NullThreadingPlatform(),
-                fontManagerImpl: new MockFontManagerImpl(),
-                textShaperImpl: new MockTextShaperImpl(),
-                windowingPlatform: new MockWindowingPlatform());
+                standardCursorFactory: new NullCursorFactory(),
+                theme: () => LoadFluentTheme());
 
             return UnitTestApplication.Start(services);
         }

--- a/tests/Avalonia.Benchmarks/Themes/ThemeBenchmark.cs
+++ b/tests/Avalonia.Benchmarks/Themes/ThemeBenchmark.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-
+using System.Runtime.CompilerServices;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Platform;
@@ -29,6 +29,7 @@ namespace Avalonia.Benchmarks.Themes
         }
 
         [Benchmark]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public bool InitFluentTheme()
         {
             UnitTestApplication.Current.Styles[0] = new FluentTheme();
@@ -36,6 +37,7 @@ namespace Avalonia.Benchmarks.Themes
         }
 
         [Benchmark]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public bool InitSimpleTheme()
         {
             UnitTestApplication.Current.Styles[0] = new SimpleTheme();

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ThemeDictionariesTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ThemeDictionariesTests.cs
@@ -1,9 +1,12 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Avalonia.Controls;
+using Avalonia.Controls.Documents;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Markup.Data;
 using Avalonia.Markup.Xaml.MarkupExtensions;
+using Avalonia.Markup.Xaml.Templates;
 using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.UnitTests;
@@ -140,7 +143,7 @@ public class ThemeDictionariesTests : XamlTestBase
         Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background)!.Color);
     }
 
-    [Fact(Skip = "Not implemented")]
+    [Fact]
     public void StaticResource_Inside_Of_ThemeDictionaries_Should_Use_Same_Theme_Key()
     {
         var themeVariantScope = (ThemeVariantScope)AvaloniaRuntimeXamlLoader.Load(@"
@@ -182,6 +185,135 @@ public class ThemeDictionariesTests : XamlTestBase
         themeVariantScope.RequestedThemeVariant = ThemeVariant.Dark;
 
         Assert.Equal(Colors.Black, ((ISolidColorBrush)border.Background)!.Color);
+    }
+    
+    [Fact]
+    public void StaticResource_Inside_Of_ThemeDictionaries_Should_Use_Same_Theme_Key_From_Inner_File()
+    {
+        var documents = new[]
+        {
+            new RuntimeXamlLoaderDocument(new Uri("avares://Tests/Inner.xaml"), @"
+<ResourceDictionary xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <StaticResource x:Key='InnerKey' ResourceKey='OuterKey' />
+</ResourceDictionary>"),
+            new RuntimeXamlLoaderDocument(@"
+<ResourceDictionary xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key='Default'>
+            <Color x:Key='OuterKey'>Green</Color>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source='avares://Tests/Inner.xaml'/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key='Dark'>
+            <Color x:Key='OuterKey'>White</Color>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source='avares://Tests/Inner.xaml'/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+</ResourceDictionary>")
+        };
+        
+        var parsed = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
+        var dictionary = (ResourceDictionary)parsed[1]!;
+        
+        dictionary.TryGetResource("InnerKey", ThemeVariant.Dark, out var resource);
+        var colorResource = Assert.IsType<Color>(resource);
+        Assert.Equal(Colors.White, colorResource);
+        
+        dictionary.TryGetResource("InnerKey", ThemeVariant.Light, out resource);
+        colorResource = Assert.IsType<Color>(resource);
+        Assert.Equal(Colors.Green, colorResource);
+    }
+    
+    [Fact]
+    public void DynamicResource_Inside_Of_ThemeDictionaries_Should_Use_Same_Theme_Key_From_Inner_File()
+    {
+        var documents = new[]
+        {
+            new RuntimeXamlLoaderDocument(new Uri("avares://Tests/Inner.xaml"), @"
+<ResourceDictionary xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <SolidColorBrush x:Key='InnerKey' Color='{DynamicResource OuterKey}' />
+</ResourceDictionary>"),
+            new RuntimeXamlLoaderDocument(@"
+<ResourceDictionary xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key='Default'>
+            <Color x:Key='OuterKey'>Green</Color>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source='avares://Tests/Inner.xaml'/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key='Dark'>
+            <Color x:Key='OuterKey'>White</Color>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source='avares://Tests/Inner.xaml'/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+</ResourceDictionary>")
+        };
+        
+        var parsed = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
+        var dictionary1 = (ResourceDictionary)parsed[0]!;
+        var dictionary2 = (ResourceDictionary)parsed[1]!;
+        var ownerApp = new Application(); // DynamicResource needs an owner to work
+        ownerApp.RequestedThemeVariant = new ThemeVariant("FakeOne", null);
+        ownerApp.Resources.MergedDictionaries.Add(dictionary1);
+        ownerApp.Resources.MergedDictionaries.Add(dictionary2);
+        
+        dictionary2.TryGetResource("InnerKey", ThemeVariant.Dark, out var resource);
+        var colorResource = Assert.IsAssignableFrom<ISolidColorBrush>(resource);
+        Assert.Equal(Colors.White, colorResource.Color);
+        
+        dictionary2.TryGetResource("InnerKey", ThemeVariant.Light, out resource);
+        colorResource = Assert.IsAssignableFrom<ISolidColorBrush>(resource);
+        Assert.Equal(Colors.Green, colorResource.Color);
+    }
+    
+    [Fact]
+    public void DynamicResource_Inside_Control_Inside_Of_ThemeDictionaries_Should_Use_Control_Theme_Variant()
+    {
+        var documents = new[]
+        {
+            new RuntimeXamlLoaderDocument(@"
+<ResourceDictionary xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key='Light'>
+            <Color x:Key='ResourceKey'>Green</Color>
+            <Template x:Key='Template'>
+                <ThemeVariantScope RequestedThemeVariant='Dark' TextElement.Foreground='{DynamicResource ResourceKey}' />
+            </Template>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key='Dark'>
+            <Color x:Key='ResourceKey'>White</Color>
+            <Template x:Key='Template'>
+                <ThemeVariantScope RequestedThemeVariant='Light' TextElement.Foreground='{DynamicResource ResourceKey}' />
+            </Template>
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+</ResourceDictionary>")
+        };
+        
+        var parsed = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
+        var dictionary = (ResourceDictionary)parsed[0]!;
+        
+        dictionary.TryGetResource("Template", ThemeVariant.Dark, out var resource);
+        var control = Assert.IsType<ThemeVariantScope>((resource as Template)?.Build());
+        control.Resources.MergedDictionaries.Add(dictionary);
+        Assert.Equal(Colors.Green, ((ISolidColorBrush)control[TextElement.ForegroundProperty]!).Color);
+        control.Resources.MergedDictionaries.Remove(dictionary);
+
+        dictionary.TryGetResource("Template", ThemeVariant.Light, out resource);
+        control = Assert.IsType<ThemeVariantScope>((resource as Template)?.Build());
+        control.Resources.MergedDictionaries.Add(dictionary);
+        Assert.Equal(Colors.White, ((ISolidColorBrush)control[TextElement.ForegroundProperty]!).Color);
     }
 
     [Fact]


### PR DESCRIPTION
## What does the pull request do?

Makes ThemeDictionaries lookup closer to the UWP behavior.
StaticResource (as well as floating DynamicResource) defined in the ThemeDictionary should use local theme variant instead of global application one (nor Default).

## How was the solution implemented (if it's not obvious)?

I was thinking about adding a new IServiceProvider service, which would require adding support to the XamlX. I wanted to avoid that if possible as this service would be very Avalonia specific.
In this PR approach with interface and simple compiler transformer works well and doesn't cause any noticiable performance degradations:

## Benchmarks (just in case)

Master:

Method | Mean | Error | StdDev | Allocated
-- | -- | -- | -- | --
FindPreResource | 283.12 μs | 4.266 μs | 3.990 μs | -
FindPostResource | 11.68 μs | 0.039 μs | 0.036 μs | -
FindNotExistingResource | 297.48 μs | 4.413 μs | 4.128 μs | -

Method | Mean | Error | StdDev | Gen0 | Gen1 | Allocated
-- | -- | -- | -- | -- | -- | --
CreateButton | 27.16 μs | 0.103 μs | 0.091 μs | 1.8921 | 0.0610 | 34.85 KB

Method | Mean | Error | StdDev | Gen0 | Gen1 | Allocated
-- |  -- | -- | -- | -- | -- | --
InitFluentTheme | 366,026.07 ns | 1,457.901 ns | 1,363.722 ns | 40.5273 | 19.5313 | 769608 B
InitSimpleTheme | 43,979.18 ns | 383.034 ns | 358.290 ns | 5.4932 | 1.4038 | 103400 B


This PR:

Method | Mean | Error | StdDev | Allocated
-- | -- | -- | -- | --
FindPreResource | 284.93 μs | 4.974 μs | 4.652 μs | -
FindPostResource | 12.17 μs | 0.053 μs | 0.049 μs | -
FindNotExistingResource | 310.56 μs | 6.187 μs | 8.045 μs | -

Method | Mean | Error | StdDev | Gen0 | Gen1 | Allocated
-- | -- | -- | -- | -- | -- | --
CreateButton | 27.49 μs | 0.181 μs | 0.170 μs | 1.8921 | 0.0610 | 35.06 KB

Method | Mean | Error | StdDev | Gen0 | Gen1 | Allocated
-- | -- | -- | -- | -- | -- | --
InitFluentTheme | 361,861.45 ns | 1,878.032 ns | 1,756.712 ns | 40.5273 | 19.5313 | 769936 B
InitSimpleTheme |  44,886.64 ns | 769.670 ns | 719.950 ns | 5.4932 | 1.4038 | 103664 B

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [-] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Fixed issues

Fixes #10727
