### PR TITLE
Fix offset expression animation

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerObject.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerObject.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Rendering.Composition.Server
 
             public void Invalidate()
             {
-                if (IsValid)
+                if (!IsValid)
                     return;
                 IsValid = false;
                 if (Subscribers != null)

--- a/src/tools/DevGenerators/CompositionGenerator/Generator.cs
+++ b/src/tools/DevGenerators/CompositionGenerator/Generator.cs
@@ -435,7 +435,8 @@ return;
             "Matrix4x4",
             "Quaternion",
             "Color",
-            "Avalonia.Media.Color"
+            "Avalonia.Media.Color",
+            "Vector3D"
         };
 
         static BlockSyntax ApplyGetProperty(BlockSyntax body, GProperty prop, string? expr = null)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
1. Fixing `if` condition in the Invalidate method in the ServerObjectSubscriptionStore.
2. Add Vector3D to VariantPropertyTypes.


## What is the current behavior?
1. After first property reading, invalidation never happens.
2. CompositionGenerator ignoring Vector3D type and properties of this type don't added to GetPropertyForAnimation.

## What is the updated/expected behavior with this PR?
ExpressionAnimation with reference to Vector3D property will worked.

## Fixed issues
Fixes #12939
