### PR TITLE
WIP: Implement Automation ITextProvider

### DIFF
--- a/Avalonia.Desktop.slnf
+++ b/Avalonia.Desktop.slnf
@@ -62,7 +62,8 @@
       "tests\\Avalonia.ReactiveUI.UnitTests\\Avalonia.ReactiveUI.UnitTests.csproj",
       "tests\\Avalonia.Skia.RenderTests\\Avalonia.Skia.RenderTests.csproj",
       "tests\\Avalonia.Skia.UnitTests\\Avalonia.Skia.UnitTests.csproj",
-      "tests\\Avalonia.UnitTests\\Avalonia.UnitTests.csproj"
+      "tests\\Avalonia.UnitTests\\Avalonia.UnitTests.csproj",
+      "tests\\Avalonia.Win32.UnitTests\\Avalonia.Win32.UnitTests.csproj"
     ]
   }
 }

--- a/Avalonia.sln
+++ b/Avalonia.sln
@@ -270,6 +270,7 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalonia.Headless.NUnit.UnitTests", "tests\Avalonia.Headless.NUnit.UnitTests\Avalonia.Headless.NUnit.UnitTests.csproj", "{2999D79E-3C20-4A90-B651-CA7E0AC92D35}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalonia.Headless.XUnit.UnitTests", "tests\Avalonia.Headless.XUnit.UnitTests\Avalonia.Headless.XUnit.UnitTests.csproj", "{F83FC908-A4E3-40DE-B4CF-A4BA1E92CDB3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Win32.UnitTests", "tests\Avalonia.Win32.UnitTests\Avalonia.Win32.UnitTests.csproj", "{DA23EE40-733D-4DC3-BD2E-DE8E263E6654}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -658,6 +659,10 @@ Global
 		{F83FC908-A4E3-40DE-B4CF-A4BA1E92CDB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F83FC908-A4E3-40DE-B4CF-A4BA1E92CDB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F83FC908-A4E3-40DE-B4CF-A4BA1E92CDB3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA23EE40-733D-4DC3-BD2E-DE8E263E6654}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA23EE40-733D-4DC3-BD2E-DE8E263E6654}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA23EE40-733D-4DC3-BD2E-DE8E263E6654}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA23EE40-733D-4DC3-BD2E-DE8E263E6654}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -742,6 +747,7 @@ Global
 		{4B8EBBEB-A1AD-49EC-8B69-B93ED15BFA64} = {C5A00AC3-B34C-4564-9BDD-2DA473EF4D8B}
 		{2999D79E-3C20-4A90-B651-CA7E0AC92D35} = {C5A00AC3-B34C-4564-9BDD-2DA473EF4D8B}
 		{F83FC908-A4E3-40DE-B4CF-A4BA1E92CDB3} = {C5A00AC3-B34C-4564-9BDD-2DA473EF4D8B}
+		{DA23EE40-733D-4DC3-BD2E-DE8E263E6654} = {C5A00AC3-B34C-4564-9BDD-2DA473EF4D8B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {87366D66-1391-4D90-8999-95A620AD786A}

--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -198,6 +198,11 @@ private:
     {
         return [NSNumber numberWithDouble:_peer->RangeValueProvider_GetValue()];
     }
+    else if (_peer->IsTextProvider())
+    {
+        // Only return the first 100 characters as text can be long.
+        return GetNSStringAndRelease(_peer->TextProvider_GetText(0, 100));
+    }
     else if (_peer->IsToggleProvider())
     {
         switch (_peer->ToggleProvider_GetToggleState()) {
@@ -386,7 +391,7 @@ private:
     {
         return _peer->IsRangeValueProvider();
     }
-    
+
     return [super isAccessibilitySelectorAllowed:selector];
 }
 

--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -467,8 +467,9 @@ private:
 
 - (void)setAccessibilitySelectedTextRange:(NSRange)accessibilitySelectedTextRange
 {
-    // We need to implement this function for VoiceOver to announce the current character,
-    // even though we don't do anything and doesn't seem to ever be called ¯\_(ツ)_/¯.
+    if (_peer->IsTextProvider())
+        _peer->TextProvider_Select((int)accessibilitySelectedTextRange.location, (int)accessibilitySelectedTextRange.length);
+    return [super setAccessibilitySelectedTextRange:accessibilitySelectedTextRange];
 }
 
 - (NSString *)accessibilityStringForRange:(NSRange)range

--- a/native/Avalonia.Native/src/OSX/automation.mm
+++ b/native/Avalonia.Native/src/OSX/automation.mm
@@ -438,6 +438,13 @@ private:
     return [super accessibilityNumberOfCharacters];
 }
 
+- (NSString *)accessibilityPlaceholderValue
+{
+    if (_peer->IsTextProvider())
+        return GetNSStringAndRelease(_peer->TextProvider_GetPlaceholderText());
+    return [super accessibilityPlaceholderValue];
+}
+
 - (NSRange)accessibilityRangeForLine:(NSInteger)line
 {
     if (_peer->IsTextProvider())

--- a/src/Avalonia.Base/Layout/LayoutManager.cs
+++ b/src/Avalonia.Base/Layout/LayoutManager.cs
@@ -2,11 +2,11 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Avalonia.Logging;
 using Avalonia.Rendering;
 using Avalonia.Threading;
 using Avalonia.Utilities;
+using Avalonia.VisualTree;
 
 #nullable enable
 
@@ -213,7 +213,7 @@ namespace Avalonia.Layout
             _effectiveViewportChangedListeners ??= new List<EffectiveViewportChangedListener>();
             _effectiveViewportChangedListeners.Add(new EffectiveViewportChangedListener(
                 control,
-                CalculateEffectiveViewport(control)));
+                control.CalculateEffectiveViewport()));
         }
 
         void ILayoutManager.UnregisterEffectiveViewportListener(Layoutable control)
@@ -373,7 +373,7 @@ namespace Avalonia.Layout
                             continue;
                         }
 
-                        var viewport = CalculateEffectiveViewport(l.Listener);
+                        var viewport = l.Listener.CalculateEffectiveViewport();
 
                         if (viewport != l.Viewport)
                         {
@@ -389,45 +389,6 @@ namespace Avalonia.Layout
             }
 
             return startCount != _toMeasure.Count + _toArrange.Count;
-        }
-
-        private Rect CalculateEffectiveViewport(Visual control)
-        {
-            var viewport = new Rect(0, 0, double.PositiveInfinity, double.PositiveInfinity);
-            CalculateEffectiveViewport(control, control, ref viewport);
-            return viewport;
-        }
-
-        private void CalculateEffectiveViewport(Visual target, Visual control, ref Rect viewport)
-        {
-            // Recurse until the top level control.
-            if (control.VisualParent is object)
-            {
-                CalculateEffectiveViewport(target, control.VisualParent, ref viewport);
-            }
-            else
-            {
-                viewport = new Rect(control.Bounds.Size);
-            }
-
-            // Apply the control clip bounds if it's not the target control. We don't apply it to
-            // the target control because it may itself be clipped to bounds and if so the viewport
-            // we calculate would be of no use.
-            if (control != target && control.ClipToBounds)
-            {
-                viewport = control.Bounds.Intersect(viewport);
-            }
-
-            // Translate the viewport into this control's coordinate space.
-            viewport = viewport.Translate(-control.Bounds.Position);
-
-            if (control != target && control.RenderTransform is object)
-            {
-                var origin = control.RenderTransformOrigin.ToPixels(control.Bounds.Size);
-                var offset = Matrix.CreateTranslation(origin);
-                var renderTransform = (-offset) * control.RenderTransform.Value.Invert() * (offset);
-                viewport = viewport.TransformToAABB(renderTransform);
-            }
         }
 
         private class EffectiveViewportChangedListener

--- a/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/AutomationPeer.cs
@@ -96,6 +96,12 @@ namespace Avalonia.Automation.Peers
         public string GetClassName() => GetClassNameCore() ?? string.Empty;
 
         /// <summary>
+        /// Gets text that describes the functionality of the control that is associated with the
+        /// automation peer.
+        /// </summary>
+        public string? GetHelpText() => GetHelpTextCore();
+
+        /// <summary>
         /// Gets the automation peer for the label that is targeted to the element.
         /// </summary>
         /// <returns></returns>
@@ -231,6 +237,7 @@ namespace Avalonia.Automation.Peers
         protected abstract Rect GetBoundingRectangleCore();
         protected abstract IReadOnlyList<AutomationPeer> GetOrCreateChildrenCore();
         protected abstract string GetClassNameCore();
+        protected abstract string? GetHelpTextCore();
         protected abstract AutomationPeer? GetLabeledByCore();
         protected abstract string? GetNameCore();
         protected abstract AutomationPeer? GetParentCore();

--- a/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
@@ -148,6 +148,7 @@ namespace Avalonia.Automation.Peers
         protected override string? GetAutomationIdCore() => AutomationProperties.GetAutomationId(Owner) ?? Owner.Name;
         protected override Rect GetBoundingRectangleCore() => GetBounds(Owner);
         protected override string GetClassNameCore() => Owner.GetType().Name;
+        protected override string? GetHelpTextCore() => AutomationProperties.GetHelpText(Owner);
         protected override bool HasKeyboardFocusCore() => Owner.IsFocused;
         protected override bool IsContentElementCore() => true;
         protected override bool IsControlElementCore() => true;

