### PR TITLE
Ignore mouse move when left window

### DIFF
--- a/src/Avalonia.Base/Input/PointerOverPreProcessor.cs
+++ b/src/Avalonia.Base/Input/PointerOverPreProcessor.cs
@@ -41,14 +41,16 @@ namespace Avalonia.Input
                     _lastActivePointerDevice = pointerDevice;
                 }
 
-                if (args.Type is RawPointerEventType.LeaveWindow or RawPointerEventType.NonClientLeftButtonDown 
-                    or RawPointerEventType.TouchCancel or RawPointerEventType.TouchEnd
-                    && _currentPointer is var (lastPointer, lastPosition))
+                if (args.Type is RawPointerEventType.LeaveWindow or RawPointerEventType.NonClientLeftButtonDown
+                    or RawPointerEventType.TouchCancel or RawPointerEventType.TouchEnd)
                 {
-                    _currentPointer = null;
-                    ClearPointerOver(lastPointer, args.Root, 0, PointToClient(args.Root, lastPosition),
-                        new PointerPointProperties(args.InputModifiers, args.Type.ToUpdateKind()),
-                        args.InputModifiers.ToKeyModifiers());
+                    if (_currentPointer is var (lastPointer, lastPosition))
+                    {
+                        _currentPointer = null;
+                        ClearPointerOver(lastPointer, args.Root, 0, PointToClient(args.Root, lastPosition),
+                            new PointerPointProperties(args.InputModifiers, args.Type.ToUpdateKind()),
+                            args.InputModifiers.ToKeyModifiers());
+                    }
                 }
                 else if (args.Type is RawPointerEventType.TouchBegin or RawPointerEventType.TouchUpdate && args.Root is Visual visual)
                 {


### PR DESCRIPTION
## What does the pull request do?
Fix a bug when you resize or move a window and still receive PointerOver mouse events.
It is an Avalonia 11 regression from my previous PR https://github.com/AvaloniaUI/Avalonia/pull/7804.

## What is the current behavior?
Resize and move a window and see that seemingly random controls receive PointerOver events. This triggers mouse over style changes but also tooltips appearing, etc.

## What is the updated/expected behavior with this PR?
no PointerOver events

cc: @maxkatz6 This may interest you, thanks. 