### PR TITLE
Try to combine AvaloniaResources with the same system path

### DIFF
--- a/src/Avalonia.Build.Tasks/GenerateAvaloniaResourcesTask.cs
+++ b/src/Avalonia.Build.Tasks/GenerateAvaloniaResourcesTask.cs
@@ -80,7 +80,13 @@ namespace Avalonia.Build.Tasks
         {
             AvaloniaResourcesIndexReaderWriter.WriteResources(
                 output,
-                sources.Select(source => (source.Path, source.Size, (Func<Stream>) source.Open)).ToList());
+                sources.Select(source => new AvaloniaResourcesEntry
+                {
+                    Path = source.Path,
+                    Size = source.Size,
+                    SystemPath = source.SystemPath,
+                    Open = source.Open
+                }).ToList());
         }
 
         private bool PreProcessXamlFiles(List<Source> sources)

--- a/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.Helpers.cs
+++ b/src/Avalonia.Build.Tasks/XamlCompilerTaskExecutor.Helpers.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Avalonia.Platform.Internal;
 using Avalonia.Utilities;
 using Mono.Cecil;
@@ -67,11 +68,13 @@ namespace Avalonia.Build.Tasks
 
                 AvaloniaResourcesIndexReaderWriter.WriteResources(
                     output,
-                    _resources.Select(x => (
-                        Path: x.Key,
-                        Size: x.Value.FileContents.Length,
-                        Open: (Func<Stream>) (() => new MemoryStream(x.Value.FileContents))
-                    )).ToList());
+                    _resources.Select(x => new AvaloniaResourcesEntry
+                    {
+                        Path = x.Key,
+                        Size = x.Value.FileContents.Length,
+                        SystemPath = x.Value.FilePath,
+                        Open = () => new MemoryStream(x.Value.FileContents)
+                    }).ToList());
 
                 output.Position = 0L;
                 _embedded = new EmbeddedResource(Constants.AvaloniaResourceName, ManifestResourceAttributes.Public, output);

--- a/tests/Avalonia.Base.UnitTests/Utilities/AvaloniaResourcesIndexTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Utilities/AvaloniaResourcesIndexTests.cs
@@ -85,7 +85,7 @@ public class AvaloniaResourcesIndexTests
         Assert.Equal(resourceBytes.Length, index[0].Size);
 
         Assert.Equal("!__AvaloniaDefaultWindowIcon", index[1].Path);
-        Assert.Equal(0, index[0].Offset);
-        Assert.Equal(resourceBytes.Length, index[0].Size);
+        Assert.Equal(0, index[1].Offset);
+        Assert.Equal(resourceBytes.Length, index[1].Size);
     }
 }

--- a/tests/Avalonia.Base.UnitTests/Utilities/AvaloniaResourcesIndexTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Utilities/AvaloniaResourcesIndexTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using System.Text;
+using Avalonia.Utilities;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests;
+
+public class AvaloniaResourcesIndexTests
+{
+    [Fact]
+    public void Should_Write_And_Read_The_Same_Resources()
+    {
+        using var memoryStream = new MemoryStream();
+
+        var fooBytes = Encoding.UTF8.GetBytes("foo");
+        var booBytes = Encoding.UTF8.GetBytes("boo");
+        AvaloniaResourcesIndexReaderWriter.WriteResources(memoryStream,
+            new[]
+            {
+                new AvaloniaResourcesEntry
+                {
+                    Path = "foo.xaml", Size = fooBytes.Length, Open = () => new MemoryStream(fooBytes)
+                },
+                new AvaloniaResourcesEntry
+                {
+                    Path = "boo.xaml", Size = booBytes.Length, Open = () => new MemoryStream(booBytes)
+                }
+            });
+
+        memoryStream.Seek(4, SeekOrigin.Begin); // skip 4 bytes for "index size" field.
+
+        var index = AvaloniaResourcesIndexReaderWriter.ReadIndex(memoryStream);
+        var resourcesBasePosition = memoryStream.Position;
+
+        Span<byte> buffer = stackalloc byte[index[0].Size];
+
+        Assert.Equal("foo.xaml", index[0].Path);
+        Assert.Equal(0, index[0].Offset);
+        Assert.Equal(fooBytes.Length, index[0].Size);
+
+        memoryStream.Seek(resourcesBasePosition + index[0].Offset, SeekOrigin.Begin);
+        memoryStream.ReadExactly(buffer);
+        Assert.Equal(fooBytes, buffer.ToArray());
+
+        Assert.Equal("boo.xaml", index[1].Path);
+        Assert.Equal(fooBytes.Length, index[1].Offset);
+        Assert.Equal(booBytes.Length, index[1].Size);
+
+        memoryStream.Seek(resourcesBasePosition + index[1].Offset, SeekOrigin.Begin);
+        memoryStream.ReadExactly(buffer);
+        Assert.Equal(booBytes, buffer.ToArray());
+    }
+
+    [Fact]
+    public void Should_Combined_Same_Physical_Path_Resources()
+    {
+        using var memoryStream = new MemoryStream();
+
+        var resourceBytes = Encoding.UTF8.GetBytes("resource-data");
+        AvaloniaResourcesIndexReaderWriter.WriteResources(memoryStream, new[]
+        {
+            new AvaloniaResourcesEntry
+            {
+                Path = "app.xaml",
+                SystemPath = "app.ico",
+                Size = resourceBytes.Length,
+                Open = () => new MemoryStream(resourceBytes)
+            },
+            new AvaloniaResourcesEntry
+            {
+                Path = "!__AvaloniaDefaultWindowIcon",
+                SystemPath = "app.ico",
+                Size = resourceBytes.Length,
+                Open = () => new MemoryStream(resourceBytes)
+            }
+        });
+
+        memoryStream.Seek(4, SeekOrigin.Begin); // skip 4 bytes for "index size" field.
+
+        var index = AvaloniaResourcesIndexReaderWriter.ReadIndex(memoryStream);
+
+        Assert.Equal("app.xaml", index[0].Path);
+        Assert.Equal(0, index[0].Offset);
+        Assert.Equal(resourceBytes.Length, index[0].Size);
+
+        Assert.Equal("!__AvaloniaDefaultWindowIcon", index[1].Path);
+        Assert.Equal(0, index[0].Offset);
+        Assert.Equal(resourceBytes.Length, index[0].Size);
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Follow-up PR/optimization after [previous PR](https://github.com/AvaloniaUI/Avalonia/pull/15298).
If the same file was included multiple times, but with different path/link, we should try to combine them into a single resource with aliases. 

## How was the solution implemented (if it's not obvious)?

No changes to the protocol. Just adjust offset properties for duplicated indexes, and don't write the same data twice.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

