### PR TITLE
Fix ScrollContentPresenter's child margin with layout rounding

### DIFF
--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -7,7 +7,7 @@ using Avalonia.Input.GestureRecognizers;
 using Avalonia.Utilities;
 using Avalonia.VisualTree;
 using System.Linq;
-using Avalonia.Interactivity;
+using Avalonia.Layout;
 
 namespace Avalonia.Controls.Presenters
 {
@@ -473,7 +473,15 @@ namespace Avalonia.Controls.Presenters
             }
 
             Viewport = finalSize;
-            Extent = Child!.Bounds.Size.Inflate(Child.Margin);
+
+            var childMargin = Child!.Margin;
+            if (Child.UseLayoutRounding)
+            {
+                var scale = LayoutHelper.GetLayoutScale(Child);
+                childMargin = LayoutHelper.RoundLayoutThickness(childMargin, scale, scale);
+            }
+
+            Extent = Child!.Bounds.Size.Inflate(childMargin);
             _isAnchorElementDirty = true;
 
             return finalSize;

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ScrollContentPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ScrollContentPresenterTests.cs
@@ -4,6 +4,7 @@ using System.Reactive.Linq;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Layout;
+using Avalonia.UnitTests;
 using Xunit;
 
 namespace Avalonia.Controls.UnitTests.Presenters
@@ -242,6 +243,36 @@ namespace Avalonia.Controls.UnitTests.Presenters
             target.Arrange(new Rect(0, 0, 50, 50));
 
             Assert.Equal(new Size(110, 110), target.Extent);
+        }
+
+        [Fact]
+        public void Extent_Should_Include_Content_Margin_Scaled_With_Layout_Rounding()
+        {
+            var root = new TestRoot
+            {
+                LayoutScaling = 1.25,
+                UseLayoutRounding = true
+            };
+
+            var target = new ScrollContentPresenter
+            {
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                Content = new Border
+                {
+                    Width = 200,
+                    Height = 200,
+                    Margin = new Thickness(2)
+                }
+            };
+
+            root.Child = target;
+            target.UpdateChild();
+            target.Measure(new Size(1000, 1000));
+            target.Arrange(new Rect(0, 0, 1000, 1000));
+
+            Assert.Equal(new Size(203.2, 203.2), target.Viewport);
+            Assert.Equal(new Size(203.2, 203.2), target.Extent);
         }
 
         [Fact]


### PR DESCRIPTION
## What does the pull request do?
After #7867, the margins of a control are correctly rounded with layout scaling ≠ 1 and `UseLayoutRounding = true`.
However, `ScrollContentPresenter` wasn't rounding the margins of its child in the same way when calculating its extent. This could result in an extent larger than needed, and scrollbars showing unnecessarily (#9501, #11373).

For example, a child with `Width="200" Height="200" Margin="2"` and 125% scaling resulted in a viewport of 203.2×203.2 pixels but an extent of 204×204 pixels.

A unit test has been added.

## Fixed issues
Fixes #9501
