### PR TITLE
feat(DevTools): Avoid events reporting coming from the DevTools popup.

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/DevTools.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/DevTools.cs
@@ -104,7 +104,7 @@ namespace Avalonia.Diagnostics
             if (topLevelGroup.Items.Count == 1 && topLevelGroup.Items is not INotifyCollectionChanged)
             {
                 var singleTopLevel = topLevelGroup.Items.First();
-                
+
                 foreach (var group in s_open)
                 {
                     if (group.Key.Items.Contains(singleTopLevel))
@@ -115,7 +115,7 @@ namespace Avalonia.Diagnostics
                     }
                 }
             }
-            
+
             var window = new MainWindow
             {
                 Root = root,
@@ -143,6 +143,24 @@ namespace Avalonia.Diagnostics
             var window = (MainWindow)sender!;
             window.Closed -= DevToolsClosed;
             s_open.Remove((IDevToolsTopLevelGroup)window.Tag!);
+        }
+
+        public static bool IsBelongsToDevTool(this Visual v)
+        {
+            var topLevel = TopLevel.GetTopLevel(v);
+
+            while (topLevel is not null && topLevel is not Views.MainWindow)
+            {
+                if (topLevel is Avalonia.Controls.Primitives.PopupRoot pr)
+                {
+                    topLevel = pr.ParentTopLevel;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 }

--- a/src/Avalonia.Diagnostics/Diagnostics/DevTools.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/DevTools.cs
@@ -145,7 +145,7 @@ namespace Avalonia.Diagnostics
             s_open.Remove((IDevToolsTopLevelGroup)window.Tag!);
         }
 
-        public static bool IsBelongsToDevTool(this Visual v)
+        internal static bool DoesBelongToDevTool(this Visual v)
         {
             var topLevel = TopLevel.GetTopLevel(v);
 

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/EventTreeNode.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/EventTreeNode.cs
@@ -66,7 +66,7 @@ namespace Avalonia.Diagnostics.ViewModels
         {
             if (!_isRegistered || IsEnabled == false)
                 return;
-            if (sender is Visual v && BelongsToDevTool(v))
+            if (sender is Visual v && v.IsBelongsToDevTool())
                 return;
 
             var s = sender!;
@@ -101,7 +101,7 @@ namespace Avalonia.Diagnostics.ViewModels
         {
             if (!_isRegistered || IsEnabled == false)
                 return;
-            if (e.Source is Visual v && BelongsToDevTool(v))
+            if (e.Source is Visual v && v.IsBelongsToDevTool())
                 return;
 
             var s = e.Source;
@@ -126,21 +126,6 @@ namespace Avalonia.Diagnostics.ViewModels
                 handler();
         }
 
-        private static bool BelongsToDevTool(Visual v)
-        {
-            var current = v;
 
-            while (current != null)
-            {
-                if (current is MainView || current is MainWindow)
-                {
-                    return true;
-                }
-
-                current = current.VisualParent;
-            }
-
-            return false;
-        }
     }
 }

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/EventTreeNode.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/EventTreeNode.cs
@@ -66,7 +66,7 @@ namespace Avalonia.Diagnostics.ViewModels
         {
             if (!_isRegistered || IsEnabled == false)
                 return;
-            if (sender is Visual v && v.IsBelongsToDevTool())
+            if (sender is Visual v && v.DoesBelongToDevTool())
                 return;
 
             var s = sender!;
@@ -101,7 +101,7 @@ namespace Avalonia.Diagnostics.ViewModels
         {
             if (!_isRegistered || IsEnabled == false)
                 return;
-            if (e.Source is Visual v && v.IsBelongsToDevTool())
+            if (e.Source is Visual v && v.DoesBelongToDevTool())
                 return;
 
             var s = e.Source;

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/MainViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/MainViewModel.cs
@@ -267,10 +267,9 @@ namespace Avalonia.Diagnostics.ViewModels
             _currentFocusHighlightAdorner?.Dispose();
             if (FocusHighlighter is IBrush brush
                 && element is InputElement input
-                && !input.IsBelongsToDevTool()
+                && !input.DoesBelongToDevTool()
                 )
             {
-
                 _currentFocusHighlightAdorner = Controls.ControlHighlightAdorner.Add(input, brush);
             }
         }

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/MainViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/MainViewModel.cs
@@ -2,7 +2,6 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Avalonia.Controls;
-using Avalonia.Diagnostics.Models;
 using Avalonia.Input;
 using Avalonia.Metadata;
 using Avalonia.Threading;
@@ -10,7 +9,6 @@ using Avalonia.Reactive;
 using Avalonia.Rendering;
 using System.Collections.Generic;
 using Avalonia.Media;
-using Avalonia.Controls.Primitives;
 
 namespace Avalonia.Diagnostics.ViewModels
 {
@@ -269,13 +267,10 @@ namespace Avalonia.Diagnostics.ViewModels
             _currentFocusHighlightAdorner?.Dispose();
             if (FocusHighlighter is IBrush brush
                 && element is InputElement input
-                && TopLevel.GetTopLevel(input) is { } topLevel
-                && (topLevel is not Views.MainWindow))
+                && !input.IsBelongsToDevTool()
+                )
             {
-                if (topLevel is PopupRoot pr && pr.ParentTopLevel is Views.MainWindow)
-                {
-                    return;
-                }
+
                 _currentFocusHighlightAdorner = Controls.ControlHighlightAdorner.Add(input, brush);
             }
         }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Avoid events reporting coming from the DevTools popup.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

If in DevTools Events tab, a event like `Control.RequestBringIntoView` is enable and open DevTools menu like `Overlay` the `Control.RequestBringIntoView` event is reported in events lits.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Reporting coming from the DevTools popup

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

If the current visual topLevel is `PopupRoot`, traverses the entire `PopupRoot` hierarchy until ParentTopLevel is not null and is not `Views.MainWindow`

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
