### PR TITLE
Special handling for macos dispatcher quirks

### DIFF
--- a/src/Avalonia.Base/Threading/Dispatcher.Timers.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.Timers.cs
@@ -127,7 +127,7 @@ public partial class Dispatcher
         if (needToPromoteTimers)
             PromoteTimers();
         if (needToProcessQueue)
-            ExecuteJobsCore();
+            ExecuteJobsCore(false);
         UpdateOSTimer();
     }
     

--- a/src/Avalonia.Base/Threading/Dispatcher.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.cs
@@ -34,6 +34,9 @@ public partial class Dispatcher : IDispatcher
         _controlledImpl = _impl as IControlledDispatcherImpl;
         _pendingInputImpl = _impl as IDispatcherImplWithPendingInput;
         _backgroundProcessingImpl = _impl as IDispatcherImplWithExplicitBackgroundProcessing;
+        _maximumInputStarvationTime = _backgroundProcessingImpl == null ?
+            MaximumInputStarvationTimeInFallbackMode :
+            MaximumInputStarvationTimeInExplicitProcessingExplicitMode;
         if (_backgroundProcessingImpl != null)
             _backgroundProcessingImpl.ReadyForBackgroundProcessing += OnReadyForExplicitBackgroundProcessing;
     }

--- a/src/Avalonia.Base/Threading/DispatcherFrame.cs
+++ b/src/Avalonia.Base/Threading/DispatcherFrame.cs
@@ -38,10 +38,14 @@ public class DispatcherFrame
     ///        for their important criteria to be met.  These frames
     ///        should have a timeout associated with them.
     /// </param>
-    public DispatcherFrame(bool exitWhenRequested)
+    public DispatcherFrame(bool exitWhenRequested) : this(Dispatcher.UIThread, exitWhenRequested)
     {
-        Dispatcher = Dispatcher.UIThread;
         Dispatcher.VerifyAccess();
+    }
+
+    internal DispatcherFrame(Dispatcher dispatcher, bool exitWhenRequested)
+    {
+        Dispatcher = dispatcher;
         _exitWhenRequested = exitWhenRequested;
         _continue = true;
     }


### PR DESCRIPTION
We need to make sure that background tasks are executed ONLY from the explicit "ready for background processing" callback from the platform implementation. Since there is no way to check if input is pending, we can end up with a `Background` priority job triggering a render pass followed by another background job, without any way to actually process the input.