### PR TITLE
Use ShowWindowCommand.Hide when positioning an unshown win32 window

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -618,6 +618,9 @@ namespace Avalonia.Win32
                             SizeCommand.Maximized => WindowState.Maximized,
                             SizeCommand.Minimized => WindowState.Minimized,
                             _ when _isFullScreenActive => WindowState.FullScreen,
+                            // Ignore state changes for unshown windows. We always tell Windows that we are hidden
+                            // until shown, so the OS value should be ignored while we are in the unshown state.
+                            _ when !_shown => _lastWindowState,
                             _ => WindowState.Normal,
                         };
 

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -607,7 +607,7 @@ namespace Avalonia.Win32
 
             windowPlacement.NormalPosition = requestedWindowRect;
 
-            windowPlacement.ShowCmd = _lastWindowState switch
+            windowPlacement.ShowCmd = !_shown ? ShowWindowCommand.Hide : _lastWindowState switch
             {
                 WindowState.Minimized => ShowWindowCommand.ShowMinNoActive,
                 WindowState.Maximized => ShowWindowCommand.ShowMaximized,


### PR DESCRIPTION
There is a race condition when these conditions are met:

1. `WindowStartupLocation="CenterScreen"`
2. `Width` and/or `Height` are defined
3. The window takes a long time to construct its visual tree

(`Thread.Sleep` can be called in `OnApplyTemplate` to artificially fulfil the third requirement.)

In this situation, the window can be seen opening in one location then later moving to another location. This seems to be happening because it isn't centred on the screen until measured? In any case, the PR fixes the issue by keeping the window hidden until it is shown.

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #15003
