### PR TITLE
Fix #11677 AvaloniaTestAttribute base class

### DIFF
--- a/src/Headless/Avalonia.Headless.NUnit/AvaloniaTest.cs
+++ b/src/Headless/Avalonia.Headless.NUnit/AvaloniaTest.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Headless.NUnit;
 /// such that awaited expressions resume on the test's "main thread".
 /// </summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
-public sealed class AvaloniaTestAttribute : TestCaseAttribute, IWrapSetUpTearDown
+public sealed class AvaloniaTestAttribute : TestAttribute, IWrapSetUpTearDown
 {
     public TestCommand Wrap(TestCommand command)
     {

--- a/tests/Avalonia.Headless.UnitTests/ThreadingTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/ThreadingTests.cs
@@ -18,7 +18,7 @@ public class ThreadingTests
     }
 
 #if NUNIT
-    [AvaloniaTest(Ignore = "This test should always fail, enable to test if it fails")]
+    [AvaloniaTest, Ignore("This test should always fail, enable to test if it fails")]
 #elif XUNIT
     [AvaloniaFact(Skip = "This test should always fail, enable to test if it fails")]
 #endif


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
I reported #11677, which relates to `Avalonia.Headless.NUnit.AvaloniaTestAttribute`, a few days ago. @maxkatz6 confirmed that it should be just a matter of changing the base class, so I'm creating this PR to do so.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Adding the `[AvaloniaTest]` attribute to a test method currently behaves similarly to adding the NUnit `[TestCase]` attribute, but the latter is intended to accept test data as arguments, whereas the former does not accept any arguments. This kind-of works for non-parameterized tests (test runners will treat it as a parameterized test with a single test case with no arguments), but it makes it impossible to write real parameterized tests.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
With this PR, adding the `[AvaloniaTest]` to a test method behaves similarly to adding the NUnit `[Test]` attribute. This should work better for non-parameterized tests, while allowing parameterized tests to be written by adding regular `[TestCase]` attributes.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Simply changing the attribute's base class.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

I have not added any unit tests or documentation. It might make sense to add one or more parameterized test to https://github.com/AvaloniaUI/Avalonia/tree/master/tests/Avalonia.Headless.UnitTests, but as a first-time contributor I'm not confident in my ability to do so. To be honest, I have not run tested this change myself yet. I'm hoping that creating this PR will give me a build that allows me to do so without building it myself.

## Breaking changes
<!--- List any breaking changes here. -->
I think changing the base class is a breaking change, but this class looks to be new in Avalonia 11?

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #11677