### PR TITLE
Fix for ManagedFileChooser -  Filter not applied correctly

### DIFF
--- a/src/Avalonia.Dialogs/Internal/ManagedFileChooserFilterViewModel.cs
+++ b/src/Avalonia.Dialogs/Internal/ManagedFileChooserFilterViewModel.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Dialogs.Internal
             }
 
             _patterns = filter.Patterns?
-                .Select(e => new Regex(Regex.Escape(e).Replace(@"\*", ".*").Replace(@"\?", "."), RegexOptions.Singleline | RegexOptions.IgnoreCase))
+                .Select(e => new Regex("^" + Regex.Escape(e).Replace("\\*", ".*") + "$", RegexOptions.Singleline | RegexOptions.IgnoreCase))
                 .ToArray();
         }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
Technically a file chooser now may not display files that were displayed before. But as these were filtered wrong, I assume it's not a breaking change.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/11824
