### PR TITLE
Wrap Clipboard.GetTextAsync in a try-catch to mimic WPF default behavior (Avalonia 0.10)

### DIFF
--- a/build/SharedVersion.props
+++ b/build/SharedVersion.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Avalonia</Product>
-    <Version>0.10.999</Version>
+    <Version>0.10.22</Version>
     <Copyright>Copyright 2022 &#169; The AvaloniaUI Project</Copyright>
     <PackageProjectUrl>https://avaloniaui.net</PackageProjectUrl>
     <RepositoryUrl>https://github.com/AvaloniaUI/Avalonia/</RepositoryUrl>

--- a/src/Avalonia.Controls/MaskedTextBox.cs
+++ b/src/Avalonia.Controls/MaskedTextBox.cs
@@ -214,7 +214,15 @@ namespace Avalonia.Controls
                 if (clipboard is null)
                     return;
 
-                var text = await clipboard.GetTextAsync();
+                string? text = null;
+                try
+                {
+                    text = await clipboard.GetTextAsync();
+                }
+                catch (TimeoutException)
+                {
+                    // Silently ignore.
+                }
 
                 if (text == null)
                     return;

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -711,7 +711,15 @@ namespace Avalonia.Controls
                 return;
             }
 
-            var text = await ((IClipboard)AvaloniaLocator.Current.GetService(typeof(IClipboard))).GetTextAsync();
+            string text = null;
+            try
+            {
+                text = await ((IClipboard)AvaloniaLocator.Current.GetService(typeof(IClipboard))).GetTextAsync();
+            }
+            catch (TimeoutException)
+            {
+                // Silently ignore.
+            }
 
             if (string.IsNullOrEmpty(text))
             {


### PR DESCRIPTION
(this is a fix for 0.10 branch, even if 0.10.23 was never going to be released, I would really want to use a nightly build until my app is upgraded to Avalonia 11)

## What does the pull request do?
In this PR clipboard GetText calls are wrapped in a try-catch and in case of a TimeoutException, the exception is silently ignored. This mimics WPF default behaviour - https://github.com/dotnet/wpf/blob/main/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorCopyPaste.cs#L389

## What is the current behavior?
If GetText() throws a TimeoutException, the whole app crashes. The exception can be thrown due to [clipboard locking issues in TS sessions](https://github.com/dotnet/wpf/blob/main/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/clipboard.cs#L597)


## What is the updated/expected behavior with this PR?
The app won't crash when clipboard method fails.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
Technically it changes the behaviour, but I don't think anybody depends on their app crashes?

## Obsoletions / Deprecations
n/a

## Fixed issues
Fixes #13716