### PR TITLE
fix: AvaloniaVS can not resolve resource relative path in Previewer

### DIFF
--- a/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
+++ b/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
@@ -29,7 +29,7 @@ namespace Avalonia.DesignerSupport
                 if (assemblyPath != null)
                 {
                     if (xamlFileProjectPath == null)
-                        xamlFileProjectPath = "/Designer/Fake.xaml";
+                        xamlFileProjectPath = "/Fake.xaml";
                     //Fabricate fake Uri
                     baseUri =
                         new Uri($"avares://{Path.GetFileNameWithoutExtension(assemblyPath)}{xamlFileProjectPath}");
@@ -43,7 +43,7 @@ namespace Avalonia.DesignerSupport
                 {
                     LocalAssembly = localAsm,
                     DesignMode = true,
-                    UseCompiledBindingsByDefault = bool.TryParse(useCompiledBindings, out var parsedValue ) && parsedValue 
+                    UseCompiledBindingsByDefault = bool.TryParse(useCompiledBindings, out var parsedValue) && parsedValue
                 });
                 var style = loaded as IStyle;
                 var resources = loaded as ResourceDictionary;
@@ -90,14 +90,14 @@ namespace Avalonia.DesignerSupport
                         };
                 }
                 else if (loaded is Application)
-                    control = new TextBlock {Text = "Application can't be previewed in design view"};
+                    control = new TextBlock { Text = "Application can't be previewed in design view" };
                 else
-                    control = (Control) loaded;
+                    control = (Control)loaded;
 
                 window = control as Window;
                 if (window == null)
                 {
-                    window = new Window() {Content = (Control)control};
+                    window = new Window() { Content = (Control)control };
                 }
 
                 if (window.PlatformImpl is OffscreenTopLevelImplBase offscreenImpl)


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix baseUri

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

When using xaml like this:

```xaml
<Application xmlns="https://github.com/avaloniaui"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
             xmlns:local="using:ACTest"
             x:Class="ACTest.App">
  <Application.DataTemplates>
    <local:ViewLocator/>
  </Application.DataTemplates>

  <Application.Resources>
    <ResourceDictionary>
      <ResourceDictionary.MergedDictionaries>
        <ResourceInclude Source="Icons.axaml" />
      </ResourceDictionary.MergedDictionaries>

    </ResourceDictionary>

  </Application.Resources>

  <Application.Styles>
    <FluentTheme/>
  </Application.Styles>
</Application>
```
When opening Designer, the following error is reported

```cmd
Unable to resolve XAML resource "avares://ACTest/Designer/Icons.axaml" in the "ACTest" assembly. Line 12, position 26.	ACTest	C:\Users\Utente\Source\Repos\ACTest\ACTest\App.axaml	12	
```


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

No error is raised

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes https://github.com/AvaloniaUI/AvaloniaVS/issues/324