### PR TITLE
Rename Win32SpecificOptions to Win32Properties

### DIFF
--- a/src/Avalonia.Controls/Platform/IWin32OptionsTopLevelImpl.cs
+++ b/src/Avalonia.Controls/Platform/IWin32OptionsTopLevelImpl.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Avalonia.Metadata;
 using Avalonia.Platform;
-using static Avalonia.Controls.Platform.Win32SpecificOptions;
+using static Avalonia.Controls.Win32Properties;
 
 namespace Avalonia.Controls.Platform
 {

--- a/src/Avalonia.Controls/Platform/Win32Properties.cs
+++ b/src/Avalonia.Controls/Platform/Win32Properties.cs
@@ -4,13 +4,14 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Controls.Platform;
 using Avalonia.Metadata;
 using Avalonia.Platform;
 using static Avalonia.Controls.Platform.IWin32OptionsTopLevelImpl;
 
-namespace Avalonia.Controls.Platform
+namespace Avalonia.Controls
 {
-    public static class Win32SpecificOptions
+    public static class Win32Properties
     {
         public delegate (uint style, uint exStyle) CustomWindowStylesCallback(uint style, uint exStyle);
         public delegate IntPtr CustomWndProcHookCallback(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam, ref bool handled);

--- a/src/Avalonia.Controls/Platform/Win32Properties.cs
+++ b/src/Avalonia.Controls/Platform/Win32Properties.cs
@@ -11,6 +11,9 @@ using static Avalonia.Controls.Platform.IWin32OptionsTopLevelImpl;
 
 namespace Avalonia.Controls
 {
+    /// <summary>
+    /// Set of Win32 specific properties and events that allow deeper customization of the application per platform.
+    /// </summary>
     public static class Win32Properties
     {
         public delegate (uint style, uint exStyle) CustomWindowStylesCallback(uint style, uint exStyle);

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -27,7 +27,7 @@ using System.Diagnostics;
 using Avalonia.Platform.Storage.FileIO;
 using Avalonia.Threading;
 using static Avalonia.Controls.Platform.IWin32OptionsTopLevelImpl;
-using static Avalonia.Controls.Platform.Win32SpecificOptions;
+using static Avalonia.Controls.Win32Properties;
 
 namespace Avalonia.Win32
 {


### PR DESCRIPTION
## What does the pull request do?

Renames Win32Properties class to be in line with https://github.com/AvaloniaUI/Avalonia/pull/14348 and https://github.com/AvaloniaUI/Avalonia/pull/14619 PRs as well.
Other option was to name them simply Win32, MacOS, X11, but it would clash with our namespaces.

+ Moves namespace to Avalonia.Controls to be easier accessible from XAML.

## Breaking changes

This PR changes API that wasn't yet shipped in stable releases, so it's not considered a breaking change.

