### PR TITLE
feat(NumericUpDown): Add InnerLeftContent and InnerRightContent

### DIFF
--- a/samples/ControlCatalog/Pages/NumericUpDownPage.xaml
+++ b/samples/ControlCatalog/Pages/NumericUpDownPage.xaml
@@ -114,27 +114,21 @@
       </StackPanel>
     </WrapPanel>
 
-    <WrapPanel>
-      <StackPanel Margin="5">
-        <Label Content="Inner Right Content"
-               FontWeight="Bold"/>
-        <NumericUpDown ButtonSpinnerLocation="Left"
-                       MinWidth="200">
-          <NumericUpDown.InnerContent>
-            <Button Content="X"/>
-          </NumericUpDown.InnerContent>
-        </NumericUpDown>
-      </StackPanel>
-      <StackPanel Margin="5">
-        <Label Content="Inner Left Content"
-               FontWeight="Bold"/>
-        <NumericUpDown ButtonSpinnerLocation="Right"
-                       MinWidth="200">
-          <NumericUpDown.InnerContent>
-            <Button Content="X"/>
-          </NumericUpDown.InnerContent>
-        </NumericUpDown>
-      </StackPanel>
-    </WrapPanel>
+    <StackPanel Margin="10">
+      <Label FontSize="14" FontWeight="Bold" Target="InnerContent"
+             Content="Inner Contents"/>
+      <NumericUpDown ButtonSpinnerLocation="Left"
+                     TextAlignment="Right"
+                     x:Name="InnerContent">
+        <NumericUpDown.InnerLeftContent>
+          <TextBlock Text="m"
+            TextAlignment="Center"
+            VerticalAlignment="Center"/>
+        </NumericUpDown.InnerLeftContent>
+        <NumericUpDown.InnerRightContent>
+          <Button Content="X"/>
+        </NumericUpDown.InnerRightContent>
+      </NumericUpDown>
+    </StackPanel>
   </StackPanel>
 </UserControl>

--- a/samples/ControlCatalog/Pages/NumericUpDownPage.xaml
+++ b/samples/ControlCatalog/Pages/NumericUpDownPage.xaml
@@ -114,5 +114,27 @@
       </StackPanel>
     </WrapPanel>
 
+    <WrapPanel>
+      <StackPanel Margin="5">
+        <Label Content="Inner Right Content"
+               FontWeight="Bold"/>
+        <NumericUpDown ButtonSpinnerLocation="Left"
+                       MinWidth="200">
+          <NumericUpDown.InnerContent>
+            <Button Content="X"/>
+          </NumericUpDown.InnerContent>
+        </NumericUpDown>
+      </StackPanel>
+      <StackPanel Margin="5">
+        <Label Content="Inner Left Content"
+               FontWeight="Bold"/>
+        <NumericUpDown ButtonSpinnerLocation="Right"
+                       MinWidth="200">
+          <NumericUpDown.InnerContent>
+            <Button Content="X"/>
+          </NumericUpDown.InnerContent>
+        </NumericUpDown>
+      </StackPanel>
+    </WrapPanel>
   </StackPanel>
 </UserControl>

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -133,10 +133,16 @@ namespace Avalonia.Controls
             TextBox.TextAlignmentProperty.AddOwner<NumericUpDown>();
 
         /// <summary>
-        /// Defines the <see cref="InnerContent"/> property
+        /// Defines the <see cref="InnerLeftContent"/> property
         /// </summary>
-        public static readonly StyledProperty<object?> InnerContentProperty =
-            AvaloniaProperty.Register<NumericUpDown, object?>(nameof(InnerContent));
+        public static readonly StyledProperty<object?> InnerLeftContentProperty =
+            TextBox.InnerLeftContentProperty.AddOwner<NumericUpDown>();
+
+        /// <summary>
+        /// Defines the <see cref="InnerRightContent"/> property
+        /// </summary>
+        public static readonly StyledProperty<object?> InnerRightContentProperty =
+            TextBox.InnerRightContentProperty.AddOwner<NumericUpDown>();
 
         private IDisposable? _textBoxTextChangedSubscription;
 
@@ -338,12 +344,22 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
-        /// Gets or sets custom content in inside layout box. It is positioned on the opposite side to <see cref="ButtonSpinnerLocation"/>
+        /// Gets or sets custom content that is positioned on the left side of the text layout box
         /// </summary>
