### PR TITLE
DataGrid add property to specify Number Format of items count

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
@@ -430,6 +430,10 @@ namespace Avalonia.Controls
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value that indicates number format of items count
+        /// </summary>
+        public string CountFormat { get; set; } = "N1";
         internal void UpdateTitleElements()
         {
             if (_propertyNameElement != null)
@@ -444,10 +448,10 @@ namespace Avalonia.Controls
             if (_itemCountElement != null && RowGroupInfo != null && RowGroupInfo.CollectionViewGroup != null)
             {
                 string formatString;
-                if(RowGroupInfo.CollectionViewGroup.ItemCount == 1)
+                if (RowGroupInfo.CollectionViewGroup.ItemCount == 1)
                     formatString = "({0} Item)";
                 else
-                    formatString = "({0} Items)";
+                    formatString = $"({{0:{CountFormat}}} Items)";
 
                 _itemCountElement.Text = String.Format(formatString, RowGroupInfo.CollectionViewGroup.ItemCount);
             }

--- a/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
@@ -49,6 +49,20 @@ namespace Avalonia.Controls
             set { SetValue(IsItemCountVisibleProperty, value); }
         }
 
+
+        public static readonly StyledProperty<string> CountFormatProperty =
+            AvaloniaProperty.Register<DataGridRowGroupHeader, string>(nameof(CountFormat));
+
+        /// <summary>
+        /// Gets or sets a value that indicates number format of items count
+        /// </summary>
+        public string CountFormat
+        {
+            get { return GetValue(CountFormatProperty); }
+            set { SetValue(CountFormatProperty, value); }
+        }
+
+
         public static readonly StyledProperty<string> PropertyNameProperty =
             AvaloniaProperty.Register<DataGridRowGroupHeader, string>(nameof(PropertyName));
 
@@ -430,10 +444,6 @@ namespace Avalonia.Controls
             }
         }
 
-        /// <summary>
-        /// Gets or sets a value that indicates number format of items count
-        /// </summary>
-        public string CountFormat { get; set; } = "N1";
         internal void UpdateTitleElements()
         {
             if (_propertyNameElement != null)
@@ -449,9 +459,9 @@ namespace Avalonia.Controls
             {
                 string formatString;
                 if (RowGroupInfo.CollectionViewGroup.ItemCount == 1)
-                    formatString = "({0} Item)";
+                    formatString = (CountFormat == null ? "({0} Item)" : CountFormat);
                 else
-                    formatString = $"({{0:{CountFormat}}} Items)";
+                    formatString = (CountFormat == null ? "({0} Items)" : CountFormat);
 
                 _itemCountElement.Text = String.Format(formatString, RowGroupInfo.CollectionViewGroup.ItemCount);
             }

--- a/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRowGroupHeader.cs
@@ -50,16 +50,16 @@ namespace Avalonia.Controls
         }
 
 
-        public static readonly StyledProperty<string> CountFormatProperty =
-            AvaloniaProperty.Register<DataGridRowGroupHeader, string>(nameof(CountFormat));
+        public static readonly StyledProperty<string> ItemCountFormatProperty =
+            AvaloniaProperty.Register<DataGridRowGroupHeader, string>(nameof(ItemCountFormat));
 
         /// <summary>
         /// Gets or sets a value that indicates number format of items count
         /// </summary>
-        public string CountFormat
+        public string ItemCountFormat
         {
-            get { return GetValue(CountFormatProperty); }
-            set { SetValue(CountFormatProperty, value); }
+            get { return GetValue(ItemCountFormatProperty); }
+            set { SetValue(ItemCountFormatProperty, value); }
         }
 
 
@@ -459,9 +459,9 @@ namespace Avalonia.Controls
             {
                 string formatString;
                 if (RowGroupInfo.CollectionViewGroup.ItemCount == 1)
-                    formatString = (CountFormat == null ? "({0} Item)" : CountFormat);
+                    formatString = (ItemCountFormat == null ? "({0} Item)" : ItemCountFormat);
                 else
-                    formatString = (CountFormat == null ? "({0} Items)" : CountFormat);
+                    formatString = (ItemCountFormat == null ? "({0} Items)" : ItemCountFormat);
 
                 _itemCountElement.Text = String.Format(formatString, RowGroupInfo.CollectionViewGroup.ItemCount);
             }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
DataGrid add property to specify Number Format of items count.
**edit** - after sugestions scope of this issue is to cover not only number but whole header text


## What is the current behavior?
format cant be change easly


## What is the updated/expected behavior with this PR?
format can be changed on LoadingRowGroup event


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes  #14464
