### PR TITLE
macOS native: fix destructors accessing freed .NET objects

### DIFF
--- a/native/Avalonia.Native/src/OSX/app.mm
+++ b/native/Avalonia.Native/src/OSX/app.mm
@@ -2,6 +2,7 @@
 #include "AvnString.h"
 @interface AvnAppDelegate : NSObject<NSApplicationDelegate>
 -(AvnAppDelegate* _Nonnull) initWithEvents: (IAvnApplicationEvents* _Nonnull) events;
+-(void) releaseEvents;
 @end
 
 NSApplicationActivationPolicy AvnDesiredActivationPolicy = NSApplicationActivationPolicyRegular;
@@ -13,6 +14,11 @@ ComPtr<IAvnApplicationEvents> _events;
 {
     _events = events;
     return self;
+}
+
+- (void)releaseEvents
+{
+    _events = nil;
 }
 
 - (void)applicationWillFinishLaunching:(NSNotification *)notification
@@ -102,6 +108,18 @@ extern void InitializeAvnApp(IAvnApplicationEvents* events, bool disableAppDeleg
         NSApplication* app = [AvnApplication sharedApplication];
         id delegate = [[AvnAppDelegate alloc] initWithEvents:events];
         [app setDelegate:delegate];
+    }
+}
+
+extern void ReleaseAvnAppEvents()
+{
+    NSApplication* app = [AvnApplication sharedApplication];
+    id delegate = [app delegate];
+    if ([delegate isMemberOfClass:[AvnAppDelegate class]])
+    {
+        AvnAppDelegate* avnDelegate = delegate;
+        [avnDelegate releaseEvents];
+        [app setDelegate:nil];
     }
 }
 

--- a/native/Avalonia.Native/src/OSX/common.h
+++ b/native/Avalonia.Native/src/OSX/common.h
@@ -38,6 +38,7 @@ extern IAvnMenu* GetAppMenu ();
 extern NSMenuItem* GetAppMenuItem ();
 
 extern void InitializeAvnApp(IAvnApplicationEvents* events, bool disableAppDelegate);
+extern void ReleaseAvnAppEvents();
 extern NSApplicationActivationPolicy AvnDesiredActivationPolicy;
 extern NSPoint ToNSPoint (AvnPoint p);
 extern NSRect ToNSRect (AvnRect r);

--- a/native/Avalonia.Native/src/OSX/main.mm
+++ b/native/Avalonia.Native/src/OSX/main.mm
@@ -198,7 +198,8 @@ class AvaloniaNative : public ComSingleObject<IAvaloniaNativeFactory, &IID_IAval
 public:
     FORWARD_IUNKNOWN()
     
-    virtual ~AvaloniaNative() override {
+    virtual ~AvaloniaNative() override
+    {
         ReleaseAvnAppEvents();
         _deallocator = nullptr;
         _dispatcher = nullptr;

--- a/native/Avalonia.Native/src/OSX/main.mm
+++ b/native/Avalonia.Native/src/OSX/main.mm
@@ -197,6 +197,13 @@ class AvaloniaNative : public ComSingleObject<IAvaloniaNativeFactory, &IID_IAval
     
 public:
     FORWARD_IUNKNOWN()
+    
+    virtual ~AvaloniaNative() override {
+        ReleaseAvnAppEvents();
+        _deallocator = nullptr;
+        _dispatcher = nullptr;
+    }
+    
     virtual HRESULT Initialize(IAvnGCHandleDeallocatorCallback* deallocator,
             IAvnApplicationEvents* events,
             IAvnDispatcher* dispatcher) override

--- a/src/Avalonia.Native/AvaloniaNativePlatform.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatform.cs
@@ -162,12 +162,12 @@ namespace Avalonia.Native
 
             Compositor = new Compositor(_platformGraphics, true);
 
-            Dispatcher.UIThread.ShutdownFinished += OnDispatcherShutdownFinished;
+            AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
         }
 
-        private void OnDispatcherShutdownFinished(object? sender, EventArgs e)
+        private void OnProcessExit(object? sender, EventArgs e)
         {
-            Dispatcher.UIThread.ShutdownFinished -= OnDispatcherShutdownFinished;
+            AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
             _factory.Dispose();
         }
 

--- a/src/Avalonia.Native/AvaloniaNativePlatform.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatform.cs
@@ -3,9 +3,7 @@ using System.Runtime.InteropServices;
 using Avalonia.Controls.Platform;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
-using Avalonia.MicroCom;
 using Avalonia.Native.Interop;
-using Avalonia.OpenGL;
 using Avalonia.Platform;
 using Avalonia.Rendering;
 using Avalonia.Rendering.Composition;
@@ -163,6 +161,14 @@ namespace Avalonia.Native
             
 
             Compositor = new Compositor(_platformGraphics, true);
+
+            Dispatcher.UIThread.ShutdownFinished += OnDispatcherShutdownFinished;
+        }
+
+        private void OnDispatcherShutdownFinished(object? sender, EventArgs e)
+        {
+            Dispatcher.UIThread.ShutdownFinished -= OnDispatcherShutdownFinished;
+            _factory.Dispose();
         }
 
         public ITrayIconImpl CreateTrayIcon()


