### PR TITLE
Added support for image formats aside from PNG

### DIFF
--- a/src/Skia/Avalonia.Skia/Helpers/ImageSavingHelper.cs
+++ b/src/Skia/Avalonia.Skia/Helpers/ImageSavingHelper.cs
@@ -32,10 +32,9 @@ namespace Avalonia.Skia.Helpers
 
             var format = GetFormatFromExtension(Path.GetExtension(fileName));
 
-            using (var stream = File.Create(fileName))
-            {
-                SaveImage(image, stream, format, quality);
-            }
+            using var data = image.Encode(format, quality ?? 100) ?? throw new NotSupportedException(format.ToString());
+            using var stream = File.Create(fileName);
+            data.SaveTo(stream);
         }
 
         /// <summary>
@@ -82,6 +81,8 @@ namespace Avalonia.Skia.Helpers
                 throw new ArgumentOutOfRangeException(nameof(quality), "[0, 100]");
 
             using var data = image.Encode(format, quality ?? 100);
+            if (data is null)
+                throw new NotSupportedException(format.ToString());
             data.SaveTo(stream);
         }
 
@@ -90,12 +91,13 @@ namespace Avalonia.Skia.Helpers
             {
                 ".png" => SKEncodedImageFormat.Png,
                 ".jpg" or ".jpeg" or ".jpe" => SKEncodedImageFormat.Jpeg,
-                ".bmp" => SKEncodedImageFormat.Bmp,
-                ".gif" => SKEncodedImageFormat.Gif,
-                ".ico" => SKEncodedImageFormat.Ico,
                 ".webp" => SKEncodedImageFormat.Webp,
-                ".heif" or ".heic" => SKEncodedImageFormat.Heif,
-                ".avif" => SKEncodedImageFormat.Avif,
+                // the following formats are defined but not supported by SkiaSharp
+                //".bmp" => SKEncodedImageFormat.Bmp,
+                //".gif" => SKEncodedImageFormat.Gif,
+                //".ico" => SKEncodedImageFormat.Ico,
+                //".heif" or ".heic" => SKEncodedImageFormat.Heif,
+                //".avif" => SKEncodedImageFormat.Avif,
                 _ => GetFallbackFormat(),
             };
 

--- a/src/Skia/Avalonia.Skia/Helpers/ImageSavingHelper.cs
+++ b/src/Skia/Avalonia.Skia/Helpers/ImageSavingHelper.cs
@@ -1,5 +1,9 @@
 using System;
 using System.IO;
+using System.Threading;
+
+using Avalonia.Logging;
+
 using SkiaSharp;
 
 namespace Avalonia.Skia.Helpers
@@ -21,12 +25,16 @@ namespace Avalonia.Skia.Helpers
         /// </param>
         public static void SaveImage(SKImage image, string fileName, int? quality = null)
         {
-            if (image == null) throw new ArgumentNullException(nameof(image));
-            if (fileName == null) throw new ArgumentNullException(nameof(fileName));
+            if (image == null)
+                throw new ArgumentNullException(nameof(image));
+            if (fileName == null)
+                throw new ArgumentNullException(nameof(fileName));
+
+            var format = GetFormatFromExtension(Path.GetExtension(fileName));
 
             using (var stream = File.Create(fileName))
             {
-                SaveImage(image, stream, quality);
+                SaveImage(image, stream, format, quality);
             }
         }
 
@@ -40,25 +48,67 @@ namespace Avalonia.Skia.Helpers
         /// The quality value is interpreted from 0 - 100. If quality is null 
         /// the encoder applies the default quality value.
         /// </param>
