### PR TITLE
Fix: FloatingResourceObservable should handle ActualThemeVariantChanged

### DIFF
--- a/src/Avalonia.Base/Controls/ResourceNodeExtensions.cs
+++ b/src/Avalonia.Base/Controls/ResourceNodeExtensions.cs
@@ -221,11 +221,25 @@ namespace Avalonia.Controls
                 {
                     _owner.ResourcesChanged += ResourcesChanged;
                 }
+                if (_overrideThemeVariant is null && _owner is IThemeVariantHost themeVariantHost)
+                {
+                    themeVariantHost.ActualThemeVariantChanged += ActualThemeVariantChanged;
+                }
             }
 
             protected override void Deinitialize()
             {
                 _target.OwnerChanged -= OwnerChanged;
+
+                if (_owner is not null)
+                {
+                    _owner.ResourcesChanged -= ResourcesChanged;
+                }
+                if (_overrideThemeVariant is null && _owner is IThemeVariantHost themeVariantHost)
+                {
+                    themeVariantHost.ActualThemeVariantChanged -= ActualThemeVariantChanged;
+                }
+
                 _owner = null;
             }
 
@@ -253,7 +267,7 @@ namespace Avalonia.Controls
                 }
                 if (_overrideThemeVariant is null && _owner is IThemeVariantHost themeVariantHost)
                 {
-                    themeVariantHost.ActualThemeVariantChanged += ActualThemeVariantChanged;
+                    themeVariantHost.ActualThemeVariantChanged -= ActualThemeVariantChanged;
                 }
 
                 _owner = _target.Owner;
@@ -264,7 +278,7 @@ namespace Avalonia.Controls
                 }
                 if (_overrideThemeVariant is null && _owner is IThemeVariantHost themeVariantHost2)
                 {
-                    themeVariantHost2.ActualThemeVariantChanged -= ActualThemeVariantChanged;
+                    themeVariantHost2.ActualThemeVariantChanged += ActualThemeVariantChanged;
                 }
 
                 PublishNext();

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ThemeDictionariesTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ThemeDictionariesTests.cs
@@ -111,6 +111,39 @@ public class ThemeDictionariesTests : XamlTestBase
     }
 
     [Fact]
+    public void DynamicResource_In_ResourceProvider_Updated_When_Control_Theme_Changed()
+    {
+        var themeVariantScope = new ThemeVariantScope
+        {
+            RequestedThemeVariant = ThemeVariant.Light,
+            Resources = new ResourceDictionary
+            {
+                ThemeDictionaries =
+                {
+                    [ThemeVariant.Dark] = new ResourceDictionary { ["DemoBackground"] = Brushes.Black },
+                    [ThemeVariant.Light] = new ResourceDictionary { ["DemoBackground"] = Brushes.White }
+                }
+            },
+            Child = new Border()
+        };
+        
+        var resources = (ResourceDictionary)AvaloniaRuntimeXamlLoader.Load(@"
+<ResourceDictionary xmlns='https://github.com/avaloniaui' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <GeometryDrawing x:Key='Geo' Brush='{DynamicResource DemoBackground}' />
+</ResourceDictionary>");
+        
+        themeVariantScope.Resources.MergedDictionaries.Add(resources);
+        var geo = (GeometryDrawing)themeVariantScope.FindResource("Geo");
+        
+        Assert.NotNull(geo);
+        Assert.Equal(Colors.White, ((ISolidColorBrush)geo.Brush)!.Color);
+
+        themeVariantScope.RequestedThemeVariant = ThemeVariant.Dark;
+        
+        Assert.Equal(Colors.Black, ((ISolidColorBrush)geo.Brush)!.Color);
+    }
+
+    [Fact]
     public void Intermediate_StaticResource_Can_Be_Reached_From_ThemeDictionaries()
     {
         var themeVariantScope = (ThemeVariantScope)AvaloniaRuntimeXamlLoader.Load(@"


### PR DESCRIPTION
## What does the pull request do?
`DynamicResource` bindings don't react to `ActualThemeVariant` changes when they are anchored to an `IResourceProvider` (e.g. `ResourceDictionary` or `Style`). This PR fixes the `FloatingResourceObservable`, which is responsible for providing the value in this case. 

## What is the current behavior?
`DynamicResource` bindings anchored to a `IResourceProvider` are not updated when the `ActualThemeVariant` changes.
`DynamicResource` bindings defined in/anchored to `StyledElement` or `Application` are updated correctly.

## What is the updated/expected behavior with this PR?
`DynamicResource` bindings are now updated automatically when the `ActualThemeVariant` changes.

## How was the solution implemented (if it's not obvious)?
I have added a new unit test that covers this case.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

## Obsoletions / Deprecations

## Fixed issues
Fixes #11324
