### PR TITLE
Fix incorrect `Color.ToUint32` to `ToUInt32`

### DIFF
--- a/samples/RenderDemo/Pages/WriteableBitmapPage.cs
+++ b/samples/RenderDemo/Pages/WriteableBitmapPage.cs
@@ -59,7 +59,7 @@ namespace RenderDemo.Pages
                                 color = new Color(fillAlpha, r, g, b);
                             }
 
-                            data[y * fb.Size.Width + x] = (int) color.ToUint32();
+                            data[y * fb.Size.Width + x] = (int) color.ToUInt32();
                         }
                     }
 

--- a/src/Avalonia.Base/Media/Color.cs
+++ b/src/Avalonia.Base/Media/Color.cs
@@ -449,7 +449,7 @@ namespace Avalonia.Media
         /// </returns>
         public override string ToString()
         {
-            uint rgb = ToUint32();
+            uint rgb = ToUInt32();
             return KnownColors.GetKnownColorName(rgb) ?? $"#{rgb.ToString("x8", CultureInfo.InvariantCulture)}";
         }
 
@@ -459,9 +459,16 @@ namespace Avalonia.Media
         /// <returns>
         /// The integer representation of the color.
         /// </returns>
-        public uint ToUint32()
+        public uint ToUInt32()
         {
             return ((uint)A << 24) | ((uint)R << 16) | ((uint)G << 8) | (uint)B;
+        }
+
+        /// <inheritdoc cref="Color.ToUInt32"/>
+        [Obsolete("Use Color.ToUInt32() instead.")]
+        public uint ToUint32()
+        {
+            return ToUInt32();
         }
 
         /// <summary>

--- a/src/Avalonia.Base/Media/GeometryDrawing.cs
+++ b/src/Avalonia.Base/Media/GeometryDrawing.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Media
     public class GeometryDrawing : Drawing
     {
         // Adding the Pen's stroke thickness here could yield wrong results due to transforms.
-        private static readonly IPen s_boundsPen = new ImmutablePen(Colors.Black.ToUint32(), 0);
+        private static readonly IPen s_boundsPen = new ImmutablePen(Colors.Black.ToUInt32(), 0);
 
         /// <summary>
         /// Defines the <see cref="Geometry"/> property.

--- a/src/Avalonia.Base/Media/HslColor.cs
+++ b/src/Avalonia.Base/Media/HslColor.cs
@@ -98,43 +98,13 @@ namespace Avalonia.Media
             L = hsl.L;
         }
 
-        /// <summary>
-        /// Gets the Alpha (transparency) component in the range from 0..1 (percentage).
-        /// </summary>
-        /// <remarks>
-        /// <list type="bullet">
-        ///   <item>0 is fully transparent.</item>
-        ///   <item>1 is fully opaque.</item>
-        /// </list>
-        /// </remarks>
+        /// <inheritdoc cref="HsvColor.A"/>
         public double A { get; }
 
-        /// <summary>
-        /// Gets the Hue component in the range from 0..360 (degrees).
-        /// This is the color's location, in degrees, on a color wheel/circle from 0 to 360.
-        /// Note that 360 is equivalent to 0 and will be adjusted automatically.
-        /// </summary>
-        /// <remarks>
-        /// <list type="bullet">
-        ///   <item>0/360 degrees is Red.</item>
-        ///   <item>60 degrees is Yellow.</item>
-        ///   <item>120 degrees is Green.</item>
-        ///   <item>180 degrees is Cyan.</item>
-        ///   <item>240 degrees is Blue.</item>
-        ///   <item>300 degrees is Magenta.</item>
-        /// </list>
-        /// </remarks>
+        /// <inheritdoc cref="HsvColor.H"/>
         public double H { get; }
 
-        /// <summary>
-        /// Gets the Saturation component in the range from 0..1 (percentage).
-        /// </summary>
-        /// <remarks>
-        /// <list type="bullet">
-        ///   <item>0 is a shade of gray (no color).</item>
-        ///   <item>1 is the full color.</item>
-        /// </list>
-        /// </remarks>
+        /// <inheritdoc cref="HsvColor.S"/>
         public double S { get; }
 
         /// <summary>

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
@@ -155,7 +155,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                 result = new XamlStaticOrTargetedReturnMethodCallNode(node,
                     type.GetMethod(
                         new FindMethodMethodSignature("FromUInt32", type, types.UInt) { IsStatic = true }),
-                    new[] { new XamlConstantNode(node, types.UInt, color.ToUint32()) });
+                    new[] { new XamlConstantNode(node, types.UInt, color.ToUInt32()) });
 
                 return true;
             }
@@ -242,7 +242,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
 
                     result = new XamlAstNewClrObjectNode(node, brushTypeRef,
                         types.ImmutableSolidColorBrushConstructorColor,
-                        new List<IXamlAstValueNode> { new XamlConstantNode(node, types.UInt, color.ToUint32()) });
+                        new List<IXamlAstValueNode> { new XamlConstantNode(node, types.UInt, color.ToUInt32()) });
 
                     return true;
                 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/DynamicResourceExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/DynamicResourceExtensionTests.cs
