### PR TITLE
Add option to set MacOS rendering timer

### DIFF
--- a/src/Avalonia.Native/AvaloniaNativePlatform.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatform.cs
@@ -98,6 +98,8 @@ namespace Avalonia.Native
                 _factory.MacOptions.SetShowInDock(macOpts.ShowInDock ? 1 : 0);
                 _factory.MacOptions.SetDisableSetProcessName(macOpts.DisableSetProcessName ? 1 : 0);
             }
+            
+            var timerFps = macOpts?.DefaultRenderTimerFps ?? 60;
 
             AvaloniaLocator.CurrentMutable
                 .Bind<IDispatcherImpl>()
@@ -108,7 +110,7 @@ namespace Avalonia.Native
                 .Bind<IPlatformSettings>().ToConstant(new NativePlatformSettings(_factory.CreatePlatformSettings()))
                 .Bind<IWindowingPlatform>().ToConstant(this)
                 .Bind<IClipboard>().ToConstant(new ClipboardImpl(_factory.CreateClipboard()))
-                .Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(60))
+                .Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(timerFps))
                 .Bind<IMountedVolumeInfoProvider>().ToConstant(new MacOSMountedVolumeInfoProvider())
                 .Bind<IPlatformDragSource>().ToConstant(new AvaloniaNativeDragSource(_factory))
                 .Bind<IPlatformLifetimeEventsImpl>().ToConstant(applicationPlatform)

--- a/src/Avalonia.Native/AvaloniaNativePlatformExtensions.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatformExtensions.cs
@@ -107,5 +107,7 @@ namespace Avalonia
         /// Disabling this can be useful in some scenarios like when running as a plugin inside an existing macOS application.
         /// </summary>
         public bool DisableAvaloniaAppDelegate { get; set; }
+        
+        public int DefaultRenderTimerFps { get; set; } = 60;
     }
 }


### PR DESCRIPTION
## What does the pull request do?

It allows to set render timer to different value than 60 which is currently hardcoded for Mac. There is also no way to configure this due to how Mac platform is initialized.

## What is the current behavior?

Currently `60` fps is hardcoded for MacOS. There is no config option to change this.

## What is the updated/expected behavior with this PR?

`MacOSPlatformOptions` has one new property `DefaultRenderTimerFps` to set requested fps for the renderer with default value of 60 as before.

`MacOSPlatformOptions.DefaultRenderTimerFps` is used instead of value `60` in `AvaloniaNativePlatform` as parameter in the `DefaultRenderTimer` constructor.

## Breaking changes

Nothing I am aware of.

## Obsoletions / Deprecations
Nothing

## Fixed issues
I did not find any issue about this subject.
