### PR TITLE
Use TypeSystem.String instead of typeof(string) when resolving types from Cecil

### DIFF
--- a/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
+++ b/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
@@ -149,7 +149,7 @@ namespace Avalonia.Build.Tasks
             {
                 var ctor = asm.MainModule.ImportReference(typeSystem.GetTypeReference(asmMetadata).Resolve()
                     .GetConstructors().First(c => c.Parameters.Count == 2).Resolve());
-                var strType = asm.MainModule.ImportReference(typeof(string));
+                var strType = asm.MainModule.TypeSystem.String;
                 var arg1 = new CustomAttributeArgument(strType, "AvaloniaUseCompiledBindingsByDefault");
                 var arg2 = new CustomAttributeArgument(strType, defaultCompileBindings.ToString());
                 asm.CustomAttributes.Add(new CustomAttribute(ctor) { ConstructorArguments = { arg1, arg2 } });


### PR DESCRIPTION
## How was the solution implemented (if it's not obvious)?

1. typeof(string) returns RuntimeType defined in System.Private.CoreLib.
2. System.Private.CoreLib is used from the build runtime version, i.e. 7.0.
3. It's getting included in the built assembly with the same version.
4. Avoiding typeof helps to avoid System.Private.CoreLib completely.

TIL, to not use typeof with cecil.

## Fixed issues

Fixes #10859
