### PR TITLE
Modernizing syntax

### DIFF
--- a/src/Avalonia.Base/Threading/Dispatcher.Invoke.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.Invoke.cs
@@ -98,7 +98,7 @@ public partial class Dispatcher
         if (timeout.TotalMilliseconds < 0 &&
             timeout != TimeSpan.FromMilliseconds(-1))
         {
-            throw new ArgumentOutOfRangeException("timeout");
+            throw new ArgumentOutOfRangeException(nameof(timeout));
         }
 
         // Fast-Path: if on the same thread, and invoking at Send priority,
@@ -220,7 +220,7 @@ public partial class Dispatcher
         if (timeout.TotalMilliseconds < 0 &&
             timeout != TimeSpan.FromMilliseconds(-1))
         {
-            throw new ArgumentOutOfRangeException("timeout");
+            throw new ArgumentOutOfRangeException(nameof(timeout));
         }
 
         // Fast-Path: if on the same thread, and invoking at Send priority,

--- a/src/Avalonia.Base/Threading/DispatcherTimer.cs
+++ b/src/Avalonia.Base/Threading/DispatcherTimer.cs
@@ -112,11 +112,11 @@ public partial class DispatcherTimer
             bool updateOSTimer = false;
 
             if (value.TotalMilliseconds < 0)