+        [Obsolete("Use overloads that take format parameter")]
         public static void SaveImage(SKImage image, Stream stream, int? quality = null)
         {
-            if (image == null) throw new ArgumentNullException(nameof(image));
-            if (stream == null) throw new ArgumentNullException(nameof(stream));
+            if (image == null)
+                throw new ArgumentNullException(nameof(image));
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
 
-            if (quality == null)
+            using var data = image.Encode();
+            data.SaveTo(stream);
+        }
+
+        /// <summary>
+        /// Save Skia image to a stream.
+        /// </summary>
+        /// <param name="image">Image to save</param>
+        /// <param name="stream">The output stream to save the image.</param>
+        /// <param name="format">The file format used to encode the image.</param>
+        /// <param name="quality">
+        /// The optional quality setting for image encoder. 
+        /// The quality value is interpreted from 0 - 100. If quality is null 
+        /// the encoder applies the default quality value. 
+        /// Some formats completely ignore this value.
+        /// </param>
+        public static void SaveImage(SKImage image, Stream stream, SKEncodedImageFormat format, int? quality = null)
+        {
+            if (image == null)
+                throw new ArgumentNullException(nameof(image));
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+            if (quality < 0 || quality > 100)
+                throw new ArgumentOutOfRangeException(nameof(quality), "[0, 100]");
+
+            using var data = image.Encode(format, quality ?? 100);
+            data.SaveTo(stream);
+        }
+
+        private static SKEncodedImageFormat GetFormatFromExtension(string extension)
+            => extension.ToLowerInvariant() switch
             {
-                using (var data = image.Encode())
-                {
-                    data.SaveTo(stream);
-                }
-            }
-            else
+                ".png" => SKEncodedImageFormat.Png,
+                ".jpg" or ".jpeg" or ".jpe" => SKEncodedImageFormat.Jpeg,
+                ".bmp" => SKEncodedImageFormat.Bmp,
+                ".gif" => SKEncodedImageFormat.Gif,
+                ".ico" => SKEncodedImageFormat.Ico,
+                ".webp" => SKEncodedImageFormat.Webp,
+                ".heif" or ".heic" => SKEncodedImageFormat.Heif,
+                ".avif" => SKEncodedImageFormat.Avif,
+                _ => GetFallbackFormat(),
+            };
+
+        private static int s_warnedAboutFallback = 0;
+        private static SKEncodedImageFormat GetFallbackFormat()
+        {
+            if (Interlocked.CompareExchange(ref s_warnedAboutFallback, 1, 0) == 0)
             {
-                using (var data = image.Encode(SKEncodedImageFormat.Png, (int)quality))
-                {
-                    data.SaveTo(stream);
-                }
+                Logger.TryGet(LogEventLevel.Warning, nameof(Skia))
+                    ?.Log(null, "Obsolete behavior: can not deduce image format from extension. Will throw an exception in the future. For now using PNG.");
             }
+
+            return SKEncodedImageFormat.Png;
         }
 
         // This method is here mostly for debugging purposes

--- a/src/Skia/Avalonia.Skia/ImmutableBitmap.cs
+++ b/src/Skia/Avalonia.Skia/ImmutableBitmap.cs
@@ -161,10 +161,17 @@ namespace Avalonia.Skia
         /// <inheritdoc />
         public void Save(string fileName, int? quality = null)
         {
-            ImageSavingHelper.SaveImage(_image, fileName);
+            ImageSavingHelper.SaveImage(_image, fileName, quality);
         }
 
         /// <inheritdoc />
