### PR TITLE
Validate all width/height properties of Layoutable when they are set

### DIFF
--- a/src/Avalonia.Base/Layout/Layoutable.cs
+++ b/src/Avalonia.Base/Layout/Layoutable.cs
@@ -74,37 +74,37 @@ namespace Avalonia.Layout
         /// Defines the <see cref="Width"/> property.
         /// </summary>
         public static readonly StyledProperty<double> WidthProperty =
-            AvaloniaProperty.Register<Layoutable, double>(nameof(Width), double.NaN);
+            AvaloniaProperty.Register<Layoutable, double>(nameof(Width), double.NaN, validate: ValidateDimension);
 
         /// <summary>
         /// Defines the <see cref="Height"/> property.
         /// </summary>
         public static readonly StyledProperty<double> HeightProperty =
-            AvaloniaProperty.Register<Layoutable, double>(nameof(Height), double.NaN);
+            AvaloniaProperty.Register<Layoutable, double>(nameof(Height), double.NaN, validate: ValidateDimension);
 
         /// <summary>
         /// Defines the <see cref="MinWidth"/> property.
         /// </summary>
         public static readonly StyledProperty<double> MinWidthProperty =
-            AvaloniaProperty.Register<Layoutable, double>(nameof(MinWidth));
+            AvaloniaProperty.Register<Layoutable, double>(nameof(MinWidth), validate: ValidateMinimumDimension);
 
         /// <summary>
         /// Defines the <see cref="MaxWidth"/> property.
         /// </summary>
         public static readonly StyledProperty<double> MaxWidthProperty =
-            AvaloniaProperty.Register<Layoutable, double>(nameof(MaxWidth), double.PositiveInfinity);
+            AvaloniaProperty.Register<Layoutable, double>(nameof(MaxWidth), double.PositiveInfinity, validate: ValidateMaximumDimension);
 
         /// <summary>
         /// Defines the <see cref="MinHeight"/> property.
         /// </summary>
         public static readonly StyledProperty<double> MinHeightProperty =
-            AvaloniaProperty.Register<Layoutable, double>(nameof(MinHeight));
+            AvaloniaProperty.Register<Layoutable, double>(nameof(MinHeight), validate: ValidateMinimumDimension);
 
         /// <summary>
         /// Defines the <see cref="MaxHeight"/> property.
         /// </summary>
         public static readonly StyledProperty<double> MaxHeightProperty =
-            AvaloniaProperty.Register<Layoutable, double>(nameof(MaxHeight), double.PositiveInfinity);
+            AvaloniaProperty.Register<Layoutable, double>(nameof(MaxHeight), double.PositiveInfinity, validate: ValidateMaximumDimension);
 
         /// <summary>
         /// Defines the <see cref="Margin"/> property.
@@ -152,6 +152,10 @@ namespace Avalonia.Layout
                 HorizontalAlignmentProperty,
                 VerticalAlignmentProperty);
         }
+
+        private static bool ValidateDimension(double value) => double.IsNaN(value) || ValidateMinimumDimension(value);
+        private static bool ValidateMinimumDimension(double value) => !double.IsPositiveInfinity(value) && ValidateMaximumDimension(value);
+        private static bool ValidateMaximumDimension(double value) => value >= 0;
 
         /// <summary>
         /// Occurs when the element's effective viewport changes.

--- a/tests/Avalonia.Base.UnitTests/Layout/LayoutableTests.cs
+++ b/tests/Avalonia.Base.UnitTests/Layout/LayoutableTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.UnitTests;
@@ -385,6 +386,29 @@ namespace Avalonia.Base.UnitTests.Layout
             Assert.True(target.IsMeasureValid);
             Assert.True(target.IsArrangeValid);
             Assert.Equal(default, child.DesiredSize);
+        }
+
+        [Fact]
+        public void Size_Properties_Reject_Invalid_Values()
+        {
+            var target = new Layoutable();
+
+            Assert.Multiple(() =>
+            {
+                SetShouldThrow([Layoutable.WidthProperty, Layoutable.HeightProperty], double.PositiveInfinity);
+                SetShouldThrow([Layoutable.WidthProperty, Layoutable.HeightProperty], -10);
+
+                SetShouldThrow([Layoutable.MinWidthProperty, Layoutable.MinHeightProperty], double.PositiveInfinity);
+                SetShouldThrow([Layoutable.MinWidthProperty, Layoutable.MinHeightProperty], -10);
+
+                SetShouldThrow([Layoutable.MaxWidthProperty, Layoutable.MaxHeightProperty], -10);
+
+                void SetShouldThrow(IEnumerable<StyledProperty<double>> properies, double value)
+                {
+                    foreach (var prop in properies)
+                        Assert.Throws<ArgumentException>(() => target.SetValue(prop, value));
+                }
+            });
         }
 
         private class TestLayoutable : Layoutable


### PR DESCRIPTION
It is currently possible to set the `Width`, `Height` and associated min/max properties of `Layoutable` to values which result in a `InvalidOperationException` when `Measure` is called.

If the control is visible, then changing the properties will immediately trigger a new measure and the exception above will be thrown. But if the control is not visible, then the exception will not be thrown until later on, and the point at which the invalid value was set will not be known.

This behaviour makes validation and debugging harder. Users of Avalonia must validate the values they set manually, which means duplicating logic from inside Avalonia's private methods.

## What is the updated/expected behavior with this PR?
The relevant properties now have validation methods which immediately block invalid values, no matter what state the control is in.

An exception will be thrown when an invalid value is set. This allows immediate error handling with a try/catch block.

The exception message will be something like `-10 is not a valid value for 'Width'`, which is considerably more useful than `Invalid size returned for Measure`, which is the message of the exception that would otherwise be thrown by `Measure`.

## Breaking changes
It's possible that a custom control somewhere supports values that the validation methods in this PR reject. This can happen if its overridden `MeasureOverride` method continues to return a valid size.

This weird situation could be worked around by providing new properties on the custom control which don't block negative or infinite values.

## Obsoletions / Deprecations
None