### PR TITLE
Hackfix for calling SelectAll with SelectedItem binding

### DIFF
--- a/src/Avalonia.Controls/Selection/SelectionModel.cs
+++ b/src/Avalonia.Controls/Selection/SelectionModel.cs
@@ -69,6 +69,18 @@ namespace Avalonia.Controls.Selection
             get => _selectedIndex;
             set
             {
+                if (_operation is not null && _operation.UpdateCount == 0)
+                {
+                    // An operation is in the process of being committed. In this case, if the new
+                    // value for SelectedIndex is unchanged then we need to ignore it. It could be
+                    // the result of a two-way binding to SelectedIndex writing back to the
+                    // property. The binding system should really be fixed to ensure that it's not
+                    // writing back the same value, but this is a workaround until the binding
+                    // refactor is complete. See #13676.
+                    if (value == _selectedIndex)
+                        return;
+                }
+
                 using var update = BatchUpdate();
                 Clear();
                 Select(value);
@@ -675,8 +687,6 @@ namespace Avalonia.Controls.Selection
                     }
                 }
                 
-                
-
                 if (raisePropertyChanged)
                 {
                     if (oldSelectedIndex != _selectedIndex)

--- a/tests/Avalonia.Controls.UnitTests/ListBoxTests_Multiple.cs
+++ b/tests/Avalonia.Controls.UnitTests/ListBoxTests_Multiple.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
+using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Styling;
@@ -575,6 +576,64 @@ namespace Avalonia.Controls.UnitTests
             Assert.Equal(new[] { "Foo", "Bar", "Baz", "Qux" }, target.SelectedItems);
             Assert.Equal(new[] { 0, 1, 2, 3 }, SelectedContainers(target));
             Assert.True(target.ContainerFromIndex(3).IsFocused);
+        }
+
+        [Fact]
+        public void SelectAll_Works_From_No_Selection_When_SelectedItem_Is_Bound_TwoWay()
+        {
+            // Issue #13676
+            using var app = UnitTestApplication.Start(TestServices.RealFocus);
+            var target = new ListBox
+            {
+                Template = new FuncControlTemplate(CreateListBoxTemplate),
+                ItemsSource = new[] { "Foo", "Bar", "Baz", "Qux" },
+                SelectionMode = SelectionMode.Multiple,
+                Width = 100,
+                Height = 100,
+            };
+
+            var root = new TestRoot(target);
+            root.LayoutManager.ExecuteInitialLayoutPass();
+
+            target.Bind(ListBox.SelectedItemProperty, new Binding("Tag") 
+            { 
+                Mode = BindingMode.TwoWay,
+                RelativeSource = new RelativeSource(RelativeSourceMode.Self),
+            });
+
+            target.SelectAll();
+
+            Assert.Equal(new[] { 0, 1, 2, 3 }, target.Selection.SelectedIndexes);
+            Assert.Equal(new[] { "Foo", "Bar", "Baz", "Qux" }, target.SelectedItems);
+        }
+
+        [Fact]
+        public void SelectAll_Works_From_No_Selection_When_SelectedIndex_Is_Bound_TwoWay()
+        {
+            // Issue #13676
+            using var app = UnitTestApplication.Start(TestServices.RealFocus);
+            var target = new ListBox
+            {
+                Template = new FuncControlTemplate(CreateListBoxTemplate),
+                ItemsSource = new[] { "Foo", "Bar", "Baz", "Qux" },
+                SelectionMode = SelectionMode.Multiple,
+                Width = 100,
+                Height = 100,
+            };
+
+            var root = new TestRoot(target);
+            root.LayoutManager.ExecuteInitialLayoutPass();
+
+            target.Bind(ListBox.SelectedIndexProperty, new Binding("Tag")
+            {
+                Mode = BindingMode.TwoWay,
+                RelativeSource = new RelativeSource(RelativeSourceMode.Self),
+            });
+
+            target.SelectAll();
+
+            Assert.Equal(new[] { 0, 1, 2, 3 }, target.Selection.SelectedIndexes);
+            Assert.Equal(new[] { "Foo", "Bar", "Baz", "Qux" }, target.SelectedItems);
         }
 
         private Control CreateListBoxTemplate(TemplatedControl parent, INameScope scope)


### PR DESCRIPTION
## What does the pull request do?

As described in #13676, calling `SelectAll()` on a `ListBox` with no current selection and a two-way `SelectedIndex` or `SelectedItem` binding in place, causes `SelectAll()` to fail. What was happening is:

1. `SelectAll()` is called
2. This selects all items, and updates the `SelectedIndex`/`SelectedItem` property on the `SelectionModel`
3. This causes `PropertyChanged` to be raised for `SelectedIndex`/`SelectedItem` on the `ListBox`
4. The binding system writes the new value to the source
5. The binding system notices that the value has changed in the source
6. The binding system writes the new value back to the target `SelectedIndex`/`SelectedItem`, even though this value hasn't changed
7. Setting `SelectedIndex`/`SelectedItem`'s semantics are such that setting them clears all other selected items

Step 6 is a bug in the binding system: we should not be writing an unchanged value back to the target due to a change in the source, and this will be fixed in the upcoming binding system refactor. However in the meantime, I think we need a hackfix as an interim solution. The easiest way to do this is to add the fix to `SelectionModel`.

## Fixed issues

Fixes #13676 