### PR TITLE
Fixes #16346

### DIFF
--- a/src/Avalonia.Controls/VirtualizingStackPanel.cs
+++ b/src/Avalonia.Controls/VirtualizingStackPanel.cs
@@ -842,6 +842,8 @@ namespace Avalonia.Controls
         {
             Debug.Assert(ItemContainerGenerator is not null);
 
+            _scrollAnchorProvider?.UnregisterAnchorCandidate(element);
+
             var recycleKey = element.GetValue(RecycleKeyProperty);
             
             if (recycleKey is null || recycleKey == s_itemIsItsOwnContainer)


### PR DESCRIPTION
## What does the pull request do?

This PR prevents recycled elements from being used as anchors by `ScrollContentPresenter` in the case that those elements have not been arranged before `EnsureAnchorElementSelection` is called.

## What is the current behavior?

Currently, emitting a `Reset` event causes items to be recycled without removing them as anchor candidates. This causes the incorrect element to be selected as an anchor element when arranging `ScrollContentPresenter`. This incorrect anchor element is then interpreted as a change in offset, causing the `ScrollViewer` to scroll more than intended.

## What is the updated/expected behavior with this PR?

This can be tested with the following sample repository.

https://github.com/mpylon/ava-virtualization/tree/master

## Fixed issues

Fixes #16346