### PR TITLE
Fix popups position on X11

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -1100,10 +1100,12 @@ namespace Avalonia.X11
                     UpdateSizeHints(null);
                 }
 
+                XTranslateCoordinates(_x11.Display, _parentHandle, _x11.RootWindow, 0, 0, out var wx, out var wy, out _);
+
                 var changes = new XWindowChanges
                 {
-                    x = value.X,
-                    y = (int)value.Y
+                    x = value.X - wx,
+                    y = (int)value.Y - wy
                 };
 
                 XConfigureWindow(_x11.Display, _handle, ChangeWindowFlags.CWX | ChangeWindowFlags.CWY,


### PR DESCRIPTION
https://github.com/AvaloniaUI/Avalonia/commit/567561e27212a2c39ef59448a98d4e3497dd647c caused the origin of window to not be (0, 0) for popups on X.

As a result, all popups were wrongly positioned.

This change Position to translate from root window coordinates (the display space) to parent window coordinates.

I also changed every X calls to depends on the correct parent in X11Window.

This is a major regression in Avalonia 11.0.8, sorry about that. :sweat_smile: 

This time tested under KDE Plasma 5 and gamescope.