### PR TITLE
Fix the scrollbar attaching to wrong scrollviewer, like scrollviewer …

### DIFF
--- a/src/Avalonia.Controls/Primitives/ScrollBar.cs
+++ b/src/Avalonia.Controls/Primitives/ScrollBar.cs
@@ -195,14 +195,15 @@ namespace Avalonia.Controls.Primitives
         }
 
         /// <summary>
-        /// Locates the first <see cref="ScrollViewer"/> ancestor and binds to its properties. Properties which have been set through other means are not bound.
+        /// Try to attach to TemplatedParent if it is a <see cref="ScrollViewer"/> and binds to its properties.
+        /// Properties which have been set through other means are not bound.
         /// </summary>
         /// <remarks>
         /// This method is automatically called when the control is attached to a visual tree.
         /// </remarks>
         internal void AttachToScrollViewer()
         {
-            var owner = this.FindAncestorOfType<ScrollViewer>();
+            var owner = this.TemplatedParent as ScrollViewer;
 
             if (owner == null)
             {


### PR DESCRIPTION
…outer a datagrid.

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix the bug that the scrollbar could attach to a wrong scrollviewer, like a scrollviewer outer a datagrid. #12482 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The scrollbar in control template of datagrid will find a nearest ancestor scrollviewer and attach to it. And there is no scrollviewer in control template of datagrid, the scrollbar in it's template will attach to the scrollviewer outer the datagrid, if it exsits. 

**Then, if we scroll the datagrid, the outer scrollviewer will be scrolled too.**

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
The scrollbar will not find the ancestor scrollviewer to attach to now. Instead it will try to attach to it's templatedparent if it is a scrollviewer.

I don't find any case that the scrollbar should bind to a scrollviewer that is not the scrollbar's tempatedparent. So if the case exists, stop this PR please.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
None.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #12482
-->
Fixes #12482

