### PR TITLE
Unsubscribe android back handler when toplevel is disposed

### DIFF
--- a/src/Android/Avalonia.Android/Platform/AndroidSystemNavigationManager.cs
+++ b/src/Android/Avalonia.Android/Platform/AndroidSystemNavigationManager.cs
@@ -6,8 +6,10 @@ using Avalonia.Platform;
 
 namespace Avalonia.Android.Platform
 {
-    internal class AndroidSystemNavigationManagerImpl : ISystemNavigationManagerImpl
+    internal class AndroidSystemNavigationManagerImpl : ISystemNavigationManagerImpl, IDisposable
     {
+        private readonly IActivityNavigationService? _navigationService;
+
         public event EventHandler<RoutedEventArgs>? BackRequested;
 
         public AndroidSystemNavigationManagerImpl(IActivityNavigationService? navigationService)
@@ -16,6 +18,7 @@ namespace Avalonia.Android.Platform
             {
                 navigationService.BackRequested += OnBackRequested;
             }
+            _navigationService = navigationService;
         }
 
         private void OnBackRequested(object? sender, AndroidBackRequestedEventArgs e)
@@ -25,6 +28,14 @@ namespace Avalonia.Android.Platform
             BackRequested?.Invoke(this, routedEventArgs);
 
             e.Handled = routedEventArgs.Handled;
+        }
+
+        public void Dispose()
+        {
+            if (_navigationService != null)
+            {
+                _navigationService.BackRequested -= OnBackRequested;
+            }
         }
     }
 }

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -45,7 +45,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         private readonly AndroidInputMethod<ViewImpl> _textInputMethod;
         private readonly INativeControlHostImpl _nativeControlHost;
         private readonly IStorageProvider _storageProvider;
-        private readonly ISystemNavigationManagerImpl _systemNavigationManager;
+        private readonly AndroidSystemNavigationManagerImpl _systemNavigationManager;
         private readonly AndroidInsetsManager _insetsManager;
         private readonly ClipboardImpl _clipboard;
         private ViewImpl _view;
@@ -155,6 +155,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         
         public virtual void Dispose()
         {
+            _systemNavigationManager.Dispose();
             _view.Dispose();
             _view = null;
         }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
When the ToplevelImpl on android is disposed, unsubscribe from the activity's back requested event.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #13829
