### PR TITLE
Fixed memory leak in MethodCommandNode.cs

### DIFF
--- a/src/Avalonia.Base/Data/Core/ExpressionNodes/MethodCommandNode.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNodes/MethodCommandNode.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Text;
 using System.Windows.Input;
 using Avalonia.Data.Converters;
-using Avalonia.Threading;
 
 namespace Avalonia.Data.Core.ExpressionNodes;
 
@@ -86,8 +85,8 @@ internal sealed class MethodCommandNode : ExpressionNode
 
         public void RaiseCanExecuteChanged()
         {
-            Dispatcher.UIThread.Post(() => CanExecuteChanged?.Invoke(this, EventArgs.Empty)
-               , DispatcherPriority.Input);
+            Threading.Dispatcher.UIThread.Post(() => CanExecuteChanged?.Invoke(this, EventArgs.Empty)
+               , Threading.DispatcherPriority.Input);
         }
 
         public bool CanExecute(object? parameter)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fix a memory leak in MethodCommandNode.cs that keeps controls in memory even when a window is closed.

## What is the current behavior?
Binding to methods keeps the `source` and the control in memory indefinitely.

## What is the updated/expected behavior with this PR?
No memory leaks 

## How was the solution implemented (if it's not obvious)?
I am not sure what's the lifecycle of `ExpressionNode`, as it doesn't have any `Dispose` methods.
I changed subscription to `PropertyChanged` to be based on weak reference.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
