### PR TITLE
Make Classic ApplicationLifetime API a bit more reliable

### DIFF
--- a/src/Avalonia.Controls/AppBuilder.cs
+++ b/src/Avalonia.Controls/AppBuilder.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Platform;
 using Avalonia.Media.Fonts;
 using Avalonia.Media;
+using Avalonia.Metadata;
 
 namespace Avalonia
 {
@@ -53,6 +54,11 @@ namespace Avalonia
         /// Gets or sets a method to call the initialize the windowing subsystem.
         /// </summary>
         public Action? RenderingSubsystemInitializer { get; private set; }
+
+        /// <summary>
+        /// Gets a method to override a lifetime factory.
+        /// </summary>
+        public Func<Type, IApplicationLifetime?>? LifetimeOverride { get; private set; }
 
         /// <summary>
         /// Gets the name of the currently selected rendering subsystem.
@@ -235,6 +241,13 @@ namespace Avalonia
         {
             RuntimePlatformServicesInitializer = () => StandardRuntimePlatformServices.Register(ApplicationType?.Assembly);
             RuntimePlatformServicesName = nameof(StandardRuntimePlatform);
+            return Self;
+        }
+
+        [PrivateApi]
+        public AppBuilder UseLifetimeOverride(Func<Type, IApplicationLifetime?> func)
+        {
+            LifetimeOverride = func;
             return Self;
         }
 

--- a/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
@@ -197,28 +197,44 @@ namespace Avalonia
 {
     public static class ClassicDesktopStyleApplicationLifetimeExtensions
     {
-        public static int StartWithClassicDesktopLifetime(
-            this AppBuilder builder, string[] args, Action<IClassicDesktopStyleApplicationLifetime> lifetimeBuilder)
+        private static ClassicDesktopStyleApplicationLifetime PrepareLifetime(string[] args,
+            Action<IClassicDesktopStyleApplicationLifetime>? lifetimeBuilder)
         {
             var lifetime = AvaloniaLocator.Current.GetService<ClassicDesktopStyleApplicationLifetime>();
-
             if (lifetime == null)
             {
                 lifetime = new ClassicDesktopStyleApplicationLifetime();
             }
 
             lifetime.Args = args;
-            lifetimeBuilder(lifetime);
-
+            lifetimeBuilder?.Invoke(lifetime);
             lifetime.Setup();
+
+            return lifetime;
+        }
+
+        public static AppBuilder SetupWithClassicDesktopLifetime(this AppBuilder builder, string[] args,
+            Action<IClassicDesktopStyleApplicationLifetime>? lifetimeBuilder = null)
+        {
+            var lifetime = PrepareLifetime(args, lifetimeBuilder);
+            return builder.SetupWithLifetime(lifetime);
+        }
+
+        public static int StartWithClassicDesktopLifetime(
+            this AppBuilder builder, string[] args,
+            Action<IClassicDesktopStyleApplicationLifetime>? lifetimeBuilder = null)
+        {
+            var lifetime = PrepareLifetime(args, lifetimeBuilder);
             builder.SetupWithLifetime(lifetime);
             return lifetime.Start(args);
         }
-        
+
         public static int StartWithClassicDesktopLifetime(
-            this AppBuilder builder, string[] args, ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose)
+            this AppBuilder builder, string[] args, ShutdownMode shutdownMode)
         {
-            return builder.StartWithClassicDesktopLifetime(args, l => l.ShutdownMode = shutdownMode);
+            var lifetime = PrepareLifetime(args, l => l.ShutdownMode = shutdownMode);
+            builder.SetupWithLifetime(lifetime);
+            return lifetime.Start(args);
         }
     }
 }

