### PR TITLE
fix: ICommadSource Implemetation

### DIFF
--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -34,8 +34,10 @@ namespace Avalonia.Controls
     [PseudoClasses(pcFlyoutOpen, pcPressed)]
     public class Button : ContentControl, ICommandSource, IClickableControl
     {
-        private const string pcPressed    = ":pressed";
+        private const string pcPressed = ":pressed";
         private const string pcFlyoutOpen = ":flyout-open";
+        private EventHandler? _canExecuteChangeHandler = default;
+        private EventHandler CanExecuteChangedHandler => _canExecuteChangeHandler ??= new(CanExecuteChanged);
 
         /// <summary>
         /// Defines the <see cref="ClickMode"/> property.
@@ -250,10 +252,11 @@ namespace Avalonia.Controls
 
             base.OnAttachedToLogicalTree(e);
 
-            if (Command != null)
+            (var command, var parameter) = (Command, CommandParameter);
+            if (command is not null)
             {
-                Command.CanExecuteChanged += CanExecuteChanged;
-                CanExecuteChanged(this, EventArgs.Empty);
+                command.CanExecuteChanged += CanExecuteChangedHandler;
+                CanExecuteChanged(command, parameter);
             }
         }
 
@@ -269,9 +272,9 @@ namespace Avalonia.Controls
 
             base.OnDetachedFromLogicalTree(e);
 
-            if (Command != null)
+            if (Command is { } command)
             {
-                Command.CanExecuteChanged -= CanExecuteChanged;
+                command.CanExecuteChanged -= CanExecuteChangedHandler;
             }
         }
 
@@ -343,9 +346,10 @@ namespace Avalonia.Controls
                 var e = new RoutedEventArgs(ClickEvent);
                 RaiseEvent(e);
 
-                if (!e.Handled && Command?.CanExecute(CommandParameter) == true)
+                (var command, var parameter) = (Command, CommandParameter);
+                if (!e.Handled && command is not null && command.CanExecute(parameter))
                 {
-                    Command.Execute(CommandParameter);
+                    command.Execute(parameter);
                     e.Handled = true;
                 }
             }
@@ -451,25 +455,24 @@ namespace Avalonia.Controls
 
             if (change.Property == CommandProperty)
             {
+                var (oldValue, newValue) = change.GetOldAndNewValue<ICommand?>();
                 if (((ILogical)this).IsAttachedToLogicalTree)
                 {
-                    var (oldValue, newValue) = change.GetOldAndNewValue<ICommand?>();
                     if (oldValue is ICommand oldCommand)
                     {
-                        oldCommand.CanExecuteChanged -= CanExecuteChanged;
+                        oldCommand.CanExecuteChanged -= CanExecuteChangedHandler;
                     }
 
                     if (newValue is ICommand newCommand)
                     {
-                        newCommand.CanExecuteChanged += CanExecuteChanged;
+                        newCommand.CanExecuteChanged += CanExecuteChangedHandler;
                     }
                 }
-
-                CanExecuteChanged(this, EventArgs.Empty);
+                CanExecuteChanged(newValue, CommandParameter);
             }
             else if (change.Property == CommandParameterProperty)
             {
-                CanExecuteChanged(this, EventArgs.Empty);
+                CanExecuteChanged(Command, change.NewValue);
             }
             else if (change.Property == IsCancelProperty)
             {
@@ -557,7 +560,18 @@ namespace Avalonia.Controls
         /// <param name="e">The event args.</param>
         private void CanExecuteChanged(object? sender, EventArgs e)
         {
-            var canExecute = Command == null || Command.CanExecute(CommandParameter);
+            CanExecuteChanged(Command, CommandParameter);
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        private void CanExecuteChanged(ICommand? command, object? parameter)
+        {
+            if (!((ILogical)this).IsAttachedToLogicalTree)
+            {
+                return;
+            }
+
+            var canExecute = command == null || command.CanExecute(parameter);
 
             if (canExecute != _commandCanExecute)
             {

--- a/tests/Avalonia.Base.UnitTests/Input/KeyboardNavigationTests_Tab.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/KeyboardNavigationTests_Tab.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Threading;
 using Avalonia.UnitTests;
 using Xunit;
 
@@ -1282,6 +1283,8 @@ namespace Avalonia.Base.UnitTests.Input
             Button expected;
             bool executed = false;
 
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
             var top = new StackPanel
             {
                 [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Cycle,
@@ -1303,6 +1306,12 @@ namespace Avalonia.Base.UnitTests.Input
                     }
                 }
             };
+
+            var testRoot = new TestRoot(top);
+
+            top.ApplyTemplate();
+
+            Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
 
             var result = KeyboardNavigationHandler.GetNext(current, NavigationDirection.Next) as Button;
 

--- a/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/MenuItemTests.cs
@@ -99,7 +99,9 @@ namespace Avalonia.Controls.UnitTests
                 [!MenuItem.CommandProperty] = new Binding("Command"),
             };
             var root = new TestRoot { Child = target };
-                
+
+            Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
+
             Assert.True(target.IsEnabled);
             Assert.False(target.IsEffectivelyEnabled);
 
@@ -164,7 +166,7 @@ namespace Avalonia.Controls.UnitTests
             root.Child = null;
             Assert.Equal(0, command.SubscriptionCount);
         }
-        
+
         [Fact]
         public void MenuItem_Invokes_CanExecute_When_Added_To_Logical_Tree_And_CommandParameter_Changed()
         {
@@ -172,13 +174,15 @@ namespace Avalonia.Controls.UnitTests
             var target = new MenuItem { Command = command };
             var root = new TestRoot { Child = target };
 
+            Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
+
             target.CommandParameter = true;
             Assert.True(target.IsEffectivelyEnabled);
 
             target.CommandParameter = false;
             Assert.False(target.IsEffectivelyEnabled);
         }
-        
+
         [Fact]
         public void MenuItem_Does_Not_Invoke_CanExecute_When_ContextMenu_Closed()
         {
@@ -196,7 +200,8 @@ namespace Avalonia.Controls.UnitTests
                 window.ApplyStyling();
                 window.ApplyTemplate();
                 window.Presenter.ApplyTemplate();
-                
+                Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
+
                 Assert.True(target.IsEffectivelyEnabled);
                 target.Command = command;
                 Assert.Equal(0, canExecuteCallCount);
@@ -206,8 +211,9 @@ namespace Avalonia.Controls.UnitTests
 
                 command.RaiseCanExecuteChanged();
                 Assert.Equal(0, canExecuteCallCount);
-                
+
                 contextMenu.Open();
+                Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
                 Assert.Equal(3, canExecuteCallCount);// 3 because popup is changing logical child and moreover we need to invalidate again after the item is attached to the visual tree
 
                 command.RaiseCanExecuteChanged();
@@ -217,7 +223,7 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Equal(5, canExecuteCallCount);
             }
         }
