### PR TITLE
Removing compositional renderer license. Reverting to MIT

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/License.md
+++ b/src/Avalonia.Base/Rendering/Composition/License.md
@@ -1,7 +1,0 @@
-Please note: Any code in this directory is excluded from the normal MIT license.
-
-This code is owned and copyright to Avalonia OU.
-
-This code may be used free of charge by any application that consumes Avalonia binary packages as a direct or indirect dependency.
-
-Explicit permission is required for any other use outside of Avalonia applications.


### PR DESCRIPTION
As @robloo has pointed out, we need to change the renderer license. This PR removes the temporary license and reverts the code to MIT. 