### PR TITLE
Made PART_Track optional for Slider

### DIFF
--- a/src/Avalonia.Controls/Slider.cs
+++ b/src/Avalonia.Controls/Slider.cs
@@ -45,7 +45,7 @@ namespace Avalonia.Controls
     /// </summary>
     [TemplatePart("PART_DecreaseButton", typeof(Button))]
     [TemplatePart("PART_IncreaseButton", typeof(Button))]
-    [TemplatePart("PART_Track",          typeof(Track), IsRequired = true)]
+    [TemplatePart("PART_Track",          typeof(Track))]
     [PseudoClasses(":vertical", ":horizontal", ":pressed")]
     public class Slider : RangeBase
     {
@@ -203,22 +203,26 @@ namespace Avalonia.Controls
             _increaseButtonReleaseDispose?.Dispose();
             _pointerMovedDispose?.Dispose();
 
-            _decreaseButton = e.NameScope.Find<Button>("PART_DecreaseButton");
-            _track = e.NameScope.Get<Track>("PART_Track");
-            _increaseButton = e.NameScope.Find<Button>("PART_IncreaseButton");
+            _track = e.NameScope.Find<Track>("PART_Track");
 
-            _track.IgnoreThumbDrag = true;
-
-            if (_decreaseButton != null)
+            if (_track != null)
             {
-                _decreaseButtonPressDispose = _decreaseButton.AddDisposableHandler(PointerPressedEvent, TrackPressed, RoutingStrategies.Tunnel);
-                _decreaseButtonReleaseDispose = _decreaseButton.AddDisposableHandler(PointerReleasedEvent, TrackReleased, RoutingStrategies.Tunnel);
-            }
+                _track.IgnoreThumbDrag = true;
 
-            if (_increaseButton != null)
-            {
-                _increaseButtonSubscription = _increaseButton.AddDisposableHandler(PointerPressedEvent, TrackPressed, RoutingStrategies.Tunnel);
-                _increaseButtonReleaseDispose = _increaseButton.AddDisposableHandler(PointerReleasedEvent, TrackReleased, RoutingStrategies.Tunnel);
+                _decreaseButton = e.NameScope.Find<Button>("PART_DecreaseButton");
+                _increaseButton = e.NameScope.Find<Button>("PART_IncreaseButton");
+
+                if (_decreaseButton != null)
+                {
+                    _decreaseButtonPressDispose = _decreaseButton.AddDisposableHandler(PointerPressedEvent, TrackPressed, RoutingStrategies.Tunnel);
+                    _decreaseButtonReleaseDispose = _decreaseButton.AddDisposableHandler(PointerReleasedEvent, TrackReleased, RoutingStrategies.Tunnel);
+                }
+
+                if (_increaseButton != null)
+                {
+                    _increaseButtonSubscription = _increaseButton.AddDisposableHandler(PointerPressedEvent, TrackPressed, RoutingStrategies.Tunnel);
+                    _increaseButtonReleaseDispose = _increaseButton.AddDisposableHandler(PointerReleasedEvent, TrackReleased, RoutingStrategies.Tunnel);
+                }
             }
 
             _pointerMovedDispose = this.AddDisposableHandler(PointerMovedEvent, TrackMoved, RoutingStrategies.Tunnel);


### PR DESCRIPTION
This part was made required in #14180, and this causes a build error in our product when using 11.1.0-beta1. This PR reverts the changes and also ensures that the `_track` field is not accessed when no track exists in the control template.

Our use case is that we have specialised slider controls, the templates of which do not contain tracks. One contains a nested slider (plus various other controls), and it is this nested slider which has a track and handles input. The other does not contain a track at all, and we handle all input ourselves.

There is also a workaround for this issue. Add the following XAML to the offending template:

``` xaml
<Track Name="PART_Track" IsVisible="False"/>
```

## What is the current behavior?
```
Avalonia error AVLN2205: Required template part with x:Name 'PART_Track' must be defined on 'SemiCircularSlider' ControlTemplate.
```

## Breaking changes
None

## Obsoletions / Deprecations
None