### PR TITLE
Fix creating fields for attached properties called name. closes #12283

### DIFF
--- a/src/tools/Avalonia.Generators/Common/XamlXNameResolver.cs
+++ b/src/tools/Avalonia.Generators/Common/XamlXNameResolver.cs
@@ -38,6 +38,7 @@ internal class XamlXNameResolver : INameResolver, IXamlAstVisitor
         {
             if (child is XamlAstXamlPropertyValueNode propertyValueNode &&
                 propertyValueNode.Property is XamlAstNamePropertyReference namedProperty &&
+                !IsAttachedProperty(namedProperty) &&
                 namedProperty.Name == "Name" &&
                 propertyValueNode.Values.Count > 0 &&
                 propertyValueNode.Values[0] is XamlAstTextNode text)
@@ -88,5 +89,10 @@ internal class XamlXNameResolver : INameResolver, IXamlAstVisitor
             "notpublic" => "internal",
             _ => _defaultFieldModifier
         };
+    }
+
+    private static bool IsAttachedProperty(XamlAstNamePropertyReference namedProperty)
+    {
+        return !namedProperty.DeclaringType.Equals(namedProperty.TargetType);
     }
 }

--- a/tests/Avalonia.Generators.Tests/Views/NamedControl.xml
+++ b/tests/Avalonia.Generators.Tests/Views/NamedControl.xml
@@ -2,6 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Sample.App.NamedControl">
     <TextBox Name="UserNameTextBox"
+             AutomationProperties.Name="The user name"
              Watermark="Username input"
              UseFloatingWatermark="True" />
 </Window>

--- a/tests/Avalonia.Generators.Tests/Views/xNamedControl.xml
+++ b/tests/Avalonia.Generators.Tests/Views/xNamedControl.xml
@@ -2,6 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Sample.App.xNamedControl">
     <TextBox x:Name="UserNameTextBox"
+             AutomationProperties.Name="The user name"
              Watermark="Username input"
              UseFloatingWatermark="True" />
 </Window>


### PR DESCRIPTION
## What does the pull request do?
This fixes the issue that the Avalonia.Generators is creating fields for attached proerties that have the name "Name"


## What is the current behavior?
A field is created for attached properties called "Name", leading to compile errors, if they contain characters not valid for field names like spaces. A common use case for this is the `AutomationProperties.Name`. (#12283)


## What is the updated/expected behavior with this PR?
No field is generated for attached properties with name "Name"


## How was the solution implemented (if it's not obvious)?
Filtering out attached properties in XamlNameResolver by checking if `DeclaringType` is different to `TargetType`.


## Checklist

- [x] Added unit tests? -> adjusted existing test
- [ ] Added XML documentation to any related classes? ->not relevant
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation -> not needed

## Breaking changes
Technical yes, if users would have relied on a wrongly generated field, but I would say that is rather unlikely and is easily fixable by the user.

## Obsoletions / Deprecations
none

## Fixed issues
Fixes #12283
