### PR TITLE
fixed restarting renderer when window is minimized and restored progr…

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -648,6 +648,7 @@ namespace Avalonia.X11
                     SendNetWMMessage(_x11.Atoms._NET_ACTIVE_WINDOW, (IntPtr)1, _x11.LastActivityTimestamp,
                         IntPtr.Zero);
                 }
+                WindowStateChanged?.Invoke(value);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
Resumes window rendering on programmatical window state change on linux.

## What is the current behavior?
In some cases programmatically restoring window state does not resume rendering on linux. It changes atoms but they do not raise event that will call handler that calls X11Window.WindowStateChanged delegate. And window become unusable. 

## What is the updated/expected behavior with this PR?
Rendering is resumed in all cases.

