### PR TITLE
Change iOS initialization order

### DIFF
--- a/src/iOS/Avalonia.iOS/AvaloniaAppDelegate.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaAppDelegate.cs
@@ -29,15 +29,13 @@ namespace Avalonia.iOS
         public bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
         {
             var builder = AppBuilder.Configure<TApp>().UseiOS();
-            CustomizeAppBuilder(builder);
 
             var lifetime = new SingleViewLifetime();
 
             builder.AfterSetup(_ =>
             {
                 Window = new UIWindow();
-                
-                
+
                 var view = new AvaloniaView();
                 lifetime.View = view;
                 var controller = new DefaultAvaloniaViewController
@@ -47,7 +45,9 @@ namespace Avalonia.iOS
                 Window.RootViewController = controller;
                 view.InitWithController(controller);
             });
-            
+
+            CustomizeAppBuilder(builder);
+
             builder.SetupWithLifetime(lifetime);
 
             Window.MakeKeyAndVisible();


### PR DESCRIPTION
## What does the pull request do?

Currently any code inside of AppBuilder.AfterSetup is executed before iOS window is created:
```
protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
{
    return base.CustomizeAppBuilder(builder)
        .AfterSetup(builder => { UIWindow doesn't exist at this point });
}
```

This PR changes initialization order for a bit to make it work.