### PR TITLE
Add [GeneratedCode] and [ExcludeFromCodeCoverage] to Name Generator output members

### DIFF
--- a/src/tools/Avalonia.Generators/NameGenerator/InitializeComponentCodeGenerator.cs
+++ b/src/tools/Avalonia.Generators/NameGenerator/InitializeComponentCodeGenerator.cs
@@ -6,6 +6,8 @@ namespace Avalonia.Generators.NameGenerator;
 
 internal class InitializeComponentCodeGenerator : ICodeGenerator
 {
+    private string _generatorName = typeof(InitializeComponentCodeGenerator).FullName;
+    private string _generatorVersion = typeof(InitializeComponentCodeGenerator).Assembly.GetName().Version.ToString();
     private readonly bool _diagnosticsAreConnected;
     private const string AttachDevToolsCodeBlock = @"
 #if DEBUG
@@ -31,6 +33,7 @@ internal class InitializeComponentCodeGenerator : ICodeGenerator
         var initializations = new List<string>();
         const string thisFindNameScopeVariable = "            var __thisNameScope__ = this.FindNameScope();";
         bool hasNames = false;
+
         foreach (var resolvedName in names)
         {
             if (!hasNames)
@@ -39,7 +42,12 @@ internal class InitializeComponentCodeGenerator : ICodeGenerator
             }
 
             var (typeName, name, fieldModifier) = resolvedName;
-            properties.Add($"        {fieldModifier} {typeName} {name};");
+            var propertySource =
+            $"""
+                    [global::System.CodeDom.Compiler.GeneratedCode("{_generatorName}", "{_generatorVersion}")]
+                    {fieldModifier} {typeName} {name};
+            """;
+            properties.Add(propertySource);
             initializations.Add($"            {name} = __thisNameScope__?.Find<{typeName}>(\"{name}\");");
 
             hasNames = true;
@@ -64,6 +72,8 @@ namespace {nameSpace}
         /// </summary>
         /// <param name=""loadXaml"">Should the XAML be loaded into the component.</param>
 {(attachDevTools ? AttachDevToolsParameterDocumentation : string.Empty)}
+        [global::System.CodeDom.Compiler.GeneratedCode(""{_generatorName}"", ""{_generatorVersion}"")]
+        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public void InitializeComponent(bool loadXaml = true{(attachDevTools ? ", bool attachDevTools = true" : string.Empty)})
         {{
             if (loadXaml)

--- a/src/tools/Avalonia.Generators/NameGenerator/OnlyPropertiesCodeGenerator.cs
+++ b/src/tools/Avalonia.Generators/NameGenerator/OnlyPropertiesCodeGenerator.cs
@@ -7,10 +7,15 @@ namespace Avalonia.Generators.NameGenerator;
 
 internal class OnlyPropertiesCodeGenerator : ICodeGenerator
 {
+    private string _generatorName = typeof(OnlyPropertiesCodeGenerator).FullName;
+    private string _generatorVersion = typeof(OnlyPropertiesCodeGenerator).Assembly.GetName().Version.ToString();
+
     public string GenerateCode(string className, string nameSpace, IXamlType xamlType, IEnumerable<ResolvedName> names)
     {
         var namedControls = names
             .Select(info => "        " +
+                            $"[global::System.CodeDom.Compiler.GeneratedCode(\"{_generatorName}\", \"{_generatorVersion}\")]\n" +
+                            "        " +
                             $"{info.FieldModifier} {info.TypeName} {info.Name} => " +
                             $"this.FindNameScope()?.Find<{info.TypeName}>(\"{info.Name}\");")
             .ToList();

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/AttachedProps.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/AttachedProps.txt
@@ -8,6 +8,7 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox UserNameTextBox;
 
         /// <summary>
@@ -15,6 +16,8 @@ namespace Sample.App
         /// </summary>
         /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
 
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
+        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/AttachedPropsWithDevTools.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/AttachedPropsWithDevTools.txt
@@ -8,6 +8,7 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox UserNameTextBox;
 
         /// <summary>
@@ -16,6 +17,8 @@ namespace Sample.App
         /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
         /// <param name="attachDevTools">Should the dev tools be attached.</param>
 
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
+        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public void InitializeComponent(bool loadXaml = true, bool attachDevTools = true)
         {
             if (loadXaml)

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/ControlWithoutWindow.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/ControlWithoutWindow.txt
@@ -8,6 +8,7 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox UserNameTextBox;
 
         /// <summary>
@@ -15,6 +16,8 @@ namespace Sample.App
         /// </summary>
         /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
 
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
+        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/CustomControls.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/CustomControls.txt
@@ -8,8 +8,11 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.ReactiveUI.RoutedViewHost ClrNamespaceRoutedViewHost;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.ReactiveUI.RoutedViewHost UriRoutedViewHost;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Controls.CustomTextBox UserNameTextBox;
 
         /// <summary>
@@ -17,6 +20,8 @@ namespace Sample.App
         /// </summary>
         /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
 
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
+        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/DataTemplates.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/DataTemplates.txt
@@ -8,7 +8,9 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox UserNameTextBox;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.ListBox NamedListBox;
 
         /// <summary>
@@ -16,6 +18,8 @@ namespace Sample.App
         /// </summary>
         /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
 
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
+        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/FieldModifier.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/FieldModifier.txt
@@ -8,11 +8,17 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         public global::Avalonia.Controls.TextBox FirstNameTextBox;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         public global::Avalonia.Controls.TextBox LastNameTextBox;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         protected global::Avalonia.Controls.TextBox PasswordTextBox;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         private global::Avalonia.Controls.TextBox ConfirmPasswordTextBox;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.Button SignUpButton;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.Button RegisterButton;
 
         /// <summary>
@@ -20,6 +26,8 @@ namespace Sample.App
         /// </summary>
         /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
 
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
+        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/NamedControl.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/NamedControl.txt
@@ -8,6 +8,7 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox UserNameTextBox;
 
         /// <summary>
@@ -15,6 +16,8 @@ namespace Sample.App
         /// </summary>
         /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
 
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
+        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/NamedControls.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/NamedControls.txt
@@ -8,8 +8,11 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox UserNameTextBox;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox PasswordTextBox;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.Button SignUpButton;
 
         /// <summary>
@@ -17,6 +20,8 @@ namespace Sample.App
         /// </summary>
         /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
 
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
+        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/NoNamedControls.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/NoNamedControls.txt
@@ -15,6 +15,8 @@ namespace Sample.App
         /// </summary>
         /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
 
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
+        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/SignUpView.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/SignUpView.txt
@@ -8,15 +8,25 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Controls.CustomTextBox UserNameTextBox;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBlock UserNameValidation;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox PasswordTextBox;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBlock PasswordValidation;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.ListBox AwesomeListView;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox ConfirmPasswordTextBox;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBlock ConfirmPasswordValidation;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.Documents.Run SignUpButtonDescription;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.Button SignUpButton;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBlock CompoundValidation;
 
         /// <summary>
@@ -24,6 +34,8 @@ namespace Sample.App
         /// </summary>
         /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
 
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
+        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/xNamedControl.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/xNamedControl.txt
@@ -8,6 +8,7 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox UserNameTextBox;
 
         /// <summary>
@@ -15,6 +16,8 @@ namespace Sample.App
         /// </summary>
         /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
 
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
+        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/xNamedControls.txt
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/GeneratedInitializeComponent/xNamedControls.txt
@@ -8,8 +8,11 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox UserNameTextBox;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox PasswordTextBox;
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.Button SignUpButton;
 
         /// <summary>
@@ -17,6 +20,8 @@ namespace Sample.App
         /// </summary>
         /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
 
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "$GeneratorVersion")]
+        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public void InitializeComponent(bool loadXaml = true)
         {
             if (loadXaml)

--- a/tests/Avalonia.Generators.Tests/InitializeComponent/InitializeComponentTests.cs
+++ b/tests/Avalonia.Generators.Tests/InitializeComponent/InitializeComponentTests.cs
@@ -48,15 +48,17 @@ public class InitializeComponentTests
         var names = nameResolver.ResolveNames(classInfo.Xaml);
 
         var generator = new InitializeComponentCodeGenerator(types, devToolsMode);
+        var generatorVersion = typeof(InitializeComponentCodeGenerator).Assembly.GetName().Version.ToString();
 
         var code = generator
             .GenerateCode("SampleView", "Sample.App",  classInfo.XamlType, names)
             .Replace("\r", string.Empty);
 
-        var expected = await InitializeComponentCode.Load(expectation);
-            
+        var expected = (await InitializeComponentCode.Load(expectation))
+            .Replace("\r", string.Empty)
+            .Replace("$GeneratorVersion", generatorVersion);
             
         CSharpSyntaxTree.ParseText(code);
-        Assert.Equal(expected.Replace("\r", string.Empty), code);
+        Assert.Equal(expected, code);
     }
 }

--- a/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/AttachedProps.txt
+++ b/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/AttachedProps.txt
@@ -6,6 +6,7 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox UserNameTextBox => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
     }
 }

--- a/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/ControlWithoutWindow.txt
+++ b/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/ControlWithoutWindow.txt
@@ -6,6 +6,7 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox UserNameTextBox => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
     }
 }

