### PR TITLE
[DBUS] Don't break when reading settings from org.freedesktop.portalSettings v1

### DIFF
--- a/src/Avalonia.FreeDesktop/DBusPlatformSettings.cs
+++ b/src/Avalonia.FreeDesktop/DBusPlatformSettings.cs
@@ -45,13 +45,16 @@ namespace Avalonia.FreeDesktop
                 if (version >= 2)
                     value = await _settings!.ReadOneAsync("org.freedesktop.appearance", "color-scheme");
                 else
-                    value = (await _settings!.ReadAsync("org.freedesktop.appearance", "color-scheme")).GetItem(0);
-                return ToColorScheme(value.GetUInt32());
+                    value = await _settings!.ReadAsync("org.freedesktop.appearance", "color-scheme");
+
+                if (value.Type == VariantValueType.Int32)
+                    return ToColorScheme(value.GetUInt32()); 
             }
             catch (DBusException)
             {
-                return null;
+                
             }
+            return null;
         }
 
         private async Task<Color?> TryGetAccentColorAsync()


### PR DESCRIPTION
https://github.com/AvaloniaUI/Avalonia/pull/15568 made an attempt to correctly handle int32-in-variant-in-another-variant value (`[Variant: [Variant(uint): 2]]` in qdbus notation), however the current version of Tmds.DBus.Protocol simply reads it as a single VariantValue with int32 type (https://github.com/tmds/Tmds.DBus/issues/282).

The PR removes GetItem call that wasn't intended to be used for unwrapping variants and adds a type check later just in case.

Verified with Plasma 5.27.
@affederaffe 