### PR TITLE
Fix WasmExtraFilesToDeploy on non-Windows .NET 8

### DIFF
--- a/samples/ControlCatalog.Browser/ControlCatalog.Browser.csproj
+++ b/samples/ControlCatalog.Browser/ControlCatalog.Browser.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\src\Browser\Avalonia.Browser\Avalonia.Browser.props" />
+  <Import Project="../../src/Browser/Avalonia.Browser/Avalonia.Browser.props" />
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
-    <WasmMainJSPath>AppBundle\main.js</WasmMainJSPath>
+    <WasmMainJSPath>AppBundle/main.js</WasmMainJSPath>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MSBuildEnableWorkloadResolver>true</MSBuildEnableWorkloadResolver>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Skia\Avalonia.Skia\Avalonia.Skia.csproj" />
-    <ProjectReference Include="..\..\src\Browser\Avalonia.Browser\Avalonia.Browser.csproj" />
-    <ProjectReference Include="..\ControlCatalog\ControlCatalog.csproj" />
+    <ProjectReference Include="../../src/Skia/Avalonia.Skia/Avalonia.Skia.csproj" />
+    <ProjectReference Include="../../src/Browser/Avalonia.Browser/Avalonia.Browser.csproj" />
+    <ProjectReference Include="../ControlCatalog/ControlCatalog.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <WasmExtraFilesToDeploy Include="AppBundle\**" />
+    <WasmExtraFilesToDeploy Include="AppBundle/**" />
   </ItemGroup>
 
-  <Import Project="..\..\src\Browser\Avalonia.Browser\Avalonia.Browser.targets" />
+  <Import Project="../../src/Browser/Avalonia.Browser/Avalonia.Browser.targets" />
 </Project>

--- a/src/Browser/Avalonia.Browser.Blazor/Avalonia.Browser.Blazor.csproj
+++ b/src/Browser/Avalonia.Browser.Blazor/Avalonia.Browser.Blazor.csproj
@@ -10,15 +10,15 @@
     <SupportedPlatform Include="browser" />
   </ItemGroup>
 
-  <Import Project="..\..\..\build\NullableEnable.props" />
-  <Import Project="..\..\..\build\TrimmingEnable.props" />
+  <Import Project="../../../build/NullableEnable.props" />
+  <Import Project="../../../build/TrimmingEnable.props" />
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Avalonia.Browser\Avalonia.Browser.csproj" />
+    <ProjectReference Include="../Avalonia.Browser/Avalonia.Browser.csproj" />
   </ItemGroup>
 
   <Target Name="_IncludeGeneratedAvaloniaStaticFiles">
@@ -32,7 +32,7 @@
                            CopyToOutputDirectory="PreserveNewest"
                            CopyToPublishDirectory="PreserveNewest"
                            ContentRoot="$(MSBuildThisFileDirectory)../Avalonia.Browser/wwwroot/"
-                           BasePath="_content\$(PackageId)"
+                           BasePath="_content/$(PackageId)"
                            CandidateAssets="@(_AvaloniaWebAssets)"
                            RelativePathFilter="**.js">
       <Output TaskParameter="Assets" ItemName="StaticWebAsset" />

--- a/src/Browser/Avalonia.Browser/Avalonia.Browser.csproj
+++ b/src/Browser/Avalonia.Browser/Avalonia.Browser.csproj
@@ -10,25 +10,25 @@
     <SupportedPlatform Include="browser" />
   </ItemGroup>
 
-  <Import Project="..\..\..\build\BuildTargets.targets" />
-  <Import Project="..\..\..\build\SkiaSharp.props" />
-  <Import Project="..\..\..\build\HarfBuzzSharp.props" />
-  <Import Project="..\..\..\build\NullableEnable.props" />
-  <Import Project="..\..\..\build\TrimmingEnable.props" />
+  <Import Project="../../../build/BuildTargets.targets" />
+  <Import Project="../../../build/SkiaSharp.props" />
+  <Import Project="../../../build/HarfBuzzSharp.props" />
+  <Import Project="../../../build/NullableEnable.props" />
+  <Import Project="../../../build/TrimmingEnable.props" />
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />
-    <ProjectReference Include="..\..\Skia\Avalonia.Skia\Avalonia.Skia.csproj" />
+    <ProjectReference Include="../../../packages/Avalonia/Avalonia.csproj" />
+    <ProjectReference Include="../../Skia/Avalonia.Skia/Avalonia.Skia.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <Content Include="*.props">
       <Pack>true</Pack>
-      <PackagePath>build\</PackagePath>
+      <PackagePath>build/</PackagePath>
     </Content>
     <Content Include="*.targets">
       <Pack>true</Pack>
-      <PackagePath>build\;buildTransitive\</PackagePath>
+      <PackagePath>build/;buildTransitive/</PackagePath>
     </Content>
     <Content Include="interop.js">
       <Pack>true</Pack>
@@ -36,7 +36,7 @@
     </Content>
     <Content Include="wwwroot/**/*.*">
       <Pack>true</Pack>
