### PR TITLE
Warning cleanup

### DIFF
--- a/build/TrimmingEnable.props
+++ b/build/TrimmingEnable.props
@@ -1,10 +1,12 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <PropertyGroup>
     <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
+
   <!-- Remove check for the AOT when we get rid of dependencies with reflection -->
   <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard2.0' and '$(PublishAot)' != 'true'">
     <ILLinkTreatWarningsAsErrors>true</ILLinkTreatWarningsAsErrors>
@@ -13,4 +15,11 @@
     <!-- NativeAOT warnings -->
     <WarningsAsErrors>$(WarningsAsErrors);IL3050;IL3051;IL3052;IL3053;IL3054;IL3055;IL3056</WarningsAsErrors>
   </PropertyGroup>
+
+  <!-- UnconditionalSuppressMessage doesn't work correctly with .NET Standard, keep trim warnings in .NET only -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+  </PropertyGroup>
+
 </Project>

--- a/samples/ControlCatalog/MainView.xaml.cs
+++ b/samples/ControlCatalog/MainView.xaml.cs
@@ -59,7 +59,7 @@ namespace ControlCatalog
             {
                 if (flowDirections.SelectedItem is FlowDirection flowDirection)
                 {
-                    TopLevel.GetTopLevel(this).FlowDirection = flowDirection;
+                    TopLevel.GetTopLevel(this)!.FlowDirection = flowDirection;
                 }
             };
 

--- a/samples/ControlCatalog/Pages/GesturePage.cs
+++ b/samples/ControlCatalog/Pages/GesturePage.cs
@@ -41,12 +41,12 @@ namespace ControlCatalog.Pages
             SetPullHandlers(this.Find<Border>("RightPullZone"), true);
             SetPullHandlers(this.Find<Border>("LeftPullZone"), false);
 
-            var image = this.Find<Image>("PinchImage");
+            var image = this.Get<Image>("PinchImage");
             SetPinchHandlers(image);
 
-            var reset = this.Find<Button>("ResetButton");
+            var reset = this.Get<Button>("ResetButton");
 
-            reset!.Click += (s, e) =>
+            reset.Click += (_, _) =>
             {
                 var compositionVisual = ElementComposition.GetElementVisual(image);
 

--- a/samples/ControlCatalog/ViewModels/ComboBoxPageViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/ComboBoxPageViewModel.cs
@@ -29,7 +29,7 @@ namespace ControlCatalog.ViewModels
 
     public class IdAndName
     {
-        public string Id { get; set; }
-        public string Name { get; set; }
+        public string? Id { get; set; }
+        public string? Name { get; set; }
     }
 }

--- a/samples/ControlCatalog/ViewModels/PlatformInformationViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/PlatformInformationViewModel.cs
@@ -1,11 +1,9 @@
-using System;
 using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Platform;
 using MiniMvvm;
 
 namespace ControlCatalog.ViewModels;
-#nullable enable
 
 public class PlatformInformationViewModel : ViewModelBase
 {
@@ -46,11 +44,7 @@ public class PlatformInformationViewModel : ViewModelBase
                 }
             }
         }
-        else
-        {
-            
-        }
     }
     
-    public string PlatformInfo { get; }
+    public string? PlatformInfo { get; }
 }

--- a/src/Avalonia.Base/Collections/AvaloniaList.cs
+++ b/src/Avalonia.Base/Collections/AvaloniaList.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Linq;
 using Avalonia.Diagnostics;
 
 namespace Avalonia.Collections
@@ -14,13 +13,13 @@ namespace Avalonia.Collections
     public enum ResetBehavior
     {
         /// <summary>
-        /// Clearing the list notifies with the <see cref="CollectionChanged"/> event with a
+        /// Clearing the list notifies with the <see cref="INotifyCollectionChanged.CollectionChanged"/> event with a
         /// <see cref="NotifyCollectionChangedAction.Reset"/> action.
         /// </summary>
         Reset,
 
         /// <summary>
-        /// Clearing the list notifies with the <see cref="CollectionChanged"/> event with a
+        /// Clearing the list notifies with the <see cref="INotifyCollectionChanged.CollectionChanged"/> event with a
         /// <see cref="NotifyCollectionChangedAction.Remove"/> action.
         /// </summary>
         Remove,

--- a/src/Avalonia.Base/Input/InputMethod.cs
+++ b/src/Avalonia.Base/Input/InputMethod.cs
@@ -29,7 +29,7 @@ namespace Avalonia.Input
         }
         
         /// <summary>
-        /// Defines the <see cref="TextInputMethodClientRequeryRequested"/> event.
+        /// Defines the TextInputMethodClientRequeryRequested event.
         /// </summary>
         public static readonly RoutedEvent<TextInputMethodClientRequeryRequestedEventArgs> TextInputMethodClientRequeryRequestedEvent =
             RoutedEvent.Register<InputElement, TextInputMethodClientRequeryRequestedEventArgs>(

--- a/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageFile.cs
+++ b/src/Avalonia.Base/Platform/Storage/FileIO/BclStorageFile.cs
@@ -94,21 +94,22 @@ internal class BclStorageFile : IStorageBookmarkFile
         GC.SuppressFinalize(this);
     }
 
-    public async Task DeleteAsync()
+    public Task DeleteAsync()
     {
         FileInfo.Delete();
+        return Task.CompletedTask;
     }
 
