### PR TITLE
Fixed FocusScopes functionality (#10433)

### DIFF
--- a/src/Avalonia.Base/Input/FocusManager.cs
+++ b/src/Avalonia.Base/Input/FocusManager.cs
@@ -54,7 +54,7 @@ namespace Avalonia.Input
             private set;
         }
 
-        public void ClearFocus(IInputElement control, IInputElement? parent)
+        internal void ClearFocus(IInputElement control, IInputElement? parent)
         {
             var currentControl = control;
             while (currentControl != null)
@@ -220,7 +220,7 @@ namespace Avalonia.Input
             return true;
         }
 
-        public void UpdateFocusWithin(IRenderRoot root)
+        internal void UpdateFocusWithin(IRenderRoot root)
         {
             HashSet<Visual>? setFocusWithin = null;
             if (_focusedControls.TryGetValue(root, out var oldFocusedControls))

--- a/src/Avalonia.Base/Input/IFocusManager.cs
+++ b/src/Avalonia.Base/Input/IFocusManager.cs
@@ -22,14 +22,8 @@ namespace Avalonia.Input
         void ClearFocus();
 
         /// <summary>
-        /// Clears focus from control while keeping focus in another scopes.
+        /// Returns list of focused controls in all focus scopes inside specified root.
         /// </summary>
-        /// <param name="control">Control which should lose focus</param>
-        /// <param name="parent">Optional control parent (for cases when it is not available from control itself, i.e. detaching from tree)</param>
-        void ClearFocus(IInputElement control, IInputElement? parent);
-
-        void UpdateFocusWithin(IRenderRoot root);
-
         IEnumerable<IInputElement> GetFocusedElements(IRenderRoot root);
     }
 }

--- a/src/Avalonia.Base/Input/IFocusManager.cs
+++ b/src/Avalonia.Base/Input/IFocusManager.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using Avalonia.Metadata;
+using Avalonia.Rendering;
 
 namespace Avalonia.Input
 {
@@ -18,5 +20,16 @@ namespace Avalonia.Input
         /// </summary>
         [Unstable("This API might be removed in 11.x minor updates. Please consider focusing another element instead of removing focus at all for better UX.")]
         void ClearFocus();
+
+        /// <summary>
+        /// Clears focus from control while keeping focus in another scopes.
+        /// </summary>
+        /// <param name="control">Control which should lose focus</param>
+        /// <param name="parent">Optional control parent (for cases when it is not available from control itself, i.e. detaching from tree)</param>
+        void ClearFocus(IInputElement control, IInputElement? parent);
+
+        void UpdateFocusWithin(IRenderRoot root);
+
+        IEnumerable<IInputElement> GetFocusedElements(IRenderRoot root);
     }
 }

