### PR TITLE
Revert "Fix TextBlock wrong caret position"

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -923,8 +923,6 @@ namespace Avalonia.Controls
             }
             else if (change.Property == SelectionEndProperty)
             {
-                _presenter?.MoveCaretToTextPosition(CaretIndex);
-
                 OnSelectionEndChanged(change);
             }
             else if (change.Property == MaxLinesProperty)


### PR DESCRIPTION
Reverts AvaloniaUI/Avalonia#14627

Causes multiple regressions and needs to be implemented in a different way