-                throw new ArgumentOutOfRangeException("value",
+                throw new ArgumentOutOfRangeException(nameof(value),
                     "TimeSpan period must be greater than or equal to zero.");
 
             if (value.TotalMilliseconds > Int32.MaxValue)
-                throw new ArgumentOutOfRangeException("value",
+                throw new ArgumentOutOfRangeException(nameof(value),
                     "TimeSpan period must be less than or equal to Int32.MaxValue.");
 
             lock (_instanceLock)
@@ -259,14 +259,14 @@ public partial class DispatcherTimer
         DispatcherPriority.Validate(priority, "priority");
         if (priority == DispatcherPriority.Inactive)
         {
-            throw new ArgumentException("Specified priority is not valid.", "priority");
+            throw new ArgumentException("Specified priority is not valid.", nameof(priority));
         }
 
         if (interval.TotalMilliseconds < 0)
-            throw new ArgumentOutOfRangeException("interval", "TimeSpan period must be greater than or equal to zero.");
+            throw new ArgumentOutOfRangeException(nameof(interval), "TimeSpan period must be greater than or equal to zero.");
 
         if (interval.TotalMilliseconds > Int32.MaxValue)
-            throw new ArgumentOutOfRangeException("interval",
+            throw new ArgumentOutOfRangeException(nameof(interval),
                 "TimeSpan period must be less than or equal to Int32.MaxValue.");
 
 

--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
@@ -807,7 +807,7 @@ namespace Avalonia.Collections
             {
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException("PageSize cannot have a negative value.");
+                    throw new ArgumentOutOfRangeException(nameof(value), "PageSize cannot have a negative value.");
                 }
 
                 // if the Refresh is currently deferred, cache the desired PageSize
@@ -1954,7 +1954,7 @@ namespace Avalonia.Collections
             // for indices larger than the count
             if (index >= Count || index < 0)
             {
-                throw new ArgumentOutOfRangeException("index");
+                throw new ArgumentOutOfRangeException(nameof(index));
             }
 
             if (IsGrouping)

--- a/src/Avalonia.Controls/Automation/Peers/ScrollViewerAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ScrollViewerAutomationPeer.cs
@@ -146,12 +146,12 @@ namespace Avalonia.Automation.Peers
 
             if (scrollHorizontally && (horizontalPercent < 0.0) || (horizontalPercent > 100.0))
             {
-                throw new ArgumentOutOfRangeException("horizontalPercent");
+                throw new ArgumentOutOfRangeException(nameof(horizontalPercent));
             }
 
             if (scrollVertically && (verticalPercent < 0.0) || (verticalPercent > 100.0))
             {
-                throw new ArgumentOutOfRangeException("verticalPercent");
+                throw new ArgumentOutOfRangeException(nameof(verticalPercent));
             }
 
             var offset = Owner.Offset;

--- a/src/Avalonia.Controls/DateTimePickers/DateTimePickerPanel.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DateTimePickerPanel.cs
@@ -165,7 +165,7 @@ namespace Avalonia.Controls.Primitives
             set
             {
                 if (value > MaximumValue || value < MinimumValue)
-                    throw new ArgumentOutOfRangeException("SelectedValue");
+                    throw new ArgumentOutOfRangeException(nameof(value));
 
                 var sel = CoerceSelected(value);
                 _selectedValue = sel;
@@ -195,7 +195,7 @@ namespace Avalonia.Controls.Primitives
             set
             {
                 if (value <= 0 || value > _range)
-                    throw new ArgumentOutOfRangeException("Increment");
+                    throw new ArgumentOutOfRangeException(nameof(value));
                 _increment = value;
                 UpdateHelperInfo();
                 var sel = CoerceSelected(SelectedValue);

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -1113,11 +1113,11 @@ namespace Avalonia.Controls
             }
             if (value < Minimum)
             {
-                throw new ArgumentOutOfRangeException(nameof(value), string.Format("Value must be greater than Minimum value of {0}", Minimum));
+                throw new ArgumentOutOfRangeException(nameof(value), $"Value must be greater than Minimum value of {Minimum}");
             }
             else if (value > Maximum)
             {
-                throw new ArgumentOutOfRangeException(nameof(value), string.Format("Value must be less than Maximum value of {0}", Maximum));
+                throw new ArgumentOutOfRangeException(nameof(value), $"Value must be less than Maximum value of {Maximum}");
             }
         }
 

--- a/src/Avalonia.Controls/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter.cs
+++ b/src/Avalonia.Controls/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter.cs
@@ -98,14 +98,14 @@ namespace Avalonia.Controls.PullToRefresh
 
             if (_scrollViewer.Content == null)
             {
-                throw new ArgumentException(nameof(adaptee), "Adaptee's content property cannot be null.");
+                throw new ArgumentException("Adaptee's content property cannot be null.", nameof(adaptee));
             }
 
             var content = adaptee.Content as Visual;
 
             if (content == null)
             {
-                throw new ArgumentException(nameof(adaptee), "Adaptee's content property must be a Visual");
+                throw new ArgumentException("Adaptee's content property must be a Visual", nameof(adaptee));
             }
 
             if (content.GetVisualParent() == null)
@@ -118,7 +118,7 @@ namespace Avalonia.Controls.PullToRefresh
 
                 if (content.Parent is not InputElement)
                 {
-                    throw new ArgumentException(nameof(adaptee), "Adaptee's content's parent must be a InputElement");
+                    throw new ArgumentException("Adaptee's content's parent must be a InputElement", nameof(adaptee));
                 }
             }
 
@@ -194,12 +194,12 @@ namespace Avalonia.Controls.PullToRefresh
             var content = _scrollViewer?.Content as Visual;
             if (content == null)
             {
-                throw new ArgumentException(nameof(_scrollViewer), "Adaptee's content property must be a Visual");
+                throw new ArgumentException("Adaptee's content property must be a Visual", nameof(_scrollViewer));
             }
 
             if (content.Parent is not InputElement parent)
             {
-                throw new ArgumentException(nameof(_scrollViewer), "Adaptee's content parent must be an InputElement");
+                throw new ArgumentException("Adaptee's content parent must be an InputElement", nameof(_scrollViewer));
             }
 
             MakeInteractionSource(parent);

--- a/src/Avalonia.Controls/Utils/VirtualizingSnapPointsList.cs
+++ b/src/Avalonia.Controls/Utils/VirtualizingSnapPointsList.cs
@@ -39,7 +39,7 @@ namespace Avalonia.Controls.Utils
             get
             {
                 if(index < 0 || index >= Count)
-                    throw new ArgumentOutOfRangeException("index");
+                    throw new ArgumentOutOfRangeException(nameof(index));
 
                 index += _start;
 

--- a/src/Avalonia.Remote.Protocol/MetsysBson.cs
+++ b/src/Avalonia.Remote.Protocol/MetsysBson.cs
@@ -752,7 +752,7 @@ namespace Metsys.Bson
 
                         if (memberExpression.Expression.NodeType != ExpressionType.Parameter && memberExpression.Expression.NodeType != ExpressionType.Convert)
                         {
-                            throw new ArgumentException(string.Format("Expression '{0}' must resolve to top-level member.", lambdaExpression), nameof(lambdaExpression));
+                            throw new ArgumentException($"Expression '{lambdaExpression}' must resolve to top-level member.", nameof(lambdaExpression));
                         }
                         return memberExpression.Member.Name;
                     default:
@@ -942,7 +942,7 @@ namespace Metsys.Bson
                     return new ListWrapper();
                 }
             }
-            throw new BsonException(string.Format("Collection of type {0} cannot be deserialized", type.FullName));
+            throw new BsonException($"Collection of type {type.FullName} cannot be deserialized");
         }
 
         public abstract void Add(object value);
