### PR TITLE
Fix DBus Tray Icon when the org.kde.StatusNotifierWatcher service is unavailable

### DIFF
--- a/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
+++ b/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
@@ -60,9 +60,9 @@ namespace Avalonia.FreeDesktop
         {
             try
             {
-                _serviceWatchDisposable = await _dBus!.WatchNameOwnerChangedAsync((_, x) => OnNameChange(x.Item2));
+                _serviceWatchDisposable = await _dBus!.WatchNameOwnerChangedAsync((_, x) => OnNameChange(x.Item1, x.Item3));
                 var nameOwner = await _dBus.GetNameOwnerAsync("org.kde.StatusNotifierWatcher");
-                OnNameChange(nameOwner);
+                OnNameChange("org.kde.StatusNotifierWatcher", nameOwner);
             }
             catch
             {
@@ -72,9 +72,9 @@ namespace Avalonia.FreeDesktop
             }
         }
 
-        private void OnNameChange(string? newOwner)
+        private void OnNameChange(string name, string? newOwner)
         {
-            if (_isDisposed || _connection is null)
+            if (_isDisposed || _connection is null || name != "org.kde.StatusNotifierWatcher")
                 return;
 
             if (!_serviceConnected & newOwner is not null)


### PR DESCRIPTION
## What does the pull request do?


## What is the current behavior?
_serviceConnected was set to true when any NameOwnerChanged signal occured, which lead to an exception because the service doesn't actually exists.

## What is the updated/expected behavior with this PR?
No exception is thrown when the service is unavailable.

## How was the solution implemented (if it's not obvious)?


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
