### PR TITLE
Add OnSizeChanged method to Control

### DIFF
--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -357,6 +357,15 @@ namespace Avalonia.Controls
             RaiseEvent(eventArgs);
         }
 
+        /// <summary>
+        /// Invoked just before the <see cref="SizeChanged"/> event.
+        /// </summary>
+        /// <param name="e">The event args.</param>
+        protected virtual void OnSizeChanged(SizeChangedEventArgs e)
+        {
+            RaiseEvent(e);
+        }
+
         /// <inheritdoc/>
         protected sealed override void OnAttachedToVisualTreeCore(VisualTreeAttachmentEventArgs e)
         {
@@ -435,6 +444,10 @@ namespace Avalonia.Controls
             }
         }
 
+        /// <summary>
+        /// Returns a new, type-specific <see cref="AutomationPeer"/> implementation for the control.
+        /// </summary>
+        /// <returns>The type-specific <see cref="AutomationPeer"/> implementation.</returns>
         protected virtual AutomationPeer OnCreateAutomationPeer()
         {
             return new NoneAutomationPeer(this);
@@ -459,6 +472,7 @@ namespace Avalonia.Controls
             return _automationPeer;
         }
 
+        /// <inheritdoc/>
         protected override void OnPointerReleased(PointerReleasedEventArgs e)
         {
             base.OnPointerReleased(e);
@@ -473,6 +487,7 @@ namespace Avalonia.Controls
             }
         }
 
+        /// <inheritdoc/>
         protected override void OnKeyUp(KeyEventArgs e)
         {
             base.OnKeyUp(e);
@@ -531,7 +546,7 @@ namespace Avalonia.Controls
                         previousSize: new Size(oldValue.Width, oldValue.Height),
                         newSize: new Size(newValue.Width, newValue.Height));
 
-                    RaiseEvent(sizeChangedEventArgs);
+                    OnSizeChanged(sizeChangedEventArgs);
                 }
             }
         }


### PR DESCRIPTION
## What does the pull request do?

Adds the `protected virtual void OnSizeChanged(SizeChangedEventArgs e)` method to `Control`. This is especially useful in custom controls (where most need to do something on size changed). It is no longer necessary to subscribe to events internally. Several custom controls I've run across so far would benefit by the addition of this method.

**Note**

This adds one more virtual method that will be called every time the size of a control changes. There could be performance implications per https://github.com/AvaloniaUI/Avalonia/pull/8277#issuecomment-1192647174. Personally, I'm not so worried about this but I want to highlight this in case others have stronger concerns here.

## What is the current behavior?

Before, the `SizeChanged` event was raised directly and could not be intercepted. To monitor this internally a new event subscription was required.

## What is the updated/expected behavior with this PR?

With the `OnSizeChanged(SizeChangedEventArgs e)` method custom controls can process (or disable) size changed without having an internal event subscription.

## How was the solution implemented (if it's not obvious)?

Obvious

## Checklist

- ~[ ] Added unit tests (if possible)?~
- [x] Added XML documentation to any related classes?
- ~[ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation~

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
N/A
