### PR TITLE
ShowInTaskBar with Owned window: make consistent with WPF

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -683,8 +683,9 @@ namespace Avalonia.Win32
             if (parentHwnd == IntPtr.Zero && !_windowProperties.ShowInTaskbar)
             {
                 parentHwnd = OffscreenParentWindow.Handle;
-                _hiddenWindowIsParent = true;
             }
+
+            _hiddenWindowIsParent = parentHwnd == OffscreenParentWindow.Handle;
 
             SetWindowLongPtr(_hwnd, (int)WindowLongParam.GWL_HWNDPARENT, parentHwnd);
         }


### PR DESCRIPTION
Repro
```
var window = CreateSampleWindow();

window.ShowInTaskbar = false;

window.Show(GetWindow());

window.Loaded += (sender, args) => { window.ShowInTaskbar = true; };
```

Current behavior (windows only)
When the loaded event happens, it will just remove the owner window. Meaning that the dialog will go behind the main window.

I checked WPFs behavior and it definately ignores ShowInTaskBar changes in this scenario.


1. ShowInTaskBar = false, causes SetParent to be called and parent set to HiddenWindow.Handle, and ` _hiddenWindowIsParent = true;`

2. Show gets called, SetParent sets the new owner. all good.
3. ShowInTaskbar gets set to true, but because `_hiddenWindowIsParent` was left true, it overwrites the owner window.
casuing the issue.


Fixed behavior:

ensure _hiddenWindowIsParent is always in sync.
ShowInTaskbar is ignored and relationship maintained.

