### PR TITLE
Implemented VulkanDevice.Dispose

### DIFF
--- a/src/Avalonia.Vulkan/Interop/VulkanDevice.Create.cs
+++ b/src/Avalonia.Vulkan/Interop/VulkanDevice.Create.cs
@@ -87,7 +87,7 @@ internal unsafe partial class VulkanDevice
 
         api.GetDeviceQueue(createdDevice, dev.QueueFamilyIndex, 0, out var createdQueue);
 
-        return new VulkanDevice(api.Instance, createdDevice, dev.PhysicalDevice, createdQueue,
+        return new VulkanDevice(api, createdDevice, dev.PhysicalDevice, createdQueue,
             dev.QueueFamilyIndex, enabledExtensions);
 
     }

--- a/src/Avalonia.Vulkan/Interop/VulkanDevice.cs
+++ b/src/Avalonia.Vulkan/Interop/VulkanDevice.cs
@@ -9,7 +9,8 @@ namespace Avalonia.Vulkan.Interop;
 
 internal partial class VulkanDevice : IVulkanDevice
 {
-    private readonly VkDevice _handle;
+    private readonly VulkanInstanceApi _instanceApi;
+    private VkDevice _handle;
     private readonly VkPhysicalDevice _physicalDeviceHandle;
     private readonly VkQueue _mainQueue;
     private readonly uint _graphicsQueueIndex;
@@ -17,14 +18,15 @@ internal partial class VulkanDevice : IVulkanDevice
     private Thread? _lockedByThread;
     private int _lockCount;
 
-    private VulkanDevice(IVulkanInstance instance, VkDevice handle, VkPhysicalDevice physicalDeviceHandle,
+    private VulkanDevice(VulkanInstanceApi instanceApi, VkDevice handle, VkPhysicalDevice physicalDeviceHandle,
         VkQueue mainQueue, uint graphicsQueueIndex, string[] enabledExtensions)
     {
+        _instanceApi = instanceApi;
         _handle = handle;
         _physicalDeviceHandle = physicalDeviceHandle;
         _mainQueue = mainQueue;
         _graphicsQueueIndex = graphicsQueueIndex;
-        Instance = instance;
+        Instance = _instanceApi.Instance;
         EnabledExtensions = enabledExtensions;
     }
 
@@ -59,7 +61,11 @@ internal partial class VulkanDevice : IVulkanDevice
     public IVulkanInstance Instance { get; }
     public void Dispose()
     {
-        // TODO
+        if (_handle.Handle != IntPtr.Zero)
+        {
+            _instanceApi.DestroyDevice(_handle, IntPtr.Zero);
+            _handle = default;
+        }
     }
 
     public object? TryGetFeature(Type featureType) => null;

--- a/src/Avalonia.Vulkan/UnmanagedInterop/VulkanInstanceApi.cs
+++ b/src/Avalonia.Vulkan/UnmanagedInterop/VulkanInstanceApi.cs
@@ -46,6 +46,9 @@ internal unsafe partial class VulkanInstanceApi
     public partial VkResult CreateDevice(VkPhysicalDevice physicalDevice, ref VkDeviceCreateInfo pCreateInfo,
         IntPtr pAllocator, out VkDevice pDevice);
 
+    [GetProcAddress("vkDestroyDevice")]
+    public partial VkResult DestroyDevice(VkDevice device, IntPtr pAllocator);
+
     [GetProcAddress("vkGetDeviceQueue")]
     public partial void GetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex,
         out VkQueue pQueue);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Implemented `VulkanDevice.Dispose`, calling `vkDestroyDevice`.

## What is the current behavior?

When using the Vulkan backend, at least 2 `VkDevice`s are created, one for initialization and one for rendering. The initialization one is always leaked, because `Dispose` is called, but it is not implemented.

## What is the updated/expected behavior with this PR?

- Debugging with RenderDoc works (it only works with one `VkDevice` per `VkInstance`)
- `VkDevice`s are no longer leaked

## How was the solution implemented (if it's not obvious)?

It's obvious

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

N/A

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

N/A

## Fixed issues

Fixes #15926
