### PR TITLE
Make VirtualizingStackPanel better handle container size changes

### DIFF
--- a/src/Avalonia.Controls/Utils/RealizedStackElements.cs
+++ b/src/Avalonia.Controls/Utils/RealizedStackElements.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Avalonia.Layout;
 using Avalonia.Utilities;
 
 namespace Avalonia.Controls.Utils
@@ -538,6 +539,34 @@ namespace Avalonia.Controls.Utils
             _elements?.Clear();
             _sizes?.Clear();
         }
-    }
 
+        /// <summary>
+        /// Validates that <see cref="StartU"/> is still valid.
+        /// </summary>
+        /// <param name="orientation">The panel orientation.</param>
+        /// <remarks>
+        /// If the U size of any element in the realized elements has changed, then the value of
+        /// <see cref="StartU"/> should be considered unstable.
+        /// </remarks>
+        public void ValidateStartU(Orientation orientation)
+        {
+            if (_elements is null || _sizes is null)
+                return;
+
+            for (var i = 0; i < _elements.Count; ++i)
+            {
+                if (_elements[i] is not { } element)
+                    continue;
+
+                var sizeU = orientation == Orientation.Horizontal ?
+                    element.Bounds.Width : element.Bounds.Height;
+
+                if (sizeU != _sizes[i])
+                {
+                    _startUUnstable = true;
+                    break;
+                }
+            }
+        }
+    }
 }

--- a/src/Avalonia.Controls/Utils/RealizedStackElements.cs
+++ b/src/Avalonia.Controls/Utils/RealizedStackElements.cs
@@ -43,16 +43,17 @@ namespace Avalonia.Controls.Utils
         public IReadOnlyList<double> SizeU => _sizes ??= new List<double>();
 
         /// <summary>
-        /// Gets the position of the first element on the primary axis.
+        /// Gets the position of the first element on the primary axis, or NaN if the position is
+        /// unstable.
         /// </summary>
-        public double StartU => _startU;
+        public double StartU => _startUUnstable ? double.NaN : _startU;
 
         /// <summary>
         /// Adds a newly realized element to the collection.
         /// </summary>
         /// <param name="index">The index of the element.</param>
         /// <param name="element">The element.</param>
-        /// <param name="u">The position of the elemnt on the primary axis.</param>
+        /// <param name="u">The position of the element on the primary axis.</param>
         /// <param name="sizeU">The size of the element on the primary axis.</param>
         public void Add(int index, Control element, double u, double sizeU)
         {
@@ -101,76 +102,6 @@ namespace Avalonia.Controls.Utils
         }
 
         /// <summary>
-        /// Gets or estimates the index and start U position of the anchor element for the
-        /// specified viewport.
-        /// </summary>
-        /// <param name="viewportStartU">The U position of the start of the viewport.</param>
-        /// <param name="viewportEndU">The U position of the end of the viewport.</param>
-        /// <param name="itemCount">The number of items in the list.</param>
-        /// <param name="estimatedElementSizeU">The current estimated element size.</param>
-        /// <returns>
-        /// A tuple containing:
-        /// - The index of the anchor element, or -1 if an anchor could not be determined
-        /// - The U position of the start of the anchor element, if determined
-        /// </returns>
-        /// <remarks>
-        /// This method tries to find an existing element in the specified viewport from which
-        /// element realization can start. Failing that it estimates the first element in the
-        /// viewport.
-        /// </remarks>
-        public (int index, double position) GetOrEstimateAnchorElementForViewport(
-            double viewportStartU,
-            double viewportEndU,
-            int itemCount,
-            ref double estimatedElementSizeU)
-        {
-            // We have no elements, nothing to do here.
-            if (itemCount <= 0)
-                return (-1, 0);
-
-            // If we're at 0 then display the first item.
-            if (MathUtilities.IsZero(viewportStartU))
-                return (0, 0);
-
-            if (_sizes is not null && !_startUUnstable)
-            {
-                var u = _startU;
-
-                for (var i = 0; i < _sizes.Count; ++i)
-                {
-                    var size = _sizes[i];
-
-                    if (double.IsNaN(size))
-                        break;
-
-                    var endU = u + size;
-
-                    if (endU > viewportStartU && u < viewportEndU)
-                        return (FirstIndex + i, u);
-
-                    u = endU;
-                }
-            }
-
-            // We don't have any realized elements in the requested viewport, or can't rely on
-            // StartU being valid. Estimate the index using only the estimated size. First,
-            // estimate the element size, using defaultElementSizeU if we don't have any realized
-            // elements.
-            var estimatedSize = EstimateElementSizeU() switch
-            {
-                -1 => estimatedElementSizeU,
-                double v => v,
-            };
-
-            // Store the estimated size for the next layout pass.
-            estimatedElementSizeU = estimatedSize;
-
-            // Estimate the element at the start of the viewport.
-            var index = Math.Min((int)(viewportStartU / estimatedSize), itemCount - 1);
-            return (index, index * estimatedSize);
-        }
-
-        /// <summary>
         /// Gets the position of the element with the requested index on the primary axis, if realized.
         /// </summary>
         /// <returns>
