### PR TITLE
Only call coerce callback a single time.

### DIFF
--- a/src/Avalonia.Base/PropertyStore/EffectiveValue`1.cs
+++ b/src/Avalonia.Base/PropertyStore/EffectiveValue`1.cs
@@ -208,7 +208,7 @@ namespace Avalonia.PropertyStore
             IsOverridenCurrentValue = isOverriddenCurrentValue;
             IsCoercedDefaultValue = isCoercedDefaultValue;
 
-            if (_uncommon?._coerce is { } coerce)
+            if (!isCoercedDefaultValue && _uncommon?._coerce is { } coerce)
                 v = coerce(owner.Owner, value);
 
             if (priority <= Priority)
@@ -262,7 +262,8 @@ namespace Avalonia.PropertyStore
             if (_uncommon?._coerce is { } coerce)
             {
                 v = coerce(owner.Owner, value);
-                bv = coerce(owner.Owner, baseValue);
+                if (priority != basePriority)
+                    bv = coerce(owner.Owner, baseValue);
             }
 
             if (!EqualityComparer<T>.Default.Equals(Value, v))

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Coercion.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Coercion.cs
@@ -125,6 +125,19 @@ namespace Avalonia.Base.UnitTests
         }
 
         [Fact]
+        public void CoerceValue_Calls_Coerce_Callback_Only_Once()
+        {
+            var target = new Class1 { Foo = 99 };
+
+            target.MaxFoo = 50;
+            
+            target.CoerceFooInvocations.Clear();
+            target.CoerceValue(Class1.FooProperty);
+
+            Assert.Equal(new[] { 99 }, target.CoerceFooInvocations);
+        }
+
+        [Fact]
         public void Coerced_Value_Can_Be_Restored_If_Limit_Changed()
         {
             var target = new Class1();
@@ -216,6 +229,18 @@ namespace Avalonia.Base.UnitTests
 
             Assert.Equal(20, target.Foo);
             Assert.Equal(1, raised);
+        }
+
+        [Fact]
+        public void Default_Value_Is_Coerced_Only_Once()
+        {
+            var target = new Class1();
+
+            target.MinFoo = 20;
+            target.CoerceFooInvocations.Clear();
+            target.CoerceValue(Class1.FooProperty);
+
+            Assert.Equal(new[] { 11 }, target.CoerceFooInvocations);
         }
 
         [Fact]
@@ -338,10 +363,12 @@ namespace Avalonia.Base.UnitTests
             public int MinFoo { get; set; } = 0;
             public int MaxFoo { get; set; } = 100;
 
+            public List<int> CoerceFooInvocations { get; } = new();
             public List<AvaloniaPropertyChangedEventArgs> CoreChanges { get; } = new();
 
             public static int CoerceFoo(AvaloniaObject instance, int value)
             {
+                (instance as Class1)?.CoerceFooInvocations.Add(value);
                 return instance is Class1 o ? 
                     Math.Clamp(value, o.MinFoo, o.MaxFoo) :
                     Math.Clamp(value, 0, 100);


### PR DESCRIPTION
## What does the pull request do?

As described in #11484, the coerce value callback was being called twice for a single coercion. This had two root causes:

- It was calling it on the already coerced default value when `IsCoercedDefaultValue` was true
- It was coercing the value and base value separately, even when they were the same

Tweak the code in `EffectiveValue` to only call the coerce value a single time.