### PR TITLE
[X11] Don't convert the current time from long to int

### DIFF
--- a/src/Avalonia.X11/X11PlatformThreading.cs
+++ b/src/Avalonia.X11/X11PlatformThreading.cs
@@ -235,7 +235,7 @@ namespace Avalonia.X11
         }
 
 
-        public long Now => (int)_clock.ElapsedMilliseconds;
+        public long Now => _clock.ElapsedMilliseconds;
         public bool CanQueryPendingInput => true;
 
         public bool HasPendingInput => _platform.EventGrouperDispatchQueue.HasJobs || XPending(_display) != 0;


### PR DESCRIPTION
It's probably a leftover from some earlier version of our dispatcher code.