### PR TITLE
Remove IKeyboardDevice/IPointerDevice/IDragDropDevice from public API, as they are not really used anywhere

### DIFF
--- a/src/Avalonia.Base/Input/IKeyboardDevice.cs
+++ b/src/Avalonia.Base/Input/IKeyboardDevice.cs
@@ -43,7 +43,7 @@ namespace Avalonia.Input
         PenBarrelButton = 2048
     }
 
-    [NotClientImplementable]
+    [PrivateApi]
     public interface IKeyboardDevice : IInputDevice
     {
     }

--- a/src/Avalonia.Base/Input/IMouseDevice.cs
+++ b/src/Avalonia.Base/Input/IMouseDevice.cs
@@ -5,7 +5,7 @@ namespace Avalonia.Input
     /// <summary>
     /// Represents a mouse device.
     /// </summary>
-    [NotClientImplementable]
+    [PrivateApi]
     public interface IMouseDevice : IPointerDevice
     {
     }

--- a/src/Avalonia.Base/Input/IPenDevice.cs
+++ b/src/Avalonia.Base/Input/IPenDevice.cs
@@ -1,8 +1,11 @@
-﻿namespace Avalonia.Input
+﻿using Avalonia.Metadata;
+
+namespace Avalonia.Input
 {
     /// <summary>
     /// Represents a pen/stylus device.
     /// </summary>
+    [PrivateApi]
     public interface IPenDevice : IPointerDevice
     {
 

--- a/src/Avalonia.Base/Input/IPointerDevice.cs
+++ b/src/Avalonia.Base/Input/IPointerDevice.cs
@@ -3,7 +3,7 @@ using Avalonia.Metadata;
 
 namespace Avalonia.Input
 {
-    [NotClientImplementable]
+    [PrivateApi]
     public interface IPointerDevice : IInputDevice
     {
         /// <summary>

--- a/src/Avalonia.Base/Input/KeyEventArgs.cs
+++ b/src/Avalonia.Base/Input/KeyEventArgs.cs
@@ -5,8 +5,6 @@ namespace Avalonia.Input
 {
     public class KeyEventArgs : RoutedEventArgs
     {
-        public IKeyboardDevice? Device { get; init; }
-
         public Key Key { get; init; }
 
         public KeyModifiers KeyModifiers { get; init; }

--- a/src/Avalonia.Base/Input/KeyboardDevice.cs
+++ b/src/Avalonia.Base/Input/KeyboardDevice.cs
@@ -192,7 +192,6 @@ namespace Avalonia.Input
                         KeyEventArgs ev = new KeyEventArgs
                         {
                             RoutedEvent = routedEvent,
-                            Device = this,
                             Key = keyInput.Key,
                             KeyModifiers = keyInput.Modifiers.ToKeyModifiers(),
                             Source = element,
@@ -241,7 +240,6 @@ namespace Avalonia.Input
             {
                 var ev = new TextInputEventArgs()
                 {
-                    Device = this,
                     Text = text.Text,
                     Source = element,
                     RoutedEvent = InputElement.TextInputEvent

--- a/src/Avalonia.Base/Input/Raw/IDragDropDevice.cs
+++ b/src/Avalonia.Base/Input/Raw/IDragDropDevice.cs
@@ -2,7 +2,7 @@
 
 namespace Avalonia.Input.Raw
 {
-    [NotClientImplementable]
+    [PrivateApi]
     public interface IDragDropDevice : IInputDevice
     {
     }

--- a/src/Avalonia.Base/Input/TextInputEventArgs.cs
+++ b/src/Avalonia.Base/Input/TextInputEventArgs.cs
@@ -4,8 +4,6 @@ namespace Avalonia.Input
 {
     public class TextInputEventArgs : RoutedEventArgs
     {
-        public IKeyboardDevice? Device { get; set; }
-
-        public string? Text { get; set; }
+        public string? Text { get; init; }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -2141,7 +2141,6 @@ namespace Avalonia.Controls.UnitTests.Primitives
                 target.RaiseEvent(new TextInputEventArgs
                 {
                     RoutedEvent = InputElement.TextInputEvent,
-                    Device = KeyboardDevice.Instance, 
                     Text = "Foo"
                 });
 
@@ -2152,7 +2151,6 @@ namespace Avalonia.Controls.UnitTests.Primitives
                 target.RaiseEvent(new TextInputEventArgs
                 {
                     RoutedEvent = InputElement.TextInputEvent, 
-                    Device = KeyboardDevice.Instance, 
                     Text = "Foo"
                 });
 


### PR DESCRIPTION
Minor breaking change.