### PR TITLE
Fix AccessKeyHandler matching on elements that are not effectively enabled.

### DIFF
--- a/src/Avalonia.Base/Input/AccessKeyHandler.cs
+++ b/src/Avalonia.Base/Input/AccessKeyHandler.cs
@@ -183,7 +183,8 @@ namespace Avalonia.Input
                 var text = e.Key.ToString();
                 var matches = _registered
                     .Where(x => string.Equals(x.AccessKey, text, StringComparison.OrdinalIgnoreCase)
-                        && x.Element.IsEffectivelyVisible)
+                        && x.Element.IsEffectivelyVisible
+                        && x.Element.IsEffectivelyEnabled)
                     .Select(x => x.Element);
 
                 // If the menu is open, only match controls in the menu's visual tree.

--- a/tests/Avalonia.Base.UnitTests/Input/AccessKeyHandlerTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/AccessKeyHandlerTests.cs
@@ -166,6 +166,30 @@ namespace Avalonia.Base.UnitTests.Input
         }
 
         [Fact]
+        public void Should_Not_Raise_AccessKeyPressed_For_Registered_Access_Key_When_Not_Effectively_Enabled()
+        {
+            var button = new Button();
+            var root = new TestRoot(button) { IsEnabled = false };
+            var target = new AccessKeyHandler();
+            var raised = 0;
+
+            target.SetOwner(root);
+            target.Register('A', button);
+            button.AddHandler(AccessKeyHandler.AccessKeyPressedEvent, (s, e) => ++raised);
+
+            KeyDown(root, Key.LeftAlt);
+            Assert.Equal(0, raised);
+
+            KeyDown(root, Key.A, KeyModifiers.Alt);
+            Assert.Equal(0, raised);
+
+            KeyUp(root, Key.A, KeyModifiers.Alt);
+            KeyUp(root, Key.LeftAlt);
+
+            Assert.Equal(0, raised);
+        }
+
+        [Fact]
         public void Should_Open_MainMenu_On_Alt_KeyUp()
         {
             var root = new TestRoot();


### PR DESCRIPTION
## What does the pull request do?
Updates `AccessKeyHandler` so that, when attempting to match an `IInputElement` for an access key, it ignores any element that is effectively disabled.


## What is the current behavior?
`AccessKeyHandler` matches the first registered element, even if it is disabled and another match is enabled.


## What is the updated/expected behavior with this PR?
`AccessKeyHandler` matches the first registered element that is enabled. This is also consistent with WPF.


## How was the solution implemented (if it's not obvious)?
Added an additional condition to the match logic.


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #13184 
