### PR TITLE
ProgressBar refactoring/cleanup.

### DIFF
--- a/src/Avalonia.Controls/ProgressBar.cs
+++ b/src/Avalonia.Controls/ProgressBar.cs
@@ -31,6 +31,8 @@ namespace Avalonia.Controls
             private double _containerAnimationEndPosition;
             private double _container2AnimationStartPosition;
             private double _container2AnimationEndPosition;
+            private double _indeterminateStartingOffset;
+            private double _indeterminateEndingOffset;
 
             /// <summary>
             /// Defines the <see cref="ContainerAnimationStartPosition"/> property.
@@ -93,14 +95,20 @@ namespace Avalonia.Controls
             /// <summary>
             /// Defines the <see cref="IndeterminateStartingOffset"/> property.
             /// </summary>
-            public static readonly StyledProperty<double> IndeterminateStartingOffsetProperty =
-                AvaloniaProperty.Register<ProgressBarTemplateSettings, double>(nameof(IndeterminateStartingOffset));
-
+            public static readonly DirectProperty<ProgressBarTemplateSettings, double> IndeterminateStartingOffsetProperty =
+                AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
+                    nameof(IndeterminateStartingOffset),
+                    p => p.IndeterminateStartingOffset,
+                    (p, o) => p.IndeterminateStartingOffset = o);
+            
             /// <summary>
             /// Defines the <see cref="IndeterminateEndingOffset"/> property.
             /// </summary>
-            public static readonly StyledProperty<double> IndeterminateEndingOffsetProperty =
-                AvaloniaProperty.Register<ProgressBarTemplateSettings, double>(nameof(IndeterminateEndingOffset));
+            public static readonly DirectProperty<ProgressBarTemplateSettings, double> IndeterminateEndingOffsetProperty =
+                AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
+                    nameof(IndeterminateEndingOffset),
+                    p => p.IndeterminateEndingOffset,
+                    (p, o) => p.IndeterminateEndingOffset = o);
 
             /// <summary>
             /// Used by <see cref="Avalonia.Themes.Fluent"/> to define the first indeterminate indicator's width.
@@ -163,17 +171,17 @@ namespace Avalonia.Controls
             /// </summary>
             public double IndeterminateStartingOffset
             {
-                get => GetValue(IndeterminateStartingOffsetProperty);
-                set => SetValue(IndeterminateStartingOffsetProperty, value);
+                get => _indeterminateStartingOffset;
+                set => SetAndRaise(IndeterminateStartingOffsetProperty, ref _indeterminateStartingOffset, value);
             }
-
+            
             /// <summary>
             /// Used by <see cref="Avalonia.Themes.Simple"/> to define the ending point of its indeterminate animation.
             /// </summary>
             public double IndeterminateEndingOffset
             {
-                get => GetValue(IndeterminateEndingOffsetProperty);
-                set => SetValue(IndeterminateEndingOffsetProperty, value);
+                get => _indeterminateEndingOffset;
+                set => SetAndRaise(IndeterminateEndingOffsetProperty, ref _indeterminateEndingOffset, value);
             }
         }
 

--- a/src/Avalonia.Controls/ProgressBar.cs
+++ b/src/Avalonia.Controls/ProgressBar.cs
@@ -32,29 +32,33 @@ namespace Avalonia.Controls
             private double _container2AnimationStartPosition;
             private double _container2AnimationEndPosition;
 
-            public static readonly DirectProperty<ProgressBarTemplateSettings, double> ContainerAnimationStartPositionProperty =
-           AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
-               nameof(ContainerAnimationStartPosition),
-               p => p.ContainerAnimationStartPosition,
-               (p, o) => p.ContainerAnimationStartPosition = o, 0d);
+            public static readonly DirectProperty<ProgressBarTemplateSettings, double>
+                ContainerAnimationStartPositionProperty =
+                    AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
+                        nameof(ContainerAnimationStartPosition),
+                        p => p.ContainerAnimationStartPosition,
+                        (p, o) => p.ContainerAnimationStartPosition = o);
 
