### PR TITLE
Fix HeadlessUnitTestSession creation race condition

### DIFF
--- a/src/Avalonia.Base/Media/MediaContext.Clock.cs
+++ b/src/Avalonia.Base/Media/MediaContext.Clock.cs
@@ -31,12 +31,12 @@ internal partial class MediaContext
         public IDisposable Subscribe(IObserver<TimeSpan> observer)
         {
             _parent.ScheduleRender(false);
-            _parent._uiThreadDispatcher.VerifyAccess();
+            _parent._dispatcher.VerifyAccess();
             _observers.Add(observer);
             _newObservers.Add(observer);
             return Disposable.Create(() =>
             {
-                _parent._uiThreadDispatcher.VerifyAccess();
+                _parent._dispatcher.VerifyAccess();
                 _observers.Remove(observer);
             });
         }

--- a/src/Avalonia.Base/Media/MediaContext.Clock.cs
+++ b/src/Avalonia.Base/Media/MediaContext.Clock.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Avalonia.Animation;
 using Avalonia.Reactive;
-using Avalonia.Threading;
-using Avalonia.Utilities;
 
 namespace Avalonia.Media;
 
@@ -33,12 +31,12 @@ internal partial class MediaContext
         public IDisposable Subscribe(IObserver<TimeSpan> observer)
         {
             _parent.ScheduleRender(false);
-            Dispatcher.UIThread.VerifyAccess();
+            _parent._uiThreadDispatcher.VerifyAccess();
             _observers.Add(observer);
             _newObservers.Add(observer);
             return Disposable.Create(() =>
             {
-                Dispatcher.UIThread.VerifyAccess();
+                _parent._uiThreadDispatcher.VerifyAccess();
                 _observers.Remove(observer);
             });
         }

--- a/src/Avalonia.Base/Media/MediaContext.Compositor.cs
+++ b/src/Avalonia.Base/Media/MediaContext.Compositor.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Linq;
-using System.Threading.Tasks;
 using Avalonia.Platform;
 using Avalonia.Rendering.Composition;
 using Avalonia.Rendering.Composition.Transport;
@@ -22,7 +20,7 @@ partial class MediaContext
         _requestedCommits.Remove(compositor);
         _pendingCompositionBatches[compositor] = commit;
         commit.Processed.ContinueWith(_ =>
-            Dispatcher.UIThread.Post(() => CompositionBatchFinished(compositor, commit), DispatcherPriority.Send));
+            _uiThreadDispatcher.Post(() => CompositionBatchFinished(compositor, commit), DispatcherPriority.Send));
         return commit;
     }
     

--- a/src/Avalonia.Base/Media/MediaContext.Compositor.cs
+++ b/src/Avalonia.Base/Media/MediaContext.Compositor.cs
@@ -20,7 +20,7 @@ partial class MediaContext
         _requestedCommits.Remove(compositor);
         _pendingCompositionBatches[compositor] = commit;
         commit.Processed.ContinueWith(_ =>
-            _uiThreadDispatcher.Post(() => CompositionBatchFinished(compositor, commit), DispatcherPriority.Send));
+            _dispatcher.Post(() => CompositionBatchFinished(compositor, commit), DispatcherPriority.Send));
         return commit;
     }
     

--- a/src/Avalonia.Base/Media/MediaContext.cs
+++ b/src/Avalonia.Base/Media/MediaContext.cs
@@ -1,8 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Avalonia.Animation;
 using Avalonia.Layout;
 using Avalonia.Rendering;
 using Avalonia.Rendering.Composition;
@@ -23,6 +20,7 @@ internal partial class MediaContext : ICompositorScheduler
     private readonly Action _inputMarkerHandler;
     private readonly HashSet<Compositor> _requestedCommits = new();
     private readonly Dictionary<Compositor, CompositionBatch> _pendingCompositionBatches = new();
+    private readonly Dispatcher _uiThreadDispatcher;
     private record  TopLevelInfo(Compositor Compositor, CompositingRenderer Renderer, ILayoutManager LayoutManager);
 
     private List<Action>? _invokeOnRenderCallbacks;
@@ -38,11 +36,12 @@ internal partial class MediaContext : ICompositorScheduler
 
     private Dictionary<object, TopLevelInfo> _topLevels = new();
 
-    private MediaContext()
+    private MediaContext(Dispatcher uiThreadDispatcher)
     {
         _render = Render;
         _inputMarkerHandler = InputMarkerHandler;
         _clock = new(this);
+        _uiThreadDispatcher = uiThreadDispatcher;
         _animationsTimer.Tick += (_, _) =>
         {
             _animationsTimer.Stop();
@@ -58,7 +57,7 @@ internal partial class MediaContext : ICompositorScheduler
             // and need to do a full reset for unit tests
             var context = AvaloniaLocator.Current.GetService<MediaContext>();
             if (context == null)
-                AvaloniaLocator.CurrentMutable.Bind<MediaContext>().ToConstant(context = new());
+                AvaloniaLocator.CurrentMutable.Bind<MediaContext>().ToConstant(context = new(Dispatcher.UIThread));
             return context;
         }
     }
