### PR TITLE
Implement check for inhertiance before calling method

### DIFF
--- a/src/Avalonia.Controls/NativeControlHost.cs
+++ b/src/Avalonia.Controls/NativeControlHost.cs
@@ -192,7 +192,10 @@ namespace Avalonia.Controls
 
         protected virtual void DestroyNativeControlCore(IPlatformHandle control)
         {
-            ((INativeControlHostDestroyableControlHandle)control).Destroy();
+            if (control is INativeControlHostDestroyableControlHandle nativeControlHostDestroyableControlHandle)
+            {
+                nativeControlHostDestroyableControlHandle.Destroy();
+            }
         }
         
     }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Based on this discussion: https://github.com/AvaloniaUI/Avalonia/discussions/15004#discussioncomment-8806279 implements a simple type check before casting to avoid exceptions.


## What is the current behavior?
Currently, the object is cast with reckless abandon, even though the object may not actually implement that interface (again - see discussion above).


## What is the updated/expected behavior with this PR?
Now, the code will check the type to see if the type cast is possible before casting.


## How was the solution implemented (if it's not obvious)?
Should be obvious :)


## Checklist

- [x] ~~Added unit tests (if possible)?~~ Not applicable
- [x] ~~Added XML documentation to any related classes?~~ Not applicable
- [x] ~~Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation~~ Not applicable

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Resolves discussion https://github.com/AvaloniaUI/Avalonia/discussions/15004
(kinda) fixes issue (in a separate repo) https://github.com/MicroSugarDeveloperOrg/Avalonia.WebView/issues/20
