### PR TITLE
Fix issue #12453, TextBox does not scroll at the end of line when entering CJK characters via IME

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -832,6 +832,8 @@ namespace Avalonia.Controls.Presenters
             else
             {
                 UpdateCaret(new CharacterHit(CaretIndex + preeditText.Length), false);
+                InvalidateMeasure();
+                CaretChanged();
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix the issue #12453 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When entering CJK characters via IME, the TextBox does not scroll even caret reaching left end of the box

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
TextBox scrolling each time you press a key and character is added to the preedit text

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #12453
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #12453
Fixes #456
-->
