### PR TITLE
Request for Feedback: Improving Startup Latency in X11

### DIFF
--- a/src/Avalonia.X11/X11CursorFactory.cs
+++ b/src/Avalonia.X11/X11CursorFactory.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Avalonia.Controls.Platform.Surfaces;
 using Avalonia.Input;
 using Avalonia.Platform;
@@ -52,13 +55,16 @@ namespace Avalonia.X11
 
         [GenerateEnumValueList]
         private static partial CursorFontShape[] GetAllCursorShapes();
-        
+
         public X11CursorFactory(IntPtr display)
         {
             _display = display;
             _nullCursor = GetNullCursor(display);
-            _cursors = GetAllCursorShapes()
-                .ToDictionary(id => id, id => XLib.XCreateFontCursor(_display, id));
+
+            var cursorShapes = GetAllCursorShapes();
+            _cursors = new Dictionary<CursorFontShape, IntPtr>(cursorShapes.Length);
+            foreach (var shape in cursorShapes)
+                _cursors[shape] = XLib.XCreateFontCursor(_display, shape);
         }
 
         public ICursorImpl GetCursor(StandardCursorType cursorType)

--- a/src/Avalonia.X11/X11CursorFactory.cs
+++ b/src/Avalonia.X11/X11CursorFactory.cs
@@ -1,16 +1,10 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using Avalonia.Controls.Platform.Surfaces;
 using Avalonia.Input;
 using Avalonia.Platform;
 using Avalonia.Platform.Internal;
-using Avalonia.SourceGenerator;
-using Avalonia.Utilities;
 
 #nullable enable
 
@@ -53,18 +47,14 @@ namespace Avalonia.X11
                 {StandardCursorType.TopRightCorner, CursorFontShape.XC_top_right_corner},
             };
 
-        [GenerateEnumValueList]
-        private static partial CursorFontShape[] GetAllCursorShapes();
-
         public X11CursorFactory(IntPtr display)
         {
             _display = display;
             _nullCursor = GetNullCursor(display);
-
-            var cursorShapes = GetAllCursorShapes();
-            _cursors = new Dictionary<CursorFontShape, IntPtr>(cursorShapes.Length);
-            foreach (var shape in cursorShapes)
-                _cursors[shape] = XLib.XCreateFontCursor(_display, shape);
+            
+            // 78 = number of items in CursorFontShape enum
+            // Unlikely to change, but, do we have a Src Gen for this?
+            _cursors = new Dictionary<CursorFontShape, IntPtr>(78);
         }
 
         public ICursorImpl GetCursor(StandardCursorType cursorType)
@@ -77,8 +67,8 @@ namespace Avalonia.X11
             else
             {
                 handle = s_mapping.TryGetValue(cursorType, out var shape)
-                ? _cursors[shape]
-                : _cursors[CursorFontShape.XC_left_ptr];
+                ? GetCursorHandleLazy(shape)
+                : GetCursorHandleLazy(CursorFontShape.XC_left_ptr);
             }
             return new CursorImpl(handle);
         }
@@ -149,6 +139,14 @@ namespace Avalonia.X11
             }
             
             public IFramebufferRenderTarget CreateFramebufferRenderTarget() => new FuncFramebufferRenderTarget(Lock);
+        }
+        
+        private nint GetCursorHandleLazy(CursorFontShape shape)
+        {
+            if (!_cursors.TryGetValue(shape, out var handle))
+                _cursors[shape] = handle = XLib.XCreateFontCursor(_display, shape);
+
+            return handle;
         }
     }
 

--- a/src/Avalonia.X11/X11Platform.cs
+++ b/src/Avalonia.X11/X11Platform.cs
@@ -2,10 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
-using Avalonia.Controls;
 using Avalonia.Controls.Platform;
 using Avalonia.FreeDesktop;
 using Avalonia.FreeDesktop.DBusIme;
@@ -59,18 +55,15 @@ namespace Avalonia.X11
             Display = XOpenDisplay(IntPtr.Zero);
             if (Display == IntPtr.Zero)
                 throw new Exception("XOpenDisplay failed");
-            
             DeferredDisplay = XOpenDisplay(IntPtr.Zero);
             if (DeferredDisplay == IntPtr.Zero)
                 throw new Exception("XOpenDisplay failed");
