### PR TITLE
Fix VirtualizingPanel's RemoveInternalChildRange() removing elements …

### DIFF
--- a/src/Avalonia.Controls/VirtualizingPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingPanel.cs
@@ -183,7 +183,7 @@ namespace Avalonia.Controls
         {
             var itemsControl = EnsureItemsControl();
             
-            for (var i = 0; i < count; ++i)
+            for (var i = index; i < count; ++i)
             {
                 var c = Children[i];
                 itemsControl.RemoveLogicalChild(c);


### PR DESCRIPTION
…from 0 (#12476)

## What does the pull request do?
Fix #12476.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The RemoveInternalChildRange() of VirtualizingPanel always remove children from 0.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
It should remove children from the index that passed in.


## Fixed issues
Fixes #12476.