+        public void Save(Stream stream, SKEncodedImageFormat format, int? quality = null)
+        {
+            ImageSavingHelper.SaveImage(_image, stream, format, quality);
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Use overloads that take format parameter")]
         public void Save(Stream stream, int? quality = null)
         {
             ImageSavingHelper.SaveImage(_image, stream);

--- a/src/Skia/Avalonia.Skia/SurfaceRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/SurfaceRenderTarget.cs
@@ -134,6 +134,16 @@ namespace Avalonia.Skia
         }
 
         /// <inheritdoc />
+        public void Save(Stream stream, SKEncodedImageFormat format, int? quality = null)
+        {
+            using (var image = SnapshotImage())
+            {
+                ImageSavingHelper.SaveImage(image, stream, format, quality);
+            }
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Use overloads that take format parameter")]
         public void Save(Stream stream, int? quality = null)
         {
             using (var image = SnapshotImage())

--- a/src/Skia/Avalonia.Skia/WriteableBitmapImpl.cs
+++ b/src/Skia/Avalonia.Skia/WriteableBitmapImpl.cs
@@ -129,11 +129,21 @@ namespace Avalonia.Skia
         }
 
         /// <inheritdoc />
+        [Obsolete("Use overloads that take format parameter")]
         public void Save(Stream stream, int? quality = null)
         {
             using (var image = GetSnapshot())
             {
                 ImageSavingHelper.SaveImage(image, stream, quality);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Save(Stream stream, SKEncodedImageFormat format, int? quality = null)
+        {
+            using (var image = GetSnapshot())
+            {
+                ImageSavingHelper.SaveImage(image, stream, format, quality);
             }
         }
 

--- a/src/Windows/Avalonia.Direct2D1/Media/Imaging/BitmapImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Imaging/BitmapImpl.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.IO;
+
+using Avalonia.Direct2D1.Media.Imaging;
 using Avalonia.Platform;
+
 using D2DBitmap = SharpDX.Direct2D1.Bitmap1;
 
 namespace Avalonia.Direct2D1.Media
@@ -15,22 +18,33 @@ namespace Avalonia.Direct2D1.Media
 
         public void Save(string fileName, int? quality = null)
         {
-            if (Path.GetExtension(fileName) != ".png")
-            {
-                // Yeah, we need to support other formats.
-                throw new NotSupportedException("Use PNG, stoopid.");
-            }
-
-            using (FileStream s = new FileStream(fileName, FileMode.Create))
-            {
-                Save(s, quality);
-            }
+            var file = new FileInfo(fileName);
+            var format = GetFormatFromExtension(file.Extension);
+            using var s = new FileStream(fileName, FileMode.Create);
+            Save(s, format, quality);
         }
 
-        public abstract void Save(Stream stream, int? quality = null);
+        public abstract void Save(Stream stream, WicImageFormat format, int? quality = null);
+
+        public void Save(Stream stream, int? quality = null)
+        {
+            Save(stream, WicImageFormat.Png, quality);
+        }
 
         public virtual void Dispose()
         {
+        }
+
+        private static WicImageFormat GetFormatFromExtension(string extension)
+        {
+            return extension.ToLowerInvariant() switch
+            {
+                ".png" => WicImageFormat.Png,
+                ".jpg" or ".jpeg" or ".jpe" => WicImageFormat.Jpeg,
+                ".bmp" => WicImageFormat.Bmp,
+                ".gif" => WicImageFormat.Gif,
+                _ => throw new NotSupportedException("Unsupported image format.")
+            };
         }
     }
 }

--- a/src/Windows/Avalonia.Direct2D1/Media/Imaging/D2DBitmapImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Imaging/D2DBitmapImpl.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+
+using Avalonia.Direct2D1.Media.Imaging;
 using Avalonia.Metadata;
 using SharpDX.Direct2D1;
 using SharpDX.WIC;
@@ -42,9 +44,9 @@ namespace Avalonia.Direct2D1.Media
             return new OptionalDispose<Bitmap1>(_direct2DBitmap, false);
         }
 
-        public override void Save(Stream stream, int? quality = null)
+        public override void Save(Stream stream, WicImageFormat format, int? quality = null)
         {
-            using (var encoder = new PngBitmapEncoder(Direct2D1Platform.ImagingFactory, stream))
+            using (var encoder = format.CreateEncoder(Direct2D1Platform.ImagingFactory, stream))
             using (var frame = new BitmapFrameEncode(encoder))
             using (var bitmapSource = _direct2DBitmap.QueryInterface<BitmapSource>())
             {

--- a/src/Windows/Avalonia.Direct2D1/Media/Imaging/D2DRenderTargetBitmapImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Imaging/D2DRenderTargetBitmapImpl.cs
@@ -56,7 +56,7 @@ namespace Avalonia.Direct2D1.Media.Imaging
             return new OptionalDispose<D2DBitmap>(_renderTarget.Bitmap.QueryInterface<Bitmap1>(), false);
         }
 
-        public override void Save(Stream stream, int? quality = null)
+        public override void Save(Stream stream, WicImageFormat format, int? quality = null)
         {
             using (var wic = new WicRenderTargetBitmapImpl(PixelSize, Dpi))
             {
@@ -69,7 +69,7 @@ namespace Avalonia.Direct2D1.Media.Imaging
                         new Rect(PixelSize.ToSizeWithDpi(Dpi.X)));
                 }
 
-                wic.Save(stream);
+                wic.Save(stream, format, quality);
             }
         }
     }

