### PR TITLE
[X11] Blacklist SVGA3D gpu driver

### DIFF
--- a/src/Avalonia.X11/X11Platform.cs
+++ b/src/Avalonia.X11/X11Platform.cs
@@ -345,7 +345,12 @@ namespace Avalonia
             // llvmpipe is a software GL rasterizer. If it's returned by glGetString,
             // that usually means that something in the system is horribly misconfigured
             // and sometimes attempts to use GLX might cause a segfault
-            "llvmpipe"
+            "llvmpipe",
+            // SVGA3D is a driver for VMWare virtual GPU
+            // There were reports of various glitches like parts of the UI not being rendered
+            // Given that VMs are mostly used by testing, we've decided to blacklist that driver
+            // for now
+            "SVGA3D"
         };
 
         


### PR DESCRIPTION
There were reports of parts of the UI not being rendered when running Ubuntu 22.04 with VMWare VM. Those glitches go away with `LIBGL_ALWAYS_SOFTWARE=1`, so it's most likely some driver-specific issue that we aren't likely to fix on our side anyway.