### PR TITLE
fix SplitView 

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/SplitView.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/SplitView.xaml
@@ -139,7 +139,7 @@
               <ContentPresenter x:Name="PART_ContentPresenter"
                                 Content="{TemplateBinding Content}"
                                 ContentTemplate="{TemplateBinding ContentTemplate}" />
-              <Rectangle Name="LightDismissLayer"/>
+              <Rectangle Name="LightDismissLayer" IsVisible="False"/>
             </Panel>
 
           </Grid>
@@ -237,7 +237,7 @@
       </Style>
     </Style>
 
-    <Style Selector="^:lightdismiss /template/ Rectangle#LightDismissLayer">
+    <Style Selector="^:lightDismiss /template/ Rectangle#LightDismissLayer">
       <Setter Property="Fill" Value="{DynamicResource SplitViewLightDismissOverlayBackground}" />
     </Style>
     <Style Selector="^:overlay:open /template/ Rectangle#LightDismissLayer">

--- a/src/Avalonia.Themes.Simple/Controls/SplitView.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/SplitView.xaml
@@ -55,7 +55,7 @@
             <Panel Name="ContentRoot">
               <ContentPresenter x:Name="PART_ContentPresenter" Content="{TemplateBinding Content}"
                                 ContentTemplate="{TemplateBinding ContentTemplate}" />
-              <Rectangle Name="LightDismissLayer" />
+              <Rectangle Name="LightDismissLayer" IsVisible="False"/>
             </Panel>
 
           </Grid>
@@ -138,7 +138,7 @@
             <Panel Name="ContentRoot">
               <ContentPresenter x:Name="PART_ContentPresenter" Content="{TemplateBinding Content}"
                                 ContentTemplate="{TemplateBinding ContentTemplate}" />
-              <Rectangle Name="LightDismissLayer" />
+              <Rectangle Name="LightDismissLayer" IsVisible="False"/>
             </Panel>
 
           </Grid>
@@ -238,7 +238,7 @@
       <Setter Property="IsVisible" Value="False" />
       <Setter Property="Fill" Value="Transparent" />
     </Style>
-    <Style Selector="^:lightdismiss /template/ Rectangle#LightDismissLayer">
+    <Style Selector="^:lightDismiss /template/ Rectangle#LightDismissLayer">
       <Setter Property="Fill">
         <SolidColorBrush Color="{DynamicResource ThemeControlLowColor}" Opacity="0.6" />
       </Setter>


### PR DESCRIPTION
1.misspelled word invalidates the background(SplitView lightDismiss).
2.make sure mask is invisible in inline mode. use dynamic brush.
