### PR TITLE
Disable InvalidateVisual when Visual's not visible

### DIFF
--- a/src/Avalonia.Base/Visual.cs
+++ b/src/Avalonia.Base/Visual.cs
@@ -409,7 +409,10 @@ namespace Avalonia
                 {
                     if (e.Sender is T sender)
                     {
-                        sender.InvalidateVisual();
+                        if (sender.IsVisible || e.Property == IsVisibleProperty)
+                        {
+                            sender.InvalidateVisual();
+                        }
                     }
                 });
             
@@ -655,7 +658,10 @@ namespace Avalonia
         /// <param name="e">The event args.</param>
         private void RenderTransformChanged(object? sender, EventArgs e)
         {
-            InvalidateVisual();
+            if (ClipToBounds && IsEffectivelyVisible)
+            {
+                InvalidateVisual();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## What does the pull request do?
Alternative to https://github.com/AvaloniaUI/Avalonia/pull/14684 - does not disable the animation but just prevents it from rendering the visual. There are many edge cases and even more InvalidateVisual calls that might be optimized. This is meant just as a draft for future work.

## What is the current behavior?
It invokes the rendering in all cases.

## What is the updated/expected behavior with this PR?
Changing property or render transform property should not fire rendering if the control is not visible.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
