### PR TITLE
Fix segmentation fault error when using Linux Framebuffer DRM mode with AOT compilation

### DIFF
--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
@@ -121,7 +121,7 @@ namespace Avalonia.LinuxFramebuffer.Output
             // prepare for the new ioctl call
             var handles = new uint[] {handle, 0, 0, 0};
             var pitches = new uint[] {stride, 0, 0, 0};
-            var offsets = Array.Empty<uint>();
+            var offsets = new uint[4];
 
             var ret = drmModeAddFB2(_card.Fd, w, h, format, handles, pitches,
                                     offsets, out var fbHandle, 0);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Changes how the `offsets` uint array variable is instantiated for the `Avalonia.LinuxFramebuffer.Output.DrmOutput:GetFbIdForBo(IntPtr bo)` method, so that it's explicitly created as a 4-length array.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When compilting an Avalonia application with AOT compilation, at least for the `linux-64` runtime with the .NET 8.0 SDK, if DRM mode is used then a fatal *Segmentation fault* will be thrown from the invoked libdrm library. This appears to be due to the aforementioned `offsets` variable being a zero-length array when the library [tries to copy data into it](https://github.com/grate-driver/libdrm/blob/master/xf86drmMode.c#L286C40-L286C47).

The application when built via JIT compilation seems to be clever enough to figure out that the array must have a certain length, but when compiled with AOT does not.


## What is the updated/expected behavior with this PR?
The libdrm function successfully manages to copy memory to the `offsets` variable, even when application is AOT compiled.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Explicitly instantializes the `offsets` variable as a 4-length uint array, rather than as an empty array.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes #14227
