### PR TITLE
Fix DataGridColumn.CellStyleClasses not settable from XAML

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
@@ -38,7 +38,7 @@ namespace Avalonia.Controls
         private ICellEditBinding _editBinding;
         private IBinding _clipboardContentBinding;
         private ControlTheme _cellTheme;
-        private readonly Classes _cellStyleClasses = new Classes();
+        private Classes _cellStyleClasses;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:Avalonia.Controls.DataGridColumn" /> class.
@@ -393,17 +393,7 @@ namespace Avalonia.Controls
             }
         }
 
-        public Classes CellStyleClasses
-        {
-            get => _cellStyleClasses;
-            set
-            {
-                if(_cellStyleClasses != value)
-                {
-                    _cellStyleClasses.Replace(value);
-                }
-            }
-        }
+        public Classes CellStyleClasses => _cellStyleClasses ??= new();
 
         /// <summary>
         ///    Backing field for CellTheme property.


### PR DESCRIPTION
## What does the pull request do?
Fix `DataGridColumn.CellStyleClasses` not being settable correctly from XAML.
The property itself should be read-only, like `StyledElement.Classes`.

## Breaking changes
**Yes.** The setter is removed.

## Fixed issues
Fixes #11887
