### PR TITLE
Fix DrmOutputOptions.ConnectorTypeId naming

### DIFF
--- a/src/Linux/Avalonia.LinuxFramebuffer/DrmOutputOptions.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/DrmOutputOptions.cs
@@ -26,21 +26,21 @@ namespace Avalonia.LinuxFramebuffer
         public Color InitialBufferSwappingColor { get; set; } = new Color(0, 0, 0, 0);
 
         /// <summary>
-        /// specific the video mode with which the DrmOutput should be created, if it is not found it will fallback to the preferred mode.
-        /// If NULL preferred mode will be used.
+        /// Specifies the video mode with which the DrmOutput should be created, if it is not found it will fallback to the preferred mode.
+        /// If null, the preferred mode will be used.
         /// </summary>
         public PixelSize? VideoMode { get; set; }
 
         /// <summary>
-        /// Specific whether our connector is HDMI-A, DVI, DisplayPort, etc.
-        /// If NULL preferred connector will be used.
+        /// Specifies whether our connector is HDMI-A, DVI, DisplayPort, etc.
+        /// If null, the preferred connector will be used.
         /// </summary>
-        public DrmConnectorType? ConnectorType { get; init; }
+        public DrmConnectorType? ConnectorType { get; set; }
 
         /// <summary>
-        /// Specific whether connector id using for <see cref="ConnectorType"/>
-        /// If NULL preferred connector id will be used
+        /// Specifies the connector type ID used with <see cref="ConnectorType"/>.
+        /// If null, the preferred connector type ID will be used.
         /// </summary>
-        public uint? ConnectorType_Id { get; init; }
+        public uint? ConnectorTypeId { get; set; }
     }
 }

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmBindings.cs
@@ -28,7 +28,7 @@ namespace Avalonia.LinuxFramebuffer.Output
         internal List<uint> EncoderIds { get; } = new List<uint>();
         public List<DrmModeInfo> Modes { get; } = new List<DrmModeInfo>();
         public DrmConnectorType ConnectorType { get; }
-        public uint ConnectorType_Id { get; }
+        public uint ConnectorTypeId { get; }
         internal DrmConnector(drmModeConnector* conn)
         {
             Connection = conn->connection;
@@ -41,7 +41,7 @@ namespace Avalonia.LinuxFramebuffer.Output
             for (var c = 0; c < conn->count_modes; c++)
                 Modes.Add(new DrmModeInfo(ref conn->modes[c]));
             ConnectorType = (DrmConnectorType)conn->connector_type;
-            ConnectorType_Id = conn->connector_type_id;
+            ConnectorTypeId = conn->connector_type_id;
             if (conn->connector_type > KnownConnectorTypes.Length - 1)
                 Name = $"Unknown({conn->connector_type})-{conn->connector_type_id}";
             else

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
@@ -67,9 +67,9 @@ namespace Avalonia.LinuxFramebuffer.Output
                 connectors = connectors.Where(c => c.ConnectorType == connectorType);
             }
 
-            if (options?.ConnectorType_Id is { } connectorType_Id)
+            if (options?.ConnectorTypeId is { } connectorTypeId)
             {
-                connectors = connectors.Where(c => c.ConnectorType_Id == connectorType_Id);
+                connectors = connectors.Where(c => c.ConnectorTypeId == connectorTypeId);
             }
 
             var connector =


### PR DESCRIPTION
## What does the pull request do?
This PR renames `DrmOutputOptions.ConnectorType_Id` (introduced in #14878) to `ConnectorTypeId`.
The underscore doesn't respect the standard .NET naming style at all.

While code style is subject to discussion, I believe public API members should respect the established platform naming.

I'm aware this can be considered nitpicking, so feel free to close if needed.

I've also changed the `init` setters to `set` ones instead since that's what the other properties use. IMO, we should aim for consistency first and discuss separately whether we want *all* options to be `set` or `init`.

## Breaking changes
Yes if updating from 11.1.0-beta2, but it's a new property as far as stable versions are concerned.
