### PR TITLE
Make ICustomDrawOperation to use ImmediateDrawingContext

### DIFF
--- a/samples/RenderDemo/Pages/CustomSkiaPage.cs
+++ b/samples/RenderDemo/Pages/CustomSkiaPage.cs
@@ -44,9 +44,9 @@ namespace RenderDemo.Pages
             public bool HitTest(Point p) => false;
             public bool Equals(ICustomDrawOperation other) => false;
             static Stopwatch St = Stopwatch.StartNew();
-            public void Render(IDrawingContextImpl context)
+            public void Render(ImmediateDrawingContext context)
             {
-                var leaseFeature = context.GetFeature<ISkiaSharpApiLeaseFeature>();
+                var leaseFeature = context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
                 if (leaseFeature == null)
                     context.DrawGlyphRun(Brushes.Black, _noSkia.PlatformImpl);
                 else

--- a/src/Avalonia.Base/Media/ImmediateDrawingContext.cs
+++ b/src/Avalonia.Base/Media/ImmediateDrawingContext.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Avalonia.Platform;
-using Avalonia.Rendering.SceneGraph;
 using Avalonia.Threading;
 using Avalonia.Utilities;
 using Avalonia.Media.Imaging;

--- a/src/Avalonia.Base/Media/PlatformDrawingContext.cs
+++ b/src/Avalonia.Base/Media/PlatformDrawingContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Avalonia.Logging;
 using Avalonia.Media.Imaging;
 using Avalonia.Media.Immutable;
 using Avalonia.Platform;
@@ -41,8 +42,19 @@ internal sealed class PlatformDrawingContext : DrawingContext, IDrawingContextWi
         BitmapInterpolationMode bitmapInterpolationMode = BitmapInterpolationMode.Default) =>
         _impl.DrawBitmap(source, opacity, sourceRect, destRect, bitmapInterpolationMode);
 
-    public override void Custom(ICustomDrawOperation custom) =>
-        custom.Render(_impl);
+    public override void Custom(ICustomDrawOperation custom)
+    {
+        using var immediateDrawingContext = new ImmediateDrawingContext(_impl, false);
+        try
+        {
+            custom.Render(immediateDrawingContext);
+        }
+        catch (Exception e)
+        {
+            Logger.TryGet(LogEventLevel.Error, LogArea.Visual)
+                ?.Log(custom, $"Exception in {custom.GetType().Name}.{nameof(ICustomDrawOperation.Render)} {{0}}", e);
+        }
+    }
 
     public override void DrawGlyphRun(IBrush? foreground, GlyphRun glyphRun)
     {

--- a/src/Avalonia.Base/Platform/IDrawingContextImpl.cs
+++ b/src/Avalonia.Base/Platform/IDrawingContextImpl.cs
@@ -1,6 +1,5 @@
 using System;
 using Avalonia.Media;
-using Avalonia.Rendering.SceneGraph;
 using Avalonia.Utilities;
 using Avalonia.Media.Imaging;
 using Avalonia.Metadata;
@@ -167,12 +166,6 @@ namespace Avalonia.Platform
         /// Pops the latest pushed bitmap blending value.
         /// </summary>
         void PopBitmapBlendMode();
-
-        /// <summary>
-        /// Adds a custom draw operation
-        /// </summary>
-        /// <param name="custom">Custom draw operation</param>
-        void Custom(ICustomDrawOperation custom);
 
         /// <summary>
         /// Attempts to get an optional feature from the drawing context implementation

--- a/src/Avalonia.Base/Rendering/Composition/Server/DrawingContextProxy.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/DrawingContextProxy.cs
@@ -143,11 +143,6 @@ internal class CompositorDrawingContextProxy : IDrawingContextImpl,
         _impl.PopBitmapBlendMode();
     }
 
-    public void Custom(ICustomDrawOperation custom)
-    {
-        _impl.Custom(custom);
-    }
-
     public object? GetFeature(Type t) => _impl.GetFeature(t);
     
 

--- a/src/Avalonia.Base/Rendering/SceneGraph/CustomDrawOperation.cs
+++ b/src/Avalonia.Base/Rendering/SceneGraph/CustomDrawOperation.cs
@@ -1,4 +1,5 @@
 using System;
