### PR TITLE
Introduced a way to lease the underlying platform graphics context from Skia context

### DIFF
--- a/api/Avalonia.Skia.nupkg.xml
+++ b/api/Avalonia.Skia.nupkg.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Avalonia.Skia.ISkiaSharpApiLease.TryLeasePlatformGraphicsApi</Target>
+    <Left>baseline/netstandard2.0/Avalonia.Skia.dll</Left>
+    <Right>target/netstandard2.0/Avalonia.Skia.dll</Right>
+  </Suppression>
+</Suppressions>

--- a/src/Skia/Avalonia.Skia/Gpu/ISkiaGpu.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/ISkiaGpu.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Avalonia.Metadata;
 using Avalonia.Platform;
 using SkiaSharp;
 
@@ -23,6 +24,13 @@ namespace Avalonia.Skia
         /// <param name="size">size in pixels.</param>
         /// <param name="session">An optional custom render session.</param>
         ISkiaSurface? TryCreateSurface(PixelSize size, ISkiaGpuRenderSession? session);
+    }
+
+    //TODO12: Merge into ISkiaGpu
+    [Unstable]
+    public interface ISkiaGpuWithPlatformGraphicsContext : ISkiaGpu
+    {
+        IPlatformGraphicsContext? PlatformGraphicsContext { get; }
     }
     
     public interface ISkiaSurface : IDisposable

--- a/src/Skia/Avalonia.Skia/Gpu/Metal/SkiaMetalGpu.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/Metal/SkiaMetalGpu.cs
@@ -2,11 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Avalonia.Metal;
+using Avalonia.Platform;
 using SkiaSharp;
 
 namespace Avalonia.Skia.Metal;
 
-internal class SkiaMetalGpu : ISkiaGpu
+internal class SkiaMetalGpu : ISkiaGpu, ISkiaGpuWithPlatformGraphicsContext
 {
     private SkiaMetalApi _api = new();
     private GRContext? _context;
@@ -31,6 +32,7 @@ internal class SkiaMetalGpu : ISkiaGpu
 
     public bool IsLost => false;
     public IDisposable EnsureCurrent() => _device.EnsureCurrent();
+    public IPlatformGraphicsContext? PlatformGraphicsContext => _device;
 
     public ISkiaGpuRenderTarget? TryCreateRenderTarget(IEnumerable<object> surfaces)
     {

--- a/src/Skia/Avalonia.Skia/Gpu/OpenGl/GlSkiaGpu.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/OpenGl/GlSkiaGpu.cs
@@ -10,7 +10,8 @@ using static Avalonia.OpenGL.GlConsts;
 
 namespace Avalonia.Skia
 {
-    internal class GlSkiaGpu : ISkiaGpu, IOpenGlTextureSharingRenderInterfaceContextFeature
+    internal class GlSkiaGpu : ISkiaGpu, IOpenGlTextureSharingRenderInterfaceContextFeature,
+        ISkiaGpuWithPlatformGraphicsContext
     {
         private readonly GRContext _grContext;
         private readonly IGlContext _glContext;
@@ -152,6 +153,7 @@ namespace Avalonia.Skia
 
         public bool IsLost => _glContext.IsLost;
         public IDisposable EnsureCurrent() => _glContext.EnsureCurrent();
+        public IPlatformGraphicsContext? PlatformGraphicsContext => _glContext;
 
         public object? TryGetFeature(Type featureType)
         {

--- a/src/Skia/Avalonia.Skia/ISkiaSharpApiLeaseFeature.cs
+++ b/src/Skia/Avalonia.Skia/ISkiaSharpApiLeaseFeature.cs
@@ -1,5 +1,6 @@
 using System;
 using Avalonia.Metadata;
+using Avalonia.Platform;
 using SkiaSharp;
 
 namespace Avalonia.Skia;
@@ -17,4 +18,11 @@ public interface ISkiaSharpApiLease : IDisposable
     GRContext? GrContext { get; }
     SKSurface? SkSurface { get; }
     double CurrentOpacity { get; }
+    ISkiaSharpPlatformGraphicsApiLease? TryLeasePlatformGraphicsApi();
+}
+
+[Unstable]
+public interface ISkiaSharpPlatformGraphicsApiLease : IDisposable
+{
+    IPlatformGraphicsContext Context { get; }
 }


### PR DESCRIPTION
Works in a similar way to how we expose the skia context from immediate drawing context.

Can be used to e. g. do OpenGL drawing directly on the render thread.