### PR TITLE
Fix tooltips not closing when the pointer leaves the window

### DIFF
--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -16,6 +16,7 @@ namespace Avalonia.Controls
         private Control? _tipControl;
         private long _lastTipCloseTime;
         private DispatcherTimer? _timer;
+        private ulong _lastTipEventTime;
 
         public ToolTipService(IInputManager inputManager)
         {
@@ -35,24 +36,34 @@ namespace Avalonia.Controls
         {
             if (e is RawPointerEventArgs pointerEvent)
             {
-                if (e.Root == _tipControl?.GetValue(ToolTip.ToolTipProperty)?.PopupHost)
-                {
-                    return; // pointer is over the current tooltip
-                }
+                if (_tipControl?.GetValue(ToolTip.ToolTipProperty) is { } currentTip && e.Root == currentTip.PopupHost)
+                    _lastTipEventTime = pointerEvent.Timestamp;
+
+                var simultaneousTipEvent = _lastTipEventTime == pointerEvent.Timestamp;
 
                 switch (pointerEvent.Type)
                 {
-                    case RawPointerEventType.Move:
+                    // sometimes there is a null hit test as soon as the pointer enters a tooltip
+                    case RawPointerEventType.Move when !(simultaneousTipEvent && pointerEvent.InputHitTestResult.element == null): 
                         Update(pointerEvent.InputHitTestResult.element as Visual);
+                        break;
+                    case RawPointerEventType.LeaveWindow when e.Root == _tipControl?.VisualRoot && !simultaneousTipEvent:
+                        ClearTip();
+                        _tipControl = null;
                         break;
                     case RawPointerEventType.LeftButtonDown:
                     case RawPointerEventType.RightButtonDown:
                     case RawPointerEventType.MiddleButtonDown:
                     case RawPointerEventType.XButton1Down:
                     case RawPointerEventType.XButton2Down:
-                        StopTimer();
-                        _tipControl?.ClearValue(ToolTip.IsOpenProperty);
+                        ClearTip();
                         break;
+                }
+
+                void ClearTip()
+                {
+                    StopTimer();
+                    _tipControl?.ClearValue(ToolTip.IsOpenProperty);
                 }
             }
         }

--- a/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ToolTipTests.cs
@@ -368,6 +368,30 @@ namespace Avalonia.Controls.UnitTests
             Assert.False(ToolTip.GetIsOpen(other));
         }
 
+        [Fact]
+        public void Should_Close_When_Pointer_Leaves_Window()
+        {
+            using (UnitTestApplication.Start(TestServices.FocusableWindow))
+            {
+                var target = new Decorator()
+                {
+                    [ToolTip.TipProperty] = "Tip",
+                    [ToolTip.ShowDelayProperty] = 0
+                };
+
+                var mouseEnter = SetupWindowAndGetMouseEnterAction(target);
+
+                mouseEnter(target);
+                Assert.True(ToolTip.GetIsOpen(target));
+
+                var topLevel = TopLevel.GetTopLevel(target);
+                topLevel.PlatformImpl.Input(new RawPointerEventArgs(s_mouseDevice, (ulong)DateTime.Now.Ticks, topLevel, 
+                    RawPointerEventType.LeaveWindow, default(RawPointerPoint), RawInputModifiers.None));
+
+                Assert.False(ToolTip.GetIsOpen(target));
+            }
+        }
+
         private Action<Control> SetupWindowAndGetMouseEnterAction(Control windowContent, [CallerMemberName] string testName = null)
         {
             var windowImpl = MockWindowingPlatform.CreateWindowMock();
@@ -390,6 +414,7 @@ namespace Avalonia.Controls.UnitTests
             Assert.True(windowContent.IsVisible);
 
             var controlIds = new Dictionary<Control, int>();
+            IInputRoot lastRoot = null;
 
             return control =>
             {
@@ -411,8 +436,19 @@ namespace Avalonia.Controls.UnitTests
                 hitTesterMock.Setup(m => m.HitTestFirst(point, window, It.IsAny<Func<Visual, bool>>()))
                     .Returns(control);
 
-                windowImpl.Object.Input(new RawPointerEventArgs(s_mouseDevice, (ulong)DateTime.Now.Ticks, (IInputRoot)control?.VisualRoot ?? window,
+                var root = (IInputRoot)control?.VisualRoot ?? window;
+                var timestamp = (ulong)DateTime.Now.Ticks;
+
+                windowImpl.Object.Input(new RawPointerEventArgs(s_mouseDevice, timestamp, root,
                         RawPointerEventType.Move, point, RawInputModifiers.None));
+
+                if (lastRoot != null && lastRoot != root)
+                {
+                    ((TopLevel)lastRoot).PlatformImpl?.Input(new RawPointerEventArgs(s_mouseDevice, timestamp, 
+                        lastRoot, RawPointerEventType.LeaveWindow, new Point(-1,-1), RawInputModifiers.None));
+                }
+
+                lastRoot = root;
 
                 Assert.True(control == null || control.IsPointerOver);
             };


### PR DESCRIPTION
Fixes a mistake I made in #14928. If a tooltip is open and the pointer leaves the window without first leaving the tooltip control, the tooltip does not close. The easiest way to replicate this is to create a control which fills the entire window (with no margin) and give it a tooltip.

This PR will conflict with #15259. I still submitted this fix separately because #15259 includes a change in behaviour, and it's not clear whether it will be added to 11.1.

## Breaking changes
None

## Obsoletions / Deprecations
None