### PR TITLE
Bump minimal TFM for mobile projects from .NET 6 to .NET 7…

### DIFF
--- a/samples/ControlCatalog.Android/ControlCatalog.Android.csproj
+++ b/samples/ControlCatalog.Android/ControlCatalog.Android.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-android</TargetFramework>
+    <TargetFramework>net7.0-android</TargetFramework>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
@@ -11,26 +11,10 @@
     <MSBuildEnableWorkloadResolver>true</MSBuildEnableWorkloadResolver>
   </PropertyGroup>
   <ItemGroup>
-    <None Remove="Resources\drawable-night-v31\avalonia_anim.xml" />
-    <None Remove="Resources\drawable-v31\avalonia_anim.xml" />
-    <None Remove="Resources\values-v31\styles.xml" />
-  </ItemGroup>
-  <ItemGroup>
     <AndroidResource Include="..\..\build\Assets\Icon.png">
       <Link>Resources\drawable\Icon.png</Link>
     </AndroidResource>
   </ItemGroup>
-
-  <PropertyGroup Condition="'$(RunAOTCompilation)'=='' and '$(Configuration)'=='Release' and '$(TF_BUILD)'==''">
-    <RunAOTCompilation>True</RunAOTCompilation>
-  </PropertyGroup>
-  
-  <!-- PropertyGroup Condition="'$(RunAOTCompilation)'=='True'">
-    <EnableLLVM>True</EnableLLVM>
-    <AndroidAotAdditionalArguments>no-write-symbols,nodebug</AndroidAotAdditionalArguments>
-    <AndroidAotMode>Hybrid</AndroidAotMode>
-    <AndroidGenerateJniMarshalMethods>True</AndroidGenerateJniMarshalMethods>
-  </PropertyGroup -->
 
   <PropertyGroup Condition="'$(AndroidEnableProfiler)'=='True'">
     <IsEmulator Condition="'$(IsEmulator)' == ''">True</IsEmulator>

--- a/samples/ControlCatalog.iOS/ControlCatalog.iOS.csproj
+++ b/samples/ControlCatalog.iOS/ControlCatalog.iOS.csproj
@@ -2,15 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ProvisioningType>manual</ProvisioningType>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net7.0-ios</TargetFramework>
     <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
-    <!-- temporal workaround for our GL interface backend -->
-    <UseInterpreter>True</UseInterpreter>
-    <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
-    <!--    <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>-->
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\iOS\Avalonia.iOS\Avalonia.iOS.csproj" />

--- a/samples/MobileSandbox.Android/MobileSandbox.Android.csproj
+++ b/samples/MobileSandbox.Android/MobileSandbox.Android.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-android</TargetFramework>
+    <TargetFramework>net7.0-android</TargetFramework>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
@@ -11,27 +11,10 @@
     <MSBuildEnableWorkloadResolver>true</MSBuildEnableWorkloadResolver>
   </PropertyGroup>
   <ItemGroup>
-    <None Remove="Resources\drawable-night-v31\avalonia_anim.xml" />
-    <None Remove="Resources\drawable-v31\avalonia_anim.xml" />
-    <None Remove="Resources\values-v31\styles.xml" />
-    <None Remove="Resources\values-night\colors.xml" />
-  </ItemGroup>
-  <ItemGroup>
     <AndroidResource Include="..\..\build\Assets\Icon.png">
       <Link>Resources\drawable\Icon.png</Link>
     </AndroidResource>
   </ItemGroup>
-
-  <PropertyGroup Condition="'$(RunAOTCompilation)'=='' and '$(Configuration)'=='Release' and '$(TF_BUILD)'==''">
-    <RunAOTCompilation>True</RunAOTCompilation>
-  </PropertyGroup>
-  
-  <!-- PropertyGroup Condition="'$(RunAOTCompilation)'=='True'">
-    <EnableLLVM>True</EnableLLVM>
-    <AndroidAotAdditionalArguments>no-write-symbols,nodebug</AndroidAotAdditionalArguments>
-    <AndroidAotMode>Hybrid</AndroidAotMode>
-    <AndroidGenerateJniMarshalMethods>True</AndroidGenerateJniMarshalMethods>
-  </PropertyGroup -->
 
   <PropertyGroup Condition="'$(AndroidEnableProfiler)'=='True'">
     <IsEmulator Condition="'$(IsEmulator)' == ''">True</IsEmulator>

--- a/samples/MobileSandbox.iOS/MobileSandbox.iOS.csproj
+++ b/samples/MobileSandbox.iOS/MobileSandbox.iOS.csproj
@@ -4,10 +4,6 @@
     <ProvisioningType>manual</ProvisioningType>
     <TargetFramework>net6.0-ios</TargetFramework>
     <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
-    <!-- temporal workaround for our GL interface backend -->
-    <UseInterpreter>True</UseInterpreter>
-    <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
-    <!--    <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>-->
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\iOS\Avalonia.iOS\Avalonia.iOS.csproj" />

--- a/samples/SafeAreaDemo.iOS/SafeAreaDemo.iOS.csproj
+++ b/samples/SafeAreaDemo.iOS/SafeAreaDemo.iOS.csproj
@@ -5,12 +5,8 @@
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <ProvisioningType>manual</ProvisioningType>
     <Nullable>enable</Nullable>
-    <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
-    
-    <!-- These properties need to be set in order to run on a real iDevice -->
-    <!--<RuntimeIdentifier>ios-arm64</RuntimeIdentifier>-->
-    <!--<CodesignKey></CodesignKey>-->
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\SafeAreaDemo\SafeAreaDemo.csproj" />
     <ProjectReference Include="..\..\src\iOS\Avalonia.iOS\Avalonia.iOS.csproj" />

--- a/src/Android/Avalonia.Android/Avalonia.Android.csproj
+++ b/src/Android/Avalonia.Android/Avalonia.Android.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-android</TargetFramework>
+    <TargetFramework>net7.0-android</TargetFramework>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MSBuildEnableWorkloadResolver>true</MSBuildEnableWorkloadResolver>

--- a/src/iOS/Avalonia.iOS/Avalonia.iOS.csproj
+++ b/src/iOS/Avalonia.iOS/Avalonia.iOS.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net7.0-ios</TargetFramework>
     <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
     <MSBuildEnableWorkloadResolver>true</MSBuildEnableWorkloadResolver>
   </PropertyGroup>


### PR DESCRIPTION
… because of MAUI support policy.

See https://dotnet.microsoft.com/en-us/platform/support/policy/maui for details.
In short, ".NET 6 for mobile" is already out of support. And it's not possible to build ".NET 6 for android" on .NET 8 SDK since https://github.com/xamarin/xamarin-android/pull/7900#issue-1632762918.

## Breaking changes

Yes. Any Avalonia Android app will be required to use .NET 7 or newer.
It's not a huge breaking change, since our templates for mobile targetted .NET 7 anyway.

Note, this breaking change will go to "11.1" release. 