### PR TITLE
Use `IsEffectivelyEnabled` in automation peers. 

### DIFF
--- a/samples/IntegrationTestApp/MainWindow.axaml
+++ b/samples/IntegrationTestApp/MainWindow.axaml
@@ -47,6 +47,9 @@
           <Button Name="DisabledButton" IsEnabled="False">
             Disabled Button
           </Button>
+          <Button Name="EffectivelyDisabledButton" Command="{ReflectionBinding DoesntExist}">
+            Effectively Disabled Button
+          </Button>
           <Button Name="BasicButton">
             Basic Button
           </Button>

--- a/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
@@ -151,7 +151,7 @@ namespace Avalonia.Automation.Peers
         protected override bool HasKeyboardFocusCore() => Owner.IsFocused;
         protected override bool IsContentElementCore() => true;
         protected override bool IsControlElementCore() => true;
-        protected override bool IsEnabledCore() => Owner.IsEnabled;
+        protected override bool IsEnabledCore() => Owner.IsEffectivelyEnabled;
         protected override bool IsKeyboardFocusableCore() => Owner.Focusable;
         protected override void SetFocusCore() => Owner.Focus();
 

--- a/tests/Avalonia.IntegrationTests.Appium/ButtonTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/ButtonTests.cs
@@ -28,6 +28,15 @@ namespace Avalonia.IntegrationTests.Appium
         }
 
         [Fact]
+        public void EffectivelyDisabledButton()
+        {
+            var button = _session.FindElementByAccessibilityId("EffectivelyDisabledButton");
+
+            Assert.Equal("Effectively Disabled Button", button.Text);
+            Assert.False(button.Enabled);
+        }
+
+        [Fact]
         public void BasicButton()
         {
             var button = _session.FindElementByAccessibilityId("BasicButton");


### PR DESCRIPTION
## What does the pull request do?

Automation's enabled state should come from `IsEffectivelyEnabled`, not `IsEnabled`.

## Fixed issues

Fixes #11370 