### PR TITLE
[IME] fix UpdateCursorRect call

### DIFF
--- a/src/Avalonia.Base/Input/TextInput/InputMethodManager.cs
+++ b/src/Avalonia.Base/Input/TextInput/InputMethodManager.cs
@@ -48,9 +48,9 @@ namespace Avalonia.Input.TextInput
                     }
 
                     _transformTracker.SetVisual(_client?.TextViewVisual);
-                    UpdateCursorRect();
                     
                     _im?.SetClient(_client);
+                    UpdateCursorRect();
                 }
                 else
                 {


### PR DESCRIPTION
## What does the pull request do?
Fixes the issue: UpdateCursorRect don't work for the first SetClient call because SetClient is not set yet. Reordering methods - fixes issue.

The issue is on macOS. UpdateCursorRect calls `invalidateCharacterCoordinates` and client is still not setted so it looks like 
firstRectForCharacterRange method returning zero rect because IsActive still false.

```
- (NSRect)firstRectForCharacterRange:(NSRange)range actualRange:(NSRangePointer)actualRange
{
    if(!_parent->InputMethod->IsActive()){
        return NSZeroRect;
    }
    
    return _cursorRect;
}
```
