### PR TITLE
OpenglControl - Don't queue update if control is not attached

### DIFF
--- a/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs
+++ b/src/Avalonia.OpenGL/Controls/OpenGlControlBase.cs
@@ -220,15 +220,15 @@ namespace Avalonia.OpenGL.Controls
 
         [Obsolete("Use RequestNextFrameRendering()"), EditorBrowsable(EditorBrowsableState.Never)]
         // ReSharper disable once MemberCanBeProtected.Global
-        public new void InvalidateVisual() => RequestNextFrameRendering(); 
-        
+        public new void InvalidateVisual() => RequestNextFrameRendering();
+
         public void RequestNextFrameRendering()
         {
             if ((_initialization == null || _initialization is { Status: TaskStatus.RanToCompletion }) &&
-                !_updateQueued)
+                !_updateQueued && _compositor != null)
             {
                 _updateQueued = true;
-                _compositor?.RequestCompositionUpdate(_update);
+                _compositor.RequestCompositionUpdate(_update);
             }
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Adds a check for compositor in `RequestNextFrameRendering` to prevent setting update as queued when a compositor is not set, i.e. when OpenglControl is not attached to visual tree.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #13879