### PR TITLE
fix: [DevTools] Invalid property Editor for char property

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/Views/PropertyValueEditorView.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/PropertyValueEditorView.cs
@@ -232,11 +232,11 @@ namespace Avalonia.Diagnostics.Views
 
             return tb;
 
-            TControl CreateControl<TControl>(AvaloniaProperty valueProperty
-                , IValueConverter? converter = null
-                , Action<TControl>? init = null
-                , AvaloniaProperty? readonlyProperty = null)
-                where TControl : Control, new()
+            TControl CreateControl<TControl>(AvaloniaProperty valueProperty,
+                    IValueConverter? converter = null,
+                    Action<TControl>? init = null,
+                    AvaloniaProperty? readonlyProperty = null)
+                    where TControl : Control, new()
             {
                 var control = new TControl();
                 var bindingMode = Property.IsReadonly ? BindingMode.OneWay : BindingMode.TwoWay;

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/PropertyValueEditorView.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/PropertyValueEditorView.cs
@@ -57,42 +57,11 @@ namespace Avalonia.Diagnostics.Views
             if (Property?.PropertyType is not { } propertyType)
                 return null;
 
-            TControl CreateControl<TControl>(AvaloniaProperty valueProperty,
-                IValueConverter? converter = null,
-                Action<TControl>? init = null,
-                AvaloniaProperty? readonlyProperty = null)
-                where TControl : Control, new()
-            {
-                var control = new TControl();
-                var bindingMode = Property.IsReadonly ? BindingMode.OneWay : BindingMode.TwoWay;
-
-                init?.Invoke(control);
-
-                control.Bind(valueProperty,
-                    new Binding(nameof(Property.Value), bindingMode)
-                    {
-                        Source = Property,
-                        Converter = converter ?? new ValueConverter(),
-                        ConverterParameter = readonlyProperty?.Name ?? valueProperty.Name,
-                    }).DisposeWith(_cleanup);
-
-                if (readonlyProperty != null)
-                {
-                    control[readonlyProperty] = Property.IsReadonly;
-                }
-                else
-                {
-                    control.IsEnabled = !Property.IsReadonly;
-                }
-
-                return control;
-            }
-
             if (propertyType == typeof(bool))
                 return CreateControl<CheckBox>(ToggleButton.IsCheckedProperty);
 
             //TODO: Infinity, NaN not working with NumericUpDown
-            if (propertyType.IsPrimitive && propertyType != typeof(float) && propertyType != typeof(double))
+            if (IsValidNumeric(propertyType))
                 return CreateControl<NumericUpDown>(
                     NumericUpDown.ValueProperty,
                     new ValueToDecimalConverter(),
@@ -139,7 +108,8 @@ namespace Avalonia.Diagnostics.Views
                         ColorView.ColorProperty,
                         new Binding(nameof(Property.Value), BindingMode.TwoWay)
                         {
-                            Source = Property, Converter = Color2Brush
+                            Source = Property,
+                            Converter = Color2Brush
                         })
                     .DisposeWith(_cleanup);
 
@@ -261,6 +231,74 @@ namespace Avalonia.Diagnostics.Views
             }
 
             return tb;
+
+            TControl CreateControl<TControl>(AvaloniaProperty valueProperty
+                , IValueConverter? converter = null
+                , Action<TControl>? init = null
+                , AvaloniaProperty? readonlyProperty = null)
+                where TControl : Control, new()
+            {
+                var control = new TControl();
+                var bindingMode = Property.IsReadonly ? BindingMode.OneWay : BindingMode.TwoWay;
+
+                init?.Invoke(control);
+
+                control.Bind(valueProperty,
+                    new Binding(nameof(Property.Value), bindingMode)
+                    {
+                        Source = Property,
+                        Converter = converter ?? new ValueConverter(),
+                        ConverterParameter = propertyType
+                    }).DisposeWith(_cleanup);
+
+                if (readonlyProperty != null)
+                {
+                    control[readonlyProperty] = Property.IsReadonly;
+                }
+                else
+                {
+                    control.IsEnabled = !Property.IsReadonly;
+                }
+
+                return control;
+            }
+
+            static bool IsValidNumeric(Type? type)
+            {
+                if (type == null)
+                {
+                    return false;
+                }
+                var typeCode = Type.GetTypeCode(type);
+                if (typeCode == TypeCode.Object)
+                {
+                    if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+                    {
+                        typeCode = Type.GetTypeCode(Nullable.GetUnderlyingType(type));
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+                switch (typeCode)
+                {
+                    case TypeCode.Byte:
+                    case TypeCode.Int16:
+                    case TypeCode.Int32:
+                    case TypeCode.Int64:
+                    case TypeCode.SByte:
+                    case TypeCode.Single:
+                    case TypeCode.UInt16:
+                    case TypeCode.UInt32:
+                    case TypeCode.UInt64:
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+
+
         }
 
         //HACK: ValueConverter that skips first target update

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/PropertyValueEditorView.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/PropertyValueEditorView.cs
@@ -73,7 +73,7 @@ namespace Avalonia.Diagnostics.Views
                     {
                         Source = Property,
                         Converter = converter ?? new ValueConverter(),
-                        ConverterParameter = propertyType
+                        ConverterParameter = readonlyProperty?.Name ?? valueProperty.Name,
                     }).DisposeWith(_cleanup);
 
                 if (readonlyProperty != null)


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Use `TextBox` as editor for `char` property.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

DevTools throws InvalidCastException when property is `char` because it uses `NumericUpDown` as editor.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

the source of the issue is the following code:

https://github.com/AvaloniaUI/Avalonia/blob/012aa1555a740437a9d3f2679d43d3eeafb660a6/src/Avalonia.Diagnostics/Diagnostics/Views/PropertyValueEditorView.cs#L95-L105

to check if property type is valid for NumericUpDown, check that `propertyType` is primitive type and not `float` or `double`, but `char` type also satisfies condition.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #11708 