### PR TITLE
Fix for browser pointer capture not released when pointer up outside of browser

### DIFF
--- a/src/Browser/Avalonia.Browser/BrowserMouseDevice.cs
+++ b/src/Browser/Avalonia.Browser/BrowserMouseDevice.cs
@@ -1,0 +1,36 @@
+using System.Runtime.InteropServices.JavaScript;
+using Avalonia.Input;
+using Avalonia.Browser.Interop;
+
+namespace Avalonia.Browser
+{
+    internal class BrowserMouseDevice : MouseDevice
+    {
+        internal long PointerId { get; }
+
+        public BrowserMouseDevice(long pointerId, JSObject container) : base( new BrowserMousePointer(pointerId, container))
+        {
+            PointerId = pointerId;
+        }
+
+        internal class BrowserMousePointer : Pointer
+        {
+            private readonly JSObject _container;
+            private readonly long _pointerId;
+
+            internal BrowserMousePointer(long pointerId, JSObject container) : base(GetNextFreeId(),PointerType.Mouse, true)
+            {
+                _pointerId = pointerId;
+                _container = container;
+            }
+            
+            protected override void PlatformCapture(IInputElement? element)
+            {
+                if (element is { })
+                    InputHelper.SetPointerCapture(_container, _pointerId);
+                else
+                    InputHelper.ReleasePointerCapture(_container, _pointerId);
+            }
+        }
+    }
+}

--- a/src/Browser/Avalonia.Browser/Interop/InputHelper.cs
+++ b/src/Browser/Avalonia.Browser/Interop/InputHelper.cs
@@ -92,6 +92,12 @@ internal static partial class InputHelper
     [JSImport("InputHelper.readClipboardText", AvaloniaModule.MainModuleName)]
     public static partial Task<string> ReadClipboardTextAsync();
 
+    [JSImport("InputHelper.setPointerCapture", AvaloniaModule.MainModuleName)]
+    public static partial void SetPointerCapture(JSObject containerElement, [JSMarshalAs<JSType.Number>] long pointerId);
+
+    [JSImport("InputHelper.releasePointerCapture", AvaloniaModule.MainModuleName)]
+    public static partial void ReleasePointerCapture(JSObject containerElement, [JSMarshalAs<JSType.Number>] long pointerId);
+
     [JSImport("globalThis.navigator.clipboard.writeText")]
     public static partial Task WriteClipboardTextAsync(string text);
 }

--- a/src/Browser/Avalonia.Browser/webapp/modules/avalonia/input.ts
+++ b/src/Browser/Avalonia.Browser/webapp/modules/avalonia/input.ts
@@ -171,13 +171,11 @@ export class InputHelper {
         const pointerDownHandler = (args: PointerEvent) => {
             pointerDownCallback(args);
             args.preventDefault();
-            element.setPointerCapture(args.pointerId);
         };
 
         const pointerUpHandler = (args: PointerEvent) => {
             pointerUpCallback(args);
             args.preventDefault();
-            element.releasePointerCapture(args.pointerId);
         };
 
         const pointerCancelHandler = (args: PointerEvent) => {
@@ -327,5 +325,15 @@ export class InputHelper {
         if (args.metaKey) { modifiers |= RawInputModifiers.Meta; }
 
         return modifiers;
+    }
+
+    public static setPointerCapture(containerElement: HTMLInputElement, pointerId: number): void {
+        containerElement.setPointerCapture(pointerId);
+    }
+
+    public static releasePointerCapture(containerElement: HTMLInputElement, pointerId: number): void {
+        if (containerElement.hasPointerCapture(pointerId)) {
+            containerElement.releasePointerCapture(pointerId);
+        }
     }
 }

--- a/src/Browser/Avalonia.Browser/webapp/modules/avalonia/input.ts
+++ b/src/Browser/Avalonia.Browser/webapp/modules/avalonia/input.ts
@@ -171,11 +171,13 @@ export class InputHelper {
         const pointerDownHandler = (args: PointerEvent) => {
             pointerDownCallback(args);
             args.preventDefault();
+            element.setPointerCapture(args.pointerId);
         };
 
         const pointerUpHandler = (args: PointerEvent) => {
             pointerUpCallback(args);
             args.preventDefault();
+            element.releasePointerCapture(args.pointerId);
         };
 
         const pointerCancelHandler = (args: PointerEvent) => {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Add use of [setPointerCapture](https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture) in **pointerDownHandler** to ensure that **pointerUpHandler** is called.

## What is the current behavior?
**pointerup** is not triggered if you move the cursor outside the window

## Verification / testing
I have tested on:
Windows desktop: Firefox, Chrome, Edge.
Android: Chrome.

## Fixed issues
Fixes #10904
