### PR TITLE
Add HotKeys Page to DevTools

### DIFF
--- a/src/Avalonia.Diagnostics/Diagnostics/DevToolsOptions.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/DevToolsOptions.cs
@@ -57,5 +57,10 @@ namespace Avalonia.Diagnostics
         /// Set the <see cref="DevToolsViewKind">kind</see> of diagnostic view that show at launch of DevTools
         /// </summary>
         public DevToolsViewKind LaunchView { get; init; }
+
+        /// <summary>
+        /// Gets or inits the <see cref="HotKeyConfiguration" /> used to activate DevTools features
+        /// </summary>
+        internal HotKeyConfiguration HotKeys { get; init; } = new();
     }
 }

--- a/src/Avalonia.Diagnostics/Diagnostics/HotKeyConfiguration.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/HotKeyConfiguration.cs
@@ -1,0 +1,32 @@
+﻿using Avalonia.Input;
+
+namespace Avalonia.Diagnostics
+{
+    internal class HotKeyConfiguration
+    {
+        /// <summary>
+        /// Freezes refreshing the Value Frames inspector for the selected Control
+        /// </summary>
+        public KeyGesture ValueFramesFreeze { get; init; } = new(Key.S, KeyModifiers.Alt);
+
+        /// <summary>
+        /// Resumes refreshing the Value Frames inspector for the selected Control
+        /// </summary>
+        public KeyGesture ValueFramesUnfreeze { get; init; } = new(Key.D, KeyModifiers.Alt);
+
+        /// <summary>
+        /// Inspects the hovered Control in the Logical or Visual Tree Page
+        /// </summary>
+        public KeyGesture InspectHoveredControl { get; init; } = new(Key.None, KeyModifiers.Shift | KeyModifiers.Control);
+
+        /// <summary>
+        /// Toggles the freezing of Popups which prevents visible Popups from closing so they can be inspected
+        /// </summary>
+        public KeyGesture TogglePopupFreeze { get; init; } = new(Key.F, KeyModifiers.Alt | KeyModifiers.Control);
+
+        /// <summary>
+        /// Saves a Screenshot of the Selected Control in the Logical or Visual Tree Page
+        /// </summary>
+        public KeyGesture ScreenshotSelectedControl { get; init; } = new(Key.F8);
+    }
+}

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/HotKeyPageViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/HotKeyPageViewModel.cs
@@ -1,21 +1,40 @@
 ﻿using System.Collections.ObjectModel;
+using Avalonia.Input;
 
