### PR TITLE
[Don't MERGE] [HACK]: Emulate touch with mouse.

### DIFF
--- a/samples/ControlCatalog.NetCore/Program.cs
+++ b/samples/ControlCatalog.NetCore/Program.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Input.Diagnostics;
 using Avalonia.Fonts.Inter;
 using Avalonia.Headless;
 using Avalonia.LogicalTree;
@@ -126,6 +127,7 @@ namespace ControlCatalog.NetCore
                 })
                 .UseSkia()
                 .WithInterFont()
+                .EmulateTouchWithMouse()
                 .AfterSetup(builder =>
                 {
                     builder.Instance!.AttachDevTools(new Avalonia.Diagnostics.DevToolsOptions()

--- a/src/Avalonia.Controls/Diagnostics/DebuggingExtensions.cs
+++ b/src/Avalonia.Controls/Diagnostics/DebuggingExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Avalonia.Input.Raw;
+using Avalonia.Reactive;
+
+namespace Avalonia.Input.Diagnostics
+{
+    public static class DebuggingExtensions
+    {
+        public static AppBuilder EmulateTouchWithMouse(this AppBuilder builder)
+        {
+            MouseDevice.EmulateTouch = true;
+            return builder;
+        }
+    }
+}

--- a/src/Windows/Avalonia.Win32/Input/WindowsMouseDevice.cs
+++ b/src/Windows/Avalonia.Win32/Input/WindowsMouseDevice.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Win32.Input
         
         internal class WindowsMousePointer : Pointer
         {
-            private WindowsMousePointer() : base(GetNextFreeId(),PointerType.Mouse, true)
+            private WindowsMousePointer() : base(GetNextFreeId(), !EmulateTouch ? PointerType.Mouse : PointerType.Touch, true)
             {
             }
             


### PR DESCRIPTION
## What does the pull request do?

Emulates a touch device with the mouse, so that people without touch screens can develop for touch. Adds a `EmulateTouchWithMouse()` extension method to the `AppBuilder`.

We may want this as an actual feature at some point, but this PR is not that: it's a hack. I'm going to open and immediately close the PR so that it's easy to find and cherry-pick the commit should it be needed.