### PR TITLE
Replace Fluent MenuItem icon presenter with a control theme

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/MenuItem.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/MenuItem.xaml
@@ -81,15 +81,11 @@
                                   SharedSizeGroup="MenuItemChevron" />
               </Grid.ColumnDefinitions>
 
-              <Viewbox Name="PART_IconPresenter"
-                       Margin="{DynamicResource MenuIconPresenterMargin}"
-                       StretchDirection="DownOnly"
-                       HorizontalAlignment="Center"
-                       VerticalAlignment="Center"
-                       IsVisible="False"
-                       Width="16" Height="16">
-                <ContentPresenter Content="{TemplateBinding Icon}"/>
-              </Viewbox>
+              <ContentControl x:Name="PART_IconPresenter"
+                              Theme="{StaticResource FluentMenuItemIconTheme}"
+                              Content="{TemplateBinding Icon}"
+                              IsVisible="False"
+                              Margin="{DynamicResource MenuIconPresenterMargin}" />
 
               <ContentPresenter Name="PART_HeaderPresenter"
                                 Content="{TemplateBinding Header}"
@@ -143,7 +139,7 @@
       </ControlTemplate>
     </Setter>
 
-    <Style Selector="^:icon /template/ Viewbox#PART_IconPresenter">
+    <Style Selector="^:icon /template/ ContentControl#PART_IconPresenter">
       <Setter Property="IsVisible" Value="True" />
     </Style>
     <Style Selector="^:selected">
@@ -209,5 +205,22 @@
   <ControlTheme x:Key="HorizontalMenuItem" TargetType="MenuItem" BasedOn="{StaticResource FluentTopLevelMenuItem}">
     <Setter Property="Padding" Value="{DynamicResource HorizontalMenuFlyoutItemThemePaddingNarrow}" />
     <Setter Property="Margin" Value="{DynamicResource HorizontalMenuFlyoutItemMargin}" />
+  </ControlTheme>
+  <ControlTheme x:Key="FluentMenuItemIconTheme"
+                TargetType="ContentControl">
+    <Setter Property="Width"
+            Value="16" />
+    <Setter Property="Height"
+            Value="16" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Viewbox
+          StretchDirection="DownOnly"
+          HorizontalAlignment="Center"
+          VerticalAlignment="Center">
+          <ContentPresenter x:Name="PART_ContentPresenter" Content="{TemplateBinding Content}" />
+        </Viewbox>
+      </ControlTemplate>
+    </Setter>
   </ControlTheme>
 </ResourceDictionary>


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Replaces Fluent MenuItem's IconPresenter with a control theme, allowing for ease of styling.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #13342
