### PR TITLE
Add null check for TextInputMethodClient in OnSelectionChanged() method

### DIFF
--- a/src/Android/Avalonia.Android/AndroidInputMethod.cs
+++ b/src/Android/Avalonia.Android/AndroidInputMethod.cs
@@ -113,6 +113,11 @@ namespace Avalonia.Android
 
         private void OnSelectionChanged()
         {
+            if (Client is null)
+            {
+                return;
+            }
+
             var selection = Client.Selection;
 
             _imm.UpdateSelection(_host, selection.Start, selection.End, selection.Start, selection.End);


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
When a text input element loses focus while typing, app crashes with NRE.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When a text input element loses focus while typing, the Client is null here
![изображение](https://github.com/AvaloniaUI/Avalonia/assets/23534700/ce1637d1-9c3a-4c3e-a047-c415ce228ae7)

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Add check for null for the Client

## Fixed issues
Fixes #12413
