### PR TITLE
Fixes ShapedTextRun drawing

### DIFF
--- a/src/Avalonia.Base/Media/TextFormatting/ShapedTextRun.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/ShapedTextRun.cs
@@ -204,8 +204,7 @@ namespace Avalonia.Media.TextFormatting
                 ShapedBuffer.FontRenderingEmSize,
                 Text,
                 ShapedBuffer,
-                biDiLevel: BidiLevel,
-                baselineOrigin: new Point());
+                biDiLevel: BidiLevel);
         }
 
         public void Dispose()

--- a/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLineImpl.cs
@@ -96,7 +96,7 @@ namespace Avalonia.Media.TextFormatting
                 {
                     case DrawableTextRun drawableTextRun:
                         {
-                            var offsetY = GetBaselineOffset(this, drawableTextRun);
+                            var offsetY = GetBaselineOffset(drawableTextRun);
 
                             drawableTextRun.Draw(drawingContext, new Point(currentX, currentY + offsetY));
 
@@ -108,29 +108,38 @@ namespace Avalonia.Media.TextFormatting
             }
         }
 
-        private static double GetBaselineOffset(TextLine textLine, DrawableTextRun textRun)
+        private double GetBaselineOffset(DrawableTextRun textRun)
         {
             var baseline = textRun.Baseline;
             var baselineAlignment = textRun.Properties?.BaselineAlignment;
 
+            var baselineOffset = -baseline;
+
             switch (baselineAlignment)
             {
                 case BaselineAlignment.Baseline:
-                    return textLine.Baseline;
+                    baselineOffset += Baseline;
+                    break;
                 case BaselineAlignment.Top:
                 case BaselineAlignment.TextTop:
-                    return textLine.Baseline - textLine.Extent + textRun.Size.Height / 2;
+                    baselineOffset += Height - Extent + textRun.Size.Height / 2;
+                    break;
                 case BaselineAlignment.Center:
-                    return textLine.Height / 2 + baseline - textRun.Size.Height / 2;
+                    baselineOffset += Height / 2 + baseline - textRun.Size.Height / 2;
+                    break;
                 case BaselineAlignment.Subscript:
                 case BaselineAlignment.Bottom:
                 case BaselineAlignment.TextBottom:
-                    return textLine.Height - textRun.Size.Height + baseline;
+                    baselineOffset += Height - textRun.Size.Height + baseline;
+                    break;
                 case BaselineAlignment.Superscript:
-                    return baseline;
+                    baselineOffset += baseline;
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(baselineAlignment), baselineAlignment, null);
             }
+
+            return baselineOffset;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
This PR reverts some changes related to the BaselineOffset calculation that caused a regression related to render transforms that might be applied to some text rendering.

Before this change a text line was drawn at a common baseline. To make this work the baseline origin of produces GlyphRuns was set to (X,0) and the current matrix was translated to the common baseline.

This change caused rotation transforms to fail because the transform-origin was no longer at the needed position.

To work around this the PR reverts the changes to the baseline origin and the baseline offset calculation is adjusted to translate each run individually to the common baseline.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