-            public static readonly DirectProperty<ProgressBarTemplateSettings, double> ContainerAnimationEndPositionProperty =
-                AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
-                    nameof(ContainerAnimationEndPosition),
-                    p => p.ContainerAnimationEndPosition,
-                    (p, o) => p.ContainerAnimationEndPosition = o, 0d);
+            public static readonly DirectProperty<ProgressBarTemplateSettings, double>
+                ContainerAnimationEndPositionProperty =
+                    AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
+                        nameof(ContainerAnimationEndPosition),
+                        p => p.ContainerAnimationEndPosition,
+                        (p, o) => p.ContainerAnimationEndPosition = o);
 
-            public static readonly DirectProperty<ProgressBarTemplateSettings, double> Container2AnimationStartPositionProperty =
-                AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
-                    nameof(Container2AnimationStartPosition),
-                    p => p.Container2AnimationStartPosition,
-                    (p, o) => p.Container2AnimationStartPosition = o, 0d);
+            public static readonly DirectProperty<ProgressBarTemplateSettings, double>
+                Container2AnimationStartPositionProperty =
+                    AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
+                        nameof(Container2AnimationStartPosition),
+                        p => p.Container2AnimationStartPosition,
+                        (p, o) => p.Container2AnimationStartPosition = o);
 
-            public static readonly DirectProperty<ProgressBarTemplateSettings, double> Container2AnimationEndPositionProperty =
-                AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
-                    nameof(Container2AnimationEndPosition),
-                    p => p.Container2AnimationEndPosition,
-                    (p, o) => p.Container2AnimationEndPosition = o);
+            public static readonly DirectProperty<ProgressBarTemplateSettings, double>
+                Container2AnimationEndPositionProperty =
+                    AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
+                        nameof(Container2AnimationEndPosition),
+                        p => p.Container2AnimationEndPosition,
+                        (p, o) => p.Container2AnimationEndPosition = o);
 
             public static readonly DirectProperty<ProgressBarTemplateSettings, double> Container2WidthProperty =
                 AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
@@ -68,10 +72,17 @@ namespace Avalonia.Controls
                     p => p.ContainerWidth,
                     (p, o) => p.ContainerWidth = o);
 
+            public static readonly StyledProperty<double> IndeterminateStartingOffsetProperty =
+                AvaloniaProperty.Register<ProgressBarTemplateSettings, double>(nameof(IndeterminateStartingOffset));
+
+            public static readonly StyledProperty<double> IndeterminateEndingOffsetProperty =
+                AvaloniaProperty.Register<ProgressBarTemplateSettings, double>(nameof(IndeterminateEndingOffset));
+
             public double ContainerAnimationStartPosition
             {
                 get => _containerAnimationStartPosition;
-                set => SetAndRaise(ContainerAnimationStartPositionProperty, ref _containerAnimationStartPosition, value);
+                set => SetAndRaise(ContainerAnimationStartPositionProperty, ref _containerAnimationStartPosition,
+                    value);
             }
 
             public double ContainerAnimationEndPosition
@@ -83,7 +94,8 @@ namespace Avalonia.Controls
             public double Container2AnimationStartPosition
             {
                 get => _container2AnimationStartPosition;
-                set => SetAndRaise(Container2AnimationStartPositionProperty, ref _container2AnimationStartPosition, value);
+                set => SetAndRaise(Container2AnimationStartPositionProperty, ref _container2AnimationStartPosition,
+                    value);
             }
 
             public double Container2Width
@@ -102,6 +114,18 @@ namespace Avalonia.Controls
             {
                 get => _container2AnimationEndPosition;
                 set => SetAndRaise(Container2AnimationEndPositionProperty, ref _container2AnimationEndPosition, value);
+            }
+
+            public double IndeterminateStartingOffset
+            {
+                get => GetValue(IndeterminateStartingOffsetProperty);
+                set => SetValue(IndeterminateStartingOffsetProperty, value);
+            }
+
+            public double IndeterminateEndingOffset
+            {
+                get => GetValue(IndeterminateEndingOffsetProperty);
+                set => SetValue(IndeterminateEndingOffsetProperty, value);
             }
         }
 
