### PR TITLE
Set isDirectory:true explicitly to help [NSURL fileURLWithPath] method

### DIFF
--- a/native/Avalonia.Native/src/OSX/SystemDialogs.mm
+++ b/native/Avalonia.Native/src/OSX/SystemDialogs.mm
@@ -94,7 +94,8 @@ public:
             if(initialDirectory != nullptr)
             {
                 auto directoryString = [NSString stringWithUTF8String:initialDirectory];
-                panel.directoryURL = [NSURL fileURLWithPath:directoryString];
+                panel.directoryURL = [NSURL fileURLWithPath:directoryString
+                                            isDirectory:true];
             }
             
             auto handler = ^(NSModalResponse result) {
@@ -169,7 +170,8 @@ public:
             if(initialDirectory != nullptr)
             {
                 auto directoryString = [NSString stringWithUTF8String:initialDirectory];
-                panel.directoryURL = [NSURL fileURLWithPath:directoryString];
+                panel.directoryURL = [NSURL fileURLWithPath:directoryString
+                                            isDirectory:true];
             }
             
             if(initialFile != nullptr)
@@ -248,7 +250,8 @@ public:
             if(initialDirectory != nullptr)
             {
                 auto directoryString = [NSString stringWithUTF8String:initialDirectory];
-                panel.directoryURL = [NSURL fileURLWithPath:directoryString];
+                panel.directoryURL = [NSURL fileURLWithPath:directoryString
+                                            isDirectory:true];
             }
             
             if(initialFile != nullptr)


### PR DESCRIPTION
Might solve random issues with initial directory not being applied on macOS dialogs.

Can't really reproduce this issue on my mac though.