### PR TITLE
Fix SplitButton commanding on KeyUp when there was no KeyDown before

### DIFF
--- a/src/Avalonia.Controls/SplitButton/SplitButton.cs
+++ b/src/Avalonia.Controls/SplitButton/SplitButton.cs
@@ -331,14 +331,17 @@ namespace Avalonia.Controls
 
             if (key == Key.Space || key == Key.Enter) // Key.GamepadA is not currently supported
             {
-                _isKeyboardPressed = false;
-                UpdatePseudoClasses();
-
-                // Consider this a click on the primary button
-                if (IsEffectivelyEnabled)
+                if (_isKeyboardPressed)
                 {
-                    OnClickPrimary(null);
-                    e.Handled = true;
+                    _isKeyboardPressed = false;
+                    UpdatePseudoClasses();
+
+                    // Consider this a click on the primary button
+                    if (IsEffectivelyEnabled)
+                    {
+                        OnClickPrimary(null);
+                        e.Handled = true;
+                    }
                 }
             }
             else if (key == Key.Down && e.KeyModifiers.HasAllFlags(KeyModifiers.Alt) && IsEffectivelyEnabled)


### PR DESCRIPTION
See #12320 

## What does the pull request do?
There was an issue with SplitButton when you add a FilePicker command and you close the FilePicker by pressing Enter on the filename's textbox. 

The FilePicker receive the KeyDown event.
The SplitButton reveive the KeyUp event and call the command a second time.

The fix check that Enter was pressed on KeyDown in addition to KeyUp to trigger the command.

## Fixed issues
Fixes #12320 
