### PR TITLE
Fix devtools after recent XAML compiler changes

### DIFF
--- a/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
+++ b/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.cs
@@ -401,8 +401,7 @@ namespace Avalonia.Build.Tasks
                             contextClass,
                             document.PopulateMethod,
                             document.BuildMethod,
-                            builder.DefineSubType(compilerConfig.WellKnownTypes.Object, "NamespaceInfo:" + res.Name,
-                                document.IsPublic),
+                            builder.DefineSubType(compilerConfig.WellKnownTypes.Object, "NamespaceInfo:" + res.Name, true),
                             (closureName, closureBaseType) =>
                                 populateBuilder.DefineSubType(closureBaseType, closureName, false),
                             (closureName, returnType, parameterTypes) =>

--- a/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorPicker.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorPicker.xaml
@@ -1,7 +1,8 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="using:Avalonia.Controls"
-                    xmlns:primitives="using:Avalonia.Controls.Primitives">
+                    xmlns:primitives="using:Avalonia.Controls.Primitives"
+                    x:ClassModifier="internal">
 
   <ControlTheme x:Key="{x:Type ColorPicker}"
                 TargetType="ColorPicker">

--- a/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorPreviewer.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorPreviewer.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:pc="using:Avalonia.Controls.Primitives.Converters">
+                    xmlns:pc="using:Avalonia.Controls.Primitives.Converters"
+                    x:ClassModifier="internal">
 
   <pc:AccentColorConverter x:Key="AccentColorConverter" />
   <x:Double x:Key="ColorPreviewerAccentSectionWidth">80</x:Double>

--- a/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorSlider.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorSlider.xaml
@@ -1,5 +1,6 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
 
   <!-- Note that the Slider thumb should generally follow the overall Slider dimensions.
        Therefore, there are not currently separate resources to control it. -->

--- a/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorSpectrum.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorSpectrum.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:controls="using:Avalonia.Controls">
+                    xmlns:controls="using:Avalonia.Controls"
+                    x:ClassModifier="internal">
 
   <ControlTheme x:Key="{x:Type ColorSpectrum}"
                 TargetType="ColorSpectrum">

--- a/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorView.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorView.xaml
@@ -4,7 +4,8 @@
                     xmlns:converters="using:Avalonia.Controls.Converters"
                     xmlns:primitives="using:Avalonia.Controls.Primitives"
                     xmlns:pc="using:Avalonia.Controls.Primitives.Converters"
-                    xmlns:globalization="using:System.Globalization">
+                    xmlns:globalization="using:System.Globalization"
+                    x:ClassModifier="internal">
 
   <pc:ContrastBrushConverter x:Key="ContrastBrushConverter" />
   <converters:ColorToDisplayNameConverter x:Key="ColorToDisplayNameConverter" />

--- a/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorPicker.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorPicker.xaml
@@ -1,7 +1,8 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="using:Avalonia.Controls"
-                    xmlns:primitives="using:Avalonia.Controls.Primitives">
+                    xmlns:primitives="using:Avalonia.Controls.Primitives"
+                    x:ClassModifier="internal">
 
   <ControlTheme x:Key="{x:Type ColorPicker}"
                 TargetType="ColorPicker">

--- a/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorPreviewer.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorPreviewer.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:pc="using:Avalonia.Controls.Primitives.Converters">
+                    xmlns:pc="using:Avalonia.Controls.Primitives.Converters"
+                    x:ClassModifier="internal">
 
   <pc:AccentColorConverter x:Key="AccentColorConverter" />
   <x:Double x:Key="ColorPreviewerAccentSectionWidth">80</x:Double>

--- a/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorSlider.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorSlider.xaml
@@ -1,5 +1,6 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:ClassModifier="internal">
 
   <!-- Note that the Slider thumb should generally follow the overall Slider dimensions.
        Therefore, there are not currently separate resources to control it. -->

--- a/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorSpectrum.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorSpectrum.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:controls="using:Avalonia.Controls">
+                    xmlns:controls="using:Avalonia.Controls"
+                    x:ClassModifier="internal">
 
   <ControlTheme x:Key="{x:Type ColorSpectrum}"
                 TargetType="ColorSpectrum">

--- a/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorView.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorView.xaml
@@ -4,7 +4,8 @@
                     xmlns:converters="using:Avalonia.Controls.Converters"
                     xmlns:primitives="using:Avalonia.Controls.Primitives"
                     xmlns:pc="using:Avalonia.Controls.Primitives.Converters"
-                    xmlns:globalization="using:System.Globalization">
+                    xmlns:globalization="using:System.Globalization"
+                    x:ClassModifier="internal">
 
   <pc:ContrastBrushConverter x:Key="ContrastBrushConverter" />
   <converters:ColorToDisplayNameConverter x:Key="ColorToDisplayNameConverter" />

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/FilterTextBox.axaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/FilterTextBox.axaml
@@ -1,7 +1,8 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="using:Avalonia.Diagnostics.Controls"
-        x:DataType="controls:FilterTextBox">
+        x:DataType="controls:FilterTextBox"
+        x:ClassModifier="internal">
 
   <Design.PreviewWith>
     <Border Padding="10">

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/ThicknessEditor.axaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/ThicknessEditor.axaml
@@ -1,6 +1,7 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="using:Avalonia.Diagnostics.Controls">
+        xmlns:controls="using:Avalonia.Diagnostics.Controls"
+        x:ClassModifier="internal">
 
     <Styles.Resources>
         <SolidColorBrush x:Key="HighlightBorderBrush" Color="CornflowerBlue" />


### PR DESCRIPTION
## What does the pull request do?

1. Instead of "internal" NamespaceInfo subclasses were generated as "private", which makes them inaccessible from the same assembly. This PR changes it back to "public", which shouldn't be an issue as these NamespaceInfo subclasses are primitive and don't reference actual XAML types.
2. Makes more XAML files internal.
## Fixed issues

Fixes #11565