@@ -131,7 +155,7 @@ namespace Avalonia.Controls
         /// Defines the <see cref="Orientation"/> property.
         /// </summary>
         public static readonly StyledProperty<Orientation> OrientationProperty =
-            AvaloniaProperty.Register<ProgressBar, Orientation>(nameof(Orientation), Orientation.Horizontal);
+            AvaloniaProperty.Register<ProgressBar, Orientation>(nameof(Orientation));
 
         /// <summary>
         /// Defines the <see cref="Percentage"/> property.
@@ -140,18 +164,6 @@ namespace Avalonia.Controls
             AvaloniaProperty.RegisterDirect<ProgressBar, double>(
                 nameof(Percentage),
                 o => o.Percentage);
-
-        /// <summary>
-        /// Defines the <see cref="IndeterminateStartingOffset"/> property.
-        /// </summary>
-        public static readonly StyledProperty<double> IndeterminateStartingOffsetProperty =
-            AvaloniaProperty.Register<ProgressBar, double>(nameof(IndeterminateStartingOffset));
-
-        /// <summary>
-        /// Defines the <see cref="IndeterminateEndingOffset"/> property.
-        /// </summary>
-        public static readonly StyledProperty<double> IndeterminateEndingOffsetProperty =
-            AvaloniaProperty.Register<ProgressBar, double>(nameof(IndeterminateEndingOffset));
 
         /// <summary>
         /// Gets the overall percentage complete of the progress 
@@ -166,26 +178,14 @@ namespace Avalonia.Controls
             private set { SetAndRaise(PercentageProperty, ref _percentage, value); }
         }
 
-        public double IndeterminateStartingOffset
-        {
-            get => GetValue(IndeterminateStartingOffsetProperty);
-            set => SetValue(IndeterminateStartingOffsetProperty, value);
-        }
-
-        public double IndeterminateEndingOffset
-        {
-            get => GetValue(IndeterminateEndingOffsetProperty);
-            set => SetValue(IndeterminateEndingOffsetProperty, value);
-        }
-
         static ProgressBar()
         {
             ValueProperty.OverrideMetadata<ProgressBar>(new(defaultBindingMode: BindingMode.OneWay));
-            ValueProperty.Changed.AddClassHandler<ProgressBar>((x, e) => x.UpdateIndicatorWhenPropChanged(e));
-            MinimumProperty.Changed.AddClassHandler<ProgressBar>((x, e) => x.UpdateIndicatorWhenPropChanged(e));
-            MaximumProperty.Changed.AddClassHandler<ProgressBar>((x, e) => x.UpdateIndicatorWhenPropChanged(e));
-            IsIndeterminateProperty.Changed.AddClassHandler<ProgressBar>((x, e) => x.UpdateIndicatorWhenPropChanged(e));
-            OrientationProperty.Changed.AddClassHandler<ProgressBar>((x, e) => x.UpdateIndicatorWhenPropChanged(e));
+            ValueProperty.Changed.AddClassHandler<ProgressBar>((x, _) => x.UpdateIndicatorWhenPropChanged());
+            MinimumProperty.Changed.AddClassHandler<ProgressBar>((x, _) => x.UpdateIndicatorWhenPropChanged());
+            MaximumProperty.Changed.AddClassHandler<ProgressBar>((x, _) => x.UpdateIndicatorWhenPropChanged());
+            IsIndeterminateProperty.Changed.AddClassHandler<ProgressBar>((x, _) => x.UpdateIndicatorWhenPropChanged());
+            OrientationProperty.Changed.AddClassHandler<ProgressBar>((x, _) => x.UpdateIndicatorWhenPropChanged());
         }
 
         /// <summary>
