### PR TITLE
Introduce AppBuilder extension to customize system fonts

### DIFF
--- a/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
+++ b/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
@@ -67,22 +67,14 @@ namespace Avalonia.Media.Fonts
             //We initialize the system font collection during construction.
         }
 
-        public void AddCustomFontFamilies(IReadOnlyList<FontFamily> customFontFamilies)
+        public void AddCustomFontSource(Uri source)
         {
-            if (customFontFamilies is null)
+            if (source is null)
             {
                 return;
             }
 
-            for (int i = 0; i < customFontFamilies.Count; i++)
-            {
-                var fontFamily = customFontFamilies[i];
-
-                if (fontFamily.Key is FontFamilyKey key)
-                {
-                    LoadGlyphTypefaces(_fontManager.PlatformImpl, key.Source);
-                }
-            }
+            LoadGlyphTypefaces(_fontManager.PlatformImpl, source);
         }
 
         private void LoadGlyphTypefaces(IFontManagerImpl fontManager, Uri source)

--- a/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
+++ b/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Avalonia.Platform;
 
 namespace Avalonia.Media.Fonts
@@ -9,12 +10,12 @@ namespace Avalonia.Media.Fonts
     internal class SystemFontCollection : FontCollectionBase
     {
         private readonly FontManager _fontManager;
-        private readonly string[] _familyNames;
+        private readonly List<string> _familyNames;
 
         public SystemFontCollection(FontManager fontManager)
         {
             _fontManager = fontManager;
-            _familyNames = fontManager.PlatformImpl.GetInstalledFontFamilyNames();
+            _familyNames = fontManager.PlatformImpl.GetInstalledFontFamilyNames().ToList();
         }
 
         public override Uri Key => FontManager.SystemFontsKey;
@@ -29,7 +30,15 @@ namespace Avalonia.Media.Fonts
             }
         }
 
-        public override int Count => _familyNames.Length;
+        public override int Count => _familyNames.Count;
+
+        public override IEnumerator<FontFamily> GetEnumerator()
+        {
+            foreach (var familyName in _familyNames)
+            {
+                yield return new FontFamily(familyName);
+            }
+        }
 
         public override bool TryGetGlyphTypeface(string familyName, FontStyle style, FontWeight weight,
             FontStretch stretch, [NotNullWhen(true)] out IGlyphTypeface? glyphTypeface)
@@ -58,11 +67,54 @@ namespace Avalonia.Media.Fonts
             //We initialize the system font collection during construction.
         }
 
-        public override IEnumerator<FontFamily> GetEnumerator()
+        public void AddCustomFontFamilies(IReadOnlyList<FontFamily> customFontFamilies)
         {
-            foreach (var familyName in _familyNames)
+            if (customFontFamilies is null)
             {
-                yield return new FontFamily(familyName);
+                return;
+            }
+
+            for (int i = 0; i < customFontFamilies.Count; i++)
+            {
+                var fontFamily = customFontFamilies[i];
+
+                if (fontFamily.Key is FontFamilyKey key)
+                {
+                    LoadGlyphTypefaces(_fontManager.PlatformImpl, key.Source);
+                }
+            }
+        }
+
+        private void LoadGlyphTypefaces(IFontManagerImpl fontManager, Uri source)
+        {
+            var assetLoader = AvaloniaLocator.Current.GetRequiredService<IAssetLoader>();
+
+            var fontAssets = FontFamilyLoader.LoadFontAssets(source);
+
+            foreach (var fontAsset in fontAssets)
+            {
+                var stream = assetLoader.Open(fontAsset);
+
+                if (fontManager.TryCreateGlyphTypeface(stream, out var glyphTypeface))
+                {
+                    if (!_glyphTypefaceCache.TryGetValue(glyphTypeface.FamilyName, out var glyphTypefaces))
+                    {
+                        glyphTypefaces = new ConcurrentDictionary<FontCollectionKey, IGlyphTypeface?>();
+
+                        if (_glyphTypefaceCache.TryAdd(glyphTypeface.FamilyName, glyphTypefaces))
+                        {
+                            //Move the user defined system font to the start of the collection
+                            _familyNames.Insert(0, glyphTypeface.FamilyName);
+                        }
+                    }
+
+                    var key = new FontCollectionKey(
+                           glyphTypeface.Style,
+                           glyphTypeface.Weight,
+                           glyphTypeface.Stretch);
+
+                    glyphTypefaces.TryAdd(key, glyphTypeface);
+                }
             }
         }
     }

