### PR TITLE
Wrap type conversions in try-catch to prevent crashes due to unhandled exceptions

### DIFF
--- a/src/Avalonia.Base/Data/Core/TargetTypeConverter.cs
+++ b/src/Avalonia.Base/Data/Core/TargetTypeConverter.cs
@@ -76,16 +76,32 @@ internal abstract class TargetTypeConverter
 
             if (toTypeConverter.CanConvertFrom(from))
             {
-                result = toTypeConverter.ConvertFrom(null, culture, value);
-                return true;
+                try
+                {
+                    result = toTypeConverter.ConvertFrom(null, culture, value);
+                    return true;
+                }
+                catch
+                {
+                    result = null;
+                    return false;
+                }
             }
 
             var fromTypeConverter = TypeDescriptor.GetConverter(from);
 
             if (fromTypeConverter.CanConvertTo(t))
             {
-                result = fromTypeConverter.ConvertTo(null, culture, value, t);
-                return true;
+                try
+                {
+                    result = fromTypeConverter.ConvertTo(null, culture, value, t);
+                    return true;
+                }
+                catch
+                {
+                    result = null;
+                    return false;
+                }
             }
 
             // TODO: This requires reflection: we probably need to make compiled bindings emit
@@ -95,8 +111,16 @@ internal abstract class TargetTypeConverter
                 t,
                 OperatorType.Implicit | OperatorType.Explicit) is { } cast)
             {
-                result = cast.Invoke(null, new[] { value });
-                return true;
+                try
+                {
+                    result = cast.Invoke(null, new[] { value });
+                    return true;
+                }
+                catch
+                {
+                    result = null;
+                    return false;
+                }
             }
 #pragma warning restore IL2067
 #pragma warning restore IL2026


### PR DESCRIPTION
## What does the pull request do?
This PR prevents crashes due to illegal conversions in `TargetTypeConverter`, i.e. if a numeric type is bound to a TextBox (only when using CompiledBindings). Yes, currently in 11.1 if you type a letter in a textbox with `{Binding NumericType}`, it will crash the whole app (with CompiledBindings).


## What is the current behavior?
The type conversion exceptions in Compiled Bindings are not handled.


## What is the updated/expected behavior with this PR?
The type conversion exceptions are silently ignored - just like before the binding refactor.


## How was the solution implemented (if it's not obvious)?
The conversion happens in TryConvert methods, which name implies that a failure should not propagate. It also worked this way before: 

https://github.com/AvaloniaUI/Avalonia/blob/d407764b84d4d71a2eb3e53c6cfe2ee0500e461c/src/Avalonia.Base/Utilities/TypeUtilities.cs#L279-L290

So I added analogous `try {} catch {}` in the new typed conveter.


## Checklist

- [x] Added unit tests
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
n/a

## Obsoletions / Deprecations

## Fixed issues
Fixes #15546
