### PR TITLE
Disable render window on X11 popups

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -105,7 +105,8 @@ namespace Avalonia.X11
             XVisualInfo? visualInfo = null;
 
             // OpenGL seems to be do weird things to it's current window which breaks resize sometimes
-            _useRenderWindow = glfeature != null;
+            // however, render window cause issues on gamescope for popups, disable it in that case
+            _useRenderWindow = !_popup && glfeature != null;
             
             var glx = glfeature as GlxPlatformGraphics;
             if (glx != null)


### PR DESCRIPTION
Gamescope cannot recognize proper relationship between a popup and the popup parent because of the child window embedded here.

Disabling render window on popups should be fine as they shouldn't be resizable.
