### PR TITLE
fix(BoxShadows): ToString()

### DIFF
--- a/src/Avalonia.Base/Media/BoxShadow.cs
+++ b/src/Avalonia.Base/Media/BoxShadow.cs
@@ -73,40 +73,44 @@ namespace Avalonia.Media
         public override string ToString()
         {
             var sb = StringBuilderCache.Acquire();
+            ToString(sb);
+            return StringBuilderCache.GetStringAndRelease(sb);
+        }
 
+        internal void ToString(StringBuilder sb)
+        {
             if (this == default)
             {
-                return "none";
+                sb.Append("none");
+                return;
             }
 
             if (IsInset)
             {
-                sb.Append("inset");
+                sb.Append("inset ");
             }
 
             if (OffsetX != 0.0)
             {
-                sb.AppendFormat(" {0}", OffsetX.ToString(CultureInfo.InvariantCulture));
+                sb.AppendFormat("{0} ", OffsetX.ToString(CultureInfo.InvariantCulture));
             }
 
             if (OffsetY != 0.0)
             {
-                sb.AppendFormat(" {0}", OffsetY.ToString(CultureInfo.InvariantCulture));
+                sb.AppendFormat("{0} ", OffsetY.ToString(CultureInfo.InvariantCulture));
             }
-            
+
             if (Blur != 0.0)
             {
-                sb.AppendFormat(" {0}", Blur.ToString(CultureInfo.InvariantCulture));
+                sb.AppendFormat("{0} ", Blur.ToString(CultureInfo.InvariantCulture));
             }
 
             if (Spread != 0.0)
             {
-                sb.AppendFormat(" {0}", Spread.ToString(CultureInfo.InvariantCulture));
+                sb.AppendFormat("{0} ", Spread.ToString(CultureInfo.InvariantCulture));
             }
 
-            sb.AppendFormat(" {0}", Color.ToString());
-
-            return StringBuilderCache.GetStringAndRelease(sb);
+            sb.AppendFormat("{0}", Color.ToString());
         }
 
         public static unsafe BoxShadow Parse(string s)

--- a/src/Avalonia.Base/Media/BoxShadows.cs
+++ b/src/Avalonia.Base/Media/BoxShadows.cs
@@ -39,20 +39,20 @@ namespace Avalonia.Media
 
         public override string ToString()
         {
-            var sb = StringBuilderCache.Acquire();
-
             if (Count == 0)
             {
                 return "none";
             }
 
+            var sb = StringBuilderCache.Acquire();
             foreach (var boxShadow in this)
             {
-                sb.AppendFormat("{0} ", boxShadow.ToString());
+                boxShadow.ToString(sb);
+                sb.Append(',');
+                sb.Append(' ');
             }
-
+            sb.Remove(sb.Length - 2, 2);
             return StringBuilderCache.GetStringAndRelease(sb);
-
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/tests/Avalonia.Base.UnitTests/Media/BoxShadowTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/BoxShadowTests.cs
@@ -41,5 +41,13 @@ namespace Avalonia.Base.UnitTests.Media
                     Assert.Equal(Colors.Red, parsed.Color);
                 }
         }
+
+        [Fact]
+        public void BoxShadows_Should_ToString()
+        {
+            const string source = "-20 -20 60 #CCFFFFFF, 20 20 60 #33000000";
+            var parsed = BoxShadows.Parse(source);
+            Assert.Equal(source, parsed.ToString(), true);
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Missing missing separetor when call BoxShadows.ToString();

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

![immagine](https://github.com/AvaloniaUI/Avalonia/assets/12531229/21a8d3e3-cb55-43c5-9950-dffd6233da2b)

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
