### PR TITLE
Reduce allocations while loading deferred resources

### DIFF
--- a/src/Avalonia.Base/Controls/IDeferredContent.cs
+++ b/src/Avalonia.Base/Controls/IDeferredContent.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Avalonia.Controls;
+
+/// <summary>
+/// Represents a deferred content.
+/// </summary>
+public interface IDeferredContent
+{
+    /// <summary>
+    /// Builds the deferred content using the specified service provider.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider to use.</param>
+    /// <returns>The built content.</returns>
+    object? Build(IServiceProvider? serviceProvider);
+}

--- a/src/Avalonia.Base/Controls/ResourceDictionary.cs
+++ b/src/Avalonia.Base/Controls/ResourceDictionary.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Avalonia.Collections;
 using Avalonia.Controls.Templates;
-using Avalonia.Media;
 using Avalonia.Styling;
 
 namespace Avalonia.Controls
@@ -16,7 +13,7 @@ namespace Avalonia.Controls
     /// </summary>
     public class ResourceDictionary : ResourceProvider, IResourceDictionary, IThemeVariantProvider
     {
-        private object? lastDeferredItemKey;
+        private object? _lastDeferredItemKey;
         private Dictionary<object, object?>? _inner;
         private AvaloniaList<IResourceProvider>? _mergedDictionaries;
         private AvaloniaDictionary<ThemeVariant, IThemeVariantProvider>? _themeDictionary;
@@ -145,10 +142,10 @@ namespace Avalonia.Controls
         }
 
         public void AddDeferred(object key, Func<IServiceProvider?, object?> factory)
-        {
-            Inner.Add(key, new DeferredItem(factory));
-            Owner?.NotifyHostedResourcesChanged(ResourcesChangedEventArgs.Empty);
-        }
+            => Add(key, new DeferredItem(factory));
+
+        public void AddDeferred(object key, IDeferredContent deferredContent)
+            => Add(key, deferredContent);
 
         public void Clear()
         {
@@ -227,10 +224,10 @@ namespace Avalonia.Controls
         {
             if (_inner is not null && _inner.TryGetValue(key, out value))
             {
-                if (value is DeferredItem deffered)
+                if (value is IDeferredContent deferred)
                 {
                     // Avoid simple reentrancy, which could commonly occur on redefining the resource.
-                    if (lastDeferredItemKey == key)
+                    if (_lastDeferredItemKey == key)
                     {
                         value = null;
                         return false;
@@ -238,8 +235,8 @@ namespace Avalonia.Controls
 
                     try
                     {
-                        lastDeferredItemKey = key;
-                        _inner[key] = value = deffered.Factory(null) switch
+                        _lastDeferredItemKey = key;
+                        _inner[key] = value = deferred.Build(null) switch
                         {
                             ITemplateResult t => t.Result,
                             { } v => v,
@@ -248,7 +245,7 @@ namespace Avalonia.Controls
                     }
                     finally
                     {
-                        lastDeferredItemKey = null;
+                        _lastDeferredItemKey = null;
                     }
                 }
                 return true;
@@ -313,7 +310,7 @@ namespace Avalonia.Controls
         {
             if (_inner is not null && _inner.TryGetValue(key, out var result))
             {
-                return result is DeferredItem;
+                return result is IDeferredContent;
             }
 
             return false;
@@ -373,10 +370,11 @@ namespace Avalonia.Controls
             }
         }
 
-        private class DeferredItem
+        private sealed class DeferredItem : IDeferredContent
         {
-            public DeferredItem(Func<IServiceProvider?, object?> factory) => Factory = factory;
-            public Func<IServiceProvider?, object?> Factory { get; }
+            private readonly Func<IServiceProvider?,object?> _factory;
+            public DeferredItem(Func<IServiceProvider?, object?> factory) => _factory = factory;
+            public object? Build(IServiceProvider? serviceProvider) => _factory(serviceProvider);
         }
     }
 }

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguage.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguage.cs
@@ -58,7 +58,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                     "TemplateResultType"
                 },
                 DeferredContentExecutorCustomization =
-                    runtimeHelpers.FindMethod(m => m.Name == "DeferredTransformationFactoryV2"),
+                    runtimeHelpers.FindMethod(m => m.Name == "DeferredTransformationFactoryV3"),
                 UsableDuringInitializationAttributes =
                 {
                     typeSystem.GetType("Avalonia.Metadata.UsableDuringInitializationAttribute"),

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguage.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguage.cs
@@ -1,13 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Linq;
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.AstNodes;
 using Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers;
-using Avalonia.Media;
-using XamlX;
 using XamlX.Ast;
 using XamlX.Emit;
 using XamlX.IL;
@@ -79,18 +73,22 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             var emit = new XamlLanguageEmitMappings<IXamlILEmitter, XamlILNodeEmitResult>
             {
                 ProvideValueTargetPropertyEmitter = XamlIlAvaloniaPropertyHelper.EmitProvideValueTarget,
-                ContextTypeBuilderCallback = definition => EmitNameScopeField(rv, typeSystem, definition)
+                ContextTypeBuilderCallback = definition =>
+                {
+                    EmitNameScopeField(rv, typeSystem, definition);
+                    EmitEagerParentStackProvider(rv, typeSystem, definition);
+                }
             };
             return (rv, emit);
         }
 
         public const string ContextNameScopeFieldName = "AvaloniaNameScope";
 
-        private static void EmitNameScopeField(XamlLanguageTypeMappings mappings,
+        private static void EmitNameScopeField(
+            XamlLanguageTypeMappings mappings,
             IXamlTypeSystem typeSystem,
             IXamlILContextDefinition<IXamlILEmitter> definition)
         {
-
             var nameScopeType = typeSystem.FindType("Avalonia.Controls.INameScope");
             var field = definition.TypeBuilder.DefineField(nameScopeType,
                 ContextNameScopeFieldName, XamlVisibility.Public, false);
@@ -102,7 +100,56 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                     typeSystem.FindType("System.Object"), typeSystem.FindType("System.Type"))))
                 .Stfld(field);
         }
