### PR TITLE
Fix InlinesCollection Logical/VisualParent update

### DIFF
--- a/src/Avalonia.Controls/Documents/InlineCollection.cs
+++ b/src/Avalonia.Controls/Documents/InlineCollection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Avalonia.Collections;
 using Avalonia.LogicalTree;
 using Avalonia.Metadata;
@@ -23,32 +24,8 @@ namespace Avalonia.Controls.Documents
             ResetBehavior = ResetBehavior.Remove;
 
             this.ForEachItem(
-                x =>
-                {
-                    x.InlineHost = InlineHost;
-
-                    LogicalChildren?.Add(x);
-
-                    if (x is InlineUIContainer container)
-                    {
-                        InlineHost?.VisualChildren.Add(container.Child);
-                    }
-
-                    Invalidate();
-                },
-                x =>
-                {
-                    LogicalChildren?.Remove(x);
-
-                    if(x is InlineUIContainer container)
-                    {
-                        InlineHost?.VisualChildren.Remove(container.Child);
-                    }
-
-                    x.InlineHost = null;
-
-                    Invalidate();
-                },
+                OnAdd,
+                OnRemove,
                 () => throw new NotSupportedException());
         }
 
@@ -70,9 +47,11 @@ namespace Avalonia.Controls.Documents
             get => _inlineHost;
             set
             {
+                var oldValue = _inlineHost;
+
                 _inlineHost = value;
 
-                OnInlineHostChanged(value);
+                OnInlineHostChanged(oldValue, value);
             }
         }
 
@@ -118,7 +97,7 @@ namespace Avalonia.Controls.Documents
         /// <summary>
         /// Adds a text segment to the collection.
         /// <remarks>
-        /// For non complex content this appends the text to the end of currently held text.
+        /// For non-complex content this appends the text to the end of currently held text.
         /// For complex content this adds a <see cref="Run"/> to the collection.
         /// </remarks>
         /// </summary>
@@ -159,25 +138,66 @@ namespace Avalonia.Controls.Documents
             Invalidated?.Invoke(this, EventArgs.Empty);
         }
 
-        private void OnParentChanged(IAvaloniaList<ILogical>? oldParent, IAvaloniaList<ILogical>? newParent)
+        private void OnParentChanged(ICollection<ILogical>? oldValue, ICollection<ILogical>? newValue)
         {
             foreach (var child in this)
             {
-                if (oldParent != newParent)
+                if (Equals(oldValue, newValue))
                 {
-                    oldParent?.Remove(child);
-
-                    newParent?.Add(child);
+                    continue;
                 }
+
+                oldValue?.Remove(child);
+
+                newValue?.Add(child);
             }
+
+            Invalidate();
         }
 
-        private void OnInlineHostChanged(IInlineHost? inlineHost)
+        private void OnInlineHostChanged(IInlineHost? oldValue, IInlineHost? newValue)
         {
             foreach (var child in this)
             {
-                child.InlineHost = inlineHost;
+                if (child is not InlineUIContainer container)
+                {
+                    continue;
+                }
+
+                oldValue?.VisualChildren.Remove(container.Child);
+
+                newValue?.VisualChildren.Add(container.Child);
             }
+
+            Invalidate();
+        }
+
+        private void OnAdd(TextElement inline)
+        {
+            inline.InlineHost = InlineHost;
+
+            LogicalChildren?.Add(inline);
+
+            if (inline is InlineUIContainer container)
+            {
+                InlineHost?.VisualChildren.Add(container.Child);
+            }
+
+            Invalidate();
+        }
+
+        private void OnRemove(TextElement inline)
+        {
+            LogicalChildren?.Remove(inline);
+
+            if (inline is InlineUIContainer container)
+            {
+                InlineHost?.VisualChildren.Remove(container.Child);
+            }
+
+            inline.InlineHost = null;
+
+            Invalidate();
         }
     }
 }

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -52,6 +52,21 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void Changing_Inlines_Should_Attach_Embedded_Controls_To_VisualTree()
+        {
+            using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
+            {
+                var target = new TextBlock();
+
+                var control = new Border(); 
+
+                target.Inlines = new InlineCollection { new InlineUIContainer{ Child = control } };
+
+                Assert.True(control.IsAttachedToVisualTree);
+            }
+        }
+
+        [Fact]
         public void Can_Call_Measure_Without_InvalidateTextLayout()
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))

--- a/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBlockTests.cs
@@ -52,17 +52,21 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
-        public void Changing_Inlines_Should_Attach_Embedded_Controls_To_VisualTree()
+        public void Changing_Inlines_Should_Attach_Embedded_Controls_To_Parents()
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface))
             {
                 var target = new TextBlock();
 
-                var control = new Border(); 
+                var control = new Border();
 
-                target.Inlines = new InlineCollection { new InlineUIContainer{ Child = control } };
+                var inlineUIContainer = new InlineUIContainer { Child = control };
 
-                Assert.True(control.IsAttachedToVisualTree);
+                target.Inlines = new InlineCollection { inlineUIContainer };
+
+                Assert.Equal(inlineUIContainer, control.Parent);
+
+                Assert.Equal(target, control.VisualParent);
             }
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR makes sure we update the Logical/VisualParent when an InlinesCollection is attached/detached to/from a TextBlock

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes: #14670