### PR TITLE
Fix TabItem memory leak

### DIFF
--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -312,9 +312,14 @@ namespace Avalonia.Controls
 
         private void UpdateTabStripPlacement()
         {
-            for (int i = 0; i < Items.Count; i++)
+            var controls = ItemsPresenterPart?.Panel?.Children;
+            if (controls is null)
             {
-                var control = ContainerFromIndex(i);
+                return;
+            }
+
+            foreach (var control in controls)
+            {
                 if (control is TabItem tabItem)
                 {
                     tabItem.TabStripPlacement = TabStripPlacement;

--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -73,6 +73,7 @@ namespace Avalonia.Controls
         {
             SelectionModeProperty.OverrideDefaultValue<TabControl>(SelectionMode.AlwaysSelected);
             ItemsPanelProperty.OverrideDefaultValue<TabControl>(DefaultPanel);
+            TabStripPlacementProperty.Changed.AddClassHandler<TabControl>((x, e) => x.UpdateTabStripPlacement());
             AffectsMeasure<TabControl>(TabStripPlacementProperty);
             SelectedItemProperty.Changed.AddClassHandler<TabControl>((x, e) => x.UpdateSelectedContent());
             AutomationProperties.ControlTypeOverrideProperty.OverrideDefaultValue<TabControl>(AutomationControlType.Tab);
@@ -153,7 +154,7 @@ namespace Avalonia.Controls
 
         protected internal override Control CreateContainerForItemOverride(object? item, int index, object? recycleKey)
         {
-            return new TabItem();
+            return new TabItem { TabStripPlacement = TabStripPlacement };
         }
 
         protected internal override bool NeedsContainerOverride(object? item, int index, out object? recycleKey)
@@ -228,6 +229,8 @@ namespace Avalonia.Controls
         {
             ItemsPresenterPart = e.NameScope.Find<ItemsPresenter>("PART_ItemsPresenter");
             ItemsPresenterPart?.ApplyTemplate();
+
+            UpdateTabStripPlacement();
 
             // Set TabNavigation to Once on the panel if not already set and
             // forward the TabOnceActiveElement to the panel.
@@ -304,6 +307,18 @@ namespace Avalonia.Controls
                 KeyboardNavigation.SetTabOnceActiveElement(
                     panel,
                     change.GetNewValue<IInputElement?>());
+            }
+        }
+
+        private void UpdateTabStripPlacement()
+        {
+            for (int i = 0; i < Items.Count; i++)
+            {
+                var control = ContainerFromIndex(i);
+                if (control is TabItem tabItem)
+                {
+                    tabItem.TabStripPlacement = TabStripPlacement;
+                }
             }
         }
     }

--- a/src/Avalonia.Controls/TabItem.cs
+++ b/src/Avalonia.Controls/TabItem.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Automation;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Metadata;
@@ -57,6 +58,11 @@ namespace Avalonia.Controls
         }
 
         protected override AutomationPeer OnCreateAutomationPeer() => new ListItemAutomationPeer(this);
+
+        [Obsolete("Owner manages its children properties by itself")]
+        protected void SubscribeToOwnerProperties(AvaloniaObject owner)
+        {
+        }
 
         private void UpdateHeader(AvaloniaPropertyChangedEventArgs obj)
         {

--- a/src/Avalonia.Controls/TabItem.cs
+++ b/src/Avalonia.Controls/TabItem.cs
@@ -75,6 +75,14 @@ namespace Avalonia.Controls
             }
         }
 
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            _ownerSubscriptions?.Dispose();
+            _ownerSubscriptions = null;
+
+            base.OnDetachedFromVisualTree(e);
+        }
+
         protected void SubscribeToOwnerProperties(AvaloniaObject owner)
         {
             _ownerSubscriptions = owner.GetObservable(TabControl.TabStripPlacementProperty).Subscribe(v => TabStripPlacement = v);

--- a/src/Avalonia.Controls/TabItem.cs
+++ b/src/Avalonia.Controls/TabItem.cs
@@ -1,11 +1,8 @@
-using System;
 using Avalonia.Automation;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Mixins;
 using Avalonia.Controls.Primitives;
-using Avalonia.Reactive;
-using Avalonia.VisualTree;
 
 namespace Avalonia.Controls
 {
@@ -16,7 +13,6 @@ namespace Avalonia.Controls
     public class TabItem : HeaderedContentControl, ISelectable
     {
         private Dock? _tabStripPlacement;
-        private IDisposable? _ownerSubscriptions;
 
         /// <summary>
         /// Defines the <see cref="TabStripPlacement"/> property.
@@ -48,7 +44,7 @@ namespace Avalonia.Controls
         public Dock? TabStripPlacement
         {
             get => _tabStripPlacement;
-            private set => SetAndRaise(TabStripPlacementProperty, ref _tabStripPlacement, value);
+            internal set => SetAndRaise(TabStripPlacementProperty, ref _tabStripPlacement, value);
         }
 
         /// <summary>
@@ -61,32 +57,6 @@ namespace Avalonia.Controls
         }
 
         protected override AutomationPeer OnCreateAutomationPeer() => new ListItemAutomationPeer(this);
-
-        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
-        {
-            base.OnAttachedToVisualTree(e);
-
-            _ownerSubscriptions?.Dispose();
-            _ownerSubscriptions = null;
-
-            if (this.FindAncestorOfType<TabControl>() is { } owner && owner.IndexFromContainer(this) != -1)
-            {
-                SubscribeToOwnerProperties(owner);
-            }
-        }
-
-        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
-        {
-            _ownerSubscriptions?.Dispose();
-            _ownerSubscriptions = null;
-
-            base.OnDetachedFromVisualTree(e);
-        }
-
-        protected void SubscribeToOwnerProperties(AvaloniaObject owner)
-        {
-            _ownerSubscriptions = owner.GetObservable(TabControl.TabStripPlacementProperty).Subscribe(v => TabStripPlacement = v);
-        }
 
         private void UpdateHeader(AvaloniaPropertyChangedEventArgs obj)
         {


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Moves update of `TabStripPlacement` to `TabContol`.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Subscription is not disposed and `TabItem` controls remain in memory.

## Fixed issues
Fixes #12416
