### PR TITLE
CompileAvaloniaXamlTask - handle no-pdb compilations

### DIFF
--- a/src/Avalonia.Build.Tasks/CompileAvaloniaXamlTask.cs
+++ b/src/Avalonia.Build.Tasks/CompileAvaloniaXamlTask.cs
@@ -38,7 +38,7 @@ namespace Avalonia.Build.Tasks
             {
                 // To simplify incremental build checks, copy the input files to the expected output locations even if the Xaml compiler didn't do anything.
                 CopyAndTouch(AssemblyFile.ItemSpec, outputPath);
-                CopyAndTouch(Path.ChangeExtension(AssemblyFile.ItemSpec, ".pdb"), Path.ChangeExtension(outputPath, ".pdb"));
+                CopyAndTouch(Path.ChangeExtension(AssemblyFile.ItemSpec, ".pdb"), Path.ChangeExtension(outputPath, ".pdb"), false);
 
                 if (!string.IsNullOrEmpty(refOutputPath))
                 {
@@ -49,13 +49,20 @@ namespace Avalonia.Build.Tasks
             return res.Success;
         }
 
-        private static void CopyAndTouch(string source, string destination)
+        private static void CopyAndTouch(string source, string destination, bool shouldExist = true)
         {
-            if (File.Exists(source))
+            if (!File.Exists(source))
             {
-                File.Copy(source, destination, overwrite: true);
-                File.SetLastWriteTimeUtc(destination, DateTime.UtcNow);
+                if (shouldExist)
+                {
+                    throw new FileNotFoundException($"Could not copy file '{source}'. File does not exist.");
+                }
+
+                return;
             }
+
+            File.Copy(source, destination, overwrite: true);
+            File.SetLastWriteTimeUtc(destination, DateTime.UtcNow);
         }
 
         [Required]

--- a/src/Avalonia.Build.Tasks/CompileAvaloniaXamlTask.cs
+++ b/src/Avalonia.Build.Tasks/CompileAvaloniaXamlTask.cs
@@ -51,8 +51,11 @@ namespace Avalonia.Build.Tasks
 
         private static void CopyAndTouch(string source, string destination)
         {
-            File.Copy(source, destination, overwrite: true);
-            File.SetLastWriteTimeUtc(destination, DateTime.UtcNow);
+            if (File.Exists(source))
+            {
+                File.Copy(source, destination, overwrite: true);
+                File.SetLastWriteTimeUtc(destination, DateTime.UtcNow);
+            }
         }
 
         [Required]


### PR DESCRIPTION
## What does the pull request do?
Fix build of C# projects with no PDB.

## What is the current behavior?
Error is thrown by msbuild
```
***\.nuget\packages\avalonia\11.1.0-beta2\buildTransitive\AvaloniaBuildTasks.targets(138,5): error MSB
4018: The "CompileAvaloniaXamlTask" task failed unexpectedly. [***]
***\.nuget\packages\avalonia\11.1.0-beta2\buildTransitive\AvaloniaBuildTasks.targets(138,5): error MSB
4018: System.IO.FileNotFoundException: Could not find file '***/net7.0-windows\win-x64\Application.pdb'. 
```

This was caused by this optimization https://github.com/AvaloniaUI/Avalonia/commit/223cfaba9ae49a7252c1a73c8970bd9d61bd8915
The original code checked for the existence of the PDB file but the new code does not.

To test this add this to any csproj file in the project with XAML files.
 ```
 <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
    <DebugType>none</DebugType>
  </PropertyGroup>
```

## What is the updated/expected behavior with this PR?
If there is no PDB then there is nothing to copy. Just ignore it.
