### PR TITLE
Added tooltip chaining and `ToolTip.BetweenShowDelay`

### DIFF
--- a/src/Avalonia.Controls/ToolTip.cs
+++ b/src/Avalonia.Controls/ToolTip.cs
@@ -56,6 +56,12 @@ namespace Avalonia.Controls
             AvaloniaProperty.RegisterAttached<ToolTip, Control, int>("ShowDelay", 400);
 
         /// <summary>
+        /// Defines the ToolTip.BetweenShowDelay property.
+        /// </summary>
+        public static readonly AttachedProperty<int> BetweenShowDelayProperty =
+            AvaloniaProperty.RegisterAttached<ToolTip, Control, int>("BetweenShowDelay", 100);
+
+        /// <summary>
         /// Defines the ToolTip.ShowOnDisabled property.
         /// </summary>
         public static readonly AttachedProperty<bool> ShowOnDisabledProperty =
@@ -224,6 +230,24 @@ namespace Avalonia.Controls
         }
 
         /// <summary>
+        /// Gets the number of milliseconds since the last tooltip closed during which the tooltip of <paramref name="element"/> will open immediately,
+        /// or a negative value indicating that the tooltip will always wait for <see cref="ShowDelayProperty"/> before opening.
+        /// </summary>
+        /// <param name="element">The control to get the property from.</param>
+        public static int GetBetweenShowDelay(Control element) => element.GetValue(BetweenShowDelayProperty);
+
+        /// <summary>
+        /// Sets the number of milliseconds since the last tooltip closed during which the tooltip of <paramref name="element"/> will open immediately.
+        /// </summary>
+        /// <remarks>
+        /// Setting a negative value disables the immediate opening behaviour. The tooltip of <paramref name="element"/> will then always wait until 
+        /// <see cref="ShowDelayProperty"/> elapses before showing.
+        /// </remarks>
+        /// <param name="element">The control to get the property from.</param>
+        /// <param name="value">The number of milliseconds to set, or a negative value to disable the behaviour.</param>
+        public static void SetBetweenShowDelay(Control element, int value) => element.SetValue(BetweenShowDelayProperty, value);
+
+        /// <summary>
         /// Gets whether a control will display a tooltip even if it disabled.
         /// </summary>
         /// <param name="element">The control to get the property from.</param>
@@ -298,6 +322,8 @@ namespace Avalonia.Controls
         }
         
         IPopupHost? IPopupHostProvider.PopupHost => _popupHost;
