### PR TITLE
Compatible with "fcitx5" envrionment variable

### DIFF
--- a/src/Avalonia.FreeDesktop/DBusIme/X11DBusImeHelper.cs
+++ b/src/Avalonia.FreeDesktop/DBusIme/X11DBusImeHelper.cs
@@ -12,6 +12,8 @@ namespace Avalonia.FreeDesktop.DBusIme
             {
                 ["fcitx"] = static conn =>
                     new DBusInputMethodFactory<FcitxX11TextInputMethod>(_ => new FcitxX11TextInputMethod(conn)),
+                ["fcitx5"] = static conn =>
+                    new DBusInputMethodFactory<FcitxX11TextInputMethod>(_ => new FcitxX11TextInputMethod(conn)),
                 ["ibus"] = static conn =>
                     new DBusInputMethodFactory<IBusX11TextInputMethod>(_ => new IBusX11TextInputMethod(conn))
             };


### PR DESCRIPTION
## What does the pull request do?
Some older Linux distributions use "GTK_IM_MODULE=fcitx5 QT_IM_MODULE=fcitx5". In this case, IME doesn't work.
This environment variable has been modified many times between fcitx5 and fcitx.
See [this debian bug report](https://bugs-devel.debian.org/cgi-bin/bugreport.cgi?bug=977203).
Although the latest version is "fcitx", we should also make those Linux distributions that stuck in "fcitx5" work normally.

## What is the current behavior?

## What is the updated/expected behavior with this PR?

## How was the solution implemented (if it's not obvious)?

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

## Obsoletions / Deprecations

## Fixed issues
