### PR TITLE
Fix popups disappearing when resized after opening

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -609,6 +609,10 @@ namespace Avalonia.Win32
                     _resizeReason = WindowResizeReason.User;
                     break;
 
+                case WindowsMessage.WM_SHOWWINDOW:
+                    _shown = wParam != default;
+                    break;
+
                 case WindowsMessage.WM_SIZE:
                     {
                         var size = (SizeCommand)wParam;

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -682,7 +682,6 @@ namespace Avalonia.Win32
         public void Hide()
         {
             UnmanagedMethods.ShowWindow(_hwnd, ShowWindowCommand.Hide);
-            _shown = false;
         }
 
         public virtual void Show(bool activate, bool isDialog)
@@ -1160,8 +1159,6 @@ namespace Avalonia.Win32
 
         private void ShowWindow(WindowState state, bool activate)
         {
-            _shown = true;
-
             if (_isClientAreaExtended)
             {
                 ExtendClientArea();


### PR DESCRIPTION
This issue was introduced with #15035. The new field `WindowImpl._shown` was only updated when the show or hide methods were called, but a window can be shown or hidden without any of that code executing.

`WindowImpl` now updates its state in response to Win32 window messages, guaranteeing synchronisation with the OS.

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes AvaloniaUI/AvaloniaEdit#407
