### PR TITLE
Handle array types when parsing XAML values

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguageParseIntrinsics.cs
@@ -416,6 +416,11 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
 
         private static IXamlType GetElementType(IXamlType type, XamlTypeWellKnownTypes types)
         {
+            if (type.IsArray)
+            {
+                return type.ArrayElementType;
+            }
+
             return type.GetAllInterfaces().FirstOrDefault(i =>
                     i.FullName.StartsWith(types.IEnumerableT.FullName))?
                 .GenericArguments[0];


### PR DESCRIPTION
Finally and actually fixes #11946. Array types have a weird relationship with `IEnumerable<T>` and need special handling.

See the bug for more details.

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #11946
