### PR TITLE
X11 clipboard incr proto

### DIFF
--- a/src/Avalonia.X11/X11Clipboard.cs
+++ b/src/Avalonia.X11/X11Clipboard.cs
@@ -168,9 +168,9 @@ namespace Avalonia.X11
                     if (_incrReadTargetAtom == actualTypeAtom && (int)nitems > 0)
                     {
                         var chunkSize = (int)nitems * (actualFormat / 8);
-                        var buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(chunkSize);
+                        var buffer = new byte[chunkSize];
                         Marshal.Copy(prop, buffer, 0, chunkSize);
-                        _incrReadData.AddRange(buffer.Take(chunkSize));
+                        _incrReadData.AddRange(buffer);
                     }
                     else
                     {

--- a/src/Avalonia.X11/X11Clipboard.cs
+++ b/src/Avalonia.X11/X11Clipboard.cs
@@ -227,6 +227,9 @@ namespace Avalonia.X11
                 var atoms = ConvertDataObject(_storedDataObject);
                 XChangeProperty(_x11.Display, window, property,
                     _x11.Atoms.XA_ATOM, 32, PropertyMode.Replace, atoms, atoms.Length);
+
+                if (UseIncrProtocol(_storedDataObject))
+                    _storeAtomTcs?.TrySetResult(true);
                 return property;
             }
 

