### PR TITLE
[MacOS] Fix NRE in Window.SetParent

### DIFF
--- a/src/Avalonia.Native/WindowImpl.cs
+++ b/src/Avalonia.Native/WindowImpl.cs
@@ -215,7 +215,7 @@ namespace Avalonia.Native
 
         public void SetParent(IWindowImpl parent)
         {
-            _native.SetParent(((WindowImpl)parent).Native);
+            _native.SetParent(((WindowImpl)parent)?.Native);
         }
 
         public void SetEnabled(bool enable)


### PR DESCRIPTION
## What does the pull request do?

Fixes recent regression from https://github.com/AvaloniaUI/Avalonia/pull/14351
Before we never had situation when IWindowImpl.SetParent had a null argument. But now it seems to be expected to be handled by the backend properly, as X11 and Win32 already do.
MacOS native source code seems to handle null values as well, and only glue code wasn't ready for that.
This PR fixes the problem with the glue code.
