### PR TITLE
Prevent gesture recognition when gesture is captured

### DIFF
--- a/src/Avalonia.Base/Input/GestureRecognizers/GestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/GestureRecognizer.cs
@@ -2,6 +2,7 @@
 {
     public abstract class GestureRecognizer : StyledElement
     {
+        private PointerEventArgs? _currentPointerEventArgs;
         protected internal IInputElement? Target { get; internal set; }
 
         protected abstract void PointerPressed(PointerPressedEventArgs e);
@@ -11,17 +12,23 @@
 
         internal void PointerPressedInternal(PointerPressedEventArgs e)
         {
+            _currentPointerEventArgs = e;
             PointerPressed(e);
+            _currentPointerEventArgs = null;
         }
 
         internal void PointerReleasedInternal(PointerReleasedEventArgs e)
         {
+            _currentPointerEventArgs = e;
             PointerReleased(e);
+            _currentPointerEventArgs = null;
         }
 
         internal void PointerMovedInternal(PointerEventArgs e)
         {
+            _currentPointerEventArgs = e;
             PointerMoved(e);
+            _currentPointerEventArgs = null;
         }
 
         internal void PointerCaptureLostInternal(IPointer pointer)
@@ -32,6 +39,8 @@
         protected void Capture(IPointer pointer)
         {
             (pointer as Pointer)?.CaptureGestureRecognizer(this);
+
+            _currentPointerEventArgs?.PreventGestureRecognition();
         }
     }
 }

--- a/src/Avalonia.Base/Input/GestureRecognizers/PullGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/PullGestureRecognizer.cs
@@ -44,7 +44,6 @@ namespace Avalonia.Input
             {
                 var currentPosition = e.GetPosition(visual);
                 Capture(e.Pointer);
-                e.PreventGestureRecognition();
 
                 Vector delta = default;
                 switch (PullDirection)

--- a/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
@@ -124,8 +124,6 @@ namespace Avalonia.Input.GestureRecognizers
                             _trackedRootPoint.Y - (_trackedRootPoint.Y >= rootPoint.Y ? ScrollStartDistance : -ScrollStartDistance));
 
                         Capture(e.Pointer);
-
-                        e.PreventGestureRecognition();
                     }
                 }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Calls `PreventGestureRecognition` in `GestureRecognizer.Capture`. Gesture Recognizers would have explicitly called it when they capture.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
This is a behavorial breaking change

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Resolves #13177 
