### PR TITLE
fix polygon/polyline load fail points within the template

### DIFF
--- a/src/Avalonia.Controls/Shapes/Polygon.cs
+++ b/src/Avalonia.Controls/Shapes/Polygon.cs
@@ -6,18 +6,13 @@ namespace Avalonia.Controls.Shapes
     public class Polygon : Shape
     {
         public static readonly StyledProperty<IList<Point>> PointsProperty =
-            AvaloniaProperty.Register<Polygon, IList<Point>>("Points");
+            AvaloniaProperty.Register<Polygon, IList<Point>>("Points", new Points());
 
         static Polygon()
         {
             AffectsGeometry<Polygon>(PointsProperty);
         }
 
-        public Polygon()
-        {
-            Points = new Points();
-        }
-        
         public IList<Point> Points
         {
             get => GetValue(PointsProperty);

--- a/src/Avalonia.Controls/Shapes/Polygon.cs
+++ b/src/Avalonia.Controls/Shapes/Polygon.cs
@@ -1,16 +1,22 @@
 using System.Collections.Generic;
 using Avalonia.Media;
+using Avalonia.Data;
 
 namespace Avalonia.Controls.Shapes
 {
     public class Polygon : Shape
     {
         public static readonly StyledProperty<IList<Point>> PointsProperty =
-            AvaloniaProperty.Register<Polygon, IList<Point>>("Points", new Points());
+            AvaloniaProperty.Register<Polygon, IList<Point>>("Points");
 
         static Polygon()
         {
             AffectsGeometry<Polygon>(PointsProperty);
+        }
+
+        public Polygon()
+        {
+            SetValue(PointsProperty, new Points(), BindingPriority.Template);
         }
 
         public IList<Point> Points

--- a/src/Avalonia.Controls/Shapes/Polyline.cs
+++ b/src/Avalonia.Controls/Shapes/Polyline.cs
@@ -3,20 +3,15 @@ using Avalonia.Media;
 
 namespace Avalonia.Controls.Shapes
 {
-    public class Polyline: Shape
+    public class Polyline : Shape
     {
         public static readonly StyledProperty<IList<Point>> PointsProperty =
-            AvaloniaProperty.Register<Polyline, IList<Point>>("Points");
+            AvaloniaProperty.Register<Polyline, IList<Point>>("Points", new Points());
 
         static Polyline()
         {
             StrokeThicknessProperty.OverrideDefaultValue<Polyline>(1);
             AffectsGeometry<Polyline>(PointsProperty);
-        }
-
-        public Polyline()
-        {
-            Points = new Points();
         }
 
         public IList<Point> Points

--- a/src/Avalonia.Controls/Shapes/Polyline.cs
+++ b/src/Avalonia.Controls/Shapes/Polyline.cs
@@ -7,7 +7,7 @@ namespace Avalonia.Controls.Shapes
     public class Polyline : Shape
     {
         public static readonly StyledProperty<IList<Point>> PointsProperty =
-            AvaloniaProperty.Register<Polyline, IList<Point>>("Points", new Points());
+            AvaloniaProperty.Register<Polyline, IList<Point>>("Points");
 
         static Polyline()
         {

--- a/src/Avalonia.Controls/Shapes/Polyline.cs
+++ b/src/Avalonia.Controls/Shapes/Polyline.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Avalonia.Media;
+using Avalonia.Data;
 
 namespace Avalonia.Controls.Shapes
 {
@@ -12,6 +13,11 @@ namespace Avalonia.Controls.Shapes
         {
             StrokeThicknessProperty.OverrideDefaultValue<Polyline>(1);
             AffectsGeometry<Polyline>(PointsProperty);
+        }
+
+        public Polyline()
+        {
+            SetValue(PointsProperty, new Points(), BindingPriority.Template);
         }
 
         public IList<Point> Points


### PR DESCRIPTION
## What does the pull request do?
use polygon in button's template,polygon invisible
i want fix polygon/polyline Unable to load points within the template.

## What is the current behavior?
![errorimage](https://github.com/AvaloniaUI/Avalonia/assets/10973919/68a6392a-a868-42f1-92dd-27b4b577bf21)


## What is the updated/expected behavior with this PR?
![Dingtalk_20230824153410](https://github.com/AvaloniaUI/Avalonia/assets/10973919/98bef346-525b-4e9b-9260-433fcc435be1)
polygon/polyline can load points within the template.

## How was the solution implemented (if it's not obvious)?
Within the polygon constructor, “Points=new Points()”，BindingPriority is LocalValue；
When in the Template，loading points from xaml，BindingPriority is Template，so loading faild，the property points always the "new Points()";

## Breaking changes

## Obsoletions / Deprecations


## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
