### PR TITLE
Don't clear ItemIsOwnContainer containers in PanelContainerGenerator.

### DIFF
--- a/src/Avalonia.Controls/Presenters/PanelContainerGenerator.cs
+++ b/src/Avalonia.Controls/Presenters/PanelContainerGenerator.cs
@@ -67,9 +67,12 @@ namespace Avalonia.Controls.Presenters
                 for (var i = 0; i < count; ++i)
                 {
                     var c = children[index + i];
+
                     if (!c.IsSet(ItemIsOwnContainerProperty))
+                    {
                         itemsControl.RemoveLogicalChild(children[i + index]);
-                    generator.ClearItemContainer(c);
+                        generator.ClearItemContainer(c);
+                    }
                 }
 
                 children.RemoveRange(index, count);

--- a/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
@@ -828,6 +828,19 @@ namespace Avalonia.Controls.UnitTests
             Layout(target);
         }
 
+        [Fact]
+        public void ItemIsOwnContainer_Content_Should_Not_Be_Cleared_When_Removed()
+        {
+            // Issue #11128.
+            using var app = Start();
+            var item = new ContentPresenter { Content = "foo" };
+            var target = CreateTarget(items: new[] { item });
+
+            target.Items.RemoveAt(0);
+
+            Assert.Equal("foo", item.Content);
+        }
+
         private static ItemsControl CreateTarget(
             object? dataContext = null,
             IBinding? displayMemberBinding = null,


### PR DESCRIPTION
## What does the pull request do?

One shouldn't call `ClearContainer` on an item that is its own container: I even specified that in the docs 🤦 .

 Adjusted `SelectingItemsControlTests` because selection is actually maintained on move when containers hold their own `IsSelected` state.

## Fixed issues

Fixes #11128
