### PR TITLE
Fix macOS clipboard formats mapping

### DIFF
--- a/native/Avalonia.Native/src/OSX/clipboard.mm
+++ b/native/Avalonia.Native/src/OSX/clipboard.mm
@@ -42,6 +42,22 @@ public:
         }
     }
     
+    virtual HRESULT SetStrings(char* type, IAvnStringArray*ppv) override
+    {
+        START_COM_CALL;
+        
+        @autoreleasepool
+        {
+            NSArray<NSString*>* data = GetNSArrayOfStringsAndRelease(ppv);
+            NSString* typeString = [NSString stringWithUTF8String:(const char*)type];
+            if(_item == nil)
+                [_pb setPropertyList: data forType: typeString];
+            else
+                [_item setPropertyList: data forType:typeString];
+            return S_OK;
+        }
+    }
+    
     virtual HRESULT GetStrings(char* type, IAvnStringArray**ppv) override
     {
         START_COM_CALL;

--- a/src/Avalonia.Base/Input/DataFormats.cs
+++ b/src/Avalonia.Base/Input/DataFormats.cs
@@ -22,7 +22,7 @@ namespace Avalonia.Input
         /// <remarks>
         /// This data format is supported only on desktop platforms.
         /// </remarks>
-        [Unstable("Use DataFormats.Files, this format is supported only on desktop platforms. And it will be removed in 12.0"), EditorBrowsable(EditorBrowsableState.Never)]
+        [Unstable("Use DataFormats.Files, this format is supported only on desktop platforms. And it will be removed in 12.0."), EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly string FileNames = nameof(FileNames);
     }
 }

--- a/src/Avalonia.Base/Input/DataFormats.cs
+++ b/src/Avalonia.Base/Input/DataFormats.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using Avalonia.Metadata;
 
 namespace Avalonia.Input
 {
@@ -18,7 +19,10 @@ namespace Avalonia.Input
         /// <summary>
         /// Dataformat for one or more filenames
         /// </summary>
-        [Obsolete("Use DataFormats.Files, this format is supported only on desktop platforms."), EditorBrowsable(EditorBrowsableState.Never)]
+        /// <remarks>
+        /// This data format is supported only on desktop platforms.
+        /// </remarks>
+        [Unstable("Use DataFormats.Files, this format is supported only on desktop platforms. And it will be removed in 12.0"), EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly string FileNames = nameof(FileNames);
     }
 }

--- a/src/Avalonia.Native/AvaloniaNativeDragSource.cs
+++ b/src/Avalonia.Native/AvaloniaNativeDragSource.cs
@@ -48,10 +48,9 @@ namespace Avalonia.Native
             using (var clipboard = new ClipboardImpl(clipboardImpl))
             using (var cb = new DndCallback(tcs))
             {
-                if (data.Contains(DataFormats.Text))
-                    // API is synchronous, so it's OK
-                    clipboard.SetTextAsync(data.GetText()).Wait();
-                
+                // Native API is synchronous, so it's OK. For now.
+                clipboard.SetDataObjectAsync(data).GetAwaiter().GetResult();
+
                 view.BeginDraggingSession((AvnDragDropEffects)allowedEffects,
                     triggerEvent.GetPosition(tl).ToAvnPoint(), clipboardImpl, cb,
                     GCHandle.ToIntPtr(GCHandle.Alloc(data)));

--- a/src/Avalonia.Native/ClipboardImpl.cs
+++ b/src/Avalonia.Native/ClipboardImpl.cs
@@ -94,19 +94,20 @@ namespace Avalonia.Native
         {
             _native.Clear();
 
+            // If there is multiple values with the same "to" format, prefer these that were not mapped.
             var formats = data.GetDataFormats().Select(f =>
                 {
-                    string fromFormat, toFormat;
-                    bool wasMapped;
+                    string from, to;
+                    bool mapped;
                     if (f == DataFormats.Text)
-                        (fromFormat, toFormat, wasMapped) = (f, NSPasteboardTypeString, true);
+                        (from, to, mapped) = (f, NSPasteboardTypeString, true);
                     else if (f == DataFormats.Files || f == DataFormats.FileNames)
-                        (fromFormat, toFormat, wasMapped) = (f, NSFilenamesPboardType, true);
-                    else (fromFormat, toFormat, wasMapped) = (fromFormat: f, toFormat: f, wasMapped: false);
-                    return (fromFormat, toFormat, wasMapped);
+                        (from, to, mapped) = (f, NSFilenamesPboardType, true);
+                    else (from, to, mapped) = (f, f, false);
+                    return (from, to, mapped);
                 })
-                .GroupBy(p => p.toFormat)
-                .Select(g => g.OrderBy(f => !f.wasMapped).First());
+                .GroupBy(p => p.to)
+                .Select(g => g.OrderBy(f => f.mapped).First());
                 
             
             foreach (var (fromFormat, toFormat, _) in formats)

--- a/src/Avalonia.Native/ClipboardImpl.cs
+++ b/src/Avalonia.Native/ClipboardImpl.cs
@@ -171,5 +171,7 @@ namespace Avalonia.Native
         public bool Contains(string dataFormat) => Formats.Contains(dataFormat);
 
         public object Get(string dataFormat) => _clipboard.GetDataAsync(dataFormat).GetAwaiter().GetResult();
+
+        public Task SetFromDataObjectAsync(IDataObject dataObject) => _clipboard.SetDataObjectAsync(dataObject);
     }
 }

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -908,6 +908,7 @@ interface IAvnClipboard : IUnknown
      HRESULT SetText(char* type, char* utf8Text);
      HRESULT ObtainFormats(IAvnStringArray**ppv);
      HRESULT GetStrings(char* type, IAvnStringArray**ppv);
+     HRESULT SetStrings(char* type, IAvnStringArray*ppv);
      HRESULT SetBytes(char* type, void* utf8Text, int len);
      HRESULT GetBytes(char* type, IAvnString**ppv);
     


### PR DESCRIPTION
## What does the pull request do?

1. Support data formats mapping from GetDataFormats method. Previously this method only returned native data types, while SetObject/GetObject did properly map data formats (in some cases). This PR fixes inconsistency.
2. Fix IStorageItem collections support.
3. Support more than just text values when Avalonia is a DnD source.
4. Adds warnings if unsupported CLR type was pushed into an IDataObject.

## Checklist

- [x] Manual testing

## Breaking changes

None.

## Obsoletions / Deprecations

DataFormats.FileNames previously was Obsolete, but now it's Unstable+Obsolete. This way we won't have warnings in Avalonia source code when using FileNames.

## Fixed issues

Fixes #11632