### PR TITLE
ResourceDictionary xaml tests

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlThemeVariantProviderTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlThemeVariantProviderTransformer.cs
@@ -10,7 +10,8 @@ internal class AvaloniaXamlIlThemeVariantProviderTransformer : IXamlAstTransform
 {
     public IXamlAstNode Transform(AstTransformationContext context, IXamlAstNode node)
     {
-        var type = context.GetAvaloniaTypes().IThemeVariantProvider;
+        var avTypes = context.GetAvaloniaTypes();
+        var type = avTypes.IThemeVariantProvider;
         if (!(node is XamlAstObjectNode on
               && type.IsAssignableFrom(on.Type.GetClrType())))
             return node;
@@ -21,6 +22,13 @@ internal class AvaloniaXamlIlThemeVariantProviderTransformer : IXamlAstTransform
         if (keyDirective is null)
             return node;
 
+        var themeDictionariesColl = avTypes.IDictionaryT.MakeGenericType(avTypes.ThemeVariant, avTypes.IThemeVariantProvider);
+        if (context.ParentNodes().FirstOrDefault() is not XamlAstXamlPropertyValueNode propertyValueNode
+            || !themeDictionariesColl.IsAssignableFrom(propertyValueNode.Property.GetClrProperty().Getter.ReturnType))
+        {
+            return node;
+        }
+        
         var keyProp = type.Properties.First(p => p.Name == "Key");
         on.Children.Add(new XamlAstXamlPropertyValueNode(keyDirective,
             new XamlAstClrProperty(keyDirective, keyProp, context.Configuration),

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -65,6 +65,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType Int { get; }
         public IXamlType Long { get; }
         public IXamlType Uri { get; }
+        public IXamlType IDictionaryT { get; }
         public IXamlType FontFamily { get; }
         public IXamlConstructor FontFamilyConstructorUriName { get; }
         public IXamlType Thickness { get; }
@@ -194,6 +195,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             Int = cfg.TypeSystem.GetType("System.Int32");
             Long = cfg.TypeSystem.GetType("System.Int64");
             Uri = cfg.TypeSystem.GetType("System.Uri");
+            IDictionaryT = cfg.TypeSystem.GetType("System.Collections.Generic.IDictionary`2");
             FontFamily = cfg.TypeSystem.GetType("Avalonia.Media.FontFamily");
             FontFamilyConstructorUriName = FontFamily.GetConstructor(new List<IXamlType> { Uri, XamlIlTypes.String });
             ThemeVariant = cfg.TypeSystem.GetType("Avalonia.Styling.ThemeVariant");

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/ResourceIncludeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/ResourceIncludeTests.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Media;
+using Avalonia.Metadata;
+using Avalonia.Styling;
 using Avalonia.UnitTests;
 using Xunit;
 
@@ -9,87 +11,146 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 {
     public class ResourceIncludeTests : XamlTestBase
     {
-        public class StaticResourceExtensionTests : XamlTestBase
+        [Fact]
+        public void ResourceInclude_Loads_ResourceDictionary()
         {
-            [Fact]
-            public void ResourceInclude_Loads_ResourceDictionary()
+            var documents = new[]
             {
-                var documents = new[]
-                {
-                    new RuntimeXamlLoaderDocument(new Uri("avares://Tests/Resource.xaml"), @"
+                new RuntimeXamlLoaderDocument(new Uri("avares://Tests/Resource.xaml"), @"
 <ResourceDictionary xmlns='https://github.com/avaloniaui'
-                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
-    <SolidColorBrush x:Key='brush'>#ff506070</SolidColorBrush>
+                xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+<SolidColorBrush x:Key='brush'>#ff506070</SolidColorBrush>
 </ResourceDictionary>"),
-                    new RuntimeXamlLoaderDocument(@"
+                new RuntimeXamlLoaderDocument(@"
 <UserControl xmlns='https://github.com/avaloniaui'
-             xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceInclude Source='avares://Tests/Resource.xaml'/>
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </UserControl.Resources>
+         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+<UserControl.Resources>
+    <ResourceDictionary>
+        <ResourceDictionary.MergedDictionaries>
+            <ResourceInclude Source='avares://Tests/Resource.xaml'/>
+        </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+</UserControl.Resources>
 
-    <Border Name='border' Background='{StaticResource brush}'/>
+<Border Name='border' Background='{StaticResource brush}'/>
 </UserControl>")
-                };
+            };
 
-                using (StartWithResources())
-                {
-                    var compiled = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
-                    var userControl = Assert.IsType<UserControl>(compiled[1]);
-                    var border = userControl.FindControl<Border>("border");
-
-                    var brush = (ISolidColorBrush)border.Background;
-                    Assert.Equal(0xff506070, brush.Color.ToUInt32());
-                }
-            }
-
-            [Fact]
-            public void Missing_ResourceKey_In_ResourceInclude_Does_Not_Cause_StackOverflow()
+            using (StartWithResources())
             {
-                var app = Application.Current;
-                var documents = new[]
-                {
-                    new RuntimeXamlLoaderDocument(new Uri("avares://Tests/Resource.xaml"), @"
-<ResourceDictionary xmlns='https://github.com/avaloniaui'
-                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
-    <StaticResource x:Key='brush' ResourceKey='missing' />
-</ResourceDictionary>"),
-                    new RuntimeXamlLoaderDocument(app, @"
-<Application xmlns='https://github.com/avaloniaui'
-             xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
-    <Application.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceInclude Source='avares://Tests/Resource.xaml'/>
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </Application.Resources>
-</Application>")
-                };
+                var compiled = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
+                var userControl = Assert.IsType<UserControl>(compiled[1]);
+                var border = userControl.FindControl<Border>("border");
 
-                using (StartWithResources())
-                {
-                    try
-                    {
-                        AvaloniaRuntimeXamlLoader.LoadGroup(documents);
-                    }
-                    catch (KeyNotFoundException)
-                    {
-
-                    }
-                }
-            }
-
-            private IDisposable StartWithResources(params (string, string)[] assets)
-            {
-                var assetLoader = new MockAssetLoader(assets);
-                var services = new TestServices(assetLoader: assetLoader);
-                return UnitTestApplication.Start(services);
+                var brush = (ISolidColorBrush)border.Background;
+                Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
+
+        [Fact]
+        public void Missing_ResourceKey_In_ResourceInclude_Does_Not_Cause_StackOverflow()
+        {
+            var app = Application.Current;
+            var documents = new[]
+            {
+                new RuntimeXamlLoaderDocument(new Uri("avares://Tests/Resource.xaml"), @"
+<ResourceDictionary xmlns='https://github.com/avaloniaui'
+                xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+<StaticResource x:Key='brush' ResourceKey='missing' />
+</ResourceDictionary>"),
+                new RuntimeXamlLoaderDocument(app, @"
+<Application xmlns='https://github.com/avaloniaui'
+         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+<Application.Resources>
+    <ResourceDictionary>
+        <ResourceDictionary.MergedDictionaries>
+            <ResourceInclude Source='avares://Tests/Resource.xaml'/>
+        </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+</Application.Resources>
+</Application>")
+            };
+
+            using (StartWithResources())
+            {
+                try
+                {
+                    AvaloniaRuntimeXamlLoader.LoadGroup(documents);
+                }
+                catch (KeyNotFoundException)
+                {
+
+                }
+            }
+        }
+        
+        [Fact]
+        public void ResourceInclude_Should_Be_Allowed_To_Have_Key_In_Custom_Container()
+        {
+            var app = Application.Current;
+            var documents = new[]
+            {
+                new RuntimeXamlLoaderDocument(new Uri("avares://Demo/en-us.axaml"), @"
+<ResourceDictionary xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <x:String x:Key='OkButton'>OK</x:String>
+</ResourceDictionary>"),
+                new RuntimeXamlLoaderDocument(app, @"
+<ResourceDictionary xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                    xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <ResourceDictionary.MergedDictionaries>
+        <local:LocaleCollection>
+            <ResourceInclude Source='avares://Demo/en-us.axaml' x:Key='English' />
+        </local:LocaleCollection>
+    </ResourceDictionary.MergedDictionaries>
+</ResourceDictionary>")
+            };
+
+            using (StartWithResources())
+            {
+                var groups = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
+                var res = Assert.IsType<ResourceDictionary>(groups[1]);
+
+                Assert.True(res.TryGetResource("OkButton", null, out var val));
+                Assert.Equal("OK", val);
+            }
+        }
+
+        private IDisposable StartWithResources(params (string, string)[] assets)
+        {
+            var assetLoader = new MockAssetLoader(assets);
+            var services = new TestServices(assetLoader: assetLoader);
+            return UnitTestApplication.Start(services);
+        }
+    }
+    
+    // See https://github.com/AvaloniaUI/Avalonia/issues/11172
+    public class LocaleCollection : IResourceProvider
+    {
+        private readonly Dictionary<object, IResourceProvider> _langs = new();
+
+        public IResourceHost Owner { get; private set; }
+
+        public bool HasResources => true;
+
+        public event EventHandler OwnerChanged;
+
+        public void AddOwner(IResourceHost owner) => Owner = owner;
+
+        public void RemoveOwner(IResourceHost owner) => Owner = null;
+
+        public bool TryGetResource(object key, ThemeVariant theme, out object? value)
+        {
+            if (_langs.TryGetValue("English", out var res))
+            {
+                return res.TryGetResource(key, theme, out value);
+            }
+            value = null;
+            return false;
+        }
+
+        // Allow Avalonia to use this class as a collection, requires x:Key on the IResourceProvider 
+        public void Add(object k, IResourceProvider v) => _langs.Add(k, v);
     }
 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ResourceDictionaryTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ResourceDictionaryTests.cs
@@ -385,6 +385,23 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
             Assert.Equal(Colors.Blue, ((ISolidColorBrush)userControl.FindResource("brush")!).Color);
         }
 
+        [Fact]
+        public void ResourceDictionary_Can_Be_Put_Inside_Of_ResourceDictionary()
+        {
+            using (StyledWindow())
+            {
+                var xaml = @"
+<ResourceDictionary xmlns='https://github.com/avaloniaui'
+                    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <ResourceDictionary x:Key='NotAThemeVariantKey' />
+</ResourceDictionary>";
+                var resources = (ResourceDictionary)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var nested = (ResourceDictionary)resources["NotAThemeVariantKey"];
+
+                Assert.NotNull(nested);
+            }
+        }
+        
         private IDisposable StyledWindow(params (string, string)[] assets)
         {
             var services = TestServices.StyledWindow.With(


### PR DESCRIPTION
## What does the pull request do?

Fixes two related problems:

1. Fixes nested resource dictionaries. Or ResourceDictionary/ResourceInclude used inside of another ResourceDictionary with a key.
2. Fixes ResourceInclude -> ResourceDictionary transformer/inliner which wasn't working with additional properties on the ResourceInclude. 

## What is the updated/expected behavior with this PR?

1. AvaloniaXamlIlThemeVariantProviderTransformer now checks dictionary type before trying to parse lThemeVariantProvider.ThemeVariant. Fixes first problem.
2. XamlIncludeGroupTransformer now passes ResourceInclude manipulations to the created ResourceDictionary object. If any property is missing on created type, it will produce more specific and clear error comparing to what was before this PR.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues

Fixes #11242
Fixes #11172 
