### PR TITLE
Don't share style instances with Or selector.

### DIFF
--- a/src/Avalonia.Base/Styling/ControlTheme.cs
+++ b/src/Avalonia.Base/Styling/ControlTheme.cs
@@ -48,7 +48,7 @@ namespace Avalonia.Styling
 
             if (HasSettersOrAnimations && TargetType.IsAssignableFrom(StyledElement.GetStyleKey(target)))
             {
-                Attach(target, null, type);
+                Attach(target, null, type, true);
                 return SelectorMatchResult.AlwaysThisType;
             }
 

--- a/src/Avalonia.Base/Styling/Style.cs
+++ b/src/Avalonia.Base/Styling/Style.cs
@@ -74,7 +74,7 @@ namespace Avalonia.Styling
 
                 if (match.IsMatch)
                 {
-                    Attach(target, match.Activator, type);
+                    Attach(target, match.Activator, type, Selector is not OrSelector);
                 }
 
                 result = match.Result;

--- a/src/Avalonia.Base/Styling/StyleBase.cs
+++ b/src/Avalonia.Base/Styling/StyleBase.cs
@@ -92,20 +92,24 @@ namespace Avalonia.Styling
             return false;
         }
 
-        internal ValueFrame Attach(StyledElement target, IStyleActivator? activator, FrameType type)
+        internal ValueFrame Attach(
+            StyledElement target,
+            IStyleActivator? activator,
+            FrameType type,
+            bool canShareInstance)
         {
             if (target is not AvaloniaObject ao)
                 throw new InvalidOperationException("Styles can only be applied to AvaloniaObjects.");
 
             StyleInstance instance;
 
-            if (_sharedInstance is not null)
+            if (_sharedInstance is not null && canShareInstance)
             {
                 instance = _sharedInstance;
             }
             else
             {
-                var canShareInstance = activator is null;
+                canShareInstance &= activator is null;
 
                 instance = new StyleInstance(this, activator, type);
 


### PR DESCRIPTION
## What does the pull request do?

Fixes the issue described in #13910 where styles that contain an "or" are erroneously applied to control that they shouldn't apply to.

Fix this by simply not allowing shared style instances when an "or" is present.

## Fixed issues

Fixes #13910 