### PR TITLE
Fix - return (0,0) as size for text selector layer on MeasureOverride

### DIFF
--- a/src/Avalonia.Controls/Primitives/TextSelectorLayer.cs
+++ b/src/Avalonia.Controls/Primitives/TextSelectorLayer.cs
@@ -27,7 +27,7 @@ namespace Avalonia.Controls.Primitives
         {
             foreach (Control child in Children)
                 child.Measure(availableSize);
-            return availableSize;
+            return default;
         }
 
         protected override Size ArrangeOverride(Size finalSize)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Return (0,0) as measured size for TextSelectorLayer, instead of the size passed to it in MeasureOverride.


## What is the current behavior?
TextSelectorLayer is designed to fill the bounds of its parent, and thus previously just passed the size requested by the parent back. If the parent is a fixed size control, this won't cause any issue. But in some cases, Size(Infinity, Infinity) can be sent to the MeasureOverride call. This is valid as input, but not output, thus resulting in a crash here;
https://github.com/AvaloniaUI/Avalonia/blob/890df998a9273ec25e682585346b1e76678b4c1f/src/Avalonia.Base/Layout/Layoutable.cs#L382


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
