### PR TITLE
Fix: MenuItem invalidate CanExecute on opening a Menu

### DIFF
--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -394,6 +394,13 @@ namespace Avalonia.Controls
             _isEmbeddedInMenu = parent?.FindLogicalAncestorOfType<IMenu>(true) != null;
         }
 
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            
+            TryUpdateCanExecute();
+        }
+
         protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)
         {
             // This will cause the hotkey manager to dispose the observer and the reference to this control

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -394,6 +394,7 @@ namespace Avalonia.Controls
             _isEmbeddedInMenu = parent?.FindLogicalAncestorOfType<IMenu>(true) != null;
         }
 
+        /// <inheritdoc />
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);

--- a/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
@@ -209,13 +209,13 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Equal(0, canExecuteCallCount);
                 
                 contextMenu.Open();
-                Assert.Equal(2, canExecuteCallCount);//2 because popup is changing logical child
+                Assert.Equal(3, canExecuteCallCount);// 3 because popup is changing logical child and moreover we need to invalidate again after the item is attached to the visual tree
 
                 command.RaiseCanExecuteChanged();
-                Assert.Equal(3, canExecuteCallCount);
+                Assert.Equal(4, canExecuteCallCount);
 
                 target.CommandParameter = true;
-                Assert.Equal(4, canExecuteCallCount);
+                Assert.Equal(5, canExecuteCallCount);
             }
         }
         
@@ -249,13 +249,13 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Equal(0, canExecuteCallCount);
 
                 flyout.ShowAt(button);
-                Assert.Equal(1, canExecuteCallCount);
+                Assert.Equal(2, canExecuteCallCount); // 2 because we need to invalidate after the item is attached to the visual tree
 
                 command.RaiseCanExecuteChanged();
-                Assert.Equal(2, canExecuteCallCount);
+                Assert.Equal(3, canExecuteCallCount);
 
                 target.CommandParameter = true;
-                Assert.Equal(3, canExecuteCallCount);
+                Assert.Equal(4, canExecuteCallCount);
             }
         }
         


### PR DESCRIPTION
## What does the pull request do?
When a MenuItem is attached to the VisualTree, the current status of `CanExecute` may be wrong. So let's try to invalidate it in AttachedToVisualTree-override. 

## What is the current behavior?
See https://github.com/AvaloniaUI/Avalonia/issues/11112

## What is the updated/expected behavior with this PR?
MenuItems get effectively enabled / disabled based on Command-status


## How was the solution implemented (if it's not obvious)?
Invalidate the MenuItem again when it is attached to the visual tree. Probably we can remove another call to `TryUpdateCanExecute`, but I have not enough insight so judge this. So I need input form other team members 

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #11112 