### PR TITLE
feat: Ensure an extend margin calculation before Window show on Windows. 

### DIFF
--- a/src/Avalonia.Controls/Window.cs
+++ b/src/Avalonia.Controls/Window.cs
@@ -743,6 +743,8 @@ namespace Avalonia.Controls
 
                 StartRendering();
                 PlatformImpl?.Show(ShowActivated, false);
+                WindowDecorationMargin = PlatformImpl?.ExtendedMargins ?? default;
+                OffScreenMargin = PlatformImpl?.OffScreenMargin ?? default;
                 OnOpened(EventArgs.Empty);
                 _wasShownBefore = true;
             }

--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1133,6 +1133,7 @@ namespace Avalonia.Win32
         {
             if (!_shown)
             {
+                UpdateExtendMargins();
                 return;
             }
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
`WindowDecorationMargin` and `OffScreenMargin` is not properly set if WindowState is set to Maximized initially. This PR resolves this issue. 


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
See Issue #16503 


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Ensure Win32.WindowImpl `ExtendedMargin` and `OffScreenMargin`  is calculated even if window is not shown yet. 


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes #16503 
