### PR TITLE
fix macos crash at startup by not parsing all app arguments into uris.

### DIFF
--- a/native/Avalonia.Native/src/OSX/app.mm
+++ b/native/Avalonia.Native/src/OSX/app.mm
@@ -70,7 +70,7 @@ ComPtr<IAvnApplicationEvents> _events;
 {
     auto array = CreateAvnStringArray(urls);
     
-    _events->FilesOpened(array);
+    _events->UrlsOpened(array);
 }
 
 - (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender

--- a/src/Avalonia.Native/AvaloniaNativeApplicationPlatform.cs
+++ b/src/Avalonia.Native/AvaloniaNativeApplicationPlatform.cs
@@ -13,12 +13,21 @@ namespace Avalonia.Native
         void IAvnApplicationEvents.FilesOpened(IAvnStringArray urls)
         {
             ((IApplicationPlatformEvents)Application.Current).RaiseUrlsOpened(urls.ToStringArray());
+        }
+        
+        void IAvnApplicationEvents.UrlsOpened(IAvnStringArray urls)
+        {
+            // Raise the urls opened event to be compatible with legacy behavior.
+            ((IApplicationPlatformEvents)Application.Current).RaiseUrlsOpened(urls.ToStringArray());
 
             if (Application.Current?.ApplicationLifetime is MacOSClassicDesktopStyleApplicationLifetime lifetime)
             {
                 foreach (var url in urls.ToStringArray())
                 {
-                    lifetime.RaiseUrl(new Uri(url));
+                    if (Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri))
+                    {
+                        lifetime.RaiseUrl(uri);
+                    }
                 }
             }
         }

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -1085,7 +1085,8 @@ interface IAvnNativeControlHostTopLevelAttachment : IUnknown
 [uuid(6575b5af-f27a-4609-866c-f1f014c20f79)]
 interface IAvnApplicationEvents : IUnknown
 {
-     void FilesOpened (IAvnStringArray* urls);
+     void FilesOpened (IAvnStringArray* args);
+     void UrlsOpened (IAvnStringArray* urls);
      bool TryShutdown();
      void OnReopen ();
      void OnHide ();


### PR DESCRIPTION
- Fixes the crash when Avalonia starts up on macOS with arguments.

This was caused due to the "FilesOpened" callback being unexpectedly raised for all command line arguments.

The recent PR #14106 implemented a Uri protocol raised event, where the data was parsed into a uri.

Its not possible to do this for all arguments.

This PR does the following:

- Separate the macOS backend callbacks  `(void)application:(NSApplication *)sender openFiles` and `(void)application:(NSApplication *)application openURLs` into 2 separate callbacks in our backend (previously they were the same)

- Continue raising the legacy `RaiseUrlsOpened` codepath from the FilesOpened (as has worked for many years), to not break previous behaviour.

- Only raise the new uri handling code from the `openURLS` macOS callback, and use Uri.TryCreate ().


This fixes the bug and ensures the old behaviour.

Fixes https://github.com/AvaloniaUI/Avalonia/issues/14411