### PR TITLE
Make some interfaces/classes a PrivateApi.

### DIFF
--- a/src/Avalonia.Base/Layout/ILayoutManager.cs
+++ b/src/Avalonia.Base/Layout/ILayoutManager.cs
@@ -6,8 +6,8 @@ namespace Avalonia.Layout
     /// <summary>
     /// Manages measuring and arranging of controls.
     /// </summary>
-    [NotClientImplementable]
-    internal interface ILayoutManager : IDisposable
+    [PrivateApi]
+    public interface ILayoutManager : IDisposable
     {
         /// <summary>
         /// Raised when the layout manager completes a layout pass.

--- a/src/Avalonia.Base/Layout/LayoutManager.cs
+++ b/src/Avalonia.Base/Layout/LayoutManager.cs
@@ -2,9 +2,9 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Avalonia.Logging;
 using Avalonia.Media;
+using Avalonia.Metadata;
 using Avalonia.Rendering;
 using Avalonia.Threading;
 using Avalonia.Utilities;
@@ -16,7 +16,8 @@ namespace Avalonia.Layout
     /// <summary>
     /// Manages measuring and arranging of controls.
     /// </summary>
-    internal class LayoutManager : ILayoutManager, IDisposable
+    [PrivateApi]
+    public class LayoutManager : ILayoutManager, IDisposable
     {
         private const int MaxPasses = 10;
         private readonly Layoutable _owner;

--- a/src/Avalonia.Base/Rendering/IRenderRoot.cs
+++ b/src/Avalonia.Base/Rendering/IRenderRoot.cs
@@ -16,9 +16,9 @@ namespace Avalonia.Rendering
         /// <summary>
         /// Gets the renderer for the window.
         /// </summary>
-        internal IRenderer Renderer { get; }
+        public IRenderer Renderer { get; }
         
-        internal IHitTester HitTester { get; }
+        public IHitTester HitTester { get; }
 
         /// <summary>
         /// The scaling factor to use in rendering.

--- a/src/Avalonia.Base/Rendering/IRenderer.cs
+++ b/src/Avalonia.Base/Rendering/IRenderer.cs
@@ -9,7 +9,8 @@ namespace Avalonia.Rendering
     /// <summary>
     /// Defines the interface for a renderer.
     /// </summary>
-    internal interface IRenderer : IDisposable
+    [PrivateApi]
+    public interface IRenderer : IDisposable
     {
         /// <summary>
         /// Gets a value indicating whether the renderer should draw specific diagnostics.
@@ -73,7 +74,8 @@ namespace Avalonia.Rendering
         Compositor Compositor { get; }
     }
 
-    internal interface IHitTester
+    [PrivateApi]
+    public interface IHitTester
     {
         /// <summary>
         /// Hit tests a location to find the visuals at the specified point.

--- a/src/Avalonia.Base/Rendering/SceneInvalidatedEventArgs.cs
+++ b/src/Avalonia.Base/Rendering/SceneInvalidatedEventArgs.cs
@@ -1,11 +1,13 @@
 ﻿using System;
+using Avalonia.Metadata;
 
 namespace Avalonia.Rendering
 {
     /// <summary>
     /// Provides data for the <see cref="IRenderer.SceneInvalidated"/> event.
     /// </summary>
-    internal class SceneInvalidatedEventArgs : EventArgs
+    [PrivateApi]
+    public class SceneInvalidatedEventArgs : EventArgs
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SceneInvalidatedEventArgs"/> class.


### PR DESCRIPTION
## What does the pull request do?

Makes the following APIs a `[PrivateApi]` instead of `internal`:

- `ILayoutManager`
- `LayoutManager`
- `IRenderer`
- `IHitTester`
- `SceneInvalidatedEventArgs`

Required to allow people to port existing unit tests without having to rewrite using Headless. For example this is needed to get the Avalonia.Controls.TreeDataGrid unit tests working again.
