### PR TITLE
Add DataGridColumn Tag property

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
@@ -1103,6 +1103,16 @@ namespace Avalonia.Controls
             get;
             set;
         }
+
+        /// <summary>
+        /// Gets or sets an object associated with this column.
+        /// </summary>
+        public object Tag
+        {
+            get;
+            set;
+        }
+
         /// <summary>
         /// Holds a Comparer to use for sorting, if not using the default.
         /// </summary>


### PR DESCRIPTION
## What does the pull request do?

Adds a `Tag` property to the `DataGridColumn` base class.

## What is the current behavior?

This is no `Tag` property on `DataGridColumn`. This makes porting some code more difficult.

## What is the updated/expected behavior with this PR?

There is now a `Tag` property on the `DataGridColumn` base class.

## How was the solution implemented (if it's not obvious)?

This was implemented following the Community Toolkit. I'm not sure why it wasn't part of the initial port so it may have been a late add upstream. The property is only a CLR property following upstream -- that could change if ever needed in the future as a non-breaking change.

https://github.com/CommunityToolkit/WindowsCommunityToolkit/blob/77b009ddf591b78dfc5bad0088c99ce35406170b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridColumn.cs#L552-L559

## Checklist

- ~[ ] Added unit tests (if possible)?~
- [x] Added XML documentation to any related classes?
- ~[ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation~

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
None