### PR TITLE
Bump Tmds.DBus.SourceGenerator

### DIFF
--- a/src/Avalonia.FreeDesktop/Avalonia.FreeDesktop.csproj
+++ b/src/Avalonia.FreeDesktop/Avalonia.FreeDesktop.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Tmds.DBus.Protocol" Version="0.15.0" />
-    <PackageReference Include="Tmds.DBus.SourceGenerator" Version="0.0.5" PrivateAssets="All" />
+    <PackageReference Include="Tmds.DBus.SourceGenerator" Version="0.0.6" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What does the pull request do?
Bump Tmds.DBus.SourceGenerator to 0.0.6 which makes generated types internal.

## What is the current behavior?
Generated types are public, bloating Avalonia's API surface.

## What is the updated/expected behavior with this PR?
Generated types are no longer public.

## How was the solution implemented (if it's not obvious)?


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #11199 
