### PR TITLE
Fix incorrect usage of ComboBox in control catalog ViewboxPage

### DIFF
--- a/samples/ControlCatalog/Pages/ViewboxPage.xaml
+++ b/samples/ControlCatalog/Pages/ViewboxPage.xaml
@@ -27,20 +27,24 @@
             <Slider Minimum="10" Maximum="200" Value="100" x:Name="HeightSlider" TickFrequency="25" TickPlacement="TopLeft" />
             <TextBlock Text="Stretch" />
             <ComboBox x:Name="StretchSelector" HorizontalAlignment="Stretch" SelectedIndex="0" Margin="0,0,0,2">
-              <collections:ArrayList>
-                <Stretch>Uniform</Stretch>
-                <Stretch>UniformToFill</Stretch>
-                <Stretch>Fill</Stretch>
-                <Stretch>None</Stretch>
-              </collections:ArrayList>
+              <ComboBox.ItemsSource>
+                <collections:ArrayList>
+                  <Stretch>Uniform</Stretch>
+                  <Stretch>UniformToFill</Stretch>
+                  <Stretch>Fill</Stretch>
+                  <Stretch>None</Stretch>
+                </collections:ArrayList>
+              </ComboBox.ItemsSource>
             </ComboBox>
             <TextBlock Text="Stretch Direction" />
             <ComboBox x:Name="StretchDirectionSelector" SelectedIndex="0" HorizontalAlignment="Stretch">
-              <collections:ArrayList>
-                <StretchDirection>Both</StretchDirection>
-                <StretchDirection>DownOnly</StretchDirection>
-                <StretchDirection>UpOnly</StretchDirection>
-              </collections:ArrayList>
+              <ComboBox.ItemsSource>
+                <collections:ArrayList>
+                  <StretchDirection>Both</StretchDirection>
+                  <StretchDirection>DownOnly</StretchDirection>
+                  <StretchDirection>UpOnly</StretchDirection>
+                </collections:ArrayList>
+              </ComboBox.ItemsSource>
             </ComboBox>
           </StackPanel>
         </Grid>


### PR DESCRIPTION
## What does the pull request do?

This pull request tries to fix the incorrect usage of `ComboBox` in `ViewboxPage`.

## What is the current behavior?

The items of the `ComboBox` in `ViewboxPage` do not display as expected.

![image](https://github.com/AvaloniaUI/Avalonia/assets/21241496/e16c5d18-754c-49b4-812f-cc42c6f74c76)

## What is the updated/expected behavior with this PR?

The `ArrayList` should be set to `ItemsSource` property instead of the `Content` on the `ComboBox`.

![image](https://github.com/AvaloniaUI/Avalonia/assets/21241496/8cd7b181-7659-4d38-bc47-934fea9e6c49)

## How was the solution implemented (if it's not obvious)?

Moved the `ArrayList` instances into the `ItemsSource` property.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

None.

## Obsoletions / Deprecations

None.

## Fixed issues

None.
