### PR TITLE
Dispose layout manager when embeddable control root is disposed.

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaView.cs
+++ b/src/Android/Avalonia.Android/AvaloniaView.cs
@@ -42,6 +42,13 @@ namespace Avalonia.Android
             set { _root.Content = value; }
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            _root?.Dispose();
+            _root = null;
+        }
+
         public override bool DispatchKeyEvent(KeyEvent e)
         {
             return _view.View.DispatchKeyEvent(e);

--- a/src/Android/Avalonia.Android/SingleViewLifetime.cs
+++ b/src/Android/Avalonia.Android/SingleViewLifetime.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Android
             _activity = activity;
 
             if (activity is IAvaloniaActivity activableActivity)
-            {
+            { 
                 activableActivity.Activated += (_, args) => Activated?.Invoke(this, args);
                 activableActivity.Deactivated += (_, args) => Deactivated?.Invoke(this, args);
             }

--- a/src/Avalonia.Controls/Embedding/EmbeddableControlRoot.cs
+++ b/src/Avalonia.Controls/Embedding/EmbeddableControlRoot.cs
@@ -51,6 +51,11 @@ namespace Avalonia.Controls.Embedding
         }
 
         protected override Type StyleKeyOverride => typeof(EmbeddableControlRoot);
-        public void Dispose() => PlatformImpl?.Dispose();
+
+        public void Dispose()
+        {
+            PlatformImpl?.Dispose();
+            LayoutManager?.Dispose();
+        }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Disposes LayoutManager when EmbeddableControlRoot is disposed.

## What is the current behavior?
LayoutManager isn't disposed when EmbeddableControlRoot is no longer needed. This causes an issue on platforms where the root platform view can be recreated at any time, thus creating a new avalonia toplevel, like on Android. Because the old layout is never removed from the MediaContext, it attempts to layout controls on the next layout pass, when a new toplevel and layoutmanager is already created. This throws the following exception;
`System.ArgumentException: 'Attempt to call InvalidateArrange on wrong LayoutManager.'`


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #14083
