### PR TITLE
Correctly remove ContentPresenter's content from its parent host

### DIFF
--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -1,5 +1,5 @@
 using System;
-
+using Avalonia.Collections;
 using Avalonia.Controls.Documents;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
@@ -442,7 +442,7 @@ namespace Avalonia.Controls.Presenters
             var contentTemplate = ContentTemplate;
             var oldChild = Child;
             var newChild = CreateChild(content, oldChild, contentTemplate);
-            var logicalChildren = Host?.LogicalChildren ?? LogicalChildren;
+            var logicalChildren = GetEffectiveLogicalChildren();
 
             // Remove the old child if we're not recycling it.
             if (newChild != oldChild)
@@ -487,6 +487,9 @@ namespace Avalonia.Controls.Presenters
             _createdChild = true;
 
         }
+
+        private IAvaloniaList<ILogical> GetEffectiveLogicalChildren()
+            => Host?.LogicalChildren ?? LogicalChildren;
 
         /// <inheritdoc/>
         protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
@@ -692,7 +695,7 @@ namespace Avalonia.Controls.Presenters
             else if (Child != null)
             {
                 VisualChildren.Remove(Child);
-                LogicalChildren.Remove(Child);
+                GetEffectiveLogicalChildren().Remove(Child);
                 ((ISetInheritanceParent)Child).SetParent(Child.Parent);
                 Child = null;
                 _recyclingDataTemplate = null;

--- a/tests/Avalonia.Controls.UnitTests/ContentControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ContentControlTests.cs
@@ -359,16 +359,21 @@ namespace Avalonia.Controls.UnitTests
             target.Presenter.ApplyTemplate();
 
             Assert.Equal(target, target.Presenter.Child.GetLogicalParent());
+            Assert.Equal(new[] { target.Presenter.Child }, target.LogicalChildren);
 
             root.Child = null;
 
             Assert.Null(target.Template);
 
             target.Content = null;
+
+            Assert.Empty(target.LogicalChildren);
+
             root.Child = target;
             target.Content = "Bar";
 
             Assert.Equal(target, target.Presenter.Child.GetLogicalParent());
+            Assert.Equal(new[] { target.Presenter.Child }, target.LogicalChildren);
         }
 
         private static FuncControlTemplate GetTemplate()


### PR DESCRIPTION
Correctly remove `ContentPresenter`'s content from its parent host when the content is updated while being detached from the logical tree.

I've updated the existing `ContentControlTests.Should_Set_Child_LogicalParent_After_Removing_And_Adding_Back_To_Logical_Tree` test with asserts that failed before, and now pass with this change. This seems acceptable to me as it already tested the right thing (but only from the child ⇒ parent side, now from both sides), tell me if you prefer a whole new test instead.

Fixes #11149 
