### PR TITLE
feat(LibInputBackend) Handle events only from specific input handler devices

### DIFF
--- a/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackend.Touch.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackend.Touch.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using Avalonia.Input;
+using Avalonia.Input.Raw;
+using static Avalonia.LinuxFramebuffer.Input.LibInput.LibInputNativeUnsafeMethods;
+
+namespace Avalonia.LinuxFramebuffer.Input.LibInput;
+
+public partial class LibInputBackend
+{
+    private readonly Dictionary<int, Point> _pointers = new();
+    private readonly TouchDevice _touch = new();
+
+    private void HandleTouch(IntPtr ev, LibInputEventType type)
+    {
+        var tev = libinput_event_get_touch_event(ev);
+        if (tev == IntPtr.Zero)
+            return;
+        if (type < LibInputEventType.LIBINPUT_EVENT_TOUCH_FRAME)
+        {
+            var info = _screen.ScaledSize;
+            var slot = libinput_event_touch_get_slot(tev);
+            Point pt;
+
+            if (type == LibInputEventType.LIBINPUT_EVENT_TOUCH_DOWN
+                || type == LibInputEventType.LIBINPUT_EVENT_TOUCH_MOTION)
+            {
+                var x = libinput_event_touch_get_x_transformed(tev, (int)info.Width);
+                var y = libinput_event_touch_get_y_transformed(tev, (int)info.Height);
+                pt = new Point(x, y);
+                _pointers[slot] = pt;
+            }
+            else
+            {
+                _pointers.TryGetValue(slot, out pt);
+                _pointers.Remove(slot);
+            }
+
+            var ts = libinput_event_touch_get_time_usec(tev) / 1000;
+            if (_inputRoot == null)
+                return;
+            ScheduleInput(new RawTouchEventArgs(_touch, ts,
+                _inputRoot,
+                type == LibInputEventType.LIBINPUT_EVENT_TOUCH_DOWN ? RawPointerEventType.TouchBegin
+                : type == LibInputEventType.LIBINPUT_EVENT_TOUCH_UP ? RawPointerEventType.TouchEnd
+                : type == LibInputEventType.LIBINPUT_EVENT_TOUCH_MOTION ? RawPointerEventType.TouchUpdate
+                : RawPointerEventType.TouchCancel,
+                pt, RawInputModifiers.None, slot));
+        }
+    }
+}

--- a/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackend.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackend.cs
@@ -68,7 +68,7 @@ namespace Avalonia.LinuxFramebuffer.Input.LibInput
             var options = new LibInputBackendOptions()
             {
                 LibInputContext = ctx,
-                Events = _options is null
+                Events = _options?.Events is null
                     ? Directory.GetFiles("/dev/input", "event*")
                     : _options.Events,
             };

