### PR TITLE
A bit of code refactor

### DIFF
--- a/src/Avalonia.Base/AvaloniaPropertyRegistry.cs
+++ b/src/Avalonia.Base/AvaloniaPropertyRegistry.cs
@@ -331,7 +331,7 @@ namespace Avalonia
             AvaloniaObject o,
             DirectPropertyBase<T> property)
         {
-            if (property.Owner == o.GetType())
+            if (property.OwnerType == o.GetType())
             {
                 return property;
             }

--- a/src/Avalonia.Base/DirectProperty.cs
+++ b/src/Avalonia.Base/DirectProperty.cs
@@ -32,7 +32,6 @@ namespace Avalonia
         {
             Getter = getter ?? throw new ArgumentNullException(nameof(getter));
             Setter = setter;
-            IsDirect = true;
             IsReadOnly = setter is null;
         }
 
@@ -52,7 +51,6 @@ namespace Avalonia
         {
             Getter = getter ?? throw new ArgumentNullException(nameof(getter));
             Setter = setter;
-            IsDirect = true;
             IsReadOnly = setter is null;
         }
 

--- a/src/Avalonia.Base/DirectPropertyBase.cs
+++ b/src/Avalonia.Base/DirectPropertyBase.cs
@@ -28,7 +28,6 @@ namespace Avalonia
             : base(name, ownerType, ownerType, metadata)
         {
             IsDirect = true;
-            Owner = ownerType;
         }
 
         /// <summary>
@@ -44,13 +43,7 @@ namespace Avalonia
             : base(source, ownerType, metadata)
         {
             IsDirect = true;
-            Owner = ownerType;
         }
-
-        /// <summary>
-        /// Gets the type that registered the property.
-        /// </summary>
-        public Type Owner { get; }
 
         /// <summary>
         /// Gets the value of the property on the instance.

--- a/src/Avalonia.Base/DirectPropertyBase.cs
+++ b/src/Avalonia.Base/DirectPropertyBase.cs
@@ -27,6 +27,7 @@ namespace Avalonia
             AvaloniaPropertyMetadata metadata)
             : base(name, ownerType, ownerType, metadata)
         {
+            IsDirect = true;
             Owner = ownerType;
         }
 
@@ -42,6 +43,7 @@ namespace Avalonia
             AvaloniaPropertyMetadata metadata)
             : base(source, ownerType, metadata)
         {
+            IsDirect = true;
             Owner = ownerType;
         }
 

--- a/src/Avalonia.Base/IDirectPropertyAccessor.cs
+++ b/src/Avalonia.Base/IDirectPropertyAccessor.cs
@@ -17,7 +17,7 @@ namespace Avalonia
         /// <summary>
         /// Gets the class that registered the property.
         /// </summary>
-        Type Owner { get; }
+        Type OwnerType { get; }
 
         /// <summary>
         /// Gets the value of the property on the instance.


### PR DESCRIPTION
## What does the pull request do?
1 [Move IsDirect = true into DirectPropertyBase](https://github.com/AvaloniaUI/Avalonia/commit/04d64f537acd909c1ecdbde9051ef597c4b259ec)
The line below should be better moved into the base class `DirectPropertyBase` instead of `DirectProperty<TOwner, TValue>`.
```cs
IsDirect = true;
```

2 [Rename IDirectPropertyAccessor.Owner to OwnerType](https://github.com/AvaloniaUI/Avalonia/commit/5565135ae2f4e4e4b1c839a82a2737e4e8db3708)
The internal interface `IDirectPropertyAccessor` should reuse the exising property name in `AvaloniaProperty`, not introduce a new 
 duplicate one.
