### PR TITLE
Set font Subpixel to true also when edging is SKFontEdging.Antialias

### DIFF
--- a/src/Skia/Avalonia.Skia/GlyphRunImpl.cs
+++ b/src/Skia/Avalonia.Skia/GlyphRunImpl.cs
@@ -130,7 +130,7 @@ namespace Avalonia.Skia
             var font = _glyphTypefaceImpl.CreateSKFont((float)FontRenderingEmSize);
 
             font.Hinting = SKFontHinting.Full;
-            font.Subpixel = edging == SKFontEdging.SubpixelAntialias;
+            font.Subpixel = edging == SKFontEdging.SubpixelAntialias || edging == SKFontEdging.Antialias;
             font.Edging = edging;
 
             return font;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Improves text rendering quality when using RenderOptions.TextRenderingMode="Antialias"

![image](https://github.com/AvaloniaUI/Avalonia/assets/2297442/142c88c7-cfb1-44a5-a4c7-65085416432a)

![image](https://github.com/AvaloniaUI/Avalonia/assets/2297442/c83535a3-3886-43b2-9fa4-675b78edb5e2)

zoom 400%

![image](https://github.com/AvaloniaUI/Avalonia/assets/2297442/a0351e69-e1be-4c41-b353-3e6a5216ce33)

## What is the current behavior?

Text rendering quality is worse than in 0.10.21

## What is the updated/expected behavior with this PR?

Text rendering quality when using RenderOptions.TextRenderingMode="Antialias" is similar to from 0.10.21 version.


## How was the solution implemented (if it's not obvious)?

Set font Subpixel to true also when edging is SKFontEdging.Antialias

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues

Partially fixes #13265
