### PR TITLE
Event Renaming (Removing Type Prefix)

### DIFF
--- a/samples/ControlCatalog/Pages/ContextMenuPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/ContextMenuPage.xaml.cs
@@ -19,8 +19,8 @@ namespace ControlCatalog.Pages
             customContextRequestedBorder.AddHandler(ContextRequestedEvent, CustomContextRequested, RoutingStrategies.Tunnel);
 
             var cancellableContextBorder = this.Get<Border>("CancellableContextBorder");
-            cancellableContextBorder.ContextMenu!.ContextMenuClosing += ContextFlyoutPage_Closing;
-            cancellableContextBorder.ContextMenu!.ContextMenuOpening += ContextFlyoutPage_Opening;
+            cancellableContextBorder.ContextMenu!.Closing += ContextFlyoutPage_Closing;
+            cancellableContextBorder.ContextMenu!.Opening += ContextFlyoutPage_Opening;
         }
 
         private ContextPageViewModel? _model;

--- a/src/Avalonia.Base/Input/AccessKeyHandler.cs
+++ b/src/Avalonia.Base/Input/AccessKeyHandler.cs
@@ -65,14 +65,14 @@ namespace Avalonia.Input
             {
                 if (_mainMenu != null)
                 {
-                    _mainMenu.MenuClosed -= MainMenuClosed;
+                    _mainMenu.Closed -= MainMenuClosed;
                 }
 
                 _mainMenu = value;
 
                 if (_mainMenu != null)
                 {
-                    _mainMenu.MenuClosed += MainMenuClosed;
+                    _mainMenu.Closed += MainMenuClosed;
                 }
             }
         }

--- a/src/Avalonia.Base/Input/IMainMenu.cs
+++ b/src/Avalonia.Base/Input/IMainMenu.cs
@@ -26,6 +26,6 @@ namespace Avalonia.Input
         /// <summary>
         /// Occurs when the main menu closes.
         /// </summary>
-        event EventHandler<RoutedEventArgs>? MenuClosed;
+        event EventHandler<RoutedEventArgs>? Closed;
     }
 }

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -353,7 +353,7 @@ namespace Avalonia.Controls
 
             RaiseEvent(new RoutedEventArgs
             {
-                RoutedEvent = MenuOpenedEvent,
+                RoutedEvent = OpenedEvent,
                 Source = this,
             });
         }
@@ -394,7 +394,7 @@ namespace Avalonia.Controls
 
             RaiseEvent(new RoutedEventArgs
             {
-                RoutedEvent = MenuClosedEvent,
+                RoutedEvent = ClosedEvent,
                 Source = this,
             });
             

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -196,14 +196,14 @@ namespace Avalonia.Controls
         /// <see cref="P:Avalonia.Controls.ContextMenu.IsOpen" />
         /// property is changing from false to true.
         /// </summary>
-        public event CancelEventHandler? ContextMenuOpening;
+        public event CancelEventHandler? Opening;
 
         /// <summary>
         /// Occurs when the value of the
         /// <see cref="P:Avalonia.Controls.ContextMenu.IsOpen" />
         /// property is changing from true to false.
         /// </summary>
-        public event CancelEventHandler? ContextMenuClosing;
+        public event CancelEventHandler? Closing;
 
         /// <summary>
         /// Called when the <see cref="Control.ContextMenu"/> property changes on a control.
@@ -446,14 +446,14 @@ namespace Avalonia.Controls
         private bool CancelClosing()
         {
             var eventArgs = new CancelEventArgs();
-            ContextMenuClosing?.Invoke(this, eventArgs);
+            Closing?.Invoke(this, eventArgs);
             return eventArgs.Cancel;
         }
 
         private bool CancelOpening()
         {
             var eventArgs = new CancelEventArgs();
-            ContextMenuOpening?.Invoke(this, eventArgs);
+            Opening?.Invoke(this, eventArgs);
             return eventArgs.Cancel;
         }
     }

