### PR TITLE
Fixed UIA pattern matching for IExpandCollapseProvider.

### DIFF
--- a/src/Windows/Avalonia.Win32/Automation/AutomationNode.cs
+++ b/src/Windows/Avalonia.Win32/Automation/AutomationNode.cs
@@ -88,7 +88,7 @@ namespace Avalonia.Win32.Automation
 
             return (UiaPatternId)patternId switch
             {
-                UiaPatternId.ExpandCollapse => ThisIfPeerImplementsProvider<IExpandCollapseProvider>(),
+                UiaPatternId.ExpandCollapse => ThisIfPeerImplementsProvider<AAP.IExpandCollapseProvider>(),
                 UiaPatternId.Invoke => ThisIfPeerImplementsProvider<AAP.IInvokeProvider>(),
                 UiaPatternId.RangeValue => ThisIfPeerImplementsProvider<AAP.IRangeValueProvider>(),
                 UiaPatternId.Scroll => ThisIfPeerImplementsProvider<AAP.IScrollProvider>(),


### PR DESCRIPTION
## What does the pull request do?
UIA pattern matching was looking at a Win32 interface for `IExpandCollapseProvider` instead of the Avalonia-specific implementation of an interface with the same name.


## What is the current behavior?
No `AutomationPeer` classes properly support expand/collapse with UIA.


## What is the updated/expected behavior with this PR?
Any `AutomationPeer` class that implements the `IExpandCollapseProvider` interface will work with UIA.


## How was the solution implemented (if it's not obvious)?
Corrected type reference with namespace qualifier.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
None.

## Obsoletions / Deprecations
None.

## Fixed issues
No known issue logged.
