### PR TITLE
fix: #14211 BoxShadow.ToString() behavior 

### DIFF
--- a/src/Avalonia.Base/Media/BoxShadow.cs
+++ b/src/Avalonia.Base/Media/BoxShadow.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
-using Avalonia.Animation.Animators;
 using Avalonia.Utilities;
 
 namespace Avalonia.Media
@@ -90,27 +89,21 @@ namespace Avalonia.Media
                 sb.Append("inset ");
             }
 
-            if (OffsetX != 0.0)
-            {
-                sb.AppendFormat("{0} ", OffsetX.ToString(CultureInfo.InvariantCulture));
-            }
+            sb.AppendFormat(CultureInfo.InvariantCulture, "{0} ", OffsetX);
 
-            if (OffsetY != 0.0)
-            {
-                sb.AppendFormat("{0} ", OffsetY.ToString(CultureInfo.InvariantCulture));
-            }
+            sb.AppendFormat(CultureInfo.InvariantCulture, "{0} ", OffsetY);
 
-            if (Blur != 0.0)
+            if (Blur != 0.0 || Spread != 0.0)
             {
-                sb.AppendFormat("{0} ", Blur.ToString(CultureInfo.InvariantCulture));
+                sb.AppendFormat(CultureInfo.InvariantCulture, "{0} ", Blur);
             }
 
             if (Spread != 0.0)
             {
-                sb.AppendFormat("{0} ", Spread.ToString(CultureInfo.InvariantCulture));
+                sb.AppendFormat(CultureInfo.InvariantCulture, "{0} ", Spread);
             }
 
-            sb.AppendFormat("{0}", Color.ToString());
+            Color.ToString(sb);
         }
 
         public static unsafe BoxShadow Parse(string s)

--- a/src/Avalonia.Base/Media/Color.cs
+++ b/src/Avalonia.Base/Media/Color.cs
@@ -447,6 +447,20 @@ namespace Avalonia.Media
             return KnownColors.GetKnownColorName(rgb) ?? $"#{rgb.ToString("x8", CultureInfo.InvariantCulture)}";
         }
 
+        internal void ToString(System.Text.StringBuilder builder)
+        {
+            uint rgb = ToUInt32();
+            if(KnownColors.TryGetKnownColorName(rgb, out var name))
+            {
+                builder.Append(name);
+            }
+            else
+            {
+                builder.Append('#');
+                builder.AppendFormat(CultureInfo.InvariantCulture, "{0:x8}", rgb);
+            }
+        }
+
         /// <summary>
         /// Returns the integer representation of the color.
         /// </summary>

