### PR TITLE
Added ControlAutomationPeer.FromElement.

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
@@ -31,10 +31,30 @@ namespace Avalonia.Automation.Peers
             return CreatePeerForElement(element);
         }
 
+        /// <summary>
+        /// Gets the <see cref="AutomationPeer"/> for a <see cref="Control"/>, creating it if
+        /// necessary.
+        /// </summary>
+        /// <param name="element">The control.</param>
+        /// <returns>The automation peer.</returns>
+        /// <remarks>
+        /// Despite the name (which comes from the analogous WPF API), this method does not create
+        /// a new peer if one already exists: instead it returns the existing peer.
+        /// </remarks>
         public static AutomationPeer CreatePeerForElement(Control element)
         {
             return element.GetOrCreateAutomationPeer();
         }
+
+        /// <summary>
+        /// Gets an existing <see cref="AutomationPeer"/> for a <see cref="Control"/>.
+        /// </summary>
+        /// <param name="element">The control.</param>
+        /// <returns>The automation peer if already created; otherwise null.</returns>
+        /// <remarks>
+        /// To ensure that a peer is created, use <see cref="CreatePeerForElement(Control)"/>.
+        /// </remarks>
+        public static AutomationPeer? FromElement(Control element) => element.GetAutomationPeer();
 
         protected override void BringIntoViewCore() => Owner.BringIntoView();
 

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -440,6 +440,12 @@ namespace Avalonia.Controls
             return new NoneAutomationPeer(this);
         }
 
+        internal AutomationPeer? GetAutomationPeer()
+        {
+            VerifyAccess();
+            return _automationPeer;
+        }
+
         internal AutomationPeer GetOrCreateAutomationPeer()
         {
             VerifyAccess();


### PR DESCRIPTION
## What does the pull request do?

WPF has two methods for getting a peer from a UIElement:

- [`UIElementAutomationPeer.CreatePeerForElement`](https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.peers.uielementautomationpeer.createpeerforelement?view=windowsdesktop-8.0) which ensures a peer is created
- [`UIElementAutomationPeer.FromElement`](https://learn.microsoft.com/en-us/dotnet/api/system.windows.automation.peers.uielementautomationpeer.fromelement?view=windowsdesktop-8.0) which returns `null` if a peer has not yet been created for the control

We already had `ControlAutomationPeer.CreatePeerForElement` - this PR adds `ControlAutomationPeer.FromElement` like WPF.

Added some XML docs because quite frankly the naming we inherited from WPF sucks.