### PR TITLE
Add OutputVersion nuke target 

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -85,6 +85,7 @@
               "CreateNugetPackages",
               "GenerateCppHeaders",
               "OutputApiDiff",
+              "OutputVersion",
               "Package",
               "RunCoreLibsTests",
               "RunHtmlPreviewerTests",
@@ -121,6 +122,7 @@
               "CreateNugetPackages",
               "GenerateCppHeaders",
               "OutputApiDiff",
+              "OutputVersion",
               "Package",
               "RunCoreLibsTests",
               "RunHtmlPreviewerTests",
@@ -145,6 +147,9 @@
             "Quiet",
             "Verbose"
           ]
+        },
+        "version-output-dir": {
+          "type": "string"
         }
       }
     }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
   - task: PublishBuildArtifacts@1
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      ArtifactName: 'VersionNumber'
+      ArtifactName: 'PRNumber'
       publishLocation: 'Container'
       
 - job: Linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
   - task: CmdLine@2
     displayName: 'Run Build'
     inputs:
-        script: ./build.sh --target OutputVersion --version-output=$(Build.ArtifactStagingDirectory)
+        script: ./build.sh --target OutputVersion --version-output-dir $(Build.ArtifactStagingDirectory)
   - task: PublishBuildArtifacts@1
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,35 +2,23 @@ jobs:
 
 - job: GetPRNumber
   pool:
-    vmImage: 'windows-2022'
+    vmImage: 'ubuntu-20.04'
   variables:
     SolutionDir: '$(Build.SourcesDirectory)'
   steps:
-  - task: PowerShell@2
-    displayName: Get PR Number
+  - task: UseDotNet@2
+    displayName: 'Use .NET 8.0 SDK'
     inputs:
-      targetType: 'inline'
-      script: |
-        $Namespace = @{ msbuild = "http://schemas.microsoft.com/developer/msbuild/2003" }
-        $versionBase = Select-Xml -Path build\SharedVersion.props  -XPath /msbuild:Project/msbuild:PropertyGroup/msbuild:Version -Namespace $Namespace |ForEach-Object {$_.Node.Innerxml}
-        Write-Host "Base Version Number  is:-" $versionBase
-
-        $prId = $env:System_PullRequest_PullRequestNumber
-        Write-Host "PR Number  is:-" $env:System_PullRequest_PullRequestNumber
-
-        if (!([string]::IsNullOrWhiteSpace($prId)))
-        {
-          Set-Content -Path $env:Build_ArtifactStagingDirectory\prId.txt -Value $prId
-        }
-        if (!([string]::IsNullOrWhiteSpace($versionBase)))
-        {
-          Set-Content -Path $env:Build_ArtifactStagingDirectory\versionBase.txt -Value $versionBase
-        }
-      
+      packageType: sdk
+      useGlobalJson: true
+  - task: CmdLine@2
+    displayName: 'Run Build'
+    inputs:
+        script: ./build.sh --target OutputVersion --version-output=$(Build.ArtifactStagingDirectory)
   - task: PublishBuildArtifacts@1
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      ArtifactName: 'PRNumber'
+      ArtifactName: 'VersionNumber'
       publishLocation: 'Container'
       
 - job: Linux

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -150,6 +150,14 @@ partial class Build : NukeBuild
             );
         });
 
+    Target OutputVersion => _ => _
+        .Requires(() => VersionOutput)
+        .Executes(() =>
+        {
+            var currentBuildVersion = Parameters.Version;
+            File.WriteAllText(Parameters.VersionOutput, currentBuildVersion);
+        });
+
     void RunCoreTest(string projectName)
     {
         Information($"Running tests from {projectName}");

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -160,9 +160,9 @@ partial class Build : NukeBuild
             File.WriteAllText(versionFile, currentBuildVersion);
 
             var prIdFile = Path.Combine(Parameters.VersionOutputDir, "prId.txt");
-            var prId = Environment.GetEnvironmentVariable("System_PullRequest_PullRequestNumber");
+            var prId = Environment.GetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER");
             Console.WriteLine("PR Number  is: " + prId);
-            File.WriteAllText(versionFile, prIdFile);
+            File.WriteAllText(prIdFile, prId);
         });
 
     void RunCoreTest(string projectName)

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -151,11 +151,18 @@ partial class Build : NukeBuild
         });
 
     Target OutputVersion => _ => _
