### PR TITLE
Remove legacy nuget feed no longer reachable (Avalonia 0.10)

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,6 +4,5 @@
   <packageSources>
     <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet-eng" value="https://nuget.avaloniaui.net/repository/avalonia-devdeps/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Cherry pick https://github.com/AvaloniaUI/Avalonia/commit/eafaa6e584a5fcffda9ab2546888822c524b8b0d to Avalonia 0.10 branch, because [it doesn't build now](https://github.com/AvaloniaUI/Avalonia/commits/stable/0.10.x/)