### PR TITLE
Allow TransitioningContentControl to be reversed.

### DIFF
--- a/samples/ControlCatalog/Pages/TransitioningContentControlPage.axaml
+++ b/samples/ControlCatalog/Pages/TransitioningContentControlPage.axaml
@@ -69,7 +69,8 @@
         
         <Border ClipToBounds="{Binding ClipToBounds}" Margin="5">
             <TransitioningContentControl Content="{Binding SelectedImage}"
-                                         PageTransition="{Binding SelectedTransition.Transition}" >
+                                         PageTransition="{Binding SelectedTransition.Transition}" 
+                                         IsTransitionReversed="{Binding Reversed}">
                 <TransitioningContentControl.ContentTemplate>
                     <DataTemplate DataType="Bitmap">
                         <Image Source="{Binding}"  />

--- a/samples/ControlCatalog/ViewModels/TransitioningContentControlPageViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/TransitioningContentControlPageViewModel.cs
@@ -46,6 +46,7 @@ namespace ControlCatalog.ViewModels
 
 
         private Bitmap _SelectedImage;
+        private bool _Reversed;
 
         /// <summary>
         /// Gets or Sets the selected image
@@ -97,6 +98,15 @@ namespace ControlCatalog.ViewModels
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the animation is reversed.
+        /// </summary>
+        public bool Reversed
+        {
+            get { return _Reversed; }
+            set { this.RaiseAndSetIfChanged(ref _Reversed, value); }
+        }
+
         private void SetupTransitions()
         {
             if (PageTransitions.Count == 0)
@@ -127,6 +137,7 @@ namespace ControlCatalog.ViewModels
 
         public void NextImage()
         {
+            Reversed = false;
             var index = Images.IndexOf(SelectedImage) + 1;
             
             if (index >= Images.Count)
@@ -139,6 +150,7 @@ namespace ControlCatalog.ViewModels
 
         public void PrevImage()
         {
+            Reversed = true;
             var index = Images.IndexOf(SelectedImage) - 1;
 
             if (index < 0)

--- a/samples/ControlCatalog/ViewModels/TransitioningContentControlPageViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/TransitioningContentControlPageViewModel.cs
@@ -103,8 +103,8 @@ namespace ControlCatalog.ViewModels
         /// </summary>
         public bool Reversed
         {
-            get { return _Reversed; }
-            set { this.RaiseAndSetIfChanged(ref _Reversed, value); }
+            get => _Reversed;
+            set => this.RaiseAndSetIfChanged(ref _Reversed, value);
         }
 
         private void SetupTransitions()

--- a/src/Avalonia.Controls/TransitioningContentControl.cs
+++ b/src/Avalonia.Controls/TransitioningContentControl.cs
@@ -34,7 +34,7 @@ public class TransitioningContentControl : ContentControl
     /// </summary>
     public static readonly StyledProperty<bool> IsTransitionReversedProperty =
         AvaloniaProperty.Register<TransitioningContentControl, bool>(
-            nameof(PageTransition),
+            nameof(IsTransitionReversed),
             defaultValue: false);
 
     /// <summary>

--- a/src/Avalonia.Controls/TransitioningContentControl.cs
+++ b/src/Avalonia.Controls/TransitioningContentControl.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Animation;
-using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
@@ -13,11 +12,8 @@ namespace Avalonia.Controls;
 /// Displays <see cref="ContentControl.Content"/> according to an <see cref="IDataTemplate"/>,
 /// using a <see cref="PageTransition"/> to move between the old and new content. 
 /// </summary>
-[PseudoClasses(_PcReversed)]
 public class TransitioningContentControl : ContentControl
 {
-    private const string _PcReversed = ":reversed";
-
     private CancellationTokenSource? _currentTransition;
     private ContentPresenter? _presenter2;
     private bool _isFirstFull;
@@ -123,11 +119,6 @@ public class TransitioningContentControl : ContentControl
         if (change.Property == ContentProperty)
         {
             UpdateContent(true);
-            return;
-        }
-        else if (change.Property == IsTransitionReversedProperty)
-        {
-            PseudoClasses.Set(_PcReversed, IsTransitionReversed);
             return;
         }
 

--- a/src/Avalonia.Controls/TransitioningContentControl.cs
+++ b/src/Avalonia.Controls/TransitioningContentControl.cs
@@ -14,6 +14,8 @@ namespace Avalonia.Controls;
 /// </summary>
 public class TransitioningContentControl : ContentControl
 {
+    private const string _PcReversed = ":reversed";
+
     private CancellationTokenSource? _currentTransition;
     private ContentPresenter? _presenter2;
     private bool _isFirstFull;
@@ -28,12 +30,30 @@ public class TransitioningContentControl : ContentControl
             defaultValue: new ImmutableCrossFade(TimeSpan.FromMilliseconds(125)));
 
     /// <summary>
+    /// Defines the <see cref="IsTransitionReversed"/> property.
+    /// </summary>
+    public static readonly StyledProperty<bool> IsTransitionReversedProperty =
+        AvaloniaProperty.Register<TransitioningContentControl, bool>(
+            nameof(PageTransition),
+            defaultValue: false);
+
+    /// <summary>
     /// Gets or sets the animation played when content appears and disappears.
     /// </summary>
     public IPageTransition? PageTransition
     {
         get => GetValue(PageTransitionProperty);
         set => SetValue(PageTransitionProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the control will be animated in the reverse direction.
+    /// </summary>
+    /// <remarks>May not apply to all transitions.</remarks>
+    public bool IsTransitionReversed
+    {
+        get => GetValue(IsTransitionReversedProperty);
+        set => SetValue(IsTransitionReversedProperty, value);
     }
 
     protected override Size ArrangeOverride(Size finalSize)
@@ -56,7 +76,7 @@ public class TransitioningContentControl : ContentControl
                 var from = _isFirstFull ? _presenter2 : presenter;
                 var to = _isFirstFull ? presenter : _presenter2;
 
-                transition.Start(from, to, true, cancel.Token).ContinueWith(x =>
+                transition.Start(from, to, !IsTransitionReversed, cancel.Token).ContinueWith(x =>
                 {
                     if (!cancel.IsCancellationRequested)
                     {
@@ -101,6 +121,11 @@ public class TransitioningContentControl : ContentControl
         if (change.Property == ContentProperty)
         {
             UpdateContent(true);
+            return;
+        }
+        else if (change.Property == IsTransitionReversedProperty)
+        {
+            PseudoClasses.Set(_PcReversed, IsTransitionReversed);
             return;
         }
 

--- a/src/Avalonia.Controls/TransitioningContentControl.cs
+++ b/src/Avalonia.Controls/TransitioningContentControl.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Animation;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
@@ -12,6 +13,7 @@ namespace Avalonia.Controls;
 /// Displays <see cref="ContentControl.Content"/> according to an <see cref="IDataTemplate"/>,
 /// using a <see cref="PageTransition"/> to move between the old and new content. 
 /// </summary>
+[PseudoClasses(_PcReversed)]
 public class TransitioningContentControl : ContentControl
 {
     private const string _PcReversed = ":reversed";

--- a/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
@@ -209,7 +209,6 @@ namespace Avalonia.Controls.UnitTests
             Layout(target);
             sync.ExecutePostedCallbacks();
 
-            Assert.Equal(reversed, target.Classes.Contains(":reversed"));
             Assert.Equal(1, startedRaised);
             Assert.Equal("foo", target.Presenter!.Content);
             Assert.Equal("bar", presenter2.Content);

--- a/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TransitioningContentControlTests.cs
@@ -183,6 +183,38 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal("bar", presenter2.Content);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Transition_Should_Be_Reversed_If_Property_Is_Set(bool reversed)
+        {
+            using var app = Start();
+            using var sync = UnitTestSynchronizationContext.Begin();
+            var (target, transition) = CreateTarget("foo");
+            var presenter2 = GetContentPresenters2(target);
+
+            target.IsTransitionReversed = reversed;
+
+            target.Content = "bar";
+
+            var startedRaised = 0;
+
+            transition.Started += (from, to, forward) =>
+            {
+                Assert.Equal(reversed, !forward);
+
+                ++startedRaised;
+            };
+
+            Layout(target);
+            sync.ExecutePostedCallbacks();
+
+            Assert.Equal(reversed, target.Classes.Contains(":reversed"));
+            Assert.Equal(1, startedRaised);
+            Assert.Equal("foo", target.Presenter!.Content);
+            Assert.Equal("bar", presenter2.Content);
+        }
+
         [Fact]
         public void Logical_Children_Should_Not_Be_Duplicated()
         {


### PR DESCRIPTION
## What does the pull request do?
Adds the ability to set a boolean property on TransitioningContentControl that will reverse the transition direction.


## What is the current behavior?
The transition always goes "forward".


## What is the updated/expected behavior with this PR?
The transition will animate in the opposite direction if the IsTransitionReversed property is true.  The ":reversed" pseudoclass is also set on the control.  Also, the ControlCatalog was updated to reflect the changes. (Will have no visual effect on CrossFade transition.)


## How was the solution implemented (if it's not obvious)?
It's pretty obvious.


## Checklist

- [Done] Added unit tests (if possible)?
- [Done] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
#12442 
