### PR TITLE
Don't BringIntoViewOnFocusChange in Carousel.

### DIFF
--- a/src/Avalonia.Themes.Fluent/Controls/Carousel.xaml
+++ b/src/Avalonia.Themes.Fluent/Controls/Carousel.xaml
@@ -8,6 +8,7 @@
                       Background="{TemplateBinding Background}"
                       BorderBrush="{TemplateBinding BorderBrush}"
                       BorderThickness="{TemplateBinding BorderThickness}"
+                      BringIntoViewOnFocusChange="False"
                       HorizontalScrollBarVisibility="Hidden"
                       VerticalScrollBarVisibility="Hidden">
           <ItemsPresenter Name="PART_ItemsPresenter"

--- a/src/Avalonia.Themes.Simple/Controls/Carousel.xaml
+++ b/src/Avalonia.Themes.Simple/Controls/Carousel.xaml
@@ -8,6 +8,7 @@
                       Background="{TemplateBinding Background}"
                       BorderBrush="{TemplateBinding BorderBrush}"
                       BorderThickness="{TemplateBinding BorderThickness}"
+                      BringIntoViewOnFocusChange="False"
                       HorizontalScrollBarVisibility="Hidden"
                       VerticalScrollBarVisibility="Hidden">
           <ItemsPresenter Name="PART_ItemsPresenter"


### PR DESCRIPTION
## What does the pull request do?

Carousel can't actually scroll controls into view because it's a paging control so this property doesn't make much sense.

But what it does affect is other scroll viewers that are contained in it. If a control is focused within a scroll viewer within a carousel, then `BringIntoView` will be invoked by the carousel scroll viewer, even though the inner scroll viewer has `BringIntoViewOnFocusChange  = false`.
