### PR TITLE
Reworked the way we are clipping dirty rects with CompositionTarget

### DIFF
--- a/samples/ControlCatalog.NetCore/Program.cs
+++ b/samples/ControlCatalog.NetCore/Program.cs
@@ -10,6 +10,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Fonts.Inter;
 using Avalonia.Headless;
 using Avalonia.LogicalTree;
+using Avalonia.Rendering.Composition;
 using Avalonia.Threading;
 
 using ControlCatalog.Pages;
@@ -129,6 +130,10 @@ namespace ControlCatalog.NetCore
                     EnableMultiTouch = true,
                     UseDBusMenu = true,
                     EnableIme = true
+                })
+                .With(new CompositionOptions()
+                {
+                    UseRegionDirtyRectClipping = true
                 })
                 .UseSkia()
                 .WithInterFont()

--- a/samples/ControlCatalog/Pages/CompositionPage.axaml
+++ b/samples/ControlCatalog/Pages/CompositionPage.axaml
@@ -50,6 +50,10 @@
           <Button Margin="10" Click="ButtonThreadSleep">Thread.Sleep(10000);</Button>
           <Button Margin="10" Click="ButtonStartCustomVisual">Start</Button>
           <Button Margin="10" Click="ButtonStopCustomVisual">Stop</Button>
+          <CheckBox Margin="10" 
+                    x:Name="PreciseDirtyRectsCheckboxCustomVisual"
+                    IsCheckedChanged="PreciseDirtyRectsCheckboxCustomVisualChanged"
+                    >Precise dirty rects</CheckBox>
         </StackPanel>
         <Control x:Name="CustomVisualHost" />
       </DockPanel>

--- a/src/Avalonia.Base/Media/Imaging/RenderTargetBitmap.cs
+++ b/src/Avalonia.Base/Media/Imaging/RenderTargetBitmap.cs
@@ -77,7 +77,7 @@ namespace Avalonia.Media.Imaging
         /// <returns>The drawing context.</returns>
         public DrawingContext CreateDrawingContext(bool clear)
         {
-            var platform = PlatformImpl.Item.CreateDrawingContext();
+            var platform = PlatformImpl.Item.CreateDrawingContext(true);
             if(clear)
                 platform.Clear(Colors.Transparent);
             return new PlatformDrawingContext(platform);

--- a/src/Avalonia.Base/PixelSize.cs
+++ b/src/Avalonia.Base/PixelSize.cs
@@ -166,6 +166,17 @@ namespace Avalonia
         public static PixelSize FromSize(Size size, double scale) => new PixelSize(
             (int)Math.Ceiling(size.Width * scale),
             (int)Math.Ceiling(size.Height * scale));
+        
+        /// <summary>
+        /// A reversible variant of <see cref="FromSize(Size, double)"/> that uses Round instead of Ceiling to make it reversible from ToSize
+        /// </summary>
+        /// <param name="size">The size.</param>
+        /// <param name="scale">The scaling factor.</param>
+        /// <returns>The device-independent size.</returns>
+        internal static PixelSize FromSizeRounded(Size size, double scale) => new PixelSize(
+            (int)Math.Round(size.Width * scale),
+            (int)Math.Round(size.Height * scale));
+
 
         /// <summary>
         /// Converts a <see cref="Size"/> to device pixels using the specified scaling factor.

--- a/src/Avalonia.Base/Platform/IDrawingContextImpl.cs
+++ b/src/Avalonia.Base/Platform/IDrawingContextImpl.cs
@@ -3,6 +3,7 @@ using Avalonia.Media;
 using Avalonia.Utilities;
 using Avalonia.Metadata;
 using Avalonia.Media.Imaging;
+using Avalonia.Media.Immutable;
 
 namespace Avalonia.Platform
 {
@@ -75,6 +76,18 @@ namespace Avalonia.Platform
         /// </remarks>
         void DrawRectangle(IBrush? brush, IPen? pen, RoundedRect rect,
             BoxShadows boxShadows = default);
+        
+        /// <summary>
+        /// Draws the specified region with the specified Brush and Pen.
+        /// </summary>
+        /// <param name="brush">The brush used to fill the rectangle, or <c>null</c> for no fill.</param>
+        /// <param name="pen">The pen used to stroke the rectangle, or <c>null</c> for no stroke.</param>
+        /// <param name="region">The region to draw.</param>
+        /// <remarks>
+        /// The brush and the pen can both be null. If the brush is null, then no fill is performed.
+        /// If the pen is null, then no stoke is performed. If both the pen and the brush are null, then the drawing is not visible.
+        /// </remarks>
+        void DrawRegion(IBrush? brush, IPen? pen, IPlatformRenderInterfaceRegion region);
 
         /// <summary>
         /// Draws an ellipse with the specified Brush and Pen.
@@ -108,7 +121,7 @@ namespace Avalonia.Platform
         /// has to do a format conversion each time a standard render target bitmap is rendered,
         /// but a layer created via this method has no such overhead.
         /// </remarks>
-        IDrawingContextLayerImpl CreateLayer(Size size);
+        IDrawingContextLayerImpl CreateLayer(PixelSize size);
 
         /// <summary>
         /// Pushes a clip rectangle.
@@ -121,11 +134,27 @@ namespace Avalonia.Platform
         /// </summary>
         /// <param name="clip">The clip rounded rectangle</param>
         void PushClip(RoundedRect clip);
-
+        
+        /// <summary>
+        /// Pushes a clip region.
+        /// </summary>
+        /// <param name="region">The clip region</param>
+        void PushClip(IPlatformRenderInterfaceRegion region);
+        
         /// <summary>
         /// Pops the latest pushed clip rectangle.
         /// </summary>
         void PopClip();
+
+        /// <summary>
+        /// Enforces rendering to happen on an intermediate surface
+        /// </summary>
+        void PushLayer(Rect bounds);
+
+        /// <summary>
+        /// Pops the latest pushed intermediate surface layer.
+        /// </summary>
+        void PopLayer();
 
         /// <summary>
         /// Pushes an opacity value.

--- a/src/Avalonia.Base/Platform/IPlatformRenderInterface.cs
+++ b/src/Avalonia.Base/Platform/IPlatformRenderInterface.cs
@@ -199,6 +199,9 @@ namespace Avalonia.Platform
         public PixelFormat DefaultPixelFormat { get; }
 
         bool IsSupportedBitmapPixelFormat(PixelFormat format);
+        
+        bool SupportsRegions { get; }
+        IPlatformRenderInterfaceRegion CreateRegion();
     }
 
     [Unstable, PrivateApi]

--- a/src/Avalonia.Base/Platform/IPlatformRenderInterfaceRegion.cs
+++ b/src/Avalonia.Base/Platform/IPlatformRenderInterfaceRegion.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Metadata;
+
+namespace Avalonia.Platform;
+
+[Unstable, PrivateApi]
+public interface IPlatformRenderInterfaceRegion : IDisposable
+{
+    void AddRect(PixelRect rect);
+    void Reset();
+    bool IsEmpty { get; }
+    PixelRect Bounds { get; }
+    IList<PixelRect> Rects { get; }
+    bool Intersects(Rect rect);
+    bool Contains(Point pt);
+}

--- a/src/Avalonia.Base/Platform/IRenderTarget.cs
+++ b/src/Avalonia.Base/Platform/IRenderTarget.cs
@@ -16,7 +16,8 @@ namespace Avalonia.Platform
         /// <summary>
         /// Creates an <see cref="IDrawingContextImpl"/> for a rendering session.
         /// </summary>
-        IDrawingContextImpl CreateDrawingContext();
+        /// <param name="useScaledDrawing">Apply DPI reported by the render target as a hidden transform matrix</param>
+        IDrawingContextImpl CreateDrawingContext(bool useScaledDrawing);
         
         /// <summary>
         /// Indicates if the render target is no longer usable and needs to be recreated

--- a/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
@@ -172,7 +172,8 @@ internal class CompositingRenderer : IRendererWithCompositor, IHitTester
                 v.SynchronizeCompositionChildVisuals();
         _dirty.Clear();
         _recalculateChildren.Clear();
-        CompositionTarget.Size = _root.ClientSize;
+        
+        CompositionTarget.PixelSize = PixelSize.FromSizeRounded(_root.ClientSize, _root.RenderScaling);
         CompositionTarget.Scaling = _root.RenderScaling;
         
         var commit = _compositor.RequestCommitAsync();

--- a/src/Avalonia.Base/Rendering/Composition/CompositionCustomVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositionCustomVisual.cs
@@ -1,12 +1,15 @@
 using System.Collections.Generic;
 using System.Numerics;
+using Avalonia.Media;
 using Avalonia.Rendering.Composition.Server;
 using Avalonia.Rendering.Composition.Transport;
+using Avalonia.Threading;
 
 namespace Avalonia.Rendering.Composition;
 
 public sealed class CompositionCustomVisual : CompositionContainerVisual
 {
+    private static readonly ThreadSafeObjectPool<List<object>> s_messageListPool = new(); 
     private List<object>? _messages;
 
     internal CompositionCustomVisual(Compositor compositor, CompositionCustomVisualHandler handler)
@@ -17,21 +20,26 @@ public sealed class CompositionCustomVisual : CompositionContainerVisual
 
     public void SendHandlerMessage(object message)
     {
-        (_messages ??= new()).Add(message);
-        RegisterForSerialization();
+        if (_messages == null)
+        {
+            _messages = s_messageListPool.Get();
+            Compositor.RequestCompositionUpdate(OnCompositionUpdate);
+        }
+        _messages.Add(message);
     }
 
-    private protected override void SerializeChangesCore(BatchStreamWriter writer)
+    private void OnCompositionUpdate()
     {
-        base.SerializeChangesCore(writer);
-        if (_messages == null || _messages.Count == 0)
-            writer.Write(0);
-        else
+        if(_messages == null)
+            return;
+        
+        var messages = _messages;
+        _messages = null;
+        Compositor.PostServerJob(()=>
         {
-            writer.Write(_messages.Count);
-            foreach (var m in _messages)
-                writer.WriteObject(m);
-            _messages.Clear();
-        }
+            ((ServerCompositionCustomVisual)Server).DispatchMessages(messages);
+            messages.Clear();
+            s_messageListPool.ReturnAndSetNull(ref messages);
+        });
     }
 }

