### PR TITLE
Fix - Only add TextSelectionLayer when textpresenter is loaded

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Avalonia.Controls.Documents;
 using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Media.Immutable;
@@ -584,6 +585,12 @@ namespace Avalonia.Controls.Presenters
             InvalidateMeasure();
         }
 
+        protected override void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            EnsureTextSelectionLayer();
+        }
+
         protected override Size MeasureOverride(Size availableSize)
         {
             _constraint = availableSize;
@@ -850,14 +857,20 @@ namespace Avalonia.Controls.Presenters
 
             _caretTimer.Tick += CaretTimerTick;
 
+            if (TextSelectionHandleCanvas is { } canvas && _layer != null && !_layer.Children.Contains(canvas))
+                _layer?.Add(TextSelectionHandleCanvas);
+        }
+
+        private void EnsureTextSelectionLayer()
+        {
             if (TextSelectionHandleCanvas == null)
             {
                 TextSelectionHandleCanvas = new TextSelectionHandleCanvas();
+                TextSelectionHandleCanvas.SetPresenter(this);
             }
-
             _layer = TextSelectorLayer.GetTextSelectorLayer(this);
-            _layer?.Add(TextSelectionHandleCanvas);
-            TextSelectionHandleCanvas.SetPresenter(this);
+            if (_layer != null && !_layer.Children.Contains(TextSelectionHandleCanvas))
+                _layer?.Add(TextSelectionHandleCanvas);
         }
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This change moves adding of the TextSelectionLayer to OnLoaded, from OnAttachedToVisualTree. This fixes a crash when a textbox is added to the OverlayLayer.


## What is the current behavior?
When a TextBox is added to the OverLayer, it forces the TextSelectionLayer to be created and added to the VisualLayerManager, if the layer doesn't currently exist. This addition occurs during the Arrange call of the VLM and in a foreach loop on the current layers, causing a crash.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
