### PR TITLE
Use embedded pdb for analyzers and build tasks

### DIFF
--- a/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
+++ b/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0</TargetFrameworks>
-        <OutputType>exe</OutputType>
-        <GenerateDocumentationFile>false</GenerateDocumentationFile>
-        <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
-        <DefineConstants>$(DefineConstants);BUILDTASK;XAMLX_CECIL_INTERNAL;XAMLX_INTERNAL</DefineConstants>
-        <CopyLocalLockFileAssemblies Condition="$(TargetFramework) == 'netstandard2.0'">true</CopyLocalLockFileAssemblies>
-        <NoWarn>$(NoWarn);NU1605;CS8632</NoWarn>
+      <TargetFrameworks>netstandard2.0</TargetFrameworks>
+      <OutputType>exe</OutputType>
+      <GenerateDocumentationFile>false</GenerateDocumentationFile>
+      <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
+      <DefineConstants>$(DefineConstants);BUILDTASK;XAMLX_CECIL_INTERNAL;XAMLX_INTERNAL</DefineConstants>
+      <CopyLocalLockFileAssemblies Condition="$(TargetFramework) == 'netstandard2.0'">true</CopyLocalLockFileAssemblies>
+      <NoWarn>$(NoWarn);NU1605;CS8632</NoWarn>
+      <DebugType>embedded</DebugType>
+      <IncludeSymbols>false</IncludeSymbols>
     </PropertyGroup>
 
     <!--Disable Net Perf. analyzer for submodule to avoid commit issue -->

--- a/src/tools/Avalonia.Analyzers/Avalonia.Analyzers.csproj
+++ b/src/tools/Avalonia.Analyzers/Avalonia.Analyzers.csproj
@@ -4,6 +4,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <PackageId>Avalonia.Analyzers</PackageId>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <DebugType>embedded</DebugType>
     <IsPackable>true</IsPackable>
     <IncludeSymbols>false</IncludeSymbols>
     <IsRoslynComponent>true</IsRoslynComponent>

--- a/src/tools/Avalonia.Generators/Avalonia.Generators.csproj
+++ b/src/tools/Avalonia.Generators/Avalonia.Generators.csproj
@@ -4,6 +4,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <PackageId>Avalonia.Generators</PackageId>
     <DefineConstants>$(DefineConstants);XAMLX_INTERNAL</DefineConstants>
+    <DebugType>embedded</DebugType>
     <IsPackable>true</IsPackable>
     <IncludeSymbols>false</IncludeSymbols>
     <IsRoslynComponent>true</IsRoslynComponent>


### PR DESCRIPTION
After #12216, symbol packages are generated.
However, nuget.org rejects symbol packages having pdb for assemblies that aren't in the `lib` folder.

Symbols are now back to embedded for these files only.
Since they're development dependencies it won't impact app published size.