--- a/src/Avalonia.Base/Rendering/Composition/CompositionCustomVisualHandler.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositionCustomVisualHandler.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Numerics;
+using Avalonia.Collections.Pooled;
 using Avalonia.Media;
 using Avalonia.Rendering.Composition.Server;
 
@@ -8,6 +10,8 @@ namespace Avalonia.Rendering.Composition;
 public abstract class CompositionCustomVisualHandler
 {
     private ServerCompositionCustomVisual? _host;
+    private bool _inRender;
+    private Rect _currentTransformedClip;
 
     public virtual void OnMessage(object message)
     {
@@ -18,7 +22,21 @@ public abstract class CompositionCustomVisualHandler
     {
         
     }
-    
+
+    internal void Render(ImmediateDrawingContext drawingContext, Rect currentTransformedClip)
+    {
+        _inRender = true;
+        _currentTransformedClip = currentTransformedClip;
+        try
+        {
+            OnRender(drawingContext);
+        }
+        finally
+        {
+            _inRender = false;
+        }
+    }
+
     public abstract void OnRender(ImmediateDrawingContext drawingContext);
 
     void VerifyAccess()
@@ -26,6 +44,13 @@ public abstract class CompositionCustomVisualHandler
         if (_host == null)
             throw new InvalidOperationException("Object is not yet attached to the compositor");
         _host.Compositor.VerifyAccess();
+    }
+
+    void VerifyInRender()
+    {
+        VerifyAccess();
+        if (!_inRender)
+            throw new InvalidOperationException("This API is only available from OnRender");
     }
 
     protected Vector EffectiveSize
@@ -57,9 +82,29 @@ public abstract class CompositionCustomVisualHandler
         _host!.HandlerInvalidate();
     }
 
+    protected void Invalidate(Rect rc)
+    {
+        VerifyAccess();
+        _host!.HandlerInvalidate(rc);
+    }
+
     protected void RegisterForNextAnimationFrameUpdate()
     {
         VerifyAccess();
         _host!.HandlerRegisterForNextAnimationFrameUpdate();
+    }
+
+    protected bool RenderClipContains(Point pt)
+    {
+        VerifyInRender();
+        pt *= _host!.GlobalTransformMatrix;
+        return _currentTransformedClip.Contains(pt) && _host.Root!.DirtyRects.Contains(pt);
+    }
+
+    protected bool RenderClipIntersectes(Rect rc)
+    {
+        VerifyInRender();
+        rc = rc.TransformToAABB(_host!.GlobalTransformMatrix);
+        return _currentTransformedClip.Intersects(rc) && _host.Root!.DirtyRects.Intersects(rc);
     }
 }

--- a/src/Avalonia.Base/Rendering/Composition/CompositionOptions.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositionOptions.cs
@@ -1,0 +1,16 @@
+namespace Avalonia.Rendering.Composition;
+
+public class CompositionOptions
+{
+    /// <summary>
+    /// Enables more accurate tracking of dirty rects by utilizing regions if supported by the underlying
+    /// drawing context
+    /// </summary>
+    public bool? UseRegionDirtyRectClipping { get; set; }
+    /// <summary>
+    /// Enforces dirty contents to be rendered into an extra intermediate surface before being applied onto the
+    /// saved frame.
+    /// Required as a workaround for Skia bug https://issues.skia.org/issues/327877721
+    /// </summary>
+    public bool? UseSaveLayerRootClip { get; set; }
+}

