### PR TITLE
Updated RenderDataRectangleNode.HitTest to properly hit-test rounded rectangles

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Drawing/Nodes/RenderDataRectangleNode.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Drawing/Nodes/RenderDataRectangleNode.cs
@@ -1,5 +1,5 @@
+using System;
 using Avalonia.Media;
-using Avalonia.Platform;
 
 namespace Avalonia.Rendering.Composition.Drawing.Nodes;
 
@@ -7,19 +7,90 @@ class RenderDataRectangleNode : RenderDataBrushAndPenNode
 {
     public RoundedRect Rect { get; set; }
     public BoxShadows BoxShadows { get; set; }
-    
+
+    static bool IsOutsideCorner(double dx, double dy, double radius)
+    {
+        return (dx < 0) && (dy < 0) && (dx * dx + dy * dy > radius * radius);
+    }
+
+    bool RoundedRectContains(Rect bounds, Point p, double radiusAdjustment)
+    {
+        // Do a simple rectangular bounds check first
+        if (!bounds.ContainsExclusive(p))
+            return false;
+
+        // Update the radii by the adjustment amount
+        var rrect = new RoundedRect(
+            Rect.Rect,
+            new Vector(Math.Max(0, Rect.RadiiTopLeft.X + radiusAdjustment), Math.Max(0, Rect.RadiiTopLeft.Y + radiusAdjustment)),
+            new Vector(Math.Max(0, Rect.RadiiTopRight.X + radiusAdjustment), Math.Max(0, Rect.RadiiTopRight.Y + radiusAdjustment)),
+            new Vector(Math.Max(0, Rect.RadiiBottomRight.X + radiusAdjustment), Math.Max(0, Rect.RadiiBottomRight.Y + radiusAdjustment)),
+            new Vector(Math.Max(0, Rect.RadiiBottomLeft.X + radiusAdjustment), Math.Max(0, Rect.RadiiBottomLeft.Y + radiusAdjustment))
+            );
+
+        // If any radii totals exceed available bounds, determine a scale factor that needs to be applied
+        var scaleFactor = 1.0;
+        if (bounds.Width > 0)
+        {
+            var radiiWidth = Math.Max(rrect.RadiiTopLeft.X + rrect.RadiiTopRight.X, rrect.RadiiBottomLeft.X + rrect.RadiiBottomRight.X);
+            if (radiiWidth > bounds.Width)
+                scaleFactor = Math.Min(scaleFactor, bounds.Width / radiiWidth);
+        }
+        if (bounds.Height > 0)
+        {
+            var radiiHeight = Math.Max(rrect.RadiiTopLeft.Y + rrect.RadiiBottomLeft.Y, rrect.RadiiTopRight.Y + rrect.RadiiBottomRight.Y);
+            if (radiiHeight > bounds.Height)
+                scaleFactor = Math.Min(scaleFactor, bounds.Height / radiiHeight);
+        }
+
+        // Before corner hit-testing, make the point relative to the bounds' upper-left
+        p = new Point(p.X - bounds.X, p.Y - bounds.Y);
+
+        // Top-left corner
+        var radius = Math.Min(rrect.RadiiTopLeft.X, rrect.RadiiTopLeft.Y) * scaleFactor;
+        if (IsOutsideCorner(p.X - radius, p.Y - radius, radius))
+            return false;
+
+        // Top-right corner
+        radius = Math.Min(rrect.RadiiTopRight.X, rrect.RadiiTopRight.Y) * scaleFactor;
+        if (IsOutsideCorner(bounds.Width - radius - p.X, p.Y - radius, radius))
+            return false;
+
+        // Bottom-right corner
+        radius = Math.Min(rrect.RadiiBottomRight.X, rrect.RadiiBottomRight.Y) * scaleFactor;
+        if (IsOutsideCorner(bounds.Width - radius - p.X, bounds.Height - radius - p.Y, radius))
+            return false;
+
+        // Bottom-left corner
+        radius = Math.Min(rrect.RadiiBottomLeft.X, rrect.RadiiBottomLeft.Y) * scaleFactor;
+        if (IsOutsideCorner(p.X - radius, bounds.Height - radius - p.Y, radius))
+            return false;
+
+        return true;
+    }
+
     public override bool HitTest(Point p)
     {
+        var strokeThicknessAdjustment = (ClientPen?.Thickness / 2) ?? 0;
+
         if (ServerBrush != null) // it's safe to check for null
         {
-            var rect = Rect.Rect.Inflate((ClientPen?.Thickness / 2) ?? 0);
-            return rect.ContainsExclusive(p);
+            var rect = Rect.Rect.Inflate(strokeThicknessAdjustment);
+
+            if (Rect.IsRounded)
+                return RoundedRectContains(rect, p, strokeThicknessAdjustment);
+            else
+                return rect.ContainsExclusive(p);
         }
         else
         {
-            var borderRect = Rect.Rect.Inflate((ClientPen?.Thickness / 2) ?? 0);
-            var emptyRect = Rect.Rect.Deflate((ClientPen?.Thickness / 2) ?? 0);
-            return borderRect.ContainsExclusive(p) && !emptyRect.ContainsExclusive(p);
+            var borderRect = Rect.Rect.Inflate(strokeThicknessAdjustment);
+            var emptyRect = Rect.Rect.Deflate(strokeThicknessAdjustment);
+
+            if (Rect.IsRounded)
+                return RoundedRectContains(borderRect, p, strokeThicknessAdjustment) && !RoundedRectContains(emptyRect, p, -strokeThicknessAdjustment);
+            else
+                return borderRect.ContainsExclusive(p) && !emptyRect.ContainsExclusive(p);
         }
     }
 

--- a/src/Avalonia.Base/Rendering/Composition/Drawing/Nodes/RenderDataRectangleNode.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Drawing/Nodes/RenderDataRectangleNode.cs
@@ -1,4 +1,3 @@
-using System;
 using Avalonia.Media;
 
 namespace Avalonia.Rendering.Composition.Drawing.Nodes;
@@ -8,90 +7,36 @@ class RenderDataRectangleNode : RenderDataBrushAndPenNode
     public RoundedRect Rect { get; set; }
     public BoxShadows BoxShadows { get; set; }
 
-    static bool IsOutsideCorner(double dx, double dy, double radius)
-    {
-        return (dx < 0) && (dy < 0) && (dx * dx + dy * dy > radius * radius);
-    }
-
-    bool RoundedRectContains(Rect bounds, Point p, double radiusAdjustment)
-    {
-        // Do a simple rectangular bounds check first
-        if (!bounds.ContainsExclusive(p))
-            return false;
-
-        // Update the radii by the adjustment amount
-        var rrect = new RoundedRect(
-            Rect.Rect,
-            new Vector(Math.Max(0, Rect.RadiiTopLeft.X + radiusAdjustment), Math.Max(0, Rect.RadiiTopLeft.Y + radiusAdjustment)),
-            new Vector(Math.Max(0, Rect.RadiiTopRight.X + radiusAdjustment), Math.Max(0, Rect.RadiiTopRight.Y + radiusAdjustment)),
-            new Vector(Math.Max(0, Rect.RadiiBottomRight.X + radiusAdjustment), Math.Max(0, Rect.RadiiBottomRight.Y + radiusAdjustment)),
-            new Vector(Math.Max(0, Rect.RadiiBottomLeft.X + radiusAdjustment), Math.Max(0, Rect.RadiiBottomLeft.Y + radiusAdjustment))
-            );
-
-        // If any radii totals exceed available bounds, determine a scale factor that needs to be applied
-        var scaleFactor = 1.0;
-        if (bounds.Width > 0)
-        {
-            var radiiWidth = Math.Max(rrect.RadiiTopLeft.X + rrect.RadiiTopRight.X, rrect.RadiiBottomLeft.X + rrect.RadiiBottomRight.X);
-            if (radiiWidth > bounds.Width)
-                scaleFactor = Math.Min(scaleFactor, bounds.Width / radiiWidth);
-        }
-        if (bounds.Height > 0)
-        {
-            var radiiHeight = Math.Max(rrect.RadiiTopLeft.Y + rrect.RadiiBottomLeft.Y, rrect.RadiiTopRight.Y + rrect.RadiiBottomRight.Y);
-            if (radiiHeight > bounds.Height)
-                scaleFactor = Math.Min(scaleFactor, bounds.Height / radiiHeight);
-        }
-
-        // Before corner hit-testing, make the point relative to the bounds' upper-left
-        p = new Point(p.X - bounds.X, p.Y - bounds.Y);
-
-        // Top-left corner
-        var radius = Math.Min(rrect.RadiiTopLeft.X, rrect.RadiiTopLeft.Y) * scaleFactor;
-        if (IsOutsideCorner(p.X - radius, p.Y - radius, radius))
-            return false;
-
-        // Top-right corner
-        radius = Math.Min(rrect.RadiiTopRight.X, rrect.RadiiTopRight.Y) * scaleFactor;
-        if (IsOutsideCorner(bounds.Width - radius - p.X, p.Y - radius, radius))
-            return false;
-
-        // Bottom-right corner
-        radius = Math.Min(rrect.RadiiBottomRight.X, rrect.RadiiBottomRight.Y) * scaleFactor;
-        if (IsOutsideCorner(bounds.Width - radius - p.X, bounds.Height - radius - p.Y, radius))
-            return false;
-
-        // Bottom-left corner
-        radius = Math.Min(rrect.RadiiBottomLeft.X, rrect.RadiiBottomLeft.Y) * scaleFactor;
-        if (IsOutsideCorner(p.X - radius, bounds.Height - radius - p.Y, radius))
-            return false;
-
-        return true;
-    }
-
     public override bool HitTest(Point p)
     {
         var strokeThicknessAdjustment = (ClientPen?.Thickness / 2) ?? 0;
 
-        if (ServerBrush != null) // it's safe to check for null
+        if (Rect.IsRounded)
         {
-            var rect = Rect.Rect.Inflate(strokeThicknessAdjustment);
+            var outerRoundedRect = Rect.Inflate(strokeThicknessAdjustment, strokeThicknessAdjustment);
+            if (outerRoundedRect.ContainsExclusive(p))
+            {
+                if (ServerBrush != null) // it's safe to check for null
+                    return true;
 
-            if (Rect.IsRounded)
-                return RoundedRectContains(rect, p, strokeThicknessAdjustment);
-            else
-                return rect.ContainsExclusive(p);
+                var innerRoundedRect = Rect.Deflate(strokeThicknessAdjustment, strokeThicknessAdjustment);
+                return !innerRoundedRect.ContainsExclusive(p);
+            } 
         }
         else
         {
-            var borderRect = Rect.Rect.Inflate(strokeThicknessAdjustment);
-            var emptyRect = Rect.Rect.Deflate(strokeThicknessAdjustment);
+            var outerRect = Rect.Rect.Inflate(strokeThicknessAdjustment);
+            if (outerRect.ContainsExclusive(p))
+            {
+                if (ServerBrush != null) // it's safe to check for null
+                    return true;
 
-            if (Rect.IsRounded)
-                return RoundedRectContains(borderRect, p, strokeThicknessAdjustment) && !RoundedRectContains(emptyRect, p, -strokeThicknessAdjustment);
-            else
-                return borderRect.ContainsExclusive(p) && !emptyRect.ContainsExclusive(p);
+                var innerRect = Rect.Rect.Deflate(strokeThicknessAdjustment);
+                return !innerRect.ContainsExclusive(p);
+            }
         }
+
+        return false;
     }
 
     public override void Invoke(ref RenderDataNodeRenderContext context) =>

--- a/src/Avalonia.Base/RoundedRect.cs
+++ b/src/Avalonia.Base/RoundedRect.cs
@@ -183,7 +183,7 @@ namespace Avalonia
                     scaleFactor = Math.Min(scaleFactor, Rect.Height / radiiHeight);
             }
 