-        
+
         [Fact]
         public void MenuItem_Does_Not_Invoke_CanExecute_When_MenuFlyout_Closed()
         {
@@ -236,7 +242,7 @@ namespace Avalonia.Controls.UnitTests
                 window.ApplyStyling();
                 window.ApplyTemplate();
                 window.Presenter.ApplyTemplate();
-                
+                Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
                 Assert.True(target.IsEffectivelyEnabled);
                 target.Command = command;
                 Assert.Equal(0, canExecuteCallCount);
@@ -248,6 +254,7 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Equal(0, canExecuteCallCount);
 
                 flyout.ShowAt(button);
+                Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
                 Assert.Equal(2, canExecuteCallCount); // 2 because we need to invalidate after the item is attached to the visual tree
 
                 command.RaiseCanExecuteChanged();
@@ -257,7 +264,7 @@ namespace Avalonia.Controls.UnitTests
                 Assert.Equal(4, canExecuteCallCount);
             }
         }
-        
+
         [Fact]
         public void MenuItem_Does_Not_Invoke_CanExecute_When_Parent_MenuItem_Closed()
         {
@@ -277,7 +284,9 @@ namespace Avalonia.Controls.UnitTests
                 window.ApplyTemplate();
                 window.Presenter.ApplyTemplate();
                 contextMenu.Open();
-                
+
+                Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
+
                 Assert.True(target.IsEffectivelyEnabled);
                 target.Command = command;
                 Assert.Equal(0, canExecuteCallCount);
@@ -376,7 +385,7 @@ namespace Avalonia.Controls.UnitTests
             var panel = Assert.IsType<StackPanel>(menu.Presenter.Panel);
             Assert.Equal(2, panel.Children.Count);
 
-            for (var i = 0; i <  panel.Children.Count; i++)
+            for (var i = 0; i < panel.Children.Count; i++)
             {
                 var menuItem = Assert.IsType<MenuItem>(panel.Children[i]);
 
@@ -500,7 +509,7 @@ namespace Avalonia.Controls.UnitTests
 
             var window = new Window { Content = menu };
             window.Show();
-            
+
             Assert.False(menuItem1.IsChecked);
             Assert.True(menuItem2.IsChecked);
             Assert.False(menuItem3.IsChecked);
@@ -511,7 +520,7 @@ namespace Avalonia.Controls.UnitTests
             Assert.False(menuItem2.IsChecked);
             Assert.True(menuItem3.IsChecked);
         }
-        
+
         [Fact]
         public void Radio_Menu_Group_Can_Be_Changed_In_Runtime()
         {
@@ -540,7 +549,7 @@ namespace Avalonia.Controls.UnitTests
 
             var window = new Window { Content = menu };
             window.Show();
-            
+
             Assert.False(menuItem1.IsChecked);
             Assert.True(menuItem2.IsChecked);
             Assert.False(menuItem3.IsChecked);
@@ -554,12 +563,12 @@ namespace Avalonia.Controls.UnitTests
 
             menuItem3.GroupName = null;
             menuItem1.IsChecked = true;
-            
+
             Assert.True(menuItem1.IsChecked);
             Assert.False(menuItem2.IsChecked);
             Assert.True(menuItem3.IsChecked);
         }
-        
+
         [Fact]
         public void Radio_MenuItem_In_Same_Group_But_Submenu_Is_Unchecked()
         {
@@ -599,7 +608,7 @@ namespace Avalonia.Controls.UnitTests
 
             var window = new Window { Content = menu };
             window.Show();
-            
+
             Assert.False(menuItem1.IsChecked);
             Assert.False(menuItem2.IsChecked);
             Assert.True(menuItem3.IsChecked);
@@ -800,7 +809,7 @@ namespace Avalonia.Controls.UnitTests
             var screen = new PixelRect(new PixelPoint(), new PixelSize(100, 100));
             var screenImpl = new Mock<IScreenImpl>();
             screenImpl.Setup(x => x.ScreenCount).Returns(1);
-            screenImpl.Setup(X => X.AllScreens).Returns( new[] { new Screen(1, screen, screen, true) });
+            screenImpl.Setup(X => X.AllScreens).Returns(new[] { new Screen(1, screen, screen, true) });
 
             var windowImpl = MockWindowingPlatform.CreateWindowMock();
             popupImpl = MockWindowingPlatform.CreatePopupMock(windowImpl.Object);

--- a/tests/Avalonia.Controls.UnitTests/SplitButtonTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/SplitButtonTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Avalonia.Controls.UnitTests.Utils;
+using Avalonia.Input;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Controls.UnitTests;
+
+public class SplitButtonTests : ScopedTestBase
+{
+    [Fact]
+    public void SplitButton_CommandParameter_Does_Not_Change_While_Execution()
+    {
+        var target = new SplitButton();
+        object lastParamenter = "A";
+        var generator = new Random();
+        var command = new TestCommand(parameter =>
+        {
+            target.CommandParameter = generator.Next();
+            lastParamenter = parameter;
+            return true;
+        },
+        parameter =>
+        {
+            Assert.Equal(lastParamenter, parameter);
+        });
+        target.CommandParameter = lastParamenter;
+        target.Command = command;
+        var root = new TestRoot { Child = target };
+
+        (target as IClickableControl).RaiseClick();
+    }
+}

--- a/tests/Avalonia.Controls.UnitTests/Utils/TestCommand.cs
+++ b/tests/Avalonia.Controls.UnitTests/Utils/TestCommand.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace Avalonia.Controls.UnitTests.Utils;
+
+internal class TestCommand : ICommand
+{
+    private readonly Func<object, bool> _canExecute;
+    private readonly Action<object> _execute;
+    private EventHandler _canExecuteChanged;
+    private bool _enabled = true;
+
+    public TestCommand(bool enabled = true)
+    {
+        _enabled = enabled;
+        _canExecute = _ => _enabled;
+        _execute = _ => { };
+    }
+
+    public TestCommand(Func<object, bool> canExecute, Action<object> execute = null)
+    {
+        _canExecute = canExecute;
+        _execute = execute ?? (_ => { });
+    }
+
+    public bool IsEnabled
+    {
+        get { return _enabled; }
+        set
+        {
+            if (_enabled != value)
+            {
+                _enabled = value;
+                _canExecuteChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
+
+    public int SubscriptionCount { get; private set; }
+
+    public event EventHandler CanExecuteChanged
+    {
+        add { _canExecuteChanged += value; ++SubscriptionCount; }
+        remove { _canExecuteChanged -= value; --SubscriptionCount; }
+    }
+
+    public bool CanExecute(object parameter) => _canExecute(parameter);
+
+    public void Execute(object parameter) => _execute(parameter);
+
+    public void RaiseCanExecuteChanged() => _canExecuteChanged?.Invoke(this, EventArgs.Empty);
+}


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Ensure CanExecute and Execute consistence.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

The current implementation of ICommandSource does not guarantee that CanExecute and Execute occur on the same command.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

- CanExecuteChangedHandler caching to avoid multiple allocation of delegates at subscribe/unsubscribe
- Copy Commad and CommandParameter references to local variables before calling CanExecute and Execute to ensure consistency

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
