### PR TITLE
Fix IME not working in some scenarios.

### DIFF
--- a/src/Avalonia.FreeDesktop/DBusIme/DBusTextInputMethodBase.cs
+++ b/src/Avalonia.FreeDesktop/DBusIme/DBusTextInputMethodBase.cs
@@ -65,8 +65,9 @@ namespace Avalonia.FreeDesktop.DBusIme
             {
                 _disposables.Add(await dbus.WatchNameOwnerChangedAsync(OnNameChange));
             }
-            catch (DBusException)
+            catch (DBusException e)
             {
+                Logger.TryGet(LogEventLevel.Error, LogArea.FreeDesktopPlatform)?.Log(this, $"WatchNameOwnerChangedAsync failed: {e}");
             }
             foreach (var name in _knownNames)
             {
@@ -75,8 +76,9 @@ namespace Avalonia.FreeDesktop.DBusIme
                     var nameOwner = await dbus.GetNameOwnerAsync(name);
                     OnNameChange(null, (name, null, nameOwner));
                 }
-                catch (DBusException)
+                catch (DBusException e)
                 {
+                    Logger.TryGet(LogEventLevel.Error, LogArea.FreeDesktopPlatform)?.Log(this, $"GetNameOwnerAsync failed: {e}");
                 }
             }
         }


### PR DESCRIPTION
## What does the pull request do?

* If other service trigger `OnNameChange` before `GetNameOwnerAsync`, then we will incorrectly connect to other service, and will be stuck at `Connect`. We should ignore irrelevant services.

* `WatchNameOwnerChangedAsync` should be called only once.

d7904b34cd7995935b4dce91bc057c5480973031 changed the previous behavior, and caused this bug.

## What is the current behavior?

IME not work in the above scenario


## What is the updated/expected behavior with this PR?

IME works.


## How was the solution implemented (if it's not obvious)?


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes

## Obsoletions / Deprecations

## Fixed issues
