### PR TITLE
DataGrid: expose row index

### DIFF
--- a/samples/ControlCatalog/Pages/DataGridPage.xaml
+++ b/samples/ControlCatalog/Pages/DataGridPage.xaml
@@ -83,6 +83,7 @@
       <TabItem Header="Grouping">
         <DataGrid Name="dataGridGrouping" Margin="12">
           <DataGrid.Columns>
+            <DataGridTextColumn Header=" " Binding="{Binding $parent[DataGridRow].Index}" Width="60" x:DataType="local:Country" />
             <DataGridTextColumn Header="Country or Region" Binding="{Binding Name}" Width="6*" x:DataType="local:Country" />
             <DataGridTextColumn Header="Region" Binding="{Binding Region}" Width="4*" x:DataType="local:Country" />
             <DataGridTextColumn DisplayIndex="3" Header="Population" Binding="{Binding Population}" Width="3*" x:DataType="local:Country" />

--- a/samples/ControlCatalog/Pages/DataGridPage.xaml
+++ b/samples/ControlCatalog/Pages/DataGridPage.xaml
@@ -45,6 +45,11 @@
           </StackPanel>
           <DataGrid Name="dataGrid1" Margin="12" CanUserResizeColumns="True" CanUserReorderColumns="True" CanUserSortColumns="True" HeadersVisibility="All"
                     RowBackground="#1000">
+            <DataGrid.Styles>
+              <Style Selector="DataGridRow">
+                <Setter Property="Header" Value="{Binding $self.Index}"/>
+              </Style>
+            </DataGrid.Styles>
             <DataGrid.Columns>
               <!-- Using HeaderTemplate -->
               <DataGridTextColumn Header="Country or Region" HeaderTemplate="{StaticResource Demo.DataTemplates.CountryHeader}" Binding="{Binding Name}"  Width="6*" x:DataType="local:Country" />
@@ -83,7 +88,6 @@
       <TabItem Header="Grouping">
         <DataGrid Name="dataGridGrouping" Margin="12">
           <DataGrid.Columns>
-            <DataGridTextColumn Header=" " Binding="{Binding $parent[DataGridRow].Index}" Width="60" x:DataType="local:Country" />
             <DataGridTextColumn Header="Country or Region" Binding="{Binding Name}" Width="6*" x:DataType="local:Country" />
             <DataGridTextColumn Header="Region" Binding="{Binding Region}" Width="4*" x:DataType="local:Country" />
             <DataGridTextColumn DisplayIndex="3" Header="Population" Binding="{Binding Population}" Width="3*" x:DataType="local:Country" />

--- a/samples/ControlCatalog/Pages/DataGridPage.xaml.cs
+++ b/samples/ControlCatalog/Pages/DataGridPage.xaml.cs
@@ -24,7 +24,6 @@ namespace ControlCatalog.Pages
             collectionView1.SortDescriptions.Add(dataGridSortDescription);
             var dg1 = this.Get<DataGrid>("dataGrid1");
             dg1.IsReadOnly = true;
-            dg1.LoadingRow += Dg1_LoadingRow;
             dg1.Sorting += (s, a) =>
             {
                 var binding = (a.Column as DataGridBoundColumn)?.Binding as Binding;
@@ -64,11 +63,6 @@ namespace ControlCatalog.Pages
         }
 
         public IEnumerable<Person> DataGrid3Source { get; }
-        
-        private void Dg1_LoadingRow(object? sender, DataGridRowEventArgs e)
-        {
-            e.Row.Header = e.Row.GetIndex() + 1;
-        }
 
         private void InitializeComponent()
         {

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -223,10 +223,10 @@ namespace Avalonia.Controls
         /// <summary>
         /// Index of the row
         /// </summary>
-        internal int Index
+        public int Index
         {
             get;
-            set;
+            internal set;
         }
 
         internal double ActualBottomGridLineHeight

--- a/src/Avalonia.Controls.DataGrid/DataGridRow.cs
+++ b/src/Avalonia.Controls.DataGrid/DataGridRow.cs
@@ -220,13 +220,18 @@ namespace Avalonia.Controls
             set;
         }
 
+        private int _index;
+
+        public static readonly DirectProperty<DataGridRow, int> IndexProperty = AvaloniaProperty.RegisterDirect<DataGridRow, int>(
+            nameof(Index), o => o.Index, (o, v) => o.Index = v);
+
         /// <summary>
         /// Index of the row
         /// </summary>
         public int Index
         {
-            get;
-            internal set;
+            get => _index;
+            internal set => SetAndRaise(IndexProperty, ref _index, value);
         }
 
         internal double ActualBottomGridLineHeight
@@ -435,6 +440,7 @@ namespace Avalonia.Controls
         /// <returns>
         /// The index of the current row.
         /// </returns>
+        [Obsolete("This API is going to be removed in a future version. Use the Index property instead.")]
         public int GetIndex()
         {
             return Index;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Make DataGridRow.Index public get-able. 

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
It's hard to show row number.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

User can use below binding to show row index.
```xaml
<DataGridTextColumn Header=" " Binding="{Binding $parent[DataGridRow].Index}" Width="60" x:DataType="local:Country" />
```
![8fc15485cb3ce96686af2e6f0b845ee](https://github.com/AvaloniaUI/Avalonia/assets/14807942/78ea814d-9aa8-4694-8216-bc9539008824)


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
I think no. 

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
`GetIndex` method is obsoleted, should be replaced by `Index` property

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
