### PR TITLE
Fix BoxShadow style changes not triggering render updates on ContentPresenter

### DIFF
--- a/src/Avalonia.Controls/Presenters/ContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ContentPresenter.cs
@@ -169,7 +169,12 @@ namespace Avalonia.Controls.Presenters
         /// </summary>
         static ContentPresenter()
         {
-            AffectsRender<ContentPresenter>(BackgroundProperty, BorderBrushProperty, BorderThicknessProperty, CornerRadiusProperty);
+            AffectsRender<ContentPresenter>(
+                BackgroundProperty,
+                BorderBrushProperty,
+                BorderThicknessProperty,
+                CornerRadiusProperty,
+                BoxShadowProperty);
             AffectsArrange<ContentPresenter>(HorizontalContentAlignmentProperty, VerticalContentAlignmentProperty);
             AffectsMeasure<ContentPresenter>(BorderThicknessProperty, PaddingProperty);
         }


### PR DESCRIPTION
## What does the pull request do?
Fixes #13925 


## What is the current behavior?
When changing the `BoxShadow` on a `ContentPresenter` (e.g. on `:focus` loss) the render isn't triggered, so the `ContentPresenter` retains the previous `BoxShadow`. It only updates if something else on the `ContentPresenter` changes that triggers the render.


## What is the updated/expected behavior with this PR?
Now `BoxShadow` changes on `ContentPresenter` will correctly trigger an update of the render.


## How was the solution implemented (if it's not obvious)?
Added `BoxShadow` to the list of properties that trigger a render update on `ContentPresenter`


## Fixed issues
Fixes #13925 
