### PR TITLE
Made AvaloniaPropertyMetadata immutable after property initialization

### DIFF
--- a/src/Avalonia.Base/AvaloniaProperty.cs
+++ b/src/Avalonia.Base/AvaloniaProperty.cs
@@ -50,7 +50,10 @@ namespace Avalonia
             AvaloniaPropertyMetadata metadata,
             Action<AvaloniaObject, bool>? notifying = null)
         {
-            _ = name ?? throw new ArgumentNullException(nameof(name));
+            ThrowHelper.ThrowIfNull(name, nameof(name));
+            ThrowHelper.ThrowIfNull(valueType, nameof(valueType));
+            ThrowHelper.ThrowIfNull(ownerType, nameof(ownerType));
+            ThrowHelper.ThrowIfNull(metadata, nameof(metadata));
 
             if (name.Contains('.'))
             {
@@ -60,11 +63,12 @@ namespace Avalonia
             _metadata = new Dictionary<Type, AvaloniaPropertyMetadata>();
 
             Name = name;
-            PropertyType = valueType ?? throw new ArgumentNullException(nameof(valueType));
-            OwnerType = ownerType ?? throw new ArgumentNullException(nameof(ownerType));
+            PropertyType = valueType;
+            OwnerType = ownerType;
             Notifying = notifying;
             Id = s_nextId++;
 
+            metadata.Freeze();
             _metadata.Add(hostType, metadata ?? throw new ArgumentNullException(nameof(metadata)));
             _defaultMetadata = metadata.GenerateTypeSafeMetadata();
             _singleMetadata = new(hostType, metadata);
@@ -584,6 +588,7 @@ namespace Avalonia
 
             var baseMetadata = GetMetadata(type);
             metadata.Merge(baseMetadata, this);
+            metadata.Freeze();
             _metadata.Add(type, metadata);
             _metadataCache.Clear();
 

--- a/src/Avalonia.Base/AvaloniaProperty.cs
+++ b/src/Avalonia.Base/AvaloniaProperty.cs
@@ -69,7 +69,7 @@ namespace Avalonia
             Id = s_nextId++;
 
             metadata.Freeze();
-            _metadata.Add(hostType, metadata ?? throw new ArgumentNullException(nameof(metadata)));
+            _metadata.Add(hostType, metadata);
             _defaultMetadata = metadata.GenerateTypeSafeMetadata();
             _singleMetadata = new(hostType, metadata);
         }

--- a/src/Avalonia.Base/AvaloniaPropertyMetadata.cs
+++ b/src/Avalonia.Base/AvaloniaPropertyMetadata.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Data;
 
 namespace Avalonia
@@ -7,6 +8,7 @@ namespace Avalonia
     /// </summary>
     public abstract class AvaloniaPropertyMetadata
     {
+        private bool _isReadOnly;
         private BindingMode _defaultBindingMode;
 
         /// <summary>
@@ -54,6 +56,11 @@ namespace Avalonia
             AvaloniaPropertyMetadata baseMetadata, 
             AvaloniaProperty property)
         {
+            if (_isReadOnly)
+            {
+                throw new InvalidOperationException("The metadata is read-only.");
+            }
+
             if (_defaultBindingMode == BindingMode.Default)
             {
                 _defaultBindingMode = baseMetadata.DefaultBindingMode;
@@ -61,6 +68,13 @@ namespace Avalonia
 
             EnableDataValidation ??= baseMetadata.EnableDataValidation;
         }
+
+        /// <summary>
+        /// Makes this instance read-only.
+        /// No further modifications are allowed after this call.
+        /// </summary>
+        public void Freeze()
+            => _isReadOnly = true;
 
         /// <summary>
         /// Gets a copy of this object configured for use with any owner type.

--- a/src/Avalonia.Base/DirectProperty.cs
+++ b/src/Avalonia.Base/DirectProperty.cs
@@ -94,6 +94,7 @@ namespace Avalonia
                 enableDataValidation: enableDataValidation);
 
             metadata.Merge(GetMetadata<TOwner>(), this);
+            metadata.Freeze();
 
             var result = new DirectProperty<TNewOwner, TValue>(
                 (DirectPropertyBase<TValue>)this,

--- a/src/Avalonia.Base/DirectPropertyMetadata`1.cs
+++ b/src/Avalonia.Base/DirectPropertyMetadata`1.cs
@@ -46,6 +46,12 @@ namespace Avalonia
             }
         }
 
-        public override AvaloniaPropertyMetadata GenerateTypeSafeMetadata() => new DirectPropertyMetadata<TValue>(UnsetValue, DefaultBindingMode, EnableDataValidation);
+        /// <inheritdoc />
+        public override AvaloniaPropertyMetadata GenerateTypeSafeMetadata()
+        {
+            var copy = new DirectPropertyMetadata<TValue>(UnsetValue, DefaultBindingMode, EnableDataValidation);
+            copy.Freeze();
+            return copy;
+        }
     }
 }

--- a/src/Avalonia.Base/StyledPropertyMetadata`1.cs
+++ b/src/Avalonia.Base/StyledPropertyMetadata`1.cs
@@ -59,6 +59,12 @@ namespace Avalonia
             }
         }
 
-        public override AvaloniaPropertyMetadata GenerateTypeSafeMetadata() => new StyledPropertyMetadata<TValue>(DefaultValue, DefaultBindingMode, enableDataValidation: EnableDataValidation ?? false);
+        /// <inheritdoc />
+        public override AvaloniaPropertyMetadata GenerateTypeSafeMetadata()
+        {
+            var copy = new StyledPropertyMetadata<TValue>(DefaultValue, DefaultBindingMode, null, EnableDataValidation ?? false);
+            copy.Freeze();
+            return copy;
+        }
     }
 }

