### PR TITLE
Add FuncValueConverter with parameter support

### DIFF
--- a/src/Avalonia.Base/Data/Converters/FuncValueConverter.cs
+++ b/src/Avalonia.Base/Data/Converters/FuncValueConverter.cs
@@ -5,7 +5,7 @@ using Avalonia.Utilities;
 namespace Avalonia.Data.Converters
 {
     /// <summary>
-    /// A general purpose <see cref="IValueConverter"/> that uses a <see cref="Func{T1, TResult}"/>
+    /// A general purpose <see cref="IValueConverter"/> that uses a <see cref="Func{TIn, TResult}"/>
     /// to provide the converter logic.
     /// </summary>
     /// <typeparam name="TIn">The input type.</typeparam>
@@ -29,6 +29,46 @@ namespace Avalonia.Data.Converters
             if (TypeUtilities.CanCast<TIn>(value))
             {
                 return _convert((TIn?)value);
+            }
+            else
+            {
+                return AvaloniaProperty.UnsetValue;
+            }
+        }
+
+        /// <inheritdoc/>
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// A general purpose <see cref="IValueConverter"/> that uses a <see cref="Func{TIn, TParam, TResult}"/>
+    /// to provide the converter logic.
+    /// </summary>
+    /// <typeparam name="TIn">The input type.</typeparam>
+    /// <typeparam name="TParam">The param type.</typeparam>
+    /// <typeparam name="TOut">The output type.</typeparam>
+    public class FuncValueConverter<TIn, TParam, TOut> : IValueConverter
+    {
+        private readonly Func<TIn?, TParam?, TOut> _convert;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FuncValueConverter{TIn, TOut}"/> class.
+        /// </summary>
+        /// <param name="convert">The convert function.</param>
+        public FuncValueConverter(Func<TIn?, TParam?, TOut> convert)
+        {
+            _convert = convert;
+        }
+
+        /// <inheritdoc/>
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (TypeUtilities.CanCast<TIn>(value) && TypeUtilities.CanCast<TParam>(parameter))
+            {
+                return _convert((TIn?)value, (TParam?)parameter);
             }
             else
             {

--- a/src/Avalonia.Base/Data/Converters/FuncValueConverter.cs
+++ b/src/Avalonia.Base/Data/Converters/FuncValueConverter.cs
@@ -55,7 +55,7 @@ namespace Avalonia.Data.Converters
         private readonly Func<TIn?, TParam?, TOut> _convert;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FuncValueConverter{TIn, TOut}"/> class.
+        /// Initializes a new instance of the <see cref="FuncValueConverter{TIn, TParam, TOut}"/> class.
         /// </summary>
         /// <param name="convert">The convert function.</param>
         public FuncValueConverter(Func<TIn?, TParam?, TOut> convert)

--- a/src/Avalonia.Base/Data/Converters/FuncValueConverter.cs
+++ b/src/Avalonia.Base/Data/Converters/FuncValueConverter.cs
@@ -44,7 +44,7 @@ namespace Avalonia.Data.Converters
     }
 
     /// <summary>
-    /// A general purpose <see cref="IValueConverter"/> that uses a <see cref="Func{TIn, TParam, TResult}"/>
+    /// A general purpose <see cref="IValueConverter"/> that uses a <see cref="Func{TIn, TParam, TOut}"/>
     /// to provide the converter logic.
     /// </summary>
     /// <typeparam name="TIn">The input type.</typeparam>

--- a/src/Avalonia.Base/Data/Converters/ObjectConverters.cs
+++ b/src/Avalonia.Base/Data/Converters/ObjectConverters.cs
@@ -16,5 +16,17 @@ namespace Avalonia.Data.Converters
         /// </summary>
         public static readonly IValueConverter IsNotNull =
             new FuncValueConverter<object?, bool>(x => x is not null);
+
+        /// <summary>
+        /// A value converter that returns true if the input object is equal to a parameter object.
+        /// </summary>
+        public static readonly IValueConverter Equal =
+            new FuncValueConverter<object?, object?, bool>((a, b) => a is not null && a.Equals(b));
+ 
+        /// <summary>
+        /// A value converter that returns true if the input object is not equal to a parameter object.
+        /// </summary>
+        public static readonly IValueConverter NotEqual =
+            new FuncValueConverter<object?, object?, bool>((a, b) => !a?.Equals(b) ?? b is not null);
     }
 }

--- a/src/Avalonia.Base/Data/Converters/ObjectConverters.cs
+++ b/src/Avalonia.Base/Data/Converters/ObjectConverters.cs
@@ -21,7 +21,7 @@ namespace Avalonia.Data.Converters
         /// A value converter that returns true if the input object is equal to a parameter object.
         /// </summary>
         public static readonly IValueConverter Equal =
-            new FuncValueConverter<object?, object?, bool>((a, b) => a is not null && a.Equals(b));
+            new FuncValueConverter<object?, object?, bool>((a, b) => a?.Equals(b) ?? b is null);
  
         /// <summary>
         /// A value converter that returns true if the input object is not equal to a parameter object.

