### PR TITLE
Fix for canvas height on mobile browsers

### DIFF
--- a/src/Browser/Avalonia.Browser/webapp/modules/avalonia/dom.ts
+++ b/src/Browser/Avalonia.Browser/webapp/modules/avalonia/dom.ts
@@ -39,6 +39,7 @@ export class AvaloniaDOM {
         canvas.id = `canvas${randomIdPart}`;
         canvas.classList.add("avalonia-canvas");
         canvas.style.width = "100%";
+        canvas.style.height = "100%";
         canvas.style.position = "absolute";
 
         // Native controls host


### PR DESCRIPTION

## What does the pull request do?

Fix for canvas height on mobile browser. 

## Tested on:

Windows: Firefox, Google Chrome, Edge
Android: Firefox, Google Chrome, Edge
IOS: Safari

## Fixed issues

Fixes #14452