### PR TITLE
Propagate Dispose for ICustomDrawOperation through RenderDataCustomNode.

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Drawing/Nodes/RenderDataNodes.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Drawing/Nodes/RenderDataNodes.cs
@@ -78,13 +78,19 @@ interface IRenderDataItem
     bool HitTest(Point p);
 }
 
-class RenderDataCustomNode : IRenderDataItem
+class RenderDataCustomNode : IRenderDataItem, IDisposable
 {
     public ICustomDrawOperation? Operation { get; set; }
     public bool HitTest(Point p) => Operation?.HitTest(p) ?? false;
     public void Invoke(ref RenderDataNodeRenderContext context) => Operation?.Render(new(context.Context, false));
 
     public Rect? Bounds => Operation?.Bounds;
+
+    public void Dispose()
+    {
+        Operation?.Dispose();
+        Operation = null;
+    }
 }
 
 abstract class RenderDataPushNode : IRenderDataItem, IDisposable


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Implements IDisposable on RenderDataCustomNode to propagate Dispose for ICustomDrawOperation.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Currently the rendering system does not call Dispose for ICustomDrawOperation. This makes it difficult to know when a draw operation can free its resources. The deferred renderer can call Render on an ICustomDrawOperation multiple times, and so a draw operation needs to be told when it is ready to be disposed.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
ICustomDrawOperation.Dispose will be called when the renderer removes a draw operation from the scene.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Implements IDisposable for RenderDataCustomNode, which leads to Dispose being propagated up to the ICustomDrawOperation.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #15221
Discussed in #15206 
