### PR TITLE
Don't set uncoerced value to coerced default value.

### DIFF
--- a/src/Avalonia.Base/PropertyStore/EffectiveValue`1.cs
+++ b/src/Avalonia.Base/PropertyStore/EffectiveValue`1.cs
@@ -216,7 +216,7 @@ namespace Avalonia.PropertyStore
                 valueChanged = !EqualityComparer<T>.Default.Equals(Value, v);
                 Value = v;
                 Priority = priority;
-                if (_uncommon is not null)
+                if (!isCoercedDefaultValue && _uncommon is not null)
                     _uncommon._uncoercedValue = value;
             }
 
@@ -225,7 +225,7 @@ namespace Avalonia.PropertyStore
                 baseValueChanged = !EqualityComparer<T>.Default.Equals(_baseValue, v);
                 _baseValue = v;
                 BasePriority = priority;
-                if (_uncommon is not null)
+                if (!isCoercedDefaultValue && _uncommon is not null)
                     _uncommon._uncoercedBaseValue = value;
             }
 

--- a/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Coercion.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaObjectTests_Coercion.cs
@@ -244,6 +244,19 @@ namespace Avalonia.Base.UnitTests
         }
 
         [Fact]
+        public void Second_Coerce_Of_Default_Value_Is_Passed_Uncoerced_Value()
+        {
+            var target = new Class1();
+
+            target.MinFoo = 20;
+            target.CoerceFooInvocations.Clear();
+            target.CoerceValue(Class1.FooProperty);
+            target.CoerceValue(Class1.FooProperty);
+
+            Assert.Equal(new[] { 11, 11 }, target.CoerceFooInvocations);
+        }
+
+        [Fact]
         public void ClearValue_Respects_Coerced_Default_Value()
         {
             var target = new Class1();


### PR DESCRIPTION
## What does the pull request do?

If a default value is coerced then we were assigning it to the uncoerced value, meaning that next time `CoerceValue` was called, it would be called with the coerced value instead of the actual value.

## Fixed issues

Fixes #11484 