### PR TITLE
Revert Inline breaking change

### DIFF
--- a/src/Avalonia.Controls/Documents/Inline.cs
+++ b/src/Avalonia.Controls/Documents/Inline.cs
@@ -10,10 +10,11 @@ namespace Avalonia.Controls.Documents
     /// </summary>
     public abstract class Inline : TextElement
     {
+        // TODO12: change the field type to an AttachedProperty for consistency (breaking change)
         /// <summary>
         /// AvaloniaProperty for <see cref="TextDecorations" /> property.
         /// </summary>
-        public static readonly AttachedProperty<TextDecorationCollection?> TextDecorationsProperty =
+        public static readonly StyledProperty<TextDecorationCollection?> TextDecorationsProperty =
             AvaloniaProperty.RegisterAttached<Inline, Inline, TextDecorationCollection?>(
                 nameof(TextDecorations),
                 inherits: true);


### PR DESCRIPTION
#12624 introduced a binary breaking change undetected by the API diff tool: the public field `Inline.TextDecorationsProperty` has a different return type.

Fixed by reverting the declaration to `StyledProperty`, while keeping the new behavior.