### PR TITLE
Use soft DataContext synchronization for Reactive UI controls

### DIFF
--- a/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
+++ b/src/Avalonia.ReactiveUI/ReactiveUserControl.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using Avalonia;
-using Avalonia.VisualTree;
 using Avalonia.Controls;
 using ReactiveUI;
 
@@ -29,7 +25,6 @@ namespace Avalonia.ReactiveUI
             // This WhenActivated block calls ViewModel's WhenActivated
             // block if the ViewModel implements IActivatableViewModel.
             this.WhenActivated(disposables => { });
-            this.GetObservable(ViewModelProperty).Subscribe(OnViewModelChanged);
         }
 
         /// <summary>
@@ -47,21 +42,23 @@ namespace Avalonia.ReactiveUI
             set => ViewModel = (TViewModel?)value;
         }
 
-        protected override void OnDataContextChanged(EventArgs e)
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
-            base.OnDataContextChanged(e);
-            ViewModel = DataContext as TViewModel;
-        }
+            base.OnPropertyChanged(change);
 
-        private void OnViewModelChanged(object? value)
-        {
-            if (value == null)
+            if (change.Property == DataContextProperty)
             {
-                ClearValue(DataContextProperty);
+                if (Object.ReferenceEquals(change.OldValue, ViewModel))
+                {
+                    SetCurrentValue(ViewModelProperty, change.NewValue);
+                }
             }
-            else if (DataContext != value)
+            else if (change.Property == ViewModelProperty)
             {
-                DataContext = value;
+                if (Object.ReferenceEquals(change.OldValue, DataContext))
+                {
+                    SetCurrentValue(DataContextProperty, change.NewValue);
+                }
             }
         }
     }

--- a/src/Avalonia.ReactiveUI/ReactiveWindow.cs
+++ b/src/Avalonia.ReactiveUI/ReactiveWindow.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using Avalonia;
-using Avalonia.VisualTree;
 using Avalonia.Controls;
 using ReactiveUI;
 
@@ -29,8 +25,6 @@ namespace Avalonia.ReactiveUI
             // This WhenActivated block calls ViewModel's WhenActivated
             // block if the ViewModel implements IActivatableViewModel.
             this.WhenActivated(disposables => { });
-            this.GetObservable(DataContextProperty).Subscribe(OnDataContextChanged);
-            this.GetObservable(ViewModelProperty).Subscribe(OnViewModelChanged);
         }
             
         /// <summary>
@@ -48,27 +42,23 @@ namespace Avalonia.ReactiveUI
             set => ViewModel = (TViewModel?)value;
         }
 
-        private void OnDataContextChanged(object? value)
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
-            if (value is TViewModel viewModel)
-            {
-                ViewModel = viewModel;
-            }
-            else
-            {
-                ViewModel = null;
-            }
-        }
+            base.OnPropertyChanged(change);
 
-        private void OnViewModelChanged(object? value)
-        {
-            if (value == null)
+            if (change.Property == DataContextProperty)
             {
-                ClearValue(DataContextProperty);
+                if (Object.ReferenceEquals(change.OldValue, ViewModel))
+                {
+                    SetCurrentValue(ViewModelProperty, change.NewValue);
+                }
             }
-            else if (DataContext != value)
+            else if (change.Property == ViewModelProperty)
             {
-                DataContext = value;
+                if (Object.ReferenceEquals(change.OldValue, DataContext))
+                {
+                    SetCurrentValue(DataContextProperty, change.NewValue);
+                }
             }
         }
     }


### PR DESCRIPTION
## What does the pull request do?

Improves the behavior of ReactiveUI controls by synchronizing `DataContext` and `ViewModel` only when it makes sense.

## What is the current behavior?

Synchronization between `DataContext` and `ViewModel` is a bit aggressive. For example, setting `ViewModel = null` unsets `DataContext`, which becomes inherited and breaks compiled bindings. Also, at least on Windows Forms, WPF, and MAUI, these controls don't synchronize the properties at all.

## What is the updated/expected behavior with this PR?

~`DataContext` and `ViewModel` can be set independently: when one is unset, they are synchronized.~

**EDIT:** `DataContext` and `ViewModel` can be set independently: when one is updated and its old value is equal to the other, the other is updated as well.

## How was the solution implemented (if it's not obvious)?

~If `!IsSet(one)` then `SetCurrentValue(one, other)`.~

**EDIT:** If `Object.ReferenceEquals(oldOne, other)` then `SetCurrentValue(other, one)`.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

May break expected behavior.