### PR TITLE
Adjust popup working area with toplevel's safe area padding

### DIFF
--- a/src/Avalonia.Controls/Primitives/OverlayPopupHost.cs
+++ b/src/Avalonia.Controls/Primitives/OverlayPopupHost.cs
@@ -78,7 +78,7 @@ namespace Avalonia.Controls.Primitives
             Rect? rect = null)
         {
             _positionerParameters.ConfigurePosition((TopLevel)_overlayLayer.GetVisualRoot()!, target, placement, offset, anchor,
-                gravity, constraintAdjustment, rect, FlowDirection);
+                gravity, constraintAdjustment | PopupPositionerConstraintAdjustment.All, rect, FlowDirection);
             UpdatePosition();
         }
 
@@ -110,6 +110,13 @@ namespace Avalonia.Controls.Primitives
             get
             {
                 var rc = new Rect(default, _overlayLayer.AvailableSize);
+                var topLevel = TopLevel.GetTopLevel(this);
+                if(topLevel != null)
+                {
+                    var padding = topLevel.InsetsManager?.SafeAreaPadding ?? default;
+                    rc = rc.Deflate(padding);
+                }
+
                 return new[] {new ManagedPopupPositionerScreenInfo(rc, rc)};
             }
         }


### PR DESCRIPTION
## What does the pull request do?
Adjusts the working area of managed popups with toplevel's safe area. This ensures popups are not hidden by system insets.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #12010
