### PR TITLE
Set PreserveSig to true for OleGetClipboard

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/Interop/UnmanagedMethods.cs
@@ -1509,7 +1509,7 @@ namespace Avalonia.Win32.Interop
         [DllImport("user32.dll")]
         public static extern IntPtr SetClipboardData(ClipboardFormat uFormat, IntPtr hMem);
 
-        [DllImport("ole32.dll", PreserveSig = false)]
+        [DllImport("ole32.dll", PreserveSig = true)]
         public static extern int OleGetClipboard(out IntPtr dataObject);
 
         [DllImport("ole32.dll", PreserveSig = true)]


### PR DESCRIPTION
## What does the pull request do?
Fixes #12552
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
OleGetClipboard throws exception for any non-zero HRESULT. 
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
UnmanagedMethods.OleGetClipboard method will return non-zero HRESULT in case of failure.

<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Code in Avalonia.Win32.ClipboardImpl is expecting that OleGetClipboard return non-zero HRESULT:
https://github.com/AvaloniaUI/Avalonia/blob/1896e8ad68dc0fdb6c1055d36a97b926e0a32f17/src/Windows/Avalonia.Win32/ClipboardImpl.cs#L98

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #12552 
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
