### PR TITLE
Select all input for double-clicks in `TextBox` with `PasswordChar`

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1578,6 +1578,13 @@ namespace Avalonia.Controls
 
                         break;
                     case 2:
+                        if (IsPasswordBox && !RevealPassword)
+                        {
+                            // double-clicking in a cloaked single-line password box selects all text
+                            // see https://github.com/AvaloniaUI/Avalonia/issues/14956
+                            goto case 3;
+                        }
+
                         if (!StringUtils.IsStartOfWord(text, caretIndex))
                         {
                             selectionStart = StringUtils.PreviousWord(text, caretIndex);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Double-clicks in a `TextBox` with `PasswordChar` set are handled by selecting all input, when the password
is not revealed.

If the password text is revealed, the pre-existing word-based selection model remains (the word closest to the pointer position is selected.)

Related to https://github.com/AvaloniaUI/Avalonia/issues/14956

<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->


## What is the current behavior?

Double-clicking currently selects individual words/parts of a cloaked password.

## What is the updated/expected behavior with this PR?

If the password is not revealed, then double-clicking selects the entire input. 

## How was the solution implemented (if it's not obvious)?

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/14956