### PR TITLE
Update Rotate3DTransition.cs to fix flickering

### DIFF
--- a/src/Avalonia.Base/Animation/Transitions/Rotate3DTransition.cs
+++ b/src/Avalonia.Base/Animation/Transitions/Rotate3DTransition.cs
@@ -89,6 +89,7 @@ public class Rotate3DTransition: PageSlide
             {
                 Easing = SlideInEasing,
                 Duration = Duration,
+                FillMode = FillMode.Forward,
                 Children =
                 {
                     CreateKeyFrame(0d, 90d * (forward ? 1 : -1), 1),


### PR DESCRIPTION
Fix flickering after transition has finished on Rotate3DTransition. This was originally contained in my previous PR, but the commit was lost.

## What does the pull request do?
Fixes the rotate 3d transition by not falling back to previous values, which would render the control being rotated away visible for a very short amount of time.

## What is the current behavior?
After the current visual has been rotated away, it will become visible for a very short amount of time, so the control looks like its flickering.

## What is the updated/expected behavior with this PR?
No more flickering after rotation should occur.

## How was the solution implemented (if it's not obvious)?
FillMode of the animation has been set to forward, so that the visual being rotated away will not fall back to initial values, but instead stays away.
