### PR TITLE
Added default excludes for AvaloniaXaml

### DIFF
--- a/packages/Avalonia/AvaloniaBuildTasks.props
+++ b/packages/Avalonia/AvaloniaBuildTasks.props
@@ -5,7 +5,7 @@
     <PropertyPageSchema Include="$(MSBuildThisFileDirectory)AvaloniaItemSchema.xaml" />
   </ItemGroup>
   <ItemGroup Condition="'$(EnableDefaultItems)'=='True'">
-    <AvaloniaXaml Include="**\*.axaml" SubType="Designer" />
-    <AvaloniaXaml Include="**\*.paml" SubType="Designer" />
+    <AvaloniaXaml Include="**\*.axaml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" SubType="Designer" />
+    <AvaloniaXaml Include="**\*.paml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" SubType="Designer" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What does the pull request do?

Adds the default excludes to the default include of Avalonia XAML files in the build targets.

## What is the current behavior?

Avalonia XAML files included by default do not respect the default excludes, unlike all other files included by default in the .NET SDK.

## What is the updated/expected behavior with this PR?

Avalonia XAML files included by default respect the default excludes.

## How was the solution implemented (if it's not obvious)?

Copied the exclude behavior from the .NET SDK ([reference](https://github.com/dotnet/sdk/blob/e80b07ab62f322e8adef5d32bae2026a2a2bd813/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props#L30)):

```
Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)"
```

Looking at a preprocessed msbuild xml file, this exclude appears in most (if not all) default item includes in the .NET SDK.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

The default behavior of Avalonia build targets changed, but it is now aligned with the .NET SDK.

## Fixed issues

Fixes #13723
