### PR TITLE
Fix not working hotkey on a custom control. closes #12323

### DIFF
--- a/src/Avalonia.Controls/HotkeyManager.cs
+++ b/src/Avalonia.Controls/HotkeyManager.cs
@@ -149,10 +149,10 @@ namespace Avalonia.Controls
                     return;
 
                 var control = args.Sender as Control;
-                if (control is not IClickableControl)
+                if (control is not IClickableControl and not ICommandSource)
                 {
                     Logging.Logger.TryGet(Logging.LogEventLevel.Warning, Logging.LogArea.Control)?.Log(control,
-                        $"The element {args.Sender.GetType().Name} does not implement IClickableControl and does not support binding a HotKey ({args.NewValue}).");
+                        $"The element {args.Sender.GetType().Name} does not implement IClickableControl nor ICommandSource and does not support binding a HotKey ({args.NewValue}).");
                     return;
                 }
 

--- a/tests/Avalonia.Controls.UnitTests/HotKeyedControlsTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/HotKeyedControlsTests.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Windows.Input;
+using Avalonia.Input;
+using Avalonia.Input.Raw;
+using Avalonia.LogicalTree;
+using Avalonia.Platform;
+using Avalonia.UnitTests;
+using Moq;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests
+{
+    internal class HotKeyedTextBox : TextBox, ICommandSource
+    {
+        private class DelegateCommand : ICommand
+        {
+            private readonly Action _action;
+            public DelegateCommand(Action action) => _action = action;
+            public event EventHandler CanExecuteChanged { add { } remove { } }
+            public bool CanExecute(object parameter) => true;
+            public void Execute(object parameter) => _action();
+        }
+        
+        public static readonly StyledProperty<KeyGesture> HotKeyProperty =
+            HotKeyManager.HotKeyProperty.AddOwner<HotKeyedTextBox>();
+
+        private KeyGesture _hotkey;
+
+        public KeyGesture HotKey
+        {
+            get => GetValue(HotKeyProperty);
+            set => SetValue(HotKeyProperty, value);
+        }
+
+        protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
+        {
+            if (_hotkey != null)
+            {
+                this.SetValue(HotKeyProperty, _hotkey);
+            }
+
+            base.OnAttachedToLogicalTree(e);
+        }
+
+        protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)
+        {
+            if (this.HotKey != null)
+            {
+                _hotkey = this.HotKey;
+                this.SetValue(HotKeyProperty, null);
+            }
+
+            base.OnDetachedFromLogicalTree(e);
+        }
+
+        public void CanExecuteChanged(object sender, EventArgs e)
+        {
+        }
+
+        protected override Type StyleKeyOverride => typeof(TextBox);
+
+        public ICommand Command => _command;
+
+        public object CommandParameter => null;
+
+        private readonly DelegateCommand _command;
+
+        public HotKeyedTextBox()
+        {
+            _command = new DelegateCommand(() => Focus());
+        }
+    }
+
+    public class HotKeyedControlsTests
+    {
+        private static Window PreparedWindow(object content = null)
+        {
+            var platform = AvaloniaLocator.Current.GetRequiredService<IWindowingPlatform>();
+            var windowImpl = Mock.Get(platform.CreateWindow());
+            windowImpl.Setup(x => x.Compositor).Returns(RendererMocks.CreateDummyCompositor());
+            var w = new Window(windowImpl.Object) { Content = content };
+            w.ApplyTemplate();
+            return w;
+        }
+        
+        private static IDisposable CreateServicesWithFocus()
+        {
+            return UnitTestApplication.Start(
+                TestServices.StyledWindow.With(
+                    windowingPlatform: new MockWindowingPlatform(
+                        null,
+                        window => MockWindowingPlatform.CreatePopupMock(window).Object),
+                focusManager: new FocusManager(),
+                keyboardDevice: () => new KeyboardDevice()));
+        }
+        
+        [Fact]
+        public void HotKeyedTextBox_Focus_Performed_On_Hotkey()
+        {
+            using var _ = CreateServicesWithFocus();
+            
+            var keyboardDevice = new KeyboardDevice();
+            var hotKeyedTextBox = new HotKeyedTextBox { HotKey = new KeyGesture(Key.F, KeyModifiers.Control) };
+            var root = PreparedWindow();
+            root.Content = hotKeyedTextBox;
+            root.Show();
+
+            Assert.False(hotKeyedTextBox.IsFocused);
+
+            keyboardDevice.ProcessRawEvent(
+                new RawKeyEventArgs(
+                    keyboardDevice,
+                    0,
+                    root,
+                    RawKeyEventType.KeyDown,
+                    Key.F,
+                    RawInputModifiers.Control));
+            
+            Assert.True(hotKeyedTextBox.IsFocused);
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
Registration of hotkeys for controls that do not implement `Avalonia.Input.IClickableControl` but implement `Avalonia.Input.ICommandSource` is possible now.


## What is the current behavior?
Current behavior is broken/regression compare to Avalona v0.10. Currently, in Avalonia v11, you can declare type `HotKeyedTextBox` inherited from `Avalonia.Controls.TextBox` with implemented `HotKey` property, but it will not work, **but** in Avalonia v0.10 it will work. Example with working hotkey registration for custom type `HotKeyedTextBox` inherited from `Avalonia.Controls.TextBox` for Avalonia v0.10.21 and not working hotkey registration for custom type `HotKeyedTextBox` inherited from `Avalonia.Controls.TextBox` for Avalonia V11 [here](https://github.com/flexxxxer/Avalonia.V11.HotKeyedControlBug). Curren behavior was created by #7500.


## What is the updated/expected behavior with this PR?
When declaring of custom control with proper implementation of `HotKey` property possible and hotkey working as expected, like in Avalonia v0.10.


## How was the solution implemented (if it's not obvious)?
In `Avalonia.Controls.HotKeyManager.HotKeyManager()` (static constructor) condition has been changed from `if (control is not IClickableControl)` to `if (control is not IClickableControl and not ICommandSource)`.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #12323