-      <PackagePath>build\wwwroot;buildTransitive\wwwroot</PackagePath>
+      <PackagePath>build/wwwroot;buildTransitive/wwwroot</PackagePath>
     </Content>
   </ItemGroup>
 

--- a/src/Browser/Avalonia.Browser/Avalonia.Browser.targets
+++ b/src/Browser/Avalonia.Browser/Avalonia.Browser.targets
@@ -1,12 +1,12 @@
 <Project>
   <PropertyGroup>
-    <EmccExtraLDFlags>$(EmccExtraLDFlags) --js-library="$(MSBuildThisFileDirectory)\interop.js"</EmccExtraLDFlags>
+    <EmccExtraLDFlags>$(EmccExtraLDFlags) --js-library="$(MSBuildThisFileDirectory)/interop.js"</EmccExtraLDFlags>
     <EmccFlags>$(EmccExtraLDFlags) -sERROR_ON_UNDEFINED_SYMBOLS=0</EmccFlags>
   </PropertyGroup>
 
   <ItemGroup>
-    <WasmExtraFilesToDeploy Condition="'$(WasmRuntimeAssetsLocation)' == ''" Include="$(MSBuildThisFileDirectory)\wwwroot\**\*.*" />
-    <WasmExtraFilesToDeploy Condition="'$(WasmRuntimeAssetsLocation)' != ''" Include="$(MSBuildThisFileDirectory)\wwwroot\**\*.*" TargetPath="$(WasmRuntimeAssetsLocation)\%(FileName)%(Extension)" />
+    <WasmExtraFilesToDeploy Condition="'$(WasmRuntimeAssetsLocation)' == ''" Include="$(MSBuildThisFileDirectory)/wwwroot/**/*.*" />
+    <WasmExtraFilesToDeploy Condition="'$(WasmRuntimeAssetsLocation)' != ''" Include="$(MSBuildThisFileDirectory)/wwwroot/**/*.*" TargetPath="$(WasmRuntimeAssetsLocation)/%(FileName)%(Extension)" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(ShouldIncludeNativeSkiaSharp)' == 'True' or '$(ShouldIncludeNativeHarfBuzzSharp)' == 'True'">
@@ -15,19 +15,19 @@
 
   <ItemGroup Condition="'$(TargetFrameworkVersion)' != '' and '$(ShouldIncludeNativeSkiaSharp)' == 'True'">
     <!-- net7.0 -->
-    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\3.1.12\mt\*.a" Condition="!$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(WasmEnableThreads)' == 'True'" />
-    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\3.1.12\st\*.a" Condition="!$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(WasmEnableThreads)' != 'True'" />
+    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)/3.1.12/mt/*.a" Condition="!$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(WasmEnableThreads)' == 'True'" />
+    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)/3.1.12/st/*.a" Condition="!$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(WasmEnableThreads)' != 'True'" />
     <!-- net8.0 -->
-    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\3.1.34\mt\*.a" Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(WasmEnableThreads)' == 'True'" />
-    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)\3.1.34\st\*.a" Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(WasmEnableThreads)' != 'True'" />
+    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)/3.1.34/mt/*.a" Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(WasmEnableThreads)' == 'True'" />
+    <NativeFileReference Include="$(SkiaSharpStaticLibraryPath)/3.1.34/st/*.a" Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(WasmEnableThreads)' != 'True'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkVersion)' != '' and '$(ShouldIncludeNativeHarfBuzzSharp)' == 'True'">
     <!-- net7.0 -->
-    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\3.1.12\st\*.a" Condition="!$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(WasmEnableThreads)' != 'True'" />
-    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\3.1.12\mt\*.a" Condition="!$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(WasmEnableThreads)' == 'True'" />
+    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)/3.1.12/st/*.a" Condition="!$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(WasmEnableThreads)' != 'True'" />
+    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)/3.1.12/mt/*.a" Condition="!$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(WasmEnableThreads)' == 'True'" />
     <!-- net8.0 -->
-    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\3.1.34\st\*.a" Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(WasmEnableThreads)' != 'True'" />
-    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)\3.1.34\mt\*.a" Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(WasmEnableThreads)' == 'True'" />
+    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)/3.1.34/st/*.a" Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(WasmEnableThreads)' != 'True'" />
+    <NativeFileReference Include="$(HarfBuzzSharpStaticLibraryPath)/3.1.34/mt/*.a" Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0')) and '$(WasmEnableThreads)' == 'True'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What does the pull request do?
This PR changes the `TargetPath` of `WasmExtraFilesToDeploy` to use `/` as a folder separator, for proper deployment on Linux and macOS.

See [.NET 8 breaking change: Backslash mapping in Unix file paths](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/file-path-backslash) for more information.

(MSBuild still seems to recognize `\` as a path separator in `Include` and some other file path attributes, but `TargetPath` here is probably a simple string used by an inner task).

I also replaced all `\` in browser-related targets/csproj by `/`, as it doesn't hurt and may prevent future problems.

## Fixed issues
 - Fixes #13689
