### PR TITLE
Fix TimePicker empty designator on 12 hour clock

### DIFF
--- a/src/Avalonia.Controls/DateTimePickers/DateTimePickerPanel.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DateTimePickerPanel.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Linq;
 using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Utils;
 using Avalonia.Input;
 using Avalonia.Input.GestureRecognizers;
 using Avalonia.Interactivity;
@@ -516,8 +517,7 @@ namespace Avalonia.Controls.Primitives
                 case DateTimePickerPanelType.Minute:
                     return new TimeSpan(0, value, 0).ToString(ItemFormat);
                 case DateTimePickerPanelType.TimePeriod:
-                    return value == MinimumValue ? CultureInfo.CurrentCulture.DateTimeFormat.AMDesignator :
-                        CultureInfo.CurrentCulture.DateTimeFormat.PMDesignator;
+                    return value == MinimumValue ? TimeUtils.GetAMDesignator() : TimeUtils.GetPMDesignator();
                 default:
                         return "";
             }

--- a/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
+++ b/src/Avalonia.Controls/DateTimePickers/TimePicker.cs
@@ -5,6 +5,7 @@ using Avalonia.Data;
 using Avalonia.Layout;
 using System;
 using System.Globalization;
+using Avalonia.Controls.Utils;
 
 namespace Avalonia.Controls
 {
@@ -227,8 +228,7 @@ namespace Avalonia.Controls
                 _minuteText.Text = newTime.ToString("mm");
                 PseudoClasses.Set(":hasnotime", false);
 
-                _periodText.Text = time.Value.Hours >= 12 ? CultureInfo.CurrentCulture.DateTimeFormat.PMDesignator :
-                    CultureInfo.CurrentCulture.DateTimeFormat.AMDesignator;
+                _periodText.Text = time.Value.Hours >= 12 ? TimeUtils.GetPMDesignator() : TimeUtils.GetAMDesignator();
             }
             else
             {
@@ -236,8 +236,7 @@ namespace Avalonia.Controls
                 _minuteText.Text = "minute";
                 PseudoClasses.Set(":hasnotime", true);
 
-                _periodText.Text = DateTime.Now.Hour >= 12 ? CultureInfo.CurrentCulture.DateTimeFormat.PMDesignator :
-                    CultureInfo.CurrentCulture.DateTimeFormat.AMDesignator;
+                _periodText.Text = DateTime.Now.Hour >= 12 ?  TimeUtils.GetPMDesignator() :  TimeUtils.GetAMDesignator();
             }
         }
 

--- a/src/Avalonia.Controls/Utils/TimeUtils.cs
+++ b/src/Avalonia.Controls/Utils/TimeUtils.cs
@@ -1,0 +1,16 @@
+﻿using System.Globalization;
+
+namespace Avalonia.Controls.Utils;
+
+internal static class TimeUtils
+{
+    public static string GetPMDesignator() =>
+        !string.IsNullOrEmpty(CultureInfo.CurrentCulture.DateTimeFormat.PMDesignator) ?
+            CultureInfo.CurrentCulture.DateTimeFormat.PMDesignator :
+            CultureInfo.InvariantCulture.DateTimeFormat.PMDesignator;
+
+    public static string GetAMDesignator() =>
+        !string.IsNullOrEmpty(CultureInfo.CurrentCulture.DateTimeFormat.AMDesignator) ?
+            CultureInfo.CurrentCulture.DateTimeFormat.AMDesignator :
+            CultureInfo.InvariantCulture.DateTimeFormat.AMDesignator;
+}

--- a/tests/Avalonia.Controls.UnitTests/TimePickerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TimePickerTests.cs
@@ -98,6 +98,40 @@ namespace Avalonia.Controls.UnitTests
                 Assert.True(minuteText.Text == "minute");
             }
         }
+        
+        [Fact]
+        [UseEmptyDesignatorCulture]
+        public void Using_12HourClock_On_Culture_With_Empty_Period_Should_Show_Period()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                TimePicker timePicker = new TimePicker()
+                {
+                    Template = CreateTemplate(), ClockIdentifier = "12HourClock",
+                };
+                timePicker.ApplyTemplate();
+
+                var desc = timePicker.GetVisualDescendants();
+                Assert.True(desc.Count() > 1); //Should be layoutroot grid & button
+
+                Assert.True(desc.ElementAt(1) is Button);
+
+                var container = (desc.ElementAt(1) as Button).Content as Grid;
+                Assert.True(container != null);
+
+                var periodTextHost = container.Children[4] as Border;
+                Assert.NotNull(periodTextHost);
+                var periodText = periodTextHost.Child as TextBlock;
+                Assert.NotNull(periodTextHost);
+
+                TimeSpan ts = TimeSpan.FromHours(10);
+                timePicker.SelectedTime = ts;
+                Assert.False(string.IsNullOrEmpty(periodText.Text));
+
+                timePicker.SelectedTime = null;
+                Assert.False(string.IsNullOrEmpty(periodText.Text));
+            }
+        }
 
         private static TestServices Services => TestServices.MockThreadingInterface.With(
             fontManagerImpl: new HeadlessFontManagerStub(),

--- a/tests/Avalonia.UnitTests/UseEmptyDesignatorCultureAttribute.cs
+++ b/tests/Avalonia.UnitTests/UseEmptyDesignatorCultureAttribute.cs
@@ -1,0 +1,37 @@
+﻿#nullable enable
+
+using System;
+using System.Globalization;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace Avalonia.UnitTests;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public sealed class UseEmptyDesignatorCultureAttribute : BeforeAfterTestAttribute
+{
+    private CultureInfo? _previousCulture;
+    private CultureInfo? _previousUICulture;
+
+    private CultureInfo CultureInfo { get; } =
+        new(string.Empty, false) { DateTimeFormat = { AMDesignator = string.Empty, PMDesignator = string.Empty } };
+
+    public override void Before(MethodInfo methodUnderTest)
+    {
+        base.Before(methodUnderTest);
+
+        _previousCulture = CultureInfo.CurrentCulture;
+        _previousUICulture = CultureInfo.CurrentUICulture;
+
+        CultureInfo.CurrentCulture = CultureInfo;
+        CultureInfo.CurrentUICulture = CultureInfo;
+    }
+
+    public override void After(MethodInfo methodUnderTest)
+    {
+        CultureInfo.CurrentCulture = _previousCulture!;
+        CultureInfo.CurrentUICulture = _previousUICulture!;
+
+        base.After(methodUnderTest);
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR ensures that the PM/AM designator on the timepicker will be visible even if the current culture designators are empty.
As per documentation https://learn.microsoft.com/en-us/dotnet/api/system.globalization.datetimeformatinfo.amdesignator?view=net-7.0 , the designators could return an empty string.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Currently, if the current culture designator is empty and the TimePicker property is set to 12 hour type, it will show empty boxes with no text.
![image](https://github.com/AvaloniaUI/Avalonia/assets/106885623/3a5bd0ab-b704-4c41-b07b-b2c13eb32b10)



## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
If the current culture info PM/AM designators are empty, take the PM/AM designator from the invariant culture.


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

