### PR TITLE
Improve TextTrimming customization experience

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/ShapedTextRun.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/ShapedTextRun.cs
@@ -98,7 +98,7 @@ namespace Avalonia.Media.TextFormatting
         /// <returns>
         /// <c>true</c> if characters fit into the available width; otherwise, <c>false</c>.
         /// </returns>
-        internal bool TryMeasureCharacters(double availableWidth, out int length)
+        public bool TryMeasureCharacters(double availableWidth, out int length)
         {
             length = 0;
             var currentWidth = 0.0;

--- a/src/Avalonia.Base/Media/TextFormatting/TextCollapsingProperties.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextCollapsingProperties.cs
@@ -27,5 +27,56 @@ namespace Avalonia.Media.TextFormatting
         /// </summary>
         /// <param name="textLine">Text line to collapse.</param>
         public abstract TextRun[]? Collapse(TextLine textLine);
+
+        /// <summary>
+        /// Creates a list of runs for given collapsed length which includes specified symbol at the end.
+        /// </summary>
+        /// <param name="textLine">The text line.</param>
+        /// <param name="collapsedLength">The collapsed length.</param>
+        /// <param name="flowDirection">The flow direction.</param>
+        /// <param name="shapedSymbol">The symbol.</param>
+        /// <returns>List of remaining runs.</returns>
+        public static TextRun[] CreateCollapsedRuns(TextLine textLine, int collapsedLength,
+            FlowDirection flowDirection, TextRun shapedSymbol)
+        {
+            var textRuns = textLine.TextRuns;
+
+            if (collapsedLength <= 0)
+            {
+                return new[] { shapedSymbol };
+            }
+
+            if (flowDirection == FlowDirection.RightToLeft)
+            {
+                collapsedLength = textLine.Length - collapsedLength;
+            }
+
+            var objectPool = FormattingObjectPool.Instance;
+
+            var (preSplitRuns, postSplitRuns) = TextFormatterImpl.SplitTextRuns(textRuns, collapsedLength, objectPool);
+
+            try
+            {
+                if (flowDirection == FlowDirection.RightToLeft)
+                {
+                    var collapsedRuns = new TextRun[postSplitRuns!.Count + 1];
+                    postSplitRuns.CopyTo(collapsedRuns, 1);
+                    collapsedRuns[0] = shapedSymbol;
+                    return collapsedRuns;
+                }
+                else
+                {
+                    var collapsedRuns = new TextRun[preSplitRuns!.Count + 1];
+                    preSplitRuns.CopyTo(collapsedRuns);
+                    collapsedRuns[collapsedRuns.Length - 1] = shapedSymbol;
+                    return collapsedRuns;
+                }
+            }
+            finally
+            {
+                objectPool.TextRunLists.Return(ref preSplitRuns);
+                objectPool.TextRunLists.Return(ref postSplitRuns);
+            }
+        }
     }
 }

--- a/src/Avalonia.Base/Media/TextFormatting/TextEllipsisHelper.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextEllipsisHelper.cs
@@ -66,6 +66,36 @@ namespace Avalonia.Media.TextFormatting
                                                 currentBreakPosition = nextBreakPosition;
                                             }
 
+                                            var codepoint = Codepoint.ReadAt(currentRun.Text.Span, currentBreakPosition, out _);
+
+                                            //Handle strings that might look like a file path here
+                                            if (codepoint.Value == '\\')
+                                            {
+                                                var graphemeEnumerator =
+                                                    new GraphemeEnumerator(
+                                                        currentRun.Text.Span.Slice(currentBreakPosition));
+
+                                                var lengthInPath = 0;
+                                                var breakPositionInPath = 0;
+
+                                                while (graphemeEnumerator.MoveNext(out var grapheme))
+                                                {
+                                                    if (currentBreakPosition + lengthInPath + grapheme.Length >= measuredLength)
+                                                    {
+                                                        break;
+                                                    }
+
+                                                    lengthInPath += grapheme.Length;
+
+                                                    if (grapheme.FirstCodepoint.Value is '\\')
+                                                    {
+                                                        breakPositionInPath = lengthInPath;
+                                                    }
+                                                }
+
+                                                currentBreakPosition += breakPositionInPath;
+                                            }
+
                                             measuredLength = currentBreakPosition;
                                         }
                                     }

