### PR TITLE
Make Avalonia.Skia compatible with both  SkiaSharp 2.88 and 3.0

### DIFF
--- a/src/Skia/Avalonia.Skia/Avalonia.Skia.csproj
+++ b/src/Skia/Avalonia.Skia/Avalonia.Skia.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(AvsLegacyTargetFrameworks);netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks);netstandard2.0</TargetFrameworks>
     <IncludeLinuxSkia>true</IncludeLinuxSkia>
     <IncludeWasmSkia>true</IncludeWasmSkia>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKCanvas.cs
+++ b/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKCanvas.cs
@@ -10,9 +10,9 @@ internal static unsafe partial class SkiaCompat
     private static readonly delegate* managed<SKCanvas, in SKMatrix, void> s_canvasSetMatrix;
     public static void CSetMatrix(this SKCanvas canvas, in SKMatrix matrix) => s_canvasSetMatrix(canvas, matrix);
 
-    private static delegate* managed<SKCanvas, in SKMatrix, void> GetCanvasSetMatrix()
+    private static delegate* managed<SKCanvas, in SKMatrix, void> GetCanvasSetMatrix(bool isSkiaSharp3)
     {
-        if (IsSkiaSharp3)
+        if (isSkiaSharp3)
         {
 #if NET8_0_OR_GREATER
             return &NewCanvasSetMatrix;

--- a/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKCanvas.cs
+++ b/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKCanvas.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using SkiaSharp;
+
+namespace Avalonia.Skia;
+
+internal static unsafe partial class SkiaCompat
+{
+    private static readonly delegate* managed<SKCanvas, in SKMatrix, void> s_canvasSetMatrix;
+    public static void CSetMatrix(this SKCanvas canvas, in SKMatrix matrix) => s_canvasSetMatrix(canvas, matrix);
+
+#if !NET8_0_OR_GREATER
+    [DynamicDependency("SetMatrix(SkiaSharp.SKMatrix)", typeof(SKCanvas))]
+#endif
+    private static delegate* managed<SKCanvas, in SKMatrix, void> GetCanvasSetMatrix()
+    {
+        if (IsSkiaSharp3)
+        {
+#if NET8_0_OR_GREATER
+            return &NewCanvasSetMatrix;
+#else
+            var method = typeof(SKCanvas).GetMethod("SetMatrix", new[] { typeof(SKMatrix).MakeByRefType() })!;
+            return (delegate* managed<SKCanvas, in SKMatrix, void>)method.MethodHandle.GetFunctionPointer();
+#endif
+        }
+        else
+        {
+            return &LegacyCall;
+
+            static void LegacyCall(SKCanvas canvas, in SKMatrix matrix)
+            {
+                canvas.SetMatrix(matrix);
+            }
+        }
+    }
+
+#if NET8_0_OR_GREATER
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "SetMatrix")]
+    private static extern void NewCanvasSetMatrix(SKCanvas canvas, in SKMatrix matrix);
+#endif
+}

--- a/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKCanvas.cs
+++ b/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKCanvas.cs
@@ -10,9 +10,6 @@ internal static unsafe partial class SkiaCompat
     private static readonly delegate* managed<SKCanvas, in SKMatrix, void> s_canvasSetMatrix;
     public static void CSetMatrix(this SKCanvas canvas, in SKMatrix matrix) => s_canvasSetMatrix(canvas, matrix);
 
-#if !NET8_0_OR_GREATER
-    [DynamicDependency("SetMatrix(SkiaSharp.SKMatrix)", typeof(SKCanvas))]
-#endif
     private static delegate* managed<SKCanvas, in SKMatrix, void> GetCanvasSetMatrix()
     {
         if (IsSkiaSharp3)
@@ -20,8 +17,7 @@ internal static unsafe partial class SkiaCompat
 #if NET8_0_OR_GREATER
             return &NewCanvasSetMatrix;
 #else
-            var method = typeof(SKCanvas).GetMethod("SetMatrix", new[] { typeof(SKMatrix).MakeByRefType() })!;
-            return (delegate* managed<SKCanvas, in SKMatrix, void>)method.MethodHandle.GetFunctionPointer();
+            throw UnsupportedException();
 #endif
         }
         else

