### PR TITLE
Move `ScrollIntoView` into `ItemsControl`.

### DIFF
--- a/src/Avalonia.Controls/ItemsControl.cs
+++ b/src/Avalonia.Controls/ItemsControl.cs
@@ -299,6 +299,18 @@ namespace Avalonia.Controls
         public IEnumerable<Control> GetRealizedContainers() => Presenter?.GetRealizedContainers() ?? Array.Empty<Control>();
 
         /// <summary>
+        /// Scrolls the specified item into view.
+        /// </summary>
+        /// <param name="index">The index of the item.</param>
+        public void ScrollIntoView(int index) => Presenter?.ScrollIntoView(index);
+
+        /// <summary>
+        /// Scrolls the specified item into view.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        public void ScrollIntoView(object item) => ScrollIntoView(ItemsView.IndexOf(item));
+
+        /// <summary>
         /// Returns the <see cref="ItemsControl"/> that owns the specified container control.
         /// </summary>
         /// <param name="container">The container.</param>

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -410,18 +410,6 @@ namespace Avalonia.Controls.Primitives
         }
 
         /// <summary>
-        /// Scrolls the specified item into view.
-        /// </summary>
-        /// <param name="index">The index of the item.</param>
-        public void ScrollIntoView(int index) => Presenter?.ScrollIntoView(index);
-
-        /// <summary>
-        /// Scrolls the specified item into view.
-        /// </summary>
-        /// <param name="item">The item.</param>
-        public void ScrollIntoView(object item) => ScrollIntoView(ItemsView.IndexOf(item));
-
-        /// <summary>
         /// Gets the value of the <see cref="IsSelectedProperty"/> on the specified control.
         /// </summary>
         /// <param name="control">The control.</param>


### PR DESCRIPTION
## What does the pull request do?

As described in #14524, `ScrollIntoView` is useful in `ItemsControl` in general and shouldn't be only available in `SelectingItemsControl` and derived.

Moving a method to a base class isn't a breaking change according to the [MS docs](https://learn.microsoft.com/en-us/dotnet/core/compatibility/library-change-rules#members) so this should be OK.

> ✔️ ALLOWED: Moving a member into a class higher in the hierarchy than the type from which it was removed

## Fixed issues

Fixes #14524
