### PR TITLE
Touch up ManagedFileChooser design a bit

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/ManagedFileChooser.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ManagedFileChooser.xaml
@@ -179,8 +179,8 @@
               </DockPanel>
               <CheckBox IsChecked="{Binding ShowHiddenFiles}" Content="Show hidden files" DockPanel.Dock="Left"/>
               <UniformGrid x:Name="Finalize" HorizontalAlignment="Right" Rows="1">
-                <Button Command="{Binding Ok}">OK</Button>
-                <Button Command="{Binding Cancel}">Cancel</Button>
+                <Button Command="{Binding Ok}" Width="80">OK</Button>
+                <Button Command="{Binding Cancel}" Width="80">Cancel</Button>
               </UniformGrid>
             </DockPanel>
           </DockPanel>
@@ -189,7 +189,6 @@
             <Grid DockPanel.Dock="Top" Margin="15 5 0 0" HorizontalAlignment="Stretch">
               <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="20" SharedSizeGroup="Icon" />
-                <ColumnDefinition Width="16" SharedSizeGroup="Splitter"  />
                 <ColumnDefinition Width="275" SharedSizeGroup="Name" />
                 <ColumnDefinition Width="16" SharedSizeGroup="Splitter" />
                 <ColumnDefinition Width="200" SharedSizeGroup="Modified" />
@@ -197,6 +196,7 @@
                 <ColumnDefinition Width="150" SharedSizeGroup="Type" />
                 <ColumnDefinition Width="16" SharedSizeGroup="Splitter" />
                 <ColumnDefinition Width="200" SharedSizeGroup="Size" />
+                <ColumnDefinition Width="16" SharedSizeGroup="Splitter" />
               </Grid.ColumnDefinitions>
               <Grid.Styles>
                 <Style Selector="GridSplitter">
@@ -210,14 +210,14 @@
                   </Setter>
                 </Style>
               </Grid.Styles>
-              <GridSplitter Grid.Column="1" />
-              <TextBlock Grid.Column="2" Text="Name" />
-              <GridSplitter Grid.Column="3" />
-              <TextBlock Grid.Column="4" Text="Date Modified" />
-              <GridSplitter Grid.Column="5" />
-              <TextBlock Grid.Column="6" Text="Type" />
-              <GridSplitter Grid.Column="7" />
-              <TextBlock Grid.Column="8" Text="Size" />
+              <TextBlock Grid.Column="1" Text="Name" />
+              <GridSplitter Grid.Column="2" />
+              <TextBlock Grid.Column="3" Text="Date Modified" />
+              <GridSplitter Grid.Column="4" />
+              <TextBlock Grid.Column="5" Text="Type" />
+              <GridSplitter Grid.Column="6" />
+              <TextBlock Grid.Column="7" Text="Size" />
+              <GridSplitter Grid.Column="8" />
             </Grid>
             <ListBox x:Name="PART_Files"
                 ItemsSource="{Binding Items}"
@@ -231,7 +231,6 @@
                   <Grid Background="Transparent">
                     <Grid.ColumnDefinitions>
                       <ColumnDefinition SharedSizeGroup="Icon" />
-                      <ColumnDefinition SharedSizeGroup="Splitter"  />
                       <ColumnDefinition SharedSizeGroup="Name" />
                       <ColumnDefinition SharedSizeGroup="Splitter" />
                       <ColumnDefinition SharedSizeGroup="Modified" />
@@ -239,16 +238,17 @@
                       <ColumnDefinition SharedSizeGroup="Type" />
                       <ColumnDefinition SharedSizeGroup="Splitter" />
                       <ColumnDefinition SharedSizeGroup="Size" />
+                      <ColumnDefinition SharedSizeGroup="Splitter" />
                     </Grid.ColumnDefinitions>
                     <Image Width="16" Height="16">
                       <Image.Source>
                         <DrawingImage Drawing="{Binding IconKey, Converter={StaticResource Icons}}"/>
                       </Image.Source>
                     </Image>