--- a/src/Avalonia.Base/Rendering/Composition/CompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositionTarget.cs
@@ -29,6 +29,7 @@ namespace Avalonia.Rendering.Composition
         /// <returns></returns>
         public PooledList<CompositionVisual>? TryHitTest(Point point, CompositionVisual? root, Func<CompositionVisual, bool>? filter)
         {
+            point *= Scaling;
             Server.Readback.NextRead();
             root ??= Root;
             if (root == null)

--- a/src/Avalonia.Base/Rendering/Composition/Server/DiagnosticTextRenderer.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/DiagnosticTextRenderer.cs
@@ -67,7 +67,7 @@ namespace Avalonia.Rendering.Composition.Server
             {
                 var effectiveChar = c is >= FirstChar and <= LastChar ? c : ' ';
                 var run = _runs[effectiveChar - FirstChar];
-                context.Transform = originalTransform * Matrix.CreateTranslation(offset, 0.0);
+                context.Transform = Matrix.CreateTranslation(offset, 0.0) * originalTransform;
                 context.DrawGlyphRun(foreground, run.PlatformImpl.Item);
                 offset += run.Bounds.Width;
             }

--- a/src/Avalonia.Base/Rendering/Composition/Server/DirtyRectTracker.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/DirtyRectTracker.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+using Avalonia.Platform;
+using Avalonia.Reactive;
+
+namespace Avalonia.Rendering.Composition.Server;
+
+internal interface IDirtyRectTracker
+{
+    void AddRect(PixelRect rect);
+    IDisposable BeginDraw(IDrawingContextImpl ctx);
+    bool IsEmpty { get; }
+    bool Intersects(Rect rect);
+    bool Contains(Point pt);
+    void Reset();
+    void Visualize(IDrawingContextImpl context);
+    PixelRect CombinedRect { get; }
+    IList<PixelRect> Rects { get; }
+}
+
+internal class DirtyRectTracker : IDirtyRectTracker
+{
+    private PixelRect _rect;
+    private Rect _doubleRect;
+    private PixelRect[] _rectsForApi = new PixelRect[1];
+    private Random _random = new();
+    public void AddRect(PixelRect rect)
+    {
+        _rect = _rect.Union(rect);
+    }
+    
+    public IDisposable BeginDraw(IDrawingContextImpl ctx)
+    {
+        ctx.PushClip(_rect.ToRect(1));
+        _doubleRect = _rect.ToRect(1);
+        return Disposable.Create(ctx.PopClip);
+    }
+
+    public bool IsEmpty => _rect.Width == 0 | _rect.Height == 0;
+    public bool Intersects(Rect rect) => _doubleRect.Intersects(rect);
+    public bool Contains(Point pt) => _rect.Contains(PixelPoint.FromPoint(pt, 1));
+
+    public void Reset() => _rect = default;
+    public void Visualize(IDrawingContextImpl context)
+    {
+        context.DrawRectangle(
+            new ImmutableSolidColorBrush(
+                new Color(30, (byte)_random.Next(255), (byte)_random.Next(255), (byte)_random.Next(255))),
+            null, _doubleRect);
+    }
+
+    public PixelRect CombinedRect => _rect;
+
+    public IList<PixelRect> Rects
+    {
+        get
+        {
+            if (_rect.Width == 0 || _rect.Height == 0)
+                return Array.Empty<PixelRect>();
+            _rectsForApi[0] = _rect;
+            return _rectsForApi;
+        }
+    }
+}
+
+internal class RegionDirtyRectTracker : IDirtyRectTracker
+{
+    private readonly IPlatformRenderInterfaceRegion _region;
+    private Random _random = new();
+
+    public RegionDirtyRectTracker(IPlatformRenderInterface platformRender)
+    {
+        _region = platformRender.CreateRegion();
+    }
+
+    public void AddRect(PixelRect rect) => _region.AddRect(rect);
+
+    public IDisposable BeginDraw(IDrawingContextImpl ctx)
+    {
+        ctx.PushClip(_region);
+        return Disposable.Create(ctx.PopClip);
+    }
+
+    public bool IsEmpty => _region.IsEmpty;
+    public bool Intersects(Rect rect) => _region.Intersects(rect);
+    public bool Contains(Point pt) => _region.Contains(pt);
+
+    public void Reset() => _region.Reset();
+
+    public void Visualize(IDrawingContextImpl context)
+    {
+        context.DrawRegion(
+            new ImmutableSolidColorBrush(
+                new Color(150, (byte)_random.Next(255), (byte)_random.Next(255), (byte)_random.Next(255))),
+            null, _region);
+    }
+
+    public PixelRect CombinedRect => _region.Bounds;
+    public IList<PixelRect> Rects => _region.Rects;
+}

--- a/src/Avalonia.Base/Rendering/Composition/Server/DrawingContextProxy.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/DrawingContextProxy.cs
@@ -77,6 +77,9 @@ internal class CompositorDrawingContextProxy : IDrawingContextImpl,
         _impl.DrawRectangle(brush, pen, rect, boxShadows);
     }
 
+    public void DrawRegion(IBrush? brush, IPen? pen, IPlatformRenderInterfaceRegion region) =>
+        _impl.DrawRegion(brush, pen, region);
+
     public void DrawEllipse(IBrush? brush, IPen? pen, Rect rect)
     {
         _impl.DrawEllipse(brush, pen, rect);
@@ -87,7 +90,7 @@ internal class CompositorDrawingContextProxy : IDrawingContextImpl,
         _impl.DrawGlyphRun(foreground, glyphRun);
     }
 
-    public IDrawingContextLayerImpl CreateLayer(Size size)
+    public IDrawingContextLayerImpl CreateLayer(PixelSize size)
     {
         return _impl.CreateLayer(size);
     }
@@ -102,10 +105,16 @@ internal class CompositorDrawingContextProxy : IDrawingContextImpl,
         _impl.PushClip(clip);
     }
 
+    public void PushClip(IPlatformRenderInterfaceRegion region) => _impl.PushClip(region);
+
     public void PopClip()
     {
         _impl.PopClip();
     }
+
+    public void PushLayer(Rect bounds) => _impl.PushLayer(bounds);
+
+    public void PopLayer() => _impl.PopLayer();
 
     public void PushOpacity(double opacity, Rect? bounds)
     {

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionContainerVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionContainerVisual.cs
@@ -16,26 +16,27 @@ namespace Avalonia.Rendering.Composition.Server
         private Rect? _transformedContentBounds;
         private IImmutableEffect? _oldEffect;
         
-        protected override void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip)
+        protected override void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip,
+            IDirtyRectTracker dirtyRects)
         {
-            base.RenderCore(canvas, currentTransformedClip);
+            base.RenderCore(canvas, currentTransformedClip, dirtyRects);
 
             foreach (var ch in Children)
             {
-                ch.Render(canvas, currentTransformedClip);
+                ch.Render(canvas, currentTransformedClip, dirtyRects);
             }
         }
 
