### PR TITLE
upgrade `Quamotion.RemoteViewing` to 1.1.211 to work with `RealVNC Viewer`, Add `password` parameter to `StartWithHeadlessVncPlatform`

### DIFF
--- a/src/Avalonia.Base/Logging/LogArea.cs
+++ b/src/Avalonia.Base/Logging/LogArea.cs
@@ -79,5 +79,10 @@ namespace Avalonia.Logging
         /// The log event comes from Browser Platform
         /// </summary>
         public const string BrowserPlatform = nameof(BrowserPlatform);
+
+        /// <summary>
+        /// The log event comes from VNC Platform
+        /// </summary>
+        public const string VncPlatform = nameof(VncPlatform);
     }
 }

--- a/src/Headless/Avalonia.Headless.Vnc/Avalonia.Headless.Vnc.csproj
+++ b/src/Headless/Avalonia.Headless.Vnc/Avalonia.Headless.Vnc.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks)</TargetFrameworks>
+      <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks);netstandard2.0</TargetFrameworks>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Avalonia.Headless\Avalonia.Headless.csproj" />
-      <PackageReference Include="Quamotion.RemoteViewing" Version="1.1.211" />
+      <PackageReference Include="Quamotion.RemoteViewing" Version="1.1.179" />
     </ItemGroup>
 
     <Import Project="..\..\..\build\DevAnalyzers.props" />

--- a/src/Headless/Avalonia.Headless.Vnc/Avalonia.Headless.Vnc.csproj
+++ b/src/Headless/Avalonia.Headless.Vnc/Avalonia.Headless.Vnc.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Avalonia.Headless\Avalonia.Headless.csproj" />
-      <PackageReference Include="Quamotion.RemoteViewing" Version="1.1.21" />
+      <PackageReference Include="Quamotion.RemoteViewing" Version="1.1.211" />
     </ItemGroup>
 
     <Import Project="..\..\..\build\DevAnalyzers.props" />

--- a/src/Headless/Avalonia.Headless.Vnc/Avalonia.Headless.Vnc.csproj
+++ b/src/Headless/Avalonia.Headless.Vnc/Avalonia.Headless.Vnc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks);netstandard2.0</TargetFrameworks>
+      <TargetFrameworks>$(AvsCurrentTargetFramework);$(AvsLegacyTargetFrameworks)</TargetFrameworks>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/src/Headless/Avalonia.Headless.Vnc/AvaloniaVncLogger.cs
+++ b/src/Headless/Avalonia.Headless.Vnc/AvaloniaVncLogger.cs
@@ -1,0 +1,39 @@
+using System;
+using Avalonia.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions.Internal;
+
+namespace Avalonia.Headless.Vnc;
+
+internal class AvaloniaVncLogger : ILogger
+{
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+    {
+        Logger.TryGet(ToLogEventLevel(logLevel), LogArea.VncPlatform)
+            ?.Log(state, formatter(state,exception));
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return Logger.IsEnabled(ToLogEventLevel(logLevel), LogArea.VncPlatform);
+    }
+
+    public IDisposable BeginScope<TState>(TState state)
+    {
+        return NullScope.Instance;
+    }
+
+    private static LogEventLevel ToLogEventLevel(LogLevel logLevel)
+    {
+        return logLevel switch
+        {
+            LogLevel.Trace => LogEventLevel.Verbose,
+            LogLevel.Debug => LogEventLevel.Debug,
+            LogLevel.Information => LogEventLevel.Information,
+            LogLevel.Warning => LogEventLevel.Warning,
+            LogLevel.Error => LogEventLevel.Error,
+            LogLevel.Critical => LogEventLevel.Fatal,
+            _ => throw new ArgumentOutOfRangeException(nameof(logLevel))
+        };
+    }
+}

--- a/src/Headless/Avalonia.Headless.Vnc/HeadlessVncFramebufferSource.cs
+++ b/src/Headless/Avalonia.Headless.Vnc/HeadlessVncFramebufferSource.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Headless.Vnc
             session.PointerChanged += (_, args) =>
             {
                 var pt = new Point(args.X, args.Y);
-                    
+
                 var buttons = (VncButton)args.PressedButtons;
 
                 MouseButton TranslateButton(VncButton vncButton) =>
@@ -36,14 +36,14 @@ namespace Avalonia.Headless.Vnc
                     };
 
                 var modifiers = (RawInputModifiers)(((int)buttons & 7) << 4);
-                
+
                 Dispatcher.UIThread.Post(() =>
                 {
                     Window?.MouseMove(pt);
                     foreach (var btn in CheckedButtons)
                         if (_previousButtons.HasFlag(btn) && !buttons.HasFlag(btn))
                             Window?.MouseUp(pt, TranslateButton(btn), modifiers);
-                    
+
                     foreach (var btn in CheckedButtons)
                         if (!_previousButtons.HasFlag(btn) && buttons.HasFlag(btn))
                             Window?.MouseDown(pt, TranslateButton(btn), modifiers);
@@ -96,11 +96,11 @@ namespace Avalonia.Headless.Vnc
                 KeySym.AltLeft or KeySym.AltRight => RawInputModifiers.Alt,
                 _ => null
             };
-            
-            if(!toggleModifier.HasValue)
+
+            if (!toggleModifier.HasValue)
                 return false;
 
-            if(args.Pressed)
+            if (args.Pressed)
                 _keyState |= toggleModifier.Value;
             else
                 _keyState &= ~toggleModifier.Value;
@@ -309,9 +309,9 @@ namespace Avalonia.Headless.Vnc
             ScrollUp = 8,
             ScrollDown = 16
         }
