### PR TITLE
Fixes font family definitions that mix embedded and system fonts

### DIFF
--- a/src/Avalonia.Base/Media/CompositeFontFamilyKey.cs
+++ b/src/Avalonia.Base/Media/CompositeFontFamilyKey.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using Avalonia.Media.Fonts;
+
+namespace Avalonia.Media
+{
+    internal class CompositeFontFamilyKey : FontFamilyKey
+    {
+        public CompositeFontFamilyKey(Uri source, FontFamilyKey[] keys) : base(source, null)
+        {
+            Keys = keys;
+        }
+
+        public IReadOnlyList<FontFamilyKey> Keys { get; }
+    }
+}

--- a/src/Avalonia.Base/Media/FontManager.cs
+++ b/src/Avalonia.Base/Media/FontManager.cs
@@ -15,9 +15,11 @@ namespace Avalonia.Media
     /// </summary>
     public sealed class FontManager
     {
-        internal static Uri SystemFontsKey = new Uri("fonts:SystemFonts");
+        internal static Uri SystemFontsKey = new Uri("fonts:SystemFonts", UriKind.Absolute);
 
         public const string FontCollectionScheme = "fonts";
+        public const string SystemFontScheme = "systemfont";
+        public const string CompositeFontScheme = "compositefont";
 
         private readonly ConcurrentDictionary<Uri, IFontCollection> _fontCollections = new ConcurrentDictionary<Uri, IFontCollection>();
         private readonly IReadOnlyList<FontFallback>? _fontFallbacks;
@@ -95,69 +97,86 @@ namespace Avalonia.Media
 
             var fontFamily = typeface.FontFamily;
 
-            if(typeface.FontFamily.Name == FontFamily.DefaultFontFamilyName)
+            if (typeface.FontFamily.Name == FontFamily.DefaultFontFamilyName)
             {
                 return TryGetGlyphTypeface(new Typeface(DefaultFontFamily, typeface.Style, typeface.Weight, typeface.Stretch), out glyphTypeface);
             }
 
-            if (fontFamily.Key is FontFamilyKey key)
+            if (fontFamily.Key is FontFamilyKey)
             {
-                var source = key.Source;
-
-                if (!source.IsAbsoluteUri)
+                if (fontFamily.Key is CompositeFontFamilyKey compositeKey)
                 {
-                    if (key.BaseUri == null)
+                    for (int i = 0; i < compositeKey.Keys.Count; i++)
                     {
-                        throw new NotSupportedException($"{nameof(key.BaseUri)} can't be null.");
-                    }
+                        var key = compositeKey.Keys[i];
 
-                    source = new Uri(key.BaseUri, source);
-                }
-
-                if (!_fontCollections.TryGetValue(source, out var fontCollection) && (source.IsAbsoluteResm() || source.IsAvares()))
-                {
-                    var embeddedFonts = new EmbeddedFontCollection(source, source);
-
-                    embeddedFonts.Initialize(PlatformImpl);
-
-                    if (embeddedFonts.Count > 0 && _fontCollections.TryAdd(source, embeddedFonts))
-                    {
-                        fontCollection = embeddedFonts;
+                        var familyName = fontFamily.FamilyNames[i];
+                        
+                        if (TryGetGlyphTypefaceByKeyAndName(typeface, key, familyName, out glyphTypeface) && 
+                            glyphTypeface.FamilyName.Contains(familyName))
+                        {
+                            return true;
+                        }
                     }
                 }
-
-                if (fontCollection != null && fontCollection.TryGetGlyphTypeface(fontFamily.FamilyNames.PrimaryFamilyName,
-                    typeface.Style, typeface.Weight, typeface.Stretch, out glyphTypeface))
+                else
                 {
-                    return true;
-                }
-
-                if (!fontFamily.FamilyNames.HasFallbacks)
-                {
-                    return false;
-                }
-            }
-
-            for (var i = 0; i < fontFamily.FamilyNames.Count; i++)
-            {
-                var familyName = fontFamily.FamilyNames[i];
-
-                if (SystemFonts.TryGetGlyphTypeface(familyName, typeface.Style, typeface.Weight, typeface.Stretch, out glyphTypeface))
-                {
-                    if (!fontFamily.FamilyNames.HasFallbacks || glyphTypeface.FamilyName != DefaultFontFamily.Name)
+                    if (TryGetGlyphTypefaceByKeyAndName(typeface, fontFamily.Key, fontFamily.FamilyNames.PrimaryFamilyName, out glyphTypeface))
                     {
                         return true;
                     }
+
+                    return false;
+                }
+            }
+            else
+            {
+                if (SystemFonts.TryGetGlyphTypeface(fontFamily.FamilyNames.PrimaryFamilyName, typeface.Style, typeface.Weight, typeface.Stretch, out glyphTypeface))
+                {
+                    return true;
                 }
             }
 
-            if(typeface.FontFamily == DefaultFontFamily)
+            if (typeface.FontFamily == DefaultFontFamily)
             {
                 return false;
             }
 
             //Nothing was found so use the default
             return TryGetGlyphTypeface(new Typeface(FontFamily.DefaultFontFamilyName, typeface.Style, typeface.Weight, typeface.Stretch), out glyphTypeface);
+        }
+
+        private bool TryGetGlyphTypefaceByKeyAndName(Typeface typeface, FontFamilyKey key, string familyName, [NotNullWhen(true)] out IGlyphTypeface? glyphTypeface)
+        {
+            var source = key.Source;
+
+            if (source.Scheme == SystemFontScheme)
+            {
+                return SystemFonts.TryGetGlyphTypeface(familyName, typeface.Style, typeface.Weight, typeface.Stretch, out glyphTypeface);
+            }
+
+            if (!source.IsAbsoluteUri)
+            {
+                if (key.BaseUri == null)
+                {
+                    throw new NotSupportedException($"{nameof(key.BaseUri)} can't be null.");
+                }
+
+                source = new Uri(key.BaseUri, source);
+            }
+
+            if (TryGetFontCollection(source, out var fontCollection) && 
+                fontCollection.TryGetGlyphTypeface(familyName, typeface.Style, typeface.Weight, typeface.Stretch, out glyphTypeface))
+            {
+                if (glyphTypeface.FamilyName.Contains(familyName))
+                {
+                    return true;
+                }
+            }
+
+            glyphTypeface = null;
+
+            return false;
         }
 
         /// <summary>
