### PR TITLE
Add dedicated automation peers for TreeView and TreeViewItem

### DIFF
--- a/src/Avalonia.Controls/Automation/Peers/TreeViewAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/TreeViewAutomationPeer.cs
@@ -1,0 +1,16 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Automation.Peers;
+
+public class TreeViewAutomationPeer : ItemsControlAutomationPeer
+{
+    public TreeViewAutomationPeer(TreeView owner)
+        : base(owner)
+    {
+    }
+
+    protected override AutomationControlType GetAutomationControlTypeCore()
+    {
+        return AutomationControlType.Tree;
+    }
+}

--- a/src/Avalonia.Controls/Automation/Peers/TreeViewItemAutomationPeer.cs
+++ b/src/Avalonia.Controls/Automation/Peers/TreeViewItemAutomationPeer.cs
@@ -1,0 +1,16 @@
+using Avalonia.Controls;
+
+namespace Avalonia.Automation.Peers;
+
+public class TreeViewItemAutomationPeer : ItemsControlAutomationPeer
+{
+    public TreeViewItemAutomationPeer(TreeViewItem owner)
+        : base(owner)
+    {
+    }
+   
+    protected override AutomationControlType GetAutomationControlTypeCore()
+    {
+        return AutomationControlType.TreeItem;
+    }
+}

--- a/src/Avalonia.Controls/TreeView.cs
+++ b/src/Avalonia.Controls/TreeView.cs
@@ -6,6 +6,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Avalonia.Automation.Peers;
 using Avalonia.Collections;
 using Avalonia.Controls.Generators;
 using Avalonia.Controls.Primitives;
@@ -296,6 +297,12 @@ namespace Avalonia.Controls
             }
 
             return TreeItemFromContainer(this, container);
+        }
+
+        /// <inheritdoc />
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new TreeViewAutomationPeer(this);
         }
 
         private protected override void OnItemsViewCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using Avalonia.Automation.Peers;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Mixins;
 using Avalonia.Controls.Primitives;
@@ -92,6 +93,11 @@ namespace Avalonia.Controls
         }
 
         internal TreeView? TreeViewOwner => _treeView;
+
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new TreeViewItemAutomationPeer(this);
+        }
 
         protected internal override Control CreateContainerForItemOverride(object? item, int index, object? recycleKey)
         {

--- a/src/Avalonia.Controls/TreeViewItem.cs
+++ b/src/Avalonia.Controls/TreeViewItem.cs
@@ -94,6 +94,7 @@ namespace Avalonia.Controls
 
         internal TreeView? TreeViewOwner => _treeView;
 
+        /// <inheritdoc />
         protected override AutomationPeer OnCreateAutomationPeer()
         {
             return new TreeViewItemAutomationPeer(this);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Adds dedicated automation peers for TreeView and TreeViewItem

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
No dedicated automation peers for TreeView and TreeViewItem

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
TreeView and TreeViewItem have dedicated automation peers 

![image](https://github.com/AvaloniaUI/Avalonia/assets/2297442/373f0754-2a7a-4db7-a578-18cd7cd18b0b)

![image](https://github.com/AvaloniaUI/Avalonia/assets/2297442/111cd5db-deac-4cd1-bf88-32b0f51ff270)

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Created dedicated automation peers for Add dedicated automation peers for TreeView and TreeViewItem

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
