### PR TITLE
Avoid NullReferenceException in Gestures.PointerReleased

### DIFF
--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -67,6 +67,7 @@ namespace Avalonia.Input
 
         private static readonly WeakReference<object?> s_lastPress = new WeakReference<object?>(null);
         private static Point s_lastPressPoint;
+        private static PointerType s_lastHeldPointerType;
         private static IPointer? s_lastHeldPointer;
 
         public static readonly RoutedEvent<PinchEventArgs> PinchEvent =
@@ -229,7 +230,7 @@ namespace Avalonia.Input
                 {
                     if(s_isHolding && ev.Source is Interactive i)
                     {
-                        i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_lastHeldPointer.Type, e));
+                        i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_lastHeldPointerType, e));
                     }
                     s_holdCancellationToken?.Cancel();
                     s_holdCancellationToken?.Dispose();
@@ -244,6 +245,7 @@ namespace Avalonia.Input
                 {
                     s_isDoubleTapped = false;
                     s_lastPress.SetTarget(ev.Source);
+                    s_lastHeldPointerType = e.Pointer.Type;
                     s_lastHeldPointer = e.Pointer;
                     s_lastPressPoint = e.GetPosition((Visual)ev.Source);
                     s_holdCancellationToken = new CancellationTokenSource();
@@ -257,7 +259,7 @@ namespace Avalonia.Input
                             if (!token.IsCancellationRequested && e.Source is InputElement i && GetIsHoldingEnabled(i) && (e.Pointer.Type != PointerType.Mouse || GetIsHoldWithMouseEnabled(i)))
                             {
                                 s_isHolding = true;
-                                i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Started, s_lastPressPoint, s_lastHeldPointer.Type, e));
+                                i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Started, s_lastPressPoint, s_lastHeldPointerType, e));
                             }
                         }, settings.HoldWaitDuration);
                     }