--- a/src/Avalonia.Base/Media/KnownColors.cs
+++ b/src/Avalonia.Base/Media/KnownColors.cs
@@ -2,6 +2,7 @@ using System;
 using System.Reflection;
 using System.Collections.Generic;
 using Avalonia.SourceGenerator;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Avalonia.Media
 {
@@ -65,6 +66,9 @@ namespace Avalonia.Media
         {
             return _knownColors.TryGetValue(rgb, out var name) ? name : null;
         }
+
+        internal static bool TryGetKnownColorName(uint rgb, [NotNullWhen(true)] out string? name)
+            => _knownColors.TryGetValue(rgb, out name);
 
         public static Color ToColor(this KnownColor color)
         {

--- a/tests/Avalonia.Base.UnitTests/Media/BoxShadowTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/BoxShadowTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Avalonia.Media;
 using Xunit;
 
@@ -5,49 +6,111 @@ namespace Avalonia.Base.UnitTests.Media
 {
     public class BoxShadowTests
     {
-        [Fact]
-        public void BoxShadow_Should_Parse()
+        [Theory]
+        [MemberData(nameof(ParseGetData))]
+        public void BoxShadow_Should_Parse(BoxShadow expected, string source)
         {
-            foreach (var extraSpaces in new[] { false, true })
-            foreach (var inset in new[] { false, true })
-                for (var componentCount = 2; componentCount < 5; componentCount++)
-                {
-                    var s = (inset ? "inset " : "") + "10 20";
-                    double blur = 0;
-                    double spread = 0;
-                    if (componentCount > 2)
-                    {
-                        s += " 30";
-                        blur = 30;
-                    }
-
-                    if (componentCount > 3)
-                    {
-                        s += " 40";
-                        spread = 40;
-                    }
-
-                    s += " red";
-
-                    if (extraSpaces)
-                        s = " " + s.Replace(" ", "  ") + "   ";
-
-                    var parsed = BoxShadow.Parse(s);
-                    Assert.Equal(inset, parsed.IsInset);
-                    Assert.Equal(10, parsed.OffsetX);
-                    Assert.Equal(20, parsed.OffsetY);
-                    Assert.Equal(blur, parsed.Blur);
-                    Assert.Equal(spread, parsed.Spread);
-                    Assert.Equal(Colors.Red, parsed.Color);
-                }
+            var parsered = BoxShadow.Parse(source);
+            Assert.Equal(expected.IsInset, parsered.IsInset);
+            Assert.Equal(expected.OffsetX, parsered.OffsetX);
+            Assert.Equal(expected.OffsetY, parsered.OffsetY);
+            Assert.Equal(expected.Blur, parsered.Blur);
+            Assert.Equal(expected.Spread, parsered.Spread);
+            Assert.Equal(expected.Color, parsered.Color);
         }
 
-        [Fact]
-        public void BoxShadows_Should_ToString()
+        [Theory]
+        [MemberData(nameof(ToStringGetData))]
+        public void BoxShadows_Should_ToString(BoxShadows source, string expected) =>
+            Assert.Equal(expected, source.ToString(), true);
+
+        public static IEnumerable<object[]> ParseGetData()
         {
-            const string source = "-20 -20 60 #CCFFFFFF, 20 20 60 #33000000";
-            var parsed = BoxShadows.Parse(source);
-            Assert.Equal(source, parsed.ToString(), true);
+            foreach (var extraSpaces in new[] { false, true })
+                foreach (var inset in new[] { false, true })
+                    foreach (var color in new[] { "red", "#FF122403" })
+                        for (var componentCount = 2; componentCount < 5; componentCount++)
+                        {
+                            var s = (inset ? "inset " : "") + "10 20";
+                            if (componentCount > 2)
+                            {
+                                s += " 30";
+                            }
+
+                            if (componentCount > 3)
+                            {
+                                s += " 40";
+                            }
+
+                            s += " " + color;
+
+                            if (extraSpaces)
+                                s = " " + s.Replace(" ", "  ") + "   ";
+
+                            var parsed = BoxShadow.Parse(s);
+                            yield return new object[] { parsed, s };
+                        }
+        }
+
+        public static IEnumerable<object[]> ToStringGetData()
+        {
+            yield return new object[]
+            {
+                new BoxShadows(
+                    new BoxShadow()
+                    {
+                        OffsetX = -15,
+                        OffsetY = 20,
+                        Spread = 5,
+                        Color = Colors.Red,
+                    }),
+                "-15 20 0 5 red"
+            };
+            yield return new object[]
+            {
+                new BoxShadows(
+                    new BoxShadow()
+                    {
+                        IsInset = true,
+                        OffsetX = -15,
+                        OffsetY = 20,
+                        Spread = 5,
+                        Color = Colors.Red,
+                    }),
+                "inset -15 20 0 5 red"
+            };
+            yield return new object[]
+            {
+                new BoxShadows(
+                    new BoxShadow()
+                    {
+                        OffsetX = -15,
+                        OffsetY = 20,
+                        Blur = 5,
+                        Color = Colors.Red,
+                    }),
+                "-15 20 5 red"
+            };
+            yield return new object[]
+            {
+                new BoxShadows(
+                    new BoxShadow()
+                    {
+                        OffsetX = -20,
+                        OffsetY = -20,
+                        Blur = 60,
+                        Color = Color.Parse("#CCFFFFFF")
+                    },
+                    new BoxShadow[] { new()
+                    {
+                        OffsetX = 20,
+                        OffsetY = 20,
+                        Blur = 60,
+                        Color = Color.Parse("#33000000")
+                    } }),
+                "-20 -20 60 #CCFFFFFF, 20 20 60 #33000000"
+            };
+
         }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
The ToString() method of BoxShadow to not allow to Parse it again. It throw an exception.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

When invoke BoxShadow.ToString() if a any Property has  default value it is not appended

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

When invoke BoxShadow.ToString()  
   - OffsetX and OffsetY is always append 
   - if  Spread is not zero and Blur is zezo , Blur is append

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #14211