### PR TITLE
Add Drag & Drop receiver for X11

### DIFF
--- a/src/Avalonia.X11/X11Atoms.cs
+++ b/src/Avalonia.X11/X11Atoms.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Avalonia.SourceGenerator;
 using static Avalonia.X11.XLib;
 // ReSharper disable FieldCanBeMadeReadOnly.Global
 // ReSharper disable IdentifierTypo
@@ -193,6 +194,24 @@ namespace Avalonia.X11
         public IntPtr MANAGER;
         public IntPtr _KDE_NET_WM_BLUR_BEHIND_REGION;
         public IntPtr INCR;
+
+        public IntPtr XdndAware;
+        public IntPtr XdndSelection;
+        public IntPtr XdndTypeList;
+        public IntPtr XdndActionCopy;
+        public IntPtr XdndEnter;
+        public IntPtr XdndPosition;
+        public IntPtr XdndStatus;
+        public IntPtr XdndLeave;
+        public IntPtr XdndDrop;
+        public IntPtr XdndFinished;
+
+        [AtomAlternativeName("text/uri-list")]
+        public IntPtr MimeTextUriList;
+        [AtomAlternativeName("text/plain")]
+        public IntPtr MimeText;
+        [AtomAlternativeName("text/plain;charset=utf-8")]
+        public IntPtr MimeTextUtf8;
 
         private readonly Dictionary<string, IntPtr> _namesToAtoms  = new Dictionary<string, IntPtr>();
         private readonly Dictionary<IntPtr, string> _atomsToNames = new Dictionary<IntPtr, string>();

