### PR TITLE
Fix popup tests randomly failing after logical scrollable tests

### DIFF
--- a/tests/Avalonia.Controls.UnitTests/ScrollViewerTests_ILogicalScrollable.cs
+++ b/tests/Avalonia.Controls.UnitTests/ScrollViewerTests_ILogicalScrollable.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests;
 
-public class ScrollViewerTests_ILogicalScrollable
+public class ScrollViewerTests_ILogicalScrollable : ScopedTestBase
 {
     [Fact]
     public void Extent_Offset_And_Viewport_Should_Be_Read_From_ILogicalScrollable()


### PR DESCRIPTION
## What does the pull request do?
After #13066, the popup unit tests are randomly failing when run after the new `ScrollViewerTests_ILogicalScrollable` tests.
This PR makes the new test class derive from `ScopedTestBase`: `ScrollViewer` posts to the dispatcher, whose uses should be scoped.