@@ -34,7 +34,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             DelayedBinding.ApplyBindings(border);
 
             var brush = (ISolidColorBrush)border.Background;
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             DelayedBinding.ApplyBindings(border);
 
             var brush = (ISolidColorBrush)border.Background;
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -109,7 +109,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             DelayedBinding.ApplyBindings(border);
 
             var brush = (ISolidColorBrush)border.Background;
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -141,7 +141,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             DelayedBinding.ApplyBindings(border);
 
             var brush = (ISolidColorBrush)border.Background;
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -161,7 +161,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 var border = window.FindControl<Border>("border");
 
                 var brush = (SolidColorBrush)border.Background;
-                Assert.Equal(0xff506070, brush.Color.ToUint32());
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
 
@@ -187,7 +187,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 window.Show();
 
                 var brush = (SolidColorBrush)border.Background;
-                Assert.Equal(0xff506070, brush.Color.ToUint32());
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
 
@@ -214,7 +214,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 var button = window.FindControl<Button>("button");
                 var brush = (ISolidColorBrush)button.Background;
 
-                Assert.Equal(0xff506070, brush.Color.ToUint32());
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
 
@@ -243,7 +243,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 var button = window.FindControl<Button>("button");
                 var brush = (ISolidColorBrush)button.Background;
 
-                Assert.Equal(0xff506070, brush.Color.ToUint32());
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
 
@@ -279,7 +279,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 var border = window.FindControl<Border>("border");
                 var brush = (ISolidColorBrush)border.Background;
 
-                Assert.Equal(0xff506070, brush.Color.ToUint32());
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
 
@@ -323,7 +323,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 var border = (Border)button.GetVisualChildren().Single();
                 var brush = (ISolidColorBrush)border.Background;
 
-                Assert.Equal(0xff506070, brush.Color.ToUint32());
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
 
@@ -347,7 +347,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             DelayedBinding.ApplyBindings(border);
 
             var brush = (SolidColorBrush)border.Background;
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -365,7 +365,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             var application = (Application)AvaloniaRuntimeXamlLoader.Load(xaml);
             var brush = (SolidColorBrush)application.Resources["brush"];
 
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -411,7 +411,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
             var brush = (SolidColorBrush)border.Background;
             Assert.NotNull(brush);
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -434,7 +434,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
             var brush = (SolidColorBrush)border.Background;
             Assert.NotNull(brush);
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -461,7 +461,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
             var brush = (SolidColorBrush)border.Background;
             Assert.NotNull(brush);
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -491,7 +491,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
             var brush = (SolidColorBrush)border.Background;
             Assert.NotNull(brush);
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -519,7 +519,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
             var brush = (SolidColorBrush)border.Background;
             Assert.NotNull(brush);
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -551,7 +551,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
             var brush = (SolidColorBrush)border.Background;
             Assert.NotNull(brush);
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -592,7 +592,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 var borderBrush = (ISolidColorBrush)border.Background;
 
                 Assert.NotNull(borderBrush);
-                Assert.Equal(0xffff0000, borderBrush.Color.ToUint32());
+                Assert.Equal(0xffff0000, borderBrush.Color.ToUInt32());
             }
         }
 
@@ -632,7 +632,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 var borderBrush = (ISolidColorBrush)border.Background;
 
                 Assert.NotNull(borderBrush);
-                Assert.Equal(0xffff0000, borderBrush.Color.ToUint32());
+                Assert.Equal(0xffff0000, borderBrush.Color.ToUInt32());
             }
         }
 
@@ -657,7 +657,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 DelayedBinding.ApplyBindings(border);
 
                 var brush = (ISolidColorBrush)border.Background;
-                Assert.Equal(0xff506070, brush.Color.ToUint32());
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
 
                 window.Content = null;
 
@@ -666,7 +666,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 window.Content = border;
 
                 brush = (ISolidColorBrush)border.Background;
-                Assert.Equal(0xff506070, brush.Color.ToUint32());
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
 
@@ -689,7 +689,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             DelayedBinding.ApplyBindings(border);
 
             var brush = (SolidColorBrush)border.Background;
-            Assert.Equal(0u, brush.Color.ToUint32());
+            Assert.Equal(0u, brush.Color.ToUInt32());
 
             brush.GetObservable(SolidColorBrush.ColorProperty).Subscribe(_ => { });
 
@@ -735,7 +735,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             DelayedBinding.ApplyBindings(border);
 
             var brush = (SolidColorBrush)border.Background;
-            Assert.Equal(0u, brush.Color.ToUint32());
+            Assert.Equal(0u, brush.Color.ToUInt32());
 
             brush.GetObservable(SolidColorBrush.ColorProperty).Subscribe(_ => { });
 
