### PR TITLE
Fix/numeric up down decrease when null

### DIFF
--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -659,7 +659,9 @@ namespace Avalonia.Controls
             }
             else
             {
-                result = Minimum;
+                // if Minimum is set (i.e: Minimum is greater than decimal.MinValue) we set value to Minimum on Increment. 
+                // otherwise we set value to 0. It ill be clamped to be between Minimum and Maximum later, so we don't need to do it here. 
+                result = Minimum > decimal.MinValue ? Minimum : 0;
             }
 
             SetCurrentValue(ValueProperty, MathUtilities.Clamp(result, Minimum, Maximum));
@@ -678,7 +680,9 @@ namespace Avalonia.Controls
             }
             else
             {
-                result = Maximum;
+                // if Maximum is set (i.e: Maximum is smaller than decimal.MaxValue) we set value to Maximum on decrement. 
+                // otherwise we set value to 0. It ill be clamped to be between Minimum and Maximum later, so we don't need to do it here. 
+                result = Maximum < decimal.MaxValue ? Maximum : 0;
             }
 
             SetCurrentValue(ValueProperty, MathUtilities.Clamp(result, Minimum, Maximum));

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -659,9 +659,9 @@ namespace Avalonia.Controls
             }
             else
             {
-                // if Minimum is set (i.e: Minimum is greater than decimal.MinValue) we set value to Minimum on Increment. 
+                // if Minimum is set we set value to Minimum on Increment. 
                 // otherwise we set value to 0. It ill be clamped to be between Minimum and Maximum later, so we don't need to do it here. 
-                result = Minimum > decimal.MinValue ? Minimum : 0;
+                result = IsSet(MinimumProperty) ? Minimum : 0;
             }
 
             SetCurrentValue(ValueProperty, MathUtilities.Clamp(result, Minimum, Maximum));
@@ -680,9 +680,9 @@ namespace Avalonia.Controls
             }
             else
             {
-                // if Maximum is set (i.e: Maximum is smaller than decimal.MaxValue) we set value to Maximum on decrement. 
+                // if Maximum is set we set value to Maximum on decrement. 
                 // otherwise we set value to 0. It ill be clamped to be between Minimum and Maximum later, so we don't need to do it here. 
-                result = Maximum < decimal.MaxValue ? Maximum : 0;
+                result = IsSet(MaximumProperty) ? Maximum : 0;
             }
 
             SetCurrentValue(ValueProperty, MathUtilities.Clamp(result, Minimum, Maximum));

--- a/tests/Avalonia.Controls.UnitTests/NumericUpDownTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/NumericUpDownTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Subjects;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.UnitTests;
 using Xunit;
@@ -43,6 +45,38 @@ namespace Avalonia.Controls.UnitTests
             });
         }
 
+        [Theory]
+        [MemberData(nameof(Increment_Decrement_TestData))]
+        public void Increment_Decrement_Tests(decimal min, decimal max, decimal? value, SpinDirection direction,
+            decimal? expected)
+        {
+            var control = CreateControl();
+            control.Minimum = min;
+            control.Maximum = max;
+            control.Value = value;
+
+            var spinner = GetSpinner(control);
+
+            spinner.RaiseEvent(new SpinEventArgs(Spinner.SpinEvent, direction));
+            
+            Assert.Equal(control.Value, expected);
+        }
+
+        public static IEnumerable<object[]> Increment_Decrement_TestData()
+        {
+            // if min and max are not defined and value was null, 0 should be ne new value after spin
+            yield return new object[] { decimal.MinValue, decimal.MaxValue, null, SpinDirection.Decrease, 0m };
+            yield return new object[] { decimal.MinValue, decimal.MaxValue, null, SpinDirection.Increase, 0m };
+            
+            // if no value was defined, but Min or Max are defined, use these as the new value
+            yield return new object[] { -400m, -200m, null, SpinDirection.Decrease, -200m };
+            yield return new object[] { 200m, 400m, null, SpinDirection.Increase, 200m };
+            
+            // Value should be clamped to Min / Max after spinning
+            yield return new object[] { 200m, 400m, 5m, SpinDirection.Increase, 200m };
+            yield return new object[] { 200m, 400m, 200m, SpinDirection.Decrease, 200m };
+        }
+        
         private void RunTest(Action<NumericUpDown, TextBox> test)
         {
             using (UnitTestApplication.Start(Services))
@@ -76,6 +110,14 @@ namespace Avalonia.Controls.UnitTests
                           .OfType<TextBox>()
                           .First();
         }
+        
+        private static ButtonSpinner GetSpinner(NumericUpDown control)
+        {
+            return control.GetTemplateChildren()
+                .OfType<ButtonSpinner>()
+                .First();
+        }
+        
         private static IControlTemplate CreateTemplate()
         {
             return new FuncControlTemplate<NumericUpDown>((control, scope) =>

--- a/tests/Avalonia.Controls.UnitTests/NumericUpDownTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/NumericUpDownTests.cs
@@ -51,8 +51,8 @@ namespace Avalonia.Controls.UnitTests
             decimal? expected)
         {
             var control = CreateControl();
-            control.Minimum = min;
-            control.Maximum = max;
+            if (min > decimal.MinValue) control.Minimum = min;
+            if (max < decimal.MaxValue) control.Maximum = max;
             control.Value = value;
 
             var spinner = GetSpinner(control);


### PR DESCRIPTION
## What does the pull request do?
Improves the behavior of `NumericUpDown` when spinning while the value was `null`

## What is the current behavior?
if value was `null`, the new value can get `decimal.MaxValue` or `decimal.MinValue` after spinning which is clearly not expected by the user

## What is the updated/expected behavior with this PR?
if Minimum or Maximum is set, use these as the initial values, otherwise use `0`


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
I think it breaks current experience, but as this was unintended, I don't consider it as a breaking change

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #11318 
