### PR TITLE
Data grid handled events

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCell.cs
@@ -169,9 +169,13 @@ namespace Avalonia.Controls
                 return;
             }
             OwningGrid.OnCellPointerPressed(new DataGridCellPointerPressedEventArgs(this, OwningRow, OwningColumn, e));
+            if (e.Handled)
+            {
+                return;
+            }
             if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
-                if (!e.Handled && OwningGrid.IsTabStop)
+                if (OwningGrid.IsTabStop)
                 {
                     OwningGrid.Focus();
                 }
@@ -191,7 +195,7 @@ namespace Avalonia.Controls
             }
             else if (e.GetCurrentPoint(this).Properties.IsRightButtonPressed)
             {
-                if (!e.Handled && OwningGrid.IsTabStop)
+                if (OwningGrid.IsTabStop)
                 {
                     OwningGrid.Focus();
                 }

--- a/src/Avalonia.Controls.DataGrid/DataGridCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCell.cs
@@ -32,7 +32,7 @@ namespace Avalonia.Controls
         static DataGridCell()
         {
             PointerPressedEvent.AddClassHandler<DataGridCell>(
-                (x,e) => x.DataGridCell_PointerPressed(e));
+                (x,e) => x.DataGridCell_PointerPressed(e), handledEventsToo: true);
             FocusableProperty.OverrideDefaultValue<DataGridCell>(true);
             IsTabStopProperty.OverrideDefaultValue<DataGridCell>(false);
         }

--- a/src/Avalonia.Controls.DataGrid/DataGridCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCell.cs
@@ -32,7 +32,7 @@ namespace Avalonia.Controls
         static DataGridCell()
         {
             PointerPressedEvent.AddClassHandler<DataGridCell>(
-                (x,e) => x.DataGridCell_PointerPressed(e), handledEventsToo: true);
+                (x,e) => x.DataGridCell_PointerPressed(e));
             FocusableProperty.OverrideDefaultValue<DataGridCell>(true);
             IsTabStopProperty.OverrideDefaultValue<DataGridCell>(false);
         }


### PR DESCRIPTION
## What does the pull request do?
There was a breaking change in Avalonia 11.0 where some events can't be canceled (https://github.com/AvaloniaUI/Avalonia/pull/9918). This PR tries to fix DataGridCell PointerPressed.

## What is the current behavior?
You can't handle the event in a way that would prevent the bubbling. It was handled before on the framework level. Now this needs to be handled by each component.

## What is the updated/expected behavior with this PR?
If the event has been handled the bubbling should be canceled. 

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
I don't think there should be any raised handled event that should be still taken into account for this.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
