### PR TITLE
Fix SelectedItemsControl initialization property order

### DIFF
--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -195,7 +195,7 @@ namespace Avalonia.Controls.Primitives
                 {
                     return _updateState.SelectedIndex.HasValue ?
                         _updateState.SelectedIndex.Value :
-                        _selection?.SelectedIndex ?? -1;
+                        TryGetExistingSelection()?.SelectedIndex ?? -1;
                 }
 
                 return Selection.SelectedIndex;
@@ -225,7 +225,7 @@ namespace Avalonia.Controls.Primitives
                 {
                     return _updateState.SelectedItem.HasValue ?
                         _updateState.SelectedItem.Value :
-                        _selection?.SelectedItem;
+                        TryGetExistingSelection()?.SelectedItem;
                 }
 
                 return Selection.SelectedItem;
@@ -499,8 +499,11 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
-        private int GetAnchorIndex()
-            => _selection?.AnchorIndex ?? -1;
+        internal int GetAnchorIndex()
+            => TryGetExistingSelection()?.AnchorIndex ?? -1;
+
+        private ISelectionModel? TryGetExistingSelection()
+            => _updateState?.Selection.HasValue == true ? _updateState.Selection.Value : _selection;
 
         protected internal override void PrepareContainerForItemOverride(Control container, object? item, int index)
         {

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -470,11 +470,7 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnAttachedToVisualTree(e);
 
-            var anchorIndex = GetAnchorIndex();
-            if (anchorIndex >= 0)
-            {
-                AutoScrollToSelectedItemIfNecessary(anchorIndex);
-            }
+            AutoScrollToSelectedItemIfNecessary(GetAnchorIndex());
         }
 
         /// <inheritdoc />
@@ -486,11 +482,7 @@ namespace Avalonia.Controls.Primitives
             {
                 LayoutUpdated -= ExecuteScrollWhenLayoutUpdated;
 
-                var anchorIndex = GetAnchorIndex();
-                if (anchorIndex >= 0)
-                {
-                    AutoScrollToSelectedItemIfNecessary(anchorIndex);
-                }
+                AutoScrollToSelectedItemIfNecessary(GetAnchorIndex());
             }
 
             if (AutoScrollToSelectedItem)
@@ -500,7 +492,10 @@ namespace Avalonia.Controls.Primitives
         }
 
         internal int GetAnchorIndex()
-            => TryGetExistingSelection()?.AnchorIndex ?? -1;
+        {
+            var selection = _updateState is not null ? TryGetExistingSelection() : Selection;
+            return selection?.AnchorIndex ?? -1;
+        }
 
         private ISelectionModel? TryGetExistingSelection()
             => _updateState?.Selection.HasValue == true ? _updateState.Selection.Value : _selection;
@@ -657,11 +652,7 @@ namespace Avalonia.Controls.Primitives
 
             if (change.Property == AutoScrollToSelectedItemProperty)
             {
-                var anchorIndex = GetAnchorIndex();
-                if (anchorIndex >= 0)
-                {
-                    AutoScrollToSelectedItemIfNecessary(anchorIndex);
-                }
+                AutoScrollToSelectedItemIfNecessary(GetAnchorIndex());
             }
             else if (change.Property == SelectionModeProperty && _selection is object)
             {
@@ -947,11 +938,8 @@ namespace Avalonia.Controls.Primitives
                 _hasScrolledToSelectedItem = false;
 
                 var anchorIndex = GetAnchorIndex();
-                if (anchorIndex >= 0)
-                {
-                    KeyboardNavigation.SetTabOnceActiveElement(this, ContainerFromIndex(anchorIndex));
-                    AutoScrollToSelectedItemIfNecessary(anchorIndex);
-                }
+                KeyboardNavigation.SetTabOnceActiveElement(this, ContainerFromIndex(anchorIndex));
+                AutoScrollToSelectedItemIfNecessary(anchorIndex);
             }
             else if (e.PropertyName == nameof(ISelectionModel.SelectedIndex) && _oldSelectedIndex != SelectedIndex)
             {

--- a/tests/Avalonia.Controls.UnitTests/EnumerableExtensions.cs
+++ b/tests/Avalonia.Controls.UnitTests/EnumerableExtensions.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Avalonia.Controls.UnitTests
 {
@@ -14,6 +12,30 @@ namespace Avalonia.Controls.UnitTests
             {
                 action(i);
                 yield return i;
+            }
+        }
+
+        public static IEnumerable<T[]> Permutations<T>(this IEnumerable<T> source)
+        {
+            var sourceArray = source.ToArray();
+            var results = new List<T[]>();
+            Permute(sourceArray, 0, sourceArray.Length - 1);
+            return results;
+
+            void Permute(T[] elements, int depth, int maxDepth)
+            {
+                if (depth == maxDepth)
+                {
+                    results.Add(elements.ToArray());
+                    return;
+                }
+
+                for (var i = depth; i <= maxDepth; i++)
+                {
+                    (elements[depth], elements[i]) = (elements[i], elements[depth]);
+                    Permute(elements, depth + 1, maxDepth);
+                    (elements[depth], elements[i]) = (elements[i], elements[depth]);
+                }
             }
         }
     }

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -5,7 +5,6 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
-using System.Reactive.Disposables;
 using System.Threading.Tasks;
 using Avalonia.Collections;
 using Avalonia.Controls.Presenters;
