### PR TITLE
[macOS][X11] Release mouse capture when dialog shown

### DIFF
--- a/samples/IntegrationTestApp/DelegateCommand.cs
+++ b/samples/IntegrationTestApp/DelegateCommand.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace IntegrationTestApp;
+
+internal class DelegateCommand : ICommand
+{
+    private readonly Action _action;
+    private readonly Func<object?, bool> _canExecute;
+    public DelegateCommand(Action action, Func<object?, bool>? canExecute = default)
+    {
+        _action = action;
+        _canExecute = canExecute ?? new(_ => true);
+    }
+
+    public event EventHandler? CanExecuteChanged { add { } remove { } }
+    public bool CanExecute(object? parameter) => _canExecute(parameter);
+    public void Execute(object? parameter) => _action();
+}

--- a/samples/IntegrationTestApp/MainWindow.axaml
+++ b/samples/IntegrationTestApp/MainWindow.axaml
@@ -136,6 +136,21 @@
           </StackPanel>
         </DockPanel>
       </TabItem>
+
+      <TabItem Header="Pointer">
+        <StackPanel>
+          <!-- Trigger with PointerPressed rather using a Button so we have access to the pointer. -->
+          <Border Name="PointerPageShowDialog"
+                  Background="{DynamicResource ButtonBackground}"
+                  HorizontalAlignment="Left"
+                  Padding="{DynamicResource ButtonPadding}"
+                  AutomationProperties.AccessibilityView="Control"
+                  PointerPressed="PointerPageShowDialogPressed">
+            <TextBlock>Show Dialog</TextBlock>
+          </Border>
+          <TextBlock Name="PointerCaptureStatus"/>
+        </StackPanel>
+      </TabItem>
       
       <TabItem Header="Window">
         <Grid ColumnDefinitions="*,8,*">

--- a/samples/IntegrationTestApp/MainWindow.axaml.cs
+++ b/samples/IntegrationTestApp/MainWindow.axaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Avalonia;
@@ -334,6 +335,38 @@ namespace IntegrationTestApp
             var window = new ShowWindowTest();
             OnApplyWindowDecorations(window);
             window.Show();
+        }
+
+        private void PointerPageShowDialogPressed(object? sender, PointerPressedEventArgs e)
+        {
+            void CaptureLost(object? sender, PointerCaptureLostEventArgs e)
+            {
+                PointerCaptureStatus.Text = "None";
+                ((Control)sender!).PointerCaptureLost -= CaptureLost;
+            }
+
+            var captured = e.Pointer.Captured as Control;
+
+            if (captured is not null)
+            {
+                captured.PointerCaptureLost += CaptureLost;
+            }
+
+            PointerCaptureStatus.Text = captured?.ToString() ?? "None";
+
+            var dialog = new Window
+            {
+                Width = 200,
+                Height = 200,
+            };
+            
+            dialog.Content = new Button
+            {
+                Content = "Close",
+                Command = new DelegateCommand(() => dialog.Close()),
+            };
+
+            dialog.ShowDialog(this);
         }
     }
 }

--- a/src/Avalonia.Base/Input/MouseDevice.cs
+++ b/src/Avalonia.Base/Input/MouseDevice.cs
@@ -305,5 +305,10 @@ namespace Avalonia.Input
         {
             return _pointer;
         }
+
+        internal void PlatformCaptureLost()
+        {
+            _pointer.Capture(null);
+        }
     }
 }

--- a/src/Avalonia.Base/Input/TouchDevice.cs
+++ b/src/Avalonia.Base/Input/TouchDevice.cs
@@ -160,5 +160,11 @@ namespace Avalonia.Input
                 ? pointer
                 : null;
         }
+
+        internal void PlatformCaptureLost()
+        {
+            foreach (var pointer in _pointers.Values)
+                pointer.Capture(null);
+        }
     }
 }

--- a/src/Avalonia.Native/WindowImpl.cs
+++ b/src/Avalonia.Native/WindowImpl.cs
@@ -225,6 +225,13 @@ namespace Avalonia.Native
         public void SetEnabled(bool enable)
         {
             _native.SetEnabled(enable.AsComBool());
+
+            // Showing a dialog should result in mouse capture being lost. macOS doesn't have the concept of mouse
+            // capture, so no we have no OS-level event to hook into. Instead, release the mouse capture when the
+            // owner window is disabled. This behavior matches win32, which sends a WM_CANCELMODE message when
+            // EnableWindow(hWnd, false) is called from SetEnabled.
+            if (!enable && MouseDevice is MouseDevice mouse)
+                mouse.PlatformCaptureLost();
         }
 
         public override object TryGetFeature(Type featureType)

--- a/src/Avalonia.X11/X11Window.cs
+++ b/src/Avalonia.X11/X11Window.cs
@@ -1318,6 +1318,15 @@ namespace Avalonia.X11
                 // so setting it again forces the update
                 UpdateMotifHints();
             }
+            else
+            {
+                // Showing a dialog should result in pointer capture being lost. We don't currently use XGrabPointer on
+                // X11 to implement pointer capture, so no we have no OS-level event to hook into. Instead, release the 
+                // pointer capture when the owner window is disabled. This behavior matches win32, which sends a
+                // WM_CANCELMODE message when EnableWindow(hWnd, false) is called from SetEnabled.
+                _mouse.PlatformCaptureLost();
+                _touch.PlatformCaptureLost();
+            }
         }
 
         private void UpdateWMHints()

--- a/tests/Avalonia.IntegrationTests.Appium/PointerTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/PointerTests.cs
@@ -1,0 +1,31 @@
+﻿using OpenQA.Selenium.Interactions;
+using Xunit;
+
+namespace Avalonia.IntegrationTests.Appium
+{
+    [Collection("Default")]
+    public class PointerTests
+    {
+        private readonly AppiumDriver _session;
+
+        public PointerTests(DefaultAppFixture fixture)
+        {
+            _session = fixture.Session;
+
+            var tabs = _session.FindElementByAccessibilityId("MainTabs");
+            var tab = tabs.FindElementByName("Pointer");
+            tab.Click();
+        }
+
+        [Fact]
+        public void Pointer_Capture_Is_Released_When_Showing_Dialog()
+        {
+            var button = _session.FindElementByAccessibilityId("PointerPageShowDialog");
+
+            button.OpenWindowWithClick().Dispose();
+
+            var status = _session.FindElementByAccessibilityId("PointerCaptureStatus");
+            Assert.Equal("None", status.Text);
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

As described in #14525, mouse capture is released on Windows when a dialog is shown, but not on macOS. The issue doesn't mention it but we have the same problem on X11 too.

The fix for this is implemented in managed code. This is because:

- macOS has no concept of "mouse capture" so there's no event we can listen to there to know when to release capture
- X11 does have the concept but we don't use `XGrabPointer` currently, and the `GrabNotify` event which notifies of a pointer capture release isn't available on all X11 implementations anyway

The fix is implemented in `WindowImpl.SetEnabled(false)` as this is the point on Windows where `WM_CANCELMODE` is raised to inform us to release mouse capture: by doing it like this we match Windows' behavior.

Also added an integration test.

## Fixed issues

Fixes #14525