### PR TITLE
Discard additional lines upon inserting when AcceptsReturn=false 

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -16,6 +16,7 @@ using Avalonia.Utilities;
 using Avalonia.Controls.Metadata;
 using Avalonia.Media.TextFormatting;
 using Avalonia.Automation.Peers;
+using Avalonia.Media.TextFormatting.Unicode;
 using Avalonia.Threading;
 
 namespace Avalonia.Controls
@@ -1074,12 +1075,19 @@ namespace Avalonia.Controls
 
             if (!AcceptsReturn)
             {
-                var endOfFirstLine = text.IndexOfAny(crlf);
-                if (endOfFirstLine >= 0)
+                var linebreakEnumerator = new LineBreakEnumerator(text.AsSpan());
+
+                while(linebreakEnumerator.MoveNext(out var linebreak))
                 {
-                    // All lines except the first one are discarded when TextBox does not accept Return key
-                    text = text.Substring(0, endOfFirstLine);
+                    if (linebreak.Required)
+                    {
+                        // All lines except the first one are discarded when TextBox does not accept Return key
+                        text = text.Substring(0, Math.Max(0, linebreak.PositionWrap - 1));
+
+                        break;
+                    }
                 }
+
             }
 
             for (var i = 0; i < invalidCharacters.Length; i++)

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -324,6 +324,7 @@ namespace Avalonia.Controls
         private bool _canCopy;
         private bool _canPaste;
         private static readonly string[] invalidCharacters = new String[1] { "\u007f" };
+        private static readonly char[] crlf = new char[] { '\r', '\n' };
         private bool _canUndo;
         private bool _canRedo;
 
@@ -1013,7 +1014,7 @@ namespace Avalonia.Controls
                 return;
             }
 
-            input = RemoveInvalidCharacters(input);
+            input = SanitizeInputText(input);
 
             if (string.IsNullOrEmpty(input))
             {
@@ -1066,10 +1067,20 @@ namespace Avalonia.Controls
             }
         }
 
