### PR TITLE
[TransitioningContentControl] Manage his LogicalChildren

### DIFF
--- a/src/Avalonia.Controls/ContentControl.cs
+++ b/src/Avalonia.Controls/ContentControl.cs
@@ -95,6 +95,17 @@ namespace Avalonia.Controls
         /// <inheritdoc/>
         IAvaloniaList<ILogical> IContentPresenterHost.LogicalChildren => LogicalChildren;
 
+        /// <summary>
+        /// Determine whether <see cref="ContentControl"/> manage his LogicalChildren 
+        ///(default behavior) himself, or leaves the management to the inherited control.
+        /// </summary>
+        /// <remarks>
+		/// The default value is false, So the <see cref="ContentControl"/> manages itself, 
+        /// if you want to bypass this behavior and manage LogicalChildren yourself, set 
+        /// the <see cref="BypassLogicalChildrenManangment"/> to true.
+		/// </remarks>
+        protected virtual bool BypassLogicalChildrenManangment => false;
+
         /// <inheritdoc/>
         bool IContentPresenterHost.RegisterContentPresenter(ContentPresenter presenter)
         {
@@ -118,6 +129,11 @@ namespace Avalonia.Controls
 
         private void ContentChanged(AvaloniaPropertyChangedEventArgs e)
         {
+            if (BypassLogicalChildrenManangment)
+            {
+                return;
+            }
+            
             if (e.OldValue is ILogical oldChild)
             {
                 LogicalChildren.Remove(oldChild);

--- a/src/Avalonia.Controls/ContentControl.cs
+++ b/src/Avalonia.Controls/ContentControl.cs
@@ -129,7 +129,7 @@ namespace Avalonia.Controls
 
         private void ContentChanged(AvaloniaPropertyChangedEventArgs e)
         {
-            if (BypassLogicalChildrenManangment)
+            if (BypassLogicalChildrenManagement)
             {
                 return;
             }

--- a/src/Avalonia.Controls/ContentControl.cs
+++ b/src/Avalonia.Controls/ContentControl.cs
@@ -102,9 +102,9 @@ namespace Avalonia.Controls
         /// <remarks>
 		/// The default value is false, So the <see cref="ContentControl"/> manages itself, 
         /// if you want to bypass this behavior and manage LogicalChildren yourself, set 
-        /// the <see cref="BypassLogicalChildrenManangment"/> to true.
+        /// the <see cref="BypassLogicalChildrenManagement"/> to true.
 		/// </remarks>
-        protected virtual bool BypassLogicalChildrenManangment => false;
+        protected virtual bool BypassLogicalChildrenManagement => false;
 
         /// <inheritdoc/>
         bool IContentPresenterHost.RegisterContentPresenter(ContentPresenter presenter)

--- a/src/Avalonia.Controls/ContentControl.cs
+++ b/src/Avalonia.Controls/ContentControl.cs
@@ -40,11 +40,6 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<VerticalAlignment> VerticalContentAlignmentProperty =
             AvaloniaProperty.Register<ContentControl, VerticalAlignment>(nameof(VerticalContentAlignment));
 
-        static ContentControl()
-        {
-            ContentProperty.Changed.AddClassHandler<ContentControl>((x, e) => x.ContentChanged(e));
-        }
-
         /// <summary>
         /// Gets or sets the content to display.
         /// </summary>
@@ -95,21 +90,19 @@ namespace Avalonia.Controls
         /// <inheritdoc/>
         IAvaloniaList<ILogical> IContentPresenterHost.LogicalChildren => LogicalChildren;
 
-        /// <summary>
-        /// Determine whether <see cref="ContentControl"/> manage his LogicalChildren 
-        ///(default behavior) himself, or leaves the management to the inherited control.
-        /// </summary>
-        /// <remarks>
-		/// The default value is false, So the <see cref="ContentControl"/> manages itself, 
-        /// if you want to bypass this behavior and manage LogicalChildren yourself, set 
-        /// the <see cref="BypassLogicalChildrenManagement"/> to true.
-		/// </remarks>
-        protected virtual bool BypassLogicalChildrenManagement => false;
-
         /// <inheritdoc/>
         bool IContentPresenterHost.RegisterContentPresenter(ContentPresenter presenter)
         {
             return RegisterContentPresenter(presenter);
+        }
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == ContentProperty)
+            {
+                ContentChanged(change);
+            }
         }
 
         /// <summary>
@@ -129,11 +122,6 @@ namespace Avalonia.Controls
 
         private void ContentChanged(AvaloniaPropertyChangedEventArgs e)
         {
-            if (BypassLogicalChildrenManagement)
-            {
-                return;
-            }
-            
             if (e.OldValue is ILogical oldChild)
             {
                 LogicalChildren.Remove(oldChild);

--- a/src/Avalonia.Controls/ContentControl.cs
+++ b/src/Avalonia.Controls/ContentControl.cs
@@ -95,6 +95,7 @@ namespace Avalonia.Controls
         {
             return RegisterContentPresenter(presenter);
         }
+        
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
             base.OnPropertyChanged(change);

--- a/src/Avalonia.Controls/TransitioningContentControl.cs
+++ b/src/Avalonia.Controls/TransitioningContentControl.cs
@@ -36,6 +36,9 @@ public class TransitioningContentControl : ContentControl
         set => SetValue(PageTransitionProperty, value);
     }
 
+    /// <inheritdoc/>
+    protected override bool BypassLogicalChildrenManangment => true;
+
     protected override Size ArrangeOverride(Size finalSize)
     {
         var result = base.ArrangeOverride(finalSize);
@@ -79,8 +82,12 @@ public class TransitioningContentControl : ContentControl
 
     protected override bool RegisterContentPresenter(ContentPresenter presenter)
     {
-        if (!base.RegisterContentPresenter(presenter) &&
-            presenter is ContentPresenter p &&
+        if (base.RegisterContentPresenter(presenter))
+        {
+            return true;
+        }
+
+        if (presenter is ContentPresenter p &&
             p.Name == "PART_ContentPresenter2")
         {
             _presenter2 = p;

--- a/src/Avalonia.Controls/TransitioningContentControl.cs
+++ b/src/Avalonia.Controls/TransitioningContentControl.cs
@@ -36,9 +36,6 @@ public class TransitioningContentControl : ContentControl
         set => SetValue(PageTransitionProperty, value);
     }
 
-    /// <inheritdoc/>
-    protected override bool BypassLogicalChildrenManagement => true;
-
     protected override Size ArrangeOverride(Size finalSize)
     {
         var result = base.ArrangeOverride(finalSize);
@@ -101,12 +98,13 @@ public class TransitioningContentControl : ContentControl
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
-        base.OnPropertyChanged(change);
-
         if (change.Property == ContentProperty)
         {
             UpdateContent(true);
+            return;
         }
+
+        base.OnPropertyChanged(change);
     }
 
     private void UpdateContent(bool withTransition)

--- a/src/Avalonia.Controls/TransitioningContentControl.cs
+++ b/src/Avalonia.Controls/TransitioningContentControl.cs
@@ -37,7 +37,7 @@ public class TransitioningContentControl : ContentControl
     }
 
     /// <inheritdoc/>
-    protected override bool BypassLogicalChildrenManangment => true;
+    protected override bool BypassLogicalChildrenManagement => true;
 
     protected override Size ArrangeOverride(Size finalSize)
     {

--- a/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
@@ -184,7 +184,7 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
-        public void Logical_Children_Dont_Duplicated()
+        public void Logical_Children_Should_Not_Be_Duplicated()
         {
             using var app = Start();
             var (target, transition) = CreateTarget("");
@@ -194,18 +194,21 @@ namespace Avalonia.Controls.UnitTests
             target.Content = childControl;
 
             Assert.Equal(1, target.LogicalChildren.Count);
+            Assert.Equal(target.LogicalChildren[0], childControl);
         }
 
         [Fact]
-        public void First_Presenter_Register_TCC_As_Host()
+        public void First_Presenter_Should_Register_TCC_As_His_Host()
         {
             using var app = Start();
             var (target, transition) = CreateTarget("");
+            target.PageTransition = null;
 
             var childControl = new Control();
             target.Presenter!.Content = childControl;
 
-            Assert.Contains(childControl, target.LogicalChildren);
+            Assert.Equal(1, target.LogicalChildren.Count);
+            Assert.Equal(target.LogicalChildren[0], childControl);
         }
 
         private static IDisposable Start()

--- a/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
@@ -183,6 +183,31 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal("bar", presenter2.Content);
         }
 
+        [Fact]
+        public void Logical_Children_Dont_Duplicated()
+        {
+            using var app = Start();
+            var (target, transition) = CreateTarget("");
+
+            var childControl = new Control();
+            target.Content = childControl;
+
+            // There should be two, One the initial content and one the new content.
+            Assert.Equal(2, target.LogicalChildren.Count);
+        }
+
+        [Fact]
+        public void First_Presenter_Register_TCC_As_Host()
+        {
+            using var app = Start();
+            var (target, transition) = CreateTarget("");
+
+            var childControl = new Control();
+            target.Presenter!.Content = childControl;
+
+            Assert.Contains(childControl, target.LogicalChildren);
+        }
+
         private static IDisposable Start()
         {
             return UnitTestApplication.Start(

--- a/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
@@ -188,12 +188,12 @@ namespace Avalonia.Controls.UnitTests
         {
             using var app = Start();
             var (target, transition) = CreateTarget("");
+            target.PageTransition = null;
 
             var childControl = new Control();
             target.Content = childControl;
 
-            // There should be two, One the initial content and one the new content.
-            Assert.Equal(2, target.LogicalChildren.Count);
+            Assert.Equal(1, target.LogicalChildren.Count);
         }
 
         [Fact]


### PR DESCRIPTION
## What does the pull request do?
There are two problems with `TransitioningContentControl`:
- Duplicated logical children, this is because `ContentPresenter` manages his host's `LogicalChildren` (in this case TCC), and in addition `ContentControl` also manages `LogicalChildren`, which causes logical children to be duplicated.
- The first `ContentPresenter` not register the TCC as its Host, which causes it to not manage the `LogicalChildren` of the TCC.

We need to decide who will manage the logical children, CC (ContentControl) or TCC, in this case it is clear that TCC should do it, because CC is only adapted to one child, whereas TCC can have two (during animation).

~~The implementation was carried out by adding a `BypassLogicalChildrenManagement` property to the CC that allows the controls inheriting from it to manage the `LogicalChildren` themselves, in this case, TCC does not need to do anything, his presenters do it for him.~~ see comment below.

The second problem is a bug in the `RegisterContentPresenter` implementation that returned `false` even if Presenter is `PART_ContentPresenter`, which causes the Host registration to be skipped:
https://github.com/AvaloniaUI/Avalonia/blob/124f124617ffcd07da78e980ed04c0e6df595102/src/Avalonia.Controls/Presenters/ContentPresenter.cs#L702-L706

The fixes is pretty obvious.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
No.

## Fixed issues
Fixes #12158
