### PR TITLE
Actually dispose PooledList

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
+++ b/src/Avalonia.Base/Rendering/Composition/CompositingRenderer.cs
@@ -113,7 +113,7 @@ internal class CompositingRenderer : IRendererWithCompositor, IHitTester
                 return true;
             };
 
-        var res = CompositionTarget.TryHitTest(p, rootVisual, f);
+        using var res = CompositionTarget.TryHitTest(p, rootVisual, f);
         if(res == null)
             yield break;
         foreach(var v in res)


### PR DESCRIPTION
Not disposed PooledList was causing quite a bit of memory traffic on hit-testing