### PR TITLE
Don't override `ContextMenu.Placement` when `Open` called from code.

### DIFF
--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -265,7 +265,7 @@ namespace Avalonia.Controls
             }
 
             control ??= _attachedControls![0];
-            Open(control, PlacementTarget ?? control, false);
+            Open(control, PlacementTarget ?? control, Placement);
         }
 
         /// <summary>
@@ -303,7 +303,7 @@ namespace Avalonia.Controls
             remove => _popupHostChangedHandler -= value;
         }
 
-        private void Open(Control control, Control placementTarget, bool requestedByPointer)
+        private void Open(Control control, Control placementTarget, PlacementMode placement)
         {
             if (IsOpen)
             {
@@ -330,9 +330,7 @@ namespace Avalonia.Controls
                 ((ISetLogicalParent)_popup).SetParent(control);
             }
 
-            _popup.Placement = !requestedByPointer && Placement == PlacementMode.Pointer
-                ? PlacementMode.Bottom
-                : Placement;
+            _popup.Placement = placement;
 
             //Position of the line below is really important. 
             //All styles are being applied only when control has logical parent.
@@ -420,7 +418,10 @@ namespace Avalonia.Controls
                 && !contextMenu.CancelOpening())
             {
                 var requestedByPointer = e.TryGetPosition(null, out _);
-                contextMenu.Open(control, e.Source as Control ?? control, requestedByPointer);
+                contextMenu.Open(
+                    control, 
+                    e.Source as Control ?? control, 
+                    requestedByPointer ? contextMenu.Placement : PlacementMode.Bottom);
                 e.Handled = true;
             }
         }


### PR DESCRIPTION
## What does the pull request do?

#6059 changed `ContextMenu.Open` to open the context menu at the bottom of the control when the `ContextRequestedEventArgs` doesn't contain a position, however it also had the side-effect of preventing the `Placement` property from being respected when opening a `ContextMenu` from code.

Change the private `Open` method to accept a `PlacementMode` instead of a boolean flag, and only pass `Bottom` here when `ContextRequestedEventArgs` has no requested position.

## Fixed issues

Fixes #12504
