### PR TITLE
fix: XML Comment

### DIFF
--- a/src/Avalonia.Base/Input/Pointer.cs
+++ b/src/Avalonia.Base/Input/Pointer.cs
@@ -88,7 +88,6 @@ namespace Avalonia.Input
         /// Captures pointer input to the specified gesture recognizer.
         /// </summary>
         /// <param name="gestureRecognizer">The gesture recognizer.</param>
-        /// </remarks>
         internal void CaptureGestureRecognizer(GestureRecognizer? gestureRecognizer)
         {
             if (CapturedGestureRecognizer != gestureRecognizer)

--- a/src/Avalonia.Base/Media/MediaContext.cs
+++ b/src/Avalonia.Base/Media/MediaContext.cs
@@ -213,10 +213,10 @@ internal partial class MediaContext : ICompositorScheduler
     }
 
     /// <summary>
-    /// Executes the <param name="callback">callback</param> in the next iteration of the current UI-thread
+    /// Executes the <paramref name="callback">callback</paramref> in the next iteration of the current UI-thread
     /// render loop / layout pass that.
     /// </summary>
-    /// <param name="callback">Code to execute.</param>
+    /// <param name="callback"></param>
     public void BeginInvokeOnRender(Action callback)
     {
         if (_invokeOnRenderCallbacks == null)

--- a/src/Avalonia.Base/Platform/IDrawingContextImpl.cs
+++ b/src/Avalonia.Base/Platform/IDrawingContextImpl.cs
@@ -161,7 +161,7 @@ namespace Avalonia.Platform
         void PopGeometryClip();
         
         /// <summary>
-
+        /// Get Fetaure from type
         /// <summary>
         /// Attempts to get an optional feature from the drawing context implementation
         /// </summary>

--- a/src/Avalonia.Base/Rendering/RenderLoop.cs
+++ b/src/Avalonia.Base/Rendering/RenderLoop.cs
@@ -42,7 +42,6 @@ namespace Avalonia.Rendering
         /// Initializes a new instance of the <see cref="RenderLoop"/> class.
         /// </summary>
         /// <param name="timer">The render timer.</param>
-        /// <param name="dispatcher">The UI thread dispatcher.</param>
         public RenderLoop(IRenderTimer timer)
         {
             _timer = timer;

--- a/src/Avalonia.Base/Threading/Dispatcher.Invoke.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.Invoke.cs
@@ -581,11 +581,6 @@ public partial class Dispatcher
     /// <param name="action">
     ///     A Func&lt;Task&lt;TResult&gt;&gt; delegate to invoke through the dispatcher.
     /// </param>
-    /// <param name="priority">
-    ///     The priority that determines in what order the specified
-    ///     callback is invoked relative to the other pending operations
-    ///     in the Dispatcher.
-    /// </param>
     /// <returns>
     ///     An task that completes after the task returned from callback finishes
     /// </returns>


### PR DESCRIPTION
Severity|Code|Description|Project|File|Line|Suppression State 
|-|-|-|-|-|-|-|
|Warning|CS1570|XML comment has badly formed XML -- 'End tag was not expected at this location.'|Avalonia.Base (net6.0)|C:\GitHub\Avalonia\src\Avalonia.Base\Input\Pointer.cs|91|N/A 
|Warning|CS1572|XML comment has a param tag for 'dispatcher', but there is no parameter by that name|Avalonia.Base (net6.0)|C:\GitHub\Avalonia\src\Avalonia.Base\Rendering\RenderLoop.cs|45|N/A
|Warning|CS1572|XML comment has a param tag for 'priority', but there is no parameter by that name|Avalonia.Base (net6.0)|C:\GitHub\Avalonia\src\Avalonia.Base\Threading\Dispatcher.Invoke.cs|584|N/A

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
