### PR TITLE
Add InheritDataTypeFromItems for AutoCompleteBox.ValueMemberBinding

### DIFF
--- a/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.Properties.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.Properties.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Metadata;
 
 namespace Avalonia.Controls
 {
@@ -286,6 +287,7 @@ namespace Avalonia.Controls
         /// <value>The <see cref="T:Avalonia.Data.IBinding" /> object used
         /// when binding to a collection property.</value>
         [AssignBinding]
+        [InheritDataTypeFromItems(nameof(ItemsSource))]
         public IBinding? ValueMemberBinding
         {
             get => _valueBindingEvaluator?.ValueBinding;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

This pull request tags the `AutoCompleteBox.ValueMemberBinding` property with the `InheritDataTypeFromItemsAttribute` attribute to simplify the compiled binding expressions on this property in most cases.

## What is the current behavior?

The property type needs to be declared explicitly in the binding expression on this property.

## What is the updated/expected behavior with this PR?

Compiled binding expressions on this property no longer require explicit specification of the generic type for the `ItemsSource` collection type.

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

Fixes #14161 