-    public async Task<IStorageItem?> MoveAsync(IStorageFolder destination)
+    public Task<IStorageItem?> MoveAsync(IStorageFolder destination)
     {
         if (destination is BclStorageFolder storageFolder)
         {
             var newPath = System.IO.Path.Combine(storageFolder.DirectoryInfo.FullName, FileInfo.Name);
             FileInfo.MoveTo(newPath);
 
-            return new BclStorageFile(new FileInfo(newPath));
+            return Task.FromResult<IStorageItem?>(new BclStorageFile(new FileInfo(newPath)));
         }
 
-        return null;
+        return Task.FromResult<IStorageItem?>(null);
     }
 }

--- a/src/Avalonia.Base/Rendering/RenderLoop.cs
+++ b/src/Avalonia.Base/Rendering/RenderLoop.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using Avalonia.Logging;
 using Avalonia.Threading;
@@ -20,7 +19,6 @@ namespace Avalonia.Rendering
         private readonly List<IRenderLoopTask> _itemsCopy = new List<IRenderLoopTask>();
         private IRenderTimer? _timer;
         private int _inTick;
-        private readonly int _inUpdate;
         
         public static IRenderLoop LocatorAutoInstance
         {

--- a/src/Avalonia.Base/Threading/Dispatcher.Queue.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.Queue.cs
@@ -71,16 +71,28 @@ public partial class Dispatcher
         }
     }
 
-    class DummyShuttingDownUnitTestDispatcherImpl : IDispatcherImpl
+    private sealed class DummyShuttingDownUnitTestDispatcherImpl : IDispatcherImpl
     {
         public bool CurrentThreadIsLoopThread => true;
+
         public void Signal()
         {
         }
 
-        public event Action? Signaled;
-        public event Action? Timer;
+        public event Action? Signaled
+        {
+            add { }
+            remove { }
+        }
+
+        public event Action? Timer
+        {
+            add { }
+            remove { }
+        }
+
         public long Now => 0;
+
         public void UpdateTimer(long? dueTimeInMs)
         {
         }

--- a/src/Avalonia.Base/Threading/IDispatcherImpl.cs
+++ b/src/Avalonia.Base/Threading/IDispatcherImpl.cs
@@ -13,8 +13,8 @@ public interface IDispatcherImpl
 
     // Asynchronously triggers Signaled callback
     void Signal();
-    event Action Signaled;
-    event Action Timer;
+    event Action? Signaled;
+    event Action? Timer;
     long Now { get; }
     void UpdateTimer(long? dueTimeInMs);
 }
@@ -31,7 +31,7 @@ public interface IDispatcherImplWithPendingInput : IDispatcherImpl
 [PrivateApi]
 public interface IDispatcherImplWithExplicitBackgroundProcessing : IDispatcherImpl
 {
-    event Action ReadyForBackgroundProcessing;
+    event Action? ReadyForBackgroundProcessing;
     void RequestBackgroundProcessing();
 }
 
@@ -82,7 +82,7 @@ internal class LegacyDispatcherImpl : IDispatcherImpl
     }
 }
 
-class NullDispatcherImpl : IDispatcherImpl
+internal sealed class NullDispatcherImpl : IDispatcherImpl
 {
     public bool CurrentThreadIsLoopThread => true;
 
@@ -91,8 +91,17 @@ class NullDispatcherImpl : IDispatcherImpl
         
     }
     
-    public event Action? Signaled;
-    public event Action? Timer;
+    public event Action? Signaled
+    {
+        add { }
+        remove { }
+    }
+
+    public event Action? Timer
+    {
+        add { }
+        remove { }
+    }
 
     public long Now => 0;
 

--- a/src/Avalonia.Base/Utilities/AsyncEnumerableHelper.cs
+++ b/src/Avalonia.Base/Utilities/AsyncEnumerableHelper.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Avalonia.Utilities;
+
+internal static class AsyncEnumerableHelper
+{
+    public static IAsyncEnumerable<T> AsAsyncEnumerable<T>(this IEnumerable<T> enumerable)
+        => new EnumerableAsyncWrapper<T>(enumerable);
+
+    private sealed class EnumerableAsyncWrapper<T> : IAsyncEnumerable<T>
+    {
+        private readonly IEnumerable<T> _enumerable;
+
+        public EnumerableAsyncWrapper(IEnumerable<T> enumerable)
+            => _enumerable = enumerable;
+
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+            => new EnumeratorAsyncWrapper<T>(_enumerable.GetEnumerator(), cancellationToken);
+    }
+
+    private sealed class EnumeratorAsyncWrapper<T> : IAsyncEnumerator<T>
+    {
+        private readonly IEnumerator<T> _enumerator;
+        private readonly CancellationToken _cancellationToken;
+
+        public EnumeratorAsyncWrapper(IEnumerator<T> enumerator, CancellationToken cancellationToken)
+        {
+            _enumerator = enumerator;
+            _cancellationToken = cancellationToken;
+        }
+
+        public T Current
+            => _enumerator.Current;
+
+        public ValueTask<bool> MoveNextAsync()
+            => _cancellationToken.IsCancellationRequested ?
+                new(Task.FromCanceled<bool>(_cancellationToken)) :
+                new(_enumerator.MoveNext());
+
+        public ValueTask DisposeAsync()
+        {
+            _enumerator.Dispose();
+            return default;
+        }
+    }
+}

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -7,11 +7,8 @@ using Avalonia.Controls.Diagnostics;
 using Avalonia.Controls.Platform;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Primitives.PopupPositioning;
