### PR TITLE
fix: Navigation when CanExecute is fasle

### DIFF
--- a/src/Avalonia.Base/Input/Navigation/TabNavigation.cs
+++ b/src/Avalonia.Base/Input/Navigation/TabNavigation.cs
@@ -649,12 +649,12 @@ namespace Avalonia.Input.Navigation
         private static bool IsTabStop(IInputElement e)
         {
             if (e is InputElement ie)
-                return ie.Focusable && KeyboardNavigation.GetIsTabStop(ie) && ie.IsVisible && ie.IsEnabled;
+                return ie.Focusable && KeyboardNavigation.GetIsTabStop(ie) && ie.IsVisible && ie.IsEffectivelyEnabled;
             return false;
         }
 
         private static bool IsTabStopOrGroup(IInputElement e) => IsTabStop(e) || IsGroup(e);
         private static bool IsVisible(IInputElement e) => (e as Visual)?.IsVisible ?? true;
-        private static bool IsVisibleAndEnabled(IInputElement e) => IsVisible(e) && e.IsEnabled;
+        private static bool IsVisibleAndEnabled(IInputElement e) => IsVisible(e) && e.IsEffectivelyEnabled;
     }
 }

--- a/tests/Avalonia.Base.UnitTests/Input/KeyboardDeviceTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/KeyboardDeviceTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Windows.Input;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Input.Raw;
 using Avalonia.UnitTests;
@@ -112,7 +110,7 @@ namespace Avalonia.Base.UnitTests.Input
             button.KeyBindings.Add(new KeyBinding
             {
                 Gesture = new KeyGesture(Key.O, KeyModifiers.Control),
-                Command = new DelegateCommand(() =>
+                Command = new Utilities.DelegateCommand(() =>
                 {
                     button.KeyBindings.Clear();
                     ++raised;
@@ -132,15 +130,6 @@ namespace Avalonia.Base.UnitTests.Input
                     "o"));
 
             Assert.Equal(1, raised);
-        }
-
-        private class DelegateCommand : ICommand
-        {
-            private readonly Action _action;
-            public DelegateCommand(Action action) => _action = action;
-            public event EventHandler CanExecuteChanged { add { } remove { } }
-            public bool CanExecute(object parameter) => true;
-            public void Execute(object parameter) => _action();
         }
 
         [Fact]

--- a/tests/Avalonia.Base.UnitTests/Input/KeyboardNavigationTests_Tab.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/KeyboardNavigationTests_Tab.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -1273,5 +1274,42 @@ namespace Avalonia.Base.UnitTests.Input
 
             Assert.True(button.IsFocused);
         }
+
+        [Fact]
+        public void Next_Skip_Button_When_Command_CanExecute_Is_False()
+        {
+            Button current;
+            Button expected;
+            bool executed = false;
+
+            var top = new StackPanel
+            {
+                [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Cycle,
+                Children =
+                {
+                    new StackPanel
+                    {
+                        Children =
+                        {
+                            (current = new Button { Name = "Button1" }),
+                            new Button
+                            {
+                                Name = "Button2",
+                                Command = new Utilities.DelegateCommand(()=>executed = true,
+                                    _ => false),
+                            },
+                            (expected = new Button { Name = "Button3" }),
+                        }
+                    }
+                }
+            };
+
+            var result = KeyboardNavigationHandler.GetNext(current, NavigationDirection.Next) as Button;
+
+            Assert.Equal(expected.Name, result?.Name);
+            Assert.False(executed);
+        }
+
+
     }
 }

--- a/tests/Avalonia.Base.UnitTests/Utilities/DelegateCommand.cs
+++ b/tests/Avalonia.Base.UnitTests/Utilities/DelegateCommand.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace Avalonia.Base.UnitTests.Utilities;
+
+internal class DelegateCommand : ICommand
+{
+    private readonly Action _action;
+    private readonly Func<object, bool> _canExecute;
+    public DelegateCommand(Action action, Func<object, bool> canExecute = default)
+    {
+        _action = action;
+        _canExecute = canExecute ?? new(_ => true);
+    }
+
+    public event EventHandler CanExecuteChanged { add { } remove { } }
+    public bool CanExecute(object parameter) => _canExecute(parameter);
+    public void Execute(object parameter) => _action();
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Buttons with command bindings to a command that is using CanExecute blocks tab navigation when the command can't be executed and the button is disabled.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Disabled buttons should be skipped in the same manner as when buttons are disabled by using IsEnabled="False".

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #13499
