### PR TITLE
Drop original internal XAML resources after merge

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlCompiler.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlCompiler.cs
@@ -179,9 +179,11 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             return parsed;
         }
 
-        public void Compile(XamlDocument document, IXamlTypeBuilder<IXamlILEmitter> tb, IXamlMethodBuilder<IXamlILEmitter> populateMethod, IXamlMethodBuilder<IXamlILEmitter> buildMethod, string baseUri, IFileSource fileSource)
+        public void Compile(XamlDocument document, XamlDocumentTypeBuilderProvider typeBuilderProvider, string baseUri, IFileSource fileSource)
         {
-            Compile(document, _contextType, populateMethod, buildMethod,
+            var tb = typeBuilderProvider.TypeBuilder;
+
+            Compile(document, _contextType, typeBuilderProvider.PopulateMethod, typeBuilderProvider.BuildMethod,
                 _configuration.TypeMappings.XmlNamespaceInfoProvider == null ?
                     null :
                     tb.DefineSubType(_configuration.WellKnownTypes.Object,

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/IXamlDocumentResource.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/IXamlDocumentResource.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using XamlX.Ast;
+﻿using XamlX.Ast;
 using XamlX.TypeSystem;
 
 namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions;
@@ -14,4 +13,5 @@ internal interface IXamlDocumentResource
     IXamlMethod PopulateMethod { get; }
     IFileSource? FileSource { get; }
     XamlDocument XamlDocument { get; }
+    XamlDocumentUsage Usage { get; set; }
 }

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlDocumentTypeBuilderProvider.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlDocumentTypeBuilderProvider.cs
@@ -1,0 +1,23 @@
+﻿#nullable enable
+
+using XamlX.IL;
+using XamlX.TypeSystem;
+
+namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions;
+
+internal sealed class XamlDocumentTypeBuilderProvider
+{
+    public XamlDocumentTypeBuilderProvider(
+        IXamlTypeBuilder<IXamlILEmitter> typeBuilder,
+        IXamlMethodBuilder<IXamlILEmitter> populateMethod,
+        IXamlMethodBuilder<IXamlILEmitter>? buildMethod)
+    {
+        TypeBuilder = typeBuilder;
+        PopulateMethod = populateMethod;
+        BuildMethod = buildMethod;
+    }
+
+    public IXamlTypeBuilder<IXamlILEmitter> TypeBuilder { get; }
+    public IXamlMethodBuilder<IXamlILEmitter> PopulateMethod { get; }
+    public IXamlMethodBuilder<IXamlILEmitter>? BuildMethod { get; }
+}

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlDocumentUsage.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlDocumentUsage.cs
@@ -1,0 +1,8 @@
+﻿namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions;
+
+internal enum XamlDocumentUsage
+{
+    Unknown,
+    Merged,
+    Used
+}


### PR DESCRIPTION
## What does the pull request do?
After a resource dictionary is merged using `MergeResourceInclude`, this PR allows the original dictionary to be dropped from the compilation, reducing the final assembly size.

## What is the current behavior?
Currently, `MergeResourceInclude` basically compiles a resource dictionary twice: the merged version and the original one. Most of the time, the original one isn't needed anymore. That's the case for both built-in themes.

## What is the updated/expected behavior with this PR?
With this PR, dictionaries used only via `MergeResourceInclude` can be optionally dropped. This is enabled for the `Themes.Fluent`, `Themes.Simple` and `Controls.ColorPicker` projects.

## How was the solution implemented (if it's not obvious)?
Usage of each dictionary is tracked: if it's used only through merge includes, it's flagged as such.

A new MSBuild property `AvaloniaXamlDropMergedDocuments` is added to control whether the original dictionaries are dropped once merged. It's opt-in, as we don't want to drop them by default: people might want to include them in other projects we don't know about at compile time, or load them through runtime code. For the basic and fluent themes, these aren't supported scenarios so we can drop them.

Type and method builders for XAML resources are now lazy initialized to avoid creating types for documents that might be dropped later.

## Results

| Assembly              | Size before | Size after   | Change |
|:----------------------|------------:|-------------:|-------:|
| Themes.Fluent         |     1689 KB |       746 KB |   -56% |
| Themes.Simple         |      623 KB |       313 KB |   -50% |
| Controls.ColorPicker  |      627 KB |       483 KB |   -23% |

## Notes

The `XamlCompilerTaskExecutor.Compile` public overload hasn't been changed to include this option, since that would be a breaking change. Do we really want a new overload just for this: shouldn't the MSBuild task itself be the only valid public entry point? An options object as a single parameter might be a better design, as it's easy to extend in the future. I can open a PR later to implement that if needed.
