### PR TITLE
added _windowProperties override to Win32.EmbeddedWindowImpl

### DIFF
--- a/src/Windows/Avalonia.Win32/EmbeddedWindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/EmbeddedWindowImpl.cs
@@ -1,13 +1,21 @@
 ﻿using System;
-using System.ComponentModel;
-using System.Runtime.InteropServices;
-using Avalonia.Platform;
+using Avalonia.Controls;
 using Avalonia.Win32.Interop;
 
 namespace Avalonia.Win32
 {
     class EmbeddedWindowImpl : WindowImpl
     {
+        public EmbeddedWindowImpl()
+        {
+            _windowProperties = new WindowProperties
+            {
+                ShowInTaskbar = false,
+                IsResizable = false,
+                Decorations = SystemDecorations.None
+            };
+        }
+
         protected override IntPtr CreateWindowOverride(ushort atom)
         {
             var hWnd = UnmanagedMethods.CreateWindowEx(


### PR DESCRIPTION
## What does the pull request do?
Overrides the resizable and SystemDecorations properties of an embedded window.

## What is the current behavior?
Shows chrome and is resizable. Parent control should control the size of a child.

## What is the updated/expected behavior with this PR?
No chrome when embedding an avalonia control in a winforms application

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
Fixes #14640