### PR TITLE
Previewer CPU usage and scaling fixes

### DIFF
--- a/src/Avalonia.Controls/Embedding/Offscreen/OffscreenTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Embedding/Offscreen/OffscreenTopLevelImpl.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using Avalonia.Input;
 using Avalonia.Input.Raw;
-using Avalonia.Media;
 using Avalonia.Metadata;
 using Avalonia.Platform;
-using Avalonia.Rendering;
 using Avalonia.Rendering.Composition;
-using Avalonia.Threading;
 
 namespace Avalonia.Controls.Embedding.Offscreen
 {
@@ -17,7 +13,6 @@ namespace Avalonia.Controls.Embedding.Offscreen
     {
         private double _scaling = 1;
         private Size _clientSize;
-        private ManualRenderTimer _manualRenderTimer = new();
 
         public IInputRoot? InputRoot { get; private set; }
         public bool IsDisposed { get; private set; }
@@ -27,21 +22,10 @@ namespace Avalonia.Controls.Embedding.Offscreen
             IsDisposed = true;
         }
 
-        class ManualRenderTimer : IRenderTimer
-        {
-            static Stopwatch St = Stopwatch.StartNew(); 
-            public event Action<TimeSpan>? Tick;
-            public bool RunsInBackground => false;
-            public void TriggerTick() => Tick?.Invoke(St.Elapsed);
-        }
-
         public Compositor Compositor { get; }
 
         public OffscreenTopLevelImplBase()
-        {
-            Compositor = new Compositor(new RenderLoop(_manualRenderTimer), null, false,
-                MediaContext.Instance, false);
-        }
+            => Compositor = new Compositor(null);
 
         public abstract IEnumerable<object> Surfaces { get; }
 
@@ -76,7 +60,6 @@ namespace Avalonia.Controls.Embedding.Offscreen
 
         public void SetFrameThemeVariant(PlatformThemeVariant themeVariant) { }
 
-        /// <inheritdoc/>
         public AcrylicPlatformCompensationLevels AcrylicCompensationLevels { get; } = new AcrylicPlatformCompensationLevels(1, 1, 1);
 
         public void SetInputRoot(IInputRoot inputRoot) => InputRoot = inputRoot;

--- a/src/Avalonia.Controls/Platform/ManagedDispatcherImpl.cs
+++ b/src/Avalonia.Controls/Platform/ManagedDispatcherImpl.cs
@@ -99,9 +99,15 @@ public class ManagedDispatcherImpl : IControlledDispatcherImpl
                 continue;
             }
 
-            if (_nextTimer != null)
+            TimeSpan? nextTimer;
+            lock (_lock)
             {
-                var waitFor = _clock.Elapsed - _nextTimer.Value;
+                nextTimer = _nextTimer;
+            }
+
+            if (nextTimer != null)
+            {
+                var waitFor = nextTimer.Value - _clock.Elapsed;
                 if (waitFor.TotalMilliseconds < 1)
                     continue;
                 _wakeup.WaitOne(waitFor);

--- a/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.Framebuffer.cs
+++ b/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.Framebuffer.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Avalonia.Platform;
+using Avalonia.Remote.Protocol.Viewport;
+using PlatformPixelFormat = Avalonia.Platform.PixelFormat;
+using ProtocolPixelFormat = Avalonia.Remote.Protocol.Viewport.PixelFormat;
+
+namespace Avalonia.Controls.Remote.Server
+{
+    internal partial class RemoteServerTopLevelImpl
+    {
+        private enum FrameStatus
+        {
+            NotRendered,
+            Rendered,
+            CopiedToMessage
+        }
+
+        private sealed class Framebuffer
+        {
+            public static Framebuffer Empty { get; } =
+                new(ProtocolPixelFormat.Rgba8888, default, new Vector(96.0, 96.0));
+
+            private readonly object _dataLock = new();
+            private readonly byte[] _data; // for rendering only
+            private readonly byte[] _dataCopy; // for messages only
+            private FrameStatus _status = FrameStatus.NotRendered;
+
+            public Framebuffer(ProtocolPixelFormat format, Size clientSize, Vector dpi)
+            {
+                var frameSize = PixelSize.FromSizeWithDpi(clientSize, dpi);
+                if (frameSize.Width <= 0 || frameSize.Height <= 0)
+                    frameSize = PixelSize.Empty;
+
+                var bpp = format == ProtocolPixelFormat.Rgb565 ? 2 : 4;
+                var stride = frameSize.Width * bpp;
+                var dataLength = Math.Max(0, stride * frameSize.Height);
+
+                Format = format;
+                FrameSize = frameSize;
+                ClientSize = clientSize;
+                Dpi = dpi;
+
+                (Stride, _data, _dataCopy) = dataLength > 0 ?
+                    (stride, new byte[dataLength], new byte[dataLength]) :
+                    (0, Array.Empty<byte>(), Array.Empty<byte>());
+            }
+
+            public ProtocolPixelFormat Format { get; }
+
+            public Size ClientSize { get; }
+
+            public Vector Dpi { get; }
+
+            public PixelSize FrameSize { get; }
+
+            public int Stride { get; }
+
+            public FrameStatus GetStatus()
+            {
+                lock (_dataLock)
+                    return _status;
+            }
+
+            public ILockedFramebuffer Lock(Action onUnlocked)
+            {
+                var handle = GCHandle.Alloc(_data, GCHandleType.Pinned);
+                Monitor.Enter(_dataLock);
+
+                try
+                {
+                    return new LockedFramebuffer(
+                        handle.AddrOfPinnedObject(),
+                        FrameSize,
+                        Stride,
+                        Dpi,
+                        new PlatformPixelFormat((PixelFormatEnum)Format),
+                        () =>
+                        {
+                            handle.Free();
+                            Array.Copy(_data, _dataCopy, _data.Length);
+                            _status = FrameStatus.Rendered;
+                            Monitor.Exit(_dataLock);
+                            onUnlocked();
+                        });
+                }
+                catch
+                {
+                    handle.Free();
+                    Monitor.Exit(_dataLock);
+                    throw;
+                }
+            }
+
+            /// <remarks>The returned message must be kept around, as it contains a shared buffer.</remarks>
+            public FrameMessage ToMessage(long sequenceId)
+            {
+                lock (_dataLock)
+                    _status = FrameStatus.CopiedToMessage;
+
+                return new FrameMessage
+                {
+                    SequenceId = sequenceId,
+                    Data = _dataCopy,
+                    Format = Format,
+                    Width = FrameSize.Width,
+                    Height = FrameSize.Height,
+                    Stride = Stride,
+                    DpiX = Dpi.X,
+                    DpiY = Dpi.Y
+                };
+            }
+        }
+    }
+}

--- a/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
+++ b/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
@@ -53,7 +53,11 @@ namespace Avalonia.DesignerSupport.Remote
             // In previewer mode we completely ignore client-side viewport size
             if (obj is ClientViewportAllocatedMessage alloc)
             {
-                Dispatcher.UIThread.Post(() => SetDpi(new Vector(alloc.DpiX, alloc.DpiY)));
+                Dispatcher.UIThread.Post(() =>
+                {
+                    RenderScaling = alloc.DpiX / 96.0;
+                    RenderAndSendFrameIfNeeded();
+                });
                 return;
             }
             base.OnMessage(transport, obj);

--- a/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
+++ b/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
@@ -67,7 +67,7 @@ namespace Avalonia.DesignerSupport.Remote
                 Height = clientSize.Height
             });
             ClientSize = clientSize;
