### PR TITLE
feat(DataGrid): make IDataGridCollectionViewFactory and IDataGridCollectionView, Add DP CollectionView

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/DataGridCollectionView.cs
@@ -44,7 +44,7 @@ namespace Avalonia.Collections
     }
 
     /// <summary>Defines a method that enables a collection to provide a custom view for specialized sorting, filtering, grouping, and currency.</summary>
-    internal interface IDataGridCollectionViewFactory
+    public interface IDataGridCollectionViewFactory
     {
         /// <summary>Returns a custom view for specialized sorting, filtering, grouping, and currency.</summary>
         /// <returns>A custom view for specialized sorting, filtering, grouping, and currency.</returns>

--- a/src/Avalonia.Controls.DataGrid/Collections/IDataGridCollectionView.cs
+++ b/src/Avalonia.Controls.DataGrid/Collections/IDataGridCollectionView.cs
@@ -66,7 +66,7 @@ namespace Avalonia.Collections
     }
 
     /// <summary>Enables collections to have the functionalities of current record management, custom sorting, filtering, and grouping.</summary>
-    internal interface IDataGridCollectionView : IEnumerable, INotifyCollectionChanged
+    public interface IDataGridCollectionView : IEnumerable, INotifyCollectionChanged
     {
         /// <summary>Gets or sets the cultural information for any operations of the view that may differ by culture, such as sorting.</summary>
         /// <returns>The culture information to use during culture-sensitive operations. </returns>

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -716,6 +716,17 @@ namespace Avalonia.Controls
             set { SetValue(RowDetailsVisibilityModeProperty, value); }
         }
 
+
+        public static readonly DirectProperty<DataGrid, IDataGridCollectionView> CollectionViewProperty =
+            AvaloniaProperty.RegisterDirect<DataGrid, IDataGridCollectionView>(nameof(CollectionView),
+                o => o.CollectionView);
+
+        /// <summary>
+        /// Gets current <see cref="IDataGridCollectionView"/>.
+        /// </summary>
+        public IDataGridCollectionView CollectionView =>
+            DataConnection.CollectionView;
+
         static DataGrid()
         {
             AffectsMeasure<DataGrid>(
@@ -837,6 +848,8 @@ namespace Avalonia.Controls
             {
                 Debug.Assert(DataConnection != null);
 
+                var oldCollectionView = DataConnection.CollectionView;
+
                 var oldValue = (IEnumerable)e.OldValue;
                 var newItemsSource = (IEnumerable)e.NewValue;
 
@@ -865,14 +878,24 @@ namespace Avalonia.Controls
 
                 // Wrap an IEnumerable in an ICollectionView if it's not already one
                 bool setDefaultSelection = false;
-                if (newItemsSource != null && !(newItemsSource is IDataGridCollectionView))
+                if (newItemsSource is IDataGridCollectionView newCollectionView)
                 {
-                    DataConnection.DataSource = DataGridDataConnection.CreateView(newItemsSource);
-                }
-                else
-                {
-                    DataConnection.DataSource = newItemsSource;
                     setDefaultSelection = true;
+                }
+                else 
+                {
+                    newCollectionView =  newItemsSource is not null
+                        ? DataGridDataConnection.CreateView(newItemsSource)
+                        : default;
+                }
+
+                DataConnection.DataSource = newCollectionView;
+
+                if (oldCollectionView != DataConnection.CollectionView)
+                {
+                    RaisePropertyChanged(CollectionViewProperty, 
+                        oldCollectionView, 
+                        newCollectionView);
                 }
 
                 if (DataConnection.DataSource != null)

--- a/src/Avalonia.Controls.DataGrid/DataGrid.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGrid.cs
@@ -882,7 +882,7 @@ namespace Avalonia.Controls
                 {
                     setDefaultSelection = true;
                 }
-                else 
+                else
                 {
                     newCollectionView =  newItemsSource is not null
                         ? DataGridDataConnection.CreateView(newItemsSource)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Currently there is no way for the user collection to implement IDataGridCollectionViewFactory and to provide own implementation of IDataGridCollectionView. In fact, IDataGridCollectionViewFactory is not used at all.

It is needed to avoid the default implementation (DataGridCollectionView), which iterates over the whole collection and doesn't allow a user to implement data virtualization (to avoid keeping large amounts of data in memory).

Added DP CollectionView to allow sorting, grouping the DataGrid even when ItemsSource is not DataGridCollectionView


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #13650