### PR TITLE
Avoid allocations in RaiseEvent when there's no listeners

### DIFF
--- a/src/Avalonia.Base/Input/AccessKeyHandler.cs
+++ b/src/Avalonia.Base/Input/AccessKeyHandler.cs
@@ -196,10 +196,7 @@ namespace Avalonia.Input
                 var match = matches.FirstOrDefault();
 
                 // If there was a match, raise the AccessKeyPressed event on it.
-                if (match is not null)
-                {
-                    match.RaiseEvent(new RoutedEventArgs(AccessKeyPressedEvent));
-                }
+                match?.RaiseEvent(AccessKeyPressedEvent);
             }
         }
 
@@ -243,7 +240,7 @@ namespace Avalonia.Input
         }
 
         /// <summary>
-        /// Closes the <see cref="MainMenu"/> and performs other bookeeping.
+        /// Closes the <see cref="MainMenu"/> and performs other bookkeeping.
         /// </summary>
         private void CloseMenu()
         {

--- a/src/Avalonia.Base/Input/GestureRecognizers/PinchGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/PinchGestureRecognizer.cs
@@ -42,10 +42,16 @@ namespace Avalonia.Input
 
                     var degree = GetAngleDegreeFromPoints(_firstPoint, _secondPoint);
 
-                    var pinchEventArgs = new PinchEventArgs(scale, _origin, degree, _previousAngle - degree);
+                    var angleDelta = _previousAngle - degree;
+
+                    var pinchEventArgs = Target?.RaiseEvent(
+                        Gestures.PinchEvent,
+                        static (_, ctx) => new PinchEventArgs(ctx.scale, ctx.origin, ctx.degree, ctx.angleDelta),
+                        (scale, origin: _origin, degree, angleDelta));
+
                     _previousAngle = degree;
-                    Target?.RaiseEvent(pinchEventArgs);
-                    e.Handled = pinchEventArgs.Handled;
+
+                    e.Handled = pinchEventArgs?.Handled ?? false;
                     e.PreventGestureRecognition();
                 }
             }
@@ -111,7 +117,7 @@ namespace Avalonia.Input
                     _secondContact = null;
                 }
 
-                Target?.RaiseEvent(new PinchEndedEventArgs());
+                Target?.RaiseEvent(Gestures.PinchEndedEvent, static _ => new PinchEndedEventArgs());
                 return true;
             }
             return false;

--- a/src/Avalonia.Base/Input/GestureRecognizers/PullGestureRecognizer.cs
+++ b/src/Avalonia.Base/Input/GestureRecognizers/PullGestureRecognizer.cs
@@ -75,10 +75,13 @@ namespace Avalonia.Input
                 }
 
                 _pullInProgress = true;
-                var pullEventArgs = new PullGestureEventArgs(_gestureId, delta, PullDirection);
-                Target?.RaiseEvent(pullEventArgs);
 
-                e.Handled = pullEventArgs.Handled;
+                var pullEventArgs = Target.RaiseEvent(
+                    Gestures.PullGestureEvent,
+                    static (_, ctx) => new PullGestureEventArgs(ctx.gestureId, ctx.delta, ctx.pullDirection),
+                    (gestureId: _gestureId, delta, pullDirection: PullDirection));
+
+                e.Handled = pullEventArgs?.Handled ?? false;
             }
         }
 
@@ -131,7 +134,10 @@ namespace Avalonia.Input
             _initialPosition = default;
             _pullInProgress = false;
 
-            Target?.RaiseEvent(new PullGestureEndedEventArgs(_gestureId, PullDirection));
+            Target?.RaiseEvent(
+                Gestures.PullGestureEndedEvent,
+                static (_, ctx) => new PullGestureEndedEventArgs(ctx.gestureId, ctx.pullDirection),
+                (gestureId: _gestureId, pullDirection: PullDirection));
         }
     }
 }

--- a/src/Avalonia.Base/Input/InputExtensions.cs
+++ b/src/Avalonia.Base/Input/InputExtensions.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Avalonia.Interactivity;
 using Avalonia.VisualTree;
-
-#nullable enable
 
 namespace Avalonia.Input
 {
@@ -78,6 +77,53 @@ namespace Avalonia.Input
 
         /// <inheritdoc cref="InputHitTest(IInputElement, Point, Func{Visual, bool}, bool)"/>
         public static IInputElement? InputHitTest(this IInputElement element, Point p, Func<Visual, bool> filter) => InputHitTest(element, p, filter, true);
+
+        internal static TEventArgs? RaiseEvent<TEventArgs, TContext>(
+            this IInputElement inputElement,
+            RoutedEvent<TEventArgs> routedEvent,
+            Func<RoutedEvent<TEventArgs>, TContext, TEventArgs> eventArgsFactory,
+            TContext context)
+            where TEventArgs : RoutedEventArgs
+        {
+            if (inputElement is InputElement typedInputElement)
+            {
+                return typedInputElement.RaiseEvent(routedEvent, eventArgsFactory, context);
+            }
+
+            var eventArgs = eventArgsFactory(routedEvent, context);
+            inputElement.RaiseEvent(eventArgs);
+            return eventArgs;
+        }
+
+        internal static TEventArgs? RaiseEvent<TEventArgs>(
+            this IInputElement inputElement,
+            RoutedEvent<TEventArgs> routedEvent,
+            Func<RoutedEvent<TEventArgs>, TEventArgs> eventArgsFactory)
+            where TEventArgs : RoutedEventArgs
+        {
+            if (inputElement is InputElement typedInputElement)
+            {
+                return typedInputElement.RaiseEvent(routedEvent, eventArgsFactory);
+            }
+
+            var eventArgs = eventArgsFactory(routedEvent);
+            inputElement.RaiseEvent(eventArgs);
+            return eventArgs;
+        }
+
+        internal static RoutedEventArgs? RaiseEvent(
+            this IInputElement inputElement,
+            RoutedEvent<RoutedEventArgs> routedEvent)
+        {
+            if (inputElement is InputElement typedInputElement)
+            {
+                return typedInputElement.RaiseEvent(routedEvent);
+            }
+
+            var eventArgs = new RoutedEventArgs(routedEvent);
+            inputElement.RaiseEvent(eventArgs);
+            return eventArgs;
+        }
 
         private static bool IsHitTestVisible(Visual visual) => visual is { IsVisible: true, IsAttachedToVisualTree: true } and IInputElement { IsHitTestVisible: true };
 

--- a/src/Avalonia.Base/Input/KeyboardDevice.cs
+++ b/src/Avalonia.Base/Input/KeyboardDevice.cs
@@ -149,18 +149,18 @@ namespace Avalonia.Input
                 _focusedElement = element;
                 _focusedRoot = ((Visual?)_focusedElement)?.VisualRoot as IInputRoot;
 
-                interactive?.RaiseEvent(new RoutedEventArgs
-                {
-                    RoutedEvent = InputElement.LostFocusEvent,
-                });
+                interactive?.RaiseEvent(InputElement.LostFocusEvent);
 
                 interactive = element as Interactive;
 
-                interactive?.RaiseEvent(new GotFocusEventArgs
-                {
-                    NavigationMethod = method,
-                    KeyModifiers = keyModifiers,
-                });
+                interactive?.RaiseEvent(
+                    InputElement.GotFocusEvent,
+                    static (_, ctx) => new GotFocusEventArgs
+                    {
+                        NavigationMethod = ctx.method,
+                        KeyModifiers = ctx.keyModifiers,
+                    },
+                    (method, keyModifiers));
 
                 _textInputManager.SetFocusedElement(element);
                 RaisePropertyChanged(nameof(FocusedElement));
@@ -241,15 +241,17 @@ namespace Avalonia.Input
 
             if (e is RawTextInputEventArgs text)
             {
-                var ev = new TextInputEventArgs()
-                {
-                    Text = text.Text,
-                    Source = element,
-                    RoutedEvent = InputElement.TextInputEvent
-                };
+                var eventArgs = element.RaiseEvent(
+                    InputElement.TextInputEvent,
+                    static (e, ctx) => new TextInputEventArgs
+                    {
+                        Text = ctx.Text,
+                        Source = ctx.element,
+                        RoutedEvent = e
+                    },
+                    (text.Text, element));
 
-                element.RaiseEvent(ev);
-                e.Handled = ev.Handled;
+                e.Handled = eventArgs?.Handled ?? false;
             }
         }
     }

