### PR TITLE
Pass through NativeKeyCode in KeyEventArgs

### DIFF
--- a/src/Avalonia.Base/Input/KeyEventArgs.cs
+++ b/src/Avalonia.Base/Input/KeyEventArgs.cs
@@ -71,4 +71,13 @@ public class KeyEventArgs : RoutedEventArgs
     /// <see cref="Key"/>
     /// <see cref="PhysicalKey"/>
     public string? KeySymbol { get; init; }
+
+    /// <summary>
+    /// Gets the key code of the associated event.
+    /// This is platform-dependent.
+    /// <remarks>
+    /// Use this property if you need to refer to a key's native keycode.
+    /// </remarks>
+    /// </summary>
+    public int NativeKeyCode { get; init; }
 }

--- a/src/Avalonia.Base/Input/KeyboardDevice.cs
+++ b/src/Avalonia.Base/Input/KeyboardDevice.cs
@@ -196,6 +196,7 @@ namespace Avalonia.Input
                             KeyModifiers = keyInput.Modifiers.ToKeyModifiers(),
                             PhysicalKey = keyInput.PhysicalKey,
                             KeySymbol = keyInput.KeySymbol,
+                            NativeKeyCode = keyInput.NativeKeyCode,
                             Source = element
                         };
                         

--- a/src/Avalonia.Base/Input/Raw/RawKeyEventArgs.cs
+++ b/src/Avalonia.Base/Input/Raw/RawKeyEventArgs.cs
@@ -20,7 +20,7 @@ namespace Avalonia.Input.Raw
             RawKeyEventType type,
             Key key,
             RawInputModifiers modifiers)
-            : this(device, timestamp, root, type, key, modifiers, PhysicalKey.None, null)
+            : this(device, timestamp, root, type, key, modifiers, PhysicalKey.None, 0, null)
         {
             Key = key;
             Type = type;
@@ -35,6 +35,7 @@ namespace Avalonia.Input.Raw
             Key key,
             RawInputModifiers modifiers,
             PhysicalKey physicalKey,
+            int nativeKeyCode,
             string? keySymbol)
             : base(device, timestamp, root)
         {
@@ -42,6 +43,7 @@ namespace Avalonia.Input.Raw
             Modifiers = modifiers;
             Type = type;
             PhysicalKey = physicalKey;
+            NativeKeyCode = nativeKeyCode;
             KeySymbol = keySymbol;
         }
 
@@ -52,6 +54,8 @@ namespace Avalonia.Input.Raw
         public RawKeyEventType Type { get; set; }
 
         public PhysicalKey PhysicalKey { get; set; }
+
+        public int NativeKeyCode { get; set; }
 
         public string? KeySymbol { get; set; }
     }

--- a/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
+++ b/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
@@ -6,6 +6,7 @@
       <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
       <DefineConstants>$(DefineConstants);BUILDTASK;XAMLX_CECIL_INTERNAL;XAMLX_INTERNAL</DefineConstants>
       <CopyLocalLockFileAssemblies Condition="$(TargetFramework) == 'netstandard2.0'">true</CopyLocalLockFileAssemblies>
+      <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
       <NoWarn>$(NoWarn);NU1605;CS8632</NoWarn>
       <DebugType>embedded</DebugType>
       <IncludeSymbols>false</IncludeSymbols>

--- a/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Remote/Server/RemoteServerTopLevelImpl.cs
@@ -229,6 +229,7 @@ namespace Avalonia.Controls.Remote.Server
                                 (Key)key.Key,
                                 GetAvaloniaRawInputModifiers(key.Modifiers),
                                 (PhysicalKey)key.PhysicalKey,
+                                key.NativeKeyCode,
                                 key.KeySymbol));
                         }, DispatcherPriority.Input);
                         break;

