### PR TITLE
Set alpha and pixel format for Direct2D WIC bitmap

### DIFF
--- a/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
+++ b/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
@@ -84,8 +84,6 @@ namespace Avalonia.Direct2D1
 
                 var featureLevels = new[]
                 {
-                    SharpDX.Direct3D.FeatureLevel.Level_12_1,
-                    SharpDX.Direct3D.FeatureLevel.Level_12_0,
                     SharpDX.Direct3D.FeatureLevel.Level_11_1,
                     SharpDX.Direct3D.FeatureLevel.Level_11_0,
                     SharpDX.Direct3D.FeatureLevel.Level_10_1,

--- a/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
+++ b/src/Windows/Avalonia.Direct2D1/Direct2D1Platform.cs
@@ -9,7 +9,6 @@ using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Media.TextFormatting;
 using Avalonia.Platform;
-using SharpDX.DirectWrite;
 using GlyphRun = Avalonia.Media.GlyphRun;
 using SharpDX.Mathematics.Interop;
 
@@ -85,6 +84,8 @@ namespace Avalonia.Direct2D1
 
                 var featureLevels = new[]
                 {
+                    SharpDX.Direct3D.FeatureLevel.Level_12_1,
+                    SharpDX.Direct3D.FeatureLevel.Level_12_0,
                     SharpDX.Direct3D.FeatureLevel.Level_11_1,
                     SharpDX.Direct3D.FeatureLevel.Level_11_0,
                     SharpDX.Direct3D.FeatureLevel.Level_10_1,


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Set `PixelFormat` and `AlphaFormat` in Direct2D BitmapImpl.


## What is the current behavior?
The rendering failed due to `PixelFormat` and `AlphaFormat ` are null, and throws with a not supported exception.


## What is the updated/expected behavior with this PR?
No exception thrown due to not supported. 