### PR TITLE
Fix android uri activation

### DIFF
--- a/samples/ControlCatalog.Android/MainActivity.cs
+++ b/samples/ControlCatalog.Android/MainActivity.cs
@@ -1,5 +1,6 @@
 ﻿using Android.App;
 using Android.Content.PM;
+using Android.OS;
 using Avalonia;
 using Avalonia.Android;
 using static Android.Content.Intent;
@@ -10,10 +11,9 @@ using static Android.Content.Intent;
 
 namespace ControlCatalog.Android
 {
-    [Activity(Label = "ControlCatalog.Android", Theme = "@style/MyTheme.NoActionBar", Icon = "@drawable/icon", MainLauncher = true, Exported = true, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode)]
-    // CategoryBrowsable and DataScheme are required for Protocol activation.
+    [Activity(Name = "com.Avalonia.ControlCatalog.MainActivity", Label = "ControlCatalog.Android", Theme = "@style/MyTheme.NoActionBar", Icon = "@drawable/icon", MainLauncher = true, Exported = true, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode)]
     // CategoryLeanbackLauncher is required for Android TV.
-    [IntentFilter(new [] { ActionView }, Categories = new [] { CategoryDefault, CategoryBrowsable, CategoryLeanbackLauncher }, DataScheme = "avln" )]
+    [IntentFilter(new [] { ActionView }, Categories = new [] { CategoryDefault, CategoryLeanbackLauncher })]
     public class MainActivity : AvaloniaMainActivity<App>
     {
         protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
@@ -23,6 +23,21 @@ namespace ControlCatalog.Android
                  {
                      Pages.EmbedSample.Implementation = new EmbedSampleAndroid();
                  });
+        }
+    }
+
+    /// <summary>
+    /// Special activity to handle OpenUri activation.
+    /// `AvaloniaActivity` internally will redirect parameters to the Avalonia Application.
+    /// </summary>
+    [Activity(NoHistory = true, LaunchMode = LaunchMode.SingleTop, Exported = true, Theme = "@android:style/Theme.NoDisplay")]
+    [IntentFilter(new[] {ActionView}, Categories = new[] {CategoryDefault, CategoryBrowsable}, DataScheme = "avln")]
+    public class DataSchemeActivity : AvaloniaActivity
+    {
+        protected override void OnCreate(Bundle? savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+            Finish();
         }
     }
 }

--- a/src/Android/Avalonia.Android/AvaloniaActivity.cs
+++ b/src/Android/Avalonia.Android/AvaloniaActivity.cs
@@ -90,9 +90,13 @@ public class AvaloniaActivity : AppCompatActivity, IAvaloniaActivity
 
         base.OnCreate(savedInstanceState);
 
+        if (Avalonia.Application.Current?.TryGetFeature<IActivatableLifetime>()
+            is AndroidActivatableLifetime activatableLifetime)
+        {
+            activatableLifetime.CurrentIntendActivity = this;
+        }
 
-        // TODO: we probably don't need to create AvaloniaView, if it's just a protocol activation, and main activity is already created.
-        if (Intent?.Data is {} androidUri
+        if (Intent?.Data is { } androidUri
             && androidUri.IsAbsolute
             && Uri.TryCreate(androidUri.ToString(), UriKind.Absolute, out var uri))
         {
@@ -142,7 +146,7 @@ public class AvaloniaActivity : AppCompatActivity, IAvaloniaActivity
         {
             if (_listener is not null)
             {
-            _view.ViewTreeObserver?.RemoveOnGlobalLayoutListener(_listener);
+                _view.ViewTreeObserver?.RemoveOnGlobalLayoutListener(_listener);
             }
             _view.Content = null;
             _view.Dispose();

--- a/src/Android/Avalonia.Android/AvaloniaMainActivity.cs
+++ b/src/Android/Avalonia.Android/AvaloniaMainActivity.cs
@@ -10,18 +10,6 @@ public class AvaloniaMainActivity : AvaloniaActivity
 {
     private protected static SingleViewLifetime? Lifetime;
 
-    public override void OnCreate(Bundle? savedInstanceState, PersistableBundle? persistentState)
-    {
-        // Global IActivatableLifetime expects a main activity, so we need to replace it on each OnCreate.
-        if (Avalonia.Application.Current?.TryGetFeature<IActivatableLifetime>()
-            is AndroidActivatableLifetime activatableLifetime)
-        {
-            activatableLifetime.Activity = this;
-        }
-
-        base.OnCreate(savedInstanceState, persistentState);
-    }
-
     private protected override void InitializeAvaloniaView(object? initialContent)
     {
         // Android can run OnCreate + InitializeAvaloniaView multiple times per process lifetime.
@@ -54,6 +42,12 @@ public class AvaloniaMainActivity : AvaloniaActivity
             // AfterPlatformServicesSetup should always be called. If it wasn't, we have an unusual problem.
             if (_view is null)
                 throw new InvalidOperationException("Unknown error: AvaloniaView initialization has failed.");
+        }
+
+        if (Avalonia.Application.Current?.TryGetFeature<IActivatableLifetime>()
+            is AndroidActivatableLifetime activatableLifetime)
+        {
+            activatableLifetime.CurrentMainActivity = this;
         }
     }
 


### PR DESCRIPTION
## What does the pull request do?

1. Fixes android OpenUri/File activation by overriding correct `OnCreate` method.
2. Makes `AndroidActivatableLifetime` redirect secondary activity activation into main activity.
3. Makes SetContentView() call delayed. This way if derived activity doesn't set any Content (directly or view SingleViewLifetime), no SetContentView is called. Which helps for no-UI activities like DataScheme handlers.

## Fixed issues

Fixes #16474 
Fixes #16457
