### PR TITLE
Fix Dev Tools adorner highlight

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml
@@ -8,7 +8,8 @@
               BorderThickness="0"
               ItemsSource="{Binding Nodes}"
               SelectedItem="{Binding SelectedNode, Mode=TwoWay}"
-              PointerMoved="UpdateAdorner">
+              PointerMoved="UpdateAdorner"
+              PointerExited="RemoveAdorner">
       <TreeView.DataTemplates>
         <TreeDataTemplate DataType="vm:TreeNode"
                           ItemsSource="{Binding Children}">

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/TreePageView.xaml.cs
@@ -51,6 +51,12 @@ namespace Avalonia.Diagnostics.Views
             _adorner = Controls.ControlHighlightAdorner.Add(visual, visualizeMarginPadding: shouldVisualizeMarginPadding == true);
         }
 
+        private void RemoveAdorner(object? sender, PointerEventArgs e)
+        {
+            _adorner?.Dispose();
+            _adorner = null;
+        }
+
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
             base.OnPropertyChanged(change);


### PR DESCRIPTION
## What does the pull request do?
This PR changes the dev tools to remove the element adorner when the pointer leaves the treeview. This was changed in. https://github.com/AvaloniaUI/Avalonia/pull/14231, but that wasn't the intention of the PR.


## What is the current behavior?
https://github.com/AvaloniaUI/Avalonia/assets/5689666/b2559d61-b594-440d-b1a6-77930918e2b0


## What is the updated/expected behavior with this PR?


## How was the solution implemented (if it's not obvious)?


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
n/a

## Obsoletions / Deprecations
n/a

## Fixed issues
