### PR TITLE
Fix warnings in build project

### DIFF
--- a/nukebuild/.editorconfig
+++ b/nukebuild/.editorconfig
@@ -6,3 +6,12 @@ root = false
 # C# files
 [*.cs]
 dotnet_style_require_accessibility_modifiers = never
+
+[{il-repack,Numerge}/**/*.cs]
+dotnet_diagnostic.CA1304.severity = none
+dotnet_diagnostic.CA1815.severity = none
+dotnet_diagnostic.CA1820.severity = none
+dotnet_diagnostic.CA1825.severity = none
+dotnet_diagnostic.CA1829.severity = none
+dotnet_diagnostic.CA1847.severity = none
+dotnet_diagnostic.SYSLIB0017.severity = none

--- a/nukebuild/ApiDiffValidation.cs
+++ b/nukebuild/ApiDiffValidation.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Nuke.Common.Tooling;
+using static Serilog.Log;
 
 public static class ApiDiffValidation
 {
@@ -142,7 +143,7 @@ public static class ApiDiffValidation
          Avalonia.11.0.0
          */
         var packageId = GetPackageId(packagePath);
-        Build.Information("Downloading {0} {1} baseline package", packageId, baselineVersion);
+        Information("Downloading {0} {1} baseline package", packageId, baselineVersion);
 
         try
         {

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -1,21 +1,14 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Nuke.Common;
-using Nuke.Common.Git;
-using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
-using Nuke.Common.Tools.MSBuild;
 using Nuke.Common.Tools.Npm;
-using Nuke.Common.Utilities;
-using Nuke.Common.Utilities.Collections;
 using static Nuke.Common.EnvironmentInfo;
 using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.IO.PathConstruction;
@@ -23,6 +16,7 @@ using static Nuke.Common.Tools.MSBuild.MSBuildTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 using static Nuke.Common.Tools.Xunit.XunitTasks;
 using static Nuke.Common.Tools.VSWhere.VSWhereTasks;
+using static Serilog.Log;
 using MicroCom.CodeGenerator;
 
 /*

--- a/nukebuild/Shims.cs
+++ b/nukebuild/Shims.cs
@@ -1,24 +1,13 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using Nuke.Common;
 using Nuke.Common.IO;
 using Numerge;
+using static Serilog.Log;
 
 public partial class Build
 {
-    internal static void Information(string info)
-    {
-        Logger.Info(info);
-    }
-
-    internal static void Information(string info, params object[] args)
-    {
-        Logger.Info(info, args);
-    }
-
     private void Zip(AbsolutePath target, params string[] paths) => Zip(target, paths.AsEnumerable());
 
     private void Zip(AbsolutePath target, IEnumerable<string> paths)
@@ -44,16 +33,12 @@ public partial class Build
                     if (Directory.Exists(path))
                     {
                         var dirInfo = new DirectoryInfo(path);
-                        var rootPath = Path.GetDirectoryName(dirInfo.FullName);
+                        var rootPath = Path.GetDirectoryName(dirInfo.FullName)!;
                         foreach(var fsEntry in dirInfo.EnumerateFileSystemInfos("*", SearchOption.AllDirectories))
                         {
                             if (fsEntry is FileInfo)
                             {
-#if NET6
                                 var relPath = Path.GetRelativePath(rootPath, fsEntry.FullName);
-#else
-                                var relPath = GetRelativePath(rootPath, fsEntry.FullName);
-#endif
                                 AddFile(fsEntry.FullName, relPath);
                             }
                         }
@@ -82,27 +67,16 @@ public partial class Build
         }
     }
 
-    private static string GetRelativePath(string relativeTo, string path)
-    {
-        var uri = new Uri(relativeTo);
-        var rel = Uri.UnescapeDataString(uri.MakeRelativeUri(new Uri(path)).ToString()).Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-        if (rel.Contains(Path.DirectorySeparatorChar.ToString()) == false)
-        {
-            rel = $".{Path.DirectorySeparatorChar}{rel}";
-        }
-        return rel;
-    }
-
     class NumergeNukeLogger : INumergeLogger
     {
         public void Log(NumergeLogLevel level, string message)
         {
             if(level == NumergeLogLevel.Error)
-                Logger.Error(message);
+                Error(message);
             else if (level == NumergeLogLevel.Warning)
-                Logger.Warn(message);
+                Warning(message);
             else
-                Logger.Info(message);
+                Information(message);
         }
     }
 }


### PR DESCRIPTION
Another warning cleanup PR.

I can't believe I forgot about the `_build` project! (Rebuilding the solution skips it.)

- Used `Serilog.Log` instead of the obsolete `Logger`.
- Ignored analyzer warnings in `il-repack` (which could benefit from a good cleanup) and `Numerge`.
