### PR TITLE
Fix datagrid not updating when not attached to tree

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -2101,6 +2101,7 @@ namespace Avalonia.Controls
             if (DataConnection.DataSource != null && !DataConnection.EventsWired)
             {
                 DataConnection.WireEvents(DataConnection.DataSource);
+                InitializeElements(false /*recycleRows*/);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
Makes datagrid datasource changes work when not attached to the visual tree


## What is the current behavior?
When a datagrid is detached from the visual tree changes to the datasouce are not reflected when re attached


## What is the updated/expected behavior with this PR?
Changed made to the datasource should be visible


## How was the solution implemented (if it's not obvious)?


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

## Obsoletions / Deprecations

## Fixed issues
Fixes AvaloniaUI/Avalonia#9527