--- a/src/Avalonia.FreeDesktop/DBusIme/IBus/IBusX11TextInputMethod.cs
+++ b/src/Avalonia.FreeDesktop/DBusIme/IBus/IBusX11TextInputMethod.cs
@@ -50,6 +50,7 @@ namespace Avalonia.FreeDesktop.DBusIme.IBus
             FireForward(new X11InputMethodForwardedKey
             {
                 KeyVal = (int)k.keyval,
+                ScanCode = (int)k.keycode,
                 Type = state.HasAllFlags(IBusModifierMask.ReleaseMask) ? RawKeyEventType.KeyUp : RawKeyEventType.KeyDown,
                 Modifiers = mods
             });

--- a/src/Avalonia.FreeDesktop/IX11InputMethod.cs
+++ b/src/Avalonia.FreeDesktop/IX11InputMethod.cs
@@ -16,6 +16,7 @@ namespace Avalonia.FreeDesktop
 #pragma warning restore CA1815 // Override equals and operator equals on value types
     {
         public int KeyVal { get; set; }
+        public int ScanCode { get; set; }
         public KeyModifiers Modifiers { get; set; }
         public RawKeyEventType Type { get; set; }
     }

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -247,9 +247,9 @@ namespace Avalonia.Native
                 _parent.RawMouseEvent(type, timeStamp, modifiers, point, delta);
             }
 
-            int IAvnWindowBaseEvents.RawKeyEvent(AvnRawKeyEventType type, ulong timeStamp, AvnInputModifiers modifiers, AvnKey key, AvnPhysicalKey physicalKey, string keySymbol)
+            int IAvnWindowBaseEvents.RawKeyEvent(AvnRawKeyEventType type, ulong timeStamp, AvnInputModifiers modifiers, AvnKey key, AvnPhysicalKey physicalKey, string keySymbol, int nativeKeyCode)
             {
-                return _parent.RawKeyEvent(type, timeStamp, modifiers, key, physicalKey, keySymbol).AsComBool();
+                return _parent.RawKeyEvent(type, timeStamp, modifiers, key, physicalKey, keySymbol, nativeKeyCode).AsComBool();
             }
 
             int IAvnWindowBaseEvents.RawTextInputEvent(ulong timeStamp, string text)
@@ -328,7 +328,8 @@ namespace Avalonia.Native
             AvnInputModifiers modifiers,
             AvnKey key,
             AvnPhysicalKey physicalKey,
-            string keySymbol)
+            string keySymbol, 
+            int nativeKeyCode)
         {
             if (_inputRoot is null) 
                 return false;
@@ -343,6 +344,7 @@ namespace Avalonia.Native
                 (Key)key,
                 (RawInputModifiers)modifiers,
                 (PhysicalKey)physicalKey,
+                nativeKeyCode,
                 keySymbol);
 
             Input?.Invoke(args);

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -767,7 +767,7 @@ interface IAvnWindowBaseEvents : IUnknown
                                 AvnPoint point,
                                 AvnVector delta);
      bool RawKeyEvent(AvnRawKeyEventType type, u_int64_t timeStamp, AvnInputModifiers modifiers,
-                      AvnKey key, AvnPhysicalKey physicalKey, [const] char* keySymbol);
+                      AvnKey key, AvnPhysicalKey physicalKey, [const] char* keySymbol, int nativeKeyCode);
      bool RawTextInputEvent(u_int64_t timeStamp, [const] char* text);
      void ScalingChanged(double scaling);
      void RunRenderPriorityJobs();

--- a/src/Avalonia.Remote.Protocol/InputMessages.cs
+++ b/src/Avalonia.Remote.Protocol/InputMessages.cs
@@ -78,6 +78,7 @@ namespace Avalonia.Remote.Protocol.Input
         public Key Key { get; set; }
         public PhysicalKey PhysicalKey { get; set; }
         public string? KeySymbol { get; set; }
+        public int NativeKeyCode { get; set; }
     }
 
     [AvaloniaRemoteMessageGuid("C174102E-7405-4594-916F-B10B8248A17D")]