@@ -297,7 +299,7 @@ namespace Avalonia.Input
                         if (s_isHolding)
                         {
                             s_isHolding = false;
-                            i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Completed, s_lastPressPoint, s_lastHeldPointer!.Type, e));
+                            i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Completed, s_lastPressPoint, s_lastHeldPointerType, e));
                         }
                         else if (e.InitialPressMouseButton == MouseButton.Right)
                         {
@@ -341,7 +343,7 @@ namespace Avalonia.Input
 
                         if (s_isHolding)
                         {
-                            i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_lastHeldPointer!.Type, e));
+                            i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_lastHeldPointerType, e));
                             s_lastHeldPointer = null;
                         }
                     }

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -10,20 +10,7 @@ namespace Avalonia.Input
 {
     public static class Gestures
     {
-        private readonly struct GestureState
-        {
-            public GestureState(GestureStateType type, IPointer pointer, Point point)
-            {
-                Type = type;
-                Pointer = pointer;
-                Point = point;
-            }
-
-            public readonly GestureStateType Type { get; init; }
-            public readonly IPointer Pointer { get; init; }
-            public readonly Point Point { get; init; }
-        }
-
+        private record struct GestureState(GestureStateType Type, IPointer Pointer, Point Point);
         private enum GestureStateType
         {
             Pending,

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -10,8 +10,29 @@ namespace Avalonia.Input
 {
     public static class Gestures
     {
-        private static bool s_isDoubleTapped = false;
-        private static bool s_isHolding;
+        private readonly struct GestureState
+        {
+            public GestureState(GestureStateType type, IPointer pointer, Point point)
+            {
+                Type = type;
+                Pointer = pointer;
+                Point = point;
+            }
+
+            public readonly GestureStateType Type { get; init; }
+            public readonly IPointer Pointer { get; init; }
+            public readonly Point Point { get; init; }
+        }
+
+        private enum GestureStateType
+        {
+            Pending,
+            Holding,
+            DoubleTapped
+        }
+
+        private static GestureState? s_gestureState = null;
+        private static readonly WeakReference<object?> s_lastPress = new WeakReference<object?>(null);
         private static CancellationTokenSource? s_holdCancellationToken;
 
         /// <summary>
@@ -64,11 +85,6 @@ namespace Avalonia.Input
         public static readonly RoutedEvent<PointerDeltaEventArgs> PointerTouchPadGestureSwipeEvent =
             RoutedEvent.Register<PointerDeltaEventArgs>(
                 "PointerSwipeGesture", RoutingStrategies.Bubble, typeof(Gestures));
-
-        private static readonly WeakReference<object?> s_lastPress = new WeakReference<object?>(null);
-        private static Point s_lastPressPoint;
-        private static PointerType s_lastHeldPointerType;
-        private static IPointer? s_lastHeldPointer;
 
         public static readonly RoutedEvent<PinchEventArgs> PinchEvent =
             RoutedEvent.Register<PinchEventArgs>(
@@ -226,28 +242,23 @@ namespace Avalonia.Input
                 var e = (PointerPressedEventArgs)ev;
                 var visual = (Visual)ev.Source;
 
-                if(s_lastHeldPointer != null)
+                if(s_gestureState != null)
                 {
-                    if(s_isHolding && ev.Source is Interactive i)
+                    if(s_gestureState.Value.Type == GestureStateType.Holding && ev.Source is Interactive i)
                     {
-                        i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_lastHeldPointerType, e));
+                        i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Cancelled, s_gestureState.Value.Point, s_gestureState.Value.Pointer.Type, e));
                     }
                     s_holdCancellationToken?.Cancel();
                     s_holdCancellationToken?.Dispose();
                     s_holdCancellationToken = null;
 
-                    s_lastHeldPointer = null;
+                    s_gestureState = null;
                 }
-
-                s_isHolding = false;
 
                 if (e.ClickCount % 2 == 1)
                 {
-                    s_isDoubleTapped = false;
+                    s_gestureState = new GestureState(GestureStateType.Pending, e.Pointer, e.GetPosition((Visual)ev.Source));
                     s_lastPress.SetTarget(ev.Source);
-                    s_lastHeldPointerType = e.Pointer.Type;
-                    s_lastHeldPointer = e.Pointer;
-                    s_lastPressPoint = e.GetPosition((Visual)ev.Source);
                     s_holdCancellationToken = new CancellationTokenSource();
                     var token = s_holdCancellationToken.Token;
                     var settings = ((IInputRoot?)visual.GetVisualRoot())?.PlatformSettings;
@@ -256,10 +267,10 @@ namespace Avalonia.Input
                     {
                         DispatcherTimer.RunOnce(() =>
                         {
-                            if (!token.IsCancellationRequested && e.Source is InputElement i && GetIsHoldingEnabled(i) && (e.Pointer.Type != PointerType.Mouse || GetIsHoldWithMouseEnabled(i)))
+                            if (s_gestureState != null && !token.IsCancellationRequested && e.Source is InputElement i && GetIsHoldingEnabled(i) && (e.Pointer.Type != PointerType.Mouse || GetIsHoldWithMouseEnabled(i)))
                             {
-                                s_isHolding = true;
-                                i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Started, s_lastPressPoint, s_lastHeldPointerType, e));
+                                s_gestureState = new GestureState(GestureStateType.Holding, s_gestureState.Value.Pointer, s_gestureState.Value.Point);
+                                i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Started, s_gestureState.Value.Point, s_gestureState.Value.Pointer.Type, e));
                             }
                         }, settings.HoldWaitDuration);
                     }
@@ -270,7 +281,7 @@ namespace Avalonia.Input
                         target == e.Source && 
                         e.Source is Interactive i)
                     {
-                        s_isDoubleTapped = true;
+                        s_gestureState = new GestureState(GestureStateType.DoubleTapped, e.Pointer, e.GetPosition((Visual)ev.Source));
                         i.RaiseEvent(new TappedEventArgs(DoubleTappedEvent, e));
                     }
                 }
