### PR TITLE
Support non-generic `AvaloniaProperty` in `GetObservable(converter)`

### DIFF
--- a/src/Avalonia.Base/AvaloniaObjectExtensions.cs
+++ b/src/Avalonia.Base/AvaloniaObjectExtensions.cs
@@ -60,12 +60,23 @@ namespace Avalonia
         }
 
         /// <inheritdoc cref="GetObservable{T}(AvaloniaObject, AvaloniaProperty{T})"/>
+        /// <typeparam name="TSource">The type of the values held by the <paramref name="property"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the value returned by the <paramref name="converter"/>.</typeparam>
         /// <param name="o"/>
         /// <param name="property"/>
         /// <param name="converter">A method which is executed to convert each property value to <typeparamref name="TResult"/>.</param>
         public static IObservable<TResult> GetObservable<TSource, TResult>(this AvaloniaObject o, AvaloniaProperty<TSource> property, Func<TSource, TResult> converter)
         {
             return new AvaloniaPropertyObservable<TSource, TResult>(
+                o ?? throw new ArgumentNullException(nameof(o)),
+                property ?? throw new ArgumentNullException(nameof(property)),
+                converter ?? throw new ArgumentNullException(nameof(converter)));
+        }
+
+        /// <inheritdoc cref="GetObservable{TSource,TResult}"/>
+        public static IObservable<TResult> GetObservable<TResult>(this AvaloniaObject o, AvaloniaProperty property, Func<object?, TResult> converter)
+        {
+            return new AvaloniaPropertyObservable<object?, TResult>(
                 o ?? throw new ArgumentNullException(nameof(o)),
                 property ?? throw new ArgumentNullException(nameof(property)),
                 converter ?? throw new ArgumentNullException(nameof(converter)));
@@ -90,6 +101,15 @@ namespace Avalonia
             return new AvaloniaPropertyBindingObservable<object?, object?>(
                 o ?? throw new ArgumentNullException(nameof(o)),
                 property ?? throw new ArgumentNullException(nameof(property)));
+        }
+
+        /// <inheritdoc cref="GetObservable{TSource,TResult}"/>
+        public static IObservable<BindingValue<TResult>> GetBindingObservable<TResult>(this AvaloniaObject o, AvaloniaProperty property, Func<object?, TResult> converter)
+        {
+            return new AvaloniaPropertyBindingObservable<object?, TResult>(
+                o ?? throw new ArgumentNullException(nameof(o)),
+                property ?? throw new ArgumentNullException(nameof(property)),
+                converter?? throw new ArgumentNullException(nameof(converter)));
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes an oversight I made when adding converter methods to the `GetObservable` extension methods in #10824. None of the new methods were compatible with the non-generic `AvaloniaProperty` base type. 

## What is the updated/expected behavior with this PR?
You can now provide a converter that can be applied to all `AvaloniaProperty` objects. This is useful if you want to work with a shared base type of various properties, since you cannot cast (for example) an `AvaloniaProperty<ListBox>` object to `AvaloniaProperty<ItemsControl>`.

## Breaking changes
None

## Obsoletions / Deprecations
None