### PR TITLE
Fix #14216 Incorrectly Ordered Character Input in AutoCompleteBox

### DIFF
--- a/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.Properties.cs
+++ b/src/Avalonia.Controls/AutoCompleteBox/AutoCompleteBox.Properties.cs
@@ -22,8 +22,7 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<int> CaretIndexProperty =
             TextBox.CaretIndexProperty.AddOwner<AutoCompleteBox>(new(
                 defaultValue: 0,
-                defaultBindingMode:BindingMode.TwoWay,
-                coerce: TextBox.CoerceCaretIndex));
+                defaultBindingMode:BindingMode.TwoWay));
 
         public static readonly StyledProperty<string?> WatermarkProperty =
             TextBox.WatermarkProperty.AddOwner<AutoCompleteBox>();


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes AutoCompleteBox's "jumping" caret index causing incorrectly ordered text input as mentioned in #14216
![simple theme](https://i.imgur.com/gli28qy.gif)
![fluent theme](https://i.imgur.com/Fd4QMYx.gif)

## What is the current behavior?
Typed characters are incorrectly ordered.

## What is the updated/expected behavior with this PR?
Normal text input.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #14216 caused by #13463
