### PR TITLE
More Tooltip edge case fixes

### DIFF
--- a/src/Avalonia.Controls/IToolTipService.cs
+++ b/src/Avalonia.Controls/IToolTipService.cs
@@ -1,9 +1,10 @@
-﻿using Avalonia.Metadata;
+﻿using Avalonia.Input;
+using Avalonia.Metadata;
 
 namespace Avalonia.Controls;
 
 [Unstable, PrivateApi]
 internal interface IToolTipService
 {
-    void Update(Visual? candidateToolTipHost);
+    void Update(IInputRoot root, Visual? candidateToolTipHost);
 }

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -896,12 +896,12 @@ namespace Avalonia.Controls
 
         private void UpdateToolTip(Rect dirtyRect)
         {
-            if (_tooltipService != null && _pointerOverPreProcessor?.LastPosition is { } lastPos)
+            if (_tooltipService != null && IsPointerOver && _pointerOverPreProcessor?.LastPosition is { } lastPos)
             {
                 var clientPoint = this.PointToClient(lastPos);
                 if (dirtyRect.Contains(clientPoint))
                 {
-                    _tooltipService.Update(HitTester.HitTestFirst(clientPoint, this, null));
+                    _tooltipService.Update(this, HitTester.HitTestFirst(clientPoint, this, null));
                 }
             }
         }


### PR DESCRIPTION
- Never update ToolTipService while the mouse is over a tooltip (fixes flicker when redrawing a window beneath the pointer)
- Avoid race condition where a dispatcher timer callback exectues right after we stopped the timer
- Fix not closing a tooltip when its pointer exit event is the last input sent to Avalonia

The first two issues pre-date the recent tooltip service changes.

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
Fixes #15486
