### PR TITLE
Fix broken tizen/ios initialization

### DIFF
--- a/samples/MobileSandbox/MobileSandbox.csproj
+++ b/samples/MobileSandbox/MobileSandbox.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android;net8.0-browser;net8.0-tizen</TargetFrameworks>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOsPlatform('Linux'))">$(TargetFrameworks);net8.0-ios</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-android;net8.0-browser;net8.0-ios</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>

--- a/samples/SafeAreaDemo.iOS/Info.plist
+++ b/samples/SafeAreaDemo.iOS/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>10.0</string>
+	<string>13.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/samples/SafeAreaDemo.iOS/SafeAreaDemo.iOS.csproj
+++ b/samples/SafeAreaDemo.iOS/SafeAreaDemo.iOS.csproj
@@ -2,9 +2,12 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(AvsCurrentIOSTargetFramework)</TargetFramework>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
     <ProvisioningType>manual</ProvisioningType>
     <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <CodesignKey>Apple Development: maxkatz6@outlook.com (DN2P3PH6J5)</CodesignKey>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tizen/Avalonia.Tizen/NuiTizenApplication.cs
+++ b/src/Tizen/Avalonia.Tizen/NuiTizenApplication.cs
@@ -31,7 +31,7 @@ public class NuiTizenApplication<TApp> : NUIApplication
         public TopLevel? TopLevel => View.TopLevel;
     }
 
-    protected virtual AppBuilder CreateAppBuilder() => AppBuilder.Configure<Application>().UseTizen();
+    protected virtual AppBuilder CreateAppBuilder() => AppBuilder.Configure<TApp>().UseTizen();
     protected virtual AppBuilder CustomizeAppBuilder(AppBuilder builder) => builder;
 
     protected override void OnCreate()

--- a/src/iOS/Avalonia.iOS/AvaloniaAppDelegate.cs
+++ b/src/iOS/Avalonia.iOS/AvaloniaAppDelegate.cs
@@ -34,7 +34,7 @@ namespace Avalonia.iOS
             remove { _onDeactivated -= value; }
         }
 
-        protected virtual AppBuilder CreateAppBuilder() => AppBuilder.Configure<Application>().UseiOS();
+        protected virtual AppBuilder CreateAppBuilder() => AppBuilder.Configure<TApp>().UseiOS();
         protected virtual AppBuilder CustomizeAppBuilder(AppBuilder builder) => builder;
 
         [Export("window")]


### PR DESCRIPTION
In one of my previous PRs I accidentally broke iOS/Tizen non-base App initialization due, copypasting that code from android where it made sense. 

Also, fixes SafeAreaDemo min iOS version, as it was changed a while ago.