### PR TITLE
Do not call ProcessSort using Dispatcher for DataGrid sorting

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnHeader.cs
@@ -214,7 +214,7 @@ namespace Avalonia.Controls
             }
             if (OwningGrid.CommitEdit(DataGridEditingUnit.Row, exitEditingMode: true))
             {
-                Avalonia.Threading.Dispatcher.UIThread.Post(() => ProcessSort(keyModifiers, forcedDirection));
+                ProcessSort(keyModifiers, forcedDirection);
             }
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Removes usage of Avalonia.Threading.Dispatcher.UIThread.Post() for DataGrid sorting


## What is the current behavior?

Manually triggering DataGrid sorting via DataGridColumn.Sort() method is eventually dispatched using Avalonia.Threading.Dispatcher.UIThread.Post() that results in sorting delay.


## What is the updated/expected behavior with this PR?

Manually triggering DataGrid sorting via DataGridColumn.Sort() method is does not results in sorting delay.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

Removes usage of Avalonia.Threading.Dispatcher.UIThread.Post() for DataGrid sorting

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
