### PR TITLE
Fix for crash in issue 13822

### DIFF
--- a/src/Windows/Avalonia.Win32/DirectX/directx.idl
+++ b/src/Windows/Avalonia.Win32/DirectX/directx.idl
@@ -215,7 +215,7 @@ interface IDXGIAdapter : IDXGIObject
 [uuid(310d36a0-d2e7-4c0a-aa04-6a9d23b8886a)]
 interface IDXGISwapChain : IDXGIDeviceSubObject
 {
-    HRESULT Present([in] UINT SyncInterval, [in] UINT Flags);
+    INT32 Present([in] UINT SyncInterval, [in] UINT Flags);
     HRESULT GetBuffer([in] UINT Buffer, [in, annotation("_In_")] REFIID riid, [in, out, annotation("_COM_Outptr_")] void** ppSurface);
     HRESULT SetFullscreenState([in] BOOL Fullscreen, [in, annotation("_In_opt_")] IDXGIOutput* pTarget);
     HRESULT GetFullscreenState([out, annotation("_Out_opt_")] BOOL* pFullscreen, [out, annotation("_COM_Outptr_opt_result_maybenull_")] IDXGIOutput** ppTarget);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This fixes a crash in issue 13822 when remote terminal services are involved. 


## What is the current behavior?
The incorrect behaviour is repeated exceptions being thrown when the presentation call returns an occluded status-code indicating that nothing was actually done. 

The default Microcom behaviour of interpreting a non-zero code as a catastrophic failure was not appropriate for present. The IDL file has been modified to use an Int32 instead. 


## What is the updated/expected behavior with this PR?
Present calls no longer throw exceptions when the desktop is occluded via a remote terminal services connection going into standby or the screen locking. 

The crash I could only get to replicate when the debugger was attached, which was curious. 

With the fix in place I was able to seamlessly transition from remote desktop to remote-desktop-locked to remote-desktop-idle-disconnected to a physical session and all the way back again without any disruptions. 

## How was the solution implemented (if it's not obvious)?
The IDL file was modified to return a plain Int32 rather than a HRESULT


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
Not aware of any. 

## Obsoletions / Deprecations
Not applicable

## Fixed issues
#13822 