--- a/src/Avalonia.Base/Media/TextFormatting/TextEllipsisHelper.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextEllipsisHelper.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Avalonia.Media.TextFormatting.Unicode;
+﻿using Avalonia.Media.TextFormatting.Unicode;
 
 namespace Avalonia.Media.TextFormatting
 {
@@ -17,12 +16,12 @@ namespace Avalonia.Media.TextFormatting
             var runIndex = 0;
             var currentWidth = 0.0;
             var collapsedLength = 0;
-            var shapedSymbol = TextFormatterImpl.CreateSymbol(properties.Symbol, FlowDirection.LeftToRight);
+            var shapedSymbol = TextFormatter.CreateSymbol(properties.Symbol, FlowDirection.LeftToRight);
 
             if (properties.Width < shapedSymbol.GlyphRun.Bounds.Width)
             {
                 //Not enough space to fit in the symbol
-                return Array.Empty<TextRun>();
+                return [];
             }
 
             var availableWidth = properties.Width - shapedSymbol.Size.Width;
@@ -66,43 +65,13 @@ namespace Avalonia.Media.TextFormatting
                                                 currentBreakPosition = nextBreakPosition;
                                             }
 
-                                            var codepoint = Codepoint.ReadAt(currentRun.Text.Span, currentBreakPosition, out _);
-
-                                            //Handle strings that might look like a file path here
-                                            if (codepoint.Value == '\\')
-                                            {
-                                                var graphemeEnumerator =
-                                                    new GraphemeEnumerator(
-                                                        currentRun.Text.Span.Slice(currentBreakPosition));
-
-                                                var lengthInPath = 0;
-                                                var breakPositionInPath = 0;
-
-                                                while (graphemeEnumerator.MoveNext(out var grapheme))
-                                                {
-                                                    if (currentBreakPosition + lengthInPath + grapheme.Length >= measuredLength)
-                                                    {
-                                                        break;
-                                                    }
-
-                                                    lengthInPath += grapheme.Length;
-
-                                                    if (grapheme.FirstCodepoint.Value is '\\')
-                                                    {
-                                                        breakPositionInPath = lengthInPath;
-                                                    }
-                                                }
-
-                                                currentBreakPosition += breakPositionInPath;
-                                            }
-
                                             measuredLength = currentBreakPosition;
                                         }
                                     }
 
                                     collapsedLength += measuredLength;
 
-                                    return CreateCollapsedRuns(textLine, collapsedLength, FlowDirection.LeftToRight, shapedSymbol);
+                                    return TextCollapsingProperties.CreateCollapsedRuns(textLine, collapsedLength, FlowDirection.LeftToRight, shapedSymbol);
                                 }
 
                                 availableWidth -= shapedRun.Size.Width;
@@ -115,7 +84,7 @@ namespace Avalonia.Media.TextFormatting
                                 //The whole run needs to fit into available space
                                 if (currentWidth + drawableRun.Size.Width > availableWidth)
                                 {
-                                    return CreateCollapsedRuns(textLine, collapsedLength, FlowDirection.LeftToRight, shapedSymbol);
+                                    return TextCollapsingProperties.CreateCollapsedRuns(textLine, collapsedLength, FlowDirection.LeftToRight, shapedSymbol);
                                 }
 
                                 availableWidth -= drawableRun.Size.Width;
@@ -176,7 +145,7 @@ namespace Avalonia.Media.TextFormatting
 
                                     collapsedLength += measuredLength;
 
-                                    return CreateCollapsedRuns(textLine, collapsedLength, FlowDirection.RightToLeft, shapedSymbol);
+                                    return TextCollapsingProperties.CreateCollapsedRuns(textLine, collapsedLength, FlowDirection.RightToLeft, shapedSymbol);
                                 }
 
                                 availableWidth -= shapedRun.Size.Width;
@@ -189,7 +158,7 @@ namespace Avalonia.Media.TextFormatting
                                 //The whole run needs to fit into available space
                                 if (currentWidth + drawableRun.Size.Width > availableWidth)
                                 {
-                                    return CreateCollapsedRuns(textLine, collapsedLength, FlowDirection.RightToLeft, shapedSymbol);
+                                    return TextCollapsingProperties.CreateCollapsedRuns(textLine, collapsedLength, FlowDirection.RightToLeft, shapedSymbol);
                                 }
 
                                 availableWidth -= drawableRun.Size.Width;
@@ -205,49 +174,6 @@ namespace Avalonia.Media.TextFormatting
             }
       
             return null;
