### PR TITLE
fix: Fix the TouchDevice lost the touch Pressure

### DIFF
--- a/src/Avalonia.Base/Input/PointerPoint.cs
+++ b/src/Avalonia.Base/Input/PointerPoint.cs
@@ -164,6 +164,11 @@ namespace Avalonia.Input
             YTilt = yTilt;
         }
 
+        internal PointerPointProperties(RawInputModifiers modifiers, PointerUpdateKind kind, RawPointerPoint rawPoint)
+            : this(modifiers, kind, rawPoint.Twist, rawPoint.Pressure, rawPoint.XTilt, rawPoint.YTilt)
+        {
+        }
+
         internal PointerPointProperties(PointerPointProperties basedOn, RawPointerPoint rawPoint)
         {
             IsLeftButtonPressed = basedOn.IsLeftButtonPressed;

--- a/src/Avalonia.Base/Input/TouchDevice.cs
+++ b/src/Avalonia.Base/Input/TouchDevice.cs
@@ -87,7 +87,7 @@ namespace Avalonia.Input
 
                 target.RaiseEvent(new PointerPressedEventArgs(target, pointer,
                     (Visual)args.Root, args.Position, ev.Timestamp,
-                    new PointerPointProperties(GetModifiers(args.InputModifiers, true), updateKind),
+                    new PointerPointProperties(GetModifiers(args.InputModifiers, true), updateKind, args.Point),
                     keyModifier, _clickCount));
             }
 
@@ -99,7 +99,7 @@ namespace Avalonia.Input
                     target = gestureTarget ?? target;
                     var e = new PointerReleasedEventArgs(target, pointer,
                             (Visual)args.Root, args.Position, ev.Timestamp,
-                            new PointerPointProperties(GetModifiers(args.InputModifiers, false), updateKind),
+                            new PointerPointProperties(GetModifiers(args.InputModifiers, false), updateKind, args.Point),
                             keyModifier, MouseButton.Left);
                     if (gestureTarget != null)
                     {
@@ -127,7 +127,7 @@ namespace Avalonia.Input
                 target = gestureTarget ?? target;
                 var e = new PointerEventArgs(InputElement.PointerMovedEvent, target, pointer!, (Visual)args.Root,
                     args.Position, ev.Timestamp,
-                    new PointerPointProperties(GetModifiers(args.InputModifiers, true), updateKind),
+                    new PointerPointProperties(GetModifiers(args.InputModifiers, true), updateKind, args.Point),
                     keyModifier, args.IntermediatePoints);
 
                 if (gestureTarget != null)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

After https://github.com/AvaloniaUI/Avalonia/pull/15283 , and I can find the touch pressure on X11 platform. But I can not receive the touch pressure from `Avalonia.Input.PointerEventArgs`. And I find the TouchDevice will lost the touch pressure when create the 
PointerPointProperties.



## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

We can not receive the Touch Pressure in `Avalonia.Input.PointerEventArgs` on X11 platform.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

We can receive the Touch Pressure in `Avalonia.Input.PointerEventArgs` on X11 platform.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

I append the RawPointerPoint to PointerPointProperties in TouchDevice in this pull request.

## Checklist

- [ ] Added unit tests (if possible)? It is hard to write the unit tests.
- [ ] Added XML documentation to any related classes? No new public API was introduced.
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->


## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues

Fixes #3540

<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
