### PR TITLE
Fix SelectedValueBinding with items defined in XAML

### DIFF
--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -1395,10 +1395,8 @@ namespace Avalonia.Controls.Primitives
 
             public object Evaluate(object? dataContext)
             {
-                dataContext = dataContext ?? throw new ArgumentNullException(nameof(dataContext));
-
                 // Only update the DataContext if necessary
-                if (!dataContext.Equals(DataContext))
+                if (!Equals(dataContext, DataContext))
                     DataContext = dataContext;
 
                 return GetValue(ValueProperty);

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_SelectedValue.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_SelectedValue.cs
@@ -268,6 +268,22 @@ namespace Avalonia.Controls.UnitTests.Primitives
             Assert.True(called);
         }
 
+        [Fact]
+        public void Handles_Null_SelectedItem_When_SelectedValueBinding_Assigned()
+        {
+            // Issue #11220
+            var items = new object[] { null };
+            var sic = new SelectingItemsControl
+            {
+                ItemsSource = items,
+                SelectedIndex = 0,
+                SelectedValueBinding = new Binding("Name"),
+                Template = Template()
+            };
+
+            Assert.Null(sic.SelectedValue);
+        }
+
         private static FuncControlTemplate Template()
         {
             return new FuncControlTemplate<SelectingItemsControl>((control, scope) =>


### PR DESCRIPTION
## What does the pull request do?

As described in #11220, there was a problem with `SelectingItemsControl.SelectedValueBinding` and null values. This PR simply removes the check for a non-null value in `BindingHelper.Evaluate` as the binding system handles them fine.

## Fixed issues

Fixes #11220