### PR TITLE
Fix TextBox in AdornerLayer causes collection modified exception

### DIFF
--- a/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
+++ b/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
@@ -148,8 +148,12 @@ namespace Avalonia.Controls.Primitives
         /// <inheritdoc />
         protected override Size MeasureOverride(Size availableSize)
         {
-            foreach (var l in _layers)
+            for (var index = 0; index < _layers.Count; index++)
+            {
+                var l = _layers[index];
                 l.Measure(availableSize);
+            }
+
             return base.MeasureOverride(availableSize);
         }
 

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -1367,6 +1367,29 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
+        [Fact]
+        public void TextBox_In_AdornerLayer_Will_Not_Cause_Collection_Modified_In_VisualLayerManager()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var button = new Button();
+                var root = new TestRoot()
+                {
+                    Child = new VisualLayerManager()
+                    {
+                        Child = button
+                    }
+                };
+                var adorner = new TextBox { Template = CreateTemplate(), Text = "a" };
+
+                var adornerLayer = AdornerLayer.GetAdornerLayer(button);
+                adornerLayer.Children.Add(adorner);
+                AdornerLayer.SetAdornedElement(adorner, button);
+
+                root.Measure(Size.Infinity);
+            }
+        }
+
         [Theory]
         [InlineData("A\nBB\nCCC\nDDDD", 0, 0)]
         [InlineData("A\nBB\nCCC\nDDDD", 1, 2)]


### PR DESCRIPTION
## What does the pull request do?
This PR changes VisualLayerManager so that layers can be added during its Measure pass.

## What is the current behavior?
Currently, adding a layer in VisualLayerManager during a Measure pass will cause Collection Modified exception to be thrown. 

When a layer can be added during a Measure pass:

> When a TextBox with non empty Text is added to an AdornerLayer and no text box has ever been focused yet, the next Measure pass will run ApplyTemplate on the textbox, this will access the VisualLayerManager.TextSelectorLayer property, the getter will create the layer and Collection Was Modified while Enumeration exception will be thrown, because all those methods will be run from within VisualLayerManager's MeasureOverride, which iterates through its layers.


## What is the updated/expected behavior with this PR?
Layers can be added during measure pass, which means a textbox can be added to the adorner layer without a crash.


## How was the solution implemented (if it's not obvious)?
Instead of a for each loop, let's use a traditional for loop. I think it is fine since layers are never removed - only added. So even if the layer is added during the measure pass, it will still be correctly processed in the very same loop.


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
n/a

## Obsoletions / Deprecations
n/a

## Fixed issues
Fixes #14483