--- a/tests/Avalonia.Base.UnitTests/AvaloniaPropertyTests.cs
+++ b/tests/Avalonia.Base.UnitTests/AvaloniaPropertyTests.cs
@@ -83,6 +83,27 @@ namespace Avalonia.Base.UnitTests
         }
 
         [Fact]
+        public void Default_Metadata_Cannot_Be_Changed_After_Property_Initialization()
+        {
+            var metadata = new TestMetadata();
+            var property = new TestProperty<string>("test", typeof(Class1), metadata);
+
+            Assert.Throws<InvalidOperationException>(() => metadata.Merge(new TestMetadata(), property));
+        }
+
+        [Fact]
+        public void Overridden_Metadata_Cannot_Be_Changed_After_OverrideMetadata()
+        {
+            var metadata = new TestMetadata(BindingMode.TwoWay);
+            var overridden = new TestMetadata();
+            var property = new TestProperty<string>("test", typeof(Class1), metadata);
+
+            property.OverrideMetadata<Class2>(overridden);
+
+            Assert.Throws<InvalidOperationException>(() => overridden.Merge(new TestMetadata(), property));
+        }
+
+        [Fact]
         public void Changed_Observable_Fired()
         {
             var target = new Class1();

--- a/tests/Avalonia.Base.UnitTests/DirectPropertyTests.cs
+++ b/tests/Avalonia.Base.UnitTests/DirectPropertyTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Xunit;
 
 namespace Avalonia.Base.UnitTests
@@ -44,6 +45,25 @@ namespace Avalonia.Base.UnitTests
             var p2 = p1.AddOwner<Class2>(o => null, (o, v) => { });
 
             Assert.Same(p1.Changed, p2.Changed);
+        }
+
+        [Fact]
+        public void Default_GetMetadata_Cannot_Be_Changed()
+        {
+            var p1 = Class1.FooProperty;
+            var metadata = p1.GetMetadata<Class1>();
+
+            Assert.Throws<InvalidOperationException>(() => metadata.Merge(new DirectPropertyMetadata<string>(), p1));
+        }
+
+        [Fact]
+        public void AddOwnered_GetMetadata_Cannot_Be_Changed()
+        {
+            var p1 = Class1.FooProperty;
+            var p2 = p1.AddOwner<Class2>(_ => null, (_, _) => { });
+            var metadata = p2.GetMetadata<Class2>();
+
+            Assert.Throws<InvalidOperationException>(() => metadata.Merge(new DirectPropertyMetadata<string>(), p2));
         }
 
         private class Class1 : AvaloniaObject

--- a/tests/Avalonia.Base.UnitTests/StyledPropertyTests.cs
+++ b/tests/Avalonia.Base.UnitTests/StyledPropertyTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Xunit;
 
 namespace Avalonia.Base.UnitTests
@@ -30,6 +31,33 @@ namespace Avalonia.Base.UnitTests
             var p2 = p1.AddOwner<Class2>();
 
             Assert.Same(p1, p2);
+        }
+
+        [Fact]
+        public void Default_GetMetadata_Cannot_Be_Changed()
+        {
+            var p1 = new StyledProperty<string>(
+                "p1",
+                typeof(Class1),
+                typeof(Class1),
+                new StyledPropertyMetadata<string>());
+            var metadata = p1.GetMetadata<Class1>();
+
+            Assert.Throws<InvalidOperationException>(() => metadata.Merge(new StyledPropertyMetadata<string>(), p1));
+        }
+
+        [Fact]
+        public void AddOwnered_GetMetadata_Cannot_Be_Changed()
+        {
+            var p1 = new StyledProperty<string>(
+                "p1",
+                typeof(Class1),
+                typeof(Class1),
+                new StyledPropertyMetadata<string>());
+            var p2 = p1.AddOwner<Class2>();
+            var metadata = p2.GetMetadata<Class2>();
+
+            Assert.Throws<InvalidOperationException>(() => metadata.Merge(new StyledPropertyMetadata<string>(), p2));
         }
 
         private class Class1 : AvaloniaObject


### PR DESCRIPTION
## What does the pull request do?
This PR makes `AvaloniaPropertyMetadata` immutable after the `AvaloniaProperty` using it is initialized.

Rationale:
 - It's dangerous to change the metadata after the property has been initialized (no objects currently using the default value would be aware of the change).
 - It's dangerous to pass the same metadata to two different properties (the second one might get the overridden defaults from the first without realizing it).
 - Having mutable metadata prevents some optimizations, see https://github.com/AvaloniaUI/Avalonia/pull/15342#pullrequestreview-2001061403

## What is the current behavior?
The default property metadata can be modified after a property is initialized, by using the `Merge` method.

## What is the updated/expected behavior with this PR?
An `InvalidOperationException` is thrown when the metadata is modified.

## How was the solution implemented (if it's not obvious)?
A `Freeze()` method has been added to `AvaloniaPropertyMetadata`.
It would probably be better to have metadata effectively always immutable and have `Merge` return a new instance if needed instead of changing the current one, but that ship has sailed for v11 since `Merge` is public.

## Breaking changes
Yes, this is a behavioral breaking change.
In practice, any code that would hit the exception was probably introducing a bug.
