### PR TITLE
Fix CompiledBinding with RelativeSource/ElementName but no Path

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlBindingPathParser.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlBindingPathParser.cs
@@ -66,7 +66,15 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
 
                             bindingPathAssignment.Values[0] = new ParsedBindingPathNode(pathValue, context.GetAvaloniaTypes().CompiledBindingPath, nodes);
                         }
+
+                        foundPath = true;
                     }
+                }
+
+                if (!foundPath && convertedNode != null)
+                {
+                    var nodes = new List<BindingExpressionGrammar.INode> { convertedNode };
+                    binding.Arguments.Add(new ParsedBindingPathNode(binding, context.GetAvaloniaTypes().CompiledBindingPath, nodes));
                 }
             }
 

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -850,6 +850,28 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         }
 
         [Fact]
+        public void ResolvesElementNameBindingFromLongFormWithoutPath()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
+        x:DataType='local:TestDataContext'>
+    <StackPanel>
+        <TextBlock Text='{CompiledBinding StringProperty}' x:Name='text' />
+        <TextBlock Text='{CompiledBinding ElementName=text}' x:Name='text2' />
+    </StackPanel>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = window.GetControl<TextBlock>("text2");
+
+                Assert.Equal("Avalonia.Controls.TextBlock", textBlock.Text);
+            }
+        }
+
+        [Fact]
         public void ResolvesRelativeSourceBindingLongForm()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
@@ -1574,6 +1596,28 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         }
 
         [Fact]
+        public void Binds_To_Self()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
+        x:DataType='local:TestDataContext'>
+    <TextBlock Name='textBlock' Text='{CompiledBinding $self}' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = window.GetControl<TextBlock>("textBlock");
+
+                window.ApplyTemplate();
+                window.Presenter!.ApplyTemplate();
+
+                Assert.Equal("Avalonia.Controls.TextBlock", textBlock.Text);
+            }
+        }
+
+        [Fact]
         public void Binds_To_Self_Without_DataType()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
@@ -1622,6 +1666,28 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
                 button.IsEnabled = false;
 
                 Assert.False(button.IsVisible);
+            }
+        }
+
+        [Fact]
+        public void Binds_To_RelativeSource_Self()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
+        x:DataType='local:TestDataContext'>
+    <TextBlock Name='textBlock' Text='{CompiledBinding RelativeSource={RelativeSource Self}}' />
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = window.GetControl<TextBlock>("textBlock");
+
+                window.ApplyTemplate();
+                window.Presenter!.ApplyTemplate();
+
+                Assert.Equal("Avalonia.Controls.TextBlock", textBlock.Text);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

As described in #14456, `CompiledBinding`s were in some cases not respecting `RelativeSource` and `ElementName` despite this working with the "shorthand" syntax. 

The problem was that in `AvaloniaXamlIlBindingPathParser.Transform` the `convertedNode` was being discarded if the binding node had no arguments or property value assignments. Add in an extra case to make sure that doesn't happen.

## Fixed issues

Fixes #14456