### PR TITLE
fix: `ItemsControlFromItemContainer` typo

### DIFF
--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -305,7 +305,20 @@ namespace Avalonia.Controls
         /// <returns>
         /// The owning <see cref="ItemsControl"/> or null if the control is not an items container.
         /// </returns>
-        public static ItemsControl? ItemsControlFromItemContaner(Control container)
+        [Obsolete("Typo, use ItemsControlFromItemContainer instead")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Browsable(false)]
+        public static ItemsControl? ItemsControlFromItemContaner(Control container) =>
+            ItemsControlFromItemContainer(container);
+
+        /// <summary>
+        /// Returns the <see cref="ItemsControl"/> that owns the specified container control.
+        /// </summary>
+        /// <param name="container">The container.</param>
+        /// <returns>
+        /// The owning <see cref="ItemsControl"/> or null if the control is not an items container.
+        /// </returns>
+        public static ItemsControl? ItemsControlFromItemContainer(Control container)
         {
             var c = container.Parent as Control;
 

--- a/src/Avalonia.Controls/ListBoxItem.cs
+++ b/src/Avalonia.Controls/ListBoxItem.cs
@@ -55,7 +55,7 @@ namespace Avalonia.Controls
             if (e.Handled)
                 return;
 
-            if (!e.Handled && ItemsControl.ItemsControlFromItemContaner(this) is ListBox owner)
+            if (!e.Handled && ItemsControl.ItemsControlFromItemContainer(this) is ListBox owner)
             {
                 var p = e.GetCurrentPoint(this);
 
@@ -97,7 +97,7 @@ namespace Avalonia.Controls
 
                 if (new Rect(Bounds.Size).ContainsExclusive(point.Position) &&
                     tapRect.ContainsExclusive(point.Position) &&
-                    ItemsControl.ItemsControlFromItemContaner(this) is ListBox owner)
+                    ItemsControl.ItemsControlFromItemContainer(this) is ListBox owner)
                 {
                     if (owner.UpdateSelectionFromPointerEvent(this, e))
                     {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

- Renamed `ItemsControlFromItemContaner` in `ItemsControlFromItemContainer'
- Add `ItemsControlFromItemContaner`  with attributes `Obsolete` and `EditorBrowsable Never` that call `ItemsControlFromItemContainer`



## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #13116