### PR TITLE
Fix DataGrid TextBox Cursor blinking

### DIFF
--- a/src/Avalonia.Controls/Presenters/TextPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/TextPresenter.cs
@@ -461,6 +461,7 @@ namespace Avalonia.Controls.Presenters
 
         public void ShowCaret()
         {
+            EnsureCaretTimer();
             _caretBlink = true;
             _caretTimer?.Start();
             InvalidateVisual();
@@ -483,6 +484,8 @@ namespace Avalonia.Controls.Presenters
             {
                 return;
             }
+
+            EnsureCaretTimer();
 
             if (_caretTimer?.IsEnabled ?? false)
             {
@@ -727,6 +730,14 @@ namespace Avalonia.Controls.Presenters
             _navigationPosition = navigationPosition.WithY(_caretBounds.Y);
 
             CaretChanged();
+        }
+        
+        private void EnsureCaretTimer()
+        {
+            if (_caretTimer == null)
+            {
+                ResetCaretTimer();
+            }
         }
 
         private void ResetCaretTimer()


### PR DESCRIPTION
## What does the pull request do?
TextBox blinking state relies on the presence of the blinking thread - which is created lazily.

## What is the current behavior?
Cursor does not blink in some cases, e.g. DataGrid


## What is the updated/expected behavior with this PR?
let it blink


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
my issue https://github.com/AvaloniaUI/Avalonia/issues/14862