### PR TITLE
Fixed DeferredContent parents order

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguage.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/AvaloniaXamlIlLanguage.cs
@@ -110,8 +110,8 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
 
             definition.TypeBuilder.AddInterfaceImplementation(interfaceType);
 
-            // IReadOnlyList<object> DirectParents => (IReadOnlyList<object>)ParentsStack;
-            var directParentsGetter = ImplementInterfacePropertyGetter("DirectParents");
+            // IReadOnlyList<object> DirectParentsStack => (IReadOnlyList<object>)ParentsStack;
+            var directParentsGetter = ImplementInterfacePropertyGetter("DirectParentsStack");
             directParentsGetter.Generator
                 .LdThisFld(definition.ParentListField)
                 .Castclass(directParentsGetter.ReturnType)

--- a/src/Markup/Avalonia.Markup.Xaml/EagerParentStackEnumerator.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/EagerParentStackEnumerator.cs
@@ -6,7 +6,7 @@ namespace Avalonia.Markup.Xaml;
 internal struct EagerParentStackEnumerator
 {
     private IAvaloniaXamlIlEagerParentStackProvider? _provider;
-    private IReadOnlyList<object>? _currentParents;
+    private IReadOnlyList<object>? _currentParentsStack;
     private int _currentIndex; // only valid when _currentParents isn't null
 
     public EagerParentStackEnumerator(IAvaloniaXamlIlEagerParentStackProvider? provider)
@@ -16,18 +16,18 @@ internal struct EagerParentStackEnumerator
     {
         while (_provider is not null)
         {
-            if (_currentParents is null)
+            if (_currentParentsStack is null)
             {
-                _currentParents = _provider.DirectParents;
-                _currentIndex = _currentParents.Count;
+                _currentParentsStack = _provider.DirectParentsStack;
+                _currentIndex = _currentParentsStack.Count;
             }
 
             --_currentIndex;
 
             if (_currentIndex >= 0)
-                return _currentParents[_currentIndex];
+                return _currentParentsStack[_currentIndex];
 
-            _currentParents = null;
+            _currentParentsStack = null;
             _provider = _provider.ParentProvider;
         }
 

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/Runtime/IAvaloniaXamlIlParentStackProvider.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/Runtime/IAvaloniaXamlIlParentStackProvider.cs
@@ -2,15 +2,36 @@ using System.Collections.Generic;
 
 namespace Avalonia.Markup.Xaml.XamlIl.Runtime
 {
+    /// <summary>
+    /// Provides the parents for the current XAML node in a lazy way.
+    /// </summary>
+    /// <remarks>This interface is used by the XAML compiler and shouldn't be implemented in your code.</remarks>
     public interface IAvaloniaXamlIlParentStackProvider
     {
+        /// <summary>
+        /// Gets an enumerator iterating over the available parents in the whole hierarchy.
+        /// The parents are returned in normal order:
+        /// the first element is the most direct parent while the last element is the most distant ancestor.
+        /// </summary>
         IEnumerable<object> Parents { get; }
     }
 
+    /// <summary>
+    /// Provides the parents for the current XAML node in an eager way, avoiding allocations when possible.
+    /// </summary>
+    /// <remarks>This interface is used by the XAML compiler and shouldn't be implemented in your code.</remarks>
     public interface IAvaloniaXamlIlEagerParentStackProvider : IAvaloniaXamlIlParentStackProvider
     {
-        IReadOnlyList<object> DirectParents { get; }
+        /// <summary>
+        /// Gets the directly available parents (which don't include ones returned by parent providers).
+        /// The parents are returned in reverse order:
+        /// the last element is the most direct parent while the first element is the most distant ancestor.
+        /// </summary>
+        IReadOnlyList<object> DirectParentsStack { get; }
 
+        /// <summary>
+        /// Gets the parent <see cref="IAvaloniaXamlIlEagerParentStackProvider"/>, if available.
+        /// </summary>
         IAvaloniaXamlIlEagerParentStackProvider? ParentProvider { get; }
     }
 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/StaticResourceExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/StaticResourceExtensionTests.cs
@@ -340,7 +340,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
     <Button Name='button'/>
 </Window>")
             };
-            
+
             using (StyledWindow())
             {
                 var compiled = AvaloniaRuntimeXamlLoader.LoadGroup(documents);
@@ -351,7 +351,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
 
                 var border = (Border)button.GetVisualChildren().Single();
                 var brush = (ISolidColorBrush)border.Background;
-                
+
                 Assert.Equal(0xff506070, brush.Color.ToUInt32());
             }
         }
@@ -475,6 +475,40 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         }
 
         [Fact]
