### PR TITLE
Fixed build error: SourceRoot paths are required to end with a slash or backslash

### DIFF
--- a/build/SourceLink.props
+++ b/build/SourceLink.props
@@ -20,6 +20,6 @@
 
   <!-- Workaround for https://github.com/dotnet/sdk/issues/11105 -->
   <ItemGroup>
-    <SourceRoot Include="$(NuGetPackageRoot)" Condition="'$(NuGetPackageRoot)' != ''" />
+    <SourceRoot Include="$([MSBuild]::EnsureTrailingSlash($(NuGetPackageRoot)))" Condition="'$(NuGetPackageRoot)' != ''" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
If developers changed the nuget global packages folder by set NUGET_PACKAGES environment variable to a path without trailing slash, they may have a build error like this, refer to https://github.com/PrismLibrary/Prism/issues/2369

For me, I changed NUGET_PACKAGES=E:\nuget\packages, then I got
![image](https://github.com/AvaloniaUI/Avalonia/assets/3367199/a88b37bf-a1f9-4e71-8b75-54adf07af819)
