### PR TITLE
Refractor WindowNotificationManager

### DIFF
--- a/samples/ControlCatalog/Pages/NotificationsPage.xaml
+++ b/samples/ControlCatalog/Pages/NotificationsPage.xaml
@@ -1,10 +1,28 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:viewModels="using:ControlCatalog.ViewModels"
+             xmlns:system="clr-namespace:System;assembly=System.Runtime"
              x:Class="ControlCatalog.Pages.NotificationsPage"
              x:DataType="viewModels:NotificationViewModel">
-  <StackPanel Orientation="Vertical" Spacing="4" HorizontalAlignment="Left">
-        <Button Content="Show Standard Managed Notification" Command="{Binding ShowManagedNotificationCommand}" />
-        <Button Content="Show Custom Managed Notification" Command="{Binding ShowCustomManagedNotificationCommand}" />
-  </StackPanel>
+  <DockPanel>
+    <TextBlock DockPanel.Dock="Top"
+               Margin="2" Classes="h2" TextWrapping="Wrap">TopLevel bound notification manager.</TextBlock>
+    <StackPanel DockPanel.Dock="Top"
+                Orientation="Vertical" Spacing="4" HorizontalAlignment="Left">
+      <Button Content="Show Standard Managed Notification" Command="{Binding ShowManagedNotificationCommand}" />
+      <Button Content="Show Custom Managed Notification" Command="{Binding ShowCustomManagedNotificationCommand}" />
+    </StackPanel>
+    
+    <TextBlock DockPanel.Dock="Top"
+               Margin="2" Classes="h2" TextWrapping="Wrap">XAML only notification manager.</TextBlock>
+    <Button DockPanel.Dock="Top"
+            Content="Show XAML only Notification" Command="{Binding #ControlNotifications.Show}">
+      <Button.CommandParameter>
+        <Notification Title="Title" Message="Message" OnClick="NotificationOnClick" />
+      </Button.CommandParameter>
+    </Button>
+    <Border Padding="10" BorderBrush="{DynamicResource SystemAccentColor}">
+      <WindowNotificationManager x:Name="ControlNotifications" />
+    </Border>
+  </DockPanel>
 </UserControl>

--- a/samples/ControlCatalog/Pages/NotificationsPage.xaml
+++ b/samples/ControlCatalog/Pages/NotificationsPage.xaml
@@ -6,6 +6,5 @@
   <StackPanel Orientation="Vertical" Spacing="4" HorizontalAlignment="Left">
         <Button Content="Show Standard Managed Notification" Command="{Binding ShowManagedNotificationCommand}" />
         <Button Content="Show Custom Managed Notification" Command="{Binding ShowCustomManagedNotificationCommand}" />
-        <Button Content="Show Native Notification" Command="{Binding ShowNativeNotificationCommand}" />
-    </StackPanel>
+  </StackPanel>
 </UserControl>

--- a/samples/ControlCatalog/Pages/NotificationsPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/NotificationsPage.xaml.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Notifications;
 using Avalonia.Markup.Xaml;
 using ControlCatalog.ViewModels;
 
@@ -27,7 +28,12 @@ namespace ControlCatalog.Pages
         {
             base.OnAttachedToVisualTree(e);
 
-            _viewModel.NotificationManager = new Avalonia.Controls.Notifications.WindowNotificationManager(TopLevel.GetTopLevel(this));
+            _viewModel.NotificationManager = new WindowNotificationManager(TopLevel.GetTopLevel(this)!);
+        }
+
+        public void NotificationOnClick()
+        {
+            this.Get<WindowNotificationManager>("ControlNotifications").Show("Notification clicked");
         }
     }
 }

--- a/samples/ControlCatalog/ViewModels/NotificationViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/NotificationViewModel.cs
@@ -19,11 +19,6 @@ namespace ControlCatalog.ViewModels
                 NotificationManager?.Show(new Avalonia.Controls.Notifications.Notification("Welcome", "Avalonia now supports Notifications.", NotificationType.Information));
             });
 
-            ShowNativeNotificationCommand = MiniCommand.Create(() =>
-            {
-                NotificationManager?.Show(new Avalonia.Controls.Notifications.Notification("Error", "Native Notifications are not quite ready. Coming soon.", NotificationType.Error));
-            });
-
             YesCommand = MiniCommand.Create(() =>
             {
                 NotificationManager?.Show(new Avalonia.Controls.Notifications.Notification("Avalonia Notifications", "Start adding notifications to your app today."));
@@ -45,8 +40,5 @@ namespace ControlCatalog.ViewModels
         public MiniCommand ShowCustomManagedNotificationCommand { get; }
 
         public MiniCommand ShowManagedNotificationCommand { get; }
-
-        public MiniCommand ShowNativeNotificationCommand { get; }
-
     }
 }

