### PR TITLE
Fix PopupPositionerConstraintAdjustment.ResizeY value

### DIFF
--- a/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
@@ -248,7 +248,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
         /// <remarks>
         /// Resize the surface vertically so that it is completely unconstrained.
         /// </remarks>
-        ResizeY = 16,
+        ResizeY = 32,
 
         All = SlideX|SlideY|FlipX|FlipY|ResizeX|ResizeY
     }


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the `PopupPositionerConstraintAdjustment.ResizeY` which currently has the same value as `ResizeX`.

## Breaking changes
Yes, changing a constant or enum value is a breaking change.

Users that have built binaries before while using `PopupPositionerConstraintAdjustment` explicitly will experience the equivalent of not having `ResizeY` set anymore after updating Avalonia without recompiling their assemblies.

While technically breaking, I think it has very low impact.