-        public override UpdateResult Update(ServerCompositionTarget root)
+        public override UpdateResult Update(ServerCompositionTarget root, Matrix parentCombinedTransform)
         {
-            var (combinedBounds, oldInvalidated, newInvalidated) = base.Update(root);
+            var (combinedBounds, oldInvalidated, newInvalidated) = base.Update(root, parentCombinedTransform);
             foreach (var child in Children)
             {
                 if (child.AdornedVisual != null)
                     root.EnqueueAdornerUpdate(child);
                 else
                 {
-                    var res = child.Update(root);
+                    var res = child.Update(root, GlobalTransformMatrix);
                     oldInvalidated |= res.InvalidatedOld;
                     newInvalidated |= res.InvalidatedNew;
                     combinedBounds = Rect.Union(combinedBounds, res.Bounds);

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionDrawListVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionDrawListVisual.cs
@@ -40,13 +40,15 @@ internal class ServerCompositionDrawListVisual : ServerCompositionContainerVisua
         base.DeserializeChangesCore(reader, committedAt);
     }
 
-    protected override void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip)
+    protected override void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip,
+        IDirtyRectTracker dirtyRects)
     {
         if (_renderCommands != null)
         {
             _renderCommands.Render(canvas);
         }
-        base.RenderCore(canvas, currentTransformedClip);
+
+        base.RenderCore(canvas, currentTransformedClip, dirtyRects);
     }
     
     public void DependencyQueuedInvalidate(IServerRenderResource sender) => ValuesInvalidated();

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionExperimentalAcrylicVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionExperimentalAcrylicVisual.cs
@@ -5,7 +5,8 @@ namespace Avalonia.Rendering.Composition.Server;
 
 internal partial class ServerCompositionExperimentalAcrylicVisual
 {
-    protected override void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip)
+    protected override void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip,
+        IDirtyRectTracker dirtyRects)
     {
         var cornerRadius = CornerRadius;
         canvas.DrawRectangle(
@@ -15,7 +16,7 @@ internal partial class ServerCompositionExperimentalAcrylicVisual
                 cornerRadius.TopLeft, cornerRadius.TopRight,
                 cornerRadius.BottomRight, cornerRadius.BottomLeft));
 
-        base.RenderCore(canvas, currentTransformedClip);
+        base.RenderCore(canvas, currentTransformedClip, dirtyRects);
     }
 
     public override Rect OwnContentBounds => new(0, 0, Size.X, Size.Y);

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionSolidColorVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionSolidColorVisual.cs
@@ -4,7 +4,8 @@ namespace Avalonia.Rendering.Composition.Server;
 
 internal partial class ServerCompositionSolidColorVisual
 {
-    protected override void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip)
+    protected override void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip,
+        IDirtyRectTracker dirtyRects)
     {
         canvas.DrawRectangle(new ImmutableSolidColorBrush(Color), null, new Rect(0, 0, Size.X, Size.Y));
     }

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionSurfaceVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionSurfaceVisual.cs
@@ -4,7 +4,8 @@ namespace Avalonia.Rendering.Composition.Server;
 
 internal partial class ServerCompositionSurfaceVisual
 {
-    protected override void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip)
+    protected override void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip,
+        IDirtyRectTracker dirtyRects)
     {
         if (Surface == null)
             return;

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.DirtyRects.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.DirtyRects.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Collections.Pooled;
+
+namespace Avalonia.Rendering.Composition.Server;
+
+internal partial class ServerCompositionTarget
+{
+    public readonly IDirtyRectTracker DirtyRects;
+    
+    public void AddDirtyRect(Rect rect)
+    {
+        if (rect.Width == 0 && rect.Height == 0)
+            return;
+        var snapped = PixelRect.FromRect(SnapToDevicePixels(rect, Scaling), 1);
+        DebugEvents?.RectInvalidated(rect);
+        DirtyRects.AddRect(snapped);
+        _redrawRequested = true;
+    }
+    
+    public Rect SnapToDevicePixels(Rect rect) => SnapToDevicePixels(rect, Scaling);
+        
+    private static Rect SnapToDevicePixels(Rect rect, double scale)
+    {
+        return new Rect(
+            new Point(
+                Math.Floor(rect.X * scale) / scale,
+                Math.Floor(rect.Y * scale) / scale),
+            new Point(
+                Math.Ceiling(rect.Right * scale) / scale,
+                Math.Ceiling(rect.Bottom * scale) / scale));
+    }
+    
+    
+}

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionVisual.cs
@@ -22,19 +22,24 @@ namespace Avalonia.Rendering.Composition.Server
         private Rect? _transformedClipBounds;
         private Rect _combinedTransformedClipBounds;
 
-        protected virtual void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip)
+        protected virtual void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip,
+            IDirtyRectTracker dirtyRects)
         {
         }
 
-        public void Render(CompositorDrawingContextProxy canvas, Rect currentTransformedClip)
+        public void Render(CompositorDrawingContextProxy canvas, Rect? parentTransformedClip, IDirtyRectTracker dirtyRects)
         {
             if (Visible == false || IsVisibleInFrame == false)
                 return;
             if (Opacity == 0)
                 return;
 
-            currentTransformedClip = currentTransformedClip.Intersect(_combinedTransformedClipBounds);
+            var currentTransformedClip = parentTransformedClip.HasValue
+                ? parentTransformedClip.Value.Intersect(_combinedTransformedClipBounds)
+                : _combinedTransformedClipBounds;
             if (currentTransformedClip.Width == 0 && currentTransformedClip.Height == 0)
+                return;
+            if(!dirtyRects.Intersects(currentTransformedClip))
                 return;
 
             Root!.RenderedVisuals++;
@@ -67,7 +72,7 @@ namespace Avalonia.Rendering.Composition.Server
 
             canvas.RenderOptions = RenderOptions;
 
-            RenderCore(canvas, currentTransformedClip);
+            RenderCore(canvas, currentTransformedClip, dirtyRects);
             
             // Hack to force invalidation of SKMatrix
             canvas.PostTransform = transform;
@@ -116,7 +121,7 @@ namespace Avalonia.Rendering.Composition.Server
             }
         }
         
-        public virtual UpdateResult Update(ServerCompositionTarget root)
+        public virtual UpdateResult Update(ServerCompositionTarget root, Matrix parentVisualTransform)
         {
             if (Parent == null && Root == null)
                 return default;
@@ -138,7 +143,7 @@ namespace Avalonia.Rendering.Composition.Server
                 _combinedTransformDirty = false;
             }
 
-            var parentTransform = (AdornedVisual ?? Parent)?.GlobalTransformMatrix ?? Matrix.Identity;
+            var parentTransform = AdornedVisual?.GlobalTransformMatrix ?? parentVisualTransform;
 
             var newTransform = CombinedTransformMatrix * parentTransform;
 
@@ -207,7 +212,7 @@ namespace Avalonia.Rendering.Composition.Server
             _combinedTransformedClipBounds =
                 (AdornerIsClipped ? AdornedVisual?._combinedTransformedClipBounds : null)
                 ?? (Parent?.Effect == null ? Parent?._combinedTransformedClipBounds : null)
