### PR TITLE
Fix Sector Fill

### DIFF
--- a/src/Avalonia.Controls/Shapes/Sector.cs
+++ b/src/Avalonia.Controls/Shapes/Sector.cs
@@ -80,7 +80,7 @@ namespace Avalonia.Controls.Shapes
             var streamGeometry = new StreamGeometry();
             using (StreamGeometryContext context = streamGeometry.Open())
             {
-                context.BeginFigure(startCurvePoint, false);
+                context.BeginFigure(startCurvePoint, isFilled: true);
                 context.ArcTo(
                     endCurvePoint,
                     size,


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Fixes #13303 by making sure the path figure is marked as being filled. This was a copy-paste bug as the original code was copied from `Arc` which isn't filled.

## What is the current behavior?

No fill in some cases

## What is the updated/expected behavior with this PR?

Should always be filled now.

## How was the solution implemented (if it's not obvious)?

Obvious

## Checklist

- ~[ ] Added unit tests (if possible)?~
- ~[ ] Added XML documentation to any related classes?~
- ~[ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation~

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #13303
