### PR TITLE
Fix DevTools FiredEvent failing on reused RoutedEventArgs

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/FiredEvent.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/FiredEvent.cs
@@ -8,24 +8,28 @@ namespace Avalonia.Diagnostics.ViewModels
     internal class FiredEvent : ViewModelBase
     {
         private readonly RoutedEventArgs _eventArgs;
+        private readonly RoutedEvent? _originalEvent;
         private EventChainLink? _handledBy;
 
         public FiredEvent(RoutedEventArgs eventArgs, EventChainLink originator, DateTime triggerTime)
         {
             _eventArgs = eventArgs ?? throw new ArgumentNullException(nameof(eventArgs));
             Originator = originator ?? throw new ArgumentNullException(nameof(originator));
+            _originalEvent = _eventArgs.RoutedEvent;
             AddToChain(originator);
             TriggerTime = triggerTime;
         }
 
         public bool IsPartOfSameEventChain(RoutedEventArgs e)
         {
-            return e == _eventArgs;
+            // Note, Avalonia might reuse RoutedEventArgs for different events to avoid extra allocations.
+            // Like, PointerEntered and PointerExited will use the same instance of RoutedEventArgs. 
+            return e == _eventArgs && e.RoutedEvent == _originalEvent;
         }
 
         public DateTime TriggerTime { get; }
 
-        public RoutedEvent Event => _eventArgs.RoutedEvent!;
+        public RoutedEvent Event => _originalEvent!;
 
         public bool IsHandled => HandledBy?.Handled == true;
 


### PR DESCRIPTION
## What does the pull request do?

To repro:
Open devtools Events tab and observe PointerEntered and PointerExited events. All PointerEntered will be wrongly replaced with PointerExited, because RoutedEventArgs are reused.

