### PR TITLE
Fix typeface font simulations

### DIFF
--- a/src/Avalonia.Base/Media/Fonts/EmbeddedFontCollection.cs
+++ b/src/Avalonia.Base/Media/Fonts/EmbeddedFontCollection.cs
@@ -81,7 +81,7 @@ namespace Avalonia.Media.Fonts
                             fontSimulations |= FontSimulations.Oblique;
                         }
 
-                        if ((int)weight >= 600 && glyphTypeface2.Weight != weight)
+                        if ((int)weight >= 600 && glyphTypeface2.Weight < weight)
                         {
                             fontSimulations |= FontSimulations.Bold;
                         }

--- a/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
+++ b/src/Avalonia.Base/Media/Fonts/SystemFontCollection.cs
@@ -113,7 +113,7 @@ namespace Avalonia.Media.Fonts
                     fontSimulations |= FontSimulations.Oblique;
                 }
 
-                if ((int)weight >= 600 && glyphTypeface2.Weight != weight)
+                if ((int)weight >= 600 && glyphTypeface2.Weight < weight)
                 {
                     fontSimulations |= FontSimulations.Bold;
                 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR makes sure we do not apply font simulations to typefaces that aleady have a higher weight that the requested value

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes: #16537