### PR TITLE
Remove InternalsVisibleTo from Avalonia.Base to ControlCatalog

### DIFF
--- a/samples/MiniMvvm/MiniCommand.cs
+++ b/samples/MiniMvvm/MiniCommand.cs
@@ -6,10 +6,10 @@ namespace MiniMvvm
 {
     public sealed class MiniCommand<T> : MiniCommand, ICommand
     {
-        private readonly Action<T> _cb;
+        private readonly Action<T>? _cb;
+        private readonly Func<T, Task>? _acb;
         private bool _busy;
-        private Func<T, Task> _acb;
-        
+
         public MiniCommand(Action<T> cb)
         {
             _cb = cb;
@@ -31,10 +31,11 @@ namespace MiniMvvm
         }
 
         
-        public override event EventHandler CanExecuteChanged;
-        public override bool CanExecute(object parameter) => !_busy;
+        public override event EventHandler? CanExecuteChanged;
 
-        public override async void Execute(object parameter)
+        public override bool CanExecute(object? parameter) => !_busy;
+
+        public override async void Execute(object? parameter)
         {
             if(Busy)
                 return;
@@ -42,9 +43,9 @@ namespace MiniMvvm
             {
                 Busy = true;
                 if (_cb != null)
-                    _cb((T)parameter);
+                    _cb((T)parameter!);
                 else
-                    await _acb((T)parameter);
+                    await _acb!((T)parameter!);
             }
             finally
             {

--- a/samples/MiniMvvm/MiniMvvm.csproj
+++ b/samples/MiniMvvm/MiniMvvm.csproj
@@ -1,8 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
+  
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Avalonia.Base\Avalonia.Base.csproj" />
+    <ProjectReference Include="../../src/Avalonia.Base/Avalonia.Base.csproj" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <Compile Include="../../src/Avalonia.Base/Reactive/**/*.cs" Exclude="../../src/Avalonia.Base/Reactive/AnonymousObserver.cs" />
+  </ItemGroup>
+  
 </Project>

--- a/samples/MiniMvvm/ViewModelBase.cs
+++ b/samples/MiniMvvm/ViewModelBase.cs
@@ -6,8 +6,9 @@ namespace MiniMvvm
 {
     public class ViewModelBase : INotifyPropertyChanged
     {
-        public event PropertyChangedEventHandler PropertyChanged;
-        protected bool RaiseAndSetIfChanged<T>(ref T field, T value, [CallerMemberName] string propertyName = null)
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected bool RaiseAndSetIfChanged<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
         {
             if (!EqualityComparer<T>.Default.Equals(field, value))
             {
@@ -17,9 +18,8 @@ namespace MiniMvvm
             }
             return false;
         }
-        
-        
-        protected void RaisePropertyChanged([CallerMemberName] string propertyName = null)
+
+        protected void RaisePropertyChanged([CallerMemberName] string? propertyName = null)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }

--- a/src/Avalonia.Base/Avalonia.Base.csproj
+++ b/src/Avalonia.Base/Avalonia.Base.csproj
@@ -57,8 +57,6 @@
     <InternalsVisibleTo Include="Avalonia.Dialogs, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Diagnostics, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.LinuxFramebuffer, PublicKey=$(AvaloniaPublicKey)" />
-    <InternalsVisibleTo Include="MiniMvvm, PublicKey=$(AvaloniaPublicKey)" />
-    <InternalsVisibleTo Include="ControlCatalog, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
   </ItemGroup>
   


### PR DESCRIPTION
## What does the pull request do?
This PR removes the `InternalsVisibleTo` from `Avalonia.Base` to `ControlCatalog` and `MiniMvvm`.

`MiniMvvm` now has a copy of the reactive helpers from `Avalonia.Base` instead, and has nullability enabled.
