### PR TITLE
In GridSplitter.InitializeData method, add getting nearest visual ancestor if logical parent is not grid

### DIFF
--- a/samples/RemoteDemo/Properties/launchSettings.json
+++ b/samples/RemoteDemo/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "WSL": {
+      "commandName": "WSL2",
+      "distributionName": ""
+    }
+  }
+}

--- a/src/Avalonia.Controls/GridSplitter.cs
+++ b/src/Avalonia.Controls/GridSplitter.cs
@@ -12,6 +12,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Utilities;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Controls
 {
@@ -210,7 +211,8 @@ namespace Avalonia.Controls
         private void InitializeData(bool showsPreview)
         {
             // If not in a grid or can't resize, do nothing.
-            if (Parent is Grid grid)
+            Grid? grid = Parent is Grid ? Parent as Grid : this.FindAncestorOfType<Grid>();
+            if (grid != null)
             {
                 GridResizeDirection resizeDirection = GetEffectiveResizeDirection();
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
See https://github.com/AvaloniaUI/Avalonia/issues/12030
If there is an ItemsControl which has a GridSplitter within its Items, and the ItemsPanel is a Grid. In this case, the GridSplitter don't work because in the [private void InitializeData(bool showsPreview)](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/GridSplitter.cs#L210) method, It only consider its parent is Grid or not.
For another instance, I want to place GridSplitter not directly as a child under the Grid, but child of its child. In such case GridSplitter also won't work.
This PR make a little modification that the program check its visual ancestors if its logical parent is not grid.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
If the local parent is not grid, it then find nearest local ancestor that is a grid.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Any previously working use of GridSplitter should not break. GridSplitters placed as child of child should work. GirdSplitters in ItemsControl that use Grid as ItemsPanel should work.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Its very simple, just see the changed code.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
Previously not working GridSplitters (which may be made so intensionaly) may be working now if they are placed as a decendant of a Grid.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
N/A

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes https://github.com/AvaloniaUI/Avalonia/issues/12030