### PR TITLE
Win32 file picker fixes

### DIFF
--- a/src/Windows/Avalonia.Win32/Win32Com/win32.idl
+++ b/src/Windows/Avalonia.Win32/Win32Com/win32.idl
@@ -80,9 +80,9 @@ interface IShellItem : IUnknown
 
     HRESULT GetParent([out] IShellItem** ppsi);
 
-    HRESULT GetDisplayName(
+    int GetDisplayName(
         [in] uint sigdnName,
-        [out, string, annotation("_Outptr_result_nullonfailure_")] WCHAR** ppszName);
+        [string, annotation("_Outptr_result_nullonfailure_")] WCHAR** ppszName);
 
     HRESULT GetAttributes(
         [in] ULONG sfgaoMask,

--- a/src/Windows/Avalonia.Win32/Win32StorageProvider.cs
+++ b/src/Windows/Avalonia.Win32/Win32StorageProvider.cs
@@ -40,7 +40,8 @@ namespace Avalonia.Win32
             var files = await ShowFilePicker(
                 true, true,
                 options.AllowMultiple, false,
-                options.Title, null, options.SuggestedStartLocation, null, null);
+                options.Title, null, options.SuggestedStartLocation, null, null)
+                .ConfigureAwait(false);
             return files.Select(f => new BclStorageFolder(new DirectoryInfo(f))).ToArray();
         }
 
@@ -50,7 +51,8 @@ namespace Avalonia.Win32
                 true, false,
                 options.AllowMultiple, false,
                 options.Title, null, options.SuggestedStartLocation,
-                null, options.FileTypeFilter);
+                null, options.FileTypeFilter)
+                .ConfigureAwait(false);
             return files.Select(f => new BclStorageFile(new FileInfo(f))).ToArray();
         }
 
@@ -60,7 +62,8 @@ namespace Avalonia.Win32
                 false, false,
                 false, options.ShowOverwritePrompt,
                 options.Title, options.SuggestedFileName, options.SuggestedStartLocation,
-                options.DefaultExtension, options.FileTypeChoices);
+                options.DefaultExtension, options.FileTypeChoices)
+                .ConfigureAwait(false);
             return files.Select(f => new BclStorageFile(new FileInfo(f))).FirstOrDefault();
         }
 

--- a/src/Windows/Avalonia.Win32/Win32StorageProvider.cs
+++ b/src/Windows/Avalonia.Win32/Win32StorageProvider.cs
@@ -171,7 +171,7 @@ namespace Avalonia.Win32
                         for (int i = 0; i < count; i++)
                         {
                             var shellItem = shellItemArray.GetItemAt(i);
-                            if (GetAbsoluteFilePath(shellItem) is { } selected)
+                            if (GetParsingName(shellItem) is { } selected)
                             {
                                 results.Add(selected);
                             }


### PR DESCRIPTION
## What does the pull request do?

Both [WPF](https://github.com/dotnet/wpf/blob/84706a52f56c8fb12aab5501330dfa75eeada536/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/CommonItemDialog.cs#L620) and [Chrome](https://github.com/chromium/chromium/blob/4e10c9c7475d4876b18e1397003950f53e94ffaf/ui/shell_dialogs/execute_select_file_win.cc#L310) use SIGDN_DESKTOPABSOLUTEPARSING instead of SIGDN_FILESYSPATH while retrieving display-name of the picker files. We should do the same.
Also this PR:
- Add missing ConfigureAwait(false)
- Includes FOS_PATHMUSTEXIST by default (it seems to be the default, but WPF still includes it...could it not default on some OS versions?)
- Safely skip the file if GetDisplayName failed
- Avoid System.Linq as it's not really necessary here, but adds multiple iterations over the same results array

## Fixed issues

Fixes #13613
Fixes #13624
Fixes #8584
Fixes #7879
