### PR TITLE
Win32 - Ensure owner topmost flag is set if its topmost when showing a owned window 

### DIFF
--- a/samples/IntegrationTestApp/IntegrationTestApp.csproj
+++ b/samples/IntegrationTestApp/IntegrationTestApp.csproj
@@ -26,6 +26,12 @@
     <ProjectReference Include="..\..\src\Avalonia.Themes.Fluent\Avalonia.Themes.Fluent.csproj" />
     <ProjectReference Include="..\..\src\Avalonia.Fonts.Inter\Avalonia.Fonts.Inter.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="TopmostWindowTest.axaml.cs">
+      <DependentUpon>TopmostWindowTest.axaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
   
   <Import Project="..\..\build\BuildTargets.targets" />
   <Import Project="..\..\build\SampleApp.props" />

--- a/samples/IntegrationTestApp/MainWindow.axaml
+++ b/samples/IntegrationTestApp/MainWindow.axaml
@@ -170,6 +170,7 @@
             <Button Name="EnterFullscreen">Enter Fullscreen</Button>
             <Button Name="ExitFullscreen">Exit Fullscreen</Button>
             <Button Name="RestoreAll">Restore All</Button>
+            <Button Name="ShowTopmostWindow">Show Topmost Window</Button>
           </StackPanel>
           <StackPanel Grid.Column="2">
             <Button Name="ShowTransparentWindow">Transparent Window</Button>

--- a/samples/IntegrationTestApp/MainWindow.axaml.cs
+++ b/samples/IntegrationTestApp/MainWindow.axaml.cs
@@ -217,6 +217,15 @@ namespace IntegrationTestApp
                     window.WindowState = WindowState.Normal;
             }
         }
+        
+        private void ShowTopmostWindow()
+        {
+            var mainWindow = new TopmostWindowTest("OwnerWindow") { Topmost = true, Title = "Owner Window"};
+            var ownedWindow = new TopmostWindowTest("OwnedWindow") { WindowStartupLocation = WindowStartupLocation.CenterOwner, Title = "Owned Window"};
+            mainWindow.Show();
+            
+            ownedWindow.Show(mainWindow);
+        }
 
         private void InitializeGesturesTab()
         {
@@ -284,6 +293,8 @@ namespace IntegrationTestApp
                 WindowState = WindowState.Normal;
             if (source?.Name == "RestoreAll")
                 RestoreAll();
+            if (source?.Name == "ShowTopmostWindow")
+                ShowTopmostWindow();
         }
     }
 }

--- a/samples/IntegrationTestApp/TopmostWindowTest.axaml
+++ b/samples/IntegrationTestApp/TopmostWindowTest.axaml
@@ -1,0 +1,17 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        x:Class="IntegrationTestApp.TopmostWindowTest"
+        Title="TopmostWindowTest"
+        Width="640"
+        Height="480">
+  <Grid>
+    <TextBox Name="CurrentPosition"
+             Grid.Column="1"
+             Grid.Row="3"
+             IsReadOnly="True" />
+    <Button HorizontalAlignment="Center" Name="MoveButton" VerticalAlignment="Center" Click="Button_OnClick">Move</Button>
+  </Grid>
+</Window>

--- a/samples/IntegrationTestApp/TopmostWindowTest.axaml.cs
+++ b/samples/IntegrationTestApp/TopmostWindowTest.axaml.cs
@@ -1,0 +1,25 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+
+namespace IntegrationTestApp;
+
+public class TopmostWindowTest : Window
+{
+    public TopmostWindowTest(string name)
+    {
+        Name = name;
+        InitializeComponent();
+        PositionChanged += (s, e) => this.GetControl<TextBox>("CurrentPosition").Text = $"{Position}";
+    }
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private void Button_OnClick(object? sender, RoutedEventArgs e)
+    {
+        Position += new PixelPoint(100, 100);
+    }
+}

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -709,6 +709,8 @@ namespace Avalonia.Win32
 
             SetWindowLongPtr(_hwnd, (int)WindowLongParam.GWL_HWNDPARENT, parentHwnd);
 
+            // Windows doesn't seem to respect the HWND_TOPMOST flag of a window when showing an owned window for the first time.
+            // So we set the HWND_TOPMOST again before the owned window is shown. This only needs to be done once.
             (parent as WindowImpl)?.EnsureTopmost();
         }
 

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -708,6 +708,8 @@ namespace Avalonia.Win32
             _hiddenWindowIsParent = parentHwnd == OffscreenParentWindow.Handle;
 
             SetWindowLongPtr(_hwnd, (int)WindowLongParam.GWL_HWNDPARENT, parentHwnd);
