### PR TITLE
Added support for Compatibility profile in Wgl and Glx code

### DIFF
--- a/src/Avalonia.Native/AvaloniaNativeGlPlatformGraphics.cs
+++ b/src/Avalonia.Native/AvaloniaNativeGlPlatformGraphics.cs
@@ -25,7 +25,10 @@ namespace Avalonia.Native
                 var basic = new GlBasicInfoInterface(display.GetProcAddress);
                 basic.GetIntegerv(GlConsts.GL_MAJOR_VERSION, out major);
                 basic.GetIntegerv(GlConsts.GL_MINOR_VERSION, out minor);
-                _version = new GlVersion(GlProfileType.OpenGL, major, minor);
+                basic.GetIntegerv(GlConsts.GL_CONTEXT_PROFILE_MASK, out var profileMask);
+                var isCompatibilityProfile = (profileMask & GlConsts.GL_CONTEXT_COMPATIBILITY_PROFILE_BIT) == GlConsts.GL_CONTEXT_COMPATIBILITY_PROFILE_BIT;
+
+                _version = new GlVersion(GlProfileType.OpenGL, major, minor, isCompatibilityProfile);
                 glInterface = new GlInterface(_version, (name) =>
                 {
                     var rv = _display.GetProcAddress(name);

--- a/src/Avalonia.OpenGL/GlConsts.cs
+++ b/src/Avalonia.OpenGL/GlConsts.cs
@@ -1282,8 +1282,8 @@ namespace Avalonia.OpenGL
 //        public const int GL_UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER = 0x8A46;
 //        public const int GL_INVALID_INDEX = -1;
 //        public const int GL_VERSION_3_2 = 1;
-//        public const int GL_CONTEXT_CORE_PROFILE_BIT = 0x00000001;
-//        public const int GL_CONTEXT_COMPATIBILITY_PROFILE_BIT = 0x00000002;
+        public const int GL_CONTEXT_CORE_PROFILE_BIT = 0x00000001;
+        public const int GL_CONTEXT_COMPATIBILITY_PROFILE_BIT = 0x00000002;
 //        public const int GL_LINES_ADJACENCY = 0x000A;
 //        public const int GL_LINE_STRIP_ADJACENCY = 0x000B;
 //        public const int GL_TRIANGLES_ADJACENCY = 0x000C;
@@ -1303,7 +1303,7 @@ namespace Avalonia.OpenGL
 //        public const int GL_MAX_GEOMETRY_INPUT_COMPONENTS = 0x9123;
 //        public const int GL_MAX_GEOMETRY_OUTPUT_COMPONENTS = 0x9124;
 //        public const int GL_MAX_FRAGMENT_INPUT_COMPONENTS = 0x9125;
-//        public const int GL_CONTEXT_PROFILE_MASK = 0x9126;
+        public const int GL_CONTEXT_PROFILE_MASK = 0x9126;
 //        public const int GL_DEPTH_CLAMP = 0x864F;
 //        public const int GL_QUADS_FOLLOW_PROVOKING_VERTEX_CONVENTION = 0x8E4C;
 //        public const int GL_FIRST_VERTEX_CONVENTION = 0x8E4D;

--- a/src/Avalonia.OpenGL/GlVersion.cs
+++ b/src/Avalonia.OpenGL/GlVersion.cs
@@ -11,12 +11,15 @@ namespace Avalonia.OpenGL
         public GlProfileType Type { get; }
         public int Major { get; }
         public int Minor { get; }
+        public bool EnableCompatibilityProfile { get; } // Only makes sense if Type is OpenGL and Version is >= 3.2
 
-        public GlVersion(GlProfileType type, int major, int minor)
+        public GlVersion(GlProfileType type, int major, int minor) : this(type, major, minor, false) { }
+        public GlVersion(GlProfileType type, int major, int minor, bool compatibilityProfile)
         {
             Type = type;
             Major = major;
             Minor = minor;
+            EnableCompatibilityProfile = compatibilityProfile;
         }
     }
 }

--- a/src/Avalonia.OpenGL/GlVersion.cs
+++ b/src/Avalonia.OpenGL/GlVersion.cs
@@ -11,15 +11,15 @@ namespace Avalonia.OpenGL
         public GlProfileType Type { get; }
         public int Major { get; }
         public int Minor { get; }
-        public bool EnableCompatibilityProfile { get; } // Only makes sense if Type is OpenGL and Version is >= 3.2
+        public bool IsCompatibilityProfile { get; } // Only makes sense if Type is OpenGL and Version is >= 3.2
 
         public GlVersion(GlProfileType type, int major, int minor) : this(type, major, minor, false) { }
-        public GlVersion(GlProfileType type, int major, int minor, bool compatibilityProfile)
+        public GlVersion(GlProfileType type, int major, int minor, bool isCompatibilityProfile)
         {
             Type = type;
             Major = major;
             Minor = minor;
-            EnableCompatibilityProfile = compatibilityProfile;
+            IsCompatibilityProfile = isCompatibilityProfile;
         }
     }
 }

--- a/src/Avalonia.X11/Glx/GlxDisplay.cs
+++ b/src/Avalonia.X11/Glx/GlxDisplay.cs
@@ -127,8 +127,8 @@ namespace Avalonia.X11.Glx
             {
                 var profileMask = GLX_CONTEXT_CORE_PROFILE_BIT_ARB;
                 if (profile.Type == GlProfileType.OpenGL && 
-                    profile.EnableCompatibilityProfile && 
-                    profile.Major * 10 + profile.Minor >= 32)
+                    profile.IsCompatibilityProfile &&
+                    (profile.Major > 3 || profile.Major == 3 && profile.Minor >= 2))
                     profileMask = GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB;
                 else if (profile.Type == GlProfileType.OpenGLES) 
                     profileMask = GLX_CONTEXT_ES2_PROFILE_BIT_EXT;

