### PR TITLE
Fix nth child selector in data grid header

### DIFF
--- a/src/Avalonia.Controls.DataGrid/DataGridColumnCollection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnCollection.cs
@@ -12,7 +12,6 @@ namespace Avalonia.Controls
 {
     internal class DataGridColumnCollection : ObservableCollection<DataGridColumn>
     {
-        private readonly Dictionary<int, int> _columnsMap = new Dictionary<int, int>();
         private readonly DataGrid _owningGrid;
 
         public DataGridColumnCollection(DataGrid owningGrid)
@@ -280,12 +279,10 @@ namespace Avalonia.Controls
             VisibleStarColumnCount = 0;
             VisibleEdgedColumnsWidth = 0;
             VisibleColumnCount = 0;
-            _columnsMap.Clear();
 
             for (int columnIndex = 0; columnIndex < ItemsInternal.Count; columnIndex++)
             {
                 var item = ItemsInternal[columnIndex];
-                _columnsMap[columnIndex] = item.DisplayIndex;
                 if (item.IsVisible)
                 {
                     VisibleColumnCount++;
@@ -301,7 +298,12 @@ namespace Avalonia.Controls
 
         internal int GetColumnDisplayIndex(int columnIndex)
         {
-            return _columnsMap.TryGetValue(columnIndex, out var displayIndex) ? displayIndex : -1;
+            if (columnIndex < 0 || columnIndex >= ItemsInternal.Count)
+                return -1;
+            var column = ItemsInternal[columnIndex];
+            if (!column.IsVisible)
+                return -1;
+            return column.DisplayIndex;
         }
 
         internal DataGridColumn GetColumnAtDisplayIndex(int displayIndex)

--- a/src/Avalonia.Controls.DataGrid/DataGridColumnCollection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnCollection.cs
@@ -296,26 +296,6 @@ namespace Avalonia.Controls
             }
         }
 
-        /// <summary>
-        /// Gets the index of the column among the visible columns in display order. 
-        /// </summary>
-        internal int GetColumnVisibleIndex(int columnIndex)
-        {
-            if (columnIndex < 0 || columnIndex >= ItemsInternal.Count)
-                return -1;
-            var column = ItemsInternal[columnIndex];
-            if (!column.IsVisible)
-                return -1;
-
-            int index = 0;
-            while ((column = GetPreviousColumn(column, true, null, null)) != null)
-            {
-                index++;
-            }
-
-            return index;
-        }
-
         internal DataGridColumn GetColumnAtDisplayIndex(int displayIndex)
         {
             if (displayIndex < 0 || displayIndex >= ItemsInternal.Count || displayIndex >= DisplayIndexMap.Count)

--- a/src/Avalonia.Controls.DataGrid/DataGridColumnCollection.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridColumnCollection.cs
@@ -296,14 +296,24 @@ namespace Avalonia.Controls
             }
         }
 
-        internal int GetColumnDisplayIndex(int columnIndex)
+        /// <summary>
+        /// Gets the index of the column among the visible columns in display order. 
+        /// </summary>
+        internal int GetColumnVisibleIndex(int columnIndex)
         {
             if (columnIndex < 0 || columnIndex >= ItemsInternal.Count)
                 return -1;
             var column = ItemsInternal[columnIndex];
             if (!column.IsVisible)
                 return -1;
-            return column.DisplayIndex;
+
+            int index = 0;
+            while ((column = GetPreviousColumn(column, true, null, null)) != null)
+            {
+                index++;
+            }
+
+            return index;
         }
 
         internal DataGridColumn GetColumnAtDisplayIndex(int displayIndex)

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridCellsPresenter.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridCellsPresenter.cs
@@ -53,13 +53,13 @@ namespace Avalonia.Controls.Primitives
         int IChildIndexProvider.GetChildIndex(ILogical child)
         {
             return child is DataGridCell cell
-                ? OwningGrid.ColumnsInternal.GetColumnVisibleIndex(cell.ColumnIndex)
+                ? cell.OwningColumn?.DisplayIndex ?? -1
                 : throw new InvalidOperationException("Invalid cell type");
         }
 
         bool IChildIndexProvider.TryGetTotalCount(out int count)
         {
-            count = OwningGrid.ColumnsInternal.VisibleColumnCount;
+            count = Children.Count - 1; // Adjust for filler column
             return true;
         }
 

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridCellsPresenter.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridCellsPresenter.cs
@@ -53,7 +53,7 @@ namespace Avalonia.Controls.Primitives
         int IChildIndexProvider.GetChildIndex(ILogical child)
         {
             return child is DataGridCell cell
-                ? OwningGrid.ColumnsInternal.GetColumnDisplayIndex(cell.ColumnIndex)
+                ? OwningGrid.ColumnsInternal.GetColumnVisibleIndex(cell.ColumnIndex)
                 : throw new InvalidOperationException("Invalid cell type");
         }
 

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridColumnHeadersPresenter.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridColumnHeadersPresenter.cs
@@ -118,7 +118,7 @@ namespace Avalonia.Controls.Primitives
         int IChildIndexProvider.GetChildIndex(ILogical child)
         {
             return child is DataGridColumnHeader header
-                ? OwningGrid.ColumnsInternal.GetColumnDisplayIndex(header.ColumnIndex)
+                ? OwningGrid.ColumnsInternal.GetColumnVisibleIndex(header.ColumnIndex)
                 : throw new InvalidOperationException("Invalid cell type");
         }
 

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridColumnHeadersPresenter.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridColumnHeadersPresenter.cs
@@ -124,7 +124,19 @@ namespace Avalonia.Controls.Primitives
 
         bool IChildIndexProvider.TryGetTotalCount(out int count)
         {
-            count = OwningGrid.ColumnsInternal.VisibleColumnCount;
+            // VisibleColumnCount is updated the next measure pass after columns are added or removed
+            // but this is called as the column is being added or removed. 
+            // count = OwningGrid.ColumnsInternal.VisibleColumnCount;
+
+            count = 0;
+            for (int i = 0; i < Children.Count; i++)
+            {
+                if (Children[i] is DataGridColumnHeader { OwningColumn: { IsVisible: true } and not DataGridFillerColumn })
+                {
+                    count++;
+                }
+            }
+
             return true;
         }
 

--- a/src/Avalonia.Controls.DataGrid/Primitives/DataGridColumnHeadersPresenter.cs
+++ b/src/Avalonia.Controls.DataGrid/Primitives/DataGridColumnHeadersPresenter.cs
@@ -118,25 +118,13 @@ namespace Avalonia.Controls.Primitives
         int IChildIndexProvider.GetChildIndex(ILogical child)
         {
             return child is DataGridColumnHeader header
-                ? OwningGrid.ColumnsInternal.GetColumnVisibleIndex(header.ColumnIndex)
+                ? header.OwningColumn?.DisplayIndex ?? -1
                 : throw new InvalidOperationException("Invalid cell type");
         }
 
         bool IChildIndexProvider.TryGetTotalCount(out int count)
         {
-            // VisibleColumnCount is updated the next measure pass after columns are added or removed
-            // but this is called as the column is being added or removed. 
-            // count = OwningGrid.ColumnsInternal.VisibleColumnCount;
-
-            count = 0;
-            for (int i = 0; i < Children.Count; i++)
-            {
-                if (Children[i] is DataGridColumnHeader { OwningColumn: { IsVisible: true } and not DataGridFillerColumn })
-                {
-                    count++;
-                }
-            }
-
+            count = Children.Count - 1; // Adjust for filler column
             return true;
         }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Attempt at getting nth child selectors to work with data grid column headers.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
If you add or remove columns :nth-child and :nth-last-child applies to the wrong element. 

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
That nth-child and nth-last-child applies to the expected elements after adding or removing columns. 

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #14695 

