### PR TITLE
Patch Win32.TrayIconImpl DPI check for Win7/8

### DIFF
--- a/src/Windows/Avalonia.Win32/TrayIconImpl.cs
+++ b/src/Windows/Avalonia.Win32/TrayIconImpl.cs
@@ -126,13 +126,7 @@ namespace Avalonia.Win32
             Win32Icon? newIcon = null;
             if (_iconStale && _iconImpl is not null)
             {
-                var scaling = 1.0;
-                if ((HRESULT)GetDpiForMonitor(s_taskBarMonitor, MONITOR_DPI_TYPE.MDT_EFFECTIVE_DPI, out var dpiX, out var dpiY) == HRESULT.S_OK)
-                {
-                    Debug.Assert(dpiX == dpiY);
-                    scaling = dpiX / 96.0;
-                }
-
+                var scaling = GetTaskBarMonScalingOrDefault();
                 newIcon = _iconImpl.LoadSmallIcon(scaling);
             }
 
@@ -172,6 +166,26 @@ namespace Avalonia.Win32
                 _icon = newIcon;
                 _iconStale = false;
             }
+        }
+        
+        private double GetTaskBarMonScalingOrDefault()
+        {
+            if (ShCoreAvailable && Win32Platform.WindowsVersion > PlatformConstants.Windows8_1)
+            {
+                uint dpiX, dpiY;
+
+                if ((HRESULT)GetDpiForMonitor(
+                        s_taskBarMonitor,
+                        MONITOR_DPI_TYPE.MDT_EFFECTIVE_DPI,
+                        out dpiX,
+                        out dpiY)  == HRESULT.S_OK)
+                {
+                    Debug.Assert(dpiX == dpiY);
+                    return dpiX / 96.0;
+                }
+            }
+
+            return 1.0;
         }
 
         private IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Patches https://github.com/AvaloniaUI/Avalonia/issues/16146

This PR adds additional platform checks to Win32.TrayIcon. Similar to: 

https://github.com/AvaloniaUI/Avalonia/blob/eb882213be5438f6cd039f607b8952ae1153b808/src/Windows/Avalonia.Direct2D1/HwndRenderTarget.cs#L25

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->

Currently there is no `shcore.dll` availability check, which causing a crash on Win7

```
2024-06-26 14:01:32.749 -05:00 [FTL] [737508C3] App Unhandled error occured
System.DllNotFoundException: Unable to load DLL 'shcore.dll' or one of its dependencies: The specified module could not be found. (0x8007007E)
   at Avalonia.Win32.Interop.UnmanagedMethods.GetDpiForMonitor(IntPtr hmonitor, MONITOR_DPI_TYPE dpiType, UInt32& dpiX, UInt32& dpiY)
   at Avalonia.Win32.TrayIconImpl.UpdateIcon(Boolean remove)
   at Avalonia.Win32.TrayIconImpl.SetIcon(IWindowIconImpl icon)
   at Avalonia.Controls.TrayIcon.OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
   at Avalonia.AvaloniaObject.OnPropertyChangedCore(AvaloniaPropertyChangedEventArgs change)
   at Avalonia.AvaloniaObject.RaisePropertyChanged[T](AvaloniaProperty`1 property, Optional`1 oldValue, BindingValue`1 newValue, BindingPriority priority, Boolean isEffectiveValue)
   at Avalonia.PropertyStore.EffectiveValue`1.SetAndRaiseCore(ValueStore owner, StyledProperty`1 property, T value, BindingPriority priority, Boolean isOverriddenCurrentValue, Boolean isCoercedDefaultValue)
   at Avalonia.PropertyStore.EffectiveValue`1.SetLocalValueAndRaise(ValueStore owner, StyledProperty`1 property, T value)
   at Avalonia.PropertyStore.ValueStore.SetLocalValue[T](StyledProperty`1 property, T value)
   at Avalonia.PropertyStore.ValueStore.SetValue[T](StyledProperty`1 property, T value, BindingPriority priority)
   at Avalonia.AvaloniaObject.SetValue[T](StyledProperty`1 property, T value, BindingPriority priority)
   at Avalonia.Controls.TrayIcon.set_Icon(WindowIcon value)
```


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->

Additional windows version check was added to Win32.TrayIconImpl


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist
 ### N/A

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->
None.

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->
None.

## Fixed issues
Fixes #16146