--- a/src/Avalonia.X11/Glx/GlxDisplay.cs
+++ b/src/Avalonia.X11/Glx/GlxDisplay.cs
@@ -126,7 +126,11 @@ namespace Avalonia.X11.Glx
             GlxContext Create(GlVersion profile)
             {
                 var profileMask = GLX_CONTEXT_CORE_PROFILE_BIT_ARB;
-                if (profile.Type == GlProfileType.OpenGLES) 
+                if (profile.Type == GlProfileType.OpenGL && 
+                    profile.EnableCompatibilityProfile && 
+                    profile.Major * 10 + profile.Minor >= 32)
+                    profileMask = GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB;
+                else if (profile.Type == GlProfileType.OpenGLES) 
                     profileMask = GLX_CONTEXT_ES2_PROFILE_BIT_EXT;
 
                 var attrs = new int[]

--- a/src/Windows/Avalonia.Win32/OpenGl/WglConsts.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/WglConsts.cs
@@ -7,6 +7,8 @@ namespace Avalonia.Win32.OpenGl
         public const int WGL_CONTEXT_LAYER_PLANE_ARB = 0x2093;
         public const int WGL_CONTEXT_FLAGS_ARB = 0x2094;
         public const int WGL_CONTEXT_PROFILE_MASK_ARB = 0x9126;
+        public const int WGL_CONTEXT_CORE_PROFILE_BIT_ARB = 0x00000001;
+        public const int WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB = 0x00000002;
         public const int WGL_NUMBER_PIXEL_FORMATS_ARB = 0x2000;
 
         public const int WGL_DRAW_TO_WINDOW_ARB = 0x2001;

--- a/src/Windows/Avalonia.Win32/OpenGl/WglDisplay.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/WglDisplay.cs
@@ -126,6 +126,11 @@ namespace Avalonia.Win32.OpenGl
                     IntPtr context;
                     using (shareContext?.Lock())
                     {
+                        var profileMask = WGL_CONTEXT_CORE_PROFILE_BIT_ARB;
+                        if (version.EnableCompatibilityProfile &&
+                            version.Major * 10 + version.Minor >= 32)
+                            profileMask = WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB;
+
                         context = s_wglCreateContextAttribsArb(dc, shareContext?.Handle ?? IntPtr.Zero,
                             new[]
                             {
@@ -133,8 +138,8 @@ namespace Avalonia.Win32.OpenGl
                                 WGL_CONTEXT_MAJOR_VERSION_ARB, version.Major,
                                 // minor
                                 WGL_CONTEXT_MINOR_VERSION_ARB, version.Minor,
-                                // core profile
-                                WGL_CONTEXT_PROFILE_MASK_ARB, 1,
+                                // core or compatibility profile
+                                WGL_CONTEXT_PROFILE_MASK_ARB, profileMask,
                                 // debug 
                                 // WGL_CONTEXT_FLAGS_ARB, 1,
                                 // end

--- a/src/Windows/Avalonia.Win32/OpenGl/WglDisplay.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/WglDisplay.cs
@@ -127,8 +127,8 @@ namespace Avalonia.Win32.OpenGl
                     using (shareContext?.Lock())
                     {
                         var profileMask = WGL_CONTEXT_CORE_PROFILE_BIT_ARB;
-                        if (version.EnableCompatibilityProfile &&
-                            version.Major * 10 + version.Minor >= 32)
+                        if (version.IsCompatibilityProfile &&
+                            (version.Major > 3 || version.Major == 3 && version.Minor >= 2))
                             profileMask = WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB;
 
                         context = s_wglCreateContextAttribsArb(dc, shareContext?.Handle ?? IntPtr.Zero,


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

This adds an optional `EnableCompatibilityProfile` member to `GlVersion` and the code supporting it in the `CreateContext` methods of `GlxDisplay` and `WglDisplay`. This way, we can now choose to enable the compatibility profile when passing specific (X11 and Win32) platform options along with the OpenGL versions.

## What is the updated/expected behavior with this PR?

Now, when customizing the OpenGL backend (Glx and Wgl only), one can choose to enable the compatibility profile

## How was the solution implemented (if it's not obvious)?

I simply pass the relevant attributes to the function that creates the OpenGL context

## Checklist

- [ ] Added unit tests (if possible)? 
  - No: I didn't see how I could unit-test this
- [ ] Added XML documentation to any related classes? 
  - There wasn't any, so I thought I would leave things as they are
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation 
  - There is no documentation currently with respect to OpenGL features.

## Breaking changes

None: the new member/parameter is optional and its default value is consistent with the previous beghavior 

## Fixed issues

this partially fixes #11977

## Remarks

Although I didn't add any unit tests, I made sure the compatibility profile was indeed activated by tweaking the ControlCatalog demo (changes not included here). Tested this both in Windows and Linux (WSL)

I also tried to look whether things should be done in other platforms, but it seems all other platforms only support OpenGL ES; hence not relevant. I'm not too sure with respect to MacOS, but anyway I have no way to test on a Ma machine.  

I branched this off `master` because I didn't know better, but I wonder if this could go to `11.0.x` or `11.1.x`: the code I modifed should have been prettty similar at the time and thus, it should be easy to have it work in older versions
