### PR TITLE
Fix scrollbar getting stuck in certain situations

### DIFF
--- a/tests/Avalonia.Base.UnitTests/Layout/LayoutManagerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Layout/LayoutManagerTests.cs
@@ -547,5 +547,38 @@ namespace Avalonia.Base.UnitTests.Layout
             Assert.True(root.IsMeasureValid);
             Assert.True(root.IsArrangeValid);
         }
+
+        [Fact]
+        public void GreatGrandparent_Can_Invalidate_Grandparent_Measure_During_Arrange()
+        {
+            // Issue #7706 (second part: scrollbar gets stuck)
+            var child = new LayoutTestControl();
+            var parent = new LayoutTestControl { Child = child };
+            var grandparent = new LayoutTestControl { Child = parent };
+            var greatGrandparent = new LayoutTestControl { Child = grandparent };
+            var root = new LayoutTestRoot { Child = greatGrandparent };
+
+            root.LayoutManager.ExecuteInitialLayoutPass();
+
+            greatGrandparent.DoArrangeOverride = (_, s) =>
+            {
+                grandparent.InvalidateMeasure();
+                return s;
+            };
+
+            child.InvalidateArrange();
+            greatGrandparent.InvalidateArrange();
+
+            root.LayoutManager.ExecuteLayoutPass();
+
+            Assert.True(child.IsMeasureValid);
+            Assert.True(child.IsArrangeValid);
+            Assert.True(parent.IsMeasureValid);
+            Assert.True(parent.IsArrangeValid);
+            Assert.True(greatGrandparent.IsMeasureValid);
+            Assert.True(greatGrandparent.IsArrangeValid);
+            Assert.True(root.IsMeasureValid);
+            Assert.True(root.IsArrangeValid);
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Fixes a problem in the layout manager whereby if ancestor measure was invalidated in a certain order during the arrange pass then the control would be removed from the arrange queue before it was actually arranged causing issues such as the scrollbar getting stuck in #7706.

If an ancestor control results in a control not being arranged, then we need to queue that control for another arrange pass after the next measure pass.

## Fixed issues

Fixes #7706
Fixes https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/issues/174