### PR TITLE
Fix window incorrect positioning with window startup location CenterScreen on MacOS

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -151,6 +151,14 @@ HRESULT WindowBaseImpl::Hide() {
 
     @autoreleasepool {
         if (Window != nullptr) {
+            auto frame = [Window frame];
+
+            AvnPoint point;
+            point.X = frame.origin.x;
+            point.Y = frame.origin.y + frame.size.height;
+
+            lastPositionSet = ConvertPointY(point);
+            hasPosition = true;
             [Window orderOut:Window];
         }
 


### PR DESCRIPTION
## What does the pull request do?
This is the continuation of the #12093 .Previous PR fixed the problem for Windows but not for the MacOS because on the MacOS problem was located on the native side. On MacOS window gets centered when hasPosition is false,it is set to true only when you explicitly set the [position](https://github.com/AvaloniaUI/Avalonia/blob/master/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm#L403-L405). Now we store the latest window position when we hide window too and when we show the Window again it is shown on the previous position instead of being centered

