### PR TITLE
Added support for RTL view in NativeControlHost.cs

### DIFF
--- a/src/Avalonia.Controls/NativeControlHost.cs
+++ b/src/Avalonia.Controls/NativeControlHost.cs
@@ -131,13 +131,11 @@ namespace Avalonia.Controls
 
             var bounds = Bounds;
             // Native window is not rendered by Avalonia
-            var position =
-                this.TranslatePoint(
-                    FlowDirection == FlowDirection.RightToLeft ? new Point(Bounds.Width, 0) : default,
-                    _currentRoot);
-            if (position == null)
+            var transformToVisual = this.TransformToVisual(_currentRoot);
+            if (transformToVisual == null)
                 return null;
-            return new Rect(position.Value, bounds.Size);
+            var position = new Rect(default, bounds.Size).TransformToAABB(transformToVisual.Value).Position;
+            return new Rect(position, bounds.Size);
         }
 
         private void EnqueueForMoveResize()


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fix an issue that `NativeControlHost` did not respect `FlowDirection.RightToLeft`.

## What is the current behavior?
`NativeControlHost` is not positioned correctly when using `FlowDirection.RightToLeft` -
![image](https://github.com/AvaloniaUI/Avalonia/assets/27368554/dd953905-1666-4e7c-b259-b3f903b8b503)

## What is the updated/expected behavior with this PR?
The control positioned correctly -
![image](https://github.com/AvaloniaUI/Avalonia/assets/27368554/8cf847d1-b606-4c52-a794-26eb9aaafff9)

## How was the solution implemented (if it's not obvious)?
Flip the X coordinates when `FlowDirection` property set to `RightToLeft`

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
