### PR TITLE
Fix: TabItem.TabStripPlacement is not set for new tab items

### DIFF
--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -73,7 +73,6 @@ namespace Avalonia.Controls
         {
             SelectionModeProperty.OverrideDefaultValue<TabControl>(SelectionMode.AlwaysSelected);
             ItemsPanelProperty.OverrideDefaultValue<TabControl>(DefaultPanel);
-            TabStripPlacementProperty.Changed.AddClassHandler<TabControl>((x, e) => x.UpdateTabStripPlacement());
             AffectsMeasure<TabControl>(TabStripPlacementProperty);
             SelectedItemProperty.Changed.AddClassHandler<TabControl>((x, e) => x.UpdateSelectedContent());
             AutomationProperties.ControlTypeOverrideProperty.OverrideDefaultValue<TabControl>(AutomationControlType.Tab);
@@ -154,7 +153,7 @@ namespace Avalonia.Controls
 
         protected internal override Control CreateContainerForItemOverride(object? item, int index, object? recycleKey)
         {
-            return new TabItem { TabStripPlacement = TabStripPlacement };
+            return new TabItem();
         }
 
         protected internal override bool NeedsContainerOverride(object? item, int index, out object? recycleKey)
@@ -166,6 +165,11 @@ namespace Avalonia.Controls
         {
             base.PrepareContainerForItemOverride(element, item, index);
 
+            if (element is TabItem tabItem)
+            {
+                tabItem.TabStripPlacement = TabStripPlacement;
+            }
+            
             if (index == SelectedIndex)
             {
                 UpdateSelectedContent(element);

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -572,6 +572,83 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal("Header from style", tabItem.Header);
         }
 
+        [Fact]
+        public void TabItem_TabStripPlacement_Should_Be_Correctly_Set()
+        {
+            var items = new object[]
+            {
+                "Foo",
+                new TabItem { Content = new TextBlock { Text = "Baz" } }
+            };
+
+            var target = new TabControl
+            {
+                Template = TabControlTemplate(),
+                DataContext = "Base",
+                ItemsSource = items
+            };
+
+            ApplyTemplate(target);
+
+            var result = target.GetLogicalChildren()
+                .OfType<TabItem>()
+                .ToList();
+            Assert.Collection(
+                result,
+                x => Assert.Equal(Dock.Top, x.TabStripPlacement),
+                x => Assert.Equal(Dock.Top, x.TabStripPlacement)
+            );
+
+            target.TabStripPlacement = Dock.Right;
+            result = target.GetLogicalChildren()
+                .OfType<TabItem>()
+                .ToList();
+            Assert.Collection(
+                result,
+                x => Assert.Equal(Dock.Right, x.TabStripPlacement),
+                x => Assert.Equal(Dock.Right, x.TabStripPlacement)
+            );
+        }
+        
+        [Fact]
+        public void TabItem_TabStripPlacement_Should_Be_Correctly_Set_For_New_Items()
+        {
+            var items = new object[]
+            {
+                "Foo",
+                new TabItem { Content = new TextBlock { Text = "Baz" } }
+            };
+
+            var target = new TabControl
+            {
+                Template = TabControlTemplate(),
+                DataContext = "Base"
+            };
+
+            ApplyTemplate(target);
+
+            target.ItemsSource = items;
+            
+            var result = target.GetLogicalChildren()
+                .OfType<TabItem>()
+                .ToList();
+            Assert.Collection(
+                result,
+                x => Assert.Equal(Dock.Top, x.TabStripPlacement),
+                x => Assert.Equal(Dock.Top, x.TabStripPlacement)
+            );
+
+            target.TabStripPlacement = Dock.Right;
+            result = target.GetLogicalChildren()
+                .OfType<TabItem>()
+                .ToList();
+            Assert.Collection(
+                result,
+                x => Assert.Equal(Dock.Right, x.TabStripPlacement),
+                x => Assert.Equal(Dock.Right, x.TabStripPlacement)
+            );
+        }
+        
         private static IControlTemplate TabControlTemplate()
         {
             return new FuncControlTemplate<TabControl>((parent, scope) =>


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Moves the `TabItem.TabStripPlacemnt` assignment to the `TabControl.PrepareContainerForItemOverride` method. The excessive `UpdateTabStripPlacement` method call is also removed, because TabControl refreshes all its containers when `TabStripPlacement` is changed. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
After this [fix](https://github.com/AvaloniaUI/Avalonia/pull/12418), TabControl doesn't apply its TabStripPlacement to items that can be used as containers themselves (the `CreateContainerForItemOverride` method is not called in this case). 

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