-using Avalonia.Controls.Templates;
 using Avalonia.Input;
-using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
-using Avalonia.Layout;
 using Avalonia.Styling;
 using Avalonia.Automation;
 using Avalonia.Reactive;
@@ -85,8 +82,6 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<Control?> PlacementTargetProperty =
             Popup.PlacementTargetProperty.AddOwner<ContextMenu>();
 
-        private static readonly FuncTemplate<Panel?> DefaultPanel =
-            new(() => new StackPanel { Orientation = Orientation.Vertical });
         private Popup? _popup;
         private List<Control>? _attachedControls;
         private IInputElement? _previousFocus;

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -714,11 +714,6 @@ namespace Avalonia.Controls
             SelectedItem = null;
         }
 
-        private void UpdateLayout()
-        {
-            (VisualRoot as ILayoutRoot)?.LayoutManager.ExecuteLayoutPass();
-        }
-
         void ICommandSource.CanExecuteChanged(object sender, EventArgs e) => this.CanExecuteChanged(sender, e);
 
         void IClickableControl.RaiseClick()

--- a/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
+++ b/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs
@@ -92,7 +92,7 @@ namespace Avalonia.Controls.Notifications
         }
 
         /// <inheritdoc/>
-        public async void Show(object content)
+        public void Show(object content)
         {
             if (content is INotification notification)
             {

--- a/src/Avalonia.Controls/Platform/IWindowImpl.cs
+++ b/src/Avalonia.Controls/Platform/IWindowImpl.cs
@@ -31,7 +31,7 @@ namespace Avalonia.Platform
         /// Sets the parent of the window.
         /// </summary>
         /// <param name="parent">The parent <see cref="IWindowImpl"/>.</param>
-        void SetParent(IWindowImpl parent);
+        void SetParent(IWindowImpl? parent);
         
         /// <summary>
         /// Disables the window for example when a modal dialog is open.

--- a/src/Avalonia.Controls/ProgressBar.cs
+++ b/src/Avalonia.Controls/ProgressBar.cs
@@ -111,7 +111,7 @@ namespace Avalonia.Controls
                     (p, o) => p.IndeterminateEndingOffset = o);
 
             /// <summary>
-            /// Used by <see cref="Avalonia.Themes.Fluent"/> to define the first indeterminate indicator's width.
+            /// Used by Avalonia.Themes.Fluent to define the first indeterminate indicator's width.
             /// </summary>
             public double ContainerWidth
             {
@@ -120,7 +120,7 @@ namespace Avalonia.Controls
             }
             
             /// <summary>
-            /// Used by <see cref="Avalonia.Themes.Fluent"/> to define the second indeterminate indicator's width.
+            /// Used by Avalonia.Themes.Fluent to define the second indeterminate indicator's width.
             /// </summary>
             public double Container2Width
             {
@@ -129,7 +129,7 @@ namespace Avalonia.Controls
             }
 
             /// <summary>
-            /// Used by <see cref="Avalonia.Themes.Fluent"/> to define the first indeterminate indicator's start position when animated.
+            /// Used by Avalonia.Themes.Fluent to define the first indeterminate indicator's start position when animated.
             /// </summary>
             public double ContainerAnimationStartPosition
             {
@@ -139,7 +139,7 @@ namespace Avalonia.Controls
             }
 
             /// <summary>
-            /// Used by <see cref="Avalonia.Themes.Fluent"/> to define the first indeterminate indicator's end position when animated.
+            /// Used by Avalonia.Themes.Fluent to define the first indeterminate indicator's end position when animated.
             /// </summary>
             public double ContainerAnimationEndPosition
             {
@@ -148,7 +148,7 @@ namespace Avalonia.Controls
             }
 
             /// <summary>
-            /// Used by <see cref="Avalonia.Themes.Fluent"/> to define the second indeterminate indicator's start position when animated.
+            /// Used by Avalonia.Themes.Fluent to define the second indeterminate indicator's start position when animated.
             /// </summary>
             public double Container2AnimationStartPosition
             {
@@ -158,7 +158,7 @@ namespace Avalonia.Controls
             }
             
             /// <summary>
-            /// Used by <see cref="Avalonia.Themes.Fluent"/> to define the second indeterminate indicator's end position when animated.
+            /// Used by Avalonia.Themes.Fluent to define the second indeterminate indicator's end position when animated.
             /// </summary>
             public double Container2AnimationEndPosition
             {
@@ -167,7 +167,7 @@ namespace Avalonia.Controls
             }
 
             /// <summary>
-            /// Used by <see cref="Avalonia.Themes.Simple"/>  to define the starting point of its indeterminate animation.
+            /// Used by Avalonia.Themes.Simple  to define the starting point of its indeterminate animation.
             /// </summary>
             public double IndeterminateStartingOffset
             {
@@ -176,7 +176,7 @@ namespace Avalonia.Controls
             }
             
             /// <summary>
-            /// Used by <see cref="Avalonia.Themes.Simple"/> to define the ending point of its indeterminate animation.
+            /// Used by Avalonia.Themes.Simple to define the ending point of its indeterminate animation.
             /// </summary>
             public double IndeterminateEndingOffset
             {
@@ -336,6 +336,7 @@ namespace Avalonia.Controls
             UpdateIndicator();
         }
 
+        /// <inheritdoc />
         protected override AutomationPeer OnCreateAutomationPeer()
         {
             return new ProgressBarAutomationPeer(this);

--- a/src/Avalonia.DesignerSupport/Remote/HtmlTransport/SimpleWebSocketHttpServer.cs
+++ b/src/Avalonia.DesignerSupport/Remote/HtmlTransport/SimpleWebSocketHttpServer.cs
@@ -323,8 +323,8 @@ namespace Avalonia.DesignerSupport.Remote.HtmlTransport
                     header.Length64 = (ulong) IPAddress.HostToNetworkOrder((long) length);
                 }
 
-                var endOfMessage = true;
-                header.Mask = (byte) (((endOfMessage ? 1u : 0u) << 7) | ((byte) (type) & 0xf));
+                const byte endOfMessageBit = (byte)1u << 7;
+                header.Mask = (byte) (endOfMessageBit | ((byte) type & 0xf));
                 unsafe
                 {
                     Marshal.Copy(new IntPtr(&header), _sendHeaderBuffer, 0, headerLength);

--- a/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
+++ b/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
@@ -166,8 +166,6 @@ namespace Avalonia.DesignerSupport.Remote
             };
         }
 
