### PR TITLE
Use actual infinite timeout instead of zero timeout in Dispatcher.Send

### DIFF
--- a/src/Avalonia.Base/Threading/Dispatcher.Invoke.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.Invoke.cs
@@ -656,7 +656,7 @@ public partial class Dispatcher
         {
             InvokeImpl(new SendOrPostCallbackDispatcherOperation(this, priority.Value, action, arg, true),
                 CancellationToken.None,
-                default);
+                TimeSpan.FromMilliseconds(-1));
         }
     }
 


### PR DESCRIPTION
Zero means zero, not infinite.

Right now SynchronizationContext.Send always throws a cancelled exception when called from non-UI thread.

@maxkatz6 