### PR TITLE
Fix for TextBlock.TextDecorations not inheriting down to inlines.

### DIFF
--- a/src/Avalonia.Controls/Documents/Inline.cs
+++ b/src/Avalonia.Controls/Documents/Inline.cs
@@ -13,9 +13,10 @@ namespace Avalonia.Controls.Documents
         /// <summary>
         /// AvaloniaProperty for <see cref="TextDecorations" /> property.
         /// </summary>
-        public static readonly StyledProperty<TextDecorationCollection?> TextDecorationsProperty =
-            AvaloniaProperty.Register<Inline, TextDecorationCollection?>(
-                nameof(TextDecorations));
+        public static readonly AttachedProperty<TextDecorationCollection?> TextDecorationsProperty =
+            AvaloniaProperty.RegisterAttached<Inline, Inline, TextDecorationCollection?>(
+                nameof(TextDecorations),
+                inherits: true);
 
         /// <summary>
         /// AvaloniaProperty for <see cref="BaselineAlignment" /> property.
@@ -43,7 +44,27 @@ namespace Avalonia.Controls.Documents
             get { return GetValue(BaselineAlignmentProperty); }
             set { SetValue(BaselineAlignmentProperty, value); }
         }
+        
+        /// <summary>
+        /// Gets the value of the attached <see cref="TextDecorationsProperty"/> on a control.
+        /// </summary>
+        /// <param name="control">The control.</param>
+        /// <returns>The font style.</returns>
+        public static TextDecorationCollection? GetTextDecorations(Control control)
+        {
+            return control.GetValue(TextDecorationsProperty);
+        }
 
+        /// <summary>
+        /// Sets the value of the attached <see cref="TextDecorationsProperty"/> on a control.
+        /// </summary>
+        /// <param name="control">The control.</param>
+        /// <param name="value">The property value to set.</param>
+        public static void SetTextDecorations(Control control, TextDecorationCollection? value)
+        {
+            control.SetValue(TextDecorationsProperty, value);
+        }
+        
         internal abstract void BuildTextRun(IList<TextRun> textRuns);
 
         internal abstract void AppendText(StringBuilder stringBuilder);

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -135,7 +135,7 @@ namespace Avalonia.Controls
         /// Defines the <see cref="TextDecorations"/> property.
         /// </summary>
         public static readonly StyledProperty<TextDecorationCollection?> TextDecorationsProperty =
-            AvaloniaProperty.Register<TextBlock, TextDecorationCollection?>(nameof(TextDecorations));
+            Inline.TextDecorationsProperty.AddOwner<TextBlock>();
 
         /// <summary>
         /// Defines the <see cref="Inlines"/> property.

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -202,5 +202,26 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Equal(0, target.Inlines.Count);
             }
         }
+        
+        [Fact]
+        public void Setting_TextDecorations_Should_Update_Inlines()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var target = new TextBlock();
+
+                target.Inlines.Add(new Run("Hello World"));
+
+                Assert.Equal(1, target.Inlines.Count);
+
+                Assert.Null(target.Inlines[0].TextDecorations);
+
+                var underline = TextDecorations.Underline;
+
+                target.TextDecorations = underline;
+
+                Assert.Equal(underline, target.Inlines[0].TextDecorations);
+            }
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
The PR fixes a bug and updates logic so `TextBlock.TextDecorations` will apply even when `TextBlock.Inlines` are used.


## What is the current behavior?
`TextDecorations`, unlike nearly all other text related properties, do not currently inherit down from `TextBlock` to `Inlines`.  `TextDecorations` DO currently work if `TextBlock.Text` is specified though.


## What is the updated/expected behavior with this PR?
The updated behavior allows `TextDecorations` to be inherited down into inlines like other text-related properties.


## How was the solution implemented (if it's not obvious)?
Updated `Inline.TextDecorations` to be an attached inherited property like other `TextElement` properties (`FontSize`, `FontWeight`, etc.).  Updated `TextBlock` to add owner that attached property.


## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
Shouldn't be any.

## Obsoletions / Deprecations
None

## Fixed issues
None