### PR TITLE
Clear PopupFlyout target on flyout close

### DIFF
--- a/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
@@ -201,10 +201,11 @@ namespace Avalonia.Controls.Primitives
             {
                 Target.DetachedFromVisualTree -= PlacementTarget_DetachedFromVisualTree;
                 Target.KeyUp -= OnPlacementTargetOrPopupKeyUp;
-                Target = null;
             }
 
             OnClosed();
+
+            Target = null;
 
             return true;
         }

--- a/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
@@ -201,6 +201,7 @@ namespace Avalonia.Controls.Primitives
             {
                 Target.DetachedFromVisualTree -= PlacementTarget_DetachedFromVisualTree;
                 Target.KeyUp -= OnPlacementTargetOrPopupKeyUp;
+                Target = null;
             }
 
             OnClosed();


### PR DESCRIPTION
## What does the pull request do?
Flyouts hold a strong reference to target object: https://github.com/AvaloniaUI/Avalonia/issues/15465 leaking memory. Luckily when the same menu is opened on another target, the memory is released. Still, this is a bug.


## What is the current behavior?

## What is the updated/expected behavior with this PR?

## How was the solution implemented (if it's not obvious)?
The Target in PopupFlyoutBase will be cleared on popup close. I am not sure if this changes any behaviour or not.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
Not sure if this changes flyouts behaviour or not.

## Obsoletions / Deprecations

## Fixed issues
Fixes #15465