@@ -18,7 +17,6 @@ using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Markup.Data;
-using Avalonia.Platform;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.UnitTests;
@@ -2294,6 +2292,87 @@ namespace Avalonia.Controls.UnitTests.Primitives
 
         }
 
+        [Theory]
+        [MemberData(nameof(GetSelectionFieldPermutationParameters))]
+        public void SelectedItem_And_Selection_Properties_Work_In_Any_Order_When_Initializing(SelectionField[] fields)
+            => TestSelectionFields(vm => vm.SelectedItem = vm.Items[2], fields);
+
+        [Theory]
+        [MemberData(nameof(GetSelectionFieldPermutationParameters))]
+        public void SelectedIndex_And_Selection_Properties_Work_In_Any_Order_When_Initializing(SelectionField[] fields)
+            => TestSelectionFields(vm => vm.SelectedIndex = 2, fields);
+
+        [Theory]
+        [MemberData(nameof(GetSelectionFieldPermutationParameters))]
+        public void SelectedValue_And_Selection_Properties_Work_In_Any_Order_When_Initializing(SelectionField[] fields)
+            => TestSelectionFields(vm => vm.SelectedValue = 12, fields);
+
+        private void TestSelectionFields(Action<FullSelectionViewModel> setItem2, SelectionField[] fields)
+        {
+            using var _ = Start();
+
+            var vm = new FullSelectionViewModel
+            {
+                Items =
+                {
+                    new ItemModel { Id = 10, Name = "Item0" },
+                    new ItemModel { Id = 11, Name = "Item1" },
+                    new ItemModel { Id = 12, Name = "Item2" },
+                    new ItemModel { Id = 13, Name = "Item3" }
+                }
+            };
+
+            setItem2(vm);
+
+            var root = new TestRoot
+            {
+                Width = 100,
+                Height = 100
+            };
+
+            // Match the Begin/EndInit sequence emitted by the XAML compiler
+            root.BeginInit();
+            var target = new ListBox();
+            target.BeginInit();
+            root.Child = target;
+            target.DataContext = vm;
+
+            foreach (var field in fields)
+            {
+                switch (field)
+                {
+                    case SelectionField.ItemsSource:
+                        target.Bind(ItemsControl.ItemsSourceProperty, new Binding(nameof(FullSelectionViewModel.Items)));
+                        break;
+                    case SelectionField.SelectedItem:
+                        target.Bind(SelectingItemsControl.SelectedItemProperty, new Binding(nameof(FullSelectionViewModel.SelectedItem)));
+                        break;
+                    case SelectionField.SelectedIndex:
+                        target.Bind(SelectingItemsControl.SelectedIndexProperty, new Binding(nameof(FullSelectionViewModel.SelectedIndex)));
+                        break;
+                    case SelectionField.SelectedValue:
+                        target.Bind(SelectingItemsControl.SelectedValueProperty, new Binding(nameof(FullSelectionViewModel.SelectedValue)));
+                        break;
+                    case SelectionField.SelectedValueBinding:
+                        target.SelectedValueBinding = new Binding(nameof(ItemModel.Id));
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unkown field {field}");
+                }
+            }
+
+            target.EndInit();
+            root.EndInit();
+
+            Assert.Equal(vm.Items[2], target.SelectedItem);
+            Assert.Equal(2, target.SelectedIndex);
+            Assert.Equal(12, target.SelectedValue);
+
+            Assert.Equal(vm.Items[2], vm.SelectedItem);
+            Assert.Equal(2, vm.SelectedIndex);
+            Assert.Equal(12, vm.SelectedValue);
+        }
+
         private static IDisposable Start()
         {
             return UnitTestApplication.Start(TestServices.StyledWindow);
@@ -2335,6 +2414,9 @@ namespace Avalonia.Controls.UnitTests.Primitives
                     [~ItemsPresenter.ItemsPanelProperty] = control[~ItemsControl.ItemsPanelProperty],
                 }.RegisterInNameScope(scope));
         }