--- a/src/Avalonia.X11/X11Clipboard.cs
+++ b/src/Avalonia.X11/X11Clipboard.cs
@@ -174,10 +174,8 @@ namespace Avalonia.X11
             {
                 XGetWindowProperty(_x11.Display, window, property, IntPtr.Zero, new IntPtr(0x7fffffff), false,
                     _x11.Atoms.ATOM_PAIR, out _, out var actualFormat, out var nitems, out _, out var prop);
-                if (nitems == IntPtr.Zero)
-                    return IntPtr.Zero;
-                    
-                if (actualFormat == 32)
+
+                if (nitems != IntPtr.Zero && actualFormat == 32)
                 {
                     var data = (IntPtr*)prop.ToPointer();
                     for (var c = 0; c < nitems.ToInt32(); c += 2)

--- a/src/Avalonia.X11/X11Clipboard.cs
+++ b/src/Avalonia.X11/X11Clipboard.cs
@@ -50,17 +50,17 @@ namespace Avalonia.X11
                         ? Encoding.Unicode
                         : null;
         }
-        
+
         private unsafe void OnEvent(ref XEvent ev)
         {
             if (ev.type == XEventName.SelectionClear)
-            {   
+            {
                 _storeAtomTcs?.TrySetResult(true);
                 return;
             }
 
             if (ev.type == XEventName.SelectionRequest)
-            {       
+            {
                 var sel = ev.SelectionRequestEvent;
                 var resp = new XEvent
                 {
@@ -80,7 +80,7 @@ namespace Avalonia.X11
                 {
                     resp.SelectionEvent.property = WriteTargetToProperty(sel.target, sel.requestor, sel.property);
                 }
-                
+
                 XSendEvent(_x11.Display, sel.requestor, false, new IntPtr((int)EventMask.NoEventMask), ref resp);
             }
 
@@ -94,15 +94,15 @@ namespace Avalonia.X11
                         _x11.Atoms.XA_ATOM, 32, PropertyMode.Replace, atoms, atoms.Length);
                     return property;
                 }
-                else if(target == _x11.Atoms.SAVE_TARGETS && _x11.Atoms.SAVE_TARGETS != IntPtr.Zero)
+                else if (target == _x11.Atoms.SAVE_TARGETS && _x11.Atoms.SAVE_TARGETS != IntPtr.Zero)
                 {
                     return property;
                 }
-                else if ((textEnc = GetStringEncoding(target)) != null 
+                else if ((textEnc = GetStringEncoding(target)) != null
                          && _storedDataObject?.Contains(DataFormats.Text) == true)
                 {
                     var text = _storedDataObject.GetText();
-                    if(text == null)
+                    if (text == null)
                         return IntPtr.Zero;
                     var data = textEnc.GetBytes(text);
                     fixed (void* pdata = data)
@@ -136,11 +136,11 @@ namespace Avalonia.X11
 
                     return property;
                 }
-                else if(_storedDataObject?.Contains(_x11.Atoms.GetAtomName(target)) == true)
+                else if (_storedDataObject?.Contains(_x11.Atoms.GetAtomName(target)) == true)
                 {
                     var objValue = _storedDataObject.Get(_x11.Atoms.GetAtomName(target));
-                    
-                    if(!(objValue is byte[] bytes))
+
+                    if (!(objValue is byte[] bytes))
                     {
                         if (objValue is string s)
                             bytes = Encoding.UTF8.GetBytes(s);
@@ -165,7 +165,7 @@ namespace Avalonia.X11
                     _requestedFormatsTcs?.TrySetResult(null);
                     _requestedDataTcs?.TrySetResult(null);
                 }
-                XGetWindowProperty(_x11.Display, _handle, sel.property, IntPtr.Zero, new IntPtr (0x7fffffff), true, (IntPtr)Atom.AnyPropertyType,
+                XGetWindowProperty(_x11.Display, _handle, sel.property, IntPtr.Zero, new IntPtr(0x7fffffff), true, (IntPtr)Atom.AnyPropertyType,
                     out var actualTypeAtom, out var actualFormat, out var nitems, out var bytes_after, out var prop);
                 Encoding textEnc = null;
                 if (nitems == IntPtr.Zero)
@@ -229,7 +229,7 @@ namespace Avalonia.X11
         }
 
         private bool HasOwner => XGetSelectionOwner(_x11.Display, _x11.Atoms.CLIPBOARD) != IntPtr.Zero;
-        
+
         public async Task<string> GetTextAsync()
         {
             if (!HasOwner)
@@ -238,7 +238,7 @@ namespace Avalonia.X11
             var target = _x11.Atoms.UTF8_STRING;
             if (res != null)
             {
-                var preferredFormats = new[] {_x11.Atoms.UTF16_STRING, _x11.Atoms.UTF8_STRING, _x11.Atoms.XA_STRING};
+                var preferredFormats = new[] { _x11.Atoms.UTF16_STRING, _x11.Atoms.UTF8_STRING, _x11.Atoms.XA_STRING };
                 foreach (var pf in preferredFormats)
                     if (res.Contains(pf))
                     {
@@ -271,10 +271,10 @@ namespace Avalonia.X11
             {
                 var clipboardManager = XGetSelectionOwner(_x11.Display, _x11.Atoms.CLIPBOARD_MANAGER);
                 if (clipboardManager != IntPtr.Zero)
-                {          
+                {
                     if (_storeAtomTcs == null || _storeAtomTcs.Task.IsCompleted)
-                        _storeAtomTcs = new TaskCompletionSource<bool>();   
-                           
+                        _storeAtomTcs = new TaskCompletionSource<bool>();
+
                     var atoms = ConvertDataObject(data);
                     XChangeProperty(_x11.Display, _handle, _avaloniaSaveTargetsAtom, _x11.Atoms.XA_ATOM, 32,
                         PropertyMode.Replace,
@@ -302,7 +302,7 @@ namespace Avalonia.X11
         public Task SetDataObjectAsync(IDataObject data)
         {
             _storedDataObject = data;
-            XSetSelectionOwner(_x11.Display, _x11.Atoms.CLIPBOARD, _handle, IntPtr.Zero);            
+            XSetSelectionOwner(_x11.Display, _x11.Atoms.CLIPBOARD, _handle, IntPtr.Zero);
             return StoreAtomsInClipboardManager(data);
         }
 
@@ -332,7 +332,7 @@ namespace Avalonia.X11
             var res = await SendFormatRequest();
             if (!res.Contains(formatAtom))
                 return null;
-            
+
             return await SendDataRequest(formatAtom);
         }
     }

--- a/src/Avalonia.X11/X11Clipboard.cs
+++ b/src/Avalonia.X11/X11Clipboard.cs
@@ -381,7 +381,8 @@ namespace Avalonia.X11
                     string str => str.Length,
                     _ => 0
                 };
-                return dataSize > MaxRequestSize;
+                if (dataSize > MaxRequestSize)
+                    return true;
             }
             return false;
         }

--- a/src/Avalonia.X11/X11Clipboard.cs
+++ b/src/Avalonia.X11/X11Clipboard.cs
@@ -92,6 +92,7 @@ namespace Avalonia.X11
                 {
                     _requestedFormatsTcs?.TrySetResult(null);
                     _requestedDataTcs?.TrySetResult(null);
+                    return;
                 }
                 XGetWindowProperty(_x11.Display, _handle, sel.property, IntPtr.Zero, new IntPtr(0x7fffffff), true, (IntPtr)Atom.AnyPropertyType,
                     out var actualTypeAtom, out var actualFormat, out var nitems, out var bytes_after, out var prop);

--- a/src/Avalonia.X11/X11Clipboard.cs
+++ b/src/Avalonia.X11/X11Clipboard.cs
@@ -201,7 +201,7 @@ namespace Avalonia.X11
 
         private void OnIncrWritePropertyEvent(ref XEvent ev)
         {
-            if (ev.type == XEventName.PropertyNotify && (PropertyState)ev.PropertyEvent.state == PropertyState.Delete && ev.PropertyEvent.atom == _incrWriteTargetAtom)
+            if (ev.type == XEventName.PropertyNotify && (PropertyState)ev.PropertyEvent.state == PropertyState.Delete)
             {
                 if (_incrWriteData?.Length > 0)
                 {
@@ -277,7 +277,7 @@ namespace Avalonia.X11
                         return IntPtr.Zero;
                 }
 
-                if (bytes.Length > MaxRequestSize)
+                if (bytes.Length > MaxRequestSize && window != _handle)
                 {
                     _incrWriteTargetAtom = target;
                     _incrWriteWindow = window;

--- a/src/Avalonia.X11/X11Clipboard.cs
+++ b/src/Avalonia.X11/X11Clipboard.cs
@@ -24,6 +24,8 @@ namespace Avalonia.X11
         {
             _x11 = platform.Info;
             _handle = CreateEventWindow(platform, OnEvent);
+            XSelectInput(_x11.Display, _handle, new IntPtr((int)(EventMask.StructureNotifyMask | EventMask.PropertyChangeMask)));
+
             _avaloniaSaveTargetsAtom = XInternAtom(_x11.Display, "AVALONIA_SAVE_TARGETS_PROPERTY_ATOM", false);
             _textAtoms = new[]
             {
@@ -138,6 +140,12 @@ namespace Avalonia.X11
 
                 XFree(prop);
                 return;
+            }
+
+            if (ev.type == XEventName.PropertyNotify && (PropertyState)ev.PropertyEvent.state == PropertyState.NewValue)
+            {
+
+
             }
         }
 

--- a/src/Avalonia.X11/X11Clipboard.cs
+++ b/src/Avalonia.X11/X11Clipboard.cs
@@ -26,7 +26,7 @@ namespace Avalonia.X11
         private IntPtr _incrWriteWindow;
         private IntPtr _incrWriteProperty;
         private byte[] _incrWriteData;
-        private const int MaxRequestSize = 0x40000;
+        private int _chunk_size;
 
         public X11Clipboard(AvaloniaX11Platform platform)
         {
@@ -50,6 +50,13 @@ namespace Avalonia.X11
             _incrWriteWindow = IntPtr.Zero;
             _incrWriteProperty = IntPtr.Zero;
             _incrWriteData = null;
+
+            _chunk_size = (int)(XExtendedMaxRequestSize(_x11.Display) / 4);
+            if (_chunk_size == 0)
+            {
+                _chunk_size = (int)(XMaxRequestSize(_x11.Display) / 4);
+            }
+            System.Diagnostics.Debug.WriteLine($"X11Clipboard chunk_size: {_chunk_size}");
         }
 
         private bool IsStringAtom(IntPtr atom)
@@ -224,7 +231,7 @@ namespace Avalonia.X11
             {
                 if (_incrWriteData?.Length > 0)
                 {
-                    var bytes = _incrWriteData.Take(MaxRequestSize).ToArray();
+                    var bytes = _incrWriteData.Take(_chunk_size).ToArray();
                     _incrWriteData = _incrWriteData.Skip(bytes.Length).ToArray();
                     XChangeProperty(_x11.Display, _incrWriteWindow, _incrWriteProperty, _incrWriteTargetAtom, 8, PropertyMode.Replace, bytes, bytes.Length);
                     // System.Diagnostics.Debug.WriteLine($" ---- OnWritePropertyEvent 2 INCR target:{_incrWriteTargetAtom:X}, window:{_incrWriteWindow:X}, property:{_incrWriteProperty:X}, size:{bytes.Length}");
@@ -296,7 +303,7 @@ namespace Avalonia.X11
                         return IntPtr.Zero;
                 }
 
-                if (bytes.Length > MaxRequestSize)
+                if (bytes.Length > _chunk_size)
                 {
                     _incrWriteTargetAtom = target;
                     _incrWriteWindow = window;

--- a/src/Avalonia.X11/X11Clipboard.cs
+++ b/src/Avalonia.X11/X11Clipboard.cs
@@ -300,7 +300,10 @@ namespace Avalonia.X11
                         bytes = textEnc.GetBytes(s);
                     }
                     else
+                    {
+                        _storeAtomTcs?.TrySetResult(true);
                         return IntPtr.Zero;
+                    }
                 }
 
                 if (bytes.Length > MaxRequestSize && window != _handle)

--- a/src/Avalonia.X11/X11Structs.cs
+++ b/src/Avalonia.X11/X11Structs.cs
@@ -1185,6 +1185,11 @@ namespace Avalonia.X11 {
 		Prepend			= 1,
 		Append			= 2
 	}
+    	
+    internal enum PropertyState {
+		NewValue		= 0,
+		Delete			= 1
+	}
 
 	[StructLayout (LayoutKind.Sequential)]
 	internal struct XKeyBoardState {

--- a/src/Avalonia.X11/XLib.cs
+++ b/src/Avalonia.X11/XLib.cs
@@ -542,8 +542,14 @@ namespace Avalonia.X11
         public static extern bool XGetEventData(IntPtr display, void* cookie);
 
         [DllImport(libX11)]
-        public static extern void XFreeEventData(IntPtr display, void* cookie);
-        
+        public static extern void XFreeEventData(IntPtr display, void* cookie);        
+
+        [DllImport(libX11)]
+        public static extern long XMaxRequestSize(IntPtr diplay);
+
+        [DllImport(libX11)]
+        public static extern long XExtendedMaxRequestSize(IntPtr diplay);
+
         [DllImport(libX11Randr)]
         public static extern int XRRQueryExtension (IntPtr dpy,
             out int event_base_return,

--- a/src/Avalonia.X11/XLib.cs
+++ b/src/Avalonia.X11/XLib.cs
@@ -542,14 +542,8 @@ namespace Avalonia.X11
         public static extern bool XGetEventData(IntPtr display, void* cookie);
 
         [DllImport(libX11)]
-        public static extern void XFreeEventData(IntPtr display, void* cookie);        
-
-        [DllImport(libX11)]
-        public static extern long XMaxRequestSize(IntPtr diplay);
-
-        [DllImport(libX11)]
-        public static extern long XExtendedMaxRequestSize(IntPtr diplay);
-
+        public static extern void XFreeEventData(IntPtr display, void* cookie);
+        
         [DllImport(libX11Randr)]
         public static extern int XRRQueryExtension (IntPtr dpy,
             out int event_base_return,


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
improving the functionality of the X11 clipboard::
- Implement the INCR protocol (process a large amount of data from other applications)
- some minor fixes
- refactoring the X11Clipboard code (OnEvent callback and WriteTargetToProperty)
- code format the X11Clipboard code

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The INCR protocol is not implemented. (https://x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#id2588019)

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Ability to copy/paste data larger than 256 KB

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Sending/receiving data in chunks of 256 k bytes. 
_Using the XExtendedMaxRequestSize/XMaxRequestSize methods to get the fragment size supported by the system was unsuccessful because CLIPBOARD_MANAGER has a hard-coded value of 256 KB (Linux Ubuntu 18/22 and Mint 21.1 Mate)_

_Testing was performed via the Clipboard Page in samples/Control Catalog(together with the image from the clipboard PR #12246)_
