### PR TITLE
Use VirtualizedTreeView in Dev Tools to display hierarchy

### DIFF
--- a/src/Avalonia.Diagnostics/Avalonia.Diagnostics.csproj
+++ b/src/Avalonia.Diagnostics/Avalonia.Diagnostics.csproj
@@ -21,4 +21,7 @@
   <Import Project="..\..\build\BuildTargets.targets" />
   <Import Project="..\..\build\NullableEnable.props" />
   <Import Project="..\..\build\DevAnalyzers.props" />
+  <ItemGroup Label="InternalsVisibleTo">
+    <InternalsVisibleTo Include="Avalonia.Diagnostics.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
+  </ItemGroup>
 </Project>

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/FlatTree.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/FlatTree.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using Avalonia.Utilities;
+
+namespace Avalonia.Diagnostics.Controls.VirtualizedTreeView;
+
+internal class FlatTree : IReadOnlyList<FlatTreeNode>,
+    IList<FlatTreeNode>,
+    IList,
+    INotifyCollectionChanged,
+    IWeakEventSubscriber<NotifyCollectionChangedEventArgs>,
+    IWeakEventSubscriber<PropertyChangedEventArgs>
+{
+    private List<FlatTreeNode> _flatTree = new();
+
+    // In order to keep expanded state in sync, we need to keep track of expanded nodes here, not by checking IsExpanded
+    // Why: property changed can be fired even if IsExpanded is not changed
+    // Why: if there is an event bound to IsExpanded changes that changes the children, then this change can be fired before IsExpanded property change
+    // is fired in FlatTree
+    private HashSet<ITreeNode> _expanded = new();
+
+    public FlatTree(IEnumerable<ITreeNode> roots)
+    {
+        foreach (var root in roots)
+        {
+            InsertNode(root, 0, _flatTree.Count);
+        }
+    }
+
+    /// <summary>
+    /// Returns true if the given node is expanded in the flat tree
+    /// (its children have been already added to the tree)
+    /// </summary>
+    /// <param name="node">The node to check whether is expanded</param>
+    /// <returns>True if node is expanded</returns>
+    private bool IsExpanded(ITreeNode node)
+    {
+        return _expanded.Contains(node);
+    }
+
+    private void SubscribeToNode(ITreeNode node)
+    {
+        WeakEvents.CollectionChanged.Subscribe(node, this);
+        WeakEvents.ThreadSafePropertyChanged.Subscribe(node, this);
+    }
+
+    private void UnsubscribeFromNode(ITreeNode node)
+    {
+        _expanded.Remove(node);
+        WeakEvents.CollectionChanged.Unsubscribe(node, this);
+        WeakEvents.ThreadSafePropertyChanged.Unsubscribe(node, this);
+    }
+
+    /// <summary>
+    /// Inserts an ITreeNode at the given level (indent) and index along with all expanded children.
+    /// Then binds to the PropertyChanged and CollectionChanged events of the node to observer changes.
+    /// </summary>
+    /// <param name="node">Node to insert</param>
+    /// <param name="level">Indent level for the given node</param>
+    /// <param name="startIndex">Index to insert the node at</param>
+    /// <returns>Number of inserted elements to the list</returns>
+    private int InsertNode(ITreeNode node, int level, int startIndex)
+    {
+        int index = startIndex;
+        var flatChild = new FlatTreeNode(node, level);
+        _flatTree.Insert(index++, flatChild);
+
+        SubscribeToNode(node);
+
+        if (node.IsExpanded)
+        {
+            _expanded.Add(node);
+            index += InsertChildren(flatChild, index);
+        }
+
+        return index - startIndex;
+    }
+
+    /// <summary>
+    /// Inserts children of the node and all expanded children recursively starting at the given index
+    /// </summary>
+    /// <param name="parent">Parent node</param>
+    /// <param name="startIndex">Index to insert the children at</param>
+    /// <returns>Number of added nodes</returns>
+    private int InsertChildren(FlatTreeNode parent, int startIndex)
+    {
+        int index = startIndex;
+        foreach (var child in parent.Node.Children)
+        {
+            index += InsertNode(child, parent.Level + 1, index);
+        }
+
+        return index - startIndex;
+    }
+
+    /// <summary>
+    /// Counts all expanded children of the given node recursively
+    /// </summary>
+    /// <param name="parent">Parent node</param>
+    /// <param name="limit">If non null, counts only first `limit` children</param>
+    /// <returns>Number of expanded children</returns>
+    private int CountExpandedChildren(ITreeNode parent, int? limit = null)
+    {
+        int count = 0;
+        var end = limit ?? parent.Children.Count;
+        for (var index = 0; index < end; index++)
+        {
+            var child = parent.Children[index];
+            count++;
+            if (IsExpanded(child))
+                count += CountExpandedChildren(child);
+        }
+
+        return count;
+    }
+
+    private int IndexOfNode(ITreeNode node)
+    {
+        for (int i = 0; i < _flatTree.Count; i++)
+            if (ReferenceEquals(_flatTree[i].Node, node))
+                return i;
+        return -1;
+    }
+
+    public void OnEvent(object? sender, WeakEvent ev, PropertyChangedEventArgs e)
+    {
+        NodeOnPropertyChanged(sender, e);
+    }
+
+    private void NodeOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (sender == null)
+            return;
+
+        var node = (ITreeNode)sender;
+
+        if (e.PropertyName != nameof(node.IsExpanded))
+        {
+            return;
+        }
+
+        var nodeIndex = IndexOfNode(node);
+        var flatNode = _flatTree[nodeIndex];
+        if (node.IsExpanded)
+        {
+            if (!_expanded.Add(node))
+                return;
+
+            var insertedItemsCount = InsertChildren(flatNode, nodeIndex + 1);
+            var newItems = _flatTree.GetRange(nodeIndex + 1, insertedItemsCount);
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, newItems, nodeIndex + 1));
+        }
+        else
+        {
+            if (!_expanded.Remove(node))
+                return;
+
+            var removedItemsCount = CountExpandedChildren(node);
+            var removedItems = _flatTree.GetRange(nodeIndex + 1, removedItemsCount);
+            foreach (var item in removedItems)
+            {
+                UnsubscribeFromNode(item.Node);
+            }
+
+            _flatTree.RemoveRange(nodeIndex + 1, removedItemsCount);
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, removedItems, nodeIndex + 1));
+        }
+    }
+
+    public void OnEvent(object? sender, WeakEvent ev, NotifyCollectionChangedEventArgs e)
+    {
+        NodeChildrenChanged(sender, e);
+    }
+
+    private void NodeChildrenChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (sender == null)
+            return;
+
+        var parent = (ITreeNode)sender;
+        var indexOfParent = IndexOfNode(parent);
+        var flatParent = _flatTree[indexOfParent];
+
+        if (!IsExpanded(parent))
+            return;
+
+        if (e.Action == NotifyCollectionChangedAction.Add)
+        {
+            var startIndex = indexOfParent + 1 + CountExpandedChildren(parent, e.NewStartingIndex);
+            var index = startIndex;
+            for (int i = 0; i < e.NewItems!.Count; i++)
+            {
+                index += InsertNode(flatParent.Node.Children[e.NewStartingIndex + i], flatParent.Level + 1, index);
+            }
+            var count = index - startIndex;
+            var newItems = _flatTree.GetRange(startIndex, count);
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, newItems, startIndex));
+        }
+        else if (e.Action == NotifyCollectionChangedAction.Remove)
+        {
+            var startIndex = indexOfParent + 1 + CountExpandedChildren(parent, e.OldStartingIndex);
+            var count = 0;
+            for (int i = 0; i < e.OldItems!.Count; i++)
+            {
+                if (IsExpanded(_flatTree[startIndex + count].Node))
+                    count += CountExpandedChildren(_flatTree[startIndex + count].Node);
+                count++;
+            }
+            var removedItems = _flatTree.GetRange(startIndex, count);
+            foreach (var item in removedItems)
+            {
+                UnsubscribeFromNode(item.Node);
+            }
+            _flatTree.RemoveRange(startIndex, count);
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, removedItems, startIndex));
+        }
+        else
+            throw new NotImplementedException();
+    }
+
+    public IEnumerator<FlatTreeNode> GetEnumerator() => _flatTree.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public void Add(FlatTreeNode item) => throw new InvalidOperationException();
+
+    public int Add(object? value) => throw new InvalidOperationException();
+
+    public void Clear() => throw new InvalidOperationException();
+
+    public bool Contains(object? value) => _flatTree.Contains(value);
+
+    public int IndexOf(object? value) => value is FlatTreeNode node ? _flatTree.IndexOf(node) : -1;
+
+    public void Insert(int index, object? value) => throw new InvalidOperationException();
+
+    public void Remove(object? value) => throw new InvalidOperationException();
+
+    public bool Contains(FlatTreeNode item) => _flatTree.Contains(item);
+
+    public void CopyTo(FlatTreeNode[] array, int arrayIndex) => _flatTree.CopyTo(array, arrayIndex);
+
+    public bool Remove(FlatTreeNode item) => throw new InvalidOperationException();
+
+    public void CopyTo(Array array, int index) => _flatTree.CopyTo((FlatTreeNode[])array, index);
+
+    public int Count => _flatTree.Count;
+
+    public bool IsSynchronized => false;
+
+    public object SyncRoot => this;
+
+    public bool IsReadOnly => true;
+
+    object? IList.this[int index]
+    {
+        get => this[index];
+        set => throw new InvalidOperationException();
+    }
+
+    public int IndexOf(FlatTreeNode item) => _flatTree.IndexOf(item);
+
+    public void Insert(int index, FlatTreeNode item) => throw new InvalidOperationException();
+
+    public void RemoveAt(int index) => throw new InvalidOperationException();
+
+    public bool IsFixedSize => false;
+
+    public FlatTreeNode this[int index]
+    {
+        get => _flatTree[index];
+        set => throw new InvalidOperationException();
+    }
+
+    public event NotifyCollectionChangedEventHandler? CollectionChanged;
+}

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/FlatTreeNode.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/FlatTreeNode.cs
@@ -1,0 +1,13 @@
+namespace Avalonia.Diagnostics.Controls.VirtualizedTreeView;
+
+internal class FlatTreeNode
+{
+    public ITreeNode Node { get; }
+    public int Level { get; }
+    
+    public FlatTreeNode(ITreeNode node, int level)
+    {
+        Node = node;
+        Level = level;
+    }
+}

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/ITreeNode.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/ITreeNode.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+namespace Avalonia.Diagnostics.Controls.VirtualizedTreeView;
+
+internal interface ITreeNode : INotifyPropertyChanged, INotifyCollectionChanged
+{
+    bool IsExpanded { get; set; }
+    bool HasChildren { get; }
+    IReadOnlyList<ITreeNode> Children { get; }
+}

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeListBox.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeListBox.cs
@@ -1,0 +1,14 @@
+using System;
+using Avalonia.Controls;
+
+namespace Avalonia.Diagnostics.Controls.VirtualizedTreeView;
+
+internal sealed class VirtualizedTreeListBox : ListBox
+{
+    protected override Type StyleKeyOverride => typeof(ListBox);
+
+    protected internal override Control CreateContainerForItemOverride(object? item, int index, object? recycleKey)
+    {
+        return new VirtualizedTreeViewItem();
+    }
+}

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeListBox.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeListBox.cs
@@ -11,4 +11,9 @@ internal sealed class VirtualizedTreeListBox : ListBox
     {
         return new VirtualizedTreeViewItem();
     }
