### PR TITLE
Fix AutoCompleteBox not opening when the text box is empty

### DIFF
--- a/samples/ControlCatalog/Pages/AutoCompleteBoxPage.xaml
+++ b/samples/ControlCatalog/Pages/AutoCompleteBoxPage.xaml
@@ -19,6 +19,10 @@
         </Style>
       </UniformGrid.Styles>
       <StackPanel>
+        <TextBlock Text="MinimumPrefixLength: 0" />
+        <AutoCompleteBox MinimumPrefixLength="0" />
+      </StackPanel>
+      <StackPanel>
         <TextBlock Text="MinimumPrefixLength: 1" />
         <AutoCompleteBox MinimumPrefixLength="1" />
       </StackPanel>
@@ -42,7 +46,6 @@
         <TextBlock Text="Disabled" />
         <AutoCompleteBox IsEnabled="False" />
       </StackPanel>
-
       <StackPanel>
         <TextBlock Text="ValueMemberBinding" />
         <AutoCompleteBox ValueMemberBinding="{Binding Capital, x:DataType=models:StateData}" />

--- a/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.cs
@@ -1320,17 +1320,14 @@ namespace Avalonia.Controls
             // Evaluate the conditions needed for completion.
             // 1. Minimum prefix length
             // 2. If a delay timer is in use, use it
-            bool populateReady = newText.Length >= MinimumPrefixLength && MinimumPrefixLength >= 0;
-            if (populateReady && MinimumPrefixLength == 0 && String.IsNullOrEmpty(newText) && String.IsNullOrEmpty(SearchText))
-            {
-                populateReady = false;
-            }
-            _userCalledPopulate = populateReady ? userInitiated : false;
+            bool minimumLengthReached = newText.Length >= MinimumPrefixLength && MinimumPrefixLength >= 0;
+
+            _userCalledPopulate = minimumLengthReached && userInitiated;
 
             // Update the interface and values only as necessary
             UpdateTextValue(newText, userInitiated);
 
-            if (populateReady)
+            if (minimumLengthReached)
             {
                 _ignoreTextSelectionChange = true;
 

--- a/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
@@ -1,21 +1,15 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using Avalonia.Controls.Primitives;
-using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
-using Avalonia.Markup.Data;
-using Avalonia.Platform;
 using Avalonia.Threading;
 using Avalonia.UnitTests;
-using Moq;
 using Xunit;
 using System.Collections.ObjectModel;
-using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using Avalonia.Input;
 
 namespace Avalonia.Controls.UnitTests
 {
@@ -436,6 +430,29 @@ namespace Avalonia.Controls.UnitTests
 
                 Assert.Equal(DataValidationErrors.GetHasErrors(control), true);
                 Assert.Equal(DataValidationErrors.GetErrors(control).SequenceEqual(new[] { exception }), true);
+            });
+        }
+
+        [Fact]
+        public void Explicit_Dropdown_Open_Request_MinimumPrefixLength_0()
+        {
+            RunTest((control, textbox) =>
+            {
+                control.Text = "";
+                control.MinimumPrefixLength = 0;
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.False(control.IsDropDownOpen);
+
+                control.RaiseEvent(new KeyEventArgs
+                {
+                    RoutedEvent = InputElement.KeyDownEvent,
+                    Key = Key.Down
+                });
+
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.True(control.IsDropDownOpen);
             });
         }
 
@@ -1072,14 +1089,14 @@ namespace Avalonia.Controls.UnitTests
 
         private AutoCompleteBox CreateControl()
         {
-            var datePicker =
+            var autoCompleteBox =
                 new AutoCompleteBox
                 {
                     Template = CreateTemplate()
                 };
 
-            datePicker.ApplyTemplate();
-            return datePicker;
+            autoCompleteBox.ApplyTemplate();
+            return autoCompleteBox;
         }
         private TextBox GetTextBox(AutoCompleteBox control)
         {


### PR DESCRIPTION
## What does the pull request do?
This PR removes an old workaround that mistakenly prevented the `AutoCompleteBox` dropdown from opening in certain scenarios. More context is provided [here](https://github.com/AvaloniaUI/Avalonia/issues/8903#issuecomment-1622259872).


## What is the current behavior?
Previously, an `AutoCompleteBox` with `MinimumPrefixLength=0` would not open when the user pressed the down arrow key with no text in the text box.


## What is the updated/expected behavior with this PR?
When pressing the down arrow key in an `AutoCompleteBox` with `MinimumPrefixLength=0`, the dropdown will now open as expected.


## How was the solution implemented (if it's not obvious)?
I removed a check that was introduced as a workaround in #1570 in order to fix #1554. The underlying cause for #1554 appears to have been resolved since then, so the workaround is no longer needed.


## Checklist

- [x] Added a unit test

## Fixed issues
Fixes #8903
