### PR TITLE
Add option to enable/disable input focus proxy for X11.

### DIFF
--- a/src/Avalonia.X11/X11Platform.cs
+++ b/src/Avalonia.X11/X11Platform.cs
@@ -284,6 +284,12 @@ namespace Avalonia
         /// on their input devices by using sequences of characters or mouse operations that are natively available on their input devices.
         /// </remarks>
         public bool? EnableIme { get; set; }
+
+        /// <summary>
+        /// Determines whether to use Input Focus Proxy.
+        /// The default value is false.
+        /// </summary> 
+        public bool EnableInputFocusProxy { get; set; }
         
         /// <summary>
         /// Determines whether to enable support for the

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -219,13 +219,14 @@ namespace Avalonia.X11
                 _nativeMenuExporter = DBusMenuExporter.TryCreateTopLevelNativeMenu(_handle);
             _nativeControlHost = new X11NativeControlHost(_platform, this);
             InitializeIme();
+
+            var data = new List<IntPtr> { _x11.Atoms.WM_DELETE_WINDOW, _x11.Atoms._NET_WM_SYNC_REQUEST };
             
             if(platform.Options.EnableInputFocusProxy)
-                XChangeProperty(_x11.Display, _handle, _x11.Atoms.WM_PROTOCOLS, _x11.Atoms.XA_ATOM, 32,
-                    PropertyMode.Replace, new[] { _x11.Atoms.WM_DELETE_WINDOW, _x11.Atoms.WM_TAKE_FOCUS, _x11.Atoms._NET_WM_SYNC_REQUEST }, 3);
-            else
-                XChangeProperty(_x11.Display, _handle, _x11.Atoms.WM_PROTOCOLS, _x11.Atoms.XA_ATOM, 32,
-                    PropertyMode.Replace, new[] { _x11.Atoms.WM_DELETE_WINDOW, _x11.Atoms._NET_WM_SYNC_REQUEST }, 2);
+                data.Add(_x11.Atoms.WM_TAKE_FOCUS);
+
+            XChangeProperty(_x11.Display, _handle, _x11.Atoms.WM_PROTOCOLS, _x11.Atoms.XA_ATOM, 32,
+                    PropertyMode.Replace, data.ToArray(), data.Count);
 
             if (_x11.HasXSync)
             {


### PR DESCRIPTION
Some Xorg servers (including XWayland) are having a hard time distinguishing the proxy window for an actual window to focus, hence making Avalonia's buttons and menus not work on affected Linux systems that uses Wayland/XWayland. This disables the input proxy by default and can be enabled by X11PlatformOptions in App setup if user desires.