### PR TITLE
Update Avalonia.Browser.props

### DIFF
--- a/src/Browser/Avalonia.Browser/Avalonia.Browser.props
+++ b/src/Browser/Avalonia.Browser/Avalonia.Browser.props
@@ -3,5 +3,8 @@
     <ShouldIncludeAvaloniaJavaScript Condition=" '$(ShouldIncludeAvaloniaJavaScript)' == '' ">True</ShouldIncludeAvaloniaJavaScript>
     <ShouldIncludeNativeSkiaSharp Condition=" '$(ShouldIncludeNativeSkiaSharp)' == '' ">True</ShouldIncludeNativeSkiaSharp>
     <ShouldIncludeNativeHarfBuzzSharp Condition=" '$(ShouldIncludeNativeHarfBuzzSharp)' == '' ">True</ShouldIncludeNativeHarfBuzzSharp>
+    <!-- .NET 8 changes default location for dotnet script to the "_framework" subfolder, -->
+    <!-- But this change would introduce a breaking change to Avalonia users, so we revert it back to the .NET 7 state. -->
+    <WasmRuntimeAssetsLocation Condition="'$(WasmRuntimeAssetsLocation)' == ''">./</WasmRuntimeAssetsLocation>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
See https://github.com/dotnet/runtime/blob/88b5e3d4b77dd8238331ade1b31ac8ddc62f22f7/src/mono/wasm/build/WasmApp.targets#L85-L90

This PR helps us to avoid an annoying breaking change in .NET 8, which would break Avalonia apps otherwise.