### PR TITLE
Only update selection on focus in TabControl if focus comes from TabItem.

### DIFF
--- a/src/Avalonia.Controls/TabControl.cs
+++ b/src/Avalonia.Controls/TabControl.cs
@@ -256,7 +256,7 @@ namespace Avalonia.Controls
         {
             base.OnGotFocus(e);
 
-            if (e.NavigationMethod == NavigationMethod.Directional)
+            if (e.NavigationMethod == NavigationMethod.Directional && e.Source is TabItem)
             {
                 e.Handled = UpdateSelectionFromEventSource(e.Source);
             }


### PR DESCRIPTION
## What does the pull request do?

This is a temporary workaround to help Actipro's issue #15433: they're embedding other controls in a `TabControl`-derived control and they don't want these other controls to change the selection when they're focused.

Ideally as that issue says, we'd be moving all interactions out of `TabControl` and into `TabItem` but given that this would be a big behavioural breaking change to anyone deriving from `TabControl`, we need to take smaller steps. This fix, along with them overriding `TabControl.OnPointerPressed` and `TabControl.OnPointerReleased` should allow them to work around the issue.
