### PR TITLE
PageSlide.cs documentation error fix

### DIFF
--- a/src/Avalonia.Base/Animation/PageSlide.cs
+++ b/src/Avalonia.Base/Animation/PageSlide.cs
@@ -47,7 +47,7 @@ namespace Avalonia.Animation
         public TimeSpan Duration { get; set; }
 
         /// <summary>
-        /// Gets the duration of the animation.
+        /// Gets the orientation of the animation.
         /// </summary>
         public SlideAxis Orientation { get; set; }
         


### PR DESCRIPTION
Orientation was mislabeled as duration

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
none

