### PR TITLE
Add Clear function to Date and Time pickers.

### DIFF
--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
@@ -918,5 +918,13 @@ namespace Avalonia.Controls
         {
             return !string.IsNullOrWhiteSpace(formatString);
         }
+
+        /// <summary>
+        /// Clear SelectedDate
+        /// </summary>
+        public void Clear()
+        {
+            SetCurrentValue(SelectedDateProperty, null);
+        }
     }
 }

--- a/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
+++ b/src/Avalonia.Controls/CalendarDatePicker/CalendarDatePicker.cs
@@ -920,7 +920,7 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Clear SelectedDate
+        /// Clear <see cref="SelectedDate"/>.
         /// </summary>
         public void Clear()
         {

--- a/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
@@ -412,7 +412,7 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Clear SelectedDate
+        /// Clear <see cref="SelectedDate"/>.
         /// </summary>
         public void Clear()
         {

--- a/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DatePicker.cs
@@ -410,5 +410,13 @@ namespace Avalonia.Controls
         {
             SelectedDateChanged?.Invoke(sender, e);
         }
+
+        /// <summary>
+        /// Clear SelectedDate
+        /// </summary>
+        public void Clear()
+        {
+            SetCurrentValue(SelectedDateProperty, null);
+        }
     }
 }

--- a/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
@@ -283,5 +283,13 @@ namespace Avalonia.Controls
             _popup!.Close();
             SetCurrentValue(SelectedTimeProperty, _presenter!.Time);
         }
+
+        /// <summary>
+        /// Clear SelectedTime.
+        /// </summary>
+        public void Clear()
+        {
+            SetCurrentValue(SelectedTimeProperty, null);
+        }
     }
 }

--- a/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
@@ -285,7 +285,7 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Clear SelectedTime.
+        /// Clear <see cref="SelectedTime"/>.
         /// </summary>
         public void Clear()
         {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Add Clear function to DatePicker, TimePicker, CalendarDatePicker
Follow up of https://github.com/AvaloniaUI/Avalonia/pull/12217 
This would allow addition clear button (or default ContextFlyout MenuItem) be easily added to control template like TextBox did. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
