### PR TITLE
iOS some pointer/keyboard fixes

### DIFF
--- a/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
@@ -94,8 +94,7 @@ namespace Avalonia.Input.GestureRecognizers
 
         protected override void PointerPressed(PointerPressedEventArgs e)
         {
-            if (e.Pointer.IsPrimary && 
-                (e.Pointer.Type == PointerType.Touch || e.Pointer.Type == PointerType.Pen))
+            if (e.Pointer.Type == PointerType.Touch || e.Pointer.Type == PointerType.Pen)
             {
                 EndGesture();
                 _tracking = e.Pointer;

--- a/src/Avalonia.Base/Input/PenDevice.cs
+++ b/src/Avalonia.Base/Input/PenDevice.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Avalonia.Input.GestureRecognizers;
 using Avalonia.Input.Raw;
 using Avalonia.Interactivity;
 using Avalonia.Metadata;
-using Avalonia.Platform;
 using Avalonia.VisualTree;
 
 #pragma warning disable CS0618
@@ -20,12 +18,18 @@ namespace Avalonia.Input
     public class PenDevice : IPenDevice, IDisposable
     {
         private readonly Dictionary<long, Pointer> _pointers = new();
+        private readonly bool _releasePointerOnPenUp;
         private int _clickCount;
         private Rect _lastClickRect;
         private ulong _lastClickTime;
         private MouseButton _lastMouseDownButton;
 
         private bool _disposed;
+
+        public PenDevice(bool releasePointerOnPenUp = false)
+        {
+            _releasePointerOnPenUp = releasePointerOnPenUp;
+        }
 
         public void ProcessRawEvent(RawInputEventArgs e)
         {
@@ -52,26 +56,35 @@ namespace Avalonia.Input
             var keyModifiers = e.InputModifiers.ToKeyModifiers();
 
             bool shouldReleasePointer = false;
-            switch (e.Type)
+            try
             {
-                case RawPointerEventType.LeaveWindow:
-                    shouldReleasePointer = true;
-                    break;
-                case RawPointerEventType.LeftButtonDown:
-                    e.Handled = PenDown(pointer, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult);
-                    break;
-                case RawPointerEventType.LeftButtonUp:
-                    e.Handled = PenUp(pointer, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult);
-                    break;
-                case RawPointerEventType.Move:
-                    e.Handled = PenMove(pointer, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult, e.IntermediatePoints);
-                    break;
+                switch (e.Type)
+                {
+                    case RawPointerEventType.LeaveWindow:
+                        shouldReleasePointer = true;
+                        break;
+                    case RawPointerEventType.LeftButtonDown:
+                        e.Handled = PenDown(pointer, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult);
+                        break;
+                    case RawPointerEventType.LeftButtonUp:
+                        if (_releasePointerOnPenUp)
+                        {
+                            shouldReleasePointer = true;
+                        }
+                        e.Handled = PenUp(pointer, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult);
+                        break;
+                    case RawPointerEventType.Move:
+                        e.Handled = PenMove(pointer, e.Timestamp, e.Root, e.Position, props, keyModifiers, e.InputHitTestResult, e.IntermediatePoints);
+                        break;
+                }
             }
-
-            if (shouldReleasePointer)
+            finally
             {
-                pointer.Dispose();
-                _pointers.Remove(e.RawPointerId);
+                if (shouldReleasePointer)
+                {
+                    pointer.Dispose();
+                    _pointers.Remove(e.RawPointerId);
+                }
             }
         }
 

--- a/src/iOS/Avalonia.iOS/InputHandler.cs
+++ b/src/iOS/Avalonia.iOS/InputHandler.cs
@@ -17,7 +17,7 @@ internal sealed class InputHandler
     private readonly ITopLevelImpl _tl;
     private readonly TouchDevice _touchDevice = new();
     private readonly MouseDevice _mouseDevice = new();
-    private readonly PenDevice _penDevice = new();
+    private readonly PenDevice _penDevice = new(releasePointerOnPenUp: true);
     private static long _nextTouchPointId = 1;
     private readonly Dictionary<UITouch, long> _knownTouches = new();
 
@@ -71,9 +71,10 @@ internal sealed class InputHandler
                     (_, UITouchPhase.Began) => IsRightClick()
                         ? RawPointerEventType.RightButtonDown
                         : RawPointerEventType.LeftButtonDown,
-                    (_, UITouchPhase.Ended or UITouchPhase.Cancelled) => IsRightClick()
+                    (_, UITouchPhase.Ended) => IsRightClick()
                         ? RawPointerEventType.RightButtonUp
                         : RawPointerEventType.LeftButtonUp,
+                    (_, UITouchPhase.Cancelled) => RawPointerEventType.LeaveWindow,
                     (_, _) => RawPointerEventType.Move,
                 }, ToPointerPoint(t), modifiers, id)
             {

--- a/src/iOS/Avalonia.iOS/InputHandler.cs
+++ b/src/iOS/Avalonia.iOS/InputHandler.cs
@@ -292,7 +292,8 @@ internal sealed class InputHandler
         [UIKeyboardHidUsage.Keyboard0] = PhysicalKey.Digit0,
         [UIKeyboardHidUsage.KeyboardReturnOrEnter] = PhysicalKey.Enter,
         [UIKeyboardHidUsage.KeyboardEscape] = PhysicalKey.Escape,
-        [UIKeyboardHidUsage.KeyboardDeleteOrBackspace] = PhysicalKey.Delete,
+        // See KeyboardDeleteForward for an actual Delete.
+        [UIKeyboardHidUsage.KeyboardDeleteOrBackspace] = PhysicalKey.Backspace,
         [UIKeyboardHidUsage.KeyboardTab] = PhysicalKey.Tab,
         [UIKeyboardHidUsage.KeyboardSpacebar] = PhysicalKey.Space,
         [UIKeyboardHidUsage.KeyboardHyphen] = PhysicalKey.NumPadSubtract,

--- a/src/iOS/Avalonia.iOS/InputHandler.cs
+++ b/src/iOS/Avalonia.iOS/InputHandler.cs
@@ -68,8 +68,12 @@ internal sealed class InputHandler
                     (TouchDevice, UITouchPhase.Cancelled) => RawPointerEventType.TouchCancel,
                     (TouchDevice, _) => RawPointerEventType.TouchUpdate,
                     
-                    (_, UITouchPhase.Began) => IsRightClick() ? RawPointerEventType.RightButtonDown : RawPointerEventType.LeftButtonDown,
-                    (_, UITouchPhase.Ended or UITouchPhase.Cancelled) => IsRightClick() ? RawPointerEventType.RightButtonUp : RawPointerEventType.RightButtonDown,
+                    (_, UITouchPhase.Began) => IsRightClick()
+                        ? RawPointerEventType.RightButtonDown
+                        : RawPointerEventType.LeftButtonDown,
+                    (_, UITouchPhase.Ended or UITouchPhase.Cancelled) => IsRightClick()
+                        ? RawPointerEventType.RightButtonUp
+                        : RawPointerEventType.LeftButtonUp,
                     (_, _) => RawPointerEventType.Move,
                 }, ToPointerPoint(t), modifiers, id)
             {


### PR DESCRIPTION
## What does the pull request do?

1. Delete/Backspace mapping was wrong
2. Pen-up state mapping was incorrectly mapped as right-click-down.
3. Fixes PenPointer.IsPrimary calculation for iOS (other backends should be double checked as well, since old behavior was made specifically for Windows, which is much more flexible with pen input)
4. Don't limit scroll gesture by only primary pointer

## Fixed issues

Fixes #15011
Fixes #14837 
Possibly #15019 