### PR TITLE
Fix NotificationCard to determine the type of notification from an inherited INotification object

### DIFF
--- a/src/Avalonia.Controls/Notifications/NotificationCard.cs
+++ b/src/Avalonia.Controls/Notifications/NotificationCard.cs
@@ -39,7 +39,7 @@ namespace Avalonia.Controls.Notifications
             this.GetObservable(ContentProperty)
                 .Subscribe(x =>
                 {
-                    if (x is Notification notification)
+                    if (x is INotification notification)
                     {
                         switch (notification.Type)
                         {


### PR DESCRIPTION
## What does the pull request do?
Fixed a very small flaw where `NotificationCard` only defined the notification type from the `Notification` class, but not from the `INotification` interface, resulting in the notification type always remaining the default if the object is inherited from the interface.


## What is the updated/expected behavior with this PR?
`NotificationCard` now takes all classes inherited from `INotification` to define the type of notification.