--- a/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
@@ -195,6 +195,9 @@ namespace Avalonia.Controls.ApplicationLifetimes
 
 namespace Avalonia
 {
+    /// <summary>
+    /// IClassicDesktopStyleApplicationLifetime related AppBuilder extensions.
+    /// </summary>
     public static class ClassicDesktopStyleApplicationLifetimeExtensions
     {
         private static ClassicDesktopStyleApplicationLifetime PrepareLifetime(string[] args,
@@ -213,6 +216,13 @@ namespace Avalonia
             return lifetime;
         }
 
+        /// <summary>
+        /// Setups the Application with a IClassicDesktopStyleApplicationLifetime, but doesn't show the main window and doesn't run application main loop.
+        /// </summary>
+        /// <param name="builder">Application builder.</param>
+        /// <param name="args">Startup arguments.</param>
+        /// <param name="lifetimeBuilder">Lifetime builder to modify the lifetime before application started.</param>
+        /// <returns>Exit code.</returns>
         public static AppBuilder SetupWithClassicDesktopLifetime(this AppBuilder builder, string[] args,
             Action<IClassicDesktopStyleApplicationLifetime>? lifetimeBuilder = null)
         {
@@ -220,6 +230,13 @@ namespace Avalonia
             return builder.SetupWithLifetime(lifetime);
         }
 
+        /// <summary>
+        /// Starts the Application with a IClassicDesktopStyleApplicationLifetime, shows main window and runs application main loop.
+        /// </summary>
+        /// <param name="builder">Application builder.</param>
+        /// <param name="args">Startup arguments.</param>
+        /// <param name="lifetimeBuilder">Lifetime builder to modify the lifetime before application started.</param>
+        /// <returns>Exit code.</returns>
         public static int StartWithClassicDesktopLifetime(
             this AppBuilder builder, string[] args,
             Action<IClassicDesktopStyleApplicationLifetime>? lifetimeBuilder = null)
@@ -229,6 +246,13 @@ namespace Avalonia
             return lifetime.StartMainLoop();
         }
 
+        /// <summary>
+        /// Starts the Application with a IClassicDesktopStyleApplicationLifetime, shows main window and runs application main loop.
+        /// </summary>
+        /// <param name="builder">Application builder.</param>
+        /// <param name="args">Startup arguments.</param>
+        /// <param name="shutdownMode">Lifetime shutdown mode.</param>
+        /// <returns>Exit code.</returns>
         public static int StartWithClassicDesktopLifetime(
             this AppBuilder builder, string[] args, ShutdownMode shutdownMode)
         {

--- a/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
@@ -68,7 +68,7 @@ namespace Avalonia.Controls.ApplicationLifetimes
             return DoShutdown(new ShutdownRequestedEventArgs(), true, false, exitCode);
         }
 
-        public void Setup()
+        public void Setup(string[] args)
         {
             _compositeDisposable = new CompositeDisposable(
                 Window.WindowOpenedEvent.AddClassHandler(typeof(Window), (sender, _) =>
@@ -85,10 +85,7 @@ namespace Avalonia.Controls.ApplicationLifetimes
                     _windows.Remove(window);
                     HandleWindowClosed(window);
                 }));
-        }
 
-        public int Start(string[] args)
-        {
             Startup?.Invoke(this, new ControlledApplicationLifetimeStartupEventArgs(args));
 
             var options = AvaloniaLocator.Current.GetService<ClassicDesktopStyleApplicationLifetimeOptions>();
@@ -105,9 +102,12 @@ namespace Avalonia.Controls.ApplicationLifetimes
 
             if (lifetimeEvents != null)
                 lifetimeEvents.ShutdownRequested += OnShutdownRequested;
+        }
 
+        public int StartMainLoop()
+        {
             _cts = new CancellationTokenSource();
-            
+
             // Note due to a bug in the JIT we wrap this in a method, otherwise MainWindow
             // gets stuffed into a local var and can not be GCed until after the program stops.
             // this method never exits until program end.
@@ -208,7 +208,7 @@ namespace Avalonia
 
             lifetime.Args = args;
             lifetimeBuilder?.Invoke(lifetime);
-            lifetime.Setup();
+            lifetime.Setup(args);
 
             return lifetime;
         }
@@ -226,7 +226,7 @@ namespace Avalonia
         {
             var lifetime = PrepareLifetime(args, lifetimeBuilder);
             builder.SetupWithLifetime(lifetime);
-            return lifetime.Start(args);
+            return lifetime.StartMainLoop();
         }
 
         public static int StartWithClassicDesktopLifetime(
@@ -234,7 +234,7 @@ namespace Avalonia
         {
             var lifetime = PrepareLifetime(args, l => l.ShutdownMode = shutdownMode);
             builder.SetupWithLifetime(lifetime);
-            return lifetime.Start(args);
+            return lifetime.StartMainLoop();
         }
     }
 }

