### PR TITLE
Fix DBus Exception on window close

### DIFF
--- a/src/Avalonia.FreeDesktop/DBusIme/DBusTextInputMethodBase.cs
+++ b/src/Avalonia.FreeDesktop/DBusIme/DBusTextInputMethodBase.cs
@@ -184,8 +184,11 @@ namespace Avalonia.FreeDesktop.DBusIme
             foreach(var d in _disposables)
                 d.Dispose();
             _disposables.Clear();
-            _ = DisconnectAsync();
-            _currentName = null;
+            if (IsConnected)
+            {
+                _ = DisconnectAsync();
+                _currentName = null;
+            }
         }
 
         protected abstract Task SetCursorRectCore(PixelRect rect);

--- a/src/Avalonia.FreeDesktop/DBusIme/DBusTextInputMethodBase.cs
+++ b/src/Avalonia.FreeDesktop/DBusIme/DBusTextInputMethodBase.cs
@@ -179,16 +179,24 @@ namespace Avalonia.FreeDesktop.DBusIme
                 _disposables.Add(d);
         }
 
-        public void Dispose()
+        public async void Dispose()
         {
             foreach(var d in _disposables)
                 d.Dispose();
             _disposables.Clear();
-            if (IsConnected)
+            if (!IsConnected)
+                return;
+            try
             {
-                _ = DisconnectAsync();
-                _currentName = null;
+                await DisconnectAsync();
             }
+            catch (Exception ex)
+            {
+                Logger.TryGet(LogEventLevel.Error, "IME")
+                    ?.Log(this, "Error while destroying the context:\n" + ex);
+            }
+
+            _currentName = null;
         }
 
         protected abstract Task SetCursorRectCore(PixelRect rect);


### PR DESCRIPTION
## What does the pull request do?
Fix an issue when Avalonia is instructed to use ibus as IME but ibus is not available, e.g. by settings the env var `GTK_IM_MODULE=ibus`
The IM context is (somehow) successfully created but doesn't actually exist, so naturally Destroy fails when it's called on Dispose.

## What is the current behavior?
The app crashes

## What is the updated/expected behavior with this PR?
The exception is caught.

## How was the solution implemented (if it's not obvious)?

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
#13863
