### PR TITLE
Improve bitmap icon decoding on Windows 

### DIFF
--- a/src/Headless/Avalonia.Headless/HeadlessPlatformStubs.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessPlatformStubs.cs
@@ -254,24 +254,41 @@ namespace Avalonia.Headless
     {
         private class IconStub : IWindowIconImpl
         {
+            private readonly MemoryStream _memoryStream;
+
+            public IconStub(MemoryStream memoryStream)
+            {
+                _memoryStream = memoryStream;
+            }
+
             public void Save(Stream outputStream)
             {
-
+                _memoryStream.CopyTo(outputStream);
             }
-        }
-        public IWindowIconImpl LoadIcon(string fileName)
-        {
-            return new IconStub();
         }
 
         public IWindowIconImpl LoadIcon(Stream stream)
         {
-            return new IconStub();
+            var memoryStream = new MemoryStream();
+            stream.CopyTo(memoryStream);
+            return new IconStub(memoryStream);
         }
 
+        public IWindowIconImpl LoadIcon(string fileName)
+        {
+            using (var stream = File.OpenRead(fileName))
+            {
+                return LoadIcon(stream);
+            }
+        }
+        
         public IWindowIconImpl LoadIcon(IBitmapImpl bitmap)
         {
-            return new IconStub();
+            using (var memoryStream = new MemoryStream())
+            {
+                bitmap.Save(memoryStream);
+                return LoadIcon(memoryStream);
+            }
         }
     }
 


### PR DESCRIPTION
## What does the pull request do?

Currently, icon decoding logic on Windows is following:
Try to create a new System.Drawing.Icon from the stream. If it fails (like when the stream wasn't a .ico file), then create System.Drawing.Bitmap first, and convert it to HIcon from the bitmap.

This PR changes this a little:
1. If the stream is not seekable - don't try to use multiple APIs, just use Bitmap right away, as we won't be able to seek back if ico fails.
2. Check a file header, if it's not a 0010 (ico file format), then we don't even need to try to create ico 
3. Additionally: makes headless platform icon stub more useful (actually keep memory stream internally).

Fixes #7784