### PR TITLE
Fix property analyzer exception with object initializers in cctors

### DIFF
--- a/src/tools/Avalonia.Analyzers/AvaloniaPropertyAnalyzer.CompileAnalyzer.cs
+++ b/src/tools/Avalonia.Analyzers/AvaloniaPropertyAnalyzer.CompileAnalyzer.cs
@@ -168,9 +168,9 @@ public partial class AvaloniaPropertyAnalyzer
 
                             foreach (var descendant in node.DescendantNodes().Where(n => n.IsKind(SyntaxKind.SimpleAssignmentExpression)))
                             {
-                                var assignmentOperation = (IAssignmentOperation)model.GetOperation(descendant, cancellationToken)!;
 
-                                if (GetReferencedFieldOrProperty(assignmentOperation.Target) is { } target)
+                                if (model.GetOperation(descendant, cancellationToken) is IAssignmentOperation assignmentOperation &&
+                                    GetReferencedFieldOrProperty(assignmentOperation.Target) is { } target)
                                 {
                                     RegisterAssignment(target, assignmentOperation.Value);
                                 }


### PR DESCRIPTION
## What does the pull request do?
This PR fixes an exception occurring in the property analyzer when an object initializer is present in a static constructor.
See #12743 for a simple repro.

## Remarks
I'm a bit surprised we don't have unit tests here, as it's usually the easiest way to quickly test analyzers.

## Fixed issues
Fixes #12743
