### PR TITLE
Enhance SplitPropertyPath to conditionally handle parentheses in prop…

### DIFF
--- a/src/Avalonia.Controls.DataGrid/Utils/ReflectionHelper.cs
+++ b/src/Avalonia.Controls.DataGrid/Utils/ReflectionHelper.cs
@@ -19,6 +19,8 @@ namespace Avalonia.Controls.Utils
         internal const char LeftIndexerToken = '[';
         internal const char PropertyNameSeparator = '.';
         internal const char RightIndexerToken = ']';
+        internal const char LeftParenthesisToken  = '(';
+        internal const char RightParenthesisToken = ')';
 
         private static Type FindGenericType(Type definition, Type type)
         {
@@ -482,12 +484,35 @@ namespace Avalonia.Controls.Utils
             List<string> propertyPaths = new List<string>();
             if (!string.IsNullOrEmpty(propertyPath))
             {
+                bool parenthesisOn = false;
                 int startIndex = 0;
                 for (int index = 0; index < propertyPath.Length; index++)
                 {
-                    if (propertyPath[index] == PropertyNameSeparator)
+                    if (parenthesisOn)
                     {
-                        propertyPaths.Add(propertyPath.Substring(startIndex, index - startIndex));
+                        if (propertyPath[index] == RightParenthesisToken)
+                        {
+                            parenthesisOn = false;
+                            startIndex = index + 1;
+                        }
+                        continue;
+                    }
+
+                    if (propertyPath[index] == LeftParenthesisToken)
+                    {
+                        parenthesisOn = true;
+                        if (startIndex != index)
+                        {
+                            propertyPaths.Add(propertyPath.Substring(startIndex, index - startIndex));
+                            startIndex = index + 1;
+                        }
+                    }
+                    else if (propertyPath[index] == PropertyNameSeparator)
+                    {
+                        if (startIndex != index)
+                        {
+                            propertyPaths.Add(propertyPath.Substring(startIndex, index - startIndex));
+                        }
                         startIndex = index + 1;
                     }
                     else if (startIndex != index && propertyPath[index] == LeftIndexerToken)

--- a/tests/Avalonia.Controls.DataGrid.UnitTests/Utils/ReflectionHelperTests.cs
+++ b/tests/Avalonia.Controls.DataGrid.UnitTests/Utils/ReflectionHelperTests.cs
@@ -1,0 +1,20 @@
+
+using Avalonia.Controls.Utils;
+using Xunit;
+
+namespace Avalonia.Controls.DataGrid.UnitTests.Utils
+{
+    public class ReflectionHelperTests
+    {
+        [Fact]
+        public void SplitPropertyPath_Splits_PropertyPath_With_Cast()
+        {
+            var path = "(Type).Property";
+            var expected = new [] { "Property" };
+
+            var result = TypeHelper.SplitPropertyPath(path);
+            
+            Assert.Equal(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
Parenthesis encircles the property type in front of properties in a property path. Example `(Contact).Name`. The `SplitPropertyPath` method from ReflectionHelper could not handle this, making datagrid cells automatically uneditable when there is a cast of property type in the path. Now, I am conditionally handling that, and the issue is resolved by removing the property type cast from the property path.

## What is the current behavior?
property casting happens in a property path and automatically makes the datagrid cell uneditable when it is there.

## What is the updated/expected behavior with this PR?
If there is a cast of a property type with parenthesis on the property path, it is removed from the path, and there is no making it uneditable because of that issue

## Fixed issues
Fixes #15865