@@ -1514,7 +1514,7 @@ namespace Metsys.Bson.Configuration
                     result = Visit((MemberExpression)expression.Left);
                 }
                 var index = Expression.Lambda(expression.Right).Compile().DynamicInvoke();
-                return result + string.Format("[{0}]", index);
+                return result + $"[{index}]";
             }
 
             private string Visit(MemberExpression expression)
@@ -1540,7 +1540,7 @@ namespace Metsys.Bson.Configuration
                 if (expression.Method.Name == "get_Item" && expression.Arguments.Count == 1)
                 {
                     var index = Expression.Lambda(expression.Arguments[0]).Compile().DynamicInvoke();
-                    name += string.Format("[{0}]", index);
+                    name += $"[{index}]";
                 }
                 return name;
             }

--- a/src/Avalonia.X11/X11Structs.cs
+++ b/src/Avalonia.X11/X11Structs.cs
@@ -1109,7 +1109,7 @@ namespace Avalonia.X11 {
 
 		public override string ToString ()
 		{
-			return string.Format("MotifWmHints <flags={0}, functions={1}, decorations={2}, input_mode={3}, status={4}", (MotifFlags) flags.ToInt32 (), (MotifFunctions) functions.ToInt32 (), (MotifDecorations) decorations.ToInt32 (), (MotifInputMode) input_mode.ToInt32 (), status.ToInt32 ());
+			return $"MotifWmHints <flags={(MotifFlags)flags.ToInt32()}, functions={(MotifFunctions)functions.ToInt32()}, decorations={(MotifDecorations)decorations.ToInt32()}, input_mode={(MotifInputMode)input_mode.ToInt32()}, status={status.ToInt32()}";
 		}
 	}
 
@@ -1707,8 +1707,7 @@ namespace Avalonia.X11 {
 
 		public override string ToString ()
 		{
-			return string.Format ("XCursorImage (version: {0}, size: {1}, width: {2}, height: {3}, xhot: {4}, yhot: {5}, delay: {6}, pixels: {7}", 
-				version, size, width, height, xhot, yhot, delay, pixels);
+			return $"XCursorImage (version: {version}, size: {size}, width: {width}, height: {height}, xhot: {xhot}, yhot: {yhot}, delay: {delay}, pixels: {pixels}";
 		}
 	} ;
 


### PR DESCRIPTION
## What does the pull request do?
- Modernized syntax used for argument checking exceptions. String literals have been converted to `nameof()`
- Some instances of `ArgumentException` were being created incorrectly (arguments were in wrong order) so they were switched
- Many places where `string.Format` was used were converted to interpolated string for readability

## What is the updated/expected behavior with this PR?
No significant changes in behavior
