### PR TITLE
Fix OnFormFactor use in DataTemplates

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/Runtime/XamlIlRuntimeHelpers.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/Runtime/XamlIlRuntimeHelpers.cs
@@ -50,6 +50,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.Runtime
             private readonly IServiceProvider? _parentProvider;
             private readonly List<IResourceNode>? _parentResourceNodes;
             private readonly INameScope _nameScope;
+            private readonly IRuntimePlatform? _runtimePlatform;
 
             public DeferredParentServiceProvider(IServiceProvider? parentProvider, List<IResourceNode>? parentResourceNodes,
                 object rootObject, INameScope nameScope)
@@ -58,6 +59,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.Runtime
                 _parentResourceNodes = parentResourceNodes;
                 _nameScope = nameScope;
                 RootObject = rootObject;
+                _runtimePlatform = AvaloniaLocator.Current.GetService<IRuntimePlatform>();
             }
 
             public IEnumerable<object> Parents => GetParents();
@@ -80,6 +82,8 @@ namespace Avalonia.Markup.Xaml.XamlIl.Runtime
                     return this;
                 if (serviceType == typeof(IAvaloniaXamlIlControlTemplateProvider))
                     return this;
+                if (serviceType == typeof(IRuntimePlatform))
+                    return _runtimePlatform;
                 return _parentProvider?.GetService(serviceType);
             }
 

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/Runtime/XamlIlRuntimeHelpers.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/Runtime/XamlIlRuntimeHelpers.cs
@@ -50,7 +50,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.Runtime
             private readonly IServiceProvider? _parentProvider;
             private readonly List<IResourceNode>? _parentResourceNodes;
             private readonly INameScope _nameScope;
-            private readonly IRuntimePlatform? _runtimePlatform;
+            private IRuntimePlatform? _runtimePlatform;
 
             public DeferredParentServiceProvider(IServiceProvider? parentProvider, List<IResourceNode>? parentResourceNodes,
                 object rootObject, INameScope nameScope)
@@ -59,7 +59,6 @@ namespace Avalonia.Markup.Xaml.XamlIl.Runtime
                 _parentResourceNodes = parentResourceNodes;
                 _nameScope = nameScope;
                 RootObject = rootObject;
-                _runtimePlatform = AvaloniaLocator.Current.GetService<IRuntimePlatform>();
             }
 
             public IEnumerable<object> Parents => GetParents();
@@ -83,7 +82,11 @@ namespace Avalonia.Markup.Xaml.XamlIl.Runtime
                 if (serviceType == typeof(IAvaloniaXamlIlControlTemplateProvider))
                     return this;
                 if (serviceType == typeof(IRuntimePlatform))
+                {
+                    if(_runtimePlatform == null)
+                        _runtimePlatform = AvaloniaLocator.Current.GetService<IRuntimePlatform>();
                     return _runtimePlatform;
+                }
                 return _parentProvider?.GetService(serviceType);
             }
 


### PR DESCRIPTION
## What does the pull request do?
Fixes an issue where `IRuntimePlatform` isn't available to OnFormFactor markup extension.


## What is the current behavior?
`DeferredParentServiceProvider` has a null `_parentProvider` due to no valid value being passed to it in the constructor. Ideally a service provider is passed to it from `ResourceDictionary`, but for the purpose of making `OnFormFactor` work, a saved `IRuntimePlatform` instance is sufficient.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #11154