--- a/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackend.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackend.cs
@@ -11,10 +11,8 @@ namespace Avalonia.LinuxFramebuffer.Input.LibInput
     {
         private IScreenInfoProvider _screen;
         private IInputRoot _inputRoot;
-        private TouchDevice _touch = new TouchDevice();
         private const string LibInput = nameof(Avalonia.LinuxFramebuffer) + "/" + nameof(Avalonia.LinuxFramebuffer.Input) + "/" + nameof(LibInput);
         private Action<RawInputEventArgs> _onInput;
-        private Dictionary<int, Point> _pointers = new Dictionary<int, Point>();
 
         public LibInputBackend()
         {
@@ -57,44 +55,6 @@ namespace Avalonia.LinuxFramebuffer.Input.LibInput
         }
 
         private void ScheduleInput(RawInputEventArgs ev) => _onInput.Invoke(ev);
-
-        private void HandleTouch(IntPtr ev, LibInputEventType type)
-        {
-            var tev = libinput_event_get_touch_event(ev);
-            if (tev == IntPtr.Zero)
-                return;
-            if (type < LibInputEventType.LIBINPUT_EVENT_TOUCH_FRAME)
-            {
-                var info = _screen.ScaledSize;
-                var slot = libinput_event_touch_get_slot(tev);
-                Point pt;
-
-                if (type == LibInputEventType.LIBINPUT_EVENT_TOUCH_DOWN
-                    || type == LibInputEventType.LIBINPUT_EVENT_TOUCH_MOTION)
-                {
-                    var x = libinput_event_touch_get_x_transformed(tev, (int)info.Width);
-                    var y = libinput_event_touch_get_y_transformed(tev, (int)info.Height);
-                    pt = new Point(x, y);
-                    _pointers[slot] = pt;
-                }
-                else
-                {
-                    _pointers.TryGetValue(slot, out pt);
-                    _pointers.Remove(slot);
-                }
-
-                var ts = libinput_event_touch_get_time_usec(tev) / 1000;
-                if (_inputRoot == null)
-                    return;
-                ScheduleInput(new RawTouchEventArgs(_touch, ts,
-                    _inputRoot,
-                    type == LibInputEventType.LIBINPUT_EVENT_TOUCH_DOWN ? RawPointerEventType.TouchBegin
-                    : type == LibInputEventType.LIBINPUT_EVENT_TOUCH_UP ? RawPointerEventType.TouchEnd
-                    : type == LibInputEventType.LIBINPUT_EVENT_TOUCH_MOTION ? RawPointerEventType.TouchUpdate
-                    : RawPointerEventType.TouchCancel,
-                    pt, RawInputModifiers.None, slot));
-            }
-        }
 
         public void Initialize(IScreenInfoProvider screen, Action<RawInputEventArgs> onInput)
         {

--- a/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackend.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackend.cs
@@ -25,7 +25,6 @@ namespace Avalonia.LinuxFramebuffer.Input.LibInput
             _options = options;
         }
 
-
         private unsafe void InputThread(object? state)
         {
             var options = (LibInputBackendOptions)state!;

--- a/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackendOptions.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackendOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿#nullable enable
 using System.Collections.Generic;
 
 namespace Avalonia.LinuxFramebuffer.Input.LibInput;
@@ -9,12 +9,7 @@ namespace Avalonia.LinuxFramebuffer.Input.LibInput;
 public sealed record class LibInputBackendOptions
 {
     /// <summary>
-    /// Used internally to pass libinput context to <see cref="LibInputBackend.InputThread(object?)"/>.
-    /// </summary>
-    internal IntPtr LibInputContext { get; init; }
-
-    /// <summary>
     /// List Events of events handler to monitoring eg: /dev/eventX.
     /// </summary>
-    public IReadOnlyList<string> Events { get; init; } = null;
+    public IReadOnlyList<string>? Events { get; init; } = null;
 }

--- a/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackendOptions.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackendOptions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Avalonia.LinuxFramebuffer.Input.LibInput;
+
+/// <summary>
+/// LibInputBackend Options.
+/// </summary>
+public sealed record class LibInputBackendOptions
+{
+    /// <summary>
+    /// Used internally to pass libinput context to <see cref="LibInputBackend.InputThread(object?)"/>.
+    /// </summary>
+    internal IntPtr LibInputContext { get; init; }
+
+    /// <summary>
+    /// List Events of events handler to monitoring eg: /dev/eventX.
+    /// </summary>
+    public IReadOnlyList<string> Events { get; init; } = Array.Empty<string>();
+}

--- a/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackendOptions.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackendOptions.cs
@@ -16,5 +16,5 @@ public sealed record class LibInputBackendOptions
     /// <summary>
     /// List Events of events handler to monitoring eg: /dev/eventX.
     /// </summary>
-    public IReadOnlyList<string> Events { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<string> Events { get; init; } = null;
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Handle events only from specific input handler devices

- Move HandleTouch from `LibInputBackend.cs` to `LibInputBackend.Tocuch.cs`
- Added LibInputBackendOptions
- Added LibInputBackend ctor overload that accepts LibInputBackendOptions
- Moved input thread initialization from ctor to the Initialize method

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

 Allways handle all `/dev/input/event*` events

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Closes #14996