--- a/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
@@ -209,7 +209,7 @@ namespace Avalonia
     public static class ClassicDesktopStyleApplicationLifetimeExtensions
     {
         public static int StartWithClassicDesktopLifetime(
-            this AppBuilder builder, string[] args, ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose)
+            this AppBuilder builder, string[] args, Action<IClassicDesktopStyleApplicationLifetime> lifetimeBuilder)
         {
             var lifetime = AvaloniaLocator.Current.GetService<ClassicDesktopStyleApplicationLifetime>();
 
@@ -219,10 +219,16 @@ namespace Avalonia
             }
 
             lifetime.Args = args;
-            lifetime.ShutdownMode = shutdownMode;
+            lifetimeBuilder(lifetime);
 
             builder.SetupWithLifetime(lifetime);
             return lifetime.Start(args);
+        }
+        
+        public static int StartWithClassicDesktopLifetime(
+            this AppBuilder builder, string[] args, ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose)
+        {
+            return builder.StartWithClassicDesktopLifetime(args, l => l.ShutdownMode = shutdownMode);
         }
     }
 }

--- a/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
@@ -209,14 +209,11 @@ namespace Avalonia
     /// </summary>
     public static class ClassicDesktopStyleApplicationLifetimeExtensions
     {
-        private static ClassicDesktopStyleApplicationLifetime PrepareLifetime(string[] args,
+        private static ClassicDesktopStyleApplicationLifetime PrepareLifetime(AppBuilder builder, string[] args,
             Action<IClassicDesktopStyleApplicationLifetime>? lifetimeBuilder)
         {
-            var lifetime = AvaloniaLocator.Current.GetService<ClassicDesktopStyleApplicationLifetime>();
-            if (lifetime == null)
-            {
-                lifetime = new ClassicDesktopStyleApplicationLifetime();
-            }
+            var lifetime = builder.LifetimeOverride?.Invoke(typeof(ClassicDesktopStyleApplicationLifetime)) as ClassicDesktopStyleApplicationLifetime 
+                ?? new ClassicDesktopStyleApplicationLifetime();
 
             lifetime.Args = args;
             lifetimeBuilder?.Invoke(lifetime);
@@ -234,7 +231,7 @@ namespace Avalonia
         public static AppBuilder SetupWithClassicDesktopLifetime(this AppBuilder builder, string[] args,
             Action<IClassicDesktopStyleApplicationLifetime>? lifetimeBuilder = null)
         {
-            var lifetime = PrepareLifetime(args, lifetimeBuilder);
+            var lifetime = PrepareLifetime(builder, args, lifetimeBuilder);
             lifetime.SetupCore(args);
             return builder.SetupWithLifetime(lifetime);
         }
@@ -250,7 +247,7 @@ namespace Avalonia
             this AppBuilder builder, string[] args,
             Action<IClassicDesktopStyleApplicationLifetime>? lifetimeBuilder = null)
         {
-            var lifetime = PrepareLifetime(args, lifetimeBuilder);
+            var lifetime = PrepareLifetime(builder, args, lifetimeBuilder);
             builder.SetupWithLifetime(lifetime);
             return lifetime.Start(args);
         }
@@ -265,7 +262,7 @@ namespace Avalonia
         public static int StartWithClassicDesktopLifetime(
             this AppBuilder builder, string[] args, ShutdownMode shutdownMode)
         {
-            var lifetime = PrepareLifetime(args, l => l.ShutdownMode = shutdownMode);
+            var lifetime = PrepareLifetime(builder, args, l => l.ShutdownMode = shutdownMode);
             builder.SetupWithLifetime(lifetime);
             return lifetime.Start(args);
         }

--- a/src/Avalonia.Native/AvaloniaNativePlatformExtensions.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatformExtensions.cs
@@ -13,20 +13,19 @@ namespace Avalonia
             builder
                 .UseStandardRuntimePlatformSubsystem()
                 .UseWindowingSubsystem(() =>
-            {
-                var platform = AvaloniaNativePlatform.Initialize(
-                    AvaloniaLocator.Current.GetService<AvaloniaNativePlatformOptions>() ??
-                    new AvaloniaNativePlatformOptions());
+                {
+                    var platform = AvaloniaNativePlatform.Initialize(
+                        AvaloniaLocator.Current.GetService<AvaloniaNativePlatformOptions>() ??
+                        new AvaloniaNativePlatformOptions());
 
-                    builder.AfterSetup (x=>
-                    {
-                        platform.SetupApplicationName();
-                        platform.SetupApplicationMenuExporter();
-                    });
-            });
-
-            AvaloniaLocator.CurrentMutable.Bind<ClassicDesktopStyleApplicationLifetime>()
-                .ToConstant(new MacOSClassicDesktopStyleApplicationLifetime());
+                        builder.AfterSetup (x=>
+                        {
+                            platform.SetupApplicationName();
+                            platform.SetupApplicationMenuExporter();
+                        });
+                })
+                .UseLifetimeOverride(type => type == typeof(ClassicDesktopStyleApplicationLifetime)
+                    ? new MacOSClassicDesktopStyleApplicationLifetime() : null);
 
             return builder;
         }

