### PR TITLE
In `Avalonia.Controls`, modernized `get`ter/`set`ter syntax

### DIFF
--- a/src/Avalonia.Controls/Application.cs
+++ b/src/Avalonia.Controls/Application.cs
@@ -83,8 +83,8 @@ namespace Avalonia
         /// </remarks>
         public object? DataContext
         {
-            get { return GetValue(DataContextProperty); }
-            set { SetValue(DataContextProperty, value); }
+            get => GetValue(DataContextProperty);
+            set => SetValue(DataContextProperty, value);
         }
 
         /// <inheritdoc cref="ThemeVariantScope.RequestedThemeVariant"/>
@@ -107,7 +107,7 @@ namespace Avalonia
         /// </value>
         public static Application? Current
         {
-            get { return AvaloniaLocator.Current.GetService<Application>(); }
+            get => AvaloniaLocator.Current.GetService<Application>();
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.cs
@@ -933,8 +933,8 @@ namespace Avalonia.Controls
         /// </summary>
         public event EventHandler<SelectionChangedEventArgs> SelectionChanged
         {
-            add { AddHandler(SelectionChangedEvent, value); }
-            remove { RemoveHandler(SelectionChangedEvent, value); }
+            add => AddHandler(SelectionChangedEvent, value);
+            remove => RemoveHandler(SelectionChangedEvent, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Automation/Peers/ProgressBarAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ProgressBarAutomationPeer.cs
@@ -35,28 +35,19 @@ namespace Avalonia.Controls.Automation.Peers
         ///returns True if the control is read-only</summary>
         bool IRangeValueProvider.IsReadOnly
         {
-            get
-            {
-                return true;
-            }
+            get => true;
         }
 
         ///<summary>Value of a Large Change</summary>
         double IRangeValueProvider.LargeChange
         {
-            get
-            {
-                return double.NaN;
-            }
+            get => double.NaN;
         }
 
         ///<summary>Value of a Small Change</summary>
         double IRangeValueProvider.SmallChange
         {
-            get
-            {
-                return double.NaN;
-            }
+            get => double.NaN;
         }
     }
 }

--- a/src/Avalonia.Controls/ButtonSpinner.cs
+++ b/src/Avalonia.Controls/ButtonSpinner.cs
@@ -49,12 +49,12 @@ namespace Avalonia.Controls
         /// </summary>
         private Button? DecreaseButton
         {
-            get { return _decreaseButton; }
+            get => _decreaseButton;
             set
             {
                 if (_decreaseButton != null)
                 {
-                    _decreaseButton.Click  -= OnButtonClick;
+                    _decreaseButton.Click -= OnButtonClick;
                 }
                 _decreaseButton = value;
                 if (_decreaseButton != null)
@@ -70,10 +70,7 @@ namespace Avalonia.Controls
         /// </summary>
         private Button? IncreaseButton
         {
-            get
-            {
-                return _increaseButton;
-            }
+            get => _increaseButton;
             set
             {
                 if (_increaseButton != null)
@@ -101,8 +98,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool AllowSpin
         {
-            get { return GetValue(AllowSpinProperty); }
-            set { SetValue(AllowSpinProperty, value); }
+            get => GetValue(AllowSpinProperty);
+            set => SetValue(AllowSpinProperty, value);
         }
 
         /// <summary>
@@ -110,8 +107,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool ShowButtonSpinner
         {
-            get { return GetValue(ShowButtonSpinnerProperty); }
-            set { SetValue(ShowButtonSpinnerProperty, value); }
+            get => GetValue(ShowButtonSpinnerProperty);
+            set => SetValue(ShowButtonSpinnerProperty, value);
         }
 
         /// <summary>
@@ -119,8 +116,8 @@ namespace Avalonia.Controls
         /// </summary>
         public Location ButtonSpinnerLocation
         {
-            get { return GetValue(ButtonSpinnerLocationProperty); }
-            set { SetValue(ButtonSpinnerLocationProperty, value); }
+            get => GetValue(ButtonSpinnerLocationProperty);
+            set => SetValue(ButtonSpinnerLocationProperty, value);
         }
 
         /// <inheritdoc />

--- a/src/Avalonia.Controls/Calendar/Calendar.cs
+++ b/src/Avalonia.Controls/Calendar/Calendar.cs
@@ -269,8 +269,8 @@ namespace Avalonia.Controls
         /// </value>
         public DayOfWeek FirstDayOfWeek
         {
-            get { return GetValue(FirstDayOfWeekProperty); }
-            set { SetValue(FirstDayOfWeekProperty, value); }
+            get => GetValue(FirstDayOfWeekProperty);
+            set => SetValue(FirstDayOfWeekProperty, value);
         }
 
         /// <summary>
@@ -323,8 +323,8 @@ namespace Avalonia.Controls
         /// </value>
         public bool IsTodayHighlighted
         {
-            get { return GetValue(IsTodayHighlightedProperty); }
-            set { SetValue(IsTodayHighlightedProperty, value); }
+            get => GetValue(IsTodayHighlightedProperty);
+            set => SetValue(IsTodayHighlightedProperty, value);
         }
 
         /// <summary>
@@ -346,8 +346,8 @@ namespace Avalonia.Controls
 
         public IBrush? HeaderBackground
         {
-            get { return GetValue(HeaderBackgroundProperty); }
-            set { SetValue(HeaderBackgroundProperty, value); }
+            get => GetValue(HeaderBackgroundProperty);
+            set => SetValue(HeaderBackgroundProperty, value);
         }
 
         public static readonly StyledProperty<CalendarMode> DisplayModeProperty =
@@ -365,8 +365,8 @@ namespace Avalonia.Controls
         /// </value>
         public CalendarMode DisplayMode
         {
-            get { return GetValue(DisplayModeProperty); }
-            set { SetValue(DisplayModeProperty, value); }
+            get => GetValue(DisplayModeProperty);
+            set => SetValue(DisplayModeProperty, value);
         }
 
         /// <summary>
@@ -458,8 +458,8 @@ namespace Avalonia.Controls
         /// </remarks>
         public CalendarSelectionMode SelectionMode
         {
-            get { return GetValue(SelectionModeProperty); }
-            set { SetValue(SelectionModeProperty, value); }
+            get => GetValue(SelectionModeProperty);
+            set => SetValue(SelectionModeProperty, value);
         }
 
         private void OnSelectionModeChanged(AvaloniaPropertyChangedEventArgs e)
@@ -649,7 +649,7 @@ namespace Avalonia.Controls
         internal DateTime? LastSelectedDateInternal { get; set; }
         internal DateTime? LastSelectedDate
         {
-            get { return LastSelectedDateInternal; }
+            get => LastSelectedDateInternal;
             set
             {
                 LastSelectedDateInternal = value;
@@ -671,7 +671,7 @@ namespace Avalonia.Controls
 
         internal DateTime SelectedMonth
         {
-            get { return _selectedMonth; }
+            get => _selectedMonth;
             set
             {
                 int monthDifferenceStart = DateTimeHelper.CompareYearMonth(value, DisplayDateRangeStart);
@@ -697,7 +697,7 @@ namespace Avalonia.Controls
         }
         internal DateTime SelectedYear
         {
-            get { return _selectedYear; }
+            get => _selectedYear;
             set
             {
                 if (value.Year < DisplayDateRangeStart.Year)
@@ -888,7 +888,7 @@ namespace Avalonia.Controls
         }
         internal DateTime DisplayDateRangeStart
         {
-            get { return DisplayDateStart.GetValueOrDefault(DateTime.MinValue); }
+            get => DisplayDateStart.GetValueOrDefault(DateTime.MinValue);
         }
 
         public static readonly StyledProperty<DateTime?> DisplayDateEndProperty =
@@ -973,7 +973,7 @@ namespace Avalonia.Controls
         }
         internal DateTime DisplayDateRangeEnd
         {
-            get { return DisplayDateEnd.GetValueOrDefault(DateTime.MaxValue); }
+            get => DisplayDateEnd.GetValueOrDefault(DateTime.MaxValue);
         }
 
         internal DateTime? HoverStart { get; set; }
@@ -981,7 +981,7 @@ namespace Avalonia.Controls
         internal DateTime? HoverEndInternal { get; set; }
         internal DateTime? HoverEnd
         {
-            get { return HoverEndInternal; }
+            get => HoverEndInternal;
             set
             {
                 HoverEndInternal = value;

--- a/src/Avalonia.Controls/Calendar/CalendarButton.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarButton.cs
@@ -52,7 +52,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         internal bool IsCalendarButtonFocused
         {
-            get { return _isCalendarButtonFocused; }
+            get => _isCalendarButtonFocused;
             set
             {
                 if (_isCalendarButtonFocused != value)
@@ -68,7 +68,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         internal bool IsInactive
         {
-            get { return _isInactive; }
+            get => _isInactive;
             set
             {
                 if (_isInactive != value)
@@ -84,7 +84,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         internal bool IsSelected
         {
-            get { return _isSelected; }
+            get => _isSelected;
             set
             {
                 if (_isSelected != value)

--- a/src/Avalonia.Controls/Calendar/CalendarDayButton.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarDayButton.cs
@@ -49,7 +49,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         internal bool IsCurrent
         {
-            get { return _isCurrent; }
+            get => _isCurrent;
             set
             {
                 if (_isCurrent != value)
@@ -93,7 +93,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         internal bool IsBlackout
         {
-            get { return _isBlackout; }
+            get => _isBlackout;
             set
             {
                 if (_isBlackout != value)
@@ -110,7 +110,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         internal bool IsToday
         {
-            get { return _isToday; }
+            get => _isToday;
             set
             {
                 if (_isToday != value)
@@ -125,7 +125,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         internal bool IsInactive
         {
-            get { return _isInactive; }
+            get => _isInactive;
             set
             {
                 if (_isInactive != value)
@@ -141,7 +141,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         internal bool IsSelected
         {
-            get { return _isSelected; }
+            get => _isSelected;
             set
             {
                 if (_isSelected != value)

--- a/src/Avalonia.Controls/Calendar/CalendarItem.cs
+++ b/src/Avalonia.Controls/Calendar/CalendarItem.cs
@@ -56,8 +56,8 @@ namespace Avalonia.Controls.Primitives
 
         public IBrush? HeaderBackground
         {
-            get { return GetValue(HeaderBackgroundProperty); }
-            set { SetValue(HeaderBackgroundProperty, value); }
+            get => GetValue(HeaderBackgroundProperty);
+            set => SetValue(HeaderBackgroundProperty, value);
         }
 
         public static readonly StyledProperty<ITemplate<Control>?> DayTitleTemplateProperty =
@@ -77,7 +77,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         internal Button? HeaderButton
         {
-            get { return _headerButton; }
+            get => _headerButton;
             private set
             {
                 if (_headerButton != null)
@@ -98,7 +98,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         internal Button? NextButton
         {
-            get { return _nextButton; }
+            get => _nextButton;
             private set
             {
                 if (_nextButton != null)
@@ -129,7 +129,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         internal Button? PreviousButton
         {
-            get { return _previousButton; }
+            get => _previousButton;
             private set
             {
                 if (_previousButton != null)

--- a/src/Avalonia.Controls/Carousel.cs
+++ b/src/Avalonia.Controls/Carousel.cs
@@ -38,8 +38,8 @@ namespace Avalonia.Controls
         /// </summary>
         public IPageTransition? PageTransition
         {
-            get { return GetValue(PageTransitionProperty); }
-            set { SetValue(PageTransitionProperty, value); }
+            get => GetValue(PageTransitionProperty);
+            set => SetValue(PageTransitionProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/ColumnDefinition.cs
+++ b/src/Avalonia.Controls/ColumnDefinition.cs
@@ -69,14 +69,8 @@ namespace Avalonia.Controls
         /// </summary>
         public double MaxWidth
         {
-            get
-            {
-                return GetValue(MaxWidthProperty);
-            }
-            set
-            {
-                SetValue(MaxWidthProperty, value);
-            }
+            get => GetValue(MaxWidthProperty);
+            set => SetValue(MaxWidthProperty, value);
         }
 
         /// <summary>
@@ -84,14 +78,8 @@ namespace Avalonia.Controls
         /// </summary>
         public double MinWidth
         {
-            get
-            {
-                return GetValue(MinWidthProperty);
-            }
-            set
-            {
-                SetValue(MinWidthProperty, value);
-            }
+            get => GetValue(MinWidthProperty);
+            set => SetValue(MinWidthProperty, value);
         }
 
         /// <summary>
@@ -99,14 +87,8 @@ namespace Avalonia.Controls
         /// </summary>
         public GridLength Width
         {
-            get
-            {
-                return GetValue(WidthProperty);
-            }
-            set
-            {
-                SetValue(WidthProperty, value);
-            }
+            get => GetValue(WidthProperty);
+            set => SetValue(WidthProperty, value);
         }
 
         internal override GridLength UserSizeValueCache => this.Width;

--- a/src/Avalonia.Controls/ContentControl.cs
+++ b/src/Avalonia.Controls/ContentControl.cs
@@ -47,8 +47,8 @@ namespace Avalonia.Controls
         [DependsOn(nameof(ContentTemplate))]
         public object? Content
         {
-            get { return GetValue(ContentProperty); }
-            set { SetValue(ContentProperty, value); }
+            get => GetValue(ContentProperty);
+            set => SetValue(ContentProperty, value);
         }
 
         /// <summary>
@@ -56,8 +56,8 @@ namespace Avalonia.Controls
         /// </summary>
         public IDataTemplate? ContentTemplate
         {
-            get { return GetValue(ContentTemplateProperty); }
-            set { SetValue(ContentTemplateProperty, value); }
+            get => GetValue(ContentTemplateProperty);
+            set => SetValue(ContentTemplateProperty, value);
         }
 
         /// <summary>
@@ -74,8 +74,8 @@ namespace Avalonia.Controls
         /// </summary>
         public HorizontalAlignment HorizontalContentAlignment
         {
-            get { return GetValue(HorizontalContentAlignmentProperty); }
-            set { SetValue(HorizontalContentAlignmentProperty, value); }
+            get => GetValue(HorizontalContentAlignmentProperty);
+            set => SetValue(HorizontalContentAlignmentProperty, value);
         }
 
         /// <summary>
@@ -83,8 +83,8 @@ namespace Avalonia.Controls
         /// </summary>
         public VerticalAlignment VerticalContentAlignment
         {
-            get { return GetValue(VerticalContentAlignmentProperty); }
-            set { SetValue(VerticalContentAlignmentProperty, value); }
+            get => GetValue(VerticalContentAlignmentProperty);
+            set => SetValue(VerticalContentAlignmentProperty, value);
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/DataValidationErrors.cs
+++ b/src/Avalonia.Controls/DataValidationErrors.cs
@@ -44,8 +44,8 @@ namespace Avalonia.Controls
 
         public Control? Owner
         {
-            get { return _owner; }
-            set { SetAndRaise(OwnerProperty, ref _owner, value); }
+            get => _owner;
+            set => SetAndRaise(OwnerProperty, ref _owner, value);
         }
 
         /// <summary>
@@ -68,8 +68,8 @@ namespace Avalonia.Controls
 
         public IDataTemplate ErrorTemplate
         {
-            get { return GetValue(ErrorTemplateProperty); }
-            set { SetValue(ErrorTemplateProperty, value); }
+            get => GetValue(ErrorTemplateProperty);
+            set => SetValue(ErrorTemplateProperty, value);
         }
 
         private static void ErrorsChanged(AvaloniaPropertyChangedEventArgs e)

--- a/src/Avalonia.Controls/Decorator.cs
+++ b/src/Avalonia.Controls/Decorator.cs
@@ -35,8 +35,8 @@ namespace Avalonia.Controls
         [Content]
         public Control? Child
         {
-            get { return GetValue(ChildProperty); }
-            set { SetValue(ChildProperty, value); }
+            get => GetValue(ChildProperty);
+            set => SetValue(ChildProperty, value);
         }
 
         /// <summary>
@@ -44,8 +44,8 @@ namespace Avalonia.Controls
         /// </summary>
         public Thickness Padding
         {
-            get { return GetValue(PaddingProperty); }
-            set { SetValue(PaddingProperty, value); }
+            get => GetValue(PaddingProperty);
+            set => SetValue(PaddingProperty, value);
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/DefinitionBase.cs
+++ b/src/Avalonia.Controls/DefinitionBase.cs
@@ -23,8 +23,8 @@ namespace Avalonia.Controls
         /// </summary>
         public string? SharedSizeGroup
         {
-            get { return GetValue(SharedSizeGroupProperty); }
-            set { SetValue(SharedSizeGroupProperty, value); }
+            get => GetValue(SharedSizeGroupProperty);
+            set => SetValue(SharedSizeGroupProperty, value);
         }
 
         /// <summary>
@@ -146,7 +146,7 @@ namespace Avalonia.Controls
         /// </summary>
         internal bool IsShared
         {
-            get { return (_sharedState != null); }
+            get => (_sharedState != null);
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace Avalonia.Controls
         /// </summary>
         internal GridLength UserSize
         {
-            get { return (_sharedState != null ? _sharedState.UserSize : UserSizeValueCache); }
+            get => (_sharedState != null ? _sharedState.UserSize : UserSizeValueCache);
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace Avalonia.Controls
         /// </summary>
         internal double UserMinSize
         {
-            get { return (UserMinSizeValueCache); }
+            get => (UserMinSizeValueCache);
         }
 
         /// <summary>
@@ -170,7 +170,7 @@ namespace Avalonia.Controls
         /// </summary>
         internal double UserMaxSize
         {
-            get { return (UserMaxSizeValueCache); }
+            get => (UserMaxSizeValueCache);
         }
 
         /// <summary>
@@ -178,10 +178,7 @@ namespace Avalonia.Controls
         /// </summary>
         internal int Index
         {
-            get
-            {
-                return (_parentIndex);
-            }
+            get => (_parentIndex);
             set
             {
                 Debug.Assert(value >= -1);
@@ -194,8 +191,8 @@ namespace Avalonia.Controls
         /// </summary>
         internal Grid.LayoutTimeSizeType SizeType
         {
-            get { return (_sizeType); }
-            set { _sizeType = value; }
+            get => (_sizeType);
+            set => _sizeType = value;
         }
 
         /// <summary>
@@ -203,8 +200,8 @@ namespace Avalonia.Controls
         /// </summary>
         internal double MeasureSize
         {
-            get { return (_measureSize); }
-            set { _measureSize = value; }
+            get => (_measureSize);
+            set => _measureSize = value;
         }
 
         /// <summary>
@@ -232,8 +229,8 @@ namespace Avalonia.Controls
         /// </summary>
         internal double SizeCache
         {
-            get { return (_sizeCache); }
-            set { _sizeCache = value; }
+            get => (_sizeCache);
+            set => _sizeCache = value;
         }
 
         /// <summary>
@@ -277,8 +274,8 @@ namespace Avalonia.Controls
         /// </summary>
         internal double FinalOffset
         {
-            get { return _offset; }
-            set { _offset = value; }
+            get => _offset;
+            set => _offset = value;
         }
 
         /// <summary>
@@ -417,8 +414,8 @@ namespace Avalonia.Controls
         /// </summary>
         private bool UseSharedMinimum
         {
-            get { return (CheckFlagsAnd(Flags.UseSharedMinimum)); }
-            set { SetFlags(value, Flags.UseSharedMinimum); }
+            get => (CheckFlagsAnd(Flags.UseSharedMinimum));
+            set => SetFlags(value, Flags.UseSharedMinimum);
         }
 
         /// <summary>
@@ -426,8 +423,8 @@ namespace Avalonia.Controls
         /// </summary>
         private bool LayoutWasUpdated
         {
-            get { return (CheckFlagsAnd(Flags.LayoutWasUpdated)); }
-            set { SetFlags(value, Flags.LayoutWasUpdated); }
+            get => (CheckFlagsAnd(Flags.LayoutWasUpdated));
+            set => SetFlags(value, Flags.LayoutWasUpdated);
         }
 
         private Flags _flags;                           //  flags reflecting various aspects of internal state

--- a/src/Avalonia.Controls/DockPanel.cs
+++ b/src/Avalonia.Controls/DockPanel.cs
@@ -71,8 +71,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool LastChildFill
         {
-            get { return GetValue(LastChildFillProperty); }
-            set { SetValue(LastChildFillProperty, value); }
+            get => GetValue(LastChildFillProperty);
+            set => SetValue(LastChildFillProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Documents/Inline.cs
+++ b/src/Avalonia.Controls/Documents/Inline.cs
@@ -32,8 +32,8 @@ namespace Avalonia.Controls.Documents
         /// </summary>
         public TextDecorationCollection? TextDecorations
         {
-            get { return GetValue(TextDecorationsProperty); }
-            set { SetValue(TextDecorationsProperty, value); }
+            get => GetValue(TextDecorationsProperty);
+            set => SetValue(TextDecorationsProperty, value);
         }
 
         /// <summary>
@@ -42,10 +42,10 @@ namespace Avalonia.Controls.Documents
         /// </summary>
         public BaselineAlignment BaselineAlignment
         {
-            get { return GetValue(BaselineAlignmentProperty); }
-            set { SetValue(BaselineAlignmentProperty, value); }
+            get => GetValue(BaselineAlignmentProperty);
+            set => SetValue(BaselineAlignmentProperty, value);
         }
-        
+
         /// <summary>
         /// Gets the value of the attached <see cref="TextDecorationsProperty"/> on a control.
         /// </summary>

--- a/src/Avalonia.Controls/Documents/Run.cs
+++ b/src/Avalonia.Controls/Documents/Run.cs
@@ -46,8 +46,8 @@ namespace Avalonia.Controls.Documents
         /// </summary>
         [Content]
         public string? Text {
-            get { return GetValue (TextProperty); }
-            set { SetValue (TextProperty, value); }
+            get => GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
         }
 
         internal override void BuildTextRun(IList<TextRun> textRuns)

--- a/src/Avalonia.Controls/Documents/TextElement.cs
+++ b/src/Avalonia.Controls/Documents/TextElement.cs
@@ -74,8 +74,8 @@ namespace Avalonia.Controls.Documents
         /// </summary>
         public IBrush? Background
         {
-            get { return GetValue(BackgroundProperty); }
-            set { SetValue(BackgroundProperty, value); }
+            get => GetValue(BackgroundProperty);
+            set => SetValue(BackgroundProperty, value);
         }
 
         /// <summary>
@@ -83,8 +83,8 @@ namespace Avalonia.Controls.Documents
         /// </summary>
         public FontFamily FontFamily
         {
-            get { return GetValue(FontFamilyProperty); }
-            set { SetValue(FontFamilyProperty, value); }
+            get => GetValue(FontFamilyProperty);
+            set => SetValue(FontFamilyProperty, value);
         }
 
         /// <summary>
@@ -92,8 +92,8 @@ namespace Avalonia.Controls.Documents
         /// </summary>
         public double FontSize
         {
-            get { return GetValue(FontSizeProperty); }
-            set { SetValue(FontSizeProperty, value); }
+            get => GetValue(FontSizeProperty);
+            set => SetValue(FontSizeProperty, value);
         }
 
         /// <summary>
@@ -101,8 +101,8 @@ namespace Avalonia.Controls.Documents
         /// </summary>
         public FontStyle FontStyle
         {
-            get { return GetValue(FontStyleProperty); }
-            set { SetValue(FontStyleProperty, value); }
+            get => GetValue(FontStyleProperty);
+            set => SetValue(FontStyleProperty, value);
         }
 
         /// <summary>
@@ -110,8 +110,8 @@ namespace Avalonia.Controls.Documents
         /// </summary>
         public FontWeight FontWeight
         {
-            get { return GetValue(FontWeightProperty); }
-            set { SetValue(FontWeightProperty, value); }
+            get => GetValue(FontWeightProperty);
+            set => SetValue(FontWeightProperty, value);
         }
 
         /// <summary>
@@ -119,8 +119,8 @@ namespace Avalonia.Controls.Documents
         /// </summary>
         public FontStretch FontStretch
         {
-            get { return GetValue(FontStretchProperty); }
-            set { SetValue(FontStretchProperty, value); }
+            get => GetValue(FontStretchProperty);
+            set => SetValue(FontStretchProperty, value);
         }
 
         /// <summary>
@@ -128,8 +128,8 @@ namespace Avalonia.Controls.Documents
         /// </summary>
         public IBrush? Foreground
         {
-            get { return GetValue(ForegroundProperty); }
-            set { SetValue(ForegroundProperty, value); }
+            get => GetValue(ForegroundProperty);
+            set => SetValue(ForegroundProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Embedding/Offscreen/OffscreenTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Embedding/Offscreen/OffscreenTopLevelImpl.cs
@@ -31,7 +31,7 @@ namespace Avalonia.Controls.Embedding.Offscreen
 
         public Size ClientSize
         {
-            get { return _clientSize; }
+            get => _clientSize;
             set
             {
                 _clientSize = value;
@@ -43,14 +43,14 @@ namespace Avalonia.Controls.Embedding.Offscreen
 
         public double RenderScaling
         {
-            get { return _scaling; }
+            get => _scaling;
             set
             {
                 _scaling = value;
                 ScalingChanged?.Invoke(value);
             }
         }
-        
+
         public Action<RawInputEventArgs>? Input { get; set; }
         public Action<Rect>? Paint { get; set; }
         public Action<Size, WindowResizeReason>? Resized { get; set; }

--- a/src/Avalonia.Controls/ExperimentalAcrylicBorder.cs
+++ b/src/Avalonia.Controls/ExperimentalAcrylicBorder.cs
@@ -35,8 +35,8 @@ namespace Avalonia.Controls
         /// </summary>
         public CornerRadius CornerRadius
         {
-            get { return GetValue(CornerRadiusProperty); }
-            set { SetValue(CornerRadiusProperty, value); }
+            get => GetValue(CornerRadiusProperty);
+            set => SetValue(CornerRadiusProperty, value);
         }
 
         public ExperimentalAcrylicMaterial Material

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -157,8 +157,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool ShowGridLines
         {
-            get { return GetValue(ShowGridLinesProperty); }
-            set { SetValue(ShowGridLinesProperty, value); }
+            get => GetValue(ShowGridLinesProperty);
+            set => SetValue(ShowGridLinesProperty, value);
         }
 
         /// <summary>
@@ -630,8 +630,8 @@ namespace Avalonia.Controls
         /// </summary>
         internal bool MeasureOverrideInProgress
         {
-            get { return CheckFlags(Flags.MeasureOverrideInProgress); }
-            set { SetFlags(value, Flags.MeasureOverrideInProgress); }
+            get => CheckFlags(Flags.MeasureOverrideInProgress);
+            set => SetFlags(value, Flags.MeasureOverrideInProgress);
         }
 
         /// <summary>
@@ -639,8 +639,8 @@ namespace Avalonia.Controls
         /// </summary>
         internal bool ArrangeOverrideInProgress
         {
-            get { return CheckFlags(Flags.ArrangeOverrideInProgress); }
-            set { SetFlags(value, Flags.ArrangeOverrideInProgress); }
+            get => CheckFlags(Flags.ArrangeOverrideInProgress);
+            set => SetFlags(value, Flags.ArrangeOverrideInProgress);
         }
 
         /// <summary>
@@ -2415,7 +2415,7 @@ namespace Avalonia.Controls
         /// </summary>
         private IReadOnlyList<DefinitionBase> DefinitionsU
         {
-            get { return _extData!.DefinitionsU!; }
+            get => _extData!.DefinitionsU!;
         }
 
         /// <summary>
@@ -2423,7 +2423,7 @@ namespace Avalonia.Controls
         /// </summary>
         private IReadOnlyList<DefinitionBase> DefinitionsV
         {
-            get { return _extData!.DefinitionsV!; }
+            get => _extData!.DefinitionsV!;
         }
 
         /// <summary>
@@ -2506,7 +2506,7 @@ namespace Avalonia.Controls
         /// </summary>
         private CellCache[] PrivateCells
         {
-            get { return _extData!.CellCachesCollection!; }
+            get => _extData!.CellCachesCollection!;
         }
 
         /// <summary>
@@ -2514,8 +2514,8 @@ namespace Avalonia.Controls
         /// </summary>
         private bool CellsStructureDirty
         {
-            get { return !CheckFlags(Flags.ValidCellsStructure); }
-            set { SetFlags(!value, Flags.ValidCellsStructure); }
+            get => !CheckFlags(Flags.ValidCellsStructure);
+            set => SetFlags(!value, Flags.ValidCellsStructure);
         }
 
         /// <summary>
@@ -2523,8 +2523,8 @@ namespace Avalonia.Controls
         /// </summary>
         private bool ListenToNotifications
         {
-            get { return CheckFlags(Flags.ListenToNotifications); }
-            set { SetFlags(value, Flags.ListenToNotifications); }
+            get => CheckFlags(Flags.ListenToNotifications);
+            set => SetFlags(value, Flags.ListenToNotifications);
         }
 
         /// <summary>
@@ -2532,8 +2532,8 @@ namespace Avalonia.Controls
         /// </summary>
         private bool SizeToContentU
         {
-            get { return CheckFlags(Flags.SizeToContentU); }
-            set { SetFlags(value, Flags.SizeToContentU); }
+            get => CheckFlags(Flags.SizeToContentU);
+            set => SetFlags(value, Flags.SizeToContentU);
         }
 
         /// <summary>
@@ -2541,8 +2541,8 @@ namespace Avalonia.Controls
         /// </summary>
         private bool SizeToContentV
         {
-            get { return CheckFlags(Flags.SizeToContentV); }
-            set { SetFlags(value, Flags.SizeToContentV); }
+            get => CheckFlags(Flags.SizeToContentV);
+            set => SetFlags(value, Flags.SizeToContentV);
         }
 
         /// <summary>
@@ -2550,8 +2550,8 @@ namespace Avalonia.Controls
         /// </summary>
         private bool HasStarCellsU
         {
-            get { return CheckFlags(Flags.HasStarCellsU); }
-            set { SetFlags(value, Flags.HasStarCellsU); }
+            get => CheckFlags(Flags.HasStarCellsU);
+            set => SetFlags(value, Flags.HasStarCellsU);
         }
 
         /// <summary>
@@ -2559,8 +2559,8 @@ namespace Avalonia.Controls
         /// </summary>
         private bool HasStarCellsV
         {
-            get { return CheckFlags(Flags.HasStarCellsV); }
-            set { SetFlags(value, Flags.HasStarCellsV); }
+            get => CheckFlags(Flags.HasStarCellsV);
+            set => SetFlags(value, Flags.HasStarCellsV);
         }
 
         /// <summary>
@@ -2568,8 +2568,8 @@ namespace Avalonia.Controls
         /// </summary>
         private bool HasGroup3CellsInAutoRows
         {
-            get { return CheckFlags(Flags.HasGroup3CellsInAutoRows); }
-            set { SetFlags(value, Flags.HasGroup3CellsInAutoRows); }
+            get => CheckFlags(Flags.HasGroup3CellsInAutoRows);
+            set => SetFlags(value, Flags.HasGroup3CellsInAutoRows);
         }
 
         /// <summary>
@@ -2826,18 +2826,18 @@ namespace Avalonia.Controls
             /// <summary>
             /// Returns start index of the span.
             /// </summary>
-            internal int Start { get { return (_start); } }
+            internal int Start { get => (_start); }
 
             /// <summary>
             /// Returns span count.
             /// </summary>
-            internal int Count { get { return (_count); } }
+            internal int Count { get => (_count); }
 
             /// <summary>
             /// Returns <c>true</c> if this is a column span.
             /// <c>false</c> if this is a row span.
             /// </summary>
-            internal bool U { get { return (_u); } }
+            internal bool U { get => (_u); }
 
             private int _start;
             private int _count;

--- a/src/Avalonia.Controls/Image.cs
+++ b/src/Avalonia.Controls/Image.cs
@@ -45,8 +45,8 @@ namespace Avalonia.Controls
         [Content]
         public IImage? Source
         {
-            get { return GetValue(SourceProperty); }
-            set { SetValue(SourceProperty, value); }
+            get => GetValue(SourceProperty);
+            set => SetValue(SourceProperty, value);
         }
 
         /// <summary>
@@ -54,8 +54,8 @@ namespace Avalonia.Controls
         /// </summary>
         public Stretch Stretch
         {
-            get { return GetValue(StretchProperty); }
-            set { SetValue(StretchProperty, value); }
+            get => GetValue(StretchProperty);
+            set => SetValue(StretchProperty, value);
         }
 
         /// <summary>
@@ -63,8 +63,8 @@ namespace Avalonia.Controls
         /// </summary>
         public StretchDirection StretchDirection
         {
-            get { return GetValue(StretchDirectionProperty); }
-            set { SetValue(StretchDirectionProperty, value); }
+            get => GetValue(StretchDirectionProperty);
+            set => SetValue(StretchDirectionProperty, value);
         }
 
         /// <inheritdoc />

--- a/src/Avalonia.Controls/LayoutTransformControl.cs
+++ b/src/Avalonia.Controls/LayoutTransformControl.cs
@@ -39,8 +39,8 @@ namespace Avalonia.Controls
         /// </summary>
         public ITransform? LayoutTransform
         {
-            get { return GetValue(LayoutTransformProperty); }
-            set { SetValue(LayoutTransformProperty, value); }
+            get => GetValue(LayoutTransformProperty);
+            set => SetValue(LayoutTransformProperty, value);
         }
 
         /// <summary>
@@ -48,8 +48,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool UseRenderTransform
         {
-            get { return GetValue(UseRenderTransformProperty); }
-            set { SetValue(UseRenderTransformProperty, value); }
+            get => GetValue(UseRenderTransformProperty);
+            set => SetValue(UseRenderTransformProperty, value);
         }
 
         public Control? TransformRoot => Child;

--- a/src/Avalonia.Controls/ListBox.cs
+++ b/src/Avalonia.Controls/ListBox.cs
@@ -73,8 +73,8 @@ namespace Avalonia.Controls
         /// </summary>
         public IScrollable? Scroll
         {
-            get { return _scroll; }
-            private set { SetAndRaise(ScrollProperty, ref _scroll, value); }
+            get => _scroll;
+            private set => SetAndRaise(ScrollProperty, ref _scroll, value);
         }
 
         /// <inheritdoc/>
@@ -102,8 +102,8 @@ namespace Avalonia.Controls
             Justification = "This property is owned by SelectingItemsControl, but protected there. ListBox changes its visibility.")]
         public new SelectionMode SelectionMode
         {
-            get { return base.SelectionMode; }
-            set { base.SelectionMode = value; }
+            get => base.SelectionMode;
+            set => base.SelectionMode = value;
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/ListBoxItem.cs
+++ b/src/Avalonia.Controls/ListBoxItem.cs
@@ -37,8 +37,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool IsSelected
         {
-            get { return GetValue(IsSelectedProperty); }
-            set { SetValue(IsSelectedProperty, value); }
+            get => GetValue(IsSelectedProperty);
+            set => SetValue(IsSelectedProperty, value);
         }
 
         protected override AutomationPeer OnCreateAutomationPeer()

--- a/src/Avalonia.Controls/MenuBase.cs
+++ b/src/Avalonia.Controls/MenuBase.cs
@@ -87,11 +87,8 @@ namespace Avalonia.Controls
                     (IMenuItem?)ContainerFromIndex(index) :
                     null;
             }
-            set
-            {
-                SelectedIndex = value is Control c ?
+            set => SelectedIndex = value is Control c ?
                     IndexFromContainer(c) : -1;
-            }
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -164,8 +164,8 @@ namespace Avalonia.Controls
         /// </summary>
         public event EventHandler<RoutedEventArgs>? Click
         {
-            add { AddHandler(ClickEvent, value); }
-            remove { RemoveHandler(ClickEvent, value); }
+            add => AddHandler(ClickEvent, value);
+            remove => RemoveHandler(ClickEvent, value);
         }
 
         /// <summary>
@@ -176,8 +176,8 @@ namespace Avalonia.Controls
         /// </remarks>
         public event EventHandler<RoutedEventArgs>? PointerEnteredItem
         {
-            add { AddHandler(PointerEnteredItemEvent, value); }
-            remove { RemoveHandler(PointerEnteredItemEvent, value); }
+            add => AddHandler(PointerEnteredItemEvent, value);
+            remove => RemoveHandler(PointerEnteredItemEvent, value);
         }
 
         /// <summary>
@@ -188,8 +188,8 @@ namespace Avalonia.Controls
         /// </remarks>
         public event EventHandler<RoutedEventArgs>? PointerExitedItem
         {
-            add { AddHandler(PointerExitedItemEvent, value); }
-            remove { RemoveHandler(PointerExitedItemEvent, value); }
+            add => AddHandler(PointerExitedItemEvent, value);
+            remove => RemoveHandler(PointerExitedItemEvent, value);
         }
 
         /// <summary>
@@ -197,8 +197,8 @@ namespace Avalonia.Controls
         /// </summary>
         public event EventHandler<RoutedEventArgs>? SubmenuOpened
         {
-            add { AddHandler(SubmenuOpenedEvent, value); }
-            remove { RemoveHandler(SubmenuOpenedEvent, value); }
+            add => AddHandler(SubmenuOpenedEvent, value);
+            remove => RemoveHandler(SubmenuOpenedEvent, value);
         }
 
         /// <summary>
@@ -215,8 +215,8 @@ namespace Avalonia.Controls
         /// </summary>
         public KeyGesture? HotKey
         {
-            get { return GetValue(HotKeyProperty); }
-            set { SetValue(HotKeyProperty, value); }
+            get => GetValue(HotKeyProperty);
+            set => SetValue(HotKeyProperty, value);
         }
 
         /// <summary>
@@ -225,8 +225,8 @@ namespace Avalonia.Controls
         /// </summary>
         public object? CommandParameter
         {
-            get { return GetValue(CommandParameterProperty); }
-            set { SetValue(CommandParameterProperty, value); }
+            get => GetValue(CommandParameterProperty);
+            set => SetValue(CommandParameterProperty, value);
         }
 
         /// <summary>
@@ -234,8 +234,8 @@ namespace Avalonia.Controls
         /// </summary>
         public object? Icon
         {
-            get { return GetValue(IconProperty); }
-            set { SetValue(IconProperty, value); }
+            get => GetValue(IconProperty);
+            set => SetValue(IconProperty, value);
         }
 
         /// <summary>
@@ -247,8 +247,8 @@ namespace Avalonia.Controls
         /// </remarks>
         public KeyGesture? InputGesture
         {
-            get { return GetValue(InputGestureProperty); }
-            set { SetValue(InputGestureProperty, value); }
+            get => GetValue(InputGestureProperty);
+            set => SetValue(InputGestureProperty, value);
         }
 
         /// <summary>
@@ -256,8 +256,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool IsSelected
         {
-            get { return GetValue(IsSelectedProperty); }
-            set { SetValue(IsSelectedProperty, value); }
+            get => GetValue(IsSelectedProperty);
+            set => SetValue(IsSelectedProperty, value);
         }
 
         /// <summary>
@@ -266,8 +266,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool IsSubMenuOpen
         {
-            get { return GetValue(IsSubMenuOpenProperty); }
-            set { SetValue(IsSubMenuOpenProperty, value); }
+            get => GetValue(IsSubMenuOpenProperty);
+            set => SetValue(IsSubMenuOpenProperty, value);
         }
 
         /// <summary>
@@ -276,8 +276,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool StaysOpenOnClick
         {
-            get { return GetValue(StaysOpenOnClickProperty); }
-            set { SetValue(StaysOpenOnClickProperty, value); }
+            get => GetValue(StaysOpenOnClickProperty);
+            set => SetValue(StaysOpenOnClickProperty, value);
         }
 
         /// <summary>
@@ -311,10 +311,7 @@ namespace Avalonia.Controls
                     (IMenuItem?)ContainerFromIndex(index) :
                     null;
             }
-            set
-            {
-                SelectedIndex = value is Control c ? IndexFromContainer(c) : -1;
-            }
+            set => SelectedIndex = value is Control c ? IndexFromContainer(c) : -1;
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/NativeMenuItem.cs
+++ b/src/Avalonia.Controls/NativeMenuItem.cs
@@ -136,8 +136,8 @@ namespace Avalonia.Controls
         /// </summary>
         public object? CommandParameter
         {
-            get { return GetValue(CommandParameterProperty); }
-            set { SetValue(CommandParameterProperty, value); }
+            get => GetValue(CommandParameterProperty);
+            set => SetValue(CommandParameterProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Notifications/NotificationCard.cs
+++ b/src/Avalonia.Controls/Notifications/NotificationCard.cs
@@ -33,8 +33,8 @@ namespace Avalonia.Controls.Notifications
         /// </summary>
         public bool IsClosing
         {
-            get { return _isClosing; }
-            private set { SetAndRaise(IsClosingProperty, ref _isClosing, value); }
+            get => _isClosing;
+            private set => SetAndRaise(IsClosingProperty, ref _isClosing, value);
         }
 
         /// <summary>
@@ -63,8 +63,8 @@ namespace Avalonia.Controls.Notifications
         /// </summary>
         public NotificationType NotificationType
         {
-            get { return GetValue(NotificationTypeProperty); }
-            set { SetValue(NotificationTypeProperty, value); }
+            get => GetValue(NotificationTypeProperty);
+            set => SetValue(NotificationTypeProperty, value);
         }
 
         /// <summary>
@@ -85,8 +85,8 @@ namespace Avalonia.Controls.Notifications
         /// </summary>
         public event EventHandler<RoutedEventArgs>? NotificationClosed
         {
-            add { AddHandler(NotificationClosedEvent, value); }
-            remove { RemoveHandler(NotificationClosedEvent, value); }
+            add => AddHandler(NotificationClosedEvent, value);
+            remove => RemoveHandler(NotificationClosedEvent, value);
         }
 
         public static bool GetCloseOnClick(Button obj)

--- a/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
+++ b/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
@@ -31,8 +31,8 @@ namespace Avalonia.Controls.Notifications
         /// <seealso cref="NotificationPosition"/>
         public NotificationPosition Position
         {
-            get { return GetValue(PositionProperty); }
-            set { SetValue(PositionProperty, value); }
+            get => GetValue(PositionProperty);
+            set => SetValue(PositionProperty, value);
         }
 
         /// <summary>
@@ -46,10 +46,10 @@ namespace Avalonia.Controls.Notifications
         /// </summary>
         public int MaxItems
         {
-            get { return GetValue(MaxItemsProperty); }
-            set { SetValue(MaxItemsProperty, value); }
+            get => GetValue(MaxItemsProperty);
+            set => SetValue(MaxItemsProperty, value);
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="WindowNotificationManager"/> class.
         /// </summary>

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -153,8 +153,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool AllowSpin
         {
-            get { return GetValue(AllowSpinProperty); }
-            set { SetValue(AllowSpinProperty, value); }
+            get => GetValue(AllowSpinProperty);
+            set => SetValue(AllowSpinProperty, value);
         }
 
         /// <summary>
@@ -162,8 +162,8 @@ namespace Avalonia.Controls
         /// </summary>
         public Location ButtonSpinnerLocation
         {
-            get { return GetValue(ButtonSpinnerLocationProperty); }
-            set { SetValue(ButtonSpinnerLocationProperty, value); }
+            get => GetValue(ButtonSpinnerLocationProperty);
+            set => SetValue(ButtonSpinnerLocationProperty, value);
         }
 
         /// <summary>
@@ -171,8 +171,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool ShowButtonSpinner
         {
-            get { return GetValue(ShowButtonSpinnerProperty); }
-            set { SetValue(ShowButtonSpinnerProperty, value); }
+            get => GetValue(ShowButtonSpinnerProperty);
+            set => SetValue(ShowButtonSpinnerProperty, value);
         }
 
         /// <summary>
@@ -198,8 +198,8 @@ namespace Avalonia.Controls
         /// </summary>
         public string FormatString
         {
-            get { return GetValue(FormatStringProperty); }
-            set { SetValue(FormatStringProperty, value); }
+            get => GetValue(FormatStringProperty);
+            set => SetValue(FormatStringProperty, value);
         }
 
         /// <summary>
@@ -207,8 +207,8 @@ namespace Avalonia.Controls
         /// </summary>
         public decimal Increment
         {
-            get { return GetValue(IncrementProperty); }
-            set { SetValue(IncrementProperty, value); }
+            get => GetValue(IncrementProperty);
+            set => SetValue(IncrementProperty, value);
         }
 
         /// <summary>
@@ -216,8 +216,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool IsReadOnly
         {
-            get { return GetValue(IsReadOnlyProperty); }
-            set { SetValue(IsReadOnlyProperty, value); }
+            get => GetValue(IsReadOnlyProperty);
+            set => SetValue(IsReadOnlyProperty, value);
         }
 
         /// <summary>
@@ -225,8 +225,8 @@ namespace Avalonia.Controls
         /// </summary>
         public decimal Maximum
         {
-            get { return GetValue(MaximumProperty); }
-            set { SetValue(MaximumProperty, value); }
+            get => GetValue(MaximumProperty);
+            set => SetValue(MaximumProperty, value);
         }
 
         /// <summary>
@@ -234,8 +234,8 @@ namespace Avalonia.Controls
         /// </summary>
         public decimal Minimum
         {
-            get { return GetValue(MinimumProperty); }
-            set { SetValue(MinimumProperty, value); }
+            get => GetValue(MinimumProperty);
+            set => SetValue(MinimumProperty, value);
         }
 
         /// <summary>
@@ -283,8 +283,8 @@ namespace Avalonia.Controls
         /// </summary>
         public string? Watermark
         {
-            get { return GetValue(WatermarkProperty); }
-            set { SetValue(WatermarkProperty, value); }
+            get => GetValue(WatermarkProperty);
+            set => SetValue(WatermarkProperty, value);
         }
 
         /// <summary>
@@ -973,8 +973,8 @@ namespace Avalonia.Controls
         /// </summary>
         public event EventHandler<NumericUpDownValueChangedEventArgs>? ValueChanged
         {
-            add { AddHandler(ValueChangedEvent, value); }
-            remove { RemoveHandler(ValueChangedEvent, value); }
+            add => AddHandler(ValueChangedEvent, value);
+            remove => RemoveHandler(ValueChangedEvent, value);
         }
 
         private bool CommitInput(bool forceTextUpdate = false)

--- a/src/Avalonia.Controls/Panel.cs
+++ b/src/Avalonia.Controls/Panel.cs
@@ -54,8 +54,8 @@ namespace Avalonia.Controls
         /// </summary>
         public IBrush? Background
         {
-            get { return GetValue(BackgroundProperty); }
-            set { SetValue(BackgroundProperty, value); }
+            get => GetValue(BackgroundProperty);
+            set => SetValue(BackgroundProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/PathIcon.cs
+++ b/src/Avalonia.Controls/PathIcon.cs
@@ -14,8 +14,8 @@ namespace Avalonia.Controls
 
         public Geometry Data
         {
-            get { return GetValue(DataProperty); }
-            set { SetValue(DataProperty, value); }
+            get => GetValue(DataProperty);
+            set => SetValue(DataProperty, value);
         }
     }
 }

--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -184,8 +184,8 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         public IBrush? Background
         {
-            get { return GetValue(BackgroundProperty); }
-            set { SetValue(BackgroundProperty, value); }
+            get => GetValue(BackgroundProperty);
+            set => SetValue(BackgroundProperty, value);
         }
 
         /// <summary>
@@ -193,8 +193,8 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         public IBrush? BorderBrush
         {
-            get { return GetValue(BorderBrushProperty); }
-            set { SetValue(BorderBrushProperty, value); }
+            get => GetValue(BorderBrushProperty);
+            set => SetValue(BorderBrushProperty, value);
         }
 
         /// <summary>
@@ -202,8 +202,8 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         public Thickness BorderThickness
         {
-            get { return GetValue(BorderThicknessProperty); }
-            set { SetValue(BorderThicknessProperty, value); }
+            get => GetValue(BorderThicknessProperty);
+            set => SetValue(BorderThicknessProperty, value);
         }
 
         /// <summary>
@@ -211,8 +211,8 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         public CornerRadius CornerRadius
         {
-            get { return GetValue(CornerRadiusProperty); }
-            set { SetValue(CornerRadiusProperty, value); }
+            get => GetValue(CornerRadiusProperty);
+            set => SetValue(CornerRadiusProperty, value);
         }
 
         /// <summary>
@@ -328,8 +328,8 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         public Control? Child
         {
-            get { return _child; }
-            private set { SetAndRaise(ChildProperty, ref _child, value); }
+            get => _child;
+            private set => SetAndRaise(ChildProperty, ref _child, value);
         }
 
         /// <summary>
@@ -338,8 +338,8 @@ namespace Avalonia.Controls.Presenters
         [DependsOn(nameof(ContentTemplate))]
         public object? Content
         {
-            get { return GetValue(ContentProperty); }
-            set { SetValue(ContentProperty, value); }
+            get => GetValue(ContentProperty);
+            set => SetValue(ContentProperty, value);
         }
 
         /// <summary>
@@ -347,8 +347,8 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         public IDataTemplate? ContentTemplate
         {
-            get { return GetValue(ContentTemplateProperty); }
-            set { SetValue(ContentTemplateProperty, value); }
+            get => GetValue(ContentTemplateProperty);
+            set => SetValue(ContentTemplateProperty, value);
         }
 
         /// <summary>
@@ -356,8 +356,8 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         public HorizontalAlignment HorizontalContentAlignment
         {
-            get { return GetValue(HorizontalContentAlignmentProperty); }
-            set { SetValue(HorizontalContentAlignmentProperty, value); }
+            get => GetValue(HorizontalContentAlignmentProperty);
+            set => SetValue(HorizontalContentAlignmentProperty, value);
         }
 
         /// <summary>
@@ -365,8 +365,8 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         public VerticalAlignment VerticalContentAlignment
         {
-            get { return GetValue(VerticalContentAlignmentProperty); }
-            set { SetValue(VerticalContentAlignmentProperty, value); }
+            get => GetValue(VerticalContentAlignmentProperty);
+            set => SetValue(VerticalContentAlignmentProperty, value);
         }
 
         /// <summary>
@@ -374,8 +374,8 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         public Thickness Padding
         {
-            get { return GetValue(PaddingProperty); }
-            set { SetValue(PaddingProperty, value); }
+            get => GetValue(PaddingProperty);
+            set => SetValue(PaddingProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -147,8 +147,8 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         public Size Extent
         {
-            get { return _extent; }
-            private set { SetAndRaise(ExtentProperty, ref _extent, value); }
+            get => _extent;
+            private set => SetAndRaise(ExtentProperty, ref _extent, value);
         }
 
         /// <summary>
@@ -165,8 +165,8 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         public Size Viewport
         {
-            get { return _viewport; }
-            private set { SetAndRaise(ViewportProperty, ref _viewport, value); }
+            get => _viewport;
+            private set => SetAndRaise(ViewportProperty, ref _viewport, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/AccessText.cs
+++ b/src/Avalonia.Controls/Primitives/AccessText.cs
@@ -53,8 +53,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public bool ShowAccessKey
         {
-            get { return GetValue(ShowAccessKeyProperty); }
-            set { SetValue(ShowAccessKeyProperty, value); }
+            get => GetValue(ShowAccessKeyProperty);
+            set => SetValue(ShowAccessKeyProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/HeaderedItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/HeaderedItemsControl.cs
@@ -40,8 +40,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public object? Header
         {
-            get { return GetValue(HeaderProperty); }
-            set { SetValue(HeaderProperty, value); }
+            get => GetValue(HeaderProperty);
+            set => SetValue(HeaderProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/HeaderedSelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/HeaderedSelectingItemsControl.cs
@@ -40,8 +40,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public object? Header
         {
-            get { return GetValue(HeaderProperty); }
-            set { SetValue(HeaderProperty, value); }
+            get => GetValue(HeaderProperty);
+            set => SetValue(HeaderProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/ScrollBar.cs
+++ b/src/Avalonia.Controls/Primitives/ScrollBar.cs
@@ -110,8 +110,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public double ViewportSize
         {
-            get { return GetValue(ViewportSizeProperty); }
-            set { SetValue(ViewportSizeProperty, value); }
+            get => GetValue(ViewportSizeProperty);
+            set => SetValue(ViewportSizeProperty, value);
         }
 
         /// <summary>
@@ -120,8 +120,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public ScrollBarVisibility Visibility
         {
-            get { return GetValue(VisibilityProperty); }
-            set { SetValue(VisibilityProperty, value); }
+            get => GetValue(VisibilityProperty);
+            set => SetValue(VisibilityProperty, value);
         }
 
         /// <summary>
@@ -129,8 +129,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public Orientation Orientation
         {
-            get { return GetValue(OrientationProperty); }
-            set { SetValue(OrientationProperty, value); }
+            get => GetValue(OrientationProperty);
+            set => SetValue(OrientationProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -187,16 +187,14 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public int SelectedIndex
         {
-            get
-            {
+            get =>
                 // When a Begin/EndInit/DataContext update is in place we return the value to be
                 // updated here, even though it's not yet active and the property changed notification
                 // has not yet been raised. If we don't do this then the old value will be written back
                 // to the source when two-way bound, and the update value will be lost.
-                return _updateState?.SelectedIndex.HasValue == true ?
+                _updateState?.SelectedIndex.HasValue == true ?
                     _updateState.SelectedIndex.Value :
                     Selection.SelectedIndex;
-            }
             set
             {
                 if (_updateState is object)
@@ -215,13 +213,11 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public object? SelectedItem
         {
-            get
-            {
+            get =>
                 // See SelectedIndex setter for more information.
-                return _updateState?.SelectedItem.HasValue == true ?
+                _updateState?.SelectedItem.HasValue == true ?
                     _updateState.SelectedItem.Value :
                     Selection.SelectedItem;
-            }
             set
             {
                 if (_updateState is object)
@@ -306,12 +302,9 @@ namespace Avalonia.Controls.Primitives
         [AllowNull]
         protected ISelectionModel Selection
         {
-            get
-            {
-                return _updateState?.Selection.HasValue == true ?
+            get => _updateState?.Selection.HasValue == true ?
                     _updateState.Selection.Value :
                     GetOrCreateSelectionModel();
-            }
             set
             {
                 value ??= CreateDefaultSelectionModel();
@@ -1373,10 +1366,7 @@ namespace Avalonia.Controls.Primitives
             public Optional<object?> SelectedValue
             {
                 get => _selectedValue;
-                set
-                {
-                    _selectedValue = value;
-                }
+                set => _selectedValue = value;
             }
         }
 

--- a/src/Avalonia.Controls/Primitives/TemplatedControl.cs
+++ b/src/Avalonia.Controls/Primitives/TemplatedControl.cs
@@ -118,8 +118,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public event EventHandler<TemplateAppliedEventArgs>? TemplateApplied
         {
-            add { AddHandler(TemplateAppliedEvent, value); }
-            remove { RemoveHandler(TemplateAppliedEvent, value); }
+            add => AddHandler(TemplateAppliedEvent, value);
+            remove => RemoveHandler(TemplateAppliedEvent, value);
         }
 
         /// <summary>
@@ -127,8 +127,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public IBrush? Background
         {
-            get { return GetValue(BackgroundProperty); }
-            set { SetValue(BackgroundProperty, value); }
+            get => GetValue(BackgroundProperty);
+            set => SetValue(BackgroundProperty, value);
         }
 
         /// <summary>
@@ -136,8 +136,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public IBrush? BorderBrush
         {
-            get { return GetValue(BorderBrushProperty); }
-            set { SetValue(BorderBrushProperty, value); }
+            get => GetValue(BorderBrushProperty);
+            set => SetValue(BorderBrushProperty, value);
         }
 
         /// <summary>
@@ -145,8 +145,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public Thickness BorderThickness
         {
-            get { return GetValue(BorderThicknessProperty); }
-            set { SetValue(BorderThicknessProperty, value); }
+            get => GetValue(BorderThicknessProperty);
+            set => SetValue(BorderThicknessProperty, value);
         }
 
         /// <summary>
@@ -154,8 +154,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public CornerRadius CornerRadius
         {
-            get { return GetValue(CornerRadiusProperty); }
-            set { SetValue(CornerRadiusProperty, value); }
+            get => GetValue(CornerRadiusProperty);
+            set => SetValue(CornerRadiusProperty, value);
         }
 
         /// <summary>
@@ -163,8 +163,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public FontFamily FontFamily
         {
-            get { return GetValue(FontFamilyProperty); }
-            set { SetValue(FontFamilyProperty, value); }
+            get => GetValue(FontFamilyProperty);
+            set => SetValue(FontFamilyProperty, value);
         }
 
         /// <summary>
@@ -172,8 +172,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public double FontSize
         {
-            get { return GetValue(FontSizeProperty); }
-            set { SetValue(FontSizeProperty, value); }
+            get => GetValue(FontSizeProperty);
+            set => SetValue(FontSizeProperty, value);
         }
 
         /// <summary>
@@ -181,8 +181,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public FontStyle FontStyle
         {
-            get { return GetValue(FontStyleProperty); }
-            set { SetValue(FontStyleProperty, value); }
+            get => GetValue(FontStyleProperty);
+            set => SetValue(FontStyleProperty, value);
         }
 
         /// <summary>
@@ -190,8 +190,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public FontWeight FontWeight
         {
-            get { return GetValue(FontWeightProperty); }
-            set { SetValue(FontWeightProperty, value); }
+            get => GetValue(FontWeightProperty);
+            set => SetValue(FontWeightProperty, value);
         }
 
         /// <summary>
@@ -199,8 +199,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public FontStretch FontStretch
         {
-            get { return GetValue(FontStretchProperty); }
-            set { SetValue(FontStretchProperty, value); }
+            get => GetValue(FontStretchProperty);
+            set => SetValue(FontStretchProperty, value);
         }
 
         /// <summary>
@@ -208,8 +208,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public IBrush? Foreground
         {
-            get { return GetValue(ForegroundProperty); }
-            set { SetValue(ForegroundProperty, value); }
+            get => GetValue(ForegroundProperty);
+            set => SetValue(ForegroundProperty, value);
         }
 
         /// <summary>
@@ -217,8 +217,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public Thickness Padding
         {
-            get { return GetValue(PaddingProperty); }
-            set { SetValue(PaddingProperty, value); }
+            get => GetValue(PaddingProperty);
+            set => SetValue(PaddingProperty, value);
         }
 
         /// <summary>
@@ -226,8 +226,8 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public IControlTemplate? Template
         {
-            get { return GetValue(TemplateProperty); }
-            set { SetValue(TemplateProperty, value); }
+            get => GetValue(TemplateProperty);
+            set => SetValue(TemplateProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/Thumb.cs
+++ b/src/Avalonia.Controls/Primitives/Thumb.cs
@@ -30,20 +30,20 @@ namespace Avalonia.Controls.Primitives
 
         public event EventHandler<VectorEventArgs>? DragStarted
         {
-            add { AddHandler(DragStartedEvent, value); }
-            remove { RemoveHandler(DragStartedEvent, value); }
+            add => AddHandler(DragStartedEvent, value);
+            remove => RemoveHandler(DragStartedEvent, value);
         }
 
         public event EventHandler<VectorEventArgs>? DragDelta
         {
-            add { AddHandler(DragDeltaEvent, value); }
-            remove { RemoveHandler(DragDeltaEvent, value); }
+            add => AddHandler(DragDeltaEvent, value);
+            remove => RemoveHandler(DragDeltaEvent, value);
         }
 
         public event EventHandler<VectorEventArgs>? DragCompleted
         {
-            add { AddHandler(DragCompletedEvent, value); }
-            remove { RemoveHandler(DragCompletedEvent, value); }
+            add => AddHandler(DragCompletedEvent, value);
+            remove => RemoveHandler(DragCompletedEvent, value);
         }
 
         internal void AdjustDrag(Vector v)

--- a/src/Avalonia.Controls/Primitives/Track.cs
+++ b/src/Avalonia.Controls/Primitives/Track.cs
@@ -80,45 +80,45 @@ namespace Avalonia.Controls.Primitives
 
         public double ViewportSize
         {
-            get { return GetValue(ViewportSizeProperty); }
-            set { SetValue(ViewportSizeProperty, value); }
+            get => GetValue(ViewportSizeProperty);
+            set => SetValue(ViewportSizeProperty, value);
         }
 
         public Orientation Orientation
         {
-            get { return GetValue(OrientationProperty); }
-            set { SetValue(OrientationProperty, value); }
+            get => GetValue(OrientationProperty);
+            set => SetValue(OrientationProperty, value);
         }
 
         [Content]
         public Thumb? Thumb
         {
-            get { return GetValue(ThumbProperty); }
-            set { SetValue(ThumbProperty, value); }
+            get => GetValue(ThumbProperty);
+            set => SetValue(ThumbProperty, value);
         }
 
         public Button? IncreaseButton
         {
-            get { return GetValue(IncreaseButtonProperty); }
-            set { SetValue(IncreaseButtonProperty, value); }
+            get => GetValue(IncreaseButtonProperty);
+            set => SetValue(IncreaseButtonProperty, value);
         }
 
         public Button? DecreaseButton
         {
-            get { return GetValue(DecreaseButtonProperty); }
-            set { SetValue(DecreaseButtonProperty, value); }
+            get => GetValue(DecreaseButtonProperty);
+            set => SetValue(DecreaseButtonProperty, value);
         }
 
         public bool IsDirectionReversed
         {
-            get { return GetValue(IsDirectionReversedProperty); }
-            set { SetValue(IsDirectionReversedProperty, value); }
+            get => GetValue(IsDirectionReversedProperty);
+            set => SetValue(IsDirectionReversedProperty, value);
         }
 
         public bool IgnoreThumbDrag
         {
-            get { return GetValue(IgnoreThumbDragProperty); }
-            set { SetValue(IgnoreThumbDragProperty, value); }
+            get => GetValue(IgnoreThumbDragProperty);
+            set => SetValue(IgnoreThumbDragProperty, value);
         }
 
         private double ThumbCenterOffset { get; set; }

--- a/src/Avalonia.Controls/ProgressBar.cs
+++ b/src/Avalonia.Controls/ProgressBar.cs
@@ -231,7 +231,7 @@ namespace Avalonia.Controls
         public double Percentage
         {
             get => _percentage;
-            private set { SetAndRaise(PercentageProperty, ref _percentage, value); }
+            private set => SetAndRaise(PercentageProperty, ref _percentage, value);
         }
 
         static ProgressBar()

--- a/src/Avalonia.Controls/PullToRefresh/RefreshInfoProvider.cs
+++ b/src/Avalonia.Controls/PullToRefresh/RefreshInfoProvider.cs
@@ -61,10 +61,7 @@ namespace Avalonia.Controls.PullToRefresh
         public double InteractionRatio
         {
             get => _interactionRatio;
-            set
-            {
-                SetAndRaise(InteractionRatioProperty, ref _interactionRatio, value);
-            }
+            set => SetAndRaise(InteractionRatioProperty, ref _interactionRatio, value);
         }
 
         public double ExecutionRatio

--- a/src/Avalonia.Controls/PullToRefresh/RefreshVisualizer.cs
+++ b/src/Avalonia.Controls/PullToRefresh/RefreshVisualizer.cs
@@ -74,10 +74,7 @@ namespace Avalonia.Controls
         [System.Diagnostics.CodeAnalysis.SuppressMessage("AvaloniaProperty", "AVP1032", Justification = "False positive")]
         protected RefreshVisualizerState RefreshVisualizerState
         {
-            get
-            {
-                return _refreshVisualizerState;
-            }
+            get => _refreshVisualizerState;
             private set
             {
                 SetAndRaise(RefreshVisualizerStateProperty, ref _refreshVisualizerState, value);
@@ -90,14 +87,8 @@ namespace Avalonia.Controls
         /// </summary>
         public RefreshVisualizerOrientation Orientation
         {
-            get
-            {
-                return _orientation;
-            }
-            set
-            {
-                SetAndRaise(OrientationProperty, ref _orientation, value);
-            }
+            get => _orientation;
+            set => SetAndRaise(OrientationProperty, ref _orientation, value);
         }
 
         internal PullDirection PullDirection

--- a/src/Avalonia.Controls/RepeatButton.cs
+++ b/src/Avalonia.Controls/RepeatButton.cs
@@ -28,8 +28,8 @@ namespace Avalonia.Controls
         /// </summary>
         public int Interval
         {
-            get { return GetValue(IntervalProperty); }
-            set { SetValue(IntervalProperty, value); }
+            get => GetValue(IntervalProperty);
+            set => SetValue(IntervalProperty, value);
         }
 
         /// <summary>
@@ -37,8 +37,8 @@ namespace Avalonia.Controls
         /// </summary>
         public int Delay
         {
-            get { return GetValue(DelayProperty); }
-            set { SetValue(DelayProperty, value); }
+            get => GetValue(DelayProperty);
+            set => SetValue(DelayProperty, value);
         }
 
         private void StartTimer()

--- a/src/Avalonia.Controls/RowDefinition.cs
+++ b/src/Avalonia.Controls/RowDefinition.cs
@@ -69,14 +69,8 @@ namespace Avalonia.Controls
         /// </summary>
         public double MaxHeight
         {
-            get
-            {
-                return GetValue(MaxHeightProperty);
-            }
-            set
-            {
-                SetValue(MaxHeightProperty, value);
-            }
+            get => GetValue(MaxHeightProperty);
+            set => SetValue(MaxHeightProperty, value);
         }
 
         /// <summary>
@@ -84,14 +78,8 @@ namespace Avalonia.Controls
         /// </summary>
         public double MinHeight
         {
-            get
-            {
-                return GetValue(MinHeightProperty);
-            }
-            set
-            {
-                SetValue(MinHeightProperty, value);
-            }
+            get => GetValue(MinHeightProperty);
+            set => SetValue(MinHeightProperty, value);
         }
 
         /// <summary>
@@ -99,14 +87,8 @@ namespace Avalonia.Controls
         /// </summary>
         public GridLength Height
         {
-            get
-            {
-                return GetValue(HeightProperty);
-            }
-            set
-            {
-                SetValue(HeightProperty, value);
-            }
+            get => GetValue(HeightProperty);
+            set => SetValue(HeightProperty, value);
         }
 
         internal override GridLength UserSizeValueCache => this.Height;

--- a/src/Avalonia.Controls/ScrollViewer.cs
+++ b/src/Avalonia.Controls/ScrollViewer.cs
@@ -205,10 +205,7 @@ namespace Avalonia.Controls
         /// </summary>
         public Size Extent
         {
-            get
-            {
-                return _extent;
-            }
+            get => _extent;
 
             internal set
             {
@@ -233,10 +230,7 @@ namespace Avalonia.Controls
         /// </summary>
         public Size Viewport
         {
-            get
-            {
-                return _viewport;
-            }
+            get => _viewport;
 
             internal set
             {
@@ -262,8 +256,8 @@ namespace Avalonia.Controls
         /// </summary>
         public ScrollBarVisibility HorizontalScrollBarVisibility
         {
-            get { return GetValue(HorizontalScrollBarVisibilityProperty); }
-            set { SetValue(HorizontalScrollBarVisibilityProperty, value); }
+            get => GetValue(HorizontalScrollBarVisibilityProperty);
+            set => SetValue(HorizontalScrollBarVisibilityProperty, value);
         }
 
         /// <summary>
@@ -271,8 +265,8 @@ namespace Avalonia.Controls
         /// </summary>
         public ScrollBarVisibility VerticalScrollBarVisibility
         {
-            get { return GetValue(VerticalScrollBarVisibilityProperty); }
-            set { SetValue(VerticalScrollBarVisibilityProperty, value); }
+            get => GetValue(VerticalScrollBarVisibilityProperty);
+            set => SetValue(VerticalScrollBarVisibilityProperty, value);
         }
 
         /// <summary>
@@ -280,7 +274,7 @@ namespace Avalonia.Controls
         /// </summary>
         protected bool CanHorizontallyScroll
         {
-            get { return HorizontalScrollBarVisibility != ScrollBarVisibility.Disabled; }
+            get => HorizontalScrollBarVisibility != ScrollBarVisibility.Disabled;
         }
 
         /// <summary>
@@ -288,7 +282,7 @@ namespace Avalonia.Controls
         /// </summary>
         protected bool CanVerticallyScroll
         {
-            get { return VerticalScrollBarVisibility != ScrollBarVisibility.Disabled; }
+            get => VerticalScrollBarVisibility != ScrollBarVisibility.Disabled;
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/Shapes/Line.cs
+++ b/src/Avalonia.Controls/Shapes/Line.cs
@@ -18,14 +18,14 @@ namespace Avalonia.Controls.Shapes
 
         public Point StartPoint
         {
-            get { return GetValue(StartPointProperty); }
-            set { SetValue(StartPointProperty, value); }
+            get => GetValue(StartPointProperty);
+            set => SetValue(StartPointProperty, value);
         }
 
         public Point EndPoint
         {
-            get { return GetValue(EndPointProperty); }
-            set { SetValue(EndPointProperty, value); }
+            get => GetValue(EndPointProperty);
+            set => SetValue(EndPointProperty, value);
         }
 
         protected override Geometry CreateDefiningGeometry()

--- a/src/Avalonia.Controls/Shapes/Path.cs
+++ b/src/Avalonia.Controls/Shapes/Path.cs
@@ -18,8 +18,8 @@ namespace Avalonia.Controls.Shapes
 
         public Geometry Data
         {
-            get { return GetValue(DataProperty); }
-            set { SetValue(DataProperty, value); }
+            get => GetValue(DataProperty);
+            set => SetValue(DataProperty, value);
         }
 
         private EventHandler? GeometryChangedHandler => _geometryChangedHandler ??= GeometryChanged;

--- a/src/Avalonia.Controls/Slider.cs
+++ b/src/Avalonia.Controls/Slider.cs
@@ -136,8 +136,8 @@ namespace Avalonia.Controls
         /// </summary>
         public Orientation Orientation
         {
-            get { return GetValue(OrientationProperty); }
-            set { SetValue(OrientationProperty, value); }
+            get => GetValue(OrientationProperty);
+            set => SetValue(OrientationProperty, value);
         }
 
         /// <summary>
@@ -149,8 +149,8 @@ namespace Avalonia.Controls
         /// </value>
         public bool IsDirectionReversed
         {
-            get { return GetValue(IsDirectionReversedProperty); }
-            set { SetValue(IsDirectionReversedProperty, value); }
+            get => GetValue(IsDirectionReversedProperty);
+            set => SetValue(IsDirectionReversedProperty, value);
         }
 
         /// <summary>
@@ -158,8 +158,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool IsSnapToTickEnabled
         {
-            get { return GetValue(IsSnapToTickEnabledProperty); }
-            set { SetValue(IsSnapToTickEnabledProperty, value); }
+            get => GetValue(IsSnapToTickEnabledProperty);
+            set => SetValue(IsSnapToTickEnabledProperty, value);
         }
 
         /// <summary>
@@ -167,8 +167,8 @@ namespace Avalonia.Controls
         /// </summary>
         public double TickFrequency
         {
-            get { return GetValue(TickFrequencyProperty); }
-            set { SetValue(TickFrequencyProperty, value); }
+            get => GetValue(TickFrequencyProperty);
+            set => SetValue(TickFrequencyProperty, value);
         }
 
         /// <summary>
@@ -177,8 +177,8 @@ namespace Avalonia.Controls
         /// </summary>
         public TickPlacement TickPlacement
         {
-            get { return GetValue(TickPlacementProperty); }
-            set { SetValue(TickPlacementProperty, value); }
+            get => GetValue(TickPlacementProperty);
+            set => SetValue(TickPlacementProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Spinner.cs
+++ b/src/Avalonia.Controls/Spinner.cs
@@ -117,8 +117,8 @@ namespace Avalonia.Controls
         /// </summary>
         public event EventHandler<SpinEventArgs>? Spin
         {
-            add { AddHandler(SpinEvent, value); }
-            remove { RemoveHandler(SpinEvent, value); }
+            add => AddHandler(SpinEvent, value);
+            remove => RemoveHandler(SpinEvent, value);
         }
 
         /// <summary>
@@ -126,8 +126,8 @@ namespace Avalonia.Controls
         /// </summary>
         public ValidSpinDirections ValidSpinDirection
         {
-            get { return GetValue(ValidSpinDirectionProperty); }
-            set { SetValue(ValidSpinDirectionProperty, value); }
+            get => GetValue(ValidSpinDirectionProperty);
+            set => SetValue(ValidSpinDirectionProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/StackPanel.cs
+++ b/src/Avalonia.Controls/StackPanel.cs
@@ -72,8 +72,8 @@ namespace Avalonia.Controls
         /// </summary>
         public double Spacing
         {
-            get { return GetValue(SpacingProperty); }
-            set { SetValue(SpacingProperty, value); }
+            get => GetValue(SpacingProperty);
+            set => SetValue(SpacingProperty, value);
         }
 
         /// <summary>
@@ -81,8 +81,8 @@ namespace Avalonia.Controls
         /// </summary>
         public Orientation Orientation
         {
-            get { return GetValue(OrientationProperty); }
-            set { SetValue(OrientationProperty, value); }
+            get => GetValue(OrientationProperty);
+            set => SetValue(OrientationProperty, value);
         }
 
         /// <summary>
@@ -108,8 +108,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool AreHorizontalSnapPointsRegular
         {
-            get { return GetValue(AreHorizontalSnapPointsRegularProperty); }
-            set { SetValue(AreHorizontalSnapPointsRegularProperty, value); }
+            get => GetValue(AreHorizontalSnapPointsRegularProperty);
+            set => SetValue(AreHorizontalSnapPointsRegularProperty, value);
         }
 
         /// <summary>
@@ -117,8 +117,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool AreVerticalSnapPointsRegular
         {
-            get { return GetValue(AreVerticalSnapPointsRegularProperty); }
-            set { SetValue(AreVerticalSnapPointsRegularProperty, value); }
+            get => GetValue(AreVerticalSnapPointsRegularProperty);
+            set => SetValue(AreVerticalSnapPointsRegularProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -84,8 +84,8 @@ namespace Avalonia.Controls
         /// </summary>
         public HorizontalAlignment HorizontalContentAlignment
         {
-            get { return GetValue(HorizontalContentAlignmentProperty); }
-            set { SetValue(HorizontalContentAlignmentProperty, value); }
+            get => GetValue(HorizontalContentAlignmentProperty);
+            set => SetValue(HorizontalContentAlignmentProperty, value);
         }
 
         /// <summary>
@@ -93,8 +93,8 @@ namespace Avalonia.Controls
         /// </summary>
         public VerticalAlignment VerticalContentAlignment
         {
-            get { return GetValue(VerticalContentAlignmentProperty); }
-            set { SetValue(VerticalContentAlignmentProperty, value); }
+            get => GetValue(VerticalContentAlignmentProperty);
+            set => SetValue(VerticalContentAlignmentProperty, value);
         }
 
         /// <summary>
@@ -102,8 +102,8 @@ namespace Avalonia.Controls
         /// </summary>
         public Dock TabStripPlacement
         {
-            get { return GetValue(TabStripPlacementProperty); }
-            set { SetValue(TabStripPlacementProperty, value); }
+            get => GetValue(TabStripPlacementProperty);
+            set => SetValue(TabStripPlacementProperty, value);
         }
 
         /// <summary>
@@ -111,8 +111,8 @@ namespace Avalonia.Controls
         /// </summary>
         public IDataTemplate? ContentTemplate
         {
-            get { return GetValue(ContentTemplateProperty); }
-            set { SetValue(ContentTemplateProperty, value); }
+            get => GetValue(ContentTemplateProperty);
+            set => SetValue(ContentTemplateProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/TabItem.cs
+++ b/src/Avalonia.Controls/TabItem.cs
@@ -53,8 +53,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool IsSelected
         {
-            get { return GetValue(IsSelectedProperty); }
-            set { SetValue(IsSelectedProperty, value); }
+            get => GetValue(IsSelectedProperty);
+            set => SetValue(IsSelectedProperty, value);
         }
 
         protected override AutomationPeer OnCreateAutomationPeer() => new ListItemAutomationPeer(this);

--- a/src/Avalonia.Controls/TextBlock.cs
+++ b/src/Avalonia.Controls/TextBlock.cs
@@ -178,8 +178,8 @@ namespace Avalonia.Controls
         /// </summary>
         public Thickness Padding
         {
-            get { return GetValue(PaddingProperty); }
-            set { SetValue(PaddingProperty, value); }
+            get => GetValue(PaddingProperty);
+            set => SetValue(PaddingProperty, value);
         }
 
         /// <summary>
@@ -187,8 +187,8 @@ namespace Avalonia.Controls
         /// </summary>
         public IBrush? Background
         {
-            get { return GetValue(BackgroundProperty); }
-            set { SetValue(BackgroundProperty, value); }
+            get => GetValue(BackgroundProperty);
+            set => SetValue(BackgroundProperty, value);
         }
 
         /// <summary>
@@ -207,8 +207,8 @@ namespace Avalonia.Controls
         /// </summary>
         public FontFamily FontFamily
         {
-            get { return GetValue(FontFamilyProperty); }
-            set { SetValue(FontFamilyProperty, value); }
+            get => GetValue(FontFamilyProperty);
+            set => SetValue(FontFamilyProperty, value);
         }
 
         /// <summary>
@@ -216,8 +216,8 @@ namespace Avalonia.Controls
         /// </summary>
         public double FontSize
         {
-            get { return GetValue(FontSizeProperty); }
-            set { SetValue(FontSizeProperty, value); }
+            get => GetValue(FontSizeProperty);
+            set => SetValue(FontSizeProperty, value);
         }
 
         /// <summary>
@@ -225,8 +225,8 @@ namespace Avalonia.Controls
         /// </summary>
         public FontStyle FontStyle
         {
-            get { return GetValue(FontStyleProperty); }
-            set { SetValue(FontStyleProperty, value); }
+            get => GetValue(FontStyleProperty);
+            set => SetValue(FontStyleProperty, value);
         }
 
         /// <summary>
@@ -234,8 +234,8 @@ namespace Avalonia.Controls
         /// </summary>
         public FontWeight FontWeight
         {
-            get { return GetValue(FontWeightProperty); }
-            set { SetValue(FontWeightProperty, value); }
+            get => GetValue(FontWeightProperty);
+            set => SetValue(FontWeightProperty, value);
         }
 
         /// <summary>
@@ -243,8 +243,8 @@ namespace Avalonia.Controls
         /// </summary>
         public FontStretch FontStretch
         {
-            get { return GetValue(FontStretchProperty); }
-            set { SetValue(FontStretchProperty, value); }
+            get => GetValue(FontStretchProperty);
+            set => SetValue(FontStretchProperty, value);
         }
 
         /// <summary>
@@ -252,8 +252,8 @@ namespace Avalonia.Controls
         /// </summary>
         public IBrush? Foreground
         {
-            get { return GetValue(ForegroundProperty); }
-            set { SetValue(ForegroundProperty, value); }
+            get => GetValue(ForegroundProperty);
+            set => SetValue(ForegroundProperty, value);
         }
 
         /// <summary>
@@ -288,8 +288,8 @@ namespace Avalonia.Controls
         /// </summary>
         public TextWrapping TextWrapping
         {
-            get { return GetValue(TextWrappingProperty); }
-            set { SetValue(TextWrappingProperty, value); }
+            get => GetValue(TextWrappingProperty);
+            set => SetValue(TextWrappingProperty, value);
         }
 
         /// <summary>
@@ -297,8 +297,8 @@ namespace Avalonia.Controls
         /// </summary>
         public TextTrimming TextTrimming
         {
-            get { return GetValue(TextTrimmingProperty); }
-            set { SetValue(TextTrimmingProperty, value); }
+            get => GetValue(TextTrimmingProperty);
+            set => SetValue(TextTrimmingProperty, value);
         }
 
         /// <summary>
@@ -306,8 +306,8 @@ namespace Avalonia.Controls
         /// </summary>
         public TextAlignment TextAlignment
         {
-            get { return GetValue(TextAlignmentProperty); }
-            set { SetValue(TextAlignmentProperty, value); }
+            get => GetValue(TextAlignmentProperty);
+            set => SetValue(TextAlignmentProperty, value);
         }
 
         /// <summary>
@@ -338,8 +338,8 @@ namespace Avalonia.Controls
         /// </summary>
         public double BaselineOffset
         {
-            get { return (double)GetValue(BaselineOffsetProperty); }
-            set { SetValue(BaselineOffsetProperty, value); }
+            get => (double)GetValue(BaselineOffsetProperty);
+            set => SetValue(BaselineOffsetProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/TickBar.cs
+++ b/src/Avalonia.Controls/TickBar.cs
@@ -62,8 +62,8 @@ namespace Avalonia.Controls
         /// </summary>
         public IBrush? Fill
         {
-            get { return GetValue(FillProperty); }
-            set { SetValue(FillProperty, value); }
+            get => GetValue(FillProperty);
+            set => SetValue(FillProperty, value);
         }
 
         /// <summary>
@@ -77,11 +77,8 @@ namespace Avalonia.Controls
         /// </summary>
         public double Minimum
         {
-            get { return GetValue(MinimumProperty); }
-            set
-            {
-                SetValue(MinimumProperty, value);
-            }
+            get => GetValue(MinimumProperty);
+            set => SetValue(MinimumProperty, value);
         }
 
         /// <summary>
@@ -95,8 +92,8 @@ namespace Avalonia.Controls
         /// </summary>
         public double Maximum
         {
-            get { return GetValue(MaximumProperty); }
-            set { SetValue(MaximumProperty, value); }
+            get => GetValue(MaximumProperty);
+            set => SetValue(MaximumProperty, value);
         }
 
         /// <summary>
@@ -110,8 +107,8 @@ namespace Avalonia.Controls
         /// </summary>
         public double TickFrequency
         {
-            get { return GetValue(TickFrequencyProperty); }
-            set { SetValue(TickFrequencyProperty, value); }
+            get => GetValue(TickFrequencyProperty);
+            set => SetValue(TickFrequencyProperty, value);
         }
 
         /// <summary>
@@ -125,8 +122,8 @@ namespace Avalonia.Controls
         /// </summary>
         public Orientation Orientation
         {
-            get { return GetValue(OrientationProperty); }
-            set { SetValue(OrientationProperty, value); }
+            get => GetValue(OrientationProperty);
+            set => SetValue(OrientationProperty, value);
         }
 
         /// <summary>
@@ -142,8 +139,8 @@ namespace Avalonia.Controls
         /// </summary>
         public AvaloniaList<double>? Ticks
         {
-            get { return GetValue(TicksProperty); }
-            set { SetValue(TicksProperty, value); }
+            get => GetValue(TicksProperty);
+            set => SetValue(TicksProperty, value);
         }
 
         /// <summary>
@@ -160,8 +157,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool IsDirectionReversed
         {
-            get { return GetValue(IsDirectionReversedProperty); }
-            set { SetValue(IsDirectionReversedProperty, value); }
+            get => GetValue(IsDirectionReversedProperty);
+            set => SetValue(IsDirectionReversedProperty, value);
         }
 
         /// <summary>
@@ -177,8 +174,8 @@ namespace Avalonia.Controls
         /// </summary>
         public TickBarPlacement Placement
         {
-            get { return GetValue(PlacementProperty); }
-            set { SetValue(PlacementProperty, value); }
+            get => GetValue(PlacementProperty);
+            set => SetValue(PlacementProperty, value);
         }
 
         /// <summary>
@@ -195,8 +192,8 @@ namespace Avalonia.Controls
         /// </summary>
         public Rect ReservedSpace
         {
-            get { return GetValue(ReservedSpaceProperty); }
-            set { SetValue(ReservedSpaceProperty, value); }
+            get => GetValue(ReservedSpaceProperty);
+            set => SetValue(ReservedSpaceProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/ToggleSwitch.cs
+++ b/src/Avalonia.Controls/ToggleSwitch.cs
@@ -85,8 +85,8 @@ namespace Avalonia.Controls
         /// </summary>
         public object? OnContent
         {
-            get { return GetValue(OnContentProperty); }
-            set { SetValue(OnContentProperty, value); }
+            get => GetValue(OnContentProperty);
+            set => SetValue(OnContentProperty, value);
         }
 
         /// <summary>
@@ -94,8 +94,8 @@ namespace Avalonia.Controls
         /// </summary>
         public object? OffContent
         {
-            get { return GetValue(OffContentProperty); }
-            set { SetValue(OffContentProperty, value); }
+            get => GetValue(OffContentProperty);
+            set => SetValue(OffContentProperty, value);
         }
 
         public ContentPresenter? OffContentPresenter
@@ -115,8 +115,8 @@ namespace Avalonia.Controls
         /// </summary>
         public IDataTemplate? OffContentTemplate
         {
-            get { return GetValue(OffContentTemplateProperty); }
-            set { SetValue(OffContentTemplateProperty, value); }
+            get => GetValue(OffContentTemplateProperty);
+            set => SetValue(OffContentTemplateProperty, value);
         }
 
         /// <summary>
@@ -124,8 +124,8 @@ namespace Avalonia.Controls
         /// </summary>
         public IDataTemplate? OnContentTemplate
         {
-            get { return GetValue(OnContentTemplateProperty); }
-            set { SetValue(OnContentTemplateProperty, value); }
+            get => GetValue(OnContentTemplateProperty);
+            set => SetValue(OnContentTemplateProperty, value);
         }
 
         /// <summary>
@@ -133,11 +133,11 @@ namespace Avalonia.Controls
         /// </summary>
         public Transitions KnobTransitions
         {
-            get { return GetValue(KnobTransitionsProperty); }
-            set { SetValue(KnobTransitionsProperty, value); }
+            get => GetValue(KnobTransitionsProperty);
+            set => SetValue(KnobTransitionsProperty, value);
         }
 
-        
+
 
         private void OffContentChanged(AvaloniaPropertyChangedEventArgs e)
         {

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -318,8 +318,8 @@ namespace Avalonia.Controls
         /// </summary>
         public Size ClientSize
         {
-            get { return _clientSize; }
-            protected set { SetAndRaise(ClientSizeProperty, ref _clientSize, value); }
+            get => _clientSize;
+            protected set => SetAndRaise(ClientSizeProperty, ref _clientSize, value);
         }
 
         /// <summary>
@@ -327,8 +327,8 @@ namespace Avalonia.Controls
         /// </summary>
         public Size? FrameSize
         {
-            get { return _frameSize; }
-            protected set { SetAndRaise(FrameSizeProperty, ref _frameSize, value); }
+            get => _frameSize;
+            protected set => SetAndRaise(FrameSizeProperty, ref _frameSize, value);
         }
 
         /// <summary>
@@ -339,8 +339,8 @@ namespace Avalonia.Controls
         /// </summary>
         public IReadOnlyList<WindowTransparencyLevel> TransparencyLevelHint
         {
-            get { return GetValue(TransparencyLevelHintProperty); }
-            set { SetValue(TransparencyLevelHintProperty, value); }
+            get => GetValue(TransparencyLevelHintProperty);
+            set => SetValue(TransparencyLevelHintProperty, value);
         }
 
         /// <summary>
@@ -374,8 +374,8 @@ namespace Avalonia.Controls
         /// </summary>
         public event EventHandler<RoutedEventArgs> BackRequested
         {
-            add { AddHandler(BackRequestedEvent, value); }
-            remove { RemoveHandler(BackRequestedEvent, value); }
+            add => AddHandler(BackRequestedEvent, value);
+            remove => RemoveHandler(BackRequestedEvent, value);
         }
 
         internal ILayoutManager LayoutManager
@@ -464,8 +464,8 @@ namespace Avalonia.Controls
         /// <inheritdoc/>
         IInputElement? IInputRoot.PointerOverElement
         {
-            get { return GetValue(PointerOverElementProperty); }
-            set { SetValue(PointerOverElementProperty, value); }
+            get => GetValue(PointerOverElementProperty);
+            set => SetValue(PointerOverElementProperty, value);
         }
 
         /// <summary>
@@ -473,8 +473,8 @@ namespace Avalonia.Controls
         /// </summary>
         bool IInputRoot.ShowAccessKeys
         {
-            get { return GetValue(AccessText.ShowAccessKeyProperty); }
-            set { SetValue(AccessText.ShowAccessKeyProperty, value); }
+            get => GetValue(AccessText.ShowAccessKeyProperty);
+            set => SetValue(AccessText.ShowAccessKeyProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/TrayIcon.cs
+++ b/src/Avalonia.Controls/TrayIcon.cs
@@ -140,8 +140,8 @@ namespace Avalonia.Controls
         /// </summary>
         public object? CommandParameter
         {
-            get { return GetValue(CommandParameterProperty); }
-            set { SetValue(CommandParameterProperty, value); }
+            get => GetValue(CommandParameterProperty);
+            set => SetValue(CommandParameterProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Utils/SelectingItemsControlSelectionAdapter.cs
+++ b/src/Avalonia.Controls/Utils/SelectingItemsControlSelectionAdapter.cs
@@ -40,7 +40,7 @@ namespace Avalonia.Controls.Utils
         /// control.</value>
         public SelectingItemsControl? SelectorControl
         {
-            get { return _selector; }
+            get => _selector;
 
             set
             {
@@ -111,10 +111,7 @@ namespace Avalonia.Controls.Utils
         /// <value>The selected item of the underlying selection adapter.</value>
         public object? SelectedItem
         {
-            get
-            {
-                return SelectorControl?.SelectedItem;
-            }
+            get => SelectorControl?.SelectedItem;
 
             set
             {
@@ -142,10 +139,7 @@ namespace Avalonia.Controls.Utils
         /// adapter.</value>
         public IEnumerable? ItemsSource
         {
-            get
-            {
-                return SelectorControl?.ItemsSource;
-            }
+            get => SelectorControl?.ItemsSource;
             set
             {
                 if (SelectorControl != null)

--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -119,8 +119,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool AreHorizontalSnapPointsRegular
         {
-            get { return GetValue(AreHorizontalSnapPointsRegularProperty); }
-            set { SetValue(AreHorizontalSnapPointsRegularProperty, value); }
+            get => GetValue(AreHorizontalSnapPointsRegularProperty);
+            set => SetValue(AreHorizontalSnapPointsRegularProperty, value);
         }
 
         /// <summary>
@@ -128,8 +128,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool AreVerticalSnapPointsRegular
         {
-            get { return GetValue(AreVerticalSnapPointsRegularProperty); }
-            set { SetValue(AreVerticalSnapPointsRegularProperty, value); }
+            get => GetValue(AreVerticalSnapPointsRegularProperty);
+            set => SetValue(AreVerticalSnapPointsRegularProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -245,8 +245,8 @@ namespace Avalonia.Controls
         /// </remarks>
         public SizeToContent SizeToContent
         {
-            get { return GetValue(SizeToContentProperty); }
-            set { SetValue(SizeToContentProperty, value); }
+            get => GetValue(SizeToContentProperty);
+            set => SetValue(SizeToContentProperty, value);
         }
 
         /// <summary>
@@ -254,8 +254,8 @@ namespace Avalonia.Controls
         /// </summary>
         public string? Title
         {
-            get { return GetValue(TitleProperty); }
-            set { SetValue(TitleProperty, value); }
+            get => GetValue(TitleProperty);
+            set => SetValue(TitleProperty, value);
         }
 
         /// <summary>
@@ -263,8 +263,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool ExtendClientAreaToDecorationsHint
         {
-            get { return GetValue(ExtendClientAreaToDecorationsHintProperty); }
-            set { SetValue(ExtendClientAreaToDecorationsHintProperty, value); }
+            get => GetValue(ExtendClientAreaToDecorationsHintProperty);
+            set => SetValue(ExtendClientAreaToDecorationsHintProperty, value);
         }
 
         /// <summary>
@@ -323,8 +323,8 @@ namespace Avalonia.Controls
         /// </summary>
         public SystemDecorations SystemDecorations
         {
-            get { return GetValue(SystemDecorationsProperty); }
-            set { SetValue(SystemDecorationsProperty, value); }
+            get => GetValue(SystemDecorationsProperty);
+            set => SetValue(SystemDecorationsProperty, value);
         }
 
         /// <summary>
@@ -332,8 +332,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool ShowActivated
         {
-            get { return GetValue(ShowActivatedProperty); }
-            set { SetValue(ShowActivatedProperty, value); }
+            get => GetValue(ShowActivatedProperty);
+            set => SetValue(ShowActivatedProperty, value);
         }
 
         /// <summary>
@@ -342,8 +342,8 @@ namespace Avalonia.Controls
         /// 
         public bool ShowInTaskbar
         {
-            get { return GetValue(ShowInTaskbarProperty); }
-            set { SetValue(ShowInTaskbarProperty, value); }
+            get => GetValue(ShowInTaskbarProperty);
+            set => SetValue(ShowInTaskbarProperty, value);
         }
 
         /// <summary>
@@ -351,8 +351,8 @@ namespace Avalonia.Controls
         /// </summary>
         public WindowState WindowState
         {
-            get { return GetValue(WindowStateProperty); }
-            set { SetValue(WindowStateProperty, value); }
+            get => GetValue(WindowStateProperty);
+            set => SetValue(WindowStateProperty, value);
         }
 
         /// <summary>
@@ -360,8 +360,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool CanResize
         {
-            get { return GetValue(CanResizeProperty); }
-            set { SetValue(CanResizeProperty, value); }
+            get => GetValue(CanResizeProperty);
+            set => SetValue(CanResizeProperty, value);
         }
 
         /// <summary>
@@ -369,8 +369,8 @@ namespace Avalonia.Controls
         /// </summary>
         public WindowIcon? Icon
         {
-            get { return GetValue(IconProperty); }
-            set { SetValue(IconProperty, value); }
+            get => GetValue(IconProperty);
+            set => SetValue(IconProperty, value);
         }
 
         /// <summary>
@@ -387,11 +387,8 @@ namespace Avalonia.Controls
         /// </summary>
         public PixelPoint Position
         {
-            get { return PlatformImpl?.Position ?? PixelPoint.Origin; }
-            set
-            {
-                PlatformImpl?.Move(value);
-            }
+            get => PlatformImpl?.Position ?? PixelPoint.Origin;
+            set => PlatformImpl?.Move(value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/WindowBase.cs
+++ b/src/Avalonia.Controls/WindowBase.cs
@@ -102,10 +102,10 @@ namespace Avalonia.Controls
         /// </summary>
         public bool IsActive
         {
-            get { return _isActive; }
-            private set { SetAndRaise(IsActiveProperty, ref _isActive, value); }
+            get => _isActive;
+            private set => SetAndRaise(IsActiveProperty, ref _isActive, value);
         }
-        
+
         public Screens Screens { get; }
 
         /// <summary>
@@ -113,8 +113,8 @@ namespace Avalonia.Controls
         /// </summary>
         public WindowBase? Owner
         {
-            get { return _owner; }
-            protected set { SetAndRaise(OwnerProperty, ref _owner, value); }
+            get => _owner;
+            protected set => SetAndRaise(OwnerProperty, ref _owner, value);
         }
 
         /// <summary>
@@ -122,8 +122,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool Topmost
         {
-            get { return GetValue(TopmostProperty); }
-            set { SetValue(TopmostProperty, value); }
+            get => GetValue(TopmostProperty);
+            set => SetValue(TopmostProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/WrapPanel.cs
+++ b/src/Avalonia.Controls/WrapPanel.cs
@@ -50,8 +50,8 @@ namespace Avalonia.Controls
         /// </summary>
         public Orientation Orientation
         {
-            get { return GetValue(OrientationProperty); }
-            set { SetValue(OrientationProperty, value); }
+            get => GetValue(OrientationProperty);
+            set => SetValue(OrientationProperty, value);
         }
 
         /// <summary>
@@ -59,8 +59,8 @@ namespace Avalonia.Controls
         /// </summary>
         public double ItemWidth
         {
-            get { return GetValue(ItemWidthProperty); }
-            set { SetValue(ItemWidthProperty, value); }
+            get => GetValue(ItemWidthProperty);
+            set => SetValue(ItemWidthProperty, value);
         }
 
         /// <summary>
@@ -68,8 +68,8 @@ namespace Avalonia.Controls
         /// </summary>
         public double ItemHeight
         {
-            get { return GetValue(ItemHeightProperty); }
-            set { SetValue(ItemHeightProperty, value); }
+            get => GetValue(ItemHeightProperty);
+            set => SetValue(ItemHeightProperty, value);
         }
 
         /// <summary>
@@ -279,12 +279,12 @@ namespace Avalonia.Controls
 
             internal double Width
             {
-                get { return _orientation == Orientation.Horizontal ? U : V; }
+                get => _orientation == Orientation.Horizontal ? U : V;
                 set { if (_orientation == Orientation.Horizontal) U = value; else V = value; }
             }
             internal double Height
             {
-                get { return _orientation == Orientation.Horizontal ? V : U; }
+                get => _orientation == Orientation.Horizontal ? V : U;
                 set { if (_orientation == Orientation.Horizontal) V = value; else U = value; }
             }
         }


### PR DESCRIPTION
## What does the pull request do?
Modernizes syntax of single-expression or single-statement getters and setters

## What is the updated/expected behavior with this PR?
No behavioral changes