### PR TITLE
Warning cleanup, part 3

### DIFF
--- a/build/XUnit.props
+++ b/build/XUnit.props
@@ -13,5 +13,6 @@
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\avalonia.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>False</SignAssembly>
+    <NoWarn>$(NoWarn);CS8002</NoWarn> <!-- ignore signing warnings for unit tests -->
   </PropertyGroup>
 </Project>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,10 +1,14 @@
 <Project>
+
   <PropertyGroup>
-      <IsPackable>false</IsPackable>
-      <AvaloniaPreviewerNetCoreToolPath>$(MSBuildThisFileDirectory)..\src\tools\Avalonia.Designer.HostApp\bin\Debug\netcoreapp2.0\Avalonia.Designer.HostApp.dll</AvaloniaPreviewerNetCoreToolPath>
-      <EnableNETAnalyzers>false</EnableNETAnalyzers>
-      <LangVersion>11</LangVersion>
+    <IsPackable>false</IsPackable>
+    <AvaloniaPreviewerNetCoreToolPath>$(MSBuildThisFileDirectory)..\src\tools\Avalonia.Designer.HostApp\bin\Debug\netcoreapp2.0\Avalonia.Designer.HostApp.dll</AvaloniaPreviewerNetCoreToolPath>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <LangVersion>11</LangVersion>
+    <NoWarn>$(NoWarn);CS8002</NoWarn> <!-- ignore signing warnings for samples -->
   </PropertyGroup>
-  <Import Project="..\build\SharedVersion.props" />
-  <Import Project="..\build\DevAnalyzers.props" />
+
+  <Import Project="..\build\SharedVersion.props"/>
+  <Import Project="..\build\DevAnalyzers.props"/>
+
 </Project>


### PR DESCRIPTION
A simple one: ignore warnings about referencing assemblies without strong name (CS8002) in tests and samples.

Notes:
- Tests are strong named because they're referenced in `InternalsVisibleTo` from the base libraries, which are strong named.
- The `MiniMvvm` and `ControlCatalog` samples are also referenced through `InternalsVisibleTo`. Ideally samples should use only public API (and we could then drop the signing for them). But that's another issue.