### PR TITLE
Fix watermark alignment of TextBox in the Simple theme #5802

### DIFF
--- a/src/Avalonia.Themes.Simple/Controls/TextBox.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/TextBox.xaml
@@ -134,6 +134,8 @@
                               VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
                   <Panel>
                     <TextBlock Name="watermark"
+                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"   
                                IsVisible="{TemplateBinding Text,
                                                            Converter={x:Static StringConverters.IsNullOrEmpty}}"
                                Opacity="0.5"


### PR DESCRIPTION
## What does the pull request do?

Adds horizontal and vertical alignment template bindings so that the watermark of the `TextBox` in the simple theme is not affected by the default `TextBlock` style.

## What is the current behavior?
The `TextBox` watermark will have the same alignment as the style for a generic `TextBlock`. See #5802

## What is the updated/expected behavior with this PR?
Fix the alignment of `TextBox` watermarks in the simple theme.

## How was the solution implemented (if it's not obvious)?
Two simple `TemplateBinding` from the Horizontal/VerticalContentAlignment of the `TextBox` to the watermark `TextBlock` Horizontal/VerticalAlignment.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

Unsure if this requires a test case. I've not seen any test cases related to the Simple theme, so please advise if there is a place to add unit tests.

## Breaking changes
Probably not.

## Fixed issues

Fixes #5802