### PR TITLE
Clear Popup.PlacementTarget in PopupFlyout

### DIFF
--- a/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
+++ b/src/Avalonia.Controls/Flyouts/PopupFlyoutBase.cs
@@ -205,7 +205,7 @@ namespace Avalonia.Controls.Primitives
 
             OnClosed();
 
-            Target = null;
+            Popup.PlacementTarget = Target = null;
 
             return true;
         }


### PR DESCRIPTION
## What does the pull request do?
Not only Target in PopupFlyoutBase has to be cleared, but also Popup.PlacementTarget. It shouldn't be a problem, because PlacementTarget is set in the very same line as `Target`, so I don't think it is necessary to keep this value just like it is not necessary to keep Target

## What is the current behavior?


## What is the updated/expected behavior with this PR?


## How was the solution implemented (if it's not obvious)?


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

## Obsoletions / Deprecations


## Fixed issues
#15465
