### PR TITLE
Warning fixes: spring wave

### DIFF
--- a/build/Base.props
+++ b/build/Base.props
@@ -1,9 +1,6 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- '!NET6_0_OR_GREATER' equivalent -->
   <ItemGroup Condition="!('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')))">
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/build/ImageSharp.props
+++ b/build/ImageSharp.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.7" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.8" />
   </ItemGroup>
 </Project>

--- a/build/SampleApp.props
+++ b/build/SampleApp.props
@@ -1,13 +1,22 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <PropertyGroup Condition="'$(TargetFramework)'=='net461'" >
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\src\Avalonia.Desktop\Avalonia.Desktop.csproj" />
+
+  <ItemGroup Condition="'$(TargetFramework)'!='net461'">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)../src/Avalonia.Desktop/Avalonia.Desktop.csproj" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net461'">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)../src/Windows/Avalonia.Win32/Avalonia.Win32.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)../src/Skia/Avalonia.Skia/Avalonia.Skia.csproj" />
+  </ItemGroup>
+
   <Target Name="GatherReferences" AfterTargets="CoreCompile">
     <WriteLinesToFile File="$(TargetPath).refs"
                       Lines="@(ReferencePathWithRefAssemblies)"
                       Overwrite="true" />
   </Target>
+
 </Project>

--- a/samples/ControlCatalog.Desktop/Program.cs
+++ b/samples/ControlCatalog.Desktop/Program.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Linq;
 using Avalonia;
-using Avalonia.Controls;
 using Avalonia.Platform;
 using ControlCatalog.NetCore;
 using ControlCatalog.Pages;
@@ -29,7 +27,8 @@ namespace ControlCatalog
 
                     EmbedSample.Implementation = new EmbedSampleWin();
                 })
-                .UsePlatformDetect();
+                .UseWin32()
+                .UseSkia();
 
         private static void ConfigureAssetAssembly(AppBuilder builder)
         {

--- a/samples/ControlCatalog/Pages/OpenGl/OpenGlContent.cs
+++ b/samples/ControlCatalog/Pages/OpenGl/OpenGlContent.cs
@@ -183,7 +183,7 @@ internal class OpenGlContent
             Console.WriteLine(err);
     }
 
-    public string Info { get; private set; }
+    public string Info { get; private set; } = string.Empty;
     
     public unsafe void Init(GlInterface GL, GlVersion version)
     {

--- a/samples/ControlCatalog/Pages/OpenGl/OpenGlLeasePage.xaml.cs
+++ b/samples/ControlCatalog/Pages/OpenGl/OpenGlLeasePage.xaml.cs
@@ -169,7 +169,7 @@ public class OpenGlLeasePage : UserControl
         _knobs.PropertyChanged += KnobsPropertyChanged;
     }
 
