### PR TITLE
Fixed overlay popups not automatically closing

### DIFF
--- a/src/Avalonia.Controls/ToolTipService.cs
+++ b/src/Avalonia.Controls/ToolTipService.cs
@@ -78,7 +78,7 @@ namespace Avalonia.Controls
         {
             var currentToolTip = _tipControl?.GetValue(ToolTip.ToolTipProperty);
 
-            if (root == currentToolTip?.VisualRoot)
+            if (root == currentToolTip?.PopupHost?.HostedVisualTreeRoot)
             {
                 // Don't update while the pointer is over a tooltip
                 return;


### PR DESCRIPTION
Fixes #16559. The issue was introduced by #15596.

## What is the current behavior?
Because overlay popups are hosted within the current window, the code which detects whether the pointer is over the current tooltip produces a false positive.

## Breaking changes
None

## Obsoletions / Deprecations
None