### PR TITLE
Added WinPE detection

### DIFF
--- a/src/Windows/Avalonia.Win32/Win32PlatformSettings.cs
+++ b/src/Windows/Avalonia.Win32/Win32PlatformSettings.cs
@@ -32,7 +32,7 @@ internal class Win32PlatformSettings : DefaultPlatformSettings
     
     public override PlatformColorValues GetColorValues()
     {
-        if (Win32Platform.WindowsVersion.Major < 10)
+        if (Win32Platform.WindowsVersion.Major < 10 || IsWindowsPE())
         {
             return base.GetColorValues();
         }
@@ -74,6 +74,14 @@ internal class Win32PlatformSettings : DefaultPlatformSettings
         }
     }
     
+        private static bool IsWindowsPE()
+        {
+            // because Windows PE is running off of X: most of the time and a "full" Windows SHOULD be running off of C:
+            // we can be relatively sure it's a PE if the system drive is anything other than C: 
+            var systemDrive = Environment.GetEnvironmentVariable("SystemDrive");
+            return systemDrive != "C:";
+        }
+            
     internal void OnColorValuesChanged()
     {
         var oldColorValues = _lastColorValues;


### PR DESCRIPTION
## What does the pull request do?
This pull request adds detecting if the application runs in Windows PE, where the accent color detection is not available. If it runs in PE, it returns the base color.


## What is the current behavior?
Avalonia apps will crash if started in Windows PE, see https://github.com/AvaloniaUI/Avalonia/discussions/14040


## What is the updated/expected behavior with this PR?
Apps should be able to start in PE


## How was the solution implemented (if it's not obvious)?
The solution checks if the system drive has the drive letter C:, because a full Windows installation should have C: as it's system drive. If it's not C: it's probably a PE, where the system drive is X: most of the time

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
/

## Obsoletions / Deprecations
/

## Fixed issues
/
