### PR TITLE
Update single project capabilities

### DIFF
--- a/packages/Avalonia/AvaloniaSingleProject.targets
+++ b/packages/Avalonia/AvaloniaSingleProject.targets
@@ -176,6 +176,8 @@
   </Target>
 
   <!-- IDE capabilities -->
+  <!-- Keep synced with https://github.com/dotnet/maui/blob/f0c4dd19d4c4cba7c6060ec5ceb8ba150bbdf9a5/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets#L25 -->
+  <!-- Otherwise Visual Studio single project support might be broken. -->
   <ItemGroup Condition=" '$(AvaloniaSingleProject)' == 'true' ">
     <ProjectCapability Include="Msix" />
     <ProjectCapability Include="MauiSingleProject" />
@@ -185,6 +187,12 @@
     <!-- Otherwise define LaunchProfilesGroupByPlatformFilters by default -->
     <ProjectCapability Include="LaunchProfilesGroupByPlatformFilters" Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &gt;= '17.0' " />
     <ProjectCapability Include="SingleTargetBuildForStartupProjects" Condition=" '$(EnableSingleTargetBuildForStartupProjects)' != 'false' " />
+
+    <ProjectCapability Include="UseMauiCore" />
+
+    <!-- .NET MAUI features (also required for single project) -->
+    <ProjectCapability Include="MauiCore" />
+    <ProjectCapability Include="Maui" />
   </ItemGroup>
 
   <!-- Android -->

--- a/samples/MobileSandbox/MobileSandbox.csproj
+++ b/samples/MobileSandbox/MobileSandbox.csproj
@@ -23,6 +23,11 @@
     <ProjectReference Include="..\SampleControls\ControlSamples.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Only useful in VS, but https://www.vsixcookbook.com/tips/projects.html -->
+    <ProjectCapability Include="DiagnoseCapabilities" />
+  </ItemGroup>
+
   <Import Project="..\..\build\BuildTargets.targets" />
   <Import Project="..\..\build\SourceGenerators.props" />
 </Project>


### PR DESCRIPTION
## What does the pull request do?

Note: single project support is still experimental feature, which we don't recommend using yet. 
For some reason, Visual Studio assumes that only MAUI projects are allowed to have multitargetted single project support (i.e. executable project with "net8.0;net8.0-ios;net8.0-android;net8.0-browser" targets). We need to set project capability and lie to the IDE.

Before:
![image](https://github.com/AvaloniaUI/Avalonia/assets/3163374/c07a5b1b-ec93-4d63-92f8-193f9f2170fa)

After:
![image](https://github.com/AvaloniaUI/Avalonia/assets/3163374/cc4e4318-1d7f-47fe-882c-377e5642bd69)


## What is the current behavior?

Rider: works, it's possible to select target and run.
VisualStudio: broken, it's not possible to run a target.

## What is the updated/expected behavior with this PR?

Rider: works
VisualStudio: works