@@ -305,22 +305,14 @@ namespace Avalonia.Controls
                     TemplateSettings.Container2AnimationStartPosition = barIndicatorWidth2 * -1.5; // Position at -150%
                     TemplateSettings.Container2AnimationEndPosition = barIndicatorWidth2 * 1.66; // Position at 166%
 
-                    // Remove these properties when we switch to fluent as default and removed the old one.
-                    SetCurrentValue(IndeterminateStartingOffsetProperty,-dim);
-                    SetCurrentValue(IndeterminateEndingOffsetProperty,dim);
-
-                    var padding = Padding;
-                    var rectangle = new RectangleGeometry(
-                        new Rect(
-                            padding.Left,
-                            padding.Top,
-                            barSize.Width - (padding.Right + padding.Left),
-                            barSize.Height - (padding.Bottom + padding.Top)
-                            ));
+                    TemplateSettings.IndeterminateStartingOffset = -dim;  
+                    TemplateSettings.IndeterminateEndingOffset = dim;
                 }
                 else
                 {
-                    double percent = Maximum == Minimum ? 1.0 : (Value - Minimum) / (Maximum - Minimum);
+                    var percent = Math.Abs(Maximum - Minimum) < double.Epsilon ?
+                        1.0 :
+                        (Value - Minimum) / (Maximum - Minimum);
 
                     // When the Orientation changed, the indicator's Width or Height should set to double.NaN.
                     // Indicator size calculation should consider the ProgressBar's Padding property setting
@@ -332,7 +324,8 @@ namespace Avalonia.Controls
                     else
                     {
                         _indicator.Width = double.NaN;
-                        _indicator.Height = (barSize.Height - _indicator.Margin.Top - _indicator.Margin.Bottom) * percent;
+                        _indicator.Height = (barSize.Height - _indicator.Margin.Top - _indicator.Margin.Bottom) *
+                                            percent;
                     }
 
 
@@ -341,7 +334,7 @@ namespace Avalonia.Controls
             }
         }
 
-        private void UpdateIndicatorWhenPropChanged(AvaloniaPropertyChangedEventArgs e)
+        private void UpdateIndicatorWhenPropChanged()
         {
             UpdateIndicator();
         }
@@ -355,11 +348,9 @@ namespace Avalonia.Controls
                 PseudoClasses.Set(":indeterminate", isIndeterminate.Value);
             }
 
-            if (o.HasValue)
-            {
-                PseudoClasses.Set(":vertical", o == Orientation.Vertical);
-                PseudoClasses.Set(":horizontal", o == Orientation.Horizontal);
-            }
+            if (!o.HasValue) return;
+            PseudoClasses.Set(":vertical", o == Orientation.Vertical);
+            PseudoClasses.Set(":horizontal", o == Orientation.Horizontal);
         }
     }
 }

--- a/src/Avalonia.Controls/ProgressBar.cs
+++ b/src/Avalonia.Controls/ProgressBar.cs
@@ -32,6 +32,9 @@ namespace Avalonia.Controls
             private double _container2AnimationStartPosition;
             private double _container2AnimationEndPosition;
 
+            /// <summary>
+            /// Defines the <see cref="ContainerAnimationStartPosition"/> property.
+            /// </summary>
             public static readonly DirectProperty<ProgressBarTemplateSettings, double>
                 ContainerAnimationStartPositionProperty =
                     AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
@@ -39,6 +42,9 @@ namespace Avalonia.Controls
                         p => p.ContainerAnimationStartPosition,
                         (p, o) => p.ContainerAnimationStartPosition = o);
 
+            /// <summary>
+            /// Defines the <see cref="ContainerAnimationEndPosition"/> property.
+            /// </summary>
             public static readonly DirectProperty<ProgressBarTemplateSettings, double>
                 ContainerAnimationEndPositionProperty =
                     AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
@@ -46,6 +52,9 @@ namespace Avalonia.Controls
                         p => p.ContainerAnimationEndPosition,
                         (p, o) => p.ContainerAnimationEndPosition = o);
 