--- a/src/Avalonia.Base/Input/Pointer.cs
+++ b/src/Avalonia.Base/Input/Pointer.cs
@@ -47,7 +47,11 @@ namespace Avalonia.Input
                 {
                     if (notifyTarget == commonParent)
                         break;
-                    notifyTarget.RaiseEvent(new PointerCaptureLostEventArgs(notifyTarget, this));
+
+                    notifyTarget.RaiseEvent(
+                        InputElement.PointerCaptureLostEvent,
+                        static (_, ctx) => new PointerCaptureLostEventArgs(ctx.notifyTarget, ctx.pointer),
+                        (notifyTarget, pointer: this));
                 }
             }
 

--- a/src/Avalonia.Base/Input/TextInput/InputMethodManager.cs
+++ b/src/Avalonia.Base/Input/TextInput/InputMethodManager.cs
@@ -161,13 +161,11 @@ namespace Avalonia.Input.TextInput
                 return;
             }
 
-            var clientQuery = new TextInputMethodClientRequestedEventArgs
-            {
-                RoutedEvent = InputElement.TextInputMethodClientRequestedEvent
-            };
+            var clientQuery = focused.RaiseEvent(
+                InputElement.TextInputMethodClientRequestedEvent,
+                static e => new TextInputMethodClientRequestedEventArgs { RoutedEvent = e });
 
-            _focusedElement.RaiseEvent(clientQuery);
-            Client = clientQuery.Client;
+            Client = clientQuery?.Client;
         }
     }
 }