+
+        public static IEnumerable<object[]> GetSelectionFieldPermutationParameters()
+            => Enum.GetValues<SelectionField>().Permutations().Select(fields => new object[] { fields });
 
         private class Item : Control, ISelectable
         {
@@ -2466,6 +2548,62 @@ namespace Avalonia.Controls.UnitTests.Primitives
             }
 
             public event NotifyCollectionChangedEventHandler CollectionChanged;
+        }
+
+#nullable enable
+
+        private sealed class FullSelectionViewModel : NotifyingBase
+        {
+            private ItemModel? _selectedItem;
+            private int? _selectedIndex;
+            private int? _selectedValue;
+
+            public ObservableCollection<ItemModel> Items { get; } = new();
+
+            public ItemModel? SelectedItem
+            {
+                get => _selectedItem;
+                set => SetField(ref _selectedItem, value);
+            }
+
+            public int? SelectedIndex
+            {
+                get => _selectedIndex;
+                set => SetField(ref _selectedIndex, value);
+            }
+
+            public int? SelectedValue
+            {
+                get => _selectedValue;
+                set => SetField(ref _selectedValue, value);
+            }
+        }
+
+        private sealed class ItemModel : NotifyingBase
+        {
+            private int _id;
+            private string? _name;
+
+            public int Id
+            {
+                get => _id;
+                set => SetField(ref _id, value);
+            }
+
+            public string? Name
+            {
+                get => _name;
+                set => SetField(ref _name, value);
+            }
+        }
+
+        public enum SelectionField
+        {
+            ItemsSource,
+            SelectedItem,
+            SelectedIndex,
+            SelectedValue,
+            SelectedValueBinding
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -2373,6 +2373,53 @@ namespace Avalonia.Controls.UnitTests.Primitives
             Assert.Equal(12, vm.SelectedValue);
         }
 
