### PR TITLE
Reduce EAGL related warnings in iOS project

### DIFF
--- a/src/iOS/Avalonia.iOS/AvaloniaView.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaView.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 using Avalonia.Controls;
 using Avalonia.Controls.Embedding;
 using Avalonia.Controls.Platform;
@@ -46,6 +47,15 @@ namespace Avalonia.iOS
 
             _topLevel.StartRendering();
 
+            InitEagl();
+            MultipleTouchEnabled = true;
+        }
+
+        [ObsoletedOSPlatform("ios12.0", "Use 'Metal' instead.")]
+        [SupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("maccatalyst")]
+        private void InitEagl()
+        {
             var l = (CAEAGLLayer)Layer;
             l.ContentsScale = UIScreen.MainScreen.Scale;
             l.Opaque = true;
@@ -54,7 +64,6 @@ namespace Avalonia.iOS
                 EAGLDrawableProperty.ColorFormat, EAGLColorFormat.RGBA8
             );
             _topLevelImpl.Surfaces = new[] { new EaglLayerSurface(l) };
-            MultipleTouchEnabled = true;
         }
 
         /// <inheritdoc />

--- a/src/iOS/Avalonia.iOS/EaglDisplay.cs
+++ b/src/iOS/Avalonia.iOS/EaglDisplay.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 using Avalonia.OpenGL;
 using Avalonia.Platform;
 using Avalonia.Reactive;
@@ -7,6 +8,8 @@ using OpenGLES;
 
 namespace Avalonia.iOS
 {
+    [ObsoletedOSPlatform("ios12.0", "Use 'Metal' instead.")]
+    [SupportedOSPlatform("ios")]
     class EaglPlatformGraphics : IPlatformGraphics
     {
         public IPlatformGraphicsContext GetSharedContext() => Context;
@@ -28,6 +31,8 @@ namespace Avalonia.iOS
         }
     }
 
+    [ObsoletedOSPlatform("ios12.0", "Use 'Metal' instead.")]
+    [SupportedOSPlatform("ios")]
     class GlContext : IGlContext
     {
         public EAGLContext Context { get; private set; }

--- a/src/iOS/Avalonia.iOS/EaglLayerSurface.cs
+++ b/src/iOS/Avalonia.iOS/EaglLayerSurface.cs
@@ -1,5 +1,6 @@
 
 using System;
+using System.Runtime.Versioning;
 using System.Threading;
 using Avalonia.OpenGL;
 using Avalonia.OpenGL.Surfaces;
@@ -7,6 +8,8 @@ using CoreAnimation;
 
 namespace Avalonia.iOS
 {
+    [ObsoletedOSPlatform("ios12.0", "Use 'Metal' instead.")]
+    [SupportedOSPlatform("ios")]
     class EaglLayerSurface : IGlPlatformSurface
     {
         private readonly CAEAGLLayer _layer;

--- a/src/iOS/Avalonia.iOS/LayerFbo.cs
+++ b/src/iOS/Avalonia.iOS/LayerFbo.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Runtime.Versioning;
 using Avalonia.OpenGL;
 using CoreAnimation;
 using OpenGLES;
 
 namespace Avalonia.iOS
 {
+    [ObsoletedOSPlatform("ios12.0", "Use 'Metal' instead.")]
+    [SupportedOSPlatform("ios")]
     internal class LayerFbo
     {
         private readonly EAGLContext _context;
@@ -90,6 +93,8 @@ namespace Avalonia.iOS
         }
     }
 
+    [ObsoletedOSPlatform("ios12.0", "Use 'Metal' instead.")]
+    [SupportedOSPlatform("ios")]
     class SizeSynchronizedLayerFbo : IDisposable
     {
         private readonly EAGLContext _context;

--- a/src/iOS/Avalonia.iOS/Platform.cs
+++ b/src/iOS/Avalonia.iOS/Platform.cs
@@ -38,7 +38,7 @@ namespace Avalonia.iOS
             var keyboard = new KeyboardDevice();
 
             AvaloniaLocator.CurrentMutable
-                .Bind<IPlatformGraphics>().ToConstant(GlFeature)
+                .Bind<IPlatformGraphics>().ToConstant((IPlatformGraphics) GlFeature)
                 .Bind<ICursorFactory>().ToConstant(new CursorFactoryStub())
                 .Bind<IWindowingPlatform>().ToConstant(new WindowingPlatformStub())
                 .Bind<IPlatformSettings>().ToSingleton<PlatformSettings>()

--- a/src/iOS/Avalonia.iOS/Properties/AssemblyInfo.cs
+++ b/src/iOS/Avalonia.iOS/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.Versioning;
+
+// Remove spurious warnings for maccatalyst (which isn't targeted): https://github.com/dotnet/roslyn-analyzers/issues/6269
+[assembly: UnsupportedOSPlatform("maccatalyst")]


### PR DESCRIPTION
## What does the pull request do?
This PR reduces the warnings related to EAGL in the iOS projects.

They're real warnings that should be fixed later by using Metal, but we don't need 25 of them: leave them at the entry points instead by annotating the EAGL-related classes.

Also remove some incorrect warnings related to the non-targeted `maccatalyst` platform, see https://github.com/dotnet/roslyn-analyzers/issues/6269