+        public void StaticResource_Is_Correctly_Chosen_For_DeferredContent()
+        {
+            using (StyledWindow())
+            {
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(@"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'>
+
+  <Window.Resources>
+    <Color x:Key='Color'>Purple</Color>
+  </Window.Resources>
+
+  <Border>
+   <Border.Resources>
+      <Color x:Key='Color'>Red</Color>
+      <SolidColorBrush x:Key='Brush' Color='{StaticResource Color}' />
+    </Border.Resources>
+    <TextBlock Foreground='{StaticResource Brush}' />
+  </Border>
+
+</Window>");
+
+                window.Show();
+
+                var textBlock = window.GetVisualDescendants().OfType<TextBlock>().Single();
+
+                Assert.NotNull(textBlock);
+                var brush = Assert.IsAssignableFrom<ISolidColorBrush>(textBlock.Foreground);
+                Assert.Equal(Colors.Red, brush.Color);
+            }
+        }
+
+        [Fact]
         public void Control_Property_Is_Not_Updated_When_Parent_Is_Changed()
         {
             var xaml = @"
@@ -518,7 +552,7 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
             var brush = (ISolidColorBrush)border.Background;
             Assert.Equal(0xff506070, brush.Color.ToUInt32());
         }
-        
+
         [Fact]
         public void Automatically_Converts_Color_To_SolidColorBrush_From_Setter()
         {

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ParentStackProviderTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/ParentStackProviderTests.cs
@@ -1,0 +1,86 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml.XamlIl.Runtime;
+using Avalonia.Media;
+using Avalonia.UnitTests;
+using Xunit;
+
+namespace Avalonia.Markup.Xaml.UnitTests.Xaml;
+
+public class ParentStackProviderTests : XamlTestBase
+{
+    [Fact]
+    public void Parents_Are_Correct_For_Deferred_Content()
+    {
+        using var _ = UnitTestApplication.Start(TestServices.StyledWindow);
+
+        var capturedParents = new CapturedParents();
+        AvaloniaLocator.CurrentMutable.BindToSelf(capturedParents);
+
+        var window = (Window)AvaloniaRuntimeXamlLoader.Load(@"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.Xaml;assembly=Avalonia.Markup.Xaml.UnitTests'>
+
+  <Window.Resources>
+    <SolidColorBrush x:Key='Brush' Color='{local:CapturingParentsMarkupExtension}' />
+  </Window.Resources>
+
+  <TextBlock Foreground='{StaticResource Brush}' />
+
+</Window>");
+
+        window.Show();
+
+        VerifyParents(capturedParents.LazyParents);
+        VerifyParents(capturedParents.EagerParents);
+
+        static void VerifyParents(object[]? parents)
+        {
+            Assert.NotNull(parents);
+            Assert.NotEmpty(parents);
+            Assert.Collection(
+                parents,
+                o => Assert.IsType<SolidColorBrush>(o),
+                o => Assert.IsType<Window>(o),
+                o => Assert.IsType<UnitTestApplication>(o));
+        }
+    }
+}
+
+public class CapturedParents
+{
+    public object[]? LazyParents { get; set; }
+
+    public object[]? EagerParents { get; set; }
+}
+
+public class CapturingParentsMarkupExtension
+{
+    public object ProvideValue(IServiceProvider serviceProvider)
+    {
+        var parentsProvider = serviceProvider.GetRequiredService<IAvaloniaXamlIlParentStackProvider>();
+        var eagerParentsProvider = Assert.IsAssignableFrom<IAvaloniaXamlIlEagerParentStackProvider>(parentsProvider);
+
+        var capturedParents = AvaloniaLocator.Current.GetRequiredService<CapturedParents>();
+        capturedParents.LazyParents = parentsProvider.Parents.ToArray();
+        capturedParents.EagerParents = EnumerateEagerParents(eagerParentsProvider);
+
+        return Colors.Blue;
+    }
+
+    private static object[] EnumerateEagerParents(IAvaloniaXamlIlEagerParentStackProvider provider)
+    {
+        var parents = new List<object>();
+
+        var enumerator = new EagerParentStackEnumerator(provider);
+        while (enumerator.TryGetNext() is { } parent)
+            parents.Add(parent);
+
+        return parents.ToArray();
+    }
+}

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleIncludeTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/StyleIncludeTests.cs
@@ -346,8 +346,8 @@ public class TestServiceProvider :
     }
 
     public Uri BaseUri { get; set; }
-    public List<object> Parents { get; set; } = new List<object> { new ContentControl() };
-    IEnumerable<object> IAvaloniaXamlIlParentStackProvider.Parents => Parents;
-    public IReadOnlyList<object> DirectParents => Parents;
-    public IAvaloniaXamlIlEagerParentStackProvider ParentProvider => null;
+    public List<object> ParentsStack { get; set; } = [new ContentControl()];
+    IEnumerable<object> IAvaloniaXamlIlParentStackProvider.Parents => ParentsStack.AsEnumerable().Reverse();
+    IReadOnlyList<object> IAvaloniaXamlIlEagerParentStackProvider.DirectParentsStack => ParentsStack;
+    IAvaloniaXamlIlEagerParentStackProvider IAvaloniaXamlIlEagerParentStackProvider.ParentProvider => null;
 }

--- a/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/XamlIlTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/Xaml/XamlIlTests.cs
@@ -309,7 +309,7 @@ namespace Avalonia.Markup.Xaml.UnitTests
         {
             var sp = new TestServiceProvider
             {
-                Parents = new List<object>
+                ParentsStack = new List<object>
                 {
                     new UserControl { Resources = { ["Resource1"] = new SolidColorBrush(Colors.Blue) } }
                 }


### PR DESCRIPTION
## What does the pull request do?
This PR fixes a bug where parent nodes for deferred content were reversed after #15070.
Unit tests have been added.

## What is the current behavior?
Parent nodes were reversed for deferred content, effectively looking up the resources in the wrong order for `StaticResource`.
(Note that the bug doesn't manifest everywhere, as it depends on the exact hierarchy of deferred contents, which can be subtle.)

## How was the solution implemented (if it's not obvious)?
`IAvaloniaXamlIlEagerParentStackProvider` had both implementations where `DirectParents` were in normal order (`DeferredParentServiceProvider`), and implementations where they were in stack order, reversed (`XamlIlContext`, generated by the XAML compiler).

With this PR, the parents are always in stack order, as this was expected by `EagerParentStackEnumerator`.

## Breaking changes
I renamed `IAvaloniaXamlIlEagerParentStackProvider.DirectParents` to `DirectParentsStack` to make the expected order clearer (alongside documentation comments). Since this interface isn't supposed to be implemented by users and is new in 11.1-beta2, it isn't really part of the official public API yet. If that isn't acceptable, please let me know and I'll rename it back.

## Fixed issues
 - Fixes #15647