### PR TITLE
feat: Allow to initialize `DrmCard` from existing file descriptor.

### DIFF
--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
@@ -170,6 +170,11 @@ namespace Avalonia.LinuxFramebuffer.Output
             }
         }
 
+        public DrmCard(int fd)
+        {
+            Fd = fd;
+        }
+
         public DrmResources GetResources(bool connectorsForceProbe = false) => new DrmResources(Fd, connectorsForceProbe);
         public void Dispose()
         {

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
@@ -7,10 +7,8 @@ using Avalonia.OpenGL;
 using Avalonia.OpenGL.Egl;
 using Avalonia.OpenGL.Surfaces;
 using Avalonia.Platform;
-using Avalonia.Platform.Interop;
 using static Avalonia.LinuxFramebuffer.NativeUnsafeMethods;
 using static Avalonia.LinuxFramebuffer.Output.LibDrm;
-using static Avalonia.LinuxFramebuffer.Output.LibDrm.GbmColorFormats;
 
 namespace Avalonia.LinuxFramebuffer.Output
 {
@@ -51,11 +49,14 @@ namespace Avalonia.LinuxFramebuffer.Output
         }
 
         public DrmOutput(string path = null, bool connectorsForceProbe = false, DrmOutputOptions options = null)
+            :this(new DrmCard(path), connectorsForceProbe, options)
+        {
+        }
+
+        public DrmOutput(DrmCard card, bool connectorsForceProbe = false, DrmOutputOptions options = null)
         {
             if (options != null)
                 _outputOptions = options;
-
-            var card = new DrmCard(path);
 
             var resources = card.GetResources(connectorsForceProbe);
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Added a constructor to `DrmCard` that takes the existing card file descriptor, it allows for scenarios like #14881 in Avalonia.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

`DrmCard` constructor accept only card path.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