--- a/src/Avalonia.Base/Interactivity/Interactive.cs
+++ b/src/Avalonia.Base/Interactivity/Interactive.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Avalonia.Layout;
-using Avalonia.VisualTree;
-
-#nullable enable
+using Avalonia.Utilities;
 
 namespace Avalonia.Interactivity
 {
@@ -32,8 +30,8 @@ namespace Avalonia.Interactivity
             RoutingStrategies routes = RoutingStrategies.Direct | RoutingStrategies.Bubble,
             bool handledEventsToo = false)
         {
-            routedEvent = routedEvent ?? throw new ArgumentNullException(nameof(routedEvent));
-            handler = handler ?? throw new ArgumentNullException(nameof(handler));
+            ThrowHelper.ThrowIfNull(routedEvent, nameof(routedEvent));
+            ThrowHelper.ThrowIfNull(handler, nameof(handler));
 
             var subscription = new EventSubscription(handler, routes, handledEventsToo);
 
@@ -54,7 +52,7 @@ namespace Avalonia.Interactivity
             RoutingStrategies routes = RoutingStrategies.Direct | RoutingStrategies.Bubble,
             bool handledEventsToo = false) where TEventArgs : RoutedEventArgs
         {
-            routedEvent = routedEvent ?? throw new ArgumentNullException(nameof(routedEvent));
+            ThrowHelper.ThrowIfNull(routedEvent, nameof(routedEvent));
 
             if (handler is null)
                 return;
@@ -79,10 +77,10 @@ namespace Avalonia.Interactivity
         /// <param name="handler">The handler.</param>
         public void RemoveHandler(RoutedEvent routedEvent, Delegate handler)
         {
-            routedEvent = routedEvent ?? throw new ArgumentNullException(nameof(routedEvent));
-            handler = handler ?? throw new ArgumentNullException(nameof(handler));
+            ThrowHelper.ThrowIfNull(routedEvent, nameof(routedEvent));
+            ThrowHelper.ThrowIfNull(handler, nameof(handler));
 
-            if (_eventHandlers is object &&
+            if (_eventHandlers is not null &&
                 _eventHandlers.TryGetValue(routedEvent, out var subscriptions))
             {
                 for (var i = subscriptions.Count - 1; i >= 0; i--)
@@ -114,16 +112,128 @@ namespace Avalonia.Interactivity
         /// <param name="e">The event args.</param>
         public void RaiseEvent(RoutedEventArgs e)
         {
-            e = e ?? throw new ArgumentNullException(nameof(e));
+            ThrowHelper.ThrowIfNull(e, nameof(e));
 
             if (e.RoutedEvent == null)
             {
-                throw new ArgumentException("Cannot raise an event whose RoutedEvent is null.");
+                throw new ArgumentException($"Cannot raise an event whose {nameof(RoutedEventArgs.RoutedEvent)} is null.");
             }
 
-            using var route = BuildEventRoute(e.RoutedEvent);
-            route.RaiseEvent(this, e);
+            using var route = BuildLightweightEventRoute(e.RoutedEvent);
+            route.RaiseEventWithArgs(this, e);
         }
+
+        /// <summary>
+        /// Raises a routed event by creating the <see cref="RoutedEventArgs"/> only if they're needed.
+        /// Prefer this method over <see cref="RaiseEvent(RoutedEventArgs)"/> to avoid allocations if there's no event listeners.
+        /// </summary>
+        /// <typeparam name="TContext">The arbitrary context type, used to create the event arguments.</typeparam>
+        /// <param name="routedEvent">The routed event.</param>
+        /// <param name="eventArgsFactory">A factory used to create the <see cref="RoutedEventArgs"/>.</param>
+        /// <param name="context">
+        /// An arbitrary object used as a context to create the event arguments.
+        /// Use this argument to avoid closures.
+        /// </param>
+        /// <returns>
+        /// The created <see cref="RoutedEventArgs"/> used to raise the event,
+        /// or null if the event wasn't raised because it didn't have any listeners.
+        /// </returns>
+        public RoutedEventArgs? RaiseEvent<TContext>(
+            RoutedEvent routedEvent,
+            Func<RoutedEvent, TContext, RoutedEventArgs> eventArgsFactory,
+            TContext context)
+        {
+            ThrowHelper.ThrowIfNull(routedEvent, nameof(routedEvent));
+            ThrowHelper.ThrowIfNull(eventArgsFactory, nameof(eventArgsFactory));
+
+            using var route = BuildLightweightEventRoute(routedEvent);
+            return route.RaiseEvent(this, eventArgsFactory, context);
+        }
+
+        /// <summary>
+        /// Raises a routed event by creating the <see cref="RoutedEventArgs"/> only if they're needed.
+        /// Prefer this method over <see cref="RaiseEvent(RoutedEventArgs)"/> to avoid allocations if there's no event listeners.
+        /// </summary>
+        /// <param name="routedEvent">The routed event.</param>
+        /// <param name="eventArgsFactory">A factory used to create the <see cref="RoutedEventArgs"/>.</param>
+        /// <returns>
+        /// The created <see cref="RoutedEventArgs"/> used to raise the event,
+        /// or null if the event wasn't raised because it didn't have any listeners.
+        /// </returns>
+        public RoutedEventArgs? RaiseEvent(
+            RoutedEvent routedEvent,
+            Func<RoutedEvent, RoutedEventArgs> eventArgsFactory)
+        {
+            ThrowHelper.ThrowIfNull(routedEvent, nameof(routedEvent));
+            ThrowHelper.ThrowIfNull(eventArgsFactory, nameof(eventArgsFactory));
+
+            using var route = BuildLightweightEventRoute(routedEvent);
+            return route.RaiseEvent(this, eventArgsFactory);
+        }
+
+        /// <summary>
+        /// Raises a routed event by creating the <see cref="RoutedEventArgs"/> only if they're needed.
+        /// Prefer this method over <see cref="RaiseEvent(RoutedEventArgs)"/> to avoid allocations if there's no event listeners.
+        /// </summary>
+        /// <typeparam name="TEventArgs">The type of event arguments.</typeparam>
+        /// <typeparam name="TContext">The arbitrary context type, used to create the event arguments.</typeparam>
+        /// <param name="routedEvent">The routed event.</param>
+        /// <param name="eventArgsFactory">A factory used to create the <see cref="RoutedEventArgs"/>.</param>
+        /// <param name="context">
+        /// An arbitrary object used as a context to create the event arguments.
+        /// Use this argument to avoid closures.
+        /// </param>
+        /// <returns>
+        /// The created <see cref="RoutedEventArgs"/> used to raise the event,
+        /// or null if the event wasn't raised because it didn't have any listeners.
+        /// </returns>
+        public TEventArgs? RaiseEvent<TEventArgs, TContext>(
+            RoutedEvent<TEventArgs> routedEvent,
+            Func<RoutedEvent<TEventArgs>, TContext, TEventArgs> eventArgsFactory,
+            TContext context)
+            where TEventArgs : RoutedEventArgs
+        {
+            ThrowHelper.ThrowIfNull(routedEvent, nameof(routedEvent));
+            ThrowHelper.ThrowIfNull(eventArgsFactory, nameof(eventArgsFactory));
+
+            using var route = BuildLightweightEventRoute(routedEvent);
+            return route.RaiseEvent(this, eventArgsFactory, context);
+        }
+
+        /// <summary>
+        /// Raises a routed event by creating the <see cref="RoutedEventArgs"/> only if they're needed.
+        /// Prefer this method over <see cref="RaiseEvent(RoutedEventArgs)"/> to avoid allocations if there's no event listeners.
+        /// </summary>
+        /// <typeparam name="TEventArgs">The type of event arguments.</typeparam>
+        /// <param name="routedEvent">The routed event.</param>
+        /// <param name="eventArgsFactory">A factory used to create the <see cref="RoutedEventArgs"/>.</param>
+        /// <returns>
+        /// The created <see cref="RoutedEventArgs"/> used to raise the event,
+        /// or null if the event wasn't raised because it didn't have any listeners.
+        /// </returns>
+        public TEventArgs? RaiseEvent<TEventArgs>(
+            RoutedEvent<TEventArgs> routedEvent,
+            Func<RoutedEvent<TEventArgs>, TEventArgs> eventArgsFactory)
+            where TEventArgs : RoutedEventArgs
+        {
+            ThrowHelper.ThrowIfNull(routedEvent, nameof(routedEvent));
+            ThrowHelper.ThrowIfNull(eventArgsFactory, nameof(eventArgsFactory));
+
+            using var route = BuildLightweightEventRoute(routedEvent);
+            return route.RaiseEvent(this, eventArgsFactory);
+        }
+
+        /// <summary>
+        /// Raises a routed event by creating the <see cref="RoutedEventArgs"/> only if they're needed.
+        /// Prefer this method over <see cref="RaiseEvent(RoutedEventArgs)"/> to avoid allocations if there's no event listeners.
+        /// </summary>
+        /// <param name="routedEvent">The routed event.</param>
+        /// <returns>
+        /// The created <see cref="RoutedEventArgs"/> used to raise the event,
+        /// or null if the event wasn't raised because it didn't have any listeners.
+        /// </returns>
+        public RoutedEventArgs? RaiseEvent(RoutedEvent<RoutedEventArgs> routedEvent)
+            => RaiseEvent(routedEvent, static e => new RoutedEventArgs(e));
 
         /// <summary>
         /// Builds an event route for a routed event.
@@ -137,27 +247,41 @@ namespace Avalonia.Interactivity
         /// this method to build the event route and check the <see cref="EventRoute.HasHandlers"/>
         /// property to see if there are any handlers registered on the route. If there are, call
         /// <see cref="EventRoute.RaiseEvent(Interactive, RoutedEventArgs)"/> to raise the event.
+        ///
+        /// Alternatively, use one of the following overloads to avoid creating both the event args
+        /// and the event route unless necessary:
+        /// <list type="bullet">
+        /// <item><term><see cref="RaiseEvent{TContext}(Avalonia.Interactivity.RoutedEvent,Func{Avalonia.Interactivity.RoutedEvent,TContext,Avalonia.Interactivity.RoutedEventArgs},TContext)"/></term></item>
+        /// <item><term><see cref="RaiseEvent(Avalonia.Interactivity.RoutedEvent,Func{Avalonia.Interactivity.RoutedEvent,Avalonia.Interactivity.RoutedEventArgs})"/></term></item>
+        /// <item><term><see cref="RaiseEvent{TEventArgs,TContext}(Avalonia.Interactivity.RoutedEvent{TEventArgs},Func{Avalonia.Interactivity.RoutedEvent{TEventArgs},TContext,TEventArgs},TContext)"/></term></item>
+        /// <item><term><see cref="RaiseEvent{TEventArgs}(Avalonia.Interactivity.RoutedEvent{TEventArgs},Func{Avalonia.Interactivity.RoutedEvent{TEventArgs},TEventArgs})"/></term></item>
+        /// <item><term><see cref="RaiseEvent(Avalonia.Interactivity.RoutedEvent{Avalonia.Interactivity.RoutedEventArgs})"/></term></item>
+        /// </list>
         /// </remarks>
         protected EventRoute BuildEventRoute(RoutedEvent e)
         {
-            e = e ?? throw new ArgumentNullException(nameof(e));
+            ThrowHelper.ThrowIfNull(e, nameof(e));
 
-            var result = new EventRoute(e);
+            return new EventRoute(BuildLightweightEventRoute(e));
+        }
+
+        private LightweightEventRoute BuildLightweightEventRoute(RoutedEvent e)
+        {
+            var result = new LightweightEventRoute(e);
             var hasClassHandlers = e.HasRaisedSubscriptions;
 
-            if (e.RoutingStrategies.HasAllFlags(RoutingStrategies.Bubble) ||
-                e.RoutingStrategies.HasAllFlags(RoutingStrategies.Tunnel))
+            if (e.RoutingStrategies.HasAnyFlag(RoutingStrategies.Bubble | RoutingStrategies.Tunnel))
             {
-                Interactive? element = this;
+                var element = this;
 
-                while (element != null)
+                while (element is not null)
                 {
                     if (hasClassHandlers)
                     {
                         result.AddClassHandler(element);
                     }
 
-                    element.AddToEventRoute(e, result);
+                    element.AddToEventRoute(e, ref result);
                     element = element.InteractiveParent;
                 }
             }
@@ -168,7 +292,7 @@ namespace Avalonia.Interactivity
                     result.AddClassHandler(this);
                 }
 
-                AddToEventRoute(e, result);
+                AddToEventRoute(e, ref result);
             }
 
             return result;
@@ -187,12 +311,9 @@ namespace Avalonia.Interactivity
             subscriptions.Add(subscription);
         }
 
-        private void AddToEventRoute(RoutedEvent routedEvent, EventRoute route)
+        private void AddToEventRoute(RoutedEvent routedEvent, ref LightweightEventRoute route)
         {
-            routedEvent = routedEvent ?? throw new ArgumentNullException(nameof(routedEvent));
-            route = route ?? throw new ArgumentNullException(nameof(route));
-
-            if (_eventHandlers != null &&
+            if (_eventHandlers is not null &&
                 _eventHandlers.TryGetValue(routedEvent, out var subscriptions))
             {
                 foreach (var sub in subscriptions)

--- a/src/Avalonia.Base/Interactivity/LightweightEventRoute.cs
+++ b/src/Avalonia.Base/Interactivity/LightweightEventRoute.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Diagnostics;
+using Avalonia.Collections.Pooled;
+
+namespace Avalonia.Interactivity;
+
+/// <summary>
+/// Struct counterpart of <see cref="EventRoute"/> to avoid allocations unless there are listeners.
+/// </summary>
+internal struct LightweightEventRoute : IDisposable
+{
+    private readonly RoutedEvent _event;
+    private PooledList<RouteItem>? _route;
+
+    public LightweightEventRoute(RoutedEvent e)
+        => _event = e;
+
+    public bool HasHandlers
+        => _route is not null || _event.HasRouteFinishedSubscriptions;
+
+    public void Add(
+        Interactive target,
+        Delegate handler,
+        RoutingStrategies routes,
+        bool handledEventsToo,
+        Action<Delegate, object, RoutedEventArgs>? adapter)
+    {
+        _route ??= new PooledList<RouteItem>(16);
+        _route.Add(new RouteItem(target, handler, adapter, routes, handledEventsToo));
+    }
+
+    public void AddClassHandler(Interactive target)
+    {
+        _route ??= new PooledList<RouteItem>(16);
+        _route.Add(new RouteItem(target, null, null, 0, false));
+    }
+
+    public RoutedEventArgs? RaiseEvent<TContext>(
+        Interactive source,
+        Func<RoutedEvent, TContext, RoutedEventArgs> eventArgsFactory,
+        TContext context)
+    {
+        if (!HasHandlers)
+        {
+            return null;
+        }
+
+        var e = eventArgsFactory(_event, context);
+        RaiseEventWithArgs(source, e);
+        return e;
+    }
+
+    public RoutedEventArgs? RaiseEvent(
+        Interactive source,
+        Func<RoutedEvent, RoutedEventArgs> eventArgsFactory)
+    {
+        if (!HasHandlers)
+        {
+            return null;
+        }
+
+        var e = eventArgsFactory(_event);
+        RaiseEventWithArgs(source, e);
+        return e;
+    }
+
+    public TEventArgs? RaiseEvent<TEventArgs, TContext>(
+        Interactive source,
+        Func<RoutedEvent<TEventArgs>, TContext, TEventArgs> eventArgsFactory,
+        TContext context)
+        where TEventArgs : RoutedEventArgs
+    {
+        if (!HasHandlers)
+        {
+            return null;
+        }
+
+        var e = eventArgsFactory((RoutedEvent<TEventArgs>)_event, context);
+        RaiseEventWithArgs(source, e);
+        return e;
+    }
+
+    public TEventArgs? RaiseEvent<TEventArgs>(
+        Interactive source,
+        Func<RoutedEvent<TEventArgs>, TEventArgs> eventArgsFactory)
+        where TEventArgs : RoutedEventArgs
+    {
+        if (!HasHandlers)
+        {
+            return null;
+        }
+
+        var e = eventArgsFactory((RoutedEvent<TEventArgs>)_event);
+        RaiseEventWithArgs(source, e);
+        return e;
+    }
+
+    public void RaiseEventWithArgs(Interactive source, RoutedEventArgs e)
+    {
+        if (e.RoutedEvent != _event)
+        {
+            throw new InvalidOperationException(
+                $"Event {e.RoutedEvent?.ToString() ?? "<null>"} from the event arguments differs from the route's event {_event}");
+        }
+
+        e.Source = source;
+
+        if (_event.RoutingStrategies == RoutingStrategies.Direct)
+        {
+            RaiseEventWithStrategy(e, RoutingStrategies.Direct);
+        }
+        else
+        {
+            if ((_event.RoutingStrategies & RoutingStrategies.Tunnel) != 0)
+            {
+                RaiseEventWithStrategy(e, RoutingStrategies.Tunnel);
+            }
+
+            if ((_event.RoutingStrategies & RoutingStrategies.Bubble) != 0)
+            {
+                RaiseEventWithStrategy(e, RoutingStrategies.Bubble);
+            }
+        }
+    }
+
+    private void RaiseEventWithStrategy(RoutedEventArgs e, RoutingStrategies strategy)
+    {
+        e.Route = strategy;
+        RaiseEventImpl(e);
+        _event.InvokeRouteFinished(e);
+    }
+
+    private void RaiseEventImpl(RoutedEventArgs e)
+    {
+        if (_route is null)
+        {
+            return;
+        }
+
+        Interactive? lastTarget = null;
+        var start = 0;
+        var end = _route.Count;
+        var step = 1;
+
+        if (e.Route == RoutingStrategies.Tunnel)
+        {
+            start = end - 1;
+            step = end = -1;
+        }
+
+        for (var i = start; i != end; i += step)
+        {
+            var entry = _route[i];
+
+            // If we've got to a new control then call any RoutedEvent.Raised listeners.
+            if (entry.Target != lastTarget)
+            {
+                _event.InvokeRaised(entry.Target, e);
+
+                // If this is a direct event and we've already raised events then we're finished.
+                if (e.Route == RoutingStrategies.Direct && lastTarget is not null)
+                {
+                    return;
+                }
+
+                lastTarget = entry.Target;
+            }
+
+            // Raise the event handler.
+            if (entry.Handler is not null &&
+                entry.Routes.HasAllFlags(e.Route) &&
+                (!e.Handled || entry.HandledEventsToo))
+            {
+                if (entry.Adapter is not null)
+                {
+                    entry.Adapter(entry.Handler, entry.Target, e);
+                }
+                else
+                {
+                    entry.Handler.DynamicInvoke(entry.Target, e);
+                }
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _route?.Dispose();
+        _route = null;
+    }
+
+    private readonly struct RouteItem
+    {
+        public RouteItem(
+            Interactive target,
+            Delegate? handler,
+            Action<Delegate, object, RoutedEventArgs>? adapter,
+            RoutingStrategies routes,
+            bool handledEventsToo)
+        {
+            Target = target;
+            Handler = handler;
+            Adapter = adapter;
+            Routes = routes;
+            HandledEventsToo = handledEventsToo;
+        }
+
+        public Interactive Target { get; }
+        public Delegate? Handler { get; }
+        public Action<Delegate, object, RoutedEventArgs>? Adapter { get; }
+        public RoutingStrategies Routes { get; }
+        public bool HandledEventsToo { get; }
+    }
+}

--- a/src/Avalonia.Base/Interactivity/RoutedEvent.cs
+++ b/src/Avalonia.Base/Interactivity/RoutedEvent.cs
@@ -45,9 +45,18 @@ namespace Avalonia.Interactivity
 
         public RoutingStrategies RoutingStrategies { get; }
 
+        /// <summary>
+        /// Gets whether the <see cref="RoutedEvent"/> has active subscribers to <see cref="Raised"/>.
+        /// </summary>
         public bool HasRaisedSubscriptions => _raised.HasObservers;
 
+        /// <summary>
+        /// Gets whether the <see cref="RoutedEvent"/> has active subscribers to <see cref="RouteFinished"/>.
+        /// </summary>
+        public bool HasRouteFinishedSubscriptions => _routeFinished.HasObservers;
+
         public IObservable<(object, RoutedEventArgs)> Raised => _raised;
+
         public IObservable<RoutedEventArgs> RouteFinished => _routeFinished;
 
         public static RoutedEvent<TEventArgs> Register<TOwner, TEventArgs>(

--- a/src/Avalonia.Controls/Button.cs
+++ b/src/Avalonia.Controls/Button.cs
@@ -343,14 +343,17 @@ namespace Avalonia.Controls
                     OpenFlyout();
                 }
 
-                var e = new RoutedEventArgs(ClickEvent);
-                RaiseEvent(e);
+                var e = RaiseEvent(ClickEvent);
+                var handled = e?.Handled ?? false;
 
                 (var command, var parameter) = (Command, CommandParameter);
-                if (!e.Handled && command is not null && command.CanExecute(parameter))
+                if (!handled && command is not null && command.CanExecute(parameter))
                 {
                     command.Execute(parameter);
-                    e.Handled = true;
+                    if (e is not null)
+                    {
+                        e.Handled = true;
+                    }
                 }
             }
         }

--- a/src/Avalonia.Controls/ContextMenu.cs
+++ b/src/Avalonia.Controls/ContextMenu.cs
@@ -344,11 +344,7 @@ namespace Avalonia.Controls
             IsOpen = true;
             _popup.IsOpen = true;
 
-            RaiseEvent(new RoutedEventArgs
-            {
-                RoutedEvent = OpenedEvent,
-                Source = this,
-            });
+            RaiseEvent(OpenedEvent);
         }
 
         private void PopupOpened(object? sender, EventArgs e)
@@ -382,11 +378,7 @@ namespace Avalonia.Controls
                 _popup!.SetPopupParent(null);
             }
 
-            RaiseEvent(new RoutedEventArgs
-            {
-                RoutedEvent = ClosedEvent,
-                Source = this,
-            });
+            RaiseEvent(ClosedEvent);
             
             _popupHostChangedHandler?.Invoke(null);
         }

--- a/src/Avalonia.Controls/Control.cs
+++ b/src/Avalonia.Controls/Control.cs
@@ -383,12 +383,15 @@ namespace Avalonia.Controls
             if (e.Source == this && !e.Handled && e.HoldingState == HoldingState.Started)
             {
                 // Trigger ContentRequest when hold has started
-                var contextEvent = e.PointerEventArgs is { } ev ? new ContextRequestedEventArgs(ev) : new ContextRequestedEventArgs();
-                RaiseEvent(contextEvent);
-
-                e.Handled = contextEvent.Handled;
+                var args = RaiseContextRequested(e.PointerEventArgs);
+                e.Handled = args?.Handled ?? false;
             }
         }
+
+        private ContextRequestedEventArgs? RaiseContextRequested(PointerEventArgs? pointerArgs)
+            => pointerArgs is not null ?
+                RaiseEvent(ContextRequestedEvent, static (_, ctx) => new ContextRequestedEventArgs(ctx), pointerArgs) :
+                RaiseEvent(ContextRequestedEvent, static _ => new ContextRequestedEventArgs());
 
         /// <inheritdoc/>
         protected sealed override void OnDetachedFromVisualTreeCore(VisualTreeAttachmentEventArgs e)
@@ -484,9 +487,8 @@ namespace Avalonia.Controls
                 && !e.Handled
                 && e.InitialPressMouseButton == MouseButton.Right)
             {
-                var args = new ContextRequestedEventArgs(e);
-                RaiseEvent(args);
-                e.Handled = args.Handled;
+                var args = RaiseContextRequested(e);
+                e.Handled = args?.Handled ?? false;
             }
         }
 
