### PR TITLE
Considering scaling when centering windows

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -94,6 +94,7 @@ namespace Avalonia.Controls
         private Thickness _windowDecorationMargin;
         private Thickness _offScreenMargin;
         private bool _canHandleResized = false;
+        private Size _arrangeBounds;
 
         /// <summary>
         /// Defines the <see cref="SizeToContent"/> property.
@@ -198,6 +199,7 @@ namespace Avalonia.Controls
         private readonly Size _maxPlatformClientSize;
         private bool _shown;
         private bool _showingAsDialog;
+        private bool _positionWasSet;
         private bool _wasShownBefore;
 
         /// <summary>
@@ -428,7 +430,11 @@ namespace Avalonia.Controls
         public PixelPoint Position
         {
             get => PlatformImpl?.Position ?? PixelPoint.Origin;
-            set => PlatformImpl?.Move(value);
+            set
+            {
+                PlatformImpl?.Move(value);
+                _positionWasSet = true;
+            }
         }
 
         /// <summary>
@@ -695,7 +701,7 @@ namespace Avalonia.Controls
             }
         }
 
-        private Task<TResult> ShowCore<TResult>(Window? owner, bool modal)
+        private Task<TResult>? ShowCore<TResult>(Window? owner, bool modal)
         {
             using (FreezeVisibilityChangeHandling())
             {
@@ -725,33 +731,69 @@ namespace Avalonia.Controls
                 _showingAsDialog = modal;
                 IsVisible = true;
 
-                // We need to set position first because it is required for getting correct display scale. If position is not manual then it can be
-                // determined only by calling this method. But here it will calculate not precise location because scaling may not yet be applied (see i.e. X11Window),
-                // thus we ought to call it again later to center window correctly if needed, when scaling will be already applied
+                // If window position was not set before then platform may provide incorrect scaling at this time,
+                // but we need it for proper calculation of position and in some cases size (size to content)
+                SetExpectedScaling(owner);
+
+                var initialSize = new Size(
+                    double.IsNaN(Width) ? ClientSize.Width : Width,
+                    double.IsNaN(Height) ? ClientSize.Height : Height);
+                
+                initialSize = new Size(
+                MathUtilities.Clamp(initialSize.Width, MinWidth, MaxWidth),
+                MathUtilities.Clamp(initialSize.Height, MinHeight, MaxHeight));
+
+                var clientSizeChanged = initialSize != ClientSize;
+                ClientSize = initialSize; // ClientSize is required for Measure and Arrange
+                
+                // this will call ArrangeSetBounds
+                LayoutManager.ExecuteInitialLayoutPass();
+
+                if (SizeToContent.HasFlag(SizeToContent.Width))
+                {
+                    initialSize = initialSize.WithWidth(MathUtilities.Clamp(_arrangeBounds.Width, MinWidth, MaxWidth));
+                    clientSizeChanged |= initialSize != ClientSize;
+                    ClientSize = initialSize;
+                }
+
+                if (SizeToContent.HasFlag(SizeToContent.Height))
+                {
+                    initialSize = initialSize.WithHeight(MathUtilities.Clamp(_arrangeBounds.Height, MinHeight, MaxHeight));
+                    clientSizeChanged |= initialSize != ClientSize;
+                    ClientSize = initialSize;
+                }
+                
+                Owner = owner;
+
                 SetWindowStartupLocation(owner);
+                
+                DesktopScalingOverride = null;
+                
+                if (clientSizeChanged || ClientSize != PlatformImpl?.ClientSize)
+                {
+                    // Previously it was called before ExecuteInitialLayoutPass
+                    PlatformImpl?.Resize(ClientSize, WindowResizeReason.Layout);
+                    
+                    // we do not want PlatformImpl?.Resize to trigger HandleResized yet because it will set Width and Height.
+                    // So perform some important actions from HandleResized
+                    
+                    Renderer.Resized(ClientSize);
+                    OnResized(new WindowResizedEventArgs(ClientSize, WindowResizeReason.Layout));
+
+                    if (!double.IsNaN(Width))
+                        Width = ClientSize.Width;
+                    if (!double.IsNaN(Height))
+                        Height = ClientSize.Height;
+                }
+
+                FrameSize = PlatformImpl?.FrameSize;
 
                 _canHandleResized = true; 
                 
-                var initialSize = new Size(
-                    double.IsNaN(Width) ? Math.Max(MinWidth, ClientSize.Width) : Width,
-                    double.IsNaN(Height) ? Math.Max(MinHeight, ClientSize.Height) : Height);
-
-                if (initialSize != ClientSize)
-                {
-                    PlatformImpl?.Resize(initialSize, WindowResizeReason.Layout);
-                }
-
-                LayoutManager.ExecuteInitialLayoutPass();
-
-                Owner = owner;
-
-                // Second call will calculate correct position because both current and owner windows have correct scaling.
-                SetWindowStartupLocation(owner);
-
                 StartRendering();
                 PlatformImpl?.Show(ShowActivated, modal);
 
-                Task<TResult> result = null;
+                Task<TResult>? result = null;
                 if (modal)
                 {
                     var tcs = new TaskCompletionSource<TResult>();
@@ -762,7 +804,7 @@ namespace Avalonia.Controls
                         .Take(1)
                         .Subscribe(_ =>
                         {
-                            owner.Activate();
+                            owner!.Activate();
                             tcs.SetResult((TResult)(_dialogResult ?? default(TResult)!));
                         });
                     result = tcs.Task;
@@ -801,7 +843,7 @@ namespace Avalonia.Controls
         /// <returns>.
         /// A task that can be used to retrieve the result of the dialog when it closes.
         /// </returns>
-        public Task<TResult> ShowDialog<TResult>(Window owner) => ShowCore<TResult>(owner, true);
+        public Task<TResult> ShowDialog<TResult>(Window owner) => ShowCore<TResult>(owner, true)!;
 
         /// <summary>
         /// Sorts the windows ascending by their Z order - the topmost window will be the last in the list.
@@ -886,31 +928,67 @@ namespace Avalonia.Controls
             }
         }
 
-        private void SetWindowStartupLocation(Window? owner = null)
+        private void SetExpectedScaling(WindowBase? owner)
         {
-            if (_wasShownBefore == true)
+            if (_wasShownBefore)
             {
                 return;
             }
+            
+            var location = GetEffectiveWindowStartupLocation(owner);
 
+            switch (location)
+            {
+                case WindowStartupLocation.CenterOwner:
+                    DesktopScalingOverride = owner?.DesktopScaling;
+                    break;
+                case WindowStartupLocation.CenterScreen:
+                    DesktopScalingOverride = owner?.DesktopScaling ?? Screens.ScreenFromPoint(Position)?.Scaling ?? Screens.Primary?.Scaling;
+                    break;
+                case WindowStartupLocation.Manual:
+                    DesktopScalingOverride = Screens.ScreenFromPoint(Position)?.Scaling;
+                    break;
+            }
+        }
+
+        private WindowStartupLocation GetEffectiveWindowStartupLocation(WindowBase? owner)
+        {
             var startupLocation = WindowStartupLocation;
 
             if (startupLocation == WindowStartupLocation.CenterOwner &&
                 (owner is null ||
-                 (Owner is Window ownerWindow && ownerWindow.WindowState == WindowState.Minimized))
-                )
+                 (owner is Window ownerWindow && ownerWindow.WindowState == WindowState.Minimized))
+               )
             {
                 // If startup location is CenterOwner, but owner is null or minimized then fall back
                 // to CenterScreen. This behavior is consistent with WPF.
                 startupLocation = WindowStartupLocation.CenterScreen;
             }
 
