### PR TITLE
Replace old Roadmap link with link to Blog

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,8 +14,8 @@ Considered by many to be the spiritual successor to WPF, Avalonia UI provides a 
 
 For those seeking a cross-platform WPF, we have created [Avalonia XPF](https://avaloniaui.net/xpf), enabling WPF applications to run on macOS and Linux with little to no code changes. Avalonia XPF is a commercial product and is licensed per-app, per-platform. 
 
-#### Roadmap
-To see the status of some of our features, look at our [Roadmap](https://github.com/AvaloniaUI/Avalonia/issues/2239). 
+#### Blog
+To see the latest announcements and read about the state of Avalonia, check out the [Avalonia UI Blog](https://www.avaloniaui.net/Blog/).
 
 #### Breaking Changes
 You can also see what [breaking changes](https://github.com/AvaloniaUI/Avalonia/issues/3538) we have planned and what our [past breaking changes](https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes) have been. 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR replaces the link to the old Roadmap issue with a link to the Blog until a new one is made.

The blog seems to currently be the best place to get roadmap-related information.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Currently the link goes to an old, out of date closed issue.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Don't confuse new users and instead direct them to the blog where they can find similar info in the blog posts.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Replaced roadmap section with blog section.

If the maintainers are opposed to referencing the blog. We can just remove the Roadmap section without anything in its place.
