### PR TITLE
Fix XAML name generator with non-Avalonia XAML files

### DIFF
--- a/samples/Generators.Sandbox/Generators.Sandbox.csproj
+++ b/samples/Generators.Sandbox/Generators.Sandbox.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
@@ -8,7 +8,7 @@
   <ItemGroup>
     <AvaloniaResource Include="**\*.xaml"/>
     <!-- Note this AdditionalFiles directive. -->
-    <AdditionalFiles Include="**\*.xaml"/>
+    <AdditionalFiles Include="**\*.xaml" SourceItemGroup="AvaloniaXaml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tools/Avalonia.Generators/GeneratorContextExtensions.cs
+++ b/src/tools/Avalonia.Generators/GeneratorContextExtensions.cs
@@ -21,6 +21,7 @@ internal static class GeneratorContextExtensions
         context.Report(UnhandledErrorDescriptorId,
             "Unhandled exception occured while generating typed Name references. " +
             "Please file an issue: https://github.com/avaloniaui/Avalonia",
+            error.Message,
             error.ToString());
 
     public static void ReportNameGeneratorInvalidType(this GeneratorExecutionContext context, string typeName) =>
@@ -28,9 +29,16 @@ internal static class GeneratorContextExtensions
             $"Avalonia x:Name generator was unable to generate names for type '{typeName}'. " +
             $"The type '{typeName}' does not exist in the assembly.");
 
-    private static void Report(this GeneratorExecutionContext context, string id, string title, string message = null) =>
+    private static void Report(this GeneratorExecutionContext context, string id, string title, string message = null, string description = null) =>
         context.ReportDiagnostic(
             Diagnostic.Create(
-                new DiagnosticDescriptor(id, title, message ?? title, "Usage", DiagnosticSeverity.Error, true),
+                new DiagnosticDescriptor(
+                    id: id,
+                    title: title,
+                    messageFormat: message ?? title,
+                    category: "Usage",
+                    defaultSeverity: DiagnosticSeverity.Error,
+                    isEnabledByDefault: true,
+                    description),
                 Location.None));
 }

--- a/src/tools/Avalonia.Generators/NameGenerator/AvaloniaNameSourceGenerator.cs
+++ b/src/tools/Avalonia.Generators/NameGenerator/AvaloniaNameSourceGenerator.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
 using Avalonia.Generators.Common;
 using Avalonia.Generators.Common.Domain;
 using Avalonia.Generators.Compiler;
@@ -10,6 +13,8 @@ namespace Avalonia.Generators.NameGenerator;
 [Generator]
 public class AvaloniaNameSourceGenerator : ISourceGenerator
 {
+    private const string SourceItemGroupMetadata = "build_metadata.AdditionalFiles.SourceItemGroup";
+
     public void Initialize(GeneratorInitializationContext context) { }
 
     public void Execute(GeneratorExecutionContext context)
@@ -22,7 +27,7 @@ public class AvaloniaNameSourceGenerator : ISourceGenerator
                 return;
             }
 
-            var partials = generator.GenerateNameReferences(context.AdditionalFiles, context.CancellationToken);
+            var partials = generator.GenerateNameReferences(ResolveAdditionalFiles(context), context.CancellationToken);
             foreach (var (fileName, content) in partials)
             {
                 if(context.CancellationToken.IsCancellationRequested)
@@ -40,6 +45,16 @@ public class AvaloniaNameSourceGenerator : ISourceGenerator
         {
             context.ReportNameGeneratorUnhandledError(exception);
         }
+    }
+
+    private static IEnumerable<AdditionalText> ResolveAdditionalFiles(GeneratorExecutionContext context)
+    {
+        return context
+            .AdditionalFiles
+            .Where(f => context.AnalyzerConfigOptions
+                .GetOptions(f)
+                .TryGetValue(SourceItemGroupMetadata, out var sourceItemGroup)
+                && sourceItemGroup == "AvaloniaXaml");
     }
 
     private static INameGenerator CreateNameGenerator(GeneratorExecutionContext context)


### PR DESCRIPTION
## What does the pull request do?

AdditionalFiles metadata was previously ignored. 

## Fixed issues

Fixes #12855
Fixes #12841 (unrelated, but also fixed)

