### PR TITLE
DataGrid inertial scroll support (#13502)

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -412,6 +412,21 @@ namespace Avalonia.Controls
             }
         }
 
+        /// <summary>
+        /// Defines the <see cref="IsScrollInertiaEnabled"/> property.
+        /// </summary>
+        public static readonly AttachedProperty<bool> IsScrollInertiaEnabledProperty =
+            ScrollViewer.IsScrollInertiaEnabledProperty.AddOwner<DataGrid>();
+
+        /// <summary>
+        /// Gets or sets whether scroll gestures should include inertia in their behavior and value.
+        /// </summary>
+        public bool IsScrollInertiaEnabled
+        {
+            get => GetValue(IsScrollInertiaEnabledProperty);
+            set => SetValue(IsScrollInertiaEnabledProperty, value);
+        }
+
         private bool _isValid = true;
 
         public static readonly DirectProperty<DataGrid, bool> IsValidProperty =

--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -532,9 +532,13 @@
               <DataGridRowsPresenter Name="PART_RowsPresenter"
                                      Grid.Row="1"
                                      Grid.RowSpan="2"
-                                     Grid.ColumnSpan="3" Grid.Column="0">
+                                     Grid.ColumnSpan="3"
+                                     Grid.Column="0"
+                                     ScrollViewer.IsScrollInertiaEnabled="{TemplateBinding IsScrollInertiaEnabled}">
                 <DataGridRowsPresenter.GestureRecognizers>
-                  <ScrollGestureRecognizer CanHorizontallyScroll="True" CanVerticallyScroll="True" />
+                  <ScrollGestureRecognizer CanHorizontallyScroll="True"
+                                           CanVerticallyScroll="True"
+                                           IsScrollInertiaEnabled="{Binding (ScrollViewer.IsScrollInertiaEnabled), ElementName=PART_RowsPresenter}" />
                 </DataGridRowsPresenter.GestureRecognizers>
               </DataGridRowsPresenter>
               <Rectangle Name="PART_BottomRightCorner"

--- a/src/Avalonia.Controls.DataGrid/Themes/Simple.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Simple.xaml
@@ -335,10 +335,12 @@
 
               <DataGridRowsPresenter Name="PART_RowsPresenter"
                                      Grid.Row="1"
-                                     Grid.ColumnSpan="2">
+                                     Grid.ColumnSpan="2"
+                                     ScrollViewer.IsScrollInertiaEnabled="{TemplateBinding IsScrollInertiaEnabled}">
                 <DataGridRowsPresenter.GestureRecognizers>
                   <ScrollGestureRecognizer CanHorizontallyScroll="True"
-                                           CanVerticallyScroll="True" />
+                                           CanVerticallyScroll="True"
+                                           IsScrollInertiaEnabled="{Binding (ScrollViewer.IsScrollInertiaEnabled), ElementName=PART_RowsPresenter}" />
                 </DataGridRowsPresenter.GestureRecognizers>
               </DataGridRowsPresenter>
               <Rectangle Name="PART_BottomRightCorner"


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Adds inertial scrolling support to DataGrid via a new IsScrollInertiaEnabled property, which is true by default. See #13502.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
DataGrid does not currently support inertial scrolling, meaning that when the user scrolls the grid with a touch gesture, scrolling always stops as soon as the gesture ends.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
With this PR, DataGrid supports inertial scrolling, and it is enabled by default, meaning that when the user scrolls the grid with a "flick" gesture, scrolling will decelerate rather than stop as soon as the gesture ends. The current behavior can be restored by setting the IsScrollInertiaEnabled property to false.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
As described in #13502, a property was added to [DataGrid](https://github.com/AvaloniaUI/Avalonia/pull/13511/files#diff-24f121237b70a53601a67a0b0eb051fdef7785801648f96091d851981a6d573e), and the [Fluent](https://github.com/AvaloniaUI/Avalonia/pull/13511/files#diff-3d080ffb23dd9adac5c6a750cef02551786a480752309de03a20c66f989ff1e5) and [Simple](https://github.com/AvaloniaUI/Avalonia/pull/13511/files#diff-c4919dbaa46dcfbb2fd24b8e1140f16df4cb87f3f4c2a1fb084bb0c646241c7d) templates were updated to use it.

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
As the new property defaults to true, DataGrid will now use inertial scrolling by default. IMO this is expected behavior (consistent with other controls that use ScrollViewer), not a breaking change.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
None.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #13502