### PR TITLE
Fix `ICommand` bindings in style setters

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlWellKnownTypes.cs
@@ -108,6 +108,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
         public IXamlType TextDecorations { get; }
         public IXamlType TextTrimming { get; }
         public IXamlType SetterBase { get; }
+        public IXamlType Setter { get; }
         public IXamlType IStyle { get; }
         public IXamlType StyleInclude { get; }
         public IXamlType ResourceInclude { get; }
@@ -297,6 +298,7 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
             TextDecorations = cfg.TypeSystem.GetType("Avalonia.Media.TextDecorations");
             TextTrimming = cfg.TypeSystem.GetType("Avalonia.Media.TextTrimming");
             SetterBase = cfg.TypeSystem.GetType("Avalonia.Styling.SetterBase");
+            Setter = cfg.TypeSystem.GetType("Avalonia.Styling.Setter");
             IStyle = cfg.TypeSystem.GetType("Avalonia.Styling.IStyle");
             StyleInclude = cfg.TypeSystem.GetType("Avalonia.Markup.Xaml.Styling.StyleInclude");
             ResourceInclude = cfg.TypeSystem.GetType("Avalonia.Markup.Xaml.Styling.ResourceInclude");

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
@@ -85,10 +85,10 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             {
                 return transformed;
             }
-
+            
             var lastElement = transformed.Elements.LastOrDefault();
             
-            if (parentNode.Property?.Getter?.ReturnType == context.GetAvaloniaTypes().ICommand && lastElement is XamlIlClrMethodPathElementNode methodPathElement)
+            if (GetPropertyType(context, parentNode) == context.GetAvaloniaTypes().ICommand && lastElement is XamlIlClrMethodPathElementNode methodPathElement)
             {
                 IXamlMethod executeMethod = methodPathElement.Method;
                 IXamlMethod canExecuteMethod = executeMethod.DeclaringType.FindMethod(new FindMethodMethodSignature($"Can{executeMethod.Name}", context.Configuration.WellKnownTypes.Boolean, context.Configuration.WellKnownTypes.Object));
@@ -108,6 +108,29 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             }
 
             return transformed;
+        }
+
+        private static IXamlType GetPropertyType(AstTransformationContext context, XamlPropertyAssignmentNode node)
+        {
+            var setterType = context.GetAvaloniaTypes().Setter;
+
+            if (node.Property.DeclaringType == setterType && node.Property.Name == "Value")
+            {
+                // The property is a Setter.Value property. We need to get the type of the property that the Setter.Value property is setting.
+                var setter = context.ParentNodes()
+                    .SkipWhile(x => x != node)
+                    .OfType<XamlAstConstructableObjectNode>()
+                    .Take(1)
+                    .FirstOrDefault(x => x.Type.GetClrType() == setterType);
+                var propertyAssignment = setter?.Children.OfType<XamlPropertyAssignmentNode>()
+                    .FirstOrDefault(x => x.Property.GetClrProperty().Name == "Property");
+                var property = propertyAssignment?.Values.FirstOrDefault() as IXamlIlAvaloniaPropertyNode;
+
+                if (property.AvaloniaPropertyType is { } propertyType)
+                    return propertyType;
+            }
+
+            return node.Property?.Getter?.ReturnType;
         }
 
         private static XamlIlBindingPathNode TransformBindingPath(AstTransformationContext context, IXamlLineInfo lineInfo, Func<IXamlType> startTypeResolver, IXamlType selfType, IEnumerable<BindingExpressionGrammar.INode> bindingExpression)

--- a/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
+++ b/tests/Avalonia.Markup.Xaml.UnitTests/MarkupExtensions/CompiledBindingExtensionTests.cs
@@ -1929,6 +1929,36 @@ namespace Avalonia.Markup.Xaml.UnitTests.MarkupExtensions
         }
 
         [Fact]
+        public void Binding_Method_To_Command_In_Style_Works()
+        {
+            using (UnitTestApplication.Start(TestServices.StyledWindow))
+            {
+                var xaml = @"
+<Window xmlns='https://github.com/avaloniaui'
+        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+        xmlns:local='clr-namespace:Avalonia.Markup.Xaml.UnitTests.MarkupExtensions;assembly=Avalonia.Markup.Xaml.UnitTests'
+        x:DataType='local:MethodAsCommandDataContext'>
+    <Window.Styles>
+        <Style Selector='Button'>
+            <Setter Property='Command' Value='{CompiledBinding Method}'/>
+        </Style>
+    </Window.Styles>
+    <Button Name='button'/>
+</Window>";
+                var window = (Window)AvaloniaRuntimeXamlLoader.Load(xaml);
+                var button = window.GetControl<Button>("button");
+                var vm = new MethodAsCommandDataContext();
+
+                button.DataContext = vm;
+                window.ApplyTemplate();
+
+                Assert.NotNull(button.Command);
+                PerformClick(button);
+                Assert.Equal("Called", vm.Value);
+            }
+        }
+
+        [Fact]
         public void ResolvesDataTypeForAssignBinding()
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))


### PR DESCRIPTION
## What does the pull request do?

As described in #16113, when compiling a binding to e.g. `Button.Command` in a style `Setter`, we were not converting `XamlIlClrMethodPathElementNode` to `XamlIlClrMethodAsCommandPathElementNode` as we were only testing whether the property that the binding was being assigned to is an `ICommand`: in this case `Setter.Value` is an `object` so the conversion wasn't happening.

If we detect that we're assigning the binding to a `Setter.Value` then we need to look in the `Setter.Property` to see check whether the property is an `ICommand` too.

## Fixed issues

Fixes #16113
