### PR TITLE
Hide obsoleted members from listing in auto-completions

### DIFF
--- a/src/Avalonia.Base/Data/BindingPriority.cs
+++ b/src/Avalonia.Base/Data/BindingPriority.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace Avalonia.Data
 {
@@ -47,7 +48,7 @@ namespace Avalonia.Data
         /// </summary>
         Unset = int.MaxValue,
 
-        [Obsolete("Use Template priority")]
+        [Obsolete("Use Template priority"), EditorBrowsable(EditorBrowsableState.Never)]
         TemplatedParent = Template,
     }
 }

--- a/src/Avalonia.Base/Data/InstancedBinding.cs
+++ b/src/Avalonia.Base/Data/InstancedBinding.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using Avalonia.Reactive;
 using ObservableEx = Avalonia.Reactive.Observable;
 
@@ -49,7 +50,7 @@ namespace Avalonia.Data
         /// </summary>
         public IObservable<object?> Source { get; }
 
-        [Obsolete("Use Source property")]
+        [Obsolete("Use Source property"), EditorBrowsable(EditorBrowsableState.Never)]
         public IObservable<object?> Observable => Source;
 
         /// <summary>

--- a/src/Avalonia.Base/Input/DataFormats.cs
+++ b/src/Avalonia.Base/Input/DataFormats.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace Avalonia.Input
 {
@@ -17,7 +18,7 @@ namespace Avalonia.Input
         /// <summary>
         /// Dataformat for one or more filenames
         /// </summary>
-        [Obsolete("Use DataFormats.Files, this format is supported only on desktop platforms.")]
+        [Obsolete("Use DataFormats.Files, this format is supported only on desktop platforms."), EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly string FileNames = nameof(FileNames);
     }
 }

--- a/src/Avalonia.Base/Input/DataObjectExtensions.cs
+++ b/src/Avalonia.Base/Input/DataObjectExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Avalonia.Platform.Storage;
 
@@ -25,7 +26,7 @@ namespace Avalonia.Input
         /// <returns>
         /// Collection of file names. If format isn't available, returns null.
         /// </returns>
-        [System.Obsolete("Use GetFiles, this method is supported only on desktop platforms.")]
+        [System.Obsolete("Use GetFiles, this method is supported only on desktop platforms."), EditorBrowsable(EditorBrowsableState.Never)]
         public static IEnumerable<string>? GetFileNames(this IDataObject dataObject)
         {
             return (dataObject.Get(DataFormats.FileNames) as IEnumerable<string>)

--- a/src/Avalonia.Base/Media/Color.cs
+++ b/src/Avalonia.Base/Media/Color.cs
@@ -6,6 +6,7 @@
 // Licensed to The Avalonia Project under MIT License, courtesy of The .NET Foundation.
 
 using System;
+using System.ComponentModel;
 using System.Globalization;
 #if !BUILDTASK
 using Avalonia.Animation.Animators;
@@ -465,7 +466,7 @@ namespace Avalonia.Media
         }
 
         /// <inheritdoc cref="Color.ToUInt32"/>
