### PR TITLE
Add isStroked overload for IGeometryContext

### DIFF
--- a/src/Avalonia.Base/Media/StreamGeometryContext.cs
+++ b/src/Avalonia.Base/Media/StreamGeometryContext.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Media
     /// of <see cref="StreamGeometryContext"/> is obtained by calling
     /// <see cref="StreamGeometry.Open"/>.
     /// </remarks>
-    public class StreamGeometryContext : IGeometryContext
+    public class StreamGeometryContext : IGeometryContext, IGeometryContextEx
     {
         private readonly IStreamGeometryContextImpl _impl;
 
@@ -127,6 +127,21 @@ namespace Avalonia.Media
         public void Dispose()
         {
             _impl.Dispose();
+        }
+
+        /// <summary>
+        /// Draws a line to the specified point.
+        /// </summary>
+        /// <param name="point">The destination point.</param>
+        /// <param name="isStroked">Whether the segment is stroked</param>
+        public void LineTo(Point point, bool isStroked)
+        {
+            if (_impl is IGeometryContextEx contextEx)
+                contextEx.LineTo(point, isStroked);
+            else
+                _impl.LineTo(point);
+
+            _currentPoint = point;
         }
     }
 }

--- a/src/Avalonia.Base/Platform/IGeometryContext.cs
+++ b/src/Avalonia.Base/Platform/IGeometryContext.cs
@@ -61,14 +61,4 @@ namespace Avalonia.Platform
         void SetFillRule(FillRule fillRule);
     }
 
-    public interface IGeometryContextEx : IGeometryContext
-    {
-        /// <summary>
-        /// Draws a line to the specified point.
-        /// </summary>
-        /// <param name="point">The destination point.</param>
-        /// <param name="isStroked">Whether the segment is stroked</param>
-        void LineTo(Point point, bool isStroked);
-    }
-
 }

--- a/src/Avalonia.Base/Platform/IGeometryContext.cs
+++ b/src/Avalonia.Base/Platform/IGeometryContext.cs
@@ -60,4 +60,15 @@ namespace Avalonia.Platform
         /// <param name="fillRule">The fill rule.</param>
         void SetFillRule(FillRule fillRule);
     }
+
+    public interface IGeometryContextEx : IGeometryContext
+    {
+        /// <summary>
+        /// Draws a line to the specified point.
+        /// </summary>
+        /// <param name="point">The destination point.</param>
+        /// <param name="isStroked">Whether the segment is stroked</param>
+        void LineTo(Point point, bool isStroked);
+    }
+
 }

--- a/src/Avalonia.Base/Platform/IGeometryContextEx.cs
+++ b/src/Avalonia.Base/Platform/IGeometryContextEx.cs
@@ -1,0 +1,13 @@
+﻿namespace Avalonia.Platform
+{
+    public interface IGeometryContextEx : IGeometryContext
+    {
+        /// <summary>
+        /// Draws a line to the specified point.
+        /// </summary>
+        /// <param name="point">The destination point.</param>
+        /// <param name="isStroked">Whether the segment is stroked</param>
+        void LineTo(Point point, bool isStroked);
+    }
+
+}

--- a/src/Skia/Avalonia.Skia/StreamGeometryImpl.cs
+++ b/src/Skia/Avalonia.Skia/StreamGeometryImpl.cs
@@ -189,19 +189,18 @@ namespace Avalonia.Skia
             {
                 if (isStroked)
                 {
-                    if (Stroke == Fill)
-                        _geometryImpl._fillPath = Stroke.Clone();
 
                     Stroke.LineTo((float)point.X, (float)point.Y);
-                    if (Duplicate)
-                        Fill.LineTo((float)point.X, (float)point.Y);
                 }
                 else
                 {
+                    if (Stroke == Fill)
+                        _geometryImpl._fillPath = Stroke.Clone();
+
                     Stroke.MoveTo((float)point.X, (float)point.Y);
-                    if (Duplicate)
-                        Fill.MoveTo((float)point.X, (float)point.Y);
                 }
+                if (Duplicate)
+                    Fill.LineTo((float)point.X, (float)point.Y);
             }
         }
     }

