### PR TITLE
Previewer: more scaling fixes

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -159,14 +159,15 @@ namespace Avalonia.Rendering.Composition.Server
             _redrawRequested = false;
             using (var targetContext = _renderTarget.CreateDrawingContext())
             {
-                var layerSize = Size * Scaling;
+                var size = Size;
+                var layerSize = size * Scaling;
                 if (layerSize != _layerSize || _layer == null || _layer.IsCorrupted)
                 {
                     _layer?.Dispose();
                     _layer = null;
-                    _layer = targetContext.CreateLayer(Size);
+                    _layer = targetContext.CreateLayer(size);
                     _layerSize = layerSize;
-                    _dirtyRect = new Rect(0, 0, layerSize.Width, layerSize.Height);
+                    _dirtyRect = new Rect(0, 0, size.Width, size.Height);
                 }
 
                 if (_dirtyRect.Width != 0 || _dirtyRect.Height != 0)
@@ -187,7 +188,7 @@ namespace Avalonia.Rendering.Composition.Server
                 else
                     targetContext.DrawBitmap(_layer, 1,
                         new Rect(_layerSize),
-                        new Rect(Size));
+                        new Rect(size));
 
                 if (DebugOverlays != RendererDebugOverlays.None)
                 {

--- a/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
+++ b/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using Avalonia.Controls;
+using Avalonia.Controls.Embedding.Offscreen;
 using Avalonia.Controls.Platform;
 using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
@@ -13,6 +14,9 @@ namespace Avalonia.DesignerSupport
     public class DesignWindowLoader
     {
         public static Window LoadDesignerWindow(string xaml, string assemblyPath, string xamlFileProjectPath)
+            => LoadDesignerWindow(xaml, assemblyPath, xamlFileProjectPath, 1.0);
+
+        public static Window LoadDesignerWindow(string xaml, string assemblyPath, string xamlFileProjectPath, double renderScaling)
         {
             Window window;
             Control control;
@@ -95,6 +99,9 @@ namespace Avalonia.DesignerSupport
                 {
                     window = new Window() {Content = (Control)control};
                 }
+
+                if (window.PlatformImpl is OffscreenTopLevelImplBase offscreenImpl)
+                    offscreenImpl.RenderScaling = renderScaling;
 
                 Design.ApplyDesignModeProperties(window, control);
 

--- a/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
+++ b/src/Avalonia.DesignerSupport/Remote/PreviewerWindowImpl.cs
@@ -67,8 +67,8 @@ namespace Avalonia.DesignerSupport.Remote
         {
             _transport.Send(new RequestViewportResizeMessage
             {
-                Width = clientSize.Width,
-                Height = clientSize.Height
+                Width = Math.Ceiling(clientSize.Width * RenderScaling),
+                Height = Math.Ceiling(clientSize.Height * RenderScaling)
             });
             ClientSize = clientSize;
             RenderAndSendFrameIfNeeded();

--- a/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
+++ b/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
@@ -1,13 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Reflection;
 using System.Threading;
-using System.Xml;
 using Avalonia.Controls;
 using Avalonia.DesignerSupport.Remote.HtmlTransport;
-using Avalonia.Input;
 using Avalonia.Remote.Protocol;
 using Avalonia.Remote.Protocol.Designer;
 using Avalonia.Remote.Protocol.Viewport;
@@ -20,6 +17,7 @@ namespace Avalonia.DesignerSupport.Remote
         private static ClientSupportedPixelFormatsMessage s_supportedPixelFormats;
         private static ClientViewportAllocatedMessage s_viewportAllocatedMessage;
         private static ClientRenderInfoMessage s_renderInfoMessage;
+        private static double s_lastRenderScaling = 1.0;
 
         private static IAvaloniaRemoteTransportConnection s_transport;
         class CommandLineArgs
@@ -226,6 +224,9 @@ namespace Avalonia.DesignerSupport.Remote
             }
             if (obj is UpdateXamlMessage xaml)
             {
+                if (s_currentWindow is not null)
+                    s_lastRenderScaling = s_currentWindow.RenderScaling;
+
                 try
                 {
                     s_currentWindow?.Close();
@@ -237,7 +238,7 @@ namespace Avalonia.DesignerSupport.Remote
                 s_currentWindow = null;
                 try
                 {
-                    s_currentWindow = DesignWindowLoader.LoadDesignerWindow(xaml.Xaml, xaml.AssemblyPath, xaml.XamlFileProjectPath);
+                    s_currentWindow = DesignWindowLoader.LoadDesignerWindow(xaml.Xaml, xaml.AssemblyPath, xaml.XamlFileProjectPath, s_lastRenderScaling);
                     s_transport.Send(new UpdateXamlResultMessage(){Handle = s_currentWindow.PlatformImpl?.Handle?.Handle.ToString()});
                 }
                 catch (Exception e)


### PR DESCRIPTION
Here's a last batch of scaling related fixes for the previewer.

Commit 1:
 - The last known render scaling is used when a XAML update is requested: it avoids seeing a 1.0 scaled frame for a very short time, immediately replaced by the one with the correct current zoom. It was very noticeable when the zoom wasn't 100%.
 - An overload taking the render scaling has been added to `DesignWindowLoader.LoadDesignerWindow` to avoid binary breaking changes since it's public. If binary breaking changes are still acceptable at this time, an optional parameter can be used instead.
 - For correctness, `RequestViewportResizeMessage` now takes the scaling into account when requesting the client to resize the viewport, even if this message is ignored by all known designers I could find (AvaloniaVS, AvaloniaRider, AvantGarde).

Commit 2:
 - In `ServerCompositionTarget`, the first dirty rect was incorrectly taking scaling into account. Not noticeable for scaling > 1.0 since the rect gets bigger than the client size, but for scaling < 1.0 a part of the frame wasn't being rendered. Noticeable on previewers with zoom < 100%, but generally fixes any render using that kind of scaling.