@@ -230,24 +249,45 @@ namespace Avalonia.Media
             }
 
             //Try to match against fallbacks first
-            if (fontFamily != null && fontFamily.FamilyNames.HasFallbacks)
+            if (fontFamily != null && fontFamily.Key is CompositeFontFamilyKey compositeKey)
             {
-                for (int i = 1; i < fontFamily.FamilyNames.Count; i++)
+                for (int i = 0; i < compositeKey.Keys.Count; i++)
                 {
+                    var key = compositeKey.Keys[i];
                     var familyName = fontFamily.FamilyNames[i];
 
-                    foreach (var fontCollection in _fontCollections.Values)
+                    if (TryGetFontCollection(key.Source, out var fontCollection) &&
+                        fontCollection.TryMatchCharacter(codepoint, fontStyle, fontWeight, fontStretch, familyName, culture, out typeface))
                     {
-                        if (fontCollection.TryMatchCharacter(codepoint, fontStyle, fontWeight, fontStretch, familyName, culture, out typeface))
-                        {
-                            return true;
-                        };
+                        return true;
                     }
                 }
             }
 
             //Try to find a match with the system font manager
             return PlatformImpl.TryMatchCharacter(codepoint, fontStyle, fontWeight, fontStretch, culture, out typeface);
+        }
+
+        private bool TryGetFontCollection(Uri source, [NotNullWhen(true)] out IFontCollection? fontCollection)
+        {
+            if(source.Scheme == SystemFontScheme)
+            {
+                source = SystemFontsKey;
+            }
+
+            if (!_fontCollections.TryGetValue(source, out fontCollection) && (source.IsAbsoluteResm() || source.IsAvares()))
+            {
+                var embeddedFonts = new EmbeddedFontCollection(source, source);
+
+                embeddedFonts.Initialize(PlatformImpl);
+
+                if (embeddedFonts.Count > 0 && _fontCollections.TryAdd(source, embeddedFonts))
+                {
+                    fontCollection = embeddedFonts;
+                }
+            }
+
+            return fontCollection != null;
         }
     }
 }