-                ?? new Rect(Root!.Size);
+                ?? new Rect(Root!.PixelSize.ToSize(1));
 
             if (_transformedClipBounds != null)
                 _combinedTransformedClipBounds = _combinedTransformedClipBounds.Intersect(_transformedClipBounds.Value);
@@ -301,7 +306,7 @@ namespace Avalonia.Rendering.Composition.Server
         protected override void ValuesInvalidated()
         {
             _isDirtyForUpdate = true;
-            Root?.Invalidate();
+            Root?.RequestUpdate();
         }
 
         public bool IsVisibleInFrame { get; set; }

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositor.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositor.cs
@@ -38,6 +38,7 @@ namespace Avalonia.Rendering.Composition.Server
         internal static readonly object RenderThreadDisposeStartMarker = new();
         internal static readonly object RenderThreadJobsStartMarker = new();
         internal static readonly object RenderThreadJobsEndMarker = new();
+        public CompositionOptions Options { get; } = AvaloniaLocator.Current.GetService<CompositionOptions>() ?? new();
 
         public ServerCompositor(IRenderLoop renderLoop, IPlatformGraphics? platformGraphics,
             BatchStreamObjectPool<object?> batchObjectPool, BatchStreamMemoryPool batchMemoryPool)

--- a/src/Avalonia.Base/composition-schema.xml
+++ b/src/Avalonia.Base/composition-schema.xml
@@ -54,7 +54,7 @@
         <Property Name="DebugOverlays" Type="RendererDebugOverlays"/>
         <Property Name="LastLayoutPassTiming" Type="LayoutPassTiming" Internal="true"/>
         <Property Name="Scaling" Type="double"/>
-        <Property Name="Size" Type="Size" />
+        <Property Name="PixelSize" Type="PixelSize" />
     </Object>
     <KeyFrameAnimation Name="Scalar" Type="float"/>
     <KeyFrameAnimation Name="Double" Type="double"/>

--- a/src/Avalonia.Controls/BorderVisual.cs
+++ b/src/Avalonia.Controls/BorderVisual.cs
@@ -45,7 +45,8 @@ class CompositionBorderVisual : CompositionDrawListVisual
         {
         }
 
-        protected override void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip)
+        protected override void RenderCore(CompositorDrawingContextProxy canvas, Rect currentTransformedClip,
+            IDirtyRectTracker dirtyRects)
         {
             if (ClipToBounds)
             {
@@ -56,7 +57,7 @@ class CompositionBorderVisual : CompositionDrawListVisual
                     canvas.PushClip(new RoundedRect(clipRect, _cornerRadius));
             }
 
-            base.RenderCore(canvas, currentTransformedClip);
+            base.RenderCore(canvas, currentTransformedClip, dirtyRects);
             
             if(ClipToBounds)
                 canvas.PopClip();

--- a/src/Avalonia.X11/X11CursorFactory.cs
+++ b/src/Avalonia.X11/X11CursorFactory.cs
@@ -115,7 +115,7 @@ namespace Avalonia.X11
                
                 using (var cpuContext = platformRenderInterface.CreateBackendContext(null))
                 using (var renderTarget = cpuContext.CreateRenderTarget(new[] { this }))
-                using (var ctx = renderTarget.CreateDrawingContext())
+                using (var ctx = renderTarget.CreateDrawingContext(true))
                 {
                     var r = new Rect(_pixelSize.ToSize(1)); 
                     ctx.DrawBitmap(bitmap, 1, r, r);

--- a/src/Avalonia.X11/X11IconLoader.cs
+++ b/src/Avalonia.X11/X11IconLoader.cs
@@ -43,7 +43,7 @@ namespace Avalonia.X11
             _bdata = new uint[_width * _height];
             using(var cpuContext = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>().CreateBackendContext(null))
             using(var rt = cpuContext.CreateRenderTarget(new[]{this}))
-            using (var ctx = rt.CreateDrawingContext())
+            using (var ctx = rt.CreateDrawingContext(true))
                 ctx.DrawBitmap(bitmap.PlatformImpl.Item, 1, new Rect(bitmap.Size),
                     new Rect(0, 0, _width, _height));
             Data = new UIntPtr[_width * _height + 2];

--- a/src/Headless/Avalonia.Headless/HeadlessPlatformRenderInterface.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessPlatformRenderInterface.cs
@@ -33,6 +33,8 @@ namespace Avalonia.Headless
 
         public PixelFormat DefaultPixelFormat => PixelFormat.Rgba8888;
         public bool IsSupportedBitmapPixelFormat(PixelFormat format) => true;
+        public bool SupportsRegions => false;
+        public IPlatformRenderInterfaceRegion CreateRegion() => throw new NotSupportedException();
 
         public IGeometryImpl CreateEllipseGeometry(Rect rect) => new HeadlessGeometryStub(rect);
 
@@ -398,7 +400,7 @@ namespace Avalonia.Headless
 
             }
 
-            public IDrawingContextImpl CreateDrawingContext()
+            public IDrawingContextImpl CreateDrawingContext(bool _)
             {
                 return new HeadlessDrawingContextStub();
             }
@@ -454,7 +456,7 @@ namespace Avalonia.Headless
 
             }
 
-            public IDrawingContextLayerImpl CreateLayer(Size size)
+            public IDrawingContextLayerImpl CreateLayer(PixelSize size)
             {
                 return new HeadlessBitmapStub(size, new Vector(96, 96));
             }
@@ -464,9 +466,22 @@ namespace Avalonia.Headless
 
             }
 
+            public void PushClip(IPlatformRenderInterfaceRegion region)
+            {
+                
+            }
+
             public void PopClip()
             {
 
+            }
+
+            public void PushLayer(Rect bounds)
+            {
+            }
+
+            public void PopLayer()
+            {
             }
 
             public void PushOpacity(double opacity, Rect? rect)
@@ -541,6 +556,11 @@ namespace Avalonia.Headless
                 
             }
 
+            public void DrawRegion(IBrush? brush, IPen? pen, IPlatformRenderInterfaceRegion region)
+            {
+                
+            }
+
             public void DrawEllipse(IBrush? brush, IPen? pen, Rect rect)
             {
             }
@@ -573,7 +593,7 @@ namespace Avalonia.Headless
 
             }
 
-            public IDrawingContextImpl CreateDrawingContext()
+            public IDrawingContextImpl CreateDrawingContext(bool _)
             {
                 return new HeadlessDrawingContextStub();
             }

--- a/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/FramebufferRenderTarget.cs
@@ -37,7 +37,7 @@ namespace Avalonia.Skia
         }
 
         /// <inheritdoc />
-        public IDrawingContextImpl CreateDrawingContext()
+        public IDrawingContextImpl CreateDrawingContext(bool scaleDrawingToDpi)
         {
             if (_renderTarget == null)
                 throw new ObjectDisposedException(nameof(FramebufferRenderTarget));
@@ -58,7 +58,8 @@ namespace Avalonia.Skia
             var createInfo = new DrawingContextImpl.CreateInfo
             {
                 Surface = _framebufferSurface,
-                Dpi = framebuffer.Dpi
+                Dpi = framebuffer.Dpi,
+                ScaleDrawingToDpi = scaleDrawingToDpi
             };
 
             return new DrawingContextImpl(createInfo, _preFramebufferCopyHandler, canvas, framebuffer);

--- a/src/Skia/Avalonia.Skia/Gpu/SkiaGpuRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/Gpu/SkiaGpuRenderTarget.cs
@@ -21,7 +21,7 @@ namespace Avalonia.Skia
             _renderTarget.Dispose();
         }
 
