### PR TITLE
Catch dbus errors so that WatchAsync can register all names

### DIFF
--- a/src/Avalonia.FreeDesktop/DBusIme/DBusTextInputMethodBase.cs
+++ b/src/Avalonia.FreeDesktop/DBusIme/DBusTextInputMethodBase.cs
@@ -62,9 +62,15 @@ namespace Avalonia.FreeDesktop.DBusIme
             foreach (var name in _knownNames)
             {
                 var dbus = new OrgFreedesktopDBus(Connection, "org.freedesktop.DBus", "/org/freedesktop/DBus");
-                _disposables.Add(await dbus.WatchNameOwnerChangedAsync(OnNameChange));
-                var nameOwner = await dbus.GetNameOwnerAsync(name);
-                OnNameChange(null, (name, null, nameOwner));
+                try
+                {
+                    _disposables.Add(await dbus.WatchNameOwnerChangedAsync(OnNameChange));
+                    var nameOwner = await dbus.GetNameOwnerAsync(name);
+                    OnNameChange(null, (name, null, nameOwner));
+                }
+                catch (DBusException)
+                {
+                }
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
Fixes #12371 


## What is the current behavior?
for loop exits early due to exception calling GetNameOwnerAsync and doesn't register every name.


## What is the updated/expected behavior with this PR?
Catch exceptions from GetNameOwnerAsync so the for loop can continue


## Checklist

- [ ] Added unit tests (if possible)?

- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #12371 