--- a/src/Avalonia.X11/X11Window.Ime.cs
+++ b/src/Avalonia.X11/X11Window.Ime.cs
@@ -98,6 +98,7 @@ namespace Avalonia.X11
                 X11KeyTransform.KeyFromX11Key(x11Key),
                 (RawInputModifiers)forwardedKey.Modifiers,
                 PhysicalKey.None,
+                forwardedKey.ScanCode,
                 keySymbol));
         }
 
@@ -119,6 +120,7 @@ namespace Avalonia.X11
                     key,
                     modifiers,
                     physicalKey,
+                    ev.KeyEvent.keycode,
                     symbol,
                     TranslateEventToString(ref ev, symbol)) :
                 new RawKeyEventArgs(
@@ -129,6 +131,7 @@ namespace Avalonia.X11
                     key,
                     modifiers,
                     physicalKey,
+                    ev.KeyEvent.keycode,
                     symbol);
 
             ScheduleKeyInput(args, ref ev, (int)x11Key, ev.KeyEvent.keycode);
@@ -338,9 +341,10 @@ namespace Avalonia.X11
                 Key key,
                 RawInputModifiers modifiers,
                 PhysicalKey physicalKey,
+                int nativeKeyCode,
                 string? keySymbol,
                 string? text)
-                : base(device, timestamp, root, type, key, modifiers, physicalKey, keySymbol)
+                : base(device, timestamp, root, type, key, modifiers, physicalKey, nativeKeyCode, keySymbol)
             {
                 Text = text;
             }

