### PR TITLE
Reset scroller valuators on XI2Manager.cs

### DIFF
--- a/src/Avalonia.X11/XI2Manager.cs
+++ b/src/Avalonia.X11/XI2Manager.cs
@@ -217,6 +217,11 @@ namespace Avalonia.X11
                      detail == XiEnterLeaveDetail.XINotifyVirtual)
                     && buttons == default)
                 {
+                    foreach (var scroller in _pointerDevice.Scrollers)
+                    {
+                       _pointerDevice.Valuators[scroller.Number].Value = 0;
+                    }
+                    
                     client.ScheduleXI2Input(new RawPointerEventArgs(client.MouseDevice, (ulong)ev.time.ToInt64(),
                         client.InputRoot,
                         RawPointerEventType.LeaveWindow, new Point(ev.event_x, ev.event_y), buttons));


### PR DESCRIPTION
When the focus is lost to avoid instant jumps when coming/scrolling from another linux window.

cc @kekekeks 

