### PR TITLE
Fix changing `ItemsControl.ItemContainerTheme`

### DIFF
--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -665,12 +665,10 @@ namespace Avalonia.Controls
         {
             var itemContainerTheme = ItemContainerTheme;
 
-            if (itemContainerTheme is not null &&
-                !container.IsSet(ThemeProperty) &&
-                StyledElement.GetStyleKey(container) == itemContainerTheme.TargetType)
-            {
+            if (itemContainerTheme is null)
+                container.Theme = null;
+            else if (GetStyleKey(container) == itemContainerTheme.TargetType)
                 container.Theme = itemContainerTheme;
-            }
 
             if (item is not Control)
                 container.DataContext = item;

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -68,7 +68,7 @@ namespace Avalonia.Controls
             AvaloniaProperty.Register<ItemsControl, IBinding?>(nameof(DisplayMemberBinding));
 
         private static readonly AttachedProperty<ControlTheme?> AppliedItemContainerTheme =
-            AvaloniaProperty.RegisterAttached<ItemsControl, Control, ControlTheme?>("HasAppliedItemContainerTheme");
+            AvaloniaProperty.RegisterAttached<ItemsControl, Control, ControlTheme?>("AppliedItemContainerTheme");
 
         /// <summary>
         /// Gets or sets the <see cref="IBinding"/> to use for binding to the display member of each item.

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -682,7 +682,7 @@ namespace Avalonia.Controls
                 }
                 else
                 {
-                    // Otherwise clear the theme and the HasAppliedItemContainerTheme property.
+                    // Otherwise clear the theme and the AppliedItemContainerTheme property.
                     container.ClearValue(ThemeProperty);
                     container.ClearValue(AppliedItemContainerTheme);
                 }

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -67,6 +67,9 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<IBinding?> DisplayMemberBindingProperty =
             AvaloniaProperty.Register<ItemsControl, IBinding?>(nameof(DisplayMemberBinding));
 
+        private static readonly AttachedProperty<ControlTheme?> AppliedItemContainerTheme =
+            AvaloniaProperty.RegisterAttached<ItemsControl, Control, ControlTheme?>("HasAppliedItemContainerTheme");
+
         /// <summary>
         /// Gets or sets the <see cref="IBinding"/> to use for binding to the display member of each item.
         /// </summary>
@@ -663,12 +666,27 @@ namespace Avalonia.Controls
 
         internal void PrepareItemContainer(Control container, object? item, int index)
         {
-            var itemContainerTheme = ItemContainerTheme;
+            // If the container has no theme set, or we've already applied our ItemContainerTheme
+            // (and it hasn't changed since) then we're in control of the container's Theme and may
+            // need to update it.
+            if (!container.IsSet(ThemeProperty) || container.GetValue(AppliedItemContainerTheme) == container.Theme)
+            {
+                var itemContainerTheme = ItemContainerTheme;
 
-            if (itemContainerTheme is null)
-                container.Theme = null;
-            else if (itemContainerTheme.TargetType?.IsAssignableFrom(GetStyleKey(container)) == true)
-                container.Theme = itemContainerTheme;
+                if (itemContainerTheme?.TargetType?.IsAssignableFrom(GetStyleKey(container)) == true)
+                {
+                    // We have an ItemContainerTheme and it matches the container. Set the Theme
+                    // property, and mark the container as having had ItemContainerTheme applied.
+                    container.SetCurrentValue(ThemeProperty, itemContainerTheme);
+                    container.SetValue(AppliedItemContainerTheme, itemContainerTheme);
+                }
+                else
+                {
+                    // Otherwise clear the theme and the HasAppliedItemContainerTheme property.
+                    container.ClearValue(ThemeProperty);
+                    container.ClearValue(AppliedItemContainerTheme);
+                }
+            }
 
             if (item is not Control)
                 container.DataContext = item;

--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -667,7 +667,7 @@ namespace Avalonia.Controls
 
             if (itemContainerTheme is null)
                 container.Theme = null;
-            else if (GetStyleKey(container) == itemContainerTheme.TargetType)
+            else if (itemContainerTheme.TargetType?.IsAssignableFrom(GetStyleKey(container)) == true)
                 container.Theme = itemContainerTheme;
 
             if (item is not Control)

--- a/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
@@ -14,6 +14,7 @@ using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.LogicalTree;
 using Avalonia.Markup.Xaml.Templates;
+using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.UnitTests;
 using Avalonia.VisualTree;
@@ -126,6 +127,102 @@ namespace Avalonia.Controls.UnitTests
             var container = GetContainer(target);
 
             Assert.Same(container.Theme, theme);
+        }
+
+        [Fact]
+        public void ItemContainerTheme_Can_Be_Changed()
+        {
+            using var app = Start();
+            
+            var theme1 = new ControlTheme 
+            { 
+                TargetType = typeof(ContentPresenter),
+                Setters = { new Setter(ContentPresenter.BackgroundProperty, Brushes.Red) }
+            };
+
+            var theme2 = new ControlTheme
+            {
+                TargetType = typeof(ContentPresenter),
+                Setters = { new Setter(ContentPresenter.BackgroundProperty, Brushes.Green) }
+            };
+
+            var target = CreateTarget(
+                itemsSource: new[] { "Foo" },
+                itemContainerTheme: theme1);
+
+            var container = GetContainer(target);
+
+            Assert.Same(container.Theme, theme1);
+            Assert.Equal(container.Background, Brushes.Red);
+
+            target.ItemContainerTheme = theme2;
+
+            container = GetContainer(target);
+            Assert.Same(container.Theme, theme2);
+            Assert.Equal(container.Background, Brushes.Green);
+        }
+
+        [Fact]
+        public void ItemContainerTheme_Can_Be_Changed_Virtualizing()
+        {
+            using var app = Start();
+
+            var theme1 = new ControlTheme
+            {
+                TargetType = typeof(ContentPresenter),
+                Setters = { new Setter(ContentPresenter.BackgroundProperty, Brushes.Red) }
+            };
+
+            var theme2 = new ControlTheme
+            {
+                TargetType = typeof(ContentPresenter),
+                Setters = { new Setter(ContentPresenter.BackgroundProperty, Brushes.Green) }
+            };
+
+            var itemsPanel = new FuncTemplate<Panel?>(() => new VirtualizingStackPanel());
+            var target = CreateTarget(
+                itemsSource: new[] { "Foo" },
+                itemContainerTheme: theme1,
+                itemsPanel: itemsPanel);
+
+            var container = GetContainer(target);
+
+            Assert.Same(container.Theme, theme1);
+            Assert.Equal(container.Background, Brushes.Red);
+
+            target.ItemContainerTheme = theme2;
+            Layout(target);
+
+            container = GetContainer(target);
+            Assert.Same(container.Theme, theme2);
+            Assert.Equal(container.Background, Brushes.Green);
+        }
+
+        [Fact]
+        public void ItemContainerTheme_Can_Be_Cleared()
+        {
+            using var app = Start();
+
+            var theme = new ControlTheme
+            {
+                TargetType = typeof(ContentPresenter),
+                Setters = { new Setter(ContentPresenter.BackgroundProperty, Brushes.Red) }
+            };
+
+            var target = CreateTarget(
+                itemsSource: new[] { "Foo" },
+                itemContainerTheme: theme);
+
+            var container = GetContainer(target);
+
+            Assert.Same(container.Theme, theme);
+            Assert.Equal(container.Background, Brushes.Red);
+
+            target.ItemContainerTheme = null;
+
+            container = GetContainer(target);
+            Assert.Null(container.Theme);
+            Assert.Null(container.Background);
         }
 
         [Fact]
