### PR TITLE
Fix Linux X11 Atoms lost: Before the window was mapped, only the first atom was set.

### DIFF
--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -1392,7 +1392,7 @@ namespace Avalonia.X11
                 var ptr = (IntPtr*)prop.ToPointer();
                 var newAtoms = new HashSet<IntPtr>();
                 for (var c = 0; c < nitems.ToInt64(); c++) 
-                    newAtoms.Add(*ptr);
+                    newAtoms.Add(*(ptr+c));
                 XFree(prop);
                 foreach(var atom in atoms)
                     if (enable)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->

1. We can set multiple atoms before the window is mapped, e.g. `ShowInTaskBar="False"`, `Topmost="True"`, `WindowState = WindowState.FullScreen`.
1. Before this PR, only the first atom was set. All other atoms were lost.
1. This PR fixes the issue by setting all atoms before the window is mapped.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

For example, if we set window properties like this:

```xml
public MainWindow()
{
    InitializeComponent();

    ShowInTaskbar = false;
    Topmost = true;
    WindowState = WindowState.FullScreen;
}
```

Before this PR, we can only find that the taskbar icon is hidden, but the window is not topmost and not full screen.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

After this PR, we can find that the taskbar icon is hidden, the window is topmost, and the window is full screen.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->

See the code before this PR:

```csharp
XGetWindowProperty(_x11.Display, _handle, _x11.Atoms._NET_WM_STATE, IntPtr.Zero, new IntPtr(256),
    false, (IntPtr)Atom.XA_ATOM, out _, out _, out var nitems, out _,
    out var prop);
var ptr = (IntPtr*)prop.ToPointer();
var newAtoms = new HashSet<IntPtr>();
for (var c = 0; c < nitems.ToInt64(); c++) 
    newAtoms.Add(*ptr);
XFree(prop);
foreach(var atom in atoms)
    if (enable)
        newAtoms.Add(atom);
    else
        newAtoms.Remove(atom);
```

The newAtoms add only the header of the pointer `ptr`. So only the first atom was added even if the `for` runs multiple times.

We changed the code to:

```diff
    for (var c = 0; c < nitems.ToInt64(); c++) 
--      newAtoms.Add(*ptr);
++      newAtoms.Add(*(ptr+c));
```

So all atoms are added to the newAtoms.

## Checklist

- [x] Added unit tests (if possible)? *No unit tests are added*
- [x] Added XML documentation to any related classes? *No XML documentation is added*
- [x] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation *This is a bug fix, no user documentation is needed*

## Breaking changes
<!--- List any breaking changes here. -->

None.

The X11 atoms change is unique and the X system auto removes the repeated atoms so it is safe to add multiple atoms even if the developers add the same atoms themselves.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

None.

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
