### PR TITLE
Fix blocking  shutdown app with LibInput

### DIFF
--- a/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackend.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackend.cs
@@ -19,7 +19,10 @@ namespace Avalonia.LinuxFramebuffer.Input.LibInput
         public LibInputBackend()
         {
             var ctx = libinput_path_create_context();
-            new Thread(() => InputThread(ctx)).Start();
+            new Thread(() => InputThread(ctx))
+            {
+                IsBackground = true
+            }.Start();
         }
 
         private unsafe void InputThread(IntPtr ctx)


### PR DESCRIPTION
## What does the pull request do?
Fix application crash when using LibInputBackend due to thread not being background

## What is the current behavior?
When the application is terminated (for example, calling Shutdown from lifetime), the application does not close

## What is the updated/expected behavior with this PR?
The application shuts down

## How was the solution implemented (if it's not obvious)?
The IsBackground property for the thread is set

## Fixes
Fixes #12334 