### PR TITLE
DataGrid selection refactoring

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -1828,12 +1828,6 @@ namespace Avalonia.Controls
             private set;
         }
 
-        internal bool UpdatedStateOnMouseLeftButtonDown
-        {
-            get;
-            set;
-        }
-
         /// <summary>
         /// Indicates whether or not to use star-sizing logic.  If the DataGrid has infinite available space,
         /// then star sizing doesn't make sense.  In this case, all star columns grow to a predefined size of

--- a/src/Avalonia.Controls.DataGrid/DataGridCell.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridCell.cs
@@ -189,8 +189,6 @@ namespace Avalonia.Controls
                     {
                         e.Handled = handled;
                     }
-
-                    OwningGrid.UpdatedStateOnMouseLeftButtonDown = true;
                 }
             }
             else if (e.GetCurrentPoint(this).Properties.IsRightButtonPressed)

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -771,14 +771,6 @@ namespace Avalonia.Controls
             if (OwningGrid != null)
             {
                 OwningGrid.IsDoubleClickRecordsClickOnCall(this);
-                if (OwningGrid.UpdatedStateOnMouseLeftButtonDown)
-                {
-                    OwningGrid.UpdatedStateOnMouseLeftButtonDown = false;
-                }
-                else
-                {
-                    e.Handled = OwningGrid.UpdateStateOnMouseLeftButtonDown(e, -1, Slot, false);
-                }
             }
         }
 

--- a/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowHeader.cs
@@ -195,7 +195,6 @@ namespace Avalonia.Controls.Primitives
                     Debug.Assert(sender is DataGridRowHeader);
                     Debug.Assert(sender == this);
                     e.Handled = OwningGrid.UpdateStateOnMouseLeftButtonDown(e, -1, Slot, false);
-                    OwningGrid.UpdatedStateOnMouseLeftButtonDown = true;
                 }
             }
             else if (e.GetCurrentPoint(this).Properties.IsRightButtonPressed)


### PR DESCRIPTION
## What does the pull request do?
This is a continuation of https://github.com/AvaloniaUI/Avalonia/pull/13680 where handled events were ignored in the `DataGridCell`. There is similar logic in `DataGridRows `that is quite convoluted and makes no sense to me. It is very old code but there are several code smells
1. internal flag `UpdatedStateOnMouseLeftButtonDown `steps in for event bubbling here (instead of event `Handled `property this uses this property on a DataGrid level)
2. there is always some DataGridCell or header that will handle the PointerPressed event. It handles the selection as well.

## What is the updated/expected behavior with this PR?
The behavior is the same as before. The code is simpler and as with https://github.com/AvaloniaUI/Avalonia/pull/13680 the motivation is to be able to hook to mouse clicks to update selection logic if needed.

## Breaking changes
I don't know about any but if there is any case where the user can click on a row but not on a cell then this is wrong.
