### PR TITLE
Fixed issue where RowDetailsTemplate was getting the wrong DataContext

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridRows.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRows.cs
@@ -2969,8 +2969,8 @@ namespace Avalonia.Controls
                 var detailsContent = RowDetailsTemplate.Build(dataItem);
                 if (detailsContent != null)
                 {
-                    _rowsPresenter.Children.Add(detailsContent);
                     detailsContent.DataContext = dataItem;
+                    _rowsPresenter.Children.Add(detailsContent);
                     detailsContent.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
                     RowDetailsHeightEstimate = detailsContent.DesiredSize.Height;
                     _rowsPresenter.Children.Remove(detailsContent);

--- a/src/Avalonia.Controls.DataGrid/DataGridRows.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRows.cs
@@ -2970,10 +2970,7 @@ namespace Avalonia.Controls
                 if (detailsContent != null)
                 {
                     _rowsPresenter.Children.Add(detailsContent);
-                    if (dataItem != null)
-                    {
-                        detailsContent.DataContext = dataItem;
-                    }
+                    detailsContent.DataContext = dataItem;
                     detailsContent.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
                     RowDetailsHeightEstimate = detailsContent.DesiredSize.Height;
                     _rowsPresenter.Children.Remove(detailsContent);


### PR DESCRIPTION
Hello,

in this [issue](https://github.com/AvaloniaUI/Avalonia.Controls.DataGrid/issues/66) i noticed that the RowDetailsTemplate was getting the wrong DataContext when the first measurement pass was done which could cause a InvalidCastException or a StackOverflow (if a ContentControl is used).


## What is the current behavior?

https://github.com/AvaloniaUI/Avalonia/blob/194044692eb3967b8c6bd0ed140a954f53b48e0e/src/Avalonia.Controls.DataGrid/DataGridRows.cs#L2967-L2977


Right now the `detailsContent.DataContext` is only changed if the dataItem is not null.
So when no list or an empty one is provided `detailsContent.DataContext` is not changed and it's still on the value provided by  `_rowsPresenter.Children.Add(detailsContent);` (which is the DataContext of the DataGrid).

## What is the updated/expected behavior with this PR?

I removed the null check of the dataItem so:
- If the dataItem is set, `detailsContent.DataContext` will the item.
- If there no dataItem, the `detailsContent.DataContext` is set to null.

After this change the issues mentioned above are not happening anymore.
I tested setting the ItemsSource:
- Empty list -> works
- List with items -> works
- null -> works

Also no problem with RowDetailsVisibilityMode=Collapsed/Visible/VisibleWhenSelected

More details in the issue.

## Fixed issues
[Fixes AvaloniaUI/Avalonia.Controls.DataGrid#66](https://github.com/AvaloniaUI/Avalonia.Controls.DataGrid/issues/66)
