### PR TITLE
Fix crash in TreeView when removing a node.

### DIFF
--- a/samples/ControlCatalog/ViewModels/TreeViewPageViewModel.cs
+++ b/samples/ControlCatalog/ViewModels/TreeViewPageViewModel.cs
@@ -49,9 +49,8 @@ namespace ControlCatalog.ViewModels
         {
             while (SelectedItems.Count > 0)
             {
-                Node lastItem = (Node)SelectedItems[0];
+                var lastItem = SelectedItems[0];
                 RecursiveRemove(Items, lastItem);
-                SelectedItems.RemoveAt(0);
             }
 
             bool RecursiveRemove(ObservableCollection<Node> items, Node selectedItem)


### PR DESCRIPTION
When trying to remove a node in the TreeView sample the App crashes with:

```
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
   at System.Collections.ObjectModel.Collection`1.RemoveAt(Int32 index)
   at ControlCatalog.ViewModels.TreeViewPageViewModel.RemoveItem() in 
```

The reason is that `SelectedItems` are already updated via `TreeView.OnItemsViewCollectionChanged`.

`TreeViewTests` already asserts that this is the case.


