### PR TITLE
Added a separate diagnostics graph to track Update method timing

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -136,6 +136,8 @@ namespace Avalonia.Rendering.Composition.Server
             _updateRequested = false;
             Readback.CompleteWrite(Revision);
 
+            _overlays.MarkUpdateCallEnd();
+            
             if (!_redrawRequested)
                 return;
             _redrawRequested = false;


### PR DESCRIPTION
Needed to track perf

(8c29f8b60c9f9d3634bfc3f9983ff09b10ff33ab)