-            RenderIfNeeded();
+            RenderAndSendFrameIfNeeded();
         }
 
         public void Move(PixelPoint point)

--- a/src/Avalonia.DesignerSupport/Remote/PreviewerWindowingPlatform.cs
+++ b/src/Avalonia.DesignerSupport/Remote/PreviewerWindowingPlatform.cs
@@ -52,7 +52,7 @@ namespace Avalonia.DesignerSupport.Remote
                 .Bind<IKeyboardDevice>().ToConstant(Keyboard)
                 .Bind<IPlatformSettings>().ToSingleton<DefaultPlatformSettings>()
                 .Bind<IDispatcherImpl>().ToConstant(new ManagedDispatcherImpl(null))
-                .Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(60))
+                .Bind<IRenderTimer>().ToConstant(new UiThreadRenderTimer(60))
                 .Bind<IWindowingPlatform>().ToConstant(instance)
                 .Bind<IPlatformIconLoader>().ToSingleton<IconLoaderStub>()
                 .Bind<PlatformHotkeyConfiguration>().ToSingleton<PlatformHotkeyConfiguration>();


### PR DESCRIPTION
## What does the pull request do?

This PR fixes:
 - The excessive CPU usage when using the Avalonia previewer: https://github.com/AvaloniaUI/Avalonia/issues/10203. Summer is coming, I need my computer to stay cool :)
 - Some incorrect scaling when zooming in the previewer: https://github.com/AvaloniaUI/AvaloniaVS/issues/295

There are 4 commits:
 - The first commit fixes a small mistake that costs a lot of CPU time: in `ManagedDispatcherImpl`, the time to wait until the next timer was always negative: the thread was never paused!
 - The second commit is a rework of `RemoteServerTopLevelImpl ` to better work with the compositing renderer. It implements a frame buffer that the renderer can update when some visual is invalidated, using a standard render timer, like in most other implementations. Once a new frame is rendered to that buffer, it's sent to the previewer. This commit also changes the frame buffer to be reused between frames (as long as the size doesn't change) instead of having a new one allocated each time.
 - The third commit does some cleanup of the `RemoteServerTopLevelImpl` message handler: it avoids trying all branches since a message can only match one case. It also removes some reentrant locks since the whole handler is already under a lock.
 - The fourth commit ensures that `RenderScaling` is properly updated: the compositor then scales the content properly according to the previewer requested DPI.

Tested with AvaloniaVS and AvaloniaRider.

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/10203
Fixes https://github.com/AvaloniaUI/AvaloniaVS/issues/295