--- a/src/Windows/Avalonia.Direct2D1/Media/Imaging/WicBitmapImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Imaging/WicBitmapImpl.cs
@@ -7,6 +7,7 @@ using AlphaFormat = Avalonia.Platform.AlphaFormat;
 using D2DBitmap = SharpDX.Direct2D1.Bitmap1;
 using Avalonia.Platform;
 using PixelFormat = SharpDX.WIC.PixelFormat;
+using Avalonia.Direct2D1.Media.Imaging;
 
 namespace Avalonia.Direct2D1.Media
 {
@@ -189,9 +190,9 @@ namespace Avalonia.Direct2D1.Media
             return new OptionalDispose<D2DBitmap>(d2dBitmap, true);
         }
 
-        public override void Save(Stream stream, int? quality = null)
+        public override void Save(Stream stream, WicImageFormat format, int? quality = null)
         {
-            using (var encoder = new PngBitmapEncoder(Direct2D1Platform.ImagingFactory, stream))
+            using (var encoder = format.CreateEncoder(Direct2D1Platform.ImagingFactory, stream))
             using (var frame = new BitmapFrameEncode(encoder))
             {
                 frame.Initialize();

--- a/src/Windows/Avalonia.Direct2D1/Media/Imaging/WicImageFormat.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Imaging/WicImageFormat.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+
+using SharpDX.WIC;
+
+namespace Avalonia.Direct2D1.Media.Imaging
+{
+    internal enum WicImageFormat
+    {
+        Png,
+        Jpeg,
+        Bmp,
+        Gif,
+    }
+
+    internal static class WicImageFormatExtensions
+    {
+        public static Guid ToContainerFormat(this WicImageFormat format)
+        {
+            return format switch
+            {
+                WicImageFormat.Png => ContainerFormatGuids.Png,
+                WicImageFormat.Jpeg => ContainerFormatGuids.Jpeg,
+                WicImageFormat.Bmp => ContainerFormatGuids.Bmp,
+                WicImageFormat.Gif => ContainerFormatGuids.Gif,
+                _ => throw new ArgumentException("Invalid image format."),
+            };
+        }
+
+        public static BitmapEncoder CreateEncoder(this WicImageFormat format, ImagingFactory factory, Stream stream)
+        {
+            return format switch
+            {
+                WicImageFormat.Png => new PngBitmapEncoder(factory, stream),
+                WicImageFormat.Jpeg => new JpegBitmapEncoder(factory, stream),
+                WicImageFormat.Bmp => new BmpBitmapEncoder(factory, stream),
+                WicImageFormat.Gif => new GifBitmapEncoder(factory, stream),
+                _ => throw new ArgumentException("Invalid image format."),
+            };
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
Adds support for .JPG and .WEBP to `Image.Save`.


## What is the current behavior?
When `Image.Save(...)` is called regardless of the file extension the output is a PNG image.


## What is the updated/expected behavior with this PR?
When `Image.Save(...)` is called if the extension matches to a known format, the output is in this format. Otherwise the output is in PNG (for compatibility).


## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
I suggest Avalonia stop using PNG unless explicitly requested in the future.

## Obsoletions / Deprecations
I only marked internal APIs obsolete

## Fixed issues
https://github.com/AvaloniaUI/Avalonia/issues/12493