--- a/src/Skia/Avalonia.Skia/StreamGeometryImpl.cs
+++ b/src/Skia/Avalonia.Skia/StreamGeometryImpl.cs
@@ -77,7 +77,7 @@ namespace Avalonia.Skia
         /// <summary>
         /// A Skia implementation of a <see cref="IStreamGeometryContextImpl"/>.
         /// </summary>
-        private class StreamContext : IStreamGeometryContextImpl
+        private class StreamContext : IStreamGeometryContextImpl, IGeometryContextEx
         {
             private readonly StreamGeometryImpl _geometryImpl;
             private SKPath Stroke => _geometryImpl._strokePath;
@@ -93,7 +93,7 @@ namespace Avalonia.Skia
             {
                 _geometryImpl = geometryImpl;
             }
-            
+
             /// <inheritdoc />
             /// <remarks>Will update bounds of passed geometry.</remarks>
             public void Dispose()
@@ -117,7 +117,7 @@ namespace Avalonia.Skia
                     sweep,
                     (float)point.X,
                     (float)point.Y);
-                if(Duplicate)
+                if (Duplicate)
                     Fill.ArcTo(
                         (float)size.Width,
                         (float)size.Height,
@@ -136,10 +136,10 @@ namespace Avalonia.Skia
                     if (Stroke == Fill)
                         _geometryImpl._fillPath = Stroke.Clone();
                 }
-                
+
                 _isFilled = isFilled;
                 Stroke.MoveTo((float)startPoint.X, (float)startPoint.Y);
-                if(Duplicate)
+                if (Duplicate)
                     Fill.MoveTo((float)startPoint.X, (float)startPoint.Y);
             }
 
@@ -147,7 +147,7 @@ namespace Avalonia.Skia
             public void CubicBezierTo(Point point1, Point point2, Point point3)
             {
                 Stroke.CubicTo((float)point1.X, (float)point1.Y, (float)point2.X, (float)point2.Y, (float)point3.X, (float)point3.Y);
-                if(Duplicate)
+                if (Duplicate)
                     Fill.CubicTo((float)point1.X, (float)point1.Y, (float)point2.X, (float)point2.Y, (float)point3.X, (float)point3.Y);
             }
 
@@ -155,7 +155,7 @@ namespace Avalonia.Skia
             public void QuadraticBezierTo(Point point1, Point point2)
             {
                 Stroke.QuadTo((float)point1.X, (float)point1.Y, (float)point2.X, (float)point2.Y);
-                if(Duplicate)
+                if (Duplicate)
                     Fill.QuadTo((float)point1.X, (float)point1.Y, (float)point2.X, (float)point2.Y);
             }
 
@@ -163,7 +163,7 @@ namespace Avalonia.Skia
             public void LineTo(Point point)
             {
                 Stroke.LineTo((float)point.X, (float)point.Y);
-                if(Duplicate)
+                if (Duplicate)
                     Fill.LineTo((float)point.X, (float)point.Y);
             }
 
@@ -182,6 +182,26 @@ namespace Avalonia.Skia
             public void SetFillRule(FillRule fillRule)
             {
                 Fill.FillType = fillRule == FillRule.EvenOdd ? SKPathFillType.EvenOdd : SKPathFillType.Winding;
+            }
+
+            /// <inheritdoc />
+            public void LineTo(Point point, bool isStroked)
+            {
+                if (isStroked)
+                {
+                    if (Stroke == Fill)
+                        _geometryImpl._fillPath = Stroke.Clone();
+
+                    Stroke.LineTo((float)point.X, (float)point.Y);
+                    if (Duplicate)
+                        Fill.LineTo((float)point.X, (float)point.Y);
+                }
+                else
+                {
+                    Stroke.MoveTo((float)point.X, (float)point.Y);
+                    if (Duplicate)
+                        Fill.MoveTo((float)point.X, (float)point.Y);
+                }
             }
         }
     }


### PR DESCRIPTION
## What does the pull request do?
Adds an `IGeomtryContextEx` interface, with a LineTo method that allow disabling stroke on a line.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
