### PR TITLE
Allow users to change menu show delay

### DIFF
--- a/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
+++ b/src/Avalonia.Controls/Platform/DefaultMenuInteractionHandler.cs
@@ -49,7 +49,7 @@ namespace Avalonia.Controls.Platform
 
         internal IMenu? Menu { get; private set; }
 
-        protected static TimeSpan MenuShowDelay { get; } = TimeSpan.FromMilliseconds(400);
+        public static TimeSpan MenuShowDelay { get; set;} = TimeSpan.FromMilliseconds(400);
 
         protected internal virtual void GotFocus(object? sender, GotFocusEventArgs e)
         {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Allow users to change `DefaultMenuInteractionHandler.MenuShowDelay`.

## What is the current behavior?
 Currently there is no easy way to set the menu show delay.

## What is the updated/expected behavior with this PR?
Change to public to allow users to modify the delay.

