### PR TITLE
Avoid Adreno DXGI adapter on Win-ARM devices

### DIFF
--- a/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32EglDisplay.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32EglDisplay.cs
@@ -85,10 +85,7 @@ namespace Avalonia.Win32.OpenGl.Angle
                     chosenAdapter = adapters
                         .OrderByDescending(x =>
                             // Put adreno in lower priority - it's broken in Avalonia.
-                            x.name.Contains("adreno") ? -1
-                            : x.name.Contains("nvidia") ? 2
-                            : x.name.Contains("amd") ? 1
-                            : 0)
+                            x.name.Contains("adreno") ? -1 : 0)
                         .First().adapter
                         .CloneReference();
 

--- a/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32EglDisplay.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32EglDisplay.cs
@@ -46,8 +46,7 @@ namespace Avalonia.Win32.OpenGl.Angle
             }, AngleOptions.PlatformApi.DirectX11);
         }
 
-        public static unsafe AngleWin32EglDisplay CreateD3D11Display(Win32AngleEglInterface egl,
-            bool preferDiscreteAdapter = false)
+        public static unsafe AngleWin32EglDisplay CreateD3D11Display(Win32AngleEglInterface egl)
         {
             var featureLevels = new[]
             {
@@ -65,7 +64,9 @@ namespace Avalonia.Win32.OpenGl.Angle
                 using var factory = MicroComRuntime.CreateProxyFor<IDXGIFactory1>(pDxgiFactory, true);
 
                 void* pAdapter = null;
-                if (preferDiscreteAdapter)
+                // As for now, we only need to redefine default adapter only on ARM64 just in case of Adreno GPU.
+                var redefineDefaultAdapter = RuntimeInformation.ProcessArchitecture == Architecture.Arm64;
+                if (redefineDefaultAdapter)
                 {
                     ushort adapterIndex = 0;
                     var adapters = new List<(IDXGIAdapter1 adapter, string name)>();
@@ -80,9 +81,17 @@ namespace Avalonia.Win32.OpenGl.Angle
 
                     if (adapters.Count == 0)
                         throw new OpenGlException("No adapters found");
+
                     chosenAdapter = adapters
-                        .OrderByDescending(x => x.name.Contains("nvidia") ? 2 : x.name.Contains("amd") ? 1 : 0)
-                        .First().adapter.CloneReference();
+                        .OrderByDescending(x =>
+                            // Put adreno in lower priority - it's broken in Avalonia.
+                            x.name.Contains("adreno") ? -1
+                            : x.name.Contains("nvidia") ? 2
+                            : x.name.Contains("amd") ? 1
+                            : 0)
+                        .First().adapter
+                        .CloneReference();
+
                     foreach (var a in adapters)
                         a.adapter.Dispose();
                 }


### PR DESCRIPTION
![Screenshot 2023-11-08 005935](https://github.com/AvaloniaUI/Avalonia/assets/3163374/1b3771cf-2431-439c-b3ba-6bdfb2aa0674)


## What does the pull request do?

Ignoring Adreno DXGI adapter seems to fix Avalonia running on win-arm devices. On my arm device, the second adapter to be used is Microsoft Basic Renderer which doesn't have these issues. I would expect it to be slower, but I don't really want to solve these problems right now. 
While it's **probably** not the best solution, an application still is feature complete (like, winui composition works fine).


## Fixed issues

Fixes #10405