### PR TITLE
Fix popups in Windows being offset incorrectly by a workaround for another issue

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -552,7 +552,7 @@ namespace Avalonia.Win32
             get
             {
                 // Windows 10 and 11 add a 7 pixel invisible border on the left/right/bottom of windows for resizing
-                if (Win32Platform.WindowsVersion.Major < 10 || !HasFullDecorations)
+                if (Win32Platform.WindowsVersion.Major < 10 || !HasFullDecorations || GetStyle().HasFlag(WindowStyles.WS_POPUP))
                 {
                     return PixelSize.Empty;
                 }


### PR DESCRIPTION
## What does the pull request do?
Fixes a bug that was introduced by a workaround for another `Window` issue in Windows.  The bug causes popups to be offset incorrectly from their intended location by a pixel.

## What is the current behavior?
Popups are often offset incorrectly by a pixel in Windows.

## What is the updated/expected behavior with this PR?
The incorrect offset is fixed.

## How was the solution implemented (if it's not obvious)?
Updated code to not apply the Windows `HiddenBorderSize` workaround when the window is for a popup.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #12587 