### PR TITLE
Remove from logical children and clear item container on reset

### DIFF
--- a/src/Avalonia.Controls/Presenters/PanelContainerGenerator.cs
+++ b/src/Avalonia.Controls/Presenters/PanelContainerGenerator.cs
@@ -136,12 +136,15 @@ namespace Avalonia.Controls.Presenters
                 return;
 
             var itemsControl = _presenter.ItemsControl;
+            var generator = itemsControl.ItemContainerGenerator;
             var panel = _presenter.Panel;
 
             foreach (var c in panel.Children)
             {
+                itemsControl.RemoveLogicalChild(c);
+
                 if (!c.IsSet(ItemIsOwnContainerProperty))
-                    itemsControl.RemoveLogicalChild(c);
+                    generator.ClearItemContainer(c);
             }
         }
     }

--- a/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/ItemsControlTests.cs
@@ -977,6 +977,29 @@ namespace Avalonia.Controls.UnitTests
         }
 
         [Fact]
+        public void ContainerClearing_Is_Raised_When_ItemsSource_Is_Cleared()
+        {
+            using var app = Start();
+            var itemsSource = new ObservableCollection<object> { "Foo", "Bar", "Baz" };
+            var target = CreateTarget(itemsSource: itemsSource);
+
+            var expectedContainers = itemsSource.Select(x => target.ContainerFromItem(x)).ToArray();
+            var actualContainers = new List<Control>();
+            var raised = 0;
+
+            target.ContainerClearing += (s, e) =>
+            {
+                actualContainers.Add(e.Container);
+                ++raised;
+            };
+
+            itemsSource.Clear();
+
+            Assert.Equal(3, raised);
+            Assert.Equal(expectedContainers, actualContainers);
+        }
+
+        [Fact]
         public void Handles_Recycling_Control_Items_Inside_Containers()
         {
             // Issue #10825


### PR DESCRIPTION
## What does the pull request do?
On collection reset remove from logical children and clear container (similarly like OnItemsChanged.Remove)

## What is the current behavior?
Currently on collection reset removing from logical children happen after checking for ItemIsOwnContainer. And the container is not cleared at all.