### PR TITLE
Convert IAvaloniaXamlIlParentStackProvider to eager one if needed

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
+++ b/src/Markup/Avalonia.Markup.Xaml/Avalonia.Markup.Xaml.csproj
@@ -52,6 +52,7 @@
     <Compile Include="XamlIl\Runtime\IAvaloniaXamlIlControlTemplateProvider.cs" />
     <Compile Include="XamlIl\Runtime\IAvaloniaXamlIlParentStackProvider.cs" />
     <Compile Include="XamlIl\Runtime\IAvaloniaXamlIlXmlNamespaceInfoProviderV1.cs" />
+    <Compile Include="XamlIl\Runtime\XamlIlParentStackProviderWrapper.cs" />
     <Compile Include="XamlIl\Runtime\XamlIlRuntimeHelpers.cs" />
     <Compile Include="XamlLoadException.cs" />
     <Compile Include="XamlTypes.cs" />

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/Runtime/XamlIlParentStackProviderWrapper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/Runtime/XamlIlParentStackProviderWrapper.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Avalonia.Markup.Xaml.XamlIl.Runtime;
+
+/// <summary>
+/// Wraps a <see cref="IAvaloniaXamlIlParentStackProvider"/> into a <see cref="IAvaloniaXamlIlEagerParentStackProvider"/>,
+/// for backwards compatibility.
+/// </summary>
+internal sealed class XamlIlParentStackProviderWrapper : IAvaloniaXamlIlEagerParentStackProvider
+{
+    private readonly IAvaloniaXamlIlParentStackProvider _provider;
+
+    private IReadOnlyList<object>? _directParentsStack;
+
+    public XamlIlParentStackProviderWrapper(IAvaloniaXamlIlParentStackProvider provider)
+        => _provider = provider;
+
+    public IEnumerable<object> Parents
+        => _provider.Parents;
+
+    public IReadOnlyList<object> DirectParentsStack
+        => _directParentsStack ??= _provider.Parents.Reverse().ToArray();
+
+    public IAvaloniaXamlIlEagerParentStackProvider? ParentProvider
+        => null;
+}

--- a/src/Markup/Avalonia.Markup.Xaml/XamlIl/Runtime/XamlIlRuntimeHelpers.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/XamlIl/Runtime/XamlIlRuntimeHelpers.cs
@@ -95,6 +95,14 @@ namespace Avalonia.Markup.Xaml.XamlIl.Runtime
             return resourceNodes;
         }
 
+        /// <summary>
+        /// Converts a <see cref="IAvaloniaXamlIlParentStackProvider"/> into a
+        /// <see cref="IAvaloniaXamlIlEagerParentStackProvider"/>.
+        /// </summary>
+        public static IAvaloniaXamlIlEagerParentStackProvider AsEagerParentStackProvider(
+            this IAvaloniaXamlIlParentStackProvider provider)
+            => provider as IAvaloniaXamlIlEagerParentStackProvider ?? new XamlIlParentStackProviderWrapper(provider);
+
         // Parent resource nodes are often the same (e.g. most values in a ResourceDictionary), cache the last ones.
         private sealed class LastParentStack
         {


### PR DESCRIPTION
## What does the pull request do?
This PR correctly handles `IAvaloniaXamlIlParentStackProvider` parents that don't implement the new `IAvaloniaXamlIlEagerParentStackProvider`, in the generated XAML `Context`.

This happens when a XAML file compiled with Avalonia 11.0 implicitly loads a XAML file that is now compiled with Avalonia 11.1 (for example, loading `FluentTheme`).

## What is the current behavior?
An `InvalidCastException` occurs.

## What is the updated/expected behavior with this PR?
No exception, everything works.

## How was the solution implemented (if it's not obvious)?
An intermediate `XamlIlParentStackProviderWrapper` is instantiated if needed.

## Fixed issues
 - Fixes #16020