### PR TITLE
Return PlatformSettings API after being previously hidden

### DIFF
--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -182,7 +182,7 @@ namespace Avalonia.Input
                     s_lastPressPoint = e.GetPosition((Visual)ev.Source);
                     s_holdCancellationToken = new CancellationTokenSource();
                     var token = s_holdCancellationToken.Token;
-                    var settings = AvaloniaLocator.Current.GetService<IPlatformSettings>();
+                    var settings = ((IInputRoot?)visual.GetVisualRoot())?.PlatformSettings;
 
                     if (settings != null)
                     {
@@ -221,7 +221,7 @@ namespace Avalonia.Input
                     e.Source is Interactive i)
                 {
                     var point = e.GetCurrentPoint((Visual)target);
-                    var settings = AvaloniaLocator.Current.GetService<IPlatformSettings>();
+                    var settings = ((IInputRoot?)i.GetVisualRoot())?.PlatformSettings;
                     var tapSize = settings?.GetTapSize(point.Pointer.Type) ?? new Size(4, 4);
                     var tapRect = new Rect(s_lastPressPoint, new Size())
                         .Inflate(new Thickness(tapSize.Width, tapSize.Height));
@@ -260,10 +260,10 @@ namespace Avalonia.Input
                 var e = (PointerEventArgs)ev;
                 if (s_lastPress.TryGetTarget(out var target))
                 {
-                    if (e.Pointer == s_lastPointer)
+                    if (e.Pointer == s_lastPointer && ev.Source is Interactive i)
                     {
                         var point = e.GetCurrentPoint((Visual)target);
-                        var settings = AvaloniaLocator.Current.GetService<IPlatformSettings>();
+                        var settings = ((IInputRoot?)i.GetVisualRoot())?.PlatformSettings;
                         var tapSize = settings?.GetTapSize(point.Pointer.Type) ?? new Size(4, 4);
                         var tapRect = new Rect(s_lastPressPoint, new Size())
                             .Inflate(new Thickness(tapSize.Width, tapSize.Height));
@@ -273,7 +273,7 @@ namespace Avalonia.Input
                             return;
                         }
 
-                        if (s_isHolding && ev.Source is Interactive i)
+                        if (s_isHolding)
                         {
                             i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_lastPointer!.Type));
                         }

--- a/src/Avalonia.Base/Input/IInputRoot.cs
+++ b/src/Avalonia.Base/Input/IInputRoot.cs
@@ -1,4 +1,5 @@
 using Avalonia.Metadata;
