### PR TITLE
Fix UI thread main loop cancellation from another thread on macOS

### DIFF
--- a/native/Avalonia.Native/src/OSX/platformthreading.mm
+++ b/native/Avalonia.Native/src/OSX/platformthreading.mm
@@ -17,7 +17,6 @@ public:
         Cancelled = true;
         if(Running)
         {
-            Running = false;
             if(![NSThread isMainThread])
             {
                 AddRef();
@@ -28,22 +27,22 @@ public:
                 });
                 return;
             };
+
+            Running = false;
             if(IsApp)
                 [NSApp stop:nil];
-            else
-            {
-                // Wakeup the event loop
-                NSEvent* event = [NSEvent otherEventWithType:NSEventTypeApplicationDefined
-                                                    location:NSMakePoint(0, 0)
-                                               modifierFlags:0
-                                                   timestamp:0
-                                                windowNumber:0
-                                                     context:nil
-                                                     subtype:0
-                                                       data1:0
-                                                       data2:0];
-                [NSApp postEvent:event atStart:YES];
-            }
+
+            // Wakeup the event loop
+            NSEvent* event = [NSEvent otherEventWithType:NSEventTypeApplicationDefined
+                                                location:NSMakePoint(0, 0)
+                                            modifierFlags:0
+                                                timestamp:0
+                                            windowNumber:0
+                                                    context:nil
+                                                    subtype:0
+                                                    data1:0
+                                                    data2:0];
+            [NSApp postEvent:event atStart:YES];
         }
     };
 };


### PR DESCRIPTION
## What does the pull request do?

Ensure that the UI thread main loop is stopped.

## What is the current behavior?

Cancelling the UI thread main loop from a different thread does not really stop the loop on macOS.

## What is the updated/expected behavior with this PR?

Cancelling the UI thread main loop from a different thread stops the loop on macOS.

## How was the solution implemented (if it's not obvious)?

When canceling the UI thread main loop from another thread on macOS, `dispatch_async()` is used to post the work, `[NSApp stop:nil]`, into the loop. However this will not stop the loop as it doesn't result in the posting of an `NSEvent` object (see https://developer.apple.com/documentation/appkit/nsapplication/1428473-stop for details). This PR posts the object to ensure the loop is stopped.

This PR also fixes an issue that the `Running` flag is set too early. 

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
