### PR TITLE
Propagate exceptions from compositor to unit/render tests

### DIFF
--- a/src/Avalonia.Base/Media/MediaContext.Compositor.cs
+++ b/src/Avalonia.Base/Media/MediaContext.Compositor.cs
@@ -91,7 +91,7 @@ partial class MediaContext
     /// Executes a synchronous commit when we need to wait for composition jobs to be done
     /// Is used in resize and TopLevel destruction scenarios
     /// </summary>
-    private void SyncCommit(Compositor compositor, bool waitFullRender)
+    private void SyncCommit(Compositor compositor, bool waitFullRender, bool catchExceptions)
     {
         // Unit tests are assuming that they can call any API without setting up platforms
         if (AvaloniaLocator.Current.GetService<IPlatformRenderInterface>() == null)
@@ -109,7 +109,7 @@ partial class MediaContext
         else
         {
             CommitCompositor(compositor);
-            compositor.Server.Render();
+            compositor.Server.Render(catchExceptions);
         }
     }
     
@@ -118,9 +118,9 @@ partial class MediaContext
     /// </summary>
     // TODO: do we need to execute a render pass here too?
     // We've previously tried that and it made the resize experience worse
-    public void ImmediateRenderRequested(CompositionTarget target)
+    public void ImmediateRenderRequested(CompositionTarget target, bool catchExceptions)
     {
-        SyncCommit(target.Compositor, true);
+        SyncCommit(target.Compositor, true, catchExceptions);
     }
 
 
@@ -133,7 +133,7 @@ partial class MediaContext
         compositionTarget.Dispose();
         
         // TODO: introduce a way to skip any actual rendering for other targets and only do a dispose?
-        SyncCommit(compositionTarget.Compositor, false);
+        SyncCommit(compositionTarget.Compositor, false, true);
     }
     
     /// <summary>

--- a/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
@@ -211,14 +211,15 @@ internal class CompositingRenderer : IRendererWithCompositor, IHitTester
     }
 
     /// <inheritdoc />
-    public void Paint(Rect rect)
+    public void Paint(Rect rect) => Paint(rect, true);
+    public void Paint(Rect rect, bool catchExceptions)
     {
         if (_isDisposed)
             return;
 
         QueueUpdate();
         CompositionTarget.RequestRedraw();
-        MediaContext.Instance.ImmediateRenderRequested(CompositionTarget);
+        MediaContext.Instance.ImmediateRenderRequested(CompositionTarget, catchExceptions);
     }
 
     /// <inheritdoc />

--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositor.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositor.cs
@@ -157,7 +157,8 @@ namespace Avalonia.Rendering.Composition.Server
             _reusableToNotifyRenderedList.Clear();
         }
 
-        public void Render()
+        public void Render() => Render(true);
+        public void Render(bool catchExceptions)
         {
             if (Dispatcher.UIThread.CheckAccess())
             {
@@ -167,7 +168,7 @@ namespace Avalonia.Rendering.Composition.Server
                 try
                 {
                     using (Dispatcher.UIThread.DisableProcessing()) 
-                        RenderReentrancySafe();
+                        RenderReentrancySafe(catchExceptions);
                 }
                 finally
                 {
@@ -175,10 +176,10 @@ namespace Avalonia.Rendering.Composition.Server
                 }
             }
             else
-                RenderReentrancySafe();
+                RenderReentrancySafe(catchExceptions);
         }
         
-        private void RenderReentrancySafe()
+        private void RenderReentrancySafe(bool catchExceptions)
         {
             lock (_lock)
             {
@@ -187,11 +188,7 @@ namespace Avalonia.Rendering.Composition.Server
                     try
                     {
                         _safeThread = Thread.CurrentThread;
-                        RenderCore();
-                    }
-                    catch (Exception e) when (RT_OnContextLostExceptionFilterObserver(e) && false)
-                    // Will never get here, only using exception filter side effect
-                    {
+                        RenderCore(catchExceptions);
                     }
                     finally
                     {
@@ -205,7 +202,7 @@ namespace Avalonia.Rendering.Composition.Server
             }
         }
         
-        private void RenderCore()
+        private void RenderCore(bool catchExceptions)
         {
             UpdateServerTime();
             ApplyPendingBatches();
@@ -228,7 +225,7 @@ namespace Avalonia.Rendering.Composition.Server
                 foreach (var t in _activeTargets)
                     t.Render();
             }
-            catch (Exception e)
+            catch (Exception e) when(RT_OnContextLostExceptionFilterObserver(e) && catchExceptions)
             {
                 Logger.TryGet(LogEventLevel.Error, LogArea.Visual)?.Log(this, "Exception when rendering: {Error}", e);
             }

--- a/src/Browser/Avalonia.Browser/AvaloniaView.cs
+++ b/src/Browser/Avalonia.Browser/AvaloniaView.cs
@@ -454,7 +454,7 @@ namespace Avalonia.Browser
 
             if (_topLevel.Renderer is CompositingRenderer dr)
             {
-                MediaContext.Instance.ImmediateRenderRequested(dr.CompositionTarget);
+                MediaContext.Instance.ImmediateRenderRequested(dr.CompositionTarget, true);
             }
         }
 

--- a/tests/Avalonia.Base.UnitTests/Media/RenderResourceTestHelper.cs
+++ b/tests/Avalonia.Base.UnitTests/Media/RenderResourceTestHelper.cs
@@ -42,7 +42,7 @@ internal class RenderResourceTestHelper : IDisposable
         Assert.True(Compositor.UnitTestIsRegisteredForSerialization(resource));
         
         Compositor.Commit();
-        Compositor.Server.Render();
+        Compositor.Server.Render(false);
         
         Assert.False(Compositor.UnitTestIsRegisteredForSerialization(resource));
         cb();

--- a/tests/Avalonia.Base.UnitTests/Rendering/SceneGraph/DrawOperationTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Rendering/SceneGraph/DrawOperationTests.cs
@@ -31,7 +31,7 @@ namespace Avalonia.Base.UnitTests.Rendering.SceneGraph
             public void ForceRender()
             {
                 _compositor.Commit();
-                _compositor.Server.Render();
+                _compositor.Server.Render(false);
             }
             
             public Rect? GetBounds()

--- a/tests/Avalonia.RenderTests/TestBase.cs
+++ b/tests/Avalonia.RenderTests/TestBase.cs
@@ -120,7 +120,7 @@ namespace Avalonia.Direct2D1.RenderTests
                     root.Initialize(renderer, target);
                     renderer.Start();
                     Dispatcher.UIThread.RunJobs();
-                    timer.TriggerTick();
+                    renderer.Paint(new Rect(root.Bounds.Size), false);
                 }
                 writableBitmap.Save(compositedPath);
             }


### PR DESCRIPTION
Right now an exception on the compositor side results in a transparent output.