### PR TITLE
Fix DataGridHeader style

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -170,26 +170,28 @@
                   CornerRadius="{TemplateBinding CornerRadius}">
             <Grid Name="PART_ColumnHeaderRoot" ColumnDefinitions="*,Auto">
 
-              <Grid Margin="{TemplateBinding Padding}"
+              <StackPanel Margin="{TemplateBinding Padding}"
                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                <Grid.ColumnDefinitions>
-                  <ColumnDefinition Width="*" />
-                  <ColumnDefinition Width="Auto" MinWidth="{DynamicResource DataGridSortIconMinWidth}" />
-                </Grid.ColumnDefinitions>
-
-                <ContentPresenter Content="{TemplateBinding Content}"
-                                  ContentTemplate="{TemplateBinding ContentTemplate}" />
-
-                <Path Name="SortIcon"
-                      IsVisible="False"
-                      Grid.Column="1"
-                      Height="12"
-                      HorizontalAlignment="Center"
-                      VerticalAlignment="Center"
-                      Fill="{TemplateBinding Foreground}"
-                      Stretch="Uniform" />
-              </Grid>
+                <Grid>
+                  <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" MinWidth="{DynamicResource DataGridSortIconMinWidth}" />
+                  </Grid.ColumnDefinitions>
+                
+                  <ContentPresenter Content="{TemplateBinding Content}"
+                                    ContentTemplate="{TemplateBinding ContentTemplate}" />
+                
+                  <Path Name="SortIcon"
+                        IsVisible="False"
+                        Grid.Column="1"
+                        Height="12"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Fill="{TemplateBinding Foreground}"
+                        Stretch="Uniform" />
+                </Grid>
+              </StackPanel>
 
               <Rectangle Name="VerticalSeparator"
                          Grid.Column="1"

--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -170,7 +170,7 @@
                   CornerRadius="{TemplateBinding CornerRadius}">
             <Grid Name="PART_ColumnHeaderRoot" ColumnDefinitions="*,Auto">
 
-              <StackPanel Margin="{TemplateBinding Padding}"
+              <Panel Margin="{TemplateBinding Padding}"
                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                 <Grid>
@@ -191,7 +191,7 @@
                         Fill="{TemplateBinding Foreground}"
                         Stretch="Uniform" />
                 </Grid>
-              </StackPanel>
+              </Panel>
 
               <Rectangle Name="VerticalSeparator"
                          Grid.Column="1"


### PR DESCRIPTION
## What does the pull request do?
Update DataGrid Fluent style.


## What is the current behavior?
DataGridHeader right separater line will cover by header background.


## What is the updated/expected behavior with this PR?
Update DataGrid Fluent style make DataGridHeader separater won't be covered.


## How was the solution implemented (if it's not obvious)?
Use `Panel` control boxing the Grid control clip it.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
Nope

## Obsoletions / Deprecations
Nope

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/11938