--- a/src/Avalonia.Controls/Menu.cs
+++ b/src/Avalonia.Controls/Menu.cs
@@ -60,7 +60,7 @@ namespace Avalonia.Controls
 
             RaiseEvent(new RoutedEventArgs
             {
-                RoutedEvent = MenuClosedEvent,
+                RoutedEvent = ClosedEvent,
                 Source = this,
             });
         }
@@ -77,7 +77,7 @@ namespace Avalonia.Controls
 
             RaiseEvent(new RoutedEventArgs
             {
-                RoutedEvent = MenuOpenedEvent,
+                RoutedEvent = OpenedEvent,
                 Source = this,
             });
         }

--- a/src/Avalonia.Controls/MenuBase.cs
+++ b/src/Avalonia.Controls/MenuBase.cs
@@ -25,16 +25,16 @@ namespace Avalonia.Controls
                 o => o.IsOpen);
 
         /// <summary>
-        /// Defines the <see cref="MenuOpened"/> event.
+        /// Defines the <see cref="Opened"/> event.
         /// </summary>
-        public static readonly RoutedEvent<RoutedEventArgs> MenuOpenedEvent =
-            RoutedEvent.Register<MenuBase, RoutedEventArgs>(nameof(MenuOpened), RoutingStrategies.Bubble);
+        public static readonly RoutedEvent<RoutedEventArgs> OpenedEvent =
+            RoutedEvent.Register<MenuBase, RoutedEventArgs>(nameof(Opened), RoutingStrategies.Bubble);
 
         /// <summary>
-        /// Defines the <see cref="MenuClosed"/> event.
+        /// Defines the <see cref="Closed"/> event.
         /// </summary>
-        public static readonly RoutedEvent<RoutedEventArgs> MenuClosedEvent =
-            RoutedEvent.Register<MenuBase, RoutedEventArgs>(nameof(MenuClosed), RoutingStrategies.Bubble);
+        public static readonly RoutedEvent<RoutedEventArgs> ClosedEvent =
+            RoutedEvent.Register<MenuBase, RoutedEventArgs>(nameof(Closed), RoutingStrategies.Bubble);
 
         private bool _isOpen;
 
@@ -68,8 +68,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool IsOpen
         {
-            get { return _isOpen; }
-            protected set { SetAndRaise(IsOpenProperty, ref _isOpen, value); }
+            get => _isOpen;
+            protected set => SetAndRaise(IsOpenProperty, ref _isOpen, value);
         }
 
         /// <inheritdoc/>
@@ -105,19 +105,19 @@ namespace Avalonia.Controls
         /// <summary>
         /// Occurs when a <see cref="Menu"/> is opened.
         /// </summary>
-        public event EventHandler<RoutedEventArgs>? MenuOpened
+        public event EventHandler<RoutedEventArgs>? Opened
         {
-            add { AddHandler(MenuOpenedEvent, value); }
-            remove { RemoveHandler(MenuOpenedEvent, value); }
+            add => AddHandler(OpenedEvent, value);
+            remove => RemoveHandler(OpenedEvent, value);
         }
 
         /// <summary>
         /// Occurs when a <see cref="Menu"/> is closed.
         /// </summary>
