### PR TITLE
Fix `XcursorImageDestroy` interop signature

### DIFF
--- a/src/Avalonia.X11/X11CursorFactory.cs
+++ b/src/Avalonia.X11/X11CursorFactory.cs
@@ -92,6 +92,7 @@ namespace Avalonia.X11
 
         private unsafe class XImageCursor : CursorImpl, IFramebufferPlatformSurface, IPlatformHandle
         {
+            private readonly IntPtr _display;
             private readonly PixelSize _pixelSize;
             private readonly UnmanagedBlob _blob;
 
@@ -101,6 +102,7 @@ namespace Avalonia.X11
                     (bitmap.PixelSize.Width * bitmap.PixelSize.Height * 4);
                 var platformRenderInterface = AvaloniaLocator.Current.GetRequiredService<IPlatformRenderInterface>();
 
+                _display = display;
                 _pixelSize = bitmap.PixelSize;
                 _blob = new UnmanagedBlob(size);
                 
@@ -128,7 +130,7 @@ namespace Avalonia.X11
 
             public override void Dispose()
             {
-                XLib.XcursorImageDestroy(Handle);
+                XLib.XFreeCursor(_display, Handle);
                 _blob.Dispose();
             }
 

--- a/src/Avalonia.X11/XLib.cs
+++ b/src/Avalonia.X11/XLib.cs
@@ -604,7 +604,7 @@ namespace Avalonia.X11
         public static extern IntPtr XcursorImageLoadCursor(IntPtr display, IntPtr image);
 
         [DllImport(libXCursor)]
-        public static extern IntPtr XcursorImageDestroy(IntPtr image);
+        public static extern void XcursorImageDestroy(IntPtr image);
 
         public static void XISetMask(ref int mask, XiEventType ev)
         {

--- a/src/Avalonia.X11/XLib.cs
+++ b/src/Avalonia.X11/XLib.cs
@@ -603,9 +603,6 @@ namespace Avalonia.X11
         [DllImport(libXCursor)]
         public static extern IntPtr XcursorImageLoadCursor(IntPtr display, IntPtr image);
 
-        [DllImport(libXCursor)]
-        public static extern void XcursorImageDestroy(IntPtr image);
-
         public static void XISetMask(ref int mask, XiEventType ev)
         {
             mask |= (1 << (int)ev);


### PR DESCRIPTION
The native API return type is `void`, per https://www.x.org/releases/current/doc/man/man3/Xcursor.3.xhtml#heading6

```c
void XcursorImageDestroy (XcursorImage *image)
```

Update the C# interop method to match.

May help with https://github.com/AvaloniaUI/Avalonia/issues/10425

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes #10425