### PR TITLE
Invalidate brush when transform changed event is fired

### DIFF
--- a/src/Avalonia.Base/Media/Brush.cs
+++ b/src/Avalonia.Base/Media/Brush.cs
@@ -90,14 +90,26 @@ namespace Avalonia.Media
         
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
-            if (change.Property == TransformProperty) 
+            if (change.Property == TransformProperty)
+            {
+                var (oldValue, newValue) = change.GetOldAndNewValue<ITransform>();
+
+                if (oldValue is IMutableTransform oldMutableValue)
+                    oldMutableValue.Changed -= OnTransformChanged;
+                
+                if (newValue is IMutableTransform newMutableValue)
+                    newMutableValue.Changed += OnTransformChanged;
                 _resource.ProcessPropertyChangeNotification(change);
+            }
 
             RegisterForSerialization();
             
             base.OnPropertyChanged(change);
         }
-        
+
+        private void OnTransformChanged(object? sender, EventArgs e) 
+            => RegisterForSerialization();
+
         private protected void RegisterForSerialization() =>
             _resource.RegisterForInvalidationOnAllCompositors(this);
 


### PR DESCRIPTION
## What does the pull request do?
Brushes will be invalidated when their bound Transforms fire a Changed event.

## What is the current behavior?
Brushes are not invalidated when their bound Transform is changed (not the property, but the inner matrix).


## What is the updated/expected behavior with this PR?
Changes to bound transform will cause the brush to invalidate and redraw.


## How was the solution implemented (if it's not obvious)?



## Checklist

- [ ] Added unit tests (if possible)? **how can I unit test it?**
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
n/a

## Obsoletions / Deprecations
n/a

## Fixed issues
Fixes #15097