+using Avalonia.Platform;
 
 namespace Avalonia.Input
 {
@@ -17,9 +18,17 @@ namespace Avalonia.Input
         /// Gets focus manager of the root.
         /// </summary>
         /// <remarks>
-        /// Focus manager can be null only if application wasn't initialized yet.
+        /// Focus manager can be null only if window wasn't initialized yet.
         /// </remarks>
         IFocusManager? FocusManager { get; }
+        
+        /// <summary>
+        /// Represents a contract for accessing platform-specific settings and information.
+        /// </summary>
+        /// <remarks>
+        /// Focus manager can be null only if window wasn't initialized yet.
+        /// </remarks>
+        IPlatformSettings? PlatformSettings { get; }
         
         /// <summary>
         /// Gets or sets the input element that the pointer is currently over.

--- a/src/Avalonia.Base/Input/IInputRoot.cs
+++ b/src/Avalonia.Base/Input/IInputRoot.cs
@@ -26,7 +26,7 @@ namespace Avalonia.Input
         /// Represents a contract for accessing platform-specific settings and information.
         /// </summary>
         /// <remarks>
-        /// Focus manager can be null only if window wasn't initialized yet.
+        /// PlatformSettings can be null only if window wasn't initialized yet.
         /// </remarks>
         IPlatformSettings? PlatformSettings { get; }
         

--- a/src/Avalonia.Base/Input/IInputRoot.cs
+++ b/src/Avalonia.Base/Input/IInputRoot.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Input
         IFocusManager? FocusManager { get; }
         
         /// <summary>
-        /// Represents a contract for accessing platform-specific settings and information.
+        /// Represents a contract for accessing top-level platform-specific settings.
         /// </summary>
         /// <remarks>
         /// PlatformSettings can be null only if window wasn't initialized yet.

--- a/src/Avalonia.Base/Input/MouseDevice.cs
+++ b/src/Avalonia.Base/Input/MouseDevice.cs
@@ -2,9 +2,12 @@ using System;
 using System.Collections.Generic;
 using Avalonia.Reactive;
 using Avalonia.Input.Raw;
+using Avalonia.Interactivity;
 using Avalonia.Metadata;
 using Avalonia.Platform;
 using Avalonia.Utilities;
+using Avalonia.VisualTree;
+
 #pragma warning disable CS0618
 
 namespace Avalonia.Input
@@ -126,9 +129,10 @@ namespace Avalonia.Input
             if (source != null)
             {
                 _pointer.Capture(source);
-                if (source != null)
+
+                var settings = ((IInputRoot?)(source as Interactive)?.GetVisualRoot())?.PlatformSettings;
+                if (settings is not null)
                 {
-                    var settings = AvaloniaLocator.Current.GetRequiredService<IPlatformSettings>();
                     var doubleClickTime = settings.GetDoubleTapTime(PointerType.Mouse).TotalMilliseconds;
                     var doubleClickSize = settings.GetDoubleTapSize(PointerType.Mouse);
 
@@ -141,11 +145,12 @@ namespace Avalonia.Input
                     _lastClickTime = timestamp;
                     _lastClickRect = new Rect(p, new Size())
                         .Inflate(new Thickness(doubleClickSize.Width / 2, doubleClickSize.Height / 2));
-                    _lastMouseDownButton = properties.PointerUpdateKind.GetMouseButton();
-                    var e = new PointerPressedEventArgs(source, _pointer, (Visual)root, p, timestamp, properties, inputModifiers, _clickCount);
-                    source.RaiseEvent(e);
-                    return e.Handled;
                 }
+
+                _lastMouseDownButton = properties.PointerUpdateKind.GetMouseButton();
+                var e = new PointerPressedEventArgs(source, _pointer, (Visual)root, p, timestamp, properties, inputModifiers, _clickCount);
+                source.RaiseEvent(e);
+                return e.Handled;
             }
 
             return false;

--- a/src/Avalonia.Base/Input/PenDevice.cs
+++ b/src/Avalonia.Base/Input/PenDevice.cs
@@ -3,8 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Avalonia.Input.Raw;
+using Avalonia.Interactivity;
 using Avalonia.Metadata;
 using Avalonia.Platform;
+using Avalonia.VisualTree;
+
 #pragma warning disable CS0618
 
 namespace Avalonia.Input
@@ -80,19 +83,23 @@ namespace Avalonia.Input
             if (source != null)
             {
                 pointer.Capture(source);
-                var settings = AvaloniaLocator.Current.GetService<IPlatformSettings>();
-                var doubleClickTime = settings?.GetDoubleTapTime(PointerType.Pen).TotalMilliseconds ?? 500;
-                var doubleClickSize = settings?.GetDoubleTapSize(PointerType.Pen) ?? new Size(4, 4);
-
-                if (!_lastClickRect.Contains(p) || timestamp - _lastClickTime > doubleClickTime)
+                var settings = ((IInputRoot?)(source as Interactive)?.GetVisualRoot())?.PlatformSettings;
+                if (settings is not null)
                 {
-                    _clickCount = 0;
+                    var doubleClickTime = settings.GetDoubleTapTime(PointerType.Pen).TotalMilliseconds;
+                    var doubleClickSize = settings.GetDoubleTapSize(PointerType.Pen);
+
+                    if (!_lastClickRect.Contains(p) || timestamp - _lastClickTime > doubleClickTime)
+                    {
+                        _clickCount = 0;
+                    }
+
+                    ++_clickCount;
+                    _lastClickTime = timestamp;
+                    _lastClickRect = new Rect(p, new Size())
+                        .Inflate(new Thickness(doubleClickSize.Width / 2, doubleClickSize.Height / 2));
                 }
 
-                ++_clickCount;
-                _lastClickTime = timestamp;
-                _lastClickRect = new Rect(p, new Size())
-                    .Inflate(new Thickness(doubleClickSize.Width / 2, doubleClickSize.Height / 2));
                 _lastMouseDownButton = properties.PointerUpdateKind.GetMouseButton();
                 var e = new PointerPressedEventArgs(source, pointer, (Visual)root, p, timestamp, properties, inputModifiers, _clickCount);
                 source.RaiseEvent(e);

--- a/src/Avalonia.Base/Input/Platform/PlatformHotkeyConfiguration.cs
+++ b/src/Avalonia.Base/Input/Platform/PlatformHotkeyConfiguration.cs
@@ -8,15 +8,6 @@ namespace Avalonia.Input.Platform
     /// </summary>
     public sealed class PlatformHotkeyConfiguration
     {
-        /// <summary>
-        /// Retrieves shared static instance of PlatformHotkeyConfiguration. 
-        /// </summary>
-        /// <remarks>
-        /// Return value might be null, when application wasn't yet initialized.
-        /// </remarks>
-        public static PlatformHotkeyConfiguration? Instance =>
-            AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>();
-        
         [PrivateApi]
         public PlatformHotkeyConfiguration() : this(KeyModifiers.Control)
         {

--- a/src/Avalonia.Base/Input/Platform/PlatformHotkeyConfiguration.cs
+++ b/src/Avalonia.Base/Input/Platform/PlatformHotkeyConfiguration.cs
@@ -1,16 +1,29 @@
 using System.Collections.Generic;
-
-#nullable enable
+using Avalonia.Metadata;
 
 namespace Avalonia.Input.Platform
 {
-    public class PlatformHotkeyConfiguration
+    /// <summary>
+    /// The PlatformHotkeyConfiguration class represents a configuration for platform-specific hotkeys in an Avalonia application. 
+    /// </summary>
+    public sealed class PlatformHotkeyConfiguration
     {
+        /// <summary>
+        /// Retrieves shared static instance of PlatformHotkeyConfiguration. 
+        /// </summary>
+        /// <remarks>
+        /// Return value might be null, when application wasn't yet initialized.
+        /// </remarks>
+        public static PlatformHotkeyConfiguration? Instance =>
+            AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>();
+        
+        [PrivateApi]
         public PlatformHotkeyConfiguration() : this(KeyModifiers.Control)
         {
 
         }
 
+        [PrivateApi]
         public PlatformHotkeyConfiguration(KeyModifiers commandModifiers,
             KeyModifiers selectionModifiers = KeyModifiers.Shift,
             KeyModifiers wholeWordTextActionModifiers = KeyModifiers.Control)

--- a/src/Avalonia.Base/Input/TouchDevice.cs
+++ b/src/Avalonia.Base/Input/TouchDevice.cs
@@ -3,8 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Avalonia.Input.Raw;
+using Avalonia.Interactivity;
 using Avalonia.Metadata;
 using Avalonia.Platform;
+using Avalonia.VisualTree;
+
 #pragma warning disable CS0618
 
 namespace Avalonia.Input
@@ -62,19 +65,23 @@ namespace Avalonia.Input
                 }
                 else
                 {
-                    var settings = AvaloniaLocator.Current.GetRequiredService<IPlatformSettings>();
-                    var doubleClickTime = settings.GetDoubleTapTime(PointerType.Touch).TotalMilliseconds;
-                    var doubleClickSize = settings.GetDoubleTapSize(PointerType.Touch);
-
-                    if (!_lastClickRect.Contains(args.Position)
-                        || ev.Timestamp - _lastClickTime > doubleClickTime)
+                    var settings = ((IInputRoot?)(target as Interactive)?.GetVisualRoot())?.PlatformSettings;
+                    if (settings is not null)
                     {
-                        _clickCount = 0;
+                        var doubleClickTime = settings.GetDoubleTapTime(PointerType.Touch).TotalMilliseconds;
+                        var doubleClickSize = settings.GetDoubleTapSize(PointerType.Touch);
+
+                        if (!_lastClickRect.Contains(args.Position)
+                            || ev.Timestamp - _lastClickTime > doubleClickTime)
+                        {
+                            _clickCount = 0;
+                        }
+
+                        ++_clickCount;
+                        _lastClickTime = ev.Timestamp;
+                        _lastClickRect = new Rect(args.Position, new Size())
+                            .Inflate(new Thickness(doubleClickSize.Width / 2, doubleClickSize.Height / 2));
                     }
-                    ++_clickCount;
-                    _lastClickTime = ev.Timestamp;
-                    _lastClickRect = new Rect(args.Position, new Size())
-                        .Inflate(new Thickness(doubleClickSize.Width / 2, doubleClickSize.Height / 2));
                 }
 
                 target.RaiseEvent(new PointerPressedEventArgs(target, pointer,

--- a/src/Avalonia.Base/Platform/DefaultPlatformSettings.cs
+++ b/src/Avalonia.Base/Platform/DefaultPlatformSettings.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Media;
 using Avalonia.Metadata;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Platform
 {
@@ -30,7 +32,10 @@ namespace Avalonia.Platform
         public virtual TimeSpan GetDoubleTapTime(PointerType type) => TimeSpan.FromMilliseconds(500);
 
         public virtual TimeSpan HoldWaitDuration => TimeSpan.FromMilliseconds(300);
-        
+
+        public PlatformHotkeyConfiguration HotkeyConfiguration =>
+            AvaloniaLocator.Current.GetRequiredService<PlatformHotkeyConfiguration>();
+
         public virtual PlatformColorValues GetColorValues()
         {
             return new PlatformColorValues

--- a/src/Avalonia.Base/Platform/DefaultPlatformSettings.cs
+++ b/src/Avalonia.Base/Platform/DefaultPlatformSettings.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.Metadata;
 
 namespace Avalonia.Platform
 {
     /// <summary>
     /// A default implementation of <see cref="IPlatformSettings"/> for platforms.
     /// </summary>
+    [PrivateApi]
     public class DefaultPlatformSettings : IPlatformSettings
     {
         public virtual Size GetTapSize(PointerType type)

--- a/src/Avalonia.Base/Platform/IPlatformSettings.cs
+++ b/src/Avalonia.Base/Platform/IPlatformSettings.cs
@@ -4,7 +4,11 @@ using Avalonia.Metadata;
 
 namespace Avalonia.Platform
 {
-    [Unstable]
+    /// <summary>
+    /// The <see cref="IPlatformSettings"/> interface represents a contract for accessing platform-specific settings and information.
+    /// Some of these settings might be changed by used globally in the OS in runtime.
+    /// </summary>
+    [NotClientImplementable]
     public interface IPlatformSettings
     {
         /// <summary>

--- a/src/Avalonia.Base/Platform/IPlatformSettings.cs
+++ b/src/Avalonia.Base/Platform/IPlatformSettings.cs
@@ -1,5 +1,6 @@
 using System;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Metadata;
 
 namespace Avalonia.Platform
@@ -36,6 +37,11 @@ namespace Avalonia.Platform
         /// Holding duration between pointer press and when event is fired.
         /// </summary>
         TimeSpan HoldWaitDuration { get; }
+        
+        /// <summary>
+        /// Get a configuration for platform-specific hotkeys in an Avalonia application.
+        /// </summary>
+        PlatformHotkeyConfiguration HotkeyConfiguration { get; }
         
         /// <summary>
         /// Gets current system color values including dark mode and accent colors.

--- a/src/Avalonia.Base/Utilities/ThrowHelper.cs
+++ b/src/Avalonia.Base/Utilities/ThrowHelper.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Avalonia.Utilities;
+
+/// <summary>
+/// Helper method to help inlining methods that do a throw check.
+/// Equivalent of .NET6+ ArgumentNullException.ThrowIfNull() for netstandard2.0+
+/// </summary>
+internal class ThrowHelper
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNull([NotNull] object? argument, string paramName)
+    {
+        if (argument is null)
+        {
+            ThrowArgumentNullException(paramName);
+        }
+    }
+
+    [DoesNotReturn]
+    private static void ThrowArgumentNullException(string paramName) => throw new ArgumentNullException(paramName);
+}

--- a/src/Avalonia.Base/VisualTree/VisualExtensions.cs
+++ b/src/Avalonia.Base/VisualTree/VisualExtensions.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Avalonia.Rendering;
+using Avalonia.Utilities;
 
 namespace Avalonia.VisualTree
 {
@@ -125,9 +128,9 @@ namespace Avalonia.VisualTree
         /// <returns>The visual's ancestors.</returns>
         public static IEnumerable<Visual> GetVisualAncestors(this Visual visual)
         {
-            Visual? v = visual ?? throw new ArgumentNullException(nameof(visual));
+            ThrowHelper.ThrowIfNull(visual, nameof(visual));
 
-            v = v.VisualParent;
+            var v = visual.VisualParent;
 
             while (v != null)
             {
@@ -194,7 +197,7 @@ namespace Avalonia.VisualTree
         /// <returns>The visual and its ancestors.</returns>
         public static IEnumerable<Visual> GetSelfAndVisualAncestors(this Visual visual)
         {
-            _ = visual ?? throw new ArgumentNullException(nameof(visual));
+            ThrowHelper.ThrowIfNull(visual, nameof(visual));
 
             yield return visual;
 
@@ -275,7 +278,7 @@ namespace Avalonia.VisualTree
         /// <returns>The visual at the requested point.</returns>
         public static Visual? GetVisualAt(this Visual visual, Point p)
         {
-            _ = visual ?? throw new ArgumentNullException(nameof(visual));
+            ThrowHelper.ThrowIfNull(visual, nameof(visual));
 
             return visual.GetVisualAt(p, x => x.IsVisible);
         }
@@ -292,7 +295,7 @@ namespace Avalonia.VisualTree
         /// <returns>The visual at the requested point.</returns>
         public static Visual? GetVisualAt(this Visual visual, Point p, Func<Visual, bool> filter)
         {
-            _ = visual ?? throw new ArgumentNullException(nameof(visual));
+            ThrowHelper.ThrowIfNull(visual, nameof(visual));
 
             var root = visual.GetVisualRoot();
 
@@ -321,7 +324,7 @@ namespace Avalonia.VisualTree
             this Visual visual,
             Point p)
         {
-            _ = visual ?? throw new ArgumentNullException(nameof(visual));
+            ThrowHelper.ThrowIfNull(visual, nameof(visual));
 
             return visual.GetVisualsAt(p, x => x.IsVisible);
         }
@@ -341,7 +344,7 @@ namespace Avalonia.VisualTree
             Point p,
             Func<Visual, bool> filter)
         {
-            _ = visual ?? throw new ArgumentNullException(nameof(visual));
+            ThrowHelper.ThrowIfNull(visual, nameof(visual));
 
             var root = visual.GetVisualRoot();
 
@@ -435,7 +438,7 @@ namespace Avalonia.VisualTree
         /// </returns>
         public static IRenderRoot? GetVisualRoot(this Visual visual)
         {
-            _ = visual ?? throw new ArgumentNullException(nameof(visual));
+            ThrowHelper.ThrowIfNull(visual, nameof(visual));
 
             return visual as IRenderRoot ?? visual.VisualRoot;
         }

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -2660,25 +2660,25 @@ namespace Avalonia.Controls
 
         internal bool ProcessDownKey(KeyEventArgs e)
         {
-            KeyboardHelper.GetMetaKeyState(e.KeyModifiers, out bool ctrl, out bool shift);
+            KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool shift);
             return ProcessDownKeyInternal(shift, ctrl);
         }
 
         internal bool ProcessEndKey(KeyEventArgs e)
         {
-            KeyboardHelper.GetMetaKeyState(e.KeyModifiers, out bool ctrl, out bool shift);
+            KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool shift);
             return ProcessEndKey(shift, ctrl);
         }
 
         internal bool ProcessEnterKey(KeyEventArgs e)
         {
-            KeyboardHelper.GetMetaKeyState(e.KeyModifiers, out bool ctrl, out bool shift);
+            KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool shift);
             return ProcessEnterKey(shift, ctrl);
         }
 
         internal bool ProcessHomeKey(KeyEventArgs e)
         {
-            KeyboardHelper.GetMetaKeyState(e.KeyModifiers, out bool ctrl, out bool shift);
+            KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool shift);
             return ProcessHomeKey(shift, ctrl);
         }
 
@@ -2718,25 +2718,25 @@ namespace Avalonia.Controls
 
         internal bool ProcessLeftKey(KeyEventArgs e)
         {
-            KeyboardHelper.GetMetaKeyState(e.KeyModifiers, out bool ctrl, out bool shift);
+            KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool shift);
             return ProcessLeftKey(shift, ctrl);
         }
 
         internal bool ProcessNextKey(KeyEventArgs e)
         {
-            KeyboardHelper.GetMetaKeyState(e.KeyModifiers, out bool ctrl, out bool shift);
+            KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool shift);
             return ProcessNextKey(shift, ctrl);
         }
 
         internal bool ProcessPriorKey(KeyEventArgs e)
         {
-            KeyboardHelper.GetMetaKeyState(e.KeyModifiers, out bool ctrl, out bool shift);
+            KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool shift);
             return ProcessPriorKey(shift, ctrl);
         }
 
         internal bool ProcessRightKey(KeyEventArgs e)
         {
-            KeyboardHelper.GetMetaKeyState(e.KeyModifiers, out bool ctrl, out bool shift);
+            KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool shift);
             return ProcessRightKey(shift, ctrl);
         }
 
@@ -2854,7 +2854,7 @@ namespace Avalonia.Controls
 
         internal bool ProcessUpKey(KeyEventArgs e)
         {
-            KeyboardHelper.GetMetaKeyState(e.KeyModifiers, out bool ctrl, out bool shift);
+            KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool shift);
             return ProcessUpKey(shift, ctrl);
         }
 
@@ -3124,13 +3124,13 @@ namespace Avalonia.Controls
         //TODO: Ensure right button is checked for
         internal bool UpdateStateOnMouseRightButtonDown(PointerPressedEventArgs pointerPressedEventArgs, int columnIndex, int slot, bool allowEdit)
         {
-            KeyboardHelper.GetMetaKeyState(pointerPressedEventArgs.KeyModifiers, out bool ctrl, out bool shift);
+            KeyboardHelper.GetMetaKeyState(this, pointerPressedEventArgs.KeyModifiers, out bool ctrl, out bool shift);
             return UpdateStateOnMouseRightButtonDown(pointerPressedEventArgs, columnIndex, slot, allowEdit, shift, ctrl);
         }
         //TODO: Ensure left button is checked for
         internal bool UpdateStateOnMouseLeftButtonDown(PointerPressedEventArgs pointerPressedEventArgs, int columnIndex, int slot, bool allowEdit)
         {
-            KeyboardHelper.GetMetaKeyState(pointerPressedEventArgs.KeyModifiers, out bool ctrl, out bool shift);
+            KeyboardHelper.GetMetaKeyState(this, pointerPressedEventArgs.KeyModifiers, out bool ctrl, out bool shift);
             return UpdateStateOnMouseLeftButtonDown(pointerPressedEventArgs, columnIndex, slot, allowEdit, shift, ctrl);
         }
 
@@ -4654,7 +4654,7 @@ namespace Avalonia.Controls
 
         private bool ProcessAKey(KeyEventArgs e)
         {
-            KeyboardHelper.GetMetaKeyState(e.KeyModifiers, out bool ctrl, out bool shift, out bool alt);
+            KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool shift, out bool alt);
 
             if (ctrl && !shift && !alt && SelectionMode == DataGridSelectionMode.Extended)
             {
@@ -4923,7 +4923,7 @@ namespace Avalonia.Controls
 
         private bool ProcessF2Key(KeyEventArgs e)
         {
-            KeyboardHelper.GetMetaKeyState(e.KeyModifiers, out bool ctrl, out bool shift);
+            KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool shift);
 
             if (!shift && !ctrl &&
                 _editingColumnIndex == -1 && CurrentColumnIndex != -1 && GetRowSelection(CurrentSlot) &&
@@ -5280,7 +5280,7 @@ namespace Avalonia.Controls
 
         private bool ProcessTabKey(KeyEventArgs e)
         {
-            KeyboardHelper.GetMetaKeyState(e.KeyModifiers, out bool ctrl, out bool shift);
+            KeyboardHelper.GetMetaKeyState(this, e.KeyModifiers, out bool ctrl, out bool shift);
             return ProcessTabKey(e, shift, ctrl);
         }
 
@@ -6099,7 +6099,7 @@ namespace Avalonia.Controls
         /// <returns>Whether or not the DataGrid handled the key press.</returns>
         private bool ProcessCopyKey(KeyModifiers modifiers)
         {
-            KeyboardHelper.GetMetaKeyState(modifiers, out bool ctrl, out bool shift, out bool alt);
+            KeyboardHelper.GetMetaKeyState(this, modifiers, out bool ctrl, out bool shift, out bool alt);
 
             if (ctrl && !shift && !alt && ClipboardCopyMode != DataGridClipboardCopyMode.None && SelectedItems.Count > 0)
             {

--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
@@ -703,7 +703,7 @@ namespace Avalonia.Controls
         public void ClearSort()
         {
             //InvokeProcessSort is already validating if sorting is possible
-            _headerCell?.InvokeProcessSort(KeyboardHelper.GetPlatformCtrlOrCmdKeyModifier());
+            _headerCell?.InvokeProcessSort(KeyboardHelper.GetPlatformCtrlOrCmdKeyModifier(OwningGrid));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
@@ -241,7 +241,7 @@ namespace Avalonia.Controls
                     DataGrid owningGrid = OwningGrid;
                     DataGridSortDescription newSort;
 
-                    KeyboardHelper.GetMetaKeyState(keyModifiers, out bool ctrl, out bool shift);
+                    KeyboardHelper.GetMetaKeyState(this, keyModifiers, out bool ctrl, out bool shift);
 
                     DataGridSortDescription sort = OwningColumn.GetSortDescription();
                     IDataGridCollectionView collectionView = owningGrid.DataConnection.CollectionView;

--- a/src/Avalonia.Controls.DataGrid/Utils/KeyboardHelper.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/KeyboardHelper.cs
@@ -24,9 +24,9 @@ namespace Avalonia.Controls.Utils
         }
 
         public static KeyModifiers GetPlatformCtrlOrCmdKeyModifier()
-        {                
-            var keymap = AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>();
-            return keymap?.CommandModifiers ?? KeyModifiers.Control;
+        {
+            var keymap = PlatformHotkeyConfiguration.Instance;
+            return keymap.CommandModifiers;
         }
     }
 }

--- a/src/Avalonia.Controls.DataGrid/Utils/KeyboardHelper.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/KeyboardHelper.cs
@@ -10,22 +10,22 @@ namespace Avalonia.Controls.Utils
 {
     internal static class KeyboardHelper
     {
-        public static void GetMetaKeyState(KeyModifiers modifiers, out bool ctrlOrCmd, out bool shift)
+        public static void GetMetaKeyState(Control target, KeyModifiers modifiers, out bool ctrlOrCmd, out bool shift)
         {
-            ctrlOrCmd = modifiers.HasFlag(GetPlatformCtrlOrCmdKeyModifier());
+            ctrlOrCmd = modifiers.HasFlag(GetPlatformCtrlOrCmdKeyModifier(target));
             shift = modifiers.HasFlag(KeyModifiers.Shift);
         }
 
-        public static void GetMetaKeyState(KeyModifiers modifiers, out bool ctrlOrCmd, out bool shift, out bool alt)
+        public static void GetMetaKeyState(Control target, KeyModifiers modifiers, out bool ctrlOrCmd, out bool shift, out bool alt)
         {
-            ctrlOrCmd = modifiers.HasFlag(GetPlatformCtrlOrCmdKeyModifier());
+            ctrlOrCmd = modifiers.HasFlag(GetPlatformCtrlOrCmdKeyModifier(target));
             shift = modifiers.HasFlag(KeyModifiers.Shift);
             alt = modifiers.HasFlag(KeyModifiers.Alt);
         }
 
-        public static KeyModifiers GetPlatformCtrlOrCmdKeyModifier()
+        public static KeyModifiers GetPlatformCtrlOrCmdKeyModifier(Control target)
         {
-            var keymap = PlatformHotkeyConfiguration.Instance;
+            var keymap = TopLevel.GetTopLevel(target)!.PlatformSettings!.HotkeyConfiguration;
             return keymap.CommandModifiers;
         }
     }

--- a/src/Avalonia.Controls/Application.cs
+++ b/src/Avalonia.Controls/Application.cs
@@ -180,6 +180,17 @@ namespace Avalonia
         /// </summary>
         public IApplicationLifetime? ApplicationLifetime { get; set; }
 
+        /// <summary>
+        /// Represents a contract for accessing platform-specific settings and information.
+        /// </summary>
+        /// <remarks>
+        /// PlatformSettings can be null only if application wasn't initialized yet.
+        /// <see cref="TopLevel"/>'s <see cref="TopLevel.PlatformSettings"/> is an equivalent API
+        /// which should always be preferred over a global one,
+        /// as specific top levels might have different settings set-up. 
+        /// </remarks>
+        public IPlatformSettings? PlatformSettings => AvaloniaLocator.Current.GetService<IPlatformSettings>();
+        
         event Action<IReadOnlyList<IStyle>>? IGlobalStyles.GlobalStylesAdded
         {
             add => _stylesAdded += value;
@@ -229,10 +240,12 @@ namespace Avalonia
             var focusManager = new FocusManager();
             InputManager = new InputManager();
 
-            var settings = AvaloniaLocator.Current.GetRequiredService<IPlatformSettings>();
-            settings.ColorValuesChanged += OnColorValuesChanged;
-            OnColorValuesChanged(settings, settings.GetColorValues());
-            
+            if (PlatformSettings is { } settings)
+            {
+                settings.ColorValuesChanged += OnColorValuesChanged;
+                OnColorValuesChanged(settings, settings.GetColorValues());
+            }
+
             AvaloniaLocator.CurrentMutable
                 .Bind<IAccessKeyHandler>().ToTransient<AccessKeyHandler>()
                 .Bind<IGlobalDataTemplates>().ToConstant(this)
@@ -242,7 +255,7 @@ namespace Avalonia
                 .Bind<IInputManager>().ToConstant(InputManager)
                 .Bind<IKeyboardNavigationHandler>().ToTransient<KeyboardNavigationHandler>()
                 .Bind<IDragDropDevice>().ToConstant(DragDropDevice.Instance);
-            
+
             // TODO: Fix this, for now we keep this behavior since someone might be relying on it in 0.9.x
             if (AvaloniaLocator.Current.GetService<IPlatformDragSource>() == null)
                 AvaloniaLocator.CurrentMutable

--- a/src/Avalonia.Controls/Application.cs
+++ b/src/Avalonia.Controls/Application.cs
@@ -181,7 +181,7 @@ namespace Avalonia
         public IApplicationLifetime? ApplicationLifetime { get; set; }
 
         /// <summary>
-        /// Represents a contract for accessing platform-specific settings and information.
+        /// Represents a contract for accessing global platform-specific settings.
         /// </summary>
         /// <remarks>
         /// PlatformSettings can be null only if application wasn't initialized yet.

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -405,7 +405,7 @@ namespace Avalonia.Controls
         {
             if (IsOpen)
             {
-                var keymap = AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>();
+                var keymap = PlatformHotkeyConfiguration.Instance;
 
                 if (keymap?.OpenContextMenu.Any(k => k.Matches(e)) == true
                     && !CancelClosing())

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -405,7 +405,7 @@ namespace Avalonia.Controls
         {
             if (IsOpen)
             {
-                var keymap = PlatformHotkeyConfiguration.Instance;
+                var keymap = Application.Current!.PlatformSettings!.HotkeyConfiguration;
 
                 if (keymap?.OpenContextMenu.Any(k => k.Matches(e)) == true
                     && !CancelClosing())

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -480,7 +480,7 @@ namespace Avalonia.Controls
             if (e.Source == this
                 && !e.Handled)
             {
-                var keymap = PlatformHotkeyConfiguration.Instance?.OpenContextMenu;
+                var keymap = Application.Current!.PlatformSettings?.HotkeyConfiguration.OpenContextMenu;
 
                 if (keymap is null)
                 {

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -480,7 +480,7 @@ namespace Avalonia.Controls
             if (e.Source == this
                 && !e.Handled)
             {
-                var keymap = AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>()?.OpenContextMenu;
+                var keymap = PlatformHotkeyConfiguration.Instance?.OpenContextMenu;
 
                 if (keymap is null)
                 {

--- a/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
@@ -9,6 +9,7 @@ using Avalonia.Input.Raw;
 using Avalonia.Layout;
 using Avalonia.Logging;
 using Avalonia.Reactive;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.Primitives
 {
@@ -392,7 +393,7 @@ namespace Avalonia.Controls.Primitives
                 && IsOpen
                 && Target?.ContextFlyout == this)
             {
-                var keymap = PlatformHotkeyConfiguration.Instance;
+                var keymap = Application.Current!.PlatformSettings?.HotkeyConfiguration;
 
                 if (keymap?.OpenContextMenu.Any(k => k.Matches(e)) == true)
                 {

--- a/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
@@ -392,7 +392,7 @@ namespace Avalonia.Controls.Primitives
                 && IsOpen
                 && Target?.ContextFlyout == this)
             {
-                var keymap = AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>();
+                var keymap = PlatformHotkeyConfiguration.Instance;
 
                 if (keymap?.OpenContextMenu.Any(k => k.Matches(e)) == true)
                 {

--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -9,6 +9,7 @@ using Avalonia.Controls.Selection;
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Controls
 {
@@ -127,7 +128,7 @@ namespace Avalonia.Controls
 
         protected override void OnKeyDown(KeyEventArgs e)
         {
-            var hotkeys = PlatformHotkeyConfiguration.Instance;
+            var hotkeys = Application.Current!.PlatformSettings?.HotkeyConfiguration;
             var ctrl = hotkeys is not null && e.KeyModifiers.HasAllFlags(hotkeys.CommandModifiers);
 
             if (!ctrl &&
@@ -165,7 +166,7 @@ namespace Avalonia.Controls
 
         internal bool UpdateSelectionFromPointerEvent(Control source, PointerEventArgs e)
         {
-            var hotkeys = PlatformHotkeyConfiguration.Instance;
+            var hotkeys = Application.Current!.PlatformSettings?.HotkeyConfiguration;
             var toggle = hotkeys is not null && e.KeyModifiers.HasAllFlags(hotkeys.CommandModifiers);
 
             return UpdateSelectionFromEventSource(

--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -127,7 +127,7 @@ namespace Avalonia.Controls
 
         protected override void OnKeyDown(KeyEventArgs e)
         {
-            var hotkeys = AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>();
+            var hotkeys = PlatformHotkeyConfiguration.Instance;
             var ctrl = hotkeys is not null && e.KeyModifiers.HasAllFlags(hotkeys.CommandModifiers);
 
             if (!ctrl &&
@@ -165,7 +165,7 @@ namespace Avalonia.Controls
 
         internal bool UpdateSelectionFromPointerEvent(Control source, PointerEventArgs e)
         {
-            var hotkeys = AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>();
+            var hotkeys = PlatformHotkeyConfiguration.Instance;
             var toggle = hotkeys is not null && e.KeyModifiers.HasAllFlags(hotkeys.CommandModifiers);
 
             return UpdateSelectionFromEventSource(

--- a/src/Avalonia.Controls/ListBoxItem.cs
+++ b/src/Avalonia.Controls/ListBoxItem.cs
@@ -90,7 +90,7 @@ namespace Avalonia.Controls
                 e.InitialPressMouseButton is MouseButton.Left or MouseButton.Right)
             {
                 var point = e.GetCurrentPoint(this);
-                var settings = AvaloniaLocator.Current.GetService<IPlatformSettings>();
+                var settings = TopLevel.GetTopLevel(e.Source as Visual)?.PlatformSettings;
                 var tapSize = settings?.GetTapSize(point.Pointer.Type) ?? new Size(4, 4);
                 var tapRect = new Rect(_pointerDownPoint, new Size())
                     .Inflate(new Thickness(tapSize.Width, tapSize.Height));

--- a/src/Avalonia.Controls/MaskedTextBox.cs
+++ b/src/Avalonia.Controls/MaskedTextBox.cs
@@ -204,7 +204,7 @@ namespace Avalonia.Controls
                 return;
             }
 
-            var keymap = AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>();
+            var keymap = PlatformHotkeyConfiguration.Instance;
 
             bool Match(List<KeyGesture> gestures) => gestures.Any(g => g.Matches(e));
 

--- a/src/Avalonia.Controls/MaskedTextBox.cs
+++ b/src/Avalonia.Controls/MaskedTextBox.cs
@@ -7,6 +7,7 @@ using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Styling;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Controls
 {
@@ -204,7 +205,7 @@ namespace Avalonia.Controls
                 return;
             }
 
-            var keymap = PlatformHotkeyConfiguration.Instance;
+            var keymap = Application.Current!.PlatformSettings?.HotkeyConfiguration;
 
             bool Match(List<KeyGesture> gestures) => gestures.Any(g => g.Matches(e));
 

--- a/src/Avalonia.Controls/SelectableTextBlock.cs
+++ b/src/Avalonia.Controls/SelectableTextBlock.cs
@@ -198,7 +198,7 @@ namespace Avalonia.Controls
 
             var handled = false;
             var modifiers = e.KeyModifiers;
-            var keymap = PlatformHotkeyConfiguration.Instance!;
+            var keymap = Application.Current!.PlatformSettings!.HotkeyConfiguration;
 
             bool Match(List<KeyGesture> gestures) => gestures.Any(g => g.Matches(e));
 

--- a/src/Avalonia.Controls/SelectableTextBlock.cs
+++ b/src/Avalonia.Controls/SelectableTextBlock.cs
@@ -198,7 +198,7 @@ namespace Avalonia.Controls
 
             var handled = false;
             var modifiers = e.KeyModifiers;
-            var keymap = AvaloniaLocator.Current.GetRequiredService<PlatformHotkeyConfiguration>();
+            var keymap = PlatformHotkeyConfiguration.Instance!;
 
             bool Match(List<KeyGesture> gestures) => gestures.Any(g => g.Matches(e));
 

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -32,20 +32,17 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets a platform-specific <see cref="KeyGesture"/> for the Cut action
         /// </summary>
-        public static KeyGesture? CutGesture { get; } = AvaloniaLocator.Current
-            .GetService<PlatformHotkeyConfiguration>()?.Cut.FirstOrDefault();
+        public static KeyGesture? CutGesture { get; } = PlatformHotkeyConfiguration.Instance?.Cut.FirstOrDefault();
 
         /// <summary>
         /// Gets a platform-specific <see cref="KeyGesture"/> for the Copy action
         /// </summary>
-        public static KeyGesture? CopyGesture { get; } = AvaloniaLocator.Current
-            .GetService<PlatformHotkeyConfiguration>()?.Copy.FirstOrDefault();
+        public static KeyGesture? CopyGesture { get; } = PlatformHotkeyConfiguration.Instance?.Copy.FirstOrDefault();
 
         /// <summary>
         /// Gets a platform-specific <see cref="KeyGesture"/> for the Paste action
         /// </summary>
-        public static KeyGesture? PasteGesture { get; } = AvaloniaLocator.Current
-            .GetService<PlatformHotkeyConfiguration>()?.Paste.FirstOrDefault();
+        public static KeyGesture? PasteGesture { get; } = PlatformHotkeyConfiguration.Instance?.Paste.FirstOrDefault();
 
         /// <summary>
         /// Defines the <see cref="AcceptsReturn"/> property
@@ -1103,7 +1100,7 @@ namespace Avalonia.Controls
             var handled = false;
             var modifiers = e.KeyModifiers;
 
-            var keymap = AvaloniaLocator.Current.GetRequiredService<PlatformHotkeyConfiguration>();
+            var keymap = PlatformHotkeyConfiguration.Instance!;
 
             bool Match(List<KeyGesture> gestures) => gestures.Any(g => g.Matches(e));
             bool DetectSelection() => e.KeyModifiers.HasAllFlags(keymap.SelectionModifiers);

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -32,17 +32,17 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets a platform-specific <see cref="KeyGesture"/> for the Cut action
         /// </summary>
-        public static KeyGesture? CutGesture { get; } = PlatformHotkeyConfiguration.Instance?.Cut.FirstOrDefault();
+        public static KeyGesture? CutGesture => Application.Current?.PlatformSettings?.HotkeyConfiguration.Cut.FirstOrDefault();
 
         /// <summary>
         /// Gets a platform-specific <see cref="KeyGesture"/> for the Copy action
         /// </summary>
-        public static KeyGesture? CopyGesture { get; } = PlatformHotkeyConfiguration.Instance?.Copy.FirstOrDefault();
+        public static KeyGesture? CopyGesture => Application.Current?.PlatformSettings?.HotkeyConfiguration.Copy.FirstOrDefault();
 
         /// <summary>
         /// Gets a platform-specific <see cref="KeyGesture"/> for the Paste action
         /// </summary>
-        public static KeyGesture? PasteGesture { get; } = PlatformHotkeyConfiguration.Instance?.Paste.FirstOrDefault();
+        public static KeyGesture? PasteGesture => Application.Current?.PlatformSettings?.HotkeyConfiguration.Paste.FirstOrDefault();
 
         /// <summary>
         /// Defines the <see cref="AcceptsReturn"/> property
@@ -1100,7 +1100,7 @@ namespace Avalonia.Controls
             var handled = false;
             var modifiers = e.KeyModifiers;
 
-            var keymap = PlatformHotkeyConfiguration.Instance!;
+            var keymap = Application.Current!.PlatformSettings!.HotkeyConfiguration;
 
             bool Match(List<KeyGesture> gestures) => gestures.Any(g => g.Matches(e));
             bool DetectSelection() => e.KeyModifiers.HasAllFlags(keymap.SelectionModifiers);

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -250,7 +250,7 @@ namespace Avalonia.Controls
 
                 if (e is RawKeyEventArgs rawKeyEventArgs && rawKeyEventArgs.Type == RawKeyEventType.KeyDown)
                 {
-                    var keymap = AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>()?.Back;
+                    var keymap = PlatformHotkeyConfiguration.Instance?.Back;
 
                     if (keymap != null)
                     {

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -250,7 +250,7 @@ namespace Avalonia.Controls
 
                 if (e is RawKeyEventArgs rawKeyEventArgs && rawKeyEventArgs.Type == RawKeyEventType.KeyDown)
                 {
-                    var keymap = PlatformHotkeyConfiguration.Instance?.Back;
+                    var keymap = PlatformSettings?.HotkeyConfiguration.Back;
 
                     if (keymap != null)
                     {

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -487,6 +487,9 @@ namespace Avalonia.Controls
         /// <inheritdoc />
         public IFocusManager? FocusManager => AvaloniaLocator.Current.GetService<IFocusManager>();
 
+        /// <inheritdoc />
+        public IPlatformSettings? PlatformSettings => AvaloniaLocator.Current.GetService<IPlatformSettings>();
+        
         /// <inheritdoc/>
         Point IRenderRoot.PointToClient(PixelPoint p)
         {

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -571,7 +571,7 @@ namespace Avalonia.Controls
 
             if (!e.Handled)
             {
-                var keymap = PlatformHotkeyConfiguration.Instance;
+                var keymap = Application.Current!.PlatformSettings!.HotkeyConfiguration;
                 bool Match(List<KeyGesture>? gestures) => gestures?.Any(g => g.Matches(e)) ?? false;
 
                 if (this.SelectionMode == SelectionMode.Multiple && Match(keymap?.SelectAll))
@@ -652,11 +652,12 @@ namespace Avalonia.Controls
 
                 if (point.Properties.IsLeftButtonPressed || point.Properties.IsRightButtonPressed)
                 {
+                    var keymap = Application.Current!.PlatformSettings!.HotkeyConfiguration;
                     e.Handled = UpdateSelectionFromEventSource(
                         e.Source,
                         true,
                         e.KeyModifiers.HasAllFlags(KeyModifiers.Shift),
-                        e.KeyModifiers.HasAllFlags(PlatformHotkeyConfiguration.Instance!.CommandModifiers),
+                        e.KeyModifiers.HasAllFlags(keymap.CommandModifiers),
                         point.Properties.IsRightButtonPressed);
                 }
             }

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -571,7 +571,7 @@ namespace Avalonia.Controls
 
             if (!e.Handled)
             {
-                var keymap = AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>();
+                var keymap = PlatformHotkeyConfiguration.Instance;
                 bool Match(List<KeyGesture>? gestures) => gestures?.Any(g => g.Matches(e)) ?? false;
 
                 if (this.SelectionMode == SelectionMode.Multiple && Match(keymap?.SelectAll))
@@ -656,7 +656,7 @@ namespace Avalonia.Controls
                         e.Source,
                         true,
                         e.KeyModifiers.HasAllFlags(KeyModifiers.Shift),
-                        e.KeyModifiers.HasAllFlags(AvaloniaLocator.Current.GetRequiredService<PlatformHotkeyConfiguration>().CommandModifiers),
+                        e.KeyModifiers.HasAllFlags(PlatformHotkeyConfiguration.Instance!.CommandModifiers),
                         point.Properties.IsRightButtonPressed);
                 }
             }

--- a/src/Avalonia.Native/AvaloniaNativePlatform.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatform.cs
@@ -108,20 +108,18 @@ namespace Avalonia.Native
                 .Bind<IWindowingPlatform>().ToConstant(this)
                 .Bind<IClipboard>().ToConstant(new ClipboardImpl(_factory.CreateClipboard()))
                 .Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(60))
-                .Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration(KeyModifiers.Meta, wholeWordTextActionModifiers: KeyModifiers.Alt))
                 .Bind<IMountedVolumeInfoProvider>().ToConstant(new MacOSMountedVolumeInfoProvider())
                 .Bind<IPlatformDragSource>().ToConstant(new AvaloniaNativeDragSource(_factory))
                 .Bind<IPlatformLifetimeEventsImpl>().ToConstant(applicationPlatform)
                 .Bind<INativeApplicationCommands>().ToConstant(new MacOSNativeMenuCommands(_factory.CreateApplicationCommands()));
 
-            var hotkeys = PlatformHotkeyConfiguration.Instance;
-            if (hotkeys is not null)
-            {
-                hotkeys.MoveCursorToTheStartOfLine.Add(new KeyGesture(Key.Left, hotkeys.CommandModifiers));
-                hotkeys.MoveCursorToTheStartOfLineWithSelection.Add(new KeyGesture(Key.Left, hotkeys.CommandModifiers | hotkeys.SelectionModifiers));
-                hotkeys.MoveCursorToTheEndOfLine.Add(new KeyGesture(Key.Right, hotkeys.CommandModifiers));
-                hotkeys.MoveCursorToTheEndOfLineWithSelection.Add(new KeyGesture(Key.Right, hotkeys.CommandModifiers | hotkeys.SelectionModifiers));
-            }
+            var hotkeys = new PlatformHotkeyConfiguration(KeyModifiers.Meta, wholeWordTextActionModifiers: KeyModifiers.Alt);
+            hotkeys.MoveCursorToTheStartOfLine.Add(new KeyGesture(Key.Left, hotkeys.CommandModifiers));
+            hotkeys.MoveCursorToTheStartOfLineWithSelection.Add(new KeyGesture(Key.Left, hotkeys.CommandModifiers | hotkeys.SelectionModifiers));
+            hotkeys.MoveCursorToTheEndOfLine.Add(new KeyGesture(Key.Right, hotkeys.CommandModifiers));
+            hotkeys.MoveCursorToTheEndOfLineWithSelection.Add(new KeyGesture(Key.Right, hotkeys.CommandModifiers | hotkeys.SelectionModifiers));
+
+            AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(hotkeys);
             
             if (_options.UseGpu)
             {

--- a/src/Avalonia.Native/AvaloniaNativePlatform.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatform.cs
@@ -113,8 +113,8 @@ namespace Avalonia.Native
                 .Bind<IPlatformDragSource>().ToConstant(new AvaloniaNativeDragSource(_factory))
                 .Bind<IPlatformLifetimeEventsImpl>().ToConstant(applicationPlatform)
                 .Bind<INativeApplicationCommands>().ToConstant(new MacOSNativeMenuCommands(_factory.CreateApplicationCommands()));
-            
-            var hotkeys = AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>();
+
+            var hotkeys = PlatformHotkeyConfiguration.Instance;
             if (hotkeys is not null)
             {
                 hotkeys.MoveCursorToTheStartOfLine.Add(new KeyGesture(Key.Left, hotkeys.CommandModifiers));

--- a/tests/Avalonia.Base.UnitTests/Input/GesturesTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/GesturesTests.cs
@@ -24,13 +24,13 @@ namespace Avalonia.Base.UnitTests.Input
         public void Tapped_Should_Follow_Pointer_Pressed_Released()
         {
             Border border = new Border();
-            var decorator = new Decorator
+            var root = new TestRoot
             {
                 Child = border
             };
             var result = new List<string>();
 
-            AddHandlers(decorator, border, result, false);
+            AddHandlers(root, border, result, false);
 
             _mouse.Click(border);
 
@@ -41,13 +41,13 @@ namespace Avalonia.Base.UnitTests.Input
         public void Tapped_Should_Be_Raised_Even_When_Pressed_Released_Handled()
         {
             Border border = new Border();
-            var decorator = new Decorator
+            var root = new TestRoot
             {
                 Child = border
             };
             var result = new List<string>();
 
-            AddHandlers(decorator, border, result, true);
+            AddHandlers(root, border, result, true);
 
             _mouse.Click(border);
 
@@ -58,13 +58,13 @@ namespace Avalonia.Base.UnitTests.Input
         public void Tapped_Should_Not_Be_Raised_For_Middle_Button()
         {
             Border border = new Border();
-            var decorator = new Decorator
+            var root = new TestRoot
             {
                 Child = border
             };
             var raised = false;
 
-            decorator.AddHandler(Gestures.TappedEvent, (_, _) => raised = true);
+            root.AddHandler(Gestures.TappedEvent, (_, _) => raised = true);
 
             _mouse.Click(border, MouseButton.Middle);
 
@@ -75,13 +75,13 @@ namespace Avalonia.Base.UnitTests.Input
         public void Tapped_Should_Not_Be_Raised_For_Right_Button()
         {
             Border border = new Border();
-            var decorator = new Decorator
+            var root = new TestRoot
             {
                 Child = border
             };
             var raised = false;
 
-            decorator.AddHandler(Gestures.TappedEvent, (_, _) => raised = true);
+            root.AddHandler(Gestures.TappedEvent, (_, _) => raised = true);
 
             _mouse.Click(border, MouseButton.Right);
 
@@ -92,13 +92,13 @@ namespace Avalonia.Base.UnitTests.Input
         public void RightTapped_Should_Be_Raised_For_Right_Button()
         {
             Border border = new Border();
-            var decorator = new Decorator
+            var root = new TestRoot
             {
                 Child = border
             };
             var raised = false;
 
-            decorator.AddHandler(Gestures.RightTappedEvent, (_, _) => raised = true);
+            root.AddHandler(Gestures.RightTappedEvent, (_, _) => raised = true);
 
             _mouse.Click(border, MouseButton.Right);
 
@@ -109,13 +109,13 @@ namespace Avalonia.Base.UnitTests.Input
         public void DoubleTapped_Should_Follow_Pointer_Pressed_Released_Pressed()
         {
             Border border = new Border();
-            var decorator = new Decorator
+            var root = new TestRoot
             {
                 Child = border
             };
             var result = new List<string>();
 
-            AddHandlers(decorator, border, result, false);
+            AddHandlers(root, border, result, false);
 
             _mouse.Click(border);
             _mouse.Down(border, clickCount: 2);
@@ -127,13 +127,13 @@ namespace Avalonia.Base.UnitTests.Input
         public void DoubleTapped_Should_Be_Raised_Even_When_Pressed_Released_Handled()
         {
             Border border = new Border();
-            var decorator = new Decorator
+            var root = new TestRoot
             {
                 Child = border
             };
             var result = new List<string>();
 
-            AddHandlers(decorator, border, result, true);
+            AddHandlers(root, border, result, true);
 
             _mouse.Click(border);
             _mouse.Down(border, clickCount: 2);
@@ -145,13 +145,13 @@ namespace Avalonia.Base.UnitTests.Input
         public void DoubleTapped_Should_Not_Be_Raised_For_Middle_Button()
         {
             Border border = new Border();
-            var decorator = new Decorator
+            var root = new TestRoot
             {
                 Child = border
             };
             var raised = false;
 
-            decorator.AddHandler(Gestures.DoubleTappedEvent, (_, _) => raised = true);
+            root.AddHandler(Gestures.DoubleTappedEvent, (_, _) => raised = true);
 
             _mouse.Click(border, MouseButton.Middle);
             _mouse.Down(border, MouseButton.Middle, clickCount: 2);
@@ -163,13 +163,13 @@ namespace Avalonia.Base.UnitTests.Input
         public void DoubleTapped_Should_Not_Be_Raised_For_Right_Button()
         {
             Border border = new Border();
-            var decorator = new Decorator
+            var root = new TestRoot
             {
                 Child = border
             };
             var raised = false;
 
-            decorator.AddHandler(Gestures.DoubleTappedEvent, (_, _) => raised = true);
+            root.AddHandler(Gestures.DoubleTappedEvent, (_, _) => raised = true);
 
             _mouse.Click(border, MouseButton.Right);
             _mouse.Down(border, MouseButton.Right, clickCount: 2);
@@ -191,13 +191,13 @@ namespace Avalonia.Base.UnitTests.Input
 
             Border border = new Border();
             Gestures.SetIsHoldWithMouseEnabled(border, true);
-            var decorator = new Decorator
+            var root = new TestRoot
             {
                 Child = border
             };
             HoldingState holding = HoldingState.Cancelled;
 
-            decorator.AddHandler(Gestures.HoldingEvent, (_, e) => holding = e.HoldingState);
+            root.AddHandler(Gestures.HoldingEvent, (_, e) => holding = e.HoldingState);
             
             _mouse.Down(border);
             Assert.False(holding != HoldingState.Cancelled);
@@ -227,13 +227,13 @@ namespace Avalonia.Base.UnitTests.Input
 
             Border border = new Border();
             Gestures.SetIsHoldWithMouseEnabled(border, true);
-            var decorator = new Decorator
+            var root = new TestRoot
             {
                 Child = border
             };
             var raised = false;
 
-            decorator.AddHandler(Gestures.HoldingEvent, (_, e) => raised = e.HoldingState == HoldingState.Started);
+            root.AddHandler(Gestures.HoldingEvent, (_, e) => raised = e.HoldingState == HoldingState.Started);
             
             _mouse.Down(border);
             Assert.False(raised);
@@ -262,13 +262,13 @@ namespace Avalonia.Base.UnitTests.Input
 
             Border border = new Border();
             Gestures.SetIsHoldWithMouseEnabled(border, true);
-            var decorator = new Decorator
+            var root = new TestRoot
             {
                 Child = border
             };
             var raised = false;
 
-            decorator.AddHandler(Gestures.HoldingEvent, (_, e) => raised = e.HoldingState == HoldingState.Completed);
+            root.AddHandler(Gestures.HoldingEvent, (_, e) => raised = e.HoldingState == HoldingState.Completed);
             
             _mouse.Down(border);
             Assert.False(raised);
@@ -297,13 +297,13 @@ namespace Avalonia.Base.UnitTests.Input
 
             Border border = new Border();
             Gestures.SetIsHoldWithMouseEnabled(border, true);
-            var decorator = new Decorator
+            var root = new TestRoot
             {
                 Child = border
             };
             var cancelled = false;
 
-            decorator.AddHandler(Gestures.HoldingEvent, (_, e) => cancelled = e.HoldingState == HoldingState.Cancelled);
+            root.AddHandler(Gestures.HoldingEvent, (_, e) => cancelled = e.HoldingState == HoldingState.Cancelled);
             
             _mouse.Down(border);
             Assert.False(cancelled);
@@ -333,13 +333,13 @@ namespace Avalonia.Base.UnitTests.Input
 
             Border border = new Border();
             Gestures.SetIsHoldWithMouseEnabled(border, true);
-            var decorator = new Decorator
+            var root = new TestRoot()
             {
                 Child = border
             };
             var cancelled = false;
 
-            decorator.AddHandler(Gestures.HoldingEvent, (_, e) => cancelled = e.HoldingState == HoldingState.Cancelled);
+            root.AddHandler(Gestures.HoldingEvent, (_, e) => cancelled = e.HoldingState == HoldingState.Cancelled);
             
             _mouse.Down(border);
 
@@ -369,13 +369,13 @@ namespace Avalonia.Base.UnitTests.Input
             
             Border border = new Border();
             Gestures.SetIsHoldWithMouseEnabled(border, true);
-            var decorator = new Decorator
+            var testRoot = new TestRoot
             {
                 Child = border
             };
             var raised = false;
 
-            decorator.AddHandler(Gestures.HoldingEvent, (_, e) => raised = e.HoldingState == HoldingState.Completed);
+            testRoot.AddHandler(Gestures.HoldingEvent, (_, e) => raised = e.HoldingState == HoldingState.Completed);
 
             var secondMouse = new MouseTestHelper();
 
@@ -392,12 +392,12 @@ namespace Avalonia.Base.UnitTests.Input
         }
         
         private static void AddHandlers(
-            Decorator decorator,
+            TestRoot root,
             Border border,
             IList<string> result,
             bool markHandled)
         {
-            decorator.AddHandler(InputElement.PointerPressedEvent, (_, e) =>
+            root.AddHandler(InputElement.PointerPressedEvent, (_, e) =>
             {
                 result.Add("dp");
 
@@ -407,7 +407,7 @@ namespace Avalonia.Base.UnitTests.Input
                 }
             });
 
-            decorator.AddHandler(InputElement.PointerReleasedEvent, (_, e) =>
+            root.AddHandler(InputElement.PointerReleasedEvent, (_, e) =>
             {
                 result.Add("dr");
 
@@ -420,8 +420,8 @@ namespace Avalonia.Base.UnitTests.Input
             border.AddHandler(InputElement.PointerPressedEvent, (_, _) => result.Add("bp"));
             border.AddHandler(InputElement.PointerReleasedEvent, (_, _) => result.Add("br"));
 
-            decorator.AddHandler(Gestures.TappedEvent, (_, _) => result.Add("dt"));
-            decorator.AddHandler(Gestures.DoubleTappedEvent, (_, _) => result.Add("ddt"));
+            root.AddHandler(Gestures.TappedEvent, (_, _) => result.Add("dt"));
+            root.AddHandler(Gestures.DoubleTappedEvent, (_, _) => result.Add("ddt"));
             border.AddHandler(Gestures.TappedEvent, (_, _) => result.Add("bt"));
             border.AddHandler(Gestures.DoubleTappedEvent, (_, _) => result.Add("bdt"));
         }
@@ -438,13 +438,13 @@ namespace Avalonia.Base.UnitTests.Input
                 Background = new SolidColorBrush(Colors.Red)
             };
             border.GestureRecognizers.Add(new PinchGestureRecognizer());
-            var decorator = new Decorator
+            var root = new TestRoot
             {
                 Child = border
             };
             var raised = false;
 
-            decorator.AddHandler(Gestures.PinchEvent, (_, _) => raised = true);
+            root.AddHandler(Gestures.PinchEvent, (_, _) => raised = true);
 
             var firstPoint = new Point(5, 5);
             var secondPoint = new Point(10, 10);
@@ -466,13 +466,13 @@ namespace Avalonia.Base.UnitTests.Input
                 Background = new SolidColorBrush(Colors.Red)
             };
             border.GestureRecognizers.Add(new PinchGestureRecognizer());
-            var decorator = new Decorator
+            var root = new TestRoot
             {
                 Child = border
             };
             var raised = false;
 
-            decorator.AddHandler(Gestures.PinchEvent, (_, _) => raised = true);
+            root.AddHandler(Gestures.PinchEvent, (_, _) => raised = true);
 
             var firstPoint = new Point(5, 5);
             var secondPoint = new Point(10, 10);
@@ -502,13 +502,13 @@ namespace Avalonia.Base.UnitTests.Input
                 CanVerticallyScroll = true,
                 ScrollStartDistance = 50
             });
-            var decorator = new Decorator
+            var root = new TestRoot
             {
                 Child = border
             };
             var raised = false;
 
-            decorator.AddHandler(Gestures.ScrollGestureEvent, (_, _) => raised = true);
+            root.AddHandler(Gestures.ScrollGestureEvent, (_, _) => raised = true);
 
             var firstTouch = new TouchTestHelper();
 

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests_Multiple.cs
@@ -34,7 +34,7 @@ namespace Avalonia.Controls.UnitTests
                 var root = new TestRoot(target);
                 root.LayoutManager.ExecuteInitialLayoutPass();
 
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 _helper.Click(target.Presenter.Panel.Children[2], modifiers: KeyModifiers.Shift);
 
                 Assert.Equal(new[] { "Foo", "Bar", "Baz" }, target.SelectedItems);
@@ -60,7 +60,7 @@ namespace Avalonia.Controls.UnitTests
                 var root = new TestRoot(target);
                 root.LayoutManager.ExecuteInitialLayoutPass();
 
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
 
                 SelectionChangedEventArgs receivedArgs = null;
 
@@ -118,7 +118,7 @@ namespace Avalonia.Controls.UnitTests
                 var root = new TestRoot(target);
                 root.LayoutManager.ExecuteInitialLayoutPass();
 
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 _helper.Click(target.Presenter.Panel.Children[1]);
                 _helper.Click(target.Presenter.Panel.Children[2], modifiers: KeyModifiers.Control);
                 _helper.Click(target.Presenter.Panel.Children[3], modifiers: KeyModifiers.Control);
@@ -152,7 +152,7 @@ namespace Avalonia.Controls.UnitTests
                 var root = new TestRoot(target);
                 root.LayoutManager.ExecuteInitialLayoutPass();
 
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 _helper.Click(target.Presenter.Panel.Children[1]);
                 _helper.Click(target.Presenter.Panel.Children[2], modifiers: KeyModifiers.Control);
 
@@ -183,7 +183,7 @@ namespace Avalonia.Controls.UnitTests
                 var root = new TestRoot(target);
                 root.LayoutManager.ExecuteInitialLayoutPass();
 
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 _helper.Click(target.Presenter.Panel.Children[3]);
                 _helper.Click(target.Presenter.Panel.Children[4], modifiers: KeyModifiers.Control);
 
@@ -211,7 +211,7 @@ namespace Avalonia.Controls.UnitTests
                 var root = new TestRoot(target);
                 root.LayoutManager.ExecuteInitialLayoutPass();
 
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 _helper.Click(target.Presenter.Panel.Children[3]);
                 _helper.Click(target.Presenter.Panel.Children[5], modifiers: KeyModifiers.Shift);
 
@@ -239,7 +239,7 @@ namespace Avalonia.Controls.UnitTests
                 var root = new TestRoot(target);
                 root.LayoutManager.ExecuteInitialLayoutPass();
 
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 _helper.Click(target.Presenter.Panel.Children[0]);
                 _helper.Click(target.Presenter.Panel.Children[5], modifiers: KeyModifiers.Shift);
 
@@ -266,7 +266,7 @@ namespace Avalonia.Controls.UnitTests
                 var root = new TestRoot(target);
                 root.LayoutManager.ExecuteInitialLayoutPass();
 
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
 
                 SelectionChangedEventArgs receivedArgs = null;
 
@@ -319,7 +319,7 @@ namespace Avalonia.Controls.UnitTests
                 var root = new TestRoot(target);
                 root.LayoutManager.ExecuteInitialLayoutPass();
 
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 _helper.Click(target.Presenter.Panel.Children[0]);
 
                 Assert.Equal(new[] { "Foo" }, target.SelectedItems);
@@ -414,7 +414,7 @@ namespace Avalonia.Controls.UnitTests
                 var root = new TestRoot(target);
                 root.LayoutManager.ExecuteInitialLayoutPass();
 
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 _helper.Click(target.Presenter.Panel.Children[0]);
                 _helper.Click(target.Presenter.Panel.Children[1], modifiers: KeyModifiers.Shift);
 
@@ -444,7 +444,7 @@ namespace Avalonia.Controls.UnitTests
                 var root = new TestRoot(target);
                 root.LayoutManager.ExecuteInitialLayoutPass();
 
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
 
                 _helper.Click(target.Presenter.Panel.Children[0]);
                 _helper.Click(target.Presenter.Panel.Children[2], MouseButton.Right, modifiers: KeyModifiers.Shift);
@@ -471,7 +471,7 @@ namespace Avalonia.Controls.UnitTests
                 var root = new TestRoot(target);
                 root.LayoutManager.ExecuteInitialLayoutPass();
 
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
 
                 _helper.Click(target.Presenter.Panel.Children[0]);
                 _helper.Click(target.Presenter.Panel.Children[2], MouseButton.Right, modifiers: KeyModifiers.Control);

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests_Single.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests_Single.cs
@@ -49,7 +49,7 @@ namespace Avalonia.Controls.UnitTests
                     Template = new FuncControlTemplate(CreateListBoxTemplate),
                     ItemsSource = new[] { "Foo", "Bar", "Baz " },
                 };
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 ApplyTemplate(target);
 
                 target.Presenter.Panel.Children[0].RaiseEvent(new GotFocusEventArgs
@@ -79,7 +79,7 @@ namespace Avalonia.Controls.UnitTests
                     Template = new FuncControlTemplate(CreateListBoxTemplate),
                     ItemsSource = new[] { "Foo", "Bar", "Baz " },
                 };
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 ApplyTemplate(target);
                 _mouse.Click(target.Presenter.Panel.Children[0]);
 
@@ -97,7 +97,7 @@ namespace Avalonia.Controls.UnitTests
                     Template = new FuncControlTemplate(CreateListBoxTemplate),
                     ItemsSource = new[] { "Foo", "Bar", "Baz " },
                 };
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 ApplyTemplate(target);
                 target.SelectedIndex = 0;
 
@@ -118,7 +118,7 @@ namespace Avalonia.Controls.UnitTests
                     ItemsSource = new[] { "Foo", "Bar", "Baz " },
                     SelectionMode = SelectionMode.Single | SelectionMode.Toggle,
                 };
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 ApplyTemplate(target);
 
                 _mouse.Click(target.Presenter.Panel.Children[0]);
@@ -139,7 +139,7 @@ namespace Avalonia.Controls.UnitTests
                     SelectionMode = SelectionMode.Toggle,
                 };
 
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 ApplyTemplate(target);
                 target.SelectedIndex = 0;
 
@@ -160,7 +160,7 @@ namespace Avalonia.Controls.UnitTests
                     ItemsSource = new[] { "Foo", "Bar", "Baz " },
                     SelectionMode = SelectionMode.Toggle | SelectionMode.AlwaysSelected,
                 };
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 ApplyTemplate(target);
                 target.SelectedIndex = 0;
 
@@ -181,7 +181,7 @@ namespace Avalonia.Controls.UnitTests
                     ItemsSource = new[] { "Foo", "Bar", "Baz " },
                     SelectionMode = SelectionMode.Single | SelectionMode.Toggle,
                 };
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 ApplyTemplate(target);
                 target.SelectedIndex = 1;
 

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -1234,7 +1234,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                     Template = Template(),
                     ItemsSource = new[] { "Foo", "Bar", "Baz " },
                 };
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 Prepare(target);
 
                 var container = target.ContainerFromIndex(1)!;
@@ -1258,7 +1258,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                     Template = Template(),
                     ItemsSource = items,
                 };
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 Prepare(target);
 
                 _helper.Down(target.Presenter.Panel.Children[1]);
@@ -1355,7 +1355,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                     Template = Template(),
                     ItemsSource = new[] { "Foo", "Bar", "Baz", "Foo", "Bar", "Baz" },
                 };
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 Prepare(target);
                 _helper.Down((Interactive)target.Presenter.Panel.Children[3]);
 
@@ -1373,7 +1373,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                     Template = Template(),
                     ItemsSource = new[] { "Foo", "Bar", "Baz", "Foo", "Bar", "Baz" },
                 };
-                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new Mock<PlatformHotkeyConfiguration>().Object);
+                AvaloniaLocator.CurrentMutable.Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration());
                 Prepare(target);
                 _helper.Down((Interactive)target.Presenter.Panel.Children[3]);
 

--- a/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
@@ -1045,7 +1045,7 @@ namespace Avalonia.Controls.UnitTests
             var data = CreateTestTreeData();
             var target = CreateTarget(data: data, multiSelect: true);
             var rootNode = data[0];
-            var keymap = AvaloniaLocator.Current.GetRequiredService<PlatformHotkeyConfiguration>();
+            var keymap = PlatformHotkeyConfiguration.Instance!;
             var selectAllGesture = keymap.SelectAll.First();
 
             var keyEvent = new KeyEventArgs
@@ -1075,7 +1075,7 @@ namespace Avalonia.Controls.UnitTests
             ClickContainer(fromContainer, KeyModifiers.None);
             ClickContainer(toContainer, KeyModifiers.Shift);
 
-            var keymap = AvaloniaLocator.Current.GetRequiredService<PlatformHotkeyConfiguration>();
+            var keymap = PlatformHotkeyConfiguration.Instance!;
             var selectAllGesture = keymap.SelectAll.First();
 
             var keyEvent = new KeyEventArgs
@@ -1105,7 +1105,7 @@ namespace Avalonia.Controls.UnitTests
             ClickContainer(fromContainer, KeyModifiers.None);
             ClickContainer(toContainer, KeyModifiers.Shift);
 
-            var keymap = AvaloniaLocator.Current.GetRequiredService<PlatformHotkeyConfiguration>();
+            var keymap = PlatformHotkeyConfiguration.Instance!;
             var selectAllGesture = keymap.SelectAll.First();
 
             var keyEvent = new KeyEventArgs

--- a/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TreeViewTests.cs
@@ -1045,7 +1045,7 @@ namespace Avalonia.Controls.UnitTests
             var data = CreateTestTreeData();
             var target = CreateTarget(data: data, multiSelect: true);
             var rootNode = data[0];
-            var keymap = PlatformHotkeyConfiguration.Instance!;
+            var keymap = Application.Current!.PlatformSettings!.HotkeyConfiguration;
             var selectAllGesture = keymap.SelectAll.First();
 
             var keyEvent = new KeyEventArgs
@@ -1075,7 +1075,7 @@ namespace Avalonia.Controls.UnitTests
             ClickContainer(fromContainer, KeyModifiers.None);
             ClickContainer(toContainer, KeyModifiers.Shift);
 
-            var keymap = PlatformHotkeyConfiguration.Instance!;
+            var keymap = Application.Current!.PlatformSettings!.HotkeyConfiguration;
             var selectAllGesture = keymap.SelectAll.First();
 
             var keyEvent = new KeyEventArgs
@@ -1105,7 +1105,7 @@ namespace Avalonia.Controls.UnitTests
             ClickContainer(fromContainer, KeyModifiers.None);
             ClickContainer(toContainer, KeyModifiers.Shift);
 
-            var keymap = PlatformHotkeyConfiguration.Instance!;
+            var keymap = Application.Current!.PlatformSettings!.HotkeyConfiguration;
             var selectAllGesture = keymap.SelectAll.First();
 
             var keyEvent = new KeyEventArgs

--- a/tests/Avalonia.UnitTests/TestRoot.cs
+++ b/tests/Avalonia.UnitTests/TestRoot.cs
@@ -67,6 +67,7 @@ namespace Avalonia.UnitTests
 
         public IKeyboardNavigationHandler KeyboardNavigationHandler => null;
         public IFocusManager FocusManager => AvaloniaLocator.Current.GetService<IFocusManager>();
+        public IPlatformSettings PlatformSettings => AvaloniaLocator.Current.GetService<IPlatformSettings>();
 
         public IInputElement PointerOverElement { get; set; }
         

--- a/tests/Avalonia.UnitTests/UnitTestApplication.cs
+++ b/tests/Avalonia.UnitTests/UnitTestApplication.cs
@@ -77,7 +77,8 @@ namespace Avalonia.UnitTests
                 .Bind<IDispatcherImpl>().ToConstant(Services.DispatcherImpl)
                 .Bind<ICursorFactory>().ToConstant(Services.StandardCursorFactory)
                 .Bind<IWindowingPlatform>().ToConstant(Services.WindowingPlatform)
-                .Bind<PlatformHotkeyConfiguration>().ToSingleton<PlatformHotkeyConfiguration>();
+                .Bind<PlatformHotkeyConfiguration>().ToSingleton<PlatformHotkeyConfiguration>()
+                .Bind<IPlatformSettings>().ToSingleton<DefaultPlatformSettings>();
             
             // This is a hack to make tests work, we need to refactor the way font manager is registered
             // See https://github.com/AvaloniaUI/Avalonia/issues/10081


### PR DESCRIPTION
## What does the pull request do?

New APIs:
```csharp
public class Applcation
{
    /// Represents a contract for accessing global platform-specific settings.
    IPlatformSettings? PlatformSettings { get; }
}

public class TopLevel : IInputRoot
{
    /// Represents a contract for accessing top-level platform-specific settings.
    IPlatformSettings? PlatformSettings { get; }
}

public interface IPlatformSettings
{
    /// Retrieves shared static instance of PlatformHotkeyConfiguration.
    PlatformHotkeyConfiguration HotkeyConfiguration { get; }
}
```

Why do we need two PlatformSettings properties?
We want users to use top-level platform settings where possible, as different top-levels technically can have different settings set or even run in different desktop environments. In the future, it might be the only available option to access platform settings as well, so in the long term, it is recommended.
At the same time, Avalonia itself is not well adapted to this scenario, as whole styling/theming system relies on the resources owner which is usually an Application, meaning we still need an API available from the Application. The same goes to third-party themes, like Fluent Avalonia, which need to have platform settings access while constructing their theme.
A proper solution would be to abstract the styling system from the Application (in the end, only a specific top-level subtree can be styled), but definitely not in the 11.x timeframe.

With this PR, internally these APIs still use AvaloniaLocator. But in perspective, we want to make TopLevel-PlatformSettings aware of current top-level instead of a global instance, which won't be a breaking change.

Also updates usage of these APIs in the repository.

Closes https://github.com/AvaloniaUI/Avalonia/issues/11381