### PR TITLE
Fix ImageBrush crash when source bitmap gets disposed

### DIFF
--- a/src/Avalonia.Base/Media/Imaging/Bitmap.cs
+++ b/src/Avalonia.Base/Media/Imaging/Bitmap.cs
@@ -284,6 +284,16 @@ namespace Avalonia.Media.Imaging
             return AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
         }
 
-        IRef<IBitmapImpl> IImageBrushSource.Bitmap => PlatformImpl;
+        IRef<IBitmapImpl>? IImageBrushSource.Bitmap
+        {
+            get
+            {
+                // TODO12: We should probably make PlatformImpl to be nullable or make it possible to check
+                // and fix IRef<T> in general (right now Item is not nullable while it internally is)
+                if (PlatformImpl.Item == null!)
+                    return null;
+                return PlatformImpl;
+            }
+        }
     }
 }


### PR DESCRIPTION
We need to change the way we handle IRef too at some point, but this fix should be sufficient to prevent crashes