### PR TITLE
Fix app shutdown cancellation via window

### DIFF
--- a/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
+++ b/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs
@@ -163,6 +163,7 @@ namespace Avalonia.Controls.ApplicationLifetimes
 
             _exitCode = exitCode;
             _isShuttingDown = true;
+            var shutdownCancelled = false;
 
             try
             {
@@ -180,6 +181,7 @@ namespace Avalonia.Controls.ApplicationLifetimes
                 if (!force && Windows.Count > 0)
                 {
                     e.Cancel = true;
+                    shutdownCancelled = true;
                     return false;
                 }
 
@@ -189,10 +191,14 @@ namespace Avalonia.Controls.ApplicationLifetimes
             }
             finally
             {
-                _cts?.Cancel();
-                _cts = null;
                 _isShuttingDown = false;
-                Dispatcher.UIThread.InvokeShutdown();
+
+                if (!shutdownCancelled)
+                {
+                    _cts?.Cancel();
+                    _cts = null;
+                    Dispatcher.UIThread.InvokeShutdown();
+                }
             }
 
             return true;

--- a/tests/Avalonia.Controls.UnitTests/DesktopStyleApplicationLifetimeTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DesktopStyleApplicationLifetimeTests.cs
@@ -355,9 +355,13 @@ namespace Avalonia.Controls.UnitTests
             {
                 lifetime.SetupCore(Array.Empty<string>());
 
-                var hasExit = false;
+                lifetime.Exit += (_, _) => Assert.Fail("lifetime.Exit was called.");
+                Dispatcher.UIThread.ShutdownStarted += UiThreadOnShutdownStarted;
 
-                lifetime.Exit += (_, _) => hasExit = true;
+                static void UiThreadOnShutdownStarted(object sender, EventArgs e)
+                {
+                    Assert.Fail("Dispatcher.UIThread.ShutdownStarted was called.");
+                }
 
                 var windowA = new Window();
 
@@ -378,7 +382,8 @@ namespace Avalonia.Controls.UnitTests
                 lifetime.TryShutdown();
 
                 Assert.Equal(1, raised);
-                Assert.False(hasExit);
+
+                Dispatcher.UIThread.ShutdownStarted -= UiThreadOnShutdownStarted;
             }
         }
         


### PR DESCRIPTION
## What does the pull request do?

App shutdown method is supposed to be cancelled, if at least one window did cancel this event. 
When at least one window is cancelled, TryShutdown was returning false as expected. Unfortunately, dispatcher was still killed in the same method in finalizer that was always executing. 

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues

Fixes https://github.com/AvaloniaUI/Avalonia/issues/14748