### PR TITLE
Fix #13463 AutoCompleteBox should have a bindable Property for CaretIndex

### DIFF
--- a/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.Properties.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.Properties.cs
@@ -15,6 +15,15 @@ namespace Avalonia.Controls
 {
     public partial class AutoCompleteBox
     {
+        /// <summary>
+        /// Defines see <see cref="TextBox.CaretIndex"/> property.
+        /// </summary>
+        public static readonly StyledProperty<int> CaretIndexProperty =
+            TextBox.CaretIndexProperty.AddOwner<AutoCompleteBox>(new(
+                defaultValue: 0,
+                defaultBindingMode:BindingMode.TwoWay,
+                coerce: TextBox.CoerceCaretIndex));
+
         public static readonly StyledProperty<string?> WatermarkProperty =
             TextBox.WatermarkProperty.AddOwner<AutoCompleteBox>();
 
@@ -157,6 +166,15 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<Func<string?, CancellationToken, Task<IEnumerable<object>>>?> AsyncPopulatorProperty =
             AvaloniaProperty.Register<AutoCompleteBox, Func<string?, CancellationToken, Task<IEnumerable<object>>>?>(
                 nameof(AsyncPopulator));
+
+        /// <summary>
+        /// Gets or sets the caret index
+        /// </summary>
+        public int CaretIndex
+        {
+            get => GetValue(CaretIndexProperty);
+            set => SetValue(CaretIndexProperty, value);
+        }
 
         /// <summary>
         /// Gets or sets the minimum number of characters required to be entered

--- a/src/Avalonia.Themes.Fluent/Controls/AutoCompleteBox.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/AutoCompleteBox.xaml
@@ -42,6 +42,7 @@
                      BorderBrush="{TemplateBinding BorderBrush}"
                      BorderThickness="{TemplateBinding BorderThickness}"
                      CornerRadius="{TemplateBinding CornerRadius}"
+                     CaretIndex="{TemplateBinding CaretIndex, Mode=TwoWay}"
                      FontSize="{TemplateBinding FontSize}"
                      FontFamily="{TemplateBinding FontFamily}"
                      FontWeight="{TemplateBinding FontWeight}"

--- a/src/Avalonia.Themes.Simple/Controls/AutoCompleteBox.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/AutoCompleteBox.xaml
@@ -16,6 +16,7 @@
                    BorderBrush="{TemplateBinding BorderBrush}"
                    BorderThickness="{TemplateBinding BorderThickness}"
                    CornerRadius="{TemplateBinding CornerRadius}"
+                   CaretIndex="{TemplateBinding CaretIndex, Mode=TwoWay}"
                    DataValidationErrors.Errors="{TemplateBinding (DataValidationErrors.Errors)}"
                    Watermark="{TemplateBinding Watermark}" />
 

--- a/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/AutoCompleteBoxTests.cs
@@ -456,6 +456,45 @@ namespace Avalonia.Controls.UnitTests
             });
         }
 
+        [Fact]
+        public void CaretIndex_Changes()
+        {
+            string text = "Sample text";
+            string expectedText = "Saple text";
+            RunTest((control, textbox) =>
+            {
+                control.Text = text;
+                control.Measure(Size.Infinity);
+                Dispatcher.UIThread.RunJobs();
+
+                textbox.RaiseEvent(new KeyEventArgs
+                {
+                    RoutedEvent = InputElement.KeyDownEvent,
+                    Key = Key.Right
+                });
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.Equal(1, control.CaretIndex);
+                Assert.Equal(textbox.CaretIndex, control.CaretIndex);
+
+                control.CaretIndex = 3;
+
+                Assert.Equal(3, control.CaretIndex);
+                Assert.Equal(textbox.CaretIndex, control.CaretIndex);
+
+                textbox.RaiseEvent(new KeyEventArgs
+                {
+                    RoutedEvent = InputElement.KeyDownEvent,
+                    Key = Key.Back
+                });
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.Equal(2, control.CaretIndex);
+                Assert.Equal(textbox.CaretIndex, control.CaretIndex);
+                Assert.True(control.Text == expectedText && textbox.Text == expectedText);
+            });
+        }
+
         /// <summary>
         /// Retrieves a defined predicate filter through a new AutoCompleteBox 
         /// control instance.
@@ -1111,7 +1150,8 @@ namespace Avalonia.Controls.UnitTests
                 var textBox =
                     new TextBox
                     {
-                        Name = "PART_TextBox"
+                        Name = "PART_TextBox",
+                        [!!TextBox.CaretIndexProperty] = control[!!AutoCompleteBox.CaretIndexProperty]
                     }.RegisterInNameScope(scope);
                 var listbox =
                     new ListBox


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Adds caret index property to autocompletebox as discussed in #13423


## What is the current behavior?
There's needed [workaround](https://github.com/AvaloniaUI/Avalonia/discussions/13423#discussioncomment-7454283), otherwise caret index can't be changed/read.

## What is the updated/expected behavior with this PR?
You can modify TextBox's caret index position from AutoCompleteBox property or vice versa


## How was the solution implemented (if it's not obvious)?
Adds AutoCompleteBox owner to registered CaretIndex TextBox property, also adds template binding to theme xaml files.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #13463

