### PR TITLE
[DO NOT MERGE] Include Adorners in matrix calculations in VisualExtensions

### DIFF
--- a/src/Avalonia.Base/Controls/AdornerLayerBase.cs
+++ b/src/Avalonia.Base/Controls/AdornerLayerBase.cs
@@ -6,7 +6,7 @@ namespace Avalonia.Controls;
 public class AdornerLayerBase
 {
     /// <summary>
-    /// Allows for getting and setting of the adorned element.
+    ///  Allows for getting and setting of the adorned element.
     /// </summary>
     public static readonly AttachedProperty<Visual?> AdornedElementProperty =
         AvaloniaProperty.RegisterAttached<AdornerLayerBase, Visual, Visual?>("AdornedElement");

--- a/src/Avalonia.Base/Controls/AdornerLayerBase.cs
+++ b/src/Avalonia.Base/Controls/AdornerLayerBase.cs
@@ -1,0 +1,23 @@
+using Avalonia.Metadata;
+
+namespace Avalonia.Controls;
+
+[PrivateApi]
+public class AdornerLayerBase
+{
+    /// <summary>
+    /// Allows for getting and setting of the adorned element.
+    /// </summary>
+    public static readonly AttachedProperty<Visual?> AdornedElementProperty =
+        AvaloniaProperty.RegisterAttached<AdornerLayerBase, Visual, Visual?>("AdornedElement");
+
+    public static Visual? GetAdornedElement(Visual adorner)
+    {
+        return adorner.GetValue(AdornedElementProperty);
+    }
+
+    public static void SetAdornedElement(Visual adorner, Visual? adorned)
+    {
+        adorner.SetValue(AdornedElementProperty, adorned);
+    }
+}

--- a/src/Avalonia.Base/Controls/IAdornerLayer.cs
+++ b/src/Avalonia.Base/Controls/IAdornerLayer.cs
@@ -1,0 +1,9 @@
+using Avalonia.Metadata;
+
+namespace Avalonia.Controls;
+
+[PrivateApi]
+[NotClientImplementable]
+public interface IAdornerLayer
+{
+}

--- a/src/Avalonia.Controls/Primitives/AdornerLayer.cs
+++ b/src/Avalonia.Controls/Primitives/AdornerLayer.cs
@@ -13,13 +13,13 @@ namespace Avalonia.Controls.Primitives
     /// <remarks>
     /// TODO: Need to track position of adorned elements and move the adorner if they move.
     /// </remarks>
-    public class AdornerLayer : Canvas
+    public class AdornerLayer : Canvas, IAdornerLayer
     {
         /// <summary>
         /// Allows for getting and setting of the adorned element.
         /// </summary>
         public static readonly AttachedProperty<Visual?> AdornedElementProperty =
-            AvaloniaProperty.RegisterAttached<AdornerLayer, Visual, Visual?>("AdornedElement");
+            AdornerLayerBase.AdornedElementProperty.AddOwner<AdornerLayer>();
 
         /// <summary>
         /// Allows for controlling clipping of the adorner.

--- a/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
+++ b/src/Avalonia.Controls/Primitives/PopupPositioning/IPopupPositioner.cs
@@ -571,15 +571,7 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             var target = positionRequest.Target;
             if (target == null)
                 throw new InvalidOperationException("Placement mode is not Pointer and PlacementTarget is null");
-            Matrix? matrix;
-            if (TryGetAdorner(target, out var adorned, out var adornerLayer))
-            {
-                matrix = adorned!.TransformToVisual(topLevel) * target.TransformToVisual(adornerLayer!);
-            }
-            else
-            {
-                matrix = target.TransformToVisual(topLevel);
-            }
+            Matrix? matrix = target.TransformToVisual(topLevel);
 
             if (matrix == null)
             {
@@ -591,25 +583,6 @@ namespace Avalonia.Controls.Primitives.PopupPositioning
             var bounds = new Rect(default, target.Bounds.Size);
             var anchorRect = positionRequest.AnchorRect ?? bounds;
             return anchorRect.Intersect(bounds).TransformToAABB(matrix.Value);
-        }
-
-        private static bool TryGetAdorner(Visual target, out Visual? adorned, out Visual? adornerLayer)
-        {
-            var element = target;
-            while (element != null)
-            {
-                if (AdornerLayer.GetAdornedElement(element) is { } adornedElement)
-                {
-                    adorned = adornedElement;
-                    adornerLayer = AdornerLayer.GetAdornerLayer(adorned);
-                    return true;
-                }
-                element = element.VisualParent;
-            }
-
-            adorned = null;
-            adornerLayer = null;
-            return false;
         }
     }
 

--- a/tests/Avalonia.Controls.UnitTests/AdornerLayerTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/AdornerLayerTests.cs
@@ -1,0 +1,34 @@
+using Avalonia.Controls.Primitives;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests;
+
+public class AdornerLayerTests : ScopedTestBase
+{
+    [Fact]
+    public void Adorners_Include_Adorned_Elements_In_Transform_Visual()
+    {
+        var button = new Button()
+        {
+            Margin = new Thickness(100, 100)
+        };
+        var root = new TestRoot()
+        {
+            Child = new VisualLayerManager()
+            {
+                Child = button
+            }
+        };
+        var adorner = new Border();
+
+        var adornerLayer = AdornerLayer.GetAdornerLayer(button);
+        adornerLayer.Children.Add(adorner);
+        AdornerLayer.SetAdornedElement(adorner, button);
+
+        root.LayoutManager.ExecuteInitialLayoutPass();
+
+        var translatedPoint = root.TranslatePoint(new Point(100, 100), adorner);
+        Assert.Equal(new Point(0, 0), translatedPoint);
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
This PR changes `VisualExtensions::TransformToVisual` to support adorners. 


## What is the current behavior?
Currently `VisualExtensions::TransformToVisual` doesn't work correctly when one of the controls is inside an Adorner Layer. Adorn**ed** element is not on a path to root from adorner element. So it is not included in calculations. Adorners are rendered correctly, because the renderer has special handling for adorners. Hence `TransformToVisual` needs some special handling too.


## What is the updated/expected behavior with this PR?
`VisualExtensions::TransformToVisual` should correctly take into account adorners.


## How was the solution implemented (if it's not obvious)?
Unfortunately, adorners are defined in `Avalonia.Controls` while `VisualExtensions` is in `Avalonia.Base`, so `VisualExtensions` doesn't know what adorners are. Therefore, this PR adds `AdornerLayerBase` with `AdornedElementProperty` and an empty `IAdornerLayer` to `Avalonia.Base` so that this information is available. This is far from perfect, but I don't know how to do it in a cleaner way.

Besides, the obvious downside of the solution is additional computation complexity in `VisualExtensions::TransformToVisual`. Each time this method is called, an adorned element needs to be found via calling GetValue(AdornedElementProperty) on each element on path to root.


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes


## Obsoletions / Deprecations

## Fixed issues
Fixes #15480
