### PR TITLE
Fixed NativeAOT on .NET 9

### DIFF
--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -169,12 +169,16 @@
     </ItemGroup>
   </Target>
 
-  <!-- For some reason the IL Compiler hardcodes $(IntermediateOutputPath)$(TargetName)$(TargetExt) instead of using @(IntermediateAssembly), change that to our assembly. -->
+  <!--
+    For some reason the IL Compiler hardcodes $(IntermediateOutputPath)$(TargetName)$(TargetExt)
+    instead of using @(IntermediateAssembly), change that to our assembly.
+    This is fixed in .NET 9.0 (https://github.com/dotnet/runtime/pull/99732)
+  -->
   <Target Name="InjectIlcAvaloniaXamlOutput"
           DependsOnTargets="InjectAvaloniaXamlOutput"
           AfterTargets="ComputeIlcCompileInputs"
           BeforeTargets="PrepareForILLink"
-          Condition="'@(AvaloniaResource)@(AvaloniaXaml)' != '' AND $(EnableAvaloniaXamlCompilation) != false">
+          Condition="$([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '9.0')) AND '@(AvaloniaResource)@(AvaloniaXaml)' != '' AND $(EnableAvaloniaXamlCompilation) != false">
     <ItemGroup>
       <ManagedBinary Remove="$(IntermediateOutputPath)$(TargetName)$(TargetExt)" />
       <ManagedBinary Include="@(_AvaloniaXamlCompiledAssembly)" />


### PR DESCRIPTION
## What does the pull request do?
This PR fixes NativeAOT compilation when targeting .NET 9.0.
See #15646 for details.

## How was the solution implemented (if it's not obvious)?
https://github.com/dotnet/runtime/pull/99732 means we don't need https://github.com/AvaloniaUI/Avalonia/pull/14966 anymore, so that target is now skipped on .NET ≥ 9.0.

Note that `TargetFrameworkVersion` is checked, and not `NETCoreSdkVersion`.
The fixed code is in the `Microsoft.DotNet.ILCompiler` package which depends on the target framework, not the SDK.

## Fixed issues
 - Fixes #15646
