### PR TITLE
Seek stream before loading icon

### DIFF
--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -240,6 +240,7 @@ namespace Avalonia.Win32
             using (var memoryStream = new MemoryStream())
             {
                 bitmap.Save(memoryStream);
+                stream.Seek(0, SeekOrigin.Begin);
                 return new IconImpl(memoryStream);
             }
         }

--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -240,7 +240,7 @@ namespace Avalonia.Win32
             using (var memoryStream = new MemoryStream())
             {
                 bitmap.Save(memoryStream);
-                stream.Seek(0, SeekOrigin.Begin);
+                memoryStream.Seek(0, SeekOrigin.Begin);
                 return new IconImpl(memoryStream);
             }
         }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Seek stream before loading icon.

## What is the current behavior?
After `bitmap.Save(memoryStream)`, the position of stream will be set to the end, which leads to `System.IO.EndOfStreamException: Unable to read beyond the end of the stream` in the following `CreateIconImpl` call.

## What is the updated/expected behavior with this PR?
Seek stream before loading icon to fix this issue.

