### PR TITLE
Fix for AccessText underlines being very blurry

### DIFF
--- a/src/Avalonia.Controls/Primitives/AccessText.cs
+++ b/src/Avalonia.Controls/Primitives/AccessText.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using Avalonia.Reactive;
 using Avalonia.Media;
 using Avalonia.Media.TextFormatting;
+using System;
 
 namespace Avalonia.Controls.Primitives
 {
@@ -68,11 +69,15 @@ namespace Avalonia.Controls.Primitives
             if (underscore != -1 && ShowAccessKey)
             {
                 var rect = TextLayout!.HitTestTextPosition(underscore);
-                var offset = new Vector(0, -1.5);
+
+                var x1 = Math.Round(rect.Left, MidpointRounding.AwayFromZero);
+                var x2 = Math.Round(rect.Right, MidpointRounding.AwayFromZero);
+                var y = Math.Round(rect.Bottom, MidpointRounding.AwayFromZero) - 1.5;
+
                 context.DrawLine(
                     new Pen(Foreground, 1),
-                    rect.BottomLeft + offset,
-                    rect.BottomRight + offset);
+                    new Point(x1, y),
+                    new Point(x2, y));
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
Updates `AccessText.RenderCore` logic to align the rendered underline to pixel bounds for clarity.

## What is the current behavior?
The `DrawLine` method was rendering at non-pixel bounds, which made lines very blurry.

This simple XAML shows blurry underlines:
```
<AccessText Text="_Access text" />
```
![image](https://github.com/AvaloniaUI/Avalonia/assets/5760058/f8e98260-de61-4cd7-92b2-fff23f65e4a2)

## What is the updated/expected behavior with this PR?
Now lines render crisply like this:
![image](https://github.com/AvaloniaUI/Avalonia/assets/5760058/9432cbc8-3999-48e9-a0c9-937e144df9cf)

## How was the solution implemented (if it's not obvious)?
Rounded line coordinates to render on pixel bounds.

## Checklist
N/A

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
None