--- a/samples/ControlCatalog/ViewModels/NotificationViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/NotificationViewModel.cs
@@ -11,7 +11,7 @@ namespace ControlCatalog.ViewModels
         {
             ShowCustomManagedNotificationCommand = MiniCommand.Create(() =>
             {
-                NotificationManager?.Show(new NotificationViewModel() { Title = "Hey There!", Message = "Did you know that Avalonia now supports Custom In-Window Notifications?" , NotificationManager = NotificationManager});
+                NotificationManager?.Show(new NotificationViewModel() { Title = "Hey There!", Message = "Did you know that Avalonia now supports Custom In-Window Notifications?" , NotificationManager = NotificationManager}, NotificationType.Warning);
             });
 
             ShowManagedNotificationCommand = MiniCommand.Create(() =>

--- a/src/Avalonia.Controls/Notifications/IManagedNotificationManager.cs
+++ b/src/Avalonia.Controls/Notifications/IManagedNotificationManager.cs
@@ -19,13 +19,19 @@ namespace Avalonia.Controls.Notifications
         /// Shows a notification.
         /// </summary>
         /// <param name="content">The content to be displayed.</param>
+        void Show(object content);
+        
+        /// <summary>
+        /// Shows a notification.
+        /// </summary>
+        /// <param name="content">The content to be displayed.</param>
         /// <param name="type">The <see cref="NotificationType"/> of the notification.</param>
         /// <param name="expiration">the expiration time of the notification after which it will automatically close. If the value is <see cref="TimeSpan.Zero"/> then the notification will remain open until the user closes it.</param>
         /// <param name="onClick">an Action to be run when the notification is clicked.</param>
         /// <param name="onClose">an Action to be run when the notification is closed.</param>
         /// <param name="classes">Style-classes to ba added to the notification card</param>
         void Show(object content,
-            NotificationType type = NotificationType.Information,
+            NotificationType type,
             TimeSpan? expiration = null,
             Action? onClick = null,
             Action? onClose = null, 

--- a/src/Avalonia.Controls/Notifications/IManagedNotificationManager.cs
+++ b/src/Avalonia.Controls/Notifications/IManagedNotificationManager.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Metadata;
+﻿using System;
+using Avalonia.Metadata;
 
 namespace Avalonia.Controls.Notifications
 {
@@ -18,6 +19,14 @@ namespace Avalonia.Controls.Notifications
         /// Shows a notification.
         /// </summary>
         /// <param name="content">The content to be displayed.</param>
-        void Show(object content);
+        /// <param name="type">The <see cref="NotificationType"/> of the notification.</param>
+        /// <param name="expiration">the expiration time of the notification after which it will automatically close. If the value is <see cref="TimeSpan.Zero"/> then the notification will remain open until the user closes it.</param>
+        /// <param name="onClick">an Action to be run when the notification is clicked.</param>
+        /// <param name="onClose">an Action to be run when the notification is closed.</param>
+        void Show(object content,
+            NotificationType type = NotificationType.Information,
+            TimeSpan? expiration = null,
+            Action? onClick = null,
+            Action? onClose = null);
     }
 }

--- a/src/Avalonia.Controls/Notifications/IManagedNotificationManager.cs
+++ b/src/Avalonia.Controls/Notifications/IManagedNotificationManager.cs
@@ -20,21 +20,5 @@ namespace Avalonia.Controls.Notifications
         /// </summary>
         /// <param name="content">The content to be displayed.</param>
         void Show(object content);
-        
-        /// <summary>
-        /// Shows a notification.
-        /// </summary>
-        /// <param name="content">The content to be displayed.</param>
-        /// <param name="type">The <see cref="NotificationType"/> of the notification.</param>
-        /// <param name="expiration">the expiration time of the notification after which it will automatically close. If the value is <see cref="TimeSpan.Zero"/> then the notification will remain open until the user closes it.</param>
-        /// <param name="onClick">an Action to be run when the notification is clicked.</param>
-        /// <param name="onClose">an Action to be run when the notification is closed.</param>
-        /// <param name="classes">Style-classes to ba added to the notification card</param>
-        void Show(object content,
-            NotificationType type,
-            TimeSpan? expiration = null,
-            Action? onClick = null,
-            Action? onClose = null, 
-            string[]? classes = null);
     }
 }

