### PR TITLE
Fix Previewer crash from Refit reflection (#14282)

### DIFF
--- a/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
+++ b/src/Avalonia.DesignerSupport/DesignWindowLoader.cs
@@ -35,7 +35,7 @@ namespace Avalonia.DesignerSupport
                         new Uri($"avares://{Path.GetFileNameWithoutExtension(assemblyPath)}{xamlFileProjectPath}");
                 }
 
-                var localAsm = assemblyPath != null ? Assembly.LoadFile(Path.GetFullPath(assemblyPath)) : null;
+                var localAsm = assemblyPath != null ? Assembly.LoadFrom(Path.GetFullPath(assemblyPath)) : null;
                 var useCompiledBindings = localAsm?.GetCustomAttributes<AssemblyMetadataAttribute>()
                     .FirstOrDefault(a => a.Key == "AvaloniaUseCompiledBindingsByDefault")?.Value;
 

--- a/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
+++ b/src/Avalonia.DesignerSupport/Remote/RemoteDesignerEntryPoint.cs
@@ -172,7 +172,7 @@ namespace Avalonia.DesignerSupport.Remote
             var transport = CreateTransport(args);
             if (transport is ITransportWithEnforcedMethod enforcedMethod)
                 args.Method = enforcedMethod.PreviewerMethod;
-            var asm = Assembly.LoadFile(System.IO.Path.GetFullPath(args.AppPath));
+            var asm = Assembly.LoadFrom(System.IO.Path.GetFullPath(args.AppPath));
             var entryPoint = asm.EntryPoint ?? throw Die($"Assembly {args.AppPath} doesn't have an entry point");
             Log($"Initializing application in design mode");
             Design.IsDesignMode = true;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Due to its use of reflection, invoking Refit causes the Previewer to crash, since `Assembly.LoadFile` doesn't make the app's assembly available for reflection within the context of the Previewer. Therefore, Refit's reflection-based generator fails. See https://github.com/reactiveui/refit/issues/1476 for more details.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Using Refit causes the Previewer to crash.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
The app assembly is now available for reflection within the context of the Previewer, so the Previewer will not crash.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Changes the Avalonia previewer's `Assembly.LoadFile` usage to `Assembly.LoadFrom`.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #14282