### PR TITLE
Fix: Crossfade animation causes other animations to have hidden elements

### DIFF
--- a/src/Avalonia.Base/Animation/CrossFade.cs
+++ b/src/Avalonia.Base/Animation/CrossFade.cs
@@ -132,25 +132,23 @@ namespace Avalonia.Animation
             }
 
             var tasks = new List<Task>();
-            using (var disposables = new CompositeDisposable(1))
+
+            if (from != null)
             {
-                if (from != null)
-                {
-                    tasks.Add(_fadeOutAnimation.RunAsync(from, null, cancellationToken));
-                }
+                tasks.Add(_fadeOutAnimation.RunAsync(from, null, cancellationToken));
+            }
 
-                if (to != null)
-                {
-                    to.IsVisible = true;
-                    tasks.Add(_fadeInAnimation.RunAsync(to, null, cancellationToken));
-                }
+            if (to != null)
+            {
+                to.IsVisible = true;
+                tasks.Add(_fadeInAnimation.RunAsync(to, null, cancellationToken));
+            }
 
-                await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks);
 
-                if (from != null && !cancellationToken.IsCancellationRequested)
-                {
-                    from.IsVisible = false;
-                }
+            if (from != null && !cancellationToken.IsCancellationRequested)
+            {
+                from.IsVisible = false;
             }
         }
 

--- a/src/Avalonia.Base/Animation/CrossFade.cs
+++ b/src/Avalonia.Base/Animation/CrossFade.cs
@@ -134,20 +134,13 @@ namespace Avalonia.Animation
             var tasks = new List<Task>();
             using (var disposables = new CompositeDisposable(1))
             {
-                if (to != null)
-                {
-                    disposables.Add(to.SetValue(Visual.OpacityProperty, 0, Data.BindingPriority.Animation)!);
-                }
-
                 if (from != null)
                 {
-                    from.Opacity = 0f;
                     tasks.Add(_fadeOutAnimation.RunAsync(from, null, cancellationToken));
                 }
 
                 if (to != null)
                 {
-                    to.Opacity = 1f;
                     to.IsVisible = true;
                     tasks.Add(_fadeInAnimation.RunAsync(to, null, cancellationToken));
                 }


### PR DESCRIPTION
## What does the pull request do?
Fix for CrossFade animation overwriting opacity causing elements to not show if you change the transition style (eg. PageSlide or none) 


## What is the current behavior?
When switching transition types on a control (EG. TransitioningContentControl) the opacity change is not reversed. This causes content to not show on other transition types.

This can be tested using the Catalog samples TransitioningContentControl. 
Use the cross fade transition and move to another element in the control, then change to none and when transitioning some elements are hidden.


## What is the updated/expected behavior with this PR?
Elements will maintain their existing opacity after a transition using CrossFade.

This can be tested using the Catalog samples TransitioningContentControl. 
Use the cross fade transition and move to another element in the control, then change to none and when transitioning, elements should show as expected. 


## How was the solution implemented (if it's not obvious)?
Remove the opacity changes on the to/from Visual components and supporting code as the transition keyframes will take care of the opacity.


## Fixed issues
Fixes #14054
