### PR TITLE
X11Window should probably ignore X11 grab focus events

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -453,11 +453,17 @@ namespace Avalonia.X11
             {
                 if (ActivateTransientChildIfNeeded())
                     return;
+                // See: https://github.com/fltk/fltk/issues/295
+                if ((NotifyMode)ev.FocusChangeEvent.mode is not NotifyMode.NotifyNormal)
+                    return;
                 Activated?.Invoke();
                 _imeControl?.SetWindowActive(true);
             }
             else if (ev.type == XEventName.FocusOut)
             {
+                // See: https://github.com/fltk/fltk/issues/295
+                if ((NotifyMode)ev.FocusChangeEvent.mode is not NotifyMode.NotifyNormal)
+                    return;
                 _imeControl?.SetWindowActive(false);
                 Deactivated?.Invoke();
             }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

Xorg 1.20 changed some behaviour in how grabs are handled, which resulted in extra FocusIn and FocusOut events being sent out. This make the X11Window receives and raises extra `Activated` and `Deactivated` events to the `Avalonia.Window` which may cause some bugs that are hard to resolve outside of the framework.

Related Links:

- https://cgit.freedesktop.org/xorg/xserver/commit/?id=c67f2eac56518163981af59f5accb7c79bc00f6a
- https://github.com/fltk/fltk/issues/295
- https://github.com/TigerVNC/tigervnc/issues/660
- https://tronche.com/gui/x/xlib/input/XGrabKeyboard.html

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

If we do these two things on an Avalonia window:

1. Drag on the title bar to move the window
1. Long press anywhere on the window using a touch screen and your finger

We will see the window is deactivated and activated almost at the same time.

If we are trying to do something on the `Activated` or `Deactivated` event, the operations will be done but the user actually don't see the real window activation changes. This may cause some unexpected behaviours.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

If this PR is merged, the `Activated` and `Deactivated` events will be raised only when the window is really activated or deactivated.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

See this official description here:

- https://tronche.com/gui/x/xlib/input/XGrabKeyboard.html

I fitered the `FocusIn` and `FocusOut` events by checking the `mode` field of the `XFocusChangeEvent` structure.

```csharp
if ((NotifyMode)ev.FocusChangeEvent.mode is not NotifyMode.NotifyNormal)
    return;
```

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

If someone uses the extra `Activated` and `Deactivated` events to do some extra operations, they may lost the chance to do these. In my opition, this may not be a breaking change because the fix will make the behavior on X11 be the same as on Windows.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

None

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

This fix has no related issues.
