### PR TITLE
win32: Fix edge-case bug with DPI scaling

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -130,6 +130,7 @@ namespace Avalonia.Win32
                     }
 
                 case WindowsMessage.WM_DPICHANGED:
+                    if (!_ignoreDpiChanges)
                     {
                         _dpi = (uint)wParam >> 16;
                         var newDisplayRect = Marshal.PtrToStructure<RECT>(lParam);
@@ -151,6 +152,7 @@ namespace Avalonia.Win32
 
                         return IntPtr.Zero;
                     }
+                    break;
 
                 case WindowsMessage.WM_GETICON:
                     if (_iconImpl == null)

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -107,6 +107,7 @@ namespace Avalonia.Win32
         private bool _shown;
         private bool _hiddenWindowIsParent;
         private uint _langid;
+        private bool _ignoreDpiChanges;
         internal bool _ignoreWmChar;
         private WindowTransparencyLevel _transparencyLevel;
         private readonly WindowTransparencyLevel _defaultTransparencyLevel;
@@ -707,7 +708,20 @@ namespace Avalonia.Win32
 
             _hiddenWindowIsParent = parentHwnd == OffscreenParentWindow.Handle;
 
+            // I can't find mention of this *anywhere* online, but it seems that setting
+            // GWL_HWNDPARENT to a window which is on the non-primary monitor can cause two
+            // WM_DPICHANGED messages to be sent: the first changing the DPI to the parent's DPI,
+            // then another changing the DPI back. This then causes Windows to provide an incorrect
+            // suggested new rectangle to the WM_DPICHANGED message if the window is immediately
+            // moved to the parent window's monitor (e.g. when using
+            // WindowStartupLocation.CenterOwner) causing the window to be shown with an incorrect
+            // size.
+            //
+            // Just ignore any WM_DPICHANGED while we're setting the parent as this shouldn't
+            // change the DPI anyway.
+            _ignoreDpiChanges = true;
             SetWindowLongPtr(_hwnd, (int)WindowLongParam.GWL_HWNDPARENT, parentHwnd);
+            _ignoreDpiChanges = false;
         }
 
         public void SetEnabled(bool enable) => EnableWindow(_hwnd, enable);


### PR DESCRIPTION
## What does the pull request do?

Fixes an issue reported to us by @danipen that can be reproduced by https://github.com/danipen/AvaloniaDpiIssue:

- Have two monitors, the primary monitor with 125% scaling the secondary with 100% scaling
- Run the repro
- Move the window to the secondary monitor
- Show the dialog
- See that the dialog is cropped

This appears to be caused by a win32 bug. Not sure I can describe it any better than the in-code comment:

```
// I can't find mention of this *anywhere* online, but it seems that setting
// GWL_HWNDPARENT to a window which is on the non-primary monitor can cause two
// WM_DPICHANGED messages to be sent: the first changing the DPI to the parent's DPI,
// then another changing the DPI back. This then causes Windows to provide an incorrect
// suggested new rectangle to the WM_DPICHANGED message if the window is immediately
// moved to the parent window's monitor (e.g. when using
// WindowStartupLocation.CenterOwner) causing the window to be shown with an incorrect
// size.
//
// Just ignore any WM_DPICHANGED while we're setting the parent as this shouldn't
// change the DPI anyway.
```

The solution seems to be to simply ignore DPI changes while `GWL_HWNDPARENT` is being set.