--- a/src/Avalonia.X11/Xdnd.cs
+++ b/src/Avalonia.X11/Xdnd.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Avalonia.Input;
+using Avalonia.Platform.Storage.FileIO;
+
+namespace Avalonia.X11;
+
+using static XLib;
+
+internal static class Xdnd
+{
+    public static int ProtocolVersion = 5;
+}
+
+/// Reference: https://freedesktop.org/wiki/Specifications/XDND/
+internal class XdndDataObject : IDataObject
+{
+    private readonly X11Info _x11;
+
+    private IEnumerable<string> KnownDataFormats { get; set; }
+    private IntPtr MimeAtom { get; set; }
+
+    internal XdndDataObject(X11Info x11, ref XEvent ev)
+    {
+        _x11 = x11;
+
+        if (ev.type != XEventName.ClientMessage || ev.ClientMessageEvent.message_type != x11.Atoms.XdndEnter)
+        {
+            throw new ArgumentException($"Event has to be of type {nameof(X11Atoms.XdndEnter)}");
+        }
+
+        if (((ulong)ev.ClientMessageEvent.ptr2 & 1) == 0)
+        {
+            if (!TryAtom(ev.ClientMessageEvent.ptr3) &&
+                !TryAtom(ev.ClientMessageEvent.ptr4) &&
+                !TryAtom(ev.ClientMessageEvent.ptr5))
+            {
+                throw new Exception($"No supported Mimetype detected");
+            }
+        }
+        else
+        {
+            var result = XGetWindowProperty(
+                x11.Display,
+                ev.ClientMessageEvent.ptr1,
+                x11.Atoms.XdndTypeList,
+                IntPtr.Zero,
+                new IntPtr(1024),
+                false,
+                x11.Atoms.AnyPropertyType,
+                out var type,
+                out _,
+                out var nItems,
+                out _,
+                out var prop
+            );
+            if (result != (int)Status.Success)
+            {
+                throw new Exception("XGetWindowProperty failed");
+            }
+
+            unsafe
+            {
+                var ptr = (IntPtr*)prop;
+                if (type != IntPtr.Zero && prop != IntPtr.Zero && ptr != null)
+                {
+                    for (ulong i = 0; i < (ulong)nItems; ++i)
+                    {
+                        if (TryAtom(ptr[i])) break;
+                    }
+                }
+            }
+
+            XFree(prop);
+        }
+    }
+
+    private bool TryAtom(IntPtr atom)
+    {
+        if (atom == _x11.Atoms.MimeTextUriList)
+        {
+            KnownDataFormats = new[] { DataFormats.Files };
+            MimeAtom = atom;
+            return true;
+        }
+
+        if (atom == _x11.Atoms.MimeTextUtf8 || atom == _x11.Atoms.MimeText)
+        {
+            KnownDataFormats = new[] { DataFormats.Text };
+            MimeAtom = atom;
+            return true;
+        }
+
+        return false;
+    }
+
+    private object Content { get; set; }
+
+    public IEnumerable<string> GetDataFormats()
+    {
+        return KnownDataFormats;
+    }
+
+    public bool Contains(string dataFormat)
+    {
+        return KnownDataFormats.Contains(dataFormat);
+    }
+
+    public object Get(string dataFormat)
+    {
+        if (Content == null || !KnownDataFormats.Contains(dataFormat)) return null;
+
+        return Content;
+    }
+
+    public void RequestContent(IntPtr timestamp, IntPtr window)
+    {
+        if (!KnownDataFormats.Any()) return;
+
+        XConvertSelection(
+            _x11.Display,
+            _x11.Atoms.XdndSelection,
+            MimeAtom,
+            _x11.Atoms.XdndSelection,
+            window,
+            timestamp
+        );
+    }
+
+    public void ReceiveContent(IntPtr window)
+    {
+        var result = XGetWindowProperty(
+            _x11.Display,
+            window,
+            _x11.Atoms.XdndSelection,
+            IntPtr.Zero,
+            new IntPtr(1024),
+            false,
+            _x11.Atoms.AnyPropertyType,
+            out var type,
+            out _,
+            out var nItems,
+            out var remaining,
+            out var prop
+        );
+        if (result != (int)Status.Success)
+        {
+            throw new Exception("XGetWindowProperty failed");
+        }
+
+        if (remaining != IntPtr.Zero)
+        {
+            XDeleteProperty(_x11.Display, window, prop);
+            result = XGetWindowProperty(
+                _x11.Display,
+                window,
+                _x11.Atoms.XdndSelection,
+                IntPtr.Zero,
+                remaining + 1024,
+                false,
+                _x11.Atoms.AnyPropertyType,
+                out type,
+                out _,
+                out nItems,
+                out remaining,
+                out prop
+            );
+            if (result != (int)Status.Success)
+            {
+                throw new Exception("XGetWindowProperty failed");
+            }
+        }
+
+        if (type != MimeAtom || prop == IntPtr.Zero)
+        {
+            XDeleteProperty(_x11.Display, window, prop);
+            return;
+        }
+
+        var text =
+            Marshal.PtrToStringAnsi(prop, (int)nItems);
+
+        if (type == _x11.Atoms.MimeTextUriList)
+        {
+            Content =
+                Uri.UnescapeDataString(text)
+                    .Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries)
+                    .Where(line => !line.StartsWith("#"))
+                    .Select(line => line.StartsWith("file://") ? line.Substring(7) : line)
+                    .Select(line => StorageProviderHelpers.TryCreateBclStorageItem(line)!)
+                    .ToList();
+        }
+        else
+        {
+            Content = text;
+        }
+
+        XDeleteProperty(_x11.Display, window, prop);
+    }
+}

--- a/src/Shared/SourceGeneratorAttributes.cs
+++ b/src/Shared/SourceGeneratorAttributes.cs
@@ -51,4 +51,12 @@ namespace Avalonia.SourceGenerator
     internal sealed class GenerateEnumValueListAttribute : Attribute
     {
     }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    internal sealed class AtomAlternativeNameAttribute : Attribute
+    {
+        public AtomAlternativeNameAttribute(string name)
+        {
+        }
+    }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Implements the X Windows Drag-and-Drop Protocol ([XDND](https://freedesktop.org/wiki/Specifications/XDND/) for receiving text and files.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Previously, Drag-and-Drop would not work on any Linux platform.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Drag-and-Drop with Avalonia on the receiving site works.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
The Client Window sets the flag XdndAware so that the server will send XDND events to it. "Enter", "Position" and "Leave" Events are forwarded to the Avalonia-Internal Drag handler.
Currently I always tell the X-Server that a file can be dropped with no mind off the underlying UI component.
Also because of the limitation of the IDataObject, contents are always received in full on "Drop" before awaiting the user to make a choice of data type (See https://github.com/AvaloniaUI/Avalonia/issues/6085).

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [X] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
  - The broken behavior was never documented there so it makes no sense to do so now.

<!--- 
## Breaking changes
List any breaking changes here. -->

<!--- 
## Obsoletions / Deprecations
Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #6085
