### PR TITLE
Fix TextBox in AdornerLayer causes collection modified exception in Arrange pass

### DIFF
--- a/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
+++ b/src/Avalonia.Controls/Primitives/VisualLayerManager.cs
@@ -160,8 +160,12 @@ namespace Avalonia.Controls.Primitives
         /// <inheritdoc />
         protected override Size ArrangeOverride(Size finalSize)
         {
-            foreach (var l in _layers)
+            for (var index = 0; index < _layers.Count; index++)
+            {
+                var l = _layers[index];
                 l.Arrange(new Rect(finalSize));
+            }
+
             return base.ArrangeOverride(finalSize);
         }
     }

--- a/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/TextBoxTests.cs
@@ -1406,7 +1406,7 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
-        public void TextBox_In_AdornerLayer_Will_Not_Cause_Collection_Modified_In_VisualLayerManager()
+        public void TextBox_In_AdornerLayer_Will_Not_Cause_Collection_Modified_In_VisualLayerManager_Measure()
         {
             using (UnitTestApplication.Start(Services))
             {
@@ -1425,6 +1425,29 @@ namespace Avalonia.Controls.UnitTests
                 AdornerLayer.SetAdornedElement(adorner, button);
 
                 root.Measure(Size.Infinity);
+            }
+        }
+
+        [Fact]
+        public void TextBox_In_AdornerLayer_Will_Not_Cause_Collection_Modified_In_VisualLayerManager_Arrange()
+        {
+            using (UnitTestApplication.Start(Services))
+            {
+                var button = new Button();
+                var visualLayerManager = new VisualLayerManager() { Child = button };
+                var root = new TestRoot()
+                {
+                    Child = visualLayerManager
+                };
+                var adorner = new TextBox { Template = CreateTemplate(), Text = "a" };
+                var adornerLayer = AdornerLayer.GetAdornerLayer(button);
+
+                root.Measure(new Size(10, 10));
+
+                adornerLayer.Children.Add(adorner);
+                AdornerLayer.SetAdornedElement(adorner, button);
+
+                root.Arrange(new Rect(0, 0, 10, 10));
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?
This PR changes VisualLayerManager so that layers can be added during its Arrange pass.

## What is the current behavior?
In my previous PR https://github.com/AvaloniaUI/Avalonia/pull/14484 I intentionally didn't touch ArrangeOverride method, as I didn't want to touch things that are not directly required.

However, it turned out it is required.

I assumed that Measure will always be called before Arrange. However, this is not always true. Consider this:
```
root.Measure(new Size(10, 10));

var adorner = new TextBox();
adornerLayer.Children.Add(adorner);
AdornerLayer.SetAdornedElement(adorner, button);

root.Arrange(new Rect(0, 0, 10, 10));
```

In `root.Arrange`, `root` already has valid measurement (IsMeasureValid = true) yet in the meantime a new control was added, which will reference VisualLayerManager.TextSelectorLayer -> crash.


## What is the updated/expected behavior with this PR?
Both Measure and Arrange methods in VisualLayerManager will support adding layers during iteration.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
n/a

## Obsoletions / Deprecations
n/a

## Fixed issues
#14483