### PR TITLE
Use single .NET SDK version in pipelines

### DIFF
--- a/azure-pipelines-integrationtests.yml
+++ b/azure-pipelines-integrationtests.yml
@@ -5,14 +5,16 @@ jobs:
 
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 6.0.415'
+    displayName: 'Use .NET 6.0 Runtime'
     inputs:
-      version: 6.0.415
+      packageType: runtime
+      version: 6.0.x
 
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 7.0.402'
+    displayName: 'Use .NET 7.0 SDK'
     inputs:
-      version: 7.0.402
+      packageType: sdk
+      useGlobalJson: true
 
   - script: system_profiler SPDisplaysDataType |grep Resolution
     displayName: 'Get Resolution'
@@ -57,14 +59,16 @@ jobs:
 
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 6.0.404'
+    displayName: 'Use .NET 6.0 Runtime'
     inputs:
-      version: 6.0.404
+      packageType: runtime
+      version: 6.0.x
 
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 7.0.101'
+    displayName: 'Use .NET 7.0 SDK'
     inputs:
-      version: 7.0.101
+      packageType: sdk
+      useGlobalJson: true
 
   - task: Windows Application Driver@0
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,14 +30,16 @@ jobs:
     vmImage: 'ubuntu-20.04'
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 6.0.415'
+    displayName: 'Use .NET 6.0 Runtime'
     inputs:
-      version: 6.0.415
+      packageType: runtime
+      version: 6.0.x
 
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 7.0.402'
+    displayName: 'Use .NET 7.0 SDK'
     inputs:
-      version: 7.0.402
+      packageType: sdk
+      useGlobalJson: true
 
   - task: CmdLine@2
     displayName: 'Install Workloads'
@@ -74,14 +76,16 @@ jobs:
     vmImage: 'macos-12'
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 6.0.404'
+    displayName: 'Use .NET 6.0 Runtime'
     inputs:
-      version: 6.0.404
+      packageType: runtime
+      version: 6.0.x
 
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 7.0.101'
+    displayName: 'Use .NET 7.0 SDK'
     inputs:
-      version: 7.0.101
+      packageType: sdk
+      useGlobalJson: true
 
   - task: CmdLine@2
     displayName: 'Install Workloads'
@@ -152,14 +156,16 @@ jobs:
     SolutionDir: '$(Build.SourcesDirectory)'
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 6.0.404'
+    displayName: 'Use .NET 6.0 Runtime'
     inputs:
-      version: 6.0.404
+      packageType: runtime
+      version: 6.0.x
 
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 7.0.101'
+    displayName: 'Use .NET 7.0 SDK'
     inputs:
-      version: 7.0.101
+      packageType: sdk
+      useGlobalJson: true
 
   - task: CmdLine@2
     displayName: 'Install Workloads'

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "7.0.101",
+        "version": "7.0.404",
         "rollForward": "latestFeature"
     },
     "msbuild-sdks": {


### PR DESCRIPTION
## What does the pull request do?
This PR ensures that the same .NET 7.0 SDK version is used in all build pipelines and on developer machines, by using `global.json` as the single source of truth.

.NET 6 is installed as runtime only (to run tests), making it clearer that the .NET 6 SDK isn't used (and saving a few seconds of installation time).

## What is the current behavior?
Multiple different SDK versions (7.0.101, 7.0.402) are used.
6 different locations in 3 files must be edited to change the SDK everywhere.
