### PR TITLE
Add event trigger time in DevTools. #11338

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/EventTreeNode.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/EventTreeNode.cs
@@ -72,12 +72,13 @@ namespace Avalonia.Diagnostics.ViewModels
             var s = sender!;
             var handled = e.Handled;
             var route = e.Route;
+            var triggerTime = DateTime.Now;
 
             void handler()
             {
                 if (_currentEvent == null || !_currentEvent.IsPartOfSameEventChain(e))
                 {
-                    _currentEvent = new FiredEvent(e, new EventChainLink(s, handled, route));
+                    _currentEvent = new FiredEvent(e, new EventChainLink(s, handled, route), triggerTime);
 
                     _parentViewModel.RecordedEvents.Add(_currentEvent);
 

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/FiredEvent.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/FiredEvent.cs
@@ -10,17 +10,20 @@ namespace Avalonia.Diagnostics.ViewModels
         private readonly RoutedEventArgs _eventArgs;
         private EventChainLink? _handledBy;
 
-        public FiredEvent(RoutedEventArgs eventArgs, EventChainLink originator)
+        public FiredEvent(RoutedEventArgs eventArgs, EventChainLink originator, DateTime triggerTime)
         {
             _eventArgs = eventArgs ?? throw new ArgumentNullException(nameof(eventArgs));
             Originator = originator ?? throw new ArgumentNullException(nameof(originator));
             AddToChain(originator);
+            TriggerTime = triggerTime;
         }
 
         public bool IsPartOfSameEventChain(RoutedEventArgs e)
         {
             return e == _eventArgs;
         }
+
+        public DateTime TriggerTime { get; }
 
         public RoutedEvent Event => _eventArgs.RoutedEvent!;
 

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/EventsPageView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/EventsPageView.xaml
@@ -77,21 +77,23 @@
         <ListBox.ItemTemplate>
           <DataTemplate>
             <ListBoxItem Classes.handled="{Binding IsHandled}">
-              <Grid ColumnDefinitions="Auto,Auto,*,Auto">
+              <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto">
 
-                <StackPanel Grid.Column="0" Spacing="2" Orientation="Horizontal" >
+                <TextBlock Grid.Column="0"  Text="{Binding TriggerTime, StringFormat={}{0:HH:mm:ss.fff}}"/>
+
+                <StackPanel Margin="10,0,0,0" Grid.Column="1" Spacing="2" Orientation="Horizontal" >
                   <TextBlock Tag="{Binding Event}" DoubleTapped="NavigateTo" Text="{Binding Event.Name}" FontWeight="Bold" Classes="nav" />
                   <TextBlock Text="on" />
                   <TextBlock Tag="{Binding Originator}" DoubleTapped="NavigateTo" Text="{Binding Originator.HandlerName}" Classes="nav" />
                 </StackPanel>
 
-                <StackPanel Margin="2,0,0,0" Grid.Column="1" Spacing="2" Orientation="Horizontal" IsVisible="{Binding IsHandled}" >
+                <StackPanel Margin="2,0,0,0" Grid.Column="2" Spacing="2" Orientation="Horizontal" IsVisible="{Binding IsHandled}" >
                   <TextBlock Text="::" />
                   <TextBlock Text="Handled by" />
                   <TextBlock Tag="{Binding HandledBy}" DoubleTapped="NavigateTo" Text="{Binding HandledBy.HandlerName}" Classes="nav" />
                 </StackPanel>
 
-                <StackPanel Grid.Column="3" Orientation="Horizontal" HorizontalAlignment="Right">
+                <StackPanel Grid.Column="4" Orientation="Horizontal" HorizontalAlignment="Right">
                   <TextBlock Text="Routing (" />
                   <TextBlock Text="{Binding Event.RoutingStrategies}"/>
                   <TextBlock Text=")"/>


### PR DESCRIPTION
## What does the pull request do?
Add event trigger time in DevTools.


## What is the current behavior?
Events in list have no time.


## What is the updated/expected behavior with this PR?
Each event record has its trigger time in the left of the line.


## How was the solution implemented (if it's not obvious)?
Add a `TriggerTime` property to `FiredEvent` and use the time where `EventTreeNode.HandleEvent` triggered as the event trigger time


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
No

## Obsoletions / Deprecations
No

## Fixed issues
Fixes #11338
