### PR TITLE
Fix - Use root visual to calculate offsets is scroll gesture

### DIFF
--- a/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
@@ -21,6 +21,7 @@ namespace Avalonia.Input.GestureRecognizers
         private int _gestureId;
         private Point _pointerPressedPoint;
         private VelocityTracker? _velocityTracker;
+        private Visual? _rootTarget;
 
         // Movement per second
         private Vector _inertia;
@@ -99,7 +100,8 @@ namespace Avalonia.Input.GestureRecognizers
                 EndGesture();
                 _tracking = e.Pointer;
                 _gestureId = ScrollGestureEventArgs.GetNextFreeId();
-                _trackedRootPoint = _pointerPressedPoint = e.GetPosition((Visual?)Target);
+                _rootTarget = (Visual?)(Target as Visual)?.VisualRoot;
+                _trackedRootPoint = _pointerPressedPoint = e.GetPosition(_rootTarget);
             }
         }
 
@@ -107,7 +109,7 @@ namespace Avalonia.Input.GestureRecognizers
         {
             if (e.Pointer == _tracking)
             {
-                var rootPoint = e.GetPosition((Visual?)Target);
+                var rootPoint = e.GetPosition(_rootTarget);
                 if (!_scrolling)
                 {
                     if (CanHorizontallyScroll && Math.Abs(_trackedRootPoint.X - rootPoint.X) > ScrollStartDistance)
@@ -134,8 +136,8 @@ namespace Avalonia.Input.GestureRecognizers
                     _velocityTracker?.AddPosition(TimeSpan.FromMilliseconds(e.Timestamp), _pointerPressedPoint - rootPoint);
 
                     _lastMoveTimestamp = e.Timestamp;
-                    _trackedRootPoint = rootPoint;
                     Target!.RaiseEvent(new ScrollGestureEventArgs(_gestureId, vector));
+                    _trackedRootPoint = rootPoint;
                     e.Handled = true;
                 }
             }
@@ -156,6 +158,7 @@ namespace Avalonia.Input.GestureRecognizers
                 Target!.RaiseEvent(new ScrollGestureEndedEventArgs(_gestureId));
                 _gestureId = 0;
                 _lastMoveTimestamp = null;
+                _rootTarget = null;
             }
             
         }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Uses the gesture's target's VisualRoot to calculate scroll gesture offset, instead of the Target. This ensures the reference visual is always fixed, since we update the tracking position every input frame. 


## What is the current behavior?
A moving reference target, especially when affected by inertia, can move beyond the current pointer position, and thus cause a reverse in scrolling in the next input frame. This causes jittering.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #14300
