### PR TITLE
[Text] Use CultureInfo.Name instead of ISOLanguageName for character matching

### DIFF
--- a/src/Skia/Avalonia.Skia/FontManagerImpl.cs
+++ b/src/Skia/Avalonia.Skia/FontManagerImpl.cs
@@ -55,9 +55,8 @@ namespace Avalonia.Skia
 
             culture ??= CultureInfo.CurrentUICulture;
 
-            t_languageTagBuffer ??= new string[2];
-            t_languageTagBuffer[0] = culture.TwoLetterISOLanguageName;
-            t_languageTagBuffer[1] = culture.ThreeLetterISOLanguageName;
+            t_languageTagBuffer ??= new string[1];
+            t_languageTagBuffer[0] = culture.Name;
 
             using var skTypeface = _skFontManager.MatchCharacter(null, skFontStyle, t_languageTagBuffer, codepoint);
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
It changes character matching to use a full bcp47 language identifier to be able to distinguish between different variants of a language family. The previous solution of specifying a two or three-letter tag wasn't enough to achieve this.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes: #12349