### PR TITLE
Fix for Win32Platform ArgumentException when creating WindowIcon from Bitmap

### DIFF
--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -236,13 +236,11 @@ namespace Avalonia.Win32
 
         public IWindowIconImpl LoadIcon(IBitmapImpl bitmap)
         {
-            using (var memoryStream = new MemoryStream())
+            using (var stream = new MemoryStream())
             {
-                bitmap.Save(memoryStream);
+                bitmap.Save(stream);
 
-                var iconData = memoryStream.ToArray();
-
-                return new IconImpl(new Win32Icon(iconData), iconData);
+                return CreateIconImpl(stream);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
The PR fixes the issue #14541, by extending the **Win32Platform** correction already provided in [this PR](https://github.com/AvaloniaUI/Avalonia/pull/13466).

The other relevant implementations of **IPlatformIconLoader** in **Avalonia.X11.X11IconLoader** and **Avalonia.Native.IconLoader** implement the logic correctly, thus are not affected by the issue.

## What is the current behavior?
The **Win32Platform** implementation of **IWindowIconImpl LoadIcon(IBitmapImpl bitmap)** _throws_ an **ArgumentException**.

## What is the updated/expected behavior with this PR?
The Win32Platform implementation of **IWindowIconImpl LoadIcon(IBitmapImpl bitmap)** _does not throw_ an **ArgumentException** anymore.

## How was the solution implemented?
The fix calls the method **IconImpl CreateIconImpl(Stream stream)**, just like the other two **LoadIcon()** methods in the class **Win32Platform**.

## Fixed issues
Fixes #14541
