### PR TITLE
Fix segfault on Linux when typing in a TexBox

### DIFF
--- a/src/Avalonia.X11/X11Platform.cs
+++ b/src/Avalonia.X11/X11Platform.cs
@@ -36,12 +36,11 @@ namespace Avalonia.X11
         public IntPtr OrphanedWindow { get; private set; }
         public X11Globals Globals { get; private set; }
         public ManualRawEventGrouperDispatchQueue EventGrouperDispatchQueue { get; } = new();
-        [DllImport("libc")]
-        private static extern void setlocale(int type, string s);
+
         public void Initialize(X11PlatformOptions options)
         {
             Options = options;
-            
+
             bool useXim = false;
             if (EnableIme(options))
             {
@@ -49,9 +48,6 @@ namespace Avalonia.X11
                 if (!X11DBusImeHelper.DetectAndRegister() && ShouldUseXim())
                     useXim = true;
             }
-
-            // We have problems with text input otherwise
-            setlocale(0, "");
 
             XInitThreads();
             Display = XOpenDisplay(IntPtr.Zero);
@@ -64,7 +60,7 @@ namespace Avalonia.X11
             OrphanedWindow = XCreateSimpleWindow(Display, XDefaultRootWindow(Display), 0, 0, 1, 1, 0, IntPtr.Zero,
                 IntPtr.Zero);
             XError.Init();
-            
+
             Info = new X11Info(Display, DeferredDisplay, useXim);
             Globals = new X11Globals(this);
             //TODO: log

--- a/src/Avalonia.X11/X11Window.Ime.cs
+++ b/src/Avalonia.X11/X11Window.Ime.cs
@@ -133,13 +133,20 @@ namespace Avalonia.X11
         {
             if (ImeBuffer == IntPtr.Zero)
                 ImeBuffer = Marshal.AllocHGlobal(ImeBufferSize);
-            
-            var len = Xutf8LookupString(_xic, ref ev, ImeBuffer.ToPointer(), ImeBufferSize, 
-                out _, out var istatus);
-            var status = (XLookupStatus)istatus;
+
+            IntPtr istatus;
+            int len;
+            if(_xic != IntPtr.Zero)
+                len = Xutf8LookupString(_xic, ref ev, ImeBuffer.ToPointer(),
+                    ImeBufferSize, out _, out istatus);
+            else
+                len = XLookupString(ref ev, ImeBuffer.ToPointer(), ImeBufferSize,
+                    out _, out istatus);
 
             if (len == 0)
                 return null;
+
+            var status = (XLookupStatus)istatus;
 
             string text;
             if (status == XLookupStatus.XBufferOverflow)

--- a/src/Avalonia.X11/XLib.cs
+++ b/src/Avalonia.X11/XLib.cs
@@ -468,7 +468,7 @@ namespace Avalonia.X11
         public static extern unsafe int XLookupString(ref XEvent xevent, void* buffer, int num_bytes, out IntPtr keysym, out IntPtr status);
         
         [DllImport (libX11)]
-        public static extern unsafe int Xutf8LookupString(IntPtr xic, ref XEvent xevent, void* buffer, int num_bytes, out IntPtr keysym, out UIntPtr status);
+        public static extern unsafe int Xutf8LookupString(IntPtr xic, ref XEvent xevent, void* buffer, int num_bytes, out IntPtr keysym, out IntPtr status);
         
         [DllImport (libX11)]
         public static extern unsafe int Xutf8LookupString(IntPtr xic, XEvent* xevent, void* buffer, int num_bytes, out IntPtr keysym, out IntPtr status);


### PR DESCRIPTION
See https://github.com/AvaloniaUI/Avalonia/issues/12049

## What does the pull request do?
Fixes a segfault caused by a null XIC passed to xlibi18n/ICWrap.c:424.

## What is the current behavior?
Segfault when typing in a TextBox.

## What is the updated/expected behavior with this PR?
No more segfaulting when typing in a TextBox.


## How was the solution implemented (if it's not obvious)?
The logic may be summarized like this:
1. if `setlocale(0, "")` makes `XSetLocaleModifiers()` fail, try `setlocale(0, "en_US.UTF-8")` and if `XSetLocaleModifiers()` still fails -- use `setlocale(0, "C.UTF-8")` which should guarantee `XSetLocaleModifiers()` won't fail
2. normally after 1. we should have a valid xim & xic, but if still invalid, use `XLookupString()` (which doesn't require xic) instead of `Xutf8LookupString()`

## Fixed issues
Fixes #12049

