### PR TITLE
Translate glyphRun bounds by the baseline origin

### DIFF
--- a/src/Avalonia.Base/Media/GlyphRun.cs
+++ b/src/Avalonia.Base/Media/GlyphRun.cs
@@ -153,7 +153,8 @@ namespace Avalonia.Media
         /// <summary>
         ///     Gets the conservative bounding box of the <see cref="GlyphRun"/>.
         /// </summary>
-        public Rect Bounds => new Rect(new Size(Metrics.WidthIncludingTrailingWhitespace, Metrics.Height));
+        public Rect Bounds => new Rect(new Point(BaselineOrigin.X, 0),
+            new Size(Metrics.WidthIncludingTrailingWhitespace, Metrics.Height));
 
         public Rect InkBounds => PlatformImpl.Item.Bounds;
 

--- a/src/Skia/Avalonia.Skia/GlyphRunImpl.cs
+++ b/src/Skia/Avalonia.Skia/GlyphRunImpl.cs
@@ -78,7 +78,7 @@ namespace Avalonia.Skia
             ArrayPool<SKRect>.Shared.Return(glyphBounds);
 
             BaselineOrigin = baselineOrigin;
-            Bounds = runBounds;
+            Bounds = runBounds.Translate(new Vector(baselineOrigin.X, 0));
         }
 
         public IGlyphTypeface GlyphTypeface => _glyphTypefaceImpl;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
GlyphRun currently ignores the x-offset of specified baselineOrigin which potentially produces wrong content bounds.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
