### PR TITLE
fix:Previewer connection fails from VSCode

### DIFF
--- a/src/Avalonia.DesignerSupport/Remote/HtmlTransport/HtmlTransport.cs
+++ b/src/Avalonia.DesignerSupport/Remote/HtmlTransport/HtmlTransport.cs
@@ -112,7 +112,7 @@ namespace Avalonia.DesignerSupport.Remote.HtmlTransport
                     }
                     else
                     {
-                        if (req.Headers.TryGetValue("Origin", out var origin) && origin == _listenUri.OriginalString)
+                        if (IsValidOrigin(req))
                         {
                             var socket = await req.AcceptWebSocket();
                             SocketReceiveWorker(socket);
@@ -129,6 +129,12 @@ namespace Avalonia.DesignerSupport.Remote.HtmlTransport
                     }
                 }
             }
+        }
+
+        bool IsValidOrigin(SimpleWebSocketHttpRequest request)
+        {
+            return request.Headers.TryGetValue("Origin", out var origin) &&
+                   (origin == _listenUri.OriginalString || origin.StartsWith("vscode-webview:"));
         }
 
         async void SocketReceiveWorker(SimpleWebSocket socket)


### PR DESCRIPTION
The origin doesn't match when previewer hosted in the VSCode resulting the previewer failure

## What does the pull request do?
Fixes the issue https://github.com/AvaloniaUI/AvaloniaVSCode/issues/65