-
-            Info = new X11Info(Display, DeferredDisplay, useXim);
-            var graphicsTask = Task.Run(() => InitializeGraphics(options, Info));
+                
             OrphanedWindow = XCreateSimpleWindow(Display, XDefaultRootWindow(Display), 0, 0, 1, 1, 0, IntPtr.Zero,
                 IntPtr.Zero);
-            
             XError.Init();
-            
+
+            Info = new X11Info(Display, DeferredDisplay, useXim);
             Globals = new X11Globals(this);
             Resources = new XResources(this);
             //TODO: log
@@ -103,7 +96,7 @@ namespace Avalonia.X11
                     XI2 = xi2;
             }
 
-            var graphics = graphicsTask.Result;
+            var graphics = InitializeGraphics(options, Info);
             if (graphics is not null)
             {
                 AvaloniaLocator.CurrentMutable.Bind<IPlatformGraphics>().ToConstant(graphics);

--- a/src/Avalonia.X11/X11Platform.cs
+++ b/src/Avalonia.X11/X11Platform.cs
@@ -88,6 +88,7 @@ namespace Avalonia.X11
                 .Bind<PlatformHotkeyConfiguration>().ToConstant(new PlatformHotkeyConfiguration(KeyModifiers.Control))
                 .Bind<KeyGestureFormatInfo>().ToConstant(new KeyGestureFormatInfo(new Dictionary<Key, string>() { }, meta: "Super"))
                 .Bind<IKeyboardDevice>().ToFunc(() => KeyboardDevice)
+                .Bind<ICursorFactory>().ToConstant(new X11CursorFactory(Display))
                 .Bind<IClipboard>().ToConstant(new X11Clipboard(this))
                 .Bind<IPlatformSettings>().ToSingleton<DBusPlatformSettings>()
                 .Bind<IPlatformIconLoader>().ToConstant(new X11IconLoader())
@@ -101,8 +102,6 @@ namespace Avalonia.X11
                 if (xi2.Init(this))
                     XI2 = xi2;
             }
-            
-            AvaloniaLocator.CurrentMutable.Bind<ICursorFactory>().ToConstant(new X11CursorFactory(Display));
 
             var graphics = graphicsTask.Result;
             if (graphics is not null)


### PR DESCRIPTION
## What does the pull request do?

This pull request reduces the latency required to display the first Window when running Avalonia under the X11 backend.

## What is the updated/expected behavior with this PR?

On my machine, running Hyprland and a 5900X, a blank Avalonia project compiled with NativeAOT previously took `80-105ms` from running `AppBuilder.Configure` to running `Initialize` in `App.axaml.cs`.

This PR improves it to `66-81ms` or `40-51ms` depending on commit used.

## How was the solution implemented (if it's not obvious)?

Startup is largely bottlenecked on X11 by the following methods:

- `X11CursorFactory__ctor`
- `InitializeGraphics(options, Info)`

During the backend initialization.
These two methods alone take around half the startup time.

Because these methods don't depend on each other's inputs/outputs,
and have approximately the same runtime, they can be ran in parallel
to speed up booting.

Note: [We call XInitThreads](https://www.x.org/releases/X11R7.5/doc/man/man3/XInitThreads.3.html), which enables concurrent access to X11.

## Two Implementations

There are two implementations in this PR, pick the preferred commit.

Baseline: 80-105ms

- cf309951b628c8d9d0e228d8c53b42cabdcf3b05 creates the cursors in parallel to graphics, resulting in `66-81ms` (0.825x the time).
- bfb2ef20b31e77850aa7e89f1ce51ebbd951df67 instead lazily creates the X11 cursors as needed, resulting in `40-51ms` startup times. (0.5x the time).

My lower end laptop with 4 threads yielded similar results.

## Request for Feedback

> [!NOTE]  
> This concerns the original parallel implementation
> PR was updated to instead make the lazy implementation the current one, since I believe it may be preferable.

I would like to know if this could potentially be further improved.
Oddly, I was expecting slightly greater savings, something approximately equal to not calling `X11CursorFactory` at all.

Although I am seeing an improvement, the improvement is not as large as I expected it to be. I'm not sure if this is due to some sort of resource locking in the XWayland implementation powering my desktop behind the scenes, or whether it's due to another reason.

I did investigate the latency with which the threadpool tasks were immediately started; starting a dedicated thread, etc. And it seems to be somewhere in well, not Avalonia code.

## Why?

I thought Startup could be faster.
So I made it a bit faster.

I think this can even be further improved by starting the processing right at the call to `UseX11(this AppBuilder builder)`, but I can't see that passing review, as that should be used for configuration, not execution.