### PR TITLE
Fixed bad test for TryModifyOrCreate to call InvalidateVisual in Shape

### DIFF
--- a/src/Avalonia.Controls/Shapes/Shape.cs
+++ b/src/Avalonia.Controls/Shapes/Shape.cs
@@ -254,7 +254,7 @@ namespace Avalonia.Controls.Shapes
                     InvalidateMeasure();
                 }
                 
-                if (!Pen.TryModifyOrCreate(ref _strokePen, Stroke, StrokeThickness, StrokeDashArray, StrokeDashOffset, StrokeLineCap, StrokeJoin))
+                if (Pen.TryModifyOrCreate(ref _strokePen, Stroke, StrokeThickness, StrokeDashArray, StrokeDashOffset, StrokeLineCap, StrokeJoin))
                 {
                     InvalidateVisual();
                 }


### PR DESCRIPTION
I think there is a mistake with Shape invalidate visual, as nothing happen when I change, for example, the StrokeJoin property.

## What does the pull request do?
Remove the '!' in the following test:
```
if (!Pen.TryModifyOrCreate(ref _strokePen, Stroke, StrokeThickness, StrokeDashArray, StrokeDashOffset, StrokeLineCap, StrokeJoin))
{
    InvalidateVisual();
}
```

## What is the current behavior?
Currently, when the Stroke properties change such as StrokeJoin, the visual is not invalidated.


## What is the updated/expected behavior with this PR?
The visual of the Shape is now updated on Stroke properties change.


## How was the solution implemented (if it's not obvious)?
Just negated the test on Pen.TryModifyOrCreate as visual invalidation is required when this method return True, not False:
`/// <returns>If a new instance was created and visual invalidation required.</returns>`

Here I create a Rectangle with StrokeJoin = Miter by default, and cycle the StrokeJoin value with a button, the rect is not updated.
```
<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
    <Rectangle
        x:Name="rect"
        Width="200"
        Height="200"
        Stroke="Red"
        StrokeThickness="50" />
    <TextBlock Text="{Binding StrokeJoin, ElementName=rect}" />
    <Button x:Name="strokeJoinBtn" Content="Cycle StrokeJoin" />
</StackPanel>
```
It should be round here:
![image](https://github.com/AvaloniaUI/Avalonia/assets/3595443/77deb110-67aa-46f4-9b11-a67ef89cf905)

It become round only if I resize the window to clip the rectangle for example.
![image](https://github.com/AvaloniaUI/Avalonia/assets/3595443/b68e0ad8-8a7a-4f79-93c3-bf88333b7c61)
