### PR TITLE
[SKIA] Don't skip setting SKCanvas.TotalMatrix when we aren't sure what the current transform is due to Save/Restore calls

### DIFF
--- a/src/Skia/Avalonia.Skia/SkiaSharpExtensions.cs
+++ b/src/Skia/Avalonia.Skia/SkiaSharpExtensions.cs
@@ -124,6 +124,11 @@ namespace Avalonia.Skia
             return sm;
         }
 
+        internal static Matrix ToAvaloniaMatrix(this SKMatrix m) => new(
+            m.ScaleX, m.SkewY, m.Persp0,
+            m.SkewX, m.ScaleY, m.Persp1,
+            m.TransX, m.TransY, m.Persp2);
+
         public static SKColor ToSKColor(this Color c)
         {
             return new SKColor(c.R, c.G, c.B, c.A);


### PR DESCRIPTION
We are caching the last set transform in a field, but it's value could be no longer valid after SKCanvas.Restore call, since Skia pushes the entire state.

We have workarounds for that somewhere in the rendering code (don't remember where exactly, will remove once I see that line next time), but it's better to just fix it in the backend instead.