### PR TITLE
Fix text wrapping for chinese etc.

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
@@ -607,19 +607,19 @@ namespace Avalonia.Media.TextFormatting
                                         }
 
                                         break;
-                                    }                              
+                                    }
 
                                     var clusterLength = Math.Max(0, nextInfo.GlyphCluster - currentInfo.GlyphCluster);
 
-                                    if(clusterLength == 0)
+                                    if (clusterLength == 0)
                                     {
                                         clusterLength = currentRun.Length - runLength;
                                     }
 
-                                    if(clusterLength == 0)
+                                    if (clusterLength == 0)
                                     {
                                         clusterLength = shapedTextCharacters.GlyphRun.Metrics.FirstCluster + currentRun.Length - currentInfo.GlyphCluster;
-                                    }   
+                                    }
 
                                     if (currentWidth + clusterWidth > paragraphWidth)
                                     {
@@ -713,7 +713,7 @@ namespace Avalonia.Media.TextFormatting
 
             var measuredLength = MeasureLength(textRuns, paragraphWidth);
 
-            if(measuredLength == 0 && paragraphProperties.TextWrapping == TextWrapping.WrapWithOverflow)
+            if (measuredLength == 0 && paragraphProperties.TextWrapping == TextWrapping.WrapWithOverflow)
             {
                 for (int i = 0; i < textRuns.Count; i++)
                 {
@@ -841,7 +841,7 @@ namespace Avalonia.Media.TextFormatting
                                     break;
                                 }
 
-                                if (lineBreak.PositionMeasure != lineBreak.PositionWrap)
+                                if (lineBreak.PositionMeasure != lineBreak.PositionWrap || lineBreak.PositionWrap != currentRun.Length)
                                 {
                                     lastWrapPosition = currentLength + lineBreak.PositionWrap;
                                 }
@@ -856,12 +856,6 @@ namespace Avalonia.Media.TextFormatting
                     currentLength += currentRun.Length;
 
                     continue;
-                }
-
-                //We don't want to surpass the measuredLength with trailing whitespace when we are in a right to left setting.
-                if(currentPosition > measuredLength && resolvedFlowDirection == FlowDirection.RightToLeft)
-                {
-                    break;
                 }
 
                 measuredLength = currentPosition;

--- a/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/TextFormatting/TextFormatterTests.cs
@@ -822,6 +822,22 @@ namespace Avalonia.Skia.UnitTests.Media.TextFormatting
             
         }
 
+        [Fact]
+        public void Should_Wrap_Chinese()
+        {
+            using (Start())
+            {
+                var defaultRunProperties = new GenericTextRunProperties(Typeface.Default);
+                var paragraphProperties = new GenericTextParagraphProperties(defaultRunProperties, textWrap: TextWrapping.Wrap);
+
+                var text = "一二三四 TEXT 一二三四五六七八九十零";
+
+                var textLine = TextFormatter.Current.FormatLine(new SimpleTextSource(text, defaultRunProperties), 0, 120, paragraphProperties);
+
+                Assert.Equal(3, textLine.TextRuns.Count);
+            }
+        }
+
         protected readonly record struct SimpleTextSource : ITextSource
         {
             private readonly string _text;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
The previous implementation assumed that PositionMeasure and PositionWrap need to be different for a valid last break position. This is not true for languages that can break at every character `PositionMeasure == PositionWrap`

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes: #13166
Fixes: #12113