### PR TITLE
Add locks in GeometryImpl for safe multithreaded access

### DIFF
--- a/src/Skia/Avalonia.Skia/GeometryImpl.cs
+++ b/src/Skia/Avalonia.Skia/GeometryImpl.cs
@@ -13,6 +13,7 @@ namespace Avalonia.Skia
     /// </summary>
     internal abstract class GeometryImpl : IGeometryImpl
     {
+        private readonly object _lock = new();
         private PathCache _pathCache;
         private SKPathMeasure? _cachedPathMeasure;
 
@@ -45,7 +46,7 @@ namespace Avalonia.Skia
         /// <inheritdoc />
         public bool StrokeContains(IPen? pen, Point point)
         {
-            lock (this)
+            lock (_lock)
             {
                 _pathCache.UpdateIfNeeded(StrokePath, pen);
 
@@ -76,7 +77,7 @@ namespace Avalonia.Skia
         /// <inheritdoc />
         public Rect GetRenderBounds(IPen? pen)
         {
-            lock (this)
+            lock (_lock)
             {
                 _pathCache.UpdateIfNeeded(StrokePath, pen);
                 return _pathCache.RenderBounds;
@@ -160,7 +161,7 @@ namespace Avalonia.Skia
         /// </summary>
         protected void InvalidateCaches()
         {
-            lock (this)
+            lock (_lock)
             {
                 _pathCache.Dispose();
                 _pathCache = default;

--- a/src/Skia/Avalonia.Skia/GeometryImpl.cs
+++ b/src/Skia/Avalonia.Skia/GeometryImpl.cs
@@ -45,9 +45,12 @@ namespace Avalonia.Skia
         /// <inheritdoc />
         public bool StrokeContains(IPen? pen, Point point)
         {
-            _pathCache.UpdateIfNeeded(StrokePath, pen);
+            lock (this)
+            {
+                _pathCache.UpdateIfNeeded(StrokePath, pen);
 
-            return PathContainsCore(_pathCache.ExpandedPath, point);
+                return PathContainsCore(_pathCache.ExpandedPath, point);
+            }
         }
         
         /// <summary>
@@ -73,8 +76,11 @@ namespace Avalonia.Skia
         /// <inheritdoc />
         public Rect GetRenderBounds(IPen? pen)
         {
-            _pathCache.UpdateIfNeeded(StrokePath, pen);
-            return _pathCache.RenderBounds;
+            lock (this)
+            {
+                _pathCache.UpdateIfNeeded(StrokePath, pen);
+                return _pathCache.RenderBounds;
+            }
         }
 
         public IGeometryImpl GetWidenedGeometry(IPen pen)
@@ -154,8 +160,11 @@ namespace Avalonia.Skia
         /// </summary>
         protected void InvalidateCaches()
         {
-            _pathCache.Dispose();
-            _pathCache = default;
+            lock (this)
+            {
+                _pathCache.Dispose();
+                _pathCache = default;
+            }
         }
 
         private struct PathCache : IDisposable


### PR DESCRIPTION
## What does the pull request do?
Three methods that use `pathCache` (`StrokeContains`, `GetRenderBounds`, `InvalidateCaches`) can be accessed from different threads simultaneously (the render thread and the main thread). This PR wraps all these methods in a lock.

I don't think `IRef<T>` could be used here:

https://github.com/AvaloniaUI/Avalonia/blob/0b72cdb512187c8a4eded47e864e1194111e621f/src/Skia/Avalonia.Skia/GeometryImpl.cs#L184-L189

The path can be disposed in the method `UpdateIfNeeded`. These two lines (dispose and assignment) must be in a locked somehow anyway (otherwise it is possible that a method would acquire a path AFTER it was disposed and BEFORE it was assigned again).

## What is the current behavior?
The path can be disposed while it is accessed by another thread.

## What is the updated/expected behavior with this PR?
Methods will no longer be executed simultaneously on different threads.

## How was the solution implemented (if it's not obvious)?


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
n/a

## Obsoletions / Deprecations
n/a

## Fixed issues
#15120