### PR TITLE
Fix "BindingExpression has not been started"

### DIFF
--- a/src/Avalonia.Base/Data/Core/UntypedBindingExpressionBase.cs
+++ b/src/Avalonia.Base/Data/Core/UntypedBindingExpressionBase.cs
@@ -403,6 +403,9 @@ public abstract class UntypedBindingExpressionBase : BindingExpressionBase,
     /// <param name="error">The new binding or data validation error.</param>
     private protected void PublishValue(object? value, BindingError? error = null)
     {
+        if (!IsRunning)
+            return;
+
         // When binding to DataContext and the expression results in a binding error, the binding
         // expression should produce null rather than UnsetValue in order to not propagate
         // incorrect DataContexts from parent controls while things are being set up.


### PR DESCRIPTION
## What does the pull request do?

The fix is pretty simple here; the challenge was finding a minimal repro to put in a test.

What happens is:

1. An event is raised with 2 binding expression subscribers (in the case of #14753 the subscribers are `DynamicResourceExpression`s)
2. The first subscriber causes the 2nd subscriber to be stopped
3. The second subscriber is called from the event, even though it has been stopped and has removed its event subscription (as the invocation list was cached at step 1)
4. It calls `PublishValue` causing an exception

The easiest and safest fix is to just do nothing in `PublishValue` when the binding expression isn't running. I didn't do that before because I figured it's a logic error but the above scenario means that it's kinda not always, really.

## Fixed issues

Fixes #14753 