-                    <TextBlock Grid.Column="2" Text="{Binding DisplayName}"/>
-                    <TextBlock Grid.Column="4" Text="{Binding Modified}" />
-                    <TextBlock Grid.Column="6" Text="{Binding Type}" />
-                    <TextBlock Grid.Column="8">
+                    <TextBlock Grid.Column="1" Text="{Binding DisplayName}"/>
+                    <TextBlock Grid.Column="3" Text="{Binding Modified}" />
+                    <TextBlock Grid.Column="5" Text="{Binding Type}" />
+                    <TextBlock Grid.Column="7" HorizontalAlignment="Right">
                       <TextBlock.Text>
                         <Binding Path="Size">
                           <Binding.Converter>

--- a/src/Avalonia.Themes.Fluent/Controls/ManagedFileChooser.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ManagedFileChooser.xaml
@@ -179,8 +179,8 @@
               </DockPanel>
               <CheckBox IsChecked="{Binding ShowHiddenFiles}" Content="Show hidden files" DockPanel.Dock="Left"/>
               <UniformGrid x:Name="Finalize" HorizontalAlignment="Right" Rows="1">
-                <Button Command="{Binding Ok}" Width="80">OK</Button>
-                <Button Command="{Binding Cancel}" Width="80">Cancel</Button>
+                <Button Command="{Binding Ok}" MinWidth="80">OK</Button>
+                <Button Command="{Binding Cancel}" MinWidth="80">Cancel</Button>
               </UniformGrid>
             </DockPanel>
           </DockPanel>

--- a/src/Avalonia.Themes.Simple/Controls/ManagedFileChooser.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ManagedFileChooser.xaml
@@ -49,7 +49,7 @@
                 TargetType="dialogs:ManagedFileChooser">
     <Setter Property="Template">
       <ControlTemplate x:DataType="internal:ManagedFileChooserViewModel">
-        <DockPanel>
+        <DockPanel Margin="5">
           <DockPanel Margin="0,0,0,5"
                      DockPanel.Dock="Top">
             <internal:ChildFitter Width="{Binding ElementName=Location, Path=Bounds.Height}"
@@ -93,8 +93,8 @@
                   <Setter Property="Margin" Value="4" />
                 </Style>
               </StackPanel.Styles>
-              <Button Command="{Binding Ok}">OK</Button>
-              <Button Command="{Binding Cancel}">Cancel</Button>
+              <Button Command="{Binding Ok}" Width="60">OK</Button>
+              <Button Command="{Binding Cancel}" Width="60">Cancel</Button>
             </StackPanel>
           </DockPanel>
 
@@ -136,7 +136,6 @@
                   DockPanel.Dock="Top">
               <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="20" SharedSizeGroup="Icon" />
-                <ColumnDefinition Width="16" SharedSizeGroup="Splitter" />
                 <ColumnDefinition Width="400" SharedSizeGroup="Name" />
                 <ColumnDefinition Width="16" SharedSizeGroup="Splitter" />
                 <ColumnDefinition Width="200" SharedSizeGroup="Modified" />
@@ -144,19 +143,45 @@
                 <ColumnDefinition Width="150" SharedSizeGroup="Type" />
                 <ColumnDefinition Width="16" SharedSizeGroup="Splitter" />
                 <ColumnDefinition Width="200" SharedSizeGroup="Size" />
+                <ColumnDefinition Width="16" SharedSizeGroup="Splitter" />
               </Grid.ColumnDefinitions>
-              <GridSplitter Grid.Column="1" />
-              <TextBlock Grid.Column="2"
+              <TextBlock Grid.Column="1"
                          Text="Name" />
-              <GridSplitter Grid.Column="3" />
-              <TextBlock Grid.Column="4"
+              <GridSplitter Grid.Column="2"
+                            ResizeDirection="Columns"
+                            Background="Transparent" />
+              <Rectangle HorizontalAlignment="Left" Grid.Column="2" VerticalAlignment="Stretch" Width="1" Fill="{DynamicResource ThemeControlMidBrush}"/>
+              <TextBlock Grid.Column="3"
                          Text="Date Modified" />
