### PR TITLE
fix NumericUpDown ParsingNumberStyle

### DIFF
--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -713,7 +713,14 @@ namespace Avalonia.Controls
             decimal result;
             if (Value.HasValue)
             {
-                result = Value.Value + Increment;
+                if (this.ParsingNumberStyle == NumberStyles.None || this.ParsingNumberStyle == NumberStyles.Integer)
+                {
+                    result = Value.Value + (int)Increment;
+                }
+                else
+                {
+                    result = Value.Value + Increment;
+                }
             }
             else
             {
@@ -734,7 +741,15 @@ namespace Avalonia.Controls
 
             if (Value.HasValue)
             {
-                result = Value.Value - Increment;
+                if (this.ParsingNumberStyle == NumberStyles.None || this.ParsingNumberStyle == NumberStyles.Integer)
+                {
+                    result = Value.Value - (int)Increment;
+                }
+                else
+                {
+                    result = Value.Value - Increment;
+                }
+                
             }
             else
             {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
fix `NumericUpDown` when `ParsingNumberStyle` is `None` or `Integer`
issue log https://github.com/AvaloniaUI/Avalonia/issues/14672

## What is the current behavior?
the `NumericUpDown` control show decimal if style is `integer`


## What is the updated/expected behavior with this PR?
the `NumericUpDown` control will `removed` decimal if style is `integer`


## How was the solution implemented (if it's not obvious)?
im `casting` from decimal to integer if ParsingNumberStyle style is integer


## Checklist
N/A

## Breaking changes
N/A


## Fixed issues
https://github.com/AvaloniaUI/Avalonia/issues/14672

## Notes
i cannot do unit test because 
i still cannot find how to trigger event `OnLostFocus` on the unit test 

