### PR TITLE
Use latest Tmds.DBus version.

### DIFF
--- a/src/Avalonia.FreeDesktop/Avalonia.FreeDesktop.csproj
+++ b/src/Avalonia.FreeDesktop/Avalonia.FreeDesktop.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tmds.DBus.Protocol" Version="0.14.0" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.15.0" />
     <PackageReference Include="Tmds.DBus.SourceGenerator" Version="0.0.5" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
As part of the 0.15.0 version, there is a fix in how the protocol library picks up the `SynchronizationContext`: https://github.com/tmds/Tmds.DBus/pull/192.

@maxkatz6 @kekekeks @affederaffe it's likely this fix applies for Avalonia's use of the library.