--- a/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/CustomControls.txt
+++ b/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/CustomControls.txt
@@ -6,8 +6,11 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.ReactiveUI.RoutedViewHost ClrNamespaceRoutedViewHost => this.FindNameScope()?.Find<global::Avalonia.ReactiveUI.RoutedViewHost>("ClrNamespaceRoutedViewHost");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.ReactiveUI.RoutedViewHost UriRoutedViewHost => this.FindNameScope()?.Find<global::Avalonia.ReactiveUI.RoutedViewHost>("UriRoutedViewHost");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Controls.CustomTextBox UserNameTextBox => this.FindNameScope()?.Find<global::Controls.CustomTextBox>("UserNameTextBox");
     }
 }

--- a/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/DataTemplates.txt
+++ b/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/DataTemplates.txt
@@ -6,7 +6,9 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox UserNameTextBox => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.ListBox NamedListBox => this.FindNameScope()?.Find<global::Avalonia.Controls.ListBox>("NamedListBox");
     }
 }

--- a/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/FieldModifier.txt
+++ b/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/FieldModifier.txt
@@ -6,11 +6,17 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         public global::Avalonia.Controls.TextBox FirstNameTextBox => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("FirstNameTextBox");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         public global::Avalonia.Controls.TextBox LastNameTextBox => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("LastNameTextBox");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         protected global::Avalonia.Controls.TextBox PasswordTextBox => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("PasswordTextBox");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         private global::Avalonia.Controls.TextBox ConfirmPasswordTextBox => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("ConfirmPasswordTextBox");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.Button SignUpButton => this.FindNameScope()?.Find<global::Avalonia.Controls.Button>("SignUpButton");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.Button RegisterButton => this.FindNameScope()?.Find<global::Avalonia.Controls.Button>("RegisterButton");
     }
 }

