### PR TITLE
Fix controls not showing up in accessibility when made visibile

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/ControlAutomationPeer.cs
@@ -87,9 +87,11 @@ namespace Avalonia.Automation.Peers
 
             foreach (var child in children)
             {
-                if (child is Control c && c.IsVisible)
+                if (child is Control c)
                 {
-                    result.Add(GetOrCreate(c));
+                    var peer = GetOrCreate(c);
+                    if (c.IsVisible)
+                        result.Add(peer);
                 }
             }
 

--- a/tests/Avalonia.Controls.UnitTests/Automation/ControlAutomationPeerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Automation/ControlAutomationPeerTests.cs
@@ -102,7 +102,7 @@ namespace Avalonia.Controls.UnitTests.Automation
             }
 
             [Fact]
-            public void Updates_Children_When_Visibility_Changes()
+            public void Updates_Children_When_Visibility_Changes_From_Visible_To_Invisible()
             {
                 var panel = new Panel
                 {
@@ -120,6 +120,27 @@ namespace Avalonia.Controls.UnitTests.Automation
 
                 panel.Children[1].IsVisible = false;
                 children = target.GetChildren();
+                Assert.Equal(1, children.Count);
+
+                panel.Children[1].IsVisible = true;
+                children = target.GetChildren();
+                Assert.Equal(2, children.Count);
+            }
+
+            [Fact]
+            public void Updates_Children_When_Visibility_Changes_From_Invisible_To_Visible()
+            {
+                var panel = new Panel
+                {
+                    Children =
+                    {
+                        new Border(),
+                        new Border { IsVisible = false },
+                    },
+                };
+
+                var target = CreatePeer(panel);
+                var children = target.GetChildren();
                 Assert.Equal(1, children.Count);
 
                 panel.Children[1].IsVisible = true;


### PR DESCRIPTION
## What does the pull request do?

When an invisible control is encountered, unless a peer is created for it, there is nothing to listen for the `IsVisible` property changing to `true`. Make sure we create a peer even for invisible controls; we just don't add them to the child collection. The peer will then pick up the control being made visible and cause the parent to recalculate its children.