### PR TITLE
Suspend selection updates in TextBoxTextInputMethodClient until all changes are completed

### DIFF
--- a/src/Android/Avalonia.Android/AndroidInputMethod.cs
+++ b/src/Android/Avalonia.Android/AndroidInputMethod.cs
@@ -117,16 +117,20 @@ namespace Avalonia.Android
 
         private void OnSelectionChanged()
         {
-            if (Client is null)
+            if (Client is null || _inputConnection is null)
             {
                 return;
             }
 
+            OnSurroundingTextChanged();
+
             var selection = Client.Selection;
 
-            _imm.UpdateSelection(_host, selection.Start, selection.End, selection.Start, selection.End);
+            _inputConnection.SetSelection(selection.Start, selection.End);
 
-            _inputConnection?.SetSelection(selection.Start, selection.End);
+            var composition = _inputConnection.EditableWrapper.CurrentComposition;
+
+            _imm.UpdateSelection(_host, selection.Start, selection.End, composition.Start, composition.End);
         }
 
         private void _client_SurroundingTextChanged(object? sender, EventArgs e)
@@ -140,8 +144,6 @@ namespace Avalonia.Android
         {
             if (_inputConnection is null || _inputConnection.IsInBatchEdit)
                 return;
-
-            OnSurroundingTextChanged();
             OnSelectionChanged();
         }
 

--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -406,6 +406,8 @@ namespace Avalonia.Controls
             if (IsUndoEnabled && _undoRedoHelper.TryGetLastState(out state) && state.Text == Text)
                 _undoRedoHelper.UpdateLastState();
 
+            using var _ = _imClient.BeginChange();
+
             var newValue = e.GetNewValue<int>();
             SetCurrentValue(SelectionStartProperty, newValue);
             SetCurrentValue(SelectionEndProperty, newValue);
@@ -1216,6 +1218,8 @@ namespace Avalonia.Controls
 
             var keymap = Application.Current!.PlatformSettings!.HotkeyConfiguration;
 
+            using var _ = _imClient.BeginChange();
+
             bool Match(List<KeyGesture> gestures) => gestures.Any(g => g.Matches(e));
             bool DetectSelection() => e.KeyModifiers.HasAllFlags(keymap.SelectionModifiers);
 
@@ -1547,6 +1551,8 @@ namespace Avalonia.Controls
             var text = Text;
             var clickInfo = e.GetCurrentPoint(this);
 
+            using var _ = _imClient.BeginChange();
+
             if (text != null && (e.Pointer.Type == PointerType.Mouse || e.ClickCount >= 2) && clickInfo.Properties.IsLeftButtonPressed &&
                 !(clickInfo.Pointer?.Captured is Border))
             {
@@ -1631,6 +1637,7 @@ namespace Avalonia.Controls
             {
                 return;
             }
+            using var _ = _imClient.BeginChange();
 
             // selection should not change during pointer move if the user right clicks
             if (e.Pointer.Captured == _presenter && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
@@ -1712,6 +1719,8 @@ namespace Avalonia.Controls
             {
                 return;
             }
+
+            using var _ = _imClient.BeginChange();
 
             if (e.Pointer.Type != PointerType.Mouse && !_isDoubleTapped)
             {
@@ -1856,6 +1865,8 @@ namespace Avalonia.Controls
             {
                 return;
             }
+
+            using var _ = _imClient.BeginChange();
 
             var text = Text ?? string.Empty;
             var selectionStart = SelectionStart;
@@ -2017,6 +2028,8 @@ namespace Avalonia.Controls
         /// </summary>
         public void SelectAll()
         {
+            using var _ = _imClient.BeginChange();
+
             SetCurrentValue(SelectionStartProperty, 0);
             SetCurrentValue(SelectionEndProperty, Text?.Length ?? 0);
         }
@@ -2033,6 +2046,8 @@ namespace Avalonia.Controls
         {
             if (IsReadOnly)
                 return true;
+
+            using var _ = _imClient.BeginChange();
 
             var (start, end) = GetSelectionRange();
 
@@ -2141,6 +2156,8 @@ namespace Avalonia.Controls
             var text = Text ?? string.Empty;
             var selectionStart = CaretIndex;
 
+            using var _ = _imClient.BeginChange();
+
             MoveHorizontal(-1, true, false, false);
 
             if (SelectionEnd > 0 &&
@@ -2159,6 +2176,8 @@ namespace Avalonia.Controls
             {
                 return;
             }
+
+            using var _ = _imClient.BeginChange();
 
             SetCurrentValue(SelectionStartProperty, CaretIndex);
 

--- a/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
+++ b/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
@@ -2,6 +2,7 @@ using System;
 using Avalonia.Controls.Presenters;
 using Avalonia.Input.TextInput;
 using Avalonia.Media.TextFormatting;
+using Avalonia.Reactive;
 using Avalonia.Utilities;
 
 namespace Avalonia.Controls
@@ -10,6 +11,8 @@ namespace Avalonia.Controls
     {
         private TextBox? _parent;
         private TextPresenter? _presenter;
+        private bool _selectionChanged;
+        private bool _isInChange;
 
         public override Visual TextViewVisual => _presenter!;
 
@@ -190,8 +193,30 @@ namespace Avalonia.Controls
 
             if (e.Property == TextBox.SelectionStartProperty || e.Property == TextBox.SelectionEndProperty)
             {
-                RaiseSelectionChanged();
+                if (_isInChange)
+                    _selectionChanged = true;
+                else
+                    RaiseSelectionChanged();
             }
+        }
+
+        internal IDisposable BeginChange()
+        {
+            if (_isInChange)
+                return Disposable.Empty;
+
+            _isInChange = true;
+            return Disposable.Create(RaiseEvents);
+        }
+
+        private void RaiseEvents()
+        {
+            _isInChange = false;
+
+            if (_selectionChanged)
+                RaiseSelectionChanged();
+
+            _selectionChanged = false;
         }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Suspend sending selection update events from `TextBoxTextInputMethodClient` until all selection changes in textbox are completed for an action.


## What is the current behavior?
Currently, we update selection when caret position changes by first setting the start and end in 2 properties, i.e. SelectionStart and SelectionEnd. Those 2 updates are sent to the OS as 2 selection updates. Because of that, keyboards that support advance editing will detect it as a selection in progress, and will enable the selection flag on the keyboard.

https://github.com/AvaloniaUI/Avalonia/assets/5307160/c2ccde85-8572-4aef-a6ae-d33474d4ec9a



## What is the updated/expected behavior with this PR?
When selection or caret changes occur for actions handled by TextBox, the selection updates aren't sent to the input method until the action is completed and selection is done.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