@@ -283,7 +294,8 @@ namespace Avalonia.Input
             {
                 var e = (PointerReleasedEventArgs)ev;
 
-                if (s_lastPress.TryGetTarget(out var target) &&
+                if (s_gestureState != null &&
+                    s_lastPress.TryGetTarget(out var target) &&
                     target == e.Source &&
                     e.InitialPressMouseButton is MouseButton.Left or MouseButton.Right &&
                     e.Source is Interactive i)
@@ -291,28 +303,27 @@ namespace Avalonia.Input
                     var point = e.GetCurrentPoint((Visual)target);
                     var settings = ((IInputRoot?)i.GetVisualRoot())?.PlatformSettings;
                     var tapSize = settings?.GetTapSize(point.Pointer.Type) ?? new Size(4, 4);
-                    var tapRect = new Rect(s_lastPressPoint, new Size())
+                    var tapRect = new Rect(s_gestureState.Value.Point, new Size())
                         .Inflate(new Thickness(tapSize.Width, tapSize.Height));
 
                     if (tapRect.ContainsExclusive(point.Position))
                     {
-                        if (s_isHolding)
+                        if (s_gestureState.Value.Type == GestureStateType.Holding)
                         {
-                            s_isHolding = false;
-                            i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Completed, s_lastPressPoint, s_lastHeldPointerType, e));
+                            i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Completed, s_gestureState.Value.Point, s_gestureState.Value.Pointer.Type, e));
                         }
                         else if (e.InitialPressMouseButton == MouseButton.Right)
                         {
                             i.RaiseEvent(new TappedEventArgs(RightTappedEvent, e));
                         }
-                        //s_isDoubleTapped needed here to prevent invoking Tapped event when DoubleTapped is called.
+                        //GestureStateType.DoubleTapped needed here to prevent invoking Tapped event when DoubleTapped is called.
                         //This behaviour matches UWP behaviour.
-                        else if (s_isDoubleTapped == false)
+                        else if (s_gestureState.Value.Type != GestureStateType.DoubleTapped)
                         {
                             i.RaiseEvent(new TappedEventArgs(TappedEvent, e));
                         }
                     }
-                    s_lastHeldPointer = null;
+                    s_gestureState = null;
                 }
 
                 s_holdCancellationToken?.Cancel();
@@ -328,12 +339,12 @@ namespace Avalonia.Input
                 var e = (PointerEventArgs)ev;
                 if (s_lastPress.TryGetTarget(out var target))
                 {
-                    if (e.Pointer == s_lastHeldPointer && ev.Source is Interactive i)
+                    if (e.Pointer == s_gestureState?.Pointer && ev.Source is Interactive i)
                     {
                         var point = e.GetCurrentPoint((Visual)target);
                         var settings = ((IInputRoot?)i.GetVisualRoot())?.PlatformSettings;
                         var holdSize = new Size(4, 4);
-                        var holdRect = new Rect(s_lastPressPoint, new Size())
+                        var holdRect = new Rect(s_gestureState.Value.Point, new Size())
                             .Inflate(new Thickness(holdSize.Width, holdSize.Height));
 
                         if (holdRect.ContainsExclusive(point.Position))
@@ -341,10 +352,9 @@ namespace Avalonia.Input
                             return;
                         }
 
-                        if (s_isHolding)
+                        if (s_gestureState.Value.Type == GestureStateType.Holding)
                         {
-                            i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_lastHeldPointerType, e));
-                            s_lastHeldPointer = null;
+                            i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Cancelled, s_gestureState.Value.Point, s_gestureState.Value.Pointer.Type, e));
                         }
                     }
                 }
@@ -352,7 +362,7 @@ namespace Avalonia.Input
                 s_holdCancellationToken?.Cancel();
                 s_holdCancellationToken?.Dispose();
                 s_holdCancellationToken = null;
