### PR TITLE
Fixed an issue that windows empty Win32 window would show unnecessarily

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1409,7 +1409,7 @@ namespace Avalonia.Win32
             }
 
             // Ensure window state if decorations change
-            if (oldProperties.Decorations != newProperties.Decorations)
+            if (_shown && oldProperties.Decorations != newProperties.Decorations)
                 ShowWindow(WindowState, false);
         }
 


### PR DESCRIPTION
Fixed an issue that windows empty Win32 window would show when changing properties of `Window`.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
