### PR TITLE
Updated Transition to use direct properties via use of new TransitionBase class

### DIFF
--- a/src/Avalonia.Base/Animation/TransitionBase.cs
+++ b/src/Avalonia.Base/Animation/TransitionBase.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Avalonia.Animation.Easings;
+
+namespace Avalonia.Animation
+{
+    /// <summary>
+    /// Defines how a property should be animated using a transition.
+    /// </summary>
+    public abstract class TransitionBase : AvaloniaObject, ITransition
+    {
+        /// <summary>
+        /// Defines the <see cref="Duration"/> property.
+        /// </summary>
+        public static readonly DirectProperty<TransitionBase, TimeSpan> DurationProperty =
+            AvaloniaProperty.RegisterDirect<TransitionBase, TimeSpan>(
+                nameof(Duration),
+                o => o._duration,
+                (o, v) => o._duration = v);
+        
+        /// <summary>
+        /// Defines the <see cref="Delay"/> property.
+        /// </summary>
+        public static readonly DirectProperty<TransitionBase, TimeSpan> DelayProperty =
+            AvaloniaProperty.RegisterDirect<TransitionBase, TimeSpan>(
+                nameof(Delay),
+                o => o._delay,
+                (o, v) => o._delay = v);
+        
+        /// <summary>
+        /// Defines the <see cref="Easing"/> property.
+        /// </summary>
+        public static readonly DirectProperty<TransitionBase, Easing> EasingProperty =
+            AvaloniaProperty.RegisterDirect<TransitionBase, Easing>(
+                nameof(Easing),
+                o => o._easing,
+                (o, v) => o._easing = v);
+        
+        /// <summary>
+        /// Defines the <see cref="Property"/> property.
+        /// </summary>
+        public static readonly DirectProperty<TransitionBase, AvaloniaProperty?> PropertyProperty =
+            AvaloniaProperty.RegisterDirect<TransitionBase, AvaloniaProperty?>(
+                nameof(Property),
+                o => o._prop,
+                (o, v) => o._prop = v);
+
+        private TimeSpan _duration;
+        private TimeSpan _delay = TimeSpan.Zero;
+        private Easing _easing = new LinearEasing();
+        private AvaloniaProperty? _prop;
+
+        /// <summary>
+        /// Gets or sets the duration of the transition.
+        /// </summary> 
+        public TimeSpan Duration
+        {
+            get { return _duration; }
+            set { SetAndRaise(DurationProperty, ref _duration, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets delay before starting the transition.
+        /// </summary> 
+        public TimeSpan Delay
+        {
+            get { return _delay; }
+            set { SetAndRaise(DelayProperty, ref _delay, value); }
+        }
+
+        /// <summary>
+        /// Gets the easing class to be used.
+        /// </summary>
+        public Easing Easing
+        {
+            get { return _easing; }
+            set { SetAndRaise(EasingProperty, ref _easing, value); }
+        }
+
+        /// <inheritdocs/>
+        [DisallowNull]
+        public AvaloniaProperty? Property
+        {
+            get { return _prop; }
+            set { SetAndRaise(PropertyProperty, ref _prop, value); }
+        }
+
+        AvaloniaProperty ITransition.Property
+        {
+            get => Property ?? throw new InvalidOperationException("Transition has no property specified.");
+            set => Property = value;
+        }
+
+        /// <inheritdocs/>
+        IDisposable ITransition.Apply(Animatable control, IClock clock, object? oldValue, object? newValue)
+            => Apply(control, clock, oldValue, newValue);
+        
+        internal abstract IDisposable Apply(Animatable control, IClock clock, object? oldValue, object? newValue);
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
Updates the generic `Transition` class to use direct properties instead of plain CLR properties.

## What is the current behavior?
CLR properties were used before, which didn't allow bindings.  Bindings are necessary to properly support some features we want to implement.  The `Animation` class already uses direct properties similar to the changes this PR makes.

## What is the updated/expected behavior with this PR?
The properties now are direct properties, which do allow bindings.

## How was the solution implemented (if it's not obvious)?
Per @kekekeks advice, created a non-generic `TransitionBase` class to define the direct properties since they can't be defined on a generic type.  Updated `Transition` to inherit `TransitionBase`.

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
Everything using `Transition` types should continue working as-is.  These were just backend property implementation changes.

## Obsoletions / Deprecations
None

## Fixed issues
None