@@ -520,9 +522,8 @@ namespace Avalonia.Controls
 
                 if (matches)
                 {
-                    var args = new ContextRequestedEventArgs();
-                    RaiseEvent(args);
-                    e.Handled = args.Handled;
+                    var args = RaiseContextRequested(null);
+                    e.Handled = args?.Handled ?? false;
                 }
             }
         }

--- a/src/Avalonia.Controls/ControlExtensions.cs
+++ b/src/Avalonia.Controls/ControlExtensions.cs
@@ -30,14 +30,15 @@ namespace Avalonia.Controls
 
             if (control.IsEffectivelyVisible)
             {
-                var ev = new RequestBringIntoViewEventArgs
-                {
-                    RoutedEvent = Control.RequestBringIntoViewEvent,
-                    TargetObject = control,
-                    TargetRect = rect,
-                };
-
-                control.RaiseEvent(ev);
+                control.RaiseEvent(
+                    Control.RequestBringIntoViewEvent,
+                    static (e, ctx) => new RequestBringIntoViewEventArgs
+                    {
+                        RoutedEvent = e,
+                        TargetObject = ctx.control,
+                        TargetRect = ctx.rect
+                    },
+                    (control, rect));
             }
         }
 

--- a/src/Avalonia.Controls/Menu.cs
+++ b/src/Avalonia.Controls/Menu.cs
@@ -58,11 +58,7 @@ namespace Avalonia.Controls
             IsOpen = false;
             SelectedIndex = -1;
 
