### PR TITLE
feat(NumericUpDown): TextAlignment

### DIFF
--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -126,6 +126,12 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<VerticalAlignment> VerticalContentAlignmentProperty =
             ContentControl.VerticalContentAlignmentProperty.AddOwner<NumericUpDown>();
 
+        /// <summary>
+        /// Defines the <see cref="TextAlignment"/> property
+        /// </summary>
+        public static readonly StyledProperty<Media.TextAlignment> TextAlignmentProperty =
+            TextBox.TextAlignmentProperty.AddOwner<NumericUpDown>();
+
         private IDisposable? _textBoxTextChangedSubscription;
 
         private bool _internalValueSet;
@@ -297,6 +303,15 @@ namespace Avalonia.Controls
         {
             get => GetValue(VerticalContentAlignmentProperty);
             set => SetValue(VerticalContentAlignmentProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Media.TextAlignment"/> of the <see cref="NumericUpDown"/>
+        /// </summary>
+        public Media.TextAlignment TextAlignment
+        {
+            get => GetValue(TextAlignmentProperty);
+            set => SetValue(TextAlignmentProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Themes.Fluent/Controls/NumericUpDown.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/NumericUpDown.xaml
@@ -57,6 +57,7 @@
                    VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                    Text="{TemplateBinding Text}"
+                   TextAlignment="{TemplateBinding TextAlignment}"
                    AcceptsReturn="False"
                    TextWrapping="NoWrap" />
         </ButtonSpinner>

--- a/src/Avalonia.Themes.Simple/Controls/NumericUpDown.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/NumericUpDown.xaml
@@ -31,6 +31,7 @@
                    DataValidationErrors.Errors="{TemplateBinding (DataValidationErrors.Errors)}"
                    IsReadOnly="{TemplateBinding IsReadOnly}"
                    Text="{TemplateBinding Text}"
+                   TextAlignment="{TemplateBinding TextAlignment}"
                    TextWrapping="NoWrap"
                    Watermark="{TemplateBinding Watermark}" />
         </ButtonSpinner>


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Add TextAlignment property to NumericUpDown

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

It doesn't have the TextAlignment property. To change the alignment you need to create a style selector like this:

```xaml
    <Style Selector="NumericUpDown /template/ TextBox#PART_TextBox">
      <Setter Property="TextAlignment" Value="Right"/>
    </Style>
```
This solution has the disadvantage of strictly depending on the theme used.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes #12367