-            // Before corner hit-testing, make the point relative to the Rect' upper-left
+            // Before corner hit-testing, make the point relative to the bounds' upper-left
             p = new Point(p.X - Rect.X, p.Y - Rect.Y);
 
             // Top-left corner

--- a/src/Avalonia.Base/RoundedRect.cs
+++ b/src/Avalonia.Base/RoundedRect.cs
@@ -150,5 +150,64 @@ namespace Avalonia
         /// For now it's internal to keep some loud community members happy about the API being pretty 
         /// </summary>
         internal bool IsEmpty() => this == default;
+
+        static bool IsOutsideCorner(double dx, double dy, double radius)
+        {
+            return (dx < 0) && (dy < 0) && (dx * dx + dy * dy > radius * radius);
+        }
+
+        /// <summary>
+        /// Determines whether a point is in the bounds of the rounded rectangle, exclusive of the
+        /// rounded rectangle's bottom/right edge.
+        /// </summary>
+        /// <param name="p">The point.</param>
+        /// <returns>true if the point is in the bounds of the rounded rectangle; otherwise false.</returns>    
+        public bool ContainsExclusive(Point p)
+        {
+            // Do a simple rectangular bounds check first
+            if (!Rect.ContainsExclusive(p))
+                return false;
+
+            // If any radii totals exceed available bounds, determine a scale factor that needs to be applied
+            var scaleFactor = 1.0;
+            if (Rect.Width > 0)
+            {
+                var radiiWidth = Math.Max(RadiiTopLeft.X + RadiiTopRight.X, RadiiBottomLeft.X + RadiiBottomRight.X);
+                if (radiiWidth > Rect.Width)
+                    scaleFactor = Math.Min(scaleFactor, Rect.Width / radiiWidth);
+            }
+            if (Rect.Height > 0)
+            {
+                var radiiHeight = Math.Max(RadiiTopLeft.Y + RadiiBottomLeft.Y, RadiiTopRight.Y + RadiiBottomRight.Y);
+                if (radiiHeight > Rect.Height)
+                    scaleFactor = Math.Min(scaleFactor, Rect.Height / radiiHeight);
+            }
+
+            // Before corner hit-testing, make the point relative to the Rect' upper-left
+            p = new Point(p.X - Rect.X, p.Y - Rect.Y);
+
+            // Top-left corner
+            var radius = Math.Min(RadiiTopLeft.X, RadiiTopLeft.Y) * scaleFactor;
+            if (IsOutsideCorner(p.X - radius, p.Y - radius, radius))
+                return false;
+
+            // Top-right corner
+            radius = Math.Min(RadiiTopRight.X, RadiiTopRight.Y) * scaleFactor;
+            if (IsOutsideCorner(Rect.Width - radius - p.X, p.Y - radius, radius))
+                return false;
+
+            // Bottom-right corner
+            radius = Math.Min(RadiiBottomRight.X, RadiiBottomRight.Y) * scaleFactor;
+            if (IsOutsideCorner(Rect.Width - radius - p.X, Rect.Height - radius - p.Y, radius))
+                return false;
+
+            // Bottom-left corner
+            radius = Math.Min(RadiiBottomLeft.X, RadiiBottomLeft.Y) * scaleFactor;
+            if (IsOutsideCorner(p.X - radius, Rect.Height - radius - p.Y, radius))
+                return false;
+
+            return true;
+        }
+
     }
 }

