### PR TITLE
Fix composition render resources invalidation

### DIFF
--- a/src/Avalonia.Base/Utilities/SmallDictionary.cs
+++ b/src/Avalonia.Base/Utilities/SmallDictionary.cs
@@ -51,7 +51,7 @@ internal struct InlineDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, 
                         throw new ArgumentException("Key already exists in dictionary");
                 }
 
-                if (arr[c].Key == null)
+                if (arr[c].Key == null && free == -1)
                     free = c;
             }
 
@@ -337,11 +337,15 @@ internal struct InlineDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, 
             }
             else if (_type == Type.Array)
             {
-                var next = _index + 1;
-                if (_arr!.Length - 1 < next || _arr[next].Key == null)
-                    return false;
-                _index = next;
-                return true;
+                for (var next = _index + 1; next < _arr!.Length; ++next)
+                {
+                    if (_arr[next].Key != null)
+                    {
+                        _index = next;
+                        return true;
+                    }
+                }
+                return false;
             }
             else if (_type == Type.Dictionary)
                 return _inner.MoveNext();

--- a/tests/Avalonia.Base.UnitTests/Utilities/InlineDictionaryTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Utilities/InlineDictionaryTests.cs
@@ -1,0 +1,53 @@
+﻿#nullable enable
+
+using System.Collections.Generic;
+using Avalonia.Utilities;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Utilities;
+
+public class InlineDictionaryTests
+{
+    [Fact]
+    public void Enumeration_After_Add_With_Internal_Array_Works()
+    {
+        var dic = new InlineDictionary<string, int>();
+        dic.Add("foo", 1);
+        dic.Add("bar", 2);
+        dic.Add("baz", 3);
+
+        Assert.Equal(
+            new[] {
+                new KeyValuePair<string, int>("foo", 1),
+                new KeyValuePair<string, int>("bar", 2),
+                new KeyValuePair<string, int>("baz", 3)
+            },
+            dic);
+    }
+
+    [Fact]
+    public void Enumeration_After_Remove_With_Internal_Array_Works()
+    {
+        var dic = new InlineDictionary<string, int>();
+        dic.Add("foo", 1);
+        dic.Add("bar", 2);
+        dic.Add("baz", 3);
+
+        Assert.Equal(
+            new[] {
+                new KeyValuePair<string, int>("foo", 1),
+                new KeyValuePair<string, int>("bar", 2),
+                new KeyValuePair<string, int>("baz", 3)
+            },
+            dic);
+
+        dic.Remove("bar");
+
+        Assert.Equal(
+            new[] {
+                new KeyValuePair<string, int>("foo", 1),
+                new KeyValuePair<string, int>("baz", 3)
+            },
+            dic);
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
This PR ensures that updating a render resource correctly invalidates all the other render elements using it.

## What is the current behavior?
In some situations, resources aren't correctly invalidated: see #11673 for more information.

## How was the solution implemented?
There were actually two different problems:

### Resources collection in `ServerCompositionRenderData`

In [`RenderDataDrawingContext`](https://github.com/AvaloniaUI/Avalonia/blob/ca396294d244b587f9a931b04e2385fe53792e16/src/Avalonia.Base/Rendering/Composition/Drawing/RenderDataDrawingContext.cs) exists a stack of lists of `IRenderDataItem` to eventually send to server part of the compositor. In `Pop()`, current items are added to their parent `RenderDataPushNode` if there's one. However, those child items aren't searched for resources by the `ServerCompositionRenderData`, which is responsible for setting up the resource tracking. The first commit fixes that by searching for the resources recursively inside `RenderDataPushNode` items.

I didn't add a test as there seem to be no test infrastructure currently regarding the render resource usages and invalidation, and it isn't an easy part easy to plug into.

### `InlineDictionary` enumeration

`InlineDictionary` has three backing strategies: single item, array (2 to 6 items) and dictionary (7+ items). In array mode, the enumerator was broken as it stopped at the first hole (`null` item) in the array, but all the other methods expect or add holes. This affected `Remove`, which sets the removed item to null. It also affected `Add`, which was filling the last hole instead of the first, so the enumerator could never return them unless the array was full.

The resource usages are tracked using a `RefCountingSmallDictionary`, which uses an `InlineDictionary`.

The enumeration has been fixed, and `Add()` now takes the first available hole.
Two tests have been added.

## Fixed issues
Fixes #11673