### PR TITLE
Obsolete CompiledBindingPathBuilder.SetRawSource

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlBindingPathParser.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/Transformers/AvaloniaXamlIlBindingPathParser.cs
@@ -336,20 +336,4 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions.Transformers
     {
         public IXamlType Type { get; set; }
     }
-
-    class RawSourceBindingExpressionNode : XamlAstNode, BindingExpressionGrammar.INode
-    {
-        public RawSourceBindingExpressionNode(IXamlAstValueNode rawSource)
-            : base(rawSource)
-        {
-            RawSource = rawSource;
-        }
-
-        public IXamlAstValueNode RawSource { get; private set; }
-
-        public override void VisitChildren(IXamlAstVisitor visitor)
-        {
-            RawSource = (IXamlAstValueNode)RawSource.Visit(visitor);
-        }
-    }
 }

--- a/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
+++ b/src/Markup/Avalonia.Markup.Xaml.Loader/CompilerExtensions/XamlIlBindingPathHelper.cs
@@ -325,9 +325,6 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
                         }
                         nodes.Add(new ElementNamePathElementNode(elementName.Name, elementType));
                         break;
-                    case RawSourceBindingExpressionNode rawSource:
-                        nodes.Add(new RawSourcePathElementNode(rawSource.RawSource));
-                        break;
                     case BindingExpressionGrammar.TypeCastNode typeCastNode:
                         var castType = GetType(typeCastNode.Namespace, typeCastNode.TypeName);
 
@@ -860,28 +857,6 @@ namespace Avalonia.Markup.Xaml.XamlIl.CompilerExtensions
             }
 
             public IXamlType Type => _arrayType.ArrayElementType;
-        }
-
-        class RawSourcePathElementNode : XamlAstNode, IXamlIlBindingPathElementNode
-        {
-            private readonly IXamlAstValueNode _rawSource;
-
-            public RawSourcePathElementNode(IXamlAstValueNode rawSource)
-                : base(rawSource)
-            {
-                _rawSource = rawSource;
-
-            }
-
-            public IXamlType Type => _rawSource.Type.GetClrType();
-
-            public void Emit(XamlIlEmitContext context, IXamlILEmitter codeGen)
-            {
-                context.Emit(_rawSource, codeGen, Type);
-                codeGen
-                    .EmitCall(context.GetAvaloniaTypes()
-                    .CompiledBindingPathBuilder.FindMethod(m => m.Name == "SetRawSource"));
-            }
         }
 
         class TypeCastPathElementNode : IXamlIlBindingPathElementNode

--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindings/CompiledBindingPath.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/CompiledBindings/CompiledBindingPath.cs
@@ -16,11 +16,8 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
         public CompiledBindingPath()
             => _elements = Array.Empty<ICompiledBindingPathElement>();
 
-        internal CompiledBindingPath(ICompiledBindingPathElement[] elements, object? rawSource)
-        {
-            _elements = elements;
-            RawSource = rawSource;
-        }
+        internal CompiledBindingPath(ICompiledBindingPathElement[] elements)
+            => _elements = elements;
 
         internal void BuildExpression(List<ExpressionNode> result, out bool isRooted)
         {
@@ -97,8 +94,6 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
         internal SourceMode SourceMode => Array.Exists(_elements, e => e is IControlSourceBindingPathElement)
             ? SourceMode.Control : SourceMode.Data;
 
-        internal object? RawSource { get; }
-
         /// <inheritdoc />
         public override string ToString()
             => string.Concat((IEnumerable<ICompiledBindingPathElement>) _elements);
@@ -107,7 +102,6 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
     public class CompiledBindingPathBuilder
     {
         private readonly int _apiVersion;
-        private object? _rawSource;
         private readonly List<ICompiledBindingPathElement> _elements = new();
 
         public CompiledBindingPathBuilder()
@@ -210,13 +204,13 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings
             return this;
         }
 
+        [Obsolete("This method doesn't do anything anymore. Use Binding.Source instead.")]
         public CompiledBindingPathBuilder SetRawSource(object? rawSource)
         {
-            _rawSource = rawSource;
             return this;
         }
 
-        public CompiledBindingPath Build() => new CompiledBindingPath(_elements.ToArray(), _rawSource);
+        public CompiledBindingPath Build() => new CompiledBindingPath(_elements.ToArray());
     }
 
     internal interface ICompiledBindingPathElement


### PR DESCRIPTION
## What does the pull request do?
`CompiledBindingPathBuilder.SetRawSource()` doesn't do anything anymore after the binding system refactor (#13970) in 11.1.
Setting `Binding.Source` is the expected and straightforward way.

Apparently, `SetRawSource()` hasn't been used at all by the XAML compiler since #5052.
Only users using it explicitly in C# were affected (hopefully a low number), see #16430.

`CompiledBindingPathBuilder.SetRawSource()` is now obsolete.
Remaining `RawSource`-related types have been removed from the XAML compiler.

## Fixed issues
 - Closes #16430