### PR TITLE
Add `ItemsControl.PreparingContainer` event

### DIFF
--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -213,6 +213,15 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
+        /// Occurs immediately before a container is prepared for use.
+        /// </summary>
+        /// <remarks>
+        /// The prepared element might be newly created or an existing container that is being re-
+        /// used.
+        /// </remarks>
+        public event EventHandler<ContainerPreparedEventArgs>? PreparingContainer;
+
+        /// <summary>
         /// Occurs each time a container is prepared for use.
         /// </summary>
         /// <remarks>
@@ -690,6 +699,8 @@ namespace Avalonia.Controls
 
         internal void PrepareItemContainer(Control container, object? item, int index)
         {
+            PreparingContainer?.Invoke(this, new(container, index));
+
             // If the container has no theme set, or we've already applied our ItemContainerTheme
             // (and it hasn't changed since) then we're in control of the container's Theme and may
             // need to update it.


### PR DESCRIPTION
Add a new event that is raised before an item container is prepared for use.

## What is the current behavior?
Currently it is not possible to intercept item container preparation. There is only the `ContainerPrepared` event, which is raised after the fact.

This causes issues in our product, which sometimes needs to do DI work before constructing item container templates.

## Breaking changes
None

## Obsoletions / Deprecations
None