### PR TITLE
Added WindowManagerAddShadowHint to PopupRoot.

### DIFF
--- a/src/Avalonia.Controls/Primitives/Popup.cs
+++ b/src/Avalonia.Controls/Primitives/Popup.cs
@@ -150,6 +150,9 @@ namespace Avalonia.Controls.Primitives
 
         public IPopupHost? Host => _openState?.PopupHost;
 
+        /// <summary>
+        /// Gets or sets a hint to the window manager that a shadow should be added to the popup.
+        /// </summary>
         public bool WindowManagerAddShadowHint
         {
             get => GetValue(WindowManagerAddShadowHintProperty);
@@ -653,9 +656,9 @@ namespace Avalonia.Controls.Primitives
 
         private static void WindowManagerAddShadowHintChanged(IPopupHost host, bool hint)
         {
-            if(host is PopupRoot pr && pr.PlatformImpl is not null)
+            if (host is PopupRoot pr)
             {
-                pr.PlatformImpl.SetWindowManagerAddShadowHint(hint);
+                pr.WindowManagerAddShadowHint = hint;
             }
         }
 

--- a/src/Avalonia.Controls/Primitives/PopupRoot.cs
+++ b/src/Avalonia.Controls/Primitives/PopupRoot.cs
@@ -20,6 +20,12 @@ namespace Avalonia.Controls.Primitives
         public static readonly StyledProperty<Transform?> TransformProperty =
             AvaloniaProperty.Register<PopupRoot, Transform?>(nameof(Transform));
 
+        /// <summary>
+        /// Defines the <see cref="WindowManagerAddShadowHint"/> property.
+        /// </summary>
+        public static readonly StyledProperty<bool> WindowManagerAddShadowHintProperty =
+            Popup.WindowManagerAddShadowHintProperty.AddOwner<PopupRoot>();
+
         private PopupPositionerParameters _positionerParameters;        
 
         /// <summary>
@@ -50,6 +56,7 @@ namespace Avalonia.Controls.Primitives
             : base(impl, dependencyResolver)
         {
             ParentTopLevel = parent;
+            impl.SetWindowManagerAddShadowHint(WindowManagerAddShadowHint);
         }
 
         /// <summary>
@@ -64,6 +71,15 @@ namespace Avalonia.Controls.Primitives
         {
             get => GetValue(TransformProperty);
             set => SetValue(TransformProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a hint to the window manager that a shadow should be added to the popup.
+        /// </summary>
+        public bool WindowManagerAddShadowHint
+        {
+            get => GetValue(WindowManagerAddShadowHintProperty);
+            set => SetValue(WindowManagerAddShadowHintProperty, value);
         }
 
         /// <summary>
@@ -178,6 +194,16 @@ namespace Avalonia.Controls.Primitives
         protected override AutomationPeer OnCreateAutomationPeer()
         {
             return new PopupRootAutomationPeer(this);
+        }
+
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == WindowManagerAddShadowHintProperty)
+            {
+                PlatformImpl?.SetWindowManagerAddShadowHint(change.GetNewValue<bool>());
+            }
         }
     }
 }

--- a/src/Avalonia.Controls/ToolTip.cs
+++ b/src/Avalonia.Controls/ToolTip.cs
@@ -304,7 +304,7 @@ namespace Avalonia.Controls
         {
             if (host is PopupRoot pr)
             {
-                pr.PlatformImpl?.SetWindowManagerAddShadowHint(hint);
+                pr.WindowManagerAddShadowHint = hint;
             }
         }
 


### PR DESCRIPTION
## What does the pull request do?

Previously, the `WindowManagerAddShadowHint` property was defined on `Popup` and `ContextMenu` but not `PopupRoot`: instead various controls such as the aforementioned two and `ToolTip` used the `PopupRoot.PlatformImpl.SetWindowManagerAddShadowHint` internal method to set the "add shadow" hint. This had the downside that 3rd parties could not set this property when using `PopupRoot` directly.

This PR adds a `WindowManagerAddShadowHint` property to `PopupRoot` and makes the controls that previously used the internal interface use that property instead.
