### PR TITLE
Fix simple theme for TransitioningContentControl

### DIFF
--- a/src/Avalonia.Themes.Simple/Controls/TransitioningContentControl.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/TransitioningContentControl.xaml
@@ -13,11 +13,10 @@
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="{TemplateBinding CornerRadius}"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
-                            Content="{TemplateBinding Content}"
                             Padding="{TemplateBinding Padding}"
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />
-          <ContentPresenter Name="PART_TransitionContentPresenter"
+          <ContentPresenter Name="PART_ContentPresenter2"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"


### PR DESCRIPTION
After #11721, `TransitioningContentControl` wasn't working anymore with the simple theme, due to change in part naming.