### PR TITLE
Fix Android app randomly hangs

### DIFF
--- a/src/Android/Avalonia.Android/AvaloniaActivity.cs
+++ b/src/Android/Avalonia.Android/AvaloniaActivity.cs
@@ -122,6 +122,9 @@ public class AvaloniaActivity : AppCompatActivity, IAvaloniaActivity
         {
             attributes.LayoutInDisplayCutoutMode = LayoutInDisplayCutoutMode.ShortEdges;
         }
+
+        // We inform the ContentView that it has become visible. OnVisibleChanged() sometimes doesn't get called. Issue #15807.
+        _view?.OnVisibilityChanged(true);
     }
 
     protected override void OnDestroy()

--- a/src/Android/Avalonia.Android/AvaloniaView.cs
+++ b/src/Android/Avalonia.Android/AvaloniaView.cs
@@ -68,9 +68,9 @@ namespace Avalonia.Android
             OnVisibilityChanged(visibility == ViewStates.Visible);
         }
 
-        private void OnVisibilityChanged(bool isVisible)
+        internal void OnVisibilityChanged(bool isVisible)
         {
-            if (isVisible)
+            if (isVisible && _timerSubscription == null)
             {
                 if (AvaloniaLocator.Current.GetService<IRenderTimer>() is ChoreographerTimer timer)
                 {
@@ -84,10 +84,11 @@ namespace Avalonia.Android
                     (insetsManager as AndroidInsetsManager)?.ApplyStatusBarState();
                 }
             }
-            else
+            else if (!isVisible && _timerSubscription != null)
             {
                 _root.StopRendering();
                 _timerSubscription?.Dispose();
+                _timerSubscription = null;
             }
         }
         


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

#15807 Fix Android app randomly hangs when switching between apps.


## What is the current behavior?

Sometimes after the `AvaloniaActivity.OnResume()` is called and the application is displayed, it does not call either `AvaloniaView.OnVisibilityAggregated` or `AvaloniaView.OnVisibilityChanged`. In this case, `ChoreographerTimer` does not start. See #15807.


## What is the updated/expected behavior with this PR?

Steps to repoduce and test in #15807.


## How was the solution implemented (if it's not obvious)?

Fixed resource leak and additional call from `AvaloniaActivity.OnResume` to `AvaloniaView.OnVisibilityChanged`. See Additional context in #15807.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues

Fixes #15807
