### PR TITLE
Allow any object implementing INamed to be registered in a Xaml namescope

### DIFF
--- a/src/Avalonia.Base/INamed.cs
+++ b/src/Avalonia.Base/INamed.cs
@@ -1,7 +1,8 @@
 namespace Avalonia
 {
     /// <summary>
-    /// Interface for named elements.
+    /// Objects implementing this interface and providing a value for <see cref="Name"/> will be registered in the 
+    /// relevant namescope when constructed in XAML.
     /// </summary>
     public interface INamed
     {

--- a/src/Avalonia.Base/StyledElement.cs
+++ b/src/Avalonia.Base/StyledElement.cs
@@ -33,6 +33,7 @@ namespace Avalonia
         ISetLogicalParent,
         ISetInheritanceParent,
         ISupportInitialize,
+        INamed,
 #pragma warning disable CS0618 // Type or member is obsolete
         IStyleable
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Controls
     /// - A <see cref="Tag"/> property to allow user-defined data to be attached to the control.
     /// - <see cref="ContextRequestedEvent"/> and other context menu related members.
     /// </remarks>
-    public class Control : InputElement, IDataTemplateHost, INamed, IVisualBrushInitialize, ISetterValue
+    public class Control : InputElement, IDataTemplateHost, IVisualBrushInitialize, ISetterValue
     {
         /// <summary>
         /// Defines the <see cref="FocusAdorner"/> property.

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AddNameScopeRegistration.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AddNameScopeRegistration.cs
@@ -16,7 +16,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             if (node is XamlPropertyAssignmentNode pa)
             {
                 if (pa.Property.Name == "Name"
-                    && pa.Property.DeclaringType.FullName == "Avalonia.StyledElement")
+                    && pa.Property.DeclaringType.Interfaces.Any(t => t.FullName == "Avalonia.INamed"))
                 {
                     if (context.ParentNodes().FirstOrDefault() is XamlManipulationGroupNode mg
                         && mg.Children.OfType<AvaloniaNameScopeRegistrationXamlIlNode>().Any())


### PR DESCRIPTION
This PR changes the XAML compiler's test for XAML namescope registration from "is a `Control`" to "implements `INamed`". This allows any user-defined type to be accessed via a compiler-generated field on a `UserControl`, `TopLevel`, etc. when constructed in XAML.

`Styleable` now directly includes `INamed` as an interface instead of inheriting it from `IStyleable`, which is obsolete and due for removal.

The changes were extracted from #14729 as requested.

## Breaking changes
None.

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #9958