### PR TITLE
Improved: D3D11 Adapter Creation Speed by Manually Selecting Hardware Type

### DIFF
--- a/src/Avalonia.OpenGL/OpenGlException.cs
+++ b/src/Avalonia.OpenGL/OpenGlException.cs
@@ -50,5 +50,10 @@ namespace Avalonia.OpenGL
                 return new OpenGlException($"{funcName} failed with error 0x{errorCode.ToString("X")}", intErrorCode);
             }
         }
+        
+        /// <summary>
+        ///     Throw helper that is used to allow callers to be inlined.
+        /// </summary>
+        public static OpenGlException ThrowFormattedException(string funcName, EglInterface egl) => throw GetFormattedEglException(funcName, egl.GetError());
     }
 }

--- a/src/Windows/Avalonia.Win32/DirectX/DirectXUnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/DirectX/DirectXUnmanagedMethods.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Win32.DirectX
         internal static extern bool EnumDisplaySettingsW(ushort* lpszDeviceName, uint iModeNum, DEVMODEW* lpDevMode);
 
         [DllImport("d3d11", ExactSpelling = true, PreserveSig = false)]
-        public static extern nint D3D11CreateDevice(
+        public static extern void D3D11CreateDevice(
             IntPtr adapter, D3D_DRIVER_TYPE DriverType,
             IntPtr Software,
             uint Flags,

--- a/src/Windows/Avalonia.Win32/DirectX/DirectXUnmanagedMethods.cs
+++ b/src/Windows/Avalonia.Win32/DirectX/DirectXUnmanagedMethods.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Win32.DirectX
         internal static extern bool EnumDisplaySettingsW(ushort* lpszDeviceName, uint iModeNum, DEVMODEW* lpDevMode);
 
         [DllImport("d3d11", ExactSpelling = true, PreserveSig = false)]
-        public static extern void D3D11CreateDevice(
+        public static extern nint D3D11CreateDevice(
             IntPtr adapter, D3D_DRIVER_TYPE DriverType,
             IntPtr Software,
             uint Flags,

--- a/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32EglDisplay.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32EglDisplay.cs
@@ -119,7 +119,7 @@ namespace Avalonia.Win32.OpenGl.Angle
                 if (pD3dDevice == IntPtr.Zero)
                 {
                     hr = DirectXUnmanagedMethods.D3D11CreateDevice(chosenAdapter?.GetNativeIntPtr() ?? IntPtr.Zero,
-                        driverType,
+                        D3D_DRIVER_TYPE.D3D_DRIVER_TYPE_SOFTWARE,
                         IntPtr.Zero, 0, featureLevels, (uint)featureLevels.Length,
                         7, out pD3dDevice, out _, null);
 

--- a/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32EglDisplay.cs
+++ b/src/Windows/Avalonia.Win32/OpenGl/Angle/AngleWin32EglDisplay.cs
@@ -59,6 +59,7 @@ namespace Avalonia.Win32.OpenGl.Angle
             var dxgiFactoryGuid = MicroComRuntime.GetGuidFor(typeof(IDXGIFactory1));
             DirectXUnmanagedMethods.CreateDXGIFactory1(ref dxgiFactoryGuid, out var pDxgiFactory);
             IDXGIAdapter1? chosenAdapter = null;
+            
             if (pDxgiFactory != null)
             {
                 using var factory = MicroComRuntime.CreateProxyFor<IDXGIFactory1>(pDxgiFactory, true);
@@ -80,7 +81,7 @@ namespace Avalonia.Win32.OpenGl.Angle
                     }
 
                     if (adapters.Count == 0)
-                        throw new OpenGlException("No adapters found");
+                        ThrowNoAdaptersFound();
 
                     chosenAdapter = adapters
                         .OrderByDescending(x =>
@@ -95,21 +96,41 @@ namespace Avalonia.Win32.OpenGl.Angle
                 else
                 {
                     if (factory.EnumAdapters1(0, &pAdapter) != 0)
-                        throw new OpenGlException("No adapters found");
+                        ThrowNoAdaptersFound();
                     chosenAdapter = MicroComRuntime.CreateProxyFor<IDXGIAdapter1>(pAdapter, true);
                 }
             }
 
             IntPtr pD3dDevice;
             using (chosenAdapter)
-                DirectXUnmanagedMethods.D3D11CreateDevice(chosenAdapter?.GetNativeIntPtr() ?? IntPtr.Zero,
-                    D3D_DRIVER_TYPE.D3D_DRIVER_TYPE_UNKNOWN,
+            {
+                // https://learn.microsoft.com/en-us/windows/win32/api/dxgi/ns-dxgi-dxgi_adapter_desc1
+                // https://learn.microsoft.com/en-us/windows/win32/api/dxgi/ne-dxgi-dxgi_adapter_flag
+                var isSoftwareAdapter = (chosenAdapter!.Desc1.Flags & 2) == 1;
+                var driverType = isSoftwareAdapter ?
+                    D3D_DRIVER_TYPE.D3D_DRIVER_TYPE_WARP :
+                    D3D_DRIVER_TYPE.D3D_DRIVER_TYPE_HARDWARE;
+
+                var hr = DirectXUnmanagedMethods.D3D11CreateDevice(chosenAdapter?.GetNativeIntPtr() ?? IntPtr.Zero,
+                    driverType,
                     IntPtr.Zero, 0, featureLevels, (uint)featureLevels.Length,
                     7, out pD3dDevice, out _, null);
 
+                if (pD3dDevice == IntPtr.Zero)
+                {
+                    hr = DirectXUnmanagedMethods.D3D11CreateDevice(chosenAdapter?.GetNativeIntPtr() ?? IntPtr.Zero,
+                        driverType,
+                        IntPtr.Zero, 0, featureLevels, (uint)featureLevels.Length,
+                        7, out pD3dDevice, out _, null);
+
+                    if (pD3dDevice == IntPtr.Zero)
+                        ThrowCannotCreateD3D11Device();
+                }
+            }
+
 
             if (pD3dDevice == IntPtr.Zero)
-                throw new Win32Exception("Unable to create D3D11 Device");
+                ThrowCannotCreateD3D11Device();
 
             var d3dDevice = MicroComRuntime.CreateProxyFor<ID3D11Device>(pD3dDevice, true);
             var angleDevice = IntPtr.Zero;
@@ -127,11 +148,11 @@ namespace Avalonia.Win32.OpenGl.Angle
             {
                 angleDevice = egl.CreateDeviceANGLE(EGL_D3D11_DEVICE_ANGLE, pD3dDevice, null);
                 if (angleDevice == IntPtr.Zero)
-                    throw OpenGlException.GetFormattedException("eglCreateDeviceANGLE", egl);
+                    OpenGlException.ThrowFormattedException("eglCreateDeviceANGLE", egl);
 
                 display = egl.GetPlatformDisplayExt(EGL_PLATFORM_DEVICE_EXT, angleDevice, null);
                 if (display == IntPtr.Zero)
-                    throw OpenGlException.GetFormattedException("eglGetPlatformDisplayEXT", egl);
+                    OpenGlException.ThrowFormattedException("eglGetPlatformDisplayEXT", egl);
 
 
                 var rv = new AngleWin32EglDisplay(display, egl,
@@ -155,6 +176,10 @@ namespace Avalonia.Win32.OpenGl.Angle
                     Cleanup();
                 }
             }
+
+            // Throwhelpers to aid inlining on rare paths.
+            void ThrowNoAdaptersFound() => throw new OpenGlException("No adapters found");
+            void ThrowCannotCreateD3D11Device() => throw new Win32Exception("Unable to create D3D11 Device");
         }
 
         private AngleWin32EglDisplay(IntPtr display, EglInterface egl, EglDisplayOptions options, AngleOptions.PlatformApi platformApi) : base(display, options)


### PR DESCRIPTION
## What does the pull request do?

This pull request speeds up the creation of the D3D11 device during startup by manually selecting the hardware type.

This results in a significant improvement in startup time when using Win D3D11 on NAOT.

## What is the current behavior?

Currently, the `CreateD3D11Display` method in `AngleWin32EglDisplay.cs` uses `D3D_DRIVER_TYPE_UNKNOWN` when creating the D3D11 device.

This can lead to slower startup times as the runtime needs to determine the appropriate driver type based on the available adapters.

## What is the updated/expected behavior with this PR?

With this PR, the startup time of Avalonia applications using Direct3D 11 is improved by approximately 40-50ms on most machines. On my desktop this results in a reduction of 75ms -> 25ms to initialize Avalonia under AOT.

(Measured from `AppBuilder.Configure` to running `Initialize` in `App.axaml.cs`)

The `CreateD3D11Display` method now explicitly selects the appropriate driver type (`D3D_DRIVER_TYPE_HARDWARE` or `D3D_DRIVER_TYPE_WARP`) based on the characteristics of the chosen adapter. (With a fallback to legacy `D3D_DRIVER_TYPE_SOFTWARE`)

This eliminates the overhead of the runtime determining the driver type and makes the creation of the D3D11 device essentially free. Since we're already querying the available display adapters, it would be a waste to not use that information.

## How was the solution implemented?

- Added a check to determine if the chosen adapter is a software adapter by examining the [Flags](https://learn.microsoft.com/en-us/windows/win32/api/dxgi/ne-dxgi-dxgi_adapter_flag) property of the [DXGI_ADAPTER_DESC1](https://learn.microsoft.com/en-us/windows/win32/api/dxgi/ns-dxgi-dxgi_adapter_desc1) structure.
- If the adapter is a software adapter, [D3D_DRIVER_TYPE_WARP](https://learn.microsoft.com/en-us/windows/win32/api/d3dcommon/ne-d3dcommon-d3d_driver_type#constants) is used as the driver type. Otherwise, [D3D_DRIVER_TYPE_HARDWARE](https://learn.microsoft.com/en-us/windows/win32/api/d3dcommon/ne-d3dcommon-d3d_driver_type#constants) is used.
- If the initial attempt to create the D3D11 device fails (adapter is Software and WARP is not supported, very very rare), a fallback mechanism tries to create the device with legacy [D3D_DRIVER_TYPE_SOFTWARE](https://learn.microsoft.com/en-us/windows/win32/api/d3dcommon/ne-d3dcommon-d3d_driver_type#constants) driver type.

And also

- Introduced `ThrowFormattedException` helper methods to allow callers to be inlined.