### PR TITLE
Call a layout pass on RenderTransform changes

### DIFF
--- a/src/Avalonia.Base/Layout/ILayoutManager.cs
+++ b/src/Avalonia.Base/Layout/ILayoutManager.cs
@@ -27,6 +27,12 @@ namespace Avalonia.Layout
         void InvalidateArrange(Layoutable control);
 
         /// <summary>
+        /// Notifies the layout manager that a control queues a calculation of the effective viewport.
+        /// </summary>
+        /// <param name="control">The control.</param>
+        void InvalidateViewport(Visual control);
+
+        /// <summary>
         /// Executes a layout pass.
         /// </summary>
         /// <remarks>

--- a/src/Avalonia.Base/Layout/LayoutManager.cs
+++ b/src/Avalonia.Base/Layout/LayoutManager.cs
@@ -101,6 +101,39 @@ namespace Avalonia.Layout
             QueueLayoutPass();
         }
 
+        /// <inheritdoc/>
+        public virtual void InvalidateViewport(Visual control)
+        {
+            control = control ?? throw new ArgumentNullException(nameof(control));
+            Dispatcher.UIThread.VerifyAccess();
+
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (!control.IsAttachedToVisualTree)
+            {
+#if DEBUG
+                throw new AvaloniaInternalException(
+                    "LayoutManager.InvalidateViewport called on a control that is detached from the visual tree.");
+#else
+                return;
+#endif
+            }
+
+            if (control.VisualRoot != _owner)
+            {
+                throw new ArgumentException("Attempt to call InvalidateViewport on wrong LayoutManager.");
+            }
+
+            if (_effectiveViewportChangedListeners is object &&
+                _effectiveViewportChangedListeners.Count > 0)
+            {
+                QueueLayoutPass();
+            }
+        }
+
         internal void ExecuteQueuedLayoutPass()
         {
             if (!_queued)

--- a/src/Avalonia.Base/Layout/Layoutable.cs
+++ b/src/Avalonia.Base/Layout/Layoutable.cs
@@ -842,6 +842,10 @@ namespace Avalonia.Layout
                 layoutManager.InvalidateArrange(this);
                 InvalidateVisual();
             }
+            else
+            {
+                layoutManager.InvalidateViewport(this);
+            }
 
             var count = VisualChildren.Count;
 

--- a/src/Avalonia.Base/Visual.cs
+++ b/src/Avalonia.Base/Visual.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Collections.Specialized;
 using Avalonia.Collections;
 using Avalonia.Data;
+using Avalonia.Layout;
 using Avalonia.Logging;
 using Avalonia.LogicalTree;
 using Avalonia.Media;
@@ -379,6 +380,14 @@ namespace Avalonia
         }
 
         /// <summary>
+        /// Queues a calculation of the effective viewport.
+        /// </summary>
+        protected void InvalidateViewport()
+        {
+            (VisualRoot as ILayoutRoot)?.LayoutManager?.InvalidateViewport(this);
+        }
+
+        /// <summary>
         /// Renders the visual to a <see cref="DrawingContext"/>.
         /// </summary>
         /// <param name="context">The drawing context.</param>
@@ -612,6 +621,7 @@ namespace Avalonia
                 }
                 
                 sender.InvalidateVisual();
+                sender.InvalidateViewport();
             }
         }
 
@@ -656,6 +666,7 @@ namespace Avalonia
         private void RenderTransformChanged(object? sender, EventArgs e)
         {
             InvalidateVisual();
+            InvalidateViewport();
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Adds a new InvalidateViewport method to the ILayoutManager. It queues the layout pass for calculating of effective viewport if needed.


## What is the current behavior?
EffectiveViewport calculated only with layout pass called with measure or arrange. But RenderTransform effects only to render.

## Fixed issues
Fixes #12432
