### PR TITLE
Fix TrayIcon menu crash

### DIFF
--- a/samples/IntegrationTestApp/App.axaml
+++ b/samples/IntegrationTestApp/App.axaml
@@ -1,13 +1,21 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="IntegrationTestApp.App">
+             xmlns:self="using:IntegrationTestApp"
+             x:Class="IntegrationTestApp.App"
+             x:DataType="self:App"
+             RequestedThemeVariant="Default">
     <Application.Styles>
         <FluentTheme />
     </Application.Styles>
-  <TrayIcon.Icons>
-    <TrayIcons>
-      <TrayIcon Icon="/Assets/icon.ico">
-      </TrayIcon>
-    </TrayIcons>
-  </TrayIcon.Icons>
+    <TrayIcon.Icons>
+        <TrayIcons>
+            <TrayIcon Icon="/Assets/icon.ico">
+                <TrayIcon.Menu>
+                    <NativeMenu>
+                        <NativeMenuItem Header="Show _Test Window" Command="{Binding ShowWindowCommand}" />
+                    </NativeMenu>
+                </TrayIcon.Menu>
+            </TrayIcon>
+        </TrayIcons>
+    </TrayIcon.Icons>
 </Application>

--- a/samples/IntegrationTestApp/App.axaml.cs
+++ b/samples/IntegrationTestApp/App.axaml.cs
@@ -1,11 +1,21 @@
+using System.Windows.Input;
+
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+
+using ReactiveUI;
 
 namespace IntegrationTestApp
 {
     public class App : Application
     {
+        public App()
+        {
+            ShowWindowCommand = ReactiveCommand.Create(ShowTestWindow);
+            DataContext = this;
+        }
+
         public override void Initialize()
         {
             AvaloniaXamlLoader.Load(this);
@@ -19,6 +29,15 @@ namespace IntegrationTestApp
             }
 
             base.OnFrameworkInitializationCompleted();
+        }
+
+        public ICommand ShowWindowCommand { get; }
+
+        void ShowTestWindow()
+        {
+            var window = new ShowWindowTest();
+
+            window.Show();
         }
     }
 }

--- a/samples/IntegrationTestApp/App.axaml.cs
+++ b/samples/IntegrationTestApp/App.axaml.cs
@@ -1,10 +1,10 @@
 using System.Windows.Input;
 
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
-
-using ReactiveUI;
+using MiniMvvm;
 
 namespace IntegrationTestApp
 {
@@ -12,7 +12,11 @@ namespace IntegrationTestApp
     {
         public App()
         {
-            ShowWindowCommand = ReactiveCommand.Create(ShowTestWindow);
+            ShowWindowCommand = MiniCommand.Create(() =>
+            {
+                var window = new Window() { Title = "TrayIcon demo window" };
+                window.Show();
+            });
             DataContext = this;
         }
 
@@ -32,12 +36,5 @@ namespace IntegrationTestApp
         }
 
         public ICommand ShowWindowCommand { get; }
-
-        void ShowTestWindow()
-        {
-            var window = new ShowWindowTest();
-
-            window.Show();
-        }
     }
 }

--- a/samples/IntegrationTestApp/IntegrationTestApp.csproj
+++ b/samples/IntegrationTestApp/IntegrationTestApp.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\..\src\Avalonia.Diagnostics\Avalonia.Diagnostics.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Themes.Fluent\Avalonia.Themes.Fluent.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Fonts.Inter\Avalonia.Fonts.Inter.csproj" />
+    <ProjectReference Include="..\..\src\Avalonia.ReactiveUI\Avalonia.ReactiveUI.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/IntegrationTestApp/IntegrationTestApp.csproj
+++ b/samples/IntegrationTestApp/IntegrationTestApp.csproj
@@ -25,7 +25,7 @@
     <ProjectReference Include="..\..\src\Avalonia.Diagnostics\Avalonia.Diagnostics.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Themes.Fluent\Avalonia.Themes.Fluent.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Fonts.Inter\Avalonia.Fonts.Inter.csproj" />
-    <ProjectReference Include="..\..\src\Avalonia.ReactiveUI\Avalonia.ReactiveUI.csproj" />
+    <ProjectReference Include="..\MiniMvvm\MiniMvvm.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Avalonia.Controls/NativeMenuItem.cs
+++ b/src/Avalonia.Controls/NativeMenuItem.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Media.Imaging;
 using Avalonia.Metadata;
+using Avalonia.Threading;
 using Avalonia.Utilities;
 
 namespace Avalonia.Controls
@@ -164,7 +165,10 @@ namespace Avalonia.Controls
 
         void CanExecuteChanged()
         {
-            SetCurrentValue(IsEnabledProperty, Command?.CanExecute(CommandParameter) ?? true);
+            if (!Dispatcher.UIThread.CheckAccess())
+                Dispatcher.UIThread.Invoke(() => CanExecuteChanged());
+            else
+                SetCurrentValue(IsEnabledProperty, Command?.CanExecute(CommandParameter) ?? true);
         }
 
         public bool HasClickHandlers => Click != null;


### PR DESCRIPTION
This PR addresses a crash that occurs when activating TrayIcon menu items. It contains two commits:

* 4818fa9: Adds a new `samples` project called `TrayIcon` which _should_ work. It follows all the guidelines, but with the current Avalonia code it crashes as soon as any tray icon menu item is activated.
* bb3f939: Fixes the crash observed in the `TrayIcon` sample by thunking to the UI thread when processing a `NativeMenuItem.CanExecuteChanged` notification.

## What is the current behavior?
At least on Ubuntu 24.04 running Xorg, activating a tray icon menu item causes the process to crash immediately with the exception:
```
Unhandled exception. System.InvalidOperationException: Call from invalid thread
```
This is described in detail in #15940.

## What is the updated/expected behavior with this PR?
With the fix to `NativeMenuItem.cs`, tray icon menu items can now be activated without the process crashing.

## How was the solution implemented (if it's not obvious)?
`Dispatcher.UIThread.Invoke`

## Checklist

- [n/p] Added unit tests (if possible)?
- [n/a] Added XML documentation to any related classes?
- [n/a] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
Fixes #15940
