### PR TITLE
ToggleSwitch: fix toggle on single touch tap on the knob part

### DIFF
--- a/src/Avalonia.Controls/ToggleSwitch.cs
+++ b/src/Avalonia.Controls/ToggleSwitch.cs
@@ -243,10 +243,6 @@ namespace Avalonia.Controls
                 }
                 UpdateKnobTransitions();
             }
-            else
-            {
-                base.Toggle();
-            }
 
             _isDragging = false;
 
@@ -273,14 +269,6 @@ namespace Avalonia.Controls
                 {
                     Canvas.SetLeft(_knobsPanel!, System.Math.Min(_switchKnob!.Bounds.Width, System.Math.Max(0, (_initLeft + difference.X))));
                 }
-            }
-        }
-
-        protected override void Toggle()
-        {
-            if ((_switchKnob != null) && (!_switchKnob.IsPointerOver))
-            {
-                base.Toggle();
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
Fixing issue #12519 .

## What is the current behavior?
Now tapping on the knob toggles the switch twice, returning the Checked to its original state.
On desktop: if you put mouse pointer above the knob (of an already focussed ToggleSwitch!), toggling using keyboard does not work.

## What is the updated/expected behavior with this PR?
- A single tap using touch device on the knob part of the ToggleSwitch should now toggle only once, instead of twice.
- On desktop, if you position the mouse pointer exactly above the knob of a focussed ToggleSwitch, the toggle now works using keyboard space to toggle.

## Breaking changes
None

## Fixed issues
Fixes #12519