### PR TITLE
Call CaptureLost on gestures when pointer loses capture

### DIFF
--- a/src/Avalonia.Base/Input/GestureRecognizers/GestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/GestureRecognizer.cs
@@ -3,7 +3,6 @@
     public abstract class GestureRecognizer : StyledElement
     {
         protected internal IInputElement? Target { get; internal set; }
-        protected internal GestureRecognizerCollection? GestureRecognizerCollection { get; internal set; }
 
         protected abstract void PointerPressed(PointerPressedEventArgs e);
         protected abstract void PointerReleased(PointerReleasedEventArgs e);

--- a/src/Avalonia.Base/Input/GestureRecognizers/GestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/GestureRecognizer.cs
@@ -3,6 +3,7 @@
     public abstract class GestureRecognizer : StyledElement
     {
         protected internal IInputElement? Target { get; internal set; }
+        protected internal GestureRecognizerCollection? GestureRecognizerCollection { get; internal set; }
 
         protected abstract void PointerPressed(PointerPressedEventArgs e);
         protected abstract void PointerReleased(PointerReleasedEventArgs e);

--- a/src/Avalonia.Base/Input/GestureRecognizers/GestureRecognizerCollection.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/GestureRecognizerCollection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Avalonia.Controls;
@@ -24,8 +25,14 @@ namespace Avalonia.Input.GestureRecognizers
                 _recognizers = new List<GestureRecognizer>();
             }
 
+            if(recognizer.GestureRecognizerCollection != null && recognizer.GestureRecognizerCollection != this)
+            {
+                throw new InvalidOperationException("The gesture recognizer has already been added to a gesture recognizer collection");
+            }
+
             _recognizers.Add(recognizer);
             recognizer.Target = _inputElement;
+            recognizer.GestureRecognizerCollection = this;
 
             // Hacks to make bindings work
 
@@ -57,6 +64,20 @@ namespace Avalonia.Input.GestureRecognizers
             }
 
             return e.Handled;
+        }
+
+        internal void HandleCaptureLost(IPointer pointer)
+        {
+            if (_recognizers == null || pointer is not Pointer p)
+                return;
+
+            foreach (var r in _recognizers)
+            {
+                if (p.CapturedGestureRecognizer == r)
+                    continue;
+
+                r.PointerCaptureLostInternal(pointer);
+            }
         }
 
         internal bool HandlePointerReleased(PointerReleasedEventArgs e)

--- a/src/Avalonia.Base/Input/GestureRecognizers/GestureRecognizerCollection.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/GestureRecognizerCollection.cs
@@ -25,14 +25,8 @@ namespace Avalonia.Input.GestureRecognizers
                 _recognizers = new List<GestureRecognizer>();
             }
 
-            if(recognizer.GestureRecognizerCollection != null && recognizer.GestureRecognizerCollection != this)
-            {
-                throw new InvalidOperationException("The gesture recognizer has already been added to a gesture recognizer collection");
-            }
-
             _recognizers.Add(recognizer);
             recognizer.Target = _inputElement;
-            recognizer.GestureRecognizerCollection = this;
 
             // Hacks to make bindings work
 

--- a/src/Avalonia.Base/Input/GestureRecognizers/PinchGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/PinchGestureRecognizer.cs
@@ -62,7 +62,6 @@ namespace Avalonia.Input
         {
             if (Target != null && Target is Visual visual && (e.Pointer.Type == PointerType.Touch || e.Pointer.Type == PointerType.Pen))
             {
-                Debug.WriteLine($"Pointer with ID: {e.Pointer.Id} pressed");
                 if (_firstContact == null)
                 {
                     _firstContact = e.Pointer;
@@ -112,8 +111,6 @@ namespace Avalonia.Input
 
                     _secondContact = null;
                 }
-
-                Debug.WriteLine($"Pointer with ID: {pointer.Id} removed");
 
                 Target?.RaiseEvent(new PinchEndedEventArgs());
             }

--- a/src/Avalonia.Base/Input/GestureRecognizers/PinchGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/PinchGestureRecognizer.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Input.GestureRecognizers;
+﻿using System.Diagnostics;
+using Avalonia.Input.GestureRecognizers;
 
 namespace Avalonia.Input
 {
@@ -61,6 +62,7 @@ namespace Avalonia.Input
         {
             if (Target != null && Target is Visual visual && (e.Pointer.Type == PointerType.Touch || e.Pointer.Type == PointerType.Pen))
             {
+                Debug.WriteLine($"Pointer with ID: {e.Pointer.Id} pressed");
                 if (_firstContact == null)
                 {
                     _firstContact = e.Pointer;
@@ -110,6 +112,9 @@ namespace Avalonia.Input
 
                     _secondContact = null;
                 }
+
+                Debug.WriteLine($"Pointer with ID: {pointer.Id} removed");
+
                 Target?.RaiseEvent(new PinchEndedEventArgs());
             }
         }

--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -230,6 +230,7 @@ namespace Avalonia.Input
             PointerMovedEvent.AddClassHandler<InputElement>((x, e) => x.OnGesturePointerMoved(e), handledEventsToo: true);
             PointerPressedEvent.AddClassHandler<InputElement>((x, e) => x.OnGesturePointerPressed(e), handledEventsToo: true);
             PointerReleasedEvent.AddClassHandler<InputElement>((x, e) => x.OnGesturePointerReleased(e), handledEventsToo: true);
+            PointerCaptureLostEvent.AddClassHandler<InputElement>((x, e) => x.OnGesturePointerCaptureLost(e), handledEventsToo: true);
         }
 
         public InputElement()
@@ -613,6 +614,11 @@ namespace Avalonia.Input
                 {
                     e.Handled = true;
                 }
+        }
+
+        private void OnGesturePointerCaptureLost(PointerCaptureLostEventArgs e)
+        {
+            _gestureRecognizers?.HandleCaptureLost(e.Pointer);
         }
 
         private void OnGesturePointerPressed(PointerPressedEventArgs e)