-            var scaling = owner?.DesktopScaling ?? PlatformImpl?.DesktopScaling ?? 1;
+            return startupLocation;
+        }
+        
+        private void SetWindowStartupLocation(Window? owner = null)
+        {
+            if (_wasShownBefore)
+            {
+                return;
+            }
 
+            var startupLocation = GetEffectiveWindowStartupLocation(owner);
+
+            PixelRect rect;
             // Use frame size, falling back to client size if the platform can't give it to us.
-            var rect = FrameSize.HasValue ?
-                new PixelRect(PixelSize.FromSize(FrameSize.Value, scaling)) :
-                new PixelRect(PixelSize.FromSize(ClientSize, scaling));
+            if (PlatformImpl?.FrameSize.HasValue == true)
+            {
+                // Platform may calculate FrameSize with incorrect scaling, so do not trust the value.
+                var diff = PlatformImpl.FrameSize.Value - PlatformImpl.ClientSize;
+                rect = new PixelRect(PixelSize.FromSize(ClientSize + diff, DesktopScaling));
+            }
+            else
+            {
+                rect = new PixelRect(PixelSize.FromSize(ClientSize, DesktopScaling));
+            }
 
             if (startupLocation == WindowStartupLocation.CenterScreen)
             {
@@ -923,10 +1001,16 @@ namespace Avalonia.Controls
                 }
 
                 screen ??= Screens.ScreenFromPoint(Position);
-
+                screen ??= Screens.Primary;
+                
                 if (screen is not null)
                 {
-                    Position = screen.WorkingArea.CenterRect(rect).Position;
+                    var childRect = screen.WorkingArea.CenterRect(rect);
+
+                    if (Screens.ScreenFromPoint(childRect.Position) == null)
+                        childRect = ApplyScreenConstraint(screen, childRect);
+
+                    Position = childRect.Position;
                 }
             }
             else if (startupLocation == WindowStartupLocation.CenterOwner)
