### PR TITLE
Rethrow layout exceptions

### DIFF
--- a/src/Avalonia.Base/Media/MediaContext.cs
+++ b/src/Avalonia.Base/Media/MediaContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Avalonia.Layout;
 using Avalonia.Rendering;
 using Avalonia.Rendering.Composition;
@@ -90,9 +91,10 @@ internal partial class MediaContext : ICompositorScheduler
         {
             priority = DispatcherPriority.Input;
         }
-        
 
-        _nextRenderOp = _dispatcher.InvokeAsync(_render, priority);
+        var renderOp = new DispatcherOperation(_dispatcher, priority, _render, throwOnUiThread: true);
+        _nextRenderOp = renderOp;
+        _dispatcher.InvokeAsyncImpl(renderOp, CancellationToken.None);
     }
     
     /// <summary>


### PR DESCRIPTION
## What does the pull request do?
This PR ensures that any exception thrown during a layout pass is rethrown.

## What is the current behavior?
Currently, an exception occurring during a layout pass is completely swallowed. The layout manager is usually unusable after such an exception, and rendering stops. 

Whether the problem is in user code (#12388) or Avalonia code (#13182), having nothing reported makes it very difficult for users to understand what's wrong.

## What is the updated/expected behavior with this PR?
Exceptions thrown in the layout pass are correctly rethrown.

## Breaking changes
Since applications will now crash instead of being in a crashed state with nothing working, this PR is technically a behavioral change.

## Fixed issues
 - Fixes #12388
 - Fixes #13200 
