### PR TITLE
X11 - Force window size hints when window disabled

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -297,6 +297,12 @@ namespace Avalonia.X11
             if (!IsEnabled)
             {
                 functions &= ~(MotifFunctions.Resize | MotifFunctions.Minimize);
+
+                UpdateSizeHints(null, true);
+            }
+            else
+            {
+                UpdateSizeHints(null);
             }
 
             var hints = new MotifWmHints
@@ -311,14 +317,14 @@ namespace Avalonia.X11
                 PropertyMode.Replace, ref hints, 5);
         }
 
-        private void UpdateSizeHints(PixelSize? preResize)
+        private void UpdateSizeHints(PixelSize? preResize, bool forceDisableResize = false)
         {
             if (_overrideRedirect)
                 return;
             var min = _minMaxSize.minSize;
             var max = _minMaxSize.maxSize;
 
-            if (!_canResize)
+            if (!_canResize || forceDisableResize)
             {
                 if (preResize.HasValue)
                 {
@@ -1293,6 +1299,13 @@ namespace Avalonia.X11
 
             UpdateWMHints();
             UpdateMotifHints();
+
+            if (enable)
+            {
+                // Some window managers ignore Motif hints when switching from disabled to enabled on the first update
+                // so setting it again forces the update
+                UpdateMotifHints();
+            }
         }
 
         private void UpdateWMHints()


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Update wm size hints when a window is disabled due to it being a parent of a modal dialog.


## What is the current behavior?
Some window managers may not respect flags set in our window's WM_MOTIF flags, especially the maximize flags. To force disable maximize when window is disabled, the window size hints is set to disable resizing.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
