### PR TITLE
Enable $visualparent syntax.

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
@@ -277,6 +277,30 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                             nodes.Add(new FindAncestorPathElementNode(GetType(ancestor.Namespace, ancestor.TypeName), ancestor.Level));
                         }
                         break;
+                    case BindingExpressionGrammar.VisualAncestorNode ancestor:
+                        if (ancestor.Namespace is null && ancestor.TypeName is null)
+                        {
+                            var styledElementType = context.GetAvaloniaTypes().StyledElement;
+                            var ancestorType = context
+                                .ParentNodes()
+                                .OfType<XamlAstConstructableObjectNode>()
+                                .Where(x => styledElementType.IsAssignableFrom(x.Type.GetClrType()))
+                                .Skip(1)
+                                .ElementAtOrDefault(ancestor.Level)
+                                ?.Type.GetClrType();
+
+                            if (ancestorType is null)
+                            {
+                                throw new XamlX.XamlParseException("Unable to resolve implicit visual ancestor type based on XAML tree.", lineInfo);
+                            }
+
+                            nodes.Add(new FindVisualAncestorPathElementNode(ancestorType, ancestor.Level));
+                        }
+                        else
+                        {
+                            nodes.Add(new FindVisualAncestorPathElementNode(GetType(ancestor.Namespace, ancestor.TypeName), ancestor.Level));
+                        }
+                        break;
                     case BindingExpressionGrammar.NameNode elementName:
                         IXamlType elementType = null;
                         foreach (var deferredContent in context.ParentNodes().OfType<NestedScopeMetadataNode>())

--- a/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
+++ b/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
@@ -20,7 +20,6 @@
       <Compile Include="MarkupExtensions\CompiledBindings\ArrayElementPlugin.cs" />
       <Compile Include="MarkupExtensions\CompiledBindings\CommandAccessorPlugin.cs" />
       <Compile Include="MarkupExtensions\CompiledBindings\CompiledBindingPath.cs" />
-      <Compile Include="MarkupExtensions\CompiledBindings\FindVisualAncestorNode.cs" />
       <Compile Include="MarkupExtensions\CompiledBindings\MethodAccessorPlugin.cs" />
       <Compile Include="MarkupExtensions\CompiledBindings\ObservableStreamPlugin.cs" />
       <Compile Include="MarkupExtensions\CompiledBindings\PropertyInfoAccessorFactory.cs" />

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindings/CompiledBindingPath.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindings/CompiledBindingPath.cs
@@ -292,6 +292,9 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
 
         public Type? AncestorType { get; }
         public int Level { get; }
+        
+        public override string ToString()
+            => FormattableString.Invariant($"$visualparent[{AncestorType?.Name},{Level}]");
     }
 
     internal class ElementNameElement : ICompiledBindingPathElement, IControlSourceBindingPathElement

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/ExpressionParser.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/ExpressionParser.cs
@@ -59,6 +59,9 @@ namespace Avalonia.Markup.Parsers
                     case BindingExpressionGrammar.AncestorNode ancestor:
                         nextNode = ParseFindAncestor(ancestor);
                         break;
+                    case BindingExpressionGrammar.VisualAncestorNode visualAncestor:
+                        nextNode = ParseFindVisualAncestor(visualAncestor);
+                        break;
                     case BindingExpressionGrammar.NameNode elementName:
                         nextNode = new ElementNameNode(_nameScope ?? throw new NotSupportedException("Invalid element name binding with null name scope!"), elementName.Name);
                         break;
@@ -99,6 +102,21 @@ namespace Avalonia.Markup.Parsers
             }
 
             return new FindAncestorNode(ancestorType, ancestorLevel);
+        }
+
+        private FindVisualAncestorNode ParseFindVisualAncestor(BindingExpressionGrammar.VisualAncestorNode node)
+        {
+            Type? ancestorType = null;
+            var ancestorLevel = node.Level;
+            if (!string.IsNullOrEmpty(node.TypeName))
+            {
+                if (_typeResolver == null)
+                {
+                    throw new InvalidOperationException("Cannot parse a binding path with a typed FindAncestor without a type resolver. Maybe you can use a LINQ Expression binding path instead?");
+                }
+                ancestorType = _typeResolver(node.Namespace, node.TypeName);
+            }
+            return new FindVisualAncestorNode(ancestorType, ancestorLevel);
         }
 
         private TypeCastNode ParseTypeCastNode(BindingExpressionGrammar.TypeCastNode node)

--- a/src/Markup/Avalonia.Markup/Markup/Parsers/Nodes/FindVisualAncestorNode.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/Nodes/FindVisualAncestorNode.cs
@@ -3,7 +3,7 @@ using Avalonia.Data.Core;
 using Avalonia.VisualTree;
 using Avalonia.Reactive;
 
-namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
+namespace Avalonia.Markup.Parsers.Nodes
 {
     internal class FindVisualAncestorNode : ExpressionNode
     {

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BindingTests_RelativeSource.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/BindingTests_RelativeSource.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.UnitTests;
 using System;
+using Avalonia.Media;
 using Xunit;
 
 namespace Avalonia.Markup.Xaml.UnitTests.Xaml
@@ -70,6 +71,31 @@ namespace Avalonia.Markup.Xaml.UnitTests.Xaml
                 window.Presenter.ApplyTemplate();
 
                 Assert.Equal("border2", button.Content);
+            }
+        }
+        
+        [Fact]
+        public void Binding_To_First_VisualAncestor_Works()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+    <ContentControl Name='border1' Background='Red'>
+      <ContentControl Name='border2' Background='Green'>
+        <Button Name='button' Background='{Binding $parent[ContentControl].Background}'/>
+      </ContentControl>
+    </ContentControl>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var button = window.FindControl<Button>("button");
+                var content = window.FindControl<ContentControl>("border2");
+
+                window.ApplyTemplate();
+                
+                Assert.Equal(Brushes.Green, button.Background);
             }
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Since `$parent` only works on logical tree, so `$visualparent` is needed to find relative resource on visual tree. Most related code is available in code base, so I just add them back in parsing logic.  


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
