### PR TITLE
Add TextBox.ScrollToLine

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1878,6 +1878,28 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
+        /// Scroll the <see cref="TextBox"/> to the specified line index.
+        /// </summary>
+        /// <param name="lineIndex">The line index to scroll to.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="lineIndex"/> is less than zero. -or - <paramref name="lineIndex"/> is larger than or equal to the line count.</exception>
+        public void ScrollToLine(int lineIndex)
+        {
+            if (_presenter is null)
+            {
+                return;
+            }
+
+            if (lineIndex < 0 || lineIndex >= _presenter.TextLayout.TextLines.Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(lineIndex));
+            }
+
+            var textLine = _presenter.TextLayout.TextLines[lineIndex];
+            _presenter.MoveCaretToTextPosition(textLine.FirstTextSourceIndex);
+
+        }
+
+        /// <summary>
         /// Select all text in the TextBox
         /// </summary>
         public void SelectAll()

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -1182,6 +1182,43 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
+        [Theory]
+        [InlineData("A\nBB\nCCC\nDDDD", 0, 0)]
+        [InlineData("A\nBB\nCCC\nDDDD", 1, 2)]
+        [InlineData("A\nBB\nCCC\nDDDD", 2, 5)]
+        [InlineData("A\nBB\nCCC\nDDDD", 3, 9)]
+        public void Should_Scroll_Caret_To_Line(string text, int targetLineIndex, int expectedCaretIndex)
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var tb = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = text
+                };
+                tb.ApplyTemplate();
+                tb.ScrollToLine(targetLineIndex);
+                Assert.Equal(expectedCaretIndex, tb.CaretIndex);
+            }
+        }
+
+        [Fact]
+        public void Should_Throw_ArgumentOutOfRange()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var tb = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = string.Empty
+                };
+                tb.ApplyTemplate();
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => tb.ScrollToLine(-1));
+                Assert.Throws<ArgumentOutOfRangeException>(() => tb.ScrollToLine(1));
+            }
+        }
+
         private static TestServices FocusServices => TestServices.MockThreadingInterface.With(
             focusManager: new FocusManager(),
             keyboardDevice: () => new KeyboardDevice(),

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -1187,6 +1187,10 @@ namespace Avalonia.Controls.UnitTests
         [InlineData("A\nBB\nCCC\nDDDD", 1, 2)]
         [InlineData("A\nBB\nCCC\nDDDD", 2, 5)]
         [InlineData("A\nBB\nCCC\nDDDD", 3, 9)]
+        [InlineData("واحد\nاثنين\nثلاثة\nأربعة", 0, 0)]
+        [InlineData("واحد\nاثنين\nثلاثة\nأربعة", 1, 5)]
+        [InlineData("واحد\nاثنين\nثلاثة\nأربعة", 2, 11)]
+        [InlineData("واحد\nاثنين\nثلاثة\nأربعة", 3, 17)]
         public void Should_Scroll_Caret_To_Line(string text, int targetLineIndex, int expectedCaretIndex)
         {
             using (UnitTestApplication.Start(Services))


### PR DESCRIPTION
## What does the pull request do?

Adds the method `ScrollToLine` to the `TextBox` control.

## What is the current behavior?
No obvious API for moving the caret to a specific line. This is not "compatible" with WPF.

## What is the updated/expected behavior with this PR?

- Calling `ScrollToLine` with a line index will move the caret index to the first position on the specified line index.
- There are two new test cases in `TextBoxTests.cs`

## How was the solution implemented (if it's not obvious)?

`ScrollToLine` will get the `TextLine` object from the collection and use the `TextPresenter.MoveCaretToTextPosition` API to move the caret.

Perhaps this is a bit naive implementation. The WPF implementation gets a bounding rectangle and brings that into view.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

Unsure if this method requires updated docs since not everything is included in the docs. Happy to do so if suggested.

## Breaking changes
None that I know of.

## Fixed issues

Addresses #3036 at least partially. It would be nice with convenience API:s like ScrollToHome and ScrollToEnd. Those would delegate to existing internal API or to the same API on the `ScrollViewer`.

I'll leave it to the maintainers to decide if #3036 can be closed or not.
