### PR TITLE
Remove "netcoreapp2.0" target from the Avalonia. Make previewer use netstandard2.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="$(MSBuildThisFileDirectory)/build/AvaloniaPublicKey.props"/>
   <PropertyGroup>
       <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(MSBuildThisFileDirectory)build-intermediate/nuget</PackageOutputPath>
-      <AvaloniaPreviewerNetCoreToolPath>$(MSBuildThisFileDirectory)\src\tools\Avalonia.Designer.HostApp\bin\$(Configuration)\netcoreapp2.0\Avalonia.Designer.HostApp.dll</AvaloniaPreviewerNetCoreToolPath>
+      <AvaloniaPreviewerNetCoreToolPath>$(MSBuildThisFileDirectory)\src\tools\Avalonia.Designer.HostApp\bin\$(Configuration)\netstandard2.0\Avalonia.Designer.HostApp.dll</AvaloniaPreviewerNetCoreToolPath>
       <!-- https://github.com/dotnet/msbuild/issues/2661 -->
       <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
       <MSBuildEnableWorkloadResolver>false</MSBuildEnableWorkloadResolver>

--- a/nukebuild/ApiDiffHelper.cs
+++ b/nukebuild/ApiDiffHelper.cs
@@ -105,7 +105,9 @@ public static class ApiDiffHelper
     {
         // We use StartsWith below comparing these tfm, as we ignore platform versions (like, net6.0-ios16.1)
         ("net6.0-android", "net7.0-android"),
-        ("net6.0-ios", "net7.0-ios")
+        ("net6.0-ios", "net7.0-ios"),
+        // Designer was moved from netcoreapp to netstandard 
+        ("netcoreapp2.0", "netstandard2.0")
     };
 
     public static async Task ValidatePackage(

--- a/packages/Avalonia/Avalonia.csproj
+++ b/packages/Avalonia/Avalonia.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-      <TargetFrameworks>net6.0;netstandard2.0;net461;netcoreapp2.0</TargetFrameworks>
+      <TargetFrameworks>net6.0;netstandard2.0;net461</TargetFrameworks>
       <PackageId>Avalonia</PackageId>
   </PropertyGroup>
 
@@ -27,11 +27,11 @@
   </PropertyGroup>
 
   <Target Name="AddDesignerHostAppsToPackage" BeforeTargets="GenerateNuspec">
-    <MSBuild Projects="$(DesignerHostAppPath)/Avalonia.Designer.HostApp/Avalonia.Designer.HostApp.csproj" Properties="Configuration=$(Configuration);&#xA;                         Platform=$(Platform)" />
+    <MSBuild Projects="$(DesignerHostAppPath)/Avalonia.Designer.HostApp/Avalonia.Designer.HostApp.csproj" Properties="Configuration=$(Configuration);&#xA;Platform=$(Platform)" />
 
     <ItemGroup>
-      <_PackageFiles Include="$(DesignerHostAppPath)/Avalonia.Designer.HostApp/bin/$(Configuration)/netcoreapp2.0/Avalonia.Designer.HostApp.dll">
-        <PackagePath>tools/netcoreapp2.0/designer</PackagePath>
+      <_PackageFiles Include="$(DesignerHostAppPath)/Avalonia.Designer.HostApp/bin/$(Configuration)/netstandard2.0/Avalonia.Designer.HostApp.dll">
+        <PackagePath>tools/netstandard2.0/designer</PackagePath>
         <Visible>false</Visible>
         <BuildAction>None</BuildAction>
       </_PackageFiles>

--- a/packages/Avalonia/Avalonia.props
+++ b/packages/Avalonia/Avalonia.props
@@ -1,6 +1,6 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <AvaloniaPreviewerNetCoreToolPath>$(MSBuildThisFileDirectory)\..\tools\netcoreapp2.0\designer\Avalonia.Designer.HostApp.dll</AvaloniaPreviewerNetCoreToolPath>
+    <AvaloniaPreviewerNetCoreToolPath>$(MSBuildThisFileDirectory)\..\tools\netstandard2.0\designer\Avalonia.Designer.HostApp.dll</AvaloniaPreviewerNetCoreToolPath>
     <AvaloniaPreviewerNetFullToolPath>$(MSBuildThisFileDirectory)\..\tools\net461\designer\Avalonia.Designer.HostApp.exe</AvaloniaPreviewerNetFullToolPath>
     <AvaloniaBuildTasksLocation>$(MSBuildThisFileDirectory)\..\tools\netstandard2.0\Avalonia.Build.Tasks.dll</AvaloniaBuildTasksLocation>
     <AvaloniaUseExternalMSBuild>false</AvaloniaUseExternalMSBuild>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <AvaloniaPreviewerNetCoreToolPath>$(MSBuildThisFileDirectory)..\src\tools\Avalonia.Designer.HostApp\bin\Debug\netcoreapp2.0\Avalonia.Designer.HostApp.dll</AvaloniaPreviewerNetCoreToolPath>
+    <AvaloniaPreviewerNetCoreToolPath>$(MSBuildThisFileDirectory)..\src\tools\Avalonia.Designer.HostApp\bin\Debug\netstandard2.0\Avalonia.Designer.HostApp.dll</AvaloniaPreviewerNetCoreToolPath>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <LangVersion>11</LangVersion>
     <NoWarn>$(NoWarn);CS8002</NoWarn> <!-- ignore signing warnings for samples -->

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/Avalonia.Markup.Xaml.Loader.csproj
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/Avalonia.Markup.Xaml.Loader.csproj
@@ -5,22 +5,11 @@
     <IsPackable>true</IsPackable>
     <DefineConstants>$(DefineConstants);XAMLX_INTERNAL;XAML_RUNTIME_LOADER</DefineConstants>
   </PropertyGroup>
-  <!--Disable Net Perf. analyzer for submodule to avoid commit issue -->
-  <PropertyGroup>
-    <EnableNETAnalyzers>false</EnableNETAnalyzers>
-  </PropertyGroup>
-  <Import Project="IncludeXamlIlSre.props" />
-  <ItemGroup>
-    <Compile Include="..\..\Avalonia.Base\Utilities\StringBuilderCache.cs" Link="Utilities\StringBuilderCache.cs" />
-    <Compile Include="..\..\Avalonia.Base\Compatibility\TrimmingAttributes.cs" Link="TrimmingAttributes.cs" Visible="False" />
-    <Compile Include="..\..\Shared\IsExternalInit.cs" Link="Compatibility\IsExternalInit.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Avalonia.Markup.Xaml\Avalonia.Markup.Xaml.csproj" />
   </ItemGroup>
+
+  <Import Project="IncludeXamlIlSre.props" />
   <Import Project="..\..\..\build\DevAnalyzers.props" />
   <Import Project="..\..\..\build\TrimmingEnable.props" />
   <Import Project="..\..\..\build\SourceGenerators.props" />

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/IncludeXamlIlSre.props
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/IncludeXamlIlSre.props
@@ -1,9 +1,26 @@
 <Project>
+  <!--Disable Net Perf. analyzer for submodule to avoid commit issue -->
+  <PropertyGroup>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Remove="$(MSBuildThisFileDirectory)\xamlil.github\**\*.*" />
     <Content Remove="$(MSBuildThisFileDirectory)\xamlil.github\**\*.*" />
     <Compile Remove="$(MSBuildThisFileDirectory)\xamlil.github\**\*.*" />
     <Compile Include="$(MSBuildThisFileDirectory)\xamlil.github\src\XamlX\**\*.cs" />
     <Compile Remove="$(MSBuildThisFileDirectory)\xamlil.github\**\obj\**\*.cs" />
+
+    <!-- Polyfills used by XamlX, but re-imported from this repository -->
+    <Compile Include="$(MSBuildThisFileDirectory)\..\..\Avalonia.Base\Metadata\NullableAttributes.cs" Link="NullableAttributes.cs" Visible="False" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\..\Avalonia.Base\Compatibility\TrimmingAttributes.cs" Link="TrimmingAttributes.cs" Visible="False" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\..\Shared\IsExternalInit.cs" Link="Compatibility\IsExternalInit.cs" />
+
+    <!-- Utilities used by XamlX Avalonia SRE -->
+    <Compile Include="$(MSBuildThisFileDirectory)\..\..\Avalonia.Base\Utilities\StringBuilderCache.cs" Link="Utilities\StringBuilderCache.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')))">
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/tools/Avalonia.Designer.HostApp/Avalonia.Designer.HostApp.csproj
+++ b/src/tools/Avalonia.Designer.HostApp/Avalonia.Designer.HostApp.csproj
@@ -1,31 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net6.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);XAMLX_INTERNAL</DefineConstants>
-  </PropertyGroup>
-  <!--Disable Net Perf. analyzer for submodule to avoid commit issue -->
-  <PropertyGroup>
-    <EnableNETAnalyzers>false</EnableNETAnalyzers>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Avalonia.DesignerSupport\Avalonia.DesignerSupport.csproj" />
     <ProjectReference Include="..\..\Avalonia.Base\Avalonia.Base.csproj" />
     <ProjectReference Include="..\..\Avalonia.Controls\Avalonia.Controls.csproj" />
