### PR TITLE
Make some AvaloniaProperty APIs internal.

### DIFF
--- a/src/Avalonia.Base/AttachedProperty.cs
+++ b/src/Avalonia.Base/AttachedProperty.cs
@@ -17,7 +17,7 @@ namespace Avalonia
         /// <param name="metadata">The property metadata.</param>
         /// <param name="inherits">Whether the property inherits its value.</param>
         /// <param name="validate">A value validation callback.</param>
-        public AttachedProperty(
+        internal AttachedProperty(
             string name,
             Type ownerType,
             Type hostType,

--- a/src/Avalonia.Base/AvaloniaProperty.cs
+++ b/src/Avalonia.Base/AvaloniaProperty.cs
@@ -42,7 +42,7 @@ namespace Avalonia
         /// <param name="hostType">The class that the property being is registered on.</param>
         /// <param name="metadata">The property metadata.</param>
         /// <param name="notifying">A <see cref="Notifying"/> callback.</param>
-        protected AvaloniaProperty(
+        private protected AvaloniaProperty(
             string name,
             Type valueType,
             Type ownerType,
@@ -76,7 +76,7 @@ namespace Avalonia
         /// <param name="source">The direct property to copy.</param>
         /// <param name="ownerType">The new owner type.</param>
         /// <param name="metadata">Optional overridden metadata.</param>
-        protected AvaloniaProperty(
+        private protected AvaloniaProperty(
             AvaloniaProperty source,
             Type ownerType,
             AvaloniaPropertyMetadata? metadata)
@@ -153,7 +153,7 @@ namespace Avalonia
         /// will be true before the property change notifications are sent and false afterwards. This
         /// callback is intended to support Control.IsDataContextChanging.
         /// </remarks>
-        public Action<AvaloniaObject, bool>? Notifying { get; }
+        internal Action<AvaloniaObject, bool>? Notifying { get; }
 
         /// <summary>
         /// Gets the integer ID that represents this property.
@@ -558,7 +558,7 @@ namespace Avalonia
         /// </summary>
         /// <param name="type">The type.</param>
         /// <param name="metadata">The metadata.</param>
-        protected void OverrideMetadata(Type type, AvaloniaPropertyMetadata metadata)
+        private protected void OverrideMetadata(Type type, AvaloniaPropertyMetadata metadata)
         {
             _ = type ?? throw new ArgumentNullException(nameof(type));
             _ = metadata ?? throw new ArgumentNullException(nameof(metadata));
@@ -577,7 +577,7 @@ namespace Avalonia
             _singleMetadata = null;
         }
 
-        protected abstract IObservable<AvaloniaPropertyChangedEventArgs> GetChanged();
+        private protected abstract IObservable<AvaloniaPropertyChangedEventArgs> GetChanged();
 
         private AvaloniaPropertyMetadata GetMetadataWithOverrides(Type type)
         {

--- a/src/Avalonia.Base/AvaloniaProperty`1.cs
+++ b/src/Avalonia.Base/AvaloniaProperty`1.cs
@@ -22,7 +22,7 @@ namespace Avalonia
         /// <param name="hostType">The class that the property being is registered on.</param>
         /// <param name="metadata">The property metadata.</param>
         /// <param name="notifying">A <see cref="AvaloniaProperty.Notifying"/> callback.</param>
-        protected AvaloniaProperty(
+        private protected AvaloniaProperty(
             string name,
             Type ownerType,
             Type hostType,
@@ -39,7 +39,7 @@ namespace Avalonia
         /// <param name="source">The property to copy.</param>
         /// <param name="ownerType">The new owner type.</param>
         /// <param name="metadata">Optional overridden metadata.</param>
-        protected AvaloniaProperty(
+        private protected AvaloniaProperty(
             AvaloniaProperty<TValue> source,
             Type ownerType,
             AvaloniaPropertyMetadata? metadata)
@@ -68,10 +68,10 @@ namespace Avalonia
             _changed.OnNext(e);
         }
 
-        protected override IObservable<AvaloniaPropertyChangedEventArgs> GetChanged() => Changed;
+        private protected override IObservable<AvaloniaPropertyChangedEventArgs> GetChanged() => Changed;
 
         [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = TrimmingMessages.ImplicitTypeConvertionSupressWarningMessage)]
-        protected BindingValue<object?> TryConvert(object? value)
+        private protected BindingValue<object?> TryConvert(object? value)
         {
             if (value == UnsetValue)
             {

--- a/src/Avalonia.Base/DirectProperty.cs
+++ b/src/Avalonia.Base/DirectProperty.cs
@@ -24,7 +24,7 @@ namespace Avalonia
         /// <param name="getter">Gets the current value of the property.</param>
         /// <param name="setter">Sets the value of the property. May be null.</param>
         /// <param name="metadata">The property metadata.</param>
-        public DirectProperty(
+        internal DirectProperty(
             string name,
             Func<TOwner, TValue> getter,
             Action<TOwner, TValue>? setter,
@@ -98,45 +98,6 @@ namespace Avalonia
 
             var result = new DirectProperty<TNewOwner, TValue>(
                 (DirectPropertyBase<TValue>)this,
-                getter,
-                setter,
-                metadata);
-
-            AvaloniaPropertyRegistry.Instance.Register(typeof(TNewOwner), result);
-            return result;
-        }
-
-        /// <summary>
-        /// Registers the direct property on another type.
-        /// </summary>
-        /// <typeparam name="TNewOwner">The type of the additional owner.</typeparam>
-        /// <param name="getter">Gets the current value of the property.</param>
-        /// <param name="setter">Sets the value of the property.</param>
-        /// <param name="unsetValue">
-        /// The value to use when the property is set to <see cref="AvaloniaProperty.UnsetValue"/>
-        /// </param>
-        /// <param name="defaultBindingMode">The default binding mode for the property.</param>
-        /// <param name="enableDataValidation">
-        /// Whether the property is interested in data validation.
-        /// </param>
-        /// <returns>The property.</returns>
-        public DirectProperty<TNewOwner, TValue> AddOwnerWithDataValidation<TNewOwner>(
-            Func<TNewOwner, TValue> getter,
-            Action<TNewOwner,TValue> setter,
-            TValue unsetValue = default!,
-            BindingMode defaultBindingMode = BindingMode.Default,
-            bool enableDataValidation = false)
-                where TNewOwner : AvaloniaObject
-        {
-            var metadata = new DirectPropertyMetadata<TValue>(
-                unsetValue: unsetValue,
-                defaultBindingMode: defaultBindingMode,
-                enableDataValidation: enableDataValidation);
-
-            metadata.Merge(GetMetadata<TOwner>(), this);
-
-            var result = new DirectProperty<TNewOwner, TValue>(
-                this,
                 getter,
                 setter,
                 metadata);

--- a/src/Avalonia.Base/DirectPropertyBase.cs
+++ b/src/Avalonia.Base/DirectPropertyBase.cs
@@ -20,7 +20,7 @@ namespace Avalonia
         /// <param name="name">The name of the property.</param>
         /// <param name="ownerType">The type of the class that registers the property.</param>
         /// <param name="metadata">The property metadata.</param>
-        protected DirectPropertyBase(
+        private protected DirectPropertyBase(
             string name,
             Type ownerType,
             AvaloniaPropertyMetadata metadata)
@@ -35,7 +35,7 @@ namespace Avalonia
         /// <param name="source">The property to copy.</param>
         /// <param name="ownerType">The new owner type.</param>
         /// <param name="metadata">Optional overridden metadata.</param>
-        protected DirectPropertyBase(
+        private protected DirectPropertyBase(
             DirectPropertyBase<TValue> source,
             Type ownerType,
             AvaloniaPropertyMetadata metadata)

--- a/src/Avalonia.Base/StyledProperty.cs
+++ b/src/Avalonia.Base/StyledProperty.cs
@@ -24,7 +24,7 @@ namespace Avalonia
         /// <para>This method is not part of the property's metadata and so cannot be changed after registration.</para>
         /// </param>
         /// <param name="notifying">A <see cref="AvaloniaProperty.Notifying"/> callback.</param>
-        public StyledProperty(
+        internal StyledProperty(
             string name,
             Type ownerType,
             Type hostType,


### PR DESCRIPTION
## What does the pull request do?

Makes some APIs on `AvaloniaProperty` and derived classes internal:

- Constructors are now internal: properties should only be created using the `Register*` methods anyway
- `Notifying` is now internal, this should only be needed by `DataContext` and the constructor which set this was already made internal
- Base `OverrideMetadata` methods are now internal: the implementations on `StyledProperty` should be used

These APIs were always intended to be internal anyway: there should be no need outside our own unit tests to create `AvaloniaProperty` instances without registering them. If I'm wrong, please let me know!

## Breaking changes

As above.