### PR TITLE
Break out of layout flip flop in Headless

### DIFF
--- a/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
@@ -114,23 +114,26 @@ namespace Avalonia.Headless
         public Size MaxClientSize { get; } = new Size(1920, 1280);
         public void Resize(Size clientSize, WindowResizeReason reason)
         {
+            if (ClientSize == clientSize)
+                return;
+
             // Emulate X11 behavior here
             if (IsPopup)
-                DoResize(clientSize);
+                DoResize(clientSize, reason);
             else
                 Dispatcher.UIThread.Post(() =>
                 {
-                    DoResize(clientSize);
-                });
+                    DoResize(clientSize, reason);
+                }, DispatcherPriority.Send);
         }
 
-        private void DoResize(Size clientSize)
+        private void DoResize(Size clientSize, WindowResizeReason reason)
         {
             // Uncomment this check and experience a weird bug in layout engine
             if (ClientSize != clientSize)
             {
                 ClientSize = clientSize;
-                Resized?.Invoke(clientSize, WindowResizeReason.Unspecified);
+                Resized?.Invoke(clientSize, reason);
             }
         }
 

--- a/tests/Avalonia.Headless.UnitTests/RenderingTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/RenderingTests.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls;
+﻿using System.Collections.ObjectModel;
+using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Threading;
@@ -24,6 +25,27 @@ public class RenderingTests
                 Content = new PathIcon
                 {
                     Data = StreamGeometry.Parse("M0,9 L10,0 20,9 19,10 10,2 1,10 z")
+#if NUNIT
+    [AvaloniaTest, Timeout(10000)]
+#elif XUNIT
+    [AvaloniaFact(Timeout = 10000)]
+#endif
+    public void Should_Not_Hang_With_Non_Trivial_Layout()
+    {
+        var window = new Window
+        {
+            Content = new ContentControl
+            {
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment = VerticalAlignment.Stretch,
+                Padding = new Thickness(1),
+                Content = new ListBox
+                {
+                    ItemsSource = new ObservableCollection<string>()
+                    {
+                        "Test 1",
+                        "Test 2"
+                    }
                 }
             },
             SizeToContent = SizeToContent.WidthAndHeight

--- a/tests/Avalonia.Headless.UnitTests/RenderingTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/RenderingTests.cs
@@ -25,6 +25,18 @@ public class RenderingTests
                 Content = new PathIcon
                 {
                     Data = StreamGeometry.Parse("M0,9 L10,0 20,9 19,10 10,2 1,10 z")
+                }
+            },
+            SizeToContent = SizeToContent.WidthAndHeight
+        };
+
+        window.Show();
+
+        var frame = window.CaptureRenderedFrame();
+
+        Assert.NotNull(frame);
+    }
+
 #if NUNIT
     [AvaloniaTest, Timeout(10000)]
 #elif XUNIT
@@ -50,6 +62,7 @@ public class RenderingTests
             },
             SizeToContent = SizeToContent.WidthAndHeight
         };
+
         window.Show();
 
         var frame = window.CaptureRenderedFrame();


### PR DESCRIPTION
## What does the pull request do?
There is a issue where the layout doesn't settle in headless because of how the ClientSize flow is implemented.
This PR adds an additional equality breaker to make it work, but the underlaying issue here has to do with how the DoResize is scheduled. If two DoResize calls is scheduled on the Dispatcher at the same time with different clientSize in the argument it will never settle.

## What is the current behavior?
The test included will hang without the fix.


## What is the updated/expected behavior with this PR?
Settle the layout


## How was the solution implemented (if it's not obvious)?
Quick return if Resize is called with the same ClientSize as is already set.
I also included the WindowResizeReason. It looks to me like an oversight and did cause unexpected behavior with SizeToContent.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