@@ -934,10 +1018,22 @@ namespace Avalonia.Controls
                 var ownerSize = owner!.FrameSize ?? owner.ClientSize;
                 var ownerRect = new PixelRect(
                     owner.Position,
-                    PixelSize.FromSize(ownerSize, scaling));
+                    PixelSize.FromSize(ownerSize, owner.DesktopScaling));
                 var childRect = ownerRect.CenterRect(rect);
 
-                if (Screens.ScreenFromWindow(owner)?.WorkingArea is { } constraint)
+                var screen = Screens.ScreenFromWindow(owner);
+                
+                childRect = ApplyScreenConstraint(screen, childRect);
+
+                Position = childRect.Position;
+            }
+
+            if (!_positionWasSet && DesktopScaling != PlatformImpl?.DesktopScaling) // Platform returns incorrect scaling, forcing setting position may fix it
+                PlatformImpl?.Move(Position);
+            
+            PixelRect ApplyScreenConstraint(Screen? screen, PixelRect childRect)
+            {
+                if (screen?.WorkingArea is { } constraint)
                 {
                     var maxX = constraint.Right - rect.Width;
                     var maxY = constraint.Bottom - rect.Height;
@@ -948,7 +1044,7 @@ namespace Avalonia.Controls
                         childRect = childRect.WithY(MathUtilities.Clamp(childRect.Y, constraint.Y, maxY));
                 }
 
-                Position = childRect.Position;
+                return childRect;
             }
         }
 
@@ -1009,7 +1105,9 @@ namespace Avalonia.Controls
 
         protected sealed override Size ArrangeSetBounds(Size size)
         {
-            PlatformImpl?.Resize(size, WindowResizeReason.Layout);
+            _arrangeBounds = size;
+            if (_canHandleResized)
+                PlatformImpl?.Resize(size, WindowResizeReason.Layout);
             return ClientSize;
         }
 

--- a/src/Avalonia.Controls/WindowBase.cs
+++ b/src/Avalonia.Controls/WindowBase.cs
@@ -133,7 +133,9 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets the scaling factor for Window positioning and sizing.
         /// </summary>
