### PR TITLE
Ambiguous error message when you load App.axaml

### DIFF
--- a/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
+++ b/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
@@ -90,7 +90,7 @@ namespace Avalonia.DesignerSupport
                         };
                 }
                 else if (loaded is Application)
-                    control = new TextBlock { Text = "Application can't be previewed in design view" };
+                    control = new TextBlock { Text = "This file cannot be previewed in design view" };
                 else
                     control = (Control)loaded;
 


### PR DESCRIPTION

## What does the pull request do?
Fixes the ambiguous message when user loads App.axaml file in the designer

## How was the solution implemented (if it's not obvious)?
Update the error message 

## Checklist
Not applicable 

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation



## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues

 https://github.com/AvaloniaUI/AvaloniaVS/issues/257