@@ -192,61 +123,6 @@ namespace Avalonia.Controls.Utils
                 u += _sizes[i];
 
             return u;
-        }
-
-        public double GetOrEstimateElementU(int index, ref double estimatedElementSizeU)
-        {
-            // Return the position of the existing element if realized.
-            var u = GetElementU(index);
-
-            if (!double.IsNaN(u))
-                return u;
-
-            // Estimate the element size, using defaultElementSizeU if we don't have any realized
-            // elements.
-            var estimatedSize = EstimateElementSizeU() switch
-            {
-                -1 => estimatedElementSizeU,
-                double v => v,
-            };
-
-            // Store the estimated size for the next layout pass.
-            estimatedElementSizeU = estimatedSize;
-
-            // TODO: Use _startU to work this out.
-            return index * estimatedSize;
-        }
-
-        /// <summary>
-        /// Estimates the average U size of all elements in the source collection based on the
-        /// realized elements.
-        /// </summary>
-        /// <returns>
-        /// The estimated U size of an element, or -1 if not enough information is present to make
-        /// an estimate.
-        /// </returns>
-        public double EstimateElementSizeU()
-        {
-            var total = 0.0;
-            var divisor = 0.0;
-
-            // Average the size of the realized elements.
-            if (_sizes is not null)
-            {
-                foreach (var size in _sizes)
-                {
-                    if (double.IsNaN(size))
-                        continue;
-                    total += size;
-                    ++divisor;
-                }
-            }
-
-            // We don't have any elements on which to base our estimate.
-            if (divisor == 0 || total == 0)
-                return -1;
-
-            return total / divisor;
         }
 
         /// <summary>
@@ -559,7 +435,7 @@ namespace Avalonia.Controls.Utils
                     continue;
 
                 var sizeU = orientation == Orientation.Horizontal ?
-                    element.Bounds.Width : element.Bounds.Height;
+                    element.DesiredSize.Width : element.DesiredSize.Height;
 
                 if (sizeU != _sizes[i])
                 {

--- a/src/Avalonia.Controls/Utils/RealizedStackElements.cs
+++ b/src/Avalonia.Controls/Utils/RealizedStackElements.cs
@@ -550,7 +550,7 @@ namespace Avalonia.Controls.Utils
         /// </remarks>
         public void ValidateStartU(Orientation orientation)
         {
-            if (_elements is null || _sizes is null)
+            if (_elements is null || _sizes is null || _startUUnstable)
                 return;
 
             for (var i = 0; i < _elements.Count; ++i)

--- a/src/Avalonia.Controls/VirtualizingPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingPanel.cs
@@ -192,6 +192,12 @@ namespace Avalonia.Controls
             Children.RemoveRange(index, count);
         }
 
+        private protected override void InvalidateMeasureOnChildrenChanged()
+        {
+            // Don't invalidate measure when children are added or removed: the panel is responsible
+            // for managing its children.
+        }
+
         internal void Attach(ItemsControl itemsControl)
         {
             if (ItemsControl is not null)

--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -180,6 +180,10 @@ namespace Avalonia.Controls
                 (_measureElements, _realizedElements) = (_realizedElements, _measureElements);
                 _measureElements.ResetForReuse();
 
+                // If there is a focused element is outside the visible viewport (i.e.
+                // _focusedElement is non-null), ensure it's measured.
+                _focusedElement?.Measure(availableSize);
+
                 return CalculateDesiredSize(orientation, items.Count, viewport);
             }
             finally
@@ -214,6 +218,16 @@ namespace Avalonia.Controls
                         _scrollAnchorProvider?.RegisterAnchorCandidate(e);
                         u += orientation == Orientation.Horizontal ? rect.Width : rect.Height;
                     }
