### PR TITLE
Bump version

### DIFF
--- a/build/SharedVersion.props
+++ b/build/SharedVersion.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Avalonia</Product>
-    <Version>11.1.999</Version>
+    <Version>11.2.999</Version>
     <Authors>Avalonia Team</Authors>
     <Copyright>Copyright 2013-$([System.DateTime]::Now.ToString(`yyyy`)) &#169; The AvaloniaUI Project</Copyright>
     <PackageProjectUrl>https://avaloniaui.net</PackageProjectUrl>


### PR DESCRIPTION
## What does the pull request do?

Time to switch master to 11.2. 
11.1 now will live in https://github.com/AvaloniaUI/Avalonia/tree/release/11.1.
If anything needs to be backported, we have `backport-candidate-11.1.x` label.
Process is the same as with previous releases.

TODO:
- [x] Update GitHub PR Nightly builds bot after this PR is merged. It has hardcoded version elsewhere.
- [ ] Release 11.1.0-beta1
- [ ] Update ApiDiffValidation Nuke tool, as it also has hardcoded version number, but only after 11.1 stable nuget release.
- [ ] Optional: reset ApiDiff suppressions https://github.com/AvaloniaUI/Avalonia/tree/master/api, also after 11.1 stable nuget release.
