### PR TITLE
Added support for LinkBase in Avalonia resources generator

### DIFF
--- a/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
+++ b/src/Avalonia.Build.Tasks/Avalonia.Build.Tasks.csproj
@@ -125,5 +125,10 @@
       <PackageReference Include="Microsoft.Build.Framework" Version="15.1.548" PrivateAssets="All" />
       <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     </ItemGroup>
+
+  <ItemGroup Label="InternalsVisibleTo">
+    <InternalsVisibleTo Include="Avalonia.Build.Tasks.UnitTest, PublicKey=$(AvaloniaPublicKey)" />
+  </ItemGroup>
+  
   <Import Project="..\..\build\SourceGenerators.props" />
 </Project>

--- a/src/Avalonia.Build.Tasks/GenerateAvaloniaResourcesTask.cs
+++ b/src/Avalonia.Build.Tasks/GenerateAvaloniaResourcesTask.cs
@@ -38,9 +38,12 @@ namespace Avalonia.Build.Tasks
                 _sourcePath = SPath.Combine(root, relativePath);
                 Size = (int)new FileInfo(_sourcePath).Length;
                 var link = avaloniaResourceItem.GetMetadata("Link");
+                var linkBase = avaloniaResourceItem.GetMetadata("LinkBase");
                 var path = !string.IsNullOrEmpty(link)
                     ? link
-                    : relativePath;
+                    : !string.IsNullOrEmpty(linkBase)
+                        ? linkBase 
+                        : relativePath;
                 Path = "/" + path.Replace('\\', '/');
             }
 

--- a/src/Avalonia.Build.Tasks/GenerateAvaloniaResourcesTask.cs
+++ b/src/Avalonia.Build.Tasks/GenerateAvaloniaResourcesTask.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Build.Tasks
 
         private MessageImportance _reportImportance;
 
-        class Source
+        internal class Source
         {
             public string Path { get; set; }
             public int Size { get; set; }

--- a/tests/Avalonia.Build.Tasks.UnitTest/Avalonia.Build.Tasks.UnitTest.csproj
+++ b/tests/Avalonia.Build.Tasks.UnitTest/Avalonia.Build.Tasks.UnitTest.csproj
@@ -21,6 +21,9 @@
     <Content Include="..\TestFiles\BuildTasks\PInvoke\bin\$(Configuration)\netstandard2.0\PInvoke.dll.refs" Link="Assets\PInvoke.dll.refs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\TestFiles\BuildTasks\root.xml" Link="Assets\root.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Avalonia.Build.Tasks.UnitTest/GenerateAvaloniaResourcesTaskTest.cs
+++ b/tests/Avalonia.Build.Tasks.UnitTest/GenerateAvaloniaResourcesTaskTest.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Microsoft.Build.Utilities;
+using Xunit;
+
+namespace Avalonia.Build.Tasks.UnitTest;
+
+public class GenerateAvaloniaResourcesTaskTest
+{
+    [Fact]
+    public void Does_Support_LinkBase_In_Avalonia_Resources_Generator()
+    {
+        var path = "path/to/resources";
+        var expected = "/" + path;
+        
+        var basePath = Path.Combine(Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath), "Assets");
+        var rootPath = Path.Combine(basePath, "root.xml");
+        
+        var avaloniaResourceItem = new TaskItem();
+        avaloniaResourceItem.SetMetadata("LinkBase", path);
+        var source = new GenerateAvaloniaResourcesTask.Source(avaloniaResourceItem, rootPath);
+        
+        Assert.Equal(expected, source.Path);
+    }
+}

--- a/tests/TestFiles/BuildTasks/root.xml
+++ b/tests/TestFiles/BuildTasks/root.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
## What does the pull request do?
adds support for `LinkBase` in avalonia resources generator


## What is the current behavior?
Avalonia asset loader is not resolving for `LinkBase`


## What is the updated/expected behavior with this PR?
Using LinkBase to set resources path works


## Fixed issues
Fixes #16056