### PR TITLE
Fix mac popup special keys

### DIFF
--- a/native/Avalonia.Native/src/OSX/PopupImpl.mm
+++ b/native/Avalonia.Native/src/OSX/PopupImpl.mm
@@ -26,6 +26,7 @@ private:
     PopupImpl(IAvnWindowEvents* events) : WindowBaseImpl(events)
     {
         WindowEvents = events;
+        [GetWindowProtocol() setCanBecomeKeyWindow:true];
         [Window setLevel:NSPopUpMenuWindowLevel];
     }
 protected:

--- a/src/Avalonia.Base/Input/TextInput/InputMethodManager.cs
+++ b/src/Avalonia.Base/Input/TextInput/InputMethodManager.cs
@@ -1,7 +1,6 @@
 using System;
 using Avalonia.Interactivity;
 using Avalonia.Reactive;
-using Avalonia.VisualTree;
 
 namespace Avalonia.Input.TextInput
 {
@@ -133,15 +132,7 @@ namespace Avalonia.Input.TextInput
                 InputMethod.AddTextInputMethodClientRequeryRequestedHandler(_visualRoot,
                     TextInputMethodClientRequeryRequested);
             
-            var visualRoot = (element as Visual)?.VisualRoot as Visual;
-
-            // take Popup parent
-            if (visualRoot is IHostedVisualTreeRoot visualTreeRoot)
-            {
-                visualRoot = visualTreeRoot.Host?.VisualRoot as Visual;
-            }
-            
-            var inputMethod = (visualRoot as ITextInputMethodRoot)?.InputMethod;
+            var inputMethod = ((element as Visual)?.VisualRoot as ITextInputMethodRoot)?.InputMethod;
 
             if (_im != inputMethod)
             {

--- a/src/Avalonia.Base/Input/TextInput/InputMethodManager.cs
+++ b/src/Avalonia.Base/Input/TextInput/InputMethodManager.cs
@@ -1,6 +1,7 @@
 using System;
 using Avalonia.Interactivity;
 using Avalonia.Reactive;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Input.TextInput
 {
@@ -132,7 +133,15 @@ namespace Avalonia.Input.TextInput
                 InputMethod.AddTextInputMethodClientRequeryRequestedHandler(_visualRoot,
                     TextInputMethodClientRequeryRequested);
             
-            var inputMethod = ((element as Visual)?.VisualRoot as ITextInputMethodRoot)?.InputMethod;
+            var visualRoot = (element as Visual)?.VisualRoot as Visual;
+
+            // take Popup parent
+            if (visualRoot is IHostedVisualTreeRoot visualTreeRoot)
+            {
+                visualRoot = visualTreeRoot.Host?.VisualRoot as Visual;
+            }
+            
+            var inputMethod = (visualRoot as ITextInputMethodRoot)?.InputMethod;
 
             if (_im != inputMethod)
             {

--- a/src/Avalonia.Base/Threading/Dispatcher.Queue.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.Queue.cs
@@ -194,7 +194,6 @@ public partial class Dispatcher
                 
                 if (Now - backgroundJobExecutionStartedAt.Value > _maximumInputStarvationTime)
                 {
-                    _signaled = true;
                     RequestBackgroundProcessing();
                     return;
                 }


### PR DESCRIPTION
## What does the pull request do?
Special keys don't work in Popups on macOS. (Special key is anything written with modifier - even shift+1 for bang sign)


## What is the current behavior?
InputManager is not initialized. But that's correct because the Window is still the key window and it receives the hotkeys.


## What is the updated/expected behavior with this PR?
Keep the InputManager initialized to the parent window.


## How was the solution implemented (if it's not obvious)?
I don't know if this is the correct solution in the scope of all platforms.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
test on other platforms

## Fixed issues
https://github.com/AvaloniaUI/Avalonia/issues/14408