### PR TITLE
TrayIcon tests are flacky, disable them

### DIFF
--- a/tests/Avalonia.IntegrationTests.Appium/SliderTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/SliderTests.cs
@@ -23,7 +23,7 @@ namespace Avalonia.IntegrationTests.Appium
             reset.Click();
         }
 
-        [Fact]
+        [Fact(Skip = "Flaky test, slider value is sometimes off by 1 or 2 steps.")]
         public void Horizontal_Changes_Value_Dragging_Thumb_Right()
         {
             var slider = _session.FindElementByAccessibilityId("HorizontalSlider");
@@ -44,7 +44,7 @@ namespace Avalonia.IntegrationTests.Appium
             Assert.True(currentThumbRect.Left > initialThumbRect.Left);
         }
 
-        [Fact]
+        [Fact(Skip = "Flaky test, slider value is sometimes off by 1 or 2 steps.")]
         public void Horizontal_Changes_Value_Dragging_Thumb_Left()
         {
             var slider = _session.FindElementByAccessibilityId("HorizontalSlider");

--- a/tests/Avalonia.IntegrationTests.Appium/TrayIconTests.cs
+++ b/tests/Avalonia.IntegrationTests.Appium/TrayIconTests.cs
@@ -32,7 +32,7 @@ public class TrayIconTests : IDisposable
     }
 
     // Left click is only supported on Windows.
-    [PlatformFact(TestPlatforms.Windows)]
+    [PlatformFact(TestPlatforms.Windows, Skip = "Flaky test")]
     public void Should_Handle_Left_Click()
     {
         var avaloinaTrayIconButton = GetTrayIconButton(_rootSession ?? _session, TrayIconName);
@@ -46,7 +46,7 @@ public class TrayIconTests : IDisposable
         Assert.True(checkBox.GetIsChecked());
     }
 
-    [Fact]
+    [Fact(Skip = "Flaky test")]
     public void Should_Handle_Context_Menu_Item_Click()
     {
         var avaloinaTrayIconButton = GetTrayIconButton(_rootSession ?? _session, TrayIconName);
@@ -64,7 +64,7 @@ public class TrayIconTests : IDisposable
         Assert.True(checkBox.GetIsChecked());
     }
 
-    [Fact]
+    [Fact(Skip = "Flaky test")]
     public void Can_Toggle_TrayIcon_Visibility()
     {
         var avaloinaTrayIconButton = GetTrayIconButton(_rootSession ?? _session, TrayIconName);


### PR DESCRIPTION
## What does the pull request do?

Today https://github.com/AvaloniaUI/Avalonia/pull/16154 was merged, as it finally got green tests.
Unfortunately, it was a temporary luck, and it seems to fail on CI again. Possibly depends way too much on the machine configuration.
Disabling these tests for now.