-                s_isHolding = false;
+                s_gestureState = null;
             }
         }
     }

--- a/src/Avalonia.Base/Input/Gestures.cs
+++ b/src/Avalonia.Base/Input/Gestures.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Input
 {
     public static class Gestures
     {
-        private record struct GestureState(GestureStateType Type, IPointer Pointer, Point Point);
+        private record struct GestureState(GestureStateType Type, IPointer Pointer);
         private enum GestureStateType
         {
             Pending,
@@ -20,6 +20,7 @@ namespace Avalonia.Input
 
         private static GestureState? s_gestureState = null;
         private static readonly WeakReference<object?> s_lastPress = new WeakReference<object?>(null);
+        private static Point s_lastPressPoint;
         private static CancellationTokenSource? s_holdCancellationToken;
 
         /// <summary>
@@ -233,7 +234,7 @@ namespace Avalonia.Input
                 {
                     if(s_gestureState.Value.Type == GestureStateType.Holding && ev.Source is Interactive i)
                     {
-                        i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Cancelled, s_gestureState.Value.Point, s_gestureState.Value.Pointer.Type, e));
+                        i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_gestureState.Value.Pointer.Type, e));
                     }
                     s_holdCancellationToken?.Cancel();
                     s_holdCancellationToken?.Dispose();
@@ -244,8 +245,9 @@ namespace Avalonia.Input
 
                 if (e.ClickCount % 2 == 1)
                 {
-                    s_gestureState = new GestureState(GestureStateType.Pending, e.Pointer, e.GetPosition((Visual)ev.Source));
+                    s_gestureState = new GestureState(GestureStateType.Pending, e.Pointer);
                     s_lastPress.SetTarget(ev.Source);
+                    s_lastPressPoint = e.GetPosition((Visual)ev.Source);
                     s_holdCancellationToken = new CancellationTokenSource();
                     var token = s_holdCancellationToken.Token;
                     var settings = ((IInputRoot?)visual.GetVisualRoot())?.PlatformSettings;
@@ -256,8 +258,8 @@ namespace Avalonia.Input
                         {
                             if (s_gestureState != null && !token.IsCancellationRequested && e.Source is InputElement i && GetIsHoldingEnabled(i) && (e.Pointer.Type != PointerType.Mouse || GetIsHoldWithMouseEnabled(i)))
                             {
-                                s_gestureState = new GestureState(GestureStateType.Holding, s_gestureState.Value.Pointer, s_gestureState.Value.Point);
-                                i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Started, s_gestureState.Value.Point, s_gestureState.Value.Pointer.Type, e));
+                                s_gestureState = new GestureState(GestureStateType.Holding, s_gestureState.Value.Pointer);
+                                i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Started, s_lastPressPoint, s_gestureState.Value.Pointer.Type, e));
                             }
                         }, settings.HoldWaitDuration);
                     }
@@ -268,7 +270,7 @@ namespace Avalonia.Input
                         target == e.Source && 
                         e.Source is Interactive i)
                     {
-                        s_gestureState = new GestureState(GestureStateType.DoubleTapped, e.Pointer, e.GetPosition((Visual)ev.Source));
+                        s_gestureState = new GestureState(GestureStateType.DoubleTapped, e.Pointer);
                         i.RaiseEvent(new TappedEventArgs(DoubleTappedEvent, e));
                     }
                 }