--- a/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKCanvas.cs
+++ b/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKCanvas.cs
@@ -1,28 +1,24 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using SkiaSharp;
 
 namespace Avalonia.Skia;
 
-internal static unsafe partial class SkiaCompat
+internal static partial class SkiaCompat
 {
-    private static readonly delegate* managed<SKCanvas, in SKMatrix, void> s_canvasSetMatrix;
-    public static void CSetMatrix(this SKCanvas canvas, in SKMatrix matrix) => s_canvasSetMatrix(canvas, matrix);
-
-    private static delegate* managed<SKCanvas, in SKMatrix, void> GetCanvasSetMatrix(bool isSkiaSharp3)
+    public static void SetMatrix(SKCanvas canvas, in SKMatrix matrix)
     {
-        if (isSkiaSharp3)
+        if (s_isSkiaSharp3)
         {
 #if NET8_0_OR_GREATER
-            return &NewCanvasSetMatrix;
+            NewCanvasSetMatrix(canvas, matrix);
 #else
             throw UnsupportedException();
 #endif
         }
         else
         {
-            return &LegacyCall;
+            LegacyCall(canvas, matrix);
 
             static void LegacyCall(SKCanvas canvas, in SKMatrix matrix)
             {

--- a/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKImageFilter.cs
+++ b/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKImageFilter.cs
@@ -15,9 +15,6 @@ internal static unsafe partial class SkiaCompat
     public static SKImageFilter CreateDropShadow(float dropOffsetX, float dropOffsetY, float sigma, float f, SKColor color)
         => s_sk3FilterDropShadow(dropOffsetX, dropOffsetY, sigma, f, color);
 
-#if !NET8_0_OR_GREATER
-    [DynamicDependency("CreateBlur(System.Single,System.Single)", typeof(SKImageFilter))]
-#endif
     private static delegate* managed<float, float, SKImageFilter> GetSKImageFilterCreateBlur()
     {
         if (IsSkiaSharp3)
@@ -25,8 +22,7 @@ internal static unsafe partial class SkiaCompat
 #if NET8_0_OR_GREATER
             return &NewSKImageFilterCreateBlur;
 #else
-            var method = typeof(SKImageFilter).GetMethod("CreateBlur", new[] { typeof(float), typeof(float) })!;
-            return (delegate* managed<float, float, SKImageFilter>)method.MethodHandle.GetFunctionPointer();
+            throw UnsupportedException();
 #endif
         }
         else
@@ -37,10 +33,7 @@ internal static unsafe partial class SkiaCompat
                 SKImageFilter.CreateBlur(sigmaX, sigmaY);
         }
     }
-    
-#if !NET8_0_OR_GREATER
-    [DynamicDependency("CreateDropShadow(System.Single,System.Single,System.Single,System.Single,SkiaSharp.SKColor)", typeof(SKImageFilter))]
-#endif
+
     private static delegate* managed<float, float, float, float, SKColor, SKImageFilter> GetSKImageFilterCreateDropShadow()
     {
         if (IsSkiaSharp3)
@@ -48,10 +41,7 @@ internal static unsafe partial class SkiaCompat
 #if NET8_0_OR_GREATER
             return &NewSKImageFilterCreateDropShadow;
 #else
-            var method = typeof(SKImageFilter).GetMethod("CreateDropShadow",
-                new[] { typeof(float), typeof(float), typeof(float), typeof(float), typeof(SKColor) })!;
-            return (delegate* managed<float, float, float, float, SKColor, SKImageFilter>)method
-                .MethodHandle.GetFunctionPointer();
+            throw UnsupportedException();
 #endif
         }
         else

--- a/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKImageFilter.cs
+++ b/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKImageFilter.cs
@@ -15,9 +15,9 @@ internal static unsafe partial class SkiaCompat
     public static SKImageFilter CreateDropShadow(float dropOffsetX, float dropOffsetY, float sigma, float f, SKColor color)
         => s_sk3FilterDropShadow(dropOffsetX, dropOffsetY, sigma, f, color);
 
-    private static delegate* managed<float, float, SKImageFilter> GetSKImageFilterCreateBlur()
+    private static delegate* managed<float, float, SKImageFilter> GetSKImageFilterCreateBlur(bool isSkiaSharp3)
     {
-        if (IsSkiaSharp3)
+        if (isSkiaSharp3)
         {
 #if NET8_0_OR_GREATER
             return &NewSKImageFilterCreateBlur;
@@ -34,9 +34,9 @@ internal static unsafe partial class SkiaCompat
         }
     }
 
-    private static delegate* managed<float, float, float, float, SKColor, SKImageFilter> GetSKImageFilterCreateDropShadow()
+    private static delegate* managed<float, float, float, float, SKColor, SKImageFilter> GetSKImageFilterCreateDropShadow(bool isSkiaSharp3)
     {
-        if (IsSkiaSharp3)
+        if (isSkiaSharp3)
         {
 #if NET8_0_OR_GREATER
             return &NewSKImageFilterCreateDropShadow;

--- a/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKImageFilter.cs
+++ b/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKImageFilter.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using SkiaSharp;
+
+namespace Avalonia.Skia;
+
+internal static unsafe partial class SkiaCompat
+{
+    private static readonly delegate* managed<float, float, SKImageFilter> s_sk3FilterBlur;
+    private static readonly delegate* managed<float, float, float, float, SKColor, SKImageFilter> s_sk3FilterDropShadow;
+
+    public static SKImageFilter CreateBlur(float sigmaX, float sigmaY) => s_sk3FilterBlur(sigmaX, sigmaY);
+
+    public static SKImageFilter CreateDropShadow(float dropOffsetX, float dropOffsetY, float sigma, float f, SKColor color)
+        => s_sk3FilterDropShadow(dropOffsetX, dropOffsetY, sigma, f, color);
+
+#if !NET8_0_OR_GREATER
+    [DynamicDependency("CreateBlur(System.Single,System.Single)", typeof(SKImageFilter))]
+#endif
+    private static delegate* managed<float, float, SKImageFilter> GetSKImageFilterCreateBlur()
+    {
+        if (IsSkiaSharp3)
+        {
+#if NET8_0_OR_GREATER
+            return &NewSKImageFilterCreateBlur;
+#else
+            var method = typeof(SKImageFilter).GetMethod("CreateBlur", new[] { typeof(float), typeof(float) })!;
+            return (delegate* managed<float, float, SKImageFilter>)method.MethodHandle.GetFunctionPointer();
+#endif
+        }
+        else
+        {
+            return &LegacyBlurCall;
+
+            static SKImageFilter LegacyBlurCall(float sigmaX, float sigmaY) =>
+                SKImageFilter.CreateBlur(sigmaX, sigmaY);
+        }
+    }
+    
+#if !NET8_0_OR_GREATER
+    [DynamicDependency("CreateDropShadow(System.Single,System.Single,System.Single,System.Single,SkiaSharp.SKColor)", typeof(SKImageFilter))]
+#endif
+    private static delegate* managed<float, float, float, float, SKColor, SKImageFilter> GetSKImageFilterCreateDropShadow()
+    {
+        if (IsSkiaSharp3)
+        {
+#if NET8_0_OR_GREATER
+            return &NewSKImageFilterCreateDropShadow;
+#else
+            var method = typeof(SKImageFilter).GetMethod("CreateDropShadow",
+                new[] { typeof(float), typeof(float), typeof(float), typeof(float), typeof(SKColor) })!;
+            return (delegate* managed<float, float, float, float, SKColor, SKImageFilter>)method
+                .MethodHandle.GetFunctionPointer();
+#endif
+        }
+        else
+        {
+            return &LegacyDropShadowCall;
+
+            static SKImageFilter LegacyDropShadowCall(float dropOffsetX, float dropOffsetY, float sigma, float f, SKColor color) =>
+                SKImageFilter.CreateDropShadow(dropOffsetX, dropOffsetY, sigma, f, color);
+        }
+    }
+
+#if NET8_0_OR_GREATER
+    // See https://github.com/dotnet/runtime/issues/90081 why we need `SKImageFilter _`
+    [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "CreateBlur")]
+    private static extern SKImageFilter NewSKImageFilterCreateBlur(SKImageFilter? _, float sigmaX, float sigmaY);
+    private static SKImageFilter NewSKImageFilterCreateBlur(float sigmaX, float sigmaY)
+        => NewSKImageFilterCreateBlur(null, sigmaX, sigmaY);
+
+    [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "CreateDropShadow")]
+    private static extern SKImageFilter NewSKImageFilterCreateDropShadow(SKImageFilter? _, float dropOffsetX,
+        float dropOffsetY, float sigma, float f, SKColor color);
+    private static SKImageFilter NewSKImageFilterCreateDropShadow(float dropOffsetX, float dropOffsetY, float sigma, float f, SKColor color)
+        => NewSKImageFilterCreateDropShadow(null, dropOffsetX, dropOffsetY, sigma, f, color);
+#endif
+}

--- a/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKImageFilter.cs
+++ b/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKImageFilter.cs
@@ -1,52 +1,44 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using SkiaSharp;
 
 namespace Avalonia.Skia;
 
-internal static unsafe partial class SkiaCompat
+internal static partial class SkiaCompat
 {
-    private static readonly delegate* managed<float, float, SKImageFilter> s_sk3FilterBlur;
-    private static readonly delegate* managed<float, float, float, float, SKColor, SKImageFilter> s_sk3FilterDropShadow;
-
-    public static SKImageFilter CreateBlur(float sigmaX, float sigmaY) => s_sk3FilterBlur(sigmaX, sigmaY);
-
-    public static SKImageFilter CreateDropShadow(float dropOffsetX, float dropOffsetY, float sigma, float f, SKColor color)
-        => s_sk3FilterDropShadow(dropOffsetX, dropOffsetY, sigma, f, color);
-
-    private static delegate* managed<float, float, SKImageFilter> GetSKImageFilterCreateBlur(bool isSkiaSharp3)
+    public static SKImageFilter CreateBlur(float sigmaX, float sigmaY)
     {
-        if (isSkiaSharp3)
+        if (s_isSkiaSharp3)
         {
 #if NET8_0_OR_GREATER
-            return &NewSKImageFilterCreateBlur;
+            return NewSKImageFilterCreateBlur(null, sigmaX, sigmaY);
 #else
             throw UnsupportedException();
 #endif
         }
         else
         {
-            return &LegacyBlurCall;
+            return LegacyBlurCall(sigmaX, sigmaY);
 
             static SKImageFilter LegacyBlurCall(float sigmaX, float sigmaY) =>
                 SKImageFilter.CreateBlur(sigmaX, sigmaY);
         }
     }
 
-    private static delegate* managed<float, float, float, float, SKColor, SKImageFilter> GetSKImageFilterCreateDropShadow(bool isSkiaSharp3)
+    public static SKImageFilter CreateDropShadow(float dropOffsetX, float dropOffsetY, float sigma, float f,
+        SKColor color)
     {
-        if (isSkiaSharp3)
+        if (s_isSkiaSharp3)
         {
 #if NET8_0_OR_GREATER
-            return &NewSKImageFilterCreateDropShadow;
+            return NewSKImageFilterCreateDropShadow(null!, dropOffsetX, dropOffsetY, sigma, f, color);
 #else
             throw UnsupportedException();
 #endif
         }
         else
         {
-            return &LegacyDropShadowCall;
+            return LegacyDropShadowCall(dropOffsetX, dropOffsetY, sigma, f, color);
 
             static SKImageFilter LegacyDropShadowCall(float dropOffsetX, float dropOffsetY, float sigma, float f, SKColor color) =>
                 SKImageFilter.CreateDropShadow(dropOffsetX, dropOffsetY, sigma, f, color);
@@ -57,13 +49,9 @@ internal static unsafe partial class SkiaCompat
     // See https://github.com/dotnet/runtime/issues/90081 why we need `SKImageFilter _`
     [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "CreateBlur")]
     private static extern SKImageFilter NewSKImageFilterCreateBlur(SKImageFilter? _, float sigmaX, float sigmaY);
-    private static SKImageFilter NewSKImageFilterCreateBlur(float sigmaX, float sigmaY)
-        => NewSKImageFilterCreateBlur(null, sigmaX, sigmaY);
 
     [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "CreateDropShadow")]
     private static extern SKImageFilter NewSKImageFilterCreateDropShadow(SKImageFilter? _, float dropOffsetX,
         float dropOffsetY, float sigma, float f, SKColor color);
-    private static SKImageFilter NewSKImageFilterCreateDropShadow(float dropOffsetX, float dropOffsetY, float sigma, float f, SKColor color)
-        => NewSKImageFilterCreateDropShadow(null, dropOffsetX, dropOffsetY, sigma, f, color);
 #endif
 }

--- a/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKPath.cs
+++ b/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKPath.cs
@@ -1,29 +1,24 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using SkiaSharp;
 
 namespace Avalonia.Skia;
 
-internal static unsafe partial class SkiaCompat
+internal static partial class SkiaCompat
 {
-    private static readonly delegate* managed<SKPath, in SKMatrix, void> s_pathTransform;
-
-    public static void CTransform(this SKPath path, in SKMatrix matrix) => s_pathTransform(path, matrix);
-
-    private static delegate* managed<SKPath, in SKMatrix, void> GetPathTransform(bool isSkiaSharp3)
+    public static void Transform(SKPath path, in SKMatrix matrix)
     {
-        if (isSkiaSharp3)
+        if (s_isSkiaSharp3)
         {
 #if NET8_0_OR_GREATER
-            return &NewPathTransform;
+            NewPathTransform(path, matrix);
 #else
             throw UnsupportedException();
 #endif
         }
         else
         {
-            return &LegacyCall;
+            LegacyCall(path, matrix);
 
             static void LegacyCall(SKPath path, in SKMatrix matrix) =>
                 path.Transform(matrix);

--- a/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKPath.cs
+++ b/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKPath.cs
@@ -11,9 +11,6 @@ internal static unsafe partial class SkiaCompat
 
     public static void CTransform(this SKPath path, in SKMatrix matrix) => s_pathTransform(path, matrix);
 
-#if !NET8_0_OR_GREATER
-    [DynamicDependency("Transform(SkiaSharp.SKMatrix)", typeof(SKPath))]
-#endif
     private static delegate* managed<SKPath, in SKMatrix, void> GetPathTransform()
     {
         if (IsSkiaSharp3)
@@ -21,8 +18,7 @@ internal static unsafe partial class SkiaCompat
 #if NET8_0_OR_GREATER
             return &NewPathTransform;
 #else
-            var method = typeof(SKPath).GetMethod("Transform", new[] { typeof(SKMatrix).MakeByRefType() })!;
-            return (delegate* managed<SKPath, in SKMatrix, void>)method.MethodHandle.GetFunctionPointer();
+            throw UnsupportedException();
 #endif
         }
         else

--- a/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKPath.cs
+++ b/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKPath.cs
@@ -11,9 +11,9 @@ internal static unsafe partial class SkiaCompat
 
     public static void CTransform(this SKPath path, in SKMatrix matrix) => s_pathTransform(path, matrix);
 
-    private static delegate* managed<SKPath, in SKMatrix, void> GetPathTransform()
+    private static delegate* managed<SKPath, in SKMatrix, void> GetPathTransform(bool isSkiaSharp3)
     {
-        if (IsSkiaSharp3)
+        if (isSkiaSharp3)
         {
 #if NET8_0_OR_GREATER
             return &NewPathTransform;

--- a/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKPath.cs
+++ b/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.SKPath.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using SkiaSharp;
+
+namespace Avalonia.Skia;
+
+internal static unsafe partial class SkiaCompat
+{
+    private static readonly delegate* managed<SKPath, in SKMatrix, void> s_pathTransform;
+
+    public static void CTransform(this SKPath path, in SKMatrix matrix) => s_pathTransform(path, matrix);
+
+#if !NET8_0_OR_GREATER
+    [DynamicDependency("Transform(SkiaSharp.SKMatrix)", typeof(SKPath))]
+#endif
+    private static delegate* managed<SKPath, in SKMatrix, void> GetPathTransform()
+    {
+        if (IsSkiaSharp3)
+        {
+#if NET8_0_OR_GREATER
+            return &NewPathTransform;
+#else
+            var method = typeof(SKPath).GetMethod("Transform", new[] { typeof(SKMatrix).MakeByRefType() })!;
+            return (delegate* managed<SKPath, in SKMatrix, void>)method.MethodHandle.GetFunctionPointer();
+#endif
+        }
+        else
+        {
+            return &LegacyCall;
+
+            static void LegacyCall(SKPath path, in SKMatrix matrix) =>
+                path.Transform(matrix);
+        }
+    }
+
+#if NET8_0_OR_GREATER
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "Transform")]
+    private static extern void NewPathTransform(SKPath path, in SKMatrix matrix);
+#endif
+}

--- a/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.cs
+++ b/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.cs
@@ -6,14 +6,13 @@ namespace Avalonia.Skia;
 
 internal static unsafe partial class SkiaCompat
 {
-    private static bool IsSkiaSharp3 { get; } = typeof(SKPath).Assembly.GetName().Version?.Major == 3;
-
     static SkiaCompat()
     {
-        s_canvasSetMatrix = GetCanvasSetMatrix();
-        s_pathTransform = GetPathTransform();
-        s_sk3FilterBlur = GetSKImageFilterCreateBlur();
-        s_sk3FilterDropShadow = GetSKImageFilterCreateDropShadow();
+        var isSkiaSharp3 = typeof(SKPath).Assembly.GetName().Version?.Major == 3;
+        s_canvasSetMatrix = GetCanvasSetMatrix(isSkiaSharp3);
+        s_pathTransform = GetPathTransform(isSkiaSharp3);
+        s_sk3FilterBlur = GetSKImageFilterCreateBlur(isSkiaSharp3);
+        s_sk3FilterDropShadow = GetSKImageFilterCreateDropShadow(isSkiaSharp3);
     }
 
 #if !NET8_0_OR_GREATER

--- a/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.cs
+++ b/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.cs
@@ -1,19 +1,11 @@
 using System;
-using System.Runtime.CompilerServices;
 using SkiaSharp;
 
 namespace Avalonia.Skia;
 
-internal static unsafe partial class SkiaCompat
+internal static partial class SkiaCompat
 {
-    static SkiaCompat()
-    {
-        var isSkiaSharp3 = typeof(SKPath).Assembly.GetName().Version?.Major == 3;
-        s_canvasSetMatrix = GetCanvasSetMatrix(isSkiaSharp3);
-        s_pathTransform = GetPathTransform(isSkiaSharp3);
-        s_sk3FilterBlur = GetSKImageFilterCreateBlur(isSkiaSharp3);
-        s_sk3FilterDropShadow = GetSKImageFilterCreateDropShadow(isSkiaSharp3);
-    }
+    private static readonly bool s_isSkiaSharp3 = typeof(SKPaint).Assembly.GetName().Version?.Major == 3;
 
 #if !NET8_0_OR_GREATER
     private static Exception UnsupportedException()

--- a/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.cs
+++ b/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.cs
@@ -1,0 +1,17 @@
+using System.Runtime.CompilerServices;
+using SkiaSharp;
+
+namespace Avalonia.Skia;
+
+internal static unsafe partial class SkiaCompat
+{
+    private static bool IsSkiaSharp3 { get; } = typeof(SKPath).Assembly.GetName().Version?.Major == 3;
+
+    static SkiaCompat()
+    {
+        s_canvasSetMatrix = GetCanvasSetMatrix();
+        s_pathTransform = GetPathTransform();
+        s_sk3FilterBlur = GetSKImageFilterCreateBlur();
+        s_sk3FilterDropShadow = GetSKImageFilterCreateDropShadow();
+    }
+}

--- a/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.cs
+++ b/src/Skia/Avalonia.Skia/Compatibility/SkiaCompat.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using SkiaSharp;
 
@@ -14,4 +15,11 @@ internal static unsafe partial class SkiaCompat
         s_sk3FilterBlur = GetSKImageFilterCreateBlur();
         s_sk3FilterDropShadow = GetSKImageFilterCreateDropShadow();
     }
+
+#if !NET8_0_OR_GREATER
+    private static Exception UnsupportedException()
+    {
+        return new InvalidOperationException("Avalonia doesn't support SkiaSharp 3.0 on .NET 7 and older. Please upgrade to .NET 8.");
+    }
+#endif
 }

--- a/src/Skia/Avalonia.Skia/DrawingContextImpl.Effects.cs
+++ b/src/Skia/Avalonia.Skia/DrawingContextImpl.Effects.cs
@@ -30,7 +30,7 @@ partial class DrawingContextImpl
             if (blur.Radius <= 0)
                 return null;
             var sigma = SkBlurRadiusToSigma(blur.Radius);
-            return SKImageFilter.CreateBlur(sigma, sigma);
+            return SkiaCompat.CreateBlur(sigma, sigma);
         }
 
         if (effect is IDropShadowEffect drop)
@@ -41,7 +41,7 @@ partial class DrawingContextImpl
                 alpha *= _currentOpacity;
             var color = new SKColor(drop.Color.R, drop.Color.G, drop.Color.B, (byte)Math.Max(0, Math.Min(255, alpha)));
 
-            return SKImageFilter.CreateDropShadow((float)drop.OffsetX, (float)drop.OffsetY, sigma, sigma, color);
+            return SkiaCompat.CreateDropShadow((float)drop.OffsetX, (float)drop.OffsetY, sigma, sigma, color);
         }
 
         return null;

--- a/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
+++ b/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
@@ -139,7 +139,7 @@ namespace Avalonia.Skia
                 {
                     if (!_isDisposed)
                     {
-                        _context.Canvas.CSetMatrix(_revertTransform);
+                        SkiaCompat.SetMatrix(_context.Canvas, _revertTransform);
                         _context._leased = false;
                         _isDisposed = true;
                     }
@@ -853,7 +853,7 @@ namespace Avalonia.Skia
                     transform *= _postTransform.Value;
                 }
 
-                Canvas.CSetMatrix(transform.ToSKMatrix());
+                SkiaCompat.SetMatrix(Canvas, transform.ToSKMatrix());
             }
         }
 

--- a/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
+++ b/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
@@ -139,7 +139,7 @@ namespace Avalonia.Skia
                 {
                     if (!_isDisposed)
                     {
-                        _context.Canvas.SetMatrix(_revertTransform);
+                        _context.Canvas.CSetMatrix(_revertTransform);
                         _context._leased = false;
                         _isDisposed = true;
                     }
@@ -328,7 +328,7 @@ namespace Avalonia.Skia
             {
                 var ac = shadow.Color;
 
-                var filter = SKImageFilter.CreateBlur(SkBlurRadiusToSigma(shadow.Blur), SkBlurRadiusToSigma(shadow.Blur));
+                var filter = SkiaCompat.CreateBlur(SkBlurRadiusToSigma(shadow.Blur), SkBlurRadiusToSigma(shadow.Blur));
                 var color = new SKColor(ac.R, ac.G, ac.B, (byte)(ac.A * opacity));
 
                 paint.Reset();
@@ -853,7 +853,7 @@ namespace Avalonia.Skia
                     transform *= _postTransform.Value;
                 }
 
-                Canvas.SetMatrix(transform.ToSKMatrix());
+                Canvas.CSetMatrix(transform.ToSKMatrix());
             }
         }
 

