### PR TITLE
[Android] Support `PerformContextMenuAction`

### DIFF
--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -54,7 +54,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
             {
                 throw new ArgumentException("AvaloniaView.Context must not be null");
             }
-            
+
             _view = new ViewImpl(avaloniaView.Context, this, placeOnTop);
             _textInputMethod = new AndroidInputMethod<ViewImpl>(_view);
             _keyboardHelper = new AndroidKeyboardEventsHelper<TopLevelImpl>(this);
@@ -85,7 +85,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         public virtual Size ClientSize => _view.Size.ToSize(RenderScaling);
 
         public Size? FrameSize => null;
-        
+
         public Action? Closed { get; set; }
 
         public Action<RawInputEventArgs>? Input { get; set; }
@@ -136,7 +136,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         {
             InputRoot = inputRoot;
         }
-        
+
         public virtual void Show()
         {
             _view.Visibility = ViewStates.Visible;
@@ -148,7 +148,7 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         {
             Paint?.Invoke(new Rect(new Point(0, 0), ClientSize));
         }
-        
+
         public virtual void Dispose()
         {
             _systemNavigationManager.Dispose();
@@ -264,11 +264,11 @@ namespace Avalonia.Android.Platform.SkiaPlatform
         }
 
         public IPopupImpl? CreatePopup() => null;
-        
+
         public Action? LostFocus { get; set; }
         public Action<WindowTransparencyLevel>? TransparencyLevelChanged { get; set; }
 
-        public WindowTransparencyLevel TransparencyLevel 
+        public WindowTransparencyLevel TransparencyLevel
         {
             get => _transparencyLevel;
             private set
@@ -678,6 +678,28 @@ namespace Avalonia.Android.Platform.SkiaPlatform
             }
 
             return extract;
+        }
+
+        public override bool PerformContextMenuAction(int id)
+        {
+            switch (id)
+            {
+                case global::Android.Resource.Id.SelectAll:
+                    Toplevel.Input?.Invoke(new RawKeyEventArgs(AndroidKeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, Toplevel.InputRoot!, RawKeyEventType.KeyDown, Key.A, RawInputModifiers.Control, PhysicalKey.A, "a"));
+                    return true;
+                case global::Android.Resource.Id.Cut:
+                    Toplevel.Input?.Invoke(new RawKeyEventArgs(AndroidKeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, Toplevel.InputRoot!, RawKeyEventType.KeyDown, Key.X, RawInputModifiers.Control, PhysicalKey.X, "x"));
+                    return true;
+                case global::Android.Resource.Id.Copy:
+                    Toplevel.Input?.Invoke(new RawKeyEventArgs(AndroidKeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, Toplevel.InputRoot!, RawKeyEventType.KeyDown, Key.C, RawInputModifiers.Control, PhysicalKey.C, "c"));
+                    return true;
+                case global::Android.Resource.Id.Paste:
+                    Toplevel.Input?.Invoke(new RawKeyEventArgs(AndroidKeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, Toplevel.InputRoot!, RawKeyEventType.KeyDown, Key.V, RawInputModifiers.Control, PhysicalKey.V, "v"));
+                    return true;
+                default:
+                    break;
+            }
+            return base.PerformContextMenuAction(id);
         }
     }
 }

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -684,19 +684,21 @@ namespace Avalonia.Android.Platform.SkiaPlatform
 
         public override bool PerformContextMenuAction(int id)
         {
+            if (InputMethod.Client is not { } client) return false;
+
             switch (id)
             {
                 case global::Android.Resource.Id.SelectAll:
-                    Toplevel.Input?.Invoke(new RawKeyEventArgs(AndroidKeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, Toplevel.InputRoot!, RawKeyEventType.KeyDown, Key.A, RawInputModifiers.Control, PhysicalKey.None, "a"));
+                    client.ExecuteContextMenuAction(ContextMenuAction.SelectAll);
                     return true;
                 case global::Android.Resource.Id.Cut:
-                    Toplevel.Input?.Invoke(new RawKeyEventArgs(AndroidKeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, Toplevel.InputRoot!, RawKeyEventType.KeyDown, Key.X, RawInputModifiers.Control, PhysicalKey.None, "x"));
+                    client.ExecuteContextMenuAction(ContextMenuAction.Cut);
                     return true;
                 case global::Android.Resource.Id.Copy:
-                    Toplevel.Input?.Invoke(new RawKeyEventArgs(AndroidKeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, Toplevel.InputRoot!, RawKeyEventType.KeyDown, Key.C, RawInputModifiers.Control, PhysicalKey.None, "c"));
+                    client.ExecuteContextMenuAction(ContextMenuAction.Copy);
                     return true;
                 case global::Android.Resource.Id.Paste:
-                    Toplevel.Input?.Invoke(new RawKeyEventArgs(AndroidKeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, Toplevel.InputRoot!, RawKeyEventType.KeyDown, Key.V, RawInputModifiers.Control, PhysicalKey.None, "v"));
+                    client.ExecuteContextMenuAction(ContextMenuAction.Paste);
                     return true;
                 default:
                     break;

--- a/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
+++ b/src/Android/Avalonia.Android/Platform/SkiaPlatform/TopLevelImpl.cs
@@ -685,16 +685,16 @@ namespace Avalonia.Android.Platform.SkiaPlatform
             switch (id)
             {
                 case global::Android.Resource.Id.SelectAll:
-                    Toplevel.Input?.Invoke(new RawKeyEventArgs(AndroidKeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, Toplevel.InputRoot!, RawKeyEventType.KeyDown, Key.A, RawInputModifiers.Control, PhysicalKey.A, "a"));
+                    Toplevel.Input?.Invoke(new RawKeyEventArgs(AndroidKeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, Toplevel.InputRoot!, RawKeyEventType.KeyDown, Key.A, RawInputModifiers.Control, PhysicalKey.None, "a"));
                     return true;
                 case global::Android.Resource.Id.Cut:
-                    Toplevel.Input?.Invoke(new RawKeyEventArgs(AndroidKeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, Toplevel.InputRoot!, RawKeyEventType.KeyDown, Key.X, RawInputModifiers.Control, PhysicalKey.X, "x"));
+                    Toplevel.Input?.Invoke(new RawKeyEventArgs(AndroidKeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, Toplevel.InputRoot!, RawKeyEventType.KeyDown, Key.X, RawInputModifiers.Control, PhysicalKey.None, "x"));
                     return true;
                 case global::Android.Resource.Id.Copy:
-                    Toplevel.Input?.Invoke(new RawKeyEventArgs(AndroidKeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, Toplevel.InputRoot!, RawKeyEventType.KeyDown, Key.C, RawInputModifiers.Control, PhysicalKey.C, "c"));
+                    Toplevel.Input?.Invoke(new RawKeyEventArgs(AndroidKeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, Toplevel.InputRoot!, RawKeyEventType.KeyDown, Key.C, RawInputModifiers.Control, PhysicalKey.None, "c"));
                     return true;
                 case global::Android.Resource.Id.Paste:
-                    Toplevel.Input?.Invoke(new RawKeyEventArgs(AndroidKeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, Toplevel.InputRoot!, RawKeyEventType.KeyDown, Key.V, RawInputModifiers.Control, PhysicalKey.V, "v"));
+                    Toplevel.Input?.Invoke(new RawKeyEventArgs(AndroidKeyboardDevice.Instance!, (ulong)DateTime.Now.Ticks, Toplevel.InputRoot!, RawKeyEventType.KeyDown, Key.V, RawInputModifiers.Control, PhysicalKey.None, "v"));
                     return true;
                 default:
                     break;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Support `PerformContextMenuAction` so that application can react on IME copy paste command

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
App will not react when press copy/paste/cut/select all button on IME

https://github.com/AvaloniaUI/Avalonia/assets/43789618/ed788058-6278-4203-bd82-2ea8255d3e9d


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
App will react when press copy/paste/cut/select-all button on IME now

https://github.com/AvaloniaUI/Avalonia/assets/43789618/cb52adbe-4f79-4611-828c-649ec33a1c2c

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
When press copy/paste/cut/select-all button, the Android IME will call `BaseInputConnection.performContextMenuAction(int id)` to make command work

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