-namespace Avalonia.Diagnostics.ViewModels;
-
-internal record HotKeyDescription(string Description, string LongDescription, string Gesture);
-internal class HotKeyPageViewModel : ViewModelBase
+namespace Avalonia.Diagnostics.ViewModels
 {
-    public ObservableCollection<HotKeyDescription> HotKeys { get; } = new();
+    internal record HotKeyDescription(string Gesture, string BriefDescription, string? DetailedDescription = null);
 
-    public HotKeyPageViewModel()
+    internal class HotKeyPageViewModel : ViewModelBase
     {
-        HotKeys = new()
+        private ObservableCollection<HotKeyDescription>? _hotKeyDescriptions;
+        public ObservableCollection<HotKeyDescription>? HotKeyDescriptions
         {
-            new("Enable Snapshot Frames", "Pauses refreshing the Value Frames inspector for the selected Control", "Alt+S"),
-            new("Disable Snapshot Frames", "Resumes refreshing the Value Frames inspector for the selected Control", "Alt+D"),
-            new("Inspect Control Under Pointer", "Inspects the hovered Control in the Logical or Visual Tree Page", "Ctrl+Shift"),
-            new("Toggle Popup Freeze", "Prevents visible Popups from closing so they can be inspected", "Ctrl+Alt+F"),
-            new("Screenshot Selected Control", "Saves a Screenshot of the Selected Control in the Logical or Visual Tree Page", "F8")
-        };
+            get => _hotKeyDescriptions;
+            private set => RaiseAndSetIfChanged(ref _hotKeyDescriptions, value);
+        }
+
+        public void SetOptions(DevToolsOptions options)
+        {
+            var hotKeys = options.HotKeys;
+
+            HotKeyDescriptions = new()
+            {
+                new(CreateDescription(options.Gesture), "Launch DevTools", "Launches DevTools to inspect the TopLevel that received the hotkey input"),
+                new(CreateDescription(hotKeys.ValueFramesFreeze), "Freeze Value Frames", "Pauses refreshing the Value Frames inspector for the selected Control"),
+                new(CreateDescription(hotKeys.ValueFramesUnfreeze), "Unfreeze Value Frames", "Resumes refreshing the Value Frames inspector for the selected Control"),
+                new(CreateDescription(hotKeys.InspectHoveredControl), "Inspect Control Under Pointer", "Inspects the hovered Control in the Logical or Visual Tree Page"),
+                new(CreateDescription(hotKeys.TogglePopupFreeze), "Toggle Popup Freeze", "Prevents visible Popups from closing so they can be inspected"),
+                new(CreateDescription(hotKeys.ScreenshotSelectedControl), "Screenshot Selected Control", "Saves a Screenshot of the Selected Control in the Logical or Visual Tree Page")
+            };
+        }
+
+        private string CreateDescription(KeyGesture gesture)
+        {
+            if (gesture.Key == Key.None && gesture.KeyModifiers != KeyModifiers.None)
+                return gesture.ToString().Replace("+None", "");
+            else
+                return gesture.ToString();
+        }
     }
 }

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/HotKeyPageViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/HotKeyPageViewModel.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.ObjectModel;
+
+namespace Avalonia.Diagnostics.ViewModels;
+
+internal record HotKeyDescription(string Description, string LongDescription, string Gesture);
+internal class HotKeyPageViewModel : ViewModelBase
+{
+    public ObservableCollection<HotKeyDescription> HotKeys { get; } = new();
+
+    public HotKeyPageViewModel()
+    {
+        HotKeys = new()
+        {
+            new("Enable Snapshot Frames", "Pauses refreshing the Value Frames inspector for the selected Control", "Alt+S"),
+            new("Disable Snapshot Frames", "Resumes refreshing the Value Frames inspector for the selected Control", "Alt+D"),
+            new("Inspect Control Under Pointer", "Inspects the hovered Control in the Logical or Visual Tree Page", "Ctrl+Shift"),
+            new("Toggle Popup Freeze", "Prevents visible Popups from closing so they can be inspected", "Ctrl+Alt+F"),
+            new("Screenshot Selected Control", "Saves a Screenshot of the Selected Control in the Logical or Visual Tree Page", "F8")
+        };
+    }
+}

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/MainViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/MainViewModel.cs
@@ -343,6 +343,8 @@ namespace Avalonia.Diagnostics.ViewModels
             ShowImplementedInterfaces = options.ShowImplementedInterfaces;
             FocusHighlighter = options.FocusHighlighterBrush;
             SelectedTab = (int)options.LaunchView;
+
+            _hotKeys.SetOptions(options);
         }
 
         public bool ShowImplementedInterfaces

--- a/src/Avalonia.Diagnostics/Diagnostics/ViewModels/MainViewModel.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/ViewModels/MainViewModel.cs
@@ -18,6 +18,7 @@ namespace Avalonia.Diagnostics.ViewModels
         private readonly TreePageViewModel _logicalTree;
         private readonly TreePageViewModel _visualTree;
         private readonly EventsPageViewModel _events;
+        private readonly HotKeyPageViewModel _hotKeys;
         private readonly IDisposable _pointerOverSubscription;
         private ViewModelBase? _content;
         private int _selectedTab;
@@ -40,6 +41,7 @@ namespace Avalonia.Diagnostics.ViewModels
             _logicalTree = new TreePageViewModel(this, LogicalTreeNode.Create(root), _pinnedProperties);
             _visualTree = new TreePageViewModel(this, VisualTreeNode.Create(root), _pinnedProperties);
             _events = new EventsPageViewModel(this);
+            _hotKeys = new HotKeyPageViewModel();
 
             UpdateFocusedControl();
 
@@ -194,6 +196,9 @@ namespace Avalonia.Diagnostics.ViewModels
                     case 2:
                         Content = _events;
                         break;
+                    case 3:
+                        Content = _hotKeys;
+                        break;
                     default:
                         Content = _logicalTree;
                         break;
