### PR TITLE
feat: Allow Name Generator to disable attach to DevTools

### DIFF
--- a/packages/Avalonia/Avalonia.props
+++ b/packages/Avalonia/Avalonia.props
@@ -8,6 +8,7 @@
     <EnableAvaloniaXamlCompilation Condition="'$(EnableAvaloniaXamlCompilation)'==''">true</EnableAvaloniaXamlCompilation>
     <AvaloniaXamlIlVerifyIl Condition="'$(AvaloniaXamlIlVerifyIl)'==''">false</AvaloniaXamlIlVerifyIl>
     <AvaloniaUseCompiledBindingsByDefault Condition="'$(AvaloniaUseCompiledBindingsByDefault)'==''">false</AvaloniaUseCompiledBindingsByDefault>
+    <AvaloniaNameGeneratorAttachDevTools Condition="'$(AvaloniaNameGeneratorAttachDevTools)' == ''">true</AvaloniaNameGeneratorAttachDevTools>
   </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)\AvaloniaBuildTasks.props"/>
   <Import Project="$(MSBuildThisFileDirectory)\Avalonia.Generators.props"/>

--- a/packages/Avalonia/AvaloniaRules.Project.xml
+++ b/packages/Avalonia/AvaloniaRules.Project.xml
@@ -50,7 +50,7 @@
   <BoolProperty Name="AvaloniaNameGeneratorIsEnabled"
               DisplayName="Use Name Generator"
               Description="Enable/Disable Avalonia Name Source Generator"
-              HelpUrl="https://github.com/AvaloniaUI/Avalonia/blob/master/src/tools/Avalonia.Generators/README.md"
+              HelpUrl="https://github.com/AvaloniaUI/Avalonia/blob/master/src/tools/Avalonia.Generators/README.md#advanced-usage"
               Category="NameGenerator" />
 
   <EnumProperty Name="AvaloniaNameGeneratorBehavior"
@@ -66,6 +66,18 @@
       </NameValuePair>
     </EnumProperty.Metadata>
   </EnumProperty>
+
+  <BoolProperty Name="AvaloniaNameGeneratorAttachDevTools"
+              DisplayName="Attach Dev Tools"
+              Description="Allowed to automatic attach DevTools in Window InitializeComponent method."
+              Category="NameGenerator">
+    <BoolProperty.Metadata>
+      <NameValuePair Name="DependsOn" Value="Avalonia::AvaloniaNameGeneratorBehavior" />
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-evaluated-value  "Avalonia" "AvaloniaNameGeneratorBehavior" "InitializeComponent")</NameValuePair.Value>
+      </NameValuePair>
+    </BoolProperty.Metadata>
+  </BoolProperty>
 
   <EnumProperty Name="AvaloniaNameGeneratorDefaultFieldModifier"
               DisplayName="Default Class Field/Property Modifier"

--- a/src/tools/Avalonia.Generators/Avalonia.Generators.props
+++ b/src/tools/Avalonia.Generators/Avalonia.Generators.props
@@ -6,6 +6,7 @@
     <AvaloniaNameGeneratorFilterByPath Condition="'$(AvaloniaNameGeneratorFilterByPath)' == ''">*</AvaloniaNameGeneratorFilterByPath>
     <AvaloniaNameGeneratorFilterByNamespace Condition="'$(AvaloniaNameGeneratorFilterByNamespace)' == ''">*</AvaloniaNameGeneratorFilterByNamespace>
     <AvaloniaNameGeneratorViewFileNamingStrategy Condition="'$(AvaloniaNameGeneratorViewFileNamingStrategy)' == ''">NamespaceAndClassName</AvaloniaNameGeneratorViewFileNamingStrategy>
+    <AvaloniaNameGeneratorAttachDevTools Condition="'$(AvaloniaNameGeneratorAttachDevTools)' == ''">true</AvaloniaNameGeneratorAttachDevTools>
   </PropertyGroup>
   <ItemGroup>
     <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="SourceItemGroup"/>
@@ -15,6 +16,7 @@
     <CompilerVisibleProperty Include="AvaloniaNameGeneratorFilterByPath" />
     <CompilerVisibleProperty Include="AvaloniaNameGeneratorFilterByNamespace" />
     <CompilerVisibleProperty Include="AvaloniaNameGeneratorViewFileNamingStrategy" />
+    <CompilerVisibleProperty Include="AvaloniaNameGeneratorAttachDevTools"/>
   </ItemGroup>
   <Target Name="_InjectAdditionalFiles" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
     <ItemGroup>

