### PR TITLE
Pin properties dev tool update

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -4161,7 +4161,7 @@ namespace Avalonia.Controls
 
             ResetValidationStatus();
 
-            if (exitEditingMode && CurrentColumn != null)
+            if (exitEditingMode)
             {
                 CurrentColumn.EndCellEditInternal();
                 _editingColumnIndex = -1;

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -4161,7 +4161,7 @@ namespace Avalonia.Controls
 
             ResetValidationStatus();
 
-            if (exitEditingMode)
+            if (exitEditingMode && CurrentColumn != null)
             {
                 CurrentColumn.EndCellEditInternal();
                 _editingColumnIndex = -1;

--- a/src/Avalonia.Diagnostics/Diagnostics/Converters/PinnedToBoolConverter.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Converters/PinnedToBoolConverter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace Avalonia.Diagnostics.Converters
+{
+    internal class PinnedToBoolConverter : IValueConverter
+    {
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is string status)
+            {
+                return status.Equals("Pinned", StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is bool isPinned)
+            {
+                return isPinned ? "Pinned" : "Unpinned";
+            }
+
+            return "Unknown";
+        }
+    }
+}

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/AvaloniaPropertyViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/AvaloniaPropertyViewModel.cs
@@ -7,6 +7,7 @@ namespace Avalonia.Diagnostics.ViewModels
     {
         private readonly AvaloniaObject _target;
         private Type _assignedType;
+        private bool _isPinned;
         private object? _value;
         private string _priority;
         private string _group;
@@ -19,6 +20,7 @@ namespace Avalonia.Diagnostics.ViewModels
         {
             _target = o;
             Property = property;
+            _isPinned = false;
 
             Name = property.IsAttached ?
                 $"[{property.OwnerType.Name}.{property.Name}]" :
@@ -33,6 +35,19 @@ namespace Avalonia.Diagnostics.ViewModels
         public override string Name { get; }
         public override bool? IsAttached => Property.IsAttached;
         public override string Priority => _priority;
+        public override bool IsPinned
+        {
+            get => _isPinned;
+            set
+            {
+                try
+                {
+                    _isPinned = value;
+                    OnIsPinnedChanged();
+                }
+                catch { }
+            }
+        }
         public override Type AssignedType => _assignedType;
 
         public override object? Value
@@ -56,6 +71,12 @@ namespace Avalonia.Diagnostics.ViewModels
         public override bool IsReadonly => Property.IsReadOnly;
 
         // [MemberNotNull(nameof(_type), nameof(_group), nameof(_priority))]
+        public override event EventHandler IsPinnedChanged;
+
+        protected virtual void OnIsPinnedChanged()
+        {
+            IsPinnedChanged?.Invoke(this, EventArgs.Empty);
+        }
         public override void Update()
         {
             if (Property.IsDirect)

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ClrPropertyViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ClrPropertyViewModel.cs
@@ -7,6 +7,7 @@ namespace Avalonia.Diagnostics.ViewModels
     {
         private readonly object _target;
         private Type _assignedType;
+        private bool _isPinned;
         private object? _value;
         private readonly Type _propertyType;
 
@@ -17,6 +18,7 @@ namespace Avalonia.Diagnostics.ViewModels
         {
             _target = o;
             Property = property;
+            _isPinned = false;
 
             if (property.DeclaringType == null || !property.DeclaringType.IsInterface)
             {
@@ -41,6 +43,28 @@ namespace Avalonia.Diagnostics.ViewModels
         public override Type AssignedType => _assignedType;
         public override Type PropertyType => _propertyType;
         public override bool IsReadonly => !Property.CanWrite;
+
+        //determines if property is pinned to top in dev tools
+        public override bool IsPinned
+        {
+            get => _isPinned;
+            set
+            {
+                try
+                {
+                    _isPinned = value;
+                    OnIsPinnedChanged();
+                }
+                catch { }
+            }
+        }
+
+        public override event EventHandler IsPinnedChanged;
+
+        protected virtual void OnIsPinnedChanged()
+        {
+            IsPinnedChanged?.Invoke(this, EventArgs.Empty);
+        }
 
         public override object? Value
         {

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ClrPropertyViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/ClrPropertyViewModel.cs
@@ -7,9 +7,14 @@ namespace Avalonia.Diagnostics.ViewModels
     {
         private readonly object _target;
         private Type _assignedType;
-        private bool _isPinned;
         private object? _value;
         private readonly Type _propertyType;
+        private enum PinnedStatus
+        {
+            Pinned,
+            Unpinned
+        }
+        private PinnedStatus _isPinned;
 
 #nullable disable
         // Remove "nullable disable" after MemberNotNull will work on our CI.
@@ -18,7 +23,7 @@ namespace Avalonia.Diagnostics.ViewModels
         {
             _target = o;
             Property = property;
-            _isPinned = false;
+            _isPinned = PinnedStatus.Unpinned;
 
             if (property.DeclaringType == null || !property.DeclaringType.IsInterface)
             {
@@ -45,27 +50,21 @@ namespace Avalonia.Diagnostics.ViewModels
         public override bool IsReadonly => !Property.CanWrite;
 
         //determines if property is pinned to top in dev tools
-        public override bool IsPinned
+        public override string IsPinned
         {
-            get => _isPinned;
+            get => _isPinned.ToString();
             set
             {
                 try
                 {
-                    _isPinned = value;
-                    OnIsPinnedChanged();
+                    if (Enum.TryParse(value, out PinnedStatus pinState))
+                    {
+                        _isPinned = pinState;
+                    }
                 }
                 catch { }
             }
         }
-
-        public override event EventHandler IsPinnedChanged;
-
-        protected virtual void OnIsPinnedChanged()
-        {
-            IsPinnedChanged?.Invoke(this, EventArgs.Empty);
-        }
-
         public override object? Value
         {
             get => _value;

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/PropertyViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/PropertyViewModel.cs
@@ -11,12 +11,14 @@ namespace Avalonia.Diagnostics.ViewModels
         public abstract string Name { get; }
         public abstract string Group { get; }
         public abstract Type AssignedType { get; }
+        public abstract bool IsPinned { get; set; }
         public abstract Type? DeclaringType { get; }
         public abstract object? Value { get; set; }
         public abstract string Priority { get; }
         public abstract bool? IsAttached { get; }
         public abstract void Update();
         public abstract Type PropertyType { get; }
+        public abstract event EventHandler IsPinnedChanged;
 
         public string Type => PropertyType == AssignedType ?
             PropertyType.GetTypeName() :

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/PropertyViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/PropertyViewModel.cs
@@ -11,14 +11,13 @@ namespace Avalonia.Diagnostics.ViewModels
         public abstract string Name { get; }
         public abstract string Group { get; }
         public abstract Type AssignedType { get; }
-        public abstract bool IsPinned { get; set; }
+        public abstract string IsPinned { get; set; }
         public abstract Type? DeclaringType { get; }
         public abstract object? Value { get; set; }
         public abstract string Priority { get; }
         public abstract bool? IsAttached { get; }
         public abstract void Update();
         public abstract Type PropertyType { get; }
-        public abstract event EventHandler IsPinnedChanged;
 
         public string Type => PropertyType == AssignedType ?
             PropertyType.GetTypeName() :

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/ControlDetailsView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/ControlDetailsView.xaml
@@ -40,7 +40,7 @@
         <TextBlock Grid.Column="1" Grid.Row="1" Text="{Binding SelectedEntityType}" FontStyle="Italic" />
       </Grid>
       
-      <controls:FilterTextBox Grid.Row="1"
+      <controls:FilterTextBox Grid.Row="0"
                               BorderThickness="0"
                               DataContext="{Binding TreePage.PropertiesFilter}"
                               Text="{Binding FilterString}"
@@ -49,47 +49,95 @@
                               UseWholeWordFilter="{Binding UseWholeWordFilter}"
                               UseRegexFilter="{Binding UseRegexFilter}"/>
       
-      <DataGrid 
-                x:Name="DataGrid"
-                ItemsSource="{Binding PropertiesView}"
+      <Grid RowDefinitions="Auto,*" Grid.Row="1">
+        <DataGrid
+                x:Name="FloatingDataGrid"
+                ItemsSource="{Binding PinnedPropertiesView}"
                 Grid.Row="2"
                 BorderThickness="0"
                 RowBackground="Transparent"
-                SelectedItem="{Binding SelectedProperty, Mode=TwoWay}"
                 CanUserResizeColumns="true"
-                DoubleTapped="PropertiesGrid_OnDoubleTapped">
-        <DataGrid.Columns>
-          <DataGridTextColumn Header="Property" Binding="{Binding Name}" IsReadOnly="True" x:DataType="vm:PropertyViewModel" />
-          <DataGridTemplateColumn Header="Value" Width="100">
+                DoubleTapped="PropertiesGrid_OnDoubleTapped"
+                Height="{Binding FloatingGridHeight}">
+          <DataGrid.Columns>
+            <DataGridCheckBoxColumn Header="Pin Property" Binding="{Binding IsPinned}" x:DataType="vm:PropertyViewModel"/>
+            <DataGridTextColumn Header="Property test" Binding="{Binding Name}" IsReadOnly="True" x:DataType="vm:PropertyViewModel" Width="100"/>
+            <DataGridTemplateColumn Header="Value" Width="200">
               <DataTemplate>
                 <local:PropertyValueEditorView />
               </DataTemplate>
-          </DataGridTemplateColumn>
-          <DataGridTextColumn Header="Type" Binding="{Binding Type}"
-                              IsReadOnly="True"
-                              IsVisible="{Binding !$parent[UserControl;2].((vm:MainViewModel)DataContext).ShowDetailsPropertyType}"
-                              x:DataType="vm:PropertyViewModel"
+            </DataGridTemplateColumn>
+            <DataGridTextColumn Header="Type" Binding="{Binding Type}"
+                                IsReadOnly="True"
+                                IsVisible="{Binding !$parent[UserControl;2].((vm:MainViewModel)DataContext).ShowDetailsPropertyType}"
+                                x:DataType="vm:PropertyViewModel"
+                                Width="200"
                               />
-          <DataGridTextColumn Header="Assigned Type" Binding="{Binding AssignedType, Converter={StaticResource GetTypeName}}"
-                              IsReadOnly="True"
-                              IsVisible="{Binding $parent[UserControl;2].((vm:MainViewModel)DataContext).ShowDetailsPropertyType}"
-                              x:DataType="vm:PropertyViewModel"
+            <DataGridTextColumn Header="Assigned Type" Binding="{Binding AssignedType, Converter={StaticResource GetTypeName}}"
+                                IsReadOnly="True"
+                                IsVisible="{Binding $parent[UserControl;2].((vm:MainViewModel)DataContext).ShowDetailsPropertyType}"
+                                x:DataType="vm:PropertyViewModel"
+                                Width="100"
                               />
-          <DataGridTextColumn Header="Property Type" Binding="{Binding PropertyType, Converter={StaticResource GetTypeName}}"
-                              IsReadOnly="True"
-                              IsVisible="{Binding $parent[UserControl;2].((vm:MainViewModel)DataContext).ShowDetailsPropertyType}"
-                              x:DataType="vm:PropertyViewModel"
+            <DataGridTextColumn Header="Property Type" Binding="{Binding PropertyType, Converter={StaticResource GetTypeName}}"
+                                IsReadOnly="True"
+                                IsVisible="{Binding $parent[UserControl;2].((vm:MainViewModel)DataContext).ShowDetailsPropertyType}"
+                                x:DataType="vm:PropertyViewModel"
+                                Width="300"
                               />
-          <DataGridTextColumn Header="Priority" Binding="{Binding Priority}" IsReadOnly="True" x:DataType="vm:PropertyViewModel" />
-        </DataGrid.Columns>
+            <DataGridTextColumn Header="Priority" Binding="{Binding Priority}" IsReadOnly="True" x:DataType="vm:PropertyViewModel" Width="100"/>
+          </DataGrid.Columns>
+        </DataGrid>
+      </Grid>
+      
+      <Grid RowDefinitions="Auto,*" Grid.Row="2">
+        <DataGrid
+                        x:Name="DataGrid"
+                        ItemsSource="{Binding PropertiesView}"
+                        Grid.Row="2"
+                        BorderThickness="0"
+                        RowBackground="Transparent"
+                        SelectedItem="{Binding SelectedProperty, Mode=TwoWay}"
+                        CanUserResizeColumns="true"
+                        DoubleTapped="PropertiesGrid_OnDoubleTapped"
+                        Height="1080"
+                        VerticalAlignment="Stretch">
+          <DataGrid.Columns>
+            <DataGridCheckBoxColumn Header="Pin Property" Binding="{Binding IsPinned}" x:DataType="vm:PropertyViewModel"/>
+            <DataGridTextColumn Header="Property test" Binding="{Binding Name}" IsReadOnly="True" x:DataType="vm:PropertyViewModel" Width="100"/>
+            <DataGridTemplateColumn Header="Value" Width="200">
+              <DataTemplate>
+                <local:PropertyValueEditorView />
+              </DataTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTextColumn Header="Type" Binding="{Binding Type}"
+                                IsReadOnly="True"
+                                IsVisible="{Binding !$parent[UserControl;2].((vm:MainViewModel)DataContext).ShowDetailsPropertyType}"
+                                x:DataType="vm:PropertyViewModel"
+                                Width="200"
+                              />
+            <DataGridTextColumn Header="Assigned Type" Binding="{Binding AssignedType, Converter={StaticResource GetTypeName}}"
+                                IsReadOnly="True"
+                                IsVisible="{Binding $parent[UserControl;2].((vm:MainViewModel)DataContext).ShowDetailsPropertyType}"
+                                x:DataType="vm:PropertyViewModel"
+                                Width="100"
+                              />
+            <DataGridTextColumn Header="Property Type" Binding="{Binding PropertyType, Converter={StaticResource GetTypeName}}"
+                                IsReadOnly="True"
+                                IsVisible="{Binding $parent[UserControl;2].((vm:MainViewModel)DataContext).ShowDetailsPropertyType}"
+                                x:DataType="vm:PropertyViewModel"
+                                Width="300"
+                              />
+            <DataGridTextColumn Header="Priority" Binding="{Binding Priority}" IsReadOnly="True" x:DataType="vm:PropertyViewModel" Width="100"/>
+          </DataGrid.Columns>
 
-        <DataGrid.Styles>
-          <Style Selector="DataGridRow TextBox">
-            <Setter Property="SelectionBrush" Value="LightBlue" />
-          </Style>
-        </DataGrid.Styles>
-      </DataGrid>
-
+          <DataGrid.Styles>
+            <Style Selector="DataGridRow TextBox">
+              <Setter Property="SelectionBrush" Value="LightBlue" />
+            </Style>
+          </DataGrid.Styles>
+        </DataGrid>
+      </Grid>
     </Grid>
 
     <GridSplitter Grid.Column="1"/>

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/ControlDetailsView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/ControlDetailsView.xaml
@@ -12,6 +12,7 @@
   <UserControl.Resources>
     <conv:BoolToOpacityConverter x:Key="BoolToOpacity" Opacity="0.6"/>
     <conv:GetTypeNameConverter x:Key="GetTypeName"/>
+    <conv:PinnedToBoolConverter x:Key="PinnedToBool"/>
   </UserControl.Resources>
 
   <Grid>
@@ -49,52 +50,11 @@
                               UseWholeWordFilter="{Binding UseWholeWordFilter}"
                               UseRegexFilter="{Binding UseRegexFilter}"/>
       
-      <Grid RowDefinitions="Auto,*" Grid.Row="1">
-        <DataGrid
-                x:Name="FloatingDataGrid"
-                ItemsSource="{Binding PinnedPropertiesView}"
-                Grid.Row="2"
-                BorderThickness="0"
-                RowBackground="Transparent"
-                CanUserResizeColumns="true"
-                DoubleTapped="PropertiesGrid_OnDoubleTapped"
-                Height="{Binding FloatingGridHeight}">
-          <DataGrid.Columns>
-            <DataGridCheckBoxColumn Header="Pin" Binding="{Binding IsPinned}" x:DataType="vm:PropertyViewModel"/>
-            <DataGridTextColumn Header="Property" Binding="{Binding Name}" IsReadOnly="True" x:DataType="vm:PropertyViewModel" Width="100"/>
-            <DataGridTemplateColumn Header="Value" Width="200">
-              <DataTemplate>
-                <local:PropertyValueEditorView />
-              </DataTemplate>
-            </DataGridTemplateColumn>
-            <DataGridTextColumn Header="Type" Binding="{Binding Type}"
-                                IsReadOnly="True"
-                                IsVisible="{Binding !$parent[UserControl;2].((vm:MainViewModel)DataContext).ShowDetailsPropertyType}"
-                                x:DataType="vm:PropertyViewModel"
-                                Width="200"
-                              />
-            <DataGridTextColumn Header="Assigned Type" Binding="{Binding AssignedType, Converter={StaticResource GetTypeName}}"
-                                IsReadOnly="True"
-                                IsVisible="{Binding $parent[UserControl;2].((vm:MainViewModel)DataContext).ShowDetailsPropertyType}"
-                                x:DataType="vm:PropertyViewModel"
-                                Width="100"
-                              />
-            <DataGridTextColumn Header="Property Type" Binding="{Binding PropertyType, Converter={StaticResource GetTypeName}}"
-                                IsReadOnly="True"
-                                IsVisible="{Binding $parent[UserControl;2].((vm:MainViewModel)DataContext).ShowDetailsPropertyType}"
-                                x:DataType="vm:PropertyViewModel"
-                                Width="300"
-                              />
-            <DataGridTextColumn Header="Priority" Binding="{Binding Priority}" IsReadOnly="True" x:DataType="vm:PropertyViewModel" Width="100"/>
-          </DataGrid.Columns>
-        </DataGrid>
-      </Grid>
-      
       <Grid RowDefinitions="Auto,*" Grid.Row="2">
         <DataGrid
                         x:Name="DataGrid"
                         ItemsSource="{Binding PropertiesView}"
-                        Grid.Row="2"
+                        Grid.Row="1"
                         BorderThickness="0"
                         RowBackground="Transparent"
                         SelectedItem="{Binding SelectedProperty, Mode=TwoWay}"
@@ -103,7 +63,7 @@
                         Height="1080"
                         VerticalAlignment="Stretch">
           <DataGrid.Columns>
-            <DataGridCheckBoxColumn Header="Pin" Binding="{Binding IsPinned}" x:DataType="vm:PropertyViewModel"/>
+            <DataGridCheckBoxColumn Header="Pin" Binding="{Binding IsPinned, Converter={StaticResource PinnedToBool}}" x:DataType="vm:PropertyViewModel"/>
             <DataGridTextColumn Header="Property" Binding="{Binding Name}" IsReadOnly="True" x:DataType="vm:PropertyViewModel" Width="100"/>
             <DataGridTemplateColumn Header="Value" Width="200">
               <DataTemplate>
@@ -139,7 +99,7 @@
         </DataGrid>
       </Grid>
     </Grid>
-
+   
     <GridSplitter Grid.Column="1"/>
 
     <Grid Grid.Column="2" RowDefinitions="*,Auto,*"

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/ControlDetailsView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/ControlDetailsView.xaml
@@ -28,7 +28,7 @@
       <ColumnDefinition Width="320" lb:ColumnDefinition.IsVisible="{Binding Layout, Converter={x:Static ObjectConverters.IsNotNull}}" />
     </Grid.ColumnDefinitions>
     
-    <Grid Grid.Column="0" RowDefinitions="Auto,Auto,*">
+    <Grid Grid.Column="0" RowDefinitions="Auto,Auto,Auto,*">
 
       <Grid ColumnDefinitions="Auto, *" RowDefinitions="Auto, Auto">
         <Button Grid.Column="0" Grid.RowSpan="2" Content="^" 
@@ -60,8 +60,8 @@
                 DoubleTapped="PropertiesGrid_OnDoubleTapped"
                 Height="{Binding FloatingGridHeight}">
           <DataGrid.Columns>
-            <DataGridCheckBoxColumn Header="Pin Property" Binding="{Binding IsPinned}" x:DataType="vm:PropertyViewModel"/>
-            <DataGridTextColumn Header="Property test" Binding="{Binding Name}" IsReadOnly="True" x:DataType="vm:PropertyViewModel" Width="100"/>
+            <DataGridCheckBoxColumn Header="Pin" Binding="{Binding IsPinned}" x:DataType="vm:PropertyViewModel"/>
+            <DataGridTextColumn Header="Property" Binding="{Binding Name}" IsReadOnly="True" x:DataType="vm:PropertyViewModel" Width="100"/>
             <DataGridTemplateColumn Header="Value" Width="200">
               <DataTemplate>
                 <local:PropertyValueEditorView />
@@ -103,8 +103,8 @@
                         Height="1080"
                         VerticalAlignment="Stretch">
           <DataGrid.Columns>
-            <DataGridCheckBoxColumn Header="Pin Property" Binding="{Binding IsPinned}" x:DataType="vm:PropertyViewModel"/>
-            <DataGridTextColumn Header="Property test" Binding="{Binding Name}" IsReadOnly="True" x:DataType="vm:PropertyViewModel" Width="100"/>
+            <DataGridCheckBoxColumn Header="Pin" Binding="{Binding IsPinned}" x:DataType="vm:PropertyViewModel"/>
+            <DataGridTextColumn Header="Property" Binding="{Binding Name}" IsReadOnly="True" x:DataType="vm:PropertyViewModel" Width="100"/>
             <DataGridTemplateColumn Header="Value" Width="200">
               <DataTemplate>
                 <local:PropertyValueEditorView />


### PR DESCRIPTION
What does the pull request do?
This has added a pinned variable to property view models and the functionality to use that to pin/unpin properties to the top of dev tools

What is the current behavior?
there is now a checkbox in dev tools that will allow you to pin properties to the top

What is the updated/expected behavior with this PR?
it works as intended other than one thing. It is currently using two headers: one for pinned and another for unpinned properties. I would like to only have one header but, I need to figure out how to bind the widths of each column in the separate data-grids together and have been unable to so far.

How was the solution implemented (if it's not obvious)?
I implemented a check box that is associated with an IsPinned variable on PropertyViewModel. ControlDetailsViewModel will then listen for it and add pinned properties to a separate data-grid above the original one.

Checklist
 Added unit tests (if possible)?
 Added XML documentation to any related classes?
 Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation
Breaking changes
Hopefully none, fingers crossed

Obsoletions / Deprecations
Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/12242