### PR TITLE
fix: DataGrid scroll should behave the same as ScrollViewer

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -2285,7 +2285,16 @@ namespace Avalonia.Controls
         /// <param name="e">PointerWheelEventArgs</param>
         protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
         {
-            if(UpdateScroll(e.Delta * DATAGRID_mouseWheelDelta))
+            var delta = e.Delta;
+            
+            // KeyModifiers.Shift should scroll in horizontal direction. This does not work on every platform. 
+            // If Shift-Key is pressed and X is close to 0 we swap the Vector.
+            if (e.KeyModifiers == KeyModifiers.Shift && MathUtilities.IsZero(delta.X))
+            {
+                delta = new Vector(delta.Y, delta.X);
+            }
+            
+            if(UpdateScroll(delta * DATAGRID_mouseWheelDelta))
             {
                 e.Handled = true;
             }


### PR DESCRIPTION
## What does the pull request do?
Makes sure scrolling on DataGrid behaves the same as "normal" `ScrollViewer`.


## What is the current behavior?
Holding `[Shift]` doesn't scroll horizontally on DataGrid (at least using Windows 11). This was fixed before by #7520 but was lost during code refractor.


## What is the updated/expected behavior with this PR?
Scrolling behaves the same on every control and OS. Holding `[Shift]` will scroll horizontally

## How was the solution implemented (if it's not obvious)?
copied the needed code from `ScrollContentPresenter`


## Checklist

- [ ] Added unit tests (if possible)? -> I'd like to add some UnitTests, but don't know how. If someone can guide me, I'll implement it.
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
None as far as I can see
