### PR TITLE
feat (File Picker) add WebP to FilePickerFileTypes

### DIFF
--- a/src/Avalonia.Base/Platform/Storage/FilePickerFileTypes.cs
+++ b/src/Avalonia.Base/Platform/Storage/FilePickerFileTypes.cs
@@ -21,7 +21,7 @@ public static class FilePickerFileTypes
 
     public static FilePickerFileType ImageAll { get; } = new("All Images")
     {
-        Patterns = new[] { "*.png", "*.jpg", "*.jpeg", "*.gif", "*.bmp" },
+        Patterns = new[] { "*.png", "*.jpg", "*.jpeg", "*.gif", "*.bmp", "*.webp" },
         AppleUniformTypeIdentifiers = new[] { "public.image" },
         MimeTypes = new[] { "image/*" }
     };
@@ -38,6 +38,13 @@ public static class FilePickerFileTypes
         Patterns = new[] { "*.png" },
         AppleUniformTypeIdentifiers = new[] { "public.png" },
         MimeTypes = new[] { "image/png" }
+    };
+
+    public static FilePickerFileType ImageWebp { get; } = new("WebP image")
+    {
+        Patterns = new[] { "*.webp" },
+        AppleUniformTypeIdentifiers = new[] { "org.webmproject.webp" },
+        MimeTypes = new[] { "image/webp" }
     };
 
     public static FilePickerFileType Pdf { get; } = new("PDF document")


### PR DESCRIPTION
WebP is a common image format these days, so I added it to the list of "All Images" as well as its own file picker file type.

Metadata derived from: https://developers.google.com/speed/webp/docs/riff_container

I also confirmed this locally on macOS.

I further validated this by checking on the uniform type identifier according to the `mdls` command, as mentioned at the bottom of this page: https://en.wikipedia.org/wiki/Uniform_Type_Identifier

This was the result of that command:

<img width="900" alt="mdls command result" src="https://github.com/AvaloniaUI/Avalonia/assets/5933222/1ce5f328-e979-4ede-a292-9af80c2320b3">