### PR TITLE
OverlayLayer should be always LTR

### DIFF
--- a/src/Avalonia.Controls/Primitives/OverlayLayer.cs
+++ b/src/Avalonia.Controls/Primitives/OverlayLayer.cs
@@ -6,6 +6,7 @@ namespace Avalonia.Controls.Primitives
 {
     public class OverlayLayer : Canvas
     {
+        protected override bool BypassFlowDirectionPolicies => true;
         public Size AvailableSize { get; private set; }
         public static OverlayLayer? GetOverlayLayer(Visual visual)
         {


### PR DESCRIPTION
## What does the pull request do?
Fix the issue with OverlayLayer displaying components in the wrong place in RTL mode, this is because OverlayLayer should not be in Mirror mode.

To reproduce, start ControlCatalog with `OverlayPopups = true` setting, and select RTL mode, you will see the problem:
![image](https://github.com/AvaloniaUI/Avalonia/assets/41772276/1837932f-40a5-40b3-9ce2-948727aa1f75)

## What is the current behavior?

## What is the updated/expected behavior with this PR?

## How was the solution implemented (if it's not obvious)?
Set the `BypassFlowDirectionPolicies` property to True in `OverlayLayer` like in `TopLevel`.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None

## Fixed issues
