### PR TITLE
Made Path/PathIcon.Data nullable

### DIFF
--- a/src/Avalonia.Controls/PathIcon.cs
+++ b/src/Avalonia.Controls/PathIcon.cs
@@ -9,10 +9,10 @@ namespace Avalonia.Controls
             AffectsRender<PathIcon>(DataProperty);
         }
 
-        public static readonly StyledProperty<Geometry> DataProperty =
-            AvaloniaProperty.Register<PathIcon, Geometry>(nameof(Data));
+        public static readonly StyledProperty<Geometry?> DataProperty =
+            AvaloniaProperty.Register<PathIcon, Geometry?>(nameof(Data));
 
-        public Geometry Data
+        public Geometry? Data
         {
             get => GetValue(DataProperty);
             set => SetValue(DataProperty, value);

--- a/src/Avalonia.Controls/Shapes/Path.cs
+++ b/src/Avalonia.Controls/Shapes/Path.cs
@@ -5,8 +5,8 @@ namespace Avalonia.Controls.Shapes
 {
     public class Path : Shape
     {
-        public static readonly StyledProperty<Geometry> DataProperty =
-            AvaloniaProperty.Register<Path, Geometry>(nameof(Data));
+        public static readonly StyledProperty<Geometry?> DataProperty =
+            AvaloniaProperty.Register<Path, Geometry?>(nameof(Data));
 
         private EventHandler? _geometryChangedHandler;
 
@@ -16,15 +16,15 @@ namespace Avalonia.Controls.Shapes
             DataProperty.Changed.AddClassHandler<Path>((o, e) => o.DataChanged(e));
         }
 
-        public Geometry Data
+        public Geometry? Data
         {
             get => GetValue(DataProperty);
             set => SetValue(DataProperty, value);
         }
 
-        private EventHandler? GeometryChangedHandler => _geometryChangedHandler ??= GeometryChanged;
+        private EventHandler GeometryChangedHandler => _geometryChangedHandler ??= GeometryChanged;
 
-        protected override Geometry CreateDefiningGeometry() => Data;
+        protected override Geometry? CreateDefiningGeometry() => Data;
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {


### PR DESCRIPTION
## What does the pull request do?
This PR changes `Path.Data` and `PathIcon.Data` to be nullable, as their default value is `null`, and these controls perfectly handle not having any geometry.

## Breaking changes
It's a source breaking change for code bases with enabled nullability.
The binary interface stays compatible though.
