### PR TITLE
Handle changes to the logical children collection while operating on it

### DIFF
--- a/src/Avalonia.Base/Collections/Arena.cs
+++ b/src/Avalonia.Base/Collections/Arena.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Avalonia.Collections;
+
+/// <summary>
+/// Reduces memory allocations by handing out <see cref="Span{T}"/> views of larger array chunks.
+/// </summary>
+/// <remarks>
+/// Intended for scenarios in which many short-lived collections are required simultaneously.
+/// </remarks>
+public class Arena<T>
+{
+    private readonly int _chunkSize;
+
+    private T[] _array;
+    private int _offset;
+
+    public Arena(int chunkSize = 256)
+    {
+        _chunkSize = chunkSize;
+        _array = new T[_chunkSize];
+    }
+
+    /// <summary>
+    /// Reserves and returns a section of the <see cref="Arena{T}"/>'s memory.
+    /// </summary>
+    /// <param name="size">The length of the returned <see cref="Span{T}"/>.</param>
+    /// <returns>A <see cref="Span{T}"/> which points to a segment of a larger array allocated by the <see cref="Arena{T}"/>. <strong>Do not</strong> store long-term references to this object.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="size"/> is less than zero.</exception>
+    public Span<T> Acquire(int size)
+    {
+        switch (size)
+        {
+            case < 0:
+                throw new ArgumentOutOfRangeException(nameof(size));
+            case 0:
+                return Span<T>.Empty;
+        }
+
+        if (size > _chunkSize)
+        {
+            Debug.Fail("Requested an span which is larger than the chunk size. This always requires the allocation of a new array.");
+            return new Span<T>(new T[size]);
+        }
+
+        if (_offset + size > _chunkSize)
+        {
+            _array = new T[_chunkSize];
+            _offset = 0;
+        }
+
+        var span = new Span<T>(_array, _offset, size);
+
+        _offset += size;
+
+        return span;
+    }
+
+    /// <summary>
+    /// Reserves a section of the <see cref="Arena{T}"/>'s memory, fills it with the values of <paramref name="source"/>, then returns it.
+    /// </summary>
+    /// <param name="source">A collection, the values of which will be copied into the returned <see cref="Span{T}"/>.</param>
+    /// <returns>A <see cref="Span{T}"/> which points to a segment of a larger array allocated by the <see cref="Arena{T}"/>. <strong>Do not</strong> store long-term references to this object.</returns>
+    public Span<T> AcquireCopyOf(IList<T> source)
+    {
+        var span = Acquire(source.Count);
+
+        for (var i = 0; i < source.Count; i++)
+        {
+            span[i] = source[i];
+        }
+
+        return span;
+    }
+
+    /// <inheritdoc cref="AcquireCopyOf(IList{T})"/>
+    public Span<T> AcquireCopyOf(ICollection<T> source)
+    {
+        var span = Acquire(source.Count);
+
+        int i = 0;
+        foreach (var item in source)
+        {
+            span[i++] = item;
+        }
+
+        return span;
+    }
+}

--- a/src/Avalonia.Base/Collections/Arena.cs
+++ b/src/Avalonia.Base/Collections/Arena.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Avalonia.Collections;
 
@@ -10,17 +11,30 @@ namespace Avalonia.Collections;
 /// <remarks>
 /// Intended for scenarios in which many short-lived collections are required simultaneously.
 /// </remarks>
