### PR TITLE
Fix dev tools property value converter

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/Views/PropertyValueEditorView.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/PropertyValueEditorView.cs
@@ -301,13 +301,8 @@ namespace Avalonia.Diagnostics.Views
 
         }
 
-        //HACK: ValueConverter that skips first target update
-        //TODO: Would be nice to have some kind of "InitialBindingValue" option on TwoWay bindings to control
-        //if the first value comes from the source or target
         private class ValueConverter : IValueConverter
         {
-            private bool _firstUpdate = true;
-
             object? IValueConverter.Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
             {
                 return Convert(value, targetType, parameter, culture);
@@ -315,13 +310,6 @@ namespace Avalonia.Diagnostics.Views
 
             object? IValueConverter.ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
             {
-                if (_firstUpdate)
-                {
-                    _firstUpdate = false;
-
-                    return BindingOperations.DoNothing;
-                }
-
                 //Note: targetType provided by Converter is simply "object"
                 return ConvertBack(value, (Type)parameter!, parameter, culture);
             }


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the dev tools `IValueConverter` ignoring the first changed value, which isn't necessary anymore (probably after #13970).

## What is the current behavior?
The first change of a property value is ignored.

## Fixed issue
 - Fixes #14719
