### PR TITLE
Remove missing MVID warning on XAML compilation

### DIFF
--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -131,6 +131,7 @@
       <AvaloniaXamlIlVerifyIl Condition="'$(AvaloniaXamlIlVerifyIl)' == ''">false</AvaloniaXamlIlVerifyIl>
       <AvaloniaXamlIlDebuggerLaunch Condition="'$(AvaloniaXamlIlDebuggerLaunch)' == ''">false</AvaloniaXamlIlDebuggerLaunch>
       <AvaloniaXamlVerboseExceptions Condition="'$(AvaloniaXamlVerboseExceptions)' == ''">false</AvaloniaXamlVerboseExceptions>
+      <_AvaloniaHasCompiledXaml>true</_AvaloniaHasCompiledXaml>
     </PropertyGroup>
     <WriteLinesToFile
       Condition="'$(_AvaloniaForceInternalMSBuild)' != 'true'"
@@ -195,4 +196,25 @@
     <Exec Command="dotnet exec --runtimeconfig &quot;$(APreviewerRuntimeConfigPath)&quot; --depsfile &quot;$(APreviewerDepsJsonPath)&quot; &quot;$(AvaloniaPreviewerNetCoreToolPath)&quot; --method html --html-url $(APreviewerUrl) --transport $(APreviewTransportUrl)  &quot;$(APreviewExecutable)&quot;"/>
      
   </Target>
+
+  <!--
+    Deletes the target ref assembly before the CopyRefAssembly task (in target CopyFilesToOutputDirectory) tries to access it.
+
+    CopyRefAssembly reads the ref assembly's MVID from the .mvid PE section to avoid copying if necessary.
+    However, Cecil doesn't preserve that PE section: this results in a warning.
+    By deleting the file beforehand, we're preventing the warning.
+    There are no changes in behavior since CopyRefAssembly always copy the file if it couldn't read the MVID.
+  -->
+  <Target
+    Name="AvaloniaDeleteRefAssemblyBeforeOutputCopy"
+    BeforeTargets="CopyFilesToOutputDirectory"
+    Condition="
+      '$(_AvaloniaHasCompiledXaml)' == 'true' and
+      '$(TargetRefPath)' != '' and
+      '$(ProduceReferenceAssembly)' == 'true' and
+      ('$(CopyBuildOutputToOutputDirectory)' == '' or '$(CopyBuildOutputToOutputDirectory)' == 'true') and
+      '$(SkipCopyBuildProduct)' != 'true'">
+    <Delete Files="$(TargetRefPath)" Condition="Exists('$(TargetRefPath)')" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
## What does the pull request do?
This PR removes the annoying _"Could not extract the MVID from "obj\path\refint\assembly.dll". Are you sure it is a reference assembly?"_ warning affecting builds using the XAML compiler.

While completely harmless, people often think it's a build failure, and the warning can't be easily removed.

## How was the solution implemented (if it's not obvious)?
As commented in the modified .targets file:

Deletes the target ref assembly before the `CopyRefAssembly` task (in target `CopyFilesToOutputDirectory`) tries to access it.

`CopyRefAssembly` reads the ref assembly's MVID from the `.mvid` PE section to avoid copying if necessary.
However, Cecil doesn't preserve that PE section: this results in a warning.
By deleting the file beforehand, we're preventing the warning.
There are no changes in behavior since `CopyRefAssembly` always copy the file if it couldn't read the MVID.

References:
 - [.mvid section](https://github.com/dotnet/roslyn/pull/19133)
 - [`CopyRefAssembly` source](https://github.com/dotnet/roslyn/blob/17a7dccd93d51ec113c5be6ba0a686947f147f66/src/Compilers/Core/MSBuildTask/CopyRefAssembly.cs)
 - [`CopyRefAssembly` call](https://github.com/dotnet/msbuild/blob/b59f07e4312eb6e3e33e59241453606c81992738/src/Tasks/Microsoft.Common.CurrentVersion.targets#L4806)

## Fixed issues
 - Fixes #11032
