### PR TITLE
Fix non-configurable minimum width for DataGridColumnHeader

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -42,9 +42,10 @@
 
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
-    
+
     <x:Double x:Key="ListAccentLowOpacity">0.6</x:Double>
     <x:Double x:Key="ListAccentMediumOpacity">0.8</x:Double>
+    <x:Double x:Key="DataGridSortIconMinWidth">32</x:Double>
 
     <StreamGeometry x:Key="DataGridSortIconDescendingPath">M1875 1011l-787 787v-1798h-128v1798l-787 -787l-90 90l941 941l941 -941z</StreamGeometry>
     <StreamGeometry x:Key="DataGridSortIconAscendingPath">M1965 947l-941 -941l-941 941l90 90l787 -787v1798h128v-1798l787 787z</StreamGeometry>
@@ -174,7 +175,7 @@
                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                 <Grid.ColumnDefinitions>
                   <ColumnDefinition Width="*" />
-                  <ColumnDefinition Width="Auto" MinWidth="32" />
+                  <ColumnDefinition Width="Auto" MinWidth="{DynamicResource DataGridSortIconMinWidth}" />
                 </Grid.ColumnDefinitions>
 
                 <ContentPresenter Content="{TemplateBinding Content}"
@@ -512,7 +513,7 @@
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"
                   CornerRadius="{TemplateBinding CornerRadius}">
-            <Grid ColumnDefinitions="Auto,*,Auto" 
+            <Grid ColumnDefinitions="Auto,*,Auto"
                   RowDefinitions="Auto,*,Auto,Auto"
                   ClipToBounds="True">
               <DataGridColumnHeader Name="PART_TopLeftCornerHeader"


### PR DESCRIPTION
## What does the pull request do?
Allows users to remove hardcoded whitespace from `DataGridColumnHeader` in Fluent theme.

## What is the current behavior?
Fluent theme has a hardcoded 32 pixel whitespace after header text for the sort icon that can only removed by copy/pasting the `ControlTheme`.

## What is the updated/expected behavior with this PR?
Users can override the minimum width of the sort icon by setting the resource value:
```csharp
<x:Double x:Key="DataGridSortIconMinWidth">0</x:Double>
```
and remove padding if needed (already possible):
```csharp
<Style Selector="DataGridColumnHeader">
    <Setter Property="Padding" Value="0" />
</Style>
```

## Fixed issues
Fixes #9791