### PR TITLE
Composition: ensure layer is disposed with its render target

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -128,7 +128,9 @@ namespace Avalonia.Rendering.Composition.Server
 
             if (_renderTarget?.IsCorrupted == true)
             {
-                _renderTarget!.Dispose();
+                _layer?.Dispose();
+                _layer = null;
+                _renderTarget.Dispose();
                 _renderTarget = null;
                 _redrawRequested = true;
             }


### PR DESCRIPTION
## What does the pull request do?

When a render target is marked as corrupted, the `ServerCompositionTarget` disposes it. However, the layer created from it isn't disposed: this PR fixes that.

## Example

In my case, I have a frame with a fixed physical size, that can't change at all. However, DPI can still change: the render target is marked as invalid, the client size gets adjusted, the scaling too, but `Size * Scaling` still returns the same frame size at the end and `layerSize != _layerSize` is always false here:

https://github.com/AvaloniaUI/Avalonia/blob/e0e23c251007e88d561d7cd867280283f80565d9/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs#L161

However, the layer is dependent on the current scaling, so it should be invalidated.

(Even without this quite specific case, since the layer was created from the render target, I think it probably shouldn't outlive it.)
