### PR TITLE
Fall back to linear initial velocity if there's not enough samples for inertia

### DIFF
--- a/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
@@ -102,6 +102,8 @@ namespace Avalonia.Input.GestureRecognizers
                 _gestureId = ScrollGestureEventArgs.GetNextFreeId();
                 _rootTarget = (Visual?)(Target as Visual)?.VisualRoot;
                 _trackedRootPoint = _pointerPressedPoint = e.GetPosition(_rootTarget);
+                _velocityTracker = new VelocityTracker();
+                _velocityTracker?.AddPosition(TimeSpan.FromMilliseconds(e.Timestamp), default);
             }
         }
 
@@ -117,9 +119,7 @@ namespace Avalonia.Input.GestureRecognizers
                     if (CanVerticallyScroll && Math.Abs(_trackedRootPoint.Y - rootPoint.Y) > ScrollStartDistance)
                         _scrolling = true;
                     if (_scrolling)
-                    {
-                        _velocityTracker = new VelocityTracker();
-                        
+                    {                        
                         // Correct _trackedRootPoint with ScrollStartDistance, so scrolling does not start with a skip of ScrollStartDistance
                         _trackedRootPoint = new Point(
                             _trackedRootPoint.X - (_trackedRootPoint.X >= rootPoint.X ? ScrollStartDistance : -ScrollStartDistance),

--- a/src/Avalonia.Base/Input/GestureRecognizers/VelocityTracker.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/VelocityTracker.cs
@@ -139,6 +139,9 @@ namespace Avalonia.Input.GestureRecognizers
                 sampleCount++;
             } while (sampleCount < HistorySize);
 
+            var offset = newestSample.Point - oldestSample.Point;
+            var duration = newestSample.Time - oldestSample.Time;
+
             if (sampleCount >= MinSampleSize)
             {
                 var xFit = LeastSquaresSolver.Solve(2, time.Slice(0, sampleCount), x.Slice(0, sampleCount), w.Slice(0, sampleCount));
@@ -150,11 +153,22 @@ namespace Avalonia.Input.GestureRecognizers
                         return new VelocityEstimate( // convert from pixels/ms to pixels/s
                           PixelsPerSecond: new Vector(xFit.Coefficients[1] * 1000, yFit.Coefficients[1] * 1000),
                           Confidence: xFit.Confidence * yFit.Confidence,
-                          Duration: newestSample.Time - oldestSample.Time,
-                          Offset: newestSample.Point - oldestSample.Point
+                          Duration: duration,
+                          Offset: offset
                         );
                     }
                 }
+            }
+            else if(sampleCount > 1)
+            {
+                // Return linear velocity if we don't have enough samples
+                var distance = newestSample.Point - oldestSample.Point;
+                return new VelocityEstimate(
+                  PixelsPerSecond: new Vector(distance.X / duration.Milliseconds * 1000, distance.Y / duration.Milliseconds * 1000),
+                  Confidence: 1,
+                  Duration: duration,
+                  Offset: offset
+                );
             }
 
             // We're unable to make a velocity estimate but we did have at least one
@@ -162,8 +176,8 @@ namespace Avalonia.Input.GestureRecognizers
             return new VelocityEstimate(
               PixelsPerSecond: Vector.Zero,
               Confidence: 1.0,
-              Duration: newestSample.Time - oldestSample.Time,
-              Offset: newestSample.Point - oldestSample.Point
+              Duration: duration,
+              Offset: offset
             );
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fallbacks to linear scroll velocity if not enough touchpoints have been registered in a swipe for polynomial computation of inertia.
This also adds a touch point at pointer press to the velocity tracker to ensure start and end points of the swipe are accounted for in the tracker.

## What is the current behavior?
Some mobile os and devices have reduced touch polling rate when no activity is detected on screen, or as a power saving measure. Because of this, a flick on the screen could be faster than the os can send event that, our tracker would only register 1 or 2 pointer move events. With so few points being register in that gesture, the tracker returns 0 for inertia, even though the user has completed a swipe.

## What is the updated/expected behavior with this PR?
A quick flick on a touch screen will be detected as a scroll swipe.


## How was the solution implemented (if it's not obvious)?
Since we are guaranteed a PointerPressed if a user touches the screen, we register that point as the first point(0,0) in the tracker. If a swipe is done, this will add another point to the tracker on PointerMoved. If no more pointer move event are sent, we have at least 2 points to calculate the velocity of the fling when the pointer is released.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/14919
