### PR TITLE
Update Xamarin.AndroidX

### DIFF
--- a/samples/ControlCatalog.Android/ControlCatalog.Android.csproj
+++ b/samples/ControlCatalog.Android/ControlCatalog.Android.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MobileSandbox.Android/MobileSandbox.Android.csproj
+++ b/samples/MobileSandbox.Android/MobileSandbox.Android.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Android/Avalonia.Android/Avalonia.Android.csproj
+++ b/src/Android/Avalonia.Android/Avalonia.Android.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\packages\Avalonia\Avalonia.csproj" />
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.3.1.3" />
-    <PackageReference Include="Xamarin.AndroidX.DocumentFile" Version="1.0.1.16" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel" Version="2.3.1.3" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.6.1.5" />
+    <PackageReference Include="Xamarin.AndroidX.DocumentFile" Version="1.0.1.21" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel" Version="2.6.2.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Avalonia.Base\Avalonia.Base.csproj" />


### PR DESCRIPTION
## What does the pull request do?
This PR updates the `Xamarin.AndroidX.*` packages used in the solution to the latest ones.

The currently referenced versions output a lot of spurious warnings like `JAVAC: Warning  : unknown enum constant Scope.LIBRARY_GROUP_PREFIX` when building Android projects, all fixed in the latest versions.

The targeted framework for the 3 packages is unchanged from `net6.0-android31.0` so nobody should break (Avalonia is targeting `net7.0-android33` anyways).
