### PR TITLE
macOS WindowState call on Show crash fix

### DIFF
--- a/src/Avalonia.Native/WindowImpl.cs
+++ b/src/Avalonia.Native/WindowImpl.cs
@@ -6,6 +6,7 @@ using Avalonia.Input.Raw;
 using Avalonia.Input.TextInput;
 using Avalonia.Native.Interop;
 using Avalonia.Platform;
+using MicroCom.Runtime;
 
 namespace Avalonia.Native
 {
@@ -156,6 +157,9 @@ namespace Avalonia.Native
         
         private void InvalidateExtendedMargins()
         {
+            if(_native is MicroComProxyBase pb && pb.IsDisposed) 
+                return;
+
             if (WindowState ==  WindowState.FullScreen)
             {
                 ExtendedMargins = new Thickness();


### PR DESCRIPTION
Fixes an issue when an avalonia app calls close on a window on macOS while the window is still showing up.

cc @kekekeks 