--- a/src/Avalonia.Controls/Automation/Peers/TextBlockAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/TextBlockAutomationPeer.cs
@@ -1,21 +1,86 @@
-﻿using Avalonia.Controls;
+﻿using System;
+using System.Collections.Generic;
+using Avalonia.Automation.Provider;
+using Avalonia.Controls;
+using Avalonia.Reactive;
+using Avalonia.Utilities;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Automation.Peers
 {
-    public class TextBlockAutomationPeer : ControlAutomationPeer
+    public class TextBlockAutomationPeer : ControlAutomationPeer, ITextProvider
     {
         public TextBlockAutomationPeer(TextBlock owner)
             : base(owner)
         {
+            owner.GetObservable(TextBox.TextProperty).Subscribe(OnTextChanged);
         }
 
+        public int CaretIndex => -1;
         public new TextBlock Owner => (TextBlock)base.Owner;
+        public TextRange DocumentRange => new TextRange(0, Owner.Text?.Length ?? 0);
+        public bool IsReadOnly => true;
+        public int LineCount => Owner.TextLayout.TextLines.Count;
+        public string? PlaceholderText => null;
+        public SupportedTextSelection SupportedTextSelection => SupportedTextSelection.None;
 
-        protected override AutomationControlType GetAutomationControlTypeCore()
+        public event EventHandler? TextChanged;
+        event EventHandler? ITextProvider.SelectedRangesChanged { add { } remove { } }
+
+        public IReadOnlyList<Rect> GetBounds(TextRange range)
         {
-            return AutomationControlType.Text;
+            if (Owner.GetVisualRoot() is Visual root &&
+                Owner.TransformToVisual(root) is Matrix m)
+            {
+                var source = Owner.TextLayout.HitTestTextRange(range.Start, range.Length);
+                var result = new List<Rect>();
+                foreach (var rect in source)
+                    result.Add(rect.TransformToAABB(m));
+                return result;
+            }
+
+            return Array.Empty<Rect>();
         }
 
+        public int GetLineForIndex(int index)
+        {
+            return Owner.TextLayout.GetLineIndexFromCharacterIndex(index, false);
+        }
+
+        public TextRange GetLineRange(int lineIndex)
+        {
+            var line = Owner.TextLayout.TextLines[lineIndex];
+            return new TextRange(line.FirstTextSourceIndex, line.Length);
+        }
+
+        public string GetText(TextRange range)
+        {
+            var text = Owner.Text ?? string.Empty;
+            var start = MathUtilities.Clamp(range.Start, 0, text.Length);
+            var end = MathUtilities.Clamp(range.End, 0, text.Length);
+            return text.Substring(start, end - start);
+        }
+
+        public IReadOnlyList<TextRange> GetVisibleRanges() => new[] { DocumentRange };
+
+        public TextRange RangeFromPoint(Point p)
+        {
+            var i = 0;
+
+            if (Owner.GetVisualRoot() is Visual root &&
+                root.TransformToVisual(Owner) is Matrix m)
+            {
+                i = Owner.TextLayout.HitTestPoint(p.Transform(m)).TextPosition;
+            }
+
+            return new TextRange(i, 1);
+        }
+
+        IReadOnlyList<TextRange> ITextProvider.GetSelection() => Array.Empty<TextRange>();
+        void ITextProvider.ScrollIntoView(TextRange range) { }
+        void ITextProvider.Select(TextRange range) { }
+
+        protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Text;
         protected override string? GetNameCore() => Owner.Text;
 
         protected override bool IsControlElementCore()
@@ -23,5 +88,8 @@ namespace Avalonia.Automation.Peers
             // Return false if the control is part of a control template.
             return Owner.TemplatedParent is null && base.IsControlElementCore();
         }
+
+        private void OnTextChanged(string? text) => TextChanged?.Invoke(this, EventArgs.Empty);
+
     }
 }

--- a/src/Avalonia.Controls/Automation/Peers/TextBlockAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/TextBlockAutomationPeer.cs
@@ -33,9 +33,10 @@ namespace Avalonia.Automation.Peers
                 Owner.TransformToVisual(root) is Matrix m)
             {
                 var source = Owner.TextLayout.HitTestTextRange(range.Start, range.Length);
+                var clip = Owner.CalculateEffectiveViewport();
                 var result = new List<Rect>();
                 foreach (var rect in source)
-                    result.Add(rect.TransformToAABB(m));
+                    result.Add(rect.Intersect(clip).TransformToAABB(m));
                 return result;
             }
 

--- a/src/Avalonia.Controls/Automation/Peers/TextBlockAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/TextBlockAutomationPeer.cs
@@ -62,8 +62,6 @@ namespace Avalonia.Automation.Peers
             return text.Substring(start, end - start);
         }
 
-        public IReadOnlyList<TextRange> GetVisibleRanges() => new[] { DocumentRange };
-
         public TextRange RangeFromPoint(Point p)
         {
             var i = 0;

--- a/src/Avalonia.Controls/Automation/Peers/TextBoxAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/TextBoxAutomationPeer.cs
@@ -63,7 +63,7 @@ namespace Avalonia.Automation.Peers
 
         public IReadOnlyList<TextRange> GetSelection()
         {
-            var range = TextRange.FromInclusiveStartEnd(Owner.SelectionStart, Owner.SelectionEnd);
+            var range = TextRange.FromStartEnd(Owner.SelectionStart, Owner.SelectionEnd);
             return new[] { range };
         }
 

--- a/src/Avalonia.Controls/Automation/Peers/TextBoxAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/TextBoxAutomationPeer.cs
@@ -75,12 +75,6 @@ namespace Avalonia.Automation.Peers
             return text.Substring(start, end - start);
         }
 
