### PR TITLE
Tweak DataValidation-Plugins

### DIFF
--- a/src/Avalonia.Base/Data/Core/Plugins/DataAnnotationsValidationPlugin.cs
+++ b/src/Avalonia.Base/Data/Core/Plugins/DataAnnotationsValidationPlugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
@@ -10,7 +10,7 @@ namespace Avalonia.Data.Core.Plugins
     /// <summary>
     /// Validates properties on that have <see cref="ValidationAttribute"/>s.
     /// </summary>
-    internal class DataAnnotationsValidationPlugin : IDataValidationPlugin
+    public class DataAnnotationsValidationPlugin : IDataValidationPlugin
     {
         /// <inheritdoc/>
         [RequiresUnreferencedCode(TrimmingMessages.DataValidationPluginRequiresUnreferencedCodeMessage)]

--- a/src/Avalonia.Base/Data/Core/Plugins/ExceptionValidationPlugin.cs
+++ b/src/Avalonia.Base/Data/Core/Plugins/ExceptionValidationPlugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
@@ -7,7 +7,7 @@ namespace Avalonia.Data.Core.Plugins
     /// <summary>
     /// Validates properties that report errors by throwing exceptions.
     /// </summary>
-    internal class ExceptionValidationPlugin : IDataValidationPlugin
+    public class ExceptionValidationPlugin : IDataValidationPlugin
     {
         /// <inheritdoc/>
         [RequiresUnreferencedCode(TrimmingMessages.DataValidationPluginRequiresUnreferencedCodeMessage)]

--- a/src/Avalonia.Base/Data/Core/Plugins/ExceptionValidationPlugin.cs
+++ b/src/Avalonia.Base/Data/Core/Plugins/ExceptionValidationPlugin.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
@@ -35,11 +35,11 @@ namespace Avalonia.Data.Core.Plugins
                 }
                 catch (TargetInvocationException ex) when (ex.InnerException is not null)
                 {
-                    PublishValue(new BindingNotification(ex.InnerException, BindingErrorType.DataValidationError));
+                    PublishValue(new BindingNotification(new DataValidationException(ex.InnerException.Message), BindingErrorType.DataValidationError));
                 }
                 catch (Exception ex)
                 {
-                    PublishValue(new BindingNotification(ex, BindingErrorType.DataValidationError));
+                    PublishValue(new BindingNotification(new DataValidationException(ex.Message), BindingErrorType.DataValidationError));
                 }
 
                 return false;

--- a/src/Avalonia.Base/Data/Core/Plugins/IndeiValidationPlugin.cs
+++ b/src/Avalonia.Base/Data/Core/Plugins/IndeiValidationPlugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
@@ -10,7 +10,7 @@ namespace Avalonia.Data.Core.Plugins
     /// <summary>
     /// Validates properties on objects that implement <see cref="INotifyDataErrorInfo"/>.
     /// </summary>
-    internal class IndeiValidationPlugin : IDataValidationPlugin
+    public class IndeiValidationPlugin : IDataValidationPlugin
     {
         private static readonly WeakEvent<INotifyDataErrorInfo, DataErrorsChangedEventArgs>
             ErrorsChangedWeakEvent = WeakEvent.Register<INotifyDataErrorInfo, DataErrorsChangedEventArgs>(

--- a/tests/Avalonia.Base.UnitTests/Data/Core/ExpressionObserverTests_DataValidation.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/ExpressionObserverTests_DataValidation.cs
@@ -104,7 +104,7 @@ namespace Avalonia.Base.UnitTests.Data.Core
 
                 // Exception is thrown by trying to set value to "foo".
                 new BindingNotification(
-                    new ArgumentException(errmsg),
+                    new DataValidationException(new ArgumentException(errmsg).Message),
                     BindingErrorType.DataValidationError),
 
                 // Value is set then validation is updated.

--- a/tests/Avalonia.Base.UnitTests/Data/Core/Plugins/ExceptionValidationPluginTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/Core/Plugins/ExceptionValidationPluginTests.cs
@@ -29,7 +29,7 @@ namespace Avalonia.Base.UnitTests.Data.Core.Plugins
             {
                 new BindingNotification(0),
                 new BindingNotification(5),
-                new BindingNotification(new ArgumentOutOfRangeException("value"), BindingErrorType.DataValidationError),
+                new BindingNotification(new DataValidationException(new ArgumentOutOfRangeException("value").Message), BindingErrorType.DataValidationError),
                 new BindingNotification(6),
             }, result);
 

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests_DataValidation.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests_DataValidation.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Templates;
@@ -57,7 +58,7 @@ namespace Avalonia.Controls.UnitTests
 
                 IEnumerable<object> errors = DataValidationErrors.GetErrors(target);
                 Assert.Single(errors);
-                Assert.IsType<InvalidOperationException>(errors.Single());
+                Assert.Equal(errors.Single(), "More than 10.");
                 target.Text = "1";
                 Assert.Null(DataValidationErrors.GetErrors(target));
             }

--- a/tests/Avalonia.Markup.UnitTests/Data/BindingTests_DataValidation.cs
+++ b/tests/Avalonia.Markup.UnitTests/Data/BindingTests_DataValidation.cs
@@ -33,7 +33,7 @@ namespace Avalonia.Markup.UnitTests.Data
                 target.SetValue(property, 200);
 
                 Assert.Equal(200, target.GetValue(property));
-                Assert.IsType<ArgumentOutOfRangeException>(target.DataValidationError);
+                Assert.Equal(target.DataValidationError?.Message, new ArgumentOutOfRangeException(nameof(ExceptionValidatingModel.Value)).Message);
 
                 target.SetValue(property, 10);
 
@@ -357,7 +357,7 @@ namespace Avalonia.Markup.UnitTests.Data
                 set
                 {
                     if (value > MaxValue)
-                        throw new ArgumentOutOfRangeException(nameof(value));
+                        throw new ArgumentOutOfRangeException(nameof(Value));
                     _value = value;
                 }
             }


### PR DESCRIPTION
## What does the pull request do?
1. Exception inside setter should not show the StackTrace anymore. This is in most cases not a useful info for the user (only for the developer useful)
2. Make ValidationPlugins public again. That way it's easier to add or remove them as needed 

## What is the current behavior?
1. Full StackTrace is shown which doesn't look nice and is confusing
2. Plugins are internal, making it harder to manage them

## What is the updated/expected behavior with this PR?
Both issues fixed

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)? ▶ Fixed the unit tests
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
All ValidationPlugins now use DataValidationException whereas before any Exception was used

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->