### PR TITLE
Use dynamic resources in Expander button theme.

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/Expander.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/Expander.xaml
@@ -69,10 +69,10 @@
     <Setter Property="BorderBrush" Value="{DynamicResource ExpanderHeaderBorderBrush}" />
     <Setter Property="BorderThickness" Value="{DynamicResource ExpanderHeaderBorderThickness}" />
     <Setter Property="Foreground" Value="{DynamicResource ExpanderHeaderForeground}" />
-    <Setter Property="Padding" Value="{StaticResource ExpanderHeaderPadding}" />
+    <Setter Property="Padding" Value="{DynamicResource ExpanderHeaderPadding}" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
-    <Setter Property="HorizontalContentAlignment" Value="{StaticResource ExpanderHeaderHorizontalContentAlignment}" />
-    <Setter Property="VerticalContentAlignment" Value="{StaticResource ExpanderHeaderVerticalContentAlignment}" />
+    <Setter Property="HorizontalContentAlignment" Value="{DynamicResource ExpanderHeaderHorizontalContentAlignment}" />
+    <Setter Property="VerticalContentAlignment" Value="{DynamicResource ExpanderHeaderVerticalContentAlignment}" />
     <Setter Property="Template">
       <ControlTemplate>
         <Border x:Name="ToggleButtonBackground"
@@ -215,11 +215,11 @@
   <ControlTheme x:Key="{x:Type Expander}" TargetType="Expander">
     <Setter Property="IsTabStop" Value="False"/>
     <Setter Property="MinWidth" Value="{DynamicResource FlyoutThemeMinWidth}" />
-    <Setter Property="MinHeight" Value="{StaticResource ExpanderMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource ExpanderMinHeight}" />
     <Setter Property="Background" Value="{DynamicResource ExpanderContentBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ExpanderContentBorderBrush}" />
     <Setter Property="BorderThickness" Value="{DynamicResource ExpanderContentDownBorderThickness}" />
-    <Setter Property="Padding" Value="{StaticResource ExpanderContentPadding}" />
+    <Setter Property="Padding" Value="{DynamicResource ExpanderContentPadding}" />
     <Setter Property="HorizontalAlignment" Value="Left" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -309,16 +309,16 @@
     </Style>
 
     <Style Selector="^:left /template/ ToggleButton#ExpanderHeader">
-      <Setter Property="Theme" Value="{StaticResource FluentExpanderToggleButtonLeftTheme}" />
+      <Setter Property="Theme" Value="{DynamicResource FluentExpanderToggleButtonLeftTheme}" />
     </Style>
     <Style Selector="^:up /template/ ToggleButton#ExpanderHeader">
-      <Setter Property="Theme" Value="{StaticResource FluentExpanderToggleButtonUpTheme}" />
+      <Setter Property="Theme" Value="{DynamicResource FluentExpanderToggleButtonUpTheme}" />
     </Style>
     <Style Selector="^:right /template/ ToggleButton#ExpanderHeader">
-      <Setter Property="Theme" Value="{StaticResource FluentExpanderToggleButtonRightTheme}" />
+      <Setter Property="Theme" Value="{DynamicResource FluentExpanderToggleButtonRightTheme}" />
     </Style>
     <Style Selector="^:down /template/ ToggleButton#ExpanderHeader">
-      <Setter Property="Theme" Value="{StaticResource FluentExpanderToggleButtonDownTheme}" />
+      <Setter Property="Theme" Value="{DynamicResource FluentExpanderToggleButtonDownTheme}" />
     </Style>
 
     <Style Selector="^:left /template/ Border#ExpanderContent">


### PR DESCRIPTION
## What does the pull request do?

I'm not sure why, but the fluent `Expander` theme uses a mix of static and dynamic resources with seemingly no reason to differentiate them. It's not so much a problem for the resources in the default values for `Expander` as these can be overridden with local values, but for the toggle button and trigger styles, it means there's no way to customize these values.

Converted all of the `StaticResource`s to `DynamicResource`s.

Pinging @robloo who wrote this theme to check whether this change makes sense, or whether the static resources were there for a reason.
