### PR TITLE
Fixed style activator not publishing changes, causing animations not to start/stop

### DIFF
--- a/src/Avalonia.Base/Styling/Activators/StyleActivatorBase.cs
+++ b/src/Avalonia.Base/Styling/Activators/StyleActivatorBase.cs
@@ -6,9 +6,14 @@ namespace Avalonia.Styling.Activators
     internal abstract class StyleActivatorBase : IStyleActivator
     {
         private IStyleActivatorSink? _sink;
-        private bool _value;
+        private bool? _value;
 
-        public bool GetIsActive() => _value = EvaluateIsActive();
+        public bool GetIsActive()
+        {
+            var value = EvaluateIsActive();
+            _value ??= value;
+            return value;
+        }
 
         public bool IsSubscribed => _sink is not null;
 
@@ -63,7 +68,7 @@ namespace Avalonia.Styling.Activators
         /// </returns>
         protected bool ReevaluateIsActive()
         {
-            var value = EvaluateIsActive();
+            var value = GetIsActive();
 
             if (value != _value)
             {

--- a/tests/Avalonia.Base.UnitTests/Styling/StyleTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Styling/StyleTests.cs
@@ -5,7 +5,7 @@ using Avalonia.Base.UnitTests.Animation;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
-using Avalonia.PropertyStore;
+using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.UnitTests;
 using Moq;
@@ -961,6 +961,72 @@ namespace Avalonia.Base.UnitTests.Styling
 
             target.Classes.Remove("foo");
             Assert.Equal(0.0, target.Double);
+        }
+
+        [Fact]
+        public void Animations_With_Activator_Trigger_Should_Be_Activated_And_Deactivated()
+        {
+            var clock = new TestClock();
+            var border = new Border();
+
+            var root = new TestRoot
+            {
+                Clock = clock,
+                Styles =
+                {
+                    new Style(x => x.OfType<Border>().Not(default(Selector).Class("foo")))
+                    {
+                        Setters =
+                        {
+                            new Setter(Border.BackgroundProperty, Brushes.Yellow),
+                        },
+                        Animations =
+                        {
+                            new Avalonia.Animation.Animation
+                            {
+                                Duration = TimeSpan.FromSeconds(1.0),
+                                Children =
+                                {
+                                    new KeyFrame
+                                    {
+                                        Setters =
+                                        {
+                                            new Setter(Border.BackgroundProperty, Brushes.Green)
+                                        },
+                                        Cue = new Cue(0.0)
+                                    },
+                                    new KeyFrame
+                                    {
+                                        Setters =
+                                        {
+                                            new Setter(Border.BackgroundProperty, Brushes.Green)
+                                        },
+                                        Cue = new Cue(1.0)
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new Style(x => x.OfType<Border>().Class("foo"))
+                    {
+                        Setters =
+                        {
+                            new Setter(Border.BackgroundProperty, Brushes.Blue),
+                        }
+                    }
+                },
+                Child = border
+            };
+
+            root.Measure(Size.Infinity);
+
+            Assert.Equal(Brushes.Yellow, border.Background);
+
+            clock.Step(TimeSpan.FromSeconds(0.5));
+            Assert.Equal(Brushes.Green, border.Background);
+
+            border.Classes.Add("foo");
+            Assert.Equal(Brushes.Blue, border.Background);
         }
 
         private class Class1 : Control


### PR DESCRIPTION
## What does the pull request do?
This PR ensures that `StyleActivatorBase.ReevaluateIsActive()` publishes changes that may have happened in `GetIsActive()`.

A test has been added.

## What is the current behavior?
`StyleActivatorBase.GetIsActive()` has a side effect and may change its `_value`. When this happens, the next call to `ReevaluateIsActive()` doesn't publish the updated value since it hasn't changed from its point of view.

This is not theoretical, this happens in two places currently:
 - `ValueStore.ReevaluateEffectiveValues()`: calls `frame.IsActive`
 - `ValueStore.ReevaluateEffectiveValue()`: calls `frame.TryGetEntryIfActive()`

In our case, the frame is a `StyleInstance` subscribed to the activator to know when to start or stop its animations. This results in animations never stopping or never starting. See #11803 for reproduction code, or the added unit test.

## What is the updated/expected behavior with this PR?
`StyleActivatorBase.ReevaluateIsActive()` correctly publishes changes.

## How was the solution implemented (if it's not obvious)?
`GetIsActive()` doesn't have any side effect anymore: the value isn't changed when this method is called, making it easier to reason about and debug. The exception being the very first call, used for initialization purposes, since `ReevaluateIsActive` must only publish changes happening *after* the initial value.

This change solved the problem, and all tests passed except `Style_Can_Use_NthChild_Selector_With_ItemsRepeater`. It turns out that the activator fix exposed a bug in `NthChildActivator`. When `ItemsRepeater.OnElementClearing` clears an element, it triggers a `ChildIndexChanged` event with an index of `-1`. But `-1` is already a special value in that activator meaning "I don't know what the index is, ask the container". Except that since the element is being cleared, `-1` in this case is really "I don't have an index anymore", and asking the container returns a wrong index since the repeater is in the middle of clearing the items.

This is fixed by treating `-1` as itself (effectively never matching the selector) and using `null` for unknown index.

## Fixed issues
Fixes #11803
