### PR TITLE
Allow custom ILauncher implementations with ILauncherFactory

### DIFF
--- a/src/Avalonia.Controls/Platform/ILauncherFactory.cs
+++ b/src/Avalonia.Controls/Platform/ILauncherFactory.cs
@@ -1,0 +1,14 @@
+﻿using Avalonia.Metadata;
+using Avalonia.Platform.Storage;
+
+namespace Avalonia.Controls.Platform;
+
+/// <summary>
+/// Factory allows to register custom ILauncher.
+/// Can be used for overriding some URL handlers for example
+/// </summary>
+[Unstable]
+public interface ILauncherFactory
+{
+    ILauncher CreateLauncher(TopLevel topLevel);
+}

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -546,7 +546,9 @@ namespace Avalonia.Controls
 
         public IInsetsManager? InsetsManager => PlatformImpl?.TryGetFeature<IInsetsManager>();
         public IInputPane? InputPane => PlatformImpl?.TryGetFeature<IInputPane>();
-        public ILauncher Launcher => PlatformImpl?.TryGetFeature<ILauncher>() ?? new NoopLauncher();
+        public ILauncher Launcher => new ChainLauncher(
+            AvaloniaLocator.Current.GetService<ILauncherFactory>()?.CreateLauncher(this), 
+            PlatformImpl?.TryGetFeature<ILauncher>());
 
         /// <summary>
         /// Gets the platform's clipboard implementation


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
It is currently impossible to intercept URLs launched with ILauncher.

There's another PR with an event-driven way of doing things (#15674), where [robloo](https://github.com/robloo) [said the following](https://github.com/AvaloniaUI/Avalonia/pull/15674#issuecomment-2104560614) (condensed a bit):
> ILauncher is clean and simple as is and works for most apps. If you need to customize a service, then you need to provide your own ILauncher implementation. That said, I'm not sure we have a way of registering service overrides. We probably should support that. 

So instead I've opted to do it similarly to the `IStorageProviderFactory` pattern visible just a few lines above the new TopLevel code, and marking the new interface unstable, just like `IStorageProviderFactory`. 

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
URLs can be intercepted if required, and can still be passed on to the platform implementation if not wanting to intercept it.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Adds a new unstable interface, `ILauncherFactory` similar to `IStorageProviderFactory`.
Can be registered with the `AppBuilder.With` method, like so: `.With<ILauncherFactory>(new YourImplementationHere())`

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

Fixes #15673

## Questions
I'm not sure if the formatting is entirely correct.  