--- a/src/Skia/Avalonia.Skia/SurfaceRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/SurfaceRenderTarget.cs
@@ -157,7 +157,7 @@ namespace Avalonia.Skia
                 var oldMatrix = context.Canvas.TotalMatrix;
                 context.Canvas.ResetMatrix();
                 _surface.Surface.Draw(context.Canvas, 0, 0, null);
-                context.Canvas.SetMatrix(oldMatrix);
+                context.Canvas.CSetMatrix(oldMatrix);
             }
         }
 

--- a/src/Skia/Avalonia.Skia/SurfaceRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/SurfaceRenderTarget.cs
@@ -157,7 +157,7 @@ namespace Avalonia.Skia
                 var oldMatrix = context.Canvas.TotalMatrix;
                 context.Canvas.ResetMatrix();
                 _surface.Surface.Draw(context.Canvas, 0, 0, null);
-                context.Canvas.CSetMatrix(oldMatrix);
+                SkiaCompat.SetMatrix(context.Canvas, oldMatrix);
             }
         }
 

--- a/src/Skia/Avalonia.Skia/TransformedGeometryImpl.cs
+++ b/src/Skia/Avalonia.Skia/TransformedGeometryImpl.cs
@@ -20,8 +20,8 @@ namespace Avalonia.Skia
             var matrix = transform.ToSKMatrix();
 
             var transformedPath = StrokePath =  source.StrokePath.Clone();
