### PR TITLE
Update ImageSharp to 2.1.7

### DIFF
--- a/build/ImageSharp.props
+++ b/build/ImageSharp.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.7" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What does the pull request do?
This PR updates ImageSharp to 2.1.7.

## What is the current behavior?
The currently used version, 2.1.3, has a high security vulnerability: https://github.com/advisories/GHSA-65x7-c272-7g7r