+
+    protected internal override bool NeedsContainerOverride(object? item, int index, out object? recycleKey)
+    {
+        return NeedsContainer<VirtualizedTreeViewItem>(item, out recycleKey);
+    }
 }

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeView.axaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeView.axaml
@@ -12,8 +12,8 @@
                                            SelectedValue="{TemplateBinding SelectedItem, Mode=TwoWay}">
             <treeView:VirtualizedTreeListBox.ItemTemplate>
               <DataTemplate x:DataType="treeView:FlatTreeNode">
-                <ContentPresenter Content="{CompiledBinding Node}"
-                                  ContentTemplate="{Binding $parent[treeView:VirtualizedTreeView].ItemTemplate}" />
+                <ContentControl Content="{CompiledBinding Node}"
+                                ContentTemplate="{Binding $parent[treeView:VirtualizedTreeView].ItemTemplate}" />
               </DataTemplate>
             </treeView:VirtualizedTreeListBox.ItemTemplate>
           </treeView:VirtualizedTreeListBox>

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeView.axaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeView.axaml
@@ -1,0 +1,30 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:treeView="clr-namespace:Avalonia.Diagnostics.Controls.VirtualizedTreeView"
+        x:ClassModifier="internal">
+  <Styles.Resources>
+    <ControlTheme x:Key="{x:Type treeView:VirtualizedTreeView}"
+                  TargetType="treeView:VirtualizedTreeView">
+      <Setter Property="Template">
+        <ControlTemplate>
+          <treeView:VirtualizedTreeListBox ItemsSource="{TemplateBinding Source}"
+                                           SelectedValueBinding="{ReflectionBinding Node}"
+                                           SelectedValue="{TemplateBinding SelectedItem, Mode=TwoWay}">
+            <treeView:VirtualizedTreeListBox.ItemTemplate>
+              <DataTemplate x:DataType="treeView:FlatTreeNode">
+                <ContentPresenter Content="{CompiledBinding Node}"
+                                  ContentTemplate="{Binding $parent[treeView:VirtualizedTreeView].ItemTemplate}" />
+              </DataTemplate>
+            </treeView:VirtualizedTreeListBox.ItemTemplate>
+          </treeView:VirtualizedTreeListBox>
+        </ControlTemplate>
+      </Setter>
+    </ControlTheme>
+  </Styles.Resources>
+
+  <Style Selector="treeView|VirtualizedTreeView treeView|VirtualizedTreeViewItem">
+    <Setter Property="IsExpanded" Value="{CompiledBinding Node.IsExpanded}" x:DataType="treeView:FlatTreeNode" />
+    <Setter Property="HasChildren" Value="{CompiledBinding Node.HasChildren}" x:DataType="treeView:FlatTreeNode" />
+    <Setter Property="IndentLevel" Value="{CompiledBinding Level}" x:DataType="treeView:FlatTreeNode" />
+  </Style>
+</Styles>

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeView.axaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeView.axaml
@@ -1,30 +1,31 @@
-<Styles xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:treeView="clr-namespace:Avalonia.Diagnostics.Controls.VirtualizedTreeView"
-        x:ClassModifier="internal">
-  <Styles.Resources>
-    <ControlTheme x:Key="{x:Type treeView:VirtualizedTreeView}"
-                  TargetType="treeView:VirtualizedTreeView">
-      <Setter Property="Template">
-        <ControlTemplate>
-          <treeView:VirtualizedTreeListBox ItemsSource="{TemplateBinding Source}"
-                                           SelectedValueBinding="{ReflectionBinding Node}"
-                                           SelectedValue="{TemplateBinding SelectedItem, Mode=TwoWay}">
-            <treeView:VirtualizedTreeListBox.ItemTemplate>
-              <DataTemplate x:DataType="treeView:FlatTreeNode">
-                <ContentControl Content="{CompiledBinding Node}"
-                                ContentTemplate="{Binding $parent[treeView:VirtualizedTreeView].ItemTemplate}" />
-              </DataTemplate>
-            </treeView:VirtualizedTreeListBox.ItemTemplate>
-          </treeView:VirtualizedTreeListBox>
-        </ControlTemplate>
-      </Setter>
-    </ControlTheme>
-  </Styles.Resources>
-
-  <Style Selector="treeView|VirtualizedTreeView treeView|VirtualizedTreeViewItem">
-    <Setter Property="IsExpanded" Value="{CompiledBinding Node.IsExpanded}" x:DataType="treeView:FlatTreeNode" />
-    <Setter Property="HasChildren" Value="{CompiledBinding Node.HasChildren}" x:DataType="treeView:FlatTreeNode" />
-    <Setter Property="IndentLevel" Value="{CompiledBinding Level}" x:DataType="treeView:FlatTreeNode" />
-  </Style>
-</Styles>
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:treeView="clr-namespace:Avalonia.Diagnostics.Controls.VirtualizedTreeView"
+                    x:ClassModifier="internal">
+  <ControlTheme x:Key="{x:Type treeView:VirtualizedTreeView}"
+                TargetType="treeView:VirtualizedTreeView">
+    <Setter Property="Template">
+      <ControlTemplate>
+        <treeView:VirtualizedTreeListBox ItemsSource="{TemplateBinding Source}"
+                                         SelectedValueBinding="{ReflectionBinding Node}"
+                                         SelectedValue="{TemplateBinding SelectedItem, Mode=TwoWay}"
+                                         ItemContainerTheme="{TemplateBinding ItemContainerTheme}">
+          <treeView:VirtualizedTreeListBox.ItemTemplate>
+            <DataTemplate x:DataType="treeView:FlatTreeNode">
+              <ContentControl Content="{CompiledBinding Node}"
+                              ContentTemplate="{Binding $parent[treeView:VirtualizedTreeView].ItemTemplate}" />
+            </DataTemplate>
+          </treeView:VirtualizedTreeListBox.ItemTemplate>
+        </treeView:VirtualizedTreeListBox>
+      </ControlTemplate>
+    </Setter>
+    <Setter Property="ItemContainerTheme">
+      <ControlTheme BasedOn="{StaticResource {x:Type treeView:VirtualizedTreeViewItem}}"
+                    TargetType="treeView:VirtualizedTreeViewItem">
+        <Setter Property="IsExpanded" Value="{CompiledBinding Node.IsExpanded}" x:DataType="treeView:FlatTreeNode" />
+        <Setter Property="HasChildren" Value="{CompiledBinding Node.HasChildren}" x:DataType="treeView:FlatTreeNode" />
+        <Setter Property="IndentLevel" Value="{CompiledBinding Level}" x:DataType="treeView:FlatTreeNode" />
+      </ControlTheme>
+    </Setter>
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeView.axaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeView.axaml.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Styling;
 
 namespace Avalonia.Diagnostics.Controls.VirtualizedTreeView;
 