-        public IDrawingContextImpl CreateDrawingContext()
+        public IDrawingContextImpl CreateDrawingContext(bool useScaledDrawing)
         {
             var session = _renderTarget.BeginRenderingSession();
 
@@ -30,6 +30,7 @@ namespace Avalonia.Skia
                 GrContext = session.GrContext,
                 Surface = session.SkSurface,
                 Dpi = SkiaPlatform.DefaultDpi * session.ScaleFactor,
+                ScaleDrawingToDpi = useScaledDrawing,
                 Gpu = _skiaGpu,
                 CurrentSession =  session
             };

--- a/src/Skia/Avalonia.Skia/PictureRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/PictureRenderTarget.cs
@@ -38,6 +38,7 @@ internal class PictureRenderTarget : IDisposable
         var createInfo = new DrawingContextImpl.CreateInfo
         {
             Canvas = canvas,
+            ScaleDrawingToDpi = true,
             Dpi = _dpi,
             DisableSubpixelTextRendering = true,
             GrContext = _grContext,

--- a/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
+++ b/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs
@@ -50,6 +50,9 @@ namespace Avalonia.Skia
             || format == PixelFormats.Bgra8888
             || format == PixelFormats.Rgba8888;
 
+        public bool SupportsRegions => true;
+        public IPlatformRenderInterfaceRegion CreateRegion() => new SkiaRegionImpl();
+
         public IGeometryImpl CreateEllipseGeometry(Rect rect) => new EllipseGeometryImpl(rect);
 
         public IGeometryImpl CreateLineGeometry(Point p1, Point p2) => new LineGeometryImpl(p1, p2);

--- a/src/Skia/Avalonia.Skia/RenderTargetBitmapImpl.cs
+++ b/src/Skia/Avalonia.Skia/RenderTargetBitmapImpl.cs
@@ -19,7 +19,8 @@ internal class RenderTargetBitmapImpl : WriteableBitmapImpl,
         _renderTarget = new FramebufferRenderTarget(this);
     }
 
-    public IDrawingContextImpl CreateDrawingContext() => _renderTarget.CreateDrawingContext();
+    IDrawingContextImpl IRenderTarget.CreateDrawingContext(bool useScaledDrawing) =>
+        _renderTarget.CreateDrawingContext(useScaledDrawing);
 
     public bool IsCorrupted => false;
     

--- a/src/Skia/Avalonia.Skia/SkiaRegionImpl.cs
+++ b/src/Skia/Avalonia.Skia/SkiaRegionImpl.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Platform;
+using SkiaSharp;
+
+namespace Avalonia.Skia;
+
+internal class SkiaRegionImpl : IPlatformRenderInterfaceRegion
+{
+    private SKRegion? _region = new();
+    public SKRegion Region => _region ?? throw new ObjectDisposedException(nameof(SkiaRegionImpl));
+    private bool _rectsValid;
+    private List<PixelRect>? _rects;
+    public void Dispose()
+    {
+        _region?.Dispose();
+        _region = null;
+    }
+
+    public void AddRect(PixelRect rect)
+    {
+        _rectsValid = false;
+        Region.Op(rect.X, rect.Y, rect.Right, rect.Bottom, SKRegionOperation.Union);
+    }
+
+    public void Reset()
+    {
+        _rectsValid = false;
+        Region.SetEmpty();
+    }
+
+    public bool IsEmpty => Region.IsEmpty;
+    public PixelRect Bounds => Region.Bounds.ToAvaloniaPixelRect();
+
+    public IList<PixelRect> Rects
+    {
+        get
+        {
+            _rects ??= new();
+            if (!_rectsValid)
+            {
+                _rects.Clear();
+                using var iter = Region.CreateRectIterator();
+                while (iter.Next(out var rc))
+                    _rects.Add(rc.ToAvaloniaPixelRect());
+            }
+            return _rects;
+        }
+    }
+
+    public bool Intersects(Rect rect) => Region.Intersects(PixelRect.FromRect(rect, 1).ToSKRectI());
+    public bool Contains(Point pt) => Region.Contains((int)pt.X, (int)pt.Y);
+}

--- a/src/Skia/Avalonia.Skia/SkiaSharpExtensions.cs
+++ b/src/Skia/Avalonia.Skia/SkiaSharpExtensions.cs
@@ -75,6 +75,11 @@ namespace Avalonia.Skia
         {
             return new SKRect((float)r.X, (float)r.Y, (float)r.Right, (float)r.Bottom);
         }
+        
+        public static SKRectI ToSKRectI(this PixelRect r)
+        {
+            return new SKRectI(r.X, r.Y, r.Right, r.Bottom);
+        }
 
         public static SKRoundRect ToSKRoundRect(this RoundedRect r)
         {
@@ -94,6 +99,11 @@ namespace Avalonia.Skia
         public static Rect ToAvaloniaRect(this SKRect r)
         {
             return new Rect(r.Left, r.Top, r.Right - r.Left, r.Bottom - r.Top);
+        }
+        
+        public static PixelRect ToAvaloniaPixelRect(this SKRectI r)
+        {
+            return new PixelRect(r.Left, r.Top, r.Right - r.Left, r.Bottom - r.Top);
         }
 
         public static SKMatrix ToSKMatrix(this Matrix m)

--- a/src/Skia/Avalonia.Skia/SurfaceRenderTarget.cs
+++ b/src/Skia/Avalonia.Skia/SurfaceRenderTarget.cs
@@ -97,7 +97,7 @@ namespace Avalonia.Skia
         }
 
         /// <inheritdoc />
-        public IDrawingContextImpl CreateDrawingContext()
+        public IDrawingContextImpl CreateDrawingContext(bool useScaledDrawing)
         {
             _canvas.RestoreToCount(-1);
             _canvas.ResetMatrix();
@@ -106,6 +106,7 @@ namespace Avalonia.Skia
             {
                 Surface = _surface.Surface,
                 Dpi = Dpi,
+                ScaleDrawingToDpi = useScaledDrawing,
                 DisableSubpixelTextRendering = _disableLcdRendering,
                 GrContext = _grContext,
                 Gpu = _gpu,

--- a/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
+++ b/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
@@ -296,5 +296,8 @@ namespace Avalonia.Direct2D1
         public bool IsSupportedBitmapPixelFormat(PixelFormat format) =>
             format == PixelFormats.Bgra8888 
             || format == PixelFormats.Rgba8888;
+
+        public bool SupportsRegions => false;
+        public IPlatformRenderInterfaceRegion CreateRegion() => throw new NotSupportedException();
     }
 }

