### PR TITLE
Handle case when TaskBarList could not be created

### DIFF
--- a/src/Windows/Avalonia.Win32/Interop/TaskBarList.cs
+++ b/src/Windows/Avalonia.Win32/Interop/TaskBarList.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Win32.Interop
         {
             int result = CoCreateInstance(in ShellIds.TaskBarList, IntPtr.Zero, 1, in ShellIds.ITaskBarList2, out IntPtr instance);
 
-            if (result != 0)
+            if (result != (int)HRESULT.S_OK)
             {
                 return IntPtr.Zero;
             }

--- a/src/Windows/Avalonia.Win32/Interop/TaskBarList.cs
+++ b/src/Windows/Avalonia.Win32/Interop/TaskBarList.cs
@@ -19,6 +19,11 @@ namespace Avalonia.Win32.Interop
         {
             int result = CoCreateInstance(in ShellIds.TaskBarList, IntPtr.Zero, 1, in ShellIds.ITaskBarList2, out IntPtr instance);
 
+            if (result != 0)
+            {
+                return IntPtr.Zero;
+            }
+
             var ptr = (ITaskBarList3VTable**)instance.ToPointer();
 
             s_hrInitDelegate ??= Marshal.GetDelegateForFunctionPointer<HrInit>((*ptr)->HrInit);


### PR DESCRIPTION
## What does the pull request do?
Checks whether TaskBarList successfully created.


## What is the current behavior?
Current code assumes TaskBarList is supported on all windows version. On Windows Server Core editions TaskBarList is not supported (no taskbar) and creating a window crashes the application.


## What is the updated/expected behavior with this PR?
Applications could start on Windows Server Core. Tested on Windows Server 2016 Core.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
Fixes #15840
