### PR TITLE
Fix overlapping items in `VirtualizingStackPanel`

### DIFF
--- a/src/Avalonia.Controls/Utils/RealizedStackElements.cs
+++ b/src/Avalonia.Controls/Utils/RealizedStackElements.cs
@@ -294,6 +294,7 @@ namespace Avalonia.Controls.Utils
                 {
                     // The insertion point was before the first element, update the first index.
                     _firstIndex += count;
+                    _startUUnstable = true;
                 }
                 else
                 {

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
@@ -843,6 +843,28 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(1, panel.VisualChildren.Count);
         }
 
+        [Fact]
+        public void Inserting_Item_Before_Viewport_Preserves_FirstRealizedIndex()
+        {
+            // Issue #12744
+            using var app = App();
+            var (target, scroll, itemsControl) = CreateTarget();
+            var items = (IList)itemsControl.ItemsSource!;
+
+            // Scroll down 20 items.
+            scroll.Offset = new Vector(0, 200);
+            target.UpdateLayout();
+            Assert.Equal(20, target.FirstRealizedIndex);
+
+            // Insert an item at the beginning.
+            items.Insert(0, "New Item");
+            target.UpdateLayout();
+
+            // The first realized index should still be 20 as the scroll should be unchanged.
+            Assert.Equal(20, target.FirstRealizedIndex);
+            Assert.Equal(new(0, 200), scroll.Offset);
+        }
+
         private static IReadOnlyList<int> GetRealizedIndexes(VirtualizingStackPanel target, ItemsControl itemsControl)
         {
             return target.GetRealizedElements()


### PR DESCRIPTION
## What does the pull request do?

As described in #12744, sometimes items in a virtualized `ItemsControl` would start overlapping.

The reason is simple: inserting items before the current viewport should cause `RealizedStackElements` to mark `StartU` as unstable because we don't now actually know the start U position any more (we haven't measured the inserted item).

This is a port of a fix for [`TreeDataGrid`](https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/pull/229) but this time I actually wrote a simple unit test which tests the source of the problem (although a unit test for the _actual_ visible effect of this bug is a lot more difficult, and I've still not managed to repro in a unit test).

## Fixed issues

Fixes #12744 
Part of #13736