### PR TITLE
Replace external MSBuild processes with `TaskHostFactory`

### DIFF
--- a/build/BuildTargets.targets
+++ b/build/BuildTargets.targets
@@ -1,11 +1,16 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AvaloniaBuildTasksLocation>$(MSBuildThisFileDirectory)\..\src\Avalonia.Build.Tasks\bin\$(Configuration)\netstandard2.0\Avalonia.Build.Tasks.dll</AvaloniaBuildTasksLocation>
-    <AvaloniaUseExternalMSBuild>true</AvaloniaUseExternalMSBuild>
     <AvaloniaXamlIlVerifyIl>true</AvaloniaXamlIlVerifyIl>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <AvaloniaXamlVerboseExceptions Condition="'$(AvaloniaXamlVerboseExceptions)' == ''">true</AvaloniaXamlVerboseExceptions>
   </PropertyGroup>
+
+  <!--TaskHostFactory is a built-in factory which causes the Avalonia.Build.Tasks assembly to always be loaded in an isolated process. This avoids build errors
+      when the project is rebuilt during a development session.-->
+  <UsingTask TaskName="GenerateAvaloniaResourcesTask" AssemblyFile="$(AvaloniaBuildTasksLocation)" TaskFactory="TaskHostFactory"/>
+  <UsingTask TaskName="CompileAvaloniaXamlTask" AssemblyFile="$(AvaloniaBuildTasksLocation)" TaskFactory="TaskHostFactory"/>
+  
   <Import Project="$(MSBuildThisFileDirectory)\..\packages\Avalonia\AvaloniaBuildTasks.props"/>
   <Import Project="$(MSBuildThisFileDirectory)\..\packages\Avalonia\AvaloniaBuildTasks.targets"/>
 </Project>

--- a/packages/Avalonia/Avalonia.props
+++ b/packages/Avalonia/Avalonia.props
@@ -3,7 +3,6 @@
     <AvaloniaPreviewerNetCoreToolPath>$(MSBuildThisFileDirectory)\..\tools\netstandard2.0\designer\Avalonia.Designer.HostApp.dll</AvaloniaPreviewerNetCoreToolPath>
     <AvaloniaPreviewerNetFullToolPath>$(MSBuildThisFileDirectory)\..\tools\net461\designer\Avalonia.Designer.HostApp.exe</AvaloniaPreviewerNetFullToolPath>
     <AvaloniaBuildTasksLocation>$(MSBuildThisFileDirectory)\..\tools\netstandard2.0\Avalonia.Build.Tasks.dll</AvaloniaBuildTasksLocation>
-    <AvaloniaUseExternalMSBuild>false</AvaloniaUseExternalMSBuild>
     <UsedAvaloniaProducts>$(UsedAvaloniaProducts);AvaloniaUI</UsedAvaloniaProducts>
     <EnableAvaloniaXamlCompilation Condition="'$(EnableAvaloniaXamlCompilation)'==''">true</EnableAvaloniaXamlCompilation>
     <AvaloniaXamlIlVerifyIl Condition="'$(AvaloniaXamlIlVerifyIl)'==''">false</AvaloniaXamlIlVerifyIl>

--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -1,7 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_AvaloniaUseExternalMSBuild>$(AvaloniaUseExternalMSBuild)</_AvaloniaUseExternalMSBuild>
-    <_AvaloniaUseExternalMSBuild Condition="'$(_AvaloniaForceInternalMSBuild)' == 'true'">false</_AvaloniaUseExternalMSBuild>
     <AvaloniaXamlReportImportance Condition="'$(AvaloniaXamlReportImportance)' == ''">low</AvaloniaXamlReportImportance>
     <_AvaloniaSkipXamlCompilation Condition="'$(_AvaloniaSkipXamlCompilation)' == ''">false</_AvaloniaSkipXamlCompilation>
     <AvaloniaUseCompiledBindingsByDefault Condition="'$(AvaloniaUseCompiledBindingsByDefault)' == ''">false</AvaloniaUseCompiledBindingsByDefault>
@@ -57,8 +55,8 @@
   </Target>
   
   <PropertyGroup>