+            /// <summary>
+            /// Defines the <see cref="Container2AnimationStartPosition"/> property.
+            /// </summary>
             public static readonly DirectProperty<ProgressBarTemplateSettings, double>
                 Container2AnimationStartPositionProperty =
                     AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
@@ -53,6 +62,9 @@ namespace Avalonia.Controls
                         p => p.Container2AnimationStartPosition,
                         (p, o) => p.Container2AnimationStartPosition = o);
 
+            /// <summary>
+            /// Defines the <see cref="Container2AnimationEndPosition"/> property.
+            /// </summary>
             public static readonly DirectProperty<ProgressBarTemplateSettings, double>
                 Container2AnimationEndPositionProperty =
                     AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
@@ -60,24 +72,57 @@ namespace Avalonia.Controls
                         p => p.Container2AnimationEndPosition,
                         (p, o) => p.Container2AnimationEndPosition = o);
 
+            /// <summary>
+            /// Defines the <see cref="Container2Width"/> property.
+            /// </summary>
             public static readonly DirectProperty<ProgressBarTemplateSettings, double> Container2WidthProperty =
                 AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
                     nameof(Container2Width),
                     p => p.Container2Width,
                     (p, o) => p.Container2Width = o);
 
+            /// <summary>
+            /// Defines the <see cref="ContainerWidth"/> property.
+            /// </summary>
             public static readonly DirectProperty<ProgressBarTemplateSettings, double> ContainerWidthProperty =
                 AvaloniaProperty.RegisterDirect<ProgressBarTemplateSettings, double>(
                     nameof(ContainerWidth),
                     p => p.ContainerWidth,
                     (p, o) => p.ContainerWidth = o);
 
+            /// <summary>
+            /// Defines the <see cref="IndeterminateStartingOffset"/> property.
+            /// </summary>
             public static readonly StyledProperty<double> IndeterminateStartingOffsetProperty =
                 AvaloniaProperty.Register<ProgressBarTemplateSettings, double>(nameof(IndeterminateStartingOffset));
 
+            /// <summary>
+            /// Defines the <see cref="IndeterminateEndingOffset"/> property.
+            /// </summary>
             public static readonly StyledProperty<double> IndeterminateEndingOffsetProperty =
                 AvaloniaProperty.Register<ProgressBarTemplateSettings, double>(nameof(IndeterminateEndingOffset));
 
+            /// <summary>
+            /// Used by <see cref="Avalonia.Themes.Fluent"/> to define the first indeterminate indicator's width.
+            /// </summary>
+            public double ContainerWidth
+            {
+                get => _containerWidth;
+                set => SetAndRaise(ContainerWidthProperty, ref _containerWidth, value);
+            }
+            
+            /// <summary>
+            /// Used by <see cref="Avalonia.Themes.Fluent"/> to define the second indeterminate indicator's width.
+            /// </summary>
+            public double Container2Width
+            {
+                get => _container2Width;
+                set => SetAndRaise(Container2WidthProperty, ref _container2Width, value);
+            }
+
+            /// <summary>
+            /// Used by <see cref="Avalonia.Themes.Fluent"/> to define the first indeterminate indicator's start position when animated.
+            /// </summary>
             public double ContainerAnimationStartPosition
             {
                 get => _containerAnimationStartPosition;
@@ -85,43 +130,46 @@ namespace Avalonia.Controls
                     value);
             }
 
+            /// <summary>
+            /// Used by <see cref="Avalonia.Themes.Fluent"/> to define the first indeterminate indicator's end position when animated.
+            /// </summary>
             public double ContainerAnimationEndPosition
             {
                 get => _containerAnimationEndPosition;
                 set => SetAndRaise(ContainerAnimationEndPositionProperty, ref _containerAnimationEndPosition, value);
             }
 