@@ -851,6 +948,7 @@ namespace Avalonia.Controls.UnitTests
             IList? itemsSource = null,
             ControlTheme? itemContainerTheme = null,
             IDataTemplate? itemTemplate = null,
+            ITemplate<Panel?>? itemsPanel = null,
             IEnumerable<IDataTemplate>? dataTemplates = null,
             bool performLayout = true)
         {
@@ -861,6 +959,7 @@ namespace Avalonia.Controls.UnitTests
                 itemsSource: itemsSource,
                 itemContainerTheme: itemContainerTheme,
                 itemTemplate: itemTemplate,
+                itemsPanel: itemsPanel,
                 dataTemplates: dataTemplates,
                 performLayout: performLayout);
         }

--- a/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
@@ -130,6 +130,20 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Container_Should_Have_Theme_Set_To_ItemContainerTheme_With_Base_TargetType()
+        {
+            using var app = Start();
+            var theme = new ControlTheme { TargetType = typeof(Control) };
+            var target = CreateTarget(
+                itemsSource: new[] { "Foo" },
+                itemContainerTheme: theme);
+
+            var container = GetContainer(target);
+
+            Assert.Same(container.Theme, theme);
+        }
+
+        [Fact]
         public void ItemContainerTheme_Can_Be_Changed()
         {
             using var app = Start();

--- a/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
@@ -240,6 +240,45 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void ItemContainerTheme_Should_Not_Override_LocalValue_Theme()
+        {
+            using var app = Start();
+
+            var theme1 = new ControlTheme
+            {
+                TargetType = typeof(ContentPresenter),
+                Setters = { new Setter(ContentPresenter.BackgroundProperty, Brushes.Red) }
+            };
+
+            var theme2 = new ControlTheme
+            {
+                TargetType = typeof(Control),
+                Setters = { new Setter(ContentPresenter.BackgroundProperty, Brushes.Green) }
+            };
+
+            var items = new object[]
+            {
+                new ContentPresenter(),
+                new ContentPresenter
+                {
+                    Theme = theme2
+                },
+            };
+
+            var target = CreateTarget(
+                itemsSource: items,
+                itemContainerTheme: theme1);
+
+            Assert.Same(theme1, GetContainer(target, 0).Theme);
+            Assert.Same(theme2, GetContainer(target, 1).Theme);
+
+            target.ItemContainerTheme = null;
+
+            Assert.Null(GetContainer(target, 0).Theme);
+            Assert.Same(theme2, GetContainer(target, 1).Theme);
+        }
+
+        [Fact]
         public void Container_Should_Have_LogicalParent_Set_To_ItemsControl()
         {
             using var app = UnitTestApplication.Start(TestServices.StyledWindow);


### PR DESCRIPTION
## What does the pull request do?

As described in #12620, changing an `ItemsControl`'s `ItemContainerTheme` didn't result in the change being reflected visually in some cases. The solution provided in #12620 by @timunie was almost correct but didn't correctly handle the `ItemContainerTheme` being set to null.

Fixed these issues and added unit tests.

In doing so, I noticed that the check for `GetStyleKey(container) == itemContainerTheme.TargetType` was incorrect as it should be possible to specify the `TargetType` using a base class. Also added a test for this and fixed it.


## Fixed issues

Fixes #12620 