### PR TITLE
Added guards for compositor reentrancy and exposed batch lifetime events

### DIFF
--- a/src/Avalonia.Base/Media/MediaContext.Compositor.cs
+++ b/src/Avalonia.Base/Media/MediaContext.Compositor.cs
@@ -16,7 +16,7 @@ partial class MediaContext
     /// Actually sends the current batch to the compositor and does the required housekeeping
     /// This is the only place that should be allowed to call Commit
     /// </summary>
-    private Batch CommitCompositor(Compositor compositor)
+    private CompositionBatch CommitCompositor(Compositor compositor)
     {
         var commit = compositor.Commit();
         _requestedCommits.Remove(compositor);
@@ -29,7 +29,7 @@ partial class MediaContext
     /// <summary>
     /// Handles batch completion, required to re-schedule a render pass if one was skipped due to compositor throttling
     /// </summary>
-    private void CompositionBatchFinished(Compositor compositor, Batch batch)
+    private void CompositionBatchFinished(Compositor compositor, CompositionBatch batch)
     {
         // Check if it was the last commited batch, since sometimes we are forced to send a new
         // one without waiting for the previous one to complete  

--- a/src/Avalonia.Base/Media/MediaContext.cs
+++ b/src/Avalonia.Base/Media/MediaContext.cs
@@ -22,7 +22,7 @@ internal partial class MediaContext : ICompositorScheduler
     private readonly Action _render;
     private readonly Action _inputMarkerHandler;
     private readonly HashSet<Compositor> _requestedCommits = new();
-    private readonly Dictionary<Compositor, Batch> _pendingCompositionBatches = new();
+    private readonly Dictionary<Compositor, CompositionBatch> _pendingCompositionBatches = new();
     private record  TopLevelInfo(Compositor Compositor, CompositingRenderer Renderer, ILayoutManager LayoutManager);
 
     private List<Action>? _invokeOnRenderCallbacks;

--- a/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
@@ -26,6 +26,7 @@ internal class CompositingRenderer : IRendererWithCompositor, IHitTester
     private readonly Action _update;
 
     private bool _queuedUpdate;
+    private bool _queuedSceneInvalidation;
     private bool _updating;
     private bool _isDisposed;
 
@@ -173,13 +174,17 @@ internal class CompositingRenderer : IRendererWithCompositor, IHitTester
         _recalculateChildren.Clear();
         CompositionTarget.Size = _root.ClientSize;
         CompositionTarget.Scaling = _root.RenderScaling;
-        TriggerSceneInvalidatedOnBatchCompletion(_compositor.RequestCommitAsync());
-    }
-
-    private async void TriggerSceneInvalidatedOnBatchCompletion(Task batchCompletion)
-    {
-        await Dispatcher.UIThread.AwaitWithPriority(batchCompletion, DispatcherPriority.Input);
-        SceneInvalidated?.Invoke(this, new SceneInvalidatedEventArgs(_root, new Rect(_root.ClientSize)));
+        
+        var commit = _compositor.RequestCommitAsync();
+        if (!_queuedSceneInvalidation)
+        {
+            _queuedSceneInvalidation = true;
+            commit.ContinueWith(_ => Dispatcher.UIThread.Post(() =>
+            {
+                _queuedSceneInvalidation = false;
+                SceneInvalidated?.Invoke(this, new SceneInvalidatedEventArgs(_root, new Rect(_root.ClientSize)));
+            }, DispatcherPriority.Input));
+        }
     }
 
     public void TriggerSceneInvalidatedForUnitTests(Rect rect) =>

--- a/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
@@ -8,6 +8,7 @@ using Avalonia.Collections;
 using Avalonia.Collections.Pooled;
 using Avalonia.Media;
 using Avalonia.Rendering.Composition.Drawing;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Rendering.Composition;
@@ -177,7 +178,7 @@ internal class CompositingRenderer : IRendererWithCompositor, IHitTester
 
     private async void TriggerSceneInvalidatedOnBatchCompletion(Task batchCompletion)
     {
-        await batchCompletion;
+        await Dispatcher.UIThread.AwaitWithPriority(batchCompletion, DispatcherPriority.Input);
         SceneInvalidated?.Invoke(this, new SceneInvalidatedEventArgs(_root, new Rect(_root.ClientSize)));
     }
 

--- a/src/Avalonia.Base/Rendering/Composition/Server/SimpleServerObject.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/SimpleServerObject.cs
@@ -17,7 +17,7 @@ class SimpleServerObject
 
     }
 
