### PR TITLE
[Macos] Fixed range null and text Out of bounds

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -677,13 +677,24 @@
 
 - (NSAttributedString *)attributedSubstringForProposedRange:(NSRange)range actualRange:(NSRangePointer)actualRange
 {
-    if(actualRange){
-        range = *actualRange;
+    NSAttributedString* subString;
+    @try
+    {
+        if(actualRange){
+            range = *actualRange;
+        }
+        if(!range.location)
+        {
+            return subString;
+        }
+        subString = [_text attributedSubstringFromRange:range];
     }
-    
-    NSAttributedString* subString = [_text attributedSubstringFromRange:range];
-    
-    return subString;
+    @catch(NSException *exception)
+    {
+        NSLog( @"Name: %@", exception.name);
+        NSLog( @"Reason: %@", exception.reason );
+    }
+    return subString;       
 }
 
 - (void)insertText:(id)string replacementRange:(NSRange)replacementRange


### PR DESCRIPTION
I temporarily use try catch to get out of bounds because I'm not very good at programming in oc

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixed range null and text Out of bounds


## What is the current behavior?
Program crashes after entering Chinese characters


## What is the updated/expected behavior with this PR?
Will not crash after entering Chinese
But try catch Solving the out of bounds problem is not a good idea


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #14222