-        public object? InnerContent
+        public object? InnerLeftContent
         {
-            get => GetValue(InnerContentProperty);
-            set => SetValue(InnerContentProperty, value);
+            get => GetValue(InnerLeftContentProperty);
+            set => SetValue(InnerLeftContentProperty, value);
+        }
+
+
+        /// <summary>
+        /// Gets or sets custom content that is positioned on the right side of the text layout box
+        /// </summary>
+        public object? InnerRightContent
+        {
+            get => GetValue(InnerRightContentProperty);
+            set => SetValue(InnerRightContentProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -132,6 +132,12 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<Media.TextAlignment> TextAlignmentProperty =
             TextBox.TextAlignmentProperty.AddOwner<NumericUpDown>();
 
+        /// <summary>
+        /// Defines the <see cref="InnerContent"/> property
+        /// </summary>
+        public static readonly StyledProperty<object?> InnerContentProperty =
+            AvaloniaProperty.Register<NumericUpDown, object?>(nameof(InnerContent));
+
         private IDisposable? _textBoxTextChangedSubscription;
 
         private bool _internalValueSet;
@@ -329,6 +335,15 @@ namespace Avalonia.Controls
 
                 SetValidSpinDirection();
             };
+        }
+
+        /// <summary>
+        /// Gets or sets custom content in inside layout box. It is positioned on the opposite side to <see cref="ButtonSpinnerLocation"/>
+        /// </summary>
+        public object? InnerContent
+        {
+            get => GetValue(InnerContentProperty);
+            set => SetValue(InnerContentProperty, value);
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -194,14 +194,14 @@ namespace Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="InnerLeftContent"/> property
         /// </summary>
-        public static readonly StyledProperty<object> InnerLeftContentProperty =
-            AvaloniaProperty.Register<TextBox, object>(nameof(InnerLeftContent));
+        public static readonly StyledProperty<object?> InnerLeftContentProperty =
+            AvaloniaProperty.Register<TextBox, object?>(nameof(InnerLeftContent));
 
         /// <summary>
         /// Defines the <see cref="InnerRightContent"/> property
         /// </summary>
-        public static readonly StyledProperty<object> InnerRightContentProperty =
-            AvaloniaProperty.Register<TextBox, object>(nameof(InnerRightContent));
+        public static readonly StyledProperty<object?> InnerRightContentProperty =
+            AvaloniaProperty.Register<TextBox, object?>(nameof(InnerRightContent));
 
         /// <summary>
         /// Defines the <see cref="RevealPassword"/> property
@@ -653,7 +653,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets or sets custom content that is positioned on the left side of the text layout box
         /// </summary>
-        public object InnerLeftContent
+        public object? InnerLeftContent
         {
             get => GetValue(InnerLeftContentProperty);
             set => SetValue(InnerLeftContentProperty, value);
@@ -662,7 +662,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets or sets custom content that is positioned on the right side of the text layout box
         /// </summary>
-        public object InnerRightContent
+        public object? InnerRightContent
         {
             get => GetValue(InnerRightContentProperty);
             set => SetValue(InnerRightContentProperty, value);

--- a/src/Avalonia.Themes.Fluent/Controls/NumericUpDown.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/NumericUpDown.xaml
@@ -15,6 +15,16 @@
                        HorizontalContentAlignment="Center"
                        ButtonSpinnerLocation="Left"
                        Watermark="Enter text" />
+        <NumericUpDown ButtonSpinnerLocation="Left">
+          <NumericUpDown.InnerContent>
+            <Button Content="X"/>
+          </NumericUpDown.InnerContent>
+        </NumericUpDown>
+        <NumericUpDown ButtonSpinnerLocation="Right">
+          <NumericUpDown.InnerContent>
+            <Button Content="X"/>
+          </NumericUpDown.InnerContent>
+        </NumericUpDown>
       </StackPanel>
     </Border>
   </Design.PreviewWith>
@@ -62,5 +72,12 @@
         </ButtonSpinner>
       </ControlTemplate>
     </Setter>
+    <Style Selector="^[ButtonSpinnerLocation=Left] /template/ TextBox#PART_TextBox">
+      <Setter Property="InnerRightContent" Value="{Binding InnerContent, RelativeSource={RelativeSource TemplatedParent}}"/>
+    </Style>
+
+    <Style Selector="^[ButtonSpinnerLocation=Right] /template/ TextBox#PART_TextBox">
+      <Setter Property="InnerLeftContent" Value="{Binding InnerContent, RelativeSource={RelativeSource TemplatedParent}}"/>
+    </Style>
   </ControlTheme>
 </ResourceDictionary>

--- a/src/Avalonia.Themes.Fluent/Controls/NumericUpDown.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/NumericUpDown.xaml
@@ -32,7 +32,7 @@
           <NumericUpDown.InnerRightContent>
             <TextBlock Text="m"
               TextAlignment="Center"
-              VerticalAlignment="Center"/>            
+              VerticalAlignment="Center"/>
           </NumericUpDown.InnerRightContent>
         </NumericUpDown>
       </StackPanel>

--- a/src/Avalonia.Themes.Fluent/Controls/NumericUpDown.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/NumericUpDown.xaml
@@ -16,14 +16,24 @@
                        ButtonSpinnerLocation="Left"
                        Watermark="Enter text" />
         <NumericUpDown ButtonSpinnerLocation="Left">
-          <NumericUpDown.InnerContent>
+          <NumericUpDown.InnerLeftContent>
+            <TextBlock Text="m"
+              TextAlignment="Center"
+              VerticalAlignment="Center"/>
+          </NumericUpDown.InnerLeftContent>
+          <NumericUpDown.InnerRightContent>
             <Button Content="X"/>
-          </NumericUpDown.InnerContent>
+          </NumericUpDown.InnerRightContent>
         </NumericUpDown>
         <NumericUpDown ButtonSpinnerLocation="Right">
-          <NumericUpDown.InnerContent>
+          <NumericUpDown.InnerLeftContent>
             <Button Content="X"/>
-          </NumericUpDown.InnerContent>
+          </NumericUpDown.InnerLeftContent>
+          <NumericUpDown.InnerRightContent>
+            <TextBlock Text="m"
+              TextAlignment="Center"
+              VerticalAlignment="Center"/>            
+          </NumericUpDown.InnerRightContent>
         </NumericUpDown>
       </StackPanel>
     </Border>
@@ -68,16 +78,12 @@
                    Text="{TemplateBinding Text}"
                    TextAlignment="{TemplateBinding TextAlignment}"
                    AcceptsReturn="False"
-                   TextWrapping="NoWrap" />
+                   TextWrapping="NoWrap"
+                   InnerLeftContent="{Binding InnerLeftContent, RelativeSource={RelativeSource TemplatedParent}}"
+                   InnerRightContent="{Binding InnerRightContent, RelativeSource={RelativeSource TemplatedParent}}"
+                   />
         </ButtonSpinner>
       </ControlTemplate>
     </Setter>
-    <Style Selector="^[ButtonSpinnerLocation=Left] /template/ TextBox#PART_TextBox">
-      <Setter Property="InnerRightContent" Value="{Binding InnerContent, RelativeSource={RelativeSource TemplatedParent}}"/>
-    </Style>
-
-    <Style Selector="^[ButtonSpinnerLocation=Right] /template/ TextBox#PART_TextBox">
-      <Setter Property="InnerLeftContent" Value="{Binding InnerContent, RelativeSource={RelativeSource TemplatedParent}}"/>
-    </Style>
   </ControlTheme>
 </ResourceDictionary>

--- a/src/Avalonia.Themes.Simple/Controls/NumericUpDown.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/NumericUpDown.xaml
@@ -34,16 +34,12 @@
                    Text="{TemplateBinding Text}"
                    TextAlignment="{TemplateBinding TextAlignment}"
                    TextWrapping="NoWrap"
-                   Watermark="{TemplateBinding Watermark}" />
+                   Watermark="{TemplateBinding Watermark}"
+                   InnerLeftContent="{Binding InnerLeftContent, RelativeSource={RelativeSource TemplatedParent}}"
+                   InnerRightContent="{Binding InnerRightContent, RelativeSource={RelativeSource TemplatedParent}}"
+                   />
         </ButtonSpinner>
       </ControlTemplate>
     </Setter>
-    <Style Selector="^[ButtonSpinnerLocation=Left] /template/ TextBox#PART_TextBox">
-      <Setter Property="InnerRightContent" Value="{Binding InnerContent, RelativeSource={RelativeSource TemplatedParent}}"/>
-    </Style>
-
-    <Style Selector="^[ButtonSpinnerLocation=Right] /template/ TextBox#PART_TextBox">
-      <Setter Property="InnerLeftContent" Value="{Binding InnerContent, RelativeSource={RelativeSource TemplatedParent}}"/>
-    </Style>
   </ControlTheme>
 </ResourceDictionary>

--- a/src/Avalonia.Themes.Simple/Controls/NumericUpDown.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/NumericUpDown.xaml
@@ -38,5 +38,12 @@
         </ButtonSpinner>
       </ControlTemplate>
     </Setter>
+    <Style Selector="^[ButtonSpinnerLocation=Left] /template/ TextBox#PART_TextBox">
+      <Setter Property="InnerRightContent" Value="{Binding InnerContent, RelativeSource={RelativeSource TemplatedParent}}"/>
+    </Style>
+
+    <Style Selector="^[ButtonSpinnerLocation=Right] /template/ TextBox#PART_TextBox">
+      <Setter Property="InnerLeftContent" Value="{Binding InnerContent, RelativeSource={RelativeSource TemplatedParent}}"/>
+    </Style>
   </ControlTheme>
 </ResourceDictionary>


### PR DESCRIPTION
Add InnerLeftContent and InnerRightContent to NumericUpDown. 

![immagine](https://github.com/AvaloniaUI/Avalonia/assets/12531229/881852a1-07ac-499f-9faf-8fea39794f17)



<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes #14314
