### PR TITLE
Revert "Fix ImportCompleted spelling"

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/CompositionExternalMemory.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositionExternalMemory.cs
@@ -91,8 +91,7 @@ public interface ICompositionGpuImportedObject : IAsyncDisposable
     /// the user code is allowed to free the resource owner in case when a non-owning
     /// sharing handle was used
     /// </summary>
-    Task ImportCompleted { get; }
-
+    Task ImportCompeted { get; }
     /// <summary>
     /// Indicates if the device context this instance is associated with is no longer available
     /// </summary>

--- a/src/Avalonia.Base/Rendering/Composition/CompositionInterop.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositionInterop.cs
@@ -67,18 +67,18 @@ abstract class CompositionGpuImportedObjectBase : ICompositionGpuImportedObject
         Context = context;
         Feature = feature;
         
-        ImportCompleted = Compositor.InvokeServerJobAsync(Import);
+        ImportCompeted = Compositor.InvokeServerJobAsync(Import);
     }
     
     protected abstract void Import();
     public abstract void Dispose();
 
-    public Task ImportCompleted { get; }
+    public Task ImportCompeted { get; }
     public bool IsLost => Context.IsLost;
 
     public ValueTask DisposeAsync() => new(Compositor.InvokeServerJobAsync(() =>
     {
-        if (ImportCompleted.Status == TaskStatus.RanToCompletion)
+        if (ImportCompeted.Status == TaskStatus.RanToCompletion)
             Dispose();
     }));
 }

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionDrawingSurface.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionDrawingSurface.cs
@@ -31,12 +31,12 @@ internal class ServerCompositionDrawingSurface : ServerCompositionSurface, IDisp
             throw new PlatformGraphicsContextLostException();
 
         // This should never happen, but check for it anyway to avoid a deadlock
-        if (!image.ImportCompleted.IsCompleted)
+        if (!image.ImportCompeted.IsCompleted)
             throw new InvalidOperationException("The import operation is not completed yet");
 
         // Rethrow the import here exception
-        if (image.ImportCompleted.IsFaulted)
-            image.ImportCompleted.GetAwaiter().GetResult();
+        if (image.ImportCompeted.IsFaulted)
+            image.ImportCompeted.GetAwaiter().GetResult();
     }
 
     void Update(IBitmapImpl newImage, IPlatformRenderInterfaceContext context)


### PR DESCRIPTION
Reverts AvaloniaUI/Avalonia#11997

That PR was merged before 11.0, but for some reason wasn't included in 11.0 release. In the stable packages spelling error is still there.

Reverting it now. Ideally we should fix this spelling mistake by marking old member Obsolete and adding a new one.