### PR TITLE
perf(Android): Avoid allocation of object array

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.Versioning;
 using System.Threading;
 using Android.App;
 using Android.Content;
 using Android.Graphics;
 using Android.Graphics.Drawables;
-using Android.OS;
 using Android.Runtime;
 using Android.Text;
 using Android.Views;
@@ -27,10 +25,8 @@ using Avalonia.OpenGL.Egl;
 using Avalonia.OpenGL.Surfaces;
 using Avalonia.Platform;
 using Avalonia.Platform.Storage;
-using Avalonia.Rendering;
 using Avalonia.Rendering.Composition;
 using Java.Lang;
-using static System.Net.Mime.MediaTypeNames;
 using ClipboardManager = Android.Content.ClipboardManager;
 
 namespace Avalonia.Android.Platform.SkiaPlatform
@@ -50,6 +46,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         private readonly ClipboardImpl _clipboard;
         private ViewImpl _view;
         private WindowTransparencyLevel _transparencyLevel;
+        private readonly object[] _surfaces;
 
         public TopLevelImpl(AvaloniaView avaloniaView, bool placeOnTop = false)
         {
@@ -76,6 +73,8 @@ namespace Avalonia.Android.Platform.SkiaPlatform
             _transparencyLevel = WindowTransparencyLevel.None;
 
             _systemNavigationManager = new AndroidSystemNavigationManagerImpl(avaloniaView.Context as IActivityNavigationService);
+
+            _surfaces = new object[] { _gl, _framebuffer, Handle };
         }
 
         public virtual Point GetAvaloniaPointFromEvent(MotionEvent e, int pointerIndex) =>
@@ -107,7 +106,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
 
         public IPlatformHandle Handle => _view;
 
-        public IEnumerable<object> Surfaces => new object[] { _gl, _framebuffer, Handle };
+        public IEnumerable<object> Surfaces => _surfaces;
 
         public Compositor Compositor => AndroidPlatform.Compositor;
         

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -46,7 +46,6 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         private readonly ClipboardImpl _clipboard;
         private ViewImpl _view;
         private WindowTransparencyLevel _transparencyLevel;
-        private readonly object[] _surfaces;
 
         public TopLevelImpl(AvaloniaView avaloniaView, bool placeOnTop = false)
         {
@@ -74,7 +73,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
 
             _systemNavigationManager = new AndroidSystemNavigationManagerImpl(avaloniaView.Context as IActivityNavigationService);
 
-            _surfaces = new object[] { _gl, _framebuffer, Handle };
+            Surfaces = new object[] { _gl, _framebuffer, Handle };
         }
 
         public virtual Point GetAvaloniaPointFromEvent(MotionEvent e, int pointerIndex) =>
@@ -106,7 +105,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
 
         public IPlatformHandle Handle => _view;
 
-        public IEnumerable<object> Surfaces => _surfaces;
+        public IEnumerable<object> Surfaces { get; }
 
         public Compositor Compositor => AndroidPlatform.Compositor;
         


### PR DESCRIPTION
Avoid allocating a new array of objects when the Compositor enumeration the surfaces

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
