### PR TITLE
Standardize CaptionButtons to Minimize/Maximize spelling

### DIFF
--- a/src/Avalonia.Controls/Chrome/CaptionButtons.cs
+++ b/src/Avalonia.Controls/Chrome/CaptionButtons.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Controls.Chrome
     /// </summary>
     [TemplatePart("PART_CloseButton",      typeof(Button))]
     [TemplatePart("PART_RestoreButton",    typeof(Button))]
-    [TemplatePart("PART_MinimiseButton",   typeof(Button))]
+    [TemplatePart("PART_MinimizeButton",   typeof(Button))]
     [TemplatePart("PART_FullScreenButton", typeof(Button))]
     [PseudoClasses(":minimized", ":normal", ":maximized", ":fullscreen")]
     public class CaptionButtons : TemplatedControl
@@ -97,12 +97,12 @@ namespace Avalonia.Controls.Chrome
 
             var closeButton = e.NameScope.Get<Button>("PART_CloseButton");
             var restoreButton = e.NameScope.Get<Button>("PART_RestoreButton");
-            var minimiseButton = e.NameScope.Get<Button>("PART_MinimiseButton");
+            var minimizeButton = e.NameScope.Get<Button>("PART_MinimizeButton");
             var fullScreenButton = e.NameScope.Get<Button>("PART_FullScreenButton");
 
             closeButton.Click += (sender, e) => OnClose();
             restoreButton.Click += (sender, e) => OnRestore();
-            minimiseButton.Click += (sender, e) => OnMinimize();
+            minimizeButton.Click += (sender, e) => OnMinimize();
             fullScreenButton.Click += (sender, e) => OnToggleFullScreen();
 
             restoreButton.IsEnabled = HostWindow?.CanResize ?? true;

--- a/src/Avalonia.Controls/Chrome/CaptionButtons.cs
+++ b/src/Avalonia.Controls/Chrome/CaptionButtons.cs
@@ -8,13 +8,18 @@ namespace Avalonia.Controls.Chrome
     /// <summary>
     /// Draws window minimize / maximize / close buttons in a <see cref="TitleBar"/> when managed client decorations are enabled.
     /// </summary>
