### PR TITLE
Fix changing selection source in selection changed

### DIFF
--- a/.ncrunch/MobileSandbox.Browser.v3.ncrunchproject
+++ b/.ncrunch/MobileSandbox.Browser.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/.ncrunch/WindowsInteropTest.net461.v3.ncrunchproject
+++ b/.ncrunch/WindowsInteropTest.net461.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/.ncrunch/WindowsInteropTest.net6.0-windows.v3.ncrunchproject
+++ b/.ncrunch/WindowsInteropTest.net6.0-windows.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/src/Avalonia.Controls/Selection/SelectionModel.cs
+++ b/src/Avalonia.Controls/Selection/SelectionModel.cs
@@ -277,7 +277,7 @@ namespace Avalonia.Controls.Selection
         {
             if (base.Source != value)
             {
-                if (_operation is not null)
+                if (_operation?.UpdateCount > 0)
                 {
                     throw new InvalidOperationException("Cannot change source while update is in progress.");
                 }

--- a/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Single.cs
+++ b/tests/Avalonia.Controls.UnitTests/Selection/SelectionModelTests_Single.cs
@@ -300,6 +300,27 @@ namespace Avalonia.Controls.UnitTests.Selection
 
                 target.Source = new[] { 1, 2, 3 };
             }
+
+            [Fact]
+            public void Can_Change_Source_In_SelectedItem_Change_Handler()
+            {
+                // Issue #11617
+                var target = CreateTarget();
+                var raised = 0;
+
+                target.PropertyChanged += (s, e) =>
+                {
+                    if (e.PropertyName == nameof(target.SelectedItem) && raised == 0)
+                    {
+                        ++raised;
+                        target.Source = new[] { "foo", "baz", "bar" };
+                    }
+                };
+
+                target.SelectedIndex = 1;
+
+                Assert.Equal(-1, target.SelectedIndex);
+            }
         }
 
         public class SelectedIndex


### PR DESCRIPTION
## What does the pull request do?

As described by #11617, a crash was occurring when changing the selection source during a selection changed event.

Checking `_operation` for null isn't enough: instead check if `UpdateCount` is not 0 to allow recursive setting of `Source`.

I have a vague feeling that this isn't actually the correct solution, and that more issues are going to arise around this scenario but for now I'm unable to create a failing test so let's go with the simple solution for now. Thanks to @workgroupengineering for finding the fix.

(PR also updates ncrunch configuration files due to new projects being added).

## Fixed issues

Fixes #11617