### PR TITLE
Removing compositional renderer license part 2

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/readme.md
+++ b/src/Avalonia.Base/Rendering/Composition/readme.md
@@ -1,3 +1,0 @@
-Please note the composition renderer is not subject to the usual MIT license.
-
-Please contact us for more details and see [License.md](https://raw.githubusercontent.com/AvaloniaUI/Avalonia/master/src/Avalonia.Base/Rendering/Composition/License.md)


### PR DESCRIPTION
We missed removing readme.md, thanks @MichalPetryka for pointing it out! 