### PR TITLE
Fix NativeAOT not using the XAML compilation output

### DIFF
--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -161,6 +161,21 @@
       <_DebugSymbolsIntermediatePath Include="@(_AvaloniaXamlCompiledSymbols)"/>
     </ItemGroup>
   </Target>
+
+  <!-- For some reason the IL Compiler hardcodes $(IntermediateOutputPath)$(TargetName)$(TargetExt) instead of using @(IntermediateAssembly), change that to our assembly. -->
+  <Target Name="InjectIlcAvaloniaXamlOutput"
+          DependsOnTargets="InjectAvaloniaXamlOutput"
+          AfterTargets="ComputeIlcCompileInputs"
+          BeforeTargets="PrepareForILLink"
+          Condition="'@(AvaloniaResource)@(AvaloniaXaml)' != '' AND $(EnableAvaloniaXamlCompilation) != false">
+    <ItemGroup>
+      <ManagedBinary Remove="$(IntermediateOutputPath)$(TargetName)$(TargetExt)" />
+      <ManagedBinary Include="@(_AvaloniaXamlCompiledAssembly)" />
+
+      <IlcCompileInput Remove="$(IntermediateOutputPath)$(TargetName)$(TargetExt)" />
+      <IlcCompileInput Include="@(_AvaloniaXamlCompiledAssembly)" />
+    </ItemGroup>
+  </Target>
   
   <Target Name="Avalonia_CollectUpToDateCheckOutputDesignTime" Condition="'@(AvaloniaResource)@(AvaloniaXaml)' != '' AND $(EnableAvaloniaXamlCompilation) != false" 
           BeforeTargets="CollectUpToDateCheckOutputDesignTime" DependsOnTargets="PrepareToCompileAvaloniaXaml">


### PR DESCRIPTION
## What does the pull request do?
This PR fixes NativeAOT to work with the XAML compiler again.

## What is the current behavior?
The wrong intermediate assembly is used by the IL Compiler, which doesn't contain the output from the XAML compiler. The resulting native application crashes.

## What is the updated/expected behavior with this PR?
NativeAOT works.

## How was the solution implemented (if it's not obvious)?
The problem was introduced by #13840, which doesn't swap the final intermediate assembly anymore (a good thing).
Instead, the `IntermediateAssembly` MSBuild item is changed to be the assembly output from the Avalonia XAML compiler.
However, for some reason, the NativeAOT target doesn't use `IntermediateAssembly` but [hardcodes that to the original assembly](https://github.com/dotnet/runtime/blob/eb864bfd57c8031b4497be6962fbc0c4bc327c29/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets#L171).

This PR adds a new target that change the ILC input to the correct assembly.

## Fixed issues
 - Fixes #14963
