### PR TITLE
Add support for CombinedGeometry and GeometryGroup in Headless renderer

### DIFF
--- a/src/Headless/Avalonia.Headless/HeadlessPlatformRenderInterface.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessPlatformRenderInterface.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Avalonia.Media;
 using Avalonia.Platform;
@@ -48,8 +49,14 @@ namespace Avalonia.Headless
         }
 
         public IStreamGeometryImpl CreateStreamGeometry() => new HeadlessStreamingGeometryStub();
-        public IGeometryImpl CreateGeometryGroup(FillRule fillRule, IReadOnlyList<IGeometryImpl> children) => throw new NotImplementedException();
-        public IGeometryImpl CreateCombinedGeometry(GeometryCombineMode combineMode, IGeometryImpl g1, IGeometryImpl g2) => throw new NotImplementedException();
+
+        public IGeometryImpl CreateGeometryGroup(FillRule fillRule, IReadOnlyList<IGeometryImpl> children) =>
+            new HeadlessGeometryStub(children.Count != 0 ?
+                children.Select(c => c.Bounds).Aggregate((a, b) => a.Union(b)) :
+                default);
+
+        public IGeometryImpl CreateCombinedGeometry(GeometryCombineMode combineMode, IGeometryImpl g1, IGeometryImpl g2) 
+            => new HeadlessGeometryStub(g1.Bounds.Union(g2.Bounds));
 
         public IRenderTarget CreateRenderTarget(IEnumerable<object> surfaces) => new HeadlessRenderTarget();
         public bool IsLost => false;

--- a/tests/Avalonia.Headless.UnitTests/RenderingTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/RenderingTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Threading;
@@ -25,6 +26,73 @@ public class RenderingTests
                 Content = new PathIcon
                 {
                     Data = StreamGeometry.Parse("M0,9 L10,0 20,9 19,10 10,2 1,10 z")
+                }
+            },
+            SizeToContent = SizeToContent.WidthAndHeight
+        };
+
+        window.Show();
+
+        var frame = window.CaptureRenderedFrame();
+
+        Assert.NotNull(frame);
+    }
+    
+#if NUNIT
+    [AvaloniaTest, Timeout(10000)]
+#elif XUNIT
+    [AvaloniaFact(Timeout = 10000)]
+#endif
+    public void Should_Not_Crash_On_GeometryGroup()
+    {
+        var window = new Window
+        {
+            Content = new ContentControl
+            {
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment = VerticalAlignment.Stretch,
+                Padding = new Thickness(4),
+                Content = new PathIcon
+                {
+                    Data = new GeometryGroup()
+                    {
+                        Children = new GeometryCollection(new []
+                        {
+                            new RectangleGeometry(new Rect(0, 0, 50, 50)),
+                            new RectangleGeometry(new Rect(50, 50, 100, 100))
+                        })
+                    }
+                }
+            },
+            SizeToContent = SizeToContent.WidthAndHeight
+        };
+
+        window.Show();
+
+        var frame = window.CaptureRenderedFrame();
+
+        Assert.NotNull(frame);
+    }
+    
+#if NUNIT
+    [AvaloniaTest, Timeout(10000)]
+#elif XUNIT
+    [AvaloniaFact(Timeout = 10000)]
+#endif
+    public void Should_Not_Crash_On_CombinedGeometry()
+    {
+        var window = new Window
+        {
+            Content = new ContentControl
+            {
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment = VerticalAlignment.Stretch,
+                Padding = new Thickness(4),
+                Content = new PathIcon
+                {
+                    Data = new CombinedGeometry(GeometryCombineMode.Union,
+                        new RectangleGeometry(new Rect(0, 0, 50, 50)),
+                        new RectangleGeometry(new Rect(50, 50, 100, 100)))
                 }
             },
             SizeToContent = SizeToContent.WidthAndHeight


### PR DESCRIPTION
## What does the pull request do?
Add support to Headless renderer to work with combined and geometry groups.

## What is the current behavior?
Throws a not supported exception.

## What is the updated/expected behavior with this PR?
Should no longer throw.

## Checklist

- [x ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
Fixes #14356
