### PR TITLE
Fix compiled binding indexer always forcing integer boxing

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlClrPropertyInfoHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlClrPropertyInfoHelper.cs
@@ -34,9 +34,9 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             return baseKey + $"[{indexerArgumentsKey}]";
         }
 
-        public IXamlType Emit(XamlEmitContext<IXamlILEmitter, XamlILNodeEmitResult> context, IXamlILEmitter codeGen, IXamlProperty property, IEnumerable<IXamlAstValueNode> indexerArguments = null, string indexerArgumentsKey = null)
+        public IXamlType Emit(XamlEmitContext<IXamlILEmitter, XamlILNodeEmitResult> context, IXamlILEmitter codeGen, IXamlProperty property, IReadOnlyCollection<IXamlAstValueNode> indexerArguments = null, string indexerArgumentsKey = null)
         {
-            indexerArguments = indexerArguments ?? Enumerable.Empty<IXamlAstValueNode>();
+            indexerArguments = indexerArguments ?? Array.Empty<IXamlAstValueNode>();
             var types = context.GetAvaloniaTypes();
             IXamlMethod Get()
             {
@@ -101,10 +101,12 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                     Load(property.Setter, setter.Generator, !property.Getter.IsStatic);
                     
                     setter.Generator.Ldarg(1);
-                    if (property.Setter.Parameters[0].IsValueType)
-                        setter.Generator.Unbox_Any(property.Setter.Parameters[0]);
+
+                    var valueIndex = indexerArguments.Count;
+                    if (property.Setter.Parameters[valueIndex].IsValueType)
+                        setter.Generator.Unbox_Any(property.Setter.Parameters[valueIndex]);
                     else
-                        setter.Generator.Castclass(property.Setter.Parameters[0]);
+                        setter.Generator.Castclass(property.Setter.Parameters[valueIndex]);
                     setter.Generator
                         .EmitCall(property.Setter, true)
                         .Ret();

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -306,6 +306,36 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         }
 
         [Fact]
+        public void IndexerSetterBindsCorrectly()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(@"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
+        x:DataType='local:TestDataContext'>
+    <TextBox Text='{CompiledBinding ListProperty[3], Mode=TwoWay}' Name='textBox' />
+</Window>");
+                var textBox = window.GetControl<TextBox>("textBox");
+
+                var dataContext = new TestDataContext
+                {
+                    ListProperty = { "A", "B", "C", "D", "E" }
+                };
+
+                window.DataContext = dataContext;
+
+                Assert.Equal(dataContext.ListProperty[3], textBox.Text);
+
+                textBox.Text = "Z";
+
+                Assert.Equal("Z", dataContext.ListProperty[3]);
+                Assert.Equal(dataContext.ListProperty[3], textBox.Text);
+            }
+        }
+
+        [Fact]
         public void ResolvesArrayIndexerBindingCorrectly()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))


### PR DESCRIPTION
## What does the pull request do?

Working on https://github.com/AvaloniaUI/Avalonia/pull/16108 I noticed invalid IL warnings produced by AOT compiler. 
Apparently, our indexer setter were always invalid, at least with compiled bindings.
Didn't find any opened issues, but repro is pretty simple - any twoway binding to the indexer property.


## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