@@ -11,8 +12,8 @@ internal class VirtualizedTreeView : TemplatedControl
 {
     private FlatTree _source = new(Array.Empty<ITreeNode>());
 
-    public static readonly DirectProperty<VirtualizedTreeView, FlatTree> SourceProperty = 
-        AvaloniaProperty.RegisterDirect<VirtualizedTreeView, FlatTree>(nameof(Source), 
+    public static readonly DirectProperty<VirtualizedTreeView, FlatTree> SourceProperty =
+        AvaloniaProperty.RegisterDirect<VirtualizedTreeView, FlatTree>(nameof(Source),
             o => o.Source);
 
     /// <summary>
@@ -34,12 +35,18 @@ internal class VirtualizedTreeView : TemplatedControl
         AvaloniaProperty.Register<VirtualizedTreeView, object?>(nameof(SelectedItem),
             defaultBindingMode: BindingMode.TwoWay);
 
+    /// <summary>
+    /// Defines the <see cref="ItemContainerTheme"/> property.
+    /// </summary>
+    public static readonly StyledProperty<ControlTheme?> ItemContainerThemeProperty =
+        AvaloniaProperty.Register<VirtualizedTreeView, ControlTheme?>(nameof(ItemContainerTheme));
+
     public IEnumerable? ItemsSource
     {
         get => GetValue(ItemsSourceProperty);
         set => SetValue(ItemsSourceProperty, value);
     }
-    
+
     public IDataTemplate? ItemTemplate
     {
         get => GetValue(ItemTemplateProperty);
@@ -50,6 +57,12 @@ internal class VirtualizedTreeView : TemplatedControl
     {
         get => GetValue(SelectedItemProperty);
         set => SetValue(SelectedItemProperty, value);
+    }
+
+    public ControlTheme? ItemContainerTheme
+    {
+        get => GetValue(ItemContainerThemeProperty);
+        set => SetValue(ItemContainerThemeProperty, value);
     }
 
     public FlatTree Source

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeView.axaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeView.axaml.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+
+namespace Avalonia.Diagnostics.Controls.VirtualizedTreeView;
+
+internal class VirtualizedTreeView : TemplatedControl
+{
+    private FlatTree _source = new(Array.Empty<ITreeNode>());
+
+    public static readonly DirectProperty<VirtualizedTreeView, FlatTree> SourceProperty = 
+        AvaloniaProperty.RegisterDirect<VirtualizedTreeView, FlatTree>(nameof(Source), 
+            o => o.Source);
+
+    /// <summary>
+    /// Defines the <see cref="ItemsSource"/> property.
+    /// </summary>
+    public static readonly StyledProperty<IEnumerable?> ItemsSourceProperty =
+        AvaloniaProperty.Register<VirtualizedTreeView, IEnumerable?>(nameof(ItemsSource));
+
+    /// <summary>
+    /// Defines the <see cref="ItemTemplate"/> property.
+    /// </summary>
+    public static readonly StyledProperty<IDataTemplate?> ItemTemplateProperty =
+        AvaloniaProperty.Register<VirtualizedTreeView, IDataTemplate?>(nameof(ItemTemplate));
+
+    /// <summary>
+    /// Defines the <see cref="SelectedItem"/> property.
+    /// </summary>
+    public static readonly StyledProperty<object?> SelectedItemProperty =
+        AvaloniaProperty.Register<VirtualizedTreeView, object?>(nameof(SelectedItem),
+            defaultBindingMode: BindingMode.TwoWay);
+
+    public IEnumerable? ItemsSource
+    {
+        get => GetValue(ItemsSourceProperty);
+        set => SetValue(ItemsSourceProperty, value);
+    }
+    
+    public IDataTemplate? ItemTemplate
+    {
+        get => GetValue(ItemTemplateProperty);
+        set => SetValue(ItemTemplateProperty, value);
+    }
+
+    public object? SelectedItem
+    {
+        get => GetValue(SelectedItemProperty);
+        set => SetValue(SelectedItemProperty, value);
+    }
+
+    public FlatTree Source
+    {
+        get { return _source; }
+        set { SetAndRaise(SourceProperty, ref _source, value); }
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == ItemsSourceProperty)
+        {
+            var oldSource = Source;
+            FlatTree newSource;
+            if (ItemsSource is IEnumerable<ITreeNode> sourceNodes)
+            {
+                newSource = new FlatTree(sourceNodes);
+            }
+            else
+            {
+                newSource = new FlatTree(Array.Empty<ITreeNode>());
+            }
+            Source = newSource;
+            RaisePropertyChanged(SourceProperty, oldSource, newSource);
+        }
+    }
+}

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeViewItem.axaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeViewItem.axaml
@@ -1,0 +1,68 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:treeView="clr-namespace:Avalonia.Diagnostics.Controls.VirtualizedTreeView"
+                    xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls"
+                    xmlns:converters1="clr-namespace:Avalonia.Diagnostics.Converters"
+                    x:ClassModifier="internal">
+
+  <x:Double x:Key="TreeViewItemIndent">16</x:Double>
+  <converters:MarginMultiplierConverter Indent="{StaticResource TreeViewItemIndent}"
+                                        Left="True"
+                                        x:Key="TreeViewItemLeftMarginConverter" />
+  <converters1:BoolToOpacityConverter x:Key="TreeViewItemOpacityConverter" />
+  <Thickness x:Key="TreeViewItemExpandCollapseChevronMargin">12, 0, 12, 0</Thickness>
+
+  <ControlTheme x:Key="{x:Type treeView:VirtualizedTreeViewItem}"
+                TargetType="treeView:VirtualizedTreeViewItem">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="Padding" Value="2 1" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Name="PART_Border"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}">
+          <DockPanel Margin="{TemplateBinding IndentLevel, Converter={StaticResource TreeViewItemLeftMarginConverter}}"
+                     Name="PART_ChevronWithContentPresenter">
+            <ToggleButton Name="PART_ExpandCollapseChevron"
+                          Focusable="False"
+                          IsChecked="{TemplateBinding IsExpanded, Mode=TwoWay}"
+                          Theme="{DynamicResource SimpleTreeViewItemToggleButtonTheme}"
+                          Margin="{StaticResource TreeViewItemExpandCollapseChevronMargin}"
+                          Opacity="{TemplateBinding HasChildren, Converter={StaticResource TreeViewItemOpacityConverter}}"
+                          IsHitTestVisible="{TemplateBinding HasChildren}"/>
+            <ContentPresenter Name="PART_ContentPresenter"
+                              Padding="{TemplateBinding Padding}"
+                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                              Content="{TemplateBinding Content}"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"/>
+          </DockPanel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+
+    <Style Selector="^:pointerover /template/ Border#PART_Border">
+      <Setter Property="Background" Value="{DynamicResource ThemeControlHighlightMidBrush}" />
+    </Style>
+
+    <Style Selector="^:selected /template/ Border#PART_Border">
+      <Setter Property="Background" Value="{DynamicResource ThemeAccentBrush4}" />
+    </Style>
+
+    <Style Selector="^:selected:focus /template/ Border#PART_Border">
+      <Setter Property="Background" Value="{DynamicResource ThemeAccentBrush3}" />
+    </Style>
+
+    <Style Selector="^:selected:pointerover /template/ Border#PART_Border">
+      <Setter Property="Background" Value="{DynamicResource ThemeAccentBrush3}" />
+    </Style>
+
+    <Style Selector="^:selected:focus:pointerover /template/ Border#PART_Border">
+      <Setter Property="Background" Value="{DynamicResource ThemeAccentBrush2}" />
+    </Style>
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeViewItem.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeViewItem.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Threading;
+
+namespace Avalonia.Diagnostics.Controls.VirtualizedTreeView;
+
+internal sealed class VirtualizedTreeViewItem : ListBoxItem
+{
+    /// <summary>
+    /// Defines the <see cref="IsExpanded"/> property.
+    /// </summary>
+    public static readonly StyledProperty<bool> IsExpandedProperty =
+        AvaloniaProperty.Register<VirtualizedTreeViewItem, bool>(
+            nameof(IsExpanded),
+            defaultBindingMode: BindingMode.TwoWay);
+
+    /// <summary>
+    /// Defines the <see cref="IndentLevel"/> property.
+    /// </summary>
+    public static readonly StyledProperty<int> IndentLevelProperty =
+        AvaloniaProperty.Register<VirtualizedTreeViewItem, int>(
+            nameof(IndentLevel));
+
+    /// <summary>
+    /// Defines the <see cref="HasChildren"/> property.
+    /// </summary>
+    public static readonly StyledProperty<bool> HasChildrenProperty =
+        AvaloniaProperty.Register<VirtualizedTreeViewItem, bool>(
+            nameof(HasChildren));
+
+    private Control? _presenter;
+    private Control? _chevronWithContentPresenter;
+
+    static VirtualizedTreeViewItem()
+    {
+        RequestBringIntoViewEvent.AddClassHandler<VirtualizedTreeViewItem>((x, e) => x.OnRequestBringIntoView(e));
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the item is expanded to show its children.
+    /// </summary>
+    public bool IsExpanded
+    {
+        get => GetValue(IsExpandedProperty);
+        set => SetValue(IsExpandedProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the indent level of the item.
+    /// </summary>
+    public int IndentLevel
+    {
+        get => GetValue(IndentLevelProperty);
+        set => SetValue(IndentLevelProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the item has children.
+    /// </summary>
+    public bool HasChildren
+    {
+        get => GetValue(HasChildrenProperty);
+        set => SetValue(HasChildrenProperty, value);
+    }
+
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        if (_presenter is InputElement previousInputMethod)
+        {
+            previousInputMethod.DoubleTapped -= HeaderDoubleTapped;
+        }
+
+        _chevronWithContentPresenter = e.NameScope.Find<Control>("PART_ChevronWithContentPresenter");
+        _presenter = e.NameScope.Find<Control>("PART_ContentPresenter");
+
+        if (_presenter is InputElement im)
+        {
+            im.DoubleTapped += HeaderDoubleTapped;
+        }
+    }
+
+    private void OnRequestBringIntoView(RequestBringIntoViewEventArgs e)
+    {
+        if (e.TargetObject == this)
+        {
+            if (_chevronWithContentPresenter != null)
+            {
+                var m = _chevronWithContentPresenter.TransformToVisual(this);
+
+                if (m.HasValue)
+                {
+                    var bounds = new Rect(_chevronWithContentPresenter.Bounds.Size);
+                    var rect = bounds.TransformToAABB(m.Value);
+                    e.TargetRect = rect;
+                }
+            }
+        }
+    }
+
+    private void HeaderDoubleTapped(object? sender, TappedEventArgs e)
+    {
+        OnHeaderDoubleTapped(e);
+    }
+
+    private void OnHeaderDoubleTapped(TappedEventArgs e)
+    {
+        if (HasChildren)
+        {
+            SetCurrentValue(IsExpandedProperty, !IsExpanded);
+            e.Handled = true;
+        }
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (!e.Handled)
+        {
+            var handler =
+                e.Key switch
+                {
+                    Key.Left => ApplyToItemOrRecursivelyIfCtrl(FocusAwareCollapseItem, e.KeyModifiers),
+                    Key.Right => ApplyToItemOrRecursivelyIfCtrl(ExpandItem, e.KeyModifiers),
+                    Key.Enter => ApplyToItemOrRecursivelyIfCtrl(IsExpanded ? CollapseItem : ExpandItem, e.KeyModifiers),
+
+                    // do not handle CTRL with numpad keys
+                    Key.Subtract => FocusAwareCollapseItem,
+                    Key.Add => ExpandItem,
+                    Key.Divide => ApplyToSubtree(CollapseItem),
+                    Key.Multiply => ApplyToSubtree(ExpandItem),
+                    _ => null,
+                };
+
+            if (handler is not null)
+            {
+                e.Handled = handler(this);
+            }
+
+            // NOTE: these local functions do not use the TreeView.Expand/CollapseSubtree
+            // function because we want to know if any items were in fact expanded to set the
+            // event handled status. Also the handling here avoids a potential infinite recursion/stack overflow.
+            static Func<VirtualizedTreeViewItem, bool> ApplyToSubtree(Func<VirtualizedTreeViewItem, bool> f)
+            {
+                // Calling toList enumerates all items before applying functions. This avoids a
+                // potential infinite loop if there is an infinite tree (the control catalog is
+                // lazily infinite). But also means a lazily loaded tree will not be expanded completely.
+                return t => SubTree(t)
+                    .ToList()
+                    .Select(VirtualizedTreeViewItem => f(VirtualizedTreeViewItem))
+                    .Aggregate(false, (p, c) => p || c);
+            }
+
+            static Func<VirtualizedTreeViewItem, bool> ApplyToItemOrRecursivelyIfCtrl(Func<VirtualizedTreeViewItem,bool> f, KeyModifiers keyModifiers)
+            {
+                if (keyModifiers.HasAllFlags(KeyModifiers.Control))
+                {
+                    return ApplyToSubtree(f);
+                }
+
+                return f;
+            }
+
+            static bool ExpandItem(VirtualizedTreeViewItem VirtualizedTreeViewItem)
+            {
+                if (VirtualizedTreeViewItem.HasChildren && !VirtualizedTreeViewItem.IsExpanded)
+                {
+                    VirtualizedTreeViewItem.SetCurrentValue(IsExpandedProperty, true);
+                    return true;
+                }
+
+                return false;
+            }
+
+            static bool CollapseItem(VirtualizedTreeViewItem VirtualizedTreeViewItem)
+            {
+                if (VirtualizedTreeViewItem.HasChildren && VirtualizedTreeViewItem.IsExpanded)
+                {
+                    VirtualizedTreeViewItem.SetCurrentValue(IsExpandedProperty, false);
+                    return true;
+                }
+
+                return false;
+            }
+
+            static bool FocusAwareCollapseItem(VirtualizedTreeViewItem VirtualizedTreeViewItem)
+            {
+                if (VirtualizedTreeViewItem.HasChildren && VirtualizedTreeViewItem.IsExpanded)
+                {
+                    if (VirtualizedTreeViewItem.IsFocused)
+                    {
+                        VirtualizedTreeViewItem.SetCurrentValue(IsExpandedProperty, false);
+                    }
+                    else
+                    {
+                        VirtualizedTreeViewItem.Focus(NavigationMethod.Directional);
+                    }
+
+                    return true;
+                }
+
+                return false;
+            }
+
+            static IEnumerable<VirtualizedTreeViewItem> SubTree(VirtualizedTreeViewItem VirtualizedTreeViewItem)
+            {
+                return new[] { VirtualizedTreeViewItem }.Concat(VirtualizedTreeViewItem.LogicalChildren.OfType<VirtualizedTreeViewItem>().SelectMany(child => SubTree(child)));
+            }
+        }
+    }
+}

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/LogicalTreeNode.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/LogicalTreeNode.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Specialized;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.LogicalTree;
@@ -8,7 +9,7 @@ using Avalonia.Reactive;
 
 namespace Avalonia.Diagnostics.ViewModels
 {
-    internal class LogicalTreeNode : TreeNode
+    internal sealed class LogicalTreeNode : TreeNode
     {
         public LogicalTreeNode(AvaloniaObject avaloniaObject, TreeNode? parent)
             : base(avaloniaObject, parent)
@@ -19,9 +20,17 @@ namespace Avalonia.Diagnostics.ViewModels
                 Controls.TopLevelGroup host => new TopLevelGroupHostLogical(this, host),
                 _ => TreeNodeCollection.Empty
             };
+
+            Children.CollectionChanged += (_, e) =>
+            {
+                CollectionChanged?.Invoke(this, e);
+                RaisePropertyChanged(nameof(HasChildren));
+            };
         }
 
         public override TreeNodeCollection Children { get; }
+        
+        public override event NotifyCollectionChangedEventHandler? CollectionChanged;
 
         public static LogicalTreeNode[] Create(object control)
         {

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/TreeNode.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/TreeNode.cs
@@ -1,15 +1,17 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Diagnostics.Controls.VirtualizedTreeView;
 using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Avalonia.Reactive;
 
 namespace Avalonia.Diagnostics.ViewModels
 {
-    internal abstract class TreeNode : ViewModelBase, IDisposable
+    internal abstract class TreeNode : ViewModelBase, ITreeNode, IDisposable
     {
         private readonly IDisposable? _classesSubscription;
         private string _classes;
@@ -49,6 +51,10 @@ namespace Avalonia.Diagnostics.ViewModels
                                Visual is IPopupHost;
 
         public FontWeight FontWeight { get; }
+
+        public bool HasChildren => Children.Count > 0;
+        
+        IReadOnlyList<ITreeNode> ITreeNode.Children => Children;
 
         public abstract TreeNodeCollection Children
         {
@@ -93,5 +99,7 @@ namespace Avalonia.Diagnostics.ViewModels
             _classesSubscription?.Dispose();
             Children.Dispose();
         }
+
+        public abstract event NotifyCollectionChangedEventHandler? CollectionChanged;
     }
 }

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/TreePageViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/TreePageViewModel.cs
@@ -106,8 +106,8 @@ namespace Avalonia.Diagnostics.ViewModels
 
             if (node != null)
             {
-                SelectedNode = node;
                 ExpandNode(node.Parent);
+                SelectedNode = node;
             }
         }
 

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/VisualTreeNode.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/VisualTreeNode.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Specialized;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Diagnostics;
@@ -11,7 +12,7 @@ using System.Linq;
 
 namespace Avalonia.Diagnostics.ViewModels
 {
-    internal class VisualTreeNode : TreeNode
+    internal sealed class VisualTreeNode : TreeNode
     {
         public VisualTreeNode(AvaloniaObject avaloniaObject, TreeNode? parent, string? customName = null)
             : base(avaloniaObject, parent, customName)
@@ -25,11 +26,19 @@ namespace Avalonia.Diagnostics.ViewModels
 
             if (Visual is StyledElement styleable)
                 IsInTemplate = styleable.TemplatedParent != null;
+
+            Children.CollectionChanged += (_, e) =>
+            {
+                CollectionChanged?.Invoke(this, e);
+                RaisePropertyChanged(nameof(HasChildren));
+            };
         }
 
         public bool IsInTemplate { get; }
 
         public override TreeNodeCollection Children { get; }
+        
+        public override event NotifyCollectionChangedEventHandler? CollectionChanged;
 
         public static VisualTreeNode[] Create(object control)
         {

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml
@@ -10,12 +10,21 @@
     <diag:ViewLocator/>
   </Window.DataTemplates>
 
+  <Window.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <MergeResourceInclude Source="avares://Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeViewItem.axaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Window.Resources>
+
   <Window.Styles>
     <SimpleTheme />
     <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Simple.xaml"/>
     <StyleInclude Source="avares://Avalonia.Diagnostics/Diagnostics/Controls/ThicknessEditor.axaml" />
     <StyleInclude Source="avares://Avalonia.Diagnostics/Diagnostics/Controls/FilterTextBox.axaml" />
     <StyleInclude Source="avares://Avalonia.Diagnostics/Diagnostics/Controls/BrushEditor.axaml" />
+    <StyleInclude Source="avares://Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeView.axaml" />
     <StyleInclude Source="avares://Avalonia.Controls.ColorPicker/Themes/Simple/Simple.xaml" />
   </Window.Styles>
   <Window.KeyBindings>

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml
@@ -14,6 +14,7 @@
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <MergeResourceInclude Source="avares://Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeViewItem.axaml" />
+        <MergeResourceInclude Source="avares://Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeView.axaml" />
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
   </Window.Resources>
@@ -24,7 +25,6 @@
     <StyleInclude Source="avares://Avalonia.Diagnostics/Diagnostics/Controls/ThicknessEditor.axaml" />
     <StyleInclude Source="avares://Avalonia.Diagnostics/Diagnostics/Controls/FilterTextBox.axaml" />
     <StyleInclude Source="avares://Avalonia.Diagnostics/Diagnostics/Controls/BrushEditor.axaml" />
-    <StyleInclude Source="avares://Avalonia.Diagnostics/Diagnostics/Controls/VirtualizedTreeView/VirtualizedTreeView.axaml" />
     <StyleInclude Source="avares://Avalonia.Controls.ColorPicker/Themes/Simple/Simple.xaml" />
   </Window.Styles>
   <Window.KeyBindings>

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml
@@ -1,31 +1,25 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:Avalonia.Diagnostics.ViewModels"
+             xmlns:virtualizedTreeView="clr-namespace:Avalonia.Diagnostics.Controls.VirtualizedTreeView"
              x:Class="Avalonia.Diagnostics.Views.TreePageView"
              x:DataType="vm:TreePageViewModel">
   <Grid ColumnDefinitions="0.35*,4,0.65*">
-    <TreeView Name="tree"
+    <virtualizedTreeView:VirtualizedTreeView Name="tree"
               BorderThickness="0"
               ItemsSource="{Binding Nodes}"
               SelectedItem="{Binding SelectedNode, Mode=TwoWay}"
               PointerMoved="UpdateAdorner">
-      <TreeView.DataTemplates>
-        <TreeDataTemplate DataType="vm:TreeNode"
-                          ItemsSource="{Binding Children}">
+      <virtualizedTreeView:VirtualizedTreeView.ItemTemplate>
+        <DataTemplate DataType="vm:TreeNode">
           <StackPanel Orientation="Horizontal" Spacing="8">
             <TextBlock Text="{Binding Type}" FontWeight="{Binding FontWeight}"/>
             <TextBlock Text="{Binding Classes}"/>
             <TextBlock Foreground="Gray" Text="{Binding ElementName}"/>
           </StackPanel>
-        </TreeDataTemplate>
-      </TreeView.DataTemplates>
-      <TreeView.Styles>
-        <Style Selector="TreeViewItem" x:DataType="vm:TreeNode">
-          <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
-          <Setter Property="Background" Value="Transparent" />
-        </Style>
-      </TreeView.Styles>
-      <TreeView.ContextFlyout>
+        </DataTemplate>
+      </virtualizedTreeView:VirtualizedTreeView.ItemTemplate>
+      <virtualizedTreeView:VirtualizedTreeView.ContextFlyout>
         <MenuFlyout>
           <MenuItem Header="Copy">
             <MenuItem Header="Copy individual node selector" Command="{Binding CopySelector}" />
@@ -38,8 +32,8 @@
           <MenuItem Header="Bring into view" Command="{Binding BringIntoView}" />
           <MenuItem Header="Focus" Command="{Binding Focus}" />
         </MenuFlyout>
-      </TreeView.ContextFlyout>
-    </TreeView>
+      </virtualizedTreeView:VirtualizedTreeView.ContextFlyout>
+    </virtualizedTreeView:VirtualizedTreeView>
 
     <GridSplitter Background="{DynamicResource ThemeControlMidBrush}" Width="1" Grid.Column="1"/>
     <ContentControl Content="{Binding Details}" Grid.Column="2"/>

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml.cs
@@ -1,6 +1,8 @@
 using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Selection;
+using Avalonia.Diagnostics.Controls.VirtualizedTreeView;
 using Avalonia.Diagnostics.ViewModels;
 using Avalonia.Input;
 using Avalonia.LogicalTree;
@@ -13,13 +15,13 @@ namespace Avalonia.Diagnostics.Views
     {
         private readonly Panel _adorner;
         private AdornerLayer? _currentLayer;
-        private TreeViewItem? _hovered;
-        private TreeView _tree;
+        private VirtualizedTreeViewItem? _hovered;
+        private VirtualizedTreeView _tree;
 
         public TreePageView()
         {
             InitializeComponent();
-            _tree = this.GetControl<TreeView>("tree");
+            _tree = this.GetControl<VirtualizedTreeView>("tree");
 
             _adorner = new Panel
             {
@@ -44,7 +46,7 @@ namespace Avalonia.Diagnostics.Views
 
         protected void AddAdorner(object? sender, PointerEventArgs e)
         {
-            var node = (TreeNode?)((Control)sender!).DataContext;
+            var node = (TreeNode?)((FlatTreeNode?)((Control)sender!).DataContext)?.Node;
             var vm = (TreePageViewModel?)DataContext;
             if (node is null || vm is null)
             {
@@ -103,7 +105,7 @@ namespace Avalonia.Diagnostics.Views
                 return;
             }
 
-            var item = source.FindLogicalAncestorOfType<TreeViewItem>();
+            var item = source.FindLogicalAncestorOfType<VirtualizedTreeViewItem>();
             if (item == _hovered)
             {
                 return;
@@ -111,7 +113,7 @@ namespace Avalonia.Diagnostics.Views
 
             RemoveAdorner(sender, e);
 
-            if (item is null || item.TreeViewOwner != _tree)
+            if (item is null)
             {
                 _hovered = null;
                 return;

--- a/tests/Avalonia.Diagnostics.UnitTests/Avalonia.Diagnostics.UnitTests.csproj
+++ b/tests/Avalonia.Diagnostics.UnitTests/Avalonia.Diagnostics.UnitTests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <Import Project="..\..\build\UnitTests.NetCore.targets" />
+  <Import Project="..\..\build\UnitTests.NetFX.props" />
+  <Import Project="..\..\build\Moq.props" />
+  <Import Project="..\..\build\XUnit.props" />
+  <Import Project="..\..\build\Base.props" />
+  <Import Project="..\..\build\SharedVersion.props" />
+  <Import Project="..\..\build\HarfBuzzSharp.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Avalonia.Diagnostics\Avalonia.Diagnostics.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/tests/Avalonia.Diagnostics.UnitTests/Diagnostics/Controls/VirtualizedTreeView/FlatTreeTests.cs
+++ b/tests/Avalonia.Diagnostics.UnitTests/Diagnostics/Controls/VirtualizedTreeView/FlatTreeTests.cs
@@ -1,0 +1,355 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using Avalonia.Diagnostics.Controls.VirtualizedTreeView;
+using Xunit;
+
+namespace Avalonia.Diagnostics.UnitTests;
+
+public class FlatTreeTests
+{
+    private class MockTreeNode : ITreeNode
+    {
+        private bool _isExpanded;
+
+        public MockTreeNode(params MockTreeNode[] children)
+        {
+            foreach (var child in children)
+            {
+                ChildrenNodes.Add(child);
+            }
+
+            ChildrenNodes.CollectionChanged += (_, e) =>
+            {
+                CollectionChanged?.Invoke(this, e);
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HasChildren)));
+            };
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        public event NotifyCollectionChangedEventHandler CollectionChanged;
+        public ObservableCollection<MockTreeNode> ChildrenNodes { get; } = new();
+        public IReadOnlyList<ITreeNode> Children => ChildrenNodes;
+        public bool HasChildren => ChildrenNodes.Count > 0;
+        public bool IsExpanded
+        {
+            get => _isExpanded;
+            set
+            {
+                _isExpanded = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsExpanded)));
+            }
+        }
+    }
+
+    [Fact]
+    public void FlatTree_Empty_When_No_Roots_On_Create()
+    {
+        var roots = Array.Empty<MockTreeNode>();
+        var flatTree = new FlatTree(roots);
+
+        AssertFlatTreeEqual(roots, flatTree);
+    }
+
+    [Fact]
+    public void FlatTree_Contains_Only_Roots_When_All_Collapsed_On_Create()
+    {
+        var roots = new MockTreeNode[]
+        {
+            new (new MockTreeNode()),
+            new (new MockTreeNode()),
+            new (new MockTreeNode()),
+            new (new MockTreeNode())
+        };
+        var flatTree = new FlatTree(roots);
+
+        AssertFlatTreeEqual(roots, flatTree);
+    }
+
+    [Fact]
+    public void FlatTree_Contains_All_Nodes_When_All_Expanded_On_Create()
+    {
+        var roots = new MockTreeNode[]
+        {
+            new (new MockTreeNode(new MockTreeNode(), new MockTreeNode())),
+            new (new MockTreeNode()),
+            new (new MockTreeNode(new MockTreeNode())),
+            new (new MockTreeNode())
+        };
+        ExpandAll(roots);
+        var flatTree = new FlatTree(roots);
+
+        AssertFlatTreeEqual(roots, flatTree);
+    }
+
+    [Fact]
+    public void FlatTree_Displays_Children_When_Node_Becomes_Expanded()
+    {
+        var roots = new MockTreeNode[]
+        {
+            new (new MockTreeNode(new MockTreeNode(), new MockTreeNode())),
+        };
+        var flatTree = new FlatTree(roots);
+
+        roots[0].IsExpanded = true;
+
+        AssertFlatTreeEqual(roots, flatTree);
+    }
+
+    [Fact]
+    public void FlatTree_Ignores_Double_Property_Changes()
+    {
+        var roots = new MockTreeNode[]
+        {
+            new (new MockTreeNode(new MockTreeNode(), new MockTreeNode())),
+        };
+        var flatTree = new FlatTree(roots);
+
+        roots[0].IsExpanded = true;
+        roots[0].IsExpanded = true;
+
+        AssertFlatTreeEqual(roots, flatTree);
+
+        roots[0].IsExpanded = false;
+        roots[0].IsExpanded = false;
+
+        AssertFlatTreeEqual(roots, flatTree);
+    }
+
+    [Fact]
+    public void FlatTree_Hides_Children_When_Node_Becomes_Collapsed()
+    {
+        var roots = new MockTreeNode[]
+        {
+            new (new MockTreeNode(new MockTreeNode(), new MockTreeNode())),
+        };
+        ExpandAll(roots);
+        var flatTree = new FlatTree(roots);
+
+        roots[0].IsExpanded = false;
+
+        AssertFlatTreeEqual(roots, flatTree);
+    }
+
+    [Fact]
+    public void FlatTree_Ignores_Expand_When_Collapsed_Node_Is_Expanded()
+    {
+        var roots = new MockTreeNode[]
+        {
+            new (new MockTreeNode(new MockTreeNode(), new MockTreeNode())),
+        };
+        var flatTree = new FlatTree(roots);
+
+        roots[0].ChildrenNodes[0].IsExpanded = false;
+
+        AssertFlatTreeEqual(roots, flatTree);
+    }
+
+    [Fact]
+    public void FlatTree_Adds_Children_When_One_But_Last_Root_Expanded()
+    {
+        var roots = new MockTreeNode[]
+        {
+            new (new MockTreeNode()),
+            new (new MockTreeNode()),
+            new (new MockTreeNode(), new MockTreeNode()),
+            new (new MockTreeNode()),
+        };
+        var flatTree = new FlatTree(roots);
+
+        ExpandAll(new []{roots[2]});
+
+        AssertFlatTreeEqual(roots, flatTree);
+    }
+
+    [Fact]
+    public void FlatTree_Lazily_Adds_Children_For_Infinite_Trees()
+    {
+        MockTreeNode Create()
+        {
+            var node = new MockTreeNode();
+            node.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName != nameof(MockTreeNode.IsExpanded))
+                    return;
+
+                if (node.IsExpanded)
+                    node.ChildrenNodes.Add(Create());
+            };
+            return node;
+        }
+        var roots = new MockTreeNode[]
+        {
+            Create(),
+            Create(),
+            Create(),
+            Create(),
+        };
+        var flatTree = new FlatTree(roots);
+
+        roots[0].IsExpanded = true;
+
+        AssertFlatTreeEqual(roots, flatTree);
+
+        roots[0].ChildrenNodes[0].IsExpanded = true;
+
+        AssertFlatTreeEqual(roots, flatTree);
+    }
+
+    [Fact]
+    public void FlatTree_Dynamically_Adds_Child_To_Empty_Node()
+    {
+        var roots = new MockTreeNode[]
+        {
+            new () { IsExpanded = true }
+        };
+        var flatTree = new FlatTree(roots);
+
+        roots[0].ChildrenNodes.Add(new MockTreeNode());
+
+        AssertFlatTreeEqual(roots, flatTree);
+    }
+
+    [Fact]
+    public void FlatTree_Dynamically_Adds_Child_To_Non_Empty_Node()
+    {
+        var roots = new MockTreeNode[]
+        {
+            new (new MockTreeNode()) { IsExpanded = true },
+            new (new MockTreeNode(), new MockTreeNode(), new MockTreeNode()) { IsExpanded = true },
+            new (new MockTreeNode()) { IsExpanded = true },
+        };
+        var flatTree = new FlatTree(roots);
+
+        roots[1].ChildrenNodes.Insert(1, new MockTreeNode());
+        roots[1].ChildrenNodes.Insert(2,
+            new MockTreeNode(new MockTreeNode()) { IsExpanded = true });
+
+        AssertFlatTreeEqual(roots, flatTree);
+    }
+
+    [Fact]
+    public void FlatTree_Ignores_Collapsed_Children_Removal()
+    {
+        var roots = new MockTreeNode[]
+        {
+            new (new MockTreeNode(), new MockTreeNode()),
+        };
+        var flatTree = new FlatTree(roots);
+
+        roots[0].ChildrenNodes.RemoveAt(0);
+        roots[0].ChildrenNodes.RemoveAt(0);
+
+        AssertFlatTreeEqual(roots, flatTree);
+    }
+
+    [Fact]
+    public void FlatTree_Hides_Node_On_Children_Removal()
+    {
+        var roots = new MockTreeNode[]
+        {
+            new (new MockTreeNode(), new MockTreeNode()) { IsExpanded = true },
+        };
+        var flatTree = new FlatTree(roots);
+
+        roots[0].ChildrenNodes.RemoveAt(1);
+        roots[0].ChildrenNodes.RemoveAt(0);
+
+        AssertFlatTreeEqual(roots, flatTree);
+    }
+
+    [Fact]
+    public void FlatTree_Hides_Nodes_Recursively_On_Children_Removal()
+    {
+        var roots = new MockTreeNode[]
+        {
+            new (new MockTreeNode(), new MockTreeNode()),
+            new (new MockTreeNode(), new MockTreeNode(
+                new MockTreeNode(new MockTreeNode(), new MockTreeNode()), new MockTreeNode())),
+            new (new MockTreeNode(), new MockTreeNode())
+        };
+        ExpandAll(roots);
+        var flatTree = new FlatTree(roots);
+
+        roots[0].ChildrenNodes.RemoveAt(1);
+
+        AssertFlatTreeEqual(roots, flatTree);
+    }
+
+    [Fact]
+    public void FlatTree_Nodes_Can_Be_Expanded_After_Being_Expanded_And_Collapsed()
+    {
+        var roots = new MockTreeNode[]
+        {
+            new (new MockTreeNode(), new MockTreeNode(
+                new MockTreeNode(new MockTreeNode(), new MockTreeNode()), new MockTreeNode()))
+        };
+        var flatTree = new FlatTree(roots);
+
+        ExpandAll(roots);
+        CollapseAll(roots);
+        ExpandAll(roots);
+
+        AssertFlatTreeEqual(roots, flatTree);
+    }
+
+    private void AssertFlatTreeEqual(MockTreeNode[] roots, FlatTree flatTree)
+    {
+        void FlattenExpandedNodes(ITreeNode node, List<ITreeNode> output)
+        {
+            output.Add(node);
+            if (node.IsExpanded)
+            {
+                foreach (var child in node.Children)
+                {
+                    FlattenExpandedNodes(child, output);
+                }
+            }
+        }
+
+        List<ITreeNode> FlattenExpandedTree()
+        {
+            List<ITreeNode> output = new();
+            foreach (var root in roots)
+            {
+                FlattenExpandedNodes(root, output);
+            }
+            return output;
+        }
+
+        var expected = FlattenExpandedTree();
+        var actual = flatTree.Select(x => x.Node).ToList();
+
+        Assert.Equal(expected, actual);
+    }
+
+    private void ExpandAll(MockTreeNode[] roots)
+    {
+        Traverse(roots, node => node.IsExpanded = true);
+    }
+
+    private void CollapseAll(MockTreeNode[] roots)
+    {
+        Traverse(roots, node => node.IsExpanded = false);
+    }
+
+    private void Traverse(MockTreeNode[] roots, Action<MockTreeNode> action)
+    {
+        void Recur(MockTreeNode node)
+        {
+            action(node);
+            foreach (var child in node.ChildrenNodes)
+            {
+                Recur(child);
+            }
+        }
+
+        foreach (var root in roots)
+        {
+            Recur(root);
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
This PR introduces an internal control called VirtualizedTreeView, which is built upon the ListBox to use virtualization for tree structures. It allows displaying the tree children without impacting the visual tree's depth.

The old TreeView in the dev tools used to display the logical/visual tree has been replaced with the new VirtualizedTreeView.

Thanks to styling, visually the VirtualizedTreeView is almost indistinguishable from the old TreeView:


https://github.com/AvaloniaUI/Avalonia/assets/5689666/fe5575fa-3194-454d-9a6d-327298bf0097



~~**HOWEVER** there is a small bug related to `BringToView` in `VirtualizedStackPanel`. Unfortunately despite providing correct bounds in `BringToView`, `VirtualizedStackPanel` sometimes doesn't scroll properly when currently displayed elements are shorter than the row that has just been brought to view. This is a virtualization bug, not in this implementation. See: https://github.com/AvaloniaUI/Avalonia/issues/14418~~

## What is the current behavior?
The current Dev Tools use a regular TreeView, where each TreeNodeItem visually displays its children nodes as actual visual children. This design leads to a quick increase in the depth of the TreeView's visual tree. According to my tests, Avalonia 11 can handle approximately 400-450 nested controls (tested on Windows and Mac).

Despite being a downgrade compared to Avalonia 0.10 (~1000 nested controls in my tests), the new limit remains reasonable, however, the challenge arises when attempting to display a hierarchy of 400 nested controls, causing the TreeView to require about four times more depth. Consequently, I am experiencing crashes in the Dev Tools when working with just around 130 nested controls, which is not that much in more advanced scenarios.

## What is the updated/expected behavior with this PR?
With this PR, Dev Tools will no longer crash when displaying deep logical/visual trees, because VirtualizedTreeView, unlike TreeView, does not suffer from depth-related issues. 

## How was the solution implemented
As expected, the VirtualizedTreeView flattens the tree structure into a list and presents the flattened list within a ListBox. To ensure optimal performance, the tree is differentially flattened, avoiding regeneration each time the tree structure undergoes changes. The FlatTree class observes for changes to the IsExpanded property and children collection, applying the necessary adjustments to the flat list.

Differential flattening can be error prone, therefore I have included unit tests for the FlatTree class, even though `Avalonia.Diagnostics` at the moment doesn't have any tests (I had to create a test project). If you think the `FlatTree` class should be in a different project, please let me know.

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?

## Breaking changes
n/a

## Obsoletions / Deprecations
n/a

## Fixed issues
Fixes #14382 (doesn't fix this issue per se, but with this change all supported visual trees can be displayed in the dev tools)
Fixes #5993