### PR TITLE
Enhanced Clipping and Rendered Visuals Tracking in ServerCompositionVisual

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/ICompositionTargetDebugEvents.cs
+++ b/src/Avalonia.Base/Rendering/Composition/ICompositionTargetDebugEvents.cs
@@ -2,5 +2,7 @@ namespace Avalonia.Rendering.Composition;
 
 internal interface ICompositionTargetDebugEvents
 {
+    public int RenderedVisuals { get; }
+    void IncrementRenderedVisuals();
     void RectInvalidated(Rect rc);
 }

--- a/src/Avalonia.Base/Rendering/Composition/ICompositionTargetDebugEvents.cs
+++ b/src/Avalonia.Base/Rendering/Composition/ICompositionTargetDebugEvents.cs
@@ -2,7 +2,7 @@ namespace Avalonia.Rendering.Composition;
 
 internal interface ICompositionTargetDebugEvents
 {
-    public int RenderedVisuals { get; }
+    int RenderedVisuals { get; }
     void IncrementRenderedVisuals();
     void RectInvalidated(Rect rc);
 }

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.DirtyProperties.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.DirtyProperties.cs
@@ -38,6 +38,7 @@ partial class ServerCompositionVisual
         CompositionVisualChangedFields.Size
         | CompositionVisualChangedFields.SizeAnimated
         | CompositionVisualChangedFields.ClipToBounds
+        | CompositionVisualChangedFields.Clip
         | CompositionVisualChangedFields.ClipToBoundsAnimated;
         
     partial void OnFieldsDeserialized(CompositionVisualChangedFields changed)

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.cs
@@ -38,6 +38,7 @@ namespace Avalonia.Rendering.Composition.Server
                 return;
 
             Root!.RenderedVisuals++;
+            Root!.DebugEvents?.IncrementRenderedVisuals();
 
             var boundsRect = new Rect(new Size(Size.X, Size.Y));
 

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.cs
@@ -182,11 +182,24 @@ namespace Avalonia.Rendering.Composition.Server
 
             if (_clipSizeDirty || positionChanged)
             {
-                _transformedClipBounds = ClipToBounds
-                    ? new Rect(new Size(Size.X, Size.Y))
-                        .TransformToAABB(GlobalTransformMatrix)
-                    : null;
+                Rect? transformedVisualBounds = null;
+                Rect? transformedClipBounds = null;
                 
+                if (ClipToBounds)
+                    transformedVisualBounds = new Rect(new Size(Size.X, Size.Y)).TransformToAABB(GlobalTransformMatrix);
+                
+                 if (Clip != null)
+                     transformedClipBounds = Clip.Bounds.TransformToAABB(GlobalTransformMatrix);
+
+                 if (transformedVisualBounds != null && transformedClipBounds != null)
+                     _transformedClipBounds = transformedVisualBounds.Value.Intersect(transformedClipBounds.Value);
+                 else if (transformedVisualBounds != null)
+                     _transformedClipBounds = transformedVisualBounds;
+                 else if (transformedClipBounds != null)
+                     _transformedClipBounds = transformedClipBounds;
+                 else
+                     _transformedClipBounds = null;
+                 
                 _clipSizeDirty = false;
             }
 

