### PR TITLE
Removes hard-coded Grid.RowSpan and Grid.ColumnSpan from FluentTheme …

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
+++ b/src/Avalonia.Controls.DataGrid/Themes/Fluent.xaml
@@ -535,8 +535,6 @@
 
               <DataGridRowsPresenter Name="PART_RowsPresenter"
                                      Grid.Row="1"
-                                     Grid.RowSpan="2"
-                                     Grid.ColumnSpan="3"
                                      Grid.Column="0"
                                      ScrollViewer.IsScrollInertiaEnabled="{TemplateBinding IsScrollInertiaEnabled}">
                 <DataGridRowsPresenter.GestureRecognizers>
@@ -588,6 +586,10 @@
         <Style Selector="^ /template/ Rectangle#PART_ColumnHeadersAndRowsSeparator">
           <Setter Property="IsVisible" Value="False" />
         </Style>
+      </Style>
+      <Style Selector="^ /template/ DataGridRowsPresenter#PART_RowsPresenter">
+        <Setter Property="Grid.RowSpan" Value="2" />
+        <Setter Property="Grid.ColumnSpan" Value="3" />
       </Style>
     </ControlTheme>
    </ResourceDictionary>


### PR DESCRIPTION
…in Data grid - based on #12301

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Removes hard-coded Grid.RowSpan and Grid.ColumnSpan from FluentTheme
## What is the current behavior?
it's hard to override this values

## What is the updated/expected behavior with this PR?
Properties can be overridden easly.  

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #14458

