### PR TITLE
GestureRecognizerCollection remove method

### DIFF
--- a/src/Avalonia.Base/Input/GestureRecognizers/GestureRecognizerCollection.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/GestureRecognizerCollection.cs
@@ -47,6 +47,18 @@ namespace Avalonia.Input.GestureRecognizers
             _recognizers.Remove(recognizer);
             recognizer.Target = null;
         }
+        
+        public void RemoveAll()
+        {
+            if (_recognizers == null)
+                return;
+
+            foreach (var r in _recognizers)
+            {
+                r.Target = null;
+            }
+            _recognizers.Clear();
+        }
 
         static readonly List<GestureRecognizer> s_Empty = new List<GestureRecognizer>();
 

--- a/src/Avalonia.Base/Input/GestureRecognizers/GestureRecognizerCollection.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/GestureRecognizerCollection.cs
@@ -38,6 +38,15 @@ namespace Avalonia.Input.GestureRecognizers
                     styleableParent.GetObservable(StyledElement.TemplatedParentProperty).Subscribe(parent => styleableRecognizer.TemplatedParent = parent);
             }
         }
+        
+        public void Remove(GestureRecognizer recognizer)
+        {
+            if (_recognizers == null)
+                return;
+
+            _recognizers.Remove(recognizer);
+            recognizer.Target = null;
+        }
 
         static readonly List<GestureRecognizer> s_Empty = new List<GestureRecognizer>();
 

--- a/tests/Avalonia.Base.UnitTests/Input/GesturesTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/GesturesTests.cs
@@ -457,6 +457,26 @@ namespace Avalonia.Base.UnitTests.Input
         }
 
         [Fact]
+        public void GestureRecognizer_Should_Not_Be_Part_Of_GestureRecognizers_After_Being_Removed()
+        {
+            Border border = new Border()
+            {
+                Width = 100,
+                Height = 100,
+                Background = new SolidColorBrush(Colors.Red)
+            };
+
+            var pinchGestureRecognizer = new PinchGestureRecognizer();
+            border.GestureRecognizers.Add(pinchGestureRecognizer);
+            
+            Assert.Equal(1, border.GestureRecognizers.Count);
+            
+            border.GestureRecognizers.Remove(pinchGestureRecognizer);
+            
+            Assert.Equal(0, border.GestureRecognizers.Count);
+        }
+
+        [Fact]
         public void Pinched_Should_Be_Raised_For_Two_Pointers_Moving()
         {
             Border border = new Border()

--- a/tests/Avalonia.Base.UnitTests/Input/GesturesTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/GesturesTests.cs
@@ -475,6 +475,28 @@ namespace Avalonia.Base.UnitTests.Input
             
             Assert.Equal(0, border.GestureRecognizers.Count);
         }
+        
+        [Fact]
+        public void GestureRecognizer_Should_Not_Be_Part_Of_GestureRecognizers_After_RemoveAll()
+        {
+            Border border = new Border()
+            {
+                Width = 100,
+                Height = 100,
+                Background = new SolidColorBrush(Colors.Red)
+            };
+
+            var pinchGestureRecognizer = new PinchGestureRecognizer();
+            border.GestureRecognizers.Add(pinchGestureRecognizer);
+            var scrollGestureRecognizer = new ScrollGestureRecognizer();
+            border.GestureRecognizers.Add(scrollGestureRecognizer);
+            
+            Assert.Equal(2, border.GestureRecognizers.Count);
+            
+            border.GestureRecognizers.RemoveAll();
+            
+            Assert.Equal(0, border.GestureRecognizers.Count);
+        }
 
         [Fact]
         public void Pinched_Should_Be_Raised_For_Two_Pointers_Moving()


### PR DESCRIPTION
## What does the pull request do?
- Updates GestureRecognizerCollection exposing a `Remove` method

## What is the current behavior?
GestureRecognizerCollection does not expose `Remove` option


## What is the updated/expected behavior with this PR?

Being able to remove a gesture recognizer.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/12558

