### PR TITLE
Fix AdornerLayer.IsClipEnabled when set on adorned element

### DIFF
--- a/src/Avalonia.Controls/Primitives/AdornerLayer.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerLayer.cs
@@ -295,7 +295,7 @@ namespace Avalonia.Controls.Primitives
             if (adorner.CompositionVisual != null)
             {
                 adorner.CompositionVisual.AdornedVisual = adorned?.CompositionVisual;
-                adorner.CompositionVisual.AdornerIsClipped = GetIsClipEnabled(adorner);
+                adorner.CompositionVisual.AdornerIsClipped = GetIsClipEnabled(adorned);
             }
 
             var info = adorner.GetValue(s_adornedElementInfoProperty);

--- a/src/Avalonia.Controls/Primitives/AdornerLayer.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerLayer.cs
@@ -295,7 +295,7 @@ namespace Avalonia.Controls.Primitives
             if (adorner.CompositionVisual != null)
             {
                 adorner.CompositionVisual.AdornedVisual = adorned?.CompositionVisual;
-                adorner.CompositionVisual.AdornerIsClipped = GetIsClipEnabled(adorned);
+                adorner.CompositionVisual.AdornerIsClipped = adorned is not null ? GetIsClipEnabled(adorned) : true;
             }
 
             var info = adorner.GetValue(s_adornedElementInfoProperty);


### PR DESCRIPTION
## What does the pull request do?

Fixes AdornerLayer.IsClipEnabled not being respected when set on adorned element.

```xaml
<Panel>
  <TextBox Text="Test" 
           ClipToBounds="True"
           AdornerLayer.IsClipEnabled="True" 
           HorizontalAlignment="Center" VerticalAlignment="Center">
    <AdornerLayer.Adorner>
      <Rectangle Fill="Red" 
                 Width="20" Height="20" 
                 Margin="-10,-10,0,0"
                 HorizontalAlignment="Left" VerticalAlignment="Top" />
    </AdornerLayer.Adorner>
  </TextBox>
</Panel>
```

## What is the current behavior?

The adorner is clipped even when AdornerLayer.IsClipEnabled=false

## What is the updated/expected behavior with this PR?

The adorner is not clipped when AdornerLayer.IsClipEnabled=false

## How was the solution implemented (if it's not obvious)?

Passed proper control to GetIsClipEnabled call.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
