### PR TITLE
Improving TextBox behaviour on Ctrl+Backspace down event

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1307,13 +1307,13 @@ namespace Avalonia.Controls
                 {
                     case Key.Left:
                         selection = DetectSelection();
-                        MoveHorizontal(-1, hasWholeWordModifiers, selection);
+                        MoveHorizontal(-1, hasWholeWordModifiers, selection, true);
                         movement = true;
                         break;
 
                     case Key.Right:
                         selection = DetectSelection();
-                        MoveHorizontal(1, hasWholeWordModifiers, selection);
+                        MoveHorizontal(1, hasWholeWordModifiers, selection, true);
                         movement = true;
                         break;
 
@@ -1781,7 +1781,7 @@ namespace Avalonia.Controls
         /// </summary>
         public void Clear() => SetCurrentValue(TextProperty, string.Empty);
 
-        private void MoveHorizontal(int direction, bool wholeWord, bool isSelecting)
+        private void MoveHorizontal(int direction, bool wholeWord, bool isSelecting, bool moveCaretPosition)
         {
             if (_presenter == null)
             {
@@ -1836,10 +1836,13 @@ namespace Avalonia.Controls
                 }
 
                 SetCurrentValue(SelectionEndProperty, SelectionEnd + offset);
+                
+                if (moveCaretPosition)
+                {
+                    _presenter.MoveCaretToTextPosition(SelectionEnd);
+                }
 
-                _presenter.MoveCaretToTextPosition(SelectionEnd);
-
-                if (!isSelecting)
+                if (!isSelecting && moveCaretPosition)
                 {
                     SetCurrentValue(CaretIndexProperty, SelectionEnd);
                 }
@@ -2069,7 +2072,7 @@ namespace Avalonia.Controls
             var text = Text ?? string.Empty;
             var selectionStart = CaretIndex;
 
-            MoveHorizontal(-1, true, false);
+            MoveHorizontal(-1, true, false, false);
             
             if (SelectionEnd > 0 && 
                 selectionStart < text.Length && text[selectionStart] == ' ')
@@ -2090,7 +2093,7 @@ namespace Avalonia.Controls
 
             SetCurrentValue(SelectionStartProperty, CaretIndex);
 
-            MoveHorizontal(1, true, true);
+            MoveHorizontal(1, true, true, false);
 
             if (SelectionEnd < textLength && Text![SelectionEnd] == ' ')
             {

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1976,7 +1976,7 @@ namespace Avalonia.Controls
 
                 _presenter?.MoveCaretToTextPosition(start);
 
-                SetCurrentValue(CaretIndexProperty, start);
+                SetCurrentValue(SelectionStartProperty, start);
 
                 ClearSelection();
 

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -2066,9 +2066,16 @@ namespace Avalonia.Controls
 
         private void SetSelectionForControlBackspace()
         {
+            var text = Text ?? string.Empty;
             var selectionStart = CaretIndex;
 
             MoveHorizontal(-1, true, false);
+            
+            if (SelectionEnd > 0 && 
+                selectionStart < text.Length && text[selectionStart] == ' ')
+            {
+                SetCurrentValue(SelectionEndProperty, SelectionEnd - 1);
+            }
 
             SetCurrentValue(SelectionStartProperty, selectionStart);
         }

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -200,6 +200,32 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Control_Backspace_Undo_Should_Return_Caret_Position()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var target = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "First Second Third",
+                    SelectionStart = 9,
+                    SelectionEnd = 9
+                };
+
+                target.ApplyTemplate();
+                
+                // (First Second| Third)
+                RaiseKeyEvent(target, Key.Back, KeyModifiers.Control);
+                // (First| Third)
+                
+                target.Undo();
+                // (First Second| Third)
+
+                Assert.Equal(9, target.CaretIndex);
+            }
+        }
+
+        [Fact]
         public void Press_Ctrl_A_Select_All_Text()
         {
             using (UnitTestApplication.Start(Services))

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -175,6 +175,29 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Equal(6, target.CaretIndex);
             }
         }
+        
+        [Fact]
+        public void Control_Backspace_Should_Remove_The_Double_Whitespace_If_Caret_Index_Was_At_The_End_Of_A_Word()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var target = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "First Second Third",
+                    SelectionStart = 12,
+                    SelectionEnd = 12
+                };
+
+                target.ApplyTemplate();
+                
+                // (First Second| Third)
+                RaiseKeyEvent(target, Key.Back, KeyModifiers.Control);
+                // (First| Third)
+
+                Assert.Equal("First Third", target.Text);
+            }
+        }
 
         [Fact]
         public void Press_Ctrl_A_Select_All_Text()

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -151,6 +151,30 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Equal(4, target.CaretIndex);
             }
         }
+        
+        [Fact]
+        public void Control_Backspace_Should_Set_Caret_Position_To_The_Start_Of_The_Deletion()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var target = new TextBox
+                {
+                    Template = CreateTemplate(),
+                    Text = "First Second Third",
+                    SelectionStart = 13,
+                    SelectionEnd = 13
+                };
+
+                target.CaretIndex = 10;
+                target.ApplyTemplate();
+
+                // (First Second |Third)
+                RaiseKeyEvent(target, Key.Back, KeyModifiers.Control);
+                // (First |Third)
+                
+                Assert.Equal(6, target.CaretIndex);
+            }
+        }
 
         [Fact]
         public void Press_Ctrl_A_Select_All_Text()


### PR DESCRIPTION
## What does the pull request do?
This PR improves `TextBox` behaviour on `Ctrl+Backspace` gesture down event


## What is the current behavior?
* After deletion, `TextBox` doesn't change the caret position accordingly to the text shift
* If the caret position is set to the end of a word, `TextBox` doesn't remove a whitespace before the deleting word, which results in a double space at its place after deletion
* When undoing a deletion, `TextBox` doesn't reset the caret position to the place before deletion


## What is the updated/expected behavior with this PR?
* After deletion, `TextBox` sets the caret position to the start of the deleted word
* If the caret position is set to the end of a word, `TextBox` removes a whitespace before the deleting word
* When undoing a deletion, `TextBox` resets the caret position to the place before deletion


## Checklist

- [x] Added unit tests (if possible)?