-        }
-
-        private static TextRun[] CreateCollapsedRuns(TextLine textLine, int collapsedLength,
-            FlowDirection flowDirection, TextRun shapedSymbol)
-        {
-            var textRuns = textLine.TextRuns;
-
-            if (collapsedLength <= 0)
-            {
-                return new[] { shapedSymbol };
-            }
-
-            if(flowDirection == FlowDirection.RightToLeft)
-            {
-                collapsedLength = textLine.Length - collapsedLength;
-            }
-
-            var objectPool = FormattingObjectPool.Instance;
-
-            var (preSplitRuns, postSplitRuns) = TextFormatterImpl.SplitTextRuns(textRuns, collapsedLength, objectPool);
-
-            try
-            {
-                if (flowDirection == FlowDirection.RightToLeft)
-                {
-                    var collapsedRuns = new TextRun[postSplitRuns!.Count + 1];
-                    postSplitRuns.CopyTo(collapsedRuns, 1);
-                    collapsedRuns[0] = shapedSymbol;
-                    return collapsedRuns;
-                }
-                else
-                {
-                    var collapsedRuns = new TextRun[preSplitRuns!.Count + 1];
-                    preSplitRuns.CopyTo(collapsedRuns);
-                    collapsedRuns[collapsedRuns.Length - 1] = shapedSymbol;
-                    return collapsedRuns;
-                }
-            }
-            finally
-            {
-                objectPool.TextRunLists.Return(ref preSplitRuns);
-                objectPool.TextRunLists.Return(ref postSplitRuns);
-            }
         }
     }
 }

--- a/src/Avalonia.Base/Media/TextFormatting/TextFormatter.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextFormatter.cs
@@ -40,5 +40,31 @@
         /// <returns>The formatted line.</returns>
         public abstract TextLine? FormatLine(ITextSource textSource, int firstTextSourceIndex, double paragraphWidth,
             TextParagraphProperties paragraphProperties, TextLineBreak? previousLineBreak = null);
+
+        /// <summary>
+        /// Creates a shaped symbol.
+        /// </summary>
+        /// <param name="textRun">The symbol run to shape.</param>
+        /// <param name="flowDirection">The flow direction.</param>
+        /// <returns>
+        /// The shaped symbol.
+        /// </returns>
+        public static ShapedTextRun CreateSymbol(TextRun textRun, FlowDirection flowDirection)
+        {
+            var textShaper = TextShaper.Current;
+
+            var glyphTypeface = textRun.Properties!.CachedGlyphTypeface;
+
+            var fontRenderingEmSize = textRun.Properties.FontRenderingEmSize;
+
+            var cultureInfo = textRun.Properties.CultureInfo;
+
+            var shaperOptions = new TextShaperOptions(glyphTypeface, textRun.Properties.FontFeatures,
+                fontRenderingEmSize, (sbyte)flowDirection, cultureInfo);
+
+            var shapedBuffer = textShaper.ShapeText(textRun.Text, shaperOptions);
+
+            return new ShapedTextRun(shapedBuffer, textRun.Properties);
+        }
     }
 }

--- a/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextFormatterImpl.cs
@@ -957,31 +957,5 @@ namespace Avalonia.Media.TextFormatting
                 return true;
             }
         }
-
-        /// <summary>
-        /// Creates a shaped symbol.
-        /// </summary>
-        /// <param name="textRun">The symbol run to shape.</param>
-        /// <param name="flowDirection">The flow direction.</param>
-        /// <returns>
-        /// The shaped symbol.
-        /// </returns>
-        internal static ShapedTextRun CreateSymbol(TextRun textRun, FlowDirection flowDirection)
-        {
-            var textShaper = TextShaper.Current;
-
-            var glyphTypeface = textRun.Properties!.CachedGlyphTypeface;
-
-            var fontRenderingEmSize = textRun.Properties.FontRenderingEmSize;
-
-            var cultureInfo = textRun.Properties.CultureInfo;
-
-            var shaperOptions = new TextShaperOptions(glyphTypeface, textRun.Properties.FontFeatures, 
-                fontRenderingEmSize, (sbyte)flowDirection, cultureInfo);
-
-            var shapedBuffer = textShaper.ShapeText(textRun.Text, shaperOptions);
-
-            return new ShapedTextRun(shapedBuffer, textRun.Properties);
-        }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR changes the visibility of some helper functions from internal to public to make the process of adding a custom TextTrimming implementation easier.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->

### Sample

