### PR TITLE
Fix OnOpenGlInit getting called twice

### DIFF
--- a/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs
+++ b/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs
@@ -108,8 +108,6 @@ namespace Avalonia.OpenGL.Controls
             _visual.Size = new Vector(Bounds.Width, Bounds.Height);
             _visual.Surface = _resources.Surface;
             ElementComposition.SetElementChildVisual(this, _visual);
-            using (_resources.Context.MakeCurrent())
-                OnOpenGlInit(_resources.Context.GlInterface);
             return true;
 
         }


### PR DESCRIPTION
## What does the pull request do?
This fixes #10371 it removes the call to `OnOpenGlInit` in the method `EnsureInitializedCore` so now it only gets called at the end of `InitializeAsync`.


## What is the current behavior?
Currently `InitializeAsync` calls `EnsureInitializedCore`, which calls `OnOpenGlInit` at the end and returns true after that `InitializeAsync` calls `OnOpenGlInit` aswell.


## What is the updated/expected behavior with this PR?
Now if u create a Control inheriting from `OpenGlControlBase` the method `OnOpenGlInit` will only be called once per initialization.


## How was the solution implemented (if it's not obvious)?
Removed the call to `OnOpenGlInit` in `EnsureInitializedCore`.


## Fixed issues
Fixes #10371

