### PR TITLE
fixed wrong patterns for predefined DashStyle (#13390)

### DIFF
--- a/src/Avalonia.Base/Media/DashStyle.cs
+++ b/src/Avalonia.Base/Media/DashStyle.cs
@@ -69,17 +69,17 @@ namespace Avalonia.Media
         /// <summary>
         /// Represents a dotted <see cref="DashStyle"/>.
         /// </summary>
-        public static IDashStyle Dot => s_dot ??= new ImmutableDashStyle(new double[] { 0, 2 }, 0);
+        public static IDashStyle Dot => s_dot ??= new ImmutableDashStyle(new double[] { 1, 1 }, 0);
 
         /// <summary>
         /// Represents a dashed dotted <see cref="DashStyle"/>.
         /// </summary>
-        public static IDashStyle DashDot => s_dashDot ??= new ImmutableDashStyle(new double[] { 2, 2, 0, 2 }, 1);
+        public static IDashStyle DashDot => s_dashDot ??= new ImmutableDashStyle(new double[] { 3, 1, 1, 1 }, 1);
 
         /// <summary>
         /// Represents a dashed double dotted <see cref="DashStyle"/>.
         /// </summary>
-        public static IDashStyle DashDotDot => s_dashDotDot ??= new ImmutableDashStyle(new double[] { 2, 2, 0, 2, 0, 2 }, 1);
+        public static IDashStyle DashDotDot => s_dashDotDot ??= new ImmutableDashStyle(new double[] { 3, 1, 1, 1, 1, 1 }, 1);
 
         /// <summary>
         /// Gets or sets the length of alternating dashes and gaps.


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixed wrong patterns for predefined DashStyle (#13390)


## What is the current behavior?
Predefined DashStyle values (DashStyle.Dot, DashStyle.DashDot, DashStyle.DashDotDot) do not show dots (see #13390)

## What is the updated/expected behavior with this PR?
Patterns with dots should display them.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #13390 
