### PR TITLE
[stable] Make Avalonia.Win32.Interoperability build again on CI

### DIFF
--- a/dirs.proj
+++ b/dirs.proj
@@ -18,7 +18,7 @@
     <ProjectReference Remove="src/iOS/**/*.*proj" />
     <ProjectReference Remove="samples/ControlCatalog.iOS/ControlCatalog.iOS.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsOsPlatform('Windows')) OR '$(MSBuildRuntimeType)' != 'Full'">
+  <ItemGroup Condition="!$([MSBuild]::IsOsPlatform('Windows'))">
     <ProjectReference Remove="src/Windows/Avalonia.Win32.Interop/Avalonia.Win32.Interop.csproj" />
     <ProjectReference Remove="samples/interop/**/*.*proj" />
     <ProjectReference Remove="samples/ControlCatalog.Desktop/*.*proj" />


### PR DESCRIPTION
## What does the pull request do?

Backport of 691ff9f33a6e832abfdeda32ee321a2122134d1f from #11488 to stable branch.

The `Avalonia.Win32.Interop` nuget package has not been built since 0.10.18 on the stable branch. #11488 fixed this for 11.x but it was never backported; this PR does that.