--- a/src/Headless/Avalonia.Headless.Vnc/HeadlessVncFramebufferSource.cs
+++ b/src/Headless/Avalonia.Headless.Vnc/HeadlessVncFramebufferSource.cs
@@ -77,9 +77,9 @@ namespace Avalonia.Headless.Vnc
                 Dispatcher.UIThread.Post(() =>
                 {
                     if (args.Pressed)
-                        Window?.KeyPress(key, _keyState, PhysicalKey.None, keySymbol);
+                        Window?.KeyPress(key, _keyState, PhysicalKey.None, (int)args.Keysym, keySymbol);
                     else
-                        Window?.KeyRelease(key, _keyState, PhysicalKey.None, keySymbol);
+                        Window?.KeyRelease(key, _keyState, PhysicalKey.None, (int)args.Keysym, keySymbol);
 
                     if (inputText != null)
                         Window?.KeyTextInput(inputText);

--- a/src/Headless/Avalonia.Headless/HeadlessWindowExtensions.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowExtensions.cs
@@ -43,42 +43,42 @@ public static class HeadlessWindowExtensions
     /// <summary>
     /// Simulates keyboard press on the headless window/toplevel.
     /// </summary>
-    [Obsolete("Use the overload that takes a physical key and key symbol instead, or KeyPressQwerty alternatively.")]
+    [Obsolete("Use the overload that takes a physical key, key symbol and keycode instead, or KeyPressQwerty alternatively.")]
     public static void KeyPress(this TopLevel topLevel, Key key, RawInputModifiers modifiers) =>
-        KeyPress(topLevel, key, modifiers, PhysicalKey.None, null);
+        KeyPress(topLevel, key, modifiers, PhysicalKey.None, 0, null);
 
     /// <summary>
     /// Simulates keyboard press on the headless window/toplevel.
     /// </summary>
-    public static void KeyPress(this TopLevel topLevel, Key key, RawInputModifiers modifiers, PhysicalKey physicalKey,
+    public static void KeyPress(this TopLevel topLevel, Key key, RawInputModifiers modifiers, PhysicalKey physicalKey, int keyCode,
         string? keySymbol) =>
-        RunJobsOnImpl(topLevel, w => w.KeyPress(key, modifiers, physicalKey, keySymbol));
+        RunJobsOnImpl(topLevel, w => w.KeyPress(key, modifiers, physicalKey, keyCode, keySymbol));
 
     /// <summary>
     /// Simulates keyboard press on the headless window/toplevel, as if typed on a QWERTY keyboard.
     /// </summary>
-    public static void KeyPressQwerty(this TopLevel topLevel, PhysicalKey physicalKey, RawInputModifiers modifiers) =>
-        RunJobsOnImpl(topLevel, w => w.KeyPress(physicalKey.ToQwertyKey(), modifiers, physicalKey, physicalKey.ToQwertyKeySymbol()));
+    public static void KeyPressQwerty(this TopLevel topLevel, PhysicalKey physicalKey, RawInputModifiers modifiers, int keyCode) =>
+        RunJobsOnImpl(topLevel, w => w.KeyPress(physicalKey.ToQwertyKey(), modifiers, physicalKey, keyCode, physicalKey.ToQwertyKeySymbol()));
 
     /// <summary>
     /// Simulates keyboard release on the headless window/toplevel.
     /// </summary>
-    [Obsolete("Use the overload that takes a physical key and key symbol instead, or KeyReleaseQwerty alternatively.")]
+    [Obsolete("Use the overload that takes a physical key, key symbol and keycode instead, or KeyReleaseQwerty alternatively.")]
     public static void KeyRelease(this TopLevel topLevel, Key key, RawInputModifiers modifiers) =>
-        KeyRelease(topLevel, key, modifiers, PhysicalKey.None, null);
+        KeyRelease(topLevel, key, modifiers, PhysicalKey.None, 0, null);
 
     /// <summary>
     /// Simulates keyboard release on the headless window/toplevel.
     /// </summary>
-    public static void KeyRelease(this TopLevel topLevel, Key key, RawInputModifiers modifiers, PhysicalKey physicalKey,
+    public static void KeyRelease(this TopLevel topLevel, Key key, RawInputModifiers modifiers, PhysicalKey physicalKey, int keyCode,
         string? keySymbol) =>
-        RunJobsOnImpl(topLevel, w => w.KeyRelease(key, modifiers, physicalKey, keySymbol));
+        RunJobsOnImpl(topLevel, w => w.KeyRelease(key, modifiers, physicalKey, keyCode, keySymbol));
 
     /// <summary>
     /// Simulates keyboard release on the headless window/toplevel, as if typed on a QWERTY keyboard.
     /// </summary>
-    public static void KeyReleaseQwerty(this TopLevel topLevel, PhysicalKey physicalKey, RawInputModifiers modifiers) =>
-        RunJobsOnImpl(topLevel, w => w.KeyRelease(physicalKey.ToQwertyKey(), modifiers, physicalKey, physicalKey.ToQwertyKeySymbol()));
+    public static void KeyReleaseQwerty(this TopLevel topLevel, PhysicalKey physicalKey, RawInputModifiers modifiers, int keyCode) =>
+        RunJobsOnImpl(topLevel, w => w.KeyRelease(physicalKey.ToQwertyKey(), modifiers, physicalKey, keyCode, physicalKey.ToQwertyKeySymbol()));
 
     /// <summary>
     /// Simulates a text input event on the headless window/toplevel

--- a/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
@@ -268,7 +268,7 @@ namespace Avalonia.Headless
             return null;
         }
 
-        void IHeadlessWindow.KeyPress(Key key, RawInputModifiers modifiers, PhysicalKey physicalKey, string? keySymbol)
+        void IHeadlessWindow.KeyPress(Key key, RawInputModifiers modifiers, PhysicalKey physicalKey, int nativeKeyCode, string? keySymbol)
         {
             Input?.Invoke(new RawKeyEventArgs(
                 _keyboard,
@@ -278,10 +278,11 @@ namespace Avalonia.Headless
                 key,
                 modifiers,
                 physicalKey,
+                nativeKeyCode,
                 keySymbol));
         }
 
-        void IHeadlessWindow.KeyRelease(Key key, RawInputModifiers modifiers, PhysicalKey physicalKey, string? keySymbol)
+        void IHeadlessWindow.KeyRelease(Key key, RawInputModifiers modifiers, PhysicalKey physicalKey, int nativeKeyCode, string? keySymbol)
         {
             Input?.Invoke(new RawKeyEventArgs(
                 _keyboard,
@@ -291,6 +292,7 @@ namespace Avalonia.Headless
                 key,
                 modifiers,
                 physicalKey,
+                nativeKeyCode,
                 keySymbol));
         }
 

--- a/src/Headless/Avalonia.Headless/IHeadlessWindow.cs
+++ b/src/Headless/Avalonia.Headless/IHeadlessWindow.cs
@@ -7,8 +7,8 @@ namespace Avalonia.Headless
     internal interface IHeadlessWindow
     {
         WriteableBitmap? GetLastRenderedFrame();
-        void KeyPress(Key key, RawInputModifiers modifiers, PhysicalKey physicalKey, string? keySymbol);
-        void KeyRelease(Key key, RawInputModifiers modifiers, PhysicalKey physicalKey, string? keySymbol);
+        void KeyPress(Key key, RawInputModifiers modifiers, PhysicalKey physicalKey, int nativeKeyCode, string? keySymbol);
+        void KeyRelease(Key key, RawInputModifiers modifiers, PhysicalKey physicalKey, int nativeKeyCode, string? keySymbol);
         void TextInput(string text);
         void MouseDown(Point point, MouseButton button, RawInputModifiers modifiers = RawInputModifiers.None);
         void MouseMove(Point point, RawInputModifiers modifiers = RawInputModifiers.None);

--- a/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
+++ b/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
@@ -327,7 +327,7 @@ namespace Avalonia.Win32.Input
 
                 if (Client.SupportsSurroundingText && Client.Selection.Start != Client.Selection.End)
                 {
-                    KeyPress(Key.Delete, PhysicalKey.Delete);
+                    KeyPress(Key.Delete, PhysicalKey.Delete, (int)VirtualKeyStates.VK_DELETE);
                 }
             }
 
@@ -398,15 +398,15 @@ namespace Avalonia.Win32.Input
             return (int)(ptr.ToInt64() & 0xffffffff);
         }
 
-        private void KeyPress(Key key, PhysicalKey physicalKey)
+        private void KeyPress(Key key, PhysicalKey physicalKey, int nativeKeyCode)
         {
             if (_parent?.Input != null)
             {
                 _parent.Input(new RawKeyEventArgs(KeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, _parent.Owner,
-                RawKeyEventType.KeyDown, key, RawInputModifiers.None, physicalKey, null));
+                RawKeyEventType.KeyDown, key, RawInputModifiers.None, physicalKey, nativeKeyCode, null));
 
                 _parent.Input(new RawKeyEventArgs(KeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, _parent.Owner,
-                RawKeyEventType.KeyUp, key, RawInputModifiers.None, physicalKey, null));
+                RawKeyEventType.KeyUp, key, RawInputModifiers.None, physicalKey, nativeKeyCode, null));
 
             }
         }

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -1172,6 +1172,7 @@ namespace Avalonia.Win32
                 key,
                 WindowsKeyboardDevice.Instance.Modifiers,
                 physicalKey,
+                virtualKey,
                 keySymbol);
         }
     }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Adds a NativeKeyCode property into KeyEventArgs, which has the OS's native scancode inside (0 if unsupported).

## How was the solution implemented (if it's not obvious)?
Added a NativeKeyCode int property and made edits to all necessary code to pass through the scancode.


## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
- [ ] Write code for the rest of the platforms (currently only have code for X11, VNC, Win32)
- [ ] Write tests (virtual keypresses?)

## Breaking changes
RawKeyEventArgs constructor now takes a `int nativeKeyCode` before the `string? keySymbol`.
IAvnWindowBaseEvents.RawKeyEvent has new required argument `int nativeKeyCode`

## Fixed issues
Fixes #13254 
