### PR TITLE
[Mac] Fixes raw keyDown/textInput handling

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -537,11 +537,13 @@
 - (void)keyDown:(NSEvent *)event
 {
     _lastKeyHandled = false;
-        
+    
     [self keyboardEvent:event withType:KeyDown];
+        
+    BOOL isKeyDownConsumed = [[self inputContext] handleEvent:event];
     
     if(!_lastKeyHandled){
-        [[self inputContext] handleEvent:event];
+        _lastKeyHandled = isKeyDownConsumed == YES;
     }
 }
 
@@ -552,7 +554,6 @@
 }
 
 - (void) doCommandBySelector:(SEL)selector{
-    
 }
 
 - (AvnInputModifiers)getModifiers:(NSEventModifierFlags)mod
@@ -599,8 +600,6 @@
 
 - (void)setMarkedText:(id)string selectedRange:(NSRange)selectedRange replacementRange:(NSRange)replacementRange
 {
-    _lastKeyHandled = true;
-    
     NSString* markedText;
         
     if([string isKindOfClass:[NSAttributedString class]])
@@ -669,8 +668,7 @@
         
     uint64_t timestamp = static_cast<uint64_t>([NSDate timeIntervalSinceReferenceDate] * 1000);
         
-    _lastKeyHandled = _parent->BaseEvents->RawTextInputEvent(timestamp, [text UTF8String]);
-    
+    _parent->BaseEvents->RawTextInputEvent(timestamp, [text UTF8String]);
 }
 
 - (NSUInteger)characterIndexForPoint:(NSPoint)point


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR preserves the order of keyDown/textInput processing but still allows the current IME to consume keyDown events.

`_lastKeyHandled` no longer prevents keyDown events. It is now only used for some internal state.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes: #12571