-            RaiseEvent(new RoutedEventArgs
-            {
-                RoutedEvent = ClosedEvent,
-                Source = this,
-            });
+            RaiseEvent(ClosedEvent);
         }
 
         /// <inheritdoc/>
@@ -75,11 +71,7 @@ namespace Avalonia.Controls
 
             IsOpen = true;
 
-            RaiseEvent(new RoutedEventArgs
-            {
-                RoutedEvent = OpenedEvent,
-                Source = this,
-            });
+            RaiseEvent(OpenedEvent);
         }
 
         /// <inheritdoc/>

--- a/src/Avalonia.Controls/MenuItem.cs
+++ b/src/Avalonia.Controls/MenuItem.cs
@@ -378,7 +378,7 @@ namespace Avalonia.Controls
         public void Close() => SetCurrentValue(IsSubMenuOpenProperty, false);
 
         /// <inheritdoc/>
-        void IMenuItem.RaiseClick() => RaiseEvent(new RoutedEventArgs(ClickEvent));
+        void IMenuItem.RaiseClick() => RaiseEvent(ClickEvent);
 
         protected internal override Control CreateContainerForItemOverride(object? item, int index, object? recycleKey)
         {
@@ -805,7 +805,7 @@ namespace Avalonia.Controls
                     item.TryUpdateCanExecute();
                 }
 
