### PR TITLE
Pinvoke for static linking

### DIFF
--- a/samples/ControlCatalog.NetCore/NativeControls/Win/WinApi.cs
+++ b/samples/ControlCatalog.NetCore/NativeControls/Win/WinApi.cs
@@ -39,7 +39,7 @@ internal unsafe class WinApi
     [DllImport("user32.dll", SetLastError = true)]
     public static extern bool DestroyWindow(IntPtr hwnd);
 
-    [DllImport("kernel32.dll")]
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, EntryPoint = "LoadLibraryW", ExactSpelling = true)]
     public static extern IntPtr LoadLibrary(string lib);
 
 

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1827,6 +1827,9 @@ namespace Avalonia.Win32.Interop
             return result;
         }
 
+        [DllImport("user32.dll")]
+        internal static extern int SetWindowCompositionAttribute(IntPtr hwnd, ref WindowCompositionAttributeData data);
+
         [Flags]
         public enum GCS : uint
         {

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1827,9 +1827,6 @@ namespace Avalonia.Win32.Interop
             return result;
         }
 
-        [DllImport("user32.dll")]
-        internal static extern int SetWindowCompositionAttribute(IntPtr hwnd, ref WindowCompositionAttributeData data);
-
         [Flags]
         public enum GCS : uint
         {

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1827,8 +1827,21 @@ namespace Avalonia.Win32.Interop
             return result;
         }
 
-        [DllImport("user32.dll")]
-        internal static extern int SetWindowCompositionAttribute(IntPtr hwnd, ref WindowCompositionAttributeData data);
+        internal static int SetWindowCompositionAttribute(IntPtr hwnd, ref WindowCompositionAttributeData data)
+        {
+            var user32 = LoadLibrary("user32.dll");
+            var pfnSetWindowCompositionAttribute = (delegate* unmanaged[Stdcall]<IntPtr, WindowCompositionAttributeData*, int>)GetProcAddress(user32, nameof(SetWindowCompositionAttribute));
+            if (pfnSetWindowCompositionAttribute == null)
+            {
+                // This preserves the same behavior as using the DllImport attribute.
+                throw new EntryPointNotFoundException("The unsupported SetWindowCompositionAttribute-function has been removed from the operating system.");
+            }
+
+            fixed (WindowCompositionAttributeData* pData = &data)
+            {
+                return pfnSetWindowCompositionAttribute(hwnd, pData);
+            }
+        }
 
         [Flags]
         public enum GCS : uint

--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1161,7 +1161,7 @@ namespace Avalonia.Win32.Interop
         [DllImport("user32.dll")]
         public static extern bool ClientToScreen(IntPtr hWnd, ref POINT lpPoint);
 
-        [DllImport("user32.dll", SetLastError = true)]
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "CreateWindowExW", ExactSpelling = true)]
         public static extern IntPtr CreateWindowEx(
            int dwExStyle,
            uint lpClassName,
@@ -1215,16 +1215,16 @@ namespace Avalonia.Win32.Interop
         [DllImport("user32.dll")]
         public static extern int GetMessageTime();
 
-        [DllImport("kernel32.dll")]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, EntryPoint = "GetModuleHandleW", ExactSpelling = true)]
         public static extern IntPtr GetModuleHandle(string? lpModuleName);
 
         [DllImport("user32.dll")]
         public static extern int GetSystemMetrics(SystemMetric smIndex);
 
-        [DllImport("user32.dll", SetLastError = true)]
+        [DllImport("user32.dll", SetLastError = true, EntryPoint = "GetWindowLongPtrW", ExactSpelling = true)]
         public static extern uint GetWindowLongPtr(IntPtr hWnd, int nIndex);
 
-        [DllImport("user32.dll", SetLastError = true, EntryPoint = "GetWindowLong")]
+        [DllImport("user32.dll", SetLastError = true, EntryPoint = "GetWindowLongW", ExactSpelling = true)]
         public static extern uint GetWindowLong32b(IntPtr hWnd, int nIndex);
 
         public static uint GetWindowLong(IntPtr hWnd, int nIndex)
@@ -1239,10 +1239,10 @@ namespace Avalonia.Win32.Interop
             }
         }
 
-        [DllImport("user32.dll", SetLastError = true, EntryPoint = "SetWindowLong")]
+        [DllImport("user32.dll", SetLastError = true, EntryPoint = "SetWindowLongW", ExactSpelling = true)]
         private static extern uint SetWindowLong32b(IntPtr hWnd, int nIndex, uint value);
 