@@ -281,8 +283,7 @@ namespace Avalonia.Input
             {
                 var e = (PointerReleasedEventArgs)ev;
 
-                if (s_gestureState != null &&
-                    s_lastPress.TryGetTarget(out var target) &&
+                if (s_lastPress.TryGetTarget(out var target) &&
                     target == e.Source &&
                     e.InitialPressMouseButton is MouseButton.Left or MouseButton.Right &&
                     e.Source is Interactive i)
@@ -290,14 +291,14 @@ namespace Avalonia.Input
                     var point = e.GetCurrentPoint((Visual)target);
                     var settings = ((IInputRoot?)i.GetVisualRoot())?.PlatformSettings;
                     var tapSize = settings?.GetTapSize(point.Pointer.Type) ?? new Size(4, 4);
-                    var tapRect = new Rect(s_gestureState.Value.Point, new Size())
+                    var tapRect = new Rect(s_lastPressPoint, new Size())
                         .Inflate(new Thickness(tapSize.Width, tapSize.Height));
 
                     if (tapRect.ContainsExclusive(point.Position))
                     {
-                        if (s_gestureState.Value.Type == GestureStateType.Holding)
+                        if (s_gestureState?.Type == GestureStateType.Holding)
                         {
-                            i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Completed, s_gestureState.Value.Point, s_gestureState.Value.Pointer.Type, e));
+                            i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Completed, s_lastPressPoint, s_gestureState.Value.Pointer.Type, e));
                         }
                         else if (e.InitialPressMouseButton == MouseButton.Right)
                         {
@@ -305,7 +306,7 @@ namespace Avalonia.Input
                         }
                         //GestureStateType.DoubleTapped needed here to prevent invoking Tapped event when DoubleTapped is called.
                         //This behaviour matches UWP behaviour.
-                        else if (s_gestureState.Value.Type != GestureStateType.DoubleTapped)
+                        else if (s_gestureState?.Type != GestureStateType.DoubleTapped)
                         {
                             i.RaiseEvent(new TappedEventArgs(TappedEvent, e));
                         }
@@ -331,7 +332,7 @@ namespace Avalonia.Input
                         var point = e.GetCurrentPoint((Visual)target);
                         var settings = ((IInputRoot?)i.GetVisualRoot())?.PlatformSettings;
                         var holdSize = new Size(4, 4);
-                        var holdRect = new Rect(s_gestureState.Value.Point, new Size())
+                        var holdRect = new Rect(s_lastPressPoint, new Size())
                             .Inflate(new Thickness(holdSize.Width, holdSize.Height));
 
                         if (holdRect.ContainsExclusive(point.Position))
@@ -341,7 +342,7 @@ namespace Avalonia.Input
 
                         if (s_gestureState.Value.Type == GestureStateType.Holding)
                         {
-                            i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Cancelled, s_gestureState.Value.Point, s_gestureState.Value.Pointer.Type, e));
+                            i.RaiseEvent(new HoldingRoutedEventArgs(HoldingState.Cancelled, s_lastPressPoint, s_gestureState.Value.Pointer.Type, e));
                         }
                     }
                 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

PR allows you to avoid crashes during multi-touch input #14249. This is not a complete fix as I'm not sure the new behavior is correct. 

## What is the current behavior?

The bug is described in #14249. In my case, I created an application with one large button. I pressed the Linux device's touch display several times with three fingers. After a few touches the app crashes with message:

Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
at Avalonia.Input.Gestures.PointerReleased(RoutedEventArgs ev)

## What is the updated/expected behavior with this PR?

The application does not crash.

## How was the solution implemented (if it's not obvious)?

There is three ways to avoid NRE here:

1) Add a null check in `PointerReleased` before raising the event. In this case the `HoldingState.Completed` event will not be raised in some cases. Is it good or bad? I don't know.
2) Store the value of `s_lastHeldPointer.Type` in separate field. Event `HoldingState.Completed` will be raised even if `s_lastHeldPointer` is `null`. I think this is better than the first case.
3) Figure out why `s_lastHeldPointer` might be `null` and causes NRE and rewrite (refactor?) this code.

I decided to take the second path as it is more reliable. I also changed the `PointerPressed` and `PointerMoved` methods to use `s_lastHeldPointerType` field just for consistency. These two methods do not throw NRE exceptions.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
