### PR TITLE
Fix windows with BorderOnly decoration being unresizable

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -59,7 +59,7 @@ namespace Avalonia.Win32
 
                 case WindowsMessage.WM_NCCALCSIZE:
                     {
-                        if (ToInt32(wParam) == 1 && _isClientAreaExtended)
+                        if (ToInt32(wParam) == 1 && _windowProperties.Decorations == SystemDecorations.None ||  _isClientAreaExtended)
                         {
                             return IntPtr.Zero;
                         }

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -59,7 +59,7 @@ namespace Avalonia.Win32
 
                 case WindowsMessage.WM_NCCALCSIZE:
                     {
-                        if (ToInt32(wParam) == 1 && !HasFullDecorations || _isClientAreaExtended)
+                        if (ToInt32(wParam) == 1 && _isClientAreaExtended)
                         {
                             return IntPtr.Zero;
                         }

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1340,14 +1340,12 @@ namespace Avalonia.Win32
 
                 if (!_isFullScreenActive)
                 {
-                    var margin = newProperties.Decorations == SystemDecorations.BorderOnly ? 1 : 0;
-
                     var margins = new MARGINS
                     {
-                        cyBottomHeight = margin,
-                        cxRightWidth = margin,
-                        cxLeftWidth = margin,
-                        cyTopHeight = margin
+                        cyBottomHeight = 0,
+                        cxRightWidth = 0,
+                        cxLeftWidth = 0,
+                        cyTopHeight = 0
                     };
 
                     DwmExtendFrameIntoClientArea(_hwnd, ref margins);


### PR DESCRIPTION
## What does the pull request do?
Removes the check for decoration in the window message handler for `WM_NCCALCSIZE`. This enables borders to be handled by the default window message handler, thus making resizing possible in BorderOnly and None decoration modes.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #6786