+
+        internal IPopupHost? PopupHost => _popupHost;
 
         event Action<IPopupHost?>? IPopupHostProvider.PopupHostChanged 
         { 

--- a/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
@@ -12,39 +12,52 @@ using Xunit;
 
 namespace Avalonia.Controls.UnitTests
 {
-    public class ToolTipTests
+    public class ToolTipTests_Popup : ToolTipTests
     {
+        protected override TestServices ConfigureServices(TestServices baseServices) => baseServices;
+    }
+
+    public class ToolTipTests_Overlay : ToolTipTests
+    {
+        protected override TestServices ConfigureServices(TestServices baseServices) =>
+            baseServices.With(windowingPlatform: new MockWindowingPlatform(popupImpl: window => null));
+    }
+
+    public abstract class ToolTipTests
+    {
+        protected abstract TestServices ConfigureServices(TestServices baseServices);
+
         private static readonly MouseDevice s_mouseDevice = new(new Pointer(0, PointerType.Mouse, true));
 
         [Fact]
         public void Should_Close_When_Control_Detaches()
         {
-            using (UnitTestApplication.Start(TestServices.FocusableWindow))
+            using (UnitTestApplication.Start(ConfigureServices(TestServices.FocusableWindow)))
             {
                 var panel = new Panel();
-                
+
                 var target = new Decorator()
                 {
                     [ToolTip.TipProperty] = "Tip",
                     [ToolTip.ShowDelayProperty] = 0
                 };
-                
+
                 panel.Children.Add(target);
 
                 SetupWindowAndActivateToolTip(panel, target);
 
                 Assert.True(ToolTip.GetIsOpen(target));
-                
+
                 panel.Children.Remove(target);
-                
+
                 Assert.False(ToolTip.GetIsOpen(target));
             }
         }
-        
+
         [Fact]
         public void Should_Close_When_Tip_Is_Opened_And_Detached_From_Visual_Tree()
         {
-            using (UnitTestApplication.Start(TestServices.FocusableWindow))
+            using (UnitTestApplication.Start(ConfigureServices(TestServices.FocusableWindow)))
             {
                 var target = new Decorator
                 {
@@ -64,7 +77,7 @@ namespace Avalonia.Controls.UnitTests
                 Assert.True(ToolTip.GetIsOpen(target));
 
                 panel.Children.Remove(target);
-                
+
                 Assert.False(ToolTip.GetIsOpen(target));
             }
         }
@@ -72,7 +85,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Should_Open_On_Pointer_Enter()
         {
-            using (UnitTestApplication.Start(TestServices.FocusableWindow))
+            using (UnitTestApplication.Start(ConfigureServices(TestServices.FocusableWindow)))
             {
                 var target = new Decorator()
                 {
@@ -85,11 +98,11 @@ namespace Avalonia.Controls.UnitTests
                 Assert.True(ToolTip.GetIsOpen(target));
             }
         }
-        
+
         [Fact]
         public void Content_Should_Update_When_Tip_Property_Changes_And_Already_Open()
         {
-            using (UnitTestApplication.Start(TestServices.FocusableWindow))
+            using (UnitTestApplication.Start(ConfigureServices(TestServices.FocusableWindow)))
             {
                 var target = new Decorator()
                 {
@@ -101,7 +114,7 @@ namespace Avalonia.Controls.UnitTests
 
                 Assert.True(ToolTip.GetIsOpen(target));
                 Assert.Equal("Tip", target.GetValue(ToolTip.ToolTipProperty).Content);
-                
+
                 ToolTip.SetTip(target, "Tip1");
                 Assert.Equal("Tip1", target.GetValue(ToolTip.ToolTipProperty).Content);
             }
@@ -110,7 +123,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Should_Open_On_Pointer_Enter_With_Delay()
         {
-            using (UnitTestApplication.Start(TestServices.FocusableWindow))
+            using (UnitTestApplication.Start(ConfigureServices(TestServices.FocusableWindow)))
             {
                 var target = new Decorator()
                 {
@@ -133,7 +146,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Open_Class_Should_Not_Initially_Be_Added()
         {
-            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            using (UnitTestApplication.Start(ConfigureServices(TestServices.StyledWindow)))
             {
                 var toolTip = new ToolTip();
                 var window = new Window();
@@ -156,7 +169,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Setting_IsOpen_Should_Add_Open_Class()
         {
-            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            using (UnitTestApplication.Start(ConfigureServices(TestServices.StyledWindow)))
             {
                 var toolTip = new ToolTip();
                 var window = new Window();
@@ -181,7 +194,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Clearing_IsOpen_Should_Remove_Open_Class()
         {
-            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            using (UnitTestApplication.Start(ConfigureServices(TestServices.StyledWindow)))
             {
                 var toolTip = new ToolTip();
                 var window = new Window();
@@ -207,7 +220,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Should_Close_On_Null_Tip()
         {
-            using (UnitTestApplication.Start(TestServices.FocusableWindow))
+            using (UnitTestApplication.Start(ConfigureServices(TestServices.FocusableWindow)))
             {
                 var target = new Decorator()
                 {
@@ -228,7 +241,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Should_Not_Close_When_Pointer_Is_Moved_Over_ToolTip()
         {
-            using (UnitTestApplication.Start(TestServices.FocusableWindow))
+            using (UnitTestApplication.Start(ConfigureServices(TestServices.FocusableWindow)))
             {
                 var target = new Decorator()
                 {
@@ -253,7 +266,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Should_Not_Close_When_Pointer_Is_Moved_From_ToolTip_To_Original_Control()
         {
-            using (UnitTestApplication.Start(TestServices.FocusableWindow))
+            using (UnitTestApplication.Start(ConfigureServices(TestServices.FocusableWindow)))
             {
                 var target = new Decorator()
                 {
@@ -280,7 +293,7 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void Should_Close_When_Pointer_Is_Moved_From_ToolTip_To_Another_Control()
         {
-            using (UnitTestApplication.Start(TestServices.FocusableWindow))
+            using (UnitTestApplication.Start(ConfigureServices(TestServices.FocusableWindow)))
             {
                 var target = new Decorator()
                 {
@@ -309,6 +322,50 @@ namespace Avalonia.Controls.UnitTests
 
                 Assert.False(ToolTip.GetIsOpen(target));
             }
+        }
+
+        [Fact]
+        public void New_ToolTip_Replaces_Other_ToolTip_Immediately()
+        {
+            using var app = UnitTestApplication.Start(ConfigureServices(TestServices.FocusableWindow));
+            
+            var target = new Decorator()
+            {
+                [ToolTip.TipProperty] = "Tip",
+                [ToolTip.ShowDelayProperty] = 0
+            };
+
+            var other = new Decorator()
+            {
+                [ToolTip.TipProperty] = "Tip",
+                [ToolTip.ShowDelayProperty] = (int) TimeSpan.FromHours(1).TotalMilliseconds,
+            };
+
+            var panel = new StackPanel
+            {
+                Children = { target, other }
+            };
+
+            var mouseEnter = SetupWindowAndGetMouseEnterAction(panel);
+            
+            mouseEnter(other);
+            Assert.False(ToolTip.GetIsOpen(other)); // long delay
+
+            mouseEnter(target);
+            Assert.True(ToolTip.GetIsOpen(target)); // no delay
+
+            mouseEnter(other);
+            Assert.True(ToolTip.GetIsOpen(other)); // delay skipped, a tooltip was already open
+
+            // Now disable the between-show system
+
+            mouseEnter(target);
+            Assert.True(ToolTip.GetIsOpen(target));
+
+            ToolTip.SetBetweenShowDelay(other, -1);
+
+            mouseEnter(other);
+            Assert.False(ToolTip.GetIsOpen(other));
         }
 
         private Action<Control> SetupWindowAndGetMouseEnterAction(Control windowContent, [CallerMemberName] string testName = null)
@@ -354,7 +411,7 @@ namespace Avalonia.Controls.UnitTests
                 hitTesterMock.Setup(m => m.HitTestFirst(point, window, It.IsAny<Func<Visual, bool>>()))
                     .Returns(control);
 
-                windowImpl.Object.Input(new RawPointerEventArgs(s_mouseDevice, (ulong)DateTime.Now.Ticks, window,
+                windowImpl.Object.Input(new RawPointerEventArgs(s_mouseDevice, (ulong)DateTime.Now.Ticks, (IInputRoot)control?.VisualRoot ?? window,
                         RawPointerEventType.Move, point, RawInputModifiers.None));
 
                 Assert.True(control == null || control.IsPointerOver);


### PR DESCRIPTION
This PR adds "tooltip chaining". If a tooltip is open and the pointer moves quickly to another control with a tooltip, that second control's tooltip will open immediately. The normal `ShowDelay` will be skipped.

This is [a feature of WPF](https://learn.microsoft.com/dotnet/desktop/wpf/controls/how-to-use-the-betweenshowdelay-property) and of many other desktop applications. It makes viewing multiple tooltips in succession much easier, because after the first tip opens there is no need to wait for each and every subsequent tip to open.

The new `BetweenShowDelay` property is the maximum amount of time _after a tooltip closes_ that tooltip chaining remains active. The name is the same as [the WPF property](https://learn.microsoft.com/dotnet/api/system.windows.controls.tooltipservice.betweenshowdelay). The default value is 100ms, also the same as WPF.

The PR also fixes glitches revealed by opening tooltips immediately, such as sometimes double-starting the timer due to handling of the mouse leave event of the previous tooltip's popup window.

## What is the current behavior?
Currently a tooltip always waits for `ToolTip.ShowDelay` before opening.

## Breaking changes
This PR doesn't break API compatibility, but does substantially change the runtime behaviour of tooltips.

Users who want the old behaviour back can set `BetweenShowDelay` to -1.

## Obsoletions / Deprecations
None
