### PR TITLE
Make MenuItem check mark visible with Simple theme

### DIFF
--- a/src/Avalonia.Themes.Simple/Controls/MenuItem.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/MenuItem.xaml
@@ -112,7 +112,6 @@
       <Setter Property="IsVisible" Value="False" />
     </Style>
     <Style Selector="^:checked:toggle /template/ ContentControl#PART_ToggleIconPresenter">
-      <Setter Property="IsVisible" Value="True" />
       <Setter Property="Content">
         <Template>
           <Path VerticalAlignment="Center"

--- a/src/Avalonia.Themes.Simple/Controls/MenuItem.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/MenuItem.xaml
@@ -112,6 +112,7 @@
       <Setter Property="IsVisible" Value="False" />
     </Style>
     <Style Selector="^:checked:toggle /template/ ContentControl#PART_ToggleIconPresenter">
+      <Setter Property="IsVisible" Value="True" />
       <Setter Property="Content">
         <Template>
           <Path VerticalAlignment="Center"

--- a/src/Avalonia.Themes.Simple/Controls/MenuItem.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/MenuItem.xaml
@@ -105,7 +105,7 @@
       <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}" />
     </Style>
     
-    <Style Selector="^:toggle /template/ Viewbox#PART_ToggleIconPresenter, ^:radio /template/ Viewbox#PART_ToggleIconPresenter">
+    <Style Selector="^:toggle /template/ ContentControl#PART_ToggleIconPresenter, ^:radio /template/ ContentControl#PART_ToggleIconPresenter">
       <Setter Property="IsVisible" Value="True" />
     </Style>
     <Style Selector="^:toggle /template/ ContentPresenter#PART_IconPresenter, ^:radio /template/ ContentPresenter#PART_IconPresenter">


### PR DESCRIPTION
## What does the pull request do?
This PR makes the check mark in a `MenuItem` control with `ToggleType="CheckBox"` and `ToggleType="Radio"` visible.

## What is the current behavior?
The check mark is mistakingly invisible by default, even though the XAML code for the actual check mark is there.

## What is the updated/expected behavior with this PR?
It sets the check mark visible, just like with the Fluent theme.

## Fixed issues
Fixes #15417