### PR TITLE
Solve #11353 and #11355, IME, Windows - buffer overrun and loss of converted string

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1902,7 +1902,7 @@ namespace Avalonia.Win32.Interop
 
             if (bufferLength > 0)
             {
-                var buffer = bufferLength <= 64 ? stackalloc byte[bufferLength] : new byte[bufferLength];
+                var buffer = bufferLength <= 64 ? stackalloc byte[bufferLength + 8] : new byte[bufferLength];
 
                 fixed (byte* bufferPtr = buffer)
                 {


### PR DESCRIPTION
… entering long composition string

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Relate to the issue #11353, fix potential buffer overrun when you enter a long composition string in the IME (tested for Japanese IME). Also relate to the issue #11355, fix loss of converted string when you do not press enter to confirm IME's conversion and start directly typing next word to convert.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
See issues #11353 and #11355. Also videos attached to these issue reports.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Open ControlCatalog, go to Clipboard page, activate IME, enter a large string as a composition string (without commiting conversion, just enter more than 8, 16, 24,... characters, no RETURN key). 

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
For #11353, buffer for ImmGetCompositionString obtained from stack by stackalloc enlarged.
For #11355, WM_IME_COMPOSITION handling added to accept the converted string.



## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #11353
Fixes #11355