-        public IReadOnlyList<TextRange> GetVisibleRanges()
-        {
-            // Not sure this is necessary, QT just returns the document range too.
-            return new[] { DocumentRange };
-        }
-
         public TextRange RangeFromPoint(Point p)
         {
             if (Owner.Presenter is null)

--- a/src/Avalonia.Controls/Automation/Peers/TextBoxAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/TextBoxAutomationPeer.cs
@@ -1,23 +1,131 @@
-﻿using Avalonia.Automation.Provider;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Avalonia.Automation.Provider;
 using Avalonia.Controls;
+using Avalonia.Reactive;
+using Avalonia.Utilities;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Automation.Peers
 {
-    public class TextBoxAutomationPeer : ControlAutomationPeer, IValueProvider
+    public class TextBoxAutomationPeer : ControlAutomationPeer, ITextProvider, IValueProvider
     {
         public TextBoxAutomationPeer(TextBox owner)
             : base(owner)
         {
+            owner.GetObservable(TextBox.SelectionStartProperty).Subscribe(OnSelectionChanged);
+            owner.GetObservable(TextBox.SelectionEndProperty).Subscribe(OnSelectionChanged);
+            owner.GetObservable(TextBox.TextProperty).Subscribe(OnTextChanged);
         }
 
+        public int CaretIndex => Owner.CaretIndex;
         public new TextBox Owner => (TextBox)base.Owner;
         public bool IsReadOnly => Owner.IsReadOnly;
+        public int LineCount => Owner.Presenter?.TextLayout.TextLines.Count ?? 0;
         public string? Value => Owner.Text;
+        public TextRange DocumentRange => new TextRange(0, Owner.Text?.Length ?? 0);
+        public string? PlaceholderText => Owner.Watermark;
+        public SupportedTextSelection SupportedTextSelection => SupportedTextSelection.Single;
+
+        public event EventHandler? SelectedRangesChanged;
+        public event EventHandler? TextChanged;
+
+        public IReadOnlyList<Rect> GetBounds(TextRange range)
+        {
+            if (Owner.GetVisualRoot() is Visual root &&
+                Owner.Presenter?.TransformToVisual(root) is Matrix m)
+            {
+                var source = Owner.Presenter?.TextLayout.HitTestTextRange(range.Start, range.Length)
+                    ?? Array.Empty<Rect>();
+                var result = new List<Rect>();
+                foreach (var rect in source)
+                    result.Add(rect.TransformToAABB(m));
+                return result;
+            }
+
+            return Array.Empty<Rect>();
+        }
+
+        public int GetLineForIndex(int index)
+        {
+            return Owner.Presenter?.TextLayout.GetLineIndexFromCharacterIndex(index, false) ?? -1;
+        }
+
+        public TextRange GetLineRange(int lineIndex)
+        {
+            if (Owner.Presenter is null)
+                return TextRange.Empty;
+
+            var line = Owner.Presenter.TextLayout.TextLines[lineIndex];
+            return new TextRange(line.FirstTextSourceIndex, line.Length);
+        }
+
+        public IReadOnlyList<TextRange> GetSelection()
+        {
+            var range = TextRange.FromInclusiveStartEnd(Owner.SelectionStart, Owner.SelectionEnd);
+            return new[] { range };
+        }
+
+        public string GetText(TextRange range)
+        {
+            var text = Owner.Text ?? string.Empty;
+            var start = MathUtilities.Clamp(range.Start, 0, text.Length);
+            var end = MathUtilities.Clamp(range.End, 0, text.Length);
+            return text.Substring(start, end - start);
+        }
+
+        public IReadOnlyList<TextRange> GetVisibleRanges()
+        {
+            // Not sure this is necessary, QT just returns the document range too.
+            return new[] { DocumentRange };
+        }
+
+        public TextRange RangeFromPoint(Point p)
+        {
+            if (Owner.Presenter is null)
+                return TextRange.Empty;
+
+            var i = 0;
+
+            if (Owner.GetVisualRoot() is Visual root &&
+                root.TransformToVisual(Owner) is Matrix m)
+            {
+                i = Owner.Presenter.TextLayout.HitTestPoint(p.Transform(m)).TextPosition;
+            }
+
+            return new TextRange(i, 1);
+        }
+
+        public void ScrollIntoView(TextRange range)
+        {
+            if (Owner.Presenter is null || Owner.Scroll is null)
+                return;
+
+            var rects = Owner.Presenter.TextLayout.HitTestTextRange(range.Start, range.Length);
+            var rect = default(Rect);
+
+            foreach (var r in rects)
+                rect = rect.Union(r);
+
+            Owner.Presenter.BringIntoView(rect);
+        }
+
+        public void Select(TextRange range)
+        {
+            Owner.SelectionStart = range.Start;
+            Owner.SelectionEnd = range.End;
+        }
+
         public void SetValue(string? value) => Owner.Text = value;
 
         protected override AutomationControlType GetAutomationControlTypeCore()
         {
             return AutomationControlType.Edit;
         }
+
+
+        private void OnSelectionChanged(int obj) => SelectedRangesChanged?.Invoke(this, EventArgs.Empty);
+        private void OnTextChanged(string? text) => TextChanged?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/src/Avalonia.Controls/Automation/Peers/TextBoxAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/TextBoxAutomationPeer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using Avalonia.Automation.Provider;
 using Avalonia.Controls;
@@ -36,11 +35,12 @@ namespace Avalonia.Automation.Peers
             if (Owner.GetVisualRoot() is Visual root &&
                 Owner.Presenter?.TransformToVisual(root) is Matrix m)
             {
-                var source = Owner.Presenter?.TextLayout.HitTestTextRange(range.Start, range.Length)
+                var source = Owner.Presenter.TextLayout.HitTestTextRange(range.Start, range.Length)
                     ?? Array.Empty<Rect>();
+                var clip = Owner.Presenter.CalculateEffectiveViewport();
                 var result = new List<Rect>();
                 foreach (var rect in source)
-                    result.Add(rect.TransformToAABB(m));
+                    result.Add(rect.Intersect(clip).TransformToAABB(m));
                 return result;
             }
 
@@ -123,7 +123,6 @@ namespace Avalonia.Automation.Peers
         {
             return AutomationControlType.Edit;
         }
-
 
         private void OnSelectionChanged(int obj) => SelectedRangesChanged?.Invoke(this, EventArgs.Empty);
         private void OnTextChanged(string? text) => TextChanged?.Invoke(this, EventArgs.Empty);

--- a/src/Avalonia.Controls/Automation/Peers/UnrealizedElementAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/UnrealizedElementAutomationPeer.cs
@@ -11,6 +11,7 @@ namespace Avalonia.Automation.Peers
         public void SetParent(AutomationPeer? parent) => TrySetParent(parent);
         protected override void BringIntoViewCore() => GetParent()?.BringIntoView();
         protected override Rect GetBoundingRectangleCore() => GetParent()?.GetBoundingRectangle() ?? default;
+        protected override string? GetHelpTextCore() => null;
         protected override IReadOnlyList<AutomationPeer> GetOrCreateChildrenCore() => Array.Empty<AutomationPeer>();
         protected override bool HasKeyboardFocusCore() => false;
         protected override bool IsContentElementCore() => false;

--- a/src/Avalonia.Controls/Automation/Provider/ITextProvider.cs
+++ b/src/Avalonia.Controls/Automation/Provider/ITextProvider.cs
@@ -113,12 +113,6 @@ namespace Avalonia.Automation.Provider
         string GetText(TextRange range);
 
         /// <summary>
-        /// Retrieves a collection of disjoint text ranges from a text-based control where each
-        /// text range represents a contiguous span of visible text.
-        /// </summary>
-        IReadOnlyList<TextRange> GetVisibleRanges();
-
-        /// <summary>
         /// Returns the degenerate (empty) text range nearest to the specified coordinates.
         /// </summary>
         /// <param name="p">The point in top-level coordinates.</param>

--- a/src/Avalonia.Controls/Automation/Provider/ITextProvider.cs
+++ b/src/Avalonia.Controls/Automation/Provider/ITextProvider.cs
@@ -85,13 +85,13 @@ namespace Avalonia.Automation.Provider
         /// Retrieves the line number for the line that contains the specified character index.
         /// </summary>
         /// <param name="index">The character index.</param>
-        /// <returns>The line number, or -1 if the character index is invalid.</returns>
+        /// <returns>The 0-based line number, or -1 if the character index is invalid.</returns>
         int GetLineForIndex(int index);
 
         /// <summary>
         /// Retrieves a text range that encloses the specified line.
         /// </summary>
-        /// <param name="lineIndex">The index of the line.</param>
+        /// <param name="lineIndex">The 0-based index of the line.</param>
         TextRange GetLineRange(int lineIndex);
 
         /// <summary>
@@ -110,6 +110,10 @@ namespace Avalonia.Automation.Provider
         /// </summary>
         /// <param name="range">The text range.</param>
         /// <returns>The text.</returns>
+        /// <remarks>
+        /// The <paramref name="range"/> may be outside the <see cref="DocumentRange"/>, in which
+        /// case the start and end points should be constrained to the document range.
+        /// </remarks>
         string GetText(TextRange range);
 
         /// <summary>

--- a/src/Avalonia.Controls/Automation/Provider/ITextProvider.cs
+++ b/src/Avalonia.Controls/Automation/Provider/ITextProvider.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using Avalonia.Automation.Peers;
+
+#nullable enable
+
+namespace Avalonia.Automation.Provider
+{
+    /// <summary>
+    /// Describes the type of text selection supported by an element.
+    /// </summary>
+    public enum SupportedTextSelection
+    {
+        /// <summary>
+        /// The element does not support text selection.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The element supports a single, continuous text selection.
+        /// </summary>
+        Single,
+
+        /// <summary>
+        /// The element supports multiple, disjoint text selections.
+        /// </summary>
+        Multiple,
+    }
+
+    /// <summary>
+    /// Exposes methods and properties to support access by a UI Automation client to controls
+    /// that holds editable text.
+    /// </summary>
+    public interface ITextProvider
+    {
+        /// <summary>
+        /// Gets the current position of the caret, or -1 if there is no caret.
+        /// </summary>
+        int CaretIndex { get; }
+
+        /// <summary>
+        /// Gets a text range that encloses the main text of the document.
+        /// </summary>
+        TextRange DocumentRange { get; }
+
+        /// <summary>
+        /// Gets a value that indicates whether the text in the control is read-only.
+        /// </summary>
+        bool IsReadOnly { get; }
+
+        /// <summary>
+        /// Gets the total number of lines in the main text of the document.
+        /// </summary>
+        int LineCount { get; }
+
+        /// <summary>
+        /// Gets the placeholder text.
+        /// </summary>
+        string? PlaceholderText { get; }
+
+        /// <summary>
+        /// Gets a value that specifies the type of text selection that is supported by the control.
+        /// </summary>
+        SupportedTextSelection SupportedTextSelection { get; }
+
+        /// <summary>
+        /// Occurs when the control's selection changes.
+        /// </summary>
+        event EventHandler? SelectedRangesChanged;
+
+        /// <summary>
+        /// Occurs when the control's text changes.
+        /// </summary>
+        event EventHandler? TextChanged;
+
+        /// <summary>
+        /// Retrieves a collection of bounding rectangles for each fully or partially visible line
+        /// of text in a text range.
+        /// </summary>
+        /// <param name="range">The text range.</param>
+        /// <returns>A collection of <see cref="Rect"/>s in top-level coordinates.</returns>
+        IReadOnlyList<Rect> GetBounds(TextRange range);
+
+        /// <summary>
+        /// Retrieves the line number for the line that contains the specified character index.
+        /// </summary>
+        /// <param name="index">The character index.</param>
+        /// <returns>The line number, or -1 if the character index is invalid.</returns>
+        int GetLineForIndex(int index);
+
+        /// <summary>
+        /// Retrieves a text range that encloses the specified line.
+        /// </summary>
+        /// <param name="lineIndex">The index of the line.</param>
+        TextRange GetLineRange(int lineIndex);
+
+        /// <summary>
+        /// Retrieves a collection of text ranges that represents the currently selected text in a
+        /// text-based control.
+        /// </summary>
+        /// <remarks>
+        /// If the control contains a text insertion point but no text is selected, the result
+        /// should contain a degenerate (empty) text range at the position of the text insertion
+        /// point.
+        /// </remarks>
+        IReadOnlyList<TextRange> GetSelection();
+
+        /// <summary>
+        /// Retrieves the text for a specified range.
+        /// </summary>
+        /// <param name="range">The text range.</param>
+        /// <returns>The text.</returns>
+        string GetText(TextRange range);
+
+        /// <summary>
+        /// Retrieves a collection of disjoint text ranges from a text-based control where each
+        /// text range represents a contiguous span of visible text.
+        /// </summary>
+        IReadOnlyList<TextRange> GetVisibleRanges();
+
+        /// <summary>
+        /// Returns the degenerate (empty) text range nearest to the specified coordinates.
+        /// </summary>
+        /// <param name="p">The point in top-level coordinates.</param>
+        TextRange RangeFromPoint(Point p);
+
+        /// <summary>
+        /// Scrolls the specified range of text into view.
+        /// </summary>
+        /// <param name="range">The text range.</param>
+        void ScrollIntoView(TextRange range);
+
+        /// <summary>
+        /// Selects the specified range of text, replacing any previous selection.
+        /// </summary>
+        /// <param name="range"></param>
+        void Select(TextRange range);
+    }
+}

--- a/src/Avalonia.Controls/Automation/Provider/TextRange.cs
+++ b/src/Avalonia.Controls/Automation/Provider/TextRange.cs
@@ -45,12 +45,12 @@ namespace Avalonia.Automation.Provider
         public static TextRange Empty => new(0, 0);
 
         /// <summary>
-        /// Creates a new <see cref="TextRange"/> from an inclusive start and end index.
+        /// Creates a new <see cref="TextRange"/> from an exclusive start and end index.
         /// </summary>
-        /// <param name="start">The inclusive start index of the range.</param>
-        /// <param name="end">The inclusive end index of the range.</param>
+        /// <param name="start">The exclusive start index of the range.</param>
+        /// <param name="end">The exclusive end index of the range.</param>
         /// <returns></returns>
-        public static TextRange FromInclusiveStartEnd(int start, int end)
+        public static TextRange FromStartEnd(int start, int end)
         {
             var s = Math.Min(start, end);
             var e = Math.Max(start, end);

--- a/src/Avalonia.Controls/Automation/Provider/TextRange.cs
+++ b/src/Avalonia.Controls/Automation/Provider/TextRange.cs
@@ -1,0 +1,74 @@
+﻿using System;
+
+namespace Avalonia.Automation.Provider
+{
+    /// <summary>
+    /// Represents a range of text returned by an <see cref="ITextProvider"/>.
+    /// </summary>
+    public readonly struct TextRange : IEquatable<TextRange>
+    {
+        /// <summary>
+        /// Instantiates a new <see cref="TextRange"/> instance with the specified start index and
+        /// length.
+        /// </summary>
+        /// <param name="start">The inclusive start index of the range.</param>
+        /// <param name="length">The length of the range.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="length"/> was negative.
+        /// </exception>
+        public TextRange(int start, int length)
+        {
+            if (length < 0)
+                throw new ArgumentException("Length may not be negative", nameof(length));
+            Start = start;
+            Length = length;
+        }
+
+        /// <summary>
+        /// Gets the inclusive start index of the range.
+        /// </summary>
+        public int Start { get; }
+
+        /// <summary>
+        /// Gets the exclusive end index of the range.
+        /// </summary>
+        public int End => Start + Length;
+
+        /// <summary>
+        /// Gets the length of the range.
+        /// </summary>
+        public int Length { get; }
+
+        /// <summary>
+        /// Gets an empty <see cref="TextRange"/>.
+        /// </summary>
+        public static TextRange Empty => new(0, 0);
+
+        /// <summary>
+        /// Creates a new <see cref="TextRange"/> from an inclusive start and end index.
+        /// </summary>
+        /// <param name="start">The inclusive start index of the range.</param>
+        /// <param name="end">The inclusive end index of the range.</param>
+        /// <returns></returns>
+        public static TextRange FromInclusiveStartEnd(int start, int end)
+        {
+            var s = Math.Min(start, end);
+            var e = Math.Max(start, end);
+            return new(s, e - s);
+        }
+
+        public override bool Equals(object? obj) => obj is TextRange range && Equals(range);
+        public bool Equals(TextRange other) => Start == other.Start && Length == other.Length;
+
+        public override int GetHashCode()
+        {
+            var hashCode = -1730557556;
+            hashCode = hashCode * -1521134295 + Start.GetHashCode();
+            hashCode = hashCode * -1521134295 + Length.GetHashCode();
+            return hashCode;
+        }
+
+        public static bool operator ==(TextRange left, TextRange right) => left.Equals(right);
+        public static bool operator !=(TextRange left, TextRange right) => !(left == right);
+    }
+}

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -798,6 +798,9 @@ namespace Avalonia.Controls
             remove => RemoveHandler(TextChangingEvent, value);
         }
 
+        internal TextPresenter? Presenter => _presenter;
+        internal IScrollable? Scroll { get; private set; }
+
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
             _presenter = e.NameScope.Get<TextPresenter>("PART_TextPresenter");

--- a/src/Avalonia.Native/AvnAutomationPeer.cs
+++ b/src/Avalonia.Native/AvnAutomationPeer.cs
@@ -160,6 +160,8 @@ namespace Avalonia.Native
             *start = range.Start;
             *length = range.Length;
         }
+
+        public IAvnString TextProvider_GetPlaceholderText() => ((ITextProvider)_inner).PlaceholderText.ToAvnString();
         
         public IAvnString TextProvider_GetSelectedText()
         {

--- a/src/Avalonia.Native/AvnAutomationPeer.cs
+++ b/src/Avalonia.Native/AvnAutomationPeer.cs
@@ -134,6 +134,17 @@ namespace Avalonia.Native
         public int SelectionItemProvider_IsSelected() => ((ISelectionItemProvider)_inner).IsSelected.AsComBool();
 
         public int IsTextProvider() => (_inner is ITextProvider).AsComBool();
+
+        public AvnRect TextProvider_GetBounds(int start, int length)
+        {
+            var rects = ((ITextProvider)_inner).GetBounds(new(start, length));
+            var union = new Rect();
+
+            foreach (var rect in rects)
+                union = union.Union(rect);
+
+            return union.ToAvnRect();
+        }
         
         public int TextProvider_GetCaretLineNumber()
         {
@@ -142,6 +153,13 @@ namespace Avalonia.Native
         }
 
         public int TextProvider_GetLineForIndex(int index) => ((ITextProvider)_inner).GetLineForIndex(index);
+
+        public unsafe void TextProvider_GetLineRange(int lineIndex, int* start, int* length)
+        {
+            var range = ((ITextProvider)_inner).GetLineRange(lineIndex);
+            *start = range.Start;
+            *length = range.Length;
+        }
         
         public IAvnString TextProvider_GetSelectedText()
         {

--- a/src/Avalonia.Native/AvnAutomationPeer.cs
+++ b/src/Avalonia.Native/AvnAutomationPeer.cs
@@ -177,7 +177,8 @@ namespace Avalonia.Native
 
         public IAvnString TextProvider_GetText(int start, int length) => ((ITextProvider)_inner).GetText(new(start, length)).ToAvnString();
         public int TextProvider_GetTextLength() => ((ITextProvider)_inner).DocumentRange.Length;
-
+        public void TextProvider_Select(int start, int length) => ((ITextProvider)_inner).Select(new(start, length));
+        
         public int IsToggleProvider() => (_inner is IToggleProvider).AsComBool();
         public int ToggleProvider_GetToggleState() => (int)((IToggleProvider)_inner).ToggleState;
         public void ToggleProvider_Toggle() => ((IToggleProvider)_inner).Toggle();

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -915,8 +915,10 @@ interface IAvnAutomationPeer : IUnknown
      bool SelectionItemProvider_IsSelected();
      
      bool IsTextProvider();
+     AvnRect TextProvider_GetBounds(int start, int length);
      int TextProvider_GetCaretLineNumber();
      int TextProvider_GetLineForIndex(int index);
+     void TextProvider_GetLineRange(int lineIndex, int* start, int* length);
      IAvnString* TextProvider_GetText(int start, int length);
      int TextProvider_GetTextLength();
      IAvnString* TextProvider_GetSelectedText();

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -923,6 +923,7 @@ interface IAvnAutomationPeer : IUnknown
      int TextProvider_GetTextLength();
      IAvnString* TextProvider_GetSelectedText();
      void TextProvider_GetSelection(int* start, int* length);
+     void TextProvider_Select(int start, int length);
      
      bool IsToggleProvider();
      int ToggleProvider_GetToggleState();

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -919,6 +919,7 @@ interface IAvnAutomationPeer : IUnknown
      int TextProvider_GetCaretLineNumber();
      int TextProvider_GetLineForIndex(int index);
      void TextProvider_GetLineRange(int lineIndex, int* start, int* length);
+     IAvnString* TextProvider_GetPlaceholderText();
      IAvnString* TextProvider_GetText(int start, int length);
      int TextProvider_GetTextLength();
      IAvnString* TextProvider_GetSelectedText();

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -226,6 +226,7 @@ enum AvnAutomationProperty
     AutomationPeer_ClassName,
     AutomationPeer_Name,
     RangeValueProvider_Value,
+    TextProvider_SelectionChanged,
 }
 
 struct AvnSize
@@ -912,6 +913,14 @@ interface IAvnAutomationPeer : IUnknown
      
      bool IsSelectionItemProvider();
      bool SelectionItemProvider_IsSelected();
+     
+     bool IsTextProvider();
+     int TextProvider_GetCaretLineNumber();
+     int TextProvider_GetLineForIndex(int index);
+     IAvnString* TextProvider_GetText(int start, int length);
+     int TextProvider_GetTextLength();
+     IAvnString* TextProvider_GetSelectedText();
+     void TextProvider_GetSelection(int* start, int* length);
      
      bool IsToggleProvider();
      int ToggleProvider_GetToggleState();

--- a/src/Windows/Avalonia.Win32/Automation/AutomationNode.Text.cs
+++ b/src/Windows/Avalonia.Win32/Automation/AutomationNode.Text.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Automation.Provider;
+using UIA = Avalonia.Win32.Interop.Automation;
+
+#nullable enable
+
+namespace Avalonia.Win32.Automation
+{
+    internal partial class AutomationNode : UIA.ITextProvider
+    {
+        public UIA.ITextRangeProvider DocumentRange
+        {
+            get
+            {
+                var range = InvokeSync<ITextProvider, TextRange>(x => x.DocumentRange);
+                return new AutomationTextRange(this, range);
+            }
+        }
+
+        public UIA.SupportedTextSelection SupportedTextSelection
+        {
+            get => (UIA.SupportedTextSelection)InvokeSync<ITextProvider, SupportedTextSelection>(x => x.SupportedTextSelection);
+        }
+
+        public UIA.ITextRangeProvider[] GetVisibleRanges() => GetRanges(x => x.GetVisibleRanges());
+
+        public UIA.ITextRangeProvider? RangeFromChild(UIA.IRawElementProviderSimple childElement) => null;
+
+        public UIA.ITextRangeProvider? RangeFromPoint(Point screenLocation)
+        {
+            var p = ToClient(screenLocation);
+            var range = InvokeSync<ITextProvider, TextRange>(x => x.RangeFromPoint(screenLocation));
+            return new AutomationTextRange(this, range);
+        }
+
+        UIA.ITextRangeProvider[] UIA.ITextProvider.GetSelection() => GetRanges(x => x.GetSelection());
+
+        private UIA.ITextRangeProvider[] GetRanges(Func<ITextProvider, IReadOnlyList<TextRange>> selector)
+        {
+            var source = InvokeSync(selector);
+            return source?.Select(x => new AutomationTextRange(this, x)).ToArray() ?? Array.Empty<AutomationTextRange>();
+        }
+
+        private void InitializeTextProvider()
+        {
+            if (Peer is ITextProvider provider)
+            {
+                provider.SelectedRangesChanged += PeerSelectedTextRangesChanged;
+                provider.TextChanged += PeerTextChanged;
+            }
+        }
+
+        private void PeerSelectedTextRangesChanged(object? sender, EventArgs e)
+        {
+            RaiseEvent(UIA.UiaEventId.Text_TextSelectionChanged);
+        }
+
+        private void PeerTextChanged(object? sender, EventArgs e)
+        {
+            RaiseEvent(UIA.UiaEventId.Text_TextChanged);
+        }
+    }
+}

--- a/src/Windows/Avalonia.Win32/Automation/AutomationNode.Text.cs
+++ b/src/Windows/Avalonia.Win32/Automation/AutomationNode.Text.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Win32.Automation
             get => (UIA.SupportedTextSelection)InvokeSync<ITextProvider, SupportedTextSelection>(x => x.SupportedTextSelection);
         }
 
-        public UIA.ITextRangeProvider[] GetVisibleRanges() => GetRanges(x => x.GetVisibleRanges());
+        public UIA.ITextRangeProvider[] GetVisibleRanges() => new[] { DocumentRange };
 
         public UIA.ITextRangeProvider? RangeFromChild(UIA.IRawElementProviderSimple childElement) => null;
 

--- a/src/Windows/Avalonia.Win32/Automation/AutomationTextRange.cs
+++ b/src/Windows/Avalonia.Win32/Automation/AutomationTextRange.cs
@@ -51,7 +51,7 @@ namespace Avalonia.Win32.Automation
             }
         }
 