-        
+
+        private static void EmitEagerParentStackProvider(
+            XamlLanguageTypeMappings mappings,
+            IXamlTypeSystem typeSystem,
+            IXamlILContextDefinition<IXamlILEmitter> definition)
+        {
+            var interfaceType = typeSystem.FindType("Avalonia.Markup.Xaml.XamlIl.Runtime.IAvaloniaXamlIlEagerParentStackProvider");
+
+            definition.TypeBuilder.AddInterfaceImplementation(interfaceType);
+
+            // IReadOnlyList<object> DirectParents => (IReadOnlyList<object>)ParentsStack;
+            var directParentsGetter = ImplementInterfacePropertyGetter("DirectParents");
+            directParentsGetter.Generator
+                .LdThisFld(definition.ParentListField)
+                .Castclass(directParentsGetter.ReturnType)
+                .Ret();
+
+            var serviceProviderGetServiceMethod = mappings.ServiceProvider.GetMethod(new FindMethodMethodSignature(
+                "GetService",
+                typeSystem.FindType("System.Object"),
+                typeSystem.FindType("System.Type")));
+
+            // IAvaloniaXamlIlEagerParentStackProvider? ParentProvider
+            // => (IAvaloniaXamlIlEagerParentStackProvider)_serviceProvider.GetService(typeof(IAvaloniaXamlIlParentStackProvider))
+            var parentProviderGetter = ImplementInterfacePropertyGetter("ParentProvider");
+            parentProviderGetter.Generator
+                .LdThisFld(definition.ParentServiceProviderField)
+                .Ldtype(mappings.ParentStackProvider)
+                .EmitCall(serviceProviderGetServiceMethod)
+                .Castclass(interfaceType)
+                .Ret();
+
+            IXamlMethodBuilder<IXamlILEmitter> ImplementInterfacePropertyGetter(string propertyName)
+            {
+                var interfaceGetter = interfaceType.FindMethod(m => m.Name == "get_" + propertyName);
+
+                var getter = definition.TypeBuilder.DefineMethod(
+                    interfaceGetter.ReturnType,
+                    Array.Empty<IXamlType>(),
+                    "get_" + propertyName,
+                    XamlVisibility.Private,
+                    false,
+                    true,
+                    interfaceGetter);
+
+                definition.TypeBuilder.DefineProperty(interfaceGetter.ReturnType, propertyName, null, getter);
+
+                return getter;
+            }
+        }
 
         class AttributeResolver : IXamlCustomAttributeResolver
         {

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -261,9 +261,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             IResourceDictionary = cfg.TypeSystem.GetType("Avalonia.Controls.IResourceDictionary");
             ResourceDictionary = cfg.TypeSystem.GetType("Avalonia.Controls.ResourceDictionary");
             ResourceDictionaryDeferredAdd = ResourceDictionary.FindMethod("AddDeferred", XamlIlTypes.Void, true, XamlIlTypes.Object,
-                cfg.TypeSystem.GetType("System.Func`2").MakeGenericType(
-                    cfg.TypeSystem.GetType("System.IServiceProvider"),
-                    XamlIlTypes.Object));
+                cfg.TypeSystem.GetType("Avalonia.Controls.IDeferredContent"));
             ResourceDictionaryEnsureCapacity = ResourceDictionary.FindMethod("EnsureCapacity", XamlIlTypes.Void, true, XamlIlTypes.Int32);
             ResourceDictionaryGetCount = ResourceDictionary.FindMethod("get_Count", XamlIlTypes.Int32, true);
             IThemeVariantProvider = cfg.TypeSystem.GetType("Avalonia.Controls.IThemeVariantProvider");

