### PR TITLE
DComposition: made interop structs internal

### DIFF
--- a/src/Windows/Avalonia.Win32/DComposition/NativeStructs.cs
+++ b/src/Windows/Avalonia.Win32/DComposition/NativeStructs.cs
@@ -1,17 +1,16 @@
 ﻿using System.Runtime.InteropServices;
-using Avalonia.Win32.DirectX;
 
 namespace Avalonia.Win32.DComposition;
 
 [StructLayout(LayoutKind.Sequential)]
-public struct DXGI_RATIONAL
+internal struct DXGI_RATIONAL
 {
     public uint Numerator;
     public uint Denominator;
 }
 
 [StructLayout(LayoutKind.Sequential)]
-public struct DCOMPOSITION_FRAME_STATISTICS
+internal struct DCOMPOSITION_FRAME_STATISTICS
 {
     public long lastFrameTime;
     public DXGI_RATIONAL currentCompositionRate;


### PR DESCRIPTION
## What does the pull request do?
This PR changes the DirectComposition interop structs introduced in #13382 from public to internal, like all other interop types.

Not a breaking change yet since no official version containing this PR has been released.
