### PR TITLE
creating only one gtk thread

### DIFF
--- a/src/Avalonia.X11/NativeDialogs/Gtk.cs
+++ b/src/Avalonia.X11/NativeDialogs/Gtk.cs
@@ -256,9 +256,13 @@ namespace Avalonia.X11.NativeDialogs
 
         public static IntPtr GetForeignWindow(IntPtr xid) => gdk_x11_window_foreign_new_for_display(s_display, xid);
 
+        static object s_startGtkLock = new();
+        static Task<bool> s_startGtkTask;
+
         public static Task<bool> StartGtk()
         {
-            return StartGtkCore();
+            lock (s_startGtkLock)
+                return s_startGtkTask ??= StartGtkCore();
         }
 
         private static void GtkThread(TaskCompletionSource<bool> tcs)


### PR DESCRIPTION
## What does the pull request do?
In fa17ee9b static field with GTK task was removed, which caused creating a new thread on each RunOnGlibThread call.

## What is the current behavior?
Each call to RunOnGlibThread creates a new thread, so there will be a lot of GTK3THREAD threads that never exit

## What is the updated/expected behavior with this PR?
Call to RunOnGlibThread reuses previously created task with GTK loop.