--- a/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
+++ b/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
@@ -15,6 +15,7 @@
     <Compile Include="Converters\FontFamilyTypeConverter.cs" />
     <Compile Include="Converters\TimeSpanTypeConverter.cs" />
     <Compile Include="Data\DynamicResourceExpression.cs" />
+    <Compile Include="EagerParentStackEnumerator.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="MarkupExtension.cs" />
     <Compile Include="MarkupExtensions\CompiledBindingExtension.cs" />

--- a/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
+++ b/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
@@ -7,6 +7,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <EnableDefaultItems>false</EnableDefaultItems>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AvaloniaXamlLoader.cs" />

--- a/src/Markup/Avalonia.Markup.Xaml/EagerParentStackEnumerator.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/EagerParentStackEnumerator.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using Avalonia.Markup.Xaml.XamlIl.Runtime;
+
+namespace Avalonia.Markup.Xaml;
+
+internal struct EagerParentStackEnumerator
+{
+    private IAvaloniaXamlIlEagerParentStackProvider? _provider;
+    private IReadOnlyList<object>? _currentParents;
+    private int _currentIndex; // only valid when _currentParents isn't null
+
+    public EagerParentStackEnumerator(IAvaloniaXamlIlEagerParentStackProvider? provider)
+        => _provider = provider;
+
+    public object? TryGetNext()
+    {
+        while (_provider is not null)
+        {
+            if (_currentParents is null)
+            {
+                _currentParents = _provider.DirectParents;
+                _currentIndex = _currentParents.Count;
+            }
+
+            --_currentIndex;
+
+            if (_currentIndex >= 0)
+                return _currentParents[_currentIndex];
+
+            _currentParents = null;
+            _provider = _provider.ParentProvider;
+        }
+
+        return null;
+    }
+
+    public T? TryGetNextOfType<T>() where T : class
+    {
+        while (TryGetNext() is { } parent)
+        {
+            if (parent is T typedParent)
+                return typedParent;
+        }
+
+        return null;
+    }
+}

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/DynamicResourceExtension.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/DynamicResourceExtension.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Data.Core;
+using Avalonia.Markup.Xaml.XamlIl.Runtime;
 using Avalonia.Styling;
 
 namespace Avalonia.Markup.Xaml.MarkupExtensions
@@ -37,7 +38,8 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
                     (object?)serviceProvider.GetFirstParent<IResourceHost>();
             }
 
-            _themeVariant = StaticResourceExtension.GetDictionaryVariant(serviceProvider);
+            _themeVariant = StaticResourceExtension.GetDictionaryVariant(
+                serviceProvider.GetService<IAvaloniaXamlIlParentStackProvider>());
 
             return this;
         }

