### PR TITLE
SetDisableAppDelegate before Initialize in native code is called

### DIFF
--- a/src/Avalonia.Native/AvaloniaNativePlatform.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatform.cs
@@ -88,14 +88,17 @@ namespace Avalonia.Native
 
             var applicationPlatform = new AvaloniaNativeApplicationPlatform();
 
+            var macOpts = AvaloniaLocator.Current.GetService<MacOSPlatformOptions>() ?? new MacOSPlatformOptions();
+                        
+            if (_factory.MacOptions != null) 
+                _factory.MacOptions.SetDisableAppDelegate(macOpts.DisableAvaloniaAppDelegate ? 1 : 0);
+
             _factory.Initialize(new GCHandleDeallocator(), applicationPlatform);
+            
             if (_factory.MacOptions != null)
             {
-                var macOpts = AvaloniaLocator.Current.GetService<MacOSPlatformOptions>() ?? new MacOSPlatformOptions();
-
                 _factory.MacOptions.SetShowInDock(macOpts.ShowInDock ? 1 : 0);
                 _factory.MacOptions.SetDisableSetProcessName(macOpts.DisableSetProcessName ? 1 : 0);
-                _factory.MacOptions.SetDisableAppDelegate(macOpts.DisableAvaloniaAppDelegate ? 1 : 0);
             }
 
             AvaloniaLocator.CurrentMutable


### PR DESCRIPTION
## What does the pull request do?
MacOsPlatformOptions.DisableAvaloniaAppDelegate is considered before Initialize in native code is called.


## What is the current behavior?
The MacOsPlatformOptions has a property DisableAvaloniaAppDelegate which according to the xml comment ("Disabling this can be useful in some scenarios like when running as a plugin inside an existing macOS application") can be used for Avalonia as a plugin. The property does not do it's job, though, because even if set to true, Initialize in the native code (AvaloniaNative.Initialize) is called before MacOsPlatformOptions.DisableAvaloniaAppDelegate is considered (in AvaloniaNativePlatform c# class).


## What is the updated/expected behavior with this PR?
MacOsPlatformOptions.DisableAvaloniaAppDelegate are considered and set in the native code before Intialize is called.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
MacOsPlatformOptions.DisableAvaloniaAppDelegate is now actually considered and the AppDelegate is not set if MacOsPlatformOptions.DisableAvaloniaAppDelegate is set to true.