### PR TITLE
Fixed bug with initial size and position calculation for X11Window

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -695,6 +695,11 @@ namespace Avalonia.Controls
                 _shown = true;
                 IsVisible = true;
 
+                // We need to set position first because it is required for getting correct display scale. If position is not manual then it can be
+                // determined only by calling this method. But here it will calculate not precise location because scaling may not yet be applied (see i.e. X11Window),
+                // thus we ought to call it again later to center window correctly if needed, when scaling will be already applied
+                SetWindowStartupLocation(owner);
+
                 var initialSize = new Size(
                     double.IsNaN(Width) ? Math.Max(MinWidth, ClientSize.Width) : Width,
                     double.IsNaN(Height) ? Math.Max(MinHeight, ClientSize.Height) : Height);
@@ -714,6 +719,7 @@ namespace Avalonia.Controls
                 Owner = owner;
                 owner?.AddChild(this, false);
 
+                // Second call will calculate correct position because both current and owner windows have correct scaling.
                 SetWindowStartupLocation(owner);
 
                 StartRendering();
@@ -774,6 +780,11 @@ namespace Avalonia.Controls
                 _showingAsDialog = true;
                 IsVisible = true;
 
+                // We need to set position first because it is required for getting correct display scale. If position is not manual then it can be
+                // determined only by calling this method. But here it will calculate not precise location because scaling may not yet be applied (see i.e. X11Window),
+                // thus we ought to call it again later to center window correctly if needed, when scaling will be already applied
+                SetWindowStartupLocation(owner);
+
                 var initialSize = new Size(
                     double.IsNaN(Width) ? ClientSize.Width : Width,
                     double.IsNaN(Height) ? ClientSize.Height : Height);
@@ -791,6 +802,7 @@ namespace Avalonia.Controls
                 Owner = owner;
                 owner.AddChild(this, true);
 
+                // Second call will calculate correct position because both current and owner windows have correct scaling.
                 SetWindowStartupLocation(owner);
 
                 StartRendering();

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -977,7 +977,11 @@ namespace Avalonia.X11
 
 
         public void Resize(Size clientSize, WindowResizeReason reason) => Resize(clientSize, false, reason);
-        public void Move(PixelPoint point) => Position = point;
+        public void Move(PixelPoint point)
+        {
+            Position = point;
+            UpdateScaling();
+        }
         private void MoveResize(PixelPoint position, Size size, double scaling)
         {
             Move(position);


### PR DESCRIPTION
## What does the pull request do?

There is chicken and egg problem with position and scaling of the window on linux. To center window correctly it should know scaling, but to know scaling window should be positioned. 
So I added some workaround that calls SetWindowStartupLocation twice. Not very nice but at least it works.


## What is the current behavior?
On Linux in some cases window is positioned incorrectly (i.e. CenterScreen with scaling > 1)

## What is the updated/expected behavior with this PR?
Window position is correct on linux