--- a/src/Markup/Avalonia.Markup.Xaml/Templates/TemplateContent.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/Templates/TemplateContent.cs
@@ -7,29 +7,15 @@ namespace Avalonia.Markup.Xaml.Templates
     public static class TemplateContent
     {
         public static TemplateResult<Control>? Load(object? templateContent)
-        {
-            if (templateContent is Func<IServiceProvider?, object?> direct)
-            {
-                return (TemplateResult<Control>?)direct(null);
-            }
-
-            if (templateContent is null)
-            {
-                return null;
-            }
-
-            throw new ArgumentException($"Unexpected content {templateContent.GetType()}", nameof(templateContent));
-        }
+            => Load<Control>(templateContent);
 
         public static TemplateResult<T>? Load<T>(object? templateContent)
-        {
-            if (templateContent is Func<IServiceProvider?, object?> direct)
-                return (TemplateResult<T>?)direct(null);
-
-            if (templateContent is null)
-                return null;
-
-            throw new ArgumentException($"Unexpected content {templateContent.GetType()}", nameof(templateContent));
-        }
+            => templateContent switch
+            {
+                IDeferredContent deferred => (TemplateResult<T>?)deferred.Build(null),
+                Func<IServiceProvider?, object?> deferred => (TemplateResult<T>?)deferred(null),
+                null => null,
+                _ => throw new ArgumentException($"Unexpected content {templateContent.GetType()}", nameof(templateContent))
+            };
     }
 }

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/Runtime/IAvaloniaXamlIlParentStackProvider.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/Runtime/IAvaloniaXamlIlParentStackProvider.cs
@@ -6,4 +6,11 @@ namespace Avalonia.Markup.Xaml.XamlIl.Runtime
     {
         IEnumerable<object> Parents { get; }
     }
+
+    public interface IAvaloniaXamlIlEagerParentStackProvider : IAvaloniaXamlIlParentStackProvider
+    {
+        IReadOnlyList<object> DirectParents { get; }
+
+        IAvaloniaXamlIlEagerParentStackProvider? ParentProvider { get; }
+    }
 }

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/Runtime/XamlIlRuntimeHelpers.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/Runtime/XamlIlRuntimeHelpers.cs
@@ -37,15 +37,18 @@ namespace Avalonia.Markup.Xaml.XamlIl.Runtime
             return new DelegateDeferredContent<T>(resourceNodes, rootObject, parentScope, builder).Build;
         }
 
+        // The builder is typed as IntPtr instead of delegate*<IServiceProvider, object> because Reflection.Emit has
+        // trouble with generic methods containing function pointers. See https://github.com/dotnet/runtime/issues/100020
         public static unsafe IDeferredContent DeferredTransformationFactoryV3<T>(
-            delegate*<IServiceProvider, object> builder,
+            /*delegate*<IServiceProvider, object>*/ IntPtr builder,
             IServiceProvider provider)
         {
             var resourceNodes = AsResourceNodes(provider.GetRequiredService<IAvaloniaXamlIlParentStackProvider>());
             var rootObject = provider.GetRequiredService<IRootObjectProvider>().RootObject;
             var parentScope = provider.GetService<INameScope>();
+            var typedBuilder = (delegate*<IServiceProvider, object>)builder;
 
-            return new PointerDeferredContent<T>(resourceNodes, rootObject, parentScope, builder);
+            return new PointerDeferredContent<T>(resourceNodes, rootObject, parentScope, typedBuilder);
         }
 
         private static IResourceNode[] AsResourceNodes(IAvaloniaXamlIlParentStackProvider provider)

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleIncludeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleIncludeTests.cs
@@ -326,7 +326,10 @@ public class StyleIncludeTests
     }
 }
 
-public class TestServiceProvider : IServiceProvider, IUriContext, IAvaloniaXamlIlParentStackProvider
+public class TestServiceProvider :
+    IServiceProvider,
+    IUriContext,
+    IAvaloniaXamlIlEagerParentStackProvider
 {
     private IServiceProvider _root = XamlIlRuntimeHelpers.CreateRootServiceProviderV2();
     public object GetService(Type serviceType)
@@ -345,4 +348,6 @@ public class TestServiceProvider : IServiceProvider, IUriContext, IAvaloniaXamlI
     public Uri BaseUri { get; set; }
     public List<object> Parents { get; set; } = new List<object> { new ContentControl() };
     IEnumerable<object> IAvaloniaXamlIlParentStackProvider.Parents => Parents;
+    public IReadOnlyList<object> DirectParents => Parents;
+    public IAvaloniaXamlIlEagerParentStackProvider ParentProvider => null;
 }


### PR DESCRIPTION
## What does the pull request do?
This PR aims to remove most unnecessary allocations related to deferred content inside resources dictionaries.
While loading the Fluent theme, there's a bit less than 1450 deferred items created, and that's normal.
However, they come with several allocations, both very short lived ones, and some longer ones, stored.

This PR removes more than 15000 allocations while loading the FluentTheme, half of which were long lived.

Resuls to load the `FluentTheme`:

