### PR TITLE
Backport fix NullReferenceException in  X11Window.Activate

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -1103,7 +1103,9 @@ namespace Avalonia.X11
             else
             {
                 XRaiseWindow(_x11.Display, _handle);
-                XSetInputFocus(_x11.Display, _focusProxy._handle, 0, IntPtr.Zero);
+
+                if (_focusProxy is not null)
+                    XSetInputFocus(_x11.Display, _focusProxy._handle, 0, IntPtr.Zero);
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

In v11.0.9 the `X11Window.Activate` method throws the `NullReferenceException` when `platform.Options.EnableInputFocusProxy == false` and `x11.Atoms._NET_ACTIVE_WINDOW == IntPtr.Zero`.

The issue is fixed in the master branch: https://github.com/AvaloniaUI/Avalonia/blob/aeafbf9d3c46a459fc4803ecfdd05cbe2cffccfb/src/Avalonia.X11/X11Window.cs#L1143

This PR backports the fix to v11.0.x