### PR TITLE
Android - Add workaround for android 11 ime insets being weird

### DIFF
--- a/src/Android/Avalonia.Android/Platform/AndroidInsetsManager.cs
+++ b/src/Android/Avalonia.Android/Platform/AndroidInsetsManager.cs
@@ -4,6 +4,7 @@ using Android.App;
 using Android.OS;
 using Android.Views;
 using Android.Views.Animations;
+using AndroidX.Core.Graphics;
 using AndroidX.Core.View;
 using Avalonia.Android.Platform.SkiaPlatform;
 using Avalonia.Animation.Easings;
@@ -25,6 +26,7 @@ namespace Avalonia.Android.Platform
         private Color? _systemBarColor;
         private InputPaneState _state;
         private Rect _previousRect;
+        private Insets? _previousImeInset;
         private readonly bool _usesLegacyLayouts;
 
         private AndroidWindow Window => _activity.Window ?? throw new InvalidOperationException("Activity.Window must be set."); 
@@ -147,6 +149,19 @@ namespace Avalonia.Android.Platform
             }
 
             State = insets.IsVisible(WindowInsetsCompat.Type.Ime()) ? InputPaneState.Open : InputPaneState.Closed;
+
+            // Workaround for weird inset values for android 11
+            if(Build.VERSION.SdkInt == BuildVersionCodes.R)
+            {
+                var imeInset = insets.GetInsets(WindowInsetsCompat.Type.Ime());
+                if(_previousImeInset == default)
+                    _previousImeInset = imeInset;
+                if(imeInset.Bottom != _previousImeInset.Bottom)
+                {
+                    NotifyStateChanged(State, _previousRect, OccludedRect, TimeSpan.Zero, null);
+                }
+                _previousImeInset = imeInset;
+            }
 
             return insets;
         }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
On android 11, forwards ime inset changes as InputPane State change events.


## What is the current behavior?
On Android 11(api 30), insets have a bug where the first inset update after a config change(launching activity, orientation change) can either have 0 size, or double the actual size of the input pane on the first frame of the input pane animation. Because we calculate both the start and end bounds of the input pane at the start of the animation to enable text control editor to animate to input pane changes, on this android version, the predicted ime margin can either be covered by the input pane, or be double the input pane size at launch or when orientation changes.


## What is the updated/expected behavior with this PR?
On Android 11, every change to the ime inset will be forwarded as a State change. Since the OS will send the correct insets after the animation ends, input pane margins will be corrected when the input pane is active.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/AvaloniaUI/Avalonia/issues/16171