### PR TITLE
#13123 Fix ButtonSpinnerLocation in SimpleTheme

### DIFF
--- a/src/Avalonia.Themes.Simple/Controls/ButtonSpinner.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/ButtonSpinner.xaml
@@ -71,7 +71,7 @@
       </ControlTemplate>
     </Setter>
     <Style Selector="^:left">
-      <Style Selector="^ /template/ StackPanel#PART_SpinnerPanel">
+      <Style Selector="^ /template/ UniformGrid#PART_SpinnerPanel">
         <Setter Property="DockPanel.Dock" Value="Left" />
       </Style>
     </Style>


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes ButtonSpinnerLocation in SimpleTheme so that it works as expected when set to Location.Left. See #13123.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Setting ButtonSpinner's ButtonSpinnerLocation to Location.Left has no effect when using the Simple theme.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Setting ButtonSpinner's ButtonSpinnerLocation to Location.Left should move the spinner buttons to the left side of the content.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Fixed the selector for the style that is supposed to move the spinner buttons. It specifies a `StackPanel#PART_SpinnerPanel` but the control in the template with that name is a `UniformGrid`, so it doesn't match anything.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

I don't think any of these apply.

## Breaking changes
<!--- List any breaking changes here. -->
None.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
None.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #13123 