### PR TITLE
[Win32] Fix LoadIcon

### DIFF
--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -240,8 +240,6 @@ namespace Avalonia.Win32
             {
                 bitmap.Save(memoryStream);
 
-                memoryStream.Position = 0;
-
                 var iconData = memoryStream.ToArray();
 
                 return new IconImpl(new Win32Icon(iconData), iconData);
@@ -250,9 +248,12 @@ namespace Avalonia.Win32
 
         private static IconImpl CreateIconImpl(Stream stream)
         {
-            stream.Position = 0;
+            if (stream.CanSeek)
+            {
+                stream.Position = 0;
+            }
 
-            if(stream is MemoryStream memoryStream)
+            if (stream is MemoryStream memoryStream)
             {
                 var iconData = memoryStream.ToArray();
 

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -239,18 +239,38 @@ namespace Avalonia.Win32
             using (var memoryStream = new MemoryStream())
             {
                 bitmap.Save(memoryStream);
+
+                memoryStream.Position = 0;
+
                 var iconData = memoryStream.ToArray();
+
                 return new IconImpl(new Win32Icon(iconData), iconData);
             }
         }
 
         private static IconImpl CreateIconImpl(Stream stream)
         {
-            var ms = new MemoryStream();
-            stream.CopyTo(ms);
-            ms.Position = 0;
-            var iconData = ms.ToArray();
-            return new IconImpl(new Win32Icon(iconData), iconData);
+            stream.Position = 0;
+
+            if(stream is MemoryStream memoryStream)
+            {
+                var iconData = memoryStream.ToArray();
+
+                return new IconImpl(new Win32Icon(iconData), iconData);
+            }
+            else
+            {
+                using (var ms = new MemoryStream())
+                {
+                    stream.CopyTo(ms);
+
+                    ms.Position = 0;
+
+                    var iconData = ms.ToArray();
+
+                    return new IconImpl(new Win32Icon(iconData), iconData);
+                }
+            }
         }
 
         private static void SetDpiAwareness()


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR makes sure the source stream that holds the icon data is always reset to `Position = 0` before its content is written to a byte array

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
