### PR TITLE
Fix ToggleSwitch knob animation issues. 

### DIFF
--- a/src/Avalonia.Controls/ToggleSwitch.cs
+++ b/src/Avalonia.Controls/ToggleSwitch.cs
@@ -230,7 +230,7 @@ namespace Avalonia.Controls
                 _knobsPanel!.ClearValue(Canvas.LeftProperty);
 
                 PseudoClasses.Set(":dragging", false);
-
+  
                 if (shouldBecomeChecked == IsChecked)
                 {
                     UpdateKnobPos(shouldBecomeChecked);
@@ -239,6 +239,7 @@ namespace Avalonia.Controls
                 {
                     SetCurrentValue(IsCheckedProperty, shouldBecomeChecked);
                 }
+                UpdateKnobTransitions();
             }
             else
             {
@@ -254,6 +255,10 @@ namespace Avalonia.Controls
         {
             if (_knobsPanelPressed)
             {
+                if(_knobsPanel != null)
+                {
+                    _knobsPanel.Transitions = null;
+                }
                 var difference = e.GetPosition(_switchKnob) - _switchStartPoint;
 
                 if ((!_isDragging) && (System.Math.Abs(difference.X) > 3))

--- a/src/Avalonia.Controls/ToggleSwitch.cs
+++ b/src/Avalonia.Controls/ToggleSwitch.cs
@@ -45,7 +45,7 @@ namespace Avalonia.Controls
             });
             KnobTransitionsProperty.Changed.AddClassHandler<ToggleSwitch>((x, e) =>
             {
-                x.AssignTransitions();
+                x.UpdateKnobTransitions();
             });
         }
 
@@ -73,7 +73,11 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<IDataTemplate?> OnContentTemplateProperty =
             AvaloniaProperty.Register<ToggleSwitch, IDataTemplate?>(nameof(OnContentTemplate));
 
-        public static readonly StyledProperty<Transitions> KnobTransitionsProperty = AvaloniaProperty.Register<ToggleSwitch, Transitions>(nameof(KnobTransitions));
+        /// <summary>
+        /// Defines the <see cref="KnobTransitions"/> property.
+        /// </summary>
+        public static readonly StyledProperty<Transitions> KnobTransitionsProperty = 
+            AvaloniaProperty.Register<ToggleSwitch, Transitions>(nameof(KnobTransitions));
 
         /// <summary>
         /// Gets or Sets the Content that is displayed when in the On State.
@@ -123,6 +127,9 @@ namespace Avalonia.Controls
             set { SetValue(OnContentTemplateProperty, value); }
         }
 
+        /// <summary>
+        /// Gets or Sets the <see cref="Transitions"/> of switching knob. 
+        /// </summary>
         public Transitions KnobTransitions
         {
             get { return GetValue(KnobTransitionsProperty); }
@@ -191,16 +198,15 @@ namespace Avalonia.Controls
             {
                 UpdateKnobPos(IsChecked.Value);
             }
-            
         }
 
         protected override void OnLoaded()
         {
             base.OnLoaded();
-            AssignTransitions();
+            UpdateKnobTransitions();
         }
 
-        private void AssignTransitions()
+        private void UpdateKnobTransitions()
         {
             if (_knobsPanel != null)
             {

--- a/src/Avalonia.Controls/ToggleSwitch.cs
+++ b/src/Avalonia.Controls/ToggleSwitch.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls.Metadata;
+﻿using Avalonia.Animation;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
@@ -42,6 +43,10 @@ namespace Avalonia.Controls
                     x.UpdateKnobPos(x.IsChecked.Value);
                 }
             });
+            KnobTransitionsProperty.Changed.AddClassHandler<ToggleSwitch>((x, e) =>
+            {
+                x.AssignTransitions();
+            });
         }
 
         /// <summary>
@@ -67,6 +72,8 @@ namespace Avalonia.Controls
         /// </summary>
         public static readonly StyledProperty<IDataTemplate?> OnContentTemplateProperty =
             AvaloniaProperty.Register<ToggleSwitch, IDataTemplate?>(nameof(OnContentTemplate));
+
+        public static readonly StyledProperty<Transitions> KnobTransitionsProperty = AvaloniaProperty.Register<ToggleSwitch, Transitions>(nameof(KnobTransitions));
 
         /// <summary>
         /// Gets or Sets the Content that is displayed when in the On State.
@@ -115,6 +122,14 @@ namespace Avalonia.Controls
             get { return GetValue(OnContentTemplateProperty); }
             set { SetValue(OnContentTemplateProperty, value); }
         }
+
+        public Transitions KnobTransitions
+        {
+            get { return GetValue(KnobTransitionsProperty); }
+            set { SetValue(KnobTransitionsProperty, value); }
+        }
+
+        
 
         private void OffContentChanged(AvaloniaPropertyChangedEventArgs e)
         {
@@ -176,8 +191,23 @@ namespace Avalonia.Controls
             {
                 UpdateKnobPos(IsChecked.Value);
             }
+            
         }