-        private const string BuilderMethodName = "BuildAvaloniaApp";
-        
         public static void Main(string[] cmdline)
         {
             var args = ParseCommandLineArgs(cmdline);

--- a/src/Avalonia.DesignerSupport/Remote/Stubs.cs
+++ b/src/Avalonia.DesignerSupport/Remote/Stubs.cs
@@ -63,9 +63,14 @@ namespace Avalonia.DesignerSupport.Remote
                     }));
         }
 
-        class DummyRenderTimer : IRenderTimer
+        private sealed class DummyRenderTimer : IRenderTimer
         {
-            public event Action<TimeSpan> Tick;
+            public event Action<TimeSpan> Tick
+            {
+                add { }
+                remove { }
+            }
+
             public bool RunsInBackground => false;
         }
 

--- a/src/Avalonia.FreeDesktop/DBusIme/Fcitx/FcitxICWrapper.cs
+++ b/src/Avalonia.FreeDesktop/DBusIme/Fcitx/FcitxICWrapper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Avalonia.Reactive;
 using Tmds.DBus.SourceGenerator;
 
 namespace Avalonia.FreeDesktop.DBusIme.Fcitx
@@ -37,21 +38,21 @@ namespace Avalonia.FreeDesktop.DBusIme.Fcitx
             return await (_modern?.ProcessKeyEventAsync(keyVal, keyCode, state, type > 0, time) ?? Task.FromResult(false));
         }
 
-        public ValueTask<IDisposable?> WatchCommitStringAsync(Action<Exception?, string> handler) =>
+        public ValueTask<IDisposable> WatchCommitStringAsync(Action<Exception?, string> handler) =>
             _old?.WatchCommitStringAsync(handler)
             ?? _modern?.WatchCommitStringAsync(handler)
-            ?? new ValueTask<IDisposable?>(default(IDisposable?));
+            ?? new ValueTask<IDisposable>(Disposable.Empty);
 
-        public ValueTask<IDisposable?> WatchForwardKeyAsync(Action<Exception?, (uint keyval, uint state, int type)> handler) =>
+        public ValueTask<IDisposable> WatchForwardKeyAsync(Action<Exception?, (uint keyval, uint state, int type)> handler) =>
             _old?.WatchForwardKeyAsync(handler)
             ?? _modern?.WatchForwardKeyAsync((e, ev) => handler.Invoke(e, (ev.keyval, ev.state, ev.type ? 1 : 0)))
-            ?? new ValueTask<IDisposable?>(default(IDisposable?));
+            ?? new ValueTask<IDisposable>(Disposable.Empty);
 
-        public ValueTask<IDisposable?> WatchUpdateFormattedPreeditAsync(
-            Action<Exception?, ((string, int)[] @str, int @cursorpos)> handler) =>
-            _old?.WatchUpdateFormattedPreeditAsync(handler)
-            ?? _modern?.WatchUpdateFormattedPreeditAsync(handler)
-            ?? new(default);
+        public ValueTask<IDisposable> WatchUpdateFormattedPreeditAsync(
+            Action<Exception?, ((string?, int)[]? str, int cursorpos)> handler) =>
+            _old?.WatchUpdateFormattedPreeditAsync(handler!)
+            ?? _modern?.WatchUpdateFormattedPreeditAsync(handler!)
+            ?? new ValueTask<IDisposable>(Disposable.Empty);
         
         public Task SetCapacityAsync(uint flags) =>
             _old?.SetCapacityAsync(flags) ?? _modern?.SetCapabilityAsync(flags) ?? Task.CompletedTask;

--- a/src/Avalonia.FreeDesktop/DBusIme/Fcitx/FcitxX11TextInputMethod.cs
+++ b/src/Avalonia.FreeDesktop/DBusIme/Fcitx/FcitxX11TextInputMethod.cs
@@ -46,11 +46,11 @@ namespace Avalonia.FreeDesktop.DBusIme.Fcitx
             return true;
         }
 