--- a/src/Avalonia.Controls/Notifications/IManagedNotificationManager.cs
+++ b/src/Avalonia.Controls/Notifications/IManagedNotificationManager.cs
@@ -23,10 +23,12 @@ namespace Avalonia.Controls.Notifications
         /// <param name="expiration">the expiration time of the notification after which it will automatically close. If the value is <see cref="TimeSpan.Zero"/> then the notification will remain open until the user closes it.</param>
         /// <param name="onClick">an Action to be run when the notification is clicked.</param>
         /// <param name="onClose">an Action to be run when the notification is closed.</param>
+        /// <param name="classes">Style-classes to ba added to the notification card</param>
         void Show(object content,
             NotificationType type = NotificationType.Information,
             TimeSpan? expiration = null,
             Action? onClick = null,
-            Action? onClose = null);
+            Action? onClose = null, 
+            string[]? classes = null);
     }
 }

--- a/src/Avalonia.Controls/Notifications/Notification.cs
+++ b/src/Avalonia.Controls/Notifications/Notification.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Avalonia.Controls.Notifications
 {
@@ -9,8 +12,10 @@ namespace Avalonia.Controls.Notifications
     /// This class represents a notification that can be displayed either in a window using
     /// <see cref="WindowNotificationManager"/> or by the host operating system (to be implemented).
     /// </remarks>
-    public class Notification : INotification
+    public class Notification : INotification, INotifyPropertyChanged
     {
+        private string? _title, _message;
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="Notification"/> class.
         /// </summary>
@@ -35,23 +40,59 @@ namespace Avalonia.Controls.Notifications
             OnClick = onClick;
             OnClose = onClose;
         }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Notification"/> class.
+        /// </summary>
+        public Notification() : this(null, null)
+        {
+        }
 
         /// <inheritdoc/>
-        public string? Title { get; private set; }
+        public string? Title
+        {
+            get => _title;
+            set
+            {
+                if (_title != value)
+                {
+                    _title = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
         /// <inheritdoc/>
-        public string? Message { get; private set; }
+        public string? Message
+        {
+            get => _message;
+            set
+            {
+                if (_message != value)
+                {
+                    _message = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
         /// <inheritdoc/>
-        public NotificationType Type { get; private set; }
+        public NotificationType Type { get; set; }
 
         /// <inheritdoc/>
-        public TimeSpan Expiration { get; private set; }
+        public TimeSpan Expiration { get; set; }
 
         /// <inheritdoc/>
-        public Action? OnClick { get; private set; }
+        public Action? OnClick { get; set; }
 
         /// <inheritdoc/>
-        public Action? OnClose { get; private set; }
+        public Action? OnClose { get; set; }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
     }
 }

--- a/src/Avalonia.Controls/Notifications/NotificationCard.cs
+++ b/src/Avalonia.Controls/Notifications/NotificationCard.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Avalonia.Reactive;
 using Avalonia.Controls.Metadata;
@@ -61,6 +61,7 @@ namespace Avalonia.Controls.Notifications
                         }
                     }
                 });
+            UpdateNotificationType();
         }
 
         /// <summary>
@@ -92,6 +93,21 @@ namespace Avalonia.Controls.Notifications
         /// </summary>
         public static readonly StyledProperty<bool> IsClosedProperty =
             AvaloniaProperty.Register<NotificationCard, bool>(nameof(IsClosed));
+
+        /// <summary>
+        /// Gets or sets the type of the notification
+        /// </summary>
+        public NotificationType NotificationType
+        {
+            get { return GetValue(NotificationTypeProperty); }
+            set { SetValue(NotificationTypeProperty, value); }
+        }
+
+        /// <summary>
+        /// Defines the <see cref="NotificationType" /> property
+        /// </summary>
+        public static readonly StyledProperty<NotificationType> NotificationTypeProperty =
+            AvaloniaProperty.Register<NotificationCard, NotificationType>(nameof(NotificationType));
 
         /// <summary>
         /// Defines the <see cref="NotificationClosed"/> event.
@@ -162,6 +178,53 @@ namespace Avalonia.Controls.Notifications
             }
 
             IsClosing = true;