-        public double DesktopScaling => PlatformImpl?.DesktopScaling ?? 1;
+        public double DesktopScaling => DesktopScalingOverride ?? PlatformImpl?.DesktopScaling ?? 1;
+
+        private protected double? DesktopScalingOverride { get; set; }
         
         /// <summary>
         /// Activates the window.

--- a/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.AppWndProc.cs
@@ -149,6 +149,18 @@ namespace Avalonia.Win32
 
                         return IntPtr.Zero;
                     }
+                    else
+                    {
+                        // In case parent is on another screen with different scaling, window will have header scaled with
+                        // parent's scaling factor, so need to update frame
+                        SetWindowPos(hWnd,
+                            IntPtr.Zero, 0, 0, 0, 0,
+                            SetWindowPosFlags.SWP_FRAMECHANGED |
+                            SetWindowPosFlags.SWP_NOSIZE |
+                            SetWindowPosFlags.SWP_NOMOVE |
+                            SetWindowPosFlags.SWP_NOZORDER |
+                            SetWindowPosFlags.SWP_NOACTIVATE);
+                    }
                     break;
 
                 case WindowsMessage.WM_GETICON:

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -524,6 +524,21 @@ namespace Avalonia.Win32
                     0,
                     0,
                     SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOACTIVATE | SetWindowPosFlags.SWP_NOZORDER);
+                
+                if (ShCoreAvailable && Win32Platform.WindowsVersion >= PlatformConstants.Windows8_1)
+                {
+                    var monitor = MonitorFromPoint(new POINT() { X = value.X, Y = value.Y },
+                        MONITOR.MONITOR_DEFAULTTONEAREST);
+
+                    if (GetDpiForMonitor(
+                            monitor,
+                            MONITOR_DPI_TYPE.MDT_EFFECTIVE_DPI,
+                            out _dpi,
+                            out _) == 0)
+                    {
+                        _scaling = _dpi / StandardDpi;
+                    }
+                }
             }
         }
 

--- a/tests/Avalonia.Base.UnitTests/Input/PointerTestsBase.cs
+++ b/tests/Avalonia.Base.UnitTests/Input/PointerTestsBase.cs
@@ -41,6 +41,12 @@ public abstract class PointerTestsBase
         impl.Setup(r => r.Compositor).Returns(RendererMocks.CreateDummyCompositor());
         impl.Setup(r => r.PointToScreen(It.IsAny<Point>())).Returns<Point>(p => new PixelPoint((int)p.X, (int)p.Y));
         impl.Setup(r => r.PointToClient(It.IsAny<PixelPoint>())).Returns<PixelPoint>(p => new Point(p.X, p.Y));
+        
+        var screen1 = new Mock<Screen>(1.75, new PixelRect(new PixelSize(1920, 1080)), new PixelRect(new PixelSize(1920, 966)), true);
+        var screens = new Mock<IScreenImpl>();
+        screens.Setup(x => x.ScreenFromWindow(It.IsAny<IWindowBaseImpl>())).Returns(screen1.Object);
+        impl.Setup(x => x.TryGetFeature(It.Is<Type>(t => t == typeof(IScreenImpl)))).Returns(screens.Object);
+
         return impl;
     }
 

--- a/tests/Avalonia.Controls.UnitTests/DesktopStyleApplicationLifetimeTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/DesktopStyleApplicationLifetimeTests.cs
@@ -220,6 +220,11 @@ namespace Avalonia.Controls.UnitTests
             windowImpl.Setup(x => x.DesktopScaling).Returns(1);
             windowImpl.Setup(x => x.RenderScaling).Returns(1);
 
