### PR TITLE
Win32 - set internal _shown flag if ShowWindow will make window visible

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -790,6 +790,17 @@ namespace Avalonia.Win32
                         return UiaCoreProviderApi.UiaReturnRawElementProvider(_hwnd, wParam, lParam, node);
                     }
                     break;
+                case WindowsMessage.WM_WINDOWPOSCHANGED:
+                    var winPos = Marshal.PtrToStructure<WINDOWPOS>(lParam);
+                    if((winPos.flags & (uint)SetWindowPosFlags.SWP_SHOWWINDOW) != 0)
+                    {
+                        _shown = true;
+                    }
+                    else if ((winPos.flags & (uint)SetWindowPosFlags.SWP_HIDEWINDOW) != 0)
+                    {
+                        _shown = false;
+                    }
+                    break;
             }
 
 #if USE_MANAGED_DRAG

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1203,6 +1203,11 @@ namespace Avalonia.Win32
             if (command.HasValue)
             {
                 UnmanagedMethods.ShowWindow(_hwnd, command.Value);
+
+                if (!_shown && command.Value != ShowWindowCommand.Minimize && GetStyle().HasFlag(WindowStyles.WS_VISIBLE))
+                {
+                    _shown = true;
+                }
             }
 
             if (state == WindowState.Maximized)

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1203,11 +1203,6 @@ namespace Avalonia.Win32
             if (command.HasValue)
             {
                 UnmanagedMethods.ShowWindow(_hwnd, command.Value);
-
-                if (!_shown && command.Value != ShowWindowCommand.Minimize && GetStyle().HasFlag(WindowStyles.WS_VISIBLE))
-                {
-                    _shown = true;
-                }
             }
 
             if (state == WindowState.Maximized)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes an issue where, if a window starts out with window state Maximized, the `_shown` flag isn't set because Windows doesn't send the WM_SHOWWINDOW message for Maximize state. This flag is used internal for resize operations, and should be properly synced.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
