### PR TITLE
Add "EGL_ANGLE_flexible_surface_compatibility" ext check

### DIFF
--- a/src/Avalonia.OpenGL/Egl/EglContext.cs
+++ b/src/Avalonia.OpenGL/Egl/EglContext.cs
@@ -48,6 +48,7 @@ namespace Avalonia.OpenGL.Egl
         public int SampleCount { get; }
         public int StencilSize { get; }
         public EglDisplay Display => _disp;
+        public EglInterface EglInterface => _egl;
 
         private class RestoreContext : IDisposable
         {

--- a/src/Avalonia.OpenGL/Egl/EglDisplay.cs
+++ b/src/Avalonia.OpenGL/Egl/EglDisplay.cs
@@ -113,12 +113,20 @@ namespace Avalonia.OpenGL.Egl
                 return new EglSurface(this, s);
             }
         }
+
+        public unsafe EglSurface CreatePBufferFromClientBuffer(int bufferType, IntPtr handle, int[] attribs)
+        {
+            fixed (int* attrs = attribs)
+            {
+                return CreatePBufferFromClientBuffer(bufferType, handle, attrs);
+            }
+        }
         
         public unsafe EglSurface CreatePBufferFromClientBuffer (int bufferType, IntPtr handle, int* attribs)
         {
             using (Lock())
             {
-                var s = EglInterface.CreatePbufferFromClientBuffer(Handle, bufferType, handle,
+                var s = EglInterface.CreatePbufferFromClientBufferPtr(Handle, bufferType, handle,
                     Config, attribs);
 
                 if (s == IntPtr.Zero)

--- a/src/Avalonia.OpenGL/Egl/EglDisplay.cs
+++ b/src/Avalonia.OpenGL/Egl/EglDisplay.cs
@@ -114,7 +114,7 @@ namespace Avalonia.OpenGL.Egl
             }
         }
         
-        public EglSurface CreatePBufferFromClientBuffer (int bufferType, IntPtr handle, int[] attribs)
+        public unsafe EglSurface CreatePBufferFromClientBuffer (int bufferType, IntPtr handle, int* attribs)
         {
             using (Lock())
             {

--- a/src/Avalonia.OpenGL/Egl/EglInterface.cs
+++ b/src/Avalonia.OpenGL/Egl/EglInterface.cs
@@ -124,7 +124,7 @@ namespace Avalonia.OpenGL.Egl
         }
         
         [GetProcAddress("eglCreatePbufferFromClientBuffer")]
-        public partial IntPtr CreatePbufferFromClientBuffer(IntPtr display, int buftype, IntPtr buffer, IntPtr config, int[]? attrib_list);
+        public partial IntPtr CreatePbufferFromClientBuffer(IntPtr display, int buftype, IntPtr buffer, IntPtr config, int* attrib_list);
         
         [GetProcAddress("eglQueryDisplayAttribEXT", true)]
         public partial bool QueryDisplayAttribExt(IntPtr display, int attr, out IntPtr res);

--- a/src/Avalonia.OpenGL/Egl/EglInterface.cs
+++ b/src/Avalonia.OpenGL/Egl/EglInterface.cs
@@ -122,10 +122,13 @@ namespace Avalonia.OpenGL.Egl
                 return null;
             return Marshal.PtrToStringAnsi(rv);
         }
-        
+
         [GetProcAddress("eglCreatePbufferFromClientBuffer")]
-        public partial IntPtr CreatePbufferFromClientBuffer(IntPtr display, int buftype, IntPtr buffer, IntPtr config, int* attrib_list);
-        
+        public partial IntPtr CreatePbufferFromClientBuffer(IntPtr display, int buftype, IntPtr buffer, IntPtr config, int[]? attrib_list);
+
+        [GetProcAddress("eglCreatePbufferFromClientBuffer")]
+        public partial IntPtr CreatePbufferFromClientBufferPtr(IntPtr display, int buftype, IntPtr buffer, IntPtr config, int* attrib_list);
+
         [GetProcAddress("eglQueryDisplayAttribEXT", true)]
         public partial bool QueryDisplayAttribExt(IntPtr display, int attr, out IntPtr res);
 

--- a/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleExternalD3D11Texture2D.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleExternalD3D11Texture2D.cs
@@ -28,13 +28,13 @@ internal class AngleExternalMemoryD3D11Texture2D : IGlExternalImageTexture
 
         InternalFormat = GL_RGBA8;
 
-        _eglSurface = _context.Display.CreatePBufferFromClientBuffer(EGL_D3D_TEXTURE_ANGLE, texture2D.GetNativeIntPtr(),
-            new[]
-            {
-                EGL_WIDTH, props.Width, EGL_HEIGHT, props.Height, EGL_TEXTURE_FORMAT, EGL_TEXTURE_RGBA,
-                EGL_TEXTURE_TARGET, EGL_TEXTURE_2D, EGL_TEXTURE_INTERNAL_FORMAT_ANGLE, GL_RGBA, EGL_NONE, EGL_NONE,
-                EGL_NONE
-            });
+        var attrs = stackalloc[]
+        {
+            EGL_WIDTH, props.Width, EGL_HEIGHT, props.Height, EGL_TEXTURE_FORMAT, EGL_TEXTURE_RGBA,
+            EGL_TEXTURE_TARGET, EGL_TEXTURE_2D, EGL_TEXTURE_INTERNAL_FORMAT_ANGLE, GL_RGBA, EGL_NONE, EGL_NONE,
+            EGL_NONE
+        };
+        _eglSurface = _context.Display.CreatePBufferFromClientBuffer(EGL_D3D_TEXTURE_ANGLE, texture2D.GetNativeIntPtr(), attrs);
         
         var gl = _context.GlInterface;
         int temp = 0;

--- a/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32EglDisplay.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32EglDisplay.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Avalonia.OpenGL;
 using Avalonia.OpenGL.Angle;
@@ -168,25 +169,32 @@ namespace Avalonia.Win32.OpenGl.Angle
             return d3dDeviceHandle;
         }
 