-    <BuildAvaloniaResourcesDependsOn>$(BuildAvaloniaResourcesDependsOn);AddAvaloniaResources;ResolveReferences;_GenerateAvaloniaResourcesDependencyCache;_GenerateNoWarnForExec</BuildAvaloniaResourcesDependsOn>
-    <CompileAvaloniaXamlDependsOn>$(CompileAvaloniaXamlDependsOn);PrepareToCompileAvaloniaXaml;_GenerateNoWarnForExec</CompileAvaloniaXamlDependsOn>
+    <BuildAvaloniaResourcesDependsOn>$(BuildAvaloniaResourcesDependsOn);AddAvaloniaResources;ResolveReferences;_GenerateAvaloniaResourcesDependencyCache</BuildAvaloniaResourcesDependsOn>
+    <CompileAvaloniaXamlDependsOn>$(CompileAvaloniaXamlDependsOn);FindReferenceAssembliesForReferences;PrepareToCompileAvaloniaXaml</CompileAvaloniaXamlDependsOn>
   </PropertyGroup>
 
   <Target Name="_GenerateAvaloniaResourcesDependencyCache" BeforeTargets="GenerateAvaloniaResources">
@@ -81,14 +79,6 @@
       <FileWrites Include="$(_AvaloniaResourcesInputsCacheFilePath)" />
     </ItemGroup>
   </Target>
-
-  <Target Name="_GenerateNoWarnForExec">
-    <PropertyGroup>
-      <!-- https://github.com/dotnet/sdk/issues/8792 -->
-      <_NoWarnForExec>'"$(NoWarn)"'</_NoWarnForExec>
-      <_NoWarnForExec Condition="$([MSBuild]::IsOSPlatform('Windows'))">\"$(NoWarn)\"</_NoWarnForExec>
-    </PropertyGroup>
-  </Target>
   
   <Target Name="GenerateAvaloniaResources" 
           BeforeTargets="CoreCompile;CoreResGen"
@@ -101,22 +91,17 @@
       <AvaloniaResource Include="@(AvaloniaXaml)" />
     </ItemGroup>
     <GenerateAvaloniaResourcesTask
-      Condition="'$(_AvaloniaUseExternalMSBuild)' != 'true'"
       Output="$(AvaloniaResourcesTemporaryFilePath)"
       Root="$(MSBuildProjectDirectory)"
       Resources="@(AvaloniaResource)"
       ReportImportance="$(AvaloniaXamlReportImportance)"/>
-    <ItemGroup Condition="'$(_AvaloniaUseExternalMSBuild)' != 'true'">
+    <ItemGroup>
       <FileWrites Include="$(AvaloniaResourcesTemporaryFilePath)" />
     </ItemGroup>
-    <Exec 
-      Condition="'$(_AvaloniaUseExternalMSBuild)' == 'true'"
-      Command="dotnet msbuild /nodereuse:false $(MSBuildProjectFile) /t:GenerateAvaloniaResources /p:NoWarn=$(_NoWarnForExec) /p:_AvaloniaForceInternalMSBuild=true /p:Configuration=$(Configuration) /p:TargetFramework=$(TargetFramework) /p:RuntimeIdentifier=$(RuntimeIdentifier) /p:BuildProjectReferences=false"/>
   </Target>
 
   <Target Name="PrepareToCompileAvaloniaXaml">
     <PropertyGroup>
-      <AvaloniaXamlReferencesTemporaryFilePath Condition="'$(AvaloniaXamlReferencesTemporaryFilePath)' == ''">$(IntermediateOutputPath)/Avalonia/references</AvaloniaXamlReferencesTemporaryFilePath>
       <AvaloniaXamlIlVerifyIl Condition="'$(AvaloniaXamlIlVerifyIl)' == ''">false</AvaloniaXamlIlVerifyIl>
       <AvaloniaXamlIlDebuggerLaunch Condition="'$(AvaloniaXamlIlDebuggerLaunch)' == ''">false</AvaloniaXamlIlDebuggerLaunch>
       <AvaloniaXamlVerboseExceptions Condition="'$(AvaloniaXamlVerboseExceptions)' == ''">false</AvaloniaXamlVerboseExceptions>
@@ -132,7 +117,6 @@
       <CompileAvaloniaXamlInputs Include="@(AvaloniaResource);@(AvaloniaXaml)"/>
 
       <FileWrites Include="@(CompileAvaloniaXamlOutputs)"/>
-      <FileWrites Include="$(AvaloniaXamlReferencesTemporaryFilePath)" />
     </ItemGroup>
   </Target>
 
@@ -144,12 +128,7 @@
     Outputs="@(CompileAvaloniaXamlOutputs)"
     Condition="'@(AvaloniaResource)@(AvaloniaXaml)' != '' AND $(DesignTimeBuild) != true AND $(EnableAvaloniaXamlCompilation) != false">
 
-    <ReadLinesFromFile File="$(AvaloniaXamlReferencesTemporaryFilePath)" Condition="'$(_AvaloniaUseExternalMSBuild)' != 'true' AND '@(ReferencePathWithRefAssemblies)' == ''">
-      <Output TaskParameter="Lines" ItemName="ReferencePathWithRefAssemblies"/>
-    </ReadLinesFromFile>
-    
     <CompileAvaloniaXamlTask
