### PR TITLE
Remove unnecessary cast from RootAutomationNode.

### DIFF
--- a/src/Windows/Avalonia.Win32/Automation/RootAutomationNode.cs
+++ b/src/Windows/Avalonia.Win32/Automation/RootAutomationNode.cs
@@ -33,8 +33,7 @@ namespace Avalonia.Win32.Automation
                 return null;
 
             var p = WindowImpl.PointToClient(new PixelPoint((int)x, (int)y));
-            var peer = (WindowBaseAutomationPeer)Peer;
-            var found = InvokeSync(() => peer.GetPeerFromPoint(p));
+            var found = InvokeSync(() => Peer.GetPeerFromPoint(p));
             var result = GetOrCreate(found) as IRawElementProviderFragment;
             return result;
         }


### PR DESCRIPTION
## What does the pull request do?

`RootAutomationNode` casts its peer to `WindowBaseAutomationPeer`, meaning that no other type of automation peer can be used as a root peer. This is unnecessarily as `IRootProvider` exposes the required `GetPeerFromPoint` method anyway. 