-              <GridSplitter Grid.Column="5" />
-              <TextBlock Grid.Column="6"
+              <GridSplitter Grid.Column="4"
+                            ResizeDirection="Columns"
+                            Background="Transparent" />
+              <Rectangle HorizontalAlignment="Left"
+                         Grid.Column="4"
+                         VerticalAlignment="Stretch"
+                         Width="1"
+                         Fill="{DynamicResource ThemeControlMidBrush}"/>
+
+              <TextBlock Grid.Column="5"
                          Text="Type" />
-              <GridSplitter Grid.Column="7" />
-              <TextBlock Grid.Column="8"
+              <GridSplitter Grid.Column="6" ResizeDirection="Columns"
+                            Background="Transparent" />
+              <Rectangle HorizontalAlignment="Left"
+                         Grid.Column="6"
+                         VerticalAlignment="Stretch"
+                         Width="1"
+                         Fill="{DynamicResource ThemeControlMidBrush}"/>
+
+              <TextBlock Grid.Column="7"
                          Text="Size" />
+              <GridSplitter Grid.Column="8"
+                            ResizeDirection="Columns"
+                            Background="Transparent" />
+              <Rectangle HorizontalAlignment="Left"
+                         Grid.Column="8"
+                         VerticalAlignment="Stretch"
+                         Width="1"
+                         Fill="{DynamicResource ThemeControlMidBrush}"/>
             </Grid>
             <ListBox x:Name="PART_Files"
                      Margin="0,5"
@@ -169,7 +194,6 @@
                   <Grid Background="Transparent">
                     <Grid.ColumnDefinitions>
                       <ColumnDefinition SharedSizeGroup="Icon" />
-                      <ColumnDefinition SharedSizeGroup="Splitter" />
                       <ColumnDefinition SharedSizeGroup="Name" />
                       <ColumnDefinition SharedSizeGroup="Splitter" />
                       <ColumnDefinition SharedSizeGroup="Modified" />
@@ -177,19 +201,20 @@
                       <ColumnDefinition SharedSizeGroup="Type" />
                       <ColumnDefinition SharedSizeGroup="Splitter" />
                       <ColumnDefinition SharedSizeGroup="Size" />
+                      <ColumnDefinition SharedSizeGroup="Splitter" />
                     </Grid.ColumnDefinitions>
                     <Image Grid.Column="0"
                            Width="16"
                            Height="16">
                       <DrawingImage Drawing="{Binding IconKey, Converter={StaticResource Icons}}" />
                     </Image>
-                    <TextBlock Grid.Column="2"
+                    <TextBlock Grid.Column="1"
                                Text="{Binding DisplayName}" />
-                    <TextBlock Grid.Column="4"
+                    <TextBlock Grid.Column="3"
                                Text="{Binding Modified}" />
-                    <TextBlock Grid.Column="6"
+                    <TextBlock Grid.Column="5"
                                Text="{Binding Type}" />
-                    <TextBlock Grid.Column="8">
+                    <TextBlock Grid.Column="7" HorizontalAlignment="Right">
                       <TextBlock.Text>
                         <Binding Path="Size">
                           <Binding.Converter>

--- a/src/Avalonia.Themes.Simple/Controls/ManagedFileChooser.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ManagedFileChooser.xaml
@@ -93,8 +93,8 @@
                   <Setter Property="Margin" Value="4" />
                 </Style>
               </StackPanel.Styles>
-              <Button Command="{Binding Ok}" Width="60">OK</Button>
-              <Button Command="{Binding Cancel}" Width="60">Cancel</Button>
+              <Button Command="{Binding Ok}" MinWidth="60">OK</Button>
+              <Button Command="{Binding Cancel}" MinWidth="60">Cancel</Button>
             </StackPanel>
           </DockPanel>
 


### PR DESCRIPTION
## What does the pull request do?
Cleans up ManagedFileChooser design a bit and fixes some issues with both Simple and Fluent designs. Changes include
1. Added a margin to the root DockPanel in Simple design
2. Set fixed widths to OK and Cancel button.
3. Fixes GridSplitters not detecting the correct direction in Simple Design
4. Remove GridSplitter for Icon column. It doesn't make sense having one there. Instead, added one for Size column.
5. Size column contents are aligned to the right, to match common behaviors in grid when displaying numerical values.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
