### PR TITLE
Fix nunit tests adapter losing async locals

### DIFF
--- a/src/Headless/Avalonia.Headless.NUnit/AvaloniaTestMethodCommand.cs
+++ b/src/Headless/Avalonia.Headless.NUnit/AvaloniaTestMethodCommand.cs
@@ -79,7 +79,7 @@ internal class AvaloniaTestMethodCommand : TestCommand
 
     public override TestResult Execute(TestExecutionContext context)
     {
-        return _session.Dispatch(() => ExecuteTestMethod(context), default).GetAwaiter().GetResult();
+        return _session.DispatchCore(() => ExecuteTestMethod(context), true, default).GetAwaiter().GetResult();
     }
 
     // Unfortunately, NUnit has issues with custom synchronization contexts, which means we need to add some hacks to make it work.

--- a/src/Headless/Avalonia.Headless.NUnit/AvaloniaTestMethodCommand.cs
+++ b/src/Headless/Avalonia.Headless.NUnit/AvaloniaTestMethodCommand.cs
@@ -85,8 +85,6 @@ internal class AvaloniaTestMethodCommand : TestCommand
     // Unfortunately, NUnit has issues with custom synchronization contexts, which means we need to add some hacks to make it work.
     private async Task<TestResult> ExecuteTestMethod(TestExecutionContext context)
     {
-        context.EstablishExecutionEnvironment();
-
         _beforeTest.ForEach(a => a());
         
         var testMethod = _innerCommand.Test.Method;

--- a/src/Headless/Avalonia.Headless.NUnit/AvaloniaTestMethodCommand.cs
+++ b/src/Headless/Avalonia.Headless.NUnit/AvaloniaTestMethodCommand.cs
@@ -29,7 +29,7 @@ internal class AvaloniaTestMethodCommand : TestCommand
         .GetField("BeforeTest", BindingFlags.Instance | BindingFlags.NonPublic)!;
     private static FieldInfo s_afterTest = typeof(BeforeAndAfterTestCommand)
         .GetField("AfterTest", BindingFlags.Instance | BindingFlags.NonPublic)!;
-    
+
     private AvaloniaTestMethodCommand(
         HeadlessUnitTestSession session,
         TestCommand innerCommand,
@@ -47,7 +47,7 @@ internal class AvaloniaTestMethodCommand : TestCommand
     {
         return ProcessCommand(session, command, new List<Action>(), new List<Action>());
     }
-    
+
     private static TestCommand ProcessCommand(HeadlessUnitTestSession session, TestCommand command, List<Action> before, List<Action> after)
     {
         if (command is BeforeAndAfterTestCommand beforeAndAfterTestCommand)
@@ -85,6 +85,8 @@ internal class AvaloniaTestMethodCommand : TestCommand
     // Unfortunately, NUnit has issues with custom synchronization contexts, which means we need to add some hacks to make it work.
     private async Task<TestResult> ExecuteTestMethod(TestExecutionContext context)
     {
+        context.EstablishExecutionEnvironment();
+
         _beforeTest.ForEach(a => a());
         
         var testMethod = _innerCommand.Test.Method;

--- a/src/Headless/Avalonia.Headless/Avalonia.Headless.csproj
+++ b/src/Headless/Avalonia.Headless/Avalonia.Headless.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup Label="InternalsVisibleTo">
+    <InternalsVisibleTo Include="Avalonia.Headless.NUnit, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Headless.Vnc, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.UnitTests, PublicKey=$(AvaloniaPublicKey)" />
     <InternalsVisibleTo Include="Avalonia.Base.UnitTests, PublicKey=$(AvaloniaPublicKey)" />

--- a/tests/Avalonia.Headless.UnitTests/ThreadingTests.cs
+++ b/tests/Avalonia.Headless.UnitTests/ThreadingTests.cs
@@ -37,6 +37,7 @@ public class ThreadingTests
 #endif
     public async Task DispatcherTimer_Works_On_The_Same_Thread(int interval)
     {
+        Assert.NotNull(SynchronizationContext.Current);
         ValidateTestContext();
         var currentThread = Thread.CurrentThread;
 


### PR DESCRIPTION
## What does the pull request do?

NUnit actively uses `AsyncLocal` to globally store `TestContext`.
Avalonia Headless integration with NUnit was messing up with `ExecutionContext` causing weird bugs like:
```c#
    [AvaloniaTest]
    public void Test1() {
        // Executes first.
    }

    [AvaloniaTest]
    public void Test2() {
        // Executes second, but test context is from the first test.
        var name = TestContext.CurrentContext.Test.Name;
        Assert.That(name, Is.EqualTo("Test2")); // Fails.
    }
```

## How was the solution implemented (if it's not obvious)?

I couldn't understand exactly how was it broken, but my hypothesis is:
1. Avalonia headless runs a dedicated thread with its own `ExecutionContext`.
2. NUnit caches and saves current `TestContext` in the `AsyncLocal` (which uses ExecutionContext) - https://github.com/nunit/nunit/blob/v3.13.3/src/NUnitFramework/framework/Internal/TestExecutionContext.cs#L154
3. It picks up first `TestContext` of the first running test, caches it, and never invalidates.
4. NUnit itself resets `TestContext` via [EstablishExecutionEnvironment](https://github.com/nunit/nunit/blob/v3.13.3/src/NUnitFramework/framework/Internal/TestExecutionContext.cs#L436C21-L436C50). But it has no effect on Avalonia Tests, which don't use the same `ExecutionContext`.
5. Manually calling `EstablishExecutionEnvironment` on each tests also doesn't work, as it resets `SynchronizationContext` (!!!!) to NUnit's one as well, breaking anything Dispatcher related.

And it was fixed by explicitly capturing `ExecutionContext` of the invoking test framework (NUnit in this case), and explicitly running tests in the same context, while keeping our own `SynchronizationContext`.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