-        [DllImport("user32.dll", SetLastError = true, EntryPoint = "SetWindowLongPtr")]
+        [DllImport("user32.dll", SetLastError = true, EntryPoint = "SetWindowLongPtrW", ExactSpelling = true)]
         private static extern IntPtr SetWindowLong64b(IntPtr hWnd, int nIndex, IntPtr value);
 
         public static uint SetWindowLong(IntPtr hWnd, int nIndex, uint value)
@@ -1310,7 +1310,7 @@ namespace Avalonia.Win32.Interop
         [DllImport("user32.dll")]
         public static extern bool KillTimer(IntPtr hWnd, IntPtr uIDEvent);
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", EntryPoint = "LoadCursorW", ExactSpelling = true)]
         public static extern IntPtr LoadCursor(IntPtr hInstance, IntPtr lpCursorName);
 
         [DllImport("user32.dll")]
@@ -1319,7 +1319,7 @@ namespace Avalonia.Win32.Interop
         [DllImport("user32.dll")]
         public static extern bool DestroyIcon(IntPtr hIcon);
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", EntryPoint = "PeekMessageW", ExactSpelling = true)]
         public static extern bool PeekMessage(out MSG lpMsg, IntPtr hWnd, uint wMsgFilterMin, uint wMsgFilterMax, uint wRemoveMsg);
 
         [DllImport("user32")]
@@ -1334,7 +1334,7 @@ namespace Avalonia.Win32.Interop
         [DllImport("user32.dll")]
         public static extern bool ReleaseCapture();
 
-        [DllImport("user32.dll", SetLastError = true)]
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "RegisterWindowMessageW", ExactSpelling = true)]
         public static extern uint RegisterWindowMessage(string lpString);
 
         [DllImport("user32.dll")]
@@ -1415,7 +1415,7 @@ namespace Avalonia.Win32.Interop
         [DllImport("user32.dll")]
         public static extern bool TranslateMessage(ref MSG lpMsg);
 
-        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, EntryPoint = "UnregisterClassW", ExactSpelling = true)]
         public static extern bool UnregisterClass(string lpClassName, IntPtr hInstance);
 
         [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "SetWindowTextW")]
@@ -1439,10 +1439,10 @@ namespace Avalonia.Win32.Interop
         [DllImport("shell32", CharSet = CharSet.Auto)]
         public static extern int Shell_NotifyIcon(NIM dwMessage, NOTIFYICONDATA lpData);
 
-        [DllImport("user32.dll", EntryPoint = "SetClassLongPtr")]
+        [DllImport("user32.dll", EntryPoint = "SetClassLongPtrW", ExactSpelling = true)]
         private static extern IntPtr SetClassLong64(IntPtr hWnd, ClassLongIndex nIndex, IntPtr dwNewLong);
 
-        [DllImport("user32.dll", EntryPoint = "SetClassLong")]
+        [DllImport("user32.dll", EntryPoint = "SetClassLongW", ExactSpelling = true)]
         private static extern IntPtr SetClassLong32(IntPtr hWnd, ClassLongIndex nIndex, IntPtr dwNewLong);
 
         public static IntPtr SetClassLong(IntPtr hWnd, ClassLongIndex nIndex, IntPtr dwNewLong)
@@ -1463,10 +1463,10 @@ namespace Avalonia.Win32.Interop
                 return new IntPtr(GetClassLongPtr32(hWnd, nIndex));
         }
 
-        [DllImport("user32.dll", EntryPoint = "GetClassLong")]
+        [DllImport("user32.dll", EntryPoint = "GetClassLongW", ExactSpelling = true)]
         public static extern uint GetClassLongPtr32(IntPtr hWnd, int nIndex);
 
-        [DllImport("user32.dll", EntryPoint = "GetClassLongPtr")]
+        [DllImport("user32.dll", EntryPoint = "GetClassLongPtrW", ExactSpelling = true)]
         public static extern IntPtr GetClassLongPtr64(IntPtr hWnd, int nIndex);
 
         [DllImport("user32.dll", EntryPoint = "SetCursor")]
@@ -1527,10 +1527,10 @@ namespace Avalonia.Win32.Interop
         [DllImport("kernel32.dll", ExactSpelling = true)]
         public static extern IntPtr GlobalFree(IntPtr hMem);
 
-        [DllImport("kernel32.dll", SetLastError = true)]
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "LoadLibraryW", ExactSpelling = true)]
         public static extern IntPtr LoadLibrary(string fileName);
 
-        [DllImport("kernel32.dll", SetLastError = true)]
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "LoadLibraryExW", ExactSpelling = true)]
         public static extern IntPtr LoadLibraryEx(string fileName, IntPtr hFile, int flags);
 
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Ansi)]
@@ -1645,7 +1645,7 @@ namespace Avalonia.Win32.Interop
         [DllImport("opengl32.dll", CharSet = CharSet.Ansi)]
         public static extern IntPtr wglGetProcAddress(string name);
 
