### PR TITLE
Fix incorrect comment for CanVerticallyScroll

### DIFF
--- a/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
@@ -1,4 +1,4 @@
-using System;
+fusing System;
 using System.Diagnostics;
 using Avalonia.Threading;
 
@@ -66,7 +66,7 @@ namespace Avalonia.Input.GestureRecognizers
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the content can be scrolled horizontally.
+        /// Gets or sets a value indicating whether the content can be scrolled vertically.
         /// </summary>
         public bool CanVerticallyScroll
         {

--- a/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
@@ -1,4 +1,4 @@
-fusing System;
+using System;
 using System.Diagnostics;
 using Avalonia.Threading;
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes what I assume is a copy paste error in a comment in `ScrollGestureRecognizer` from the line above `CanVerticallyScroll`


## What is the current behavior?
The comment is incorrect


## What is the updated/expected behavior with this PR?
The comment now matches what the property name is

## How was the solution implemented (if it's not obvious)?


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None, it's just a comment.