-                RaiseEvent(new RoutedEventArgs(SubmenuOpenedEvent));
+                RaiseEvent(SubmenuOpenedEvent);
                 SetCurrentValue(IsSelectedProperty, true);
                 PseudoClasses.Add(":open");
             }
@@ -855,7 +855,7 @@ namespace Avalonia.Controls
         {
             if (IsEffectivelyEnabled)
             {
-                RaiseEvent(new RoutedEventArgs(ClickEvent));
+                RaiseEvent(ClickEvent);
             }
         }
 

--- a/src/Avalonia.Controls/MenuItemAccessKeyHandler.cs
+++ b/src/Avalonia.Controls/MenuItemAccessKeyHandler.cs
@@ -93,7 +93,7 @@ namespace Avalonia.Controls
                     .FirstOrDefault(x => string.Equals(x.AccessKey, text, StringComparison.OrdinalIgnoreCase)
                         && x.Element.IsEffectivelyVisible).Element;
 
-                focus?.RaiseEvent(new RoutedEventArgs(AccessKeyHandler.AccessKeyPressedEvent));
+                focus?.RaiseEvent(AccessKeyHandler.AccessKeyPressedEvent);
 
                 e.Handled = true;
             }

--- a/src/Avalonia.Controls/Mixins/SelectableMixin.cs
+++ b/src/Avalonia.Controls/Mixins/SelectableMixin.cs
@@ -50,10 +50,7 @@ namespace Avalonia.Controls.Mixins
                 {
                     ((IPseudoClasses)sender.Classes).Set(":selected", x.NewValue.GetValueOrDefault());
 
-                    sender.RaiseEvent(new RoutedEventArgs
-                    {
-                        RoutedEvent = SelectingItemsControl.IsSelectedChangedEvent
-                    });
+                    sender.RaiseEvent(SelectingItemsControl.IsSelectedChangedEvent);
                 }
             });
         }

--- a/src/Avalonia.Controls/Notifications/NotificationCard.cs
+++ b/src/Avalonia.Controls/Notifications/NotificationCard.cs
@@ -165,7 +165,7 @@ namespace Avalonia.Controls.Notifications
                     return;
                 }
 
-                RaiseEvent(new RoutedEventArgs(NotificationClosedEvent));
+                RaiseEvent(NotificationClosedEvent);
             }
         }
 

--- a/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs
@@ -650,8 +650,10 @@ namespace Avalonia.Controls
         /// <param name="newValue">The new value.</param>
         protected virtual void RaiseValueChangedEvent(decimal? oldValue, decimal? newValue)
         {
-            var e = new NumericUpDownValueChangedEventArgs(ValueChangedEvent, oldValue, newValue);
-            RaiseEvent(e);
+            RaiseEvent(
+                ValueChangedEvent,
+                static (e, ctx) => new NumericUpDownValueChangedEventArgs(e, ctx.oldValue, ctx.newValue),
+                (oldValue, newValue));
         }
 
         /// <summary>

--- a/src/Avalonia.Controls/Primitives/RangeBase.cs
+++ b/src/Avalonia.Controls/Primitives/RangeBase.cs
@@ -166,11 +166,10 @@ namespace Avalonia.Controls.Primitives
             }
             else if (change.Property == ValueProperty)
             {
-                var valueChangedEventArgs = new RangeBaseValueChangedEventArgs(
-                    change.GetOldValue<double>(),
-                    change.GetNewValue<double>(),
-                    ValueChangedEvent);
-                RaiseEvent(valueChangedEventArgs);
+                RaiseEvent(
+                    ValueChangedEvent,
+                    static (e, ctx) => new RangeBaseValueChangedEventArgs(ctx.oldValue, ctx.newValue, e),
+                    (oldValue: change.GetOldValue<double>(), newValue: change.GetNewValue<double>()));
             }
         }
         

--- a/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
+++ b/src/Avalonia.Controls/Primitives/SelectingItemsControl.cs
@@ -341,10 +341,10 @@ namespace Avalonia.Controls.Primitives
 
                     if (oldSelection?.Length > 0)
                     {
-                        RaiseEvent(new SelectionChangedEventArgs(
+                        RaiseEvent(
                             SelectionChangedEvent,
-                            oldSelection,
-                            Array.Empty<object>()));
+                            static (e, ctx) => new SelectionChangedEventArgs(e, ctx, Array.Empty<object>()),
+                            oldSelection);
                     }
 
                     InitializeSelectionModel(_selection);
@@ -1005,16 +1005,13 @@ namespace Avalonia.Controls.Primitives
                 UpdateSelectedValueFromItem();
             }
 
-            var route = BuildEventRoute(SelectionChangedEvent);
-
-            if (route.HasHandlers)
-            {
-                var ev = new SelectionChangedEventArgs(
-                    SelectionChangedEvent,
-                    e.DeselectedItems.ToArray(),
-                    e.SelectedItems.ToArray());
-                RaiseEvent(ev);
-            }
+            RaiseEvent(
+                SelectionChangedEvent,
+                static (evnt, ctx) => new SelectionChangedEventArgs(
+                    evnt,
+                    ctx.DeselectedItems.ToArray(),
+                    ctx.SelectedItems.ToArray()),
+                e);
         }
 
         /// <summary>
