### PR TITLE
fix DropDownButton glyph foreground color

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/DropDownButton.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/DropDownButton.xaml
@@ -71,6 +71,9 @@
         <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPointerOver}" />
         <Setter Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundPointerOver}" />
       </Style>
+      <Style Selector="^:pointerover /template/ PathIcon#DropDownGlyph">
+        <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundPointerOver}" />
+      </Style>
 
       <!--  Pressed State  -->
       <Style Selector="^:pressed">
@@ -81,6 +84,9 @@
         <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPressed}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPressed}" />
         <Setter Property="TextElement.Foreground" Value="{DynamicResource ButtonForegroundPressed}" />
+      </Style>
+      <Style Selector="^:pressed /template/ PathIcon#DropDownGlyph">
+        <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundPressed}" />
       </Style>
 
       <!--  Disabled State  -->


### PR DESCRIPTION
## What does the pull request do?
Makes the dropdown glyph part of a DropDownButton match the foreground when mouse over and pressing


## What is the current behavior?
Currently the glyph foreground only changes when disabled


## What is the updated/expected behavior with this PR?
Hovering the drop down button should make the glyph match the Foreground, same when pressed


## How was the solution implemented (if it's not obvious)?

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

## Fixed issues
