### PR TITLE
Fix SYSLIB0051 warnings (binary serialization)

### DIFF
--- a/src/Avalonia.Remote.Protocol/MetsysBson.cs
+++ b/src/Avalonia.Remote.Protocol/MetsysBson.cs
@@ -1643,6 +1643,5 @@ namespace Metsys.Bson
         public BsonException() { }
         public BsonException(string message) : base(message) { }
         public BsonException(string message, Exception innerException) : base(message, innerException) { }
-        protected BsonException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/Markup/Avalonia.Markup.Xaml/XamlLoadException.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlLoadException.cs
@@ -9,6 +9,9 @@ namespace Avalonia.Markup.Xaml
         {
         }
 
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051")]
+#endif
         protected XamlLoadException(SerializationInfo info, StreamingContext context): base(info, context)
         {
         }

--- a/src/Windows/Avalonia.Win32/DataObject.cs
+++ b/src/Windows/Avalonia.Win32/DataObject.cs
@@ -287,9 +287,8 @@ namespace Avalonia.Win32
             using (var ms = new MemoryStream())
             {
                 ms.Write(SerializedObjectGUID, 0, SerializedObjectGUID.Length);
-                BinaryFormatter binaryFormatter = new BinaryFormatter();
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-                binaryFormatter.Serialize(ms, data);
+                new BinaryFormatter().Serialize(ms, data);
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
                 return ms.ToArray();
             }

--- a/src/tools/Avalonia.Designer.HostApp/TinyJson.cs
+++ b/src/tools/Avalonia.Designer.HostApp/TinyJson.cs
@@ -8,6 +8,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text;
 
@@ -343,7 +344,11 @@ namespace TinyJson
 
         static object ParseObject(Type type, string json)
         {
+#if NET6_0_OR_GREATER
+            object instance = RuntimeHelpers.GetUninitializedObject(type);
+#else
             object instance = FormatterServices.GetUninitializedObject(type);
+#endif
 
             //The list is split into key/value pairs only, this means the split must be divisible by 2 to be valid JSON
             List<string> elems = Split(json);


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the warnings for [SYSLIB0051: Legacy serialization support APIs are obsolete](https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0051). 
This does NOT remove the `BinaryFormatter` usages related to winforms compatibility, which is tracked by #13514.