### PR TITLE
Fix AVP1012 warnings in Avalonia.Base

### DIFF
--- a/src/Avalonia.Base/Input/PinchEventArgs.cs
+++ b/src/Avalonia.Base/Input/PinchEventArgs.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Input
 
         /// <summary>
         /// Gets the angle of the pinch gesture, in degrees.
-        /// <summary>
+        /// </summary>
         /// <remarks>
         /// A pinch gesture is the movement of two pressed points closer together. This property is the measured angle of the line between those two points. Remember zero degrees is a line pointing up.
         /// </remarks>

--- a/src/Avalonia.Base/Media/PolyLineSegment.cs
+++ b/src/Avalonia.Base/Media/PolyLineSegment.cs
@@ -39,6 +39,8 @@ namespace Avalonia.Media
         /// Initializes a new instance of the <see cref="PolyLineSegment"/> class.
         /// </summary>
         /// <param name="points">The points.</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("AvaloniaProperty", "AVP1012",
+            Justification = "Collection properties shouldn't be set with SetCurrentValue.")]
         public PolyLineSegment(IEnumerable<Point> points)
         {
             Points = new Points(points);

--- a/src/Avalonia.Controls/TabItem.cs
+++ b/src/Avalonia.Controls/TabItem.cs
@@ -72,14 +72,14 @@ namespace Avalonia.Controls
                 {
                     if (Header != headered.Header)
                     {
-                        Header = headered.Header;
+                        SetCurrentValue(HeaderProperty, headered.Header);
                     }
                 }
                 else
                 {
                     if (!(obj.NewValue is Control))
                     {
-                        Header = obj.NewValue;
+                        SetCurrentValue(HeaderProperty, obj.NewValue);
                     }
                 }
             }
@@ -87,7 +87,7 @@ namespace Avalonia.Controls
             {
                 if (Header == obj.OldValue)
                 {
-                    Header = obj.NewValue;
+                    SetCurrentValue(HeaderProperty, obj.NewValue);
                 }
             }
         }

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using Avalonia.Collections;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Selection;
@@ -545,6 +544,32 @@ namespace Avalonia.Controls.UnitTests
 
             item = target.ContainerFromIndex(2);
             Assert.Same(item, root.FocusManager.GetFocusedElement());
+        }
+
+        [Fact]
+        public void TabItem_Header_Should_Be_Settable_By_Style_When_DataContext_Is_Set()
+        {
+            var tabItem = new TabItem
+            {
+                DataContext = "Some DataContext"
+            };
+
+            _ = new TestRoot
+            {
+                Styles =
+                {
+                    new Style(x => x.OfType<TabItem>())
+                    {
+                        Setters =
+                        {
+                            new Setter(HeaderedContentControl.HeaderProperty, "Header from style")
+                        }
+                    }
+                },
+                Child = tabItem
+            };
+
+            Assert.Equal("Header from style", tabItem.Header);
         }
 
         private static IControlTemplate TabControlTemplate()


### PR DESCRIPTION
## What does the pull request do?
This PR fixes all AVP1012 ("use SetCurrentValue") warnings in Avalonia.Base.

## How was the solution implemented (if it's not obvious)?
`PolylineSegment` constructor: ignore the warning, which matches the other constructor.

`TabItem.Header`: I wasn't sure of the change at first, because AVP1012 in this file has been fixed (ead92a6122a4617b19b40356fd537b50d91fa449) then reverted (6523320a7b73f13aba091069b2b58fd69692d25c), both in PR #11029. After reading the PR comments, it appears the original fix was a little too broad, hence the revert, but I think the `TabItem.Header` one should have been kept.

I've added a unit test to confirm that setting the header through a style fails without the changes.

Pinging @maxkatz6 for confirmation