-    private void KnobsPropertyChanged(object sender, AvaloniaPropertyChangedEventArgs change)
+    private void KnobsPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs change)
     {
         if (change.Property == GlPageKnobs.YawProperty
             || change.Property == GlPageKnobs.RollProperty
@@ -183,7 +183,7 @@ public class OpenGlLeasePage : UserControl
         Yaw = _knobs!.Yaw, Pitch = _knobs.Pitch, Roll = _knobs.Roll, Disco = _knobs.Disco
     };
     
-    private void ViewportAttachedToVisualTree(object sender, VisualTreeAttachmentEventArgs e)
+    private void ViewportAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
     {
         var visual = ElementComposition.GetElementVisual(_viewport!);
         if(visual == null)
@@ -206,7 +206,7 @@ public class OpenGlLeasePage : UserControl
         return size;
     }
 
-    private void ViewportDetachedFromVisualTree(object sender, VisualTreeAttachmentEventArgs e)
+    private void ViewportDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
     {
         _visual?.SendHandlerMessage(new DisposeMessage());
         _visual = null;

--- a/samples/ControlCatalog/Pages/OpenGlPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/OpenGlPage.xaml.cs
@@ -30,7 +30,7 @@ namespace ControlCatalog.Pages
             _knobs.PropertyChanged += KnobsPropertyChanged;
         }
 
-        private void KnobsPropertyChanged(object sender, AvaloniaPropertyChangedEventArgs change)
+        private void KnobsPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs change)
         {
             if (change.Property == GlPageKnobs.YawProperty
                 || change.Property == GlPageKnobs.RollProperty

--- a/samples/GpuInterop/VulkanDemo/VulkanImage.cs
+++ b/samples/GpuInterop/VulkanDemo/VulkanImage.cs
@@ -117,7 +117,8 @@ public unsafe class VulkanImage : IDisposable
             ImportMemoryWin32HandleInfoKHR handleImport = default;
             if (handleType == ExternalMemoryHandleTypeFlags.D3D11TextureBit && exportable)
             {
-                _d3dTexture2D = D3DMemoryHelper.CreateMemoryHandle(vk.D3DDevice, size, Format);
+                var d3dDevice = vk.D3DDevice ?? throw new NotSupportedException("Vulkan D3DDevice wasn't created");
+                _d3dTexture2D = D3DMemoryHelper.CreateMemoryHandle(d3dDevice, size, Format);
                 using var dxgi = _d3dTexture2D.QueryInterface<SharpDX.DXGI.Resource1>();
 
                 handleImport = new ImportMemoryWin32HandleInfoKHR

--- a/samples/UnloadableAssemblyLoadContext/UnloadableAssemblyLoadContext/AssemblyLoadContextH.cs
+++ b/samples/UnloadableAssemblyLoadContext/UnloadableAssemblyLoadContext/AssemblyLoadContextH.cs
@@ -22,13 +22,16 @@ public class AssemblyLoadContextH : AssemblyLoadContext
         Unloading += (sender) =>
         {
             AvaloniaPropertyRegistry.Instance.UnregisterByModule(sender.Assemblies.First().DefinedTypes);
-            Application.Current.Styles.Remove(MainWindow.Style);
-            AssetLoader.InvalidateAssemblyCache(sender.Assemblies.First().GetName().Name);
-            MainWindow.Style= null;
+
+            if (MainWindow.Style is { } style)
+                Application.Current?.Styles.Remove(style);
+
+            AssetLoader.InvalidateAssemblyCache(sender.Assemblies.First().GetName().Name!);
+            MainWindow.Style = null;
         };
     }
 
-    protected override Assembly Load(AssemblyName assemblyName)
+    protected override Assembly? Load(AssemblyName assemblyName)
     {
         var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
         if (assemblyPath != null)

--- a/samples/UnloadableAssemblyLoadContext/UnloadableAssemblyLoadContext/MainWindow.axaml.cs
+++ b/samples/UnloadableAssemblyLoadContext/UnloadableAssemblyLoadContext/MainWindow.axaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Threading;
@@ -33,11 +34,11 @@ public partial class MainWindow : Window
             this.AttachDevTools();
         }
     }
-    private PlugTool _plugTool;
+    private PlugTool? _plugTool;
     protected override void OnOpened(EventArgs e)
     {
         base.OnOpened(e);
-        test();
+        Test();
         //Content = _plugTool.FindControl("UnloadableAssemblyLoadContextPlug.TestControl");
 
 
@@ -75,7 +76,7 @@ public partial class MainWindow : Window
         
         
         Thread.CurrentThread.IsBackground = false;
-        var weakReference = _plugTool.Unload();
+        var weakReference = _plugTool!.Unload();
         while (weakReference.IsAlive)
         {
             GC.Collect();
@@ -88,8 +89,9 @@ public partial class MainWindow : Window
         
     }
 
-    public static IStyle Style;
-    public  void test(){
+    public static IStyle? Style;
+
+    public void Test() {
         
         //Notice : 你可以删除UnloadableAssemblyLoadContextPlug.dll所在文件夹中有关Avalonia的所有Dll,但这不是必须的
         //Notice : You can delete all Dlls about Avalonia in the folder where UnloadableAssemblyLoadContextPlug.dll is located, but this is not necessary
@@ -97,7 +99,6 @@ public partial class MainWindow : Window
         var AssemblyLoadContextH = new AssemblyLoadContextH(fileInfo.FullName,"test");
         
         var assembly = AssemblyLoadContextH.LoadFromAssemblyPath(fileInfo.FullName);
-        var assemblyDescriptorResolver = 
         _plugTool=new PlugTool();
         _plugTool.AssemblyLoadContextH = AssemblyLoadContextH;
       
@@ -106,13 +107,13 @@ public partial class MainWindow : Window
         styleInclude.Source=new Uri("ControlStyle.axaml", UriKind.Relative);
         styles.Add(styleInclude);
         Style = styles;
-        Application.Current.Styles.Add(styles);
+        Application.Current!.Styles.Add(styles);
         foreach (var type in assembly.GetTypes())
         {
             if (type.FullName=="AvaloniaPlug.Window1")
             {
                 //创建type实例
-                Window instance = (Window)type.GetConstructor( new Type[0]).Invoke(null);
+                Window? instance = (Window)type.GetConstructor([])!.Invoke(null);
                 
                 Dispatcher.UIThread.InvokeAsync(() =>
                 {

--- a/samples/UnloadableAssemblyLoadContext/UnloadableAssemblyLoadContext/PlugTool.cs
+++ b/samples/UnloadableAssemblyLoadContext/UnloadableAssemblyLoadContext/PlugTool.cs
@@ -6,23 +6,23 @@ namespace UnloadableAssemblyLoadContext;
 
 public class PlugTool
 {
-    public AssemblyLoadContextH AssemblyLoadContextH;
+    public AssemblyLoadContextH? AssemblyLoadContextH;
     public WeakReference Unload()
     {
        var weakReference = new WeakReference(AssemblyLoadContextH);
-        AssemblyLoadContextH.Unload();
+        AssemblyLoadContextH?.Unload();
         AssemblyLoadContextH = null;
         return weakReference;
     }
 
     public Control? FindControl(string type)
     {
-        var type1 = AssemblyLoadContextH.Assemblies.
+        var type1 = AssemblyLoadContextH!.Assemblies.
                                          FirstOrDefault(x => x.GetName().Name == "UnloadableAssemblyLoadContextPlug")?.
                                          GetType(type);
-        if (type1.IsSubclassOf(typeof(Control)))
+        if (type1 is not null && type1.IsSubclassOf(typeof(Control)))
         {
-            var constructorInfo = type1.GetConstructor(  Type.EmptyTypes).Invoke(null) as Control;
+            var constructorInfo = type1.GetConstructor([])!.Invoke(null) as Control;
             return constructorInfo;
         }
 

--- a/samples/UnloadableAssemblyLoadContext/UnloadableAssemblyLoadContext/UnloadableAssemblyLoadContext.csproj
+++ b/samples/UnloadableAssemblyLoadContext/UnloadableAssemblyLoadContext/UnloadableAssemblyLoadContext.csproj
@@ -10,19 +10,10 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <Compile Update="**\*.xaml.cs">
-      <DependentUpon>%(Filename)</DependentUpon>
-    </Compile>
-    <AvaloniaResource Include="**\*.xaml">
-      <SubType>Designer</SubType>
-    </AvaloniaResource>
-    <AvaloniaResource Include="Assets\*" />
-    <AvaloniaResource Include="Assets\Fonts\*" />
+    <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />
+    <AvaloniaResource Include="**\*.xaml" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Models\"/>
-    <AvaloniaResource Include="Assets\**"/>
-  </ItemGroup>
+
   <ImportGroup>
     <Import Project="..\..\..\build\BuildTargets.targets" Condition="Exists('..\..\..\build\BuildTargets.targets')" />
     <Import Project="..\..\..\build\SourceGenerators.props" />

--- a/samples/UnloadableAssemblyLoadContext/UnloadableAssemblyLoadContextPlug/Program.cs
+++ b/samples/UnloadableAssemblyLoadContext/UnloadableAssemblyLoadContextPlug/Program.cs
@@ -1,9 +1,0 @@
-﻿namespace AvaloniaPlug;
-
-class Program
-{
-    // Initialization code. Don't use any Avalonia, third-party APIs or any
-    // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
-    // yet and stuff might break.
-    private static string test = "23";
-}

--- a/samples/UnloadableAssemblyLoadContext/UnloadableAssemblyLoadContextPlug/Window1.axaml
+++ b/samples/UnloadableAssemblyLoadContext/UnloadableAssemblyLoadContextPlug/Window1.axaml
@@ -2,7 +2,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:avaloniaPlug="clr-namespace:AvaloniaPlug"
         xmlns:unloadableAssemblyLoadContextPlug="clr-namespace:UnloadableAssemblyLoadContextPlug"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="UnloadableAssemblyLoadContextPlug.Window1"

--- a/samples/UnloadableAssemblyLoadContext/UnloadableAssemblyLoadContextPlug/Window1.axaml.cs
+++ b/samples/UnloadableAssemblyLoadContext/UnloadableAssemblyLoadContextPlug/Window1.axaml.cs
@@ -1,8 +1,5 @@
-﻿using System.Diagnostics;
-using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
-using AvaloniaPlug;
 
 namespace UnloadableAssemblyLoadContextPlug;
 

--- a/src/Avalonia.Base/Compatibility/TrimmingAttributes.cs
+++ b/src/Avalonia.Base/Compatibility/TrimmingAttributes.cs
@@ -1,4 +1,6 @@
-﻿#pragma warning disable MA0048 // File name must match type name
+﻿#nullable enable
+
+#pragma warning disable MA0048 // File name must match type name
 // https://github.com/dotnet/runtime/tree/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis
 
 // Licensed to the .NET Foundation under one or more agreements.

--- a/src/Avalonia.Base/Platform/RenderTargetProperties.cs
+++ b/src/Avalonia.Base/Platform/RenderTargetProperties.cs
@@ -1,8 +1,10 @@
+using System.Diagnostics.CodeAnalysis;
 using Avalonia.Metadata;
 
 namespace Avalonia.Platform;
 
 [PrivateApi]
+[SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Private API, not meant to be compared")]
 public struct RenderTargetProperties
 {
     /// <summary>
@@ -21,6 +23,7 @@ public struct RenderTargetProperties
 }
 
 [PrivateApi]
+[SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Private API, not meant to be compared")]
 public struct RenderTargetDrawingContextProperties
 {
     /// <summary>

--- a/src/Avalonia.Base/PropertyStore/ValueStore.cs
+++ b/src/Avalonia.Base/PropertyStore/ValueStore.cs
@@ -468,7 +468,6 @@ namespace Avalonia.PropertyStore
         /// </summary>
         /// <param name="entry">The binding entry.</param>
         /// <param name="priority">The priority of binding which produced a new value.</param>
-        [Obsolete("TODO: Remove?")]
         public void OnBindingValueChanged(
             IValueEntry entry,
             BindingPriority priority)
@@ -592,7 +591,6 @@ namespace Avalonia.PropertyStore
         /// </summary>
         /// <param name="property">The previously bound property.</param>
         /// <param name="observer">The observer.</param>
-        [Obsolete("TODO: Remove?")]
         public void OnLocalValueBindingCompleted(AvaloniaProperty property, IDisposable observer)
         {
             if (_localValueBindings is not null &&

--- a/src/Avalonia.Base/Rendering/Composition/Server/DrawingContextProxy.cs
+++ b/src/Avalonia.Base/Rendering/Composition/Server/DrawingContextProxy.cs
@@ -10,9 +10,6 @@ using Avalonia.Utilities;
 
 namespace Avalonia.Rendering.Composition.Server;
 
-/// <summary>
-
-/// </summary>
 internal partial class CompositorDrawingContextProxy : IDrawingContextImpl,
     IDrawingContextWithAcrylicLikeSupport, IDrawingContextImplWithEffects
 {

--- a/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
+++ b/src/Avalonia.FreeDesktop/DBusTrayIconImpl.cs
@@ -21,7 +21,7 @@ namespace Avalonia.FreeDesktop
         private readonly OrgFreedesktopDBus? _dBus;
 
         private IDisposable? _serviceWatchDisposable;
-        private StatusNotifierItemDbusObj? _statusNotifierItemDbusObj;
+        private readonly StatusNotifierItemDbusObj? _statusNotifierItemDbusObj;
         private OrgKdeStatusNotifierWatcher? _statusNotifierWatcher;
         private (int, int, byte[]) _icon;
 
@@ -115,7 +115,7 @@ namespace Avalonia.FreeDesktop
             await _dBus!.RequestNameAsync(_sysTrayServiceName, 0);
             await _statusNotifierWatcher.RegisterStatusNotifierItemAsync(_sysTrayServiceName);
 
-            _statusNotifierItemDbusObj.SetTitleAndTooltip(_tooltipText);
+            _statusNotifierItemDbusObj!.SetTitleAndTooltip(_tooltipText);
             _statusNotifierItemDbusObj.SetIcon(_icon);
             _statusNotifierItemDbusObj.ActivationDelegate += OnClicked;
         }

--- a/src/Avalonia.Vulkan/Avalonia.Vulkan.csproj
+++ b/src/Avalonia.Vulkan/Avalonia.Vulkan.csproj
@@ -14,4 +14,9 @@
     <Import Project="..\..\build\SourceGenerators.props" />
     <Import Project="..\..\build\TrimmingEnable.props" />
     <Import Project="..\..\build\NullableEnable.props" />
+
+  <ItemGroup>
+    <Compile Remove="..\Shared\SourceGeneratorAttributes.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Avalonia.Vulkan/VulkanImageInfo.cs
+++ b/src/Avalonia.Vulkan/VulkanImageInfo.cs
@@ -1,8 +1,6 @@
-using System;
-
 namespace Avalonia.Vulkan;
 
-public struct VulkanImageInfo
+public record struct VulkanImageInfo
 {
     public uint Format { get; set; }
     public PixelSize PixelSize { get; set; }

--- a/src/Avalonia.X11/Vulkan/VulkanSupport.cs
+++ b/src/Avalonia.X11/Vulkan/VulkanSupport.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -13,7 +15,7 @@ internal class VulkanSupport
     [DllImport("libvulkan.so.1")]
     private static extern IntPtr vkGetInstanceProcAddr(IntPtr instance, string name);
     
-    public static VulkanPlatformGraphics? TryInitialize(X11Info info, VulkanOptions options)
+    public static VulkanPlatformGraphics? TryInitialize(X11Info info, VulkanOptions? options)
     {
         s_offscreenWindow = XLib.XCreateSimpleWindow(info.DeferredDisplay,
             XLib.XDefaultRootWindow(info.DeferredDisplay), 0, 0, 1,

--- a/src/Avalonia.X11/X11FramebufferSurface.cs
+++ b/src/Avalonia.X11/X11FramebufferSurface.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using Avalonia.Controls.Platform.Surfaces;
 using Avalonia.Platform;
@@ -65,7 +67,7 @@ namespace Avalonia.X11
             }
 
             properties = new FramebufferLockProperties(framebufferValid);
-            return _fb.Lock(new Vector(96, 96), Blit);
+            return _fb!.Lock(new Vector(96, 96), Blit);
         }
 
         public IFramebufferRenderTarget CreateFramebufferRenderTarget()

--- a/src/Browser/Avalonia.Browser/Rendering/RenderWorker.cs
+++ b/src/Browser/Avalonia.Browser/Rendering/RenderWorker.cs
@@ -101,7 +101,9 @@ public partial class RenderWorker
                 Name = "Manual JS worker"
             };
             _setExtLoop.Invoke(null, [th]);
+#pragma warning disable CA1416
             th.Start();
+#pragma warning restore CA1416
             return tcs.Task;
         }
         

--- a/src/Browser/Avalonia.Browser/build/Avalonia.Browser.targets
+++ b/src/Browser/Avalonia.Browser/build/Avalonia.Browser.targets
@@ -6,7 +6,7 @@
   <ItemGroup>
     <!-- So we can access Emscripten APIs -->
     <EmccExportedRuntimeMethod Include="GL" />
-    <EmccExportedRuntimeMethod Include="PThread" />
+    <EmccExportedRuntimeMethod Include="PThread" Condition="'$(WasmEnableThreads)' == 'true'" />
   </ItemGroup>
   
   <!-- Fallback for applications without StaticWebAssetsEnabled (legacy WASM SDK) -->

--- a/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackend.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Input/LibInput/LibInputBackend.cs
@@ -51,7 +51,7 @@ namespace Avalonia.LinuxFramebuffer.Input.LibInput
                     libinput_dispatch(ctx);
                 }
 
-                pollfd pfd = new pollfd { fd = fd, events = 1 };
+                var pfd = new PollFd { fd = fd, events = 1 };
                 NativeUnsafeMethods.poll(&pfd, new IntPtr(1), 10);
             }
         }

--- a/src/Linux/Avalonia.LinuxFramebuffer/NativeUnsafeMethods.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/NativeUnsafeMethods.cs
@@ -35,7 +35,7 @@ namespace Avalonia.LinuxFramebuffer
 
 
         [DllImport("libc", EntryPoint = "poll", SetLastError = true)]
-        public static extern int poll(pollfd* fds, IntPtr nfds, int timeout);
+        public static extern int poll(PollFd* fds, IntPtr nfds, int timeout);
 
         [DllImport("libevdev.so.2", EntryPoint = "libevdev_new_from_fd", SetLastError = true)]
         public static extern int libevdev_new_from_fd(int fd, out IntPtr dev);
@@ -66,7 +66,7 @@ namespace Avalonia.LinuxFramebuffer
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    struct pollfd {
+    struct PollFd {
         public int   fd;         /* file descriptor */
         public short events;     /* requested events */
         public short revents;    /* returned events */

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/DrmOutput.cs
@@ -311,7 +311,7 @@ namespace Avalonia.LinuxFramebuffer.Output
                         };
                         while (waitingForFlip)
                         {
-                            var pfd = new pollfd {events = 1, fd = _parent._card.Fd};
+                            var pfd = new PollFd {events = 1, fd = _parent._card.Fd};
                             poll(&pfd, new IntPtr(1), -1);
                             drmHandleEvent(_parent._card.Fd, &ctx);
                         }

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/FbDevBackBuffer.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/FbDevBackBuffer.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Avalonia.Platform;

--- a/src/Linux/Avalonia.LinuxFramebuffer/Output/FbDevOutputOptions.cs
+++ b/src/Linux/Avalonia.LinuxFramebuffer/Output/FbDevOutputOptions.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Avalonia.Platform;
 
 namespace Avalonia.LinuxFramebuffer.Output;
@@ -9,12 +11,14 @@ public class FbDevOutputOptions
     /// Defaults to the value in environment variable FRAMEBUFFER or /dev/fb0 when FRAMEBUFFER is not set
     /// </summary>
     public string? FileName { get; set; }
+
     /// <summary>
     /// The required pixel format for the frame buffer.
     /// A null value will leave the frame buffer in the current pixel format.
     /// Otherwise sets the frame buffer to the required format
     /// </summary>
     public PixelFormat? PixelFormat { get; set; }
+
     /// <summary>
     /// If set to true, double-buffering will be disabled and scene will be composed directly into mmap-ed memory region
     /// While this mode saves a blit, you need to check if it won't cause rendering artifacts your particular device.

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/IncludeXamlIlSre.props
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/IncludeXamlIlSre.props
@@ -9,15 +9,8 @@
     <Content Remove="$(MSBuildThisFileDirectory)\xamlil.github\**\*.*" />
     <Compile Remove="$(MSBuildThisFileDirectory)\xamlil.github\**\*.*" />
     <Compile Include="$(MSBuildThisFileDirectory)\xamlil.github\src\XamlX\**\*.cs" />
+    <Compile Remove="$(MSBuildThisFileDirectory)\xamlil.github\src\XamlX\Compatibility\*.cs" />
     <Compile Remove="$(MSBuildThisFileDirectory)\xamlil.github\**\obj\**\*.cs" />
-
-    <!-- Polyfills used by XamlX, but re-imported from this repository -->
-    <Compile Include="$(MSBuildThisFileDirectory)\..\..\Avalonia.Base\Metadata\NullableAttributes.cs" Link="NullableAttributes.cs" Visible="False" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\..\Avalonia.Base\Compatibility\TrimmingAttributes.cs" Link="TrimmingAttributes.cs" Visible="False" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\..\Shared\IsExternalInit.cs" Link="Compatibility\IsExternalInit.cs" />
-
-    <!-- Utilities used by XamlX Avalonia SRE -->
-    <Compile Include="$(MSBuildThisFileDirectory)\..\..\Avalonia.Base\Utilities\StringBuilderCache.cs" Link="Utilities\StringBuilderCache.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="!('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')))">

--- a/src/tools/Avalonia.Designer.HostApp/Avalonia.Designer.HostApp.csproj
+++ b/src/tools/Avalonia.Designer.HostApp/Avalonia.Designer.HostApp.csproj
@@ -14,6 +14,9 @@
     <Compile Include="..\..\..\src\Markup\Avalonia.Markup.Xaml.Loader\CompilerExtensions\**\*.cs" />
     <Compile Include="..\..\..\src\Markup\Avalonia.Markup.Xaml.Loader\AvaloniaXamlIlRuntimeCompiler.cs" />
     <Compile Include="..\..\..\src\Markup\Avalonia.Markup.Xaml.Loader\CompilerDynamicDependencies.cs" />
+    <Compile Include="..\..\..\src\Avalonia.Base\Metadata\NullableAttributes.cs" Link="Compatibility\NullableAttributes.cs" />
+    <Compile Include="..\..\..\src\Avalonia.Base\Compatibility\TrimmingAttributes.cs" Link="Compatibility\TrimmingAttributes.cs" />
+    <Compile Include="..\..\..\src\Shared\IsExternalInit.cs" Link="Compatibility\IsExternalInit.cs" />
   </ItemGroup>
   <Import Project="..\..\..\src\Markup\Avalonia.Markup.Xaml.Loader\IncludeXamlIlSre.props" />
   <Import Project="..\..\..\build\DevAnalyzers.props" />

--- a/tests/Avalonia.RenderTests.WpfCompare/CrossTestBase.cs
+++ b/tests/Avalonia.RenderTests.WpfCompare/CrossTestBase.cs
@@ -44,7 +44,7 @@ public class CrossTestBase
 
         while (path.Length > 0 && Path.GetFileName(path) != "tests")
         {
-            path = Path.GetDirectoryName(path);
+            path = Path.GetDirectoryName(path)!;
         }
 
         return path;

--- a/tests/Avalonia.RenderTests.WpfCompare/CrossUI.Wpf.cs
+++ b/tests/Avalonia.RenderTests.WpfCompare/CrossUI.Wpf.cs
@@ -266,13 +266,15 @@ namespace Avalonia.RenderTests.WpfCompare
             {
                 PenLineCap.Flat => WPenLineCap.Flat,
                 PenLineCap.Round => WPenLineCap.Round,
-                PenLineCap.Square => WPenLineCap.Square
+                PenLineCap.Square => WPenLineCap.Square,
+                _ => throw new InvalidOperationException()
             };
             var join = pen.LineJoin switch
             {
                 PenLineJoin.Bevel => WPenLineJoin.Bevel,
                 PenLineJoin.Miter => WPenLineJoin.Miter,
-                PenLineJoin.Round => WPenLineJoin.Round
+                PenLineJoin.Round => WPenLineJoin.Round,
+                _ => throw new InvalidOperationException()
             };
 
             return new Pen(ConvertBrush(pen.Brush), pen.Thickness)

--- a/tests/Avalonia.RenderTests/CrossTests/CrossGeometryTests.cs
+++ b/tests/Avalonia.RenderTests/CrossTests/CrossGeometryTests.cs
@@ -120,7 +120,6 @@ public class CrossGeometryTests : CrossTestBase
         InlineData(PenLineCap.Round, PenLineJoin.Bevel),
         InlineData(PenLineCap.Round, PenLineJoin.Miter),
     ]
-#endif
     public void Should_Properly_CloseFigure(PenLineCap lineCap, PenLineJoin lineJoin)
     {
         var geometry = new CrossPathGeometry();
@@ -156,4 +155,5 @@ public class CrossGeometryTests : CrossTestBase
         RenderAndCompare(control,
             $"{nameof(Should_Properly_CloseFigure)}_{lineCap}_{lineJoin}");
     }
+#endif
 }

--- a/tests/Avalonia.RenderTests/CrossUI/CrossUI.Avalonia.cs
+++ b/tests/Avalonia.RenderTests/CrossUI/CrossUI.Avalonia.cs
@@ -200,7 +200,8 @@ namespace Avalonia.Direct2D1.RenderTests.CrossUI
                                         Point1 = q.Point1,
                                         Point2 = q.Point2,
                                         IsStroked = q.IsStroked
-                                    }
+                                    },
+                                    _ => throw new InvalidOperationException()
                                 }))
                         }))
                 };

