### PR TITLE
Add StringSyntax attribute to the runtime parser code

### DIFF
--- a/src/Avalonia.Base/Avalonia.Base.csproj
+++ b/src/Avalonia.Base/Avalonia.Base.csproj
@@ -32,6 +32,7 @@
     <InternalsVisibleTo Include="Avalonia.Direct2D1, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Markup, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Markup.Xaml, PublicKey=$(AvaloniaPublicKey)" />
+    <InternalsVisibleTo Include="Avalonia.Markup.Xaml.Loader, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.OpenGL, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Skia, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Controls.ColorPicker, PublicKey=$(AvaloniaPublicKey)" />

--- a/src/Avalonia.Base/Compatibility/StringSyntaxAttribute.cs
+++ b/src/Avalonia.Base/Compatibility/StringSyntaxAttribute.cs
@@ -1,0 +1,43 @@
+#pragma warning disable MA0048 // File name must match type name
+// https://github.com/dotnet/runtime/blob/v8.0.4/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/StringSyntaxAttribute.cs
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// ReSharper disable once CheckNamespace
+namespace System.Diagnostics.CodeAnalysis
+{
+#if !NET7_0_OR_GREATER
+    /// <summary>Specifies the syntax used in a string.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    internal sealed class StringSyntaxAttribute : Attribute
+    {
+        /// <summary>Initializes the <see cref="StringSyntaxAttribute"/> with the identifier of the syntax used.</summary>
+        /// <param name="syntax">The syntax identifier.</param>
+        public StringSyntaxAttribute(string syntax)
+        {
+            Syntax = syntax;
+            Arguments = Array.Empty<object?>();
+        }
+
+        /// <summary>Initializes the <see cref="StringSyntaxAttribute"/> with the identifier of the syntax used.</summary>
+        /// <param name="syntax">The syntax identifier.</param>
+        /// <param name="arguments">Optional arguments associated with the specific syntax employed.</param>
+        public StringSyntaxAttribute(string syntax, params object?[] arguments)
+        {
+            Syntax = syntax;
+            Arguments = arguments;
+        }
+
+        /// <summary>Gets the identifier of the syntax used.</summary>
+        public string Syntax { get; }
+
+        /// <summary>Optional arguments associated with the specific syntax employed.</summary>
+        public object?[] Arguments { get; }
+
+        /// <summary>The syntax identifier for strings containing XML.</summary>
+        public const string Xml = nameof(Xml);
+    }
+#endif
+}

--- a/src/Avalonia.Base/Compatibility/TrimmingAttributes.cs
+++ b/src/Avalonia.Base/Compatibility/TrimmingAttributes.cs
@@ -7,7 +7,6 @@
 
 namespace System.Diagnostics.CodeAnalysis
 {
-#nullable enable
 #if !NET6_0_OR_GREATER
     [AttributeUsage(
         AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/AvaloniaRuntimeXamlLoader.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/AvaloniaRuntimeXamlLoader.cs
@@ -22,7 +22,7 @@ namespace Avalonia.Markup.Xaml
         /// <param name="designMode">Indicates whether the XAML is being loaded in design mode.</param>
         /// <returns>The loaded object.</returns>
         [RequiresUnreferencedCode(XamlX.TrimmingMessages.DynamicXamlReference)]
-        public static object Load(string xaml, Assembly? localAssembly = null, object? rootInstance = null, Uri? uri = null, bool designMode = false)
+        public static object Load([StringSyntax(StringSyntaxAttribute.Xml)] string xaml, Assembly? localAssembly = null, object? rootInstance = null, Uri? uri = null, bool designMode = false)
         {
             xaml = xaml ?? throw new ArgumentNullException(nameof(xaml));
 
@@ -74,7 +74,7 @@ namespace Avalonia.Markup.Xaml
         /// <param name="localAssembly">Default assembly for clr-namespace:.</param>
         /// <returns>The loaded object.</returns>
         [RequiresUnreferencedCode(XamlX.TrimmingMessages.DynamicXamlReference)]
-        public static object Parse(string xaml, Assembly? localAssembly = null)
+        public static object Parse([StringSyntax(StringSyntaxAttribute.Xml)] string xaml, Assembly? localAssembly = null)
             => Load(xaml, localAssembly);
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace Avalonia.Markup.Xaml
         /// <param name="localAssembly">>Default assembly for clr-namespace:.</param>
         /// <returns>The loaded object.</returns>
         [RequiresUnreferencedCode(XamlX.TrimmingMessages.DynamicXamlReference)]
-        public static T Parse<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string xaml, Assembly? localAssembly = null)
+        public static T Parse<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>([StringSyntax(StringSyntaxAttribute.Xml)] string xaml, Assembly? localAssembly = null)
             => (T)Parse(xaml, localAssembly);
     }
 }

--- a/src/Markup/Avalonia.Markup.Xaml/RuntimeXamlLoaderDocument.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/RuntimeXamlLoaderDocument.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 
@@ -6,24 +7,24 @@ namespace Avalonia.Markup.Xaml;
 
 public class RuntimeXamlLoaderDocument
 {
-    public RuntimeXamlLoaderDocument(string xaml)
+    public RuntimeXamlLoaderDocument([StringSyntax(StringSyntaxAttribute.Xml)] string xaml)
     {
         XamlStream = new MemoryStream(Encoding.UTF8.GetBytes(xaml));
     }
 
-    public RuntimeXamlLoaderDocument(Uri? baseUri, string xaml)
+    public RuntimeXamlLoaderDocument(Uri? baseUri, [StringSyntax(StringSyntaxAttribute.Xml)] string xaml)
         : this(xaml)
     {
         BaseUri = baseUri;
     }
 
-    public RuntimeXamlLoaderDocument(object? rootInstance, string xaml)
+    public RuntimeXamlLoaderDocument(object? rootInstance, [StringSyntax(StringSyntaxAttribute.Xml)] string xaml)
         : this(xaml)
     {
         RootInstance = rootInstance;
     }
     
-    public RuntimeXamlLoaderDocument(Uri? baseUri, object? rootInstance, string xaml)
+    public RuntimeXamlLoaderDocument(Uri? baseUri, object? rootInstance, [StringSyntax(StringSyntaxAttribute.Xml)] string xaml)
         : this(baseUri, xaml)
     {
         RootInstance = rootInstance;


### PR DESCRIPTION
## What does the pull request do?

Marks our public XAML parser APIs with StringSyntaxAttribute:
Useful for tests:
![image](https://github.com/AvaloniaUI/Avalonia/assets/3163374/77e7b9d5-1c2b-4538-8ed2-bece438f0f98)

Highlights errors as well:
![image](https://github.com/AvaloniaUI/Avalonia/assets/3163374/9a0a32e4-a3fc-4714-a4ca-645813af6788)

And conveniently, Avalonia XAML is a valid XML. 

It doesn't work with XAML in local variables:
![image](https://github.com/AvaloniaUI/Avalonia/assets/3163374/32fd3fe5-7883-4c60-bdf5-7e7aac8e2559)

Also doesn't work in Visual Studio at all for some reason. 