### PR TITLE
Fix Screens.ScreenFromWindow API

### DIFF
--- a/src/Avalonia.Controls/Screens.cs
+++ b/src/Avalonia.Controls/Screens.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Platform;
@@ -37,11 +37,22 @@ namespace Avalonia.Controls
             _iScreenImpl = iScreenImpl;
         }
 
+        /// <summary>
+        /// Retrieves a Screen for the display that contains the rectangle.
+        /// </summary>
+        /// <param name="bounds">Bounds that specifies the area for which to retrieve the display.</param>
+        /// <returns>The <see cref="Screen"/>.</returns>
         public Screen? ScreenFromBounds(PixelRect bounds)
         {
             return _iScreenImpl.ScreenFromRect(bounds);
         }
 
+        /// <summary>
+        /// Retrieves a Screen for the display that contains the specified <see cref="WindowBase"/>.
+        /// </summary>
+        /// <param name="window">The window for which to retrieve the Screen.</param>
+        /// <exception cref="ObjectDisposedException">Window platform implementation was already disposed.</exception>
+        /// <returns>The <see cref="Screen"/>.</returns>
         public Screen? ScreenFromWindow(WindowBase window)
         {
             if (window.PlatformImpl is null)
@@ -52,17 +63,32 @@ namespace Avalonia.Controls
             return _iScreenImpl.ScreenFromWindow(window.PlatformImpl);
         }
 
+        /// <summary>
+        /// Retrieves a Screen for the display that contains the specified <see cref="IWindowBaseImpl"/>.
+        /// </summary>
+        /// <param name="window">The window impl for which to retrieve the Screen.</param>
+        /// <returns>The <see cref="Screen"/>.</returns>
         [Obsolete("Use ScreenFromWindow(WindowBase) overload.")]
         public Screen? ScreenFromWindow(IWindowBaseImpl window)
         {
             return _iScreenImpl.ScreenFromWindow(window);
         }
 
+        /// <summary>
+        /// Retrieves a Screen for the display that contains the specified point.
+        /// </summary>
+        /// <param name="point">A Point that specifies the location for which to retrieve a Screen.</param>
+        /// <returns>The <see cref="Screen"/>.</returns>
         public Screen? ScreenFromPoint(PixelPoint point)
         {
             return _iScreenImpl.ScreenFromPoint(point);
         }
 
+        /// <summary>
+        /// Retrieves a Screen for the display that contains the specified <see cref="Visual"/>.
+        /// </summary>
+        /// <param name="visual">A Visual for which to retrieve a Screen.</param>
+        /// <returns>The <see cref="Screen"/>.</returns>
         public Screen? ScreenFromVisual(Visual visual)
         {
             var tl = visual.PointToScreen(visual.Bounds.TopLeft);

--- a/src/Avalonia.Controls/Screens.cs
+++ b/src/Avalonia.Controls/Screens.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Platform;
-using Avalonia.VisualTree;
 
 #nullable enable
 
@@ -43,6 +42,17 @@ namespace Avalonia.Controls
             return _iScreenImpl.ScreenFromRect(bounds);
         }
 
+        public Screen? ScreenFromWindow(WindowBase window)
+        {
+            if (window.PlatformImpl is null)
+            {
+                throw new ObjectDisposedException("Window platform implementation was already disposed.");
+            }
+
+            return _iScreenImpl.ScreenFromWindow(window.PlatformImpl);
+        }
+
+        [Obsolete("Use ScreenFromWindow(WindowBase) overload.")]
         public Screen? ScreenFromWindow(IWindowBaseImpl window)
         {
             return _iScreenImpl.ScreenFromWindow(window);

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -713,7 +713,7 @@ namespace Avalonia.Controls
                 Owner = owner;
                 owner?.AddChild(this, false);
 
-                SetWindowStartupLocation(owner?.PlatformImpl);
+                SetWindowStartupLocation(owner);
 
                 PlatformImpl?.Show(ShowActivated, false);
                 Renderer.Start();
@@ -789,7 +789,7 @@ namespace Avalonia.Controls
                 Owner = owner;
                 owner.AddChild(this, true);
 
-                SetWindowStartupLocation(owner.PlatformImpl);
+                SetWindowStartupLocation(owner);
 
                 PlatformImpl?.Show(ShowActivated, true);
 
@@ -870,7 +870,7 @@ namespace Avalonia.Controls
             }
         }
 
-        private void SetWindowStartupLocation(IWindowBaseImpl? owner = null)
+        private void SetWindowStartupLocation(Window? owner = null)
         {
             var startupLocation = WindowStartupLocation;
 


### PR DESCRIPTION
## What does the pull request do?

This method was always confusing/wrong. It should accept specific window class and not impl.
Old method is duplicated there as there is no necessity to remove it right now.
+ adds missing documentation.

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Obsoletions / Deprecations

Screens.ScreenFromWindow(IWindowBaseImpl) is not obsolete. Use Screens.ScreenFromWindow(WindowBase).

