### PR TITLE
Fix pointer sample page scrolling issue

### DIFF
--- a/samples/ControlCatalog/Pages/PointerCanvas.cs
+++ b/samples/ControlCatalog/Pages/PointerCanvas.cs
@@ -74,6 +74,7 @@ public class PointerCanvas : Control
         public void HandleEvent(PointerEventArgs e, Visual v)
         {
             e.Handled = true;
+            e.PreventGestureRecognition();
             var currentPoint = e.GetCurrentPoint(v);
             if (e.RoutedEvent == PointerPressedEvent)
                 AddPoint(currentPoint.Position, Brushes.Green, 10);

--- a/samples/ControlCatalog/Pages/PointerContactsTab.cs
+++ b/samples/ControlCatalog/Pages/PointerContactsTab.cs
@@ -72,6 +72,7 @@ public class PointerContactsTab : Control
         UpdatePointer(e);
         e.Pointer.Capture(this);
         e.Handled = true;
+        e.PreventGestureRecognition();
         base.OnPointerPressed(e);
     }
 

--- a/samples/ControlCatalog/Pages/PointersPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/PointersPage.xaml.cs
@@ -72,6 +72,7 @@ Position: ??? ???";
     {
         e.Pointer.Capture(sender as Border);
         e.Handled = true;
+        e.PreventGestureRecognition();
     }
 
     private void InitializeComponent()


### PR DESCRIPTION
## What does the pull request do?
Fixes an issue where scroll gesture stops pointer capture in the ControlCatalog Samples page.


## What is the current behavior?
Because Gestures are prioritized over captured elements, when a gesture starts, pointer capture is removed from the active control.
This is expected behavior, and a `PreventGestureRecognition` method is available in the pointer event args to disable gestures when a control needs special pointer handling. The Pointer Sample page is one such page, and previously will stop tracking the pointer when you start to scroll.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #12289
