### PR TITLE
Show adorner while hovering any part of a control's TreeViewItem in DevTools

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml
@@ -7,13 +7,12 @@
     <TreeView Name="tree"
               BorderThickness="0"
               ItemsSource="{Binding Nodes}"
-              SelectedItem="{Binding SelectedNode, Mode=TwoWay}">
+              SelectedItem="{Binding SelectedNode, Mode=TwoWay}"
+              PointerMoved="UpdateAdorner">
       <TreeView.DataTemplates>
         <TreeDataTemplate DataType="vm:TreeNode"
                           ItemsSource="{Binding Children}">
-          <StackPanel Orientation="Horizontal" Spacing="8"
-                      PointerEntered="AddAdorner"
-                      PointerExited="RemoveAdorner">
+          <StackPanel Orientation="Horizontal" Spacing="8">
             <TextBlock Text="{Binding Type}" FontWeight="{Binding FontWeight}"/>
             <TextBlock Text="{Binding Classes}"/>
             <TextBlock Foreground="Gray" Text="{Binding ElementName}"/>


### PR DESCRIPTION
## What does the pull request do?
Changes the way the overlay adorner is triggered when hovering over an item in the DevTools control tree.

## What is the current behavior?
The overlay is only displayed while the mouse is over the actual text (control type, class list or element name).

## What is the updated/expected behavior with this PR?
Hovering any part of a control's `TreeViewItem` in DevTools now causes the overlay to display.

## How was the solution implemented (if it's not obvious)?
Instead of individual event handlers for the `StackPanel` in each `TreeViewItem` there now only exists one handler for the entire `TreeView` that uses `e.Source` to determine which `TreeViewItem` the pointer event came from.

## Fixed issues
Fixes #14230
