### PR TITLE
Generate external symbol packages

### DIFF
--- a/build/SourceLink.props
+++ b/build/SourceLink.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>false</IncludeSymbols>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
@@ -12,10 +12,6 @@
   
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-  </PropertyGroup>
-  
-  <PropertyGroup>
-    <DebugType Condition="$(ContinuousIntegrationBuild) == 'true'">embedded</DebugType>
   </PropertyGroup>
   
   <ItemGroup>

--- a/nukebuild/ApiDiffValidation.cs
+++ b/nukebuild/ApiDiffValidation.cs
@@ -38,7 +38,8 @@ public static class ApiDiffValidation
             var left = new List<string>();
             var right = new List<string>();
 
-            var suppressionFile = Path.Combine(suppressionFilesFolder, GetPackageId(packagePath) + ".nupkg.xml");
+            var packageId = GetPackageId(packagePath);
+            var suppressionFile = Path.Combine(suppressionFilesFolder, packageId + ".nupkg.xml");
 
             // Don't use Path.Combine with these left and right tool parameters.
             // Microsoft.DotNet.ApiCompat.Tool is stupid and treats '/' and '\' as different assemblies in suppression files.
@@ -57,7 +58,7 @@ public static class ApiDiffValidation
                     e.target == baselineDll.target && e.entry.Name == baselineDll.entry.Name);
                 if (targetDll.entry is null)
                 {
-                    throw new InvalidOperationException($"Some assemblies are missing in the new package: {baselineDll.entry.Name} for {baselineDll.target}");
+                    throw new InvalidOperationException($"Some assemblies are missing in the new package {packageId}: {baselineDll.entry.Name} for {baselineDll.target}");
                 }
 
                 var targetDllPath = $"target/{targetDll.target}/{targetDll.entry.Name}";

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -288,7 +288,7 @@ partial class Build : NukeBuild
         .Executes(async () =>
         {
             await Task.WhenAll(
-                Directory.GetFiles(Parameters.NugetRoot).Select(nugetPackage => ApiDiffValidation.ValidatePackage(
+                Directory.GetFiles(Parameters.NugetRoot, "*.nupkg").Select(nugetPackage => ApiDiffValidation.ValidatePackage(
                     ApiCompatTool, nugetPackage, Parameters.ApiValidationBaseline,
                     Parameters.ApiValidationSuppressionFiles, Parameters.UpdateApiValidationSuppression)));
         });

--- a/nukebuild/_build.csproj
+++ b/nukebuild/_build.csproj
@@ -8,8 +8,8 @@
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
- 
- <Import Project="..\build\JetBrains.dotMemoryUnit.props" />
+
+  <Import Project="..\build\JetBrains.dotMemoryUnit.props" />
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="6.2.1" />
     <PackageReference Include="vswhere" Version="2.6.7" Condition=" '$(OS)' == 'Windows_NT' " />
@@ -32,9 +32,9 @@
 
     <!-- Common build related files -->
     <Compile Remove="Numerge/**/*.*" />
-    <Compile Include="Numerge/Numerge/**/*.cs" />
-	<EmbeddedResource Include="$(NuGetPackageRoot)sourcelink/1.1.0/tools/pdbstr.exe"></EmbeddedResource>
-	<EmbeddedResource Include="../build/avalonia.snk"></EmbeddedResource>
+    <Compile Include="Numerge/Numerge/**/*.cs" Exclude="Numerge/Numerge/obj/**/*.cs" />
+    <EmbeddedResource Include="$(NuGetPackageRoot)sourcelink/1.1.0/tools/pdbstr.exe" />
+    <EmbeddedResource Include="../build/avalonia.snk" />
     <Compile Remove="il-repack\ILRepack\Application.cs" />
   </ItemGroup>
 
@@ -43,7 +43,5 @@
       <Link>dirs.proj</Link>
     </Content>
   </ItemGroup>
-    
-    
 
 </Project>

--- a/src/tools/Avalonia.Analyzers/Avalonia.Analyzers.csproj
+++ b/src/tools/Avalonia.Analyzers/Avalonia.Analyzers.csproj
@@ -5,6 +5,7 @@
     <PackageId>Avalonia.Analyzers</PackageId>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IsPackable>true</IsPackable>
+    <IncludeSymbols>false</IncludeSymbols>
     <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 

--- a/src/tools/Avalonia.Generators/Avalonia.Generators.csproj
+++ b/src/tools/Avalonia.Generators/Avalonia.Generators.csproj
@@ -5,6 +5,7 @@
     <PackageId>Avalonia.Generators</PackageId>
     <DefineConstants>$(DefineConstants);XAMLX_INTERNAL</DefineConstants>
     <IsPackable>true</IsPackable>
+    <IncludeSymbols>false</IncludeSymbols>
     <IsRoslynComponent>true</IsRoslynComponent>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>


### PR DESCRIPTION
## Description

This PR changes the debugging symbols from being embedded inside the assemblies, to external pdb files instead.
Symbol packages (snupkg) are generated and can be published to NuGet.

The main reason is to decrease the untrimmed assemblies size by about 15%. Excluding pdb files from copy or deployment is easy and common. Removing the embedded symbols needs trimming, and even then the `TrimmerRemoveSymbols` option must be enabled, which isn't intuitive.

Historically, symbols were embedded due to various debugging issues in some IDEs when Source Link is used, which all seem resolved today.

## Local tests

I've tested publishing locally built packages with `ContinuousIntegrationBuild` set to true (so the local dev paths aren't preserved) to a local BaGet server, which is the NuGet server used by Avalonia for the nightly builds.

As long as the proper symbol server was added to the corresponding IDE's settings, there were no issues stepping into source files with:
 - Visual Studio 2022 17.6.5
 - Rider 2023.1.3
 - Rider 2023.2 EAP 9

I've even double checked in logs and on disk that the symbols were correctly downloaded.

## Symbol packages

I went with external symbol packages since that's [recommended](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/nuget#symbol-packages): users don't pay the cost of downloading the pdb files until they need them.

For nightly builds and for official builds, it means the `snupkg` files must be pushed by the CI to the corresponding server. Both the nuget.org gallery (official builds) and BaGet (nightly builds) support these.
Pinging @danwalmsley to ensure that the CI is configured to push the symbol packages as I don't have access to these settings.

For official builds using nuget.org, both Visual Studio and Rider support its symbol server automatically without any extra setting. 

Regarding the nightly builds, an extra symbol server must be configured for both IDEs. This seems acceptable to me as using a nightly build already requires some extra configuration, so adding the symbol server doesn't seem too much to ask. If that's not acceptable, we can instead include the pdb inside the main package for nightly builds.

## Numerge

Numerge has been modified to automatically merge symbol packages.
This PR is marked as a draft because it depends on https://github.com/kekekeks/Numerge/pull/4 to be merged first.
