### PR TITLE
Fix RadialGradientBrush.Radius obsolete usages

### DIFF
--- a/src/Avalonia.Base/Animation/Animators/GradientBrushAnimator.cs
+++ b/src/Avalonia.Base/Animation/Animators/GradientBrushAnimator.cs
@@ -129,7 +129,8 @@ namespace Avalonia.Animation.Animators
                         CreateStopsFromSolidColorBrush(solidColorBrush, oldRadial.GradientStops), solidColorBrush.Opacity,
                         oldRadial.Transform is { } ? new ImmutableTransform(oldRadial.Transform.Value) : null,
                         oldRadial.TransformOrigin,
-                        oldRadial.SpreadMethod, oldRadial.Center, oldRadial.GradientOrigin, oldRadial.Radius);
+                        oldRadial.SpreadMethod, oldRadial.Center, oldRadial.GradientOrigin,
+                        oldRadial.RadiusX, oldRadial.RadiusY);
 
                 case IConicGradientBrush oldConic:
                     return new ImmutableConicGradientBrush(

--- a/src/Avalonia.Base/Media/RadialGradientBrush.cs
+++ b/src/Avalonia.Base/Media/RadialGradientBrush.cs
@@ -31,6 +31,7 @@ namespace Avalonia.Media
         /// <summary>
         /// Defines the <see cref="Radius"/> property.
         /// </summary>
+        [Obsolete("Use RadiusX/RadiusY, note that those properties use _relative_ values, so Radius=0.55 would become RadiusX=55% RadiusY=55%. Radius property is always relative even if the rest of the brush uses absolute values.")]
         public static readonly StyledProperty<double> RadiusProperty =
             AvaloniaProperty.Register<RadialGradientBrush, double>(
                 nameof(Radius),
@@ -73,7 +74,9 @@ namespace Avalonia.Media
         /// Gets or sets the horizontal radius of the outermost circle of the radial
         /// gradient.
         /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete
         [DependsOn(nameof(Radius))]
+#pragma warning restore CS0618 // Type or member is obsolete
         public RelativeScalar RadiusX
         {
             get { return GetValue(RadiusXProperty); }
@@ -84,7 +87,9 @@ namespace Avalonia.Media
         /// Gets or sets the vertical radius of the outermost circle of the radial
         /// gradient.
         /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete
         [DependsOn(nameof(Radius))]
+#pragma warning restore CS0618 // Type or member is obsolete
         public RelativeScalar RadiusY
         {
             get { return GetValue(RadiusYProperty); }
@@ -119,12 +124,15 @@ namespace Avalonia.Media
 
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
+#pragma warning disable CS0618 // Type or member is obsolete: compatibility code for Radius
             if (change.IsEffectiveValueChange && change.Property == RadiusProperty)
             {
                 var compatibilityValue = new RelativeScalar(Radius, RelativeUnit.Relative);
                 SetCurrentValue(RadiusXProperty, compatibilityValue);
                 SetCurrentValue(RadiusYProperty, compatibilityValue);
             }
+#pragma warning restore CS0618 // Type or member is obsolete
+
             base.OnPropertyChanged(change);
         }
     }

--- a/src/Avalonia.Base/RelativePoint.cs
+++ b/src/Avalonia.Base/RelativePoint.cs
@@ -142,7 +142,6 @@ namespace Avalonia
         /// </summary>
         /// <param name="size">The size of the visual.</param>
         /// <returns>The origin point in pixels.</returns>
-        [Obsolete("Use ToPixels(Rect) overload to properly map relative points")]
         public Point ToPixels(Size size)
         {
             return _unit == RelativeUnit.Absolute ?

--- a/tests/Avalonia.RenderTests/Media/RadialGradientBrushTests.cs
+++ b/tests/Avalonia.RenderTests/Media/RadialGradientBrushTests.cs
@@ -125,7 +125,8 @@ namespace Avalonia.Direct2D1.RenderTests.Media
                         },
                         GradientOrigin = new RelativePoint(0.25, 0.25, RelativeUnit.Relative),
                         Center = new RelativePoint(0.5, 0.5, RelativeUnit.Relative),
-                        Radius = 0.5                        
+                        RadiusX = RelativeScalar.Middle,
+                        RadiusY = RelativeScalar.Middle
                     }
                 }
             };
@@ -157,7 +158,8 @@ namespace Avalonia.Direct2D1.RenderTests.Media
                         },
                         GradientOrigin = new RelativePoint(0.1, 0.1, RelativeUnit.Relative),
                         Center = new RelativePoint(0.5, 0.5, RelativeUnit.Relative),
-                        Radius = 0.5
+                        RadiusX = RelativeScalar.Middle,
+                        RadiusY = RelativeScalar.Middle
                     }
                 }
             };


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the remaining usages of the now obsolete `RadialGradientBrush.Radius`.
The only usages left are for compatibility purposes, with their warnings ignored.

Note that the `Obsolete` attribute has been removed from the `RelativePoint.ToPixels(Size)` overload after discussion, since its use case is a bit different from the `Rect` one.