### PR TITLE
Fix OpenGlControlBase: Ensure _updateQueued is set to false when DoCleanup() is called

### DIFF
--- a/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs
+++ b/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs
@@ -46,8 +46,9 @@ namespace Avalonia.OpenGL.Controls
             }
 
             ElementComposition.SetElementChildVisual(this, null);
+
+            _updateQueued = false;
             _visual = null;
-            
             _resources?.DisposeAsync();
             _resources = null;
             _initialization = null;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Ensure `_updateQueued` is set to false when `DoCleanup()` is called.
Currently, when `OpenGlControlBase` is detached from the visual tree. Method `DoCleanup()` will get called immediately.
However, in this method it doesn't set `_updateQueued` to false, which will fail the following check:

`OpenGlControlBase.cs` at Line [#226](https://github.com/AvaloniaUI/Avalonia/blob/a581dc3628c1b23f7da751daaba7d92a1209fe91/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs#L226):
```c#
public void RequestNextFrameRendering()
{
    if ((_initialization == null || _initialization is { Status: TaskStatus.RanToCompletion }) &&
        !_updateQueued) // This check will always failed because _updateQueued is true after DoCleanup()
    {
        _updateQueued = true;
        _compositor?.RequestCompositionUpdate(_update);
    }
}
```

As the result, the OpenGlControl will never get any frame output after it re-attached to the visual tree.

## What is the current behavior?

Now the cleanup method will ensure to set the `_updateQueud` to false in `DoCleanup()`.

## What is the updated/expected behavior with this PR?

Now the control that using OpenGL will still work after the control is re-attached to the visual tree.

