### PR TITLE
[nuke] Use a regex to detect a release branch.

### DIFF
--- a/nukebuild/BuildParameters.cs
+++ b/nukebuild/BuildParameters.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Nuke.Common;
 using Nuke.Common.CI.AzurePipelines;
@@ -38,7 +39,7 @@ public partial class Build
         public string RepositoryName { get; }
         public string RepositoryBranch { get; }
         public string ReleaseConfiguration { get; }
-        public string ReleaseBranchPrefix { get; }
+        public Regex ReleaseBranchRegex { get; }
         public string MSBuildSolution { get; }
         public bool IsLocalBuild { get; }
         public bool IsRunningOnUnix { get; }
@@ -77,7 +78,7 @@ public partial class Build
             // CONFIGURATION
             MainRepo = "https://github.com/AvaloniaUI/Avalonia";
             MasterBranch = "refs/heads/master";
-            ReleaseBranchPrefix = "refs/heads/release/";
+            ReleaseBranchRegex = new("^refs/heads/release/(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$");
             ReleaseConfiguration = "Release";
             MSBuildSolution = RootDirectory / "dirs.proj";
 
@@ -101,8 +102,7 @@ public partial class Build
                     RepositoryName);
             IsMasterBranch = StringComparer.OrdinalIgnoreCase.Equals(MasterBranch,
                 RepositoryBranch);
-            IsReleaseBranch = RepositoryBranch?.StartsWith(ReleaseBranchPrefix, StringComparison.OrdinalIgnoreCase) ==
-                              true;
+            IsReleaseBranch = RepositoryBranch is not null && ReleaseBranchRegex.IsMatch(RepositoryBranch);
 
             IsReleasable = StringComparer.OrdinalIgnoreCase.Equals(ReleaseConfiguration, Configuration);
             IsMyGetRelease = IsReleasable;


### PR DESCRIPTION
Currently our nuke build system uses a simple `Branch.StartsWith("refs/heads/release/")` check to detect if the current branch is a release branch. If a release branch is detected, the CI system doesn't append `-cibuildXXXXXXX` to the version number and instead preserves the version as defined in `build/SharedVersion.props`.

The problem is that we want to be able to use branches with names such as `release/11.0` to track the 11.0.x branch, but these branches are being detected as release branches even though the version number is incomplete.

(Previously we used the `stable/0.10.x` branch naming scheme but it would be preferable to use `release/` instead of `stable/` now that both our minor and patch version numbers are technically "stable")

This PR changes the release branch detection code to use a regex (taken from semver.org) to detect whether the current branch is a valid semver version.