### PR TITLE
[Text] Use GetBackspaceCaretCharacterHit for backspace delete handling

### DIFF
--- a/src/Avalonia.Controls/TextBox.cs
+++ b/src/Avalonia.Controls/TextBox.cs
@@ -1442,6 +1442,17 @@ namespace Avalonia.Controls
 
                                 var backspacePosition = characterHit.FirstCharacterIndex + characterHit.TrailingLength;
 
+                                var lineIndex = _presenter.TextLayout.GetLineIndexFromCharacterIndex(caretIndex, true);
+
+                                var backspaceCharacterHit = _presenter.TextLayout.TextLines[lineIndex]
+                                    .GetBackspaceCaretCharacterHit(new CharacterHit(caretIndex));
+
+                                if (backspaceCharacterHit.FirstCharacterIndex > backspacePosition &&
+                                    backspaceCharacterHit.FirstCharacterIndex < caretIndex)
+                                {
+                                    backspacePosition = backspaceCharacterHit.FirstCharacterIndex;
+                                }
+
                                 if (caretIndex != backspacePosition)
                                 {
                                     var start = Math.Min(backspacePosition, caretIndex);
@@ -1456,6 +1467,8 @@ namespace Avalonia.Controls
                                     SetCurrentValue(TextProperty, StringBuilderCache.GetStringAndRelease(sb));
 
                                     SetCurrentValue(CaretIndexProperty, start);
+
+                                    _presenter.MoveCaretToTextPosition(start, true);
                                 }
                             }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR changes TextBox so it uses GetBackspaceCaretCharacterHit to calculation the deletion range on backspace. This ensures someone can delete parts of a formed ligature.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