-    public void DeserializeChanges(BatchStreamReader reader, Batch batch)
+    public void DeserializeChanges(BatchStreamReader reader, CompositionBatch batch)
     {
         DeserializeChangesCore(reader, batch.CommittedAt);
         ValuesInvalidated();

--- a/src/Avalonia.Base/Rendering/Composition/Transport/Batch.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Transport/Batch.cs
@@ -9,16 +9,16 @@ namespace Avalonia.Rendering.Composition.Transport
     /// <summary>
     /// Represents a group of serialized changes from the UI thread to be atomically applied at the render thread
     /// </summary>
-    internal class Batch
+    public class CompositionBatch
     {
         private static long _nextSequenceId = 1;
         private static ConcurrentBag<BatchStreamData> _pool = new();
         private readonly TaskCompletionSource<int> _acceptedTcs = new();
         private readonly TaskCompletionSource<int> _renderedTcs = new();
         
-        public long SequenceId { get; }
+        internal long SequenceId { get; }
         
-        public Batch()
+        internal CompositionBatch()
         {
             SequenceId = Interlocked.Increment(ref _nextSequenceId);
             if (!_pool.TryTake(out var lst))
@@ -27,12 +27,34 @@ namespace Avalonia.Rendering.Composition.Transport
         }
 
         
-        public BatchStreamData Changes { get; private set; }
-        public TimeSpan CommittedAt { get; set; }
+        internal BatchStreamData Changes { get; private set; }
+        internal TimeSpan CommittedAt { get; set; }
+        
+        /// <summary>
+        /// Indicates that batch got deserialized on the render thread and will soon be rendered.
+        /// It's generally a good time to start producing the next one
+        /// </summary>
+        /// <remarks>
+        /// To allow timing-sensitive code to receive the notification in time, the TaskCompletionSource
+        /// is configured to invoke continuations  _synchronously_, so your `await` could happen from the render loop
+        /// if it happens to run on the UI thread.
+        /// It's recommended to use Dispatcher.AwaitOnPriority when consuming from the UI thread 
+        /// </remarks>
         public Task Processed => _acceptedTcs.Task;
+        
+        /// <summary>
+        /// Indicates that batch got rendered on the render thread.
+        /// It's generally a good time to start producing the next one
+        /// </summary>
+        /// <remarks>
+        /// To allow timing-sensitive code to receive the notification in time, the TaskCompletionSource
+        /// is configured to invoke continuations  _synchronously_, so your `await` could happen from the render loop
+        /// if it happens to run on the UI thread.
+        /// It's recommended to use Dispatcher.AwaitOnPriority when consuming from the UI thread 
+        /// </remarks>
         public Task Rendered => _renderedTcs.Task;
         
-        public void NotifyProcessed()
+        internal void NotifyProcessed()
         {
             _pool.Add(Changes);
             Changes = null!;
@@ -40,6 +62,6 @@ namespace Avalonia.Rendering.Composition.Transport
             _acceptedTcs.TrySetResult(0);
         }
         
-        public void NotifyRendered() => _renderedTcs.TrySetResult(0);
+        internal void NotifyRendered() => _renderedTcs.TrySetResult(0);
     }
 }

--- a/src/Avalonia.Base/Threading/Dispatcher.Invoke.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.Invoke.cs
@@ -619,4 +619,16 @@ public partial class Dispatcher
         _ = action ?? throw new ArgumentNullException(nameof(action));
         InvokeAsyncImpl(new SendOrPostCallbackDispatcherOperation(this, priority, action, arg, true), CancellationToken.None);
     }
+
+    /// <summary>
+    /// Returns a task awaitable that would invoke continuation on specified dispatcher priority
+    /// </summary>
+    public DispatcherPriorityAwaitable AwaitWithPriority(Task task, DispatcherPriority priority) =>
+        new(this, task, priority);
+    
+    /// <summary>
+    /// Returns a task awaitable that would invoke continuation on specified dispatcher priority
+    /// </summary>
+    public DispatcherPriorityAwaitable<T> AwaitWithPriority<T>(Task<T> task, DispatcherPriority priority) =>
+        new(this, task, priority);
 }

--- a/src/Avalonia.Base/Threading/DispatcherPriorityAwaitable.cs
+++ b/src/Avalonia.Base/Threading/DispatcherPriorityAwaitable.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Avalonia.Threading;
+
+public class DispatcherPriorityAwaitable : INotifyCompletion
+{
+    private readonly Dispatcher _dispatcher;
+    private protected readonly Task Task;
+    private readonly DispatcherPriority _priority;
+
+    internal DispatcherPriorityAwaitable(Dispatcher dispatcher, Task task, DispatcherPriority priority)
+    {
+        _dispatcher = dispatcher;
+        Task = task;
+        _priority = priority;
+    }
+    
+    public void OnCompleted(Action continuation) =>
+        Task.ContinueWith(_ => _dispatcher.Post(continuation, _priority));
+
+    public bool IsCompleted => Task.IsCompleted;
+
+    public void GetResult() => Task.GetAwaiter().GetResult();
+
+    public DispatcherPriorityAwaitable GetAwaiter() => this;
+}
+
+public class DispatcherPriorityAwaitable<T> : DispatcherPriorityAwaitable
+{
+    internal DispatcherPriorityAwaitable(Dispatcher dispatcher, Task<T> task, DispatcherPriority priority) : base(
+        dispatcher, task, priority)
+    {
+    }
+
+    public new T GetResult() => ((Task<T>)Task).GetAwaiter().GetResult();
+
+    public new DispatcherPriorityAwaitable<T> GetAwaiter() => this;
+}


### PR DESCRIPTION
We have [reports](https://github.com/AvaloniaUI/Avalonia/issues/12156) about a problem caused by reentrancy in our rendering code.

Those are hard to diagnose, since reported exception is thrown way after said reentrancy happened.

This PR:
1) Adds reentrancy guard for the compositor
2) Disables dispatcher processing if compositor is forced to produce a frame on the UI thread
3) Fixes a potential (but unlikely)  cause for possible reentrancy
4) Exposes extra information about composition batch lifetime
5) Adds Dispatcher.AwaitOnPriority

Those won't necessary fix the issue, but at least we'll get a proper stack trace.