### PR TITLE
Fix some issues with tabbing into virtualized list

### DIFF
--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -528,6 +528,17 @@ namespace Avalonia.Controls
             _itemsPresenter = e.NameScope.Find<ItemsPresenter>("PART_ItemsPresenter");
         }
 
+        protected override void OnGotFocus(GotFocusEventArgs e)
+        {
+            base.OnGotFocus(e);
+
+            // If the focus is coming from a child control, set the tab once active element to
+            // the focused control. This ensures that tabbing back into the control will focus
+            // the last focused control when TabNavigationMode == Once.
+            if (e.Source != this && e.Source is IInputElement ie)
+                KeyboardNavigation.SetTabOnceActiveElement(this, ie);
+        }
+
         /// <summary>
         /// Handles directional navigation within the <see cref="ItemsControl"/>.
         /// </summary>

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -513,6 +513,9 @@ namespace Avalonia.Controls.Primitives
                 var containerIsSelected = GetIsSelected(container);
                 UpdateSelection(index, containerIsSelected, toggleModifier: true);
             }
+
+            if (Selection.AnchorIndex == index)
+                KeyboardNavigation.SetTabOnceActiveElement(this, container);
         }
 
         /// <inheritdoc />

--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -263,6 +263,16 @@ namespace Avalonia.Controls
             }
         }
 
+        protected override void OnItemsControlChanged(ItemsControl? oldValue)
+        {
+            base.OnItemsControlChanged(oldValue);
+
+            if (oldValue is not null)
+                oldValue.PropertyChanged -= OnItemsControlPropertyChanged;
+            if (ItemsControl is not null)
+                ItemsControl.PropertyChanged += OnItemsControlPropertyChanged;
+        }
+
         protected override IInputElement? GetControl(NavigationDirection direction, IInputElement? from, bool wrap)
         {
             var count = Items.Count;
@@ -376,7 +386,7 @@ namespace Avalonia.Controls
                 var scrollToElement = GetOrCreateElement(items, index);
                 scrollToElement.Measure(Size.Infinity);
 
-                // Get the expected position of the elment and put it in place.
+                // Get the expected position of the element and put it in place.
                 var anchorU = _realizedElements.GetOrEstimateElementU(index, ref _lastEstimatedElementSizeU);
                 var rect = Orientation == Orientation.Horizontal ?
                     new Rect(anchorU, 0, scrollToElement.DesiredSize.Width, scrollToElement.DesiredSize.Height) :
@@ -659,6 +669,7 @@ namespace Avalonia.Controls
 
         private void RecycleElement(Control element, int index)
         {
+            Debug.Assert(ItemsControl is not null);
             Debug.Assert(ItemContainerGenerator is not null);
             
             _scrollAnchorProvider?.UnregisterAnchorCandidate(element);
@@ -673,11 +684,10 @@ namespace Avalonia.Controls
             {
                 element.IsVisible = false;
             }
-            else if (element.IsKeyboardFocusWithin)
+            else if (KeyboardNavigation.GetTabOnceActiveElement(ItemsControl) == element)
             {
                 _focusedElement = element;
                 _focusedIndex = index;
-                _focusedElement.LostFocus += OnUnrealizedFocusedElementLostFocus;
             }
             else
             {
@@ -744,15 +754,17 @@ namespace Avalonia.Controls
             }
         }
 
-        private void OnUnrealizedFocusedElementLostFocus(object? sender, RoutedEventArgs e)
+        private void OnItemsControlPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
         {
-            if (_focusedElement is null || sender != _focusedElement)
-                return;
-
-            _focusedElement.LostFocus -= OnUnrealizedFocusedElementLostFocus;
-            RecycleElement(_focusedElement, _focusedIndex);
-            _focusedElement = null;
-            _focusedIndex = -1;
+            if (_focusedElement is not null &&
+                e.Property == KeyboardNavigation.TabOnceActiveElementProperty && 
+                e.GetOldValue<IInputElement?>() == _focusedElement)
+            {
+                // TabOnceActiveElement has moved away from _focusedElement so we can recycle it.
+                RecycleElement(_focusedElement, _focusedIndex);
+                _focusedElement = null;
+                _focusedIndex = -1;
+            }
         }
 
         /// <inheritdoc/>

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests.cs
@@ -217,6 +217,9 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Equal(10, target.Presenter.Panel.Children.Count);
                 Assert.True(((ListBoxItem)target.Presenter.Panel.Children[0]).IsSelected);
 
+                // The selected item must not be the anchor, otherwise it won't get recycled.
+                target.Selection.AnchorIndex = -1;
+
                 // Scroll down a page.
                 target.Scroll.Offset = new Vector(0, 10);
                 Layout(target);

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests.cs
@@ -1227,6 +1227,25 @@ namespace Avalonia.Controls.UnitTests.Primitives
         }
 
         [Fact]
+        public void TabOnceActiveElement_Should_Be_Initialized_With_SelectedItem()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var target = new ListBox
+                {
+                    Template = Template(),
+                    ItemsSource = new[] { "Foo", "Bar", "Baz " },
+                    SelectedIndex = 1,
+                };
+
+                Prepare(target);
+
+                var container = target.ContainerFromIndex(1)!;
+                Assert.Same(container, KeyboardNavigation.GetTabOnceActiveElement(target));
+            }
+        }
+
+        [Fact]
         public void Setting_SelectedItem_With_Pointer_Should_Set_TabOnceActiveElement()
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))

--- a/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/Primitives/SelectingItemsControlTests_Multiple.cs
@@ -1110,7 +1110,7 @@ namespace Avalonia.Controls.UnitTests.Primitives
             Assert.Equal(19, panel.LastRealizedIndex);
 
             // The selection should be preserved.
-            Assert.Empty(SelectedContainers(target));
+            Assert.Equal(new[] { 1 }, SelectedContainers(target));
             Assert.Equal(1, target.SelectedIndex);
             Assert.Same(items[1], target.SelectedItem);
             Assert.Equal(new[] { 1 }, target.Selection.SelectedIndexes);

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
@@ -8,6 +8,7 @@ using Avalonia.Collections;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Styling;
@@ -314,14 +315,18 @@ namespace Avalonia.Controls.UnitTests
         {
             using var app = App();
             var (target, scroll, itemsControl) = CreateTarget();
+            var items = (IList)itemsControl.ItemsSource!;
 
             var focused = target.GetRealizedElements().First()!;
             focused.Focusable = true;
             focused.Focus();
             Assert.True(focused.IsKeyboardFocusWithin);
+            Assert.Equal(focused, KeyboardNavigation.GetTabOnceActiveElement(itemsControl));
 
             scroll.Offset = new Vector(0, 200);
             Layout(target);
+
+            items.RemoveAt(0);
 
             Assert.All(target.GetRealizedElements(), x => Assert.False(x!.IsKeyboardFocusWithin));
             Assert.All(target.GetRealizedElements(), x => Assert.NotSame(focused, x));


### PR DESCRIPTION
## What does the pull request do?

As described in #11878, there were some problems with tabbing into a virtualized list:

We previously had logic in place to not recycle the focused element which meant that when the focused element was scrolled out of view, pressing one of the arrow keys would cause the focus to jump back to the correct selection, however that logic didn't work when tabbing _into_ the control.

The solution for this is:

- Make `TabOnceActiveElement` always follow the anchor index, so it's always equal to the last focused element
- Use `TabOnceActiveElement` to decide when to not recycle an element instead of using actual keyboard focus. This means that the focused element isn't recycled even when focus is currently away from the items control

## Fixed issues

Fixes #11878 