### PR TITLE
Previewer: fix transparent frame on update

### DIFF
--- a/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
@@ -295,10 +295,7 @@ namespace Avalonia.Controls.Remote.Server
 
             lock (_lock)
             {
-                // Ideally we should only send a frame if its status is Rendered: since the renderer might not be
-                // initialized at the start, we're sending black frames in this case. However, this was the historical
-                // behavior and some external programs are depending on receiving a frame asap.
-                if (_lastReceivedFrame != _lastSentFrame || _framebuffer.GetStatus() == FrameStatus.CopiedToMessage)
+                if (_lastReceivedFrame != _lastSentFrame || _framebuffer.GetStatus() != FrameStatus.Rendered)
                     return;
 
                 framebuffer = _framebuffer;


### PR DESCRIPTION
## What does the pull request do?
This PR avoids sending a first transparent frame (all zeroes, unrendered) each time the previewer receives a new XAML file to render.

## Context
While making the changes in #11596, I already fixed that naturally with the rewrite, but decided later to re-add sending unrendered frames at the start because the display was initially too small in AvaloniaRider without them. It turns out that I did most of my rendering tests before implementing the proper DPI scaling for zoom which is the last commit in that PR.

AvaloniaRider was incorrectly sending an initially DPI of 1 instead of 96 (fixed in https://github.com/ForNeVeR/AvaloniaRider/pull/279), which isn't a real problem since it's later automatically adjusted. But since changing the scaling didn't work in Avalonia at that time, the display kept being incorrect even after the first frame and I wrongly assumed that the transparent frames were required.

After the scaling fixes and more testing, I can't see any rendering problem anymore in AvaloniaRider without sending the transparent frames (which the plugin processes, but explicitly doesn't render anyway). In AvaloniaVS, this prevents a "flicker on update" effect, for a smoother experience.

## Fixed issues
Fixes #4264
