### PR TITLE
Fix initial selection for TabControl with AlwaysSelected

### DIFF
--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -447,6 +447,12 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnItemsViewCollectionChanged(sender!, e);
 
+            //Do not change SelectedIndex during initialization
+            if (_updateState is not null)
+            {
+                return;
+            }
+
             if (AlwaysSelected && SelectedIndex == -1 && ItemCount > 0)
             {
                 SelectedIndex = 0;
@@ -1217,7 +1223,7 @@ namespace Avalonia.Controls.Primitives
             _oldSelectedIndex = model.SelectedIndex;
             _oldSelectedItem = model.SelectedItem;
 
-            if (AlwaysSelected && model.Count == 0)
+            if (_updateState is null && AlwaysSelected && model.Count == 0)
             {
                 model.SelectedIndex = 0;
             }
@@ -1296,6 +1302,11 @@ namespace Avalonia.Controls.Primitives
                 else if (state.SelectedItem.HasValue)
                 {
                     SelectedItem = state.SelectedItem.Value;
+                }
+
+                if (AlwaysSelected && SelectedIndex == -1 && ItemCount > 0)
+                {
+                    SelectedIndex = 0;
                 }
             }
         }

--- a/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TabControlTests.cs
@@ -2,11 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Selection;
 using Avalonia.Controls.Templates;
 using Avalonia.Controls.Utils;
+using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.LogicalTree;
 using Avalonia.Markup.Xaml;
@@ -18,6 +20,11 @@ namespace Avalonia.Controls.UnitTests
 {
     public class TabControlTests
     {
+        static TabControlTests()
+        {
+            RuntimeHelpers.RunClassConstructor(typeof(RelativeSource).TypeHandle);
+        }
+
         [Fact]
         public void First_Tab_Should_Be_Selected_By_Default()
         {
@@ -433,6 +440,29 @@ namespace Avalonia.Controls.UnitTests
 
                 Assert.Equal(0, tabControl.ItemsSource.Count());
             }
+        }
+
+        [Fact]
+        public void Should_Have_Initial_SelectedValue()
+        {
+            var xaml = @"
+        <TabControl
+            xmlns='https://github.com/avaloniaui'
+            xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+            xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'
+            x:DataType='TabItem'
+            x:Name='tabs'
+            Tag='World' 
+            SelectedValue='{Binding $self.Tag}' 
+            SelectedValueBinding='{Binding Header}'>
+            <TabItem Header='Hello'/>
+            <TabItem Header='World'/>
+        </TabControl>";
+
+            var tabControl = (TabControl)AvaloniaRuntimeXamlLoader.Load(xaml);
+
+            Assert.Equal("World", tabControl.SelectedValue);
+            Assert.Equal(1, tabControl.SelectedIndex);
         }
 
         [Fact]


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR makes sure the AlwaysSelection logic does not change the initial state before `EndUpdating` has run

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes: #14624