### PR TITLE
Propagate Dispose from RenderDataPushNode

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Drawing/Nodes/RenderDataNodes.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Drawing/Nodes/RenderDataNodes.cs
@@ -136,8 +136,8 @@ abstract class RenderDataPushNode : IRenderDataItem, IDisposable
         if (Children.Count > 0)
         {
             foreach(var ch in Children)
-                if (ch is RenderDataPushNode node)
-                    node.Dispose();
+                if (ch is IDisposable disposable)
+                    disposable.Dispose();
             Children.Dispose();
         }
     }

--- a/src/Avalonia.Base/Rendering/Composition/Drawing/Nodes/RenderDataNodes.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Drawing/Nodes/RenderDataNodes.cs
@@ -78,13 +78,19 @@ interface IRenderDataItem
     bool HitTest(Point p);
 }
 
-class RenderDataCustomNode : IRenderDataItem
+class RenderDataCustomNode : IRenderDataItem, IDisposable
 {
     public ICustomDrawOperation? Operation { get; set; }
     public bool HitTest(Point p) => Operation?.HitTest(p) ?? false;
     public void Invoke(ref RenderDataNodeRenderContext context) => Operation?.Render(new(context.Context, false));
 
     public Rect? Bounds => Operation?.Bounds;
+
+    public void Dispose()
+    {
+        Operation?.Dispose();
+        Operation = null;
+    }
 }
 
 abstract class RenderDataPushNode : IRenderDataItem, IDisposable


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This is a follow-up to issue #15221 related to the disposal of draw operations. The previous fix in #15224 was incomplete because there is also an issue in PushDataRenderNode. The Dispose function for PushDataRenderNode only propagates to other instances of PushDataRenderNode. Drawing operations issued after DrawingContext.PushRenderOptions then would NOT have their Dispose method called. This pull request changes PushDataRenderNode.Dispose to propagate to all children that implement IDisposable.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The current incorrect behavior does not propagate Dispose to draw operations, for example ICustomDrawOperation, for children of a PushDataRenderNode.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
All draw operations that implement IDisposable will now be disposed.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
PushDataRenderNode.Dispose now checks for child instances of IDisposable instead of PushDataRenderNode.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
I don't think this should have any breaking changes, and the sample ControlCatalog and RenderDemo projects work on my system (Windows 10), but I haven't been able to test it on all platforms. I would appreciate confirmation that this change is safe.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Additional fix for #15221