### PR TITLE
Add win32 platform options to select process DPI awareness

### DIFF
--- a/src/Windows/Avalonia.Win32/Win32PlatformOptions.cs
+++ b/src/Windows/Avalonia.Win32/Win32PlatformOptions.cs
@@ -26,6 +26,27 @@ public enum Win32RenderingMode
 }
 
 /// <summary>
+/// Represents the DPI Awareness for the application.
+/// </summary>
+public enum Win32DpiAwareness
+{
+    /// <summary>
+    /// The application is DPI unaware.
+    /// </summary>
+    Unaware,
+
+    /// <summary>
+    /// The application is system DPI aware. It will query DPI once and will not adjust to new DPI changes
+    /// </summary>
+    SystemDpiAware,
+
+    /// <summary>
+    /// The application is per-monitor DPI aware. It adjust its scale factor whenever DPI changes.
+    /// </summary>
+    PerMonitorDpiAware
+}
+
+/// <summary>
 /// Represents the Win32 window composition mode.
 /// </summary>
 public enum Win32CompositionMode
@@ -137,4 +158,6 @@ public class Win32PlatformOptions
     /// and <see cref="CompositionMode"/> only accepts null or <see cref="Win32CompositionMode.RedirectionSurface"/>.
     /// </summary>
     public IPlatformGraphics? CustomPlatformGraphics { get; set; }
+
+    public Win32DpiAwareness DpiAwareness { get; set; } = Win32DpiAwareness.PerMonitorDpiAware;
 }

--- a/src/Windows/Avalonia.Win32/Win32PlatformOptions.cs
+++ b/src/Windows/Avalonia.Win32/Win32PlatformOptions.cs
@@ -159,5 +159,8 @@ public class Win32PlatformOptions
     /// </summary>
     public IPlatformGraphics? CustomPlatformGraphics { get; set; }
 
+    /// <summary>
+    /// Gets or sets the application's DPI awareness.
+    /// </summary>
     public Win32DpiAwareness DpiAwareness { get; set; } = Win32DpiAwareness.PerMonitorDpiAware;
 }


### PR DESCRIPTION
## What does the pull request do?
Adds `DpiAwareness` option to the win32 platform options to allow setting of the process dpi awareness. The default DPI awareness, ie Per-Monitor DPI aware, remains.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
