### PR TITLE
Update SkiaSharp to 2.88.6 to fix a critical security vulnerability

### DIFF
--- a/build/SkiaSharp.props
+++ b/build/SkiaSharp.props
@@ -1,7 +1,7 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.3" />
-    <PackageReference Condition="'$(IncludeLinuxSkia)' == 'true'" Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
-    <PackageReference Condition="'$(IncludeWasmSkia)' == 'true'" Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp" Version="2.88.6" />
+    <PackageReference Condition="'$(IncludeLinuxSkia)' == 'true'" Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
+    <PackageReference Condition="'$(IncludeWasmSkia)' == 'true'" Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.6" />
   </ItemGroup>
 </Project>

--- a/src/Tizen/Avalonia.Tizen/Avalonia.Tizen.csproj
+++ b/src/Tizen/Avalonia.Tizen/Avalonia.Tizen.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.6" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Tizen" Version="2.8.2.3" />
     
     <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Updates SkiaSharp from 2.88.3 to 2.88.6 to pull in the fix for a critical security vulnerability reported on September 11th.

## What is the current behavior?

tl;dr A buffer overflow in libwebp, used by Skia, allows a maliciously crafted .webp file to execute arbitrary code in the rendering process.

From the [vulnerability report](https://security.snyk.io/vuln/SNYK-DOTNET-SKIASHARP-5922114):

> Overview
> 
> Affected versions of this package are vulnerable to Heap-based Buffer Overflow when the ReadHuffmanCodes() function is used. An attacker can craft a special WebP lossless file that triggers the ReadHuffmanCodes() function to allocate the HuffmanCode buffer with a size that comes from an array of precomputed sizes: kTableSize. The color_cache_bits value defines which size to use. The kTableSize array only takes into account sizes for 8-bit first-level table lookups but not second-level table lookups. libwebp allows codes that are up to 15-bit (MAX_ALLOWED_CODE_LENGTH). When BuildHuffmanTable() attempts to fill the second-level tables it may write data out-of-bounds. The OOB write to the undersized array happens in ReplicateValue.
> 
> Notes:
> 
> This is only exploitable if the color_cache_bits value defines which size to use.
> 
> This vulnerability was also published on libwebp [CVE-2023-5129](https://security.snyk.io/vuln/SNYK-UNMANAGED-WEBMPROJECTLIBWEBP-5918283)
> 

## What is the updated/expected behavior with this PR?

The security vulnerability will be closed.

## How was the solution implemented (if it's not obvious)?

Just bumped the SkiaSharp version number to the first release with the fix.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

Shouldn't be any. The Skia render tests succeed on my machine.

## Obsoletions / Deprecations

N/A

## Fixed issues

Fixes #13105
