### PR TITLE
Tooltip inherits theme from control

### DIFF
--- a/src/Avalonia.Controls/ToolTip.cs
+++ b/src/Avalonia.Controls/ToolTip.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls.Diagnostics;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Reactive;
+using Avalonia.Styling;
 
 namespace Avalonia.Controls
 {
@@ -227,6 +228,7 @@ namespace Avalonia.Controls
 
                     toolTip = tip as ToolTip ?? new ToolTip { Content = tip };
                     control.SetValue(ToolTipProperty, toolTip);
+                    toolTip.SetValue(ThemeVariant.RequestedThemeVariantProperty, control.ActualThemeVariant);
                 }
 
                 toolTip.Open(control);


### PR DESCRIPTION
## What does the pull request do?
Tooltip takes theme from control it belongs to. So using ThemeVariantScope affects tooltips also.

## What is the current behavior?
Tooltip uses default application theme. Control with different theme (i.e. wrapped in ThemeVariantScope) will have tooltips appearance that do not match.


