### PR TITLE
Reduce generated invocations to `FindNameScope`

### DIFF
--- a/src/tools/Avalonia.Generators/NameGenerator/InitializeComponentCodeGenerator.cs
+++ b/src/tools/Avalonia.Generators/NameGenerator/InitializeComponentCodeGenerator.cs
@@ -4,7 +4,7 @@ using XamlX.TypeSystem;
 
 namespace Avalonia.Generators.NameGenerator;
 
-internal class InitializeComponentCodeGenerator: ICodeGenerator
+internal class InitializeComponentCodeGenerator : ICodeGenerator
 {
     private readonly bool _diagnosticsAreConnected;
     private const string AttachDevToolsCodeBlock = @"
@@ -29,11 +29,20 @@ internal class InitializeComponentCodeGenerator: ICodeGenerator
     {
         var properties = new List<string>();
         var initializations = new List<string>();
+        const string thisFindNameScopeVariable = "            var __thisNameScope__ = this.FindNameScope();";
+        bool hasNames = false;
         foreach (var resolvedName in names)
         {
+            if (!hasNames)
+            {
+                initializations.Add(thisFindNameScopeVariable);
+            }
+
             var (typeName, name, fieldModifier) = resolvedName;
             properties.Add($"        {fieldModifier} {typeName} {name};");
-            initializations.Add($"            {name} = this.FindNameScope()?.Find<{typeName}>(\"{name}\");");
+            initializations.Add($"            {name} = __thisNameScope__?.Find<{typeName}>(\"{name}\");");
+
+            hasNames = true;
         }
 
         var attachDevTools = _diagnosticsAreConnected && IsWindow(xamlType);
@@ -68,7 +77,7 @@ namespace {nameSpace}
 }}
 ";
     }
-        
+
     private static bool IsWindow(IXamlType xamlType)
     {
         var type = xamlType;

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/AttachedProps.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/AttachedProps.txt
@@ -22,7 +22,8 @@ namespace Sample.App
                 AvaloniaXamlLoader.Load(this);
             }
 
-            UserNameTextBox = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
+            var __thisNameScope__ = this.FindNameScope();
+            UserNameTextBox = __thisNameScope__?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
         }
     }
 }

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/AttachedPropsWithDevTools.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/AttachedPropsWithDevTools.txt
@@ -30,7 +30,8 @@ namespace Sample.App
             }
 #endif
 
-            UserNameTextBox = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
+            var __thisNameScope__ = this.FindNameScope();
+            UserNameTextBox = __thisNameScope__?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
         }
     }
 }

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/ControlWithoutWindow.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/ControlWithoutWindow.txt
@@ -22,7 +22,8 @@ namespace Sample.App
                 AvaloniaXamlLoader.Load(this);
             }
 
-            UserNameTextBox = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
+            var __thisNameScope__ = this.FindNameScope();
+            UserNameTextBox = __thisNameScope__?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
         }
     }
 }

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/CustomControls.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/CustomControls.txt
@@ -24,9 +24,10 @@ namespace Sample.App
                 AvaloniaXamlLoader.Load(this);
             }
 
-            ClrNamespaceRoutedViewHost = this.FindNameScope()?.Find<global::Avalonia.ReactiveUI.RoutedViewHost>("ClrNamespaceRoutedViewHost");
-            UriRoutedViewHost = this.FindNameScope()?.Find<global::Avalonia.ReactiveUI.RoutedViewHost>("UriRoutedViewHost");
-            UserNameTextBox = this.FindNameScope()?.Find<global::Controls.CustomTextBox>("UserNameTextBox");
+            var __thisNameScope__ = this.FindNameScope();
+            ClrNamespaceRoutedViewHost = __thisNameScope__?.Find<global::Avalonia.ReactiveUI.RoutedViewHost>("ClrNamespaceRoutedViewHost");
+            UriRoutedViewHost = __thisNameScope__?.Find<global::Avalonia.ReactiveUI.RoutedViewHost>("UriRoutedViewHost");
+            UserNameTextBox = __thisNameScope__?.Find<global::Controls.CustomTextBox>("UserNameTextBox");
         }
     }
 }

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/DataTemplates.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/DataTemplates.txt
@@ -23,8 +23,9 @@ namespace Sample.App
                 AvaloniaXamlLoader.Load(this);
             }
 