+            var screen1 = new Mock<Screen>(1.75, new PixelRect(new PixelSize(1920, 1080)), new PixelRect(new PixelSize(1920, 966)), true);
+            var screens = new Mock<IScreenImpl>();
+            screens.Setup(x => x.ScreenFromWindow(It.IsAny<IWindowBaseImpl>())).Returns(screen1.Object);
+            windowImpl.Setup(x => x.TryGetFeature(It.Is<Type>(t => t == typeof(IScreenImpl)))).Returns(screens.Object);
+            
             var services = TestServices.StyledWindow.With(
                 windowingPlatform: new MockWindowingPlatform(() => windowImpl.Object));
 

--- a/tests/Avalonia.Controls.UnitTests/WindowTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/WindowTests.cs
@@ -100,11 +100,9 @@ namespace Avalonia.Controls.UnitTests
         [Fact]
         public void IsVisible_Should_Be_False_After_Impl_Signals_Close()
         {
-            var windowImpl = new Mock<IWindowImpl>();
-            windowImpl.Setup(r => r.Compositor).Returns(RendererMocks.CreateDummyCompositor());
+            var windowImpl = CreateImpl();
             windowImpl.SetupProperty(x => x.Closed);
             windowImpl.Setup(x => x.DesktopScaling).Returns(1);
-            windowImpl.Setup(x => x.RenderScaling).Returns(1);
 
             var services = TestServices.StyledWindow.With(
                 windowingPlatform: new MockWindowingPlatform(() => windowImpl.Object));
@@ -273,7 +271,7 @@ namespace Avalonia.Controls.UnitTests
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
-                var target = new Window(CreateImpl());
+                var target = new Window(CreateImpl().Object);
 
                 target.Show();
                 Assert.True(MediaContext.Instance.IsTopLevelActive(target));
@@ -286,7 +284,7 @@ namespace Avalonia.Controls.UnitTests
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
                 var parent = new Window();
-                var target = new Window(CreateImpl());
+                var target = new Window(CreateImpl().Object);
 
                 parent.Show();
                 target.ShowDialog<object>(parent);
@@ -318,7 +316,7 @@ namespace Avalonia.Controls.UnitTests
         {
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
-                var target = new Window(CreateImpl());
+                var target = new Window(CreateImpl().Object);
 
                 target.Show();
                 target.Hide();
@@ -332,7 +330,7 @@ namespace Avalonia.Controls.UnitTests
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
                 var parent = new Window();
-                var windowImpl = new Mock<IWindowImpl>();
+                var windowImpl = CreateImpl();
                 windowImpl.Setup(x => x.Compositor).Returns(RendererMocks.CreateDummyCompositor());
                 windowImpl.SetupProperty(x => x.Closed);
                 windowImpl.Setup(x => x.DesktopScaling).Returns(1);
@@ -374,7 +372,7 @@ namespace Avalonia.Controls.UnitTests
             using (UnitTestApplication.Start(TestServices.StyledWindow))
             {
                 var parent = new Window();
-                var windowImpl = new Mock<IWindowImpl>();
+                var windowImpl = CreateImpl();
                 windowImpl.Setup(x => x.Compositor).Returns(RendererMocks.CreateDummyCompositor());
                 windowImpl.SetupProperty(x => x.Closed);
                 windowImpl.Setup(x => x.DesktopScaling).Returns(1);
@@ -1099,11 +1097,18 @@ namespace Avalonia.Controls.UnitTests
             }
         }
 
-        private static IWindowImpl CreateImpl()
+        private static Mock<IWindowImpl> CreateImpl()
         {
-            var compositor = RendererMocks.CreateDummyCompositor();
-            return Mock.Of<IWindowImpl>(x => x.RenderScaling == 1 &&
-                                             x.Compositor == compositor);
+            var screen1 = new Mock<Screen>(1.75, new PixelRect(new PixelSize(1920, 1080)), new PixelRect(new PixelSize(1920, 966)), true);
+            var screens = new Mock<IScreenImpl>();
+            screens.Setup(x => x.ScreenFromWindow(It.IsAny<IWindowBaseImpl>())).Returns(screen1.Object);
+
+            var windowImpl = new Mock<IWindowImpl>();
+            windowImpl.Setup(r => r.Compositor).Returns(RendererMocks.CreateDummyCompositor());
+            windowImpl.Setup(x => x.RenderScaling).Returns(1);
+            windowImpl.Setup(x => x.TryGetFeature(It.Is<Type>(t => t == typeof(IScreenImpl)))).Returns(screens.Object);
+
+            return windowImpl;
         }
 
         private class ChildControl : Control

--- a/tests/Avalonia.IntegrationTests.Appium/SliderTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/SliderTests.cs
@@ -25,13 +25,13 @@ namespace Avalonia.IntegrationTests.Appium
 
             new Actions(Session).ClickAndHold(thumb).MoveByOffset(100, 0).Release().Perform();
 
-            var value = Math.Round(double.Parse(slider.Text, CultureInfo.InvariantCulture));
+            var value = double.Parse(slider.Text, CultureInfo.InvariantCulture);
             var boundValue = double.Parse(
                 Session.FindElementByAccessibilityId("HorizontalSliderValue").Text,
                 CultureInfo.InvariantCulture);
 
             Assert.True(value > 50);
-            Assert.Equal(value, boundValue);
+            Assert.True(Math.Abs(value - boundValue) < 2.0, $"Expected: {value}, Actual: {boundValue}");
 
             var currentThumbRect = thumb.Rect;
             Assert.True(currentThumbRect.Left > initialThumbRect.Left);
@@ -46,13 +46,13 @@ namespace Avalonia.IntegrationTests.Appium
 
             new Actions(Session).ClickAndHold(thumb).MoveByOffset(-100, 0).Release().Perform();
 
-            var value = Math.Round(double.Parse(slider.Text, CultureInfo.InvariantCulture));
+            var value = double.Parse(slider.Text, CultureInfo.InvariantCulture);
             var boundValue = double.Parse(
                 Session.FindElementByAccessibilityId("HorizontalSliderValue").Text,
                 CultureInfo.InvariantCulture);
 
             Assert.True(value < 50);
-            Assert.Equal(value, boundValue);
+            Assert.True(Math.Abs(value - boundValue) < 2.0, $"Expected: {value}, Actual: {boundValue}");
 
             var currentThumbRect = thumb.Rect;
             Assert.True(currentThumbRect.Left < initialThumbRect.Left);
@@ -67,13 +67,13 @@ namespace Avalonia.IntegrationTests.Appium
 
             new Actions(Session).MoveToElementCenter(slider, 100, 0).Click().Perform();
 
-            var value = Math.Round(double.Parse(slider.Text, CultureInfo.InvariantCulture));
+            var value = double.Parse(slider.Text, CultureInfo.InvariantCulture);
             var boundValue = double.Parse(
                 Session.FindElementByAccessibilityId("HorizontalSliderValue").Text,
                 CultureInfo.InvariantCulture);
 
             Assert.True(value > 50);
-            Assert.Equal(value, boundValue);
+            Assert.True(Math.Abs(value - boundValue) < 2.0, $"Expected: {value}, Actual: {boundValue}");
 
             var currentThumbRect = thumb.Rect;
             Assert.True(currentThumbRect.Left > initialThumbRect.Left);
@@ -88,13 +88,13 @@ namespace Avalonia.IntegrationTests.Appium
 
             new Actions(Session).MoveToElementCenter(slider, -100, 0).Click().Perform();
 
-            var value = Math.Round(double.Parse(slider.Text, CultureInfo.InvariantCulture));
+            var value = double.Parse(slider.Text, CultureInfo.InvariantCulture);
             var boundValue = double.Parse(
                 Session.FindElementByAccessibilityId("HorizontalSliderValue").Text,
                 CultureInfo.InvariantCulture);
 
             Assert.True(value < 50);
-            Assert.Equal(value, boundValue);
+            Assert.True(Math.Abs(value - boundValue) < 2.0, $"Expected: {value}, Actual: {boundValue}");
 
             var currentThumbRect = thumb.Rect;
             Assert.True(currentThumbRect.Left < initialThumbRect.Left);

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
@@ -27,6 +27,8 @@ namespace Avalonia.IntegrationTests.Appium
 
                 var secondaryWindowIndex = GetWindowOrder("SecondaryWindow");
 
+                Thread.Sleep(300); // sync with timer
+
                 Assert.Equal(1, secondaryWindowIndex);
             }
         }

