### PR TITLE
feat(Gestures): Allow using some `Gestures`  events in Xaml

### DIFF
--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -159,6 +159,9 @@ namespace Avalonia.Input
         public static void AddScrollGestureHandler(Interactive element, EventHandler<RoutedEventArgs> handler) =>
             element.AddHandler(ScrollGestureEvent, handler);
 
+        public static void AddScrollGestureEndedHandler(Interactive element, EventHandler<ScrollGestureEndedEventArgs> handler) =>
+            element.AddHandler(ScrollGestureEndedEvent, handler);
+
         public static void RemoveTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
         {
             element.RemoveHandler(TappedEvent, handler);
@@ -200,6 +203,9 @@ namespace Avalonia.Input
 
         public static void RemoveScrollGestureHandler(Interactive element, EventHandler<ScrollGestureEventArgs> handler) =>
             element.RemoveHandler(ScrollGestureEvent,handler);
+
+        public static void RemoveScrollGestureEndedHandler(Interactive element,EventHandler<ScrollGestureEndedEventArgs> handler) =>
+            element.RemoveHandler(ScrollGestureEndedEvent,handler);
 
         private static void PointerPressed(RoutedEventArgs ev)
         {

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -156,6 +156,9 @@ namespace Avalonia.Input
         public static void AddPointerTouchPadGestureSwipeHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
             element.AddHandler(PointerTouchPadGestureSwipeEvent, handler);
 
+        public static void AddScrollGestureHandler(Interactive element, EventHandler<RoutedEventArgs> handler) =>
+            element.AddHandler(ScrollGestureEvent, handler);
+
         public static void RemoveTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
         {
             element.RemoveHandler(TappedEvent, handler);
@@ -194,6 +197,9 @@ namespace Avalonia.Input
 
         public static void RemovePointerTouchPadGestureSwipeHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
             element.RemoveHandler(PointerTouchPadGestureSwipeEvent, handler);
+
+        public static void RemoveScrollGestureHandler(Interactive element, EventHandler<ScrollGestureEventArgs> handler) =>
+            element.RemoveHandler(ScrollGestureEvent,handler);
 
         private static void PointerPressed(RoutedEventArgs ev)
         {

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -147,6 +147,9 @@ namespace Avalonia.Input
         public static void AddPullGestureEndedHandler(Interactive element, EventHandler<PullGestureEndedEventArgs> handler) =>
             element.AddHandler(PullGestureEndedEvent, handler);
 
+        public static void AddPointerTouchPadGestureMagnifyHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
+            element.AddHandler(PointerTouchPadGestureMagnifyEvent, handler);
+
         public static void RemoveTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
         {
             element.RemoveHandler(TappedEvent, handler);
@@ -176,6 +179,9 @@ namespace Avalonia.Input
 
         public static void RemovePullGestureEndedHandler(Interactive element, EventHandler<PullGestureEndedEventArgs> handler) =>
             element.RemoveHandler(PullGestureEndedEvent, handler);
+
+        public static void RemovePointerTouchPadGestureMagnifyHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
+            element.RemoveHandler(PointerTouchPadGestureMagnifyEvent, handler);
 
         private static void PointerPressed(RoutedEventArgs ev)
         {

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -162,6 +162,9 @@ namespace Avalonia.Input
         public static void AddScrollGestureEndedHandler(Interactive element, EventHandler<ScrollGestureEndedEventArgs> handler) =>
             element.AddHandler(ScrollGestureEndedEvent, handler);
 
+        public static void AddScrollGestureInertiaStartingHandler(Interactive element, EventHandler<ScrollGestureInertiaStartingEventArgs> handler) =>
+            element.AddHandler(ScrollGestureInertiaStartingEvent, handler);
+
         public static void RemoveTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
         {
             element.RemoveHandler(TappedEvent, handler);
@@ -206,6 +209,9 @@ namespace Avalonia.Input
 
         public static void RemoveScrollGestureEndedHandler(Interactive element,EventHandler<ScrollGestureEndedEventArgs> handler) =>
             element.RemoveHandler(ScrollGestureEndedEvent,handler);
+
+        public static void RemoveScrollGestureInertiaStartingHandler(Interactive element, EventHandler<ScrollGestureInertiaStartingEventArgs> handler) =>
+            element.RemoveHandler(ScrollGestureInertiaStartingEvent, handler);
 
         private static void PointerPressed(RoutedEventArgs ev)
         {

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -132,6 +132,8 @@ namespace Avalonia.Input
             element.AddHandler(RightTappedEvent, handler);
         }
 
+        public static void AddHoldingHandler(Interactive element, EventHandler<HoldingRoutedEventArgs> handler) =>
+            element.AddHandler(HoldingEvent, handler);
         public static void RemoveTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
         {
             element.RemoveHandler(TappedEvent, handler);
@@ -147,6 +149,8 @@ namespace Avalonia.Input
             element.RemoveHandler(RightTappedEvent, handler);
         }
 
+        public static void RemoveHoldingHandler(Interactive element, EventHandler<RoutedEventArgs> handler) =>
+            element.RemoveHandler(HoldingEvent, handler);
         private static void PointerPressed(RoutedEventArgs ev)
         {
             if (ev.Source is null)

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -144,6 +144,9 @@ namespace Avalonia.Input
         public static void AddPullGestureHandler(Interactive element, EventHandler<PullGestureEventArgs> handler) =>
             element.AddHandler(PullGestureEvent, handler);
 
+        public static void AddPullGestureEndedHandler(Interactive element, EventHandler<PullGestureEndedEventArgs> handler) =>
+            element.AddHandler(PullGestureEndedEvent, handler);
+
         public static void RemoveTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
         {
             element.RemoveHandler(TappedEvent, handler);
@@ -170,6 +173,9 @@ namespace Avalonia.Input
 
         public static void RemovePullGestureHandler(Interactive element, EventHandler<PullGestureEventArgs> handler) =>
             element.RemoveHandler(PullGestureEvent, handler);
+
+        public static void RemovePullGestureEndedHandler(Interactive element, EventHandler<PullGestureEndedEventArgs> handler) =>
+            element.RemoveHandler(PullGestureEndedEvent, handler);
 
         private static void PointerPressed(RoutedEventArgs ev)
         {

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -134,6 +134,9 @@ namespace Avalonia.Input
 
         public static void AddHoldingHandler(Interactive element, EventHandler<HoldingRoutedEventArgs> handler) =>
             element.AddHandler(HoldingEvent, handler);
+
+        public static void AddPinchHandler(Interactive element, EventHandler<PinchEventArgs> handler) =>
+            element.AddHandler(PinchEvent, handler);
         public static void RemoveTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
         {
             element.RemoveHandler(TappedEvent, handler);
@@ -151,6 +154,10 @@ namespace Avalonia.Input
 
         public static void RemoveHoldingHandler(Interactive element, EventHandler<RoutedEventArgs> handler) =>
             element.RemoveHandler(HoldingEvent, handler);
+
+        public static void RemovePinchHandler(Interactive element, EventHandler<PinchEventArgs> handler) =>
+            element.RemoveHandler(PinchEvent, handler);
+
         private static void PointerPressed(RoutedEventArgs ev)
         {
             if (ev.Source is null)

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -153,6 +153,9 @@ namespace Avalonia.Input
         public static void AddPointerTouchPadGestureRotateHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
             element.AddHandler(PointerTouchPadGestureRotateEvent, handler);
 
+        public static void AddPointerTouchPadGestureSwipeHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
+            element.AddHandler(PointerTouchPadGestureSwipeEvent, handler);
+
         public static void RemoveTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
         {
             element.RemoveHandler(TappedEvent, handler);
@@ -188,6 +191,9 @@ namespace Avalonia.Input
 
         public static void RemovePointerTouchPadGestureRotateHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
             element.RemoveHandler(PointerTouchPadGestureRotateEvent, handler);
+
+        public static void RemovePointerTouchPadGestureSwipeHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
+            element.RemoveHandler(PointerTouchPadGestureSwipeEvent, handler);
 
         private static void PointerPressed(RoutedEventArgs ev)
         {

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -150,6 +150,9 @@ namespace Avalonia.Input
         public static void AddPointerTouchPadGestureMagnifyHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
             element.AddHandler(PointerTouchPadGestureMagnifyEvent, handler);
 
+        public static void AddPointerTouchPadGestureRotateHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
+            element.AddHandler(PointerTouchPadGestureRotateEvent, handler);
+
         public static void RemoveTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
         {
             element.RemoveHandler(TappedEvent, handler);
@@ -182,6 +185,9 @@ namespace Avalonia.Input
 
         public static void RemovePointerTouchPadGestureMagnifyHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
             element.RemoveHandler(PointerTouchPadGestureMagnifyEvent, handler);
+
+        public static void RemovePointerTouchPadGestureRotateHandler(Interactive element, EventHandler<PointerDeltaEventArgs> handler) =>
+            element.RemoveHandler(PointerTouchPadGestureRotateEvent, handler);
 
         private static void PointerPressed(RoutedEventArgs ev)
         {

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -137,6 +137,10 @@ namespace Avalonia.Input
 
         public static void AddPinchHandler(Interactive element, EventHandler<PinchEventArgs> handler) =>
             element.AddHandler(PinchEvent, handler);
+
+        public static void AddPinchEndedHandler(Interactive element, EventHandler<PinchEndedEventArgs> handler) =>
+            element.AddHandler(PinchEndedEvent, handler);
+
         public static void RemoveTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
         {
             element.RemoveHandler(TappedEvent, handler);
@@ -157,6 +161,9 @@ namespace Avalonia.Input
 
         public static void RemovePinchHandler(Interactive element, EventHandler<PinchEventArgs> handler) =>
             element.RemoveHandler(PinchEvent, handler);
+
+        public static void RemovePinchEndedHandler(Interactive element, EventHandler<PinchEndedEventArgs> handler) =>
+            element.RemoveHandler(PinchEndedEvent, handler);
 
         private static void PointerPressed(RoutedEventArgs ev)
         {

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -141,6 +141,9 @@ namespace Avalonia.Input
         public static void AddPinchEndedHandler(Interactive element, EventHandler<PinchEndedEventArgs> handler) =>
             element.AddHandler(PinchEndedEvent, handler);
 
+        public static void AddPullGestureHandler(Interactive element, EventHandler<PullGestureEventArgs> handler) =>
+            element.AddHandler(PullGestureEvent, handler);
+
         public static void RemoveTappedHandler(Interactive element, EventHandler<RoutedEventArgs> handler)
         {
             element.RemoveHandler(TappedEvent, handler);
@@ -164,6 +167,9 @@ namespace Avalonia.Input
 
         public static void RemovePinchEndedHandler(Interactive element, EventHandler<PinchEndedEventArgs> handler) =>
             element.RemoveHandler(PinchEndedEvent, handler);
+
+        public static void RemovePullGestureHandler(Interactive element, EventHandler<PullGestureEventArgs> handler) =>
+            element.RemoveHandler(PullGestureEvent, handler);
 
         private static void PointerPressed(RoutedEventArgs ev)
         {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Allow using some `Gestures`  events in Xaml

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
If using Gesture in Xaml compiler throw `AVLN: 0004: XamlX.XamlParseException: Unable to resolve suitable regular or attached property Pinch`

```xaml
<Window xmlns="https://github.com/avaloniaui"
     xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
     x:Class="Sandbox.MainWindow"
     Gestures.Pinch="Pinch">
    <Window.GestureRecognizers>
     <PinchGestureRecognizer/>
  </Window.GestureRecognizers>
</Window>
```

## What is the updated/expected behavior with this PR?

Compile



## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
`XamlC` to identify that it is an attached event, looks for the presence of a method named `Add<EventName>Handler` example for the `PinchEvent` event `AddPinchHandler`


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #13231