### PR TITLE
Fix ListBox losing selection on container focus lost

### DIFF
--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -533,7 +533,16 @@ namespace Avalonia.Controls.Primitives
         protected internal override void ClearContainerForItemOverride(Control element)
         {
             base.ClearContainerForItemOverride(element);
-            element.ClearValue(IsSelectedProperty);
+
+            try
+            {
+                _ignoreContainerSelectionChanged = true;
+                element.ClearValue(IsSelectedProperty);
+            }
+            finally
+            {
+                _ignoreContainerSelectionChanged = false;
+            }
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
## What does the pull request do?

The problem described in #11679 was that when a focused item outside the viewport loses focus, the container is recycled which causes its selected state to be cleared. Problem is that we were listening to that selection changed event and updating our selection based on it. When realizing a container we use `MarkContainerSelected` which surrounds the selection change in an `_ignoreContainerSelectionChanged` block, but we weren't doing that when clearing selection.

## Fixed issues

Fixes #11679 