-        public event EventHandler<RoutedEventArgs>? MenuClosed
+        public event EventHandler<RoutedEventArgs>? Closed
         {
-            add { AddHandler(MenuClosedEvent, value); }
-            remove { RemoveHandler(MenuClosedEvent, value); }
+            add => AddHandler(ClosedEvent, value);
+            remove => RemoveHandler(ClosedEvent, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -290,7 +290,7 @@ namespace Avalonia.Controls.Platform
             Menu.PointerPressed += PointerPressed;
             Menu.PointerReleased += PointerReleased;
             Menu.AddHandler(AccessKeyHandler.AccessKeyPressedEvent, AccessKeyPressed);
-            Menu.AddHandler(MenuBase.MenuOpenedEvent, MenuOpened);
+            Menu.AddHandler(MenuBase.OpenedEvent, MenuOpened);
             Menu.AddHandler(MenuItem.PointerEnteredItemEvent, PointerEntered);
             Menu.AddHandler(MenuItem.PointerExitedItemEvent, PointerExited);
             Menu.AddHandler(InputElement.PointerMovedEvent, PointerMoved);
@@ -326,7 +326,7 @@ namespace Avalonia.Controls.Platform
             Menu.PointerPressed -= PointerPressed;
             Menu.PointerReleased -= PointerReleased;
             Menu.RemoveHandler(AccessKeyHandler.AccessKeyPressedEvent, AccessKeyPressed);
-            Menu.RemoveHandler(MenuBase.MenuOpenedEvent, MenuOpened);
+            Menu.RemoveHandler(MenuBase.OpenedEvent, MenuOpened);
             Menu.RemoveHandler(MenuItem.PointerEnteredItemEvent, PointerEntered);
             Menu.RemoveHandler(MenuItem.PointerExitedItemEvent, PointerExited);
             Menu.RemoveHandler(InputElement.PointerMovedEvent, PointerMoved);

--- a/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
@@ -258,7 +258,7 @@ namespace Avalonia.Controls.UnitTests
                 var tracker = 0;
 
                 var c = new ContextMenu();
-                c.ContextMenuClosing += (s, e) =>
+                c.Closing += (s, e) =>
                 {
                     tracker++;
                     e.Cancel = true;
@@ -430,7 +430,7 @@ namespace Avalonia.Controls.UnitTests
                 };
                 new Window { Content = target };
 
-                sut.ContextMenuOpening += (c, e) => { eventCalled = true; e.Cancel = true; };
+                sut.Opening += (c, e) => { eventCalled = true; e.Cancel = true; };
 
                 _mouse.Click(target, MouseButton.Right);
 
@@ -574,7 +574,7 @@ namespace Avalonia.Controls.UnitTests
                 var window = PreparedWindow(target);
                 var overlay = LightDismissOverlayLayer.GetLightDismissOverlayLayer(window);
 
-                sut.ContextMenuClosing += (c, e) => { eventCalled = true; e.Cancel = true; };
+                sut.Closing += (c, e) => { eventCalled = true; e.Cancel = true; };
 
                 window.Show();
 

--- a/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ContextMenuTests.cs
@@ -35,7 +35,7 @@ namespace Avalonia.Controls.UnitTests
 
                 int openedCount = 0;
 
-                sut.MenuOpened += (sender, args) =>
+                sut.Opened += (sender, args) =>
                 {
                     openedCount++;
                 };
@@ -138,7 +138,7 @@ namespace Avalonia.Controls.UnitTests
 
                 int openedCount = 0;
 
-                sut.MenuOpened += (sender, args) =>
+                sut.Opened += (sender, args) =>
                 {
                     openedCount++;
                 };
@@ -167,7 +167,7 @@ namespace Avalonia.Controls.UnitTests
 
                 bool opened = false;
 
-                sut.MenuOpened += (sender, args) =>
+                sut.Opened += (sender, args) =>
                 {
                     opened = true;
                 };
@@ -220,7 +220,7 @@ namespace Avalonia.Controls.UnitTests
 
                 int closedCount = 0;
 
-                sut.MenuClosed += (sender, args) =>
+                sut.Closed += (sender, args) =>
                 {
                     closedCount++;
                 };


### PR DESCRIPTION
## What does the pull request do?

Standardizes event naming by removing the type prefix. See the full analysis in the issue #10663 [here](https://github.com/AvaloniaUI/Avalonia/issues/10663#issuecomment-1566191217).

## What is the current behavior?

Events are improperly named and don't follow WPF/WinUI.

## What is the updated/expected behavior with this PR?

Events are properly named removing the type prefix and follow WPF/WinUI where possible.

## How was the solution implemented (if it's not obvious)?

Obvious

## Checklist

- ~[ ] Added unit tests (if possible)?~
- ~[ ] Added XML documentation to any related classes?~
- ~[ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation~

## Breaking changes

Yes, event names have changed which will break compilation.

 * `ContextMenu`
    * `ContextMenuClosing` -> `Closing`
    * `ContextMenuOpening` -> `Opening`
 * `MenuBase`
    * `MenuClosed` -> `Closed`
    * `MenuOpened` -> `Opened`

## Obsoletions / Deprecations

None

## Fixed issues

Closes #10663 