--- a/src/Avalonia.Base/Media/FontSourceIdentifier.cs
+++ b/src/Avalonia.Base/Media/FontSourceIdentifier.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Avalonia.Media
+{
+    internal readonly record struct FontSourceIdentifier
+    {
+        public FontSourceIdentifier(string name, Uri? source)
+        {
+            Name = name;
+            Source = source;
+        }
+
+        public string Name { get; init; }
+
+        public Uri? Source { get; init; }
+    }
+}

--- a/src/Avalonia.Base/Media/Fonts/FamilyNameCollection.cs
+++ b/src/Avalonia.Base/Media/Fonts/FamilyNameCollection.cs
@@ -28,6 +28,20 @@ namespace Avalonia.Media.Fonts
             HasFallbacks = _names.Length > 1;
         }
 
+        internal FamilyNameCollection(FrugalStructList<FontSourceIdentifier> fontSources) 
+        { 
+            _names = new string[fontSources.Count];
+
+            for (int i = 0; i < fontSources.Count; i++)
+            {
+                _names[i] = fontSources[i].Name;
+            }
+
+            PrimaryFamilyName = _names[0];
+
+            HasFallbacks = _names.Length > 1;
+        }
+
         private static string[] SplitNames(string names)
 #if NET6_0_OR_GREATER
             => names.Split(',', StringSplitOptions.TrimEntries);

--- a/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
+++ b/src/Avalonia.Base/Media/Fonts/FontCollectionBase.cs
@@ -34,7 +34,7 @@ namespace Avalonia.Media.Fonts
                     {
                         if (glyphTypeface.TryGetGlyph((uint)codepoint, out _))
                         {
-                            match = new Typeface(glyphTypeface.FamilyName, style, weight, stretch);
+                            match = new Typeface(Key.AbsoluteUri + "#" + glyphTypeface.FamilyName, style, weight, stretch);
 
                             return true;
                         }
@@ -45,9 +45,9 @@ namespace Avalonia.Media.Fonts
             {
                 if (TryGetGlyphTypeface(familyName, style, weight, stretch, out var glyphTypeface))
                 {
-                    if (glyphTypeface.TryGetGlyph((uint)codepoint, out _))
+                    if (glyphTypeface.FamilyName.Contains(familyName) && glyphTypeface.TryGetGlyph((uint)codepoint, out _))
                     {
-                        match = new Typeface(familyName, style, weight, stretch);
+                        match = new Typeface(Key.AbsoluteUri + "#" + familyName, style, weight, stretch);
 
                         return true;
                     }

--- a/tests/Avalonia.Base.UnitTests/Media/FontFamilyTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/FontFamilyTests.cs
@@ -75,7 +75,7 @@ namespace Avalonia.Base.UnitTests.Media
 
             Assert.Equal("Courier New", fontFamily.Name);
 
-            Assert.Equal(2, fontFamily.FamilyNames.Count());
+            Assert.Equal(2, fontFamily.FamilyNames.Count);
 
             Assert.Equal("Times New Roman", fontFamily.FamilyNames.Last());
         }

--- a/tests/Avalonia.Direct2D1.UnitTests/Media/FontManagerImplTests.cs
+++ b/tests/Avalonia.Direct2D1.UnitTests/Media/FontManagerImplTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Avalonia.Direct2D1.Media;
+﻿using Avalonia.Direct2D1.Media;
 using Avalonia.Media;
 using Avalonia.UnitTests;
 using Xunit;
@@ -17,8 +16,9 @@ namespace Avalonia.Direct2D1.UnitTests.Media
             {
                 Direct2D1Platform.Initialize();
 
-                var glyphTypeface =
-                    new Typeface(new FontFamily("A, B, Arial")).GlyphTypeface;
+                var typeface = new Typeface(new FontFamily("A, B, Arial"));
+
+                var glyphTypeface = typeface.GlyphTypeface;
 
                 Assert.Equal("Arial", glyphTypeface.FamilyName);
             }
@@ -31,7 +31,9 @@ namespace Avalonia.Direct2D1.UnitTests.Media
             {
                 Direct2D1Platform.Initialize();
 
-                var glyphTypeface = new Typeface(new FontFamily("A, B, Arial"), weight: FontWeight.Bold).GlyphTypeface;
+                var typeface = new Typeface(new FontFamily("A, B, Arial"), weight: FontWeight.Bold);
+
+                var glyphTypeface = typeface.GlyphTypeface;
 
                 Assert.Equal("Arial", glyphTypeface.FamilyName);
 

--- a/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
@@ -139,5 +139,83 @@ namespace Avalonia.Skia.UnitTests.Media
                 }
             }
         }
