### PR TITLE
Warning fixes

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/Unicode/PropertyValueAliasHelper.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/Unicode/PropertyValueAliasHelper.cs
@@ -175,11 +175,11 @@ namespace Avalonia.Media.TextFormatting.Unicode
 
         public static string GetTag(Script script)
         {
-            if(!s_scriptToTag.ContainsKey(script))
+            if (!s_scriptToTag.TryGetValue(script, out var value))
             {
                 return "Zzzz";
             }
-            return s_scriptToTag[script];
+            return value;
         }
 
         private static readonly Dictionary<string, Script> s_tagToScript = 
@@ -353,11 +353,11 @@ namespace Avalonia.Media.TextFormatting.Unicode
 
         public static Script GetScript(string tag)
         {
-            if(!s_tagToScript.ContainsKey(tag))
+            if (!s_tagToScript.TryGetValue(tag, out var value))
             {
                 return Script.Unknown;
             }
-            return s_tagToScript[tag];
+            return value;
         }
 
         private static readonly Dictionary<string, GeneralCategory> s_tagToGeneralCategory = 
@@ -404,11 +404,11 @@ namespace Avalonia.Media.TextFormatting.Unicode
 
         public static GeneralCategory GetGeneralCategory(string tag)
         {
-            if(!s_tagToGeneralCategory.ContainsKey(tag))
+            if (!s_tagToGeneralCategory.TryGetValue(tag, out var value))
             {
                 return GeneralCategory.Other;
             }
-            return s_tagToGeneralCategory[tag];
+            return value;
         }
 
         private static readonly Dictionary<string, LineBreakClass> s_tagToLineBreakClass = 
@@ -460,11 +460,11 @@ namespace Avalonia.Media.TextFormatting.Unicode
 
         public static LineBreakClass GetLineBreakClass(string tag)
         {
-            if(!s_tagToLineBreakClass.ContainsKey(tag))
+            if (!s_tagToLineBreakClass.TryGetValue(tag, out var value))
             {
                 return LineBreakClass.Unknown;
             }
-            return s_tagToLineBreakClass[tag];
+            return value;
         }
 
         private static readonly Dictionary<string, BidiPairedBracketType> s_tagToBidiPairedBracketType = 
@@ -476,11 +476,11 @@ namespace Avalonia.Media.TextFormatting.Unicode
 
         public static BidiPairedBracketType GetBidiPairedBracketType(string tag)
         {
-            if(!s_tagToBidiPairedBracketType.ContainsKey(tag))
+            if (!s_tagToBidiPairedBracketType.TryGetValue(tag, out var value))
             {
                 return BidiPairedBracketType.None;
             }
-            return s_tagToBidiPairedBracketType[tag];
+            return value;
         }
 
         private static readonly Dictionary<string, BidiClass> s_tagToBidiClass = 
@@ -512,11 +512,11 @@ namespace Avalonia.Media.TextFormatting.Unicode
 
         public static BidiClass GetBidiClass(string tag)
         {
-            if(!s_tagToBidiClass.ContainsKey(tag))
+            if (!s_tagToBidiClass.TryGetValue(tag, out var value))
             {
                 return BidiClass.LeftToRight;
             }
-            return s_tagToBidiClass[tag];
+            return value;
         }
 
     }

--- a/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumn.cs
@@ -1061,7 +1061,7 @@ namespace Avalonia.Controls
             _settingWidthInternally = true;
             try
             {
-                Width = width;
+                SetCurrentValue(WidthProperty, width);
             }
             finally
             {
@@ -1079,7 +1079,7 @@ namespace Avalonia.Controls
             _setWidthInternalNoCallback = true;
             try
             {
-                Width = width;
+                SetCurrentValue(WidthProperty, width);
             }
             finally
             {

--- a/src/Avalonia.DesignerSupport/Remote/HtmlTransport/SimpleWebSocketHttpServer.cs
+++ b/src/Avalonia.DesignerSupport/Remote/HtmlTransport/SimpleWebSocketHttpServer.cs
@@ -325,15 +325,15 @@ namespace Avalonia.DesignerSupport.Remote.HtmlTransport
 
                 const byte endOfMessageBit = (byte)1u << 7;
                 header.Mask = (byte) (endOfMessageBit | ((byte) type & 0xf));
-                unsafe
-                {
-                    Marshal.Copy(new IntPtr(&header), _sendHeaderBuffer, 0, headerLength);
-                }
+                CopyHeaderToBuffer(header, _sendHeaderBuffer, headerLength);
 
                 await _stream.WriteAsync(_sendHeaderBuffer, 0, headerLength);
                 await _stream.WriteAsync(data, offset, length);
             }
         }