-        public TextRange Range => new(Start, End);
+        public TextRange Range => TextRange.FromStartEnd(Start, End);
 
         private AAP.ITextProvider InnerProvider => (AAP.ITextProvider)_owner.Peer;
 

--- a/src/Windows/Avalonia.Win32/Automation/AutomationTextRange.cs
+++ b/src/Windows/Avalonia.Win32/Automation/AutomationTextRange.cs
@@ -32,8 +32,7 @@ namespace Avalonia.Win32.Automation
             get => _start;
             private set
             {
-                if (value < 0)
-                    throw new InvalidOperationException();
+                value = Math.Max(0, value);
                 if (value > _end)
                     _end = value;
                 _start = value;
@@ -45,8 +44,7 @@ namespace Avalonia.Win32.Automation
             get => _end;
             private set
             {
-                if (value < 0)
-                    throw new InvalidOperationException();
+                value = Math.Max(0, value);
                 if (value < _start)
                     _start = value;
                 _end = value;

--- a/src/Windows/Avalonia.Win32/Automation/AutomationTextRange.cs
+++ b/src/Windows/Avalonia.Win32/Automation/AutomationTextRange.cs
@@ -1,0 +1,474 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Avalonia.Automation.Provider;
+using Avalonia.Utilities;
+using Avalonia.Win32.Interop.Automation;
+using AAP = Avalonia.Automation.Provider;
+
+#nullable enable
+
+namespace Avalonia.Win32.Automation
+{
+    internal class AutomationTextRange : ITextRangeProvider
+    {
+        private readonly AutomationNode _owner;
+
+        public AutomationTextRange(AutomationNode owner, TextRange range)
+            : this(owner, range.Start, range.End)
+        {
+        }
+
+        public AutomationTextRange(AutomationNode owner, int start, int end)
+        {
+            _owner = owner;
+            Start = start;
+            End = end;
+        }
+
+        public int Start { get; private set; }
+        public int End { get; private set; }
+        public TextRange Range => TextRange.FromInclusiveStartEnd(Start, End);
+
+        private AAP.ITextProvider InnerProvider => (AAP.ITextProvider)_owner.Peer;
+
+        public ITextRangeProvider Clone() => new AutomationTextRange(_owner, Range);
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public bool Compare(ITextRangeProvider range)
+        {
+            return range is AutomationTextRange other && other.Start == Start && other.End == End;
+        }
+
+        public int CompareEndpoints(
+            TextPatternRangeEndpoint endpoint,
+            ITextRangeProvider targetRange,
+            TextPatternRangeEndpoint targetEndpoint)
+        {
+            var other = targetRange as AutomationTextRange ?? throw new InvalidOperationException("Invalid text range");
+            var e1 = (endpoint == TextPatternRangeEndpoint.Start) ? Start : End;
+            var e2 = (targetEndpoint == TextPatternRangeEndpoint.Start) ? other.Start : other.End;
+            return e1 - e2;
+        }
+
+        public void ExpandToEnclosingUnit(TextUnit unit)
+        {
+            _owner.InvokeSync(() =>
+            {
+                var text = InnerProvider.GetText(InnerProvider.DocumentRange);
+
+                switch (unit)
+                {
+                    case TextUnit.Character:
+                        if (Start == End)
+                            End = MoveEndpointForward(text, End, TextUnit.Character, 1, out _);
+                        break;
+                    case TextUnit.Word:
+                        // Move start left until we reach a word boundary.
+                        for (; !AtWordBoundary(text, Start); Start--)
+                            ;
+                        // Move end right until we reach word boundary (different from Start).
+                        End = Math.Min(Math.Max(End, Start + 1), text.Length);
+                        for (; !AtWordBoundary(text, End); End++)
+                            ;
+                        break;
+                    case TextUnit.Line:
+                        if (InnerProvider.LineCount != 1)
+                        {
+                            int startLine = InnerProvider.GetLineForIndex(Start);
+                            int endLine = InnerProvider.GetLineForIndex(End);
+                            var start = InnerProvider.GetLineRange(startLine).Start;
+                            var end = InnerProvider.GetLineRange(endLine).End;
+                            MoveTo(start, end);
+                        }
+                        else
+                        {
+                            MoveTo(0, text.Length);
+                        }
+                        break;
+                    case TextUnit.Paragraph:
+                        // Move start left until we reach a paragraph boundary.
+                        for (; !AtParagraphBoundary(text, Start); Start--)
+                            ;
+                        // Move end right until we reach a paragraph boundary (different from Start).
+                        End = Math.Min(Math.Max(End, Start + 1), text.Length);
+                        for (; !AtParagraphBoundary(text, End); End++)
+                            ;
+                        break;
+                    case TextUnit.Format:
+                    case TextUnit.Page:
+                    case TextUnit.Document:
+                        MoveTo(0, text.Length);
+                        break;
+                    default:
+                        throw new ArgumentException("Invalid TextUnit.", nameof(unit));
+                }
+            });
+        }
+
+        public ITextRangeProvider? FindAttribute(
+            TextPatternAttribute attribute,
+            object? value,
+            [MarshalAs(UnmanagedType.Bool)] bool backward)
+        {
+            // TODO: Implement.
+            return null;
+        }
+
+        public ITextRangeProvider? FindText(
+            string text,
+            [MarshalAs(UnmanagedType.Bool)] bool backward,
+            [MarshalAs(UnmanagedType.Bool)] bool ignoreCase)
+        {
+            return _owner.InvokeSync(() =>
+            {
+                var rangeText = InnerProvider.GetText(Range);
+
+                if (ignoreCase)
+                {
+                    rangeText = rangeText.ToLowerInvariant();
+                    text = text.ToLowerInvariant();
+                }
+
+                var i = backward ?
+                    rangeText.LastIndexOf(text, StringComparison.Ordinal) :
+                    rangeText.IndexOf(text, StringComparison.Ordinal);
+                return i >= 0 ? new AutomationTextRange(_owner, Start + i, Start + i + text.Length) : null;
+            });
+        }
+
+        public object? GetAttributeValue(TextPatternAttribute attribute)
+        {
+            return attribute switch
+            {
+                TextPatternAttribute.IsReadOnlyAttributeId => _owner.InvokeSync(() => InnerProvider.IsReadOnly),
+                _ => null
+            };
+        }
+
+        public double[] GetBoundingRectangles()
+        {
+            return _owner.InvokeSync(() =>
+            {
+                var rects = InnerProvider.GetBounds(Range);
+                var result = new double[rects.Count * 4];
+                var root = _owner.GetRoot() as RootAutomationNode;
+
+                if (root is object)
+                {
+                    for (var i = 0; i < rects.Count; i++)
+                    {
+                        var screenRect = root.ToScreen(rects[i]);
+                        result[4 * i] = screenRect.X;
+                        result[4 * i + 1] = screenRect.Y;
+                        result[4 * i + 2] = screenRect.Width;
+                        result[4 * i + 3] = screenRect.Height;
+                    }
+                }
+
+                return result;
+            });
+        }
+
+        public IRawElementProviderSimple[] GetChildren() => Array.Empty<IRawElementProviderSimple>();
+        public IRawElementProviderSimple GetEnclosingElement() => _owner;
+
+        public string GetText(int maxLength)
+        {
+            if (maxLength < 0)
+                maxLength = int.MaxValue;
+            maxLength = Math.Min(maxLength, End - Start);
+            return _owner.InvokeSync(() => InnerProvider.GetText(new TextRange(Start, maxLength)));
+        }
+
+        public int Move(TextUnit unit, int count)
+        {
+            return _owner.InvokeSync(() =>
+            {
+                if (count == 0)
+                    return 0;
+                var text = InnerProvider.GetText(new(0, int.MaxValue));
+                // Save the start and end in case the move fails.
+                var oldStart = Start;
+                var oldEnd = End;
+                var wasDegenerate = Start == End;
+                // Move the start of the text range forward or backward in the document by the
+                // requested number of text unit boundaries.
+                var moved = MoveEndpointByUnit(TextPatternRangeEndpoint.Start, unit, count);
+                var succeeded = moved != 0;
+                if (succeeded)
+                {
+                    // Make the range degenerate at the new start point.
+                    End = Start;
+                    // If we previously had a non-degenerate range then expand the range.
+                    if (!wasDegenerate)
+                    {
+                        var forwards = count > 0;
+                        if (forwards && Start == text.Length - 1)
+                        {
+                            // The start is at the end of the document, so move the start backward by
+                            // one text unit to expand the text range from the degenerate range state.
+                            Start = MoveEndpointBackward(text, Start, unit, -1, out var expandMoved);
+                            --moved;
+                            succeeded = expandMoved == -1 && moved > 0;
+                        }
+                        else
+                        {
+                            // The start is not at the end of the document, so move the endpoint
+                            // forward by one text unit to expand the text range from the degenerate
+                            // state.
+                            End = MoveEndpointForward(text, End, unit, 1, out var expandMoved);
+                            succeeded = expandMoved > 0;
+                        }
+                    }
+                }
+                if (!succeeded)
+                {
+                    Start = oldStart;
+                    End = oldEnd;
+                    moved = 0;
+                }
+                return moved;
+            });
+        }
+
+        public void MoveEndpointByRange(TextPatternRangeEndpoint endpoint, ITextRangeProvider targetRange, TextPatternRangeEndpoint targetEndpoint)
+        {
+            var editRange = targetRange as AutomationTextRange ?? throw new InvalidOperationException("Invalid text range");
+            var e = (targetEndpoint == TextPatternRangeEndpoint.Start) ? editRange.Start : editRange.End;
+
+            if (endpoint == TextPatternRangeEndpoint.Start)
+                Start = e;
+            else
+                End = e;
+        }
+
+        public int MoveEndpointByUnit(TextPatternRangeEndpoint endpoint, TextUnit unit, int count)
+        {
+            if (count == 0)
+                return 0;
+
+            return _owner.InvokeSync(() =>
+            {
+                var text = InnerProvider.GetText(InnerProvider.DocumentRange);
+                var moved = 0;
+                var moveStart = endpoint == TextPatternRangeEndpoint.Start;
+
+                if (count > 0)
+                {
+                    if (moveStart)
+                        Start = MoveEndpointForward(text, Start, unit, count, out moved);
+                    else
+                        End = MoveEndpointForward(text, End, unit, count, out moved);
+                }
+                else if (count < 0)
+                {
+                    if (moveStart)
+                        Start = MoveEndpointBackward(text, Start, unit, count, out moved);
+                    else
+                        End = MoveEndpointBackward(text, End, unit, count, out moved);
+                }
+
+                return moved;
+            });
+        }
+
+        void ITextRangeProvider.AddToSelection() => throw new NotSupportedException();
+        void ITextRangeProvider.RemoveFromSelection() => throw new NotSupportedException();
+
+        public void ScrollIntoView([MarshalAs(UnmanagedType.Bool)] bool alignToTop)
+        {
+            _owner.InvokeSync(() => InnerProvider.ScrollIntoView(Range));
+        }
+
+        public void Select()
+        {
+            _owner.InvokeSync(() => InnerProvider.Select(Range));
+        }
+
+        private static bool AtParagraphBoundary(string text, int index)
+        {
+            return index <= 0 || index >= text.Length || (text[index] == '\r') && (text[index] != '\n');
+        }
+
+        // returns true iff index identifies a word boundary within text.
+        // following richedit & word precedent the boundaries are at the leading edge of the word
+        // so the span of a word includes trailing whitespace.
+        private static bool AtWordBoundary(string text, int index)
+        {
+            // we are at a word boundary if we are at the beginning or end of the text
+            if (index <= 0 || index >= text.Length)
+            {
+                return true;
+            }
+
+            if (AtParagraphBoundary(text, index))
+            {
+                return true;
+            }
+
+            var ch1 = text[index - 1];
+            var ch2 = text[index];
+
+            // an apostrophe does *not* break a word if it follows or precedes characters
+            if ((char.IsLetterOrDigit(ch1) && IsApostrophe(ch2))
+                || (IsApostrophe(ch1) && char.IsLetterOrDigit(ch2) && index >= 2 && char.IsLetterOrDigit(text[index - 2])))
+            {
+                return false;
+            }
+
+            // the following transitions mark boundaries.
+            // note: these are constructed to include trailing whitespace.
+            return (char.IsWhiteSpace(ch1) && !char.IsWhiteSpace(ch2))
+                || (char.IsLetterOrDigit(ch1) && !char.IsLetterOrDigit(ch2))
+                || (!char.IsLetterOrDigit(ch1) && char.IsLetterOrDigit(ch2))
+                || (char.IsPunctuation(ch1) && char.IsWhiteSpace(ch2));
+        }
+
+        private static bool IsApostrophe(char ch)
+        {
+            return ch == '\'' ||
+                   ch == (char)0x2019; // Unicode Right Single Quote Mark
+        }
+
+        private static bool IsWordBreak(char ch)
+        {
+            return char.IsWhiteSpace(ch) || char.IsPunctuation(ch);
+        }
+
+        private int MoveEndpointForward(string text, int index, TextUnit unit, int count, out int moved)
+        {
+            var limit = text.Length;
+
+            switch (unit)
+            {
+                case TextUnit.Character:
+                    moved = Math.Min(count, limit - index);
+                    index = index + moved;
+                    index = index > limit ? limit : index;
+                    break;
+
+                case TextUnit.Word:
+                    // TODO: This will need to implement the Unicode word boundaries spec.
+                    for (moved = 0; moved < count && index < text.Length; moved++)
+                    {
+                        for (index++; !AtWordBoundary(text, index); index++)
+                            ;
+                        for (; index < text.Length && IsWordBreak(text[index]); index++)
+                            ;
+                    }
+                    break;
+
+                case TextUnit.Line:
+                    {
+                        var line = InnerProvider.GetLineForIndex(index);
+                        var newLine = MathUtilities.Clamp(line + count, 0, InnerProvider.LineCount - 1);
+                        index = InnerProvider.GetLineRange(newLine).Start;
+                        moved = newLine - line;
+                    }
+                    break;
+
+                case TextUnit.Paragraph:
+                    for (moved = 0; moved < count && index < text.Length; moved++)
+                    {
+                        for (index++; !AtParagraphBoundary(text, index); index++)
+                            ;
+                    }
+                    break;
+
+                case TextUnit.Format:
+                case TextUnit.Page:
+                case TextUnit.Document:
+                    moved = index < limit ? 1 : 0;
+                    index = limit;
+                    break;
+
+                default:
+                    throw new ArgumentException("Invalid TextUnit.", nameof(unit));
+            }
+
+            return index;
+        }
+
+        // moves an endpoint backward a certain number of units.
+        // the endpoint is just an index into the text so it could represent either
+        // the endpoint.
+        private int MoveEndpointBackward(string text, int index, TextUnit unit, int count, out int moved)
+        {
+            if (index == 0)
+            {
+                moved = 0;
+                return 0;
+            }
+            switch (unit)
+            {
+                case TextUnit.Character:
+                    int oneBasedIndex = index + 1;
+                    moved = Math.Max(count, -oneBasedIndex);
+                    index += moved;
+                    index = index < 0 ? 0 : index;
+                    break;
+                case TextUnit.Word:
+                    for (moved = 0; moved > count && index > 0; moved--)
+                    {
+                        for (index--; index < text.Length && IsWordBreak(text[index]); index--)
+                            ;
+                        for (index--; !AtWordBoundary(text, index); index--)
+                            ;
+                    }
+                    break;
+                case TextUnit.Line:
+                    {
+                        var line = InnerProvider.GetLineForIndex(index);
+                        // If a line other than the first consists of only a newline, then you can
+                        // move backwards past this line and the position changes, hence this is
+                        // counted. The first line is special, though: if it is empty, and you move
+                        // say from the second line back up to the first, you cannot move further.
+                        // However if the first line is nonempty, you can move from the end of the
+                        // first line to its beginning! This latter move is counted, but if the
+                        // first line is empty, it is not counted.
+                        if (line == 0)
+                        {
+                            index = 0;
+                            moved = !IsEol(text[0]) ? -1 : 0;
+                        }
+                        else
+                        {
+                            var newLine = MathUtilities.Clamp(line + count, 0, InnerProvider.LineCount - 1);
+                            index = InnerProvider.GetLineRange(newLine).Start;
+                            moved = newLine - line;
+                        }
+                    }
+                    break;
+                case TextUnit.Paragraph:
+                    for (moved = 0; moved > count && index > 0; moved--)
+                    {
+                        for (index--; !AtParagraphBoundary(text, index); index--)
+                            ;
+                    }
+                    break;
+                case TextUnit.Format:
+                case TextUnit.Page:
+                case TextUnit.Document:
+                    moved = index > 0 ? -1 : 0;
+                    index = 0;
+                    break;
+                default:
+                    throw new ArgumentException("Invalid TextUnit.", nameof(unit));
+            }
+            return index;
+        }
+
+        private void MoveTo(int start, int end)
+        {
+            if (start < 0 || end < start)
+                throw new InvalidOperationException();
+            Start = start;
+            End = end;
+        }
+
+        public static bool IsEol(char c)
+        {
+            return c == '\r' || c == '\n';
+        }
+    }
+}

--- a/src/Windows/Avalonia.Win32/Automation/RootAutomationNode.cs
+++ b/src/Windows/Avalonia.Win32/Automation/RootAutomationNode.cs
@@ -77,7 +77,15 @@ namespace Avalonia.Win32.Automation
 
         public void FocusChanged(object? sender, EventArgs e)
         {
-            RaiseFocusChanged(GetOrCreate(Peer.GetFocus()));
+            if (GetOrCreate(Peer.GetFocus()) is AutomationNode node)
+                RaiseEvent(node, UiaEventId.AutomationFocusChanged);
+        }
+
+        public new Point ToClient(PixelPoint p)
+        {
+            if (WindowImpl is null)
+                return default;
+            return WindowImpl.PointToClient(p);
         }
 
         public Rect ToScreen(Rect rect)

--- a/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
+++ b/src/Windows/Avalonia.Win32/Avalonia.Win32.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
   <Import Project="..\..\..\build\System.Drawing.Common.props" />
   <Import Project="..\..\..\build\NullableEnable.props" />
+  <ItemGroup Label="InternalsVisibleTo">
+    <InternalsVisibleTo Include="Avalonia.Win32.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
+  </ItemGroup>
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\build\System.Drawing.Common.props" />
   <Import Project="..\..\..\build\DevAnalyzers.props" />
   <Import Project="..\..\..\build\SourceGenerators.props" />
   <ItemGroup>

--- a/src/Windows/Avalonia.Win32/Interop/Automation/ITextProvider.cs
+++ b/src/Windows/Avalonia.Win32/Interop/Automation/ITextProvider.cs
@@ -20,8 +20,8 @@ namespace Avalonia.Win32.Interop.Automation
     {
         ITextRangeProvider [] GetSelection();
         ITextRangeProvider [] GetVisibleRanges();
-        ITextRangeProvider RangeFromChild(IRawElementProviderSimple childElement);
-        ITextRangeProvider RangeFromPoint(Point screenLocation);
+        ITextRangeProvider? RangeFromChild(IRawElementProviderSimple childElement);
+        ITextRangeProvider? RangeFromPoint(Point screenLocation);
         ITextRangeProvider DocumentRange { get; }
         SupportedTextSelection SupportedTextSelection { get; }
     }

--- a/src/Windows/Avalonia.Win32/Interop/Automation/ITextRangeProvider.cs
+++ b/src/Windows/Avalonia.Win32/Interop/Automation/ITextRangeProvider.cs
@@ -1,5 +1,7 @@
 using System.Runtime.InteropServices;
 
+#nullable enable
+
 namespace Avalonia.Win32.Interop.Automation
 {
     public enum TextPatternRangeEndpoint
@@ -19,21 +21,68 @@ namespace Avalonia.Win32.Interop.Automation
         Document = 6,
     }
 
+    public enum TextPatternAttribute
+    {
+        AnimationStyleAttributeId = 40000,
+        BackgroundColorAttributeId = 40001,
+        BulletStyleAttributeId = 40002,
+        CapStyleAttributeId = 40003,
+        CultureAttributeId = 40004,
+        FontNameAttributeId = 40005,
+        FontSizeAttributeId = 40006,
+        FontWeightAttributeId = 40007,
+        ForegroundColorAttributeId = 40008,
+        HorizontalTextAlignmentAttributeId = 40009,
+        IndentationFirstLineAttributeId = 40010,
+        IndentationLeadingAttributeId = 40011,
+        IndentationTrailingAttributeId = 40012,
+        IsHiddenAttributeId = 40013,
+        IsItalicAttributeId = 40014,
+        IsReadOnlyAttributeId = 40015,
+        IsSubscriptAttributeId = 40016,
+        IsSuperscriptAttributeId = 40017,
+        MarginBottomAttributeId = 40018,
+        MarginLeadingAttributeId = 40019,
+        MarginTopAttributeId = 40020,
+        MarginTrailingAttributeId = 40021,
+        OutlineStylesAttributeId = 40022,
+        OverlineColorAttributeId = 40023,
+        OverlineStyleAttributeId = 40024,
+        StrikethroughColorAttributeId = 40025,
+        StrikethroughStyleAttributeId = 40026,
+        TabsAttributeId = 40027,
+        TextFlowDirectionsAttributeId = 40028,
+        UnderlineColorAttributeId = 40029,
+        UnderlineStyleAttributeId = 40030,
+        AnnotationTypesAttributeId = 40031,
+        AnnotationObjectsAttributeId = 40032,
+        StyleNameAttributeId = 40033,
+        StyleIdAttributeId = 40034,
+        LinkAttributeId = 40035,
+        IsActiveAttributeId = 40036,
+        SelectionActiveEndAttributeId = 40037,
+        CaretPositionAttributeId = 40038,
+        CaretBidiModeAttributeId = 40039,
+        LineSpacingAttributeId = 40040,
+        BeforeParagraphSpacingAttributeId = 40041,
+        AfterParagraphSpacingAttributeId = 40042,
+        SayAsInterpretAsAttributeId = 40043,
+    }
+
     [ComVisible(true)]
     [Guid("5347ad7b-c355-46f8-aff5-909033582f63")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     public interface ITextRangeProvider
-
     {
         ITextRangeProvider Clone();
         [return: MarshalAs(UnmanagedType.Bool)]
         bool Compare(ITextRangeProvider range);
         int CompareEndpoints(TextPatternRangeEndpoint endpoint, ITextRangeProvider targetRange, TextPatternRangeEndpoint targetEndpoint);
         void ExpandToEnclosingUnit(TextUnit unit);
-        ITextRangeProvider FindAttribute(int attribute, object value, [MarshalAs(UnmanagedType.Bool)] bool backward);
-        ITextRangeProvider FindText(string text, [MarshalAs(UnmanagedType.Bool)] bool backward, [MarshalAs(UnmanagedType.Bool)] bool ignoreCase);
-        object GetAttributeValue(int attribute);
-        double [] GetBoundingRectangles();
+        ITextRangeProvider? FindAttribute(TextPatternAttribute attribute, object? value, [MarshalAs(UnmanagedType.Bool)] bool backward);
+        ITextRangeProvider? FindText(string text, [MarshalAs(UnmanagedType.Bool)] bool backward, [MarshalAs(UnmanagedType.Bool)] bool ignoreCase);
+        object? GetAttributeValue(TextPatternAttribute attribute);
+        double[] GetBoundingRectangles();
         IRawElementProviderSimple GetEnclosingElement();
         string GetText(int maxLength);
         int Move(TextUnit unit, int count);

--- a/tests/Avalonia.Win32.UnitTests/Automation/AutomationTextRangeTests.cs
+++ b/tests/Avalonia.Win32.UnitTests/Automation/AutomationTextRangeTests.cs
@@ -20,7 +20,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Moves_Right_One_Char(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var range = new AutomationTextRange(node, 0, 1);
 
             var result = range.Move(TextUnit.Character, 1);
@@ -33,7 +33,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Does_Not_Move_Right_From_Last_Char(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var start = peer.Text.Length - 1;
             var range = new AutomationTextRange(node, start, start + 1);
 
@@ -47,7 +47,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Moves_Degenerate_Right_One_Char(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var range = new AutomationTextRange(node, 0, 0);
 
             var result = range.Move(TextUnit.Character, 1);
@@ -61,7 +61,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Moves_Right_To_Newline(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var range = new AutomationTextRange(node, 0, 1);
 
             var result = range.Move(TextUnit.Character, 1);
@@ -74,7 +74,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Moves_Right_One_Surrogate_Pair(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var start = peer.GetLineRange(6).Start;
             var range = new AutomationTextRange(node, start, start + 2);
 
@@ -90,7 +90,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Moves_Left_One_Char(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var range = new AutomationTextRange(node, 0, 1);
 
             var result = range.Move(TextUnit.Character, 1);
@@ -103,7 +103,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Does_Not_Move_Left_From_First_Char(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var range = new AutomationTextRange(node, 0, 1);
 
             var result = range.Move(TextUnit.Character, -1);
@@ -116,7 +116,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Moves_Left_One_Surrogate_Pair(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var start = peer.GetLineRange(6).Start + 2;
             var range = new AutomationTextRange(node, start, start + 1);
 
@@ -130,7 +130,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Moves_Right_One_Word_With_Trailing_Newlines(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var range = new AutomationTextRange(node, 0, 1);
 
             var result = range.Move(TextUnit.Word, 1);
@@ -148,7 +148,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Moves_Right_One_Word_With_Apostrophe(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var start = peer.GetLineRange(10).Start;
             var range = new AutomationTextRange(node, start, start + 1);
 
@@ -163,7 +163,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Moves_Left_To_Previous_Line_With_Trailing_Newlines(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var start = peer.GetLineRange(2).Start;
             var range = new AutomationTextRange(node, start, start + 1);
 
@@ -177,7 +177,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Moves_Down_To_Empty_Line(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var range = new AutomationTextRange(node, 0, peer.Lines[0].Length);
 
             var result = range.Move(TextUnit.Line, 1);
@@ -190,7 +190,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Moves_Degenerate_Down_To_Empty_Line(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var range = new AutomationTextRange(node, 0, 0);
 
             var result = range.Move(TextUnit.Line, 1);
@@ -204,7 +204,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Moves_Down_From_Mid_Line_To_Next_Line(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var range = new AutomationTextRange(node, 2, 4);
 
             var result = range.Move(TextUnit.Line, 1);
@@ -217,7 +217,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Does_Not_Move_Down_From_Last_Line(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var start = peer.GetLineRange(peer.Lines.Count - 1).Start;
             var range = new AutomationTextRange(node, start, peer.Text.Length);
 
@@ -231,7 +231,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Moves_Up_To_Empty_Line(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var start = peer.GetLineRange(2).Start;
             var range = new AutomationTextRange(node, start, start + peer.Lines[2].Length);
 
@@ -245,7 +245,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Moves_Degenerate_Up_To_Empty_Line(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var start = peer.GetLineRange(2).Start;
             var range = new AutomationTextRange(node, start, start);
 
@@ -260,7 +260,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Moves_Up_From_Mid_Line_To_Next_Line(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var start = peer.GetLineRange(2).Start + 2;
             var range = new AutomationTextRange(node, start, start + 2);
 
@@ -274,7 +274,7 @@ public class AutomationTextRangeTests
         [ClassData(typeof(Newlines))]
         public void Does_Not_Move_Up_From_First_Line(string newline)
         {
-            var (node, peer) = CreateTestNode(newline);
+            var (node, peer) = CreateTestNode(newline: newline);
             var range = new AutomationTextRange(node, 0, peer.Lines[0].Length);
 
             var result = range.Move(TextUnit.Line, -1);
@@ -284,21 +284,22 @@ public class AutomationTextRangeTests
         }
     }
 
-    private static (AutomationNode, TestPeer) CreateTestNode(string newline)
+    public class MoveEndpointByUnit
     {
-        var peer = new TestPeer(newline);
-        return (new AutomationNode(peer), peer);
+        [Fact]
+        public void Moving_Back_A_Word_Works_With_Only_Symbols()
+        {
+            var (node, peer) = CreateTestNode(lines: "(___) ___-____");
+            var range = new AutomationTextRange(node, 0, 14);
+
+            range.MoveEndpointByUnit(TextPatternRangeEndpoint.End, TextUnit.Word, -1);
+        }
     }
 
-    private class TestPeer : ControlAutomationPeer, AAP.ITextProvider
+    private static (AutomationNode, TestPeer) CreateTestNode(string newline)
     {
-        private readonly string[] _lines;
-
-        public TestPeer(string newline)
-            : base(new Control())
+        var lines = new[]
         {
-            _lines = new[]
-            {
                 "Test text:" + newline,
                 newline,
                 "Lorem ipsum dolor sit amet, ",
@@ -311,6 +312,24 @@ public class AutomationTextRangeTests
                 "commodo consequat." + newline,
                 "We can't stop now"
             };
+
+        return CreateTestNode(lines);
+    }
+
+    private static (AutomationNode, TestPeer) CreateTestNode(params string[] lines)
+    {
+        var peer = new TestPeer(lines);
+        return (new AutomationNode(peer), peer);
+    }
+
+    private class TestPeer : ControlAutomationPeer, AAP.ITextProvider
+    {
+        private readonly string[] _lines;
+
+        public TestPeer(string[] lines)
+            : base(new Control())
+        {
+            _lines = lines;
         }
 
         public bool IsReadOnly => true;
@@ -322,8 +341,8 @@ public class AutomationTextRangeTests
         public AAP.SupportedTextSelection SupportedTextSelection { get; }
         public string Text => string.Concat(_lines);
 
-        public event EventHandler SelectedRangesChanged;
-        public event EventHandler TextChanged;
+        public event EventHandler? SelectedRangesChanged;
+        public event EventHandler? TextChanged;
 
         public IReadOnlyList<Rect> GetBounds(TextRange range)
         {

--- a/tests/Avalonia.Win32.UnitTests/Automation/AutomationTextRangeTests.cs
+++ b/tests/Avalonia.Win32.UnitTests/Automation/AutomationTextRangeTests.cs
@@ -91,12 +91,12 @@ public class AutomationTextRangeTests
         public void Moves_Left_One_Char(string newline)
         {
             var (node, peer) = CreateTestNode(newline: newline);
-            var range = new AutomationTextRange(node, 0, 1);
+            var range = new AutomationTextRange(node, 1, 2);
 
-            var result = range.Move(TextUnit.Character, 1);
+            var result = range.Move(TextUnit.Character, -1);
 
-            Assert.Equal(1, result);
-            Assert.Equal(peer.Lines[0][1].ToString(), range.GetText(-1));
+            Assert.Equal(-1, result);
+            Assert.Equal(peer.Lines[0][0].ToString(), range.GetText(-1));
         }
 
         [Theory]
@@ -225,6 +225,19 @@ public class AutomationTextRangeTests
 
             Assert.Equal(0, result);
             Assert.Equal(peer.Lines[^1], range.GetText(-1));
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Moving_Down_From_DocumentRange_Moves_To_Second_Line(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline: newline);
+            var range = new AutomationTextRange(node, peer.DocumentRange);
+
+            var result = range.Move(TextUnit.Line, 1);
+
+            Assert.Equal(1, result);
+            Assert.Equal(peer.Lines[1], range.GetText(-1));
         }
 
         [Theory]

--- a/tests/Avalonia.Win32.UnitTests/Automation/AutomationTextRangeTests.cs
+++ b/tests/Avalonia.Win32.UnitTests/Automation/AutomationTextRangeTests.cs
@@ -1,0 +1,393 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Automation.Peers;
+using Avalonia.Automation.Provider;
+using Avalonia.Controls;
+using Avalonia.Win32.Automation;
+using Avalonia.Win32.Interop.Automation;
+using Xunit;
+using AAP = Avalonia.Automation.Provider;
+
+namespace Avalonia.Win32.UnitTests.Automation;
+
+public class AutomationTextRangeTests
+{
+    public class Move : AutomationTextRangeTests
+    {
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Moves_Right_One_Char(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var range = new AutomationTextRange(node, 0, 1);
+
+            var result = range.Move(TextUnit.Character, 1);
+
+            Assert.Equal(1, result);
+            Assert.Equal(peer.Lines[0][1].ToString(), range.GetText(-1));
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Does_Not_Move_Right_From_Last_Char(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var start = peer.Text.Length - 1;
+            var range = new AutomationTextRange(node, start, start + 1);
+
+            var result = range.Move(TextUnit.Character, 1);
+
+            Assert.Equal(0, result);
+            Assert.Equal(peer.Text[^1].ToString(), range.GetText(-1));
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Moves_Degenerate_Right_One_Char(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var range = new AutomationTextRange(node, 0, 0);
+
+            var result = range.Move(TextUnit.Character, 1);
+
+            Assert.Equal(1, result);
+            Assert.Equal(1, range.Start);
+            Assert.Equal(1, range.End);
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Moves_Right_To_Newline(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var range = new AutomationTextRange(node, 0, 1);
+
+            var result = range.Move(TextUnit.Character, 1);
+
+            Assert.Equal(1, result);
+            Assert.Equal(peer.Lines[0][1].ToString(), range.GetText(-1));
+        }
+
+        [Theory(Skip = "Not yet implemented")]
+        [ClassData(typeof(Newlines))]
+        public void Moves_Right_One_Surrogate_Pair(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var start = peer.GetLineRange(6).Start;
+            var range = new AutomationTextRange(node, start, start + 2);
+
+            Assert.Equal("🌉", range.GetText(-1));
+
+            var result = range.Move(TextUnit.Character, 1);
+
+            Assert.Equal(1, result);
+            Assert.Equal("U", range.GetText(-1));
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Moves_Left_One_Char(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var range = new AutomationTextRange(node, 0, 1);
+
+            var result = range.Move(TextUnit.Character, 1);
+
+            Assert.Equal(1, result);
+            Assert.Equal(peer.Lines[0][1].ToString(), range.GetText(-1));
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Does_Not_Move_Left_From_First_Char(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var range = new AutomationTextRange(node, 0, 1);
+
+            var result = range.Move(TextUnit.Character, -1);
+
+            Assert.Equal(0, result);
+            Assert.Equal(peer.Text[0].ToString(), range.GetText(-1));
+        }
+
+        [Theory(Skip = "Not yet implemented")]
+        [ClassData(typeof(Newlines))]
+        public void Moves_Left_One_Surrogate_Pair(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var start = peer.GetLineRange(6).Start + 2;
+            var range = new AutomationTextRange(node, start, start + 1);
+
+            var result = range.Move(TextUnit.Character, -1);
+
+            Assert.Equal(-1, result);
+            Assert.Equal("🌉", range.GetText(-1));
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Moves_Right_One_Word_With_Trailing_Newlines(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var range = new AutomationTextRange(node, 0, 1);
+
+            var result = range.Move(TextUnit.Word, 1);
+
+            Assert.Equal(1, result);
+
+            // From https://docs.microsoft.com/en-us/windows/win32/winauto/uiauto-uiautomationtextunits
+            // When TextUnit_Word is used to set the boundary of a text range, the resulting text range
+            // should include any word break characters that are present at the end of the word, but
+            // before the start of the next word.
+            Assert.Equal("text:" + newline + newline, range.GetText(-1));
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Moves_Right_One_Word_With_Apostrophe(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var start = peer.GetLineRange(10).Start;
+            var range = new AutomationTextRange(node, start, start + 1);
+
+            var result = range.Move(TextUnit.Word, 1);
+
+            Assert.Equal(1, result);
+
+            Assert.Equal("can't ", range.GetText(-1));
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Moves_Left_To_Previous_Line_With_Trailing_Newlines(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var start = peer.GetLineRange(2).Start;
+            var range = new AutomationTextRange(node, start, start + 1);
+
+            var result = range.Move(TextUnit.Word, -1);
+
+            Assert.Equal(-1, result);
+            Assert.Equal("text:" + newline + newline, range.GetText(-1));
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Moves_Down_To_Empty_Line(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var range = new AutomationTextRange(node, 0, peer.Lines[0].Length);
+
+            var result = range.Move(TextUnit.Line, 1);
+
+            Assert.Equal(1, result);
+            Assert.Equal(peer.Lines[1], range.GetText(-1));
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Moves_Degenerate_Down_To_Empty_Line(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var range = new AutomationTextRange(node, 0, 0);
+
+            var result = range.Move(TextUnit.Line, 1);
+
+            Assert.Equal(1, result);
+            Assert.Equal(peer.Lines[0].Length, range.Start);
+            Assert.Equal(range.Start, range.End);
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Moves_Down_From_Mid_Line_To_Next_Line(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var range = new AutomationTextRange(node, 2, 4);
+
+            var result = range.Move(TextUnit.Line, 1);
+
+            Assert.Equal(1, result);
+            Assert.Equal(peer.Lines[1], range.GetText(-1));
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Does_Not_Move_Down_From_Last_Line(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var start = peer.GetLineRange(peer.Lines.Count - 1).Start;
+            var range = new AutomationTextRange(node, start, peer.Text.Length);
+
+            var result = range.Move(TextUnit.Line, 1);
+
+            Assert.Equal(0, result);
+            Assert.Equal(peer.Lines[^1], range.GetText(-1));
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Moves_Up_To_Empty_Line(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var start = peer.GetLineRange(2).Start;
+            var range = new AutomationTextRange(node, start, start + peer.Lines[2].Length);
+
+            var result = range.Move(TextUnit.Line, -1);
+
+            Assert.Equal(-1, result);
+            Assert.Equal(peer.Lines[1], range.GetText(-1));
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Moves_Degenerate_Up_To_Empty_Line(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var start = peer.GetLineRange(2).Start;
+            var range = new AutomationTextRange(node, start, start);
+
+            var result = range.Move(TextUnit.Line, -1);
+
+            Assert.Equal(-1, result);
+            Assert.Equal(peer.Lines[0].Length, range.Start);
+            Assert.Equal(range.Start, range.End);
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Moves_Up_From_Mid_Line_To_Next_Line(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var start = peer.GetLineRange(2).Start + 2;
+            var range = new AutomationTextRange(node, start, start + 2);
+
+            var result = range.Move(TextUnit.Line, -1);
+
+            Assert.Equal(-1, result);
+            Assert.Equal(peer.Lines[1], range.GetText(-1));
+        }
+
+        [Theory]
+        [ClassData(typeof(Newlines))]
+        public void Does_Not_Move_Up_From_First_Line(string newline)
+        {
+            var (node, peer) = CreateTestNode(newline);
+            var range = new AutomationTextRange(node, 0, peer.Lines[0].Length);
+
+            var result = range.Move(TextUnit.Line, -1);
+
+            Assert.Equal(0, result);
+            Assert.Equal(peer.Lines[0], range.GetText(-1));
+        }
+    }
+
+    private static (AutomationNode, TestPeer) CreateTestNode(string newline)
+    {
+        var peer = new TestPeer(newline);
+        return (new AutomationNode(peer), peer);
+    }
+
+    private class TestPeer : ControlAutomationPeer, AAP.ITextProvider
+    {
+        private readonly string[] _lines;
+
+        public TestPeer(string newline)
+            : base(new Control())
+        {
+            _lines = new[]
+            {
+                "Test text:" + newline,
+                newline,
+                "Lorem ipsum dolor sit amet, ",
+                "consectetur adipiscing elit, ",
+                "sed do eiusmod tempor incididunt ",
+                "ut labore et dolore magna aliqua." + newline,
+                "🌉Ut enim ad minim veniam, quis ",
+                "nostrud exercitation ullamco ",
+                "laboris nisi ut aliquip ex ea ",
+                "commodo consequat." + newline,
+                "We can't stop now"
+            };
+        }
+
+        public bool IsReadOnly => true;
+        public int CaretIndex => 0;
+        public TextRange DocumentRange => new(0, _lines.Sum(x => x.Length));
+        public IList<string> Lines => _lines;
+        public int LineCount => _lines.Length;
+        public string PlaceholderText => string.Empty;
+        public AAP.SupportedTextSelection SupportedTextSelection { get; }
+        public string Text => string.Concat(_lines);
+
+        public event EventHandler SelectedRangesChanged;
+        public event EventHandler TextChanged;
+
+        public IReadOnlyList<Rect> GetBounds(TextRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int GetLineForIndex(int index)
+        {
+            var i = 0;
+
+            for (var line = 0; line < _lines.Length; ++line)
+            {
+                i += _lines[line].Length;
+                if (index < i)
+                    return line;
+            }
+
+            return -1;
+        }
+
+        public TextRange GetLineRange(int lineIndex)
+        {
+            var start = _lines.Take(lineIndex).Sum(x => x.Length);
+            var end = start + _lines[lineIndex].Length;
+            return new TextRange(start, end);
+        }
+
+        public IReadOnlyList<TextRange> GetSelection()
+        {
+            throw new NotImplementedException();
+        }
+
+        public string GetText(TextRange range)
+        {
+            var text = Text;
+            var end = Math.Min(range.End, text.Length);
+            return text.Substring(range.Start, end - range.Start);
+        }
+
+        public TextRange RangeFromPoint(Point p)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ScrollIntoView(TextRange range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Select(TextRange range)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    private class Newlines : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] { "\r" };
+            yield return new object[] { "\n" };
+            yield return new object[] { "\r\n" };
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/tests/Avalonia.Win32.UnitTests/Avalonia.Win32.UnitTests.csproj
+++ b/tests/Avalonia.Win32.UnitTests/Avalonia.Win32.UnitTests.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <Import Project="..\..\build\UnitTests.NetCore.targets" />
+  <Import Project="..\..\build\UnitTests.NetFX.props" />
+  <Import Project="..\..\build\XUnit.props" />
+  <Import Project="..\..\build\SharedVersion.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Windows\Avalonia.Win32\Avalonia.Win32.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Avalonia.Win32.UnitTests/Avalonia.Win32.UnitTests.csproj
+++ b/tests/Avalonia.Win32.UnitTests/Avalonia.Win32.UnitTests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
     <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <Import Project="..\..\build\UnitTests.NetCore.targets" />
   <Import Project="..\..\build\UnitTests.NetFX.props" />


### PR DESCRIPTION
## What does the pull request do?

Implements the `ITextProvider` automation provider to provide extended information to the operating system about text controls. Currently implemented on `TextBlockAutomationPeer` and `TextBoxAutomationPeer`. 

The `ITextProvider` interface is different to the one in UIA/WPF: the UIA/WPF one goes to great lengths to hide any clue that text is represented as a string of characters, but the macOS text accessibility APIs work purely on indexes into a string. Because of this, the `ITextProvider` here works on character indexes: this is both simpler than the (horrible) UIA API and more flexible.

With this change the OS can read and navigate words/lines/paragraphs etc inside text boxes and text blocks.

There remains a problem when searching for text in macOS where VoiceOver keeps iterating over all of the controls in an application looking for a piece of text, even when we're plainly returning text to it that contains that string. I want to try to fix this before marking the API as ready for review.