### PR TITLE
Fix headless vnc colour format

### DIFF
--- a/src/Headless/Avalonia.Headless.Vnc/HeadlessVncPlatformExtensions.cs
+++ b/src/Headless/Avalonia.Headless.Vnc/HeadlessVncPlatformExtensions.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Headless;
 using Avalonia.Headless.Vnc;
+using Avalonia.Platform;
 using RemoteViewing.Vnc;
 using RemoteViewing.Vnc.Server;
 
@@ -22,7 +23,8 @@ namespace Avalonia
             return builder
                 .UseHeadless(new AvaloniaHeadlessPlatformOptions
                 {
-                    UseHeadlessDrawing = false
+                    UseHeadlessDrawing = false,
+                    FrameBufferFormat = PixelFormat.Bgra8888
                 })
                 .AfterSetup(_ =>
                 {

--- a/src/Headless/Avalonia.Headless/AvaloniaHeadlessPlatform.cs
+++ b/src/Headless/Avalonia.Headless/AvaloniaHeadlessPlatform.cs
@@ -51,11 +51,16 @@ namespace Avalonia.Headless
 
         private class HeadlessWindowingPlatform : IWindowingPlatform
         {
-            public IWindowImpl CreateWindow() => new HeadlessWindowImpl(false);
+            readonly PixelFormat _frameBufferFormat;
+            public HeadlessWindowingPlatform(PixelFormat frameBufferFormat)
+            {
+                _frameBufferFormat = frameBufferFormat;
+            }
+            public IWindowImpl CreateWindow() => new HeadlessWindowImpl(false, _frameBufferFormat);
 
             public IWindowImpl CreateEmbeddableWindow() => throw new PlatformNotSupportedException();
 
-            public IPopupImpl CreatePopup() => new HeadlessWindowImpl(true);
+            public IPopupImpl CreatePopup() => new HeadlessWindowImpl(true, _frameBufferFormat);
 
             public ITrayIconImpl? CreateTrayIcon() => null;
         }
@@ -70,7 +75,7 @@ namespace Avalonia.Headless
                 .Bind<IPlatformIconLoader>().ToSingleton<HeadlessIconLoaderStub>()
                 .Bind<IKeyboardDevice>().ToConstant(new KeyboardDevice())
                 .Bind<IRenderTimer>().ToConstant(new RenderTimer(60))
-                .Bind<IWindowingPlatform>().ToConstant(new HeadlessWindowingPlatform())
+                .Bind<IWindowingPlatform>().ToConstant(new HeadlessWindowingPlatform(opts.FrameBufferFormat))
                 .Bind<PlatformHotkeyConfiguration>().ToSingleton<PlatformHotkeyConfiguration>();
             Compositor = new Compositor( null);
         }
@@ -92,6 +97,7 @@ namespace Avalonia.Headless
     public class AvaloniaHeadlessPlatformOptions
     {
         public bool UseHeadlessDrawing { get; set; } = true;
+        public PixelFormat FrameBufferFormat { get; set; } = PixelFormat.Rgba8888;
     }
 
     public static class AvaloniaHeadlessPlatformExtensions

--- a/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
@@ -24,9 +24,10 @@ namespace Avalonia.Headless
         private readonly Pointer _mousePointer;
         private WriteableBitmap? _lastRenderedFrame;
         private readonly object _sync = new object();
+        private readonly PixelFormat _frameBufferFormat;
         public bool IsPopup { get; }
 
-        public HeadlessWindowImpl(bool isPopup)
+        public HeadlessWindowImpl(bool isPopup, PixelFormat frameBufferFormat)
         {
             IsPopup = isPopup;
             Surfaces = new object[] { this };
@@ -34,6 +35,7 @@ namespace Avalonia.Headless
             _mousePointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, true);
             MouseDevice = new MouseDevice(_mousePointer);
             ClientSize = new Size(1024, 768);
+            _frameBufferFormat = frameBufferFormat;
         }
 
         public void Dispose()
@@ -201,7 +203,7 @@ namespace Avalonia.Headless
 
         public ILockedFramebuffer Lock()
         {
-            var bmp = new WriteableBitmap(PixelSize.FromSize(ClientSize, RenderScaling), new Vector(96, 96) * RenderScaling, PixelFormat.Rgba8888, AlphaFormat.Premul);
+            var bmp = new WriteableBitmap(PixelSize.FromSize(ClientSize, RenderScaling), new Vector(96, 96) * RenderScaling, _frameBufferFormat, AlphaFormat.Premul);
             var fb = bmp.Lock();
             return new FramebufferProxy(fb, () =>
             {


### PR DESCRIPTION
## What does the pull request do?
Using headless vnc has the blue and red colours mixed up. This fixes that and provides a mechanism to alter the pixel format from the consuming application


## What is the current behavior?

Add 3 rectangles and running in normal desktop mode produces:

![image](https://github.com/AvaloniaUI/Avalonia/assets/7722347/61d4d554-a432-40d5-a91c-254502e8a0b9)

but when viewing using Headless.VNC the following is seen:

![image](https://github.com/AvaloniaUI/Avalonia/assets/7722347/f74c6445-d80c-40dd-8e34-2a77dbdd2cda)


## What is the updated/expected behavior with this PR?
The output after applying this is:

![image](https://github.com/AvaloniaUI/Avalonia/assets/7722347/e7b77e54-0838-490f-a4ca-e08b78eacce5)


I have tested using TigerVNC and TightVNC and both have the same result
