### PR TITLE
fix: SelectingItemsControl Selection memory Leak

### DIFF
--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -348,11 +348,12 @@ namespace Avalonia.Controls.Primitives
                     }
 
                     InitializeSelectionModel(_selection);
-                    var seletcedItems = SelectedItems;
-                    if (_oldSelectedItems.TryGetTarget(out var oldSelectedItems) || oldSelectedItems != seletcedItems)
+                    var selectedItems = SelectedItems;
+                    _oldSelectedItems.TryGetTarget(out var oldSelectedItems);
+                    if (oldSelectedItems != selectedItems)
                     {
-                        RaisePropertyChanged(SelectedItemsProperty, oldSelectedItems, seletcedItems);
-                        _oldSelectedItems.SetTarget(seletcedItems);
+                        RaisePropertyChanged(SelectedItemsProperty, oldSelectedItems, selectedItems);
+                        _oldSelectedItems.SetTarget(selectedItems);
                     }
                 }
             }

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -141,8 +141,8 @@ namespace Avalonia.Controls.Primitives
         private DispatcherTimer? _textSearchTimer;
         private ISelectionModel? _selection;
         private int _oldSelectedIndex;
-        private object? _oldSelectedItem;
-        private IList? _oldSelectedItems;
+        private WeakReference _oldSelectedItem = new(null);
+        private WeakReference<IList?> _oldSelectedItems = new(null);
         private bool _ignoreContainerSelectionChanged;
         private UpdateState? _updateState;
         private bool _hasScrolledToSelectedItem;
@@ -286,7 +286,7 @@ namespace Avalonia.Controls.Primitives
                 else if (Selection is InternalSelectionModel ism)
                 {
                     var result = ism.WritableSelectedItems;
-                    _oldSelectedItems = result;
+                    _oldSelectedItems.SetTarget(result);
                     return result;
                 }
 
@@ -348,11 +348,11 @@ namespace Avalonia.Controls.Primitives
                     }
 
                     InitializeSelectionModel(_selection);
-
-                    if (_oldSelectedItems != SelectedItems)
+                    var seletcedItems = SelectedItems;
+                    if (_oldSelectedItems.TryGetTarget(out var oldSelectedItems) || oldSelectedItems != seletcedItems)
                     {
-                        RaisePropertyChanged(SelectedItemsProperty, _oldSelectedItems, SelectedItems);
-                        _oldSelectedItems = SelectedItems;
+                        RaisePropertyChanged(SelectedItemsProperty, oldSelectedItems, seletcedItems);
+                        _oldSelectedItems.SetTarget(seletcedItems);
                     }
                 }
             }
@@ -935,21 +935,35 @@ namespace Avalonia.Controls.Primitives
                 KeyboardNavigation.SetTabOnceActiveElement(this, ContainerFromIndex(anchorIndex));
                 AutoScrollToSelectedItemIfNecessary(anchorIndex);
             }
-            else if (e.PropertyName == nameof(ISelectionModel.SelectedIndex) && _oldSelectedIndex != SelectedIndex)
+            else if (e.PropertyName == nameof(ISelectionModel.SelectedIndex))
             {
-                RaisePropertyChanged(SelectedIndexProperty, _oldSelectedIndex, SelectedIndex);
-                _oldSelectedIndex = SelectedIndex;
+                var selectedIndex = SelectedIndex;
+                var oldSelectedIndex = _oldSelectedIndex;
+                if (_oldSelectedIndex != selectedIndex)
+                {
+                    RaisePropertyChanged(SelectedIndexProperty, oldSelectedIndex, selectedIndex);
+                    _oldSelectedIndex = selectedIndex;
+                }
             }
-            else if (e.PropertyName == nameof(ISelectionModel.SelectedItem) && _oldSelectedItem != SelectedItem)
+            else if (e.PropertyName == nameof(ISelectionModel.SelectedItem))
             {
-                RaisePropertyChanged(SelectedItemProperty, _oldSelectedItem, SelectedItem);
-                _oldSelectedItem = SelectedItem;
+                var selectedItem = SelectedItem;
+                var oldSelectedItem = _oldSelectedItem.Target;
+                if (selectedItem != oldSelectedItem)
+                {
+                    RaisePropertyChanged(SelectedItemProperty, oldSelectedItem, selectedItem);
+                    _oldSelectedItem.Target = selectedItem;
+                }
             }
-            else if (e.PropertyName == nameof(InternalSelectionModel.WritableSelectedItems) &&
-                     _oldSelectedItems != (Selection as InternalSelectionModel)?.SelectedItems)
+            else if (e.PropertyName == nameof(InternalSelectionModel.WritableSelectedItems))
             {
-                RaisePropertyChanged(SelectedItemsProperty, _oldSelectedItems, SelectedItems);
-                _oldSelectedItems = SelectedItems;
+                _oldSelectedItems.TryGetTarget(out var oldSelectedItems);
+                if (oldSelectedItems != (Selection as InternalSelectionModel)?.SelectedItems)
+                {
+                    var selectedItems = SelectedItems;
+                    RaisePropertyChanged(SelectedItemsProperty, oldSelectedItems, selectedItems);
+                    _oldSelectedItems.SetTarget(selectedItems);
+                }
             }
             else if (e.PropertyName == nameof(ISelectionModel.Source))
             {
@@ -1221,7 +1235,7 @@ namespace Avalonia.Controls.Primitives
             }
 
             _oldSelectedIndex = model.SelectedIndex;
-            _oldSelectedItem = model.SelectedItem;
+            _oldSelectedItem.Target = model.SelectedItem;
 
             if (_updateState is null && AlwaysSelected && model.Count == 0)
             {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Avoid SelectingItemsControl memory leak

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

When SelectingItemsControl or a derived control is bound to ObservableCollection, if you remove the selected item, the removed item will not be released from memory until there is a new _oldSelectedItem, this is because _oldSelectedItem holds a hard reference. If the collection contains only two items and you remove one, the removed item will never be released from memory.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

Instead of a hard reference using pre allocated WeakReference.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Part of #15443
