### PR TITLE
Setting child of TestRoot once

### DIFF
--- a/tests/Avalonia.UnitTests/TestRoot.cs
+++ b/tests/Avalonia.UnitTests/TestRoot.cs
@@ -35,7 +35,6 @@ namespace Avalonia.UnitTests
         public TestRoot(Control child)
             : this(false, child)
         {
-            Child = child;
         }
 
         public TestRoot(bool useGlobalStyles, Control child)


### PR DESCRIPTION
It doesn't touch anything except a class used in test. Since `TestRoot(Control)` calls `TestRoot(bool, Control)` which set child itself the assignment in the single param `ctor` was removed.