-        .Requires(() => VersionOutput)
+        .Requires(() => VersionOutputDir)
         .Executes(() =>
         {
+            var versionFile = Path.Combine(Parameters.VersionOutputDir, "version.txt");
             var currentBuildVersion = Parameters.Version;
-            File.WriteAllText(Parameters.VersionOutput, currentBuildVersion);
+            Console.WriteLine("Version is: " + currentBuildVersion);
+            File.WriteAllText(versionFile, currentBuildVersion);
+
+            var prIdFile = Path.Combine(Parameters.VersionOutputDir, "prId.txt");
+            var prId = Environment.GetEnvironmentVariable("System_PullRequest_PullRequestNumber");
+            Console.WriteLine("PR Number  is: " + prId);
+            File.WriteAllText(versionFile, prIdFile);
         });
 
     void RunCoreTest(string projectName)

--- a/nukebuild/BuildParameters.cs
+++ b/nukebuild/BuildParameters.cs
@@ -25,9 +25,12 @@ public partial class Build
 
     [Parameter(Name = "api-baseline")]
     public string ApiValidationBaseline { get; set; }
-    
+
     [Parameter(Name = "update-api-suppression")]
     public bool? UpdateApiValidationSuppression { get; set; }
+
+    [Parameter(Name = "version-output")]
+    public AbsolutePath VersionOutput { get; set; }
 
     public class BuildParameters
     {
@@ -70,6 +73,7 @@ public partial class Build
         public string ApiValidationBaseline { get; }
         public bool UpdateApiValidationSuppression { get; }
         public AbsolutePath ApiValidationSuppressionFiles { get; }
+        public AbsolutePath VersionOutput { get; }
 
         public BuildParameters(Build b, bool isPackingToLocalCache)
         {
@@ -146,6 +150,7 @@ public partial class Build
             ZipCoreArtifacts = ZipRoot / ("Avalonia-" + FileZipSuffix);
             ZipNuGetArtifacts = ZipRoot / ("Avalonia-NuGet-" + FileZipSuffix);
             ApiValidationSuppressionFiles = RootDirectory / "api";
+            VersionOutput = b.VersionOutput;
         }
 
         string GetVersion()

--- a/nukebuild/BuildParameters.cs
+++ b/nukebuild/BuildParameters.cs
@@ -29,8 +29,8 @@ public partial class Build
     [Parameter(Name = "update-api-suppression")]
     public bool? UpdateApiValidationSuppression { get; set; }
 
-    [Parameter(Name = "version-output")]
-    public AbsolutePath VersionOutput { get; set; }
+    [Parameter(Name = "version-output-dir")]
+    public AbsolutePath VersionOutputDir { get; set; }
 
     public class BuildParameters
     {
@@ -73,7 +73,7 @@ public partial class Build
         public string ApiValidationBaseline { get; }
         public bool UpdateApiValidationSuppression { get; }
         public AbsolutePath ApiValidationSuppressionFiles { get; }
-        public AbsolutePath VersionOutput { get; }
+        public AbsolutePath VersionOutputDir { get; }
 
         public BuildParameters(Build b, bool isPackingToLocalCache)
         {
@@ -150,7 +150,7 @@ public partial class Build
             ZipCoreArtifacts = ZipRoot / ("Avalonia-" + FileZipSuffix);
             ZipNuGetArtifacts = ZipRoot / ("Avalonia-NuGet-" + FileZipSuffix);
             ApiValidationSuppressionFiles = RootDirectory / "api";
-            VersionOutput = b.VersionOutput;
+            VersionOutputDir = b.VersionOutputDir;
         }
 
         string GetVersion()


### PR DESCRIPTION
## What does the pull request do?

Currently our GitHub version number bot outputs hardcoded version base (i.e. - 11.0.999 or 11.1.999 + BuildId env var), instead of using actual number. This PR is a first step to fix that.

It's based on nuke (again) just to keep version resolving in a single place, and not duplicate it in other scripts. 