### PR TITLE
Make `PreventGestureRecognition` pointer scope, and not event scope.

### DIFF
--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -504,21 +504,6 @@ namespace Avalonia.Input
             return FocusManager.GetFocusManager(this)?.Focus(this, method, keyModifiers) ?? false; 
         }
 
-        /// <summary>
-        /// Cancels the current gesture recognizer captured by the pointer, and restores the previous captured 
-        /// element if available. If no gesture is currently started by the pointer, no changes are made.
-        /// </summary>
-        /// <param name="pointer">The pointer with the captured gesture</param>
-        public void CancelCurrentGesture(Pointer pointer)
-        {
-            var captured = pointer.PreviousCaptured as Visual;
-
-            if(captured == this || this.GetVisualDescendants().Contains(captured))
-            {
-                pointer?.ReleaseGestureRecognizerCapture();
-            }
-        }
-
         /// <inheritdoc/>
         protected override void OnDetachedFromVisualTreeCore(VisualTreeAttachmentEventArgs e)
         {

--- a/src/Avalonia.Base/Input/InputElement.cs
+++ b/src/Avalonia.Base/Input/InputElement.cs
@@ -504,6 +504,21 @@ namespace Avalonia.Input
             return FocusManager.GetFocusManager(this)?.Focus(this, method, keyModifiers) ?? false; 
         }
 
+        /// <summary>
+        /// Cancels the current gesture recognizer captured by the pointer, and restores the previous captured 
+        /// element if available. If no gesture is currently started by the pointer, no changes are made.
+        /// </summary>
+        /// <param name="pointer">The pointer with the captured gesture</param>
+        public void CancelCurrentGesture(Pointer pointer)
+        {
+            var captured = pointer.PreviousCaptured as Visual;
+
+            if(captured == this || this.GetVisualDescendants().Contains(captured))
+            {
+                pointer?.ReleaseGestureRecognizerCapture();
+            }
+        }
+
         /// <inheritdoc/>
         protected override void OnDetachedFromVisualTreeCore(VisualTreeAttachmentEventArgs e)
         {

--- a/src/Avalonia.Base/Input/Pointer.cs
+++ b/src/Avalonia.Base/Input/Pointer.cs
@@ -54,6 +54,8 @@ namespace Avalonia.Input
             if (Captured is Visual v3)
                 v3.DetachedFromVisualTree += OnCaptureDetached;
 
+            PreviousCaptured = null;
+
             if (Captured != null)
                 CaptureGestureRecognizer(null);
         }
@@ -79,6 +81,12 @@ namespace Avalonia.Input
         /// </summary>
         internal GestureRecognizer? CapturedGestureRecognizer { get; private set; }
 
+        /// <summary>
+        /// The previously captured element. This is set when a <see cref="GestureRecognizer"/> captures
+        /// the pointer.
+        /// </summary>
+        internal IInputElement? PreviousCaptured { get; private set; }
+
         public void Dispose()
         {
             Capture(null);
@@ -99,7 +107,19 @@ namespace Avalonia.Input
 
             if (gestureRecognizer != null)
             {
+                if (PreviousCaptured == null)
+                    PreviousCaptured = Captured;
                 Capture(null);
+            }
+        }
+
+        internal void ReleaseGestureRecognizerCapture()
+        {
+            if(CapturedGestureRecognizer != null)
+            {
+                Capture(PreviousCaptured);
+
+                CaptureGestureRecognizer(null);
             }
         }
     }

--- a/src/Avalonia.Base/Input/Pointer.cs
+++ b/src/Avalonia.Base/Input/Pointer.cs
@@ -54,10 +54,13 @@ namespace Avalonia.Input
             if (Captured is Visual v3)
                 v3.DetachedFromVisualTree += OnCaptureDetached;
 
-            PreviousCaptured = null;
-
             if (Captured != null)
                 CaptureGestureRecognizer(null);
+
+            if(Captured == null && CapturedGestureRecognizer == null)
+            {
+                IsGestureRecognitionSkipped = false;
+            }
         }
 
         static IInputElement? GetNextCapture(Visual parent)
@@ -81,11 +84,7 @@ namespace Avalonia.Input
         /// </summary>
         internal GestureRecognizer? CapturedGestureRecognizer { get; private set; }
 
-        /// <summary>
-        /// The previously captured element. This is set when a <see cref="GestureRecognizer"/> captures
-        /// the pointer.
-        /// </summary>
-        internal IInputElement? PreviousCaptured { get; private set; }
+        public bool IsGestureRecognitionSkipped { get; set; }
 
         public void Dispose()
         {
@@ -107,19 +106,7 @@ namespace Avalonia.Input
 
             if (gestureRecognizer != null)
             {
-                if (PreviousCaptured == null)
-                    PreviousCaptured = Captured;
                 Capture(null);
-            }
-        }
-
-        internal void ReleaseGestureRecognizerCapture()
-        {
-            if(CapturedGestureRecognizer != null)
-            {
-                Capture(PreviousCaptured);
-
-                CaptureGestureRecognizer(null);
             }
         }
     }

--- a/src/Avalonia.Base/Input/PointerEventArgs.cs
+++ b/src/Avalonia.Base/Input/PointerEventArgs.cs
@@ -58,7 +58,18 @@ namespace Avalonia.Input
         /// </summary>
         public ulong Timestamp { get; }
 
-        internal bool IsGestureRecognitionSkipped { get; private set; }
+        internal bool IsGestureRecognitionSkipped
+        {
+            get
+            {
+                return (Pointer as Pointer)?.IsGestureRecognitionSkipped ?? false;
+            }
+            private set
+            {
+                if (Pointer is Pointer pointer)
+                    pointer.IsGestureRecognitionSkipped = true;
+            }
+        }
 
         /// <summary>
         /// Gets a value that indicates which key modifiers were active at the time that the pointer event was initiated.


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
`PreventGestureRecognition` now prevents gestures from receiving events from the pointer, until pointer is released.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ X ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
This is a change in behaviour

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