-        private void OnPreedit(Exception? arg1, ((string, int)[] str, int cursorpos) args)
+        private void OnPreedit(Exception? arg1, ((string?, int)[]? str, int cursorpos) args)
         {
             int? cursor = null;
-            string preeditString = null;
-            if (args.str != null! && args.str.Length > 0)
+            string? preeditString = null;
+            if (args.str != null && args.str.Length > 0)
             {
                 preeditString = string.Join("", args.str.Select(x => x.Item1));
 

--- a/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
+++ b/src/Avalonia.FreeDesktop/DBusMenuExporter.cs
@@ -38,8 +38,9 @@ namespace Avalonia.FreeDesktop
             private bool _resetQueued;
             private int _nextId = 1;
 
-            public DBusMenuExporterImpl(Connection connection, IntPtr xid) : this()
+            public DBusMenuExporterImpl(Connection connection, IntPtr xid)
             {
+                InitBackingProperties();
                 Connection = connection;
                 _xid = (uint)xid.ToInt32();
                 Path = GenerateDBusMenuObjPath;
@@ -47,8 +48,9 @@ namespace Avalonia.FreeDesktop
                 _ = InitializeAsync();
             }
 
-            public DBusMenuExporterImpl(Connection connection, string path) : this()
+            public DBusMenuExporterImpl(Connection connection, string path)
             {
+                InitBackingProperties();
                 Connection = connection;
                 _appMenu = false;
                 Path = path;
@@ -56,7 +58,7 @@ namespace Avalonia.FreeDesktop
                 _ = InitializeAsync();
             }
 
-            private DBusMenuExporterImpl()
+            private void InitBackingProperties()
             {
                 BackingProperties.Version = 4;
                 BackingProperties.Status = string.Empty;

--- a/src/Avalonia.Native/DispatcherImpl.cs
+++ b/src/Avalonia.Native/DispatcherImpl.cs
@@ -6,7 +6,6 @@ using System.Runtime.ExceptionServices;
 using System.Threading;
 using Avalonia.Native.Interop;
 using Avalonia.Threading;
-using MicroCom.Runtime;
 
 namespace Avalonia.Native;
 
@@ -24,9 +23,9 @@ internal class DispatcherImpl : IControlledDispatcherImpl, IDispatcherImplWithEx
         _native.SetEvents(events);
     }
     
-    public event Action Signaled;
-    public event Action Timer;
-    public event Action ReadyForBackgroundProcessing;
+    public event Action? Signaled;
+    public event Action? Timer;
+    public event Action? ReadyForBackgroundProcessing;
     
     private class Events : NativeCallbackBase, IAvnPlatformThreadingInterfaceEvents
     {

--- a/src/Avalonia.Native/WindowImpl.cs
+++ b/src/Avalonia.Native/WindowImpl.cs
@@ -1,21 +1,17 @@
 ﻿using System;
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Platform;
 using Avalonia.Input;
 using Avalonia.Input.Raw;
 using Avalonia.Input.TextInput;
 using Avalonia.Native.Interop;
-using Avalonia.OpenGL;
 using Avalonia.Platform;
-using Avalonia.Platform.Interop;
 
 namespace Avalonia.Native
 {
     internal class WindowImpl : WindowBaseImpl, IWindowImpl
     {
         private readonly AvaloniaNativePlatformOptions _opts;
-        private readonly AvaloniaNativeGlPlatformGraphics _graphics;
         IAvnWindow _native;
         private double _extendTitleBarHeight = -1;
         private DoubleClickHelper _doubleClickHelper;

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -143,7 +143,7 @@ namespace Avalonia.Native
         class FramebufferRenderTarget : IFramebufferRenderTarget
         {
             private readonly WindowBaseImpl _parent;
-            private IAvnSoftwareRenderTarget? _target;
+            private IAvnSoftwareRenderTarget _target;
 
             public FramebufferRenderTarget(WindowBaseImpl parent, IAvnSoftwareRenderTarget target)
             {

--- a/src/Avalonia.X11/Glx/GlxContext.cs
+++ b/src/Avalonia.X11/Glx/GlxContext.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -9,17 +11,17 @@ namespace Avalonia.X11.Glx
 {
     internal class GlxContext : IGlContext
     {
-        public  IntPtr Handle { get; }
+        public IntPtr Handle { get; }
         public GlxInterface Glx { get; }
-        private readonly GlxContext _sharedWith;
+        private readonly GlxContext? _sharedWith;
         private readonly X11Info _x11;
         private readonly IntPtr _defaultXid;
         private readonly bool _ownsPBuffer;
         private readonly object _lock = new object();
-        private ExternalObjectsOpenGlExtensionFeature? _externalObjects;
+        private readonly ExternalObjectsOpenGlExtensionFeature? _externalObjects;
 
         public GlxContext(GlxInterface glx, IntPtr handle, GlxDisplay display,
-            GlxContext sharedWith,
+            GlxContext? sharedWith,
             GlVersion version, int sampleCount, int stencilSize,
             X11Info x11, IntPtr defaultXid,
             bool ownsPBuffer)
@@ -49,13 +51,13 @@ namespace Avalonia.X11.Glx
 
         private class RestoreContext : IDisposable
         {
-            private GlxInterface _glx;
-            private IntPtr _defaultDisplay;
+            private readonly GlxInterface _glx;
+            private readonly IntPtr _defaultDisplay;
             private readonly object _l;
-            private IntPtr _display;
-            private IntPtr _context;
-            private IntPtr _read;
-            private IntPtr _draw;
+            private readonly IntPtr _display;
+            private readonly IntPtr _context;
+            private readonly IntPtr _read;
+            private readonly IntPtr _draw;
 
             public RestoreContext(GlxInterface glx, IntPtr defaultDisplay, object l)
             {
@@ -97,7 +99,7 @@ namespace Avalonia.X11.Glx
 
         public bool CanCreateSharedContext => true;
 
-        public IGlContext CreateSharedContext(IEnumerable<GlVersion> preferredVersions = null) =>
+        public IGlContext CreateSharedContext(IEnumerable<GlVersion>? preferredVersions = null) =>
             Display.CreateContext(_sharedWith ?? this);
 
         public IDisposable MakeCurrent(IntPtr xid)
@@ -129,7 +131,7 @@ namespace Avalonia.X11.Glx
                 Glx.DestroyPbuffer(_x11.DeferredDisplay, _defaultXid);
         }
 
-        public object TryGetFeature(Type featureType)
+        public object? TryGetFeature(Type featureType)
         {
             if (featureType == typeof(IGlContextExternalObjectsFeature))
                 return _externalObjects;

--- a/src/Avalonia.X11/Screens/X11Screen.Providers.cs
+++ b/src/Avalonia.X11/Screens/X11Screen.Providers.cs
@@ -35,20 +35,20 @@ internal partial class X11Screens
     internal interface IX11RawScreenInfoProvider
     {
         X11Screen[] Screens { get; }
-        event Action Changed;
+        event Action? Changed;
     }
 
     
     private class Randr15ScreensImpl : IX11RawScreenInfoProvider
     {
-        private X11Screen[] _cache;
+        private X11Screen[]? _cache;
         private readonly X11Info _x11;
         private readonly IntPtr _window;
 
         // Length of a EDID-Block-Length(128 bytes), XRRGetOutputProperty multiplies offset and length by 4
         private const int EDIDStructureLength = 32; 
 
-        public event Action Changed;
+        public event Action? Changed;
         
         public Randr15ScreensImpl(AvaloniaX11Platform platform)
         {
@@ -129,7 +129,7 @@ internal partial class X11Screens
                         }
                     }
 
-                    screens[c] = new X11Screen(bounds, mon.Primary != 0, name, pSize);
+                    screens[c] = new X11Screen(bounds, mon.Primary != 0, name ?? string.Empty, pSize);
                 }
 
                 XFree(new IntPtr(monitors));
@@ -142,8 +142,13 @@ internal partial class X11Screens
     private class FallbackScreensImpl : IX11RawScreenInfoProvider
     {
         private readonly X11Info _info;
-        public event Action? Changed;
-        
+
+        public event Action? Changed
+        {
+            add { }
+            remove { }
+        }
+
         public FallbackScreensImpl(AvaloniaX11Platform platform)
         {
             _info = platform.Info;

--- a/src/Avalonia.X11/Screens/X11Screens.Scaling.cs
+++ b/src/Avalonia.X11/Screens/X11Screens.Scaling.cs
@@ -174,7 +174,7 @@ internal partial class X11Screens
             try
             {
                 var split = screenFactorsString.Split(';').Where(x => !string.IsNullOrWhiteSpace(x)).ToArray();
-                if (split[0].Contains("="))
+                if (split[0].Contains('='))
                 {
                     userConfig = new UserScalingConfiguration
                     {

--- a/src/Avalonia.X11/X11Window.Xim.cs
+++ b/src/Avalonia.X11/X11Window.Xim.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Threading.Tasks;
 using Avalonia.FreeDesktop;
@@ -6,6 +8,7 @@ using Avalonia.Input.TextInput;
 using Avalonia.Platform.Interop;
 using Avalonia.Threading;
 using static Avalonia.X11.XLib;
+
 namespace Avalonia.X11
 {
     internal partial class X11Window
@@ -62,7 +65,7 @@ namespace Avalonia.X11
                 UpdateActive();
             }
 
-            public void SetClient(TextInputMethodClient client)
+            public void SetClient(TextInputMethodClient? client)
             {
                 _client = client;
                 UpdateActive();

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -577,7 +577,7 @@ namespace Avalonia.X11
                     else if (ev.ClientMessageEvent.ptr1 == _x11.Atoms.WM_TAKE_FOCUS && _platform.Options.EnableInputFocusProxy)
                     {
                         IntPtr time = ev.ClientMessageEvent.ptr2;
-                        XSetInputFocus(_x11.Display, _focusProxy._handle, RevertTo.Parent, time);
+                        XSetInputFocus(_x11.Display, _focusProxy!._handle, RevertTo.Parent, time);
                     }
                 }
             }
@@ -787,8 +787,8 @@ namespace Avalonia.X11
                 return;
 
             Input?.Invoke(args);
-            if (!args.Handled && args is RawKeyEventArgsWithText text && !string.IsNullOrEmpty(text.Text))
-                Input?.Invoke(new RawTextInputEventArgs(_keyboard, args.Timestamp, _inputRoot, text.Text));
+            if (!args.Handled && args is RawKeyEventArgsWithText { Text: { Length: > 0 } text })
+                Input?.Invoke(new RawTextInputEventArgs(_keyboard, args.Timestamp, _inputRoot, text));
         }
 
         public void ScheduleXI2Input(RawInputEventArgs args)
@@ -977,7 +977,7 @@ namespace Avalonia.X11
             return false;
         }
 
-        public void SetParent(IWindowImpl parent)
+        public void SetParent(IWindowImpl? parent)
         {
             if (parent == null || parent.Handle == null || parent.Handle.Handle == IntPtr.Zero)
                 XDeleteProperty(_x11.Display, _handle, _x11.Atoms.XA_WM_TRANSIENT_FOR);
@@ -1122,7 +1122,9 @@ namespace Avalonia.X11
             else
             {
                 XRaiseWindow(_x11.Display, _handle);
-                XSetInputFocus(_x11.Display, _focusProxy._handle, 0, IntPtr.Zero);
+
+                if (_focusProxy is not null)
+                    XSetInputFocus(_x11.Display, _focusProxy._handle, 0, IntPtr.Zero);
             }
         }
 

--- a/src/Avalonia.X11/XResources.cs
+++ b/src/Avalonia.X11/XResources.cs
@@ -49,11 +49,11 @@ internal class XResources
         return value;
     }
     
-    string ReadResourcesString()
+    string? ReadResourcesString()
     {
         XGetWindowProperty(_x11.Display, _x11.RootWindow, _x11.Atoms.XA_RESOURCE_MANAGER,
             IntPtr.Zero, new IntPtr(0x7fffffff),
-            false, _x11.Atoms.XA_STRING, out var actualType, out var actualFormat,
+            false, _x11.Atoms.XA_STRING, out _, out var actualFormat,
             out var nitems, out _, out var prop);
         try
         {

--- a/src/Headless/Avalonia.Headless/AvaloniaTestApplicationAttribute.cs
+++ b/src/Headless/Avalonia.Headless/AvaloniaTestApplicationAttribute.cs
@@ -9,6 +9,7 @@ namespace Avalonia.Headless;
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
 public sealed class AvaloniaTestApplicationAttribute : Attribute
 {
+    [DynamicallyAccessedMembers(HeadlessUnitTestSession.DynamicallyAccessed)]
     public Type AppBuilderEntryPointType { get; }
 
     /// <summary>

--- a/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
@@ -369,7 +369,7 @@ namespace Avalonia.Headless
             
         }
 
-        public void SetParent(IWindowImpl parent)
+        public void SetParent(IWindowImpl? parent)
         {
             
         }

--- a/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
@@ -125,9 +125,9 @@ namespace Avalonia.LinuxFramebuffer
                     _topLevel = tl;
                     
 
-                    if (_topLevel is IFocusScope scope)
+                    if (_topLevel is IFocusScope scope && _topLevel.FocusManager is FocusManager focusManager)
                     {
-                        ((FocusManager)_topLevel.FocusManager).SetFocusScope(scope);
+                        focusManager.SetFocusScope(scope);
                     }
                 }
 

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/GroupTransformers/XamlIncludeGroupTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/GroupTransformers/XamlIncludeGroupTransformer.cs
@@ -170,7 +170,7 @@ internal class AvaloniaXamlIncludeTransformer : IXamlAstGroupTransformer
         AstGroupTransformationContext context, string nodeTypeName, XamlPropertyAssignmentNode sourceProperty,
         bool strictSourceValueType)
     {
-        void OnInvalidSource(IXamlAstNode node) =>
+        void OnInvalidSource(IXamlAstNode? node) =>
             context.ReportDiagnostic(
                 AvaloniaXamlDiagnosticCodes.TransformError,
                 strictSourceValueType ? XamlDiagnosticSeverity.Error : XamlDiagnosticSeverity.Warning,

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXAmlIlClassesTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXAmlIlClassesTransformer.cs
@@ -11,12 +11,12 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
     /// <remarks>
     /// Converts the property assignment `Classes="foo bar"` to:
     /// 
-    /// <code>
+    /// <code><![CDATA[
     ///     <StyledElement.Classes>
-    ///         <x:String>foo</String>
-    ///         <x:String>bar</String>
+    ///         <x:String>foo</x:String>
+    ///         <x:String>bar</x:String>
     ///     </StyledElement.Classes>
-    /// </code>
+    /// ]]></code>
     /// </remarks>
     class AvaloniaXamlIlClassesTransformer : IXamlAstTransformer
     {

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/IncludeXamlIlSre.props
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/IncludeXamlIlSre.props
@@ -5,8 +5,5 @@
     <Compile Remove="$(MSBuildThisFileDirectory)\xamlil.github\**\*.*" />
     <Compile Include="$(MSBuildThisFileDirectory)\xamlil.github\src\XamlX\**\*.cs" />
     <Compile Remove="$(MSBuildThisFileDirectory)\xamlil.github\**\obj\**\*.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Avalonia.Markup\Markup\Parsers\SelectorGrammar.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Avalonia.Markup.Xaml\Parsers\PropertyParser.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\Avalonia.Markup\Markup\Parsers\BindingExpressionGrammar.cs" />
   </ItemGroup>
 </Project>

--- a/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
+++ b/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
@@ -72,6 +72,7 @@
   <ItemGroup Label="InternalsVisibleTo">
     <InternalsVisibleTo Include="Avalonia.Designer.HostApp, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.DesignerSupport, PublicKey=$(AvaloniaPublicKey)" />
+    <InternalsVisibleTo Include="Avalonia.Markup.Xaml.Loader, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Markup.Xaml.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
   </ItemGroup>
 </Project>

--- a/src/Windows/Avalonia.Direct2D1/FramebufferShimRenderTarget.cs
+++ b/src/Windows/Avalonia.Direct2D1/FramebufferShimRenderTarget.cs
@@ -1,8 +1,9 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using Avalonia.Controls.Platform.Surfaces;
 using Avalonia.Direct2D1.Media;
 using Avalonia.Platform;
-using Avalonia.Rendering;
 using Avalonia.Win32.Interop;
 using SharpDX.WIC;
 using PixelFormat = Avalonia.Platform.PixelFormat;

--- a/src/tools/Avalonia.Generators/Compiler/MiniCompiler.cs
+++ b/src/tools/Avalonia.Generators/Compiler/MiniCompiler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using XamlX;
 using XamlX.Compiler;
@@ -14,6 +15,7 @@ internal sealed class MiniCompiler : XamlCompiler<object, IXamlEmitResult>
 {
     public const string AvaloniaXmlnsDefinitionAttribute = "Avalonia.Metadata.XmlnsDefinitionAttribute";
 
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = TrimmingMessages.Roslyn)]
     public static MiniCompiler CreateDefault(RoslynTypeSystem typeSystem, params string[] additionalTypes)
     {
         var mappings = new XamlLanguageTypeMappings(typeSystem);

--- a/src/tools/Avalonia.Generators/Compiler/RoslynTypeSystem.cs
+++ b/src/tools/Avalonia.Generators/Compiler/RoslynTypeSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -31,11 +32,13 @@ internal class RoslynTypeSystem : IXamlTypeSystem
         Assemblies
             .FirstOrDefault(a => string.Equals(a.Name, name, StringComparison.OrdinalIgnoreCase));
 
+    [UnconditionalSuppressMessage("Trimming", "IL2092", Justification = TrimmingMessages.Roslyn)]
     public IXamlType FindType(string name) =>
         _assemblies
             .Select(assembly => assembly.FindType(name))
             .FirstOrDefault(type => type != null);
 
+    [UnconditionalSuppressMessage("Trimming", "IL2092", Justification = TrimmingMessages.Roslyn)]
     public IXamlType FindType(string name, string assembly) =>
         _assemblies
             .Select(assemblyInstance => assemblyInstance.FindType(name))

--- a/src/tools/Avalonia.Generators/TrimmingMessages.cs
+++ b/src/tools/Avalonia.Generators/TrimmingMessages.cs
@@ -1,0 +1,6 @@
+﻿namespace Avalonia.Generators;
+
+internal static class TrimmingMessages
+{
+    public const string Roslyn = "Roslyn is not getting trimmed.";
+}

--- a/src/tools/DevGenerators/CompositionGenerator/Generator.ConfigHelpers.cs
+++ b/src/tools/DevGenerators/CompositionGenerator/Generator.ConfigHelpers.cs
@@ -1,23 +1,22 @@
-
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-using static Avalonia.SourceGenerator.CompositionGenerator.Extensions;
+
 namespace Avalonia.SourceGenerator.CompositionGenerator;
 
 public partial class Generator
 {
-    class GeneratorTypeInfo
+    private sealed class GeneratorTypeInfo
     {
-        public TypeSyntax RoslynType { get; set; }
-        public string FilteredTypeName { get; set; }
+        public TypeSyntax RoslynType { get; set; } = null!;
+        public string FilteredTypeName { get; set; } = null!;
         public bool IsObject { get; set; }
         public bool IsPassthrough { get; set; }
-        public string ServerType { get; set; }
+        public string ServerType { get; set; } = null!;
         public bool IsNullable { get; set; }
     }
 
-    private Dictionary<string, GeneratorTypeInfo> _typeInfoCache = new();
+    private readonly Dictionary<string, GeneratorTypeInfo> _typeInfoCache = new();
 
     private GeneratorTypeInfo GetTypeInfo(string type)
     {


### PR DESCRIPTION
## What does the pull request do?
This PR fixes several dozens of compiler and external analyzer warnings in the desktop solution.

## How was the solution implemented?
Apart from the obvious fixes for the most common issues (nullability mismatch, wrong documentation cref, unused event), the notable changes are:
 - Disabled trim warnings for `netstandard2.0`. The suppressions don't work correctly for it, and trimming is done on a real TFM anyways. Trim warnings are still enabled as errors for `net6.0`, so nothing should be missed.
 - Added an `AsAsyncEnumerable` method to transform `IEnumerable` to `IAsyncEnumerable` without warnings.

## Remaining warnings

- Warnings in XAML loader, fixed in https://github.com/kekekeks/XamlX/pull/95 (pending merge).
- Warnings coming from Avalonia's analyzers itself, will be fixed in another PR for easier review.
- Warnings in samples, unit tests and mobile projects, will be fixed in another PR.
