### PR TITLE
Closing tooltips on control click

### DIFF
--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -1,5 +1,6 @@
 using System;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 
@@ -28,12 +29,15 @@ namespace Avalonia.Controls
             {
                 control.PointerEntered -= ControlPointerEntered;
                 control.PointerExited -= ControlPointerExited;
+                control.RemoveHandler(InputElement.PointerPressedEvent, ControlPointerPressed);
             }
 
             if (e.NewValue != null)
             {
                 control.PointerEntered += ControlPointerEntered;
                 control.PointerExited += ControlPointerExited;
+                control.AddHandler(InputElement.PointerPressedEvent, ControlPointerPressed,
+                    RoutingStrategies.Bubble | RoutingStrategies.Tunnel | RoutingStrategies.Direct, true);
             }
 
             if (ToolTip.GetIsOpen(control) && e.NewValue != e.OldValue && !(e.NewValue is ToolTip))
@@ -106,6 +110,11 @@ namespace Avalonia.Controls
         {
             var control = (Control)sender!;
             Close(control);
+        }
+
+        private void ControlPointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            StopTimer();
         }
 
         private void ControlEffectiveViewportChanged(object? sender, Layout.EffectiveViewportChangedEventArgs e)

--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -115,6 +115,7 @@ namespace Avalonia.Controls
         private void ControlPointerPressed(object? sender, PointerPressedEventArgs e)
         {
             StopTimer();
+            (sender as AvaloniaObject)?.ClearValue(ToolTip.IsOpenProperty);
         }
 
         private void ControlEffectiveViewportChanged(object? sender, Layout.EffectiveViewportChangedEventArgs e)


### PR DESCRIPTION
## What does the pull request do?
Tooltip should be hidden after interaction with control. There are two cases:

1. 
Create button that opens modal window on click. Add tooltip with show delay, i.e. 2 seconds.
Quickly click button and modal window will be opened. After 2 seconds tooltip is shown and it will hang on the screen.

2. 
Create button that opens modal window on click. Add tooltip with show delay, i.e. 2 seconds.
Wait for tooltip to be opened and click the button. Modal window will be opened and tooltip hangs on the screen.

## What is the current behavior?
Tooltip remains opened after click in cases when control do not have pointer anymore but did not receive PointerExited event (i.e. opening modal windows)

## What is the updated/expected behavior with this PR?
Tooltip is closed after clicking the control.