-      Condition="'$(_AvaloniaUseExternalMSBuild)' != 'true'"
       AssemblyFile="@(IntermediateAssembly)"
       References="@(ReferencePathWithRefAssemblies)"
       RefAssemblyFile="@(IntermediateRefAssembly)"
@@ -164,13 +143,6 @@
       DefaultCompileBindings="$(AvaloniaUseCompiledBindingsByDefault)"
       VerboseExceptions="$(AvaloniaXamlVerboseExceptions)"
       AnalyzerConfigFiles="@(EditorConfigFiles)"/>
-    
-    <WriteLinesToFile File="$(AvaloniaXamlReferencesTemporaryFilePath)" Lines="@(ReferencePathWithRefAssemblies)" Overwrite="true"
-                      Condition="'$(_AvaloniaUseExternalMSBuild)' == 'true'" />
-    
-    <Exec
-      Condition="'$(_AvaloniaUseExternalMSBuild)' == 'true'"
-      Command="dotnet msbuild /nodereuse:false $(MSBuildProjectFile) /t:CompileAvaloniaXaml /p:NoWarn=$(_NoWarnForExec) /p:_AvaloniaForceInternalMSBuild=true /p:Configuration=$(Configuration) /p:TargetFramework=$(TargetFramework) /p:RuntimeIdentifier=$(RuntimeIdentifier) /p:BuildProjectReferences=false"/>
   </Target>
   
   <Target Name="InjectAvaloniaXamlOutput" DependsOnTargets="PrepareToCompileAvaloniaXaml" AfterTargets="CompileAvaloniaXaml" BeforeTargets="CopyFilesToOutputDirectory;BuiltProjectOutputGroup"

--- a/samples/IntegrationTestApp/bundle.sh
+++ b/samples/IntegrationTestApp/bundle.sh
@@ -9,4 +9,4 @@ arch="arm64"
 fi
 
 dotnet restore -r osx-$arch
-dotnet msbuild -t:BundleApp -p:RuntimeIdentifier=osx-$arch -p:_AvaloniaUseExternalMSBuild=false
+dotnet msbuild -t:BundleApp -p:RuntimeIdentifier=osx-$arch


### PR DESCRIPTION
This PR provides a 70% improvement to build times within the Avalonia repository.

## What does the pull request do?

`Avalonia.Build.Tasks` is an MSBuild task assembly that is compiled at the start of every build. Its output assembly is then loaded by MSBuild for use by other solution projects.

Because MSBuild processes are kept alive in anticipation of future builds, the tasks assembly remains loaded after a build completes. This means that its DLL file cannot be modified (on Windows, at least). The locked assembly file causes build errors if something about the `Avalonia.Build.Tasks` project changes and the file needs to be rebuilt.

The current solution to this is to spawn an entirely new MSBuild process which spins up the entire project tree again, executes a specified target, then exits. This works, but is very slow, because MSBuild and the Avalonia project tree both take a considerable amount of time to load.

This PR replaces this system with [`TaskHostFactory`](https://learn.microsoft.com/en-us/visualstudio/msbuild/how-to-configure-targets-and-tasks?view=vs-2022#task-factories). Like starting a new MSBuild process, this isolates the use of the `Avalonia.Build.Tasks` assembly to a short-lived process. Unlike starting a new MSBuild process, only the task and its immediate inputs are loaded. This is much, much faster.

The build time improvements also apply to design-time builds within Visual Studio. The IDE is now more responsive and completes loading the solution sooner.

### Errors after switching to this branch

Please note that due to Visual Studio's project caching behaviour, you may encounter file locking errors after switching to this PR's branch with the Avalonia solution already loaded. Restarting the IDE will fix this. It's not a problem with the PR itself, and will stop being an issue once the changes are on master and spread to other branches.

The PR's changes can be easily validated under normal development circumstances by making a change to `Avalonia.Build.Tasks` and building the solution again.

## What is the updated/expected behavior with this PR?

When building Avalonia.Desktop.slnf:

| **Scenario**                      | **master** | **PR** | **Delta** |
|-----------------------------------|:----------:|:------:|:-----------:|
| Full rebuild                      |    02:22   |  0:43  |     -70%     |
| Build after invalidating projects |    01:31   |  0:25  |     -73%     |

## Breaking changes
None.

This entire subject only affects builds of the Avalonia repository, not builds of projects which consume Avalonia's Nuget packages. Package builds have always loaded the build tasks assembly normally, and continue to do so.

## Obsoletions / Deprecations
None