-        
+
+        protected override void OnLoaded()
+        {
+            base.OnLoaded();
+            AssignTransitions();
+        }
+
+        private void AssignTransitions()
+        {
+            if (_knobsPanel != null)
+            {
+                _knobsPanel.Transitions = KnobTransitions;
+            }
+        }
+
         private void KnobsPanel_PointerPressed(object? sender, Input.PointerPressedEventArgs e)
         {
             _switchStartPoint = e.GetPosition(_switchKnob);

--- a/src/Avalonia.Themes.Fluent/Controls/ToggleSwitch.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ToggleSwitch.xaml
@@ -142,11 +142,6 @@
       <Setter Property="Margin" Value="0" />
     </Style>
 
-    <!--  Dragging State  -->
-    <Style Selector="^:dragging /template/ Grid#PART_MovingKnobs">
-      <Setter Property="Transitions" Value="{x:Null}"/>
-    </Style>
-
     <!--  PointerOverState  -->
     <Style Selector="^:pointerover /template/ Border#OuterBorder">
       <Setter Property="BorderBrush" Value="{DynamicResource ToggleSwitchStrokeOffPointerOver}" />

--- a/src/Avalonia.Themes.Fluent/Controls/ToggleSwitch.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/ToggleSwitch.xaml
@@ -28,6 +28,14 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
+    <Setter Property="KnobTransitions">
+      <Transitions>
+          <DoubleTransition
+              Easing="CubicEaseOut"
+              Property="Canvas.Left"
+              Duration="0:0:0.2" />
+        </Transitions>
+    </Setter>
     <Setter Property="Template">
       <ControlTemplate>
         <Grid Background="{TemplateBinding Background}" RowDefinitions="Auto,*">
@@ -134,16 +142,9 @@
       <Setter Property="Margin" Value="0" />
     </Style>
 
-    <!--  NormalState  -->
-    <Style Selector="^:not(:dragging) /template/ Grid#PART_MovingKnobs">
-      <Setter Property="Transitions">
-        <Transitions>
-          <DoubleTransition
-              Easing="CubicEaseOut"
-              Property="Canvas.Left"
-              Duration="0:0:0.2" />
-        </Transitions>
-      </Setter>
+    <!--  Dragging State  -->
+    <Style Selector="^:dragging /template/ Grid#PART_MovingKnobs">
+      <Setter Property="Transitions" Value="{x:Null}"/>
     </Style>
 
     <!--  PointerOverState  -->

--- a/src/Avalonia.Themes.Simple/Controls/ToggleSwitch.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ToggleSwitch.xaml
@@ -150,11 +150,6 @@
       <Setter Property="Margin" Value="0" />
     </Style>
 
-    <!--  Dragging State  -->
-    <Style Selector="^:dragging /template/ Grid#PART_MovingKnobs">
-      <Setter Property="Transitions" Value="{x:Null}"/>
-    </Style>
-
     <!-- PointerOverState -->
     <Style Selector="^:pointerover /template/ Border#OuterBorder">
       <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderHighColor}" />

--- a/src/Avalonia.Themes.Simple/Controls/ToggleSwitch.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ToggleSwitch.xaml
@@ -46,6 +46,14 @@
     <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}" />
+    <Setter Property="KnobTransitions">
+      <Transitions>
+        <DoubleTransition
+            Easing="CubicEaseOut"
+            Property="Canvas.Left"
+            Duration="0:0:0.2" />
+      </Transitions>
+    </Setter>
     <Setter Property="Template">
       <ControlTemplate>
         <Grid Background="{TemplateBinding Background}"
@@ -123,11 +131,6 @@
 
               <Grid x:Name="PART_MovingKnobs"
                     Width="20" Height="20">
-                <Grid.Transitions>
-                  <Transitions>
-                    <DoubleTransition Property="Canvas.Left" Duration="0:0:0.2" Easing="CubicEaseOut" />
-                  </Transitions>
-                </Grid.Transitions>
 
                 <Ellipse x:Name="SwitchKnobOn"
                          Fill="{DynamicResource HighlightForegroundColor}"
@@ -145,6 +148,11 @@
 
     <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter:empty">
       <Setter Property="Margin" Value="0" />
+    </Style>
+
+    <!--  Dragging State  -->
+    <Style Selector="^:dragging /template/ Grid#PART_MovingKnobs">
+      <Setter Property="Transitions" Value="{x:Null}"/>
     </Style>
 
     <!-- PointerOverState -->


### PR DESCRIPTION
## What does the pull request do?
1. checked ToggleSwitch knob should not animate on first load. 
2. ToggleSwitch knob in dragging status should not have transitions. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
1. Add new StyledProperty: KnobTransitions
2. Assign this in code behind to knob panel in` OnLoaded()`
3. Remove transition assignment in Fluent and Simple styles. 
4. Remove knob transitions on dragging, and add it back when dragging finish. 


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
Custom theme designers should change transition assignment accordingly. 

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #7619
Fixes #8958
I have tested in ListBox. works well. 