### PR TITLE
Fix Design.IsDesignMode being false in BuildAvaloniaApp method

### DIFF
--- a/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
+++ b/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
@@ -173,13 +173,11 @@ namespace Avalonia.DesignerSupport.Remote
             if (transport is ITransportWithEnforcedMethod enforcedMethod)
                 args.Method = enforcedMethod.PreviewerMethod;
             var asm = Assembly.LoadFile(System.IO.Path.GetFullPath(args.AppPath));
-            var entryPoint = asm.EntryPoint;
-            if (entryPoint == null)
-                throw Die($"Assembly {args.AppPath} doesn't have an entry point");
+            var entryPoint = asm.EntryPoint ?? throw Die($"Assembly {args.AppPath} doesn't have an entry point");
+            Log($"Initializing application in design mode");
+            Design.IsDesignMode = true;
             Log($"Obtaining AppBuilder instance from {entryPoint.DeclaringType!.FullName}");
             var appBuilder = AppBuilder.Configure(entryPoint.DeclaringType);
-            Design.IsDesignMode = true;
-            Log($"Initializing application in design mode");
             var initializer =(IAppInitializer)Activator.CreateInstance(typeof(AppInitializer));
             transport = initializer.ConfigureApp(transport, args, appBuilder);
             s_transport = transport;


### PR DESCRIPTION
## What does the pull request do?
Currently when app is runned by designer Design.IsDesignMode will be false in the BuildAvaloniaApp method because we were setting it to true only after calling AppBuilder.Configure(entryPoint.DeclaringType) which invokes BuildAvaloniaApp method.