### PR TITLE
Fix TextBlock wrong caret position

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -923,6 +923,8 @@ namespace Avalonia.Controls
             }
             else if (change.Property == SelectionEndProperty)
             {
+                _presenter?.MoveCaretToTextPosition(CaretIndex);
+
                 OnSelectionEndChanged(change);
             }
             else if (change.Property == MaxLinesProperty)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Corrects caret behavior after inserting, losing window focus (detected during debugging) , or programmatically changing a TextBox.


## What is the current behavior?
After selecting text from right to left and inserting the same number of characters in the same place or losing window focus, the caret position is displayed before the last (left) character selected. At the same time, after starting to enter new text, it is entered after the first(right) character.
The actual caret position and its display are not the same.

## What is the updated/expected behavior with this PR?
The actual caret position and display now remain the same after pasting, losing window focus, or changing programmatically.

## How was the solution implemented (if it's not obvious)?
Inserting text of the same length does not trigger OnPropertyChanged for CaretIndex.
After insertion, only SelectionEnd in TextBox.cs fires and no one updates CharacterHit _lastCharacterHit in TextPresenter.cs. Same reason for changing the text field programmatically.
TextPresenter.Render(DrawingContext) uses the old index from CharacterHit _lastCharacterHit for rendering.
Added MoveCaretToTextPosition call when changing SelectionEndProperty in TextBox.cs.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues 
Fixes #13648
Fixes #13886
Fixes #14563

## Future

In general, after losing the window's focus and returning it, the selected text should remain and not show the caret, as is implemented everywhere (I don't know MacOS).