### PR TITLE
Add RangeBase.ValueChanged Event

### DIFF
--- a/src/Avalonia.Base/Interactivity/RoutedPropertyChangedEventArgs.cs
+++ b/src/Avalonia.Base/Interactivity/RoutedPropertyChangedEventArgs.cs
@@ -1,0 +1,46 @@
+﻿namespace Avalonia.Interactivity
+{
+    /// <summary>
+    /// Provides both old and new property values with a routed event.
+    /// </summary>
+    /// <typeparam name="T">The type of values.</typeparam>
+    public class RoutedPropertyChangedEventArgs<T> : RoutedEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RoutedPropertyChangedEventArgs{T}"/> class.
+        /// </summary>
+        /// <param name="oldValue">The old property value.</param>
+        /// <param name="newValue">The new property value.</param>
+        /// <param name="routedEvent">The routed event associated with these event args.</param>
+        public RoutedPropertyChangedEventArgs(T oldValue, T newValue, RoutedEvent? routedEvent)
+            : base(routedEvent)
+        {
+            OldValue = oldValue;
+            NewValue = newValue;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RoutedPropertyChangedEventArgs{T}"/> class.
+        /// </summary>
+        /// <param name="oldValue">The old property value.</param>
+        /// <param name="newValue">The new property value.</param>
+        /// <param name="routedEvent">The routed event associated with these event args.</param>
+        /// <param name="source">The source object that raised the routed event.</param>
+        public RoutedPropertyChangedEventArgs(T oldValue, T newValue, RoutedEvent? routedEvent, object? source)
+            : base(routedEvent, source)
+        {
+            OldValue = oldValue;
+            NewValue = newValue;
+        }
+
+        /// <summary>
+        /// Gets the old value of the property.
+        /// </summary>
+        public T OldValue { get; init; }
+
+        /// <summary>
+        /// Gets the new value of the property.
+        /// </summary>
+        public T NewValue { get; init; }
+    }
+}

--- a/src/Avalonia.Controls/Primitives/RangeBase.cs
+++ b/src/Avalonia.Controls/Primitives/RangeBase.cs
@@ -1,5 +1,6 @@
 using System;
 using Avalonia.Data;
+using Avalonia.Interactivity;
 using Avalonia.Utilities;
 
 namespace Avalonia.Controls.Primitives
@@ -42,7 +43,23 @@ namespace Avalonia.Controls.Primitives
             AvaloniaProperty.Register<RangeBase, double>(nameof(LargeChange), 10);
 
         /// <summary>
-        /// Gets or sets the minimum value.
+        /// Defines the <see cref="ValueChanged"/> event.
+        /// </summary>
+        public static readonly RoutedEvent<RoutedPropertyChangedEventArgs<double>> ValueChangedEvent =
+            RoutedEvent.Register<RangeBase, RoutedPropertyChangedEventArgs<double>>(
+                nameof(ValueChanged), RoutingStrategies.Bubble);
+
+        /// <summary>
+        /// Occurs when the <see cref="Value"/> property changes.
+        /// </summary>
+        public event EventHandler<RoutedPropertyChangedEventArgs<double>>? ValueChanged
+        {
+            add => AddHandler(ValueChangedEvent, value);
+            remove => RemoveHandler(ValueChangedEvent, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the minimum possible value.
         /// </summary>
         public double Minimum
         {
@@ -65,7 +82,7 @@ namespace Avalonia.Controls.Primitives
         }
 
         /// <summary>
-        /// Gets or sets the maximum value.
+        /// Gets or sets the maximum possible value.
         /// </summary>
         public double Maximum
         {
@@ -104,18 +121,25 @@ namespace Avalonia.Controls.Primitives
                 : sender.GetValue(ValueProperty);
         }
 
+        /// <summary>
+        /// Gets or sets the small increment value added or subtracted from the <see cref="Value"/>.
+        /// </summary>
         public double SmallChange
         {
             get => GetValue(SmallChangeProperty);
             set => SetValue(SmallChangeProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets the large increment value added or subtracted from the <see cref="Value"/>.
+        /// </summary>
         public double LargeChange
         {
             get => GetValue(LargeChangeProperty);
             set => SetValue(LargeChangeProperty, value);
         }
 
+        /// <inheritdoc/>
         protected override void OnInitialized()
         {
             base.OnInitialized();
@@ -124,6 +148,7 @@ namespace Avalonia.Controls.Primitives
             CoerceValue(ValueProperty);
         }
 
+        /// <inheritdoc/>
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
             base.OnPropertyChanged(change);
@@ -135,6 +160,14 @@ namespace Avalonia.Controls.Primitives
             else if (change.Property == MaximumProperty)
             {
                 OnMaximumChanged();
+            }
+            else if (change.Property == ValueProperty)
+            {
+                var valueChangedEventArgs = new RoutedPropertyChangedEventArgs<double>(
+                    change.GetOldValue<double>(),
+                    change.GetNewValue<double>(),
+                    ValueChangedEvent);
+                RaiseEvent(valueChangedEventArgs);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

Adds the RangeBase.`ValueChanged` event specifically for slider (#10080). This is based on the WPF event.

## What is the current behavior?

There is no event when, for example, the `Slider` control's `Value` changes.

## What is the updated/expected behavior with this PR?

`RangeBase` now has the `ValueChanged` event usable in all derived controls like `Slider`.

## How was the solution implemented (if it's not obvious)?

 1. WPF's implementation of this event was followed. This means:
     1. It is a Routed event (WinUI does not use a routed event)
     2. It has a generic class for `RoutedPropertyChangedEventArgs` rather than a non-generic rangebase-specific `RangeBaseValueChangedEventArgs`. This is a more universal solution and WinUI likely removed generics for COM marshelling reasons.
 1. WinUI Docs:
    * [RangeBase.ValueChanged Event](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.primitives.rangebase.valuechanged?view=winrt-22621)
    * [RangeBaseValueChangedEventArgs Class](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.primitives.rangebasevaluechangedeventargs?view=winrt-22621)
 1. WPF Docs:
    * [RangeBase.ValueChanged Event](https://learn.microsoft.com/en-us/dotnet/api/system.windows.controls.primitives.rangebase.valuechanged?view=windowsdesktop-7.0)
    * [RoutedPropertyChangedEventArgs<T> Class](https://learn.microsoft.com/en-us/dotnet/api/system.windows.routedpropertychangedeventargs-1?view=windowsdesktop-7.0)
 1. As followed for other rounted events, a new `EventHandler` delegate was NOT created. `RangeBaseValueChangedEventHandler`/`RoutedPropertyChangedEventHandler` is NOT ported over.
 1. `RoutedPropertyChangedEventArgs<T>` does have some limitations on which constructors are supported due to the use of generics and nullable ref types. No parameterless constructor (or any constructor without old/new values) is supported.

## Checklist

- ~[ ] Added unit tests (if possible)?~
- [x] Added XML documentation to any related classes?
- ~[ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation~

## Breaking changes

None

## Obsoletions / Deprecations

None

## Fixed issues

Closes #10080
