### PR TITLE
Add support for setting tooltip text for TrayIcons on MacOS

### DIFF
--- a/native/Avalonia.Native/src/OSX/trayicon.h
+++ b/native/Avalonia.Native/src/OSX/trayicon.h
@@ -28,6 +28,8 @@ public:
     virtual HRESULT SetMenu (IAvnMenu* menu) override;
     
     virtual HRESULT SetIsVisible (bool isVisible) override;
+    
+    virtual HRESULT SetToolTipText (char* text) override;
 };
 
 #endif /* trayicon_h */

--- a/native/Avalonia.Native/src/OSX/trayicon.mm
+++ b/native/Avalonia.Native/src/OSX/trayicon.mm
@@ -83,3 +83,18 @@ HRESULT AvnTrayIcon::SetIsVisible(bool isVisible)
     
     return  S_OK;
 }
+
+HRESULT AvnTrayIcon::SetToolTipText(char* text)
+{
+    START_COM_CALL;
+    
+    @autoreleasepool
+    {
+        if (text != nullptr)
+        {
+            [[_native button] setToolTip:[NSString stringWithUTF8String:(const char*)text]];
+        }
+    }
+    
+    return  S_OK;
+}

--- a/src/Avalonia.Native/TrayIconImpl.cs
+++ b/src/Avalonia.Native/TrayIconImpl.cs
@@ -50,7 +50,7 @@ namespace Avalonia.Native
 
         public void SetToolTipText(string? text)
         {
-            // NOP
+            _native.SetToolTipText(text);
         }
 
         public void SetIsVisible(bool visible)

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -810,6 +810,7 @@ interface IAvnTrayIcon : IUnknown
     HRESULT SetIcon(void* data, size_t length);
     HRESULT SetMenu(IAvnMenu* menu);
     HRESULT SetIsVisible(bool isVisible);
+    HRESULT SetToolTipText(char* text);
 }
 
 [uuid(a7724dc1-cf6b-4fa8-9d23-228bf2593edc)]


### PR DESCRIPTION
## What does the pull request do?
Previously setting tooltip text for TrayIcons was not working on MacOS, now this feature is supported.

![image](https://github.com/AvaloniaUI/Avalonia/assets/53405089/6ea14c20-a07c-4a4e-86b5-e7feaa8ae844)