--- a/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/NamedControl.txt
+++ b/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/NamedControl.txt
@@ -6,6 +6,7 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox UserNameTextBox => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
     }
 }

--- a/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/NamedControls.txt
+++ b/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/NamedControls.txt
@@ -6,8 +6,11 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox UserNameTextBox => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox PasswordTextBox => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("PasswordTextBox");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.Button SignUpButton => this.FindNameScope()?.Find<global::Avalonia.Controls.Button>("SignUpButton");
     }
 }

--- a/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/SignUpView.txt
+++ b/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/SignUpView.txt
@@ -6,15 +6,25 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Controls.CustomTextBox UserNameTextBox => this.FindNameScope()?.Find<global::Controls.CustomTextBox>("UserNameTextBox");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBlock UserNameValidation => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBlock>("UserNameValidation");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox PasswordTextBox => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("PasswordTextBox");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBlock PasswordValidation => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBlock>("PasswordValidation");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.ListBox AwesomeListView => this.FindNameScope()?.Find<global::Avalonia.Controls.ListBox>("AwesomeListView");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox ConfirmPasswordTextBox => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("ConfirmPasswordTextBox");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBlock ConfirmPasswordValidation => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBlock>("ConfirmPasswordValidation");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.Documents.Run SignUpButtonDescription => this.FindNameScope()?.Find<global::Avalonia.Controls.Documents.Run>("SignUpButtonDescription");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.Button SignUpButton => this.FindNameScope()?.Find<global::Avalonia.Controls.Button>("SignUpButton");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBlock CompoundValidation => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBlock>("CompoundValidation");
     }
 }