+        }
+
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            base.OnPropertyChanged(e);
+
+            if (e.Property == ContentProperty && e.NewValue is INotification notification)
+            {
+                SetValue(NotificationTypeProperty, notification.Type);
+            }
+
+            if (e.Property == NotificationTypeProperty)
+            {
+                UpdateNotificationType();
+            }
+
+            if (e.Property == IsClosedProperty)
+            {
+                if (!IsClosing && !IsClosed)
+                {
+                    return;
+                }
+
+                RaiseEvent(new RoutedEventArgs(NotificationClosedEvent));
+            }
+        }
+
+        private void UpdateNotificationType()
+        {
+            switch (NotificationType)
+            {
+                case NotificationType.Error:
+                    PseudoClasses.Add(":error");
+                    break;
+
+                case NotificationType.Information:
+                    PseudoClasses.Add(":information");
+                    break;
+
+                case NotificationType.Success:
+                    PseudoClasses.Add(":success");
+                    break;
+
+                case NotificationType.Warning:
+                    PseudoClasses.Add(":warning");
+                    break;
+            }
         }
     }
 }

--- a/src/Avalonia.Controls/Notifications/NotificationCard.cs
+++ b/src/Avalonia.Controls/Notifications/NotificationCard.cs
@@ -25,42 +25,6 @@ namespace Avalonia.Controls.Notifications
         /// </summary>
         public NotificationCard()
         {
-            this.GetObservable(IsClosedProperty)
-                .Subscribe(x =>
-                {
-                    if (!IsClosing && !IsClosed)
-                    {
-                        return;
-                    }
-
-                    RaiseEvent(new RoutedEventArgs(NotificationClosedEvent));
-                });
-
-            this.GetObservable(ContentProperty)
-                .Subscribe(x =>
-                {
-                    if (x is INotification notification)
-                    {
-                        switch (notification.Type)
-                        {
-                            case NotificationType.Error:
-                                PseudoClasses.Add(":error");
-                                break;
-
-                            case NotificationType.Information:
-                                PseudoClasses.Add(":information");
-                                break;
-
-                            case NotificationType.Success:
-                                PseudoClasses.Add(":success");
-                                break;
-
-                            case NotificationType.Warning:
-                                PseudoClasses.Add(":warning");
-                                break;
-                        }
-                    }
-                });
             UpdateNotificationType();
         }
 

--- a/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
+++ b/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
@@ -88,7 +88,8 @@ namespace Avalonia.Controls.Notifications
             NotificationType type = NotificationType.Information, 
             TimeSpan? expiration = null,
             Action? onClick = null, 
-            Action? onClose = null)
+            Action? onClose = null, 
+            string[]? classes = null)
         {
             var notificationControl = new NotificationCard
             {
@@ -96,6 +97,15 @@ namespace Avalonia.Controls.Notifications
                 NotificationType = type
             };
 
+            // Add style classes if any
+            if (classes != null)
+            {
+                foreach (var @class in classes)
+                {
+                    notificationControl.Classes.Add(@class);
+                }
+            }
+            
             notificationControl.NotificationClosed += (sender, args) =>
             {
                 onClose?.Invoke();

--- a/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
+++ b/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
@@ -121,7 +121,15 @@ namespace Avalonia.Controls.Notifications
             }
         }
         
-        /// <inheritdoc/>
+        /// <summary>
+        /// Shows a Notification
+        /// </summary>
+        /// <param name="content">the content of the notification</param>
+        /// <param name="type">the type of the notification</param>
+        /// <param name="expiration">the expiration time of the notification after which it will automatically close. If the value is Zero then the notification will remain open until the user closes it</param>
+        /// <param name="onClick">an Action to be run when the notification is clicked</param>
+        /// <param name="onClose">an Action to be run when the notification is closed</param>
+        /// <param name="classes">style classes to apply</param>
         public async void Show(object content, 
             NotificationType type, 
             TimeSpan? expiration = null,

--- a/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
+++ b/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
@@ -73,8 +73,8 @@ namespace Avalonia.Controls.Notifications
         /// <summary>
         /// Initializes a new instance of the <see cref="WindowNotificationManager"/> class.
         /// </summary>
-        /// <param name="host">The visual that will host the control.</param>
-        public WindowNotificationManager(Visual? host) : this()
+        /// <param name="host">The TopLevel that will host the control.</param>
+        public WindowNotificationManager(TopLevel? host) : this()
         {
             Host = host;
         }
@@ -109,8 +109,21 @@ namespace Avalonia.Controls.Notifications
         }
 
         /// <inheritdoc/>
