### PR TITLE
Grid fixes

### DIFF
--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -2357,7 +2357,7 @@ namespace Avalonia.Controls
             if (grid._extData != null    // trivial grid is 1 by 1. there is no grid lines anyway
                 && grid.ListenToNotifications)
             {
-                grid.InvalidateVisual();
+                grid.InvalidateArrange();
             }
 
             grid.SetFlags((bool)e.NewValue!, Flags.ShowGridLinesPropertyValue);

--- a/src/Avalonia.Controls/Grid.cs
+++ b/src/Avalonia.Controls/Grid.cs
@@ -2325,7 +2325,7 @@ namespace Avalonia.Controls
 
             if ((!ShowGridLines) && (_gridLinesRenderer != null))
             {
-                VisualChildren.Add(_gridLinesRenderer);
+                VisualChildren.Remove(_gridLinesRenderer);
                 _gridLinesRenderer = null;
             }
 


### PR DESCRIPTION
## What does the pull request do?
Fixes `Grid.ShowGridLines` usage - crash on false value and resize, not redraw Grid when changed.

## What is the current behavior?
1. Crash when set `ShowGridLines` = false and resize because `GridLinesRenderer` was added to `VisualChildren` instead of remove.
2. Changing `ShowGridLines` to any value is not redrawing `Grid` because `Grid` was invalidating visual but not updating `GridLinesRenderer`. `GridLinesRenderer` updates in `ArrangeOverride`.

## What is the updated/expected behavior with this PR?
No crash, correct redraw on `ShowGridLines` changed, bindings to `ShowGridLines` works.

## Fixed issues
Fixes #11478