@@ -84,7 +83,7 @@ internal partial class MediaContext : ICompositorScheduler
         
         if (_inputMarkerOp == null)
         {
-            _inputMarkerOp = Dispatcher.UIThread.InvokeAsync(_inputMarkerHandler, DispatcherPriority.Input);
+            _inputMarkerOp = _uiThreadDispatcher.InvokeAsync(_inputMarkerHandler, DispatcherPriority.Input);
             _inputMarkerAddedAt = _time.Elapsed;
         }
         else if (!now && (_time.Elapsed - _inputMarkerAddedAt).TotalSeconds > MaxSecondsWithoutInput)
@@ -93,7 +92,7 @@ internal partial class MediaContext : ICompositorScheduler
         }
         
 
-        _nextRenderOp = Dispatcher.UIThread.InvokeAsync(_render, priority);
+        _nextRenderOp = _uiThreadDispatcher.InvokeAsync(_render, priority);
     }
     
     /// <summary>

--- a/src/Avalonia.Base/Rendering/Composition/CompositionDrawingSurface.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositionDrawingSurface.cs
@@ -56,7 +56,7 @@ public class CompositionDrawingSurface : CompositionSurface, IDisposable
 
     ~CompositionDrawingSurface()
     {
-        Compositor.UIThreadDispatcher.Post(Dispose);
+        Compositor.Dispatcher.Post(Dispose);
     }
 
     public new void Dispose() => base.Dispose();

--- a/src/Avalonia.Base/Rendering/Composition/CompositionDrawingSurface.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositionDrawingSurface.cs
@@ -56,7 +56,7 @@ public class CompositionDrawingSurface : CompositionSurface, IDisposable
 
     ~CompositionDrawingSurface()
     {
-        Dispatcher.UIThread.Post(Dispose);
+        Compositor.UIThreadDispatcher.Post(Dispose);
     }
 
     public new void Dispose() => base.Dispose();

--- a/src/Avalonia.Base/Threading/Dispatcher.Queue.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.Queue.cs
@@ -108,6 +108,7 @@ public partial class Dispatcher
                 job = s_uiThread._queue.Peek();
             if (job == null || job.Priority <= DispatcherPriority.Inactive)
             {
+                s_uiThread.ShutdownImpl();
                 s_uiThread = null;
                 return;
             }

--- a/src/Headless/Avalonia.Headless.XUnit/AvaloniaTestCase.cs
+++ b/src/Headless/Avalonia.Headless.XUnit/AvaloniaTestCase.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Avalonia.Threading;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -37,10 +35,11 @@ internal class AvaloniaTestCase : XunitTestCase
 
         // We need to block the XUnit thread to ensure its concurrency throttle is effective.
         // See https://github.com/AArnott/Xunit.StaFact/pull/55#issuecomment-826187354 for details.
-        var runSummary = AvaloniaTestCaseRunner
-            .RunTest(session, this, DisplayName, SkipReason, constructorArguments,
-                TestMethodArguments, messageBus, aggregator, cancellationTokenSource)
-            .GetAwaiter().GetResult();
+        var runSummary =
+            Task.Run(() => AvaloniaTestCaseRunner.RunTest(session, this, DisplayName, SkipReason, constructorArguments,
+                TestMethodArguments, messageBus, aggregator, cancellationTokenSource))
+            .GetAwaiter()
+            .GetResult();
 
         return Task.FromResult(runSummary);
     }

--- a/tests/Avalonia.Headless.XUnit.UnitTests/AssemblyInfo.cs
+++ b/tests/Avalonia.Headless.XUnit.UnitTests/AssemblyInfo.cs
@@ -2,6 +2,5 @@
 global using Avalonia.Headless.XUnit;
 using Avalonia.Headless;
 using Avalonia.Headless.UnitTests;
-using Avalonia.Headless.XUnit;
 
 [assembly: AvaloniaTestApplication(typeof(TestApplication))]

