### PR TITLE
Fix VirtualizingStackPanel and nth-child for the currently realizing item container

### DIFF
--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -72,6 +72,8 @@ namespace Avalonia.Controls
         private Dictionary<object, Stack<Control>>? _recyclePool;
         private Control? _focusedElement;
         private int _focusedIndex = -1;
+        private Control? _realizingElement;
+        private int _realizingIndex = -1;
 
         public VirtualizingStackPanel()
         {
@@ -336,6 +338,8 @@ namespace Avalonia.Controls
                 return _scrollToElement;
             if (_focusedIndex == index)
                 return _focusedElement;
+            if (index == _realizingIndex)
+                return _realizingElement;
             if (GetRealizedElement(index) is { } realized)
                 return realized;
             if (Items[index] is Control c && c.GetValue(RecycleKeyProperty) == s_itemIsItsOwnContainer)
@@ -349,6 +353,8 @@ namespace Avalonia.Controls
                 return _scrollToIndex;
             if (container == _focusedElement)
                 return _focusedIndex;
+            if (container == _realizingElement)
+                return _realizingIndex;
             return _realizedElements?.GetIndex(container) ?? -1;
         }
 
@@ -532,7 +538,9 @@ namespace Avalonia.Controls
             // Start at the anchor element and move forwards, realizing elements.
             do
             {
+                _realizingIndex = index;
                 var e = GetOrCreateElement(items, index);
+                _realizingElement = e;
                 e.Measure(availableSize);
 
                 var sizeU = horizontal ? e.DesiredSize.Width : e.DesiredSize.Height;
@@ -543,6 +551,8 @@ namespace Avalonia.Controls
 
                 u += sizeU;
                 ++index;
+                _realizingIndex = -1;
+                _realizingElement = null;
             } while (u < viewport.viewportUEnd && index < items.Count);
 
             // Store the last index and end U position for the desired size calculation.

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
@@ -501,6 +501,33 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
+        // https://github.com/AvaloniaUI/Avalonia/issues/12838
+        [Fact]
+        public void NthChild_Selector_Works_For_ItemTemplate_Children()
+        {
+            using var app = App();
+
+            var style = new Style(x => x.OfType<ContentPresenter>().NthChild(5, 0).Child().OfType<Canvas>())
+            {
+                Setters = { new Setter(Panel.BackgroundProperty, Brushes.Red) },
+            };
+
+            var (target, _, _) = CreateTarget(styles: new[] { style });
+            var realized = target.GetRealizedContainers()!.Cast<ContentPresenter>().ToList();
+
+            Assert.Equal(10, realized.Count);
+
+            for (var i = 0; i < 10; ++i)
+            {
+                var container = realized[i];
+                var index = target.IndexFromContainer(container);
+                var expectedBackground = (i == 4 || i == 9) ? Brushes.Red : null;
+
+                Assert.Equal(i, index);
+                Assert.Equal(expectedBackground, ((Canvas) container.Child!).Background);
+            }
+        }
+
         [Fact]
         public void NthLastChild_Selector_Works()
         {
@@ -524,6 +551,33 @@ namespace Avalonia.Controls.UnitTests
 
                 Assert.Equal(i, index);
                 Assert.Equal(expectedBackground, container.Background);
+            }
+        }
+
+        // https://github.com/AvaloniaUI/Avalonia/issues/12838
+        [Fact]
+        public void NthLastChild_Selector_Works_For_ItemTemplate_Children()
+        {
+            using var app = App();
+
+            var style = new Style(x => x.OfType<ContentPresenter>().NthLastChild(5, 0).Child().OfType<Canvas>())
+            {
+                Setters = { new Setter(Panel.BackgroundProperty, Brushes.Red) },
+            };
+
+            var (target, _, _) = CreateTarget(styles: new[] { style });
+            var realized = target.GetRealizedContainers()!.Cast<ContentPresenter>().ToList();
+
+            Assert.Equal(10, realized.Count);
+
+            for (var i = 0; i < 10; ++i)
+            {
+                var container = realized[i];
+                var index = target.IndexFromContainer(container);
+                var expectedBackground = (i == 0 || i == 5) ? Brushes.Red : null;
+
+                Assert.Equal(i, index);
+                Assert.Equal(expectedBackground, ((Canvas) container.Child!).Background);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
This PR ensures that `VirtualizingStackPanel.ContainerFromIndex/IndexFromContainer` handles the container currently being realized, so index-based styles (`nth-child` and `nth-last-child`) are correctly applied.

## What is the current behavior?
Currently, any style targeting a descendant element of an item container having itself an index-based style activator isn't applied when the item container is created by a `VirtualizingStackPanel`. See #12838 for details.

## What is the updated/expected behavior with this PR?
Styles on item container descendants are correctly applied.

## How was the solution implemented (if it's not obvious)?
The container currently being realized is stored in a field, so `ContainerFromIndex` and `IndexFromContainer` can return it correctly. Before the PR, these methods looked only at the already realized items, but the currently realizing item isn't in that list yet, so `NthChildActivator` fails on it.

Why did this work previously for container styles (`ListBoxItem:nth-child(even)`) but not for styles targeting descendants inside the item template (`ListBoxItem:nth-child(even) > TextBlock`)? 

Well, it didn't at first: a matching `NthChildActivator` wasn't activated during the container creation (`CreateContainer`), similar to this issue. However, after creation the panel raises `ChildIndexChanged` (in `ItemContainerPrepared`), handled by the activator which now gets a proper index.

Elements from the item template aren't created at this point though, as this only happens when the container is measured, which is *after* `ItemContainerPrepared` (so the `ChildIndexChanged` event was already raised and handled).

While this PR adds a special case for the container being realized, ideally we should handle the indexes properly for all containers that have just been realized but aren't part of the `_realizedElements` yet (they're in `_measureElements` temporarily during `RealizeElements()`), as their index might be requested by some code. Pinging @grokys for thoughts on this.

Unit tests have been added.

## Fixed issues
- Fixes #12838