+using Avalonia.Logging;
 using Avalonia.Media;
 using Avalonia.Platform;
 
@@ -17,7 +18,16 @@ namespace Avalonia.Rendering.SceneGraph
 
         public override void Render(IDrawingContextImpl context)
         {
-            Custom.Render(context);
+            using var immediateDrawingContext = new ImmediateDrawingContext(context, false);
+            try
+            {
+                Custom.Render(immediateDrawingContext);
+            }
+            catch (Exception e)
+            {
+                Logger.TryGet(LogEventLevel.Error, LogArea.Visual)
+                    ?.Log(Custom, $"Exception in {Custom.GetType().Name}.{nameof(ICustomDrawOperation.Render)} {{0}}", e);
+            }
         }
 
         public override void Dispose() => Custom.Dispose();
@@ -48,6 +58,6 @@ namespace Avalonia.Rendering.SceneGraph
         /// Renders the node to a drawing context.
         /// </summary>
         /// <param name="context">The drawing context.</param>
-        void Render(IDrawingContextImpl context);
+        void Render(ImmediateDrawingContext context);
     }
 }

--- a/src/Browser/Avalonia.Browser/WebEmbeddableControlRoot.cs
+++ b/src/Browser/Avalonia.Browser/WebEmbeddableControlRoot.cs
@@ -37,7 +37,7 @@ namespace Avalonia.Browser
                 return false;
             }
 
-            public void Render(IDrawingContextImpl context)
+            public void Render(ImmediateDrawingContext context)
             {
                 _hasRendered = true;
                 _onFirstRender();

--- a/src/Headless/Avalonia.Headless/HeadlessPlatformRenderInterface.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessPlatformRenderInterface.cs
@@ -433,12 +433,7 @@ namespace Avalonia.Headless
             {
                 
             }
-
-            public void Custom(ICustomDrawOperation custom)
-            {
-
-            }
-
+            
             public object? GetFeature(Type t)
             {
                 return null;

--- a/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
+++ b/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
@@ -5,12 +5,9 @@ using System.Linq;
 using System.Threading;
 using Avalonia.Media;
 using Avalonia.Platform;
-using Avalonia.Rendering;
-using Avalonia.Rendering.SceneGraph;
 using Avalonia.Rendering.Utilities;
 using Avalonia.Utilities;
 using Avalonia.Media.Imaging;
-using Avalonia.Skia.Helpers;
 using SkiaSharp;
 using ISceneBrush = Avalonia.Media.ISceneBrush;
 
@@ -665,12 +662,6 @@ namespace Avalonia.Skia
         {
             CheckLease();
             _currentBlendingMode = _blendingModeStack.Pop();
-        }
-
-        public void Custom(ICustomDrawOperation custom)
-        {
-            CheckLease();
-            custom.Render(this);
         }
 
         /// <inheritdoc />

--- a/src/Windows/Avalonia.Direct2D1/Media/DrawingContextImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/DrawingContextImpl.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Numerics;
 using Avalonia.Media;
 using Avalonia.Platform;
-using Avalonia.Rendering;
-using Avalonia.Rendering.SceneGraph;
 using Avalonia.Utilities;
 using Avalonia.Media.Imaging;
 using SharpDX;
@@ -608,8 +606,7 @@ namespace Avalonia.Direct2D1.Media
         {
             PopLayer();
         }
-        
-        public void Custom(ICustomDrawOperation custom) => custom.Render(this);
+
         public object GetFeature(Type t) => null;
     }
 }


### PR DESCRIPTION
## What does the pull request do?

1. Changes ICustomDrawOperation to use ImmediateDrawingContext as a rendering context instead of Impl interface.
2. Removes IDrawingContextImpl.Custom method as it seems useless after refactoring. @kekekeks please correct me if I am wrong. This method also wasn't used before, i.e. ICustomDrawOperation.Render(IDrawingContextImpl) was called directly from non-impl classes.

ImmediateDrawingContext usage was copied from the custom composition visual, but I wonder if it's fine to allocate this wrapping context on each render call. Either way this implementation detail can be improved later.

## Fixed issues

Fixes #11160