```
<Window.Styles>
   <Style Selector="Grid.demo">
     <Style Selector="^ Label">
       <Setter Property="VerticalAlignment" Value="Center"/>
       <Setter Property="Margin" Value="0,0,4,0"/>
     </Style>

     <Style Selector="^ Border">
       <Setter Property="VerticalAlignment" Value="Center"/>
       <Setter Property="BorderBrush" Value="Black"/>
       <Setter Property="BorderThickness" Value="1"/>
     </Style>

     <Style Selector="^ TextBlock">
       <Setter Property="VerticalAlignment" Value="Center"/>
     </Style>
   </Style>
 </Window.Styles>



 <Grid ColumnDefinitions="Auto,150"
       RowDefinitions="Auto,Auto,Auto,Auto, Auto"
       Margin="10"
       Classes="demo">
   <!-- Row 0 -->

   <Label Content="1. Text with CharacterEllipsis"
          Grid.Row="0" Grid.Column="0"/>
   <Border Grid.Row="0" Grid.Column="1">
     <TextBlock Text="Some very long text that should be trimmed."
                TextTrimming="CharacterEllipsis"/>
   </Border>

   <!-- Row 1 -->
   <Label Content="2. Text with WordEllipsis"
          Grid.Row="1" Grid.Column="0"/>
   <Border Grid.Row="1" Grid.Column="1">
     <TextBlock Text="Some very long text that should be trimmed."
                TextTrimming="WordEllipsis"/>
   </Border>

   <!-- Row 2 -->
   <Label Content="3. Path with CharacterEllipsis"
          Grid.Row="2" Grid.Column="0"/>
   <Border Grid.Row="2" Grid.Column="1">
     <TextBlock Text="C:\Some\very\long\text\that\should\be\trimmed."
                TextTrimming="CharacterEllipsis"/>
   </Border>

   <!-- Row 3 -->
   <Label Content="4. Path with WordEllipsis"
          Grid.Row="3" Grid.Column="0"/>
   <Border Grid.Row="3" Grid.Column="1">
     <TextBlock Text="C:\Some\very\long\text\that\should\be\trimmed."
                TextTrimming="WordEllipsis"/>
   </Border>

   <!-- Row 4 -->
   <Label Content="5. Path with custom trimming"
          Grid.Row="4" Grid.Column="0"/>
   <Border Grid.Row="4" Grid.Column="1">
     <TextBlock Text="C:\Some\very\long\text\that\should\be\trimmed.">
       <TextBlock.TextTrimming>
         <local:CustomTextTrimming/>
       </TextBlock.TextTrimming>
     </TextBlock>
   </Border>
 </Grid>
```
CustomTextTrimming implementation
```
public class CustomTextTrimming : TextTrimming
    {
        public override TextCollapsingProperties CreateCollapsingProperties(TextCollapsingCreateInfo createInfo)
        {
            return new CustomTrailingWordEllipsis("\u2026", createInfo.Width, createInfo.TextRunProperties,
                createInfo.FlowDirection);
        }

        private class CustomTrailingWordEllipsis : TextCollapsingProperties
        {
            public CustomTrailingWordEllipsis(
                string ellipsis,
                double width,
                TextRunProperties textRunProperties,
                FlowDirection flowDirection
            )
            {
                Width = width;
                Symbol = new TextCharacters(ellipsis, textRunProperties);
                FlowDirection = flowDirection;
            }

            /// <inheritdoc/>
            public override double Width { get; }

            /// <inheritdoc/>
            public override TextRun Symbol { get; }

            public override FlowDirection FlowDirection { get; }

            /// <inheritdoc />
            public override TextRun[]? Collapse(TextLine textLine)
            {
                return Collapse(textLine, this, true);
            }

            private static TextRun[] Collapse(TextLine textLine, TextCollapsingProperties properties, bool isWordEllipsis)
            {
                var textRuns = textLine.TextRuns;

                if (textRuns.Count == 0)
                {
                    return null;
                }

                var runIndex = 0;
                var currentWidth = 0.0;
                var collapsedLength = 0;
                var shapedSymbol = TextFormatter.CreateSymbol(properties.Symbol, FlowDirection.LeftToRight);

                if (properties.Width < shapedSymbol.GlyphRun.Bounds.Width)
                {
                    //Not enough space to fit in the symbol
                    return [];
                }

                var availableWidth = properties.Width - shapedSymbol.Size.Width;

                if (properties.FlowDirection == FlowDirection.LeftToRight)
                {
                    while (runIndex < textRuns.Count)
                    {
                        var currentRun = textRuns[runIndex];

                        switch (currentRun)
                        {
                            case ShapedTextRun shapedRun:
                                {
                                    currentWidth += shapedRun.Size.Width;

                                    if (currentWidth > availableWidth)
                                    {
                                        if (shapedRun.TryMeasureCharacters(availableWidth, out var measuredLength))
                                        {
                                            if (isWordEllipsis && measuredLength < textLine.Length)
                                            {
                                                var currentBreakPosition = 0;

                                                var lineBreaker = new LineBreakEnumerator(currentRun.Text.Span);

                                                while (currentBreakPosition < measuredLength && lineBreaker.MoveNext(out var lineBreak))
                                                {
                                                    var nextBreakPosition = lineBreak.PositionMeasure;

                                                    if (nextBreakPosition == 0)
                                                    {
                                                        break;
                                                    }

                                                    if (nextBreakPosition >= measuredLength)
                                                    {
                                                        break;
                                                    }

                                                    currentBreakPosition = nextBreakPosition;
                                                }

                                                var codepoint = Codepoint.ReadAt(currentRun.Text.Span, currentBreakPosition, out _);

                                                //Handle strings that might look like a file path here
                                                if (codepoint.Value == '\\')
                                                {
                                                    var graphemeEnumerator =
                                                        new GraphemeEnumerator(
                                                            currentRun.Text.Span.Slice(currentBreakPosition));

                                                    var lengthInPath = 0;
                                                    var breakPositionInPath = 0;

                                                    while (graphemeEnumerator.MoveNext(out var grapheme))
                                                    {
                                                        if (currentBreakPosition + lengthInPath + grapheme.Length >= measuredLength)
                                                        {
                                                            break;
                                                        }

                                                        lengthInPath += grapheme.Length;

                                                        if (grapheme.FirstCodepoint.Value is '\\')
                                                        {
                                                            breakPositionInPath = lengthInPath;
                                                        }
                                                    }

                                                    currentBreakPosition += breakPositionInPath - 1;
                                                }

                                                measuredLength = currentBreakPosition;
                                            }
                                        }

                                        collapsedLength += measuredLength;

                                        return CreateCollapsedRuns(textLine, collapsedLength, FlowDirection.LeftToRight, shapedSymbol);
                                    }

                                    availableWidth -= shapedRun.Size.Width;

                                    break;
                                }

                            case DrawableTextRun drawableRun:
                                {
                                    //The whole run needs to fit into available space
                                    if (currentWidth + drawableRun.Size.Width > availableWidth)
                                    {
                                        return CreateCollapsedRuns(textLine, collapsedLength, FlowDirection.LeftToRight, shapedSymbol);
                                    }

                                    availableWidth -= drawableRun.Size.Width;

                                    break;
                                }
                        }

                        collapsedLength += currentRun.Length;

                        runIndex++;
                    }
                }
                else
                {
                    runIndex = textRuns.Count - 1;

                    while (runIndex >= 0)
                    {
                        var currentRun = textRuns[runIndex];

                        switch (currentRun)
                        {
                            case ShapedTextRun shapedRun:
                                {
                                    currentWidth += shapedRun.Size.Width;

                                    if (currentWidth > availableWidth)
                                    {
                                        if (shapedRun.TryMeasureCharacters(availableWidth, out var measuredLength))
                                        {
                                            if (isWordEllipsis && measuredLength < textLine.Length)
                                            {
                                                var currentBreakPosition = 0;

                                                var lineBreaker = new LineBreakEnumerator(currentRun.Text.Span);

                                                while (currentBreakPosition < measuredLength && lineBreaker.MoveNext(out var lineBreak))
                                                {
                                                    var nextBreakPosition = lineBreak.PositionMeasure;

                                                    if (nextBreakPosition == 0)
                                                    {
                                                        break;
                                                    }

                                                    if (nextBreakPosition >= measuredLength)
                                                    {
                                                        break;
                                                    }

                                                    currentBreakPosition = nextBreakPosition;
                                                }

                                                measuredLength = currentBreakPosition;
                                            }
                                        }

                                        collapsedLength += measuredLength;

                                        return CreateCollapsedRuns(textLine, collapsedLength, FlowDirection.RightToLeft, shapedSymbol);
                                    }

                                    availableWidth -= shapedRun.Size.Width;

                                    break;
                                }

                            case DrawableTextRun drawableRun:
                                {
                                    //The whole run needs to fit into available space
                                    if (currentWidth + drawableRun.Size.Width > availableWidth)
                                    {
                                        return CreateCollapsedRuns(textLine, collapsedLength, FlowDirection.RightToLeft, shapedSymbol);
                                    }

                                    availableWidth -= drawableRun.Size.Width;

                                    break;
                                }
                        }

                        collapsedLength += currentRun.Length;

                        runIndex--;
                    }
                }

                return null;
            }
        }
    }
```