### PR TITLE
Added UI thread rendering mode for fbdev

### DIFF
--- a/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatform.cs
@@ -60,9 +60,13 @@ namespace Avalonia.LinuxFramebuffer
 
             var opts = AvaloniaLocator.Current.GetService<LinuxFramebufferPlatformOptions>() ?? new LinuxFramebufferPlatformOptions();
 
+            var timer = opts.ShouldRenderOnUIThread
+                ? new UiThreadRenderTimer(opts.Fps)
+                : new DefaultRenderTimer(opts.Fps);
+            
             AvaloniaLocator.CurrentMutable
                 .Bind<IDispatcherImpl>().ToConstant(new ManagedDispatcherImpl(new ManualRawEventGrouperDispatchQueueDispatcherInputProvider(EventGrouperDispatchQueue)))
-                .Bind<IRenderTimer>().ToConstant(new DefaultRenderTimer(opts.Fps))
+                .Bind<IRenderTimer>().ToConstant(timer)
                 .Bind<ICursorFactory>().ToTransient<CursorFactoryStub>()
                 .Bind<IKeyboardDevice>().ToConstant(new KeyboardDevice())
                 .Bind<IPlatformIconLoader>().ToSingleton<LinuxFramebufferIconLoaderStub>()

--- a/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatformOptions.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/LinuxFramebufferPlatformOptions.cs
@@ -10,5 +10,12 @@
         /// Default 60.
         /// </summary>
         public int Fps { get; set; } = 60;
+        
+        /// <summary>
+        /// Render directly on the UI thread instead of using a dedicated render thread.
+        /// This can be usable if your device don't have multiple cores to begin with.
+        /// This setting is false by default.
+        /// </summary>
+        public bool ShouldRenderOnUIThread { get; set; }
     }
 }


### PR DESCRIPTION
Allows using UI thread render timer for fbdev. Makes sense for low-end devices that previously used immediate renderer.