--- a/src/Avalonia.Base/Input/Pointer.cs
+++ b/src/Avalonia.Base/Input/Pointer.cs
@@ -91,12 +91,17 @@ namespace Avalonia.Input
         internal void CaptureGestureRecognizer(GestureRecognizer? gestureRecognizer)
         {
             if (CapturedGestureRecognizer != gestureRecognizer)
+            {
                 CapturedGestureRecognizer?.PointerCaptureLostInternal(this);
-
-            if (gestureRecognizer != null)
-                Capture(null);
+            }
 
             CapturedGestureRecognizer = gestureRecognizer;
+
+            if (gestureRecognizer != null)
+            {
+                gestureRecognizer.GestureRecognizerCollection?.HandleCaptureLost(this);
+                Capture(null);
+            }
         }
     }
 }

--- a/src/Avalonia.Base/Input/Pointer.cs
+++ b/src/Avalonia.Base/Input/Pointer.cs
@@ -99,7 +99,6 @@ namespace Avalonia.Input
 
             if (gestureRecognizer != null)
             {
-                gestureRecognizer.GestureRecognizerCollection?.HandleCaptureLost(this);
                 Capture(null);
             }
         }

--- a/tests/Avalonia.Base.UnitTests/Input/GesturesTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/GesturesTests.cs
@@ -488,6 +488,40 @@ namespace Avalonia.Base.UnitTests.Input
         }
 
         [Fact]
+        public void Gestures_Should_Be_Cancelled_When_Pointer_Capture_Is_Lost()
+        {
+            Border border = new Border()
+            {
+                Width = 100,
+                Height = 100,
+                Background = new SolidColorBrush(Colors.Red)
+            };
+            border.GestureRecognizers.Add(new PinchGestureRecognizer());
+            var root = new TestRoot
+            {
+                Child = border
+            };
+            var raised = false;
+
+            root.AddHandler(Gestures.PinchEvent, (_, _) => raised = true);
+
+            var firstPoint = new Point(5, 5);
+            var secondPoint = new Point(10, 10);
+
+            var firstTouch = new TouchTestHelper();
+            var secondTouch = new TouchTestHelper();
+
+            firstTouch.Down(border, position: firstPoint);
+
+            firstTouch.Cancel();
+
+            secondTouch.Down(border, position: secondPoint);
+            secondTouch.Move(border, position: new Point(20, 20));
+
+            Assert.False(raised);
+        }
+
+        [Fact]
         public void Scrolling_Should_Start_After_Start_Distance_Is_Exceeded()
         {
             Border border = new Border()

--- a/tests/Avalonia.UnitTests/TouchTestHelper.cs
+++ b/tests/Avalonia.UnitTests/TouchTestHelper.cs
@@ -61,5 +61,11 @@ namespace Avalonia.UnitTests
             Down(target, source, position, modifiers);
             Up(target, source, position, modifiers);
         }
+
+        public void Cancel()
+        {
+            _pointer.Capture(null);
+            _pointer.CaptureGestureRecognizer(null);
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Ensures that the pointer capture lost event is called on all gesture recognizers attached to an input element.


## What is the current behavior?
All gestures receive the PointerPressed event, and they set states to start tracking the pointer. If PointerMoveD is received and the conditions for the gesture is met, the gesture captures the pointer, and no other gesture receives events. When the pointer is released, all gestures receive the Released events and reset their states.

In the case of Touch, if the device sends a TouchCancel event, it's interpreted as a CaptureLost event. Only the captured InputElement and the CapturedGesture handles this. For other gestures on the input element that have received the PointerPressed event and set their initial state, they don't receive any event to reset it. This is also true when none of the gestures have captured the pointer


## What is the updated/expected behavior with this PR?
When an input element loses pointer capture, all gesture recognizers attached to it that was not the source of the CaptureLost gets
 notified. When the pointer loses capture or is cancelled, all gesture recognizers of the last caputed element will be notified.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [X] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #12083