-public class Arena<T>
+internal class Arena<T>
 {
+    public const int DefaultChunkSize = 256;
     private readonly int _chunkSize;
 
-    private T[] _array;
+    private GCHandle _array;
     private int _offset;
 
-    public Arena(int chunkSize = 256)
+    private static readonly ThreadLocal<Arena<T>> s_threadArenas = new(() => new(DefaultChunkSize));
+    
+    /// <summary>
+    /// Gets an <see cref="Arena{T}"/> for the current thread with the default chunk size.
+    /// </summary>
+    public static Arena<T> Current => s_threadArenas.Value!;
+
+    public Arena(int chunkSize = DefaultChunkSize)
     {
         _chunkSize = chunkSize;
-        _array = new T[_chunkSize];
+        _array = GCHandle.Alloc(null, GCHandleType.Weak);
+    }
+
+    ~Arena()
+    {
+        _array.Free();
     }
 
     /// <summary>
@@ -41,17 +55,19 @@ public class Arena<T>
 
         if (size > _chunkSize)
         {
-            Debug.Fail("Requested an span which is larger than the chunk size. This always requires the allocation of a new array.");
+            Logging.Logger.Sink?.Log(Logging.LogEventLevel.Verbose, "MemAlloc", this, "A span which is larger than the chunk size was requested. This always requires the allocation of a new array.");
             return new Span<T>(new T[size]);
         }
 
-        if (_offset + size > _chunkSize)
+        var array = (T[]?)_array.Target;
+
+        if (array == null || _offset + size > _chunkSize)
         {
-            _array = new T[_chunkSize];
+            _array.Target = array = new T[_chunkSize];
             _offset = 0;
         }
 
-        var span = new Span<T>(_array, _offset, size);
+        var span = new Span<T>(array, _offset, size);
 
         _offset += size;
 
@@ -80,10 +96,13 @@ public class Arena<T>
     {
         var span = Acquire(source.Count);
 
-        int i = 0;
-        foreach (var item in source)
+        if (source.Count > 0)
         {
-            span[i++] = item;
+            int i = 0;
+            foreach (var item in source)
+            {
+                span[i++] = item;
+            }
         }
 
         return span;

--- a/src/Avalonia.Base/StyledElement.cs
+++ b/src/Avalonia.Base/StyledElement.cs
@@ -558,12 +558,13 @@ namespace Avalonia
         /// <param name="e">The event args.</param>
         internal virtual void NotifyChildResourcesChanged(ResourcesChangedEventArgs e)
         {
-            if (_logicalChildren?.ToArray() is { } logicalChildrenCopy)
+            if (_logicalChildren != null)
             {
                 e ??= ResourcesChangedEventArgs.Empty;
-                for (var i = 0; i < logicalChildrenCopy.Length; i++)
+                var span = Arena<ILogical>.Current.AcquireCopyOf(_logicalChildren);
+                for (var i = 0; i < span.Length; i++)
                 {
-                    logicalChildrenCopy[i].NotifyResourcesChanged(e);
+                    span[i].NotifyResourcesChanged(e);
                 }
             }
         }
@@ -871,7 +872,7 @@ namespace Avalonia
             }
         }
 
-        private void OnAttachedToLogicalTreeCore(LogicalTreeAttachmentEventArgs e, Arena<ILogical>? childrenArena = null)
+        private void OnAttachedToLogicalTreeCore(LogicalTreeAttachmentEventArgs e)
         {
             if (this.GetLogicalParent() == null && !(this is ILogicalRoot))
             {
@@ -898,21 +899,20 @@ namespace Avalonia
 
                 if (_logicalChildren != null)
                 {
-                    childrenArena ??= new();
-                    var span = childrenArena.AcquireCopyOf(_logicalChildren);
+                    var span = Arena<ILogical>.Current.AcquireCopyOf(_logicalChildren);
                     
                     for (var i = 0; i < span.Length; i++)
                     {
                         if (span[i] is StyledElement child)
                         {
-                            child.OnAttachedToLogicalTreeCore(e, childrenArena);
+                            child.OnAttachedToLogicalTreeCore(e);
                         }
                     }
                 }
             }
         }
 
-        private void OnDetachedFromLogicalTreeCore(LogicalTreeAttachmentEventArgs e, Arena<ILogical>? childrenArena = null)
+        private void OnDetachedFromLogicalTreeCore(LogicalTreeAttachmentEventArgs e)
         {
             if (_logicalRoot != null)
             {
@@ -923,14 +923,13 @@ namespace Avalonia
 
                 if (_logicalChildren != null)
                 {
-                    childrenArena ??= new();
-                    var span = childrenArena.AcquireCopyOf(_logicalChildren);
+                    var span = Arena<ILogical>.Current.AcquireCopyOf(_logicalChildren);
                     
                     for (var i = 0; i < span.Length; i++)
                     {
                         if (span[i] is StyledElement child)
                         {
-                            child.OnDetachedFromLogicalTreeCore(e, childrenArena);
+                            child.OnDetachedFromLogicalTreeCore(e);
                         }
                     }
                 }
@@ -982,7 +981,7 @@ namespace Avalonia
             }
         }
 
-        private void DetachStyles(IReadOnlyList<Style> styles, Arena<ILogical>? childrenArena = null)
+        private void DetachStyles(IReadOnlyList<Style> styles)
         {
             var values = GetValueStore();
             values.BeginStyling();
@@ -991,14 +990,13 @@ namespace Avalonia
 
             if (_logicalChildren != null)
             {
-                childrenArena ??= new();
-                var span = childrenArena.AcquireCopyOf(_logicalChildren);
+                var span = Arena<ILogical>.Current.AcquireCopyOf(_logicalChildren);
 
                 for (var i = 0; i < span.Length; i++)
                 {
                     if (span[i] is StyledElement child)
                     {
-                        child.DetachStyles(styles, childrenArena);
+                        child.DetachStyles(styles);
                     }
                 }
             }


### PR DESCRIPTION
Create an "arena" at the start of a change to child controls, and copy the current state of the child collection into it before beginning iteration over that `Span`.

Fixes exceptions when children are removed, and fixes bugs when (pre-existing) children are not processed due to new children being inserted into the collection.

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #13497
Fixes #12799
Fixes #14437