### PR DESCRIPTION
## What does the pull request do?
This PR makes sure that the COM objects referenced by `ComPtr` fields in the Avalonia.Native library are released while the managed code still runs.
The native destructors then don't run on freed objects.

## What is the current behavior?
Currently, when a macOS Avalonia app terminates, the native side still has some COM references to objects created in the managed side, like `AvnDispatcher`. When the `ComPtr`'s destructor runs, after `Main()` returns, the CLR has already freed the objects, causing an exception. For some reason, probably because the process is exiting, it isn't visible.
However, if a .NET debugger is attached, the process hangs: this is #11159.

## Details
Here's the callstack of the hanged process:

```text
frame #0: 0x00000001098130fe libcoreclr.dylib`Thread::DoAppropriateWaitWorker(int, void**, int, unsigned int, WaitMode) + 558
frame #1: 0x000000010980e600 libcoreclr.dylib`Thread::DoAppropriateWait(int, void**, int, unsigned int, WaitMode, PendingSync*) + 48
frame #2: 0x000000010992afff libcoreclr.dylib`CLREventBase::WaitEx(unsigned int, WaitMode, PendingSync*) + 63
frame #3: 0x0000000109b3bd98 libcoreclr.dylib`WaitForEndOfShutdown() + 56
frame #4: 0x0000000109768da0 libcoreclr.dylib`CrstBase::ReleaseAndBlockForShutdownIfNotSpecialThread() + 80
frame #5: 0x0000000109a43fb4 libcoreclr.dylib`Debugger::LockForEventSending(Holder<Debugger*, &Debugger::AcquireDebuggerLock(Debugger*), &Debugger::ReleaseDebuggerLock(Debugger*), 0ul, &int CompareDefault<Debugger*>(Debugger*, Debugger*), true>*) + 36
frame #6: 0x0000000109a3b286 libcoreclr.dylib`DebuggerController::DispatchPatchOrSingleStep(Thread*, _CONTEXT*, unsigned char const*, SCAN_TRIGGER) + 534
frame #7: 0x0000000109a3c57f libcoreclr.dylib`DebuggerController::DispatchNativeException(_EXCEPTION_RECORD*, _CONTEXT*, unsigned int, Thread*) + 511
frame #8: 0x0000000109a49999 libcoreclr.dylib`Debugger::FirstChanceNativeException(_EXCEPTION_RECORD*, _CONTEXT*, unsigned int, Thread*) + 89
frame #9: 0x0000000109959f86 libcoreclr.dylib`HandleHardwareException(PAL_SEHException*) + 454
frame #10: 0x00000001096e014b libcoreclr.dylib`SEHProcessException(PAL_SEHException*) + 315
frame #11: 0x000000010971a609 libcoreclr.dylib`PAL_DispatchException + 137
frame #12: 0x000000010971a293 libcoreclr.dylib`PAL_DispatchExceptionWrapper + 10
frame #13: 0x0000000110a7448e
frame #14: 0x0000000109fbb4ad libAvaloniaNative.dylib`ComPtr<IAvnDispatcher>::~ComPtr() [inlined] ComPtr<IAvnDispatcher>::~ComPtr(this=<unavailable>) at comimpl.h:85:19 [opt]
frame #15: 0x0000000109fbb49f libAvaloniaNative.dylib`ComPtr<IAvnDispatcher>::~ComPtr(this=<unavailable>) at comimpl.h:82:5 [opt]
frame #16: 0x00007ff8009d3ba1 libsystem_c.dylib`__cxa_finalize_ranges + 409
frame #17: 0x00007ff8009d39bb libsystem_c.dylib`exit + 35
frame #18: 0x00007ff800b198d3 libdyld.dylib`dyld4::LibSystemHelpers::exit(int) const + 11
frame #19: 0x00007ff8007a8458 dyld`start + 1960
```

In frames 14-16 we can notice the `ComPtr` destructors running, calling into the CLR (frame 13), causing an exception that's passed to the .NET debugger (frame 6-12).
Then we've got what seems to be a deadlock in the debugger waiting for the process to finish the shutdown (frames 0-5). I didn't investigate that part since fixing the cause is enough, but that's probably a bug in the CLR.

## How was the solution implemented?
The `AvaloniaNative` class in native code now releases in its destructor the COM objects passed by the managed code.
Its corresponding proxy stored in the managed `AvaloniaNativePlatform` is now disposed when the dispatcher shutdowns, effectively releasing the last reference and calling the destructor.

`Dispatcher.ShutdownFinished` doesn't feel like the best place to dispose the native object though. Ideally, the native platform should not have any static part and be disposable, with `Dispose` being the perfect place to release everything (but when should we call it?). That's a bit larger refactoring, which I'm not sure is worth it since the dispatcher usually has the same lifetime as the app.

Regarding the native code, it was my first time with Objective-C so please tell me if anything feels wrong. Those 10 lines of code were... an experience, let's say it that way.

## Fixed issues
Fixes #11159