-        [DllImport("kernel32.dll", SetLastError = true)]
+        [DllImport("kernel32.dll", SetLastError = true, EntryPoint = "CreateFileMappingW", ExactSpelling = true)]
         public static extern IntPtr CreateFileMapping(IntPtr hFile,
             IntPtr lpFileMappingAttributes,
             uint flProtect,
@@ -1668,16 +1668,16 @@ namespace Avalonia.Win32.Interop
         [DllImport("ole32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
         internal static extern void ReleaseStgMedium(ref STGMEDIUM medium);
 
-        [DllImport("user32.dll", BestFitMapping = false, CharSet = CharSet.Auto, SetLastError = true)]
+        [DllImport("user32.dll", BestFitMapping = false, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "GetClipboardFormatNameW", ExactSpelling = true)]
         public static extern int GetClipboardFormatName(int format, StringBuilder lpString, int cchMax);
 
-        [DllImport("user32.dll", BestFitMapping = false, CharSet = CharSet.Auto, SetLastError = true)]
+        [DllImport("user32.dll", BestFitMapping = false, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "RegisterClipboardFormatW", ExactSpelling = true)]
         public static extern int RegisterClipboardFormat(string format);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Auto, ExactSpelling = true, SetLastError = true)]
         public static extern IntPtr GlobalSize(IntPtr hGlobal);
 
-        [DllImport("shell32.dll", BestFitMapping = false, CharSet = CharSet.Auto)]
+        [DllImport("shell32.dll", BestFitMapping = false, CharSet = CharSet.Unicode, EntryPoint = "DragQueryFileW", ExactSpelling = true)]
         public static extern int DragQueryFile(IntPtr hDrop, int iFile, StringBuilder? lpszFile, int cch);
 
         [DllImport("ole32.dll", CharSet = CharSet.Auto, ExactSpelling = true, PreserveSig = false)]
@@ -1893,7 +1893,7 @@ namespace Avalonia.Win32.Interop
         [DllImport("imm32.dll")]
         public static extern bool ImmSetCompositionFont(IntPtr hIMC, ref LOGFONT lf);
 
-        [DllImport("imm32.dll", SetLastError = false, CharSet = CharSet.Unicode)]
+        [DllImport("imm32.dll", SetLastError = false, CharSet = CharSet.Unicode, EntryPoint = "ImmGetCompositionStringW", ExactSpelling = true)]
         public static extern int ImmGetCompositionString(IntPtr hIMC, GCS dwIndex, [Out, Optional] IntPtr lpBuf, uint dwBufLen);
 
         public static string? ImmGetCompositionString(IntPtr hIMC, GCS dwIndex)

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -371,7 +371,7 @@ namespace Avalonia.Win32
                 if (level == WindowTransparencyLevel.Transparent)
                     SetTransparencyTransparent(windowsVersion);
                 else if (level == WindowTransparencyLevel.Blur)
-                    SetTransparencyBlur(windowsVersion);
+                    continue; // Unsupported on all versions (unreachable)
                 else if (level == WindowTransparencyLevel.AcrylicBlur)
                     SetTransparencyAcrylicBlur(windowsVersion);
                 else if (level == WindowTransparencyLevel.Mica)
@@ -409,9 +409,9 @@ namespace Avalonia.Win32
             if (level == WindowTransparencyLevel.Transparent)
                 return windowsVersion >= PlatformConstants.Windows8;
 
-            // Blur only supported on Windows 8 and lower.
+            // Support for legacy, undocumented DWM blur has been removed.
             if (level == WindowTransparencyLevel.Blur)
-                return windowsVersion < PlatformConstants.Windows10;
+                return false;
 
             // Acrylic is supported on Windows >= 10.0.15063.
             if (level == WindowTransparencyLevel.AcrylicBlur)
@@ -426,35 +426,12 @@ namespace Avalonia.Win32
 
         private void SetTransparencyTransparent(Version windowsVersion)
         {
-            // Transparent only supported with composition on Windows 8+.
-            if (!_isUsingComposition || windowsVersion < PlatformConstants.Windows8)
+            // Transparent only supported with composition on Windows 10+.
+            if (!_isUsingComposition || windowsVersion < PlatformConstants.Windows10)
                 return;
-
-            if (windowsVersion < PlatformConstants.Windows10)
-            {
-                // Some of the AccentState Enum's values have different meanings on Windows 8.x than on
-                // Windows 10, hence using ACCENT_ENABLE_BLURBEHIND to disable blurbehind  ¯\_(ツ)_/¯.
-                // Hey, I'm just porting what was here before.
-                SetAccentState(AccentState.ACCENT_ENABLE_BLURBEHIND);
-                var blurInfo = new DWM_BLURBEHIND(false);
-                DwmEnableBlurBehindWindow(_hwnd, ref blurInfo);
-            }
 
             SetUseHostBackdropBrush(false);
             _blurHost?.SetBlur(BlurEffect.None);
-        }
-
-        private void SetTransparencyBlur(Version windowsVersion)
-        {
-            // Blur only supported with composition on Windows 8 and lower.
-            if (!_isUsingComposition || windowsVersion >= PlatformConstants.Windows10)
-                return;
-
-            // Some of the AccentState Enum's values have different meanings on Windows 8.x than on
-            // Windows 10.
-            SetAccentState(AccentState.ACCENT_DISABLED);
-            var blurInfo = new DWM_BLURBEHIND(true);
-            DwmEnableBlurBehindWindow(_hwnd, ref blurInfo);
         }
 
         private void SetTransparencyAcrylicBlur(Version windowsVersion)
@@ -475,26 +452,6 @@ namespace Avalonia.Win32
 
             SetUseHostBackdropBrush(false);
             _blurHost?.SetBlur(BlurEffect.Mica);
-        }
-
-        private void SetAccentState(AccentState state)
-        {
-            var accent = new AccentPolicy();
-            var accentStructSize = Marshal.SizeOf(accent);
-
-            //Some of the AccentState Enum's values have different meanings on Windows 8.x than on Windows 10
-            accent.AccentState = state;
-
-            var accentPtr = Marshal.AllocHGlobal(accentStructSize);
-            Marshal.StructureToPtr(accent, accentPtr, false);
-
-            var data = new WindowCompositionAttributeData();
-            data.Attribute = WindowCompositionAttribute.WCA_ACCENT_POLICY;
-            data.SizeOfData = accentStructSize;
-            data.Data = accentPtr;
-
-            SetWindowCompositionAttribute(_hwnd, ref data);
-            Marshal.FreeHGlobal(accentPtr);
         }
 
         private void SetUseHostBackdropBrush(bool useHostBackdropBrush)


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Motivated by NativeAot, this PR ensures that all PInvoke usages map to corresponding exports in the [Windows Umbrella Libraries](https://learn.microsoft.com/en-us/windows/win32/apiindex/windows-umbrella-libraries) at compile time.

The undocumented `SetWindowCompositionAttribute` function has no export in any static library in the SDK. It has been removed (see discussion in #11855).

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The DllImport-declarations do not specify the `EntryPoint` for these variants. Therefore, the fix-up is performed by the pinvoke-stub at runtime. This causes an error when linking statically to some libraries, such as User32.lib.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Avalonia can now link statically to all winapi imports on win32.
To test:
1. Open BindingDemo.csproj.
1. Change the target framework to .NET 7 (for AOT support)
1. Add the following to the csproj:
```xml
  <PropertyGroup>
    <PublishAot>true</PublishAot>
  </PropertyGroup>
  <ItemGroup Condition="'$(PublishAot)' == 'true'">
    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="7.*" />
    <PackageReference Include="System.Drawing.Common" Version="7.*" />
    <DirectPInvoke Include="User32" />
    <DirectPInvoke Include="Kernel32" />
    <DirectPInvoke Include="Ole32" />
    <DirectPInvoke Include="Dwmapi" />
    <DirectPInvoke Include="Imm32" />
    <DirectPInvoke Include="Shell32" />
    <DirectPInvoke Include="comdlg32" />
    <DirectPInvoke Include="Shcore" />
    <DirectPInvoke Include="opengl32" />
    <DirectPInvoke Include="ntdll" />
    <DirectPInvoke Include="Gdi32" />
    <NativeLibrary Include="User32.lib" />
    <NativeLibrary Include="OneCoreUap.lib" />
    <NativeLibrary Include="Gdi32.lib" />
    <NativeLibrary Include="Dwmapi.lib" />
    <NativeLibrary Include="Imm32.lib" />
    <NativeLibrary Include="Shell32.lib" />
    <NativeLibrary Include="Shcore.lib" />
    <NativeLibrary Include="opengl32.lib" />
  </ItemGroup>
```

Note: you may encounter an error saying LoadLibrary is an undefined export when building the sample. The error comes from Microsoft.CodeAnalysis.dll. Removing Avalonia.Diagnostics gets rid of the transitive reference.

None of the DllImport-declarations specified an ansi charset. Therefore, the implicit charset is unicode, hence the same behavior is preserved.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

1. Explicitly specify the -W suffix as the entry point.
1. Set ExactSpelling and CharSet for correctness.
1. Remove all code paths with `SetWindowCompositionAttribute`

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
DWM blur is no longer supported on Windows 8.

## Fixed issues
Fixes #11855
