### PR TITLE
Fix: PhysicalKeyExtensions.ToQwertyKey

### DIFF
--- a/src/Avalonia.Base/Input/PhysicalKeyExtensions.cs
+++ b/src/Avalonia.Base/Input/PhysicalKeyExtensions.cs
@@ -31,7 +31,7 @@ public static class PhysicalKeyExtensions
             PhysicalKey.Digit7 => Key.D7,
             PhysicalKey.Digit8 => Key.D8,
             PhysicalKey.Digit9 => Key.D9,
-            PhysicalKey.Equal => Key.OemMinus,
+            PhysicalKey.Equal => Key.OemPlus,
             PhysicalKey.IntlBackslash => Key.Oem102,
             PhysicalKey.IntlRo => Key.Oem102,
             PhysicalKey.IntlYen => Key.Oem5,


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
let `PhysicalKey.Equal` convert to `Key.OemPlus`

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`PhysicalKey.Equal` will convert to `Key.OemMinus`

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