+        [Fact]
+        public void SelectedItem_Can_Access_Selection_DuringInit()
+        {
+            using var _ = Start();
+
+            var target = new ListBox();
+            target.BeginInit();
+
+            var item = new ItemModel();
+
+            target.Selection = new SelectionModel<ItemModel> {
+                SelectedItem = item
+            };
+
+            Assert.Equal(item, target.SelectedItem);
+        }
+
+        [Fact]
+        public void SelectedIndex_Can_Access_Selection_DuringInit()
+        {
+            using var _ = Start();
+
+            var target = new ListBox();
+            target.BeginInit();
+
+            target.Selection = new SelectionModel<ItemModel> {
+                SelectedIndex = 42
+            };
+
+            Assert.Equal(42, target.SelectedIndex);
+        }
+
+        [Fact]
+        public void AnchorIndex_Can_Access_Selection_DuringInit()
+        {
+            using var _ = Start();
+
+            var target = new ListBox();
+            target.BeginInit();
+
+            target.Selection = new SelectionModel<ItemModel> {
+                AnchorIndex = 42
+            };
+
+            Assert.Equal(42, target.GetAnchorIndex());
+        }
+
         private static IDisposable Start()
         {
             return UnitTestApplication.Start(TestServices.StyledWindow);
@@ -2555,7 +2602,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
         private sealed class FullSelectionViewModel : NotifyingBase
         {
             private ItemModel? _selectedItem;
-            private int? _selectedIndex;
+            private int _selectedIndex = -1;
             private int? _selectedValue;
 
             public ObservableCollection<ItemModel> Items { get; } = new();
@@ -2566,7 +2613,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
                 set => SetField(ref _selectedItem, value);
             }
 
-            public int? SelectedIndex
+            public int SelectedIndex
             {
                 get => _selectedIndex;
                 set => SetField(ref _selectedIndex, value);

--- a/tests/Avalonia.UnitTests/NotifyingBase.cs
+++ b/tests/Avalonia.UnitTests/NotifyingBase.cs
@@ -1,3 +1,6 @@
+#nullable enable
+
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -6,9 +9,9 @@ namespace Avalonia.UnitTests
 {
     public class NotifyingBase : INotifyPropertyChanged
     {
-        private PropertyChangedEventHandler _propertyChanged;
+        private PropertyChangedEventHandler? _propertyChanged;
 
-        public event PropertyChangedEventHandler PropertyChanged
+        public event PropertyChangedEventHandler? PropertyChanged
         {
             add
             {
@@ -32,9 +35,19 @@ namespace Avalonia.UnitTests
             private set;
         }
 
-        public void RaisePropertyChanged([CallerMemberName] string propertyName = null)
+        public void RaisePropertyChanged([CallerMemberName] string? propertyName = null)
         {
             _propertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        protected bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+                return false;
+
+            field = value;
+            RaisePropertyChanged(propertyName);
+            return true;
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
This PR ensures the order of selection-related properties in `SelectedItemsControl` doesn't matter when set in XAML.
These properties are `ItemsSource`, `SelectedItem`, `SelectedIndex`, `SelectedValue` and `SelectedValueBinding`.

## What is the current behavior?
Behavior may differ depending on the order the properties are declared in XAML, especially when `ItemsSource` isn't set first.

## What is the updated/expected behavior with this PR?
The order doesn't matter.

## How was the solution implemented (if it's not obvious)?

Sorry, this will be a bit long, as the bug was quite hard to understand in its entirety.

### `UpdateState` and `ISelectionModel`

As I wrote in https://github.com/AvaloniaUI/Avalonia/pull/13522#issuecomment-1833942505, the selection properties are already guarded by `ISupportInitialize` (`BeginInit`/`EndInit`, called automatically by the XAML compiler). During this initialization phase, selection properties are stored in a temporary `UpdateState` object, to be applied later to the real `ISelectionModel` on `EndInit`.

The `UpdateState` works fine, but the real selection model (`Selection` property) shouldn't be accessed during this time. Initializing the selection model will result in various properties being set, as well as hooking up some event handlers. Those handlers may in turn change other properties. Stir a little more and `ISelectionModel` and `UpdateState` will start to fight against each other for the selection throne.

The `SelectionModel` is very easy to initialize without realizing it: accessing any selection-related property getter will do, *unless the property has already been set in UpdateState*.

The most common case observed is with `SelectedValue`:
 - `SelectedValue` is set normally in XAML.
 - This triggers a code path checking whether `SelectedIndex` was set previously.
 - Accessing `SelectedIndex` initializes `Selection`.
 - Later, on `EndInit`, `Selection` will have its `Source` updated.
 - Updating the source resets the `SelectedValue` to null.
 
(It took me longer than expected to get the whole flow, especially when inspecting values in the debugger was triggering the buggy path.)
 
This PR avoids initializing `Selection` as long as there's an `UpdateState`. `SelectedIndex`, `SelectedItem` and `AnchorIndex` can fall back to `-1`, `null` and `-1` respectively when there's no selection model yet.

`SelectedItems` probably still have a bug, but it's rarer to have this property bound at the same time as the other selection properties. I'll tackle this in another PR later.

### `SelectedIndex` and `SelectedItem`

Before this PR, when both `SelectedIndex` and `SelectedItem` were set at initialization time (i.e. in XAML), the last one won, erasing the other. To make that deterministic instead, I've implemented a very simple tie breaker: the "non-empty" one (`SelectedIndex >= 0`, `SelectedItem != null`) wins.

I believe this should match most users expectations: bind both `SelectedIndex` and `SelectedItem`, set only one in the VM at init time, and watch the other correctly update instead of clearing the selection.

(If both are non-empty, `SelectedIndex` is declared winner arbitrarily.)

### Tests

A bunch of permutation tests have been added, setting the five selection-related properties in all possible orders (120 tests).

Each set of permutations is tested against setting a bound `SelectedItem`, `SelectedIndex` or `SelectedValue`, ensuring they all result in the exact same selection state (so 360 tests in total).

## Fixed issues
 - Fixes #13284
 - (...and probably other weird selection loss issues)
 - Supersedes #13522 