@@ -1247,10 +1244,10 @@ namespace Avalonia.Controls.Primitives
 
             if (SelectedIndex != -1)
             {
-                RaiseEvent(new SelectionChangedEventArgs(
+                RaiseEvent(
                     SelectionChangedEvent,
-                    Array.Empty<object>(),
-                    Selection.SelectedItems.ToArray()));
+                    static (e, ctx) => new SelectionChangedEventArgs(e, Array.Empty<object>(), ctx.SelectedItems.ToArray()),
+                    Selection);
             }
         }
 

--- a/src/Avalonia.Controls/Primitives/TextSelectionCanvas.cs
+++ b/src/Avalonia.Controls/Primitives/TextSelectionCanvas.cs
@@ -334,19 +334,22 @@ namespace Avalonia.Controls.Primitives
                         flyout.VerticalOffset = topLeft.Y - verticalOffset;
                         flyout.HorizontalOffset = topLeft.X;
                         flyout.Placement = PlacementMode.TopEdgeAlignedLeft;
-                        _textBox.RaiseEvent(new ContextRequestedEventArgs());
+                        RaiseContextRequested();
 
                         return true;
                     }
                 }
                 else
                 {
-                    _textBox.RaiseEvent(new ContextRequestedEventArgs());
+                    RaiseContextRequested();
                 }
             }
 
             return false;
         }
+
+        private void RaiseContextRequested()
+            => _textBox?.RaiseEvent(ContextRequestedEvent, static _ => new ContextRequestedEventArgs());
 
         private void TextBoxPointerReleased(object? sender, PointerReleasedEventArgs e)
         {

--- a/src/Avalonia.Controls/PullToRefresh/RefreshInfoProvider.cs
+++ b/src/Avalonia.Controls/PullToRefresh/RefreshInfoProvider.cs
@@ -112,12 +112,12 @@ namespace Avalonia.Controls.PullToRefresh
 
         public void OnRefreshStarted()
         {
-            RaiseEvent(new RoutedEventArgs(RefreshStartedEvent));
+            RaiseEvent(RefreshStartedEvent);
         }
 
         public void OnRefreshCompleted()
         {
-            RaiseEvent(new RoutedEventArgs(RefreshCompletedEvent));
+            RaiseEvent(RefreshCompletedEvent);
         }
 
         internal void ValuesChanged(Vector value)

--- a/src/Avalonia.Controls/SelectableTextBlock.cs
+++ b/src/Avalonia.Controls/SelectableTextBlock.cs
@@ -128,11 +128,10 @@ namespace Avalonia.Controls
                 return;
             }
 
-            var eventArgs = new RoutedEventArgs(CopyingToClipboardEvent);
+            var eventArgs = RaiseEvent(CopyingToClipboardEvent);
+            var handled = eventArgs?.Handled ?? false;
 
-            RaiseEvent(eventArgs);
-
-            if (!eventArgs.Handled)
+            if (!handled)
             {
                 var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
 

--- a/src/Avalonia.Controls/SplitButton/SplitButton.cs
+++ b/src/Avalonia.Controls/SplitButton/SplitButton.cs
@@ -402,13 +402,16 @@ namespace Avalonia.Controls
             // Note: It is not currently required to check enabled status; however, this is a failsafe
             if (IsEffectivelyEnabled)
             {
-                var eventArgs = new RoutedEventArgs(ClickEvent);
-                RaiseEvent(eventArgs);
+                var eventArgs = RaiseEvent(ClickEvent);
+                var handled = eventArgs?.Handled ?? false;
 
-                if (!eventArgs.Handled && command?.CanExecute(parameter) == true)
+                if (!handled && command is not null && command.CanExecute(parameter))
                 {
                     command.Execute(parameter);
-                    eventArgs.Handled = true;
+                    if (eventArgs is not null)
+                    {
+                        eventArgs.Handled = true;
+                    }
                 }
             }
         }

--- a/src/Avalonia.Controls/SplitButton/ToggleSplitButton.cs
+++ b/src/Avalonia.Controls/SplitButton/ToggleSplitButton.cs
@@ -92,8 +92,7 @@ namespace Avalonia.Controls
             // IsLoaded check
             if (Parent is not null)
             {
-                var eventArgs = new RoutedEventArgs(IsCheckedChangedEvent);
-                RaiseEvent(eventArgs);
+                RaiseEvent(IsCheckedChangedEvent);
             }
 
             UpdatePseudoClasses();

--- a/src/Avalonia.Controls/StackPanel.cs
+++ b/src/Avalonia.Controls/StackPanel.cs
@@ -341,7 +341,7 @@ namespace Avalonia.Controls
                 ArrangeChild(child, rcChild, finalSize, Orientation);
             }
 
-            RaiseEvent(new RoutedEventArgs(Orientation == Orientation.Horizontal ? HorizontalSnapPointsChangedEvent : VerticalSnapPointsChangedEvent));
+            RaiseEvent(fHorizontal ? HorizontalSnapPointsChangedEvent : VerticalSnapPointsChangedEvent);
 
             return finalSize;
         }

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1119,9 +1119,10 @@ namespace Avalonia.Controls
                 return;
             }
 
-            var eventArgs = new RoutedEventArgs(CuttingToClipboardEvent);
-            RaiseEvent(eventArgs);
-            if (!eventArgs.Handled)
+            var eventArgs = RaiseEvent(CuttingToClipboardEvent);
+            var handled = eventArgs?.Handled ?? false;
+
+            if (!handled)
             {
                 SnapshotUndoRedo();
 
@@ -1147,9 +1148,10 @@ namespace Avalonia.Controls
                 return;
             }
 
