### PR TITLE
fix: missing EnforceExtendedAnalyzerRules

### DIFF
--- a/src/tools/Avalonia.Generators/Avalonia.Generators.csproj
+++ b/src/tools/Avalonia.Generators/Avalonia.Generators.csproj
@@ -6,6 +6,7 @@
     <DefineConstants>$(DefineConstants);XAMLX_INTERNAL</DefineConstants>
     <IsPackable>true</IsPackable>
     <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Warning RS1036 'Avalonia.Generators.NameGenerator.AvaloniaNameSourceGenerator': A project containing analyzers or source generators should specify the property '<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>' Avalonia.Generators C:\GitHub\Avalonia\src\tools\Avalonia.Generators\NameGenerator\AvaloniaNameSourceGenerator.cs 11 N/A

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
