### PR TITLE
Fix Avalonia.Browser running on .NET 9

### DIFF
--- a/src/Browser/Avalonia.Browser/BrowserInputHandler.cs
+++ b/src/Browser/Avalonia.Browser/BrowserInputHandler.cs
@@ -250,9 +250,9 @@ internal class BrowserInputHandler
                && dropEffect != DragDropEffects.None;
     }
 
-    private bool OnKeyDown(string code, string key, int modifier)
+    private bool OnKeyDown(string code, string key, string modifier)
     {
-        var handled = RawKeyboardEvent(RawKeyEventType.KeyDown, code, key, (RawInputModifiers)modifier);
+        var handled = RawKeyboardEvent(RawKeyEventType.KeyDown, code, key, (RawInputModifiers)int.Parse(modifier));
 
         if (!handled && key.Length == 1)
         {
@@ -262,9 +262,9 @@ internal class BrowserInputHandler
         return handled;
     }
 
-    private bool OnKeyUp(string code, string key, int modifier)
+    private bool OnKeyUp(string code, string key, string modifier)
     {
-        return RawKeyboardEvent(RawKeyEventType.KeyUp, code, key, (RawInputModifiers)modifier);
+        return RawKeyboardEvent(RawKeyEventType.KeyUp, code, key, (RawInputModifiers)int.Parse(modifier));
     }
 
     private bool RawPointerEvent(

--- a/src/Browser/Avalonia.Browser/Interop/CanvasHelper.cs
+++ b/src/Browser/Avalonia.Browser/Interop/CanvasHelper.cs
@@ -36,7 +36,8 @@ internal static partial class CanvasHelper
     public static partial void OnSizeChanged(
         JSObject canvasSurface,
         [JSMarshalAs<JSType.Function<JSType.Number, JSType.Number, JSType.Number>>]
-        Action<int, int, double> onSizeChanged);
+        // TODO: this callback should be <int, int, double>. Revert after next .NET 9 preview.  
+        Action<double, double, double> onSizeChanged);
 
     [JSImport("CanvasFactory.create", AvaloniaModule.MainModuleName)]
     private static partial JSObject Create(JSObject canvasSurface, int mode);

--- a/src/Browser/Avalonia.Browser/Interop/InputHelper.cs
+++ b/src/Browser/Avalonia.Browser/Interop/InputHelper.cs
@@ -10,10 +10,12 @@ internal static partial class InputHelper
     [JSImport("InputHelper.subscribeKeyEvents", AvaloniaModule.MainModuleName)]
     public static partial void SubscribeKeyEvents(
         JSObject htmlElement,
-        [JSMarshalAs<JSType.Function<JSType.String, JSType.String, JSType.Number, JSType.Boolean>>]
-        Func<string, string, int, bool> keyDown,
-        [JSMarshalAs<JSType.Function<JSType.String, JSType.String, JSType.Number, JSType.Boolean>>]
-        Func<string, string, int, bool> keyUp);
+        [JSMarshalAs<JSType.Function<JSType.String, JSType.String, JSType.String, JSType.Boolean>>]
+        // TODO: this callback should be <string, string, int, bool>. Revert after next .NET 9 preview.  
+        Func<string, string, string, bool> keyDown,
+        [JSMarshalAs<JSType.Function<JSType.String, JSType.String, JSType.String, JSType.Boolean>>]
+        // TODO: this callback should be <string, string, int, bool>. Revert after next .NET 9 preview.
+        Func<string, string, string, bool> keyUp);
 
     [JSImport("InputHelper.subscribeTextEvents", AvaloniaModule.MainModuleName)]
     public static partial void SubscribeTextEvents(

--- a/src/Browser/Avalonia.Browser/Rendering/BrowserSurface.cs
+++ b/src/Browser/Avalonia.Browser/Rendering/BrowserSurface.cs
@@ -87,11 +87,11 @@ internal abstract class BrowserSurface : IDisposable
         ClientSize = default;
     }
 
-    private void OnSizeChanged(int pixelWidth, int pixelHeight, double dpr)
+    private void OnSizeChanged(double pixelWidth, double pixelHeight, double dpr)
     {
         var oldScaling = Scaling;
         var oldClientSize = ClientSize;
-        RenderSize = new PixelSize(pixelWidth, pixelHeight);
+        RenderSize = new PixelSize((int)pixelWidth, (int)pixelHeight);
         ClientSize = RenderSize.ToSize(dpr);
         Scaling = dpr;
         if (oldClientSize != ClientSize)

--- a/src/Browser/Avalonia.Browser/webapp/modules/avalonia/input.ts
+++ b/src/Browser/Avalonia.Browser/webapp/modules/avalonia/input.ts
@@ -74,8 +74,8 @@ export class InputHelper {
 
     public static subscribeKeyEvents(
         element: HTMLInputElement,
-        keyDownCallback: (code: string, key: string, modifiers: RawInputModifiers) => boolean,
-        keyUpCallback: (code: string, key: string, modifiers: RawInputModifiers) => boolean) {
+        keyDownCallback: (code: string, key: string, modifiers: string) => boolean,
+        keyUpCallback: (code: string, key: string, modifiers: string) => boolean) {
         const keyDownHandler = (args: KeyboardEvent) => {
             if (keyDownCallback(args.code, args.key, this.getModifiers(args))) {
                 if (this.clipboardState !== ClipboardState.Pending) {
@@ -316,7 +316,7 @@ export class InputHelper {
         inputElement.style.width = `${inputElement.scrollWidth}px`;
     }
 
-    private static getModifiers(args: KeyboardEvent): RawInputModifiers {
+    private static getModifiers(args: KeyboardEvent): string {
         let modifiers = RawInputModifiers.None;
 
         if (args.ctrlKey) { modifiers |= RawInputModifiers.Control; }
@@ -324,7 +324,7 @@ export class InputHelper {
         if (args.shiftKey) { modifiers |= RawInputModifiers.Shift; }
         if (args.metaKey) { modifiers |= RawInputModifiers.Meta; }
 
-        return modifiers;
+        return modifiers.toString();
     }
 
     public static setPointerCapture(containerElement: HTMLInputElement, pointerId: number): void {


### PR DESCRIPTION
## What does the pull request do?

Adds hacks to make Avalonia running on .NET 9 Browser (single threaded).
Ideally this PR should be backported as soon as it's fixed in next .NET previews.

## What is the current behavior?

![image](https://github.com/AvaloniaUI/Avalonia/assets/3163374/736c2493-0fa7-4c37-bd23-410f3f2b72c5)