| Method               | Mean     | Error     | StdDev    | Gen0    | Gen1    | Allocated |
|----------------------|---------:|----------:|----------:|--------:|--------:|----------:|
| FluentTheme (Before) | 1.670 ms | 0.0192 ms | 0.0160 ms | 66.4063 | 64.4531 |   1.07 MB |
| FluentTheme (After)  | 633.4 us | 12.60 us  | 6.59 us   | 13.6719 | 12.6953 | 228.17 KB |

Note that it's still the JIT that takes most of the time when starting up the application (use NativeAOT when you can!), but I'll still take those gains :)

As part of this PR, `StaticResourceExtension.ProvideValue()` was also improved (not that it was slow to begin with):

| Method                  | Mean     | Error   | StdDev  | Gen0   | Allocated |
|------------------------ |---------:|--------:|--------:|-------:|----------:|
| StaticResource (Before) | 238.5 ns | 1.45 ns | 1.35 ns | 0.0153 |     256 B |
| StaticResource (After)  | 160.6 ns | 1.50 ns | 1.33 ns |      - |         - |


## How was the solution implemented (if it's not obvious)?
 
All numbers below are for loading the Fluent theme.
 
### Buffer resource nodes

In `XamlIlRuntimeHelpers`, a reusable buffer is now used to store the parent resources nodes and get an array out of that, without using Linq. The array is stored instead of the list.

Removes ≈4350 allocations:
 - 1450 `List<IResourceNode>` (long lived)
 - 1450 `OfType<IResourceNode>` enumerator (short lived)
 - 1450 `IResourceNode[]` backing array from `List` having to grow (short lived)
 
Extra enumerator allocations happening when the deferred resource will be built have also been removed.
 
### Cache default parents

`DefaultAvaloniaXamlIlParentStackProvider` now caches its parent as an array, since it's only the `Application.Current` instance, which is very unlikely to change between two calls.

Removes ≈1450 allocations:
 - 1450 `Parents` enumerator (short lived)
 
### List parents without allocating

A specialized version of `IAvaloniaXamlIlParentStackProvider` is introduced `IAvaloniaXamlIlEagerParentStackProvider`: it can iterate the parents without any allocation. This interface is implemented by the runtime XAML context.

Removes ≈3500 allocations:
 - 3500 `ParentStackEnumerable.Enumerator` (short lived)
 
As a bonus, using this interface makes `StaticResource.ProvideValue()` allocation-free.

### Avoid delegate allocations

`XamlIlRuntimeHelpers.DeferredTransformationFactoryV3` now returns an `IDeferredContent` instead of a `Func<IServiceProvider, object>`.
The returned closure directly implements this interface, so we can get rid of the delegate.
`ResourceDictionary` is now aware of `IDeferredContent` and can store it directly.

The XAML compiler now passes a function pointer to `DeferredTransformationFactoryV3` to build its content instead of creating a delegate.

Removes ≈4350 allocations:
 - 2900 `Func<IServiceProvider, object>` (long lived)
 - 1450 `DeferredItem` inside the resource dictionary (long lived)

### Reuse parent nodes

`DeferredTransformationFactoryV3` reuses the parent resource nodes if they're the same as the last time it was called. This method is often called with the same parents (e.g. all items in the same resource dictionary), so this change provides nice gains. Out of 1450 items in the fluent theme, there are only 20 different lists of parents.

Removes ≈1430 allocations:
 - 1430 `IResourceNode[]` (long lived)
 
### Set resource dictionary capacity

`ResourceDictionary.EnsureCapacity()` is called.
This is https://github.com/AvaloniaUI/Avalonia/pull/15069 which is the only one I could really make separate (all other modifications are intertwined), but that I measured as part of this PR.

Removes ≈30 allocations, but larger ones:
 - 30 `Dictionary+Entry[]` (short lived)

## Notes

`ResourceDictionary.AddDeferred(IDeferredContent)` and `Add(IDeferredContent)` are equivalent. I didn't bother with disallowing one or the other, but this might be worth mentioning.

## Dependencies

This PR is complete, but is marked as a draft because it contains merges from several other PR:
 - https://github.com/kekekeks/XamlX/pull/107
 - https://github.com/kekekeks/XamlX/pull/108
 - https://github.com/AvaloniaUI/Avalonia/pull/15069

When these get merged, I will rebase this PR to have a clean diff.