+
+            (parent as WindowImpl)?.EnsureTopmost();
         }
 
         public void SetEnabled(bool enable) => EnableWindow(_hwnd, enable);
@@ -858,6 +860,17 @@ namespace Avalonia.Win32
                 SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOACTIVATE);
 
             _topmost = value;
+        }
+
+        private void EnsureTopmost()
+        {
+            if(_topmost)
+            {
+                SetWindowPos(_hwnd,
+                    WindowPosZOrder.HWND_TOPMOST,
+                    0, 0, 0, 0,
+                    SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOACTIVATE);
+            }
         }
 
         public unsafe void SetFrameThemeVariant(PlatformThemeVariant themeVariant)

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
@@ -257,11 +257,11 @@ namespace Avalonia.IntegrationTests.Appium
             Assert.Equal(new Rgba32(255, 0, 0), centerColor);
         }
 
-        [Fact]
+        [PlatformFact(TestPlatforms.Windows)]
         public void Owned_Window_Should_Appear_Above_Topmost_Owner()
         {
             var showTopmostWindow = _session.FindElementByAccessibilityId("ShowTopmostWindow");
-            showTopmostWindow.OpenWindowWithClick();
+            using var window = showTopmostWindow.OpenWindowWithClick();
             Thread.Sleep(1000);
             var ownerWindow = GetWindow("OwnerWindow");
             var ownedWindow = GetWindow("OwnedWindow");
@@ -271,8 +271,6 @@ namespace Avalonia.IntegrationTests.Appium
 
             var ownerPosition = GetPosition(ownerWindow);
             var ownedPosition = GetPosition(ownedWindow);
-
-            Assert.Equal(ownerPosition, ownedPosition);
 
             // Owned Window moves 
             var moveButton = ownedWindow.FindElementByAccessibilityId("MoveButton");

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests.cs
@@ -257,6 +257,37 @@ namespace Avalonia.IntegrationTests.Appium
             Assert.Equal(new Rgba32(255, 0, 0), centerColor);
         }
 
+        [Fact]
+        public void Owned_Window_Should_Appear_Above_Topmost_Owner()
+        {
+            var showTopmostWindow = _session.FindElementByAccessibilityId("ShowTopmostWindow");
+            showTopmostWindow.OpenWindowWithClick();
+            Thread.Sleep(1000);
+            var ownerWindow = GetWindow("OwnerWindow");
+            var ownedWindow = GetWindow("OwnedWindow");
+
+            Assert.NotNull(ownerWindow);
+            Assert.NotNull(ownedWindow);
+
+            var ownerPosition = GetPosition(ownerWindow);
+            var ownedPosition = GetPosition(ownedWindow);
+
+            Assert.Equal(ownerPosition, ownedPosition);
+
+            // Owned Window moves 
+            var moveButton = ownedWindow.FindElementByAccessibilityId("MoveButton");
+            moveButton.Click();
+            Thread.Sleep(1000);
+
+            Assert.Equal(GetPosition(ownerWindow), ownerPosition);
+            Assert.NotEqual(GetPosition(ownedWindow), ownedPosition);
+
+            PixelPoint GetPosition(AppiumWebElement window)
+            {
+                return PixelPoint.Parse(window.FindElementByAccessibilityId("CurrentPosition").Text);
+            }
+        }
+
         [Theory]
         [InlineData(ShowWindowMode.NonOwned, true)]
         [InlineData(ShowWindowMode.Owned, true)]


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
If a window with an owner is being shown, and the owner is Topmost, ensure the flags for topmost window is set for that owner.

## What is the current behavior?
Topmost flag on owner isn't being respected for owned windows when being shown, making them appear behind the owner.
This is the behavior currently
1. Main Window.Topmost is true
2. Main Window shows, Topmost flag is set
3. Main Window remains topmost
4. Child window is created, shown with main window as owner
5. Child window appears behind main window
6. Main window still has Topmost flag and appears above every window. Child doesn't have topmost exstyle flag

On Wpf, child will appear above main window in 5, and will have the topmost ex style flag in 6, but not the Topmost window flag

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
If the owner window is Topmost, the `HWND_TOPMOST` is set once more before the owned window is shown. This only needs to be set once.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
