### PR TITLE
Fix headless window transparency

### DIFF
--- a/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
@@ -247,7 +247,7 @@ namespace Avalonia.Headless
 
         public Action<WindowTransparencyLevel>? TransparencyLevelChanged { get; set; }
 
-        public WindowTransparencyLevel TransparencyLevel => WindowTransparencyLevel.None;
+        public WindowTransparencyLevel TransparencyLevel => WindowTransparencyLevel.Transparent;
 
         public Action? GotInputWhenDisabled { get; set; }
 

--- a/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessWindowImpl.cs
@@ -247,7 +247,7 @@ namespace Avalonia.Headless
 
         public Action<WindowTransparencyLevel>? TransparencyLevelChanged { get; set; }
 
-        public WindowTransparencyLevel TransparencyLevel => WindowTransparencyLevel.Transparent;
+        public WindowTransparencyLevel TransparencyLevel { get; set; } = WindowTransparencyLevel.Transparent;
 
         public Action? GotInputWhenDisabled { get; set; }
 
@@ -372,7 +372,15 @@ namespace Avalonia.Headless
 
         public void SetTransparencyLevelHint(IReadOnlyList<WindowTransparencyLevel> transparencyLevel)
         {
-            
+            foreach (var item in transparencyLevel)
+            {
+                if (item == WindowTransparencyLevel.Transparent) {
+                    TransparencyLevel = item;
+                    return;
+                }
+            }
+
+            TransparencyLevel = WindowTransparencyLevel.None;
         }
 
         public void SetParent(IWindowImpl? parent)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fixes rendering headless windows that have transparent backgrounds, to actually render as transparent.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
The background of the rendered bitmap is white, although the Window's Background is set to "Transparent".
This makes it so if the user wants a transparent background, they can use TransparencyLevelHint where it previously was never transparent. 

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
The background is transparent if specifying it with TransparencyLevelHint and Background="Transparent"

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Changed the TransparencyLevel to Transparent to allow for transparent rendering. 

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
