### PR TITLE
Fix ToggleSwitch dragging

### DIFF
--- a/src/Avalonia.Controls/ToggleSwitch.cs
+++ b/src/Avalonia.Controls/ToggleSwitch.cs
@@ -228,6 +228,8 @@ namespace Avalonia.Controls
         {
             if (_isDragging)
             {
+                e.Handled = true;
+                
                 bool shouldBecomeChecked = Canvas.GetLeft(_knobsPanel!) >= (_switchKnob!.Bounds.Width / 2);
                 _knobsPanel!.ClearValue(Canvas.LeftProperty);
 


### PR DESCRIPTION
## What does the pull request do?
Fixes dragging the "knob" of a `ToggleSwitch` to set its state


## What is the current behavior?
When the mouse button is released *after dragging*, the `ToggleSwitch`'s state is set to the opposite of what it should be set to. This is a regression, which appears to have occurred sometime in 11.x


## What is the updated/expected behavior with this PR?
Dragging the "knob" of a `ToggleSwitch` now correctly sets its state


## How was the solution implemented (if it's not obvious)?
It's a two-line fix, lol