+        public async void Show(object content)
+        {
+            if (content is INotification notification)
+            {
+                Show(notification, notification.Type, notification.Expiration, notification.OnClick, notification.OnClose);
+            }
+            else
+            {
+                Show(content, NotificationType.Information);
+            }
+        }
+        
+        /// <inheritdoc/>
         public async void Show(object content, 
-            NotificationType type = NotificationType.Information, 
+            NotificationType type, 
             TimeSpan? expiration = null,
             Action? onClick = null, 
             Action? onClose = null, 
@@ -202,7 +215,7 @@ namespace Avalonia.Controls.Notifications
 
             if (adornerLayer is not null)
             {
-                adornerLayer.Children.Add(this);
+                // adornerLayer.Children.Add(this);
                 AdornerLayer.SetAdornedElement(this, adornerLayer);
             }
         }

--- a/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
+++ b/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
@@ -215,7 +215,7 @@ namespace Avalonia.Controls.Notifications
 
             if (adornerLayer is not null)
             {
-                // adornerLayer.Children.Add(this);
+                adornerLayer.Children.Add(this);
                 AdornerLayer.SetAdornedElement(this, adornerLayer);
             }
         }

--- a/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
+++ b/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
@@ -80,32 +80,32 @@ namespace Avalonia.Controls.Notifications
         /// <inheritdoc/>
         public void Show(INotification content)
         {
-            Show(content as object);
+            Show(content, content.Type, content.Expiration, content.OnClick, content.OnClose);
         }
 
         /// <inheritdoc/>
-        public async void Show(object content)
+        public async void Show(object content, 
+            NotificationType type = NotificationType.Information, 
+            TimeSpan? expiration = null,
+            Action? onClick = null, 
+            Action? onClose = null)
         {
-            var notification = content as INotification;
-
             var notificationControl = new NotificationCard
             {
-                Content = content
+                Content = content,
+                NotificationType = type
             };
 
             notificationControl.NotificationClosed += (sender, args) =>
             {
-                notification?.OnClose?.Invoke();
+                onClose?.Invoke();
 
                 _items?.Remove(sender);
             };
 
             notificationControl.PointerPressed += (sender, args) =>
             {
-                if (notification != null && notification.OnClick != null)
-                {
-                    notification.OnClick.Invoke();
-                }
+                onClick?.Invoke();
 
                 (sender as NotificationCard)?.Close();
             };
@@ -117,12 +117,12 @@ namespace Avalonia.Controls.Notifications
                 _items.OfType<NotificationCard>().First(i => !i.IsClosing).Close();
             }
 
-            if (notification != null && notification.Expiration == TimeSpan.Zero)
+            if (expiration == TimeSpan.Zero)
             {
                 return;
             }
 
-            await Task.Delay(notification?.Expiration ?? TimeSpan.FromSeconds(5));
+            await Task.Delay(expiration ?? TimeSpan.FromSeconds(5));
 
             notificationControl.Close();
         }

--- a/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
+++ b/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
@@ -54,9 +54,12 @@ namespace Avalonia.Controls.Notifications
         /// Initializes a new instance of the <see cref="WindowNotificationManager"/> class.
         /// </summary>
         /// <param name="host">The TopLevel that will host the control.</param>
-        public WindowNotificationManager(TopLevel host) : this()
+        public WindowNotificationManager(TopLevel? host) : this()
         {
-            InstallFromTopLevel(host);
+            if (host is not null)
+            {
+                InstallFromTopLevel(host);
+            }
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/AdornerLayer.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerLayer.cs
@@ -61,7 +61,7 @@ namespace Avalonia.Controls.Primitives
             return adorner.GetValue(AdornedElementProperty);
         }
 
-        public static void SetAdornedElement(Visual adorner, Visual adorned)
+        public static void SetAdornedElement(Visual adorner, Visual? adorned)
         {
             adorner.SetValue(AdornedElementProperty, adorned);
         }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Improves the WindowNotificationManager a little bit:
- Allow usage from XAML
- Allow any Visual as host, so it can be added into UserControl 
- Added an overload to .Show to allow more customization 
- Added ability to specify Card-classes (more customization)
- Don't need to wait for control to load before .Show can be called

## What is the current behavior?
WindowNotificationManager is more limited

## What is the updated/expected behavior with this PR?
Allow more flexibility for low cost

## How was the solution implemented (if it's not obvious)?
- Added DirectProperty called Host to have finer control over the Host registration
- added overload to Show with more options

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation -> Should be done once PR is accepted

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #12134 
Fixes #4462