### PR TITLE
Fix DateTimePicker scroll down

### DIFF
--- a/src/Avalonia.Controls/DateTimePickers/DateTimePickerPanel.cs
+++ b/src/Avalonia.Controls/DateTimePickers/DateTimePickerPanel.cs
@@ -406,7 +406,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         public void ScrollDown(int numItems = 1)
         {
-            var scrollHeight = _extent.Height - Viewport.Height;
+            var scrollHeight = Math.Max(Extent.Height - ItemHeight, 0);
             var newY = Math.Min(Offset.Y + (numItems * ItemHeight), scrollHeight);
             Offset = new Vector(0, newY);
         }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This PR fixes bug on down button in the Time/Date pickers.

## What is the current behavior?
Currently if you press the down button in the AM/PM designator it will go blank.
If you scroll to the end of the year part in the DatePicker, the down button will stop selecting at some point.

![TimePickerProblem1](https://github.com/AvaloniaUI/Avalonia/assets/106885623/5049445b-1afa-414a-9486-42061561a05f)
![TimePickerProblem2](https://github.com/AvaloniaUI/Avalonia/assets/106885623/f4b64d83-3618-472d-8b78-3c5ca70db44a)

The possible scroll height is calculated like in the standard scroll viewer, but in this case we can go beyond the viewport height in order to select the last items.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Down button should select the next item up till the end.

## How was the solution implemented (if it's not obvious)?
The scroll height should be extent heght minus item height. This will allow it to scroll up to the last item.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
