### PR TITLE
Ignore frame extents if window has no decorations

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -593,6 +593,9 @@ namespace Avalonia.X11
 
         private Thickness? GetFrameExtents()
         {
+            if (_systemDecorations != SystemDecorations.Full)
+                return new Thickness(0);
+
             XGetWindowProperty(_x11.Display, _handle, _x11.Atoms._NET_FRAME_EXTENTS, IntPtr.Zero,
                 new IntPtr(4), false, (IntPtr)Atom.AnyPropertyType, out var _,
                 out var _, out var nitems, out var _, out var prop);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
On x11, when system decorations for a window is removed, do not adjust the position and frame size with the frame extents. Some desktop environments seems to report a non-zero frame extent, thus FrameSize and Position report sizes as if system decorations are enabled.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
