### PR TITLE
[Win32] Fixes improper IME composition ignorance

### DIFF
--- a/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
+++ b/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs
@@ -127,7 +127,10 @@ namespace Avalonia.Win32.Input
 
                 if (himc != IntPtr.Zero)
                 {
-                    _ignoreComposition = true;
+                    if (IsComposing)
+                    {
+                        _ignoreComposition = true;
+                    }
 
                     if (_parent != null)
                     {


### PR DESCRIPTION
## What does the pull request do?

When focusing on an input element, it goes through a series of calls, ultimately reaching the `Imm32InputMethod.Reset` method via `TextInputMethodManager.TryFindAndApplyClient`. Within this method, a task submitted to the UI thread sets `_ignoreComposition` to `true`, ignoring the first typed character or the first selected candidate word to be submitted at the end of string composition.

This incorrect behavior was introduced in #11723, resolving issue #11292. However, the current solution introduces another problem, as described in #14663.

## What is the current behavior?

When the focus changes, `_ignoreComposition` is set to `true` as described above, and is reset to `false` when handling the next composition message.

https://github.com/AvaloniaUI/Avalonia/blob/a33b39e8e021e01290d8d714f51ae17752fb03fd/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs#L130-L130

https://github.com/AvaloniaUI/Avalonia/blob/a33b39e8e021e01290d8d714f51ae17752fb03fd/src/Windows/Avalonia.Win32/Input/Imm32InputMethod.cs#L352-L357

However, if there is no unfinished composition when switching focus, `_ignoreComposition` remains `true`, causing the next composition message to be unexpectedly ignored.

## What is the updated/expected behavior with this PR?

`_ignoreComposition` should not be kept `true` when no uncompleted string compositions exist, so that the next string composition message can be handled well.

## How was the solution implemented (if it's not obvious)?

The current merge request introduces a condition before setting `_ignoreComposition` to true. It only sets `_ignoreComposition` to `true` when there is ongoing input method string composition, namely `IsComposing` is `true`. This prevents `_ignoreComposition` from being inadvertently retained, addressing issue #14663.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues
Fixes #14663
Fixes #13881
