### PR TITLE
fix(X11):  CS0472 The result of the expression is always 'false'

### DIFF
--- a/src/Avalonia.X11/Screens/X11Screens.Scaling.cs
+++ b/src/Avalonia.X11/Screens/X11Screens.Scaling.cs
@@ -197,7 +197,7 @@ internal partial class X11Screens
         }
         
         
-        if (globalFactorString == null && screenFactorsString == null && usePhysicalDpi == null)
+        if (globalFactorString == null && screenFactorsString == null)
             return null;
 
         return (userConfig, globalFactor ?? 1, usePhysicalDpi);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Because following condition never be true

https://github.com/AvaloniaUI/Avalonia/blob/e40d5d624cb6e3eb54743b4046d69ebe69e56b5a/src/Avalonia.X11/Screens/X11Screens.Scaling.cs#L200

`GetScalingProvider' always return `UserConfiguredScalingProvider`

https://github.com/AvaloniaUI/Avalonia/blob/e40d5d624cb6e3eb54743b4046d69ebe69e56b5a/src/Avalonia.X11/Screens/X11Screens.Scaling.cs#L236-L241


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
