### PR TITLE
Remove viewport estimation from VirtualizingStackPanel

### DIFF
--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -55,7 +55,6 @@ namespace Avalonia.Controls
         private static readonly AttachedProperty<object?> RecycleKeyProperty =
             AvaloniaProperty.RegisterAttached<VirtualizingStackPanel, Control, object?>("RecycleKey");
 
-        private static readonly Rect s_invalidViewport = new(double.PositiveInfinity, double.PositiveInfinity, 0, 0);
         private static readonly object s_itemIsItsOwnContainer = new object();
         private readonly Action<Control, int> _recycleElement;
         private readonly Action<Control> _recycleElementOnItemRemoved;
@@ -68,7 +67,7 @@ namespace Avalonia.Controls
         private RealizedStackElements? _measureElements;
         private RealizedStackElements? _realizedElements;
         private IScrollAnchorProvider? _scrollAnchorProvider;
-        private Rect _viewport = s_invalidViewport;
+        private Rect _viewport;
         private Dictionary<object, Stack<Control>>? _recyclePool;
         private Control? _focusedElement;
         private int _focusedIndex = -1;
@@ -438,18 +437,17 @@ namespace Avalonia.Controls
 
             // If the control has not yet been laid out then the effective viewport won't have been set.
             // Try to work it out from an ancestor control.
-            var viewport = _viewport != s_invalidViewport ? _viewport : EstimateViewport();
+            var viewport = _viewport;
 
             // Get the viewport in the orientation direction.
             var viewportStart = Orientation == Orientation.Horizontal ? viewport.X : viewport.Y;
             var viewportEnd = Orientation == Orientation.Horizontal ? viewport.Right : viewport.Bottom;
 
             // Get or estimate the anchor element from which to start realization.
-            var itemCount = items?.Count ?? 0;
             var (anchorIndex, anchorU) = _realizedElements.GetOrEstimateAnchorElementForViewport(
                 viewportStart,
                 viewportEnd,
-                itemCount,
+                items.Count,
                 ref _lastEstimatedElementSizeU);
 
             // Check if the anchor element is not within the currently realized elements.
@@ -489,32 +487,6 @@ namespace Avalonia.Controls
             if (result >= 0)
                 _lastEstimatedElementSizeU = result;
             return _lastEstimatedElementSizeU;
-        }
-
-        private Rect EstimateViewport()
-        {
-            var c = this.GetVisualParent();
-            var viewport = new Rect();
-
-            if (c is null)
-            {
-                return viewport;
-            }
-
-            while (c is not null)
-            {
-                if ((c.Bounds.Width != 0 || c.Bounds.Height != 0) &&
-                    c.TransformToVisual(this) is Matrix transform)
-                {
-                    viewport = new Rect(0, 0, c.Bounds.Width, c.Bounds.Height)
-                        .TransformToAABB(transform);
-                    break;
-                }
-
-                c = c?.GetVisualParent();
-            }
-
-            return viewport.Intersect(new Rect(0, 0, double.PositiveInfinity, double.PositiveInfinity));
         }
 
         private void RealizeElements(

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
@@ -815,6 +815,34 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(3, target.Children.Count);
         }
 
+        // https://github.com/AvaloniaUI/Avalonia/issues/10968
+        [Fact]
+        public void Does_Not_Realize_Items_If_Self_Outside_Viewport()
+        {
+            using var app = App();
+            var (panel, _, itemsControl) = CreateUnrootedTarget<ItemsControl>();
+            itemsControl.Margin = new Thickness(0.0, 200.0, 0.0, 0.0);
+
+            var scrollContentPresenter = new ScrollContentPresenter
+            {
+                Width = 100,
+                Height = 100,
+                Content = itemsControl
+            };
+
+            var root = CreateRoot(scrollContentPresenter);
+            root.LayoutManager.ExecuteInitialLayoutPass();
+            Assert.Equal(1, panel.VisualChildren.Count);
+
+            scrollContentPresenter.Content = null;
+            root.LayoutManager.ExecuteLayoutPass();
+
+            scrollContentPresenter.Content = itemsControl;
+            root.LayoutManager.ExecuteLayoutPass();
+
+            Assert.Equal(1, panel.VisualChildren.Count);
+        }
+
         private static IReadOnlyList<int> GetRealizedIndexes(VirtualizingStackPanel target, ItemsControl itemsControl)
         {
             return target.GetRealizedElements()


### PR DESCRIPTION
## What does the pull request do?
This PR removes the viewport estimation in `VirtualizingStackPanel`, which could be wrong, especially in nested scroll viewers.

## What is the current behavior?
When inside a `ScrollContentPresenter`, `VirtualizingStackPanel.EstimateViewport()` tries to estimate its viewport when it doesn't have one (it just got attached to the visual tree), and can incorrectly estimate a very large viewport, effectively realizing all items. See https://github.com/AvaloniaUI/Avalonia/issues/10968#issuecomment-1751995359 or the added unit test for a simple reproduction.

## What is the updated/expected behavior with this PR?
With this PR, we don't try to estimate the parent viewport at all. If we don't have one, it's an empty viewport.

While we can refine the estimation to better handle scrollable containers, I don't think it's worth it. Let me explain:
 - It would involve knowing how each parent control in the hierarchy has arranged its children, reversing the usual roles.
 - The estimation uses the parent bounds. It means a full layout pass (measure + arrange) already occurred previously. When calling `EstimateViewport`, we're in a new measure pass: the arrange pass hasn't run yet, which means the parents bounds might change right after the estimation. In this case, we might still realize totally unneeded items, even with a better estimate.
 - This estimation never applies on the first layout pass: nothing has a size yet, so we get an empty viewport. With this PR, this is also the behavior everytime the `VirtualizingStackPanel` gets attached to an already arranged visual tree. An empty viewport means we're doing nothing[^1], and that is cheap. We can wait to have a proper viewport to realize the items properly.

[^1]: well, not *exactly*, the first item is always realized even with an empty viewport, but that's another issue.

Pinging @grokys to ensure there's nothing obvious I'm missing here.
 
A unit test has been added.

## Fixed issues
 - Fixes #10968
