### PR TITLE
Solve the issue #11353, IME, Windows - buffer overrun? when…

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1902,7 +1902,7 @@ namespace Avalonia.Win32.Interop
 
             if (bufferLength > 0)
             {
-                var buffer = bufferLength <= 64 ? stackalloc byte[bufferLength] : new byte[bufferLength];
+                var buffer = bufferLength <= 64 ? stackalloc byte[bufferLength + 8] : new byte[bufferLength];
 
                 fixed (byte* bufferPtr = buffer)
                 {

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1909,7 +1909,7 @@ namespace Avalonia.Win32.Interop
                     var result = ImmGetCompositionString(hIMC, dwIndex, (IntPtr)bufferPtr, (uint)bufferLength);
                     if (result >= 0)
                     {
-                        return Marshal.PtrToStringUni((IntPtr)bufferPtr);
+                        return Encoding.Unicode.GetString(buffer.ToArray());
                     }
                 }
             }

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1909,7 +1909,7 @@ namespace Avalonia.Win32.Interop
                     var result = ImmGetCompositionString(hIMC, dwIndex, (IntPtr)bufferPtr, (uint)bufferLength);
                     if (result >= 0)
                     {
-                        return Encoding.Unicode.GetString(bufferPtr, bufferLength);
+                        return Encoding.Unicode.GetString(bufferPtr, result);
                     }
                 }
             }

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1909,7 +1909,7 @@ namespace Avalonia.Win32.Interop
                     var result = ImmGetCompositionString(hIMC, dwIndex, (IntPtr)bufferPtr, (uint)bufferLength);
                     if (result >= 0)
                     {
-                        return Encoding.Unicode.GetString(buffer.ToArray());
+                        return Encoding.Unicode.GetString(bufferPtr, bufferLength);
                     }
                 }
             }

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1902,7 +1902,7 @@ namespace Avalonia.Win32.Interop
 
             if (bufferLength > 0)
             {
-                var buffer = bufferLength <= 64 ? stackalloc byte[bufferLength + 8] : new byte[bufferLength];
+                var buffer = bufferLength <= 64 ? stackalloc byte[bufferLength] : new byte[bufferLength];
 
                 fixed (byte* bufferPtr = buffer)
                 {


### PR DESCRIPTION
… entering long composition string

## What does the pull request do?
Relate to the issue https://github.com/AvaloniaUI/Avalonia/issues/11353, fix potential buffer overrun when you enter a long composition string in the IME (tested for Japanese IME).


## What is the current behavior?
See issue #11353


## What is the updated/expected behavior with this PR?
Open ControlCatalog, go to Clipboard page, activate IME, enter a large string as a composition string (without commiting conversion, just enter more than 8, 16, 24,... characters, no RETURN key).


## How was the solution implemented (if it's not obvious)?
For https://github.com/AvaloniaUI/Avalonia/issues/11353, buffer for ImmGetCompositionString obtained from stack by stackalloc enlarged.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #11353