### PR TITLE
fix: AvaloniaPublicKey.props multiple import

### DIFF
--- a/tests/Avalonia.UnitTests/Avalonia.UnitTests.csproj
+++ b/tests/Avalonia.UnitTests/Avalonia.UnitTests.csproj
@@ -22,5 +22,4 @@
   <Import Project="..\..\build\HarfBuzzSharp.props" />
   <Import Project="..\..\build\XUnit.props" />
   <Import Project="..\..\build\SharedVersion.props" />
-  <Import Project="..\..\build\AvaloniaPublicKey.props" />
 </Project>


### PR DESCRIPTION
Warning MSB4011 "C:\GitHub\Avalonia\build\AvaloniaPublicKey.props" cannot be imported again. It was already imported at "C:\GitHub\Avalonia\Directory.Build.props (2,3)". This is most likely a build authoring error. This subsequent import will be ignored. Avalonia.Markup.Xaml.UnitTests C:\GitHub\Avalonia\tests\Avalonia.UnitTests\Avalonia.UnitTests.csproj 25

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
