### PR TITLE
Do not crash on IsCurrent checks

### DIFF
--- a/src/Avalonia.OpenGL/Egl/EglContext.cs
+++ b/src/Avalonia.OpenGL/Egl/EglContext.cs
@@ -154,7 +154,7 @@ namespace Avalonia.OpenGL.Egl
                 ShareWith = _sharedWith ?? this
             });
 
-        public bool IsCurrent => _egl.GetCurrentDisplay() == _disp.Handle && _egl.GetCurrentContext() == Context;
+        public bool IsCurrent => _context != default && _egl.GetCurrentDisplay() == _disp.Handle && _egl.GetCurrentContext() == _context;
 
         public void Dispose()
         {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

EglContext.IsCurrent currently throws an exception, if context was already lost. This behavior doesn't seem to be replicated in other IGlContext implementations, and causes issues, when surface is being disposed **after** context was disposed.

After this change, context.EnsureCurrent will still crash with PlatformGraphicsContextLostException, but rendering backend can handle that exception properly.

## Fixed issues

Fixes #13919
Fixes #14077