-    <ProjectReference Include="..\..\Avalonia.Diagnostics\Avalonia.Diagnostics.csproj" />
-    <ProjectReference Include="..\..\Avalonia.Themes.Simple\Avalonia.Themes.Simple.csproj" />
   </ItemGroup>
-  <Import Project="..\..\..\src\Markup\Avalonia.Markup.Xaml.Loader\IncludeXamlIlSre.props" />
   <ItemGroup>
     <Compile Include="..\..\..\src\Markup\Avalonia.Markup.Xaml.Loader\CompilerExtensions\**\*.cs" />
     <Compile Include="..\..\..\src\Markup\Avalonia.Markup.Xaml.Loader\AvaloniaXamlIlRuntimeCompiler.cs" />
     <Compile Include="..\..\..\src\Markup\Avalonia.Markup.Xaml.Loader\CompilerDynamicDependencies.cs" />
-    <Compile Include="..\..\Avalonia.Base\Utilities\StringBuilderCache.cs" Link="Utilities\StringBuilderCache.cs" />
-    <Compile Include="..\..\Avalonia.Base\Compatibility\TrimmingAttributes.cs" Link="TrimmingAttributes.cs" Visible="False" />
-    <Compile Include="..\..\Shared\IsExternalInit.cs" Link="Compatibility\IsExternalInit.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Avalonia.Angle.Windows.Natives" Version="2.1.22045.20230930" />
-  </ItemGroup>
-  <Import Project="..\..\..\build\NetFX.props" />
+  <Import Project="..\..\..\src\Markup\Avalonia.Markup.Xaml.Loader\IncludeXamlIlSre.props" />
+  <Import Project="..\..\..\build\DevAnalyzers.props" />
+  <Import Project="..\..\..\build\TrimmingEnable.props" />
 </Project>

