### PR TITLE
Fix regression in rendering of non-clear type text

### DIFF
--- a/src/Skia/Avalonia.Skia/GlyphRunImpl.cs
+++ b/src/Skia/Avalonia.Skia/GlyphRunImpl.cs
@@ -130,7 +130,7 @@ namespace Avalonia.Skia
             var font = _glyphTypefaceImpl.CreateSKFont((float)FontRenderingEmSize);
 
             font.Hinting = SKFontHinting.Full;
-            font.Subpixel = edging == SKFontEdging.SubpixelAntialias;
+            font.Subpixel = edging != SKFontEdging.Alias;
             font.Edging = edging;
 
             return font;


### PR DESCRIPTION
In 0.10.x text rendered antialiased was clearer.

After investigation (you need a low res monitor with 100% scaling on MS Windows OS to really see the issue)

I found that this code:
```
private SKFont CreateFont(SKFontEdging edging)
        {
            var font = _glyphTypefaceImpl.CreateSKFont((float)FontRenderingEmSize);

            font.Hinting = SKFontHinting.Full;
            font.Subpixel = edging == SKFontEdging.SubpixelAntialias;
            font.Edging = edging;

            return font;
        }
 ```
 
 In 0.10.x you could get the equivalent of Edging = Antialias + SubPixel = true.
 
 In 11.0.x this configuration is no longer possible. Meaning you can't have ClearType disabled and have sub pixel font rendering.

I have shown in a table the different options, the differences are quite subtle, however very noticeable in some scenarios.

![telegram-cloud-photo-size-4-5809675680479297602-y](https://github.com/AvaloniaUI/Avalonia/assets/4672627/7b3f635f-21d4-4c6a-be96-e3362213c40d)


To be clear: Option 3 in the screenshot above is not possible and this PR makes it possible.

Option 4 is lost by this PR but that was a regression.

PR fixes it by making sure Skia SubPixel flag is set for all AntiAliased edging.

(Consulted with @Gillibald )
