### PR TITLE
[Android][TextBox] fix strange caret move behaviour on Android 14

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -532,8 +532,10 @@ namespace Avalonia.Android.Platform.SkiaPlatform
                 if (_inputMethod.IsActive && !_commitInProgress)
                 {
                     if (string.IsNullOrEmpty(compositionText))
-                        _inputMethod.View.DispatchKeyEvent(new KeyEvent(KeyEventActions.Down, Keycode.ForwardDel));
-
+                    {
+                        if (_editable.CurrentComposition.Start > -1)
+                            _inputMethod.View.DispatchKeyEvent(new KeyEvent(KeyEventActions.Down, Keycode.ForwardDel));
+                    }
                     else
                         _toplevel.TextInput(compositionText);
                 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Only delete `compositionText` when there is `compositionText`


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
On Android 14, move caret left or right might delete a character from the text box.

https://github.com/AvaloniaUI/Avalonia/assets/43789618/00c6ea6d-7561-4303-9499-5369e240c1be

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
On Android 14, move caret left or right won't delete a character from the text box.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Only delete `compositionText` when there is `compositionText`

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