+            /// <summary>
+            /// Used by <see cref="Avalonia.Themes.Fluent"/> to define the second indeterminate indicator's start position when animated.
+            /// </summary>
             public double Container2AnimationStartPosition
             {
                 get => _container2AnimationStartPosition;
                 set => SetAndRaise(Container2AnimationStartPositionProperty, ref _container2AnimationStartPosition,
                     value);
             }
-
-            public double Container2Width
-            {
-                get => _container2Width;
-                set => SetAndRaise(Container2WidthProperty, ref _container2Width, value);
-            }
-
-            public double ContainerWidth
-            {
-                get => _containerWidth;
-                set => SetAndRaise(ContainerWidthProperty, ref _containerWidth, value);
-            }
-
+            
+            /// <summary>
+            /// Used by <see cref="Avalonia.Themes.Fluent"/> to define the second indeterminate indicator's end position when animated.
+            /// </summary>
             public double Container2AnimationEndPosition
             {
                 get => _container2AnimationEndPosition;
                 set => SetAndRaise(Container2AnimationEndPositionProperty, ref _container2AnimationEndPosition, value);
             }
 
+            /// <summary>
+            /// Used by <see cref="Avalonia.Themes.Simple"/>  to define the starting point of its indeterminate animation.
+            /// </summary>
             public double IndeterminateStartingOffset
             {
                 get => GetValue(IndeterminateStartingOffsetProperty);
                 set => SetValue(IndeterminateStartingOffsetProperty, value);
             }
 
+            /// <summary>
+            /// Used by <see cref="Avalonia.Themes.Simple"/> to define the ending point of its indeterminate animation.
+            /// </summary>
             public double IndeterminateEndingOffset
             {
                 get => GetValue(IndeterminateEndingOffsetProperty);

--- a/src/Avalonia.Themes.Simple/Controls/ProgressBar.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ProgressBar.xaml
@@ -87,10 +87,10 @@
                    IterationCount="Infinite"
                    Duration="0:0:3">
           <KeyFrame Cue="0%">
-            <Setter Property="TranslateTransform.X" Value="{Binding IndeterminateStartingOffset, RelativeSource={RelativeSource TemplatedParent}}" />
+            <Setter Property="TranslateTransform.X" Value="{Binding $parent[ProgressBar].TemplateSettings.IndeterminateStartingOffset}" />
           </KeyFrame>
           <KeyFrame Cue="100%">
-            <Setter Property="TranslateTransform.X" Value="{Binding IndeterminateEndingOffset, RelativeSource={RelativeSource TemplatedParent}}" />
+            <Setter Property="TranslateTransform.X" Value="{Binding $parent[ProgressBar].TemplateSettings.IndeterminateEndingOffset}" />
           </KeyFrame>
         </Animation>
       </Style.Animations>
@@ -102,10 +102,10 @@
                    IterationCount="Infinite"
                    Duration="0:0:3">
           <KeyFrame Cue="0%">
-            <Setter Property="TranslateTransform.Y" Value="{Binding IndeterminateStartingOffset, RelativeSource={RelativeSource TemplatedParent}}" />
+            <Setter Property="TranslateTransform.Y" Value="{Binding $parent[ProgressBar].TemplateSettings.IndeterminateStartingOffset}" />
           </KeyFrame>
           <KeyFrame Cue="100%">
-            <Setter Property="TranslateTransform.Y" Value="{Binding IndeterminateEndingOffset, RelativeSource={RelativeSource TemplatedParent}}" />
+            <Setter Property="TranslateTransform.Y" Value="{Binding $parent[ProgressBar].TemplateSettings.IndeterminateEndingOffset}" />
           </KeyFrame>
         </Animation>
       </Style.Animations>


### PR DESCRIPTION
This could've been a bit more involved (removing the TemplateSettings and other stuff) but in the end, me and @grokys decided it was a bit too much and too big of a change for now.

This PR moves IndeterminateStarting/EndingOffset property used by the simple theme to TemplateSettings. Also fixed some warnings in ProgressBar.cs.