### PR TITLE
Allow nested BindingNotifications.

### DIFF
--- a/src/Avalonia.Base/Data/BindingNotification.cs
+++ b/src/Avalonia.Base/Data/BindingNotification.cs
@@ -57,7 +57,6 @@ namespace Avalonia.Data
         /// <param name="value">The binding value.</param>
         public BindingNotification(object? value)
         {
-            Debug.Assert(value is not BindingNotification);
             _value = value;
         }
 

--- a/src/Avalonia.Base/Data/Core/ExpressionNodes/ExpressionNode.cs
+++ b/src/Avalonia.Base/Data/Core/ExpressionNodes/ExpressionNode.cs
@@ -187,13 +187,20 @@ internal abstract class ExpressionNode
             else if (notification.ErrorType == BindingErrorType.DataValidationError)
             {
                 if (notification.HasValue)
-                    SetValue(notification.Value, notification.Error);
+                {
+                    if (notification.Value is BindingNotification n)
+                        SetValue(n);
+                    else
+                        SetValue(notification.Value, notification.Error);
+                }
                 else
+                {
                     SetDataValidationError(notification.Error!);
+                }
             }
             else
             {
-                SetValue(notification.Value, null);
+                SetValue(notification.Value);
             }
         }
         else


### PR DESCRIPTION
## What does the pull request do?

When the binding system refactor (#13970) was written, [a check](https://github.com/AvaloniaUI/Avalonia/pull/13970/files#diff-cfb25a491b9452e1815aa2c0d71465aaf81e99792a88a04a1a2ed572fd1930ffR60) was added to ensure that nested `BindingNotification`s didn't happen, and the refactor was written with the assumption that they wouldn't happen.

The problem is that they _do_ happen: when a source object implements both `INotifyDataErrorInfo` and had data annotations, then the nested data validation plugins would each wrap the value coming from the previous plugin in a new `BindingNotification`, resulting in nested `BindingNotifications`.

This adds support for nested binding notifications back in - even though IMO nesting binding notifications is a bug, if we're doing it and we previously supported it then we should continue to support it.

## Fixed issues

Fixes [#15201](https://github.com/AvaloniaUI/Avalonia/issues/15201)
