### PR TITLE
Fix Avalonia/references generation

### DIFF
--- a/packages/Avalonia/AvaloniaBuildTasks.targets
+++ b/packages/Avalonia/AvaloniaBuildTasks.targets
@@ -135,6 +135,14 @@
     Outputs="@(CompileAvaloniaXamlOutputs)"
     Condition="'@(AvaloniaResource)@(AvaloniaXaml)' != '' AND $(DesignTimeBuild) != true AND $(EnableAvaloniaXamlCompilation) != false">
 
+    <!--
+      $(IntermediateOutputPath)/Avalonia/references is using from AvaloniaVS for retrieve library references.
+    -->
+    <WriteLinesToFile
+      File="$(IntermediateOutputPath)/Avalonia/references"
+      Lines="@(ReferencePathWithRefAssemblies)"
+      Overwrite="true" />
+
     <CompileAvaloniaXamlTask
       AssemblyFile="@(IntermediateAssembly)"
       References="@(ReferencePathWithRefAssemblies)"
@@ -244,23 +252,5 @@
       ('$(CopyBuildOutputToOutputDirectory)' == '' or '$(CopyBuildOutputToOutputDirectory)' == 'true') and
       '$(SkipCopyBuildProduct)' != 'true'">
     <Delete Files="$(TargetRefPath)" Condition="Exists('$(TargetRefPath)')" />
-  </Target>
-
-  <!--
-  $(IntermediateOutputPath)/Avalonia/references is using from AvaloniaVS for retrieve library references.
-  This target generate $(IntermediateOutputPath)/Avalonia/references for in xplat Template
-  (see: https://github.com/AvaloniaUI/avalonia-dotnet-templates/tree/e4a489ae828f005f625145c563785174403e267c/templates/csharp/xplat).
-  -->
-  <Target Name="GenerateIntellisenseReferences"
-          AfterTargets="AfterCompile"
-          Condition="('@(AvaloniaResource->Count())' == 0) and ('@(AvaloniaXaml->Count())' == 0)">
-    <PropertyGroup>
-      <AvaloniaXamlReferencesTemporaryFilePath Condition="'$(AvaloniaXamlReferencesTemporaryFilePath)' == ''">$(IntermediateOutputPath)/Avalonia/references</AvaloniaXamlReferencesTemporaryFilePath>
-    </PropertyGroup>
-    <WriteLinesToFile
-      Condition="'$(_AvaloniaForceInternalMSBuild)' != 'true'"
-      File="$(AvaloniaXamlReferencesTemporaryFilePath)"
-      Lines="@(ReferencePathWithRefAssemblies)"
-      Overwrite="true" />
   </Target>
 </Project>


### PR DESCRIPTION
# What does the pull request do?

Fixes intellisense in the latest version of the VS extension.

https://github.com/AvaloniaUI/AvaloniaVS/pull/413 made a change to the VS extension that required the `references` file but https://github.com/AvaloniaUI/Avalonia/pull/14700 removed the generation of that file (I assume accidentally). https://github.com/AvaloniaUI/Avalonia/pull/14397 attempted to fix that but it looks like it didn't actually fix it - it was always skipped when it shouldn't be and not skipped when it should be.

This wasn't detected because 11.1.0 was tested with the then-current version of the extension which didn't include https://github.com/AvaloniaUI/AvaloniaVS/pull/413. After 11.1.0 was released a new version of the extension was released, and 💥 .