--- a/src/tools/Avalonia.Generators/GeneratorOptions.cs
+++ b/src/tools/Avalonia.Generators/GeneratorOptions.cs
@@ -14,7 +14,7 @@ internal enum BuildProperties
     AvaloniaNameGeneratorFilterByPath = 3,
     AvaloniaNameGeneratorFilterByNamespace = 4,
     AvaloniaNameGeneratorViewFileNamingStrategy = 5,
-    
+    AvaloniaNameGeneratorAttachDevTools = 6,
     // TODO add other generators properties here.
 }
 
@@ -47,6 +47,10 @@ internal class GeneratorOptions
     public string[] AvaloniaNameGeneratorFilterByNamespace => GetStringArrayProperty(
         BuildProperties.AvaloniaNameGeneratorFilterByNamespace,
         "*");
+
+    public bool AvaloniaNameGeneratorAttachDevTools => GetBoolProperty(
+        BuildProperties.AvaloniaNameGeneratorAttachDevTools,
+        true);
 
     private string[] GetStringArrayProperty(BuildProperties name, string defaultValue)
     {

--- a/src/tools/Avalonia.Generators/NameGenerator/AvaloniaNameSourceGenerator.cs
+++ b/src/tools/Avalonia.Generators/NameGenerator/AvaloniaNameSourceGenerator.cs
@@ -68,7 +68,7 @@ public class AvaloniaNameSourceGenerator : ISourceGenerator
         var types = new RoslynTypeSystem((CSharpCompilation)context.Compilation);
         ICodeGenerator generator = options.AvaloniaNameGeneratorBehavior switch {
             Behavior.OnlyProperties => new OnlyPropertiesCodeGenerator(),
-            Behavior.InitializeComponent => new InitializeComponentCodeGenerator(types),
+            Behavior.InitializeComponent => new InitializeComponentCodeGenerator(types, options.AvaloniaNameGeneratorAttachDevTools),
             _ => throw new ArgumentOutOfRangeException()
         };
 

--- a/src/tools/Avalonia.Generators/NameGenerator/InitializeComponentCodeGenerator.cs
+++ b/src/tools/Avalonia.Generators/NameGenerator/InitializeComponentCodeGenerator.cs
@@ -19,9 +19,10 @@ internal class InitializeComponentCodeGenerator: ICodeGenerator
         = @"        /// <param name=""attachDevTools"">Should the dev tools be attached.</param>
 ";
 
-    public InitializeComponentCodeGenerator(IXamlTypeSystem types)
+
+    public InitializeComponentCodeGenerator(IXamlTypeSystem types, bool avaloniaNameGeneratorAttachDevTools)
     {
-        _diagnosticsAreConnected = types.FindAssembly("Avalonia.Diagnostics") != null;
+        _diagnosticsAreConnected = avaloniaNameGeneratorAttachDevTools && types.FindAssembly("Avalonia.Diagnostics") != null;
     }
 
     public string GenerateCode(string className, string nameSpace, IXamlType xamlType, IEnumerable<ResolvedName> names)

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/InitializeComponentTests.cs
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/InitializeComponentTests.cs
@@ -3,7 +3,6 @@ using Avalonia.Generators.Common;
 using Avalonia.Generators.Compiler;
 using Avalonia.Generators.NameGenerator;
 using Avalonia.Generators.Tests.InitializeComponent.GeneratedInitializeComponent;
-using Avalonia.Generators.Tests.OnlyProperties.GeneratedCode;
 using Avalonia.Generators.Tests.Views;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -48,7 +47,7 @@ public class InitializeComponentTests
         var nameResolver = new XamlXNameResolver();
         var names = nameResolver.ResolveNames(classInfo.Xaml);
 
-        var generator = new InitializeComponentCodeGenerator(types);
+        var generator = new InitializeComponentCodeGenerator(types, devToolsMode);
 
         var code = generator
             .GenerateCode("SampleView", "Sample.App",  classInfo.XamlType, names)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Add property `AvaloniaNameGeneratorAttachDevTools` to Name Generaator that allow it to disable attach to DevTools

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`Name Generaator` if the target is `Window`, the DEBUG constant is defined and the project references `Avalonia.Diagnostics`, always generate code for Attach to DevTools. This behavior does not allow you to easily customize DevTools options. To do this you need to modify each window constructor to invoke `InitializeComponent(attachDevTools: false);` instead of `InitializeComponent();`.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

When add following to .csproj  does not generate code to Attach to DevTools

```xml
<PropertyGroup>
  <AvaloniaNameGeneratorAttachDevTools>false</AvaloniaNameGeneratorAttachDevTools>
</PropertyGroup>
```



## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