-        private string? RemoveInvalidCharacters(string? text)
+        private string? SanitizeInputText(string? text)
         {
             if (text is null)
                 return null;
+
+            if (!AcceptsReturn)
+            {
+                var endOfFirstLine = text.IndexOfAny(crlf);
+                if (endOfFirstLine >= 0)
+                {
+                    // All lines except the first one are discarded when TextBox does not accept Return key
+                    text = text.Substring(0, endOfFirstLine);
+                }
+            }
 
             for (var i = 0; i < invalidCharacters.Length; i++)
             {

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -838,7 +838,7 @@ namespace Avalonia.Controls
 
             _scrollViewer = e.NameScope.Find<ScrollViewer>("PART_ScrollViewer");
 
-            if(_scrollViewer != null)
+            if (_scrollViewer != null)
             {
                 _scrollViewer.ScrollChanged += ScrollViewer_ScrollChanged;
             }
@@ -887,9 +887,9 @@ namespace Avalonia.Controls
 
         private void PresenterPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
         {
-            if(e.Property == TextPresenter.PreeditTextProperty)
+            if (e.Property == TextPresenter.PreeditTextProperty)
             {
-                if(string.IsNullOrEmpty(e.OldValue as string) && !string.IsNullOrEmpty(e.NewValue as string))
+                if (string.IsNullOrEmpty(e.OldValue as string) && !string.IsNullOrEmpty(e.NewValue as string))
                 {
                     PseudoClasses.Set(":empty", false);
 
@@ -1074,19 +1074,21 @@ namespace Avalonia.Controls
 
             if (!AcceptsReturn)
             {
-                var linebreakEnumerator = new LineBreakEnumerator(text.AsSpan());
+                var lineBreakStart = 0;
+                var graphemeEnumerator = new GraphemeEnumerator(text.AsSpan());
 
-                while(linebreakEnumerator.MoveNext(out var linebreak))
+                while (graphemeEnumerator.MoveNext(out var grapheme))
                 {
-                    if (linebreak.Required)
+                    if (grapheme.FirstCodepoint.IsBreakChar)
                     {
-                        // All lines except the first one are discarded when TextBox does not accept Return key
-                        text = text.Substring(0, Math.Max(0, linebreak.PositionWrap - 1));
-
                         break;
                     }
+
+                    lineBreakStart += grapheme.Length;
                 }
 
+                // All lines except the first one are discarded when TextBox does not accept Return key
+                text = text.Substring(0, lineBreakStart);
             }
 
             for (var i = 0; i < invalidCharacters.Length; i++)
@@ -1775,7 +1777,7 @@ namespace Avalonia.Controls
                     SetCurrentValue(SelectionEndProperty, caretIndex);
                 }
 
-                if(SelectionStart != SelectionEnd)
+                if (SelectionStart != SelectionEnd)
                 {
                     _presenter.TextSelectionHandleCanvas?.ShowContextMenu();
                 }
@@ -2246,7 +2248,7 @@ namespace Avalonia.Controls
 
         protected override Size MeasureOverride(Size availableSize)
         {
-            if(_scrollViewer != null)
+            if (_scrollViewer != null)
             {
                 var maxHeight = double.PositiveInfinity;
 

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -325,7 +325,6 @@ namespace Avalonia.Controls
         private bool _canCopy;
         private bool _canPaste;
         private static readonly string[] invalidCharacters = new String[1] { "\u007f" };
-        private static readonly char[] crlf = new char[] { '\r', '\n' };
         private bool _canUndo;
         private bool _canRedo;
 

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -950,6 +950,38 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Insert_Multiline_Text_Should_Accept_Extra_Lines_When_AcceptsReturn_Is_True()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var target = new TextBox
+                {
+                    AcceptsReturn = true
+                };
+
+                RaiseTextEvent(target, $"123{Environment.NewLine}456");
+
+                Assert.Equal($"123{Environment.NewLine}456", target.Text);
+            }
+        }
+
+        [Fact]
+        public void Insert_Multiline_Text_Should_Discard_Extra_Lines_When_AcceptsReturn_Is_False()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var target = new TextBox
+                {
+                    AcceptsReturn = false
+                };
+
+                RaiseTextEvent(target, $"123{Environment.NewLine}456");
+
+                Assert.Equal("123", target.Text);
+            }
+        }
+
+        [Fact]
         public void Should_Fullfill_MaxLines_Contraint()
         {
             using (UnitTestApplication.Start(Services))

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -959,9 +959,9 @@ namespace Avalonia.Controls.UnitTests
                     AcceptsReturn = true
                 };
 
-                RaiseTextEvent(target, $"123{Environment.NewLine}456");
+                RaiseTextEvent(target, $"123 {Environment.NewLine}456");
 
-                Assert.Equal($"123{Environment.NewLine}456", target.Text);
+                Assert.Equal($"123 {Environment.NewLine}456", target.Text);
             }
         }
 
@@ -975,9 +975,9 @@ namespace Avalonia.Controls.UnitTests
                     AcceptsReturn = false
                 };
 
-                RaiseTextEvent(target, $"123{Environment.NewLine}456");
+                RaiseTextEvent(target, $"123 {Environment.NewLine}456");
 
-                Assert.Equal("123", target.Text);
+                Assert.Equal("123 ", target.Text);
             }
         }
 

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -975,7 +975,13 @@ namespace Avalonia.Controls.UnitTests
                     AcceptsReturn = false
                 };
 
-                RaiseTextEvent(target, $"123 {Environment.NewLine}456");
+                RaiseTextEvent(target, $"123 {"\r"}456");
+
+                Assert.Equal("123 ", target.Text);
+
+                target.Text = "";
+
+                RaiseTextEvent(target, $"123 {"\r\n"}456");
 
                 Assert.Equal("123 ", target.Text);
             }


### PR DESCRIPTION
## What does the pull request do?
It changes text insertion into `TextBox` with `AcceptsReturn==false` so that behavior is the same as in WPF.

## What is the current behavior?
Upon insertion of multiline text into `TextBox` with `AcceptsReturn==false` the `TextBox` becomes multiline. It is currently impossible to prevent a `TextBox` becoming multiline by user input (e.g. by pasting from clipboard).

## What is the updated/expected behavior with this PR?
Upon insertion of multiline text into `TextBox` with `AcceptsReturn==false`, only the first line will be inserted and any additional lines will be discarded.

## How was the solution implemented (if it's not obvious)?
`TextBox.RemoveInvalidCharacters` was renamed to `SanitizeInputText` and extended to handle the multiline scenario.

## Fixed issues
Fixes #5600