--- a/tests/Avalonia.Controls.UnitTests/DesktopStyleApplicationLifetimeTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DesktopStyleApplicationLifetimeTests.cs
@@ -31,6 +31,8 @@ namespace Avalonia.Controls.UnitTests
             using (UnitTestApplication.Start(new TestServices(dispatcherImpl: new ManagedDispatcherImpl(null))))
             using(var lifetime = new ClassicDesktopStyleApplicationLifetime())    
             {
+                lifetime.SetupCore(Array.Empty<string>());
+
                 Dispatcher.UIThread.Post(() => lifetime.Shutdown(1337));
                 var exitCode = lifetime.Start(Array.Empty<string>());
 
@@ -45,6 +47,8 @@ namespace Avalonia.Controls.UnitTests
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                lifetime.SetupCore(Array.Empty<string>());
+
                 var windows = new List<Window> { new Window(), new Window(), new Window(), new Window() };
 
                 foreach (var window in windows)
@@ -65,6 +69,7 @@ namespace Avalonia.Controls.UnitTests
             using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
                 lifetime.ShutdownMode = ShutdownMode.OnExplicitShutdown;
+                lifetime.SetupCore(Array.Empty<string>());
 
                 var hasExit = false;
 
@@ -99,6 +104,7 @@ namespace Avalonia.Controls.UnitTests
             using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
                 lifetime.ShutdownMode = ShutdownMode.OnMainWindowClose;
+                lifetime.SetupCore(Array.Empty<string>());
 
                 var hasExit = false;
 
@@ -127,6 +133,7 @@ namespace Avalonia.Controls.UnitTests
             using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
                 lifetime.ShutdownMode = ShutdownMode.OnLastWindowClose;
+                lifetime.SetupCore(Array.Empty<string>());
 
                 var hasExit = false;
 
@@ -156,6 +163,8 @@ namespace Avalonia.Controls.UnitTests
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                lifetime.SetupCore(Array.Empty<string>());
+
                 var window = new Window();
 
                 window.Show();
@@ -170,6 +179,8 @@ namespace Avalonia.Controls.UnitTests
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                lifetime.SetupCore(Array.Empty<string>());
+
                 var window = new Window();
 
                 window.Show();
@@ -188,6 +199,8 @@ namespace Avalonia.Controls.UnitTests
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                lifetime.SetupCore(Array.Empty<string>());
+
                 var window = new Window();
 
                 window.Show();
@@ -213,6 +226,8 @@ namespace Avalonia.Controls.UnitTests
             using (UnitTestApplication.Start(services))
             using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                lifetime.SetupCore(Array.Empty<string>());
+
                 var window = new Window();
 
                 window.Show();
@@ -261,6 +276,7 @@ namespace Avalonia.Controls.UnitTests
             using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
                 lifetime.ShutdownMode = ShutdownMode.OnMainWindowClose;
+                lifetime.SetupCore(Array.Empty<string>());
 
                 var hasExit = false;
 
@@ -298,6 +314,7 @@ namespace Avalonia.Controls.UnitTests
             using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
                 lifetime.ShutdownMode = ShutdownMode.OnLastWindowClose;
+                lifetime.SetupCore(Array.Empty<string>());
 
                 var hasExit = false;
 
@@ -336,6 +353,8 @@ namespace Avalonia.Controls.UnitTests
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                lifetime.SetupCore(Array.Empty<string>());
+
                 var hasExit = false;
 
                 lifetime.Exit += (_, _) => hasExit = true;
@@ -369,6 +388,8 @@ namespace Avalonia.Controls.UnitTests
             using (UnitTestApplication.Start(TestServices.StyledWindow.With(dispatcherImpl: CreateDispatcherWithInstantMainLoop())))
             using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                lifetime.SetupCore(Array.Empty<string>());
+
                 var hasExit = false;
 
                 lifetime.Exit += (_, _) => hasExit = true;
@@ -402,6 +423,8 @@ namespace Avalonia.Controls.UnitTests
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             using(var lifetime = new ClassicDesktopStyleApplicationLifetime())
             {
+                lifetime.SetupCore(Array.Empty<string>());
+
                 var hasExit = false;
 
                 lifetime.Exit += (_, _) => hasExit = true;

--- a/tests/Avalonia.Controls.UnitTests/DesktopStyleApplicationLifetimeTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DesktopStyleApplicationLifetimeTests.cs
@@ -32,7 +32,7 @@ namespace Avalonia.Controls.UnitTests
             using(var lifetime = new ClassicDesktopStyleApplicationLifetime())    
             {
                 Dispatcher.UIThread.Post(() => lifetime.Shutdown(1337));
-                var exitCode = lifetime.Start(Array.Empty<string>());
+                var exitCode = lifetime.StartMainLoop(Array.Empty<string>());
 
                 Assert.Equal(1337, exitCode);
             }
@@ -234,7 +234,7 @@ namespace Avalonia.Controls.UnitTests
                 
                 // Force exit immediately
                 Dispatcher.UIThread.Post(Dispatcher.UIThread.ExitAllFrames);
-                lifetime.Start(Array.Empty<string>());
+                lifetime.StartMainLoop(Array.Empty<string>());
 
                 var window = new Window();
                 var raised = 0;

--- a/tests/Avalonia.Controls.UnitTests/DesktopStyleApplicationLifetimeTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DesktopStyleApplicationLifetimeTests.cs
@@ -32,7 +32,7 @@ namespace Avalonia.Controls.UnitTests
             using(var lifetime = new ClassicDesktopStyleApplicationLifetime())    
             {
                 Dispatcher.UIThread.Post(() => lifetime.Shutdown(1337));
-                var exitCode = lifetime.StartMainLoop(Array.Empty<string>());
+                var exitCode = lifetime.Start(Array.Empty<string>());
 
                 Assert.Equal(1337, exitCode);
             }
@@ -234,7 +234,7 @@ namespace Avalonia.Controls.UnitTests
                 
                 // Force exit immediately
                 Dispatcher.UIThread.Post(Dispatcher.UIThread.ExitAllFrames);
-                lifetime.StartMainLoop(Array.Empty<string>());
+                lifetime.Start(Array.Empty<string>());
 
                 var window = new Window();
                 var raised = 0;


### PR DESCRIPTION
## What does the pull request do?

I recommend reviewing this PR commit by commit, as there are multiple independent changes.

1. StartWithClassicDesktopLifetime method now has a builder callback to modify parameters of the lifetime. As a replacement for old "ShutdownMode shutdownMode" parameter. (this change is a low benefit, can be reverted)
2.  Makes it impossible to change Application.ApplicationLifetime **after** application was already initialized. As it doesn't make sense, and Avalonia won't properly handle it.
3. Deprecates old Application.UrlsOpened - can be replaced with IActivatableApplicationLifetime which was added previously.
4. Allow creation of multiple ClassicDesktopStyleApplicationLifetime instances by avoiding static global `s_activeLifetime`. Instead lifetime should subscribe on window events after it was set-up, and not when it was constructed. And also - unsubscribe from these events.
5. Introduce SetupWithClassicDesktopLifetime method, that sets up lifetime and handlers, but doesn't run application MainLoop nor doesn't show window.
6. Adds well missing XML docs.

## Breaking changes

Application.ApplicationLifetime cannot be set after application was started. It will throw a runtime error.
Since this never was supported nor properly handled, I wouldn't consider it a blocker for backporting.

## Obsoletions / Deprecations

Application.UrlsOpened is obsolete - use IActivatableApplicationLifetime.