--- a/src/Avalonia.Base/RoundedRect.cs
+++ b/src/Avalonia.Base/RoundedRect.cs
@@ -151,7 +151,7 @@ namespace Avalonia
         /// </summary>
         internal bool IsEmpty() => this == default;
 
-        static bool IsOutsideCorner(double dx, double dy, double radius)
+        private static bool IsOutsideCorner(double dx, double dy, double radius)
         {
             return (dx < 0) && (dy < 0) && (dx * dx + dy * dy > radius * radius);
         }

--- a/tests/Avalonia.Base.UnitTests/RoundedRectTests.cs
+++ b/tests/Avalonia.Base.UnitTests/RoundedRectTests.cs
@@ -1,0 +1,35 @@
+using Xunit;
+
+namespace Avalonia.Base.UnitTests
+{
+    public class RoundedRectTests
+    {
+
+        [Theory,
+            // Corners
+            InlineData(0, 0, false),
+            InlineData(100, 0, false),
+            InlineData(100, 100, false),
+            InlineData(0, 100, false),
+            // Indent 10px
+            InlineData(10, 10, false),
+            InlineData(90, 10, true),
+            InlineData(90, 90, false),
+            InlineData(10, 90, true),
+            // Indent 17px
+            InlineData(17, 17, false),
+            InlineData(83, 17, true),
+            InlineData(83, 83, true),
+            InlineData(17, 83, true),
+            // Center
+            InlineData(50, 50, true),
+        ]
+        public void ContainsExclusive_Should_Return_Expected_Result_For_Point(double x, double y, bool expectedResult)
+        {
+            var rrect = new RoundedRect(new Rect(0, 0, 100, 100), new CornerRadius(60, 10, 50, 30));
+
+            Assert.Equal(expectedResult, rrect.ContainsExclusive(new Point(x, y)));
+        }
+
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
Updates the `RenderDataRectangleNode.HitTest` logic to properly hit-test rounded rectangle scenarios based on what is rendered on-screen.

## What is the current behavior?
Rounded rectangle hit-testing doesn't currently work right and `RenderDataRectangleNode` only does a full rectangular bounds hit-test.  This is very evident when you have something like a circular button, where the circle is provided by a `Border` or `ContentPresenter` with large `CornerRadius`.  In that scenario, the button can incorrectly be clicked when the mouse is in a corner of its rectangular bounds, even though it's well outside the visual circular bounds.

## What is the updated/expected behavior with this PR?
The old hit-test logic is still used for non-rounded rectangles.  But new hit-test logic is used for rounded rectangles.

## How was the solution implemented (if it's not obvious)?
A new `RoundedRect.ContainsExclusive` method for rounded rectangle hit-testing was added to complement the `Rect.ContainsExclusive` method used for non-rounded rectangle hit-testing.

## Breaking changes
None.

## Fixed issues
Fixes #13784
