### PR TITLE
Use tap size as default size for scrolling start. reset IsGestureRecognitionSkipped when pointer is released

### DIFF
--- a/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using Avalonia.Platform;
 using Avalonia.Threading;
 
 namespace Avalonia.Input.GestureRecognizers
@@ -13,7 +14,7 @@ namespace Avalonia.Input.GestureRecognizers
         private bool _canHorizontallyScroll;
         private bool _canVerticallyScroll;
         private bool _isScrollInertiaEnabled;
-        private int _scrollStartDistance = 30;
+        private int _scrollStartDistance = (int)((AvaloniaLocator.Current?.GetService<IPlatformSettings>()?.GetTapSize(PointerType.Touch).Height ?? 10)  / 2);
 
         private bool _scrolling;
         private Point _trackedRootPoint;
@@ -54,7 +55,7 @@ namespace Avalonia.Input.GestureRecognizers
         public static readonly DirectProperty<ScrollGestureRecognizer, int> ScrollStartDistanceProperty =
             AvaloniaProperty.RegisterDirect<ScrollGestureRecognizer, int>(nameof(ScrollStartDistance),
                 o => o.ScrollStartDistance, (o, v) => o.ScrollStartDistance = v,
-                unsetValue: 30);
+                unsetValue: (int)(AvaloniaLocator.Current.GetService<IPlatformSettings>()?.GetTapSize(PointerType.Touch).Height ?? 30));
 
         /// <summary>
         /// Gets or sets a value indicating whether the content can be scrolled horizontally.

--- a/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
@@ -14,8 +14,8 @@ namespace Avalonia.Input.GestureRecognizers
         private bool _canHorizontallyScroll;
         private bool _canVerticallyScroll;
         private bool _isScrollInertiaEnabled;
-        private readonly static int s_defatultScrollStartDistance = (int)((AvaloniaLocator.Current?.GetService<IPlatformSettings>()?.GetTapSize(PointerType.Touch).Height ?? 10) / 2);
-        private int _scrollStartDistance = s_defatultScrollStartDistance;
+        private readonly static int s_defaultScrollStartDistance = (int)((AvaloniaLocator.Current?.GetService<IPlatformSettings>()?.GetTapSize(PointerType.Touch).Height ?? 10) / 2);
+        private int _scrollStartDistance = s_defaultScrollStartDistance;
 
         private bool _scrolling;
         private Point _trackedRootPoint;
@@ -56,7 +56,7 @@ namespace Avalonia.Input.GestureRecognizers
         public static readonly DirectProperty<ScrollGestureRecognizer, int> ScrollStartDistanceProperty =
             AvaloniaProperty.RegisterDirect<ScrollGestureRecognizer, int>(nameof(ScrollStartDistance),
                 o => o.ScrollStartDistance, (o, v) => o.ScrollStartDistance = v,
-                unsetValue: s_defatultScrollStartDistance);
+                unsetValue: s_defaultScrollStartDistance);
 
         /// <summary>
         /// Gets or sets a value indicating whether the content can be scrolled horizontally.

--- a/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/ScrollGestureRecognizer.cs
@@ -14,7 +14,8 @@ namespace Avalonia.Input.GestureRecognizers
         private bool _canHorizontallyScroll;
         private bool _canVerticallyScroll;
         private bool _isScrollInertiaEnabled;
-        private int _scrollStartDistance = (int)((AvaloniaLocator.Current?.GetService<IPlatformSettings>()?.GetTapSize(PointerType.Touch).Height ?? 10)  / 2);
+        private readonly static int s_defatultScrollStartDistance = (int)((AvaloniaLocator.Current?.GetService<IPlatformSettings>()?.GetTapSize(PointerType.Touch).Height ?? 10) / 2);
+        private int _scrollStartDistance = s_defatultScrollStartDistance;
 
         private bool _scrolling;
         private Point _trackedRootPoint;
@@ -55,7 +56,7 @@ namespace Avalonia.Input.GestureRecognizers
         public static readonly DirectProperty<ScrollGestureRecognizer, int> ScrollStartDistanceProperty =
             AvaloniaProperty.RegisterDirect<ScrollGestureRecognizer, int>(nameof(ScrollStartDistance),
                 o => o.ScrollStartDistance, (o, v) => o.ScrollStartDistance = v,
-                unsetValue: (int)(AvaloniaLocator.Current.GetService<IPlatformSettings>()?.GetTapSize(PointerType.Touch).Height ?? 30));
+                unsetValue: s_defatultScrollStartDistance);
 
         /// <summary>
         /// Gets or sets a value indicating whether the content can be scrolled horizontally.

--- a/src/Avalonia.Base/Input/MouseDevice.cs
+++ b/src/Avalonia.Base/Input/MouseDevice.cs
@@ -205,6 +205,7 @@ namespace Avalonia.Input
                 {
                     _pointer.Capture(null);
                     _pointer.CaptureGestureRecognizer(null);
+                    _pointer.IsGestureRecognitionSkipped = false;
                     _lastMouseDownButton = default;
                 }
                 return e.Handled;

--- a/src/Avalonia.Base/Input/PenDevice.cs
+++ b/src/Avalonia.Base/Input/PenDevice.cs
@@ -167,6 +167,7 @@ namespace Avalonia.Input
                 {
                     pointer.Capture(null);
                     pointer.CaptureGestureRecognizer(null);
+                    pointer.IsGestureRecognitionSkipped = false;
                     _lastMouseDownButton = default;
                 }
 

--- a/src/Avalonia.Base/Input/TouchDevice.cs
+++ b/src/Avalonia.Base/Input/TouchDevice.cs
@@ -119,6 +119,8 @@ namespace Avalonia.Input
                 {
                     pointer?.Capture(null);
                     pointer?.CaptureGestureRecognizer(null);
+                    if (pointer != null)
+                        pointer.IsGestureRecognitionSkipped = false;
                 }
             }
 

--- a/tests/Avalonia.UnitTests/TouchTestHelper.cs
+++ b/tests/Avalonia.UnitTests/TouchTestHelper.cs
@@ -49,8 +49,7 @@ namespace Avalonia.UnitTests
             else
                 source.RaiseEvent(e);
 
-            _pointer.Capture(null);
-            _pointer.CaptureGestureRecognizer(null);
+           Cancel();
         }
 
         public void Tap(Interactive target, Point position = default,  KeyModifiers modifiers = default)
@@ -66,6 +65,7 @@ namespace Avalonia.UnitTests
         {
             _pointer.Capture(null);
             _pointer.CaptureGestureRecognizer(null);
+            _pointer.IsGestureRecognitionSkipped = false;
         }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Sets the default ScrollStartDistance to the Platform settings' TapSize. Resets Pointer.IsGestureRecognitionSkipped of a pointer when pointer is released.


## What is the current behavior?
The default value for ScrollStartDistance was 30. This is too large to detect for scrolling on most touch devices, and in some cases, controls maye be smaller than 30 and thus will force the scroll gesture recognizer to lose the pointer as the gesture may go over another control before it start to trigger scrolling.


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #15288