-            UserNameTextBox = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
-            NamedListBox = this.FindNameScope()?.Find<global::Avalonia.Controls.ListBox>("NamedListBox");
+            var __thisNameScope__ = this.FindNameScope();
+            UserNameTextBox = __thisNameScope__?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
+            NamedListBox = __thisNameScope__?.Find<global::Avalonia.Controls.ListBox>("NamedListBox");
         }
     }
 }

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/FieldModifier.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/FieldModifier.txt
@@ -27,12 +27,13 @@ namespace Sample.App
                 AvaloniaXamlLoader.Load(this);
             }
 
-            FirstNameTextBox = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("FirstNameTextBox");
-            LastNameTextBox = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("LastNameTextBox");
-            PasswordTextBox = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("PasswordTextBox");
-            ConfirmPasswordTextBox = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("ConfirmPasswordTextBox");
-            SignUpButton = this.FindNameScope()?.Find<global::Avalonia.Controls.Button>("SignUpButton");
-            RegisterButton = this.FindNameScope()?.Find<global::Avalonia.Controls.Button>("RegisterButton");
+            var __thisNameScope__ = this.FindNameScope();
+            FirstNameTextBox = __thisNameScope__?.Find<global::Avalonia.Controls.TextBox>("FirstNameTextBox");
+            LastNameTextBox = __thisNameScope__?.Find<global::Avalonia.Controls.TextBox>("LastNameTextBox");
+            PasswordTextBox = __thisNameScope__?.Find<global::Avalonia.Controls.TextBox>("PasswordTextBox");
+            ConfirmPasswordTextBox = __thisNameScope__?.Find<global::Avalonia.Controls.TextBox>("ConfirmPasswordTextBox");
+            SignUpButton = __thisNameScope__?.Find<global::Avalonia.Controls.Button>("SignUpButton");
+            RegisterButton = __thisNameScope__?.Find<global::Avalonia.Controls.Button>("RegisterButton");
         }
     }
 }

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/NamedControl.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/NamedControl.txt
@@ -22,7 +22,8 @@ namespace Sample.App
                 AvaloniaXamlLoader.Load(this);
             }
 
-            UserNameTextBox = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
+            var __thisNameScope__ = this.FindNameScope();
+            UserNameTextBox = __thisNameScope__?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
         }
     }
 }

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/NamedControls.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/NamedControls.txt
@@ -24,9 +24,10 @@ namespace Sample.App
                 AvaloniaXamlLoader.Load(this);
             }
 
-            UserNameTextBox = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
-            PasswordTextBox = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("PasswordTextBox");
-            SignUpButton = this.FindNameScope()?.Find<global::Avalonia.Controls.Button>("SignUpButton");
+            var __thisNameScope__ = this.FindNameScope();
+            UserNameTextBox = __thisNameScope__?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
+            PasswordTextBox = __thisNameScope__?.Find<global::Avalonia.Controls.TextBox>("PasswordTextBox");
+            SignUpButton = __thisNameScope__?.Find<global::Avalonia.Controls.Button>("SignUpButton");
         }
     }
 }

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/SignUpView.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/SignUpView.txt
@@ -31,16 +31,17 @@ namespace Sample.App
                 AvaloniaXamlLoader.Load(this);
             }
 