--- a/tests/Avalonia.Base.UnitTests/Rendering/CompositorInvalidationClippingTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Rendering/CompositorInvalidationClippingTests.cs
@@ -1,0 +1,60 @@
+using Avalonia.Controls;
+using Avalonia.Media;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Rendering;
+
+public class CompositorInvalidationClippingTests : CompositorTestsBase
+{
+    [Fact]
+    public void Siblings_Should_Be_Rendered_On_Invalidate_Without_ClipToBounds()
+    {
+        AssertRenderedVisuals(clipToBounds: false, clipGeometry: false, expectedRenderedVisualsCount: 4);
+    }
+
+    [Fact]
+    public void Siblings_Should_Not_Be_Rendered_On_Invalidate_With_ClipToBounds()
+    {
+        AssertRenderedVisuals(clipToBounds: true, clipGeometry: false, expectedRenderedVisualsCount: 3);
+    }
+
+    [Fact]
+    public void Siblings_Should_Not_Be_Rendered_On_Invalidate_With_Clip()
+    {
+        AssertRenderedVisuals(clipToBounds: false, clipGeometry: true, expectedRenderedVisualsCount: 3);
+    }
+
+    private void AssertRenderedVisuals(bool clipToBounds, bool clipGeometry, int expectedRenderedVisualsCount)
+    {
+        using (var s = new CompositorCanvas())
+        {
+            //#1 visual to render is root
+            //#2 visual to render is s.Canvas
+            
+            //#3 visual to render
+            s.Canvas.Children.Add(new Border()
+            {
+                [Canvas.LeftProperty] = 0, [Canvas.TopProperty] = 0,
+                Width = 20, Height = 10,
+                Background = Brushes.Red,
+                ClipToBounds = clipToBounds,
+                Clip = clipGeometry ? new RectangleGeometry(new Rect(new Size(20, 10))) : null
+            });
+            
+            //#4 visual to render
+            s.Canvas.Children.Add(new Border()
+            {
+                [Canvas.LeftProperty] = 30, [Canvas.TopProperty] = 50,
+                Width = 20, Height = 10,
+                Background = Brushes.Red,
+                ClipToBounds = clipToBounds,
+                Clip = clipGeometry ? new RectangleGeometry(new Rect(new Size(20, 10))) : null
+            });
+            s.RunJobs();
+            s.Events.Reset();
+            s.Canvas.Children[0].IsVisible = false;
+            s.RunJobs();
+            s.AssertRenderedVisuals(expectedRenderedVisualsCount);
+        }
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/Rendering/CompositorInvalidationClippingTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Rendering/CompositorInvalidationClippingTests.cs
@@ -3,22 +3,27 @@ using Avalonia.Media;
 using Xunit;
 
 namespace Avalonia.Base.UnitTests.Rendering;
-
+/// <summary>
+/// Test class that verifies how clipping influences rendering in the compositor
+/// </summary>
 public class CompositorInvalidationClippingTests : CompositorTestsBase
 {
     [Fact]
+    // Test case: When the ClipToBounds is false, all visuals should be rendered
     public void Siblings_Should_Be_Rendered_On_Invalidate_Without_ClipToBounds()
     {
         AssertRenderedVisuals(clipToBounds: false, clipGeometry: false, expectedRenderedVisualsCount: 4);
     }
 
     [Fact]
+    // Test case: When the ClipToBounds is true, only visuals within the clipped boundary should be rendered
     public void Siblings_Should_Not_Be_Rendered_On_Invalidate_With_ClipToBounds()
     {
         AssertRenderedVisuals(clipToBounds: true, clipGeometry: false, expectedRenderedVisualsCount: 3);
     }
 
     [Fact]
+    // Test case: When the Clip is used, only visuals within the clip geometry should be rendered
     public void Siblings_Should_Not_Be_Rendered_On_Invalidate_With_Clip()
     {
         AssertRenderedVisuals(clipToBounds: false, clipGeometry: true, expectedRenderedVisualsCount: 3);
@@ -28,10 +33,10 @@ public class CompositorInvalidationClippingTests : CompositorTestsBase
     {
         using (var s = new CompositorCanvas())
         {
-            //#1 visual to render is root
-            //#2 visual to render is s.Canvas
+            //#1 visual is top level
+            //#2 visual is s.Canvas
             
-            //#3 visual to render
+            //#3 visual is border1
             s.Canvas.Children.Add(new Border()
             {
                 [Canvas.LeftProperty] = 0, [Canvas.TopProperty] = 0,
@@ -41,7 +46,7 @@ public class CompositorInvalidationClippingTests : CompositorTestsBase
                 Clip = clipGeometry ? new RectangleGeometry(new Rect(new Size(20, 10))) : null
             });
             
-            //#4 visual to render
+            //#4 visual is border2
             s.Canvas.Children.Add(new Border()
             {
                 [Canvas.LeftProperty] = 30, [Canvas.TopProperty] = 50,
@@ -52,8 +57,11 @@ public class CompositorInvalidationClippingTests : CompositorTestsBase
             });
             s.RunJobs();
             s.Events.Reset();
+            
+            //invalidate border1
             s.Canvas.Children[0].IsVisible = false;
             s.RunJobs();
+            
             s.AssertRenderedVisuals(expectedRenderedVisualsCount);
         }
     }

--- a/tests/Avalonia.UnitTests/CompositorTestServices.cs
+++ b/tests/Avalonia.UnitTests/CompositorTestServices.cs
@@ -89,6 +89,13 @@ public class CompositorTestServices : IDisposable
         Events.Rects.Clear();
     }
 
+    public void AssertRenderedVisuals(int renderVisuals)
+    {
+        RunJobs();
+        Assert.Equal(Events.RenderedVisuals, renderVisuals);
+        Events.Rects.Clear();
+    }
+
     public void AssertHitTest(double x, double y, Func<Visual, bool> filter, params object[] expected)
         => AssertHitTest(new Point(x, y), filter, expected);
 
@@ -110,6 +117,13 @@ public class CompositorTestServices : IDisposable
     {
         public List<Rect> Rects = new();
 
+        public int RenderedVisuals { get; private set; }
+
+        public void IncrementRenderedVisuals()
+        {
+            RenderedVisuals++;
+        }
+
         public void RectInvalidated(Rect rc)
         {
             Rects.Add(rc);
@@ -118,6 +132,7 @@ public class CompositorTestServices : IDisposable
         public void Reset()
         {
             Rects.Clear();
+            RenderedVisuals = 0;
         }
     }
 


### PR DESCRIPTION
## What does the pull request do?
This PR enhances the clipping calculation within the `ServerCompositionVisual` by taking `Clip.Bounds` into account. The primary goal is to ensure that visuals, which are not within a dirty rect, are not re-rendered when different `ClipToBounds` and `Clip` geometry parameters are set.


## What is the current behavior?
Currently, `ServerCompositionVisual.Render` method do nothing if boundaries of the visual do not intersect with `DirtyRect`. This approach effectively minimizes the areas of the scene redrawn, especially when a single element is invalidated. However, this optimization is only effective when `ClipToBounds=true`. While having `ClipToBounds=false` but setting an explicit `Clip` is valid, it's not considered in the current implementation.


## What is the updated/expected behavior with this PR?
After this PR, the `ServerCompositionVisual` will also consider changes to the `Clip` property, allowing it to recalculate when the clip is altered. This ensures accurate rendering even when `ClipToBounds=false` but an explicit `Clip` is set. 

## How was the solution implemented (if it's not obvious)?
1. `Clip.Bounds` was considered in the clipping calculation within `ServerCompositionVisual`.
2. Added unit tests under `CompositorInvalidationClippingTests` to verify the correct rendering of visuals not in the dirty rect with different `ClipToBounds` and `Clip` geometry parameters.
3. For test purpuses a counter for rendered visuals in `ServerCompositionVisual` was introduced.


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes

## Obsoletions / Deprecations

## Fixed issues