-        [Obsolete("Use Color.ToUInt32() instead.")]
+        [Obsolete("Use Color.ToUInt32() instead."), EditorBrowsable(EditorBrowsableState.Never)]
         public uint ToUint32()
         {
             return ToUInt32();

--- a/src/Avalonia.Base/Media/DrawingContext.cs
+++ b/src/Avalonia.Base/Media/DrawingContext.cs
@@ -5,6 +5,7 @@ using Avalonia.Rendering.SceneGraph;
 using Avalonia.Threading;
 using Avalonia.Utilities;
 using Avalonia.Media.Imaging;
+using System.ComponentModel;
 
 namespace Avalonia.Media
 {
@@ -417,11 +418,11 @@ namespace Avalonia.Media
             return new PushedState(this);
         }
 
-        [Obsolete("Use PushTransform")]
+        [Obsolete("Use PushTransform"), EditorBrowsable(EditorBrowsableState.Never)]
         public PushedState PushPreTransform(Matrix matrix) => PushTransform(matrix);
-        [Obsolete("Use PushTransform")]
+        [Obsolete("Use PushTransform"), EditorBrowsable(EditorBrowsableState.Never)]
         public PushedState PushPostTransform(Matrix matrix) => PushTransform(matrix);
-        [Obsolete("Use PushTransform")]
+        [Obsolete("Use PushTransform"), EditorBrowsable(EditorBrowsableState.Never)]
         public PushedState PushTransformContainer() => PushTransform(Matrix.Identity);
         
         

--- a/src/Avalonia.Base/Threading/DispatcherPriority.cs
+++ b/src/Avalonia.Base/Threading/DispatcherPriority.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace Avalonia.Threading
 {
@@ -100,7 +101,7 @@ namespace Avalonia.Threading
         /// <summary>
         /// The job will be processed with the same priority as data binding.
         /// </summary>
-        [Obsolete("WPF compatibility")] public static readonly DispatcherPriority DataBind = new(Layout);
+        [Obsolete("WPF compatibility"), EditorBrowsable(EditorBrowsableState.Never)] public static readonly DispatcherPriority DataBind = new(Layout);
         
         /// <summary>
         /// The job will be processed with normal priority.

--- a/src/Avalonia.Base/VisualTree/IVisualWithRoundRectClip.cs
+++ b/src/Avalonia.Base/VisualTree/IVisualWithRoundRectClip.cs
@@ -1,14 +1,15 @@
 using System;
+using System.ComponentModel;
 
 namespace Avalonia.VisualTree
 {
-    [Obsolete("Internal API, will be removed in future versions, you've been warned")]
+    [Obsolete("Internal API, will be removed in future versions, you've been warned"), EditorBrowsable(EditorBrowsableState.Never)]
     public interface IVisualWithRoundRectClip
     {
         /// <summary>
         /// Gets a value indicating the corner radius of control's clip bounds
         /// </summary>
-        [Obsolete("Internal API, will be removed in future versions, you've been warned")]
+        [Obsolete("Internal API, will be removed in future versions, you've been warned"), EditorBrowsable(EditorBrowsableState.Never)]
         CornerRadius ClipToBoundsRadius { get; }
 
     }

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -64,7 +64,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="PlacementMode"/> property.
         /// </summary>
-        [Obsolete("Use the Placement property instead.")]
+        [Obsolete("Use the Placement property instead."), EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly StyledProperty<PlacementMode> PlacementModeProperty = PlacementProperty;
 
         /// <summary>
@@ -157,7 +157,7 @@ namespace Avalonia.Controls
         }
 
         /// <inheritdoc cref="Placement"/>
-        [Obsolete("Use the Placement property instead.")]
+        [Obsolete("Use the Placement property instead."), EditorBrowsable(EditorBrowsableState.Never)]
         public PlacementMode PlacementMode
         {
             get => GetValue(PlacementProperty);

--- a/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/ItemContainerGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace Avalonia.Controls.Generators
 {
@@ -131,10 +132,10 @@ namespace Avalonia.Controls.Generators
         /// </remarks>
         public void ClearItemContainer(Control container) => _owner.ClearItemContainer(container);
 
-        [Obsolete("Use ItemsControl.ContainerFromIndex")]
+        [Obsolete("Use ItemsControl.ContainerFromIndex"), EditorBrowsable(EditorBrowsableState.Never)]
         public Control? ContainerFromIndex(int index) => _owner.ContainerFromIndex(index);
 
-        [Obsolete("Use ItemsControl.IndexFromContainer")]
+        [Obsolete("Use ItemsControl.IndexFromContainer"), EditorBrowsable(EditorBrowsableState.Never)]
         public int IndexFromContainer(Control container) => _owner.IndexFromContainer(container);
     }
 }

--- a/src/Avalonia.Controls/Generators/TreeItemContainerGenerator.cs
+++ b/src/Avalonia.Controls/Generators/TreeItemContainerGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Avalonia.Controls.Generators
 {
@@ -20,13 +21,13 @@ namespace Avalonia.Controls.Generators
 
         internal TreeContainerIndex(TreeView owner) => _owner = owner;
 
-        [Obsolete("Use TreeView.GetRealizedTreeContainers")]
+        [Obsolete("Use TreeView.GetRealizedTreeContainers"), EditorBrowsable(EditorBrowsableState.Never)]
         public IEnumerable<Control> Containers => _owner.GetRealizedTreeContainers();
 
-        [Obsolete("Use TreeView.TreeContainerFromItem")]
+        [Obsolete("Use TreeView.TreeContainerFromItem"), EditorBrowsable(EditorBrowsableState.Never)]
         public Control? ContainerFromItem(object item) => _owner.TreeContainerFromItem(item);
 
-        [Obsolete("Use TreeView.TreeItemFromContainer")]
+        [Obsolete("Use TreeView.TreeItemFromContainer"), EditorBrowsable(EditorBrowsableState.Never)]
         public object? ItemFromContainer(Control container) => _owner.TreeItemFromContainer(container);
     }
 }

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Generators;
 using Avalonia.Controls.Metadata;
@@ -626,7 +627,7 @@ namespace Avalonia.Controls
         /// TreeView to be able to create a <see cref="TreeItemContainerGenerator"/>. Can be
         /// removed in 12.0.
         /// </remarks>
-        [Obsolete]
+        [Obsolete, EditorBrowsable(EditorBrowsableState.Never)]
         private protected virtual ItemContainerGenerator CreateItemContainerGenerator()
         {
             return new ItemContainerGenerator(this);

--- a/src/Avalonia.Controls/Platform/Dialogs/ISystemDialogImpl.cs
+++ b/src/Avalonia.Controls/Platform/Dialogs/ISystemDialogImpl.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using Avalonia.Metadata;
 
@@ -7,7 +8,7 @@ namespace Avalonia.Controls.Platform
     /// <summary>
     /// Defines a platform-specific system dialog implementation.
     /// </summary>
-    [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API")]
+    [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API"), EditorBrowsable(EditorBrowsableState.Never)]
     [Unstable]
     public interface ISystemDialogImpl
     {

--- a/src/Avalonia.Controls/Platform/Dialogs/SystemDialogImpl.cs
+++ b/src/Avalonia.Controls/Platform/Dialogs/SystemDialogImpl.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Platform.Storage;
@@ -10,7 +11,7 @@ namespace Avalonia.Controls.Platform
     /// <summary>
     /// Defines a platform-specific system dialog implementation.
     /// </summary>
-    [Obsolete]
+    [Obsolete, EditorBrowsable(EditorBrowsableState.Never)]
     internal class SystemDialogImpl : ISystemDialogImpl
     {
         public async Task<string[]?> ShowFileDialogAsync(FileDialog dialog, Window parent)

--- a/src/Avalonia.Controls/Platform/Screen.cs
+++ b/src/Avalonia.Controls/Platform/Screen.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace Avalonia.Platform
 {
@@ -17,7 +18,7 @@ namespace Avalonia.Platform
         public double Scaling { get; }
 
         /// <inheritdoc cref="Scaling"/>
-        [Obsolete("Use the Scaling property instead.")]
+        [Obsolete("Use the Scaling property instead."), EditorBrowsable(EditorBrowsableState.Never)]
         public double PixelDensity => Scaling;
 
         /// <summary>
@@ -43,7 +44,7 @@ namespace Avalonia.Platform
         public bool IsPrimary { get; }
 
         /// <inheritdoc cref="IsPrimary"/>
-        [Obsolete("Use the IsPrimary property instead.")]
+        [Obsolete("Use the IsPrimary property instead."), EditorBrowsable(EditorBrowsableState.Never)]
         public bool Primary => IsPrimary;
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -74,7 +74,7 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Defines the <see cref="PlacementMode"/> property.
         /// </summary>
-        [Obsolete("Use the Placement property instead.")]
+        [Obsolete("Use the Placement property instead."), EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly StyledProperty<PlacementMode> PlacementModeProperty = PlacementProperty;
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace Avalonia.Controls.Primitives
         }
 
         /// <inheritdoc cref="Placement"/>
-        [Obsolete("Use the Placement property instead.")]
+        [Obsolete("Use the Placement property instead."), EditorBrowsable(EditorBrowsableState.Never)]
         public PlacementMode PlacementMode
         {
             get => GetValue(PlacementProperty);

--- a/src/Avalonia.Controls/Primitives/ToggleButton.cs
+++ b/src/Avalonia.Controls/Primitives/ToggleButton.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Metadata;
 using Avalonia.Data;
@@ -28,7 +29,7 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Defines the <see cref="Checked"/> event.
         /// </summary>
-        [Obsolete("Use IsCheckedChangedEvent instead.")]
+        [Obsolete("Use IsCheckedChangedEvent instead."), EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly RoutedEvent<RoutedEventArgs> CheckedEvent =
             RoutedEvent.Register<ToggleButton, RoutedEventArgs>(
                 nameof(Checked),
@@ -37,7 +38,7 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Defines the <see cref="Unchecked"/> event.
         /// </summary>
-        [Obsolete("Use IsCheckedChangedEvent instead.")]
+        [Obsolete("Use IsCheckedChangedEvent instead."), EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly RoutedEvent<RoutedEventArgs> UncheckedEvent =
             RoutedEvent.Register<ToggleButton, RoutedEventArgs>(
                 nameof(Unchecked),
@@ -46,7 +47,7 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Defines the <see cref="Unchecked"/> event.
         /// </summary>
-        [Obsolete("Use IsCheckedChangedEvent instead.")]
+        [Obsolete("Use IsCheckedChangedEvent instead."), EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly RoutedEvent<RoutedEventArgs> IndeterminateEvent =
             RoutedEvent.Register<ToggleButton, RoutedEventArgs>(
                 nameof(Indeterminate),
@@ -72,7 +73,7 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Raised when a <see cref="ToggleButton"/> is checked.
         /// </summary>
-        [Obsolete("Use IsCheckedChanged instead.")]
+        [Obsolete("Use IsCheckedChanged instead."), EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler<RoutedEventArgs>? Checked
         {
             add => AddHandler(CheckedEvent, value);
@@ -82,7 +83,7 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Raised when a <see cref="ToggleButton"/> is unchecked.
         /// </summary>
-        [Obsolete("Use IsCheckedChanged instead.")]
+        [Obsolete("Use IsCheckedChanged instead."), EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler<RoutedEventArgs>? Unchecked
         {
             add => AddHandler(UncheckedEvent, value);
@@ -92,7 +93,7 @@ namespace Avalonia.Controls.Primitives
         /// <summary>
         /// Raised when a <see cref="ToggleButton"/> is neither checked nor unchecked.
         /// </summary>
-        [Obsolete("Use IsCheckedChanged instead.")]
+        [Obsolete("Use IsCheckedChanged instead."), EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler<RoutedEventArgs>? Indeterminate
         {
             add => AddHandler(IndeterminateEvent, value);
@@ -168,7 +169,7 @@ namespace Avalonia.Controls.Primitives
         /// Called when <see cref="IsChecked"/> becomes true.
         /// </summary>
         /// <param name="e">Event arguments for the routed event that is raised by the default implementation of this method.</param>
-        [Obsolete("Use OnIsCheckedChanged instead.")]
+        [Obsolete("Use OnIsCheckedChanged instead."), EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void OnChecked(RoutedEventArgs e)
         {
             RaiseEvent(e);
@@ -178,7 +179,7 @@ namespace Avalonia.Controls.Primitives
         /// Called when <see cref="IsChecked"/> becomes false.
         /// </summary>
         /// <param name="e">Event arguments for the routed event that is raised by the default implementation of this method.</param>
-        [Obsolete("Use OnIsCheckedChanged instead.")]
+        [Obsolete("Use OnIsCheckedChanged instead."), EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void OnUnchecked(RoutedEventArgs e)
         {
             RaiseEvent(e);
@@ -188,7 +189,7 @@ namespace Avalonia.Controls.Primitives
         /// Called when <see cref="IsChecked"/> becomes null.
         /// </summary>
         /// <param name="e">Event arguments for the routed event that is raised by the default implementation of this method.</param>
-        [Obsolete("Use OnIsCheckedChanged instead.")]
+        [Obsolete("Use OnIsCheckedChanged instead."), EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void OnIndeterminate(RoutedEventArgs e)
         {
             RaiseEvent(e);

--- a/src/Avalonia.Controls/Screens.cs
+++ b/src/Avalonia.Controls/Screens.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Avalonia.Platform;
 
@@ -68,7 +69,7 @@ namespace Avalonia.Controls
         /// </summary>
         /// <param name="window">The window impl for which to retrieve the Screen.</param>
         /// <returns>The <see cref="Screen"/>.</returns>
-        [Obsolete("Use ScreenFromWindow(WindowBase) overload.")]
+        [Obsolete("Use ScreenFromWindow(WindowBase) overload."), EditorBrowsable(EditorBrowsableState.Never)]
         public Screen? ScreenFromWindow(IWindowBaseImpl window)
         {
             return _iScreenImpl.ScreenFromWindow(window);

--- a/src/Avalonia.Controls/SystemDialog.cs
+++ b/src/Avalonia.Controls/SystemDialog.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls.Platform;
@@ -11,7 +12,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// Base class for system file dialogs.
     /// </summary>
-    [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API")]
+    [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API"), EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class FileDialog : FileSystemDialog
     {
         /// <summary>
@@ -29,7 +30,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// Base class for system file and directory dialogs.
     /// </summary>
-    [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API")]
+    [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API"), EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class FileSystemDialog : SystemDialog
     {
         /// <summary>
@@ -42,7 +43,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// Represents a system dialog that prompts the user to select a location for saving a file.
     /// </summary>
-    [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API")]
+    [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API"), EditorBrowsable(EditorBrowsableState.Never)]
     public class SaveFileDialog : FileDialog
     {
         /// <summary>
@@ -91,7 +92,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// Represents a system dialog that allows the user to select one or more files to open.
     /// </summary>
-    [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API")]
+    [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API"), EditorBrowsable(EditorBrowsableState.Never)]
     public class OpenFileDialog : FileDialog
     {
         /// <summary>
@@ -132,7 +133,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// Represents a system dialog that allows the user to select a directory.
     /// </summary>
-    [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API")]
+    [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API"), EditorBrowsable(EditorBrowsableState.Never)]
     public class OpenFolderDialog : FileSystemDialog
     {
         /// <summary>
@@ -167,7 +168,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// Base class for system dialogs.
     /// </summary>
-    [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API")]
+    [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API"), EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class SystemDialog
     {
         static SystemDialog()
@@ -188,7 +189,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// Represents a filter in an <see cref="OpenFileDialog"/> or an <see cref="SaveFileDialog"/>.
     /// </summary>
-    [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API")]
+    [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API"), EditorBrowsable(EditorBrowsableState.Never)]
     public class FileDialogFilter
     {
         /// <summary>

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Avalonia.Collections;
@@ -715,7 +716,7 @@ namespace Avalonia.Controls
             }
         }
 
-        [Obsolete]
+        [Obsolete, EditorBrowsable(EditorBrowsableState.Never)]
         private protected override ItemContainerGenerator CreateItemContainerGenerator()
         {
             return new TreeItemContainerGenerator(this);

--- a/src/Avalonia.Dialogs/ManagedFileDialogExtensions.cs
+++ b/src/Avalonia.Dialogs/ManagedFileDialogExtensions.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
@@ -39,11 +40,11 @@ namespace Avalonia.Dialogs
             return builder;
         }
 
-        [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API")]
+        [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API"), EditorBrowsable(EditorBrowsableState.Never)]
         public static Task<string[]> ShowManagedAsync(this OpenFileDialog dialog, Window parent,
             ManagedFileDialogOptions? options = null) => ShowManagedAsync<Window>(dialog, parent, options);
 
-        [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API")]
+        [Obsolete("Use Window.StorageProvider API or TopLevel.StorageProvider API"), EditorBrowsable(EditorBrowsableState.Never)]
         public static async Task<string[]> ShowManagedAsync<TWindow>(this OpenFileDialog dialog, Window parent,
             ManagedFileDialogOptions? options = null) where TWindow : Window, new()
         {

--- a/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs
+++ b/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs
@@ -8,6 +8,8 @@ using Avalonia.Rendering;
 using Avalonia.Rendering.Composition;
 using Avalonia.VisualTree;
 using Avalonia.Platform;
+using System.ComponentModel;
+
 namespace Avalonia.OpenGL.Controls
 {
     public abstract class OpenGlControlBase : Control
@@ -217,7 +219,7 @@ namespace Avalonia.OpenGL.Controls
             return true;
         }
 
-        [Obsolete("Use RequestNextFrameRendering()")]
+        [Obsolete("Use RequestNextFrameRendering()"), EditorBrowsable(EditorBrowsableState.Never)]
         // ReSharper disable once MemberCanBeProtected.Global
         public new void InvalidateVisual() => RequestNextFrameRendering(); 
         


### PR DESCRIPTION
## What does the pull request do?
Hide all obsoleted members from listing in auto-completions, so developers will not be able to find those obsoleted members in IDE easily.


## What is the current behavior?
Although deprecated members are marked as `Obsolete`, developers can still easily find those members in IDE auto-completions.


## What is the updated/expected behavior with this PR?
Those deprecated members can still be used but are no longer listed in the IDE auto-completion list.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
No
