### PR TITLE
Handle $self in compiled binding in multibinding.

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlBindingPathTransformer.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlBindingPathTransformer.cs
@@ -123,7 +123,12 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                 };
 
                 var selfType = context.ParentNodes().OfType<XamlAstConstructableObjectNode>().First().Type.GetClrType();
-                
+
+                if (context.GetAvaloniaTypes().MultiBinding.IsAssignableFrom(selfType))
+                {
+                    selfType = context.ParentNodes().OfType<XamlAstConstructableObjectNode>().Skip(1).First().Type.GetClrType();
+                }
+
                 // When using self bindings with setters we need to change target type to resolved selector type.
                 if (context.GetAvaloniaTypes().SetterBase.IsAssignableFrom(selfType))
                 {

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -21,6 +21,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlMethod AvaloniaObjectSetStyledPropertyValue { get; }
         public IXamlType AvaloniaAttachedPropertyT { get; }
         public IXamlType IBinding { get; }
+        public IXamlType MultiBinding { get; }
         public IXamlMethod AvaloniaObjectBindMethod { get; }
         public IXamlMethod AvaloniaObjectSetValueMethod { get; }
         public IXamlType IDisposable { get; }
@@ -140,6 +141,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
                                  && m.Parameters[0].Name == "StyledProperty`1"
                                  && m.Parameters[2].Equals(BindingPriority));
             IBinding = cfg.TypeSystem.GetType("Avalonia.Data.IBinding");
+            MultiBinding = cfg.TypeSystem.GetType("Avalonia.Data.MultiBinding");
             IDisposable = cfg.TypeSystem.GetType("System.IDisposable");
             ICommand = cfg.TypeSystem.GetType("System.Windows.Input.ICommand");
             Transitions = cfg.TypeSystem.GetType("Avalonia.Animation.Transitions");

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -1692,6 +1692,74 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             }
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Binds_To_RelativeSource_Self_In_MultiBinding(bool compileBindings)
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = $@"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        x:CompileBindings='{compileBindings}'>
+  <StackPanel>
+    <TextBlock Name='textBlock'>
+      <TextBlock.Text>
+        <MultiBinding StringFormat=""{{}} $self = {{0}}, $parent = {{1}}"">
+          <Binding Path=""$self.FontStyle""/>
+          <Binding Path=""$parent.Orientation""/>
+        </MultiBinding>
+      </TextBlock.Text>
+    </TextBlock>
+  </StackPanel>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = window.GetControl<TextBlock>("textBlock");
+
+                var dataContext = new TestDataContext();
+                window.DataContext = dataContext;
+
+                Assert.Equal(" $self = Normal, $parent = Vertical"
+                    , textBlock.GetValue(TextBlock.TextProperty));
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Binds_To_RelativeSource_Self_In_MultiBinding_In_Style(bool compileBindings)
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = $@"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        x:CompileBindings='{compileBindings}'>
+  <Window.Styles>
+    <Style Selector='TextBlock'>
+        <Setter Property='Text'>
+          <MultiBinding StringFormat=""{{}} $self = {{0}}"">
+            <Binding Path=""$self.FontStyle""/>
+          </MultiBinding>
+        </Setter>
+    </Style>
+  </Window.Styles>
+  <StackPanel>
+    <TextBlock Name='textBlock'/>
+  </StackPanel>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var textBlock = window.GetControl<TextBlock>("textBlock");
+
+                var dataContext = new TestDataContext();
+                window.DataContext = dataContext;
+
+                Assert.Equal(" $self = Normal"
+                    , textBlock.GetValue(TextBlock.TextProperty));
+            }
+        }
+
         [Fact]
         public void SupportsMethodBindingAsDelegate()
         {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Enables compiled bindings in multibindings.

## What is the current behavior?
Compilation error: `Avalonia error AVLN:0004: Unable to resolve property or method of name 'FontStyle' on type 'Avalonia.Data.MultiBinding'.`

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
That the bindings work the same as when using reflection bindings. 

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Tried to do something similar as to how the type is resolved in a style setter. 

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #13528