@@ -779,7 +779,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             DelayedBinding.ApplyBindings(border);
 
             var brush = (SolidColorBrush)border.Background;
-            Assert.Equal(0u, brush.Color.ToUint32());
+            Assert.Equal(0u, brush.Color.ToUInt32());
 
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
@@ -815,7 +815,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             var border = userControl.FindControl<Border>("border");
 
             var brush = (ISolidColorBrush)border.Background;
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/ResourceIncludeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/ResourceIncludeTests.cs
@@ -43,7 +43,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                     var border = userControl.FindControl<Border>("border");
 
                     var brush = (ISolidColorBrush)border.Background;
-                    Assert.Equal(0xff506070, brush.Color.ToUint32());
+                    Assert.Equal(0xff506070, brush.Color.ToUInt32());
                 }
             }
 

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/StaticResourceExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/StaticResourceExtensionTests.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             var border = userControl.FindControl<Border>("border");
 
             var brush = (ISolidColorBrush)border.Background;
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             var border = userControl.FindControl<Border>("border");
 
             var brush = (ISolidColorBrush)border.Background;
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 var border = window.FindControl<Border>("border");
 
                 var brush = (SolidColorBrush)border.Background;
-                Assert.Equal(0xff506070, brush.Color.ToUint32());
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
 
@@ -120,7 +120,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             var border = userControl.FindControl<Border>("border");
 
             var brush = (ISolidColorBrush)border.Background;
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -150,7 +150,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             var border = userControl.FindControl<Border>("border");
 
             var brush = (ISolidColorBrush)border.Background;
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -175,7 +175,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 window.Show();
 
                 var brush = (SolidColorBrush)border.Background;
-                Assert.Equal(0xff506070, brush.Color.ToUint32());
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
 
@@ -202,7 +202,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 var button = window.FindControl<Button>("button");
                 var brush = (ISolidColorBrush)button.Background;
 
-                Assert.Equal(0xff506070, brush.Color.ToUint32());
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
 
@@ -231,7 +231,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 var button = window.FindControl<Button>("button");
                 var brush = (ISolidColorBrush)button.Background;
 
-                Assert.Equal(0xff506070, brush.Color.ToUint32());
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
 
@@ -268,7 +268,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 var border = window.FindControl<Border>("border");
                 var brush = (ISolidColorBrush)border.Background;
 
-                Assert.Equal(0xff506070, brush.Color.ToUint32());
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
 
@@ -290,7 +290,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             var border = userControl.FindControl<Border>("border");
 
             var brush = (SolidColorBrush)border.Background;
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -308,7 +308,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             var styles = (Styles)AvaloniaRuntimeXamlLoader.Load(xaml);
             var brush = (SolidColorBrush)styles.Resources["brush"];
 
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -352,7 +352,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 var border = (Border)button.GetVisualChildren().Single();
                 var brush = (ISolidColorBrush)border.Background;
                 
-                Assert.Equal(0xff506070, brush.Color.ToUint32());
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
 
@@ -491,12 +491,12 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             var border = userControl.FindControl<Border>("border");
 
             var brush = (ISolidColorBrush)border.Background;
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
 
             userControl.Content = null;
 
             brush = (ISolidColorBrush)border.Background;
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
 
         [Fact]
@@ -516,7 +516,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             var border = userControl.FindControl<Border>("border");
 
             var brush = (ISolidColorBrush)border.Background;
-            Assert.Equal(0xff506070, brush.Color.ToUint32());
+            Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
         
         [Fact]
@@ -542,7 +542,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 var button = window.FindControl<Button>("button");
                 var brush = (ISolidColorBrush)button.Background;
 
-                Assert.Equal(0xff506070, brush.Color.ToUint32());
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
 

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleTests.cs
@@ -40,7 +40,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
                 var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
                 var color = (Color)((Style)userControl.Styles[0]).Resources["color"];
 
-                Assert.Equal(0xff506070, color.ToUint32());
+                Assert.Equal(0xff506070, color.ToUInt32());
             }
         }
 
@@ -112,7 +112,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
                 var userControl = (UserControl)AvaloniaRuntimeXamlLoader.Load(xaml);
                 var brush = (ISolidColorBrush)((Style)userControl.Styles[0]).Resources["brush"];
 
-                Assert.Equal(0xff506070, brush.Color.ToUint32());
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

 1. Fix incorrect named `Color.ToUint32` method to `ToUInt32`
 2. Fixes HslColor saturation property comment to match latest in HsvColor. To do this comments are now just inherited where possible.

## What is the current behavior?

Incorrect method name, out-of-date comments.

## What is the updated/expected behavior with this PR?

As desccribed.

## How was the solution implemented (if it's not obvious)?

Obvious.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

None, obsolete was used.

## Obsoletions / Deprecations

Yes, the old `Color.ToUint32` method is now marked obsolete.

## Fixed issues

Fixes #10703
