### PR TITLE
Hack to enable subpixel rendering by default.

### DIFF
--- a/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/ServerCompositionTarget.cs
@@ -205,8 +205,7 @@ namespace Avalonia.Rendering.Composition.Server
 
         void RenderRootToContextWithClip(IDrawingContextImpl context, ServerCompositionVisual root)
         {
-            var useLayerClip = Compositor.Options.UseSaveLayerRootClip ??
-                               Compositor.RenderInterface.GpuContext != null;
+            var useLayerClip = Compositor.Options.UseSaveLayerRootClip ?? false;
             
             using (DirtyRects.BeginDraw(context))
             {


### PR DESCRIPTION
## What does the pull request do?

As described in #15015: since #14806 was merged our text rendering is unable to use subpixel rendering because the API to enable subpixel rendering on layers is not exposed by SkiaSharp.. This can be fixed by setting `CompositionOptions.UseSaveLayerRootClip = false` to disable the root layer, but the current default means that subpixel rendering is disabled by default.

Given that blurry fonts are a lot more noticeable than the (rare?) rendering glitches reported in #14270, this PR changes the default. 

Until the required API is added to SkiaSharp you have to choose between #15015 and #14270, unfortunately.

## What is the current behavior?

Blurry fonts but no rendering glitches.

## What is the updated/expected behavior with this PR?

Non-blurry fonts but rare rendering glitches.

## Fixed issues

Fixes #15015