### PR TITLE
Use culture identifier instead of CultureInfo in NameTable

### DIFF
--- a/src/Avalonia.Base/Media/Fonts/Tables/Name/NameTable.cs
+++ b/src/Avalonia.Base/Media/Fonts/Tables/Name/NameTable.cs
@@ -3,26 +3,24 @@
 // Ported from: https://github.com/SixLabors/Fonts/blob/034a440aece357341fcc6b02db58ffbe153e54ef/src/SixLabors.Fonts
 
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
-using System.Linq;
 
 namespace Avalonia.Media.Fonts.Tables.Name
 {
     internal class NameTable
     {
         internal const string TableName = "name";
-        internal static OpenTypeTag Tag = OpenTypeTag.Parse(TableName);
+        internal static readonly OpenTypeTag Tag = OpenTypeTag.Parse(TableName);
 
         private readonly NameRecord[] _names;
 
-        internal NameTable(NameRecord[] names, IReadOnlyList<CultureInfo> languages)
+        internal NameTable(NameRecord[] names, IReadOnlyList<ushort> languages)
         {
             _names = names;
             Languages = languages;
         }
 
-        public IReadOnlyList<CultureInfo> Languages { get; }
+        public IReadOnlyList<ushort> Languages { get; }
 
         /// <summary>
         /// Gets the name of the font.
@@ -30,7 +28,7 @@ namespace Avalonia.Media.Fonts.Tables.Name
         /// <value>
         /// The name of the font.
         /// </value>
-        public string Id(CultureInfo culture)
+        public string Id(ushort culture)
             => GetNameById(culture, KnownNameIds.UniqueFontID);
 
         /// <summary>
@@ -39,7 +37,7 @@ namespace Avalonia.Media.Fonts.Tables.Name
         /// <value>
         /// The name of the font.
         /// </value>
-        public string FontName(CultureInfo culture)
+        public string FontName(ushort culture)
             => GetNameById(culture, KnownNameIds.FullFontName);
 
         /// <summary>
@@ -48,7 +46,7 @@ namespace Avalonia.Media.Fonts.Tables.Name
         /// <value>
         /// The name of the font.
         /// </value>
-        public string FontFamilyName(CultureInfo culture)
+        public string FontFamilyName(ushort culture)
             => GetNameById(culture, KnownNameIds.FontFamilyName);
 
         /// <summary>
@@ -57,12 +55,12 @@ namespace Avalonia.Media.Fonts.Tables.Name
         /// <value>
         /// The name of the font.
         /// </value>
-        public string FontSubFamilyName(CultureInfo culture)
+        public string FontSubFamilyName(ushort culture)
             => GetNameById(culture, KnownNameIds.FontSubfamilyName);
 
-        public string GetNameById(CultureInfo culture, KnownNameIds nameId)
+        public string GetNameById(ushort culture, KnownNameIds nameId)
         {
-            var languageId = culture.LCID;
+            var languageId = culture;
             NameRecord? usaVersion = null;
             NameRecord? firstWindows = null;
             NameRecord? first = null;
@@ -97,7 +95,7 @@ namespace Avalonia.Media.Fonts.Tables.Name
                    string.Empty;
         }
 
-        public string GetNameById(CultureInfo culture, ushort nameId)
+        public string GetNameById(ushort culture, ushort nameId)
             => GetNameById(culture, (KnownNameIds)nameId);
 
         public static NameTable Load(IGlyphTypeface glyphTypeface)
@@ -160,7 +158,7 @@ namespace Avalonia.Media.Fonts.Tables.Name
                 readable.LoadValue(reader);
             }
 
-            var cultures = new List<CultureInfo>();
+            var cultures = new List<ushort>();
 
             foreach (var nameRecord in names)
             {
@@ -169,15 +167,11 @@ namespace Avalonia.Media.Fonts.Tables.Name
                     continue;
                 }
 
-                var culture = new CultureInfo(nameRecord.LanguageID);
-
-                if (!cultures.Contains(culture))
+                if (!cultures.Contains(nameRecord.LanguageID))
                 {
-                    cultures.Add(culture);
+                    cultures.Add(nameRecord.LanguageID);
                 }
             }
-
-            //var languages = languageNames.Select(x => x.Value).ToArray();
 
             return new NameTable(names, cultures);
         }

--- a/src/Avalonia.Base/Media/IGlyphTypeface2.cs
+++ b/src/Avalonia.Base/Media/IGlyphTypeface2.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.IO;
 using Avalonia.Media.Fonts;
 
@@ -17,8 +16,9 @@ namespace Avalonia.Media
 
         /// <summary>
         /// Gets the localized family names.
+        /// <para>Keys are culture identifiers.</para>
         /// </summary>
-        IReadOnlyDictionary<CultureInfo, string> FamilyNames { get; }
+        IReadOnlyDictionary<ushort, string> FamilyNames { get; }
 
         /// <summary>
         /// Gets supported font features.

--- a/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs
+++ b/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs
@@ -100,9 +100,9 @@ namespace Avalonia.Skia
 
             _nameTable = NameTable.Load(this);
 
-            FamilyName = _nameTable.FontFamilyName(CultureInfo.InvariantCulture);
+            FamilyName = _nameTable.FontFamilyName((ushort)CultureInfo.InvariantCulture.LCID);
 
-            var familyNames = new Dictionary<CultureInfo, string>(_nameTable.Languages.Count);
+            var familyNames = new Dictionary<ushort, string>(_nameTable.Languages.Count);
 
             foreach (var language in _nameTable.Languages)
             {
@@ -112,7 +112,7 @@ namespace Avalonia.Skia
             FamilyNames = familyNames;
         }
 
-        public IReadOnlyDictionary<CultureInfo, string> FamilyNames { get; }
+        public IReadOnlyDictionary<ushort, string> FamilyNames { get; }
 
         public IReadOnlyList<OpenTypeTag> SupportedFeatures
         {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

The question was discussed on Telegram channel with @timunie and @Gillibald 

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Use culture identifier instead of `CultureInfo` in `NameTable` class.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
Without the change, applications will build but fail to run the AOT `InvariantGlobalization` flag.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
This is in order to build and run Avalonia apps with the AOT flag `<InvariantGlobalization>true</InvariantGlobalization>`.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
