### PR TITLE
Fix `AssemblyDescriptorResolver` assembly matching

### DIFF
--- a/src/Avalonia.Base/Platform/Internal/AssemblyDescriptorResolver.cs
+++ b/src/Avalonia.Base/Platform/Internal/AssemblyDescriptorResolver.cs
@@ -26,7 +26,7 @@ internal class AssemblyDescriptorResolver: IAssemblyDescriptorResolver
         if (!_assemblyNameCache.TryGetValue(name, out var rv))
         {
             var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
-            var match = loadedAssemblies.FirstOrDefault(a => a.GetName().Name == name);
+            var match = loadedAssemblies.FirstOrDefault(a => a.GetName().Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
             if (match != null)
             {
                 _assemblyNameCache[name] = rv = new AssemblyDescriptor(match);

--- a/src/Avalonia.Base/Platform/Internal/AssemblyDescriptorResolver.cs
+++ b/src/Avalonia.Base/Platform/Internal/AssemblyDescriptorResolver.cs
@@ -26,7 +26,7 @@ internal class AssemblyDescriptorResolver: IAssemblyDescriptorResolver
         if (!_assemblyNameCache.TryGetValue(name, out var rv))
         {
             var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
-            var match = loadedAssemblies.FirstOrDefault(a => a.GetName().Name?.Equals(name, StringComparison.InvariantCultureIgnoreCase) ?? false);
+            var match = loadedAssemblies.FirstOrDefault(a => name.Equals(a.GetName().Name, StringComparison.InvariantCultureIgnoreCase));
             if (match != null)
             {
                 _assemblyNameCache[name] = rv = new AssemblyDescriptor(match);

--- a/src/Avalonia.Base/Platform/Internal/AssemblyDescriptorResolver.cs
+++ b/src/Avalonia.Base/Platform/Internal/AssemblyDescriptorResolver.cs
@@ -26,7 +26,7 @@ internal class AssemblyDescriptorResolver: IAssemblyDescriptorResolver
         if (!_assemblyNameCache.TryGetValue(name, out var rv))
         {
             var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
-            var match = loadedAssemblies.FirstOrDefault(a => a.GetName().Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+            var match = loadedAssemblies.FirstOrDefault(a => a.GetName().Name?.Equals(name, StringComparison.InvariantCultureIgnoreCase) ?? false);
             if (match != null)
             {
                 _assemblyNameCache[name] = rv = new AssemblyDescriptor(match);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix a bug in assembly resolving which breaks AOT environments.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Assembly resolving of all-lowercase names will panic in AOT environments.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Uses case-insensitive comparison.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #15504
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