--- a/src/tools/Avalonia.Designer.HostApp/DesignXamlLoader.cs
+++ b/src/tools/Avalonia.Designer.HostApp/DesignXamlLoader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -9,6 +10,7 @@ using Avalonia.Markup.Xaml.XamlIl;
 
 namespace Avalonia.Designer.HostApp;
 
+[RequiresUnreferencedCode(XamlX.TrimmingMessages.DynamicXamlReference)]
 class DesignXamlLoader : AvaloniaXamlLoader.IRuntimeXamlLoader
 {
     public object Load(RuntimeXamlLoaderDocument document, RuntimeXamlLoaderConfiguration configuration)

--- a/src/tools/Avalonia.Designer.HostApp/Program.cs
+++ b/src/tools/Avalonia.Designer.HostApp/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using Avalonia.DesignerSupport;
@@ -6,6 +7,7 @@ using Avalonia.Markup.Xaml;
 
 namespace Avalonia.Designer.HostApp
 {
+    [RequiresUnreferencedCode(XamlX.TrimmingMessages.DynamicXamlReference)]
     class Program
     {
 #if NETFRAMEWORK

--- a/tests/Avalonia.DesignerSupport.Tests/DesignerSupportTests.cs
+++ b/tests/Avalonia.DesignerSupport.Tests/DesignerSupportTests.cs
@@ -19,7 +19,7 @@ namespace Avalonia.DesignerSupport.Tests
 {
     public class DesignerSupportTests
     {
-        private const string DesignerAppPath = "../../../../../src/tools/Avalonia.Designer.HostApp/bin/$BUILD/netcoreapp2.0/Avalonia.Designer.HostApp.dll";
+        private const string DesignerAppPath = "../../../../../src/tools/Avalonia.Designer.HostApp/bin/$BUILD/netstandard2.0/Avalonia.Designer.HostApp.dll";
         private readonly Xunit.Abstractions.ITestOutputHelper outputHelper;
 
         public DesignerSupportTests(Xunit.Abstractions.ITestOutputHelper outputHelper)


### PR DESCRIPTION
## What does the pull request do?

Reduces maintenance burden and number of new warnings we have with each new SDK.

## Breaking changes

One of targets was removed, which can be considered as a breaking change.
But all of actual assemblies didn't use netstandard2.0 to begin with. Only "Avalonia" umbrella project that doesn't have any actual code. And only previewer.
Still, not worth of backporting.