### PR TITLE
macOS: Don't clear clipboard in SetText.

### DIFF
--- a/native/Avalonia.Native/src/OSX/clipboard.mm
+++ b/native/Avalonia.Native/src/OSX/clipboard.mm
@@ -77,8 +77,6 @@ public:
         
         @autoreleasepool
         {
-            Clear();
-            
             auto string = [NSString stringWithUTF8String:(const char*)utf8String];
             auto typeString = [NSString stringWithUTF8String:(const char*)type];
             if(_item == nil)


### PR DESCRIPTION
## What does the pull request do?

Removes a call to `Clear()` in the unmanaged macOS clipboard code. The macOS managed code is responsible for clearing the clipboard. Clearing it here results in any [other data formats](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Native/ClipboardImpl.cs#L94) that have previously been added by `SetBytes` being cleared.

For context:

- The call to `Clear()` was added in a seemingly [unrelated commit](https://github.com/AvaloniaUI/Avalonia/commit/f053bfef3a6f948053ebe495e6eac6a0fdc1e9b3#diff-32f10514aada6451eff49014bdf1c14fae7bcc393da1ca975d387b42e99f6e22R80)
- `SetBytes` in the same file doesn't call clear
- The managed code calls clear before beginning to [set a data object](https://github.com/AvaloniaUI/Avalonia/blob/050ae370ad02f90b237ce27c869343e628030465/src/Avalonia.Native/ClipboardImpl.cs#L93) or [set text](https://github.com/AvaloniaUI/Avalonia/blob/050ae370ad02f90b237ce27c869343e628030465/src/Avalonia.Native/ClipboardImpl.cs#L37) anyway

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