--- a/src/Avalonia.Controls/SystemFontAppBuilderExtension.cs
+++ b/src/Avalonia.Controls/SystemFontAppBuilderExtension.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using Avalonia.Media;
+using Avalonia.Media.Fonts;
+
+namespace Avalonia
+{
+    public static class SystemFontAppBuilderExtension
+    {
+        public static AppBuilder WithCustomSystemFonts(this AppBuilder appBuilder, IReadOnlyList<FontFamily> customFontFamilies)
+        {
+            return appBuilder.ConfigureFonts(fontManager =>
+            {
+                if(fontManager.SystemFonts is SystemFontCollection systemFontCollection)
+                {
+                    systemFontCollection.AddCustomFontFamilies(customFontFamilies);
+                }
+            });
+        }
+    }
+}

--- a/src/Avalonia.Controls/SystemFontAppBuilderExtension.cs
+++ b/src/Avalonia.Controls/SystemFontAppBuilderExtension.cs
@@ -5,7 +5,7 @@ namespace Avalonia
 {
     public static class SystemFontAppBuilderExtension
     {
-        public static AppBuilder WithCustomSystemFont(this AppBuilder appBuilder, Uri fontSource)
+        public static AppBuilder WithSystemFontSource(this AppBuilder appBuilder, Uri fontSource)
         {
             return appBuilder.ConfigureFonts(fontManager =>
             {

--- a/src/Avalonia.Controls/SystemFontAppBuilderExtension.cs
+++ b/src/Avalonia.Controls/SystemFontAppBuilderExtension.cs
@@ -1,18 +1,17 @@
-﻿using System.Collections.Generic;
-using Avalonia.Media;
+﻿using System;
 using Avalonia.Media.Fonts;
 
 namespace Avalonia
 {
     public static class SystemFontAppBuilderExtension
     {
-        public static AppBuilder WithCustomSystemFonts(this AppBuilder appBuilder, IReadOnlyList<FontFamily> customFontFamilies)
+        public static AppBuilder WithCustomSystemFont(this AppBuilder appBuilder, Uri fontSource)
         {
             return appBuilder.ConfigureFonts(fontManager =>
             {
                 if(fontManager.SystemFonts is SystemFontCollection systemFontCollection)
                 {
-                    systemFontCollection.AddCustomFontFamilies(customFontFamilies);
+                    systemFontCollection.AddCustomFontSource(fontSource);
                 }
             });
         }

--- a/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Linq;
 using Avalonia.Headless;
 using Avalonia.Media;
+using Avalonia.Media.Fonts;
 using Avalonia.UnitTests;
 using SkiaSharp;
 using Xunit;
@@ -214,6 +216,28 @@ namespace Avalonia.Skia.UnitTests.Media
                     Assert.NotNull(glyphTypeface);
 
                     Assert.Equal(FontManager.Current.DefaultFontFamily.Name, glyphTypeface.FamilyName);
+                }
+            }
+        }
+
+        [Fact]
+        public void Should_Use_Custom_SystemFont()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface.With(fontManagerImpl: new FontManagerImpl())))
+            {
+                using (AvaloniaLocator.EnterScope())
+                {
+                    var systemFontCollection = FontManager.Current.SystemFonts as SystemFontCollection;
+
+                    Assert.NotNull(systemFontCollection);
+
+                    var customFontFamilies = new[] { new FontFamily(s_fontUri) };
+
+                    systemFontCollection.AddCustomFontFamilies(customFontFamilies);
+
+                    Assert.True(FontManager.Current.TryGetGlyphTypeface(new Typeface("Noto Mono"), out var glyphTypeface));
+
+                    Assert.Equal("Noto Mono", glyphTypeface.FamilyName);
                 }
             }
         }

--- a/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
@@ -231,9 +231,7 @@ namespace Avalonia.Skia.UnitTests.Media
 
                     Assert.NotNull(systemFontCollection);
 
-                    var customFontFamilies = new[] { new FontFamily(s_fontUri) };
-
-                    systemFontCollection.AddCustomFontFamilies(customFontFamilies);
+                    systemFontCollection.AddCustomFontSource(new Uri(s_fontUri, UriKind.Absolute));
 
                     Assert.True(FontManager.Current.TryGetGlyphTypeface(new Typeface("Noto Mono"), out var glyphTypeface));
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR introduces an option to customize the system font collection to be able to reference custom fonts as they were installed on the system

Add the font:
`.WithSystemFontSource(new Uri("avares://Avalonia.Fonts.Inter/Assets", UriKind.Absolute))`
Use it like so:
`FontFamily="Inter"`

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