--- a/tests/Avalonia.Base.UnitTests/Data/ObjectConvertersTests_Eqaul.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/ObjectConvertersTests_Eqaul.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Data;
+
+public class ObjectConvertersTests_Equal
+{
+    [Fact]
+    public void Returns_True_If_Value_And_Parameter_Are_Null()
+    {
+        var result = ObjectConverters.Equal.Convert(null, typeof(object), null, CultureInfo.InvariantCulture);
+
+        Assert.IsType<bool>(result);
+        Assert.True(result is true);
+    }
+
+    [Fact]
+    public void Returns_False_If_Value_Is_Null_And_Parameter_Is_Not_Null()
+    {
+        var result = ObjectConverters.Equal.Convert(null, typeof(object), new object(), CultureInfo.InvariantCulture);
+
+        Assert.IsType<bool>(result);
+        Assert.True(result is false);
+    }
+
+    [Fact]
+    public void Returns_False_If_Value_And_Parameter_Are_Different_Objects()
+    {
+        var result = ObjectConverters.Equal.Convert(new object(), typeof(object), new object(), CultureInfo.InvariantCulture);
+
+        Assert.IsType<bool>(result);
+        Assert.True(result is false);
+    }
+
+    [Fact]
+    public void Returns_True_If_Value_And_Parameter_Are_Same_Object()
+    {
+        var target = new object();
+        var result = ObjectConverters.Equal.Convert(target, typeof(object), target, CultureInfo.InvariantCulture);
+
+        Assert.IsType<bool>(result);
+        Assert.True(result is true);
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/Data/ObjectConvertersTests_IsNotNull.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/ObjectConvertersTests_IsNotNull.cs
@@ -1,0 +1,26 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Data;
+
+public class ObjectConvertersTests_IsNull
+{
+    [Fact]
+    public void Returns_True_If_Value_Is_Null()
+    {
+        var result = ObjectConverters.IsNull.Convert(null, typeof(object), null, CultureInfo.InvariantCulture);
+
+        Assert.IsType<bool>(result);
+        Assert.True(result is true);
+    }
+
+    [Fact]
+    public void Returns_False_If_Value_Is_Not_Null()
+    {
+        var result = ObjectConverters.IsNull.Convert(new object(), typeof(object), null, CultureInfo.InvariantCulture);
+
+        Assert.IsType<bool>(result);
+        Assert.True(result is false);
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/Data/ObjectConvertersTests_IsNull.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/ObjectConvertersTests_IsNull.cs
@@ -1,0 +1,26 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Data;
+
+public class ObjectConvertersTests_IsNotNull
+{
+    [Fact]
+    public void Returns_True_If_Value_Is_Not_Null()
+    {
+        var result = ObjectConverters.IsNotNull.Convert(new object(), typeof(object), null, CultureInfo.InvariantCulture);
+
+        Assert.IsType<bool>(result);
+        Assert.True(result is true);
+    }
+
+    [Fact]
+    public void Returns_False_If_Value_Is_Null()
+    {
+        var result = ObjectConverters.IsNotNull.Convert(null, typeof(object), null, CultureInfo.InvariantCulture);
+
+        Assert.IsType<bool>(result);
+        Assert.True(result is false);
+    }
+}

--- a/tests/Avalonia.Base.UnitTests/Data/ObjectConvertersTests_NotEqaul.cs
+++ b/tests/Avalonia.Base.UnitTests/Data/ObjectConvertersTests_NotEqaul.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Xunit;
+
+namespace Avalonia.Base.UnitTests.Data;
+
+public class ObjectConvertersTests_NotEqual
+{
+    [Fact]
+    public void Returns_False_If_Value_And_Parameter_Are_Null()
+    {
+        var result = ObjectConverters.NotEqual.Convert(null, typeof(object), null, CultureInfo.InvariantCulture);
+
+        Assert.IsType<bool>(result);
+        Assert.True(result is false);
+    }
+
+    [Fact]
+    public void Returns_True_If_Value_Is_Null_And_Parameter_Is_Not_Null()
+    {
+        var result = ObjectConverters.NotEqual.Convert(null, typeof(object), new object(), CultureInfo.InvariantCulture);
+
+        Assert.IsType<bool>(result);
+        Assert.True(result is true);
+    }
+
+    [Fact]
+    public void Returns_True_If_Value_And_Parameter_Are_Different_Objects()
+    {
+        var result = ObjectConverters.NotEqual.Convert(new object(), typeof(object), new object(), CultureInfo.InvariantCulture);
+
+        Assert.IsType<bool>(result);
+        Assert.True(result is true);
+    }
+
+    [Fact]
+    public void Returns_False_If_Value_And_Parameter_Are_Same_Object()
+    {
+        var target = new object();
+        var result = ObjectConverters.NotEqual.Convert(target, typeof(object), target, CultureInfo.InvariantCulture);
+
+        Assert.IsType<bool>(result);
+        Assert.True(result is false);
+    }
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Adds support for converter parameter into `FuncValueConverter<TIn, TParam, TOut>`  and uses it to implement `ObjectConverters.Equal `and `ObjectConverters.NotEqual` converters

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

No support for converter parameter in FuncValueConverter 

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

FuncValueConverter can be declared with parameter support in Func

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

Created new version of generic `FuncValueConverter<TIn, TParam, TOut>`

## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
