### PR TITLE
Avoid NRE from GetGlyphPath

### DIFF
--- a/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
+++ b/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
@@ -94,7 +94,7 @@ namespace Avalonia.Skia
                 var glyph = glyphRun.GlyphInfos[i].GlyphIndex;
                 var glyphPath = skFont.GetGlyphPath(glyph);
 
-                if (!glyphPath.IsEmpty)
+                if (glyphPath is not null && !glyphPath.IsEmpty)
                 {
                     path.AddPath(glyphPath, (float)currentX, (float)currentY);
                 }


### PR DESCRIPTION
## What does the pull request do?

While building glyph run geometry, GetGlyphPath can return null SKPath. I can consistently reproduce it on macOS in RenderDemo - FormattedText page.
Not sure if it's a correct fix, but seems like it, since we already ignore empty paths.
