### PR TITLE
Fix dragging a slider with a tooltip

### DIFF
--- a/src/Avalonia.Base/Input/Pointer.cs
+++ b/src/Avalonia.Base/Input/Pointer.cs
@@ -88,7 +88,10 @@ namespace Avalonia.Input
 
         public void Dispose()
         {
-            Capture(null);
+            if (Captured != null)
+            {
+                Capture(null);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #11296 by not clearing pointer capture unless the `Pointer` object has actually captured the pointer.

## What is the current behavior?
Currently pointer capture is always cleared when a window closes and destroys its `Pointer`. This means that if a window A closes while window B has mouse capture, window B incorrectly loses its capture.

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
Fixes #11296