### PR TITLE
Updated ToggleSplitButton.IsChecked to bind TwoWay by default, same as ToggleButton.

### DIFF
--- a/src/Avalonia.Controls/SplitButton/ToggleSplitButton.cs
+++ b/src/Avalonia.Controls/SplitButton/ToggleSplitButton.cs
@@ -37,8 +37,7 @@ namespace Avalonia.Controls
         /// Defines the <see cref="IsChecked"/> property.
         /// </summary>
         public static readonly StyledProperty<bool> IsCheckedProperty =
-            AvaloniaProperty.Register<ToggleSplitButton, bool>(nameof(IsChecked), false,
-                defaultBindingMode: BindingMode.TwoWay);
+            AvaloniaProperty.Register<ToggleSplitButton, bool>(nameof(IsChecked), false, defaultBindingMode: BindingMode.TwoWay);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ToggleSplitButton"/> class.

--- a/src/Avalonia.Controls/SplitButton/ToggleSplitButton.cs
+++ b/src/Avalonia.Controls/SplitButton/ToggleSplitButton.cs
@@ -2,6 +2,7 @@
 
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
+using Avalonia.Data;
 using Avalonia.Interactivity;
 using Avalonia.Styling;
 
@@ -36,8 +37,8 @@ namespace Avalonia.Controls
         /// Defines the <see cref="IsChecked"/> property.
         /// </summary>
         public static readonly StyledProperty<bool> IsCheckedProperty =
-            AvaloniaProperty.Register<ToggleSplitButton, bool>(
-                nameof(IsChecked));
+            AvaloniaProperty.Register<ToggleSplitButton, bool>(nameof(IsChecked), false,
+                defaultBindingMode: BindingMode.TwoWay);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ToggleSplitButton"/> class.


### PR DESCRIPTION
## What does the pull request do?
Changes the `ToggleSplitButton.IsChecked` property to bind `TwoWay` by default.


## What is the current behavior?
It was binding one way by default.


## What is the updated/expected behavior with this PR?
It should be binding two way by default, same as the similar `ToggleButton` already does.


## How was the solution implemented (if it's not obvious)?
Changed prop def.


## Checklist
N/A.
- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
The only break would be if someone wanted to have one way bind behavior (old default).  But that's not typically expected with a toggle button.

## Obsoletions / Deprecations
None.

## Fixed issues
None.