-            transformedPath?.Transform(matrix);
-            
+            transformedPath?.CTransform(in matrix);
+
             Bounds = transformedPath?.TightBounds.ToAvaloniaRect() ?? default;
             
             if (ReferenceEquals(source.StrokePath, source.FillPath))
@@ -29,7 +29,7 @@ namespace Avalonia.Skia
             else if (source.FillPath != null)
             {
                 FillPath = transformedPath = source.FillPath.Clone();
-                transformedPath.Transform(matrix);
+                transformedPath.CTransform(in matrix);
             }
         }
 

--- a/src/Skia/Avalonia.Skia/TransformedGeometryImpl.cs
+++ b/src/Skia/Avalonia.Skia/TransformedGeometryImpl.cs
@@ -20,7 +20,8 @@ namespace Avalonia.Skia
             var matrix = transform.ToSKMatrix();
 
             var transformedPath = StrokePath =  source.StrokePath.Clone();
-            transformedPath?.CTransform(in matrix);
+            if (transformedPath is not null)
+                SkiaCompat.Transform(transformedPath, matrix);
 
             Bounds = transformedPath?.TightBounds.ToAvaloniaRect() ?? default;
             
@@ -29,7 +30,7 @@ namespace Avalonia.Skia
             else if (source.FillPath != null)
             {
                 FillPath = transformedPath = source.FillPath.Clone();
-                transformedPath.CTransform(in matrix);
+                SkiaCompat.Transform(transformedPath, matrix);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

We have a very little choice but try to sit on both chairs with SkiaSharp. Otherwise, Avalonia is going to be locked on 2.88 version until 12.0 release which won't happen this year.

For the most part SkiaSharp 3.0 is binary compatible with SkiaSharp 2.88. But not 100%, so it still breaks Avalonia rendering backend.

Ideally, my approach with this PR and that compat is general is something like this:
1. If we are running on 2.88 (runtime check) - call original API directly
2. If we are running on 3.0 and .NET 8 - use UnsafeAccessor
3. ~If we are running on 3.0 and .NET 7 or lower - try to call reflection~ EDIT: just throw.

Note: this PR doesn't attempt to use SKSamplingOptions instead of old deprecated API as it was done in https://github.com/AvaloniaUI/Avalonia/pull/12729. In other words, we will use deprecated API until Avalonia fully migrates to 3.0 as a minimum version.

What's tested so far:
1. macOS + metal render
2. All pages on ControlCatalog and RenderDemo