-        public EglSurface WrapDirect3D11Texture( IntPtr handle)
+        public unsafe EglSurface WrapDirect3D11Texture( IntPtr handle)
         {
             if (PlatformApi != AngleOptions.PlatformApi.DirectX11)
-                throw new InvalidOperationException("Current platform API is " + PlatformApi);
-            return CreatePBufferFromClientBuffer(EGL_D3D_TEXTURE_ANGLE, handle, new[] { EGL_NONE, EGL_NONE });            
+                ThrowInvalidPlatformApi();
+            var attrs = stackalloc[] { EGL_NONE, EGL_NONE };
+            return CreatePBufferFromClientBuffer(EGL_D3D_TEXTURE_ANGLE, handle, attrs);
         }
 
-        public EglSurface WrapDirect3D11Texture(IntPtr handle, int offsetX, int offsetY, int width, int height)
+        public unsafe EglSurface WrapDirect3D11Texture(IntPtr handle, int offsetX, int offsetY, int width, int height)
         {
             if (PlatformApi != AngleOptions.PlatformApi.DirectX11)
-                throw new InvalidOperationException("Current platform API is " + PlatformApi);
-            return CreatePBufferFromClientBuffer(EGL_D3D_TEXTURE_ANGLE, handle,
-                new[]
-                {
-                    EGL_WIDTH, width, EGL_HEIGHT, height, EGL_TEXTURE_OFFSET_X_ANGLE, offsetX,
-                    EGL_TEXTURE_OFFSET_Y_ANGLE, offsetY,
-                    _flexibleSurfaceSupported ? EGL_FLEXIBLE_SURFACE_COMPATIBILITY_SUPPORTED_ANGLE : EGL_NONE, EGL_TRUE,
-                    EGL_NONE
-                });
+                ThrowInvalidPlatformApi();
+            var attrs = stackalloc[]
+            {
+                EGL_WIDTH, width, EGL_HEIGHT, height, EGL_TEXTURE_OFFSET_X_ANGLE, offsetX,
+                EGL_TEXTURE_OFFSET_Y_ANGLE, offsetY,
+                _flexibleSurfaceSupported ? EGL_FLEXIBLE_SURFACE_COMPATIBILITY_SUPPORTED_ANGLE : EGL_NONE, EGL_TRUE,
+                EGL_NONE
+            };
+            return CreatePBufferFromClientBuffer(EGL_D3D_TEXTURE_ANGLE, handle, attrs);
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ThrowInvalidPlatformApi()
+        {
+            throw new InvalidOperationException("Current platform API is " + PlatformApi);
+        } 
     }
 }


### PR DESCRIPTION
## What does the pull request do?

Extension check that fixes Avalonia compatibility with newer Angle versions.
"EGL_ANGLE_flexible_surface_compatibility" extension was removed somewhere after 2020 angle releases, while Avalonia still used it.

## How was the solution implemented (if it's not obvious)?

We could remove this attribute and upgrade Angle to the newest, but to keep compatibility with older native binaries, an extension check was added.
Also, as this code is reused between normal Angle and DXGI, some code was reused.

## Fixes

Probably fixes https://github.com/AvaloniaUI/Avalonia/issues/10405#issuecomment-1637819267 specific comment. And also possibly fixes Angle on ARM64, when used with newer builds (Edge builds for example).