### PR TITLE
Fix WASM "Hand" cursor not showing

### DIFF
--- a/src/Browser/Avalonia.Browser/webapp/modules/avalonia/input.ts
+++ b/src/Browser/Avalonia.Browser/webapp/modules/avalonia/input.ts
@@ -266,7 +266,7 @@ export class InputHelper {
     }
 
     public static setCursor(inputElement: HTMLInputElement, kind: string) {
-        if (kind === "pointer") {
+        if (kind === "default") {
             inputElement.style.removeProperty("cursor");
         } else {
             inputElement.style.cursor = kind;


### PR DESCRIPTION
## What does the pull request do?
Fixes an issue where the hand cursor in WASM wasn't working

## What is the current behavior?
All cursor types except for "Hand" are working. 

## What is the updated/expected behavior with this PR?
"Hand" cursor also works


## How was the solution implemented (if it's not obvious)?



## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #11202