### PR TITLE
Add WindowState to window properties in win32 window impl

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -615,6 +615,12 @@ namespace Avalonia.Win32
                         {
                             _lastWindowState = windowState;
 
+                            var newWindowProperties = _windowProperties;
+
+                            newWindowProperties.WindowState = windowState;
+
+                            UpdateWindowProperties(newWindowProperties);
+
                             WindowStateChanged?.Invoke(windowState);
 
                             if (_isClientAreaExtended)

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1087,6 +1087,8 @@ namespace Avalonia.Win32
                     throw new ArgumentException("Invalid WindowState.");
             }
 
+            newWindowProperties.WindowState = state;
+
             UpdateWindowProperties(newWindowProperties);
 
             if (command.HasValue)
@@ -1292,7 +1294,7 @@ namespace Avalonia.Win32
                 if (IsWindowVisible(_hwnd))
                     style |= WindowStyles.WS_VISIBLE;
 
-                if (newProperties.IsResizable)
+                if (newProperties.IsResizable || newProperties.WindowState == WindowState.Maximized)
                 {
                     style |= WindowStyles.WS_SIZEFRAME;
                     style |= WindowStyles.WS_MAXIMIZEBOX;
@@ -1303,7 +1305,7 @@ namespace Avalonia.Win32
                     style &= ~WindowStyles.WS_MAXIMIZEBOX;
                 }
 
-                const WindowStyles fullDecorationFlags = WindowStyles.WS_CAPTION | WindowStyles.WS_SYSMENU;
+                const WindowStyles fullDecorationFlags = WindowStyles.WS_CAPTION | WindowStyles.WS_SYSMENU | WindowStyles.WS_THICKFRAME | WindowStyles.WS_BORDER;
 
                 if (newProperties.Decorations == SystemDecorations.Full)
                 {
@@ -1313,7 +1315,7 @@ namespace Avalonia.Win32
                 {
                     style &= ~fullDecorationFlags;
 
-                    if (newProperties.Decorations == SystemDecorations.BorderOnly && WindowState != WindowState.Maximized)
+                    if (newProperties.Decorations == SystemDecorations.BorderOnly && newProperties.WindowState != WindowState.Maximized)
                     {
                         style |= WindowStyles.WS_THICKFRAME | WindowStyles.WS_BORDER;
                     }
@@ -1487,6 +1489,7 @@ namespace Avalonia.Win32
             public bool IsResizable;
             public SystemDecorations Decorations;
             public bool IsFullScreen;
+            public WindowState WindowState;
         }
 
         private struct ResizeReasonScope : IDisposable


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Adds WindowState to WindowProperties in win32 WindowImpl. This value is used to update window styles, ensuring BorderOnly window styles aren't applied to a Maximized window.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
