### PR TITLE
Fixed memory leaks in ContextMenu.cs

### DIFF
--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -227,6 +227,11 @@ namespace Avalonia.Controls
                 control.AttachedToVisualTree += ControlOnAttachedToVisualTree;
                 control.DetachedFromVisualTree += ControlDetachedFromVisualTree;
             }
+            
+            if (control.IsAttachedToVisualTree)
+            {
+                AttachControlToContextMenu(control);
+            }
         }
 
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -431,7 +436,12 @@ namespace Avalonia.Controls
         
         private static void ControlOnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
         {
-            if (sender is Control { ContextMenu: {} contextMenu } control)
+            AttachControlToContextMenu(sender);
+        }
+
+        private static void AttachControlToContextMenu(object? sender)
+        {
+            if (sender is Control { ContextMenu: { } contextMenu } control)
             {
                 contextMenu._attachedControls ??= new List<Control>();
                 contextMenu._attachedControls.Add(control);

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -230,7 +230,7 @@ namespace Avalonia.Controls
             
             if (control.IsAttachedToVisualTree)
             {
-                AttachControlToContextMenu(control);
+                AttachControlToContextMenu(control); 
             }
         }
 

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -114,7 +114,6 @@ namespace Avalonia.Controls
         /// </summary>
         static ContextMenu()
         {
-            ItemsPanelProperty.OverrideDefaultValue<ContextMenu>(DefaultPanel);
             PlacementProperty.OverrideDefaultValue<ContextMenu>(PlacementMode.Pointer);
             ContextMenuProperty.Changed.Subscribe(ContextMenuChanged);
             AutomationProperties.AccessibilityViewProperty.OverrideDefaultValue<ContextMenu>(AccessibilityView.Control);
@@ -216,16 +215,16 @@ namespace Avalonia.Controls
             if (e.OldValue is ContextMenu oldMenu)
             {
                 control.ContextRequested -= ControlContextRequested;
+                control.AttachedToVisualTree -= ControlOnAttachedToVisualTree;
                 control.DetachedFromVisualTree -= ControlDetachedFromVisualTree;
                 oldMenu._attachedControls?.Remove(control);
                 ((ISetLogicalParent?)oldMenu._popup)?.SetParent(null);
             }
 
-            if (e.NewValue is ContextMenu newMenu)
+            if (e.NewValue is ContextMenu)
             {
-                newMenu._attachedControls ??= new List<Control>();
-                newMenu._attachedControls.Add(control);
                 control.ContextRequested += ControlContextRequested;
+                control.AttachedToVisualTree += ControlOnAttachedToVisualTree;
                 control.DetachedFromVisualTree += ControlDetachedFromVisualTree;
             }
         }
@@ -428,11 +427,20 @@ namespace Avalonia.Controls
                 e.Handled = true;
             }
         }
+        
+        
+        private static void ControlOnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+        {
+            if (sender is Control { ContextMenu: {} contextMenu } control)
+            {
+                contextMenu._attachedControls ??= new List<Control>();
+                contextMenu._attachedControls.Add(control);
+            }
+        }
 
         private static void ControlDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
         {
-            if (sender is Control control
-                && control.ContextMenu is ContextMenu contextMenu)
+            if (sender is Control { ContextMenu: { } contextMenu } control)
             {
                 if (contextMenu._popup?.Parent == control)
                 {
@@ -440,6 +448,7 @@ namespace Avalonia.Controls
                 }
 
                 contextMenu.Close();
+                contextMenu._attachedControls?.Remove(control);
             }
         }
 

--- a/tests/Avalonia.LeakTests/ControlTests.cs
+++ b/tests/Avalonia.LeakTests/ControlTests.cs
@@ -602,11 +602,9 @@ namespace Avalonia.LeakTests
 
                     window.Show();
 
-                    // Do a layout and make sure that TextBlock gets added to visual tree with
-                    // its render transform.
+                    // Do a layout and make sure that TextBlock gets added to visual tree.
                     window.LayoutManager.ExecuteInitialLayoutPass();
-                    var textBlock = Assert.IsType<TextBlock>(window.Presenter.Child);
-                    Assert.IsType<RotateTransform>(textBlock.RenderTransform);
+                    Assert.IsType<TextBlock>(window.Presenter.Child);
 
                     // Clear the content and ensure the TextBlock is removed.
                     window.Content = null;

--- a/tests/Avalonia.LeakTests/ControlTests.cs
+++ b/tests/Avalonia.LeakTests/ControlTests.cs
@@ -583,6 +583,48 @@ namespace Avalonia.LeakTests
                     Assert.Equal(initialMenuItemCount, memory.GetObjects(where => where.Type.Is<MenuItem>()).ObjectsCount));
             }
         }
+        
+        [Fact]
+        public void Attached_Control_From_ContextMenu_Is_Freed()
+        {
+            using (Start())
+            {
+                var contextMenu = new ContextMenu();
+                Func<Window> run = () =>
+                {
+                    var window = new Window
+                    {
+                        Content = new TextBlock
+                        {
+                            ContextMenu = contextMenu
+                        }
+                    };
+
+                    window.Show();
+
+                    // Do a layout and make sure that TextBlock gets added to visual tree with
+                    // its render transform.
+                    window.LayoutManager.ExecuteInitialLayoutPass();
+                    var textBlock = Assert.IsType<TextBlock>(window.Presenter.Child);
+                    Assert.IsType<RotateTransform>(textBlock.RenderTransform);
+
+                    // Clear the content and ensure the TextBlock is removed.
+                    window.Content = null;
+                    window.LayoutManager.ExecuteLayoutPass();
+                    Assert.Null(window.Presenter.Child);
+
+                    return window;
+                };
+
+                var result = run();
+
+                // Process all Loaded events to free control reference(s)
+                Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
+
+                dotMemory.Check(memory =>
+                    Assert.Equal(0, memory.GetObjects(where => where.Type.Is<TextBlock>()).ObjectsCount));
+            }
+        }
 
         [Fact]
         public void Standalone_ContextMenu_Is_Freed()


### PR DESCRIPTION
## What does the pull request do?
Fixes two memory leaks -
1. Leak when controls are not freed when they have any `ContextMenu` set.
2. Leak when `ItemPanel` is set to `StackPanel`;' **I don't know why**.

## What is the current behavior?
Two issues:
1. When you have a Control with ContextMenu applied, for example from a `ControlTheme`, there will be only 1 ContextMenu created for all controls of these type, but each time a control is created it will be added to `_attachedControls` and will stay there forever.
2. For some reason, when a `ContextMenu` with `ItemsSource` binding have an `ItemsPanel` as `StackPanel` the items created will not be cleared. When changing `ItemsPanel` to `VirtualizingStackPanel` there is no issue.

## What is the updated/expected behavior with this PR?
No memory leaks when using ContextMenu

## How was the solution implemented (if it's not obvious)?
1. Add and remove attached controls when they attach and detach from visual tree.
2. Replace override of default `ItemsPanel`, so it uses `VirtualizingStackPanel` like every other place. I saw that this line was from 2019, and I can't think of any particular reason why it needs to stay.

**Note** - the issue when using `StackPanel` is not resolved, but I didn't have time to investigate it.

## Checklist

- [x] Added unit tests (if possible)? **I added but can't test it, all DotMemory unit tests fail for some reason**
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
