### PR TITLE
Multi-Monitor DPI scaling breaks dialog sizes

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -800,6 +800,8 @@ namespace Avalonia.Controls
                 // determined only by calling this method. But here it will calculate not precise location because scaling may not yet be applied (see i.e. X11Window),
                 // thus we ought to call it again later to center window correctly if needed, when scaling will be already applied
                 SetWindowStartupLocation(owner);
+                
+                _canHandleResized = true; 
 
                 var initialSize = new Size(
                     double.IsNaN(Width) ? ClientSize.Width : Width,

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -90,6 +90,7 @@ namespace Avalonia.Controls
         private bool _isExtendedIntoWindowDecorations;
         private Thickness _windowDecorationMargin;
         private Thickness _offScreenMargin;
+        private bool _hasSetInitialSize = false;
 
         /// <summary>
         /// Defines the <see cref="SizeToContent"/> property.
@@ -728,6 +729,8 @@ namespace Avalonia.Controls
                     PlatformImpl?.Resize(initialSize, WindowResizeReason.Layout);
                 }
 
+                _hasSetInitialSize = true; 
+
                 LayoutManager.ExecuteInitialLayoutPass();
 
                 Owner = owner;
@@ -1020,7 +1023,7 @@ namespace Avalonia.Controls
         /// <inheritdoc/>
         internal override void HandleResized(Size clientSize, WindowResizeReason reason)
         {
-            if (ClientSize != clientSize || double.IsNaN(Width) || double.IsNaN(Height))
+            if (_hasSetInitialSize && (ClientSize != clientSize || double.IsNaN(Width) || double.IsNaN(Height)))
             {
                 var sizeToContent = SizeToContent;
 

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -90,7 +90,7 @@ namespace Avalonia.Controls
         private bool _isExtendedIntoWindowDecorations;
         private Thickness _windowDecorationMargin;
         private Thickness _offScreenMargin;
-        private bool _hasSetInitialSize = false;
+        private bool _canHandleResized = false;
 
         /// <summary>
         /// Defines the <see cref="SizeToContent"/> property.
@@ -720,6 +720,8 @@ namespace Avalonia.Controls
                 // thus we ought to call it again later to center window correctly if needed, when scaling will be already applied
                 SetWindowStartupLocation(owner);
 
+                _canHandleResized = true; 
+                
                 var initialSize = new Size(
                     double.IsNaN(Width) ? Math.Max(MinWidth, ClientSize.Width) : Width,
                     double.IsNaN(Height) ? Math.Max(MinHeight, ClientSize.Height) : Height);
@@ -728,8 +730,6 @@ namespace Avalonia.Controls
                 {
                     PlatformImpl?.Resize(initialSize, WindowResizeReason.Layout);
                 }
-
-                _hasSetInitialSize = true; 
 
                 LayoutManager.ExecuteInitialLayoutPass();
 
@@ -1023,7 +1023,7 @@ namespace Avalonia.Controls
         /// <inheritdoc/>
         internal override void HandleResized(Size clientSize, WindowResizeReason reason)
         {
-            if (_hasSetInitialSize && (ClientSize != clientSize || double.IsNaN(Width) || double.IsNaN(Height)))
+            if (_canHandleResized && (ClientSize != clientSize || double.IsNaN(Width) || double.IsNaN(Height)))
             {
                 var sizeToContent = SizeToContent;
 


### PR DESCRIPTION
## What does the pull request do?
There is a bug that the new window is the wrong size
It may be platform-specific since some platforms may have the possibility to set the window position + size in one call. Windows can't do that.

## What is the current behavior?
1. have two screens with different DPI settings
2. move the main window to the secondary screen
3. open a dialog with the "center owner" setting and predefined size (e.g. 200x200)
The dialog should be 200x200 but it is not because a lot of things happen
1. the window is created in the **default location** (somewhere on the main screen) and with the **default size**
2. the window is then moved to the proper position and size but this happens in two steps (position and then size)
2a. position - the window is moved to the center of the window on the secondary screen - but this immediately changes its size since these screens have different DPI settings
**2b. the window had of course wrong size at this point but the resize callback breaks the window.Width and Height settings**
2c. window sets the size - but the Width and Height is already broken


## What is the updated/expected behavior with this PR?
Ignore Resize callbacks until the initial size is set


## How was the solution implemented (if it's not obvious)?
ugly flag - maybe somebody has a better idea
no unit tests - feel free to add some