### PR TITLE
Enable KeyDown events unconditionally on MacOS

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -544,26 +544,15 @@
     
     //InputMethod is active
     if(_parent->InputMethod->IsActive()){
-        auto hasInputModifier = modifiers != AvnInputModifiersNone;
-        
-        //Handle keyDown first if an input modifier is present
-        if(hasInputModifier){
-            if([self handleKeyDown:timestamp withKey:key withPhysicalKey:physicalKey withModifiers:modifiers withKeySymbol:keySymbol]){
-                //User code has handled the event
-                _lastKeyDownEvent = nullptr;
-                
-                return;
-            }
+              
+        if([self handleKeyDown:timestamp withKey:key withPhysicalKey:physicalKey withModifiers:modifiers withKeySymbol:keySymbol]){
+            //User code has handled the event
+            _lastKeyDownEvent = nullptr;
+            
+            return;
         }
-        
-        if([[self inputContext] handleEvent:event] == NO){
-            //KeyDown has not been consumed by the input context
-                
-            //Only raise a keyDown if we don't have a modifier
-            if(!hasInputModifier){
-                [self handleKeyDown:timestamp withKey:key withPhysicalKey:physicalKey withModifiers:modifiers withKeySymbol:keySymbol];
-            }
-        }
+
+        [[self inputContext] handleEvent:event];
         
     }
     //InputMethod not active


### PR DESCRIPTION
## What does the pull request do?

KeyDown events were removed on MacOS from being fired for controls with an IME. 

On Windows & Linux, every KeyStroke generates a KeyDown Event, then a TextInputEvent, followed by a KeyUp event.
This also happens on MacOS, unless focus is on a control with an IME, where they KeyDown Events are being consumed, unless there is a modifier key present.

This removes the ability to use a Tunneling Event Handler to validate input, or check for a localized hotkey, and set the event as handled, so that the keystroke never makes it to the IME.

Currently, the following code for a TextBox (MyText) is never executed on MacOS, it functions correctly on Windows & Linux

```/* Does not appear to ever be invoked for Keys that cause TextInput*/
MyText.AddHandler(KeyDownEvent, (sender, args) =>
{
    Debugger.Break();
}, RoutingStrategies.Tunnel);
``` 

This PR fixes this behavior.

## What is the current behavior?
KeyDown events are consumed by the IME.


## What is the updated/expected behavior with this PR?
KeyDown events are fired unconditionally, allowing the equivalent functionality of a PreviewKeyDown from WPF land, implemented as the Tunnel routing strategy.


## How was the solution implemented (if it's not obvious)?
Remove conditional checks before calling handleKeyDown


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None Known, but because of the location of this code it obviously needs to be carefully considered.

## Obsoletions / Deprecations
N/A

## Fixed issues
Fixes #15727