-        
 
-        private static VncButton[] CheckedButtons = new[] {VncButton.Left, VncButton.Middle, VncButton.Right}; 
+
+        private static VncButton[] CheckedButtons = new[] { VncButton.Left, VncButton.Middle, VncButton.Right };
 
         public unsafe VncFramebuffer Capture()
         {
@@ -338,5 +338,17 @@ namespace Avalonia.Headless.Vnc
 
             return _framebuffer;
         }
+        
+        public ExtendedDesktopSizeStatus SetDesktopSize(int width, int height)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                Window.Width = width;
+                Window.Height = height;
+            });
+            return ExtendedDesktopSizeStatus.Success;
+        }
+
+        public bool SupportsResizing => true;
     }
 }

--- a/src/Headless/Avalonia.Headless.Vnc/HeadlessVncPlatformExtensions.cs
+++ b/src/Headless/Avalonia.Headless.Vnc/HeadlessVncPlatformExtensions.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Headless;
 using Avalonia.Headless.Vnc;
 using Avalonia.Platform;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 using RemoteViewing.Vnc;
 using RemoteViewing.Vnc.Server;
 
@@ -16,35 +19,61 @@ namespace Avalonia
         public static int StartWithHeadlessVncPlatform(
             this AppBuilder builder,
             string host, int port,
-            string[] args, ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose)
+            string[] args,
+            ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose,
+            string? password = null,
+            ILogger? logger = null)
         {
+            logger = logger ??= NullLogger.Instance;
             var tcpServer = new TcpListener(host == null ? IPAddress.Loopback : IPAddress.Parse(host), port);
-            tcpServer.Start();    
+            tcpServer.Start();
             return builder
                 .UseHeadless(new AvaloniaHeadlessPlatformOptions
                 {
                     UseHeadlessDrawing = false,
                     FrameBufferFormat = PixelFormat.Bgra8888
                 })
-                .AfterApplicationSetup(_ =>
+                .AfterSetup(_ =>
                 {
-                    var lt = ((IClassicDesktopStyleApplicationLifetime)builder.Instance!.ApplicationLifetime!);
+                    var lt = ((IClassicDesktopStyleApplicationLifetime) builder.Instance!.ApplicationLifetime!);
                     lt.Startup += async delegate
                     {
                         while (true)
                         {
-                            var client = await tcpServer.AcceptTcpClientAsync();
-                            var options = new VncServerSessionOptions
+                            try
                             {
-                                AuthenticationMethod = AuthenticationMethod.None
-                            };
-                            var session = new VncServerSession();
-                            
-                            session.SetFramebufferSource(new HeadlessVncFramebufferSource(
-                                session, lt.MainWindow ?? throw new InvalidOperationException("MainWindow wasn't initialized")));
-                            session.Connect(client.GetStream(), options);
+                                var client = await tcpServer.AcceptTcpClientAsync();
+                                var options = new VncServerSessionOptions
+                                {
+                                    AuthenticationMethod = string.IsNullOrWhiteSpace(password)
+                                        ? AuthenticationMethod.None
+                                        : AuthenticationMethod.Password
+                                };
+                                var session = new VncServerSession(new VncPasswordChallenge(),
+                                    logger: logger);
+                                if (string.IsNullOrWhiteSpace(password) == false)
+                                {
+                                    session.PasswordProvided += (s, e) =>
+                                    {
+                                        e.Accept(password.ToCharArray());
+                                    };
+                                }
+
+                                session.SetFramebufferSource(new HeadlessVncFramebufferSource(
+                                    session,
+                                    lt.MainWindow ??
+                                    throw new InvalidOperationException("MainWindow wasn't initialized")));
+                                session.Connect(client.GetStream(), options);
+                            }
+                            catch (Exception e)
+                            {
+                                logger.LogError(e,"VNC Connection Exception");
+                            }
+                            finally
+                            {
+                                await Task.Delay(100);
+                            }
                         }
-                        
                     };
                 })
                 .StartWithClassicDesktopLifetime(args, shutdownMode);

--- a/src/Headless/Avalonia.Headless.Vnc/HeadlessVncPlatformExtensions.cs
+++ b/src/Headless/Avalonia.Headless.Vnc/HeadlessVncPlatformExtensions.cs
@@ -8,8 +8,6 @@ using Avalonia.Headless;
 using Avalonia.Headless.Vnc;
 using Avalonia.Logging;
 using Avalonia.Platform;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Logging;
 using RemoteViewing.Vnc;
 using RemoteViewing.Vnc.Server;
 
@@ -17,15 +15,44 @@ namespace Avalonia
 {
     public static class HeadlessVncPlatformExtensions
     {
+        /// <summary>
+        /// Start Avalonia application with Headless VNC platform without password.
+        /// </summary>
+        /// <param name="builder">Application Builder</param>
+        /// <param name="host">VNC Server IP will be bind, if null or empty IPAddress.LoopBack will be used.</param>
+        /// <param name="port">VNC Server port will be bind</param>
+        /// <param name="args">Avalonia application start args</param>
+        /// <param name="shutdownMode">shut down mode <see cref="ShutdownMode"/></param>
+        /// <returns></returns>
         public static int StartWithHeadlessVncPlatform(
             this AppBuilder builder,
             string host, int port,
             string[] args,
-            ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose,
-            string? password = null)
+            ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose)
+        {
+            return StartWithHeadlessVncPlatform(builder, host, port, null, args, shutdownMode);
+        }
+
+        /// <summary>
+        /// Start Avalonia application with Headless VNC platform with password.
+        /// </summary>
+        /// <param name="builder">Application Builder</param>
+        /// <param name="host">VNC Server IP will be bind, if null or empty IPAddress.LoopBack will be used.</param>
+        /// <param name="port">VNC Server port will be bind</param>
+        /// <param name="password">VNC connection auth password</param>
+        /// <param name="args">Avalonia application start args</param>
+        /// <param name="shutdownMode">shut down mode <see cref="ShutdownMode"/></param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        public static int StartWithHeadlessVncPlatform(
+            this AppBuilder builder,
+            string host, int port,
+            string? password,
+            string[] args,
+            ShutdownMode shutdownMode = ShutdownMode.OnLastWindowClose)
         {
             var vncLogger = new AvaloniaVncLogger();
-            var tcpServer = new TcpListener(host == null ? IPAddress.Loopback : IPAddress.Parse(host), port);
+            var tcpServer = new TcpListener(string.IsNullOrEmpty(host) ? IPAddress.Loopback : IPAddress.Parse(host), port);
             tcpServer.Start();
             return builder
                 .UseHeadless(new AvaloniaHeadlessPlatformOptions

--- a/src/Headless/Avalonia.Headless.Vnc/HeadlessVncPlatformExtensions.cs
+++ b/src/Headless/Avalonia.Headless.Vnc/HeadlessVncPlatformExtensions.cs
@@ -33,7 +33,7 @@ namespace Avalonia
                     UseHeadlessDrawing = false,
                     FrameBufferFormat = PixelFormat.Bgra8888
                 })
-                .AfterSetup(_ =>
+                .AfterApplicationSetup(_ =>
                 {
                     var lt = ((IClassicDesktopStyleApplicationLifetime) builder.Instance!.ApplicationLifetime!);
                     lt.Startup += async delegate

--- a/src/Headless/Avalonia.Headless.Vnc/HeadlessVncPlatformExtensions.cs
+++ b/src/Headless/Avalonia.Headless.Vnc/HeadlessVncPlatformExtensions.cs
@@ -24,7 +24,7 @@ namespace Avalonia
             string? password = null,
             ILogger? logger = null)
         {
-            logger = logger ??= NullLogger.Instance;
+            logger ??= NullLogger.Instance;
             var tcpServer = new TcpListener(host == null ? IPAddress.Loopback : IPAddress.Parse(host), port);
             tcpServer.Start();
             return builder


### PR DESCRIPTION
## What does the pull request do?

upgrade Quamotion.RemoteViewing to latest version to work with `RealVNC Viewer` discussed in https://github.com/AvaloniaUI/Avalonia/discussions/15336#discussioncomment-9128576

## What is the current behavior?

1. RealVNC Viewer can not connect to a Avalonia VNC Server. Only TightVNC Viewer can connect it. TightVNC only have Windows client, RealVNC Viewer has many platform supported.

2. There is no way to set password to protect application.

## What is the updated/expected behavior with this PR?

1. RealVNC Viewer can connect to a Avalonia VNC Server and work as expected.
2. User can set password to protect application.

## How was the solution implemented (if it's not obvious)?

1. Quamotion.RemoteViewing's latest version support RealVNC Viewer, so first, upgrade it  to the latest version.
2. implement the new method of the interface(`IVncFramebufferSource`) we used.
3. add the `Logger` parameter, otherwise It will load unhandled exception when a connection is closed in the `Quamotion.RemoteViewing` library internal.
4. add the `password` parameter to allow user set the vnc connection password.

## Requirement
Windows is out of box to use it, but linux/MacOS must install `jpeg-turbo` library before use it.

ubuntu:`apt install libturbojpeg`
mac: `brew install jpeg-turbo`

## Checklist

- [ ] Added unit tests (if possible) 
   I do not know how to unit test it. but I have tested in my local environment.
- [x] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
   There is no document releate to Avalonia.Headless.VNC, so I do not know where to add it.

## Breaking changes
No break changes here.

## Obsoletions / Deprecations
There is no obsoletions or deprecations.

## Fixed issues
No issue relate to this,But a discuss: https://github.com/AvaloniaUI/Avalonia/discussions/15336
