### PR TITLE
Add Distance method to Point

### DIFF
--- a/src/Avalonia.Base/Point.cs
+++ b/src/Avalonia.Base/Point.cs
@@ -165,6 +165,19 @@ namespace Avalonia
         public static Point operator *(Point point, Matrix matrix) => matrix.Transform(point);
 
         /// <summary>
+        /// Computes the Euclidean distance between the two given points.
+        /// </summary>
+        /// <param name="value1">The first point.</param>
+        /// <param name="value2">The second point.</param>
+        /// <returns>The Euclidean distance.</returns>
+        public static double Distance(Point value1, Point value2)
+        {
+            double distanceSquared = ((value2.X - value1.X) * (value2.X - value1.X)) +
+                                     ((value2.Y - value1.Y) * (value2.Y - value1.Y));
+            return Math.Sqrt(distanceSquared);
+        }
+
+        /// <summary>
         /// Parses a <see cref="Point"/> string.
         /// </summary>
         /// <param name="s">The string.</param>

--- a/src/Avalonia.Base/Vector.cs
+++ b/src/Avalonia.Base/Vector.cs
@@ -359,7 +359,7 @@ namespace Avalonia
 
         internal Vector(Vector2 v) : this(v.X, v.Y)
         {
-            
+
         }
 
         /// <summary>
@@ -379,21 +379,27 @@ namespace Avalonia
         /// </summary>
         public static Vector Max(Vector left, Vector right) =>
             new(Math.Max(left.X, right.X), Math.Max(left.Y, right.Y));
-        
+
         /// <summary>
         /// Returns a vector whose elements are the minimum of each of the pairs of elements in two specified vectors
         /// </summary>
         public static Vector Min(Vector left, Vector right) =>
             new(Math.Min(left.X, right.X), Math.Min(left.Y, right.Y));
-        
+
         /// <summary>
         /// Computes the Euclidean distance between the two given points.
         /// </summary>
+        /// <param name="value1">The first point.</param>
+        /// <param name="value2">The second point.</param>
+        /// <returns>The Euclidean distance.</returns>
         public static double Distance(Vector value1, Vector value2) => Math.Sqrt(DistanceSquared(value1, value2));
-        
+
         /// <summary>
         /// Returns the Euclidean distance squared between two specified points
         /// </summary>
+        /// <param name="value1">The first point.</param>
+        /// <param name="value2">The second point.</param>
+        /// <returns>The Euclidean distance squared.</returns>
         public static double DistanceSquared(Vector value1, Vector value2)
         {
             var difference = value1 - value2;


### PR DESCRIPTION
## What does the pull request do?

Add a method that calculates the Euclidian distance between two points.

This was a helper method on the app side but seems quite useful in the framework since vector and other types already have it. Calculating distance between points seems common.

## What is the current behavior?

Distance must be calculated manually or after converting to vectors.

## What is the updated/expected behavior with this PR?

Distance can be calculated directly.

## How was the solution implemented (if it's not obvious)?

It was implemented for the two-dimensional plane following the standard Euclidian geometry formula: https://en.wikipedia.org/wiki/Euclidean_distance#Two_dimensions. An additional optimization was done to avoid Math.Pow(x, 2) usage. Instead the squares are calculated using faster multiplication.

## Checklist

- ~[ ] Added unit tests (if possible)?~
- [x] Added XML documentation to any related classes?
- ~[ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation~

## Breaking changes

None

## Obsoletions / Deprecations

None

## Fixed issues

N/A