### PR TITLE
Fix unable to type cultural character into TextBox

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -1165,11 +1165,10 @@ namespace Avalonia.Win32
             var keyData = ToInt32(lParam);
             var key = KeyInterop.KeyFromVirtualKey(virtualKey, keyData);
             var physicalKey = KeyInterop.PhysicalKeyFromVirtualKey(virtualKey, keyData);
-
-            if (key == Key.None && physicalKey == PhysicalKey.None)
-                return null;
-
             var keySymbol = KeyInterop.GetKeySymbol(virtualKey, keyData);
+
+            if (key == Key.None && physicalKey == PhysicalKey.None && string.IsNullOrWhiteSpace(keySymbol))
+                return null;
 
             return new RawKeyEventArgs(
                 WindowsKeyboardDevice.Instance,


### PR DESCRIPTION
Check KeySymbol before return null in TryCreateRawKeyEventArgs to prevent skipping cultural character.

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
This PR makes sure we don't skip a special cultural character when it's typed using custom cultural tools.

## What is the current behavior?
Any special cultural character will be deleted upon typing into Textbox, all keyDown or keyUp events will receive a blank character instead of the special character.

## What is the updated/expected behavior with this PR?
Special cultural character should be typed and inserted normally in TextBox.

## How was the solution implemented (if it's not obvious)?

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

## Obsoletions / Deprecations

## Fixed issues
Fixes #13190 