+
+        [Fact]
+        public void Should_Load_Embedded_Fallbacks()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface.With(fontManagerImpl: new FontManagerImpl())))
+            {
+                using (AvaloniaLocator.EnterScope())
+                {
+                    var fontFamily = FontFamily.Parse("NotFound, " + s_fontUri);
+
+                    var typeface = new Typeface(fontFamily);
+
+                    var glyphTypeface = typeface.GlyphTypeface;
+
+                    Assert.NotNull(glyphTypeface);
+
+                    Assert.Equal("Noto Mono", glyphTypeface.FamilyName);
+                }
+            }
+        }
+
+        [Fact]
+        public void Should_Match_Chararcter_Width_Embedded_Fallbacks()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface.With(fontManagerImpl: new FontManagerImpl())))
+            {
+                using (AvaloniaLocator.EnterScope())
+                {
+                    var fontFamily = FontFamily.Parse("NotFound, " + s_fontUri);
+
+                    Assert.True(FontManager.Current.TryMatchCharacter('A', FontStyle.Normal, FontWeight.Normal, FontStretch.Normal, fontFamily, null, out var typeface));
+
+                    var glyphTypeface = typeface.GlyphTypeface;
+
+                    Assert.NotNull(glyphTypeface);
+
+                    Assert.Equal("Noto Mono", glyphTypeface.FamilyName);
+                }
+            }
+        }
+
+        [Fact]
+        public void Should_Match_Chararcter_From_SystemFonts()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface.With(fontManagerImpl: new FontManagerImpl())))
+            {
+                using (AvaloniaLocator.EnterScope())
+                {
+                    Assert.True(FontManager.Current.TryMatchCharacter('A', FontStyle.Normal, FontWeight.Normal, FontStretch.Normal, null, null, out var typeface));
+
+                    var glyphTypeface = typeface.GlyphTypeface;
+
+                    Assert.NotNull(glyphTypeface);
+
+                    Assert.Equal(FontManager.Current.DefaultFontFamily.Name, glyphTypeface.FamilyName);
+                }
+            }
+        }
+
+        [Fact]
+        public void Should_Match_Chararcter_Width_Fallbacks()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface.With(fontManagerImpl: new FontManagerImpl())))
+            {
+                using (AvaloniaLocator.EnterScope())
+                {
+                    var fontFamily = FontFamily.Parse("NotFound, Unknown");
+
+                    Assert.True(FontManager.Current.TryMatchCharacter('A', FontStyle.Normal, FontWeight.Normal, FontStretch.Normal, fontFamily, null, out var typeface));
+
+                    var glyphTypeface = typeface.GlyphTypeface;
+
+                    Assert.NotNull(glyphTypeface);
+
+                    Assert.Equal(FontManager.Current.DefaultFontFamily.Name, glyphTypeface.FamilyName);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR introduces a way to store multiple font sources in within the FontFamilyKey object. This is needed to be able to mix embedded and system installed fonts in a fallback sequences.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
A CompositeFontFamilyKey was introduced that holds multiple keys that were created from the original FontFamily definition.

System fonts a represented by the systemfont: scheme everything else that needed a key previously is unchanged.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes: #12806