### PR TITLE
Fix GridDefinitions parsing with space separated syntax

### DIFF
--- a/src/Avalonia.Base/Metadata/AvaloniaListAttribute.cs
+++ b/src/Avalonia.Base/Metadata/AvaloniaListAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Avalonia.Metadata;
+
+/// <summary>
+/// Defines how compiler should split avalonia list string value before parsing individual items.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class AvaloniaListAttribute : Attribute
+{
+    /// <summary>
+    /// Separator used to split input string.
+    /// Default value is ','.
+    /// </summary>
+    public string[]? Separators { get; init; }
+
+    /// <summary>
+    /// Split options used to split input string.
+    /// Default value is RemoveEmptyEntries with TrimEntries.
+    /// </summary>
+    // StringSplitOptions.TrimEntries = 2, but only on net6 target.
+    public StringSplitOptions SplitOptions { get; init; } = StringSplitOptions.RemoveEmptyEntries | (StringSplitOptions)2;
+}

--- a/src/Avalonia.Controls/DefinitionList.cs
+++ b/src/Avalonia.Controls/DefinitionList.cs
@@ -1,9 +1,11 @@
 using System.Collections;
 using System.Collections.Specialized;
 using Avalonia.Collections;
+using Avalonia.Metadata;
 
 namespace Avalonia.Controls
 {
+    [AvaloniaList(Separators = new [] { ",", " " })]
     public abstract class DefinitionList<T> : AvaloniaList<T> where T : DefinitionBase
     {
         public DefinitionList()

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
@@ -337,6 +337,20 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                     var separators = new[] { "," };
                     var splitOptions = StringSplitOptions.RemoveEmptyEntries | trimOption;
 
+                    var attribute = type.GetAllCustomAttributes().FirstOrDefault(a => a.Type == types.AvaloniaListAttribute);
+                    if (attribute is not null)
+                    {
+                        if (attribute.Properties.TryGetValue("Separators", out var separatorsArray))
+                        {
+                            separators = ((Array)separatorsArray)?.OfType<string>().ToArray();
+                        }
+
+                        if (attribute.Properties.TryGetValue("SplitOptions", out var splitOptionsObj))
+                        {
+                            splitOptions = (StringSplitOptions)splitOptionsObj;
+                        }
+                    }
+
                     items = text.Split(separators, splitOptions ^ trimOption);
                     // Compiler targets netstandard, so we need to emulate StringSplitOptions.TrimEntries, if it was requested.
                     if (splitOptions.HasFlag(trimOption))

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -33,6 +33,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType InheritDataTypeFromItemsAttribute { get; }
         public IXamlType MarkupExtensionOptionAttribute { get; }
         public IXamlType MarkupExtensionDefaultOptionAttribute { get; }
+        public IXamlType AvaloniaListAttribute { get; }
         public IXamlType AvaloniaList { get; }
         public IXamlType OnExtensionType { get; }
         public IXamlType UnsetValueType { get; }
@@ -143,6 +144,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             InheritDataTypeFromItemsAttribute = cfg.TypeSystem.GetType("Avalonia.Metadata.InheritDataTypeFromItemsAttribute");
             MarkupExtensionOptionAttribute = cfg.TypeSystem.GetType("Avalonia.Metadata.MarkupExtensionOptionAttribute");
             MarkupExtensionDefaultOptionAttribute = cfg.TypeSystem.GetType("Avalonia.Metadata.MarkupExtensionDefaultOptionAttribute");
+            AvaloniaListAttribute = cfg.TypeSystem.GetType("Avalonia.Metadata.AvaloniaListAttribute");
             AvaloniaList = cfg.TypeSystem.GetType("Avalonia.Collections.AvaloniaList`1");
             OnExtensionType = cfg.TypeSystem.GetType("Avalonia.Markup.Xaml.MarkupExtensions.On");
             AvaloniaObjectBindMethod = AvaloniaObjectExtensions.FindMethod("Bind", IDisposable, false, AvaloniaObject,

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BasicTests.cs
@@ -279,6 +279,37 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
             Assert.Equal(expected3, grid.RowDefinitions[2].Height);
             Assert.Equal(expected4, grid.RowDefinitions[3].Height);
         }
+        
+        [Fact]
+        public void Grid_Row_Col_Definitions_Are_Parsed_Space_Delimiter()
+        {
+            var xaml = @"
+<Grid xmlns='https://github.com/avaloniaui'
+        ColumnDefinitions='100 Auto * 100*'
+        RowDefinitions='100 Auto * 100*'>
+</Grid>";
+
+            var grid = AvaloniaRuntimeXamlLoader.Parse<Grid>(xaml);
+
+
+            Assert.Equal(4, grid.ColumnDefinitions.Count);
+            Assert.Equal(4, grid.RowDefinitions.Count);
+
+            var expected1 = new GridLength(100);
+            var expected2 = GridLength.Auto;
+            var expected3 = new GridLength(1, GridUnitType.Star);
+            var expected4 = new GridLength(100, GridUnitType.Star);
+
+            Assert.Equal(expected1, grid.ColumnDefinitions[0].Width);
+            Assert.Equal(expected2, grid.ColumnDefinitions[1].Width);
+            Assert.Equal(expected3, grid.ColumnDefinitions[2].Width);
+            Assert.Equal(expected4, grid.ColumnDefinitions[3].Width);
+
+            Assert.Equal(expected1, grid.RowDefinitions[0].Height);
+            Assert.Equal(expected2, grid.RowDefinitions[1].Height);
+            Assert.Equal(expected3, grid.RowDefinitions[2].Height);
+            Assert.Equal(expected4, grid.RowDefinitions[3].Height);
+        }
 
         [Fact]
         public void Named_x_Control_Is_Added_To_NameScope_Simple()


### PR DESCRIPTION
## What does the pull request do?

Apparently, it was allowed, and we didn't had tests for this.
Adds AvaloniaListAttribute back for customable parsing and fixes grid defitnion.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Fixed issues

Fixes #11118 

Also https://github.com/kekekeks/XamlX/pull/87