--- a/tests/Avalonia.RenderTests/CrossUI/CrossUI.cs
+++ b/tests/Avalonia.RenderTests/CrossUI/CrossUI.cs
@@ -162,13 +162,13 @@ public abstract record class CrossPathSegment(bool IsStroked)
 
 public class CrossDrawingBrush : CrossTileBrush
 {
-    public CrossDrawing Drawing;
+    public required CrossDrawing Drawing { get; set; }
 }
 
 public class CrossPen
 {
-    public CrossBrush Brush;
-    public double Thickness = 1;
+    public required CrossBrush Brush { get; set; }
+    public double Thickness { get; set; } = 1;
     public PenLineJoin LineJoin { get; set; } = PenLineJoin.Miter;
     public PenLineCap LineCap { get; set; } = PenLineCap.Flat;
 }
@@ -212,7 +212,7 @@ public class CrossBitmapImage : CrossImage
 
 public class CrossDrawingImage : CrossImage
 {
-    public CrossDrawing Drawing;
+    public required CrossDrawing Drawing { get; set; }
 }
 
 
@@ -251,12 +251,14 @@ public class CrossFuncControl : CrossControl
 
 public class CrossImageControl : CrossControl
 {
-    public CrossImage Image;
+    public required CrossImage Image { get; set; }
+
     public override void Render(ICrossDrawingContext ctx)
     {
         base.Render(ctx);
         var rc = new Rect(Bounds.Size);
-        ctx.DrawImage(Image, rc);
+        var image = Image;
+        ctx.DrawImage(image, rc);
     }
 }
 

--- a/tests/Avalonia.Skia.RenderTests/CrossTestBase.cs
+++ b/tests/Avalonia.Skia.RenderTests/CrossTestBase.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 using Avalonia.Skia.RenderTests;
@@ -35,6 +37,8 @@ public class CrossTestBase : IDisposable
 
     protected void RenderAndCompare(CrossControl root, [CallerMemberName] string? testName = null, double dpi = 96)
     {
+        ArgumentException.ThrowIfNullOrEmpty(testName, nameof(testName));
+
         var dir = Path.Combine(TestRenderHelper.GetTestsDirectory(), "TestFiles", "CrossTests", _groupName);
         if (!Directory.Exists(dir))
             Directory.CreateDirectory(dir);


### PR DESCRIPTION
It's spring, warnings again are blooming, now's the time for fixing!

Noteworthy changes:
 - Base: remove internal `Obsolete` attributes on `ValueStore` (with @grokys' approval).
 - RenderTests: updated ImageSharp to 2.1.8 (only used in tests, but has known vulnerabilities).
 - Browser: only enable `PThread` if `WasmEnableThreads` is true.
 - ControlCatalog.Desktop: reference Win32+Skia directly to avoid bringing incompatible packages to net461.
