### PR TITLE
Fix Cecil metadata importer

### DIFF
--- a/nukebuild/_build.csproj
+++ b/nukebuild/_build.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="vswhere" Version="2.6.7" Condition=" '$(OS)' == 'Windows_NT' " />
     <PackageReference Include="MicroCom.CodeGenerator" Version="0.11.0" />
     <!-- Keep in sync with Avalonia.Build.Tasks -->
-    <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     <PackageReference Include="SourceLink" Version="1.1.0" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Build.Framework" Version="17.3.2" PrivateAssets="All" />
     <PackageReference Include="xunit.runner.console" Version="2.4.2">

--- a/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
+++ b/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
@@ -118,7 +118,7 @@
       <Compile Include="..\Avalonia.Base\Utilities\SpanHelpers.cs" Link="Utilities\SpanHelpers.cs" />
       <Compile Remove="../Markup/Avalonia.Markup.Xaml.Loader\xamlil.github\**\obj\**\*.cs" />
       <Compile Remove="../Markup/Avalonia.Markup.Xaml.Loader\xamlil.github\src\XamlX\IL\SreTypeSystem.cs" />
-      <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+      <PackageReference Include="Mono.Cecil" Version="0.11.5" />
       <PackageReference Include="Microsoft.Build.Framework" Version="15.1.548" PrivateAssets="All" />
       <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     </ItemGroup>


### PR DESCRIPTION
## What does the pull request do?

XamlX PR https://github.com/kekekeks/XamlX/pull/88

Cecil default metadata importer seem to have not that much sense adding IL references from the dependencies of different version instead of using local ones. So, we need to help it find the way,
In general, it seems like MetadataImporter must be redefined if developer has changed AssemblyResolver logic, as these must be synced.
See submodule changes for more details https://github.com/kekekeks/XamlX/compare/e5254eb1b2017f78a92acd466c8fa1e47401056b...c5d5d8b78dce42dfb7b7f320a5c345da36a58579

+ Also updates Cecil version.
+ Also replaces reflection importer with stub throwing exceptions, as we don't need reflection importer at all (see https://github.com/AvaloniaUI/Avalonia/pull/11363 for details).

## What is the current behavior?

While building app in .NET 7 target with .NET 6 Avalonia (or .NET Core 2.1+ target with .NET Standard 2.0 Avalonia...).

Before Cecil+XAMLX:

![image](https://github.com/AvaloniaUI/Avalonia/assets/3163374/40555b64-3567-4d85-b420-97d4afa9f847)

After Cecil+XAMLX:

![image](https://github.com/AvaloniaUI/Avalonia/assets/3163374/303c7a6e-402c-48bc-b16b-c309413cea2b)

Duplicated references are from .NET 6.0 runtime (used in Avalonia assemblies APIs). But .NET 7.0 only is expected.

## What is the updated/expected behavior with this PR?

Before Cecil+XAMLX: the same as it was.

After Cecil+XAMLX:

![image](https://github.com/AvaloniaUI/Avalonia/assets/3163374/763ed64f-0689-4970-a2e5-062533e872e5)

New IL references added, but all are of correct version used from target framework.

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/5456
