### PR TITLE
Fix font fallback for composite keys containing relative URIs

### DIFF
--- a/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
+++ b/tests/Avalonia.Skia.UnitTests/Media/FontManagerTests.cs
@@ -200,14 +200,16 @@ namespace Avalonia.Skia.UnitTests.Media
             }
         }
 
-        [Fact]
-        public void Should_Match_Chararcter_Width_Fallbacks()
+        [Theory]
+        [InlineData("NotFound, Unknown", null)] // system fonts
+        [InlineData("/#NotFound, /#Unknown", "avares://some/path")] // embedded fonts
+        public void Should_Match_Character_With_Fallbacks(string familyName, string baseUri)
         {
             using (UnitTestApplication.Start(TestServices.MockPlatformRenderInterface.With(fontManagerImpl: new FontManagerImpl())))
             {
                 using (AvaloniaLocator.EnterScope())
                 {
-                    var fontFamily = FontFamily.Parse("NotFound, Unknown");
+                    var fontFamily = FontFamily.Parse(familyName, baseUri is null ? null : new Uri(baseUri));
 
                     Assert.True(FontManager.Current.TryMatchCharacter('A', FontStyle.Normal, FontWeight.Normal, FontStretch.Normal, fontFamily, null, out var typeface));
 


### PR DESCRIPTION
## What does the pull request do?
This PR fixes the font fallback mechanism throwing whenever a fallback character is needed for a composite key containing a relative URI.

A unit test has been added.

## What is the current behavior?
The application crashes with _System.InvalidOperationException: This operation is not supported for a relative URI._

## What is the updated/expected behavior with this PR?
The font fallback works.

## Note
The removal of `if (source.Scheme == SystemFontScheme) return SystemFonts.TryGetGlyphTypeface(...)` isn't an error: it's an intended simplification since `GetFontCollection` already has a special case for `SystemFontScheme`.

