### PR TITLE
Fix ItemsControl logical child removal

### DIFF
--- a/src/Avalonia.Controls/Presenters/PanelContainerGenerator.cs
+++ b/src/Avalonia.Controls/Presenters/PanelContainerGenerator.cs
@@ -68,9 +68,10 @@ namespace Avalonia.Controls.Presenters
                 {
                     var c = children[index + i];
 
+                    itemsControl.RemoveLogicalChild(children[i + index]);
+
                     if (!c.IsSet(ItemIsOwnContainerProperty))
                     {
-                        itemsControl.RemoveLogicalChild(children[i + index]);
                         generator.ClearItemContainer(c);
                     }
                 }

--- a/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
@@ -514,6 +514,41 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Control_Item_Should_Be_Removed_From_LogicalChildren()
+        {
+            using var app = Start();
+            var item = new Border();
+
+            var items = new ObservableCollection<Control>();
+            var target = CreateTarget(itemsSource: items);
+
+            items.Add(item);
+            items.Remove(item);
+
+            Assert.Empty(target.LogicalChildren);
+        }
+
+        [Fact]
+        public void Control_Item_Should_Be_Removed_From_LogicalChildren_Virtualizing()
+        {
+            using var app = Start();
+            var item = new Border();
+
+            var items = new ObservableCollection<Control>();
+            var itemsPanel = new FuncTemplate<Panel?>(() => new VirtualizingStackPanel());
+            var target = CreateTarget(
+                itemsPanel: itemsPanel,
+                itemsSource: items);
+
+            items.Add(item);
+            Layout(target);
+
+            items.Remove(item);
+
+            Assert.Empty(target.LogicalChildren);
+        }
+
+        [Fact]
         public void Should_Clear_Containers_When_ItemsPresenter_Changes()
         {
             using var app = Start();


### PR DESCRIPTION
## What does the pull request do?

In a non-virtualizing `itemsControl`, control items were not being removed from the `LogicalChildren` collection: only items that are not their own container were being removed. This was incorrect.

Add a unit test and fix this. Thanks to @jankrib for reporting this with a unit test and fix.
