### PR TITLE
Fix ShapedTextRun Split

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/ShapedTextRun.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/ShapedTextRun.cs
@@ -107,15 +107,29 @@ namespace Avalonia.Media.TextFormatting
             for (var i = 0; i < ShapedBuffer.Length; i++)
             {
                 var advance = ShapedBuffer[i].GlyphAdvance;
+                var currentCluster = ShapedBuffer[i].GlyphCluster;
 
                 if (currentWidth + advance > availableWidth)
                 {
                     break;
                 }
 
-                Codepoint.ReadAt(charactersSpan, length, out var count);
+                if(i + 1 < ShapedBuffer.Length)
+                {
+                    var nextCluster = ShapedBuffer[i + 1].GlyphCluster;
 
-                length += count;
+                    var count = nextCluster - currentCluster;
+
+                    length += count;
+                }
+                else
+                {
+                    Codepoint.ReadAt(charactersSpan, length, out var count);
+
+                    length += count;
+                }
+
+             
                 currentWidth += advance;
             }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR fixes an issue that occurred when text was split in combination with non-visible characters that belong to a shaped cluster.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #13278