### PR TITLE
Fix ScrollContentPresenter incorrectly handling BringIntoView without changing its offset

### DIFF
--- a/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
+++ b/src/Avalonia.Controls/Presenters/ScrollContentPresenter.cs
@@ -259,38 +259,34 @@ namespace Avalonia.Controls.Presenters
 
             var rect = targetRect.TransformToAABB(transform.Value);
             var offset = Offset;
-            var result = false;
 
             if (rect.Bottom > offset.Y + Viewport.Height)
             {
                 offset = offset.WithY((rect.Bottom - Viewport.Height) + Child.Margin.Top);
-                result = true;
             }
 
             if (rect.Y < offset.Y)
             {
                 offset = offset.WithY(rect.Y);
-                result = true;
             }
 
             if (rect.Right > offset.X + Viewport.Width)
             {
                 offset = offset.WithX((rect.Right - Viewport.Width) + Child.Margin.Left);
-                result = true;
             }
 
             if (rect.X < offset.X)
             {
                 offset = offset.WithX(rect.X);
-                result = true;
             }
 
-            if (result)
+            if (Offset.NearlyEquals(offset))
             {
-                SetCurrentValue(OffsetProperty, offset);
+                return false;
             }
 
-            return result;
+            SetCurrentValue(OffsetProperty, offset);
+            return true;
         }
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)

--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -453,8 +453,6 @@ namespace Avalonia.Controls
         {
             Debug.Assert(_realizedElements is not null);
 
-            // If the control has not yet been laid out then the effective viewport won't have been set.
-            // Try to work it out from an ancestor control.
             var viewport = _viewport;
 
             // Get the viewport in the orientation direction.

--- a/tests/Avalonia.Controls.UnitTests/Presenters/ScrollContentPresenterTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/Presenters/ScrollContentPresenterTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
 using Avalonia.Controls.Presenters;
-using Avalonia.Controls.Primitives;
 using Avalonia.Layout;
 using Avalonia.UnitTests;
 using Xunit;
@@ -366,7 +365,7 @@ namespace Avalonia.Controls.UnitTests.Presenters
             target.UpdateChild();
             target.Measure(Size.Infinity);
             target.Arrange(new Rect(0, 0, 100, 100));
-            target.BringDescendantIntoView(target.Child, new Rect(200, 200, 0, 0));
+            target.BringDescendantIntoView(target.Child!, new Rect(200, 200, 0, 0));
 
             Assert.Equal(new Vector(100, 100), target.Offset);
         }
@@ -398,6 +397,46 @@ namespace Avalonia.Controls.UnitTests.Presenters
             target.BringDescendantIntoView(border, new Rect(200, 200, 0, 0));
 
             Assert.Equal(new Vector(150, 150), target.Offset);
+        }
+
+        [Fact]
+        public void Nested_Presenters_Should_Scroll_Outer_When_Content_Exceeds_Viewport()
+        {
+            ScrollContentPresenter innerPresenter;
+            Border border;
+
+            var outerPresenter = new ScrollContentPresenter
+            {
+                CanHorizontallyScroll = true,
+                CanVerticallyScroll = true,
+                Width = 100,
+                Height = 100,
+                Content = innerPresenter = new ScrollContentPresenter
+                {
+                    CanHorizontallyScroll = true,
+                    CanVerticallyScroll = true,
+                    Width = 100,
+                    Height = 200,
+                    Content = border = new Border
+                    {
+                        Width = 200, // larger than viewport
+                        Height = 25,
+                        HorizontalAlignment = HorizontalAlignment.Left,
+                        VerticalAlignment = VerticalAlignment.Top,
+                        Margin = new Thickness(0, 120, 0, 0)
+                    }
+                }
+            };
+
+            innerPresenter.UpdateChild();
+            outerPresenter.UpdateChild();
+            outerPresenter.Measure(new Size(100, 100));
+            outerPresenter.Arrange(new Rect(0, 0, 100, 100));
+
+            border.BringIntoView();
+
+            Assert.Equal(new Vector(0, 45), outerPresenter.Offset);
+            Assert.Equal(new Vector(0, 0), innerPresenter.Offset);
         }
 
         private class TestControl : Control


### PR DESCRIPTION
## What does the pull request do?
This PR ensures that `ScrollContentPresenter.BringDescendantIntoView()` return `false` when it doesn't change the offset.

## What is the current behavior?
When the child to bring into view has a dimension larger than the viewport, it's possible that `BringDescendantIntoView` makes two changes to its `Offset` that effectively cancel each other.

The case was found in #13607 where there's nested `ScrollViewer`s: the inner one incorrectly handles the `RequestBringIntoView` without really changing the offset when the child's width is larger than the viewport, preventing the outer one from scrolling.

A unit test for this specific case has been added.

## What is the updated/expected behavior with this PR?
If the `Offset` doesn't effectively change, `BringDescendantIntoView()` now returns `false`, allowing the parent controls to handle the `RequestBringIntoView`.

## Fixed issues
 - Fixes #13607 (hopefully)
