### PR TITLE
Add api to allow text input method to trigger common context menu actions

### DIFF
--- a/src/Avalonia.Base/Input/TextInput/TextInputMethodClient.cs
+++ b/src/Avalonia.Base/Input/TextInput/TextInputMethodClient.cs
@@ -65,6 +65,12 @@ namespace Avalonia.Input.TextInput
         public virtual void SetPreeditText(string? preeditText) { }
 
         /// <summary>
+        /// Execute specific context menu actions
+        /// </summary>
+        /// <param name="action">The <see cref="ContextMenuAction"/> to perform</param>
+        public virtual void ExecuteContextMenuAction(ContextMenuAction action) { }
+
+        /// <summary>
         /// Sets the non-committed input string and cursor offset in that string
         /// </summary>
         public virtual void SetPreeditText(string? preeditText, int? cursorPos)
@@ -99,4 +105,12 @@ namespace Avalonia.Input.TextInput
     }
 
     public record struct TextSelection(int Start, int End);
+
+    public enum ContextMenuAction
+    {
+        Copy,
+        Cut,
+        Paste,
+        SelectAll
+    }
 }

--- a/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
+++ b/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
@@ -184,6 +184,27 @@ namespace Avalonia.Controls
             return lineText;
         }
 
+        public override void ExecuteContextMenuAction(ContextMenuAction action)
+        {
+            base.ExecuteContextMenuAction(action);
+
+            switch (action)
+            {
+                case ContextMenuAction.Copy:
+                    _parent?.Copy();
+                    break;
+                case ContextMenuAction.Cut:
+                    _parent?.Cut();
+                    break;
+                case ContextMenuAction.Paste:
+                    _parent?.Paste();
+                    break;
+                case ContextMenuAction.SelectAll:
+                    _parent?.SelectAll();
+                    break;
+            }
+        }
+
         private void OnParentPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
         {
             if (e.Property == TextBox.TextProperty)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Adds `ExecuteContextMenuAction` and `ContextMenuAction` api to `TextBoxTextInputMethodClient`. This allow text input method clients to trigger common actions associated with text editing.

This PR allows #15608 to proceed.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
