### PR TITLE
Fix Adorner Layer Clipping

### DIFF
--- a/samples/ControlCatalog/Pages/AdornerLayerPage.xaml
+++ b/samples/ControlCatalog/Pages/AdornerLayerPage.xaml
@@ -50,7 +50,8 @@
                     Background="Cyan"
                     IsHitTestVisible="False"
                     Opacity="0.3"
-                    IsVisible="True">
+                    IsVisible="True"
+                    AdornerLayer.IsClipEnabled="False">
               <Line StartPoint="-10000,0" EndPoint="10000,0" Stroke="Cyan" StrokeThickness="1" />
               <Line StartPoint="-10000,42" EndPoint="10000,42" Stroke="Cyan" StrokeThickness="1" />
               <Line StartPoint="0,-10000" EndPoint="0,10000" Stroke="Cyan" StrokeThickness="1" />

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.cs
@@ -205,7 +205,7 @@ namespace Avalonia.Rendering.Composition.Server
             }
 
             _combinedTransformedClipBounds =
-                AdornedVisual?._combinedTransformedClipBounds
+                (AdornerIsClipped ? AdornedVisual?._combinedTransformedClipBounds : null)
                 ?? (Parent?.Effect == null ? Parent?._combinedTransformedClipBounds : null)
                 ?? new Rect(Root!.Size);
 

--- a/src/Avalonia.Controls/GridSplitter.cs
+++ b/src/Avalonia.Controls/GridSplitter.cs
@@ -341,6 +341,7 @@ namespace Avalonia.Controls
                 _resizeData.Adorner = new PreviewAdorner(builtPreviewContent);
 
                 AdornerLayer.SetAdornedElement(_resizeData.Adorner, this);
+                AdornerLayer.SetIsClipEnabled(_resizeData.Adorner, false);
 
                 adornerLayer.Children.Add(_resizeData.Adorner);
 

--- a/src/Avalonia.Controls/Primitives/AdornerLayer.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerLayer.cs
@@ -174,7 +174,6 @@ namespace Avalonia.Controls.Primitives
             }
 
             SetAdornedElement(adorner, visual);
-            SetIsClipEnabled(adorner, false);
 
             ((ISetLogicalParent) adorner).SetParent(visual);
             layer.Children.Add(adorner);


### PR DESCRIPTION
## What does the pull request do?

Fixes two problems described in #10701:

- Don't override `AdornerLayer.IsClipEnabled` when adding an adorner to the adorner layer: this property should be set by the user.
- Use correct clip bounds for adorners in composition server: only take the adorned visual's clip bounds into account if the adorner is actually clipped to these bounds. This fixes the artifacts one can see in the control catalog and also fixes the `ScrollViewer` artifacts described in https://github.com/AvaloniaUI/Avalonia/issues/10701#issuecomment-1836636778

Also fixes #10700 by setting `AdornerLayer.IsClipEnabled` to false on `GridSplitter`'s adorner.

## Fixed issues

FIxes #10700 
Fixes #10701 