### PR TITLE
Changing fallback behaviour in PlatformKeyGestureConverter.ToPlatformString() to be more user friendly.

### DIFF
--- a/src/Avalonia.Controls/Converters/PlatformKeyGestureConverter.cs
+++ b/src/Avalonia.Controls/Converters/PlatformKeyGestureConverter.cs
@@ -57,7 +57,7 @@ namespace Avalonia.Controls.Converters
             }
             else
             {
-                return gesture.ToString();
+                return ToString(gesture, "Cmd");
             }
         }
 


### PR DESCRIPTION
PlatformKeyGestureConverter.ToPlatformString() falls back to KeyGesture.ToString() rather than it's own user friendly string creation method ToString(KeyGesture gesture, string meta).  This will print Key enum values such as "OemPeriod" or "D1" rather than more userfriendly strings like "." or "1"

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Change the fallback case to use ToString(gesture, "Cmd") rather than gesture.ToString().  This will print user friendly key values for when platform specific cases aren't implemented.  Specifically Android.

## What is the current behavior?
Key enum strings are printed.

## What is the updated/expected behavior with this PR?
More user friendly values are printed.

## How was the solution implemented (if it's not obvious)?


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None I can think of.

## Fixed issues
Fixes #15392

Other Notes:
I considered adding an Android specific path as well, but couldn't come to a decision about what the appropriate "Meta" string would be.  The 2 Android Devices I checked use 🔍 (U+1F50D) for the OS displayed shortcuts list, but in practice it depends on the actual physical keyboard.  The Logitech K480 I have for testing triggers those shortcuts with a key labeled "start | alt opt", while the actual key with a magnifying glass on it does not trigger them.  Another option I found was using "OS" for the meta label, but that seems to be ROM specific.  I'm not sure there is a good universal "Meta" string, so left it at as the fallback case with "Cmd", which is a minimal change from current behaviour. 
