### PR TITLE
Fix previewing XAML in the Simple theme project

### DIFF
--- a/samples/Sandbox/Sandbox.csproj
+++ b/samples/Sandbox/Sandbox.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\src\Avalonia.Controls.DataGrid\Avalonia.Controls.DataGrid.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Fonts.Inter\Avalonia.Fonts.Inter.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Themes.Fluent\Avalonia.Themes.Fluent.csproj" />
+    <ProjectReference Include="..\..\src\Avalonia.Themes.Simple\Avalonia.Themes.Simple.csproj" />
   </ItemGroup>
   
   <Import Project="..\..\build\SampleApp.props" />


### PR DESCRIPTION

## What does the pull request do?
Adds a reference to the Simple theme in the Sandbox project to enable previewing XAML in the Simple theme project.

## What is the current behavior?
- Previewing XAML in the Fluent theme works
- Previewing XAML in the Simple theme does not work

## What is the updated/expected behavior with this PR?

Previewing XAML in the Simple theme works

## How was the solution implemented (if it's not obvious)?
Add reference to the Simple theme project in the Sandbox project. This makes the previewer find the Sandbox project before the Benchmarks project, which does not work for the previewer.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None

## Related discussion

Thanks to @timunie for pointing out the problem in [#13392.](https://github.com/AvaloniaUI/Avalonia/discussions/13392)