-            UserNameTextBox = this.FindNameScope()?.Find<global::Controls.CustomTextBox>("UserNameTextBox");
-            UserNameValidation = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBlock>("UserNameValidation");
-            PasswordTextBox = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("PasswordTextBox");
-            PasswordValidation = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBlock>("PasswordValidation");
-            AwesomeListView = this.FindNameScope()?.Find<global::Avalonia.Controls.ListBox>("AwesomeListView");
-            ConfirmPasswordTextBox = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("ConfirmPasswordTextBox");
-            ConfirmPasswordValidation = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBlock>("ConfirmPasswordValidation");
-            SignUpButtonDescription = this.FindNameScope()?.Find<global::Avalonia.Controls.Documents.Run>("SignUpButtonDescription");
-            SignUpButton = this.FindNameScope()?.Find<global::Avalonia.Controls.Button>("SignUpButton");
-            CompoundValidation = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBlock>("CompoundValidation");
+            var __thisNameScope__ = this.FindNameScope();
+            UserNameTextBox = __thisNameScope__?.Find<global::Controls.CustomTextBox>("UserNameTextBox");
+            UserNameValidation = __thisNameScope__?.Find<global::Avalonia.Controls.TextBlock>("UserNameValidation");
+            PasswordTextBox = __thisNameScope__?.Find<global::Avalonia.Controls.TextBox>("PasswordTextBox");
+            PasswordValidation = __thisNameScope__?.Find<global::Avalonia.Controls.TextBlock>("PasswordValidation");
+            AwesomeListView = __thisNameScope__?.Find<global::Avalonia.Controls.ListBox>("AwesomeListView");
+            ConfirmPasswordTextBox = __thisNameScope__?.Find<global::Avalonia.Controls.TextBox>("ConfirmPasswordTextBox");
+            ConfirmPasswordValidation = __thisNameScope__?.Find<global::Avalonia.Controls.TextBlock>("ConfirmPasswordValidation");
+            SignUpButtonDescription = __thisNameScope__?.Find<global::Avalonia.Controls.Documents.Run>("SignUpButtonDescription");
+            SignUpButton = __thisNameScope__?.Find<global::Avalonia.Controls.Button>("SignUpButton");
+            CompoundValidation = __thisNameScope__?.Find<global::Avalonia.Controls.TextBlock>("CompoundValidation");
         }
     }
 }

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/xNamedControl.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/xNamedControl.txt
@@ -22,7 +22,8 @@ namespace Sample.App
                 AvaloniaXamlLoader.Load(this);
             }
 
-            UserNameTextBox = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
+            var __thisNameScope__ = this.FindNameScope();
+            UserNameTextBox = __thisNameScope__?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
         }
     }
 }

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/xNamedControls.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/xNamedControls.txt
@@ -24,9 +24,10 @@ namespace Sample.App
                 AvaloniaXamlLoader.Load(this);
             }
 
-            UserNameTextBox = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
-            PasswordTextBox = this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("PasswordTextBox");
-            SignUpButton = this.FindNameScope()?.Find<global::Avalonia.Controls.Button>("SignUpButton");
+            var __thisNameScope__ = this.FindNameScope();
+            UserNameTextBox = __thisNameScope__?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
+            PasswordTextBox = __thisNameScope__?.Find<global::Avalonia.Controls.TextBox>("PasswordTextBox");
+            SignUpButton = __thisNameScope__?.Find<global::Avalonia.Controls.Button>("SignUpButton");
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Reduces the invocations of the `FindNameScope` method on `this` on generated `InitializeComponent`. See #15365

## What is the current behavior?
For every named control, the generated code invokes `FindNameScope` within `InitializeComponent`.

## What is the updated/expected behavior with this PR?
The `FindNameScope` method is invoked only once **if** there are any named controls that would use this method.

## Checklist

- [x] Adjusted existing unit tests' expected generated code
- [ ] Added XML documentation to any related classes?

## Breaking changes
None, assuming `FindNameScope` does not return different results during the execution of `InitializeComponent`.

## Fixed issues
Fixes #15365