-            var eventArgs = new RoutedEventArgs(CopyingToClipboardEvent);
-            RaiseEvent(eventArgs);
-            if (!eventArgs.Handled)
+            var eventArgs = RaiseEvent(CopyingToClipboardEvent);
+            var handled = eventArgs?.Handled ?? false;
+
+            if (!handled)
             {
                 var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
 
@@ -1163,9 +1165,10 @@ namespace Avalonia.Controls
         /// </summary>
         public async void Paste()
         {
-            var eventArgs = new RoutedEventArgs(PastingFromClipboardEvent);
-            RaiseEvent(eventArgs);
-            if (eventArgs.Handled)
+            var eventArgs = RaiseEvent(PastingFromClipboardEvent);
+            var handled = eventArgs?.Handled ?? false;
+
+            if (handled)
             {
                 return;
             }
@@ -2126,13 +2129,11 @@ namespace Avalonia.Controls
             //    This occurs after the Text property is set.
             // 2. TextChanged occurs asynchronously after text changes and the new text is rendered.
 
-            var textChangingEventArgs = new TextChangingEventArgs(TextChangingEvent);
-            RaiseEvent(textChangingEventArgs);
+            RaiseEvent(TextChangingEvent, static e =>  new TextChangingEventArgs(e));
 
             Dispatcher.UIThread.Post(() =>
             {
-                var textChangedEventArgs = new TextChangedEventArgs(TextChangedEvent);
-                RaiseEvent(textChangedEventArgs);
+                RaiseEvent(TextChangedEvent, static e =>  new TextChangedEventArgs(e));
             }, DispatcherPriority.Normal);
         }
 

--- a/src/Avalonia.Controls/TransitioningContentControl.cs
+++ b/src/Avalonia.Controls/TransitioningContentControl.cs
@@ -96,8 +96,8 @@ public class TransitioningContentControl : ContentControl
 
                 transition.Start(from, to, !IsTransitionReversed, cancel.Token).ContinueWith(task =>
                 {
-                    OnTransitionCompleted(new TransitionCompletedEventArgs(
-                        fromContent, toContent, task.Status == TaskStatus.RanToCompletion && !cancel.IsCancellationRequested));
+                    var hasRunToCompletion = task.Status == TaskStatus.RanToCompletion && !cancel.IsCancellationRequested;
+                    OnTransitionCompleted(fromContent, toContent, hasRunToCompletion);
 
                     if (!cancel.IsCancellationRequested)
                     {
@@ -180,7 +180,7 @@ public class TransitioningContentControl : ContentControl
         else
         {
             HideOldPresenter();
-            OnTransitionCompleted(new TransitionCompletedEventArgs(fromContent, toContent, false));
+            OnTransitionCompleted(fromContent, toContent, false);
         }
     }
 
@@ -194,8 +194,11 @@ public class TransitioningContentControl : ContentControl
         }
     }
 
-    private void OnTransitionCompleted(TransitionCompletedEventArgs e)
-        => RaiseEvent(e);
+    private void OnTransitionCompleted(object? from, object? to, bool hasRunToCompletion)
+        => RaiseEvent(
+            TransitionCompletedEvent,
+            static (_, ctx) => new TransitionCompletedEventArgs(ctx.from, ctx.to, ctx.hasRunToCompletion),
+            (from, to, hasRunToCompletion));
 
     private class ImmutableCrossFade : IPageTransition
     {

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -52,7 +52,6 @@ namespace Avalonia.Controls
         public static readonly StyledProperty<SelectionMode> SelectionModeProperty =
             ListBox.SelectionModeProperty.AddOwner<TreeView>();
 
-        private static readonly IList Empty = Array.Empty<object>();
         private object? _selectedItem;
         private IList? _selectedItems;
         private bool _syncingSelectedItems;
@@ -449,11 +448,13 @@ namespace Avalonia.Controls
 
             if (added?.Count > 0 || removed?.Count > 0)
             {
-                var changed = new SelectionChangedEventArgs(
+                RaiseEvent(
                     SelectingItemsControl.SelectionChangedEvent,
-                    removed ?? Empty,
-                    added ?? Empty);
-                RaiseEvent(changed);
+                    static (evnt, ctx) => new SelectionChangedEventArgs(
+                        evnt,
+                        ctx.removed ?? Array.Empty<object>(),
+                        ctx.added ?? Array.Empty<object>()),
+                    (removed, added));
             }
         }
 

--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -193,10 +193,10 @@ namespace Avalonia.Controls
                 return default;
 
             _isInLayout = true;
+            var orientation = Orientation;
 
             try
             {
-                var orientation = Orientation;
                 var u = _realizedElements!.StartU;
 
                 for (var i = 0; i < _realizedElements.Count; ++i)
@@ -221,7 +221,7 @@ namespace Avalonia.Controls
             {
                 _isInLayout = false;
 
-                RaiseEvent(new RoutedEventArgs(Orientation == Orientation.Horizontal ? HorizontalSnapPointsChangedEvent : VerticalSnapPointsChangedEvent));
+                RaiseEvent(orientation == Orientation.Horizontal ? HorizontalSnapPointsChangedEvent : VerticalSnapPointsChangedEvent);
             }
         }
 

--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -711,7 +711,7 @@ namespace Avalonia.Controls
                     return;
                 }
 
-                RaiseEvent(new RoutedEventArgs(WindowOpenedEvent));
+                RaiseEvent(WindowOpenedEvent);
 
                 EnsureInitialized();
                 ApplyStyling();
@@ -791,7 +791,7 @@ namespace Avalonia.Controls
                     throw new InvalidOperationException("The window is already being shown.");
                 }
 
-                RaiseEvent(new RoutedEventArgs(WindowOpenedEvent));
+                RaiseEvent(WindowOpenedEvent);
 
                 EnsureInitialized();
                 ApplyStyling();
@@ -1054,7 +1054,7 @@ namespace Avalonia.Controls
 
         private protected sealed override void HandleClosed()
         {
-            RaiseEvent(new RoutedEventArgs(WindowClosedEvent));
+            RaiseEvent(WindowClosedEvent);
 
             base.HandleClosed();
 


### PR DESCRIPTION
## What does the pull request do?
This PR adds new `Interactive.RaiseEvent()` overloads which avoid creating an event route and the corresponding event arguments if there are no listeners for a given `RoutedEvent`.

Note that while there's already an existing `BuildEventRoute()` method to avoid allocating the arguments when there isn't any listener, it doesn't prevent creating the route itself.

In addition, `EventRoute.HasHandlers` now returns true if there are no handlers inside the route but `RoutedFinished` handlers exist.

## What is the current behavior?
Each time a `RoutedEvent` is raised, an `EventRoute` and a `RoutedEventArgs` (or derived) objects are always created.

## What is the updated/expected behavior with this PR?
`RoutedEventArgs` are created only if necessary (when there's at least one listener).
`EventRoute` are never created anymore.

## How was the solution implemented (if it's not obvious)?
A new `LightweightEventRoute` is introduced, which has the same behavior as an `EventRoute`, but is a struct, to avoid heap allocations.
This new type has `RaiseEvent()` methods taking an arguments factory alongside a context/state. The factory is only called if there are listeners for the event.
The expected usage is to have a static factory to avoid allocating an extra closure on each call (which would defeat the purpose of the method).

Since mutable structures are prone to errors (they must always be passed by reference to work correctly, which is hard to enforce in public API), `LightweightEventRoute` is internal and isn't exposed directly.
Instead, new public `Interactive.RaiseEvent()` overloads use the `LightweightEventRoute`.

The public `EventRoute` implementation now delegates its logic to `LightweightEventRoute`.

## Notes

The first commit is the most interesting one as it implements the new `RaiseEvent()` overloads and the `LightweightEventRoute` type.
The other commits are using the new `RaiseEvent()` overloads where it's possible.

We have several places where it isn't possible to remove the arguments allocation currently without breaking changes.

For example, there's `Control.OnLoaded/OnUnloaded/OnSizeChanged` which takes the arguments directly, added in #11828. While there are good arguments exposed in this PR for this change, I think we should also optimize for the 99% case. There are usually hundreds of controls in a given visual tree, and only a few (if any) with a `Loaded` handler.

That said, we have tons of inconsistency here in the codebase. Most routed events don't have a matching virtual `OnXxx()` method. Some have. Some of these methods have a `RoutedEventArgs` parameter. Some don't. We should really unify the behavior here in v12, document it, and stick to it (while still avoiding unnecessary allocations when possible). I plan to open a proposal to discuss that.