--- a/src/Avalonia.Base/Input/KeyboardDevice.cs
+++ b/src/Avalonia.Base/Input/KeyboardDevice.cs
@@ -135,9 +135,7 @@ namespace Avalonia.Input
         {
             if (element != FocusedElement)
             {
-                var interactive = FocusedElement as Interactive;
-
-                if (FocusedElement != null && 
+                if (FocusedElement != null &&
                     (!((Visual)FocusedElement).IsAttachedToVisualTree ||
                      _focusedRoot != ((Visual?)element)?.VisualRoot as IInputRoot) &&
                     _focusedRoot != null)
@@ -148,19 +146,6 @@ namespace Avalonia.Input
                 SetIsFocusWithin(FocusedElement, element);
                 _focusedElement = element;
                 _focusedRoot = ((Visual?)_focusedElement)?.VisualRoot as IInputRoot;
-
-                interactive?.RaiseEvent(new RoutedEventArgs
-                {
-                    RoutedEvent = InputElement.LostFocusEvent,
-                });
-
-                interactive = element as Interactive;
-
-                interactive?.RaiseEvent(new GotFocusEventArgs
-                {
-                    NavigationMethod = method,
-                    KeyModifiers = keyModifiers,
-                });
 
                 _textInputManager.SetFocusedElement(element);
                 RaisePropertyChanged(nameof(FocusedElement));

--- a/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/InputElement_Focus.cs
@@ -392,11 +392,11 @@ namespace Avalonia.Base.UnitTests.Input
 
                 target1.Focus();
                 Assert.True(target1.IsFocused);
-                Assert.True(target1.Classes.Contains(":focus-within"));
+                Assert.True(target1.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(target1.IsKeyboardFocusWithin);
-                Assert.True(root.Child.Classes.Contains(":focus-within"));
+                Assert.True(root.Child.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(root.Child.IsKeyboardFocusWithin);
-                Assert.True(root.Classes.Contains(":focus-within"));
+                Assert.True(root.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(root.IsKeyboardFocusWithin);
             }
         }
@@ -427,31 +427,31 @@ namespace Avalonia.Base.UnitTests.Input
 
                 target1.Focus();
                 Assert.True(target1.IsFocused);
-                Assert.True(target1.Classes.Contains(":focus-within"));
+                Assert.True(target1.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(target1.IsKeyboardFocusWithin);
-                Assert.True(panel1.Classes.Contains(":focus-within"));
+                Assert.True(panel1.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(panel1.IsKeyboardFocusWithin);
-                Assert.True(root.Child.Classes.Contains(":focus-within"));
+                Assert.True(root.Child.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(root.Child.IsKeyboardFocusWithin);
-                Assert.True(root.Classes.Contains(":focus-within"));
+                Assert.True(root.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(root.IsKeyboardFocusWithin);
                 
                 target2.Focus();
                 
                 Assert.False(target1.IsFocused);
-                Assert.False(target1.Classes.Contains(":focus-within"));
+                Assert.False(target1.Classes.Contains(":keyboard-focus-within"));
                 Assert.False(target1.IsKeyboardFocusWithin);
-                Assert.False(panel1.Classes.Contains(":focus-within"));
+                Assert.False(panel1.Classes.Contains(":keyboard-focus-within"));
                 Assert.False(panel1.IsKeyboardFocusWithin);
-                Assert.True(root.Child.Classes.Contains(":focus-within"));
+                Assert.True(root.Child.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(root.Child.IsKeyboardFocusWithin);
-                Assert.True(root.Classes.Contains(":focus-within"));
+                Assert.True(root.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(root.IsKeyboardFocusWithin);
                 
                 Assert.True(target2.IsFocused);
-                Assert.True(target2.Classes.Contains(":focus-within"));
+                Assert.True(target2.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(target2.IsKeyboardFocusWithin);
-                Assert.True(panel2.Classes.Contains(":focus-within"));
+                Assert.True(panel2.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(panel2.IsKeyboardFocusWithin);
             }
         }
@@ -480,11 +480,11 @@ namespace Avalonia.Base.UnitTests.Input
 
                 target1.Focus();
                 Assert.True(target1.IsFocused);
-                Assert.True(target1.Classes.Contains(":focus-within"));
+                Assert.True(target1.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(target1.IsKeyboardFocusWithin);
-                Assert.True(root.Child.Classes.Contains(":focus-within"));
+                Assert.True(root.Child.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(root.Child.IsKeyboardFocusWithin);
-                Assert.True(root.Classes.Contains(":focus-within"));
+                Assert.True(root.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(root.IsKeyboardFocusWithin);
 
                 Assert.Equal(KeyboardDevice.Instance.FocusedElement, target1);
@@ -494,9 +494,9 @@ namespace Avalonia.Base.UnitTests.Input
                 Assert.Null(KeyboardDevice.Instance.FocusedElement);
                 
                 Assert.False(target1.IsFocused);
-                Assert.False(target1.Classes.Contains(":focus-within"));
+                Assert.False(target1.Classes.Contains(":keyboard-focus-within"));
                 Assert.False(target1.IsKeyboardFocusWithin);
-                Assert.False(root.Classes.Contains(":focus-within"));
+                Assert.False(root.Classes.Contains(":keyboard-focus-within"));
                 Assert.False(root.IsKeyboardFocusWithin);
             }
         }
@@ -536,31 +536,30 @@ namespace Avalonia.Base.UnitTests.Input
 
                 target1.Focus();
                 Assert.True(target1.IsFocused);
-                Assert.True(target1.Classes.Contains(":focus-within"));
+                Assert.True(target1.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(target1.IsKeyboardFocusWithin);
-                Assert.True(root1.Child.Classes.Contains(":focus-within"));
+                Assert.True(root1.Child.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(root1.Child.IsKeyboardFocusWithin);
-                Assert.True(root1.Classes.Contains(":focus-within"));
+                Assert.True(root1.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(root1.IsKeyboardFocusWithin);
 
                 Assert.Equal(KeyboardDevice.Instance.FocusedElement, target1);
                 
                 target2.Focus();
-                
-                Assert.False(target1.IsFocused);
-                Assert.False(target1.Classes.Contains(":focus-within"));
+
+                Assert.False(target1.Classes.Contains(":keyboard-focus-within"));
                 Assert.False(target1.IsKeyboardFocusWithin);
-                Assert.False(root1.Child.Classes.Contains(":focus-within"));
+                Assert.False(root1.Child.Classes.Contains(":keyboard-focus-within"));
                 Assert.False(root1.Child.IsKeyboardFocusWithin);
-                Assert.False(root1.Classes.Contains(":focus-within"));
+                Assert.False(root1.Classes.Contains(":keyboard-focus-within"));
                 Assert.False(root1.IsKeyboardFocusWithin);
                 
                 Assert.True(target2.IsFocused);
-                Assert.True(target2.Classes.Contains(":focus-within"));
+                Assert.True(target2.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(target2.IsKeyboardFocusWithin);
-                Assert.True(root2.Child.Classes.Contains(":focus-within"));
+                Assert.True(root2.Child.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(root2.Child.IsKeyboardFocusWithin);
-                Assert.True(root2.Classes.Contains(":focus-within"));
+                Assert.True(root2.Classes.Contains(":keyboard-focus-within"));
                 Assert.True(root2.IsKeyboardFocusWithin);
             }
         }

--- a/tests/Avalonia.Base.UnitTests/Input/KeyboardDeviceTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/KeyboardDeviceTests.cs
@@ -136,33 +136,5 @@ namespace Avalonia.Base.UnitTests.Input
             public bool CanExecute(object parameter) => true;
             public void Execute(object parameter) => _action();
         }
-
-        [Fact]
-        public void Control_Focus_Should_Be_Set_Before_FocusedElement_Raises_PropertyChanged()
-        {
-            var target = new KeyboardDevice();
-            var focused = new Control();
-            var root = new TestRoot();
-            var gotFocusRaised = 0;
-            var propertyChangedRaised = 0;
-
-            focused.GotFocus += (s, e) => ++gotFocusRaised;
-
-            target.PropertyChanged += (s, e) =>
-            {
-                if (e.PropertyName == nameof(target.FocusedElement))
-                {
-                    Assert.Equal(1, gotFocusRaised);
-                    ++propertyChangedRaised;
-                }
-            };
-
-            target.SetFocusedElement(
-                focused,
-                NavigationMethod.Unspecified,
-                KeyModifiers.None);
-
-            Assert.Equal(1, propertyChangedRaised);
-        }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/FlyoutTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/FlyoutTests.cs
@@ -291,7 +291,7 @@ namespace Avalonia.Controls.UnitTests
                 button.Focus();
                 Assert.True(window.FocusManager.GetFocusedElement() == button);
                 button.Flyout.ShowAt(button);
-                Assert.False(button.IsFocused);
+                Assert.False(button.IsKeyboardFocusWithin);
                 Assert.True(window.FocusManager.GetFocusedElement() == flyoutTextBox);
             }
         }


### PR DESCRIPTION
Pls review thoroughly

## What does the pull request do?
See #10433


## What is the current behavior?
Menu steals focus from other controls.


## What is the updated/expected behavior with this PR?
It works like in WPF, control outside focus scope keeps focused state.


## How was the solution implemented (if it's not obvious)?
- moved raising GotFocusEvent and LostFocusEvent to FocusManager to avoid raising LostFocusEvent on controls in another focus scope
- added FocusWithin property that if element or one of its children has IsFocused, it depends on focus scope while IsKeyboardFocusWithin does not
- added ability to get list of focused elements from multiple focus scopes (not used inside Avalonia sources, but this is useful for 
- added ClearFocus method to prevent losing focus from another focus scopes


## Breaking changes
It slightly changes :focus-within pseudoclass meaning, which may be a breaking change for someone (I tried to find another name, but for consistency between property and pseudoclass names, renamed old pseudoclass to :keyboard-focus-within).
Also LostFocus event will not be called when focusing something in another focus scope.


## Fixed issues
Fixes #10433

