### PR TITLE
CAMetalLayer should not be opaque

### DIFF
--- a/native/Avalonia.Native/src/OSX/metal.mm
+++ b/native/Avalonia.Native/src/OSX/metal.mm
@@ -112,6 +112,7 @@ public:
 - (MetalRenderTarget *)initWithDevice:(IAvnMetalDevice *)device {
     _device = dynamic_cast<AvnMetalDevice*>(device);
     _layer = [CAMetalLayer new];
+    _layer.opaque = false;
     _layer.device = _device->device;
     _target.setNoAddRef(new AvnMetalRenderTarget(_layer, _device));
     return self;

--- a/src/iOS/Avalonia.iOS/AvaloniaView.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaView.cs
@@ -98,6 +98,7 @@ namespace Avalonia.iOS
 #endif
             if (l is CAMetalLayer metalLayer)
             {
+                metalLayer.Opaque = false;
                 _topLevelImpl.Surfaces = new[] { new Metal.MetalPlatformSurface(metalLayer, this) };
             }
         }


### PR DESCRIPTION
## What does the pull request do?

This property is supposed to be False [by default](https://developer.apple.com/documentation/quartzcore/calayer/1410763-opaque?language=objc), but it seems to not always be true as some people [has noticed](https://stackoverflow.com/questions/51354283/transparent-mtkview-not-blending-properly-with-windows-behind-it). 