### PR TITLE
Fixes TextBox measure logic for MaxLines scenario

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1880,6 +1880,37 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
+        /// Returns the sum of any vertical whitespace added between the <see cref="ScrollViewer"/> and <see cref="TextPresenter"/> in the control template.
+        /// </summary>
+        /// <returns>The total vertical whitespace.</returns>
+        private double GetVerticalSpaceBetweenScrollViewerAndPresenter()
+        {
+            var verticalSpace = 0.0;
+            if (_presenter != null)
+            {
+                Visual? visual = _presenter;
+                while ((visual != null) && (visual != this))
+                {
+                    if (visual == _scrollViewer)
+                    {
+                        // ScrollViewer is a stopping point and should only include the Padding
+                        verticalSpace += _scrollViewer.Padding.Top + _scrollViewer.Padding.Bottom;
+                        break;
+                    }
+
+                    var margin = visual.GetValue<Thickness>(Layoutable.MarginProperty);
+                    var padding = visual.GetValue<Thickness>(Decorator.PaddingProperty);
+                    
+                    verticalSpace += margin.Top + padding.Top + padding.Bottom + margin.Bottom;
+
+                    visual = visual.VisualParent;
+                }
+            }
+
+            return verticalSpace;
+        }
+
+        /// <summary>
         /// Raises both the <see cref="TextChanging"/> and <see cref="TextChanged"/> events.
         /// </summary>
         /// <remarks>
@@ -2032,8 +2063,9 @@ namespace Avalonia.Controls
                     var typeface = new Typeface(FontFamily, FontStyle, FontWeight, FontStretch);
                     var paragraphProperties = TextLayout.CreateTextParagraphProperties(typeface, fontSize, null, default, default, null, default, LineHeight, default);
                     var textLayout = new TextLayout(new MaxLinesTextSource(MaxLines), paragraphProperties);
+                    var verticalSpace = GetVerticalSpaceBetweenScrollViewerAndPresenter();
 
-                    maxHeight = Math.Ceiling(textLayout.Height);
+                    maxHeight = Math.Ceiling(textLayout.Height + verticalSpace);
                 }
 
                 _scrollViewer.SetCurrentValue(MaxHeightProperty, maxHeight);


### PR DESCRIPTION
## What does the pull request do?
The current `TextBox` control templates apply the `TextBox.Padding` (like [here](https://github.com/AvaloniaUI/Avalonia/blob/c59e63ef6f17bdd73116df8ce177de747f894510/src/Avalonia.Themes.Fluent/Controls/TextBox.xaml#L130C58-L130C58)) to controls outside of the `ScrollViewer`.  But that leads to margin around the scrollbars, which might not be a desired appearance.
![image](https://github.com/AvaloniaUI/Avalonia/assets/5760058/8f5cccf3-9b75-4ea6-a66a-8a75ea444839)

This code update walks up the visual tree between `TextPresenter` and `ScrollViewer` to look for additional margin/padding that doesn't appear in the Simple or Fluent themes but might in custom control templates.  It appends the vertical space so that `MaxLines` measures correctly in those cases.  For instance, the same kind of `TextBox` with `Padding` applied within the `ScrollViewer` would then render like this:
![image](https://github.com/AvaloniaUI/Avalonia/assets/5760058/6a2756f8-7f14-46c8-97cf-ebc5a084ef0b)


## What is the current behavior?
Current behavior does not factor in the any `Margin` or `Padding` settings that may have been set in a `TextBox` control template between the `ScrollViewer` and `TextPresenter`.  This scenario doesn't happen in Simple/Fluent themes but custom themes may run into measure issues.

Without the PR's code update, the second scenario measure incorrectly like:
![image](https://github.com/AvaloniaUI/Avalonia/assets/5760058/1799b149-c2ee-4102-b0ad-19441a8f608f)


## What is the updated/expected behavior with this PR?
The update allows for scrollbars to align right next to the outer border in custom themes, while still having padding within the `ScrollViewer` as seen above.


## How was the solution implemented (if it's not obvious)?
Explained above.


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None, the Simple/Fluent themes will still behave the same since there is no `Padding` set in the scenario that this update looks for.

## Obsoletions / Deprecations
None

## Fixed issues
None