### PR TITLE
Switch to Metal by default

### DIFF
--- a/src/iOS/Avalonia.iOS/Platform.cs
+++ b/src/iOS/Avalonia.iOS/Platform.cs
@@ -30,12 +30,12 @@ namespace Avalonia
         /// <summary>
         /// Gets or sets Avalonia rendering modes with fallbacks.
         /// The first element in the array has the highest priority.
-        /// The default value is: <see cref="iOSRenderingMode.OpenGl"/>. 
+        /// The default value is: <see cref="iOSRenderingMode.Metal"/>. 
         /// </summary>
         /// <exception cref="System.InvalidOperationException">Thrown if no values were matched.</exception>
         public IReadOnlyList<iOSRenderingMode> RenderingMode { get; set; } = new[]
         {
-            iOSRenderingMode.OpenGl, iOSRenderingMode.Metal
+            iOSRenderingMode.Metal, iOSRenderingMode.OpenGl
         };
     }
 


### PR DESCRIPTION
Backport of 11.2 changes into 11.1.
See https://github.com/AvaloniaUI/Avalonia/issues/14933#issuecomment-2149192671

Fixes #14933 (hopefully)