### PR TITLE
Button memory leaks fixes

### DIFF
--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -94,7 +94,6 @@ namespace Avalonia.Controls
         private bool _commandCanExecute = true;
         private KeyGesture? _hotkey;
         private bool _isFlyoutOpen = false;
-        private bool _isPressed = false;
 
         /// <summary>
         /// Initializes static members of the <see cref="Button"/> class.
@@ -182,8 +181,8 @@ namespace Avalonia.Controls
         /// </summary>
         public bool IsPressed
         {
-            get => _isPressed;
-            private set => SetAndRaise(IsPressedProperty, ref _isPressed, value);
+            get; 
+            private set;
         }
 
         /// <summary>
@@ -197,6 +196,11 @@ namespace Avalonia.Controls
 
         /// <inheritdoc/>
         protected override bool IsEnabledCore => base.IsEnabledCore && _commandCanExecute;
+
+        private void OnIsPressedChanged(bool oldIsPressed, bool newIsPressed)
+        {
+            RaisePropertyChanged(IsPressedProperty, oldIsPressed, newIsPressed);
+        }
 
         /// <inheritdoc/>
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -299,6 +303,7 @@ namespace Avalonia.Controls
                         }
 
                         IsPressed = true;
+                        OnIsPressedChanged(false, true);
                         e.Handled = true;
                         break;
                     }
@@ -322,6 +327,7 @@ namespace Avalonia.Controls
                     OnClick();
                 }
                 IsPressed = false;
+                OnIsPressedChanged(true, false);
                 e.Handled = true;
             }
 
@@ -395,6 +401,7 @@ namespace Avalonia.Controls
             if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
                 IsPressed = true;
+                OnIsPressedChanged(false, true);
                 e.Handled = true;
 
                 if (ClickMode == ClickMode.Press)
@@ -412,6 +419,7 @@ namespace Avalonia.Controls
             if (IsPressed && e.InitialPressMouseButton == MouseButton.Left)
             {
                 IsPressed = false;
+                OnIsPressedChanged(false, true);
                 e.Handled = true;
 
                 if (ClickMode == ClickMode.Release &&
@@ -428,6 +436,7 @@ namespace Avalonia.Controls
             base.OnPointerCaptureLost(e);
 
             IsPressed = false;
+            OnIsPressedChanged(true, false);
         }
 
         /// <inheritdoc/>
@@ -436,6 +445,7 @@ namespace Avalonia.Controls
             base.OnLostFocus(e);
 
             IsPressed = false;
+            OnIsPressedChanged(true, false);
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -294,7 +294,7 @@ namespace Avalonia.Controls
                             OnClick();
                         }
 
-                        IsPressed = true;
+                        SetCurrentValue(IsPressedProperty, true);
                         e.Handled = true;
                         break;
                     }
@@ -317,7 +317,7 @@ namespace Avalonia.Controls
                 {
                     OnClick();
                 }
-                IsPressed = false;
+                SetCurrentValue(IsPressedProperty, false);
                 e.Handled = true;
             }
 
@@ -390,7 +390,7 @@ namespace Avalonia.Controls
 
             if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
-                IsPressed = true;
+                SetCurrentValue(IsPressedProperty, true);
                 e.Handled = true;
 
                 if (ClickMode == ClickMode.Press)
@@ -407,7 +407,7 @@ namespace Avalonia.Controls
 
             if (IsPressed && e.InitialPressMouseButton == MouseButton.Left)
             {
-                IsPressed = false;
+                SetCurrentValue(IsPressedProperty, false);
                 e.Handled = true;
 
                 if (ClickMode == ClickMode.Release &&
@@ -423,7 +423,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerCaptureLost(e);
 
-            IsPressed = false;
+            SetCurrentValue(IsPressedProperty, false);
         }
 
         /// <inheritdoc/>
@@ -431,7 +431,7 @@ namespace Avalonia.Controls
         {
             base.OnLostFocus(e);
 
-            IsPressed = false;
+            SetCurrentValue(IsPressedProperty, false);
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -298,7 +298,7 @@ namespace Avalonia.Controls
                             OnClick();
                         }
 
-                        SetCurrentValue(IsPressedProperty, true);
+                        IsPressed = true;
                         e.Handled = true;
                         break;
                     }
@@ -321,7 +321,7 @@ namespace Avalonia.Controls
                 {
                     OnClick();
                 }
-                SetCurrentValue(IsPressedProperty, false);
+                IsPressed = false;
                 e.Handled = true;
             }
 
@@ -394,7 +394,7 @@ namespace Avalonia.Controls
 
             if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
-                SetCurrentValue(IsPressedProperty, true);
+                IsPressed = true;
                 e.Handled = true;
 
                 if (ClickMode == ClickMode.Press)
@@ -411,7 +411,7 @@ namespace Avalonia.Controls
 
             if (IsPressed && e.InitialPressMouseButton == MouseButton.Left)
             {
-                SetCurrentValue(IsPressedProperty, false);
+                IsPressed = false;
                 e.Handled = true;
 
                 if (ClickMode == ClickMode.Release &&
@@ -427,7 +427,7 @@ namespace Avalonia.Controls
         {
             base.OnPointerCaptureLost(e);
 
-            SetCurrentValue(IsPressedProperty, false);
+            IsPressed = false;
         }
 
         /// <inheritdoc/>
@@ -435,7 +435,7 @@ namespace Avalonia.Controls
         {
             base.OnLostFocus(e);
 
-            SetCurrentValue(IsPressedProperty, false);
+            IsPressed = false;
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -255,6 +255,8 @@ namespace Avalonia.Controls
                 Command.CanExecuteChanged += CanExecuteChanged;
                 CanExecuteChanged(this, EventArgs.Empty);
             }
+
+            RegisterFlyoutEvents(Flyout);
         }
 
         /// <inheritdoc/>
@@ -273,6 +275,8 @@ namespace Avalonia.Controls
             {
                 Command.CanExecuteChanged -= CanExecuteChanged;
             }
+ 
+            UnregisterFlyoutEvents(Flyout);
         }
 
         protected virtual void OnAccessKey(RoutedEventArgs e) => OnClick();
@@ -439,8 +443,6 @@ namespace Avalonia.Controls
         {
             base.OnApplyTemplate(e);
 
-            UnregisterFlyoutEvents(Flyout);
-            RegisterFlyoutEvents(Flyout);
             UpdatePseudoClasses();
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Trying to fix memory leaks in Button resulting from not unsubscribed event handlers for Flyout and value store holding references from IsPressed property changes.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Button causes memory leaks when clicked.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

No memory leaks.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

Changed how Flyout event are subscibed/unsuibscibed. Change how IsPressed property is handled.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
