### PR TITLE
fix: ProgressBar indeterminate animation is not running when IsVisible=false

### DIFF
--- a/src/Avalonia.Controls/ProgressBar.cs
+++ b/src/Avalonia.Controls/ProgressBar.cs
@@ -5,7 +5,6 @@ using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Layout;
-using Avalonia.Media;
 using Avalonia.Reactive;
 
 namespace Avalonia.Controls
@@ -313,8 +312,13 @@ namespace Avalonia.Controls
 
             if (change.Property == IsIndeterminateProperty)
             {
-                UpdatePseudoClasses(change.GetNewValue<bool>(), null);
+                UpdatePseudoClasses(change.GetNewValue<bool>() && IsVisible, null);
             }
+            if (change.Property == IsVisibleProperty)
+            {
+                UpdatePseudoClasses(change.GetNewValue<bool>() && IsIndeterminate, null);
+            }
+
             else if (change.Property == OrientationProperty)
             {
                 UpdatePseudoClasses(null, change.GetNewValue<Orientation>());

--- a/tests/Avalonia.Controls.UnitTests/ProgressBarTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ProgressBarTests.cs
@@ -1,0 +1,21 @@
+﻿using Xunit;
+
+namespace Avalonia.Controls.UnitTests;
+
+public class ProgressBarTests
+{
+    [Fact]
+    public void Indeterminate_Animation_Is_Not_Running_When_IsVisible_false()
+    {
+        var progressBar = new ProgressBar()
+        {
+            IsIndeterminate = true,
+        };
+
+        Assert.Contains(":indeterminate", progressBar.Classes);
+
+        progressBar.IsVisible = false;
+
+        Assert.DoesNotContain(":indeterminate", progressBar.Classes);
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

ProgressBar indeterminate animation is not running when IsVisible=false

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

ProgressBar indeterminate animation is running when IsVisible=false

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Remove :indeterminate PseudoClasses when IsIndeterminate is true and IsVisible is false

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #13139
Closes #12777
