### PR TITLE
Ensure ServerCompositionTarget is disposed when using foreground timer

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
@@ -362,10 +362,16 @@ public class CompositingRenderer : IRendererWithCompositor
 
         Stop();
         CompositionTarget.Dispose();
-        
+
         // Wait for the composition batch to be applied and rendered to guarantee that
         // render target is not used anymore and can be safely disposed
         if (Compositor.Loop.RunsInBackground)
             _compositor.Commit().Wait();
+        else
+        {
+            // Ensure the ServerCompositionTarget is disposed immediately
+            _compositor.Commit();
+            _compositor.Server.ProcessPendingBatches();
+        }
     }
 }

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -32,7 +32,6 @@ namespace Avalonia.Rendering.Composition.Server
         private Size _layerSize;
         private IDrawingContextLayerImpl? _layer;
         private bool _redrawRequested;
-        private bool _disposed;
         private HashSet<ServerCompositionVisual> _attachedVisuals = new();
         private Queue<ServerCompositionVisual> _adornerUpdateQueue = new();
 
@@ -41,6 +40,7 @@ namespace Avalonia.Rendering.Composition.Server
         public ICompositionTargetDebugEvents? DebugEvents { get; set; }
         public ReadbackIndices Readback { get; } = new();
         public int RenderedVisuals { get; set; }
+        public bool IsDisposed { get; private set; }
 
         private FpsCounter FpsCounter
             => _fpsCounter ??= new FpsCounter(_diagnosticTextRenderer);
@@ -113,7 +113,7 @@ namespace Avalonia.Rendering.Composition.Server
 
         public void Render()
         {
-            if (_disposed)
+            if (IsDisposed)
             {
                 Compositor.RemoveCompositionTarget(this);
                 return;
@@ -275,9 +275,9 @@ namespace Avalonia.Rendering.Composition.Server
 
         public void Dispose()
         {
-            if (_disposed)
+            if (IsDisposed)
                 return;
-            _disposed = true;
+            IsDisposed = true;
             using (_compositor.RenderInterface.EnsureCurrent())
             {
                 if (_layer != null)

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositor.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositor.cs
@@ -149,10 +149,8 @@ namespace Avalonia.Rendering.Composition.Server
         
         private void RenderCore()
         {
-            UpdateServerTime();
-            ApplyPendingBatches();
-            CompletePendingBatches();
-            
+            ProcessPendingBatches();
+
             foreach(var animation in _clockItems)
                 _clockItemsToUpdate.Add(animation);
 
@@ -172,6 +170,13 @@ namespace Avalonia.Rendering.Composition.Server
             {
                 Logger.TryGet(LogEventLevel.Error, LogArea.Visual)?.Log(this, "Exception when rendering: {Error}", e);
             }
+        }
+
+        internal void ProcessPendingBatches()
+        {
+            UpdateServerTime();
+            ApplyPendingBatches();
+            CompletePendingBatches();
         }
 
         public void AddCompositionTarget(ServerCompositionTarget target)

--- a/tests/Avalonia.Base.UnitTests/Rendering/CompositorDisposalTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Rendering/CompositorDisposalTests.cs
@@ -1,0 +1,44 @@
+﻿#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Rendering;
+
+public class CompositorDisposalTests : CompositorTestsBase
+{
+    [Fact]
+    public void Disposing_Renderer_Should_Dispose_ServerCompositionTarget_When_Running_In_Background()
+    {
+        using var services = new CompositorTestServices(runsInBackground: true);
+
+        var disposed = false;
+
+        _ = Task.Run(async () =>
+        {
+            // ReSharper disable once AccessToModifiedClosure, AccessToDisposedClosure
+            while (!Volatile.Read(ref disposed))
+            {
+                services.Timer.TriggerTick();
+                await Task.Delay(10);
+            }
+        });
+
+        services.Renderer.Dispose();
+        Volatile.Write(ref disposed, true);
+
+        Assert.True(services.Renderer.CompositionTarget.Server.IsDisposed);
+    }
+
+    [Fact]
+    public void Disposing_Renderer_Should_Dispose_ServerCompositionTarget_When_Running_In_Foreground()
+    {
+        using var services = new CompositorTestServices(runsInBackground: false);
+
+        services.Renderer.Dispose();
+
+        Assert.True(services.Renderer.CompositionTarget.Server.IsDisposed);
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/Rendering/CompositorTestsBase.cs
+++ b/tests/Avalonia.Base.UnitTests/Rendering/CompositorTestsBase.cs
@@ -1,24 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Reactive.Disposables;
-using System.Threading;
-using System.Threading.Tasks;
+#nullable enable
+
 using Avalonia.Controls;
-using Avalonia.Controls.Embedding;
-using Avalonia.Controls.Presenters;
-using Avalonia.Controls.Templates;
-using Avalonia.Data;
-using Avalonia.Input;
-using Avalonia.Input.Raw;
-using Avalonia.Platform;
-using Avalonia.Rendering;
-using Avalonia.Rendering.Composition;
-using Avalonia.Threading;
 using Avalonia.UnitTests;
-using Avalonia.VisualTree;
-using Xunit;
 
 namespace Avalonia.Base.UnitTests.Rendering;
 


### PR DESCRIPTION
## What does the pull request do?
This PR ensures that when `CompositingRenderer.Dispose()` returns, the underlying `ServerCompositionTarget` is guaranteed to be disposed, whether the render timer runs in background or not.

A matching test has been added.

## What is the current behavior?
When the render timer runs in background, `CompositingRenderer.Dispose()` guarantees that the target is disposed after the method returns, as it internally blocks waiting for the next timer tick.

When the render timer runs in foreground, the caller must ensure that an extra tick of the timer happens *after* Dispose for the target to be disposed. This leads to inconsistent code depending on the timer type (and leaks if there's no extra tick, which is what I encountered).

## What is the updated/expected behavior with this PR?
In both cases, `Dispose` now provides a consistent behavior.

## How was the solution implemented (if it's not obvious)?
A composition batch is committed and processed immediately, which makes sure the disposed flag is propagated to the `ServerCompositionTarget`.
