### PR TITLE
Ensure render is started when a window opens.

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -715,8 +715,8 @@ namespace Avalonia.Controls
 
                 SetWindowStartupLocation(owner);
 
-                PlatformImpl?.Show(ShowActivated, false);
                 StartRendering();
+                PlatformImpl?.Show(ShowActivated, false);
                 OnOpened(EventArgs.Empty);
             }
         }
@@ -791,9 +791,8 @@ namespace Avalonia.Controls
 
                 SetWindowStartupLocation(owner);
 
-                PlatformImpl?.Show(ShowActivated, true);
-
                 StartRendering();
+                PlatformImpl?.Show(ShowActivated, true);
 
                 Observable.FromEventPattern(
                         x => Closed += x,


### PR DESCRIPTION
On OSX if you open a window Maximised you could get an empty screen.

This is because the renderer wasnt started until after and the compositor wouldnt know to repaint the ui.