### PR TITLE
GetDpiForMonitor checks for Windows 8.0, but should check for 8.1

### DIFF
--- a/src/Windows/Avalonia.Win32/FramebufferManager.cs
+++ b/src/Windows/Avalonia.Win32/FramebufferManager.cs
@@ -88,7 +88,7 @@ namespace Avalonia.Win32
 
         private Vector GetCurrentDpi()
         {
-            if (UnmanagedMethods.ShCoreAvailable && Win32Platform.WindowsVersion > PlatformConstants.Windows8)
+            if (UnmanagedMethods.ShCoreAvailable && Win32Platform.WindowsVersion >= PlatformConstants.Windows8_1)
             {
                 var monitor =
                     UnmanagedMethods.MonitorFromWindow(_hwnd, UnmanagedMethods.MONITOR.MONITOR_DEFAULTTONEAREST);

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -937,7 +937,7 @@ namespace Avalonia.Win32
 
             RegisterTouchWindow(_hwnd, 0);
 
-            if (ShCoreAvailable && Win32Platform.WindowsVersion > PlatformConstants.Windows8)
+            if (ShCoreAvailable && Win32Platform.WindowsVersion >= PlatformConstants.Windows8_1)
             {
                 var monitor = MonitorFromWindow(
                     _hwnd,


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes #7284
Comparing windows version with Windows8_1 instead of Windows8. 
The crash occurs because the Windows Server 2012 version is 6.2.9200, which is greater than 6.2, and comparing it with version 6.2 is incorrect. The function `GetDpiForMonitor` is only supported from Windows Server 2012 R2 (version 6.3).

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The application crashes on Windows Server 2012.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Run application on Windows Server 2012 (version 6.2.9200), it should not crash on window creating.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
-->
Fixes #7284
