### PR TITLE
feat: TryGetFolderFromPathAsync return null instead of throw exception

### DIFF
--- a/src/Avalonia.Base/Platform/Storage/FileIO/StorageProviderHelpers.cs
+++ b/src/Avalonia.Base/Platform/Storage/FileIO/StorageProviderHelpers.cs
@@ -10,16 +10,19 @@ internal static class StorageProviderHelpers
 {
     public static IStorageItem? TryCreateBclStorageItem(string path)
     {
-        var directory = new DirectoryInfo(path);
-        if (directory.Exists)
+        if (!string.IsNullOrWhiteSpace(path))
         {
-            return new BclStorageFolder(directory);
-        }
-        
-        var file = new FileInfo(path);
-        if (file.Exists)
-        {
-            return new BclStorageFile(file);
+            var directory = new DirectoryInfo(path);
+            if (directory.Exists)
+            {
+                return new BclStorageFolder(directory);
+            }
+
+            var file = new FileInfo(path);
+            if (file.Exists)
+            {
+                return new BclStorageFile(file);
+            }
         }
 
         return null;


### PR DESCRIPTION
TryGetFolderFromPathAsync return null instead of throw exception when empty folder path 

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #11681