### PR TITLE
Reset LayoutTransformControl matrix when transform is removed

### DIFF
--- a/src/Avalonia.Controls/LayoutTransformControl.cs
+++ b/src/Avalonia.Controls/LayoutTransformControl.cs
@@ -215,7 +215,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Transformation matrix corresponding to _matrixTransform.
         /// </summary>
-        private Matrix _transformation;
+        private Matrix _transformation = Matrix.Identity;
         private IDisposable? _transformChangedEvent;
 
         /// <summary>
@@ -256,13 +256,16 @@ namespace Avalonia.Controls
         /// </remarks>
         private void ApplyLayoutTransform()
         {
-            if (LayoutTransform == null)
+            // Get the transform matrix and apply it
+            var matrix = LayoutTransform is null ?
+                Matrix.Identity :
+                RoundMatrix(LayoutTransform.Value, DecimalsAfterRound);
+
+            if (_transformation == matrix)
                 return;
 
-            // Get the transform matrix and apply it
-            _transformation = RoundMatrix(LayoutTransform.Value, DecimalsAfterRound);
-
-            _matrixTransform.Matrix = _transformation;
+            _transformation = matrix;
+            _matrixTransform.Matrix = matrix;
 
             // New transform means re-layout is necessary
             InvalidateMeasure();

--- a/tests/Avalonia.Controls.UnitTests/LayoutTransformControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/LayoutTransformControlTests.cs
@@ -170,6 +170,25 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Bounds_On_Transform_Applied_Then_Removed_Are_Correct()
+        {
+            using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);
+
+            var control = CreateWithChildAndMeasureAndTransform(
+                100,
+                25,
+                new RotateTransform { Angle = 90 });
+
+            Assert.Equal(new Size(25, 100), control.DesiredSize);
+
+            control.LayoutTransform = null;
+            control.Measure(Size.Infinity);
+            control.Arrange(new Rect(control.DesiredSize));
+
+            Assert.Equal(new Size(100, 25), control.DesiredSize);
+        }
+
+        [Fact]
         public void Should_Generate_RotateTransform_90_degrees()
         {
             using var app = UnitTestApplication.Start(TestServices.MockPlatformRenderInterface);


### PR DESCRIPTION
## What does the pull request do?
This PR ensures that when `LayoutTransformControl.LayoutTransform` is set to `null` after having a value previously, the applied matrix is reset to the identity one.

A test has been added.

## Fixed issues
Fixes #10567