-    [TemplatePart("PART_CloseButton",      typeof(Button))]
-    [TemplatePart("PART_RestoreButton",    typeof(Button))]
-    [TemplatePart("PART_MinimizeButton",   typeof(Button))]
-    [TemplatePart("PART_FullScreenButton", typeof(Button))]
+    [TemplatePart(PART_CloseButton,      typeof(Button))]
+    [TemplatePart(PART_RestoreButton,    typeof(Button))]
+    [TemplatePart(PART_MinimizeButton,   typeof(Button))]
+    [TemplatePart(PART_FullScreenButton, typeof(Button))]
     [PseudoClasses(":minimized", ":normal", ":maximized", ":fullscreen")]
     public class CaptionButtons : TemplatedControl
     {
+        private const string PART_CloseButton = "PART_CloseButton";
+        private const string PART_RestoreButton = "PART_RestoreButton";
+        private const string PART_MinimizeButton = "PART_MinimizeButton";
+        private const string PART_FullScreenButton = "PART_FullScreenButton";
+
         private Button? _restoreButton;
         private IDisposable? _disposables;
 
@@ -95,10 +100,10 @@ namespace Avalonia.Controls.Chrome
         {
             base.OnApplyTemplate(e);
 
-            var closeButton = e.NameScope.Get<Button>("PART_CloseButton");
-            var restoreButton = e.NameScope.Get<Button>("PART_RestoreButton");
-            var minimizeButton = e.NameScope.Get<Button>("PART_MinimizeButton");
-            var fullScreenButton = e.NameScope.Get<Button>("PART_FullScreenButton");
+            var closeButton = e.NameScope.Get<Button>(PART_CloseButton);
+            var restoreButton = e.NameScope.Get<Button>(PART_RestoreButton);
+            var minimizeButton = e.NameScope.Get<Button>(PART_MinimizeButton);
+            var fullScreenButton = e.NameScope.Get<Button>(PART_FullScreenButton);
 
             closeButton.Click += (sender, e) => OnClose();
             restoreButton.Click += (sender, e) => OnRestore();

--- a/src/Avalonia.Themes.Fluent/Controls/CaptionButtons.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/CaptionButtons.xaml
@@ -47,9 +47,9 @@
                     Data="M2048 2048v-819h-205v469l-1493 -1493h469v-205h-819v819h205v-469l1493 1493h-469v205h819z" />
             </Viewbox>
           </Button>
-          <Button x:Name="PART_MinimiseButton"
+          <Button x:Name="PART_MinimizeButton"
                   Theme="{StaticResource FluentCaptionButton}"
-                  AutomationProperties.Name="Minimise">
+                  AutomationProperties.Name="Minimize">
             <Viewbox Width="11" Margin="2">
               <Path Stretch="UniformToFill"
                     Fill="{TemplateBinding Foreground}"
@@ -58,7 +58,7 @@
           </Button>
           <Button x:Name="PART_RestoreButton"
                   Theme="{StaticResource FluentCaptionButton}"
-                  AutomationProperties.Name="Maximise">
+                  AutomationProperties.Name="Maximize">
             <Viewbox Width="11" Margin="2">
               <Viewbox.RenderTransform>
                 <RotateTransform Angle="-90" />
@@ -93,7 +93,7 @@
     <Style Selector="^:fullscreen /template/ Button#PART_RestoreButton">
       <Setter Property="IsVisible" Value="False" />
     </Style>
-    <Style Selector="^:fullscreen /template/ Button#PART_MinimiseButton">
+    <Style Selector="^:fullscreen /template/ Button#PART_MinimizeButton">
       <Setter Property="IsVisible" Value="False" />
     </Style>
     <Style Selector="^ /template/ Button#PART_RestoreButton:disabled">

--- a/src/Avalonia.Themes.Simple/Controls/CaptionButtons.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/CaptionButtons.xaml
@@ -53,9 +53,9 @@
                     Stretch="UniformToFill" />
             </Viewbox>
           </Button>
-          <Button x:Name="PART_MinimiseButton"
+          <Button x:Name="PART_MinimizeButton"
                   Theme="{StaticResource SimpleCaptionButton}"
-                  AutomationProperties.Name="Minimise">
+                  AutomationProperties.Name="Minimize">
             <Viewbox Width="11"
                      Margin="2">
               <Path Data="M2048 1229v-205h-2048v205h2048z"
@@ -65,7 +65,7 @@
           </Button>
           <Button x:Name="PART_RestoreButton"
                   Theme="{StaticResource SimpleCaptionButton}"
-                  AutomationProperties.Name="Maximise">
+                  AutomationProperties.Name="Maximize">
             <Viewbox Width="11"
                      Margin="2">
               <Viewbox.RenderTransform>
@@ -102,7 +102,7 @@
     <Style Selector="^:fullscreen /template/ Button#PART_RestoreButton">
       <Setter Property="IsVisible" Value="False" />
     </Style>
-    <Style Selector="^:fullscreen /template/ Button#PART_MinimiseButton">
+    <Style Selector="^:fullscreen /template/ Button#PART_MinimizeButton">
       <Setter Property="IsVisible" Value="False" />
     </Style>
     <Style Selector="^ /template/ Button#PART_RestoreButton:disabled">

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
@@ -263,7 +263,7 @@ namespace Avalonia.IntegrationTests.Appium
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     maximizeButton = extendClientArea ?
-                        secondaryWindow.FindElementByXPath("//Button[@Name='Maximise']") :
+                        secondaryWindow.FindElementByXPath("//Button[@Name='Maximize']") :
                         secondaryWindow.FindElementByXPath("//TitleBar/Button[2]");
                 }
                 else


### PR DESCRIPTION
## What does the pull request do?
 
 * Fixes #11329 - Standardize CaptionButtons to Minimize/Maximize spelling
 * Add private const string for template parts to remove some duplication. There is no established convention for this yet but as these are private I did it for now.

## What is the current behavior?

 * Minimize and Minimise used inconsistently
 * Maximize and Maximise used inconsistently

## What is the updated/expected behavior with this PR?

Spelling is now standardized to the EN-US culture (same as WPF). This also follows the existing pseudoclass spellings.

## How was the solution implemented (if it's not obvious)?

Obvious

## Checklist

- ~[ ] Added unit tests (if possible)?~
- ~[ ] Added XML documentation to any related classes?~
- ~[ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation~

## Breaking changes

Yes for styling. Template parts and some element names were changed.

## Obsoletions / Deprecations

None

## Fixed issues

Fixes #11329

