### PR TITLE
Fix MouseDevice not reporting clicks when any mouse buttons is hold

### DIFF
--- a/src/Avalonia.Base/Input/MouseDevice.cs
+++ b/src/Avalonia.Base/Input/MouseDevice.cs
@@ -74,9 +74,6 @@ namespace Avalonia.Input
                 case RawPointerEventType.MiddleButtonDown:
                 case RawPointerEventType.XButton1Down:
                 case RawPointerEventType.XButton2Down:
-                    if (ButtonCount(props) > 1)
-                        e.Handled = MouseMove(mouse, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.IntermediatePoints, e.InputHitTestResult);
-                    else
                         e.Handled = MouseDown(mouse, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult);
                     break;
                 case RawPointerEventType.LeftButtonUp:
@@ -84,9 +81,6 @@ namespace Avalonia.Input
                 case RawPointerEventType.MiddleButtonUp:
                 case RawPointerEventType.XButton1Up:
                 case RawPointerEventType.XButton2Up:
-                    if (ButtonCount(props) != 0)
-                        e.Handled = MouseMove(mouse, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.IntermediatePoints, e.InputHitTestResult);
-                    else
                         e.Handled = MouseUp(mouse, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult);
                     break;
                 case RawPointerEventType.Move:


### PR DESCRIPTION
## What does the pull request do?
Currently if you will click e.g button with left mouse button and hold it and start clicking the right mouse button then right mouse button wont trigger any PointerPressed\PointerReleased events. That doesen't match a WPF behavior. Also,if you hold any mouse button and click any other mouse button and don't move your mouse Avalonia will send MouseMove events which is quite strange.


## What is the current behavior?
![Анимация1](https://github.com/AvaloniaUI/Avalonia/assets/53405089/911b8902-a901-4f86-a15a-acfea454dd54)


## What is the updated/expected behavior with this PR?
![Анимация1](https://github.com/AvaloniaUI/Avalonia/assets/53405089/ec8a0264-c4c6-4bcd-86d4-0538e0cd7155)

## Breaking changes
That might be a soft breaking change for someone who is relaying on the incorrect behavior.

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/13977
