### PR TITLE
Fix for Track not arranging after IsDirectionReversed property changed.

### DIFF
--- a/src/Avalonia.Controls/Primitives/Track.cs
+++ b/src/Avalonia.Controls/Primitives/Track.cs
@@ -52,7 +52,7 @@ namespace Avalonia.Controls.Primitives
             ThumbProperty.Changed.AddClassHandler<Track>((x, e) => x.ThumbChanged(e));
             IncreaseButtonProperty.Changed.AddClassHandler<Track>((x, e) => x.ButtonChanged(e));
             DecreaseButtonProperty.Changed.AddClassHandler<Track>((x, e) => x.ButtonChanged(e));
-            AffectsArrange<Track>(MinimumProperty, MaximumProperty, ValueProperty, OrientationProperty);
+            AffectsArrange<Track>(IsDirectionReversedProperty, MinimumProperty, MaximumProperty, ValueProperty, OrientationProperty);
         }
 
         public Track()


### PR DESCRIPTION
## What does the pull request do?
Fixes the Track control not arranging after IsDirectionReversed property is changed.


## What is the current behavior?
The control doesn't update its appearance until it is resized after that property changes.


## What is the updated/expected behavior with this PR?
That the control updates immediately when the property changes.


## How was the solution implemented (if it's not obvious)?
Added to IsDirectionReversedProperty to AffectsArrange.


## Checklist

(Not applicable)
- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
None.