### PR TITLE
Fix ghost elements in VirtualizingStackPanel

### DIFF
--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -343,7 +343,7 @@ namespace Avalonia.Controls
         {
             var items = Items;
 
-            if (_isInLayout || index < 0 || index >= items.Count || _realizedElements is null)
+            if (_isInLayout || index < 0 || index >= items.Count || _realizedElements is null || !IsEffectivelyVisible)
                 return null;
 
             if (GetRealizedElement(index) is Control element)

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
@@ -657,6 +657,40 @@ namespace Avalonia.Controls.UnitTests
             root.LayoutManager.ExecuteLayoutPass();
         }
 
+        [Fact]
+        public void ScrollIntoView_On_Effectively_Invisible_Panel_Does_Not_Create_Ghost_Elements()
+        {
+            var items = new[] { "foo", "bar", "baz" };
+            var (target, _, itemsControl) = CreateUnrootedTarget(items: items);
+            var container = new Decorator { Margin = new Thickness(100), Child = itemsControl };
+            var root = new TestRoot(true, container);
+
+            root.LayoutManager.ExecuteInitialLayoutPass();
+
+            // Clear the items and do a layout to recycle all elements.
+            itemsControl.ItemsSource = null;
+            root.LayoutManager.ExecuteLayoutPass();
+
+            // Should have no realized elements and 3 unrealized elements.
+            Assert.Equal(0, target.GetRealizedElements().Count);
+            Assert.Equal(3, target.Children.Count);
+
+            // Make the panel effectively invisible and set items.
+            container.IsVisible = false;
+            itemsControl.ItemsSource = items;
+
+            // Try to scroll into view while effectively invisible.
+            target.ScrollIntoView(0);
+
+            // Make the panel visible and layout.
+            container.IsVisible = true;
+            root.LayoutManager.ExecuteLayoutPass();
+
+            // Should have 3 realized elements and no unrealized elements.
+            Assert.Equal(3, target.GetRealizedElements().Count);
+            Assert.Equal(3, target.Children.Count);
+        }
+
         private static IReadOnlyList<int> GetRealizedIndexes(VirtualizingStackPanel target, ItemsControl itemsControl)
         {
             return target.GetRealizedElements()


### PR DESCRIPTION
## What does the pull request do?

This was a bug reported by @billhenn: when a `ScrollIntoView` is requested on an effectively invisible `VirtualizingStackPanel`, "ghost" elements were created because `VirtualizingStackPanel` expects layouts to be run, but since #10864 that won't happen.

What was happening was:

- `ScrollIntoView` was called
- It creates the `_scrollToElement`
- And runs a layout, expecting that the `_scrollToElement` will be promoted to a realized element in the measure pass
- However the layout is not run
- But the `_scrollToElement` was removed from the recycle pool and remains visible

Simply do nothing if `VirtualizingStackPanel.ScrollIntoView` is called on an effectively invisible panel.