--- a/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/xNamedControl.txt
+++ b/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/xNamedControl.txt
@@ -6,6 +6,7 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox UserNameTextBox => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
     }
 }

--- a/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/xNamedControls.txt
+++ b/tests/Avalonia.Generators.Tests/OnlyProperties/GeneratedCode/xNamedControls.txt
@@ -6,8 +6,11 @@ namespace Sample.App
 {
     partial class SampleView
     {
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox UserNameTextBox => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("UserNameTextBox");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.TextBox PasswordTextBox => this.FindNameScope()?.Find<global::Avalonia.Controls.TextBox>("PasswordTextBox");
+        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.OnlyPropertiesCodeGenerator", "$GeneratorVersion")]
         internal global::Avalonia.Controls.Button SignUpButton => this.FindNameScope()?.Find<global::Avalonia.Controls.Button>("SignUpButton");
     }
 }

--- a/tests/Avalonia.Generators.Tests/OnlyProperties/OnlyPropertiesTests.cs
+++ b/tests/Avalonia.Generators.Tests/OnlyProperties/OnlyPropertiesTests.cs
@@ -41,12 +41,17 @@ public class OnlyPropertiesTests
         var names = nameResolver.ResolveNames(classInfo.Xaml);
 
         var generator = new OnlyPropertiesCodeGenerator();
+        var generatorVersion = typeof(OnlyPropertiesCodeGenerator).Assembly.GetName().Version.ToString();
+
         var code = generator
             .GenerateCode("SampleView", "Sample.App",  classInfo.XamlType, names)
             .Replace("\r", string.Empty);
 
-        var expected = await OnlyPropertiesCode.Load(expectation);
+        var expected = (await OnlyPropertiesCode.Load(expectation))
+            .Replace("\r", string.Empty)
+            .Replace("$GeneratorVersion", generatorVersion);
+
         CSharpSyntaxTree.ParseText(code);
-        Assert.Equal(expected.Replace("\r", string.Empty), code);
+        Assert.Equal(expected, code);
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Adds attributes to output of both Name Generators (`InitializeComponentCodeGenerator` and `OnlyPropertiesCodeGenerator`).

* Generated fields now have the `[GeneratedCode]` attribute.
* Generated `InitializeComponent` method now has `[GeneratedCode]` and `[ExcludeFromCodeCoverage]`

## What is the updated/expected behavior with this PR?

Code generated by `InitializeComponentCodeGenerator` now looks like:
```cs
namespace Sandbox
{
    partial class MainWindow
    {
        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "11.2.999.0")]
        internal global::Avalonia.Controls.Grid grid;
        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "11.2.999.0")]
        internal global::Avalonia.Controls.TextBlock text;

        /// <summary>
        /// Wires up the controls and optionally loads XAML markup and attaches dev tools (if Avalonia.Diagnostics package is referenced).
        /// </summary>
        /// <param name="loadXaml">Should the XAML be loaded into the component.</param>
        /// <param name="attachDevTools">Should the dev tools be attached.</param>

        [global::System.CodeDom.Compiler.GeneratedCode("Avalonia.Generators.NameGenerator.InitializeComponentCodeGenerator", "11.2.999.0")]
        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
        public void InitializeComponent(bool loadXaml = true, bool attachDevTools = true)
        {
            if (loadXaml)
            {
                AvaloniaXamlLoader.Load(this);
            }

#if DEBUG
            if (attachDevTools)
            {
                this.AttachDevTools();
            }
#endif

            var __thisNameScope__ = this.FindNameScope();
            grid = __thisNameScope__?.Find<global::Avalonia.Controls.Grid>("grid");
            text = __thisNameScope__?.Find<global::Avalonia.Controls.TextBlock>("text");
        }
    }
}
```

## How was the solution implemented (if it's not obvious)?

I mostly tried to match what Mvvm Toolkit is doing for its output, though this generator is still on `ISourceGenerator` instead of incremental. Code strings were built similar to the existing parts of the generators instead of Roslyn AST.

The unit tests and unit test data required updating. The version parameter of `[GeneratedCode]` will be ever-changing, so a `$GeneratorVersion` tag was used in test code files. Mvvm Toolkit uses `<ASSEMBLY_VERSION>` with a similar replacement strategy at test-time.

## Checklist

- [X] Updated unit tests

## Breaking changes
None

## Fixed issues
Fixes #15611 