+
+        private static unsafe void CopyHeaderToBuffer(WebSocketHeader source, byte[] destination, int headerLength)
+            => Marshal.Copy(new IntPtr(&source), destination, 0, headerLength);
 
         struct Frame
         {

--- a/src/Avalonia.Remote.Protocol/MetsysBson.cs
+++ b/src/Avalonia.Remote.Protocol/MetsysBson.cs
@@ -1588,11 +1588,12 @@ namespace Metsys.Bson.Configuration
         internal void AddMap<T>(string property, string alias)
         {
             var type = typeof(T);
-            if (!_aliasMap.ContainsKey(type))
+            if (!_aliasMap.TryGetValue(type, out var aliases))
             {
-                _aliasMap[type] = new Dictionary<string, string>();
+                aliases = new Dictionary<string, string>();
+                _aliasMap[type] = aliases;
             }
-            _aliasMap[type][property] = alias;
+            aliases[property] = alias;
         }
         internal string AliasFor(Type type, string property)
         {
@@ -1607,11 +1608,12 @@ namespace Metsys.Bson.Configuration
         public void AddIgnore<T>(string name)
         {
             var type = typeof(T);
-            if (!_ignored.ContainsKey(type))
+            if (!_ignored.TryGetValue(type, out var names))
             {
-                _ignored[type] = new HashSet<string>();
+                names = new HashSet<string>();
+                _ignored[type] = names;
             }
-            _ignored[type].Add(name);
+            names.Add(name);
         }
         public bool IsIgnored(Type type, string name)
         {
@@ -1622,11 +1624,12 @@ namespace Metsys.Bson.Configuration
         public void AddIgnoreIfNull<T>(string name)
         {
             var type = typeof(T);
-            if (!_ignoredIfNull.ContainsKey(type))
+            if (!_ignoredIfNull.TryGetValue(type, out var names))
             {
-                _ignoredIfNull[type] = new HashSet<string>();
+                names = new HashSet<string>();
+                _ignoredIfNull[type] = names;
             }
-            _ignoredIfNull[type].Add(name);
+            names.Add(name);
         }
         public bool IsIgnoredIfNull(Type type, string name)
         {

--- a/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
+++ b/src/Skia/Avalonia.Skia/DrawingContextImpl.cs
@@ -1397,7 +1397,6 @@ namespace Avalonia.Skia
         /// Create new render target compatible with this drawing context.
         /// </summary>
         /// <param name="pixelSize">The size of the render target.</param>
-        /// <param name="dpi">The DPI of the render target.</param>
         /// <param name="isLayer">Whether the render target is being created for a layer.</param>
         /// <param name="format">Pixel format.</param>
         /// <returns></returns>

--- a/src/Windows/Avalonia.Direct2D1/Media/DrawingContextImpl.cs
+++ b/src/Windows/Avalonia.Direct2D1/Media/DrawingContextImpl.cs
@@ -34,6 +34,7 @@ namespace Avalonia.Direct2D1.Media
         /// An object to use to create layers. May be null, in which case a
         /// <see cref="WicRenderTargetBitmapImpl"/> will created when a new layer is requested.
         /// </param>
+        /// <param name="useScaledDrawing">Whether to scale drawings according to the DPI of <paramref name="renderTarget"/>.</param>
         /// <param name="swapChain">An optional swap chain associated with this drawing context.</param>
         /// <param name="finishedCallback">An optional delegate to be called when context is disposed.</param>
         public DrawingContextImpl(


### PR DESCRIPTION
## What does the pull request do?
Another batch of warning fixes:
  - Fixes XML doc warnings (again)
  - Fixes CA1854: use `Dictionary.TryGetValue` instead of `ContainsKey`+indexer
  - Fixes CS9123: avoid `&` in async methods
  - Use SetCurrentValue to set `DataGridColumn.Width`