### PR TITLE
Revert "Win32 - Fix EntendClient hints not being applied window show"

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1205,8 +1205,6 @@ namespace Avalonia.Win32
                 UnmanagedMethods.ShowWindow(_hwnd, command.Value);
             }
 
-            ExtendClientArea();
-
             if (state == WindowState.Maximized)
             {
                 MaximizeWithoutCoveringTaskbar();


### PR DESCRIPTION
Unfortunately, while fixing one bug with decorations, that PR breaks `Normal -> Maximized -> Normal` window mode transitions on Windows. Size is not restored when going back to normal mode.
Integrational tests did catch it, but I merged PR too quickly. 

Reverts AvaloniaUI/Avalonia#15552