+                }
+
+                // Ensure that the focused element is in the correct position.
+                if (_focusedElement is not null && _focusedIndex >= 0)
+                {
+                    u = _realizedElements.GetOrEstimateElementU(_focusedIndex, ref _lastEstimatedElementSizeU);
+                    var rect = orientation == Orientation.Horizontal ?
+                        new Rect(u, 0, _focusedElement.DesiredSize.Width, finalSize.Height) :
+                        new Rect(0, u, finalSize.Width, _focusedElement.DesiredSize.Height);
+                    _focusedElement.Arrange(rect);
                 }
 
                 return finalSize;

--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -159,6 +159,7 @@ namespace Avalonia.Controls
 
             try
             {
+                _realizedElements?.ValidateStartU(Orientation);
                 _realizedElements ??= new();
                 _measureElements ??= new();
 

--- a/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
+++ b/tests/Avalonia.Controls.UnitTests/VirtualizingStackPanelTests.cs
@@ -1152,15 +1152,14 @@ namespace Avalonia.Controls.UnitTests
             // Scroll the last item into view.
             target.ScrollIntoView(19);
 
-            // At the time of the scroll, the average item height is 20, so the requested item
-            // should be placed at 380 (19 * 20) which therefore results in an extent of 390 to
-            // accommodate the item height of 10. This is obviously not a perfect answer, but
-            // it's the best we can do without knowing the actual item heights.
+            // After scroll, the average item height is 10, so the requested item
+            // should be placed at 190 (19 * 10) which results in an extent of 200 to
+            // accommodate the item height of 10.
             var container = Assert.IsType<ContentPresenter>(target.ContainerFromIndex(19));
-            Assert.Equal(new Rect(0, 380, 100, 10), container.Bounds);
+            Assert.Equal(new Rect(0, 190, 100, 10), container.Bounds);
             Assert.Equal(new Size(100, 100), scroll.Viewport);
-            Assert.Equal(new Size(100, 390), scroll.Extent);
-            Assert.Equal(new Vector(0, 290), scroll.Offset);
+            Assert.Equal(new Size(100, 200), scroll.Extent);
+            Assert.Equal(new Vector(0, 100), scroll.Offset);
 
             // Items 10-19 should be visible.
             AssertRealizedItems(target, itemsControl, 10, 10);


### PR DESCRIPTION
## What does the pull request do?

As described in #15712, if a container changes size after layout then glitches occur when scrolling.

To fix this:

- At the start of a measure pass, check if any realized container's U size has changed; if it has changed then `StartU` is no longer valid because the average element size will have changed, so mark is as unstable
- Use the desired size of _measured_ containers instead of the bounds: a layout pass may not had completed on the containers yet, so the bounds may not be up-to-date. It was easier to move the estimation methods out of `RealizedStackElements` and into `VirtualizingStackPanel` itself in order to do this, and arguably makes more sense
- During layout, ensure that if there is a focused element outside the visible viewport, then it is correctly measured and arranged

## Fixed issues

Fixes #15712