### PR TITLE
Fix some TextBox property summary docs

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -488,7 +488,8 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Gets or sets the maximum number of visible lines.
+        /// Gets or sets the maximum number of characters that the <see cref="TextBox"/> can accept.
+        /// This constraint only applies for manually entered (user-inputted) text.
         /// </summary>
         public int MaxLength
         {
@@ -497,7 +498,7 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Gets or sets the maximum number of lines the TextBox can contain
+        /// Gets or sets the maximum number of visible lines to size to.
         /// </summary>
         public int MaxLines
         {


### PR DESCRIPTION
## What does the pull request do?

Fixes errors in the summary docs for two properties.

 * `TextBox.MaxLength` which had the definition for `MaxLines`
 * `TextBox.MaxLines` which had an incorrect definition based on current functionality and WPF
    * https://github.com/AvaloniaUI/Avalonia/issues/13534#issuecomment-1803541433

cc @Gillibald 

## What is the current behavior?

Wrong comments

## What is the updated/expected behavior with this PR?

Fixed comments

## How was the solution implemented (if it's not obvious)?

Updated comments were sourced from WPF source here: https://github.com/dotnet/wpf/blob/main/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBox.cs. to avoid potential licensing issues with Microsoft docs. WPF is also MIT licensed. Some additional clarification was needed as well.

## Checklist

- ~[ ] Added unit tests (if possible)?~
- [x] Added XML documentation to any related classes?
- ~[ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation~

## Breaking changes

None

## Obsoletions / Deprecations

None

Related to #13534
