### PR TITLE
Fixed stride parameter not used in ImmutableBitmap ctor

### DIFF
--- a/src/Skia/Avalonia.Skia/ImmutableBitmap.cs
+++ b/src/Skia/Avalonia.Skia/ImmutableBitmap.cs
@@ -131,7 +131,7 @@ namespace Avalonia.Skia
             {
                 tmp.InstallPixels(
                     new SKImageInfo(size.Width, size.Height, format.ToSkColorType(), alphaFormat.ToSkAlphaType()),
-                    data);
+                    data, stride);
                 _bitmap = tmp.Copy();
             }
             _bitmap.SetImmutable();


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixed an issue with the stride parameter that is never used in the ImmutableBitmap constructor. See issue #15508.


## What is the current behavior?
As stride is missing in the InstallPixels call, currently, image data is not correct if stride is not equal to width * bytesPerPixel.


## What is the updated/expected behavior with this PR?
The stride parameter is important as it is not always equal to width * bytesPerPixel, for example if you want to crop inside a bitmap, or if image row data is padded.

## How was the solution implemented (if it's not obvious)?
I just added the stride param to the call to InstallPixels. I checked in a sample app that this solution fix the issue, and it is.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None

## Fixed issues
Fixes #15508

