### PR TITLE
Fix HorizontalHeadTable usage

### DIFF
--- a/src/Avalonia.Base/Media/Fonts/Tables/HorizontalHeadTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/HorizontalHeadTable.cs
@@ -59,11 +59,11 @@ namespace Avalonia.Media.Fonts.Tables
 
         public short XMaxExtent { get; }
 
-        public static HorizontalHeadTable Load(IGlyphTypeface glyphTypeface)
+        public static HorizontalHeadTable? Load(IGlyphTypeface glyphTypeface)
         {
             if (!glyphTypeface.TryGetTable(Tag, out var table))
             {
-                throw new MissingFontTableException("Could not load table", "name");
+                return null;
             }
 
             using var stream = new MemoryStream(table);

--- a/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs
+++ b/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Skia
         private readonly SKTypeface _typeface;
         private readonly NameTable _nameTable;
         private readonly OS2Table? _os2Table;
-        private readonly HorizontalHeadTable _hhTable;
+        private readonly HorizontalHeadTable? _hhTable;
         private IReadOnlyList<OpenTypeTag>? _supportedFeatures;
 
         public GlyphTypefaceImpl(SKTypeface typeface, FontSimulations fontSimulations)
@@ -38,9 +38,9 @@ namespace Avalonia.Skia
             _os2Table = OS2Table.Load(this);
             _hhTable = HorizontalHeadTable.Load(this);
 
-            int ascent;
-            int descent;
-            int lineGap;
+            var ascent = 0;
+            var descent = 0;
+            var lineGap = 0;
 
             if (_os2Table != null && (_os2Table.FontStyle & OS2Table.FontStyleSelection.USE_TYPO_METRICS) != 0)
             {
@@ -50,9 +50,12 @@ namespace Avalonia.Skia
             }
             else
             {
-                ascent = -_hhTable.Ascender;
-                descent = -_hhTable.Descender;
-                lineGap = _hhTable.LineGap;
+                if (_hhTable != null)
+                {
+                    ascent = -_hhTable.Ascender;
+                    descent = -_hhTable.Descender;
+                    lineGap = _hhTable.LineGap;
+                }
             }
 
             if (_os2Table != null && (ascent == 0 || descent == 0))


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Change HorizontalHeadTable.Load so it can return null if the table isn't present and handle that case in the GlyphTypefaceImpl

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Some fonts do not have a HorizontalHeadTable and therefore produce an exception when we try to load such font.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
