### PR TITLE
[WIP][Windows] Use InputScope API for ITextInputMethodImpl.SetOptions

### DIFF
--- a/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
+++ b/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Avalonia.Input.TextInput;
 using Avalonia.Threading;
-
 using static Avalonia.Win32.Interop.UnmanagedMethods;
 
 namespace Avalonia.Win32.Input
@@ -75,6 +73,8 @@ namespace Avalonia.Win32.Input
             _caretManager.TryDestroy();
 
             _currentHimc = IntPtr.Zero;
+
+            SetInputScope(Hwnd, InputScope.IS_DEFAULT);
         }
 
         public void SetLanguageAndWindow(WindowImpl parent, IntPtr hwnd, IntPtr HKL)
@@ -129,6 +129,8 @@ namespace Avalonia.Win32.Input
                 }
 
                 ImmReleaseContext(Hwnd, himc);
+
+                SetInputScope(Hwnd, InputScope.IS_DEFAULT);
             });
         }
 
@@ -270,7 +272,40 @@ namespace Avalonia.Win32.Input
         
         public void SetOptions(TextInputOptions options)
         {
-            // we're skipping this. not usable on windows
+            var inputScope = InputScope.IS_DEFAULT;
+
+            switch(options.ContentType)
+            {
+                case TextInputContentType.Alpha:
+                    inputScope = InputScope.IS_TEXT;
+                    break;
+                case TextInputContentType.Digits:
+                    inputScope = InputScope.IS_DIGITS;
+                    break;
+                case TextInputContentType.Pin:
+                    inputScope = InputScope.IS_ALPHANUMERIC_PIN;
+                    break;
+                case TextInputContentType.Number:
+                    inputScope = InputScope.IS_NUMBER;
+                    break;
+                case TextInputContentType.Email:
+                    inputScope = InputScope.IS_EMAILNAME_OR_ADDRESS;
+                    break;
+                case TextInputContentType.Url:
+                    inputScope = InputScope.IS_URL;
+                    break;
+                case TextInputContentType.Name:
+                    inputScope = InputScope.IS_NAME_OR_PHONENUMBER;
+                    break;
+                case TextInputContentType.Password:
+                    inputScope = InputScope.IS_PASSWORD;
+                    break;
+                case TextInputContentType.Search:
+                    inputScope = InputScope.IS_SEARCH;
+                    break;
+            }
+
+            SetInputScope(Hwnd, inputScope);
         }
 
         public void CompositionChanged(string? composition)

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using MicroCom.Runtime;
+using static Avalonia.Win32.Interop.UnmanagedMethods;
 
 // ReSharper disable InconsistentNaming
 #pragma warning disable 169, 649
@@ -1929,6 +1930,87 @@ namespace Avalonia.Win32.Interop
         public static extern IntPtr GetKeyboardLayout(int idThread);
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern int LCIDToLocaleName(uint Locale, StringBuilder lpName, int cchName, int dwFlags);
+
+        [DllImport("msctf", ExactSpelling = true)]
+        public static extern HRESULT SetInputScope(IntPtr hwnd, InputScope inputscope);
+
+        public enum InputScope
+        {
+            IS_DEFAULT = 0,
+            IS_URL = 1,
+            IS_FILE_FULLFILEPATH = 2,
+            IS_FILE_FILENAME = 3,
+            IS_EMAIL_USERNAME = 4,
+            IS_EMAIL_SMTPEMAILADDRESS = 5,
+            IS_LOGINNAME = 6,
+            IS_PERSONALNAME_FULLNAME = 7,
+            IS_PERSONALNAME_PREFIX = 8,
+            IS_PERSONALNAME_GIVENNAME = 9,
+            IS_PERSONALNAME_MIDDLENAME = 10,
+            IS_PERSONALNAME_SURNAME = 11,
+            IS_PERSONALNAME_SUFFIX = 12,
+            IS_ADDRESS_FULLPOSTALADDRESS = 13,
+            IS_ADDRESS_POSTALCODE = 14,
+            IS_ADDRESS_STREET = 15,
+            IS_ADDRESS_STATEORPROVINCE = 16,
+            IS_ADDRESS_CITY = 17,
+            IS_ADDRESS_COUNTRYNAME = 18,
+            IS_ADDRESS_COUNTRYSHORTNAME = 19,
+            IS_CURRENCY_AMOUNTANDSYMBOL = 20,
+            IS_CURRENCY_AMOUNT = 21,
+            IS_DATE_FULLDATE = 22,
+            IS_DATE_MONTH = 23,
+            IS_DATE_DAY = 24,
+            IS_DATE_YEAR = 25,
+            IS_DATE_MONTHNAME = 26,
+            IS_DATE_DAYNAME = 27,
+            IS_DIGITS = 28,
+            IS_NUMBER = 29,
+            IS_ONECHAR = 30,
+            IS_PASSWORD = 31,
+            IS_TELEPHONE_FULLTELEPHONENUMBER = 32,
+            IS_TELEPHONE_COUNTRYCODE = 33,
+            IS_TELEPHONE_AREACODE = 34,
+            IS_TELEPHONE_LOCALNUMBER = 35,
+            IS_TIME_FULLTIME = 36,
+            IS_TIME_HOUR = 37,
+            IS_TIME_MINORSEC = 38,
+            IS_NUMBER_FULLWIDTH = 39,
+            IS_ALPHANUMERIC_HALFWIDTH = 40,
+            IS_ALPHANUMERIC_FULLWIDTH = 41,
+            IS_CURRENCY_CHINESE = 42,
+            IS_BOPOMOFO = 43,
+            IS_HIRAGANA = 44,
+            IS_KATAKANA_HALFWIDTH = 45,
+            IS_KATAKANA_FULLWIDTH = 46,
+            IS_HANJA = 47,
+            IS_HANGUL_HALFWIDTH = 48,
+            IS_HANGUL_FULLWIDTH = 49,
+            IS_SEARCH = 50,
+            IS_FORMULA = 51,
+            IS_SEARCH_INCREMENTAL = 52,
+            IS_CHINESE_HALFWIDTH = 53,
+            IS_CHINESE_FULLWIDTH = 54,
+            IS_NATIVE_SCRIPT = 55,
+            IS_YOMI = 56,
+            IS_TEXT = 57,
+            IS_CHAT = 58,
+            IS_NAME_OR_PHONENUMBER = 59,
+            IS_EMAILNAME_OR_ADDRESS = 60,
+            IS_PRIVATE = 61,
+            IS_MAPS = 62,
+            IS_NUMERIC_PASSWORD = 63,
+            IS_NUMERIC_PIN = 64,
+            IS_ALPHANUMERIC_PIN = 65,
+            IS_ALPHANUMERIC_PIN_SET = 66,
+            IS_FORMULA_NUMBER = 67,
+            IS_CHAT_WITHOUT_EMOJI = 68,
+            IS_PHRASELIST = -1,
+            IS_REGULAREXPRESSION = -2,
+            IS_SRGS = -3,
+            IS_XML = -4,
+            IS_ENUMSTRING = -5,
+        }
 
         public static uint MAKELCID(uint lgid, uint srtid)
         {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Use https://learn.microsoft.com/en-us/windows/win32/api/inputscope/nf-inputscope-setinputscope to notify Windows about requested input scope

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