--- a/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/WindowTests_MacOS.cs
@@ -38,15 +38,17 @@ namespace Avalonia.IntegrationTests.Appium
 
             using (OpenWindow(new PixelSize(200, 100), ShowWindowMode.Modal, WindowStartupLocation.Manual))
             {
+                var childWindow = GetWindow("SecondaryWindow");
+
                 new Actions(Session)
-                    .MoveToElement(mainWindow, 100, 1)
+                    .MoveToElement(childWindow, 100, 1)
                     .ClickAndHold()
                     .Perform();
 
                 var secondaryWindowIndex = GetWindowOrder("SecondaryWindow");
 
                 new Actions(Session)
-                    .MoveToElement(mainWindow, 100, 1)
+                    .MoveToElement(childWindow, 100, 1)
                     .Release()
                     .Perform();
 

--- a/tests/Avalonia.LeakTests/ControlTests.cs
+++ b/tests/Avalonia.LeakTests/ControlTests.cs
@@ -463,12 +463,17 @@ namespace Avalonia.LeakTests
         {
             using (Start())
             {
+                var screen1 = new Mock<Screen>(1.75, new PixelRect(new PixelSize(1920, 1080)), new PixelRect(new PixelSize(1920, 966)), true);
+                var screens = new Mock<IScreenImpl>();
+                screens.Setup(x => x.ScreenFromWindow(It.IsAny<IWindowBaseImpl>())).Returns(screen1.Object);
+
                 var impl = new Mock<IWindowImpl>();
                 impl.Setup(r => r.TryGetFeature(It.IsAny<Type>())).Returns(null);
                 impl.SetupGet(x => x.RenderScaling).Returns(1);
                 impl.SetupProperty(x => x.Closed);
                 impl.Setup(x => x.Compositor).Returns(RendererMocks.CreateDummyCompositor());
                 impl.Setup(x => x.Dispose()).Callback(() => impl.Object.Closed());
+                impl.Setup(x => x.TryGetFeature(It.Is<Type>(t => t == typeof(IScreenImpl)))).Returns(screens.Object);
 
                 AvaloniaLocator.CurrentMutable.Bind<IWindowingPlatform>()
                     .ToConstant(new MockWindowingPlatform(() => impl.Object));


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Window.Show and ShowDialog calls 
PlatformImpl?.Resize(initialSize, WindowResizeReason.Layout); when scaling on window is not initialized (at least on Linux), so it configures pixel size as if it was 100%.
Then we call SetWindowStartupLocation, and when we do not have owner this returns 1 because we do not have owner and PlatformImpl yet do not have DesktopScaling :
`var scaling = owner?.DesktopScaling ?? PlatformImpl?.DesktopScaling ?? 1;`
And here
`Position = screen.WorkingArea.CenterRect(rect).Position;`
We are attempting to center unscaled window rect within scaled screen bounds, and get incorrect position

## What is the current behavior?

Use Linux
Set desktop scaling to for example 1.5.
Create window with some size and WindowStartupLocation = WindowStartupLocation.CenterScreen
Show window - it is not centered.

## What is the updated/expected behavior with this PR?
Window is shown on the center of the screen

should fix #14850 
should fix #15905

Actually it is reworked version of #12833 that was rolled back in #15304 for release branches, now I hope it should work correctly.

