### PR TITLE
Fixed blinking caret in case TextPresenter detached and attached again

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -97,7 +97,6 @@ namespace Avalonia.Controls.Presenters
         public TextPresenter()
         {
             _caretTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(500) };
-            _caretTimer.Tick += CaretTimerTick;
         }
 
         public event EventHandler? CaretBoundsChanged;
@@ -812,6 +811,13 @@ namespace Avalonia.Controls.Presenters
         internal Rect GetCursorRectangle()
         {
             return _caretBounds;
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+
+            _caretTimer.Tick += CaretTimerTick;
         }
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)


### PR DESCRIPTION
## What is the current behavior?
If TextPresenter is reattached to visual tree then its caret stops blinking

## What is the updated/expected behavior with this PR?
Caret blinks after multiple attach/detach from visual tree