--- a/src/Windows/Avalonia.Direct2D1/ExternalRenderTarget.cs
+++ b/src/Windows/Avalonia.Direct2D1/ExternalRenderTarget.cs
@@ -21,11 +21,11 @@ namespace Avalonia.Direct2D1
             _externalRenderTargetProvider.DestroyRenderTarget();
         }
 
-        public IDrawingContextImpl CreateDrawingContext()
+        public IDrawingContextImpl CreateDrawingContext(bool useScaledDrawing)
         {
             var target =  _externalRenderTargetProvider.GetOrCreateRenderTarget();
             _externalRenderTargetProvider.BeforeDrawing();
-            return new DrawingContextImpl( null, target, null, () =>
+            return new DrawingContextImpl( null, target, useScaledDrawing, null, () =>
             {
                 try
                 {

--- a/src/Windows/Avalonia.Direct2D1/FramebufferShimRenderTarget.cs
+++ b/src/Windows/Avalonia.Direct2D1/FramebufferShimRenderTarget.cs
@@ -25,7 +25,7 @@ namespace Avalonia.Direct2D1
             _target = null;
         }
 
-        public IDrawingContextImpl CreateDrawingContext()
+        public IDrawingContextImpl CreateDrawingContext(bool useScaledDrawing)
         {
             if (_target == null)
                 throw new ObjectDisposedException(nameof(FramebufferShimRenderTarget));
@@ -37,7 +37,7 @@ namespace Avalonia.Direct2D1
             }
 
             return new FramebufferShim(locked)
-                .CreateDrawingContext();
+                .CreateDrawingContext(useScaledDrawing);
         }
 
         public bool IsCorrupted => false;
@@ -52,9 +52,9 @@ namespace Avalonia.Direct2D1
                 _target = target;
             }
             
-            public override IDrawingContextImpl CreateDrawingContext()
+            public override IDrawingContextImpl CreateDrawingContext(bool useScaledDrawing)
             {
-                return base.CreateDrawingContext(() =>
+                return base.CreateDrawingContext(useScaledDrawing, () =>
                 {
                     using (var l = WicImpl.Lock(BitmapLockFlags.Read))
                     {

--- a/src/Windows/Avalonia.Direct2D1/Media/DrawingContextImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/DrawingContextImpl.cs
@@ -39,6 +39,7 @@ namespace Avalonia.Direct2D1.Media
         public DrawingContextImpl(
             ILayerFactory layerFactory,
             SharpDX.Direct2D1.RenderTarget renderTarget,
+            bool useScaledDrawing,
             SharpDX.DXGI.SwapChain1 swapChain = null,
             Action finishedCallback = null)
         {
@@ -58,6 +59,13 @@ namespace Avalonia.Direct2D1.Media
                 _ownsDeviceContext = true;
             }
 
+            if (!useScaledDrawing)
+            {
+                var scaling = _renderTarget.DotsPerInch.Width / 96;
+                if (!MathUtilities.AreClose(1, scaling))
+                    _postTransform = Matrix.CreateScale(1 / scaling, 1 / scaling);
+            }
+            
             _deviceContext.BeginDraw();
         }
 
@@ -66,8 +74,13 @@ namespace Avalonia.Direct2D1.Media
         /// </summary>
         public Matrix Transform
         {
-            get { return _deviceContext.Transform.ToAvalonia(); }
-            set { _deviceContext.Transform = value.ToDirect2D(); }
+            get { return _transform; }
+            set
+            {
+                _transform = value;
+                _deviceContext.Transform =
+                    (_postTransform.HasValue ? value * _postTransform.Value : value).ToDirect2D();
+            }
         }
 
         public Matrix4x4 Transform4x4
@@ -353,6 +366,11 @@ namespace Avalonia.Direct2D1.Media
             }
         }
 
+        public void DrawRegion(IBrush brush, IPen pen, IPlatformRenderInterfaceRegion region)
+        {
+            throw new NotSupportedException();
+        }
+
         /// <inheritdoc />
         public void DrawEllipse(IBrush brush, IPen pen, Rect rect)
         {
@@ -410,17 +428,17 @@ namespace Avalonia.Direct2D1.Media
             }
         }
 
-        public IDrawingContextLayerImpl CreateLayer(Size size)
+        public IDrawingContextLayerImpl CreateLayer(PixelSize pixelSize)
         {
+            var dpi = new Vector(_deviceContext.DotsPerInch.Width, _deviceContext.DotsPerInch.Height);
             if (_layerFactory != null)
             {
-                return _layerFactory.CreateLayer(size);
+                return _layerFactory.CreateLayer(pixelSize.ToSizeWithDpi(dpi));
             }
             else
             {
                 var platform = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
-                var dpi = new Vector(_deviceContext.DotsPerInch.Width, _deviceContext.DotsPerInch.Height);
-                var pixelSize = PixelSize.FromSizeWithDpi(size, dpi);
+                
                 return (IDrawingContextLayerImpl)platform.CreateRenderTargetBitmap(pixelSize, dpi);
             }
         }
@@ -441,14 +459,40 @@ namespace Avalonia.Direct2D1.Media
             _deviceContext.PushAxisAlignedClip(clip.Rect.ToDirect2D(), AntialiasMode.PerPrimitive);
         }
 
+        public void PushClip(IPlatformRenderInterfaceRegion region)
+        {
+            throw new NotSupportedException();
+        }
+
         public void PopClip()
         {
             _deviceContext.PopAxisAlignedClip();
         }
 
+        public void PushLayer(Rect bounds)
+        {
+            var parameters = new LayerParameters
+            {
+                ContentBounds = bounds.ToDirect2D(),
+                MaskTransform = PrimitiveExtensions.Matrix3x2Identity,
+                Opacity = 1
+            };
+            var layer = _layerPool.Count != 0 ? _layerPool.Pop() : new Layer(_deviceContext);
+            _deviceContext.PushLayer(ref parameters, layer);
+
+            _layers.Push(layer);
+        }
+
+        void IDrawingContextImpl.PopLayer()
+        {
+            PopLayer();
+        }
+
         readonly Stack<Layer> _layers = new Stack<Layer>();
         private readonly Stack<Layer> _layerPool = new Stack<Layer>();
         private RenderOptions _renderOptions;
+        private readonly Matrix? _postTransform;
+        private Matrix _transform = Matrix.Identity;
 
         /// <summary>
         /// Pushes an opacity value.
@@ -574,7 +618,7 @@ namespace Avalonia.Direct2D1.Media
                                    CompatibleRenderTargetOptions.None,
                                    pixelSize.ToSizeWithDpi(dpi).ToSharpDX()))
                         {
-                            using (var ctx = new RenderTarget(intermediate).CreateDrawingContext())
+                            using (var ctx = new RenderTarget(intermediate).CreateDrawingContext(true))
                             {
                                 intermediate.Clear(null);
                                 sceneBrushContent.Render(ctx,

--- a/src/Windows/Avalonia.Direct2D1/Media/ImageBrushImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/ImageBrushImpl.cs
@@ -98,7 +98,7 @@ namespace Avalonia.Direct2D1.Media
                 CompatibleRenderTargetOptions.None,
                 calc.IntermediateSize.ToSharpDX());
 
-            using (var context = new RenderTarget(result).CreateDrawingContext())
+            using (var context = new RenderTarget(result).CreateDrawingContext(true))
             {
                 var dpi = new Vector(target.DotsPerInch.Width, target.DotsPerInch.Height);
                 var rect = new Rect(bitmap.PixelSize.ToSizeWithDpi(dpi));

--- a/src/Windows/Avalonia.Direct2D1/Media/Imaging/D2DRenderTargetBitmapImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Imaging/D2DRenderTargetBitmapImpl.cs
@@ -30,9 +30,10 @@ namespace Avalonia.Direct2D1.Media.Imaging
             return new D2DRenderTargetBitmapImpl(bitmapRenderTarget);
         }
 
-        public IDrawingContextImpl CreateDrawingContext()
+        public IDrawingContextImpl CreateDrawingContext(bool useScaledDrawing)
         {
-            return new DrawingContextImpl( this, _renderTarget, null, () => Version++);
+            return new DrawingContextImpl( this, _renderTarget, useScaledDrawing, 
+                null, () => Version++);
         }
 
         public bool IsCorrupted => false;
@@ -60,7 +61,7 @@ namespace Avalonia.Direct2D1.Media.Imaging
         {
             using (var wic = new WicRenderTargetBitmapImpl(PixelSize, Dpi))
             {
-                using (var dc = wic.CreateDrawingContext(null))
+                using (var dc = wic.CreateDrawingContext(true, null))
                 {
                     dc.DrawBitmap(
                         this,

--- a/src/Windows/Avalonia.Direct2D1/Media/Imaging/WicRenderTargetBitmapImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/Imaging/WicRenderTargetBitmapImpl.cs
@@ -34,14 +34,14 @@ namespace Avalonia.Direct2D1.Media
             base.Dispose();
         }
 
-        public virtual IDrawingContextImpl CreateDrawingContext()
-            => CreateDrawingContext(null);
+        public virtual IDrawingContextImpl CreateDrawingContext(bool useScaledDrawing)
+            => CreateDrawingContext(useScaledDrawing, null);
 
         public bool IsCorrupted => false;
 
-        public IDrawingContextImpl CreateDrawingContext(Action finishedCallback)
+        public IDrawingContextImpl CreateDrawingContext(bool useScaledDrawing, Action finishedCallback)
         {
-            return new DrawingContextImpl(null, _renderTarget, finishedCallback: () =>
+            return new DrawingContextImpl(null, _renderTarget, useScaledDrawing, finishedCallback: () =>
                 {
                     Version++;
                     finishedCallback?.Invoke();

--- a/src/Windows/Avalonia.Direct2D1/RenderTarget.cs
+++ b/src/Windows/Avalonia.Direct2D1/RenderTarget.cs
@@ -25,9 +25,9 @@ namespace Avalonia.Direct2D1
         /// Creates a drawing context for a rendering session.
         /// </summary>
         /// <returns>An <see cref="Avalonia.Platform.IDrawingContextImpl"/>.</returns>
-        public IDrawingContextImpl CreateDrawingContext()
+        public IDrawingContextImpl CreateDrawingContext(bool useScaledDrawing)
         {
-            return new DrawingContextImpl(this, _renderTarget);
+            return new DrawingContextImpl(this, _renderTarget, useScaledDrawing);
         }
 
         public bool IsCorrupted => false;

--- a/src/Windows/Avalonia.Direct2D1/SwapChainRenderTarget.cs
+++ b/src/Windows/Avalonia.Direct2D1/SwapChainRenderTarget.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Direct2D1
         /// Creates a drawing context for a rendering session.
         /// </summary>
         /// <returns>An <see cref="Avalonia.Platform.IDrawingContextImpl"/>.</returns>
-        public IDrawingContextImpl CreateDrawingContext()
+        public IDrawingContextImpl CreateDrawingContext(bool useScaledDrawing)
         {
             var size = GetWindowSize();
             var dpi = GetWindowDpi();
@@ -32,7 +32,7 @@ namespace Avalonia.Direct2D1
                 Resize();
             }
 
-            return new DrawingContextImpl(this, _deviceContext, _swapChain);
+            return new DrawingContextImpl(this, _deviceContext, useScaledDrawing, _swapChain);
         }
 
         public bool IsCorrupted => false;

--- a/tests/Avalonia.RenderTests/Media/BitmapTests.cs
+++ b/tests/Avalonia.RenderTests/Media/BitmapTests.cs
@@ -72,7 +72,7 @@ namespace Avalonia.Direct2D1.RenderTests.Media
             var r = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
             using(var cpuContext = r.CreateBackendContext(null))
             using (var target = cpuContext.CreateRenderTarget(new object[] { fb }))
-            using (var ctx = target.CreateDrawingContext())
+            using (var ctx = target.CreateDrawingContext(false))
             {
                 ctx.Clear(Colors.Transparent);
                 ctx.PushOpacity(0.8, new Rect(0, 0, 80, 80));

--- a/tests/Avalonia.UnitTests/TestRoot.cs
+++ b/tests/Avalonia.UnitTests/TestRoot.cs
@@ -79,16 +79,16 @@ namespace Avalonia.UnitTests
         public IRenderTarget CreateRenderTarget()
         {
             var dc = new Mock<IDrawingContextImpl>();
-            dc.Setup(x => x.CreateLayer(It.IsAny<Size>())).Returns(() =>
+            dc.Setup(x => x.CreateLayer(It.IsAny<PixelSize>())).Returns(() =>
             {
                 var layerDc = new Mock<IDrawingContextImpl>();
                 var layer = new Mock<IDrawingContextLayerImpl>();
-                layer.Setup(x => x.CreateDrawingContext()).Returns(layerDc.Object);
+                layer.Setup(x => x.CreateDrawingContext(It.IsAny<bool>())).Returns(layerDc.Object);
                 return layer.Object;
             });
 
             var result = new Mock<IRenderTarget>();
-            result.Setup(x => x.CreateDrawingContext()).Returns(dc.Object);
+            result.Setup(x => x.CreateDrawingContext(It.IsAny<bool>())).Returns(dc.Object);
             return result.Object;
         }
 


### PR DESCRIPTION
1) CompositionTarget now expects the drawing context to be using device units rather than scaled units
2) CompositionTarget now tracks dirty rects using device coordinates
3) Added a special mode that enforces a layer to be used for rendering  (workaround for https://github.com/AvaloniaUI/Avalonia/issues/14270 / https://issues.skia.org/issues/327877721)
4) Added a special mode that utilizes SKRegion for tracking dirty rects and clipping (as opposed to expanding a single clip rect)
5) Added a way for `CompositionCustomVisualHandler` to access the current clip rect (transformed to visual coordinate space)
6) Added `CompositionOptions` class to be used with `AppBuilder.With`