### PR TITLE
Return WriteableBitmap from the GetLastRenderedFrame API

### DIFF
--- a/src/Headless/Avalonia.Headless/HeadlessWindowExtensions.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowExtensions.cs
@@ -17,7 +17,7 @@ public static class HeadlessWindowExtensions
     /// Triggers a renderer timer tick and captures last rendered frame.
     /// </summary>
     /// <returns>Bitmap with last rendered frame. Null, if nothing was rendered.</returns>
-    public static Bitmap? CaptureRenderedFrame(this TopLevel topLevel)
+    public static WriteableBitmap? CaptureRenderedFrame(this TopLevel topLevel)
     {
         Dispatcher.UIThread.RunJobs();
         AvaloniaHeadlessPlatform.ForceRenderTimerTick();
@@ -29,7 +29,7 @@ public static class HeadlessWindowExtensions
     /// Note, in order to trigger rendering timer, call <see cref="AvaloniaHeadlessPlatform.ForceRenderTimerTick"/> method.  
     /// </summary>
     /// <returns>Bitmap with last rendered frame. Null, if nothing was rendered.</returns>
-    public static Bitmap? GetLastRenderedFrame(this TopLevel topLevel)
+    public static WriteableBitmap? GetLastRenderedFrame(this TopLevel topLevel)
     {
         if (AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() is HeadlessPlatformRenderInterface)
         {

--- a/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
@@ -214,7 +214,7 @@ namespace Avalonia.Headless
             });
         }
 
-        public Bitmap? GetLastRenderedFrame()
+        public WriteableBitmap? GetLastRenderedFrame()
         {
             lock (_sync)
             {
@@ -224,7 +224,7 @@ namespace Avalonia.Headless
                 }
 
                 using var lockedFramebuffer = _lastRenderedFrame.Lock();
-                return new Bitmap(lockedFramebuffer.Format, AlphaFormat.Opaque, lockedFramebuffer.Address,
+                return new WriteableBitmap(lockedFramebuffer.Format, AlphaFormat.Opaque, lockedFramebuffer.Address,
                     lockedFramebuffer.Size, lockedFramebuffer.Dpi, lockedFramebuffer.RowBytes);
             }
         }

--- a/src/Headless/Avalonia.Headless/IHeadlessWindow.cs
+++ b/src/Headless/Avalonia.Headless/IHeadlessWindow.cs
@@ -8,7 +8,7 @@ namespace Avalonia.Headless
 {
     internal interface IHeadlessWindow
     {
-        Bitmap? GetLastRenderedFrame();
+        WriteableBitmap? GetLastRenderedFrame();
         void KeyPress(Key key, RawInputModifiers modifiers);
         void KeyRelease(Key key, RawInputModifiers modifiers);
         void MouseDown(Point point, MouseButton button, RawInputModifiers modifiers = RawInputModifiers.None);


### PR DESCRIPTION
## What does the pull request do?

Previously in 0.10 this method returned WriteableBitmapImpl. Then changed to Bitmap which limited API usage.
Now it's a proper WriteableBitmap which can be locked in the CPU memory and read.

## Fixed issues

Fixes #11130 
