### PR TITLE
Use the owner window's screen as the constraint.

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -976,7 +976,7 @@ namespace Avalonia.Controls
                     PixelSize.FromSize(ownerSize, scaling));
                 var childRect = ownerRect.CenterRect(rect);
 
-                if (Screens.ScreenFromWindow(this)?.WorkingArea is { } constraint)
+                if (Screens.ScreenFromWindow(owner)?.WorkingArea is { } constraint)
                 {
                     var maxX = constraint.Right - rect.Width;
                     var maxY = constraint.Bottom - rect.Height;


### PR DESCRIPTION
## What does the pull request do?

#14982 added some logic from WPF to contrain a window showed with `WindowStartupLocation.CenterOwner` to the screen, but it had a bug: the screen used was the screen that the window being _shown_ is currently on, not the _owner_ window.

This means that if the owner window is on a different screen to the window being shown then it will be constrained to the wrong screen.

You can see this on Windows by showing a child `Window` with `CenterOwner` when the owner window is on a secondary screen: the child window will initially be shown on the primary screen and so the constraint will be wrong, resulting in the child window being shown on the wrong screen.
