### PR TITLE
Fix MobileSandbox.iOS TFM

### DIFF
--- a/samples/MobileSandbox.iOS/MobileSandbox.iOS.csproj
+++ b/samples/MobileSandbox.iOS/MobileSandbox.iOS.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ProvisioningType>manual</ProvisioningType>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net7.0-ios</TargetFramework>
     <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the MobileSandbox.iOS project to target `net7.0`, likely missed in #13012.

## What is the current behavior?
> Error NU1201: Project Avalonia.iOS is not compatible with net6.0-ios16.1 (.NETCoreApp,Version=v6.0) / iossimulator-x64. Project Avalonia.iOS supports: net7.0-ios16.1 (.NETCoreApp,Version=v7.0)


## What is the updated/expected behavior with this PR?
No errors.
