### PR TITLE
Fix - TextPresenter ignores FontStretch property

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -476,7 +476,7 @@ namespace Avalonia.Controls.Presenters
             var caretIndex = CaretIndex;
             var preeditText = PreeditText;
             var text = GetCombinedText(Text, caretIndex, preeditText);
-            var typeface = new Typeface(FontFamily, FontStyle, FontWeight);
+            var typeface = new Typeface(FontFamily, FontStyle, FontWeight, FontStretch);
             var selectionStart = SelectionStart;
             var selectionEnd = SelectionEnd;
             var start = Math.Min(selectionStart, selectionEnd);

--- a/tests/Avalonia.Controls.UnitTests/Presenters/TextPresenter_Tests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/TextPresenter_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Avalonia.Controls.Presenters;
+using Avalonia.Media;
 using Avalonia.UnitTests;
 using Xunit;
 
@@ -49,6 +50,29 @@ namespace Avalonia.Controls.UnitTests.Presenters
                     target.TextLayout.TextLines.SelectMany(x => x.TextRuns).Select(x => x.Text.ToString()));
 
                 Assert.Equal("****", actual);
+            }
+        }
+        
+        [Theory]
+        [InlineData(FontStretch.Condensed)]
+        [InlineData(FontStretch.Expanded)]
+        [InlineData(FontStretch.Normal)]
+        [InlineData(FontStretch.ExtraCondensed)]
+        [InlineData(FontStretch.SemiCondensed)]
+        [InlineData(FontStretch.ExtraExpanded)]
+        [InlineData(FontStretch.SemiExpanded)]
+        [InlineData(FontStretch.UltraCondensed)]
+        [InlineData(FontStretch.UltraExpanded)]
+        public void TextPresenter_Should_Use_FontStretch_Property(FontStretch fontStretch)
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var presenter = new TextPresenter { FontStretch = fontStretch, Text = "test" };
+                Assert.NotNull(presenter.TextLayout);
+                Assert.Equal(1, presenter.TextLayout.TextLines.Count);
+                Assert.Equal(1, presenter.TextLayout.TextLines[0].TextRuns.Count);
+                Assert.NotNull(presenter.TextLayout.TextLines[0].TextRuns[0].Properties);
+                Assert.Equal(fontStretch, presenter.TextLayout.TextLines[0].TextRuns[0].Properties.Typeface.Stretch);
             }
         }
     }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
The PRs fixes that TextPresenter ignores non default value of the FontStretch property

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The FontStretch property of TextPresenter does not affects text drawing

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
The FontStretch property of TextPresenter affects text drawing

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
