### PR TITLE
Use SKBitmap-backed bitmap for RenderTargetBitmap

### DIFF
--- a/src/Avalonia.Base/Media/Imaging/RenderTargetBitmap.cs
+++ b/src/Avalonia.Base/Media/Imaging/RenderTargetBitmap.cs
@@ -9,7 +9,7 @@ namespace Avalonia.Media.Imaging
     /// <summary>
     /// A bitmap that holds the rendering of a <see cref="Visual"/>.
     /// </summary>
-    public class RenderTargetBitmap : Bitmap, IDisposable
+    public class RenderTargetBitmap : Bitmap
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RenderTargetBitmap"/> class.
@@ -67,6 +67,12 @@ namespace Avalonia.Media.Imaging
             var platform = PlatformImpl.Item.CreateDrawingContext();
             platform.Clear(Colors.Transparent);
             return new PlatformDrawingContext(platform);
+        }
+
+        public override void Dispose()
+        {
+            PlatformImpl.Dispose();
+            base.Dispose();
         }
     }
 }

--- a/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
+++ b/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
@@ -191,16 +191,7 @@ namespace Avalonia.Skia
                 throw new ArgumentException("Height can't be less than 1", nameof(size));
             }
 
-            var createInfo = new SurfaceRenderTarget.CreateInfo
-            {
-                Width = size.Width,
-                Height = size.Height,
-                Dpi = dpi,
-                DisableTextLcdRendering = false,
-                DisableManualFbo = true,
-            };
-
-            return new SurfaceRenderTarget(createInfo);
+            return new RenderTargetBitmapImpl(size, dpi);
         }
 
         /// <inheritdoc />

--- a/src/Skia/Avalonia.Skia/RenderTargetBitmapImpl.cs
+++ b/src/Skia/Avalonia.Skia/RenderTargetBitmapImpl.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using Avalonia.Controls.Platform.Surfaces;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using SkiaSharp;
+
+namespace Avalonia.Skia;
+
+internal class RenderTargetBitmapImpl : WriteableBitmapImpl,
+    IRenderTargetBitmapImpl,
+    IFramebufferPlatformSurface
+{
+    private readonly FramebufferRenderTarget _renderTarget;
+    
+    public RenderTargetBitmapImpl(PixelSize size, Vector dpi) : base(size, dpi, 
+        SKImageInfo.PlatformColorType == SKColorType.Rgba8888 ? PixelFormats.Rgba8888 : PixelFormat.Bgra8888,
+        AlphaFormat.Premul)
+    {
+        _renderTarget = new FramebufferRenderTarget(this);
+    }
+
+    public IDrawingContextImpl CreateDrawingContext() => _renderTarget.CreateDrawingContext();
+
+    public bool IsCorrupted => false;
+    
+    public override void Dispose()
+    {
+        _renderTarget.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/Skia/Avalonia.Skia/WriteableBitmapImpl.cs
+++ b/src/Skia/Avalonia.Skia/WriteableBitmapImpl.cs
@@ -131,7 +131,7 @@ namespace Avalonia.Skia
         }
 
         /// <inheritdoc />
-        public void Dispose()
+        public virtual void Dispose()
         {
             _bitmap.Dispose();
         }


### PR DESCRIPTION
This removes the need to Snapshot the image for saving and enables CopyPixels