### PR TITLE
Fix flaky test `VisualExtensions_GetVisualsAt.Should_Find_Control`

### DIFF
--- a/tests/Avalonia.Base.UnitTests/VisualTests.cs
+++ b/tests/Avalonia.Base.UnitTests/VisualTests.cs
@@ -365,6 +365,7 @@ namespace Avalonia.Base.UnitTests
         public void IsEffectivelyVisible_Propagates_To_Visual_Children(int[] assignOrder, bool rootV, bool child1V,
             bool child2V, bool rootExpected, bool child1Expected, bool child2Expected, bool initialSetToFalse = false)
         {
+            using var app = UnitTestApplication.Start();
             var child2 = new Decorator();
             var child1 = new Decorator { Child = child2 };
             var root = new TestRoot { Child = child1 };
@@ -402,6 +403,7 @@ namespace Avalonia.Base.UnitTests
         [Fact]
         public void Added_Child_Has_Correct_IsEffectivelyVisible()
         {
+            using var app = UnitTestApplication.Start();
             var root = new TestRoot { IsVisible = false };
             var child = new Decorator();
 
@@ -412,6 +414,7 @@ namespace Avalonia.Base.UnitTests
         [Fact]
         public void Added_Grandchild_Has_Correct_IsEffectivelyVisible()
         {
+            using var app = UnitTestApplication.Start();
             var child = new Decorator();
             var grandchild = new Decorator();
             var root = new TestRoot 
@@ -427,6 +430,7 @@ namespace Avalonia.Base.UnitTests
         [Fact]
         public void Removing_Child_Resets_IsEffectivelyVisible()
         {
+            using var app = UnitTestApplication.Start();
             var child = new Decorator();
             var root = new TestRoot { Child = child, IsVisible = false };
 
@@ -440,6 +444,7 @@ namespace Avalonia.Base.UnitTests
         [Fact]
         public void Removing_Child_Resets_IsEffectivelyVisible_Of_Grandchild()
         {
+            using var app = UnitTestApplication.Start();
             var grandchild = new Decorator();
             var child = new Decorator { Child = grandchild };
             var root = new TestRoot { Child = child, IsVisible = false };


### PR DESCRIPTION
## What does the pull request do?

Finally tracked down the source of the flaky test that was introduced by #13972. The tests in this PR implicitly create a new `MediaContext` via the following stacktrack:

```
Avalonia.Media.MediaContext..ctor(Dispatcher dispatcher) in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Base\Media\MediaContext.cs:line 44
   at Avalonia.Media.MediaContext.get_Instance() in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Base\Media\MediaContext.cs:line 68
   at Avalonia.Layout.LayoutManager.QueueLayoutPass() in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Base\Layout\LayoutManager.cs:line 356
   at Avalonia.Layout.LayoutManager.InvalidateMeasure(Layoutable control) in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Base\Layout\LayoutManager.cs:line 73
   at Avalonia.Layout.Layoutable.AncestorBecameVisible(ILayoutManager layoutManager) in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Base\Layout\Layoutable.cs:line 837
   at Avalonia.Layout.Layoutable.OnPropertyChanged(AvaloniaPropertyChangedEventArgs change) in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Base\Layout\Layoutable.cs:line 803
   at Avalonia.Input.InputElement.OnPropertyChanged(AvaloniaPropertyChangedEventArgs change) in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Base\Input\InputElement.cs:line 661
   at Avalonia.Controls.Control.OnPropertyChanged(AvaloniaPropertyChangedEventArgs change) in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Controls\Control.cs:line 533
   at Avalonia.AvaloniaObject.OnPropertyChangedCore(AvaloniaPropertyChangedEventArgs change) in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Base\AvaloniaObject.cs:line 649
   at Avalonia.Animation.Animatable.OnPropertyChangedCore(AvaloniaPropertyChangedEventArgs change) in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Base\Animation\Animatable.cs:line 191
   at Avalonia.AvaloniaObject.RaisePropertyChanged[T](AvaloniaProperty`1 property, Optional`1 oldValue, BindingValue`1 newValue, BindingPriority priority, Boolean isEffectiveValue) in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Base\AvaloniaObject.cs:line 700
   at Avalonia.PropertyStore.EffectiveValue`1.SetAndRaiseCore(ValueStore owner, StyledProperty`1 property, T value, BindingPriority priority, Boolean isOverriddenCurrentValue, Boolean isCoercedDefaultValue) in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Base\PropertyStore\EffectiveValue`1.cs:line 235
   at Avalonia.PropertyStore.EffectiveValue`1.SetLocalValueAndRaise(ValueStore owner, StyledProperty`1 property, T value) in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Base\PropertyStore\EffectiveValue`1.cs:line 74
   at Avalonia.PropertyStore.ValueStore.SetLocalValue[T](StyledProperty`1 property, T value) in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Base\PropertyStore\ValueStore.cs:line 220
   at Avalonia.PropertyStore.ValueStore.SetValue[T](StyledProperty`1 property, T value, BindingPriority priority) in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Base\PropertyStore\ValueStore.cs:line 196
   at Avalonia.AvaloniaObject.SetValue[T](StyledProperty`1 property, T value, BindingPriority priority) in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Base\AvaloniaObject.cs:line 336
   at Avalonia.Visual.set_IsVisible(Boolean value) in D:\projects\AvaloniaUI\Avalonia\src\Avalonia.Base\Visual.cs:line 233
```

`MediaContext` stores a `Dispatcher` since #12979 and this registered `MediaContext` can subsequently leak into other unit tests, who may be using a different dispatcher (installed via `Dispatcher.ResetForUnitTests`).

The "correct" way to fix this would be to make sure all of our tests use some mechanism to make sure none of their registrations leak, but that's a bigger job than I'm willing to take on right now. This should fix the flaky test at least.
