### PR TITLE
X11 - Apply current_filter extension from dbus save picker

### DIFF
--- a/samples/ControlCatalog/Pages/DialogsPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DialogsPage.xaml.cs
@@ -247,7 +247,6 @@ namespace ControlCatalog.Pages
                     FileTypeChoices = fileTypes,
                     SuggestedStartLocation = lastSelectedDirectory,
                     SuggestedFileName = "FileName",
-                    DefaultExtension = fileTypes?.Any() == true ? "txt" : null,
                     ShowOverwritePrompt = true
                 });
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Reads the selected filter from dbus save file picker, and appends the file extension in that filter if available.

## What is the current behavior?
Dbus' "current_filter" result is ignored, and thus, when using dbus save file picker, the selected filter's extension isn't applied to the file name. 

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
