### PR TITLE
Properly rethrow RegisterTick errors instead of returning generic E_FAIL

### DIFF
--- a/native/Avalonia.Native/src/OSX/PlatformRenderTimer.mm
+++ b/native/Avalonia.Native/src/OSX/PlatformRenderTimer.mm
@@ -8,7 +8,7 @@ private:
 
 public:
     FORWARD_IUNKNOWN()
-    virtual HRESULT RegisterTick (
+    virtual int RegisterTick (
         IAvnActionCallback* callback) override
     {
         START_COM_CALL;
@@ -24,13 +24,13 @@ public:
             auto result = CVDisplayLinkCreateWithActiveCGDisplays(&_displayLink);
             if (result != 0)
             {
-                return E_FAIL;
+                return result;
             }
 
             result = CVDisplayLinkSetOutputCallback(_displayLink, OnTick, this);
             if (result != 0)
             {
-                return E_FAIL;
+                return result;
             }
         }
         return S_OK;

--- a/src/Avalonia.Native/AvaloniaNativeRenderTimer.cs
+++ b/src/Avalonia.Native/AvaloniaNativeRenderTimer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Avalonia.Native.Interop;
 using Avalonia.Rendering;
 #nullable enable
@@ -29,7 +30,12 @@ internal sealed class AvaloniaNativeRenderTimer : NativeCallbackBase, IRenderTim
             if (!registered)
             {
                 registered = true;
-                _platformRenderTimer.RegisterTick(this);
+                var registrationResult = _platformRenderTimer.RegisterTick(this);
+                if (registrationResult != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Avalonia.Native was not able to start the RenderTimer. Native error code is: {registrationResult}");
+                }
             }
 
             if (_subscriberCount++ == 0)

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -1202,7 +1202,7 @@ interface IAvnPlatformBehaviorInhibition : IUnknown
 [uuid(22edf20d-5803-2d3f-9247-b4842e5e9322)]
 interface IAvnPlatformRenderTimer : IUnknown
 {
-    HRESULT RegisterTick(IAvnActionCallback* callback);
+    int RegisterTick(IAvnActionCallback* callback);
     void Start();
     void Stop();
     bool RunsInBackground();


### PR DESCRIPTION
## What does the pull request do?

This PR is mostly for testing. Can be merged, can be not.