--- a/tests/Avalonia.RenderTests/TestBase.cs
+++ b/tests/Avalonia.RenderTests/TestBase.cs
@@ -108,7 +108,7 @@ namespace Avalonia.Direct2D1.RenderTests
             var timer = new ManualRenderTimer();
 
             var compositor = new Compositor(new RenderLoop(timer), null, true,
-                new DispatcherCompositorScheduler(), true);
+                new DispatcherCompositorScheduler(), true, Dispatcher.UIThread);
             using (var writableBitmap = factory.CreateWriteableBitmap(pixelSize, dpiVector, factory.DefaultPixelFormat, factory.DefaultAlphaFormat))
             {
                 var root = new TestRenderRoot(dpiVector.X / 96, null!);

--- a/tests/Avalonia.UnitTests/CompositorTestServices.cs
+++ b/tests/Avalonia.UnitTests/CompositorTestServices.cs
@@ -46,7 +46,7 @@ public class CompositorTestServices : IDisposable
             AvaloniaLocator.CurrentMutable.Bind<IRenderTimer>().ToConstant(Timer);
 
             Compositor = new Compositor(new RenderLoop(Timer), null,
-                true, new DispatcherCompositorScheduler(), true);
+                true, new DispatcherCompositorScheduler(), true, Dispatcher.UIThread);
             var impl = new TopLevelImpl(Compositor, size ?? new Size(1000, 1000));
             TopLevel = new EmbeddableControlRoot(impl)
             {

--- a/tests/Avalonia.UnitTests/RendererMocks.cs
+++ b/tests/Avalonia.UnitTests/RendererMocks.cs
@@ -18,7 +18,7 @@ namespace Avalonia.UnitTests
 
         public static Compositor CreateDummyCompositor() =>
             new(new RenderLoop(new CompositorTestServices.ManualRenderTimer()), null, false,
-                new CompositionCommitScheduler(), true);
+                new CompositionCommitScheduler(), true, Dispatcher.UIThread);
 
         class CompositionCommitScheduler : ICompositorScheduler
         {


### PR DESCRIPTION
## What does the pull request do?

This PR fixes two race conditions related to the headless unit tests when run with xUnit, which resulted in hangs or exceptions.

## How was the solution implemented?

### Problem 1: HeadlessUnitTestSession (race condition)

`HeadlessUnitTestSession` could be incorrectly created multiple times for the same assembly.

`ConcurrentDictionary.GetOrAdd` shouldn't be used if the `valueFactory` has side effects since it can be called multiple times, as [documented](https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd):
> Since a key/value can be inserted by another thread while valueFactory is generating a value, you cannot trust that just because valueFactory executed, its produced value will be inserted into the dictionary and returned. If you call GetOrAdd simultaneously on different threads, **valueFactory may be called multiple times**, but only one key/value pair will be added to the dictionary.

This is very easy to forget (I've fallen into this trap in the past). When `valueFactory` can only be called once and concurrency throughput is important, one should ideally call the lock-free `TryGetValue`, then take a lock to insert the value if it's missing: [example](https://github.com/dotnet/runtime/blob/51498964d35068ded252ec98baf4fe6ebf6a4612/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs#L146). Since we're talking about unit tests here, I've simply used an old-school `Dictionary` with a lock to simplify things: the lock isn't a bottleneck at all here.

I've also made sure that errors are always reported if there's any problem in `HeadlessUnitTestSession` instead of hanging without any output: `EnsureApplication` wasn't called inside the `try` block, effectively crashing the session silently without completing the current test. The `Dispatch` call is also done a bit later in the test pipeline so xUnit can associate the exception with the current test.

### Problem 2: MediaContext (race condition)

After the fix for `HeadlessUnitTestSession`, we now have a single thread executing the unit tests, but still have some random race conditions.
As always with this type of issue, this was very hard to diagnose: on my machine, the problem occurred once every hundreds of runs, but it's much more frequent on the CI instances. I finally managed to have a stable enough repro.

The culprit is the renderer thread trying to post back to the UI thread:
https://github.com/AvaloniaUI/Avalonia/blob/ac00fe2bf4f4cf720c7b10b37f0058ee1cc8eddc/src/Avalonia.Base/Media/MediaContext.Compositor.cs#L25

When an headless test finishes executing, it resets the `Dispatcher.UIThread` to `null`. The next test can then get a fresh new dispatcher.
The race was the new unit test trying to create the UI thread while the `MediaContext` from a previous test was also creating a new one.

Depending on which UI thread won, this manifested either in an exception in `Dispatcher.PushFrame` or a hang in that same method, with the test never finishing (it's running on the wrong dispatcher) and thus never stopping the `DispatcherFrame`.

While it can be fixed by adding a lock to the `UIThread` getter, it's still wrong for a previous `MediaContext` to post to a new, unrelated, dispatcher.
Instead, both `Compositor` and `MediaContext` now capture the UI thread dispatcher when they're created, and use it directly.
Since the dispatcher is now properly shutdown between unit tests with this PR, the `Post` operation from the `MediaContext` will never run if the dispatcher was shutdown.

Those modifications are imperceptible for normal apps, where there's one and only `UIThread` dispatcher.

### Problem 3: AvaloniaTestCase (deadlock)

Fixing the issue with multiple sessions made an existing potential deadlock more likely to happen in `AvaloniaTestCase`. In this class, the xUnit thread running the test is blocked to allow its concurrency limit to work, as commented. If the max concurrency is reached, we have a deadlock: there's no xUnit thread free to continue the work since are all blocked waiting.

This is solved by running the test itself in a task, while the xUnit threads are simply waiting.

## Fixed issues
 - Fixes #12588
 - Should fix CI timeouts

## Remaining issue

`HeadlessUnitTestSession` is still broken for multiple assemblies: there should be an unique dispatch loop for all sessions.  
Currently, multiple sessions will set and fight for their own UI thread in parallel, quickly crashing or hanging.
