### PR TITLE
Win32.PlatformConstants uses buildNumber instead of version

### DIFF
--- a/src/Windows/Avalonia.Win32/PlatformConstants.cs
+++ b/src/Windows/Avalonia.Win32/PlatformConstants.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Win32
         /// <summary>
         /// Windows 10 Anniversary Update
         /// </summary>
-        public static readonly Version Windows10_1607 = new Version(10, 0, 1607);
+        public static readonly Version Windows10_1607 = new Version(10, 0, 14393); // 3rd digit of the Version class is build number (which is 14393 for Windows 10 Version 1607)
         public static readonly Version Windows8 = new Version(6, 2);
         public static readonly Version Windows8_1 = new Version(6, 3);
         public static readonly Version Windows7 = new Version(6, 1);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Changes the definition of `Avalonia.Win32.PlatformConstants.Windows10_1607` to correctly create the `Version` class using Windows 10-1607 buildNumber (and not the marketing version).


## What is the current behavior?
This test
```csharp
Win32Platform.WindowsVersion < PlatformConstants.Windows10_1607
```
is always false for any windows 10 version since it's comparing windows internal build number (which starts at 10240 for the first Windows 10 version) to the marketing Version (1607).


## What is the updated/expected behavior with this PR?
With this change, the previous test will correctly return false when ran on Windows 10 version 1507 (Codename Threshold, BuildNumber 10240) or on Windows 10 version 1511 (Codename Threshold2, BuildNumber 10586).

## Fixed issues
Fixes #16444