@@ -229,6 +234,11 @@ namespace Avalonia.Diagnostics.ViewModels
         {
             get => _pointerOverElementName;
             private set => RaiseAndSetIfChanged(ref _pointerOverElementName, value);
+        }
+
+        public void ShowHotKeys()
+        {
+            SelectedTab = 3;
         }
 
         public void SelectControl(Control control)

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/HotKeyPageView.axaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/HotKeyPageView.axaml
@@ -1,0 +1,36 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:Avalonia.Diagnostics.ViewModels"
+             Padding="4"
+             x:Class="Avalonia.Diagnostics.Views.HotKeyPageView"
+             x:DataType="vm:HotKeyPageViewModel">
+  <Grid RowDefinitions="auto,*" Grid.IsSharedSizeScope="True">
+    <Grid>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition SharedSizeGroup="A" Width="auto" />
+        <ColumnDefinition Width="8" />
+        <ColumnDefinition SharedSizeGroup="B" Width="*" />
+      </Grid.ColumnDefinitions>
+
+      <TextBlock FontWeight="Bold" Text="Action" />
+      <TextBlock Grid.Column="2" FontWeight="Bold" Text="Gesture" />
+    </Grid>
+
+    <ItemsControl Grid.Row="1" Grid.ColumnSpan="3" ItemsSource="{Binding HotKeys}">
+      <ItemsControl.ItemTemplate>
+        <DataTemplate>
+          <Grid>
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition SharedSizeGroup="A" Width="auto" />
+              <ColumnDefinition Width="8" />
+              <ColumnDefinition SharedSizeGroup="B" Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Text="{Binding Description}" ToolTip.Tip="{Binding LongDescription}" />
+            <TextBlock Grid.Column="2" Text="{Binding Gesture}" />
+          </Grid>
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+  </Grid>
+</UserControl>

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/HotKeyPageView.axaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/HotKeyPageView.axaml
@@ -16,7 +16,7 @@
       <TextBlock Grid.Column="2" FontWeight="Bold" Text="Gesture" />
     </Grid>
 
-    <ItemsControl Grid.Row="1" Grid.ColumnSpan="3" ItemsSource="{Binding HotKeys}">
+    <ItemsControl Grid.Row="1" Grid.ColumnSpan="3" ItemsSource="{Binding HotKeyDescriptions}">
       <ItemsControl.ItemTemplate>
         <DataTemplate>
           <Grid>
@@ -26,7 +26,7 @@
               <ColumnDefinition SharedSizeGroup="B" Width="*" />
             </Grid.ColumnDefinitions>
 
-            <TextBlock Text="{Binding Description}" ToolTip.Tip="{Binding LongDescription}" />
+            <TextBlock Text="{Binding BriefDescription}" ToolTip.Tip="{Binding DetailedDescription}" />
             <TextBlock Grid.Column="2" Text="{Binding Gesture}" />
           </Grid>
         </DataTemplate>

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/HotKeyPageView.axaml.cs
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/HotKeyPageView.axaml.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Avalonia.Diagnostics.Views
+{
+    internal class HotKeyPageView : UserControl
+    {
+        public HotKeyPageView()
+        {
+            InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/MainView.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/MainView.xaml
@@ -72,6 +72,7 @@
             </MenuItem.Icon>
           </MenuItem>
         </MenuItem>
+        <MenuItem Header="_HotKeys" Command="{Binding ShowHotKeys}" />
       </MenuItem>
       <MenuItem Header="_Overlays">
         <MenuItem Header="Margin/padding" Command="{Binding ToggleVisualizeMarginPadding}">
@@ -255,6 +256,7 @@
       <TabStripItem Content="Logical Tree" />
       <TabStripItem Content="Visual Tree" />
       <TabStripItem Content="Events" />
+      <TabStripItem Content="HotKeys" IsVisible="False" />
     </TabStrip>
 
     <ContentControl Grid.Row="2"

--- a/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml
+++ b/src/Avalonia.Diagnostics/Diagnostics/Views/MainWindow.xaml
@@ -18,8 +18,5 @@
     <StyleInclude Source="avares://Avalonia.Diagnostics/Diagnostics/Controls/BrushEditor.axaml" />
     <StyleInclude Source="avares://Avalonia.Controls.ColorPicker/Themes/Simple/Simple.xaml" />
   </Window.Styles>
-  <Window.KeyBindings>
-    <KeyBinding Gesture="F8" Command="{Binding Shot}"/>
-  </Window.KeyBindings>
   <views:MainView/>
 </Window>


### PR DESCRIPTION
## What does the pull request do?

Fixes #15390 

Adds a HotKey page because there's no in-app discoverability of DevTools hotkeys. Otherwise, the user must check docs.

## What is the updated/expected behavior with this PR?

![devtools-hotkeys](https://github.com/AvaloniaUI/Avalonia/assets/1782158/ba7131dd-4fc6-4472-90cb-362e0930f11f)

Simple display of hotkeys, no mutability. Does not display the launch hotkey as that is mutable via `DevToolOptions` and would require some wiring. If the user doesn't know that hotkey, then how are they in DevTools to begin with?

Very recently, the "Styles" snapshot action was modified to "Value Frames". I reflect this in the hotkey descriptions, but other places still use Styles, including the DevTools docs page.

## How was the solution implemented (if it's not obvious)?

Adds an invisible `TabStripItem` for the `HotKeys` page to avoid visual crowding and avoid adding more complex navigation.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation
