### PR TITLE
Seal geometry class

### DIFF
--- a/src/Avalonia.Base/CombinedGeometry.cs
+++ b/src/Avalonia.Base/CombinedGeometry.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Text;
 using Avalonia.Platform;
 
-#nullable enable
-
 namespace Avalonia.Media
 {
     public enum GeometryCombineMode
@@ -147,7 +145,7 @@ namespace Avalonia.Media
             return new CombinedGeometry(GeometryCombineMode, Geometry1, Geometry2, Transform);
         }
 
-        protected override IGeometryImpl? CreateDefiningGeometry()
+        private protected sealed override IGeometryImpl? CreateDefiningGeometry()
         {
             var g1 = Geometry1;
             var g2 = Geometry2;

--- a/src/Avalonia.Base/Media/EllipseGeometry.cs
+++ b/src/Avalonia.Base/Media/EllipseGeometry.cs
@@ -135,7 +135,7 @@ namespace Avalonia.Media
         }
 
         /// <inheritdoc/>
-        protected override IGeometryImpl? CreateDefiningGeometry()
+        private protected sealed override IGeometryImpl? CreateDefiningGeometry()
         {
             var factory = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
 

--- a/src/Avalonia.Base/Media/Geometry.cs
+++ b/src/Avalonia.Base/Media/Geometry.cs
@@ -139,7 +139,7 @@ namespace Avalonia.Media
         /// Creates the platform implementation of the geometry, without the transform applied.
         /// </summary>
         /// <returns></returns>
-        protected abstract IGeometryImpl? CreateDefiningGeometry();
+        private protected abstract IGeometryImpl? CreateDefiningGeometry();
 
         /// <summary>
         /// Invalidates the platform implementation of the geometry.

--- a/src/Avalonia.Base/Media/Geometry.cs
+++ b/src/Avalonia.Base/Media/Geometry.cs
@@ -28,6 +28,11 @@ namespace Avalonia.Media
             TransformProperty.Changed.AddClassHandler<Geometry>((x,e) => x.TransformChanged(e));
         }
 
+        internal Geometry()
+        {
+            
+        }
+        
         /// <summary>
         /// Raised when the geometry changes.
         /// </summary>

--- a/src/Avalonia.Base/Media/GeometryGroup.cs
+++ b/src/Avalonia.Base/Media/GeometryGroup.cs
@@ -1,8 +1,6 @@
 ﻿using Avalonia.Metadata;
 using Avalonia.Platform;
 
-#nullable enable
-
 namespace Avalonia.Media
 {
     /// <summary>
@@ -72,7 +70,7 @@ namespace Avalonia.Media
             newChildren.Parent = this;
         }
 
-        protected override IGeometryImpl? CreateDefiningGeometry()
+        private protected sealed override IGeometryImpl? CreateDefiningGeometry()
         {
             if (_children.Count > 0)
             {

--- a/src/Avalonia.Base/Media/LineGeometry.cs
+++ b/src/Avalonia.Base/Media/LineGeometry.cs
@@ -68,7 +68,7 @@ namespace Avalonia.Media
         }
 
         /// <inheritdoc/>
-        protected override IGeometryImpl? CreateDefiningGeometry()
+        private protected sealed override IGeometryImpl? CreateDefiningGeometry()
         {
             var factory = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
 

--- a/src/Avalonia.Base/Media/PathGeometry.cs
+++ b/src/Avalonia.Base/Media/PathGeometry.cs
@@ -43,7 +43,7 @@ namespace Avalonia.Media
         /// </summary>
         /// <param name="pathData">The s.</param>
         /// <returns></returns>
-        public static new PathGeometry Parse(string pathData)
+        public new static PathGeometry Parse(string pathData)
         {
             var pathGeometry = new PathGeometry();
 
@@ -81,7 +81,7 @@ namespace Avalonia.Media
             set { SetValue(FillRuleProperty, value); }
         }
 
-        protected override IGeometryImpl? CreateDefiningGeometry()
+        private protected sealed override IGeometryImpl? CreateDefiningGeometry()
         {
             var figures = Figures;
 

--- a/src/Avalonia.Base/Media/PlatformGeometry.cs
+++ b/src/Avalonia.Base/Media/PlatformGeometry.cs
@@ -2,7 +2,7 @@
 
 namespace Avalonia.Media
 {
-    internal class PlatformGeometry : Geometry
+    internal sealed class PlatformGeometry : Geometry
     {
         private readonly IGeometryImpl _geometryImpl;
 
@@ -16,7 +16,7 @@ namespace Avalonia.Media
             return new PlatformGeometry(_geometryImpl);
         }
 
-        protected override IGeometryImpl? CreateDefiningGeometry()
+        private protected override IGeometryImpl? CreateDefiningGeometry()
         {
            return _geometryImpl;
         }

--- a/src/Avalonia.Base/Media/PolylineGeometry.cs
+++ b/src/Avalonia.Base/Media/PolylineGeometry.cs
@@ -74,7 +74,7 @@ namespace Avalonia.Media
             return new PolylineGeometry(Points, IsFilled);
         }
 
-        protected override IGeometryImpl? CreateDefiningGeometry()
+        private protected sealed override IGeometryImpl? CreateDefiningGeometry()
         {
             var factory = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
             var geometry = factory.CreateStreamGeometry();

--- a/src/Avalonia.Base/Media/RectangleGeometry.cs
+++ b/src/Avalonia.Base/Media/RectangleGeometry.cs
@@ -47,7 +47,7 @@ namespace Avalonia.Media
         /// <inheritdoc/>
         public override Geometry Clone() => new RectangleGeometry(Rect);
 
-        protected override IGeometryImpl? CreateDefiningGeometry()
+        private protected sealed override IGeometryImpl? CreateDefiningGeometry()
         {
             var factory = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
 

--- a/src/Avalonia.Base/Media/StreamGeometry.cs
+++ b/src/Avalonia.Base/Media/StreamGeometry.cs
@@ -31,7 +31,7 @@ namespace Avalonia.Media
         /// </summary>
         /// <param name="s">The string.</param>
         /// <returns>A <see cref="StreamGeometry"/>.</returns>
-        public static new StreamGeometry Parse(string s)
+        public new static StreamGeometry Parse(string s)
         {
             var streamGeometry = new StreamGeometry();
 
@@ -62,7 +62,7 @@ namespace Avalonia.Media
         }
 
         /// <inheritdoc/>
-        protected override IGeometryImpl? CreateDefiningGeometry()
+        private protected override IGeometryImpl? CreateDefiningGeometry()
         {
             if (_impl == null)
             {

--- a/tests/Avalonia.Base.UnitTests/Media/GeometryTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/GeometryTests.cs
@@ -103,7 +103,7 @@ namespace Avalonia.Base.UnitTests.Media
                 throw new NotImplementedException();
             }
 
-            protected override IGeometryImpl CreateDefiningGeometry()
+            private protected sealed override IGeometryImpl CreateDefiningGeometry()
             {
                 return Mock.Of<IGeometryImpl>(
                     x => x.WithTransform(It.IsAny<Matrix>()) == 


### PR DESCRIPTION
For safety, makes it impossible to inherit Geometry class outside of the Base assembly.
It's still possible to define a custom Shape class using existing Geometry types in CreateDefiningGeometry method.