### PR TITLE
Remove NullDispatcherImpl and throw exception instead

### DIFF
--- a/src/Avalonia.Base/Threading/Dispatcher.cs
+++ b/src/Avalonia.Base/Threading/Dispatcher.cs
@@ -56,7 +56,7 @@ public partial class Dispatcher : IDispatcher
             if (platformThreading != null)
                 impl = new LegacyDispatcherImpl(platformThreading);
             else
-                impl = new NullDispatcherImpl();
+                throw new InvalidOperationException("Dispatcher was not initialized. Make sure Avalonia was properly set-up.");
         }
         return new Dispatcher(impl);
     }

--- a/src/Avalonia.Base/Threading/IDispatcherImpl.cs
+++ b/src/Avalonia.Base/Threading/IDispatcherImpl.cs
@@ -81,32 +81,3 @@ internal class LegacyDispatcherImpl : IDispatcherImpl
         Timer?.Invoke();
     }
 }
-
-internal sealed class NullDispatcherImpl : IDispatcherImpl
-{
-    public bool CurrentThreadIsLoopThread => true;
-
-    public void Signal()
-    {
-        
-    }
-    
-    public event Action? Signaled
-    {
-        add { }
-        remove { }
-    }
-
-    public event Action? Timer
-    {
-        add { }
-        remove { }
-    }
-
-    public long Now => 0;
-
-    public void UpdateTimer(long? dueTimeInMs)
-    {
-        
-    }
-}

--- a/src/Avalonia.Base/Threading/IDispatcherImpl.cs
+++ b/src/Avalonia.Base/Threading/IDispatcherImpl.cs
@@ -81,3 +81,32 @@ internal class LegacyDispatcherImpl : IDispatcherImpl
         Timer?.Invoke();
     }
 }
+
+internal sealed class NullDispatcherImpl : IDispatcherImpl
+{
+    public bool CurrentThreadIsLoopThread => true;
+
+    public void Signal()
+    {
+        
+    }
+    
+    public event Action? Signaled
+    {
+        add { }
+        remove { }
+    }
+
+    public event Action? Timer
+    {
+        add { }
+        remove { }
+    }
+
+    public long Now => 0;
+
+    public void UpdateTimer(long? dueTimeInMs)
+    {
+        
+    }
+}


### PR DESCRIPTION
## What does the pull request do?

Current dispatcher fallback is problematic. Instead of throwing an exception, it sets-up and caches NullDispatcherImpl, which will throw an exception only later during app setup.

Using dispatcher **before** avalonia was setup is invalid behavior.
We technically could try to support InvokeAsync that will schedule job until avalonia is ready to process them. But sync Invoke method should throw in either way.

## What is the current behavior?

```
Dispatcher.UIThread.Invoke(() => { });
BuildAvaloniaApp().StartWithClassicDesktopLifetime(args); // throws PlatformNotSupportedException
```

## What is the updated/expected behavior with this PR?

```
Dispatcher.UIThread.Invoke(() => { }); // throws InvalidOperationException
BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
```


## Fixed issues

Fixes #16268 
