### PR TITLE
Fix parsing type cast of attached property.

### DIFF
--- a/src/Markup/Avalonia.Markup/Markup/Parsers/BindingExpressionGrammar.cs
+++ b/src/Markup/Avalonia.Markup/Markup/Parsers/BindingExpressionGrammar.cs
@@ -257,8 +257,10 @@ namespace Avalonia.Markup.Parsers
                 }
 
                 result = ParseBeforeMember(ref r, nodes);
+                if (result == State.AttachedProperty)
+                    result = ParseAttachedProperty(ref r, nodes);
 
-                if(r.Peek == '[')
+                if (r.Peek == '[')
                 {
                     result = ParseIndexer(ref r, nodes);
                 }

--- a/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_AttachedProperty.cs
+++ b/tests/Avalonia.Markup.UnitTests/Parsers/ExpressionObserverBuilderTests_AttachedProperty.cs
@@ -66,6 +66,22 @@ namespace Avalonia.Markup.UnitTests.Parsers
         }
 
         [Fact]
+        public async Task Should_Get_Chained_Attached_Property_Value_With_TypeCast()
+        {
+            var expected = new Class1();
+
+            var data = new Class1();
+            data.SetValue(Owner.SomethingProperty, new Class1() { Next = expected });
+
+            var target = Build(data, "((Class1)(Owner.Something)).Next", typeResolver: (ns, name) => name == "Class1" ? typeof(Class1) : _typeResolver(ns, name));
+            var result = await target.Take(1);
+
+            Assert.Equal(expected, result);
+
+            Assert.Null(((IAvaloniaObjectDebug)data).GetPropertyChangedSubscribers());
+        }
+
+        [Fact]
         public void Should_Track_Simple_Attached_Value()
         {
             var data = new Class1();
@@ -159,6 +175,11 @@ namespace Avalonia.Markup.UnitTests.Parsers
                     "Foo",
                     typeof(Owner),
                     defaultValue: "foo");
+
+            public static readonly AttachedProperty<AvaloniaObject> SomethingProperty =
+                AvaloniaProperty.RegisterAttached<Class1, AvaloniaObject>(
+                    "Something",
+                    typeof(Owner));
         }
 
         private class Class1 : AvaloniaObject


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes error when using compiled bindings when the expression contains a type cast of an attached property. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
It fails to compile. 

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

To be able to use a binding path like `((Class1)(Owner.Something)).Next`

## Fixed issues
Fixes #13539
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
