### PR TITLE
Fix: Allow ColorPicker-Fylout to swap position if needed

### DIFF
--- a/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorPicker.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Fluent/ColorPicker.xaml
@@ -1,9 +1,11 @@
-﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="using:Avalonia.Controls"
                     xmlns:primitives="using:Avalonia.Controls.Primitives"
                     x:ClassModifier="internal">
 
+  <PlacementMode x:Key="ColorPickerFlyoutPlacement">Top</PlacementMode>
+  
   <ControlTheme x:Key="{x:Type ColorPicker}"
                 TargetType="ColorPicker">
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -51,7 +53,7 @@
           </DropDownButton.Styles>
           <DropDownButton.Flyout>
             <Flyout FlyoutPresenterClasses="nopadding"
-                    Placement="Top">
+                    Placement="{DynamicResource ColorPickerFlyoutPlacement}">
 
               <!-- The following is copy-pasted from the ColorView's control template.
                    It MUST always be kept in sync with the ColorView (which is master).

--- a/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorPicker.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorPicker.xaml
@@ -3,6 +3,7 @@
                     xmlns:controls="using:Avalonia.Controls"
                     xmlns:primitives="using:Avalonia.Controls.Primitives"
                     x:ClassModifier="internal">
+  
   <PlacementMode x:Key="ColorPickerFlyoutPlacement">Top</PlacementMode>
 
   <ControlTheme x:Key="{x:Type ColorPicker}"

--- a/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorPicker.xaml
+++ b/src/Avalonia.Controls.ColorPicker/Themes/Simple/ColorPicker.xaml
@@ -1,8 +1,9 @@
-﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="using:Avalonia.Controls"
                     xmlns:primitives="using:Avalonia.Controls.Primitives"
                     x:ClassModifier="internal">
+  <PlacementMode x:Key="ColorPickerFlyoutPlacement">Top</PlacementMode>
 
   <ControlTheme x:Key="{x:Type ColorPicker}"
                 TargetType="ColorPicker">
@@ -50,7 +51,8 @@
             </Style>
           </DropDownButton.Styles>
           <DropDownButton.Flyout>
-            <Flyout Placement="Top">
+            <Flyout FlyoutPresenterClasses="nopadding"
+                    Placement="{DynamicResource ColorPickerFlyoutPlacement}">
 
               <!-- The following is copy-pasted from the ColorView's control template.
                    It MUST always be kept in sync with the ColorView (which is master).

--- a/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
@@ -47,6 +47,13 @@ namespace Avalonia.Controls.Primitives
         public static readonly StyledProperty<IInputElement?> OverlayInputPassThroughElementProperty =
             Popup.OverlayInputPassThroughElementProperty.AddOwner<PopupFlyoutBase>();
         
+        /// <summary>
+        /// Defines the <see cref="OverlayInputPassThroughElement"/> property
+        /// </summary>
+        public static readonly StyledProperty<PopupPositionerConstraintAdjustment> PlacementConstraintAdjustmentProperty =
+            Popup.PlacementConstraintAdjustmentProperty.AddOwner<PopupFlyoutBase>();
+        
+        
         private readonly Lazy<Popup> _popupLazy;
         private Rect? _enlargedPopupRect;
         private PixelRect? _enlargePopupRectScreenPixelRect;
@@ -119,6 +126,16 @@ namespace Avalonia.Controls.Primitives
             set => SetValue(OverlayInputPassThroughElementProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets a value describing how the popup position will be adjusted if the
+        /// unadjusted position would result in the popup being partly constrained.
+        /// </summary>
+        public PopupPositionerConstraintAdjustment PlacementConstraintAdjustment
+        {
+            get => GetValue(PlacementConstraintAdjustmentProperty);
+            set => SetValue(PlacementConstraintAdjustmentProperty, value);
+        }
+        
         IPopupHost? IPopupHostProvider.PopupHost => Popup?.Host;
 
         event Action<IPopupHost?>? IPopupHostProvider.PopupHostChanged
@@ -424,9 +441,7 @@ namespace Avalonia.Controls.Primitives
             else
             {
                 Popup.Placement = Placement;
-                Popup.PlacementConstraintAdjustment =
-                    PopupPositioning.PopupPositionerConstraintAdjustment.SlideX |
-                    PopupPositioning.PopupPositionerConstraintAdjustment.SlideY;
+                Popup.PlacementConstraintAdjustment = PlacementConstraintAdjustment;
             }
         }
 

--- a/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
@@ -48,11 +48,10 @@ namespace Avalonia.Controls.Primitives
             Popup.OverlayInputPassThroughElementProperty.AddOwner<PopupFlyoutBase>();
         
         /// <summary>
-        /// Defines the <see cref="OverlayInputPassThroughElement"/> property
+        /// Defines the <see cref="PlacementConstraintAdjustment"/> property
         /// </summary>
         public static readonly StyledProperty<PopupPositionerConstraintAdjustment> PlacementConstraintAdjustmentProperty =
             Popup.PlacementConstraintAdjustmentProperty.AddOwner<PopupFlyoutBase>();
-        
         
         private readonly Lazy<Popup> _popupLazy;
         private Rect? _enlargedPopupRect;
@@ -126,10 +125,7 @@ namespace Avalonia.Controls.Primitives
             set => SetValue(OverlayInputPassThroughElementProperty, value);
         }
 
-        /// <summary>
-        /// Gets or sets a value describing how the popup position will be adjusted if the
-        /// unadjusted position would result in the popup being partly constrained.
-        /// </summary>
+        /// <inheritdoc cref="Popup.PlacementConstraintAdjustment"/>
         public PopupPositionerConstraintAdjustment PlacementConstraintAdjustment
         {
             get => GetValue(PlacementConstraintAdjustmentProperty);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Makes it easier to handle the ColorPicker-Flyout and also other Flyouts. The ColorView should no longer hide the Button if the free space is not enough to show the Fylout. Also the hard-coded positioning was changed into a `DynamicResource` in order to make adjustments easier. 

## What is the current behavior?
See #13550 

## What is the updated/expected behavior with this PR?
- Flyouts can switch orientation if the space is not enough
- Users can configure the DropDown-direction

## How was the solution implemented (if it's not obvious)?

Added `PlacementConstraintAdjustment`-Property to `PopupFyloutBase` in order to configure adjustments. Before it was hard-coded to Slide. 


## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation -> Maybe yes

## Breaking changes
Technically it is a behavior change das now the Flyout will flip position instead of slide. However in most use-cases the flip operation is preferred. Still this can be